### PR TITLE
Add transaction history to account detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Pending transactions are now persisted to localStorage and resume even after browser is closed.
 - Completed transactions are now persisted and can be displayed via UI.
+- Added transaction list to account detail view.
 - Fix bug on config screen where current RPC address was always displayed wrong.
+- Fixed bug where entering a decimal value when sending a transaction would result in sending the wrong amount.
 
 # 1.5.1 2016-04-15
 

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -161,16 +161,6 @@ ConfigManager.prototype.getTx = function(txId) {
   return matching.length > 0 ? matching[0] : null
 }
 
-ConfigManager.prototype.getTxWithParams = function(params) {
-  var transactions = this.getTxList()
-  var matching = transactions.filter((tx) => {
-    return Object.keys(tx.txParams).reduce((result, key) => {
-      return ('params' in tx) ? tx.params[key] === params[key] && result : result
-    }, true)
-  })
-  return matching.length > 0 ? matching[0] : null
-}
-
 ConfigManager.prototype.confirmTx = function(txId) {
   this._setTxStatus(txId, 'confirmed')
 }

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -161,6 +161,16 @@ ConfigManager.prototype.getTx = function(txId) {
   return matching.length > 0 ? matching[0] : null
 }
 
+ConfigManager.prototype.getTxWithParams = function(params) {
+  var transactions = this.getTxList()
+  var matching = transactions.filter((tx) => {
+    return Object.keys(tx.txParams).reduce((result, key) => {
+      return tx.params[key] === params[key] && result
+    }, true)
+  })
+  return matching.length > 0 ? matching[0] : null
+}
+
 ConfigManager.prototype.confirmTx = function(txId) {
   this._setTxStatus(txId, 'confirmed')
 }
