### PR TITLE
Put network status checkmarks at end of row

### DIFF
--- a/ui/app/components/drop-menu-item.js
+++ b/ui/app/components/drop-menu-item.js
@@ -21,6 +21,8 @@ DropMenuItem.prototype.render = function () {
       fontFamily: 'Montserrat Regular',
       color: 'rgb(125, 128, 130)',
       cursor: 'pointer',
+      display: 'flex',
+      justifyContent: 'flex-start',
     },
   }, [
     this.props.icon,

--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -158,6 +158,9 @@ textarea.twelve-word-phrase {
 
 .check {
   color: #F7861C;
+  flex: 1 0 auto;
+  display: flex;
+  justify-content: flex-end;
 }
 /*
 app sections


### PR DESCRIPTION
Before the checkmarks were kinda cramped, now they land on the far right:

Fixes #377

<img width="371" alt="screen shot 2016-07-01 at 3 03 51 pm" src="https://cloud.githubusercontent.com/assets/542863/16535552/30cf398e-3f9d-11e6-91f6-ed54ecbe35d3.png">
