### PR TITLE
Fix some formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed bug where MetaMask interfered with PDF loading.
 - Moved switch account icon into menu bar.
 - Changed status shapes to be a yellow warning sign for failure and ellipsis for pending transactions.
+- Fix formatting on terms & conditions page.
 
 ## 2.4.4 2016-06-23
 

--- a/app/scripts/lib/notifications.js
+++ b/app/scripts/lib/notifications.js
@@ -154,8 +154,8 @@ function renderNotificationSVG(content, cb){
   var container = document.createElement('div')
   var confirmView = h('div.app-primary', {
     style: {
-      width: '450px',
-      height: '300px',
+      width: '360px',
+      height: '240px',
       padding: '16px',
       // background: '#F7F7F7',
       background: 'white',
@@ -177,7 +177,7 @@ function renderNotificationSVG(content, cb){
 
 function svgWrapper(content){
   var wrapperSource = `    
-  <svg xmlns="http://www.w3.org/2000/svg" width="450" height="300">
+  <svg xmlns="http://www.w3.org/2000/svg" width="360" height="240">
      <foreignObject x="0" y="0" width="100%" height="100%">
         <body xmlns="http://www.w3.org/1999/xhtml" height="100%">{{content}}</body>
      </foreignObject>

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -145,7 +145,7 @@ AccountDetailScreen.prototype.render = function () {
             style: {
               margin: 10,
             },
-          }, 'SEND ETH'),
+          }, 'SEND'),
 
         ]),
 

--- a/ui/app/first-time/disclaimer.js
+++ b/ui/app/first-time/disclaimer.js
@@ -38,7 +38,7 @@ DisclaimerScreen.prototype.render = function () {
         style: {
           whiteSpace: 'pre-line',
           background: 'rgb(235, 235, 235)',
-          height: '336px',
+          height: '310px',
           padding: '6px',
           width: '80%',
           overflowY: 'scroll',


### PR DESCRIPTION
Fixed terms & conditions page formatting.
Shortened `SEND ETHER` button label to `SEND`.

Submitted [an issue to testrpc](https://github.com/ethereumjs/testrpc/issues/111) to limit their fake balances to remotely conceivable sums of ether, which would fix the formatting issues otherwise.

Fixes #325