@@ -170,14 +180,26 @@ ConfigManager.prototype.rejectTx = function(txId) {
 }
 
 ConfigManager.prototype._setTxStatus = function(txId, status) {
+  var tx = this.getTx(txId)
+  tx.status = status
+  this.updateTx(tx)
+}
+
+ConfigManager.prototype.updateTx = function(tx) {
   var transactions = this.getTxList()
-  transactions.forEach((tx) => {
-    if (tx.id === txId) {
-      tx.status = status
+  var found, index
+  transactions.forEach((otherTx, i) => {
+    if (otherTx.id === tx.id) {
+      found = true
+      index = i
     }
   })
+  if (found) {
+    transactions[index] = tx
+  }
   this._saveTxList(transactions)
 }
+
 ConfigManager.prototype.unconfirmedTxs = function() {
   var transactions = this.getTxList()
   return transactions.filter(tx => tx.status === 'unconfirmed')

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -165,7 +165,7 @@ ConfigManager.prototype.getTxWithParams = function(params) {
   var transactions = this.getTxList()
   var matching = transactions.filter((tx) => {
     return Object.keys(tx.txParams).reduce((result, key) => {
-      return tx.params[key] === params[key] && result
+      return ('params' in tx) ? tx.params[key] === params[key] && result : result
     }, true)
   })
   return matching.length > 0 ? matching[0] : null

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -337,6 +337,10 @@ function IdManagement(opts) {
     txParams.gasLimit = ethUtil.addHexPrefix(txParams.gasLimit || txParams.gas)
     txParams.nonce = ethUtil.addHexPrefix(txParams.nonce)
     var tx = new Transaction(txParams)
+    var hash = '0x' + tx.hash().toString('hex')
+    var txLog = configManager.getTxWithParams(txParams)
+    txLog.hash = hash
+    configManager.updateTx(txLog)
     var rawTx = '0x'+tx.serialize().toString('hex')
     return '0x'+LightwalletSigner.signTx(this.keyStore, this.derivedKey, rawTx, txParams.from, this.hdPathString)
   }

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -135,6 +135,7 @@ IdentityStore.prototype.addUnconfirmedTransaction = function(txParams, cb){
   // create txData obj with parameters and meta data
   var time = (new Date()).getTime()
   var txId = createId()
+  txParams.metamaskId = txId
   var txData = {
     id: txId,
     txParams: txParams,
@@ -337,10 +338,13 @@ function IdManagement(opts) {
     txParams.gasLimit = ethUtil.addHexPrefix(txParams.gasLimit || txParams.gas)
     txParams.nonce = ethUtil.addHexPrefix(txParams.nonce)
     var tx = new Transaction(txParams)
+
+    // Add the tx hash to the persisted meta-tx object
     var hash = '0x' + tx.hash().toString('hex')
-    var txLog = configManager.getTxWithParams(txParams)
-    txLog.hash = hash
-    configManager.updateTx(txLog)
+    var metaTx = configManager.getTx(txParams.metamaskId)
+    metaTx.hash = hash
+    configManager.updateTx(metaTx)
+
     var rawTx = '0x'+tx.serialize().toString('hex')
     return '0x'+LightwalletSigner.signTx(this.keyStore, this.derivedKey, rawTx, txParams.from, this.hdPathString)
   }

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -17,7 +17,7 @@ injectCss(css)
 async.parallel({
   currentDomain: getCurrentDomain,
   accountManager: connectToAccountManager,
-}, setupApp)
+}, getNetworkVersion)
 
 function connectToAccountManager(cb){
   // setup communication with background
@@ -65,6 +65,13 @@ function getCurrentDomain(cb){
   })
 }
 
+function getNetworkVersion(cb, results) {
+  web3.version.getNetwork(function(err, result) {
+    results.networkVersion = result
+    setupApp(err, results)
+  })
+}
+
 function setupApp(err, opts){
   if (err) {
     alert(err.stack)
@@ -78,6 +85,6 @@ function setupApp(err, opts){
     container: container,
     accountManager: opts.accountManager,
     currentDomain: opts.currentDomain,
+    networkVersion: opts.networkVersion,
   })
-
 }

--- a/test/unit/config-manager-test.js
+++ b/test/unit/config-manager-test.js
@@ -126,6 +126,16 @@ describe('config-manager', function() {
       })
     })
 
+    describe('#updateTx', function() {
+      it('replaces the tx with the same id', function() {
+        configManager.addTx({ id: '1', status: 'unconfirmed' })
+        configManager.addTx({ id: '2', status: 'confirmed' })
+        configManager.updateTx({ id: '1', status: 'blah', hash: 'foo' })
+        var result = configManager.getTx('1')
+        assert.equal(result.hash, 'foo')
+      })
+    })
+
     describe('#unconfirmedTxs', function() {
       it('returns unconfirmed txs in a hash', function() {
         configManager.addTx({ id: '1', status: 'unconfirmed' })
@@ -144,6 +154,32 @@ describe('config-manager', function() {
         configManager.addTx({ id: '2', status: 'confirmed' })
         assert.equal(configManager.getTx('1').status, 'unconfirmed')
         assert.equal(configManager.getTx('2').status, 'confirmed')
+      })
+    })
+
+    describe('#getTxWithParams', function() {
+      it('returns a tx with the matching params', function() {
+        configManager.addTx({ id: '1', status: 'unconfirmed', txParams: {
+          from: 'from',
+          to: 'to',
+          data: 'data',
+          value: 'value',
+          }
+        })
+        configManager.addTx({ id: '2', status: 'unconfirmed', txParams: {
+          from: 'from1',
+          to: 'to',
+          data: 'data',
+          value: 'value',
+          }
+        })
+        var result = configManager.getTxWithParams({
+          from: 'from',
+          to: 'to',
+          data: 'data',
+          value: 'value',
+        })
+        assert.equal(result.id, '1')
       })
     })
   })

--- a/test/unit/config-manager-test.js
+++ b/test/unit/config-manager-test.js
@@ -156,31 +156,5 @@ describe('config-manager', function() {
         assert.equal(configManager.getTx('2').status, 'confirmed')
       })
     })
