### PR TITLE
Add one wallet to new accounts instead of three.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Fix rendering of recipient SVG in tx approval notification.
+- New vaults now generate only one wallet instead of three.
 
 ## 2.6.0 2016-07-11
 

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -465,7 +465,7 @@ IdentityStore.prototype._createFirstWallet = function (entropy, derivedKey) {
   keyStore.addHdDerivationPath(this.hdPathString, derivedKey, {curve: 'secp256k1', purpose: 'sign'})
   keyStore.setDefaultHdDerivationPath(this.hdPathString)
 
-  keyStore.generateNewAddress(derivedKey, 3)
+  keyStore.generateNewAddress(derivedKey, 1)
   configManager.setWallet(keyStore.serialize())
   console.log('saved to keystore')
   return keyStore


### PR DESCRIPTION
Turns out that the ability to go straight to your first wallet is already a feature! Great! Just reduced the number of wallets on creation now.

Fixes #393
