### PR TITLE
Etherscan provider

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "__MSG_appName__",
-  "version": "1.2.1",
+  "short_name": "Metamask",
+  "version": "1.3.0",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -47,15 +47,6 @@ ConfigManager.prototype.setConfig = function(config) {
   this.setData(data)
 }
 
-ConfigManager.prototype.setRpcTarget = function(rpcUrl) {
-  var config = this.getConfig()
-  config.provider = {
-    type: 'rpc',
-    rpcTarget: rpcUrl,
-  }
-  this.setConfig(config)
-}
-
 ConfigManager.prototype.getConfig = function() {
   var data = this.migrator.getData()
   if ('config' in data) {
@@ -68,6 +59,28 @@ ConfigManager.prototype.getConfig = function() {
       }
     }
   }
+}
+
+ConfigManager.prototype.setRpcTarget = function(rpcUrl) {
+  var config = this.getConfig()
+  config.provider = {
+    type: 'rpc',
+    rpcTarget: rpcUrl,
+  }
+  this.setConfig(config)
+}
+
+ConfigManager.prototype.useEtherscanProvider = function() {
+  var config = this.getConfig()
+  config.provider = {
+    type: 'etherscan',
+  }
+  this.setConfig(config)
+}
+
+ConfigManager.prototype.getProvider = function() {
+  var config = this.getConfig()
+  return config.provider
 }
 
 ConfigManager.prototype.setData = function(data) {

--- a/app/scripts/lib/zero.js
+++ b/app/scripts/lib/zero.js
@@ -1,0 +1,65 @@
+const ProviderEngine = require('web3-provider-engine/index.js')
+const DefaultFixture = require('web3-provider-engine/subproviders/default-fixture.js')
+const NonceTrackerSubprovider = require('web3-provider-engine/subproviders/nonce-tracker.js')
+const CacheSubprovider = require('web3-provider-engine/subproviders/cache.js')
+const FilterSubprovider = require('web3-provider-engine/subproviders/filters.js')
+const HookedWalletSubprovider = require('web3-provider-engine/subproviders/hooked-wallet.js')
+const RpcSubprovider = require('web3-provider-engine/subproviders/rpc.js')
+const EtherscanSubprovider = require('web3-provider-engine/subproviders/etherscan.js')
+
+
+module.exports = ZeroClientProvider
+
+
+function ZeroClientProvider(opts){
+  opts = opts || {}
+
+  var engine = new ProviderEngine()
+
+  // static
+  var staticSubprovider = new DefaultFixture()
+  engine.addProvider(staticSubprovider)
+
+  // nonce tracker
+  engine.addProvider(new NonceTrackerSubprovider())
+
+  // cache layer
+  var cacheSubprovider = new CacheSubprovider()
+  engine.addProvider(cacheSubprovider)
+
+  // filters
+  var filterSubprovider = new FilterSubprovider()
+  engine.addProvider(filterSubprovider)
+
+  // id mgmt
+  var idmgmtSubprovider = new HookedWalletSubprovider({
+    getAccounts: opts.getAccounts,
+    approveTransaction: opts.approveTransaction,
+    signTransaction: opts.signTransaction,
+  })
+  engine.addProvider(idmgmtSubprovider)
+
+  // data source
+  var dataProvider
+  if (!opts.etherscan) {
+    dataProvider = new RpcSubprovider({
+      rpcUrl: opts.rpcUrl || 'https://testrpc.metamask.io/',
+    })
+  } else {
+    dataProvider = new EtherscanSubprovider()
+  }
+  engine.addProvider(dataProvider)
+
+  // // log new blocks
+  // engine.on('block', function(block){
+  //   console.log('================================')
+  //   console.log('BLOCK CHANGED:', '#'+block.number.toString('hex'), '0x'+block.hash.toString('hex'))
+  //   console.log('================================')
+  // })
+
+  // start polling
+  engine.start()
+
+  return engine
+
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "readable-stream": "^2.0.5",
     "through2": "^2.0.1",
     "web3": "^0.15.1",
-    "web3-provider-engine": "^7.0.0",
+    "web3-provider-engine": "^7.2.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I accidentally merged before I meant to so this reverts the revert.

New version of provider-engine includes etherscan-subprovider features required to let Metamask use it.

Hard coded the new version of `web3-provider-engine` even though it is not live on `npm` yet, because it is a dependency of this branch.

I'll deploy to the Chrome store but not merge on Github until that provider-engine is published, because it could break others' dev environments.

Requires a UI merge also before these features are revealed.
