### PR TITLE
Double confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added network name next to network indicator
 - Add copy transaction hash button to completed transaction list items.
 - Unify wording for transaction approve/reject options on notifications and the extension.
+- Fix bug where confirmation view would be shown twice.
 
 ## 2.4.5 2016-06-29
 

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -149,8 +149,6 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
   }
 }
 
-ConfigManager.prototype.clearWallet = function () {}
-
 ConfigManager.prototype.setData = function (data) {
   this.migrator.saveData(data)
 }

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -149,11 +149,7 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
   }
 }
 
-ConfigManager.prototype.clearWallet = function () {
-  var data = this.getConfig()
-  delete data.wallet
-  this.setConfig(data)
-}
+ConfigManager.prototype.clearWallet = function () {}
 
 ConfigManager.prototype.setData = function (data) {
   this.migrator.saveData(data)

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -152,7 +152,7 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
 ConfigManager.prototype.clearWallet = function () {
   var data = this.getConfig()
   delete data.wallet
-  this.setData(data)
+  this.setConfig(data)
 }
 
 ConfigManager.prototype.setData = function (data) {

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -43,9 +43,6 @@ function IdentityStore (opts = {}) {
 
 IdentityStore.prototype.createNewVault = function (password, entropy, cb) {
   delete this._keyStore
-  if (this.configManager) {
-    this.configManager.clearWallet()
-  }
 
   this._createIdmgmt(password, null, entropy, (err) => {
     if (err) return cb(err)

--- a/test/unit/config-manager-test.js
+++ b/test/unit/config-manager-test.js
@@ -42,17 +42,6 @@ describe('config-manager', function() {
     })
   })
 
-  describe('#clearWallet', function() {
-    it('should not erase confirmation', function() {
-      configManager.setConfirmed(true)
-      assert.equal(configManager.getConfirmed(), true)
-
-      configManager.clearWallet()
-
-      assert.equal(configManager.getConfirmed(), true)
-    })
-  })
-
   describe('#setConfig', function() {
     window.localStorage = {} // Hacking localStorage support into JSDom
 

--- a/test/unit/config-manager-test.js
+++ b/test/unit/config-manager-test.js
@@ -22,6 +22,7 @@ describe('config-manager', function() {
 
     describe('#setConfirmed', function() {
       it('should make getConfirmed return true once set', function() {
+        assert.equal(configManager.getConfirmed(), false)
         configManager.setConfirmed(true)
         var result = configManager.getConfirmed()
         assert.equal(result, true)
@@ -38,6 +39,17 @@ describe('config-manager', function() {
         var data = configManager.getData()
         assert.equal(data.isConfirmed, true)
       })
+    })
+  })
+
+  describe('#clearWallet', function() {
+    it('should not erase confirmation', function() {
+      configManager.setConfirmed(true)
+      assert.equal(configManager.getConfirmed(), true)
+
+      configManager.clearWallet()
+
+      assert.equal(configManager.getConfirmed(), true)
     })
   })
 
@@ -63,8 +75,9 @@ describe('config-manager', function() {
         provider: {
           type: 'rpc',
           rpcTarget: 'foobar'
-        }
+        },
       }
+      configManager.setConfirmed(true)
       configManager.setConfig(testConfig)
 
       var testWallet = {
@@ -75,6 +88,7 @@ describe('config-manager', function() {
       var result = configManager.getData()
       assert.equal(result.wallet.name, testWallet.name, 'wallet name is set')
       assert.equal(result.config.provider.rpcTarget, testConfig.provider.rpcTarget)
+      assert.equal(configManager.getConfirmed(), true)
 
       testConfig.provider.type = 'something else!'
       configManager.setConfig(testConfig)
@@ -83,6 +97,7 @@ describe('config-manager', function() {
       assert.equal(result.wallet.name, testWallet.name, 'wallet name is set')
       assert.equal(result.config.provider.rpcTarget, testConfig.provider.rpcTarget)
       assert.equal(result.config.provider.type, testConfig.provider.type)
+      assert.equal(configManager.getConfirmed(), true)
     })
   })
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -47,6 +47,7 @@ var actions = {
   unlockInProgress: unlockInProgress,
   // error handling
   displayWarning: displayWarning,
+  showWarning: showWarning, // alias
   DISPLAY_WARNING: 'DISPLAY_WARNING',
   HIDE_WARNING: 'HIDE_WARNING',
   hideWarning: hideWarning,
@@ -505,6 +506,10 @@ function hideLoadingIndication () {
   return {
     type: actions.HIDE_LOADING,
   }
+}
+
+function showWarning (text) {
+  return this.displayWarning(text)
 }
 
 function displayWarning (text) {


### PR DESCRIPTION
Fixes #372 

Was caused by an unnecessary method that was supposed to clear any old wallet before initializing a new one, even though we only initialize a new one if we have one already.

Anyways, it was a really mysterious bug because even when I emptied the `clearWallet` function, it was still somehow clearing the `isConfirmed` value!!  Totally bonkers.

It was bad cruft anyway, so I removed it, everything seems to work fine now.

Also added an alias action for `showWarning` to `displayWarning` because we had mis-typed that in multiple places, and this fixes all of those and any future mistypings.
