### PR TITLE
When no account is selected, show accounts view

### DIFF
--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -7,10 +7,11 @@ module.exports = reduceApp
 function reduceApp(state, action) {
 
   // clone and defaults
+  const selectedAccount = state.metamask.selectedAccount
   var defaultView = {
-    name: 'accountDetail',
+    name: selectedAccount ? 'accountDetail' : 'accounts',
     detailView: null,
-    context: state.metamask.selectedAccount,
+    context: selectedAccount,
   }
 
   // confirm seed words


### PR DESCRIPTION
This is a silly bug when users first open this new version when they did not previously have a persisted `selectedAccount` value.

For these users, the account detail view would appear but with all the fields unpopulated (because no account was actually selected).

Now those users will be shown the main `accounts` view instead.
