### PR TITLE
Prettier transaction list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Restored back button to account detail view.
 - Show transaction list always, never collapsed.
 - Changing provider now reloads current Dapps
+- Improved appearance of transaction list in account detail view.
 
 ## 1.7.0 2016-04-29
 

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -58,7 +58,8 @@ AccountDetailScreen.prototype.render = function() {
         showFullAddress: true,
         identity: identity,
         account: account,
-      }, []),
+        key: 'accountPanel'
+      }),
 
       h('div', {
         style: {

--- a/ui/app/accounts.js
+++ b/ui/app/accounts.js
@@ -50,7 +50,7 @@ AccountsScreen.prototype.render = function() {
        * regardless of the current domain.
        */
       h('.current-domain-panel.flex-center.font-small', [
-        h('spam', 'Selected address is visible to all sites you visit.'),
+        h('span', 'Selected address is visible to all sites you visit.'),
         // h('span', state.currentDomain),
       ]),
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -61,6 +61,7 @@ var actions = {
   signMsg: signMsg,
   cancelMsg: cancelMsg,
   sendTx: sendTx,
+  signTx: signTx,
   cancelTx: cancelTx,
   completedTx: completedTx,
   txError: txError,
@@ -161,6 +162,20 @@ function signMsg(msgData) {
 
       if (err) return dispatch(this.displayWarning(err.message))
       dispatch(this.completedTx(msgData.metamaskId))
+    })
+  }
+}
+
+function signTx(txData) {
+  return (dispatch) => {
+    dispatch(this.showLoadingIndication())
+
+    web3.eth.sendTransaction(txData, (err, data) => {
+      dispatch(this.hideLoadingIndication())
+
+      if (err) return dispatch(this.displayWarning(err.message))
+      dispatch(this.hideWarning())
+      dispatch(this.goHome())
     })
   }
 }

--- a/ui/app/components/panel.js
+++ b/ui/app/components/panel.js
@@ -1,0 +1,63 @@
+const inherits = require('util').inherits
+const ethUtil = require('ethereumjs-util')
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const Identicon = require('identicon.js')
+
+module.exports = Panel
+
+
+inherits(Panel, Component)
+function Panel() {
+  Component.call(this)
+}
+
+Panel.prototype.render = function() {
+  var state = this.props
+
+  var identity = state.identity || {}
+  var account = state.account || {}
+  var isFauceting = state.isFauceting
+
+  var identicon = new Identicon(state.identiconKey, 46).toString()
+  var identiconSrc = `data:image/png;base64,${identicon}`
+
+  return (
+    h('.identity-panel.flex-row.flex-space-between', {
+      style: {
+        flex: '1 0 auto',
+      },
+      onClick: state.onClick,
+    }, [
+
+      // account identicon
+      h('.identicon-wrapper.flex-column.select-none', [
+        h('img.identicon', {
+          src: identiconSrc,
+          style: {
+            border: 'none',
+            borderRadius: '20px',
+          }
+        }),
+        h('span.font-small', state.identiconLabel),
+      ]),
+
+      // account address, balance
+      h('.identity-data.flex-column.flex-justify-center.flex-grow.select-none', [
+
+        state.attributes.map((attr) => {
+          return h('.flex-row.flex-space-between', {
+            key: '' + Math.round(Math.random() * 1000000),
+          }, [
+            h('label.font-small', attr.key),
+            h('span.font-small', attr.value),
+          ])
+        }),
+      ]),
+
+      // outlet for inserting additional stuff
+      state.children,
+    ])
+  )
+}
+

--- a/ui/app/components/transaction-list.js
+++ b/ui/app/components/transaction-list.js
@@ -16,7 +16,9 @@ module.exports = function(transactions, network) {
       h('div.font-small', {style: {display: 'inline'}}, 'Transactions'),
 
       transactions.map((transaction) => {
-        return h('.tx.flex-row.flex-space-around', [
+        return h('.tx.flex-row.flex-space-around', {
+          key: `listed-tx-${transaction.hash}`,
+        }, [
           h('a.font-small',
           {
             href: explorerLink(transaction.hash, parseInt(network)),

--- a/ui/app/components/transaction-list.js
+++ b/ui/app/components/transaction-list.js
@@ -2,32 +2,54 @@ const h = require('react-hyperscript')
 const formatBalance = require('../util').formatBalance
 const addressSummary = require('../util').addressSummary
 const explorerLink = require('../../lib/explorer-link')
+const Panel = require('./panel')
 
 module.exports = function(transactions, network) {
-  return h('.tx-list', {
-      style: {
-        overflowY: 'auto',
-        height: '180px',
-        textAlign: 'center',
+  return h('section', [
+
+    h('.current-domain-panel.flex-center.font-small', [
+      h('span', 'Transactions'),
+    ]),
+
+    h('.tx-list', {
+        style: {
+          overflowY: 'auto',
+          height: '180px',
+          textAlign: 'center',
+        },
       },
-    },
 
-    [
-      h('div.font-small', {style: {display: 'inline'}}, 'Transactions'),
+      [
 
-      transactions.map((transaction) => {
-        return h('.tx.flex-row.flex-space-around', {
-          key: `listed-tx-${transaction.hash}`,
-        }, [
-          h('a.font-small',
-          {
-            href: explorerLink(transaction.hash, parseInt(network)),
-            target: '_blank',
-          },
-          addressSummary(transaction.txParams.to)),
-          h('div.font-small', formatBalance(transaction.txParams.value))
-        ])
-      })
-    ]
-  )
-}
+        transactions.map((transaction) => {
+          console.dir(transaction)
+
+          var panelOpts = {
+            key: `tx-${transaction.hash}`,
+            identiconKey: transaction.txParams.to,
+            style: {
+              cursor: 'pointer',
+            },
+            onClick: (event) => {
+              var url = explorerLink(transaction.hash, parseInt(network))
+              chrome.tabs.create({ url });
+            },
+            attributes: [
+              {
+                key: 'TO',
+                value: addressSummary(transaction.txParams.to),
+              },
+              {
+                key: 'VALUE',
+                value: formatBalance(transaction.txParams.value),
+              },
+            ]
+          }
+
+          return h(Panel, panelOpts)
+        })
+      ]
+    )
+
+  ])
+ }


### PR DESCRIPTION
The styles that defined the `account-panel` component now belong to the `panel` component, which is now used by the `account-panel` component for its styles.

It accepts an optional `onClick` property that it will fire when clicked!

Then used the new panel component to style up the transaction list in a consistent way.

<img width="366" alt="screen shot 2016-05-06 at 2 46 40 pm" src="https://cloud.githubusercontent.com/assets/542863/15086937/67ddbe9e-1399-11e6-8a10-c4045e43af5e.png">
