### PR TITLE
Migrate all users off `rawtestrpc` test rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added transaction list to account detail view.
 - Fix bug on config screen where current RPC address was always displayed wrong.
 - Fixed bug where entering a decimal value when sending a transaction would result in sending the wrong amount.
+- Users have been migrated from old test-net RPC to a newer test-net RPC.
 
 # 1.5.1 2016-04-15
 

--- a/app/scripts/lib/migrations.js
+++ b/app/scripts/lib/migrations.js
@@ -2,7 +2,9 @@ var path = require('path')
 var fs = require('fs')
 
 var migration2 = require('../migrations/002')
+var migration3 = require('../migrations/003')
 
 module.exports = [
   migration2,
+  migration3,
 ]

--- a/app/scripts/migrations/002.js
+++ b/app/scripts/migrations/002.js
@@ -1,13 +1,11 @@
-var oldTestRpc = 'https://rawtestrpc.metamask.io/'
-var newTestRpc = 'https://testrpc.metamask.io/'
-
 module.exports = {
-  version: 3,
+  version: 2,
 
   migrate: function(data) {
     try {
-      if (data.config.provider.rpcTarget === oldTestRpc) {
-        data.config.provider.rpcTarget = newTestRpc
+      if (data.config.provider.type === 'etherscan') {
+        data.config.provider.type = 'rpc'
+        data.config.provider.rpcTarget = 'https://rpc.metamask.io/'
       }
     } catch (e) {}
     return data

--- a/app/scripts/migrations/002.js
+++ b/app/scripts/migrations/002.js
@@ -1,11 +1,13 @@
+var oldTestRpc = 'https://rawtestrpc.metamask.io/'
+var newTestRpc = 'https://testrpc.metamask.io/'
+
 module.exports = {
-  version: 2,
+  version: 3,
 
   migrate: function(data) {
     try {
-      if (data.config.provider.type === 'etherscan') {
-        data.config.provider.type = 'rpc'
-        data.config.provider.rpcTarget = 'https://rpc.metamask.io/'
+      if (data.config.provider.rpcTarget === oldTestRpc) {
+        data.config.provider.rpcTarget = newTestRpc
       }
     } catch (e) {}
     return data

--- a/app/scripts/migrations/003.js
+++ b/app/scripts/migrations/003.js
@@ -1,11 +1,13 @@
+var oldTestRpc = 'https://rawtestrpc.metamask.io/'
+var newTestRpc = 'https://testrpc.metamask.io/'
+
 module.exports = {
-  version: 2,
+  version: 3,
 
   migrate: function(data) {
     try {
-      if (data.config.provider.type === 'etherscan') {
-        data.config.provider.type = 'rpc'
-        data.config.provider.rpcTarget = 'https://rpc.metamask.io/'
+      if (data.config.provider.rpcTarget === oldTestRpc) {
+        data.config.provider.rpcTarget = newTestRpc
       }
     } catch (e) {}
     return data

--- a/app/scripts/migrations/003.js
+++ b/app/scripts/migrations/003.js
@@ -1,0 +1,13 @@
+module.exports = {
+  version: 2,
+
+  migrate: function(data) {
+    try {
+      if (data.config.provider.type === 'etherscan') {
+        data.config.provider.type = 'rpc'
+        data.config.provider.rpcTarget = 'https://rpc.metamask.io/'
+      }
+    } catch (e) {}
+    return data
+  }
+}

--- a/test/unit/migrations-test.js
+++ b/test/unit/migrations-test.js
@@ -2,21 +2,26 @@ var assert = require('assert')
 var path = require('path')
 
 var wallet1 = require(path.join('..', 'lib', 'migrations', '001.json'))
+
 var migration2 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '002'))
 var migration3 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '003'))
 
 describe('wallet1 is migrated successfully', function() {
 
-  it('should convert etherscan provider', function(done) {
+  it('should convert providers', function(done) {
+
+    wallet1.data.config.provider = { type: 'etherscan', rpcTarget: null }
 
     var firstResult = migration2.migrate(wallet1.data)
     assert.equal(firstResult.config.provider.type, 'rpc', 'provider should be rpc')
-    assert.equal(firstResult.config.provider.rpcTarget, 'https://rpc.metamask.io/', 'provider should be our rpc')
+    assert.equal(firstResult.config.provider.rpcTarget, 'https://rpc.metamask.io/', 'main provider should be our rpc')
 
     var oldTestRpc = 'https://rawtestrpc.metamask.io/'
+    var newTestRpc = 'https://testrpc.metamask.io/'
     firstResult.config.provider.rpcTarget = oldTestRpc
+
     var secondResult = migration3.migrate(firstResult)
-    assert.equal(firstResult.config.provider.rpcTarget, 'https://testrpc.metamask.io/', 'provider should be our rpc')
+    assert.equal(secondResult.config.provider.rpcTarget, newTestRpc)
 
     done()
   })

--- a/test/unit/migrations-test.js
+++ b/test/unit/migrations-test.js
@@ -3,13 +3,21 @@ var path = require('path')
 
 var wallet1 = require(path.join('..', 'lib', 'migrations', '001.json'))
 var migration2 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '002'))
+var migration3 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '003'))
 
 describe('wallet1 is migrated successfully', function() {
 
   it('should convert etherscan provider', function(done) {
-    var result = migration2.migrate(wallet1.data)
-    assert.equal(result.config.provider.type, 'rpc', 'provider should be rpc')
-    assert.equal(result.config.provider.rpcTarget, 'https://rpc.metamask.io/', 'provider should be our rpc')
+
+    var firstResult = migration2.migrate(wallet1.data)
+    assert.equal(firstResult.config.provider.type, 'rpc', 'provider should be rpc')
+    assert.equal(firstResult.config.provider.rpcTarget, 'https://rpc.metamask.io/', 'provider should be our rpc')
+
+    var oldTestRpc = 'https://rawtestrpc.metamask.io/'
+    firstResult.config.provider.rpcTarget = oldTestRpc
+    var secondResult = migration3.migrate(firstResult)
+    assert.equal(firstResult.config.provider.rpcTarget, 'https://testrpc.metamask.io/', 'provider should be our rpc')
+
     done()
   })
 })


### PR DESCRIPTION
This migration will move users who have their clients configured to point at `rawtestrpc.metamask.io` to point at our new test-net RPC, `testrpc.metamask.io`.

Fixes #131