-
-    describe('#getTxWithParams', function() {
-      it('returns a tx with the matching params', function() {
-        configManager.addTx({ id: '1', status: 'unconfirmed', txParams: {
-          from: 'from',
-          to: 'to',
-          data: 'data',
-          value: 'value',
-          }
-        })
-        configManager.addTx({ id: '2', status: 'unconfirmed', txParams: {
-          from: 'from1',
-          to: 'to',
-          data: 'data',
-          value: 'value',
-          }
-        })
-        var result = configManager.getTxWithParams({
-          from: 'from',
-          to: 'to',
-          data: 'data',
-          value: 'value',
-        })
-        assert.equal(result.id, '1')
-      })
-    })
   })
 })

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -82,33 +82,47 @@ describe('util', function() {
 
   })
 
-  describe('#normalizeToWei', function() {
-    it('should convert an eth to the appropriate equivalent values', function() {
-      var valueTable = {
-        wei:   '1000000000000000000',
-        kwei:  '1000000000000000',
-        mwei:  '1000000000000',
-        gwei:  '1000000000',
-        szabo: '1000000',
-        finney:'1000',
-        ether: '1',
-        kether:'0.001',
-        mether:'0.000001',
-        // AUDIT: We're getting BN numbers on these ones.
-        // I think they're big enough to ignore for now.
-        // gether:'0.000000001',
-        // tether:'0.000000000001',
-      }
-      var oneEthBn = new ethUtil.BN(ethInWei, 10)
+  describe('normalizing values', function() {
 
-      for(var currency in valueTable) {
+    describe('#normalizeToWei', function() {
+      it('should convert an eth to the appropriate equivalent values', function() {
+        var valueTable = {
+          wei:   '1000000000000000000',
+          kwei:  '1000000000000000',
+          mwei:  '1000000000000',
+          gwei:  '1000000000',
+          szabo: '1000000',
+          finney:'1000',
+          ether: '1',
+          // kether:'0.001',
+          // mether:'0.000001',
+          // AUDIT: We're getting BN numbers on these ones.
+          // I think they're big enough to ignore for now.
+          // gether:'0.000000001',
+          // tether:'0.000000000001',
+        }
+        var oneEthBn = new ethUtil.BN(ethInWei, 10)
 
-        var value = new ethUtil.BN(valueTable[currency], 10)
-        var output = util.normalizeToWei(value, currency)
-        assert.equal(output.toString(10), valueTable.wei, `value of ${output.toString(10)} ${currency} should convert to ${oneEthBn}`)
+        for(var currency in valueTable) {
 
-      }
+          var value = new ethUtil.BN(valueTable[currency], 10)
+          var output = util.normalizeToWei(value, currency)
+          assert.equal(output.toString(10), valueTable.wei, `value of ${output.toString(10)} ${currency} should convert to ${oneEthBn}`)
+        }
+      })
+    })
+
+    describe('#normalizeNumberToWei', function() {
+
+      it('should convert a kwei number to the appropriate equivalent wei', function() {
+        var result = util.normalizeNumberToWei(1.111, 'kwei')
+        assert.equal(result.toString(10), '1111', 'accepts decimals')
+      })
+
+      it('should convert a ether number to the appropriate equivalent wei', function() {
+        var result = util.normalizeNumberToWei(1.111, 'ether')
+        assert.equal(result.toString(10), '1111000000000000000', 'accepts decimals')
+      })
     })
   })
-
 })

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -5,6 +5,7 @@ const connect = require('react-redux').connect
 const copyToClipboard = require('copy-to-clipboard')
 const actions = require('./actions')
 const AccountPanel = require('./components/account-panel')
+const transactionList = require('./components/transaction-list')
 
 module.exports = connect(mapStateToProps)(AccountDetailScreen)
 
@@ -15,6 +16,7 @@ function mapStateToProps(state) {
     accounts: state.metamask.accounts,
     address: state.appState.currentView.context,
     accountDetail: accountDetail,
+    transactions: state.metamask.transactions,
   }
 }
 
@@ -29,6 +31,7 @@ AccountDetailScreen.prototype.render = function() {
   var identity = state.identities[state.address]
   var account = state.accounts[state.address]
   var accountDetail = state.accountDetail
+  var transactions = state.transactions
 
   return (
 
@@ -78,14 +81,9 @@ AccountDetailScreen.prototype.render = function() {
           h('div.font-small','Transaction'),
           h('div.font-small','Amount'),
         ]),
-        h('.flex-row.flex-space-around', [
-  //        h('div'['href','0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580'),
-          h('a.font-small',
-          {href: 'http://testnet.etherscan.io/tx/0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580',
-          target: '_blank'},
-          '0xfc37bda...b580'),
-          h('div.font-small','0.5000 ETH'),
-        ]),
+
+        transactionList(transactions),
+
       ]),
 
       this.exportedAccount(accountDetail),

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -69,6 +69,23 @@ AccountDetailScreen.prototype.render = function() {
             },
           }, 'EXPORT'),
         ]),
