### PR TITLE
Unify wording for transaction options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Now enforce 30 character limit on wallet names.
 - Fix out-of-place positioning of pending transaction badges on wallet list.
 - Change network status icons to reflect current design.
+- Unify wording for transaction approve/reject options on notifications and the extension.
 
 ## 2.4.4 2016-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 - Fix out-of-place positioning of pending transaction badges on wallet list.
 - Change network status icons to reflect current design.
 
-
 ## 2.4.4 2016-06-23
 
 - Update web3-stream-provider for batch payload bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Unify wording for transaction approve/reject options on notifications and the extension.
+
 ## 2.4.5 2016-06-29
 
 - Fixed bug where MetaMask interfered with PDF loading.
@@ -13,7 +15,7 @@
 - Now enforce 30 character limit on wallet names.
 - Fix out-of-place positioning of pending transaction badges on wallet list.
 - Change network status icons to reflect current design.
-- Unify wording for transaction approve/reject options on notifications and the extension.
+
 
 ## 2.4.4 2016-06-23
 

--- a/app/scripts/lib/notifications.js
+++ b/app/scripts/lib/notifications.js
@@ -96,9 +96,9 @@ function showNotification (state) {
     title: state.title,
     message: '',
     buttons: [{
-      title: 'confirm',
+      title: 'Approve',
     }, {
-      title: 'cancel',
+      title: 'Reject',
     }],
   })
   notificationHandlers[id] = {

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -36,14 +36,14 @@ PendingTx.prototype.render = function () {
       h('.flex-row.flex-space-around', [
         h('button', {
           onClick: state.cancelTransaction,
-        }, 'Cancel'),
+        }, 'Reject'),
         h('button', {
           onClick: state.sendTransaction,
-        }, 'Send'),
+        }, 'Confirm'),
       ]),
 
     ])
-    
+
   )
 
 }

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -39,7 +39,7 @@ PendingTx.prototype.render = function () {
         }, 'Reject'),
         h('button', {
           onClick: state.sendTransaction,
-        }, 'Confirm'),
+        }, 'Approve'),
       ]),
 
     ])


### PR DESCRIPTION
Instead of having two different wordings for confirm and cancel, both notifications and the main extension now both present the option of "approve" and "reject"!
