### PR TITLE
Filter transaction list for current network

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -52,6 +52,7 @@ function setupTrustedCommunication(connectionStream){
 
 var providerConfig = configManager.getProvider()
 var idStore = new IdentityStore()
+
 var providerOpts = {
   rpcUrl: configManager.getCurrentRpcAddress(),
   getAccounts: function(cb){
@@ -64,6 +65,8 @@ var providerOpts = {
 }
 var provider = MetaMaskProvider(providerOpts)
 var web3 = new Web3(provider)
+idStore.web3 = web3
+idStore.getNetwork(3)
 
 // log new blocks
 provider.on('block', function(block){
@@ -207,18 +210,12 @@ function updateBadge(state){
 //
 
 function addUnconfirmedTx(txParams, cb){
-
-  web3.version.getNetwork(function(err, network) {
-    if (err) return cb(err)
-
-    txParams.metamaskNetworkId = network
-    var txId = idStore.addUnconfirmedTransaction(txParams, cb)
-    createTxNotification({
-      title: 'New Unsigned Transaction',
-      txParams: txParams,
-      confirm: idStore.approveTransaction.bind(idStore, txId, noop),
-      cancel: idStore.cancelTransaction.bind(idStore, txId),
-    })
+  var txId = idStore.addUnconfirmedTransaction(txParams, cb)
+  createTxNotification({
+    title: 'New Unsigned Transaction',
+    txParams: txParams,
+    confirm: idStore.approveTransaction.bind(idStore, txId, noop),
+    cancel: idStore.cancelTransaction.bind(idStore, txId),
   })
 }
 
@@ -230,6 +227,7 @@ function addUnconfirmedTx(txParams, cb){
 function setRpcTarget(rpcTarget){
   configManager.setRpcTarget(rpcTarget)
   chrome.runtime.reload()
+  idStore.getNetwork(3) // 3 retry attempts
 }
 
 function useEtherscanProvider() {

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -16,11 +16,11 @@ module.exports = IdentityStore
 
 
 inherits(IdentityStore, EventEmitter)
-function IdentityStore(ethStore) {
+function IdentityStore(opts = {}) {
   EventEmitter.call(this)
 
   // we just use the ethStore to auto-add accounts
-  this._ethStore = ethStore
+  this._ethStore = opts.ethStore
   // lightwallet key store
   this._keyStore = null
   // lightwallet wrapper
@@ -110,6 +110,16 @@ IdentityStore.prototype.setSelectedAddress = function(address){
   this._didUpdate()
 }
 
+IdentityStore.prototype.getNetwork = function(tries) {
+  if (tries === 0) return
+  this.web3.version.getNetwork((err, network) => {
+    if (err) {
+      return this.getNetwork(tries - 1, cb)
+    }
+    this._currentState.network = network
+  })
+}
+
 IdentityStore.prototype.setLocked = function(cb){
   delete this._keyStore
   delete this._idmgmt
@@ -137,6 +147,7 @@ IdentityStore.prototype.addUnconfirmedTransaction = function(txParams, cb){
   var time = (new Date()).getTime()
   var txId = createId()
   txParams.metamaskId = txId
+  txParams.metamaskNetworkId = this._currentState.network
   var txData = {
     id: txId,
     txParams: txParams,

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -17,7 +17,7 @@ injectCss(css)
 async.parallel({
   currentDomain: getCurrentDomain,
   accountManager: connectToAccountManager,
-}, getNetworkVersion)
+}, setupApp)
 
 function connectToAccountManager(cb){
   // setup communication with background
@@ -62,13 +62,6 @@ function getCurrentDomain(cb){
       return cb(null, '<unknown>')
     }
     cb(null, currentDomain)
-  })
-}
-
-function getNetworkVersion(cb, results) {
-  web3.version.getNetwork(function(err, result) {
-    results.networkVersion = result
-    setupApp(err, results)
   })
 }
 

--- a/test/unit/explorer-link-test.js
+++ b/test/unit/explorer-link-test.js
@@ -1,0 +1,11 @@
+var assert = require('assert')
+var linkGen = require('../../ui/lib/explorer-link')
+
+describe('explorer-link', function() {
+
+  it('adds testnet prefix to morden test network', function() {
+    var result = linkGen('hash', '2')
+    assert.notEqual(result.indexOf('testnet'), -1, 'testnet injected')
+  })
+
+})

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -15,7 +15,9 @@ describe('IdentityStore', function() {
       window.localStorage = {} // Hacking localStorage support into JSDom
 
       idStore = new IdentityStore({
-        addAccount(acct) { accounts.push(acct) },
+        ethStore: {
+          addAccount(acct) { accounts.push(acct) },
+        },
       })
 
       idStore.createNewVault(password, entropy, (err, seeds) => {
@@ -32,7 +34,9 @@ describe('IdentityStore', function() {
         window.localStorage = {} // Hacking localStorage support into JSDom
 
         idStore = new IdentityStore({
-          addAccount(acct) { newAccounts.push(acct) },
+          ethStore: {
+            addAccount(acct) { newAccounts.push(acct) },
+          },
         })
       })
 
@@ -61,8 +65,8 @@ describe('IdentityStore', function() {
       window.localStorage = {} // Hacking localStorage support into JSDom
 
       idStore = new IdentityStore({
-        addAccount(acct) {
-          accounts.push(acct)
+        ethStore: {
+          addAccount(acct) { accounts.push(acct) },
         },
       })
     })

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -16,7 +16,7 @@ function mapStateToProps(state) {
     address: state.appState.currentView.context,
     accountDetail: state.appState.accountDetail,
     transactions: state.metamask.transactions,
-    networkVersion: state.networkVersion,
+    networkVersion: state.metamask.network,
   }
 }
 
@@ -79,6 +79,7 @@ AccountDetailScreen.prototype.render = function() {
 
       transactionList(transactions
         .filter(tx => tx.txParams.from === state.address)
+        .filter(tx => tx.txParams.metamaskNetworkId === state.networkVersion)
         .sort((a, b) => b.time - a.time), state.networkVersion),
       this.exportedAccount(accountDetail),
 

--- a/ui/lib/explorer-link.js
+++ b/ui/lib/explorer-link.js
@@ -1,10 +1,13 @@
 module.exports = function(hash, network) {
+  const net = parseInt(network)
   let prefix
-  switch (network) {
+  switch (net) {
     case 1: // main net
       prefix = ''
+      break
     case 2: // morden test net
       prefix = 'testnet.'
+      break
     default:
       prefix = ''
   }


### PR DESCRIPTION
When starting up, we now create a `web3` inside the `background.js` process, which we pass to the `idStore` and ask for the current `network`.

We include the `network` on `app.metamask.network` in the state object.

We re-request the network when changing provider.

We filter the transaction list for transactions that match the current network.

Also fixes a bug where the network was not selecting the correct etherscan prefix.