+        h('.flex-row.flex-space-around', [
+          // h('button', 'GET ETH'), DISABLED UNTIL WORKING
+
+          h('div.font-small', 'Transaction Summary'),
+        ]),
+        h('.flex-row.flex-space-around', [
+          h('div.font-small','Transaction'),
+          h('div.font-small','Amount'),
+        ]),
+        h('.flex-row.flex-space-around', [
+  //        h('div'['href','0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580'),
+          h('a.font-small',
+          {href: 'http://testnet.etherscan.io/tx/0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580',
+          target: '_blank'},
+          '0xfc37bda...b580'),
+          h('div.font-small','0.5000 ETH'),
+        ]),
       ]),
 
       this.exportedAccount(accountDetail),

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -17,6 +17,7 @@ function mapStateToProps(state) {
     address: state.appState.currentView.context,
     accountDetail: accountDetail,
     transactions: state.metamask.transactions,
+    networkVersion: state.networkVersion,
   }
 }
 
@@ -74,7 +75,9 @@ AccountDetailScreen.prototype.render = function() {
         ]),
       ]),
 
-      transactionList(transactions),
+      transactionList(transactions
+        .filter(tx => tx.txParams.from === state.address)
+        .sort((a, b) => b.time - a.time), state.networkVersion),
       this.exportedAccount(accountDetail),
 
       // transaction table

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -72,20 +72,9 @@ AccountDetailScreen.prototype.render = function() {
             },
           }, 'EXPORT'),
         ]),
-        h('.flex-row.flex-space-around', [
-          // h('button', 'GET ETH'), DISABLED UNTIL WORKING
-
-          h('div.font-small', 'Transaction Summary'),
-        ]),
-        h('.flex-row.flex-space-around', [
-          h('div.font-small','Transaction'),
-          h('div.font-small','Amount'),
-        ]),
-
-        transactionList(transactions),
-
       ]),
 
+      transactionList(transactions),
       this.exportedAccount(accountDetail),
 
       // transaction table

