### PR TITLE
Japan localization

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "appName": {
-    "message": "metamask",
+    "message": "MetaMask",
     "description": "The name of the application"
   },
   "appDescription": {

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
+  "appDescription": {
+    "message": "EthereumのID管理",
+    "description": "The description of the application"
+  }
+}


### PR DESCRIPTION
Fixes #437 by adding Japanese localization files to the Chrome metadata.
