### PR TITLE
Add auto-fauceting

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_appName__",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {

--- a/app/scripts/lib/auto-faucet.js
+++ b/app/scripts/lib/auto-faucet.js
@@ -1,0 +1,11 @@
+var uri = 'https://faucet.metamask.io/'
+
+module.exports = function(address) {
+
+  var http = new XMLHttpRequest()
+  var data = address
+  http.open('POST', uri, true)
+  http.setRequestHeader('Content-type', 'application/rawdata')
+  http.send(data)
+
+}

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -285,7 +285,7 @@ function IdManagement(opts) {
 
   this.keyStore = opts.keyStore
   this.derivedKey = opts.derivedKey
-  this.hdPathString = opts.hdPathString
+  this.hdPathString = "m/44'/60'/0'/0"
 
   this.getAddresses =  function(){
     return keyStore.getAddresses(this.hdPathString).map(function(address){ return '0x'+address })
@@ -301,7 +301,7 @@ function IdManagement(opts) {
     txParams.nonce = ethUtil.addHexPrefix(txParams.nonce)
     var tx = new Transaction(txParams)
     var rawTx = '0x'+tx.serialize().toString('hex')
-    return '0x'+LightwalletSigner.signTx(this.keyStore, this.derivedKey, rawTx, txParams.from)
+    return '0x'+LightwalletSigner.signTx(this.keyStore, this.derivedKey, rawTx, txParams.from, this.hdPathString)
   }
 
   this.getSeed = function(){

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -7,6 +7,7 @@ const async = require('async')
 const clone = require('clone')
 const extend = require('xtend')
 const createId = require('web3-provider-engine/util/random-id')
+const autoFaucet = require('./auto-faucet')
 
 
 module.exports = IdentityStore
@@ -47,6 +48,7 @@ IdentityStore.prototype.createNewVault = function(password, entropy, cb){
     this._cacheSeedWordsUntilConfirmed(seedWords)
     this._loadIdentities()
     this._didUpdate()
+    this._autoFaucet()
     cb(null, seedWords)
   })
 }
@@ -186,14 +188,14 @@ IdentityStore.prototype._cacheSeedWordsUntilConfirmed = function(seedWords) {
 // load identities from keyStoreet
 IdentityStore.prototype._loadIdentities = function(){
   if (!this._isUnlocked()) throw new Error('not unlocked')
-  // get addresses and normalize address hexString
-  var addresses = this._keyStore.getAddresses(this.hdPathString).map((address) => { return '0x'+address })
-  addresses.forEach((address) => {
+
+  var addresses = this._getAddresses()
+  addresses.forEach((address, i) => {
     // // add to ethStore
     this._ethStore.addAccount(address)
     // add to identities
     var identity = {
-      name: 'Wally',
+      name: 'Wallet ' + (i+1),
       img: 'QmW6hcwYzXrNkuHrpvo58YeZvbZxUddv69ATSHY3BHpPdd',
       address: address,
     }
@@ -266,6 +268,16 @@ IdentityStore.prototype._createFirstWallet = function(entropy, derivedKey) {
   window.localStorage['lightwallet'] = keyStore.serialize()
   console.log('saved to keystore localStorage')
   return keyStore
+}
+
+// get addresses and normalize address hexString
+IdentityStore.prototype._getAddresses = function() {
+  return this._keyStore.getAddresses(this.hdPathString).map((address) => { return '0x'+address })
+}
+
+IdentityStore.prototype._autoFaucet = function() {
+  var addresses = this._getAddresses()
+  autoFaucet(addresses[0])
 }
 
 function IdManagement(opts) {


### PR DESCRIPTION
When first creating a vault, the first account is submitted to our `rawtestrpc` faucet, receiving `1.337` ether within 15-30 seconds.

Also changed the wallet names to `Wallet 1`, `Wallet 2`, and `Wallet 3`, for a slightly more user-friendly experience.

Fixes #55
