### PR TITLE
Fix transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Account icons are now "identicons" (deterministically generated from the address).
 - Fixed link to Slack channel.
 - Added a context guard for "define" to avoid UMD's exporting themselves to the wrong module system
+- Transaction list now only shows transactions for the current account.
+- Transaction list now only shows transactions for the current network (mainnet, testnet, testrpc).
+- Fixed transaction links to etherscan blockchain explorer.
 
 # 1.6.0 2016-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Transaction list now only shows transactions for the current account.
 - Transaction list now only shows transactions for the current network (mainnet, testnet, testrpc).
 - Fixed transaction links to etherscan blockchain explorer.
+- Fixed some UI transitions that had weird behavior.
 
 # 1.6.0 2016-04-22
 

--- a/ui/app/accounts.js
+++ b/ui/app/accounts.js
@@ -91,7 +91,7 @@ AccountsScreen.prototype.render = function() {
     var componentState = extend(actions, {
       identity: identity,
       account: account,
-      isSelected: isSelected,
+      isSelected: false,
       isFauceting: isFauceting,
     })
     return h(AccountPanel, componentState)

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -131,15 +131,11 @@ function recoverFromSeed(password, seed) {
     // dispatch(this.createNewVaultInProgress())
     dispatch(this.showLoadingIndication())
     _accountManager.recoverFromSeed(password, seed, (err, selectedAccount) => {
-      if (err) {
-        dispatch(this.hideLoadingIndication())
-        var message = err.message
-        return dispatch(this.displayWarning(err.message))
-      }
+      dispatch(this.hideLoadingIndication())
+      if (err) return dispatch(this.displayWarning(err.message))
 
       dispatch(this.unlockMetamask())
-      dispatch(this.showAccountDetail(selectedAccount))
-      dispatch(this.hideLoadingIndication())
+      dispatch(this.showAccountsPage())
    })
   }
 }
@@ -165,7 +161,7 @@ function signTx(txData) {
 
       if (err) return dispatch(this.displayWarning(err.message))
       dispatch(this.hideWarning())
-      dispatch(this.showAccountsPage())
+      dispatch(this.goHome())
     })
   }
 }
@@ -198,10 +194,8 @@ function txError(err) {
 }
 
 function cancelTx(txData){
-  return (dispatch) => {
-    _accountManager.cancelTransaction(txData.id)
-    dispatch(this.showAccountsPage())
-  }
+  _accountManager.cancelTransaction(txData.id)
+  return this.goHome()
 }
 
 //

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -199,12 +199,11 @@ function reduceApp(state, action) {
     } else {
       return extend(appState, {
         transForward: false,
-        currentView: {
-          name: 'accounts',
-          context: 0,
-        },
-        transForward: false,
         warning: null,
+        currentView: {
+          name: 'accountDetail',
+          context: appState.currentView.context,
+        },
       })
     }
 


### PR DESCRIPTION
Fixes #151
- Cancelling or completing a tx now goes back to account detail view.
- Restoring a vault now does not select an unloaded account, shows account list.
- Account list now never selects an item only uses the cells as buttons.
