### PR TITLE
Fix dropdown z-index issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix formatting of ETH balance
 - Fix formatting of account details.
+- Fix issue where dropdowns were not in front of icons.
 
 ## 2.5.0 2016-06-29
 

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -108,7 +108,7 @@ App.prototype.renderAppBar = function () {
           background: props.isUnlocked ? 'white' : 'none',
           height: '36px',
           position: 'relative',
-          zIndex: 1,
+          zIndex: 2,
         },
       }, props.isUnlocked && [
 
@@ -197,10 +197,10 @@ App.prototype.renderNetworkDropdown = function () {
     onClickOutside: (event) => {
       this.setState({ isNetworkMenuOpen: !isOpen })
     },
+    zIndex: 1,
     style: {
       position: 'absolute',
       left: 0,
-      zIndex: 0,
     },
     innerStyle: {
       background: 'white',
@@ -245,13 +245,13 @@ App.prototype.renderDropdown = function () {
 
   return h(MenuDroppo, {
     isOpen: isOpen,
+    zIndex: 1,
     onClickOutside: (event) => {
       this.setState({ isMainMenuOpen: !isOpen })
     },
     style: {
       position: 'absolute',
       right: 0,
-      zIndex: 0,
     },
     innerStyle: {
       background: 'white',


### PR DESCRIPTION
Fixes #396. Word of caution for the dropdowns: if you want to change its z-index, you have to pass it in a prop of zIndex rather than set it in styles--it'll get overwritten in the latter case.