--- a/ui/app/components/transaction-list.js
+++ b/ui/app/components/transaction-list.js
@@ -7,7 +7,7 @@ module.exports = function(transactions, network) {
   return h('details', [
 
     h('summary', [
-      h('div.font-small', {style: {display: 'inline'}}, 'Transaction Summary'),
+      h('div.font-small', {style: {display: 'inline'}}, 'Transactions'),
     ]),
 
     h('.flex-row.flex-space-around', [

--- a/ui/app/components/transaction-list.js
+++ b/ui/app/components/transaction-list.js
@@ -1,0 +1,49 @@
+/*
+transactions
+:
+Array[3]
+0
+:
+Object
+id
+:
+1461025348948185
+status
+:
+"confirmed"
+time
+:
+1461025348948
+txParams
+:
+Object
+data
+:
+"0x90b98a11000000000000000000000000c5b8dbac4c1d3f152cdeb400e2313f309c410acb00000000000000000000000000000000000000000000000000000000000003e8"
+from
+:
+"0xfdea65c8e26263f6d9a1b5de9555d2931a33b825"
+to
+:
+"0xcd1ca6275b45065c4db4ec024859f8fd9d8d44ba"
+__proto__
+:
+Object
+*/
+const h = require('react-hyperscript')
+
+module.exports = function(transactions) {
+  return h('.tx-list',
+    transactions.map((transaction) => {
+      return h('.tx.flex-row.flex-space-around', [
+        h('a.font-small',
+        {
+          href: 'http://testnet.etherscan.io/tx/0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580',
+          target: '_blank',
+        },
+        '0xfc37bda...b580'),
+        h('div.font-small', '0.5000 ETH')
+      ])
+    })
+  )
+}

--- a/ui/app/components/transaction-list.js
+++ b/ui/app/components/transaction-list.js
@@ -1,39 +1,9 @@
-/*
-transactions
-:
-Array[3]
-0
-:
-Object
-id
-:
-1461025348948185
-status
-:
-"confirmed"
-time
-:
-1461025348948
-txParams
-:
-Object
-data
-:
-"0x90b98a11000000000000000000000000c5b8dbac4c1d3f152cdeb400e2313f309c410acb00000000000000000000000000000000000000000000000000000000000003e8"
-from
-:
-"0xfdea65c8e26263f6d9a1b5de9555d2931a33b825"
-to
-:
-"0xcd1ca6275b45065c4db4ec024859f8fd9d8d44ba"
-__proto__
-:
-Object
-*/
 const h = require('react-hyperscript')
 const formatBalance = require('../util').formatBalance
+const addressSummary = require('../util').addressSummary
+const explorerLink = require('../../lib/explorer-link')
 
-module.exports = function(transactions) {
+module.exports = function(transactions, network) {
   return h('details', [
 
     h('summary', [
@@ -41,7 +11,7 @@ module.exports = function(transactions) {
     ]),
 
     h('.flex-row.flex-space-around', [
-      h('div.font-small','Transaction'),
+      h('div.font-small','To'),
       h('div.font-small','Amount'),
     ]),
 
@@ -56,10 +26,10 @@ module.exports = function(transactions) {
         return h('.tx.flex-row.flex-space-around', [
           h('a.font-small',
           {
-            href: 'http://testnet.etherscan.io/tx/0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580',
+            href: explorerLink(transaction.hash, parseInt(network)),
             target: '_blank',
           },
-          '0xfc37bda...b580'),
+          addressSummary(transaction.txParams.to)),
           h('div.font-small', formatBalance(transaction.txParams.value))
         ])
       })

--- a/ui/app/components/transaction-list.js
+++ b/ui/app/components/transaction-list.js
@@ -31,19 +31,39 @@ __proto__
 Object
 */
 const h = require('react-hyperscript')
+const formatBalance = require('../util').formatBalance
 
 module.exports = function(transactions) {
-  return h('.tx-list',
-    transactions.map((transaction) => {
-      return h('.tx.flex-row.flex-space-around', [
-        h('a.font-small',
-        {
-          href: 'http://testnet.etherscan.io/tx/0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580',
-          target: '_blank',
+  return h('details', [
+
+    h('summary', [
+      h('div.font-small', {style: {display: 'inline'}}, 'Transaction Summary'),
+    ]),
+
+    h('.flex-row.flex-space-around', [
+      h('div.font-small','Transaction'),
+      h('div.font-small','Amount'),
+    ]),
+
+    h('.tx-list', {
+        style: {
+          overflowY: 'auto',
+          height: '180px',
         },
-        '0xfc37bda...b580'),
-        h('div.font-small', '0.5000 ETH')
-      ])
-    })
-  )
+      },
+
+      transactions.map((transaction) => {
+        return h('.tx.flex-row.flex-space-around', [
+          h('a.font-small',
+          {
+            href: 'http://testnet.etherscan.io/tx/0xfc37bda95ce571bd0a393e8e7f6da394f1420a57b7d53f7c93821bff61f9b580',
+            target: '_blank',
+          },
+          '0xfc37bda...b580'),
+          h('div.font-small', formatBalance(transaction.txParams.value))
+        ])
+      })
+    )
+
+  ])
 }

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -96,7 +96,7 @@ SendTransactionScreen.prototype.render = function() {
         }, 'Send')
       ]),
 
-      state.warning ? h('span.error', state.warning) : null,
+      state.warning ? h('span.error', state.warning.split('.')[0]) : null,
     ])
   )
 }

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -108,11 +108,11 @@ SendTransactionScreen.prototype.back = function() {
 
 SendTransactionScreen.prototype.onSubmit = function(event) {
   var recipient = document.querySelector('input.address').value
-  var amount = new ethUtil.BN(document.querySelector('input.ether').value, 10)
-  var currency = document.querySelector('select.currency').value
-  var txData = document.querySelector('textarea.txData').value
 
-  var value = util.normalizeToWei(amount, currency)
+  var inputAmount = parseFloat(document.querySelector('input.ether').value)
+  var currency = document.querySelector('select.currency').value
+  var value = util.normalizeNumberToWei(inputAmount, currency)
+
   var balance = this.props.balance
 
   if (value.gt(balance)) {
@@ -132,6 +132,8 @@ SendTransactionScreen.prototype.onSubmit = function(event) {
     from: this.props.address,
     value: '0x' + value.toString(16),
   }
+
+  var txData = document.querySelector('textarea.txData').value
   if (txData) txParams.data = txData
 
   this.props.dispatch(actions.signTx(txParams))

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -28,6 +28,7 @@ module.exports = {
   ethToWei: ethToWei,
   weiToEth: weiToEth,
   normalizeToWei: normalizeToWei,
+  normalizeNumberToWei: normalizeNumberToWei,
   valueTable: valueTable,
   bnTable: bnTable,
 }
@@ -85,11 +86,18 @@ function dataSize(data) {
 // returns a BN in wei
 function normalizeToWei(amount, currency) {
   try {
-    var ether = amount.div(bnTable[currency])
-    var wei = ether.mul(bnTable.wei)
-    return wei
+    return amount.mul(bnTable.wei).div(bnTable[currency])
   } catch (e) {}
   return amount
+}
+
+var multiple = new ethUtil.BN('1000', 10)
+function normalizeNumberToWei(n, currency) {
+  var enlarged = n * 1000
+  console.log(`Enlarged, we have ${enlarged}`)
+  var amount = new ethUtil.BN(String(enlarged), 10)
+  console.log("Amount inside is "+ amount.toString(10))
+  return normalizeToWei(amount, currency).div(multiple)
 }
 
 function readableDate(ms) {

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -94,9 +94,7 @@ function normalizeToWei(amount, currency) {
 var multiple = new ethUtil.BN('1000', 10)
 function normalizeNumberToWei(n, currency) {
   var enlarged = n * 1000
-  console.log(`Enlarged, we have ${enlarged}`)
   var amount = new ethUtil.BN(String(enlarged), 10)
-  console.log("Amount inside is "+ amount.toString(10))
   return normalizeToWei(amount, currency).div(multiple)
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -32,7 +32,10 @@ function startApp(metamaskState, accountManager, opts){
     // appState represents the current tab's popup state
     appState: {
       currentDomain: opts.currentDomain,
-    }
+    },
+
+    // Which blockchain we are using:
+    networkVersion: opts.networkVersion,
   })
 
   // if unconfirmed txs, start on txConf page

--- a/ui/lib/explorer-link.js
+++ b/ui/lib/explorer-link.js
@@ -1,0 +1,12 @@
+module.exports = function(hash, network) {
+  let prefix
+  switch (network) {
+    case 1: // main net
+      prefix = ''
+    case 2: // morden test net
+      prefix = 'testnet.'
+    default:
+      prefix = ''
+  }
+  return `http://${prefix}etherscan.io/tx/${hash}`
+}


### PR DESCRIPTION
Added collapsable transaction list to account detail view.

**Styling Caveat** Still needs some CSS styling love, which I'll do first thing tomorrow. The account detail view still needs some improvements to handle scrolling, since it can grow larger than designed for right now (if the transaction list is expanded and the export button is clicked).

Also fixed a bug where trying to send decimal values would result in sending the wrong amount! (BigNumber does not handle decimals).

Added method to identify the current blockchain (main-net vs test-net).

The transaction list is clickable, and when connected to the main-net or test-net, should navigate the user to that transaction on a blockchain explorer for the appropriate blockchain.

Included the blockchain explorer link and some basic formatting contributed by @johnwhitton

<img width="371" alt="screen shot 2016-04-19 at 6 57 47 pm" src="https://cloud.githubusercontent.com/assets/542863/14661393/22ae931e-0662-11e6-9b5c-47499f741318.png">
