### PR TITLE
Put accounts view back on account "back" button?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Moved account exporting within transitioning subview on the account detail view.
 - Added buttons to the account export process.
 - Improved visual appearance of account detail transition where button heights would change.
+- Restored back button to account detail view.
 
 ## 1.7.0 2016-04-29
 

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -47,6 +47,11 @@ AccountDetailScreen.prototype.render = function() {
 
       // subtitle and nav
       h('.section-title.flex-row.flex-center', [
+        h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
+          onClick: (event) => {
+            state.dispatch(actions.goHome())
+          }
+        }),
         h('h2.page-subtitle', 'Account Detail'),
       ]),
 
@@ -62,10 +67,6 @@ AccountDetailScreen.prototype.render = function() {
           display: 'flex',
         }
       }, [
-
-        h('button', {
-          onClick: this.navigateToAccounts.bind(this),
-        }, 'CHANGE ACCT'),
 
         h('button', {
           onClick: () => {

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -48,9 +48,7 @@ AccountDetailScreen.prototype.render = function() {
       // subtitle and nav
       h('.section-title.flex-row.flex-center', [
         h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: (event) => {
-            state.dispatch(actions.goHome())
-          }
+          onClick: this.navigateToAccounts.bind(this),
         }),
         h('h2.page-subtitle', 'Account Detail'),
       ]),


### PR DESCRIPTION
The `Change Acct` button was confusing multiple users, reverted that bit.

Fixes #173 
