### PR TITLE
Fix eth resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Corrected text above account list. Selected account is visible to all sites, not just the current domain.
 - Merged the UI codebase into the main plugin codebase for simpler maintenance.
+- Fix Ether display rounding error. Now rendering to four decimal points.
 
 ## 1.5.0 2016-04-13
 

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -64,11 +64,16 @@ function weiToEth(bn) {
   return eth
 }
 
+var decimalsToKeep = 4
 function formatBalance(balance) {
   if (!balance) return 'None'
   var wei = numericBalance(balance)
-  var eth = weiToEth(wei)
-  return eth.toString(10) + ' ETH'
+  var padded = wei.toString(10)
+  var len = padded.length
+  var nonZeroIndex = padded.match(/[^0]/).index
+  var beforeDecimal = padded.substr(nonZeroIndex ? nonZeroIndex : 0, len - 18)
+  var afterDecimal = padded.substr(len - 18, decimalsToKeep)
+  return `${beforeDecimal}.${afterDecimal} ETH`
 }
 
 function dataSize(data) {

--- a/ui/test/unit/util_test.js
+++ b/ui/test/unit/util_test.js
@@ -63,9 +63,21 @@ describe('util', function() {
     })
 
     it('should return eth as string followed by ETH', function() {
-      var input = new ethUtil.BN(ethInWei).toJSON()
+      var input = new ethUtil.BN(ethInWei, 10).toJSON()
       var result = util.formatBalance(input)
-      assert.equal(result, '1 ETH')
+      assert.equal(result, '1.0000 ETH')
+    })
+
+    it('should return eth as string followed by ETH', function() {
+      var input = new ethUtil.BN(ethInWei, 10).div(new ethUtil.BN('2', 10)).toJSON()
+      var result = util.formatBalance(input)
+      assert.equal(result, '.5000 ETH')
+    })
+
+    it('should display four decimal points', function() {
+      var input = "0x128dfa6a90b28000"
+      var result = util.formatBalance(input)
+      assert.equal(result, '1.3370 ETH')
     })
 
   })


### PR DESCRIPTION
Our bignumber work was not rendering ether appropriately, was rounding balances and not showing decimals.  Now always shows ether to four decimal points, and is easily configurable to more.
