### PR TITLE
Zero value txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - UI Overhaul per Vlad Todirut's designs
 - Replaced identicons with jazzicons
 - Fixed glitchy transitions
+- Added support for capitalization-based address checksums
 
 ## 1.8.4 2016-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Current Master
 
-- UI Overhaul per Vlad Todirut's designs
-- Replaced identicons with jazzicons
-- Fixed glitchy transitions
-- Added support for capitalization-based address checksums
+- UI Overhaul per Vlad Todirut's designs.
+- Replaced identicons with jazzicons.
+- Fixed glitchy transitions.
+- Added support for capitalization-based address checksums.
+- Send value is no longer limited by javascript number precision, and is always in ETH.
 
 ## 1.8.4 2016-05-13
 

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -159,6 +159,20 @@ describe('util', function() {
       })
     })
 
+    describe('normalizeEthStringToWei', function() {
+      it('should convert decimal eth to pure wei BN', function() {
+        var input = '1.23456789'
+        var output = util.normalizeEthStringToWei(input)
+        assert.equal(output.toString(10), '1234567890000000000')
+      })
+
+      it('should convert 1 to expected wei', function() {
+        var input = '1'
+        var output = util.normalizeEthStringToWei(input)
+        assert.equal(output.toString(10), ethInWei)
+      })
+    })
+
     describe('#normalizeNumberToWei', function() {
 
       it('should handle a simple use case', function() {

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -61,6 +61,7 @@ describe('util', function() {
       var result = util.isValidAddress(address)
       assert.ok(!result)
     })
+
   })
 
   describe('numericBalance', function() {
@@ -159,6 +160,13 @@ describe('util', function() {
     })
 
     describe('#normalizeNumberToWei', function() {
+
+      it('should handle a simple use case', function() {
+        var input = 0.0002
+        var output = util.normalizeNumberToWei(input, 'ether')
+        var str = output.toString(10)
+        assert.equal(str, '200000000000000')
+      })
 
       it('should convert a kwei number to the appropriate equivalent wei', function() {
         var result = util.normalizeNumberToWei(1.111, 'kwei')

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -17,6 +17,52 @@ describe('util', function() {
     this.sinon.restore()
   })
 
+  describe('addressSummary', function() {
+    it('should add case-sensitive checksum', function() {
+      var address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
+      var result = util.addressSummary(address)
+      assert.equal(result, '0xFDEa65C8...b825')
+    })
+  })
+
+  describe('isValidAddress', function() {
+    it('should allow 40-char non-prefixed hex', function() {
+      var address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b825'
+      var result = util.isValidAddress(address)
+      assert.ok(result)
+    })
+
+    it('should allow 42-char non-prefixed hex', function() {
+      var address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
+      var result = util.isValidAddress(address)
+      assert.ok(result)
+    })
+
+    it('should not allow less non hex-prefixed', function() {
+      var address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b85'
+      var result = util.isValidAddress(address)
+      assert.ok(!result)
+    })
+
+    it('should not allow less hex-prefixed', function() {
+      var address = '0xfdea65ce26263f6d9a1b5de9555d2931a33b85'
+      var result = util.isValidAddress(address)
+      assert.ok(!result)
+    })
+
+    it('should recognize correct capitalized checksum', function() {
+      var address = '0xFDEa65C8e26263F6d9A1B5de9555D2931A33b825'
+      var result = util.isValidAddress(address)
+      assert.ok(result)
+    })
+
+    it('should recognize incorrect capitalized checksum', function() {
+      var address = '0xFDea65C8e26263F6d9A1B5de9555D2931A33b825'
+      var result = util.isValidAddress(address)
+      assert.ok(!result)
+    })
+  })
+
   describe('numericBalance', function() {
 
     it('should return a BN 0 if given nothing', function() {

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -13,6 +13,7 @@ const Identicon = require('./components/identicon')
 const EtherBalance = require('./components/eth-balance')
 const transactionList = require('./components/transaction-list')
 const ExportAccountView = require('./components/account-export')
+const ethUtil = require('ethereumjs-util')
 
 module.exports = connect(mapStateToProps)(AccountDetailScreen)
 
@@ -110,7 +111,7 @@ AccountDetailScreen.prototype.render = function() {
           }),
 
           h('i.fa.fa-clipboard.fa-md.cursor-pointer.color-orange', {
-            onClick: () => copyToClipboard(selected),
+            onClick: () => copyToClipboard(ethUtil.toChecksumAddress(selected)),
           }),
 
         ]),
@@ -133,7 +134,7 @@ AccountDetailScreen.prototype.render = function() {
           }, 'SEND ETH'),
 
         ]),
-      
+
       ]),
 
       // subview (tx history, pk export confirm)

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -219,7 +219,7 @@ SendTransactionScreen.prototype.onSubmit = function() {
     return this.props.dispatch(actions.displayWarning(message))
   }
 
-  if ((recipient.length !== 42 && !txData) || (!recipient && !txData)) {
+  if ((util.isValidAddress(recipient) && !txData) || (!recipient && !txData)) {
     var message = 'Recipient address is invalid.'
     return this.props.dispatch(actions.displayWarning(message))
   }

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -206,20 +206,21 @@ SendTransactionScreen.prototype.back = function() {
   this.props.dispatch(actions.backToAccountDetail(address))
 }
 
-SendTransactionScreen.prototype.onSubmit = function(event) {
-  var recipient = document.querySelector('input[name="address"]').value
+SendTransactionScreen.prototype.onSubmit = function() {
 
-  var inputAmount = parseFloat(document.querySelector('input[name="amount"]').value)
-  var value = util.normalizeNumberToWei(inputAmount, 'ether')
-
-  var balance = this.props.balance
+  const recipient = document.querySelector('input[name="address"]').value
+  const inputAmount = parseFloat(document.querySelector('input[name="amount"]').value)
+  const value = util.normalizeNumberToWei(inputAmount, 'ether')
+  const txData = document.querySelector('input[name="txData"]').value
+  const balance = this.props.balance
 
   if (value.gt(balance)) {
     var message = 'Insufficient funds.'
     return this.props.dispatch(actions.displayWarning(message))
   }
-  if (recipient.length !== 42) {
-    var message = 'Recipient address is the incorrect length.'
+
+  if ((recipient.length !== 42 && !txData) || (!recipient && !txData)) {
+    var message = 'Recipient address is invalid.'
     return this.props.dispatch(actions.displayWarning(message))
   }
 
@@ -232,7 +233,6 @@ SendTransactionScreen.prototype.onSubmit = function(event) {
     value: '0x' + value.toString(16),
   }
 
-  var txData = document.querySelector('input[name="txData"]').value
   if (txData) txParams.data = txData
 
   this.props.dispatch(actions.signTx(txParams))

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -219,7 +219,7 @@ SendTransactionScreen.prototype.onSubmit = function() {
     return this.props.dispatch(actions.displayWarning(message))
   }
 
-  if ((util.isValidAddress(recipient) && !txData) || (!recipient && !txData)) {
+  if ((!util.isValidAddress(recipient) && !txData) || (!recipient && !txData)) {
     var message = 'Recipient address is invalid.'
     return this.props.dispatch(actions.displayWarning(message))
   }

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -209,8 +209,8 @@ SendTransactionScreen.prototype.back = function() {
 SendTransactionScreen.prototype.onSubmit = function() {
 
   const recipient = document.querySelector('input[name="address"]').value
-  const inputAmount = parseFloat(document.querySelector('input[name="amount"]').value)
-  const value = util.normalizeNumberToWei(inputAmount, 'ether')
+  const input = document.querySelector('input[name="amount"]').value
+  const value = util.normalizeEthStringToWei(input)
   const txData = document.querySelector('input[name="txData"]').value
   const balance = this.props.balance
 

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -228,11 +228,11 @@ SendTransactionScreen.prototype.onSubmit = function() {
   this.props.dispatch(actions.showLoadingIndication())
 
   var txParams = {
-    to: recipient,
     from: this.props.address,
     value: '0x' + value.toString(16),
   }
 
+  if (recipient) txParams.to = ethUtil.addHexPrefix(recipient)
   if (txData) txParams.data = txData
 
   this.props.dispatch(actions.signTx(txParams))

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -45,6 +45,7 @@ function valuesFor(obj) {
 }
 
 function addressSummary(address) {
+  if (!address) return ''
   var checked = ethUtil.toChecksumAddress(address)
   return checked ? checked.slice(0,2+8)+'...'+checked.slice(-4) : '...'
 }
@@ -55,6 +56,7 @@ function isValidAddress(address) {
 }
 
 function isAllOneCase(address) {
+  if (!address) return true
   var lower = address.toLowerCase()
   var upper = address.toUpperCase()
   return address === lower || address === upper

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -31,6 +31,7 @@ module.exports = {
   ethToWei: ethToWei,
   weiToEth: weiToEth,
   normalizeToWei: normalizeToWei,
+  normalizeEthStringToWei: normalizeEthStringToWei,
   normalizeNumberToWei: normalizeNumberToWei,
   valueTable: valueTable,
   bnTable: bnTable,
@@ -118,6 +119,20 @@ function normalizeToWei(amount, currency) {
     return amount.mul(bnTable.wei).div(bnTable[currency])
   } catch (e) {}
   return amount
+}
+
+function normalizeEthStringToWei(str) {
+  const parts = str.split('.')
+  let eth = new ethUtil.BN(parts[0], 10).mul(bnTable.wei)
+  if (parts[1]) {
+    var decimal = parts[1]
+    while(decimal.length < 18) {
+      decimal += '0'
+    }
+    const decimalBN = new ethUtil.BN(decimal, 10)
+    eth = eth.add(decimalBN)
+  }
+  return eth
 }
 
 var multiple = new ethUtil.BN('10000', 10)

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -21,6 +21,8 @@ for (var currency in valueTable) {
 module.exports = {
   valuesFor: valuesFor,
   addressSummary: addressSummary,
+  isAllOneCase: isAllOneCase,
+  isValidAddress: isValidAddress,
   numericBalance: numericBalance,
   parseBalance: parseBalance,
   formatBalance: formatBalance,
@@ -42,7 +44,19 @@ function valuesFor(obj) {
 }
 
 function addressSummary(address) {
-  return address ? address.slice(0,2+8)+'...'+address.slice(-4) : '...'
+  var checked = ethUtil.toChecksumAddress(address)
+  return checked ? checked.slice(0,2+8)+'...'+checked.slice(-4) : '...'
+}
+
+function isValidAddress(address) {
+  var prefixed = ethUtil.addHexPrefix(address)
+  return isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed) || ethUtil.isValidChecksumAddress(prefixed)
+}
+
+function isAllOneCase(address) {
+  var lower = address.toLowerCase()
+  var upper = address.toUpperCase()
+  return address === lower || address === upper
 }
 
 // Takes wei Hex, returns wei BN, even if input is null

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -120,9 +120,9 @@ function normalizeToWei(amount, currency) {
   return amount
 }
 
-var multiple = new ethUtil.BN('1000', 10)
+var multiple = new ethUtil.BN('10000', 10)
 function normalizeNumberToWei(n, currency) {
-  var enlarged = n * 1000
+  var enlarged = n * 10000
   var amount = new ethUtil.BN(String(enlarged), 10)
   return normalizeToWei(amount, currency).div(multiple)
 }


### PR DESCRIPTION
- Allows txs with no recipient when they have a data field (for publishing contracts).
- Adds support for address capitalization checksums (always shown, always copied, and always verified unless the recipient's address is all upper/lower case)
- Increased the precision of the send field's value.  Should probably increase it indefinitely.

Fixes #148
