### PR TITLE
Etherscan provider

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "__MSG_appName__",
+  "short_name": "Metamask",
   "version": "1.2.1",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "Metamask",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -6,8 +6,7 @@ const combineStreams = require('pumpify')
 const extend = require('xtend')
 const EthStore = require('eth-store')
 const PortStream = require('./lib/port-stream.js')
-const MetaMaskProvider = require('web3-provider-engine/zero.js')
-const EtherscanProvider = require('web3-provider-engine/subproviders/etherscan')
+const MetaMaskProvider = require('./lib/zero.js')
 const IdentityStore = require('./lib/idStore')
 const createTxNotification = require('./lib/tx-notification.js')
 const configManager = require('./lib/config-manager-singleton')
@@ -48,16 +47,9 @@ var providerOpts = {
   },
   approveTransaction: addUnconfirmedTx,
   signTransaction: idStore.signTransaction.bind(idStore),
+  etherscan: providerConfig.type === 'etherscan',
 }
-var provider
-switch (providerConfig.type) {
-  case 'rpc':
-    provider = MetaMaskProvider(providerOpts)
-    break
-  case 'etherscan':
-    provider = EtherscanProvider(providerOpts)
-    break
-}
+var provider = MetaMaskProvider(providerOpts)
 
 // log new blocks
 provider.on('block', function(block){

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -7,6 +7,7 @@ const extend = require('xtend')
 const EthStore = require('eth-store')
 const PortStream = require('./lib/port-stream.js')
 const MetaMaskProvider = require('web3-provider-engine/zero.js')
+const EtherscanProvider = require('web3-provider-engine/subproviders/etherscan')
 const IdentityStore = require('./lib/idStore')
 const createTxNotification = require('./lib/tx-notification.js')
 const configManager = require('./lib/config-manager-singleton')
@@ -36,8 +37,9 @@ function handleEthRpcRequestStream(stream){
 // state and network
 //
 
+var providerConfig = configManager.getProvider()
 var idStore = new IdentityStore()
-var zeroClient = MetaMaskProvider({
+var providerOpts = {
   rpcUrl: configManager.getCurrentRpcAddress(),
   getAccounts: function(cb){
     var selectedAddress = idStore.getSelectedAddress()
@@ -46,14 +48,23 @@ var zeroClient = MetaMaskProvider({
   },
   approveTransaction: addUnconfirmedTx,
   signTransaction: idStore.signTransaction.bind(idStore),
-})
+}
+var provider
+switch (providerConfig.type) {
+  case 'rpc':
+    provider = MetaMaskProvider(providerOpts)
+    break
+  case 'etherscan':
+    provider = EtherscanProvider(providerOpts)
+    break
+}
 
 // log new blocks
-zeroClient.on('block', function(block){
+provider.on('block', function(block){
   console.log('BLOCK CHANGED:', '#'+block.number.toString('hex'), '0x'+block.hash.toString('hex'))
 })
 
-var ethStore = new EthStore(zeroClient)
+var ethStore = new EthStore(provider)
 idStore.setStore(ethStore)
 
 function getState(){
@@ -68,7 +79,7 @@ function getState(){
 // handle rpc requests
 function onRpcRequest(remoteStream, payload){
   // console.log('MetaMaskPlugin - incoming payload:', payload)
-  zeroClient.sendAsync(payload, function onPayloadHandled(err, response){
+  provider.sendAsync(payload, function onPayloadHandled(err, response){
     // provider engine errors are included in response objects
     if (!payload.isMetamaskInternal) console.log('MetaMaskPlugin - RPC complete:', payload, '->', response)
     try {
@@ -111,6 +122,7 @@ function linkDnode(stream){
   var connection = Dnode({
     getState:           function(cb){ cb(null, getState()) },
     setRpcTarget:       setRpcTarget,
+    useEtherscanProvider: useEtherscanProvider,
     // forward directly to idStore
     createNewVault:     idStore.createNewVault.bind(idStore),
     recoverFromSeed:    idStore.recoverFromSeed.bind(idStore),
@@ -176,6 +188,11 @@ function addUnconfirmedTx(txParams, cb){
 // called from popup
 function setRpcTarget(rpcTarget){
   configManager.setRpcTarget(rpcTarget)
+  chrome.runtime.reload()
+}
+
+function useEtherscanProvider() {
+  configManager.useEtherscanProvider()
   chrome.runtime.reload()
 }
 

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -47,15 +47,6 @@ ConfigManager.prototype.setConfig = function(config) {
   this.setData(data)
 }
 
-ConfigManager.prototype.setRpcTarget = function(rpcUrl) {
-  var config = this.getConfig()
-  config.provider = {
-    type: 'rpc',
-    rpcTarget: rpcUrl,
-  }
-  this.setConfig(config)
-}
-
 ConfigManager.prototype.getConfig = function() {
   var data = this.migrator.getData()
   if ('config' in data) {
@@ -68,6 +59,28 @@ ConfigManager.prototype.getConfig = function() {
       }
     }
   }
+}
+
+ConfigManager.prototype.setRpcTarget = function(rpcUrl) {
+  var config = this.getConfig()
+  config.provider = {
+    type: 'rpc',
+    rpcTarget: rpcUrl,
+  }
+  this.setConfig(config)
+}
+
+ConfigManager.prototype.useEtherscanProvider = function() {
+  var config = this.getConfig()
+  config.provider = {
+    type: 'etherscan',
+  }
+  this.setConfig(config)
+}
+
+ConfigManager.prototype.getProvider = function() {
+  var config = this.getConfig()
+  return config.provider
 }
 
 ConfigManager.prototype.setData = function(data) {

--- a/app/scripts/lib/zero.js
+++ b/app/scripts/lib/zero.js
@@ -1,0 +1,65 @@
+const ProviderEngine = require('web3-provider-engine/index.js')
+const DefaultFixture = require('web3-provider-engine/subproviders/default-fixture.js')
+const NonceTrackerSubprovider = require('web3-provider-engine/subproviders/nonce-tracker.js')
+const CacheSubprovider = require('web3-provider-engine/subproviders/cache.js')
+const FilterSubprovider = require('web3-provider-engine/subproviders/filters.js')
+const HookedWalletSubprovider = require('web3-provider-engine/subproviders/hooked-wallet.js')
+const RpcSubprovider = require('web3-provider-engine/subproviders/rpc.js')
+const EtherscanSubprovider = require('web3-provider-engine/subproviders/etherscan.js')
+
+
+module.exports = ZeroClientProvider
+
+
+function ZeroClientProvider(opts){
+  opts = opts || {}
+
+  var engine = new ProviderEngine()
+
+  // static
+  var staticSubprovider = new DefaultFixture()
+  engine.addProvider(staticSubprovider)
+
+  // nonce tracker
+  engine.addProvider(new NonceTrackerSubprovider())
+
+  // cache layer
+  var cacheSubprovider = new CacheSubprovider()
+  engine.addProvider(cacheSubprovider)
+
+  // filters
+  var filterSubprovider = new FilterSubprovider()
+  engine.addProvider(filterSubprovider)
+
+  // id mgmt
+  var idmgmtSubprovider = new HookedWalletSubprovider({
+    getAccounts: opts.getAccounts,
+    approveTransaction: opts.approveTransaction,
+    signTransaction: opts.signTransaction,
+  })
+  engine.addProvider(idmgmtSubprovider)
+
+  // data source
+  var dataProvider
+  if (!opts.etherscan) {
+    dataProvider = new RpcSubprovider({
+      rpcUrl: opts.rpcUrl || 'https://testrpc.metamask.io/',
+    })
+  } else {
+    dataProvider = new EtherscanSubprovider()
+  }
+  engine.addProvider(dataProvider)
+
+  // // log new blocks
+  // engine.on('block', function(block){
+  //   console.log('================================')
+  //   console.log('BLOCK CHANGED:', '#'+block.number.toString('hex'), '0x'+block.hash.toString('hex'))
+  //   console.log('================================')
+  // })
+
+  // start polling
+  engine.start()
+
+  return engine
+
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "readable-stream": "^2.0.5",
     "through2": "^2.0.1",
     "web3": "^0.15.1",
-    "web3-provider-engine": "^7.0.0",
+    "web3-provider-engine": "^7.2.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
New version of provider-engine includes etherscan-subprovider features required to let Metamask use it.

Hard coded the new version of `web3-provider-engine` even though it is not live on `npm` yet, because it is a dependency of this branch.

I'll deploy to the Chrome store but not merge on Github until that provider-engine is published, because it could break others' dev environments.

Requires a UI merge also before these features are revealed.
