### PR TITLE
add 'MetaMaskProvider' window global injection

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -90,6 +90,7 @@ remoteProvider.send = function(payload){
 
 var web3 = new Web3(remoteProvider)
 window.web3 = web3
+window.MetaMaskProvider = remoteProvider // support provider injection only (eventually not web3 object override)
 web3.setProvider = function(){
   console.log('MetaMask - overrode web3.setProvider')
 }


### PR DESCRIPTION
We should slowly transition out of injecting all of web3. Or at least make web3 injection optional.

The transition should/could go as follows:

current: just 'window.web3' injection
future: both 'window.web3' && 'window.MetaMaskProvider' injection
long-term: either 'window.web3' || 'window.MetaMaskProvider' injection (I can choose if I want web3 injected)

This way I can choose if I want my window.web3 global overridden. I think it's more clean to just inject the provider while I provide my own secure/safe/tested web3.js.

Example Usage:

```
if(typeof window.MetaMaskProvider !== 'undefined')
     var web3 = new Web3(new window.MetaMaskProvider());
```

Also, if we rebuild web3.js to a different module (i.e scrap Ethereum's web3.js altogether for something else). Then we are just providing a standard provider and not an antiquated or unliked web3 object global.

Thoughts?
