### PR TITLE
Easily configurable providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current Master
 
+- Initial usage of scalable blockchain backend.
+- Made official providers more easily configurable for us internally.
+
 ## 1.8.0 2016-05-10
 
 - Add support for calls to `eth.sign`.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -168,6 +168,7 @@ function setupControllerConnection(stream){
   var dnode = Dnode({
     getState:           function(cb){ cb(null, getState()) },
     setRpcTarget:       setRpcTarget,
+    setProviderType:    setProviderType,
     useEtherscanProvider: useEtherscanProvider,
     // forward directly to idStore
     createNewVault:     idStore.createNewVault.bind(idStore),
@@ -253,6 +254,12 @@ function setRpcTarget(rpcTarget){
   configManager.setRpcTarget(rpcTarget)
   chrome.runtime.reload()
   idStore.getNetwork(3) // 3 retry attempts
+}
+
+function setProviderType(type) {
+  configManager.setProviderType(type)
+  chrome.runtime.reload()
+  idStore.getNetwork(3)
 }
 
 function useEtherscanProvider() {

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -2,7 +2,8 @@ const Migrator = require('pojo-migrator')
 const extend = require('xtend')
 
 const STORAGE_KEY = 'metamask-config'
-const DEFAULT_RPC = 'https://testrpc.metamask.io/'
+const TESTNET_RPC = 'http://morden.infura.io'
+const MAINNET_RPC = 'http://mainnet.infura.io/'
 
 const migrations = require('./migrations')
 
@@ -59,8 +60,7 @@ ConfigManager.prototype.getConfig = function() {
   } else {
     return {
       provider: {
-        type: 'rpc',
-        rpcTarget: DEFAULT_RPC,
+        type: 'testnet',
       }
     }
   }
@@ -71,6 +71,14 @@ ConfigManager.prototype.setRpcTarget = function(rpcUrl) {
   config.provider = {
     type: 'rpc',
     rpcTarget: rpcUrl,
+  }
+  this.setConfig(config)
+}
+
+ConfigManager.prototype.setProviderType = function(type) {
+  var config = this.getConfig()
+  config.provider = {
+    type: type,
   }
   this.setConfig(config)
 }
@@ -130,9 +138,19 @@ ConfigManager.prototype.getShouldShowSeedWords = function() {
 }
 
 ConfigManager.prototype.getCurrentRpcAddress = function() {
-  var config = this.getConfig()
-  if (!config) return null
-  return config.provider && config.provider.rpcTarget ? config.provider.rpcTarget : DEFAULT_RPC
+  var provider = this.getProvider()
+  if (!provider) return null
+    switch (provider.type) {
+
+      case 'mainnet':
+        return MAINNET_RPC
+
+      case 'testnet':
+        return TESTNET_RPC
+
+      default:
+        return provider && provider.rpcTarget ? provider.rpcTarget : TESTNET_RPC
+   }
 }
 
 ConfigManager.prototype.clearWallet = function() {
@@ -246,7 +264,9 @@ function loadData() {
     },
     data: {
       config: {
-        rpcTarget: DEFAULT_RPC,
+        provider: {
+          type: 'testnet',
+        }
       }
     }
   }, oldData ? oldData : null, newData ? newData : null)

--- a/test/unit/actions/config_test.js
+++ b/test/unit/actions/config_test.js
@@ -36,7 +36,8 @@ describe ('config view actions', function() {
       }
 
       var result = reducers(initialState, action)
-      assert.equal(result.metamask.rpcTarget, action.value)
+      assert.equal(result.metamask.provider.type, 'rpc')
+      assert.equal(result.metamask.provider.rpcTarget, action.value)
     })
   })
 })

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -77,10 +77,12 @@ var actions = {
   // config screen
   SHOW_CONFIG_PAGE: 'SHOW_CONFIG_PAGE',
   SET_RPC_TARGET: 'SET_RPC_TARGET',
+  SET_PROVIDER_TYPE: 'SET_PROVIDER_TYPE',
   USE_ETHERSCAN_PROVIDER: 'USE_ETHERSCAN_PROVIDER',
   useEtherscanProvider: useEtherscanProvider,
   showConfigPage: showConfigPage,
   setRpcTarget: setRpcTarget,
+  setProviderType: setProviderType,
   // hacky - need a way to get a reference to account manager
   _setAccountManager: _setAccountManager,
   // loading overlay
@@ -366,6 +368,14 @@ function setRpcTarget(newRpc) {
   return {
     type: this.SET_RPC_TARGET,
     value: newRpc,
+  }
+}
+
+function setProviderType(type) {
+  _accountManager.setProviderType(type)
+  return {
+    type: this.SET_PROVIDER_TYPE,
+    value: type,
   }
 }
 

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -84,7 +84,7 @@ ConfigScreen.prototype.render = function() {
               },
               onClick(event) {
                 event.preventDefault()
-                state.dispatch(actions.setRpcTarget('https://rpc.metamask.io/'))
+                state.dispatch(actions.setProviderType('mainnet'))
               }
             }, 'Use Main Network')
           ]),
@@ -96,7 +96,7 @@ ConfigScreen.prototype.render = function() {
               },
               onClick(event) {
                 event.preventDefault()
-                state.dispatch(actions.setRpcTarget('https://testrpc.metamask.io/'))
+                state.dispatch(actions.setProviderType('testnet'))
               }
             }, 'Use Morden Test Network')
           ]),
@@ -120,9 +120,28 @@ ConfigScreen.prototype.render = function() {
 }
 
 function currentProviderDisplay(metamaskState) {
-  var rpc = metamaskState.provider.rpcTarget
+  var provider = metamaskState.provider
+  var title, value
+
+  switch (provider.type) {
+
+    case 'mainnet':
+      title = 'Current Network'
+      value = 'Main Ethereum Network'
+      break
+
+    case 'testnet':
+      title = 'Current Network'
+      value = 'Morden Test Network'
+      break
+
+    default:
+      title = 'Current RPC'
+      value = metamaskState.provider.rpcTarget
+ }
+
   return h('div', [
-    h('span', {style: { fontWeight: 'bold', paddingRight: '10px'}}, 'Current RPC'),
-    h('span', rpc)
+    h('span', {style: { fontWeight: 'bold', paddingRight: '10px'}}, title),
+    h('span', value)
   ])
 }

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -38,7 +38,17 @@ function reduceMetamask(state, action) {
 
   case actions.SET_RPC_TARGET:
     return extend(metamaskState, {
-      rpcTarget: action.value,
+      provider: {
+        type: 'rpc',
+        rpcTarget: action.value,
+      },
+    })
+
+  case actions.SET_PROVIDER_TYPE:
+    return extend(metamaskState, {
+      provider: {
+        type: action.value,
+      },
     })
 
   case actions.COMPLETED_TX:


### PR DESCRIPTION
- Move metamask to scalable rpc backend.
- Make it easier for us to update our internal providers in the future.
