### PR TITLE
Add mayBeFauceting boolean to account object

### DIFF
--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -9,6 +9,7 @@ const extend = require('xtend')
 const createId = require('web3-provider-engine/util/random-id')
 const autoFaucet = require('./auto-faucet')
 const configManager = require('./config-manager-singleton')
+const DEFAULT_RPC = 'https://rawtestrpc.metamask.io/'
 
 
 module.exports = IdentityStore
@@ -211,10 +212,26 @@ IdentityStore.prototype._loadIdentities = function(){
       name: 'Wallet ' + (i+1),
       img: 'QmW6hcwYzXrNkuHrpvo58YeZvbZxUddv69ATSHY3BHpPdd',
       address: address,
+      mayBeFauceting: this._mayBeFauceting(i),
     }
     this._currentState.identities[address] = identity
   })
   this._didUpdate()
+}
+
+// mayBeFauceting
+// If on testnet, index 0 may be fauceting.
+// The UI will have to check the balance to know.
+// If there is no balance and it mayBeFauceting,
+// then it is in fact fauceting.
+IdentityStore.prototype._mayBeFauceting = function(i) {
+  var config = configManager.getProvider()
+  if (i === 0 &&
+      config.type === 'rpc' &&
+      config.rpcTarget === DEFAULT_RPC) {
+    return true
+  }
+  return false
 }
 
 //


### PR DESCRIPTION
This boolean is computed from these requirements:
- The user is on the testnet rpc
- The account is index 0

The UI is responsible for checking the account balancing and indicating if fauceting is indeed pending or not.
