### PR TITLE
Fix eth balance tooltip to show 6 decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
--Fix tool tips on Eth balance to show the 6 decimals
+- Fix tool tips on Eth balance to show the 6 decimals
 - Fix rendering of recipient SVG in tx approval notification.
 - New vaults now generate only one wallet instead of three.
 - Bumped version of web3 provider engine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+-Fix tool tips on Eth balance to show the 6 decimals
 - Fix rendering of recipient SVG in tx approval notification.
 - New vaults now generate only one wallet instead of three.
 - Bumped version of web3 provider engine.

--- a/ui/app/components/eth-balance.js
+++ b/ui/app/components/eth-balance.js
@@ -35,7 +35,7 @@ EthBalanceComponent.prototype.render = function () {
 }
 EthBalanceComponent.prototype.renderBalance = function (value, state) {
   if (value === 'None') return value
-  var balanceObj = generateBalanceObject(value, 1)
+  var balanceObj = generateBalanceObject(value, state.shorten ? 1 : 3)
   var balance
 
   if (state.shorten) {

--- a/ui/app/components/eth-balance.js
+++ b/ui/app/components/eth-balance.js
@@ -15,7 +15,7 @@ EthBalanceComponent.prototype.render = function () {
   var state = this.props
   var style = state.style
 
-  const value = formatBalance(state.value)
+  const value = formatBalance(state.value, 6)
   var width = state.width
 
   return (

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -75,6 +75,7 @@ TransactionListItem.prototype.render = function () {
         value: txParams.value,
         width: '55px',
         shorten: true,
+        style: {fontSize: '15px'}
       }) : h('.flex-column'),
     ])
   )

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -75,7 +75,7 @@ TransactionListItem.prototype.render = function () {
         value: txParams.value,
         width: '55px',
         shorten: true,
-        style: {fontSize: '15px'}
+        style: {fontSize: '15px'},
       }) : h('.flex-column'),
     ])
   )

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -123,6 +123,7 @@ function generateBalanceObject (formattedBalance, decimalsToKeep = 1) {
   var shortBalance = shortenBalance(balance, decimalsToKeep)
 
   if (beforeDecimal === '0' && afterDecimal.substr(0, 5) === '00000') { balance = '<1.0e-5' }
+  balance = `${beforeDecimal}.${afterDecimal.slice(0, 3)}`
 
   return { balance, label, shortBalance }
 }
@@ -141,7 +142,7 @@ function shortenBalance (balance, decimalsToKeep = 1) {
     truncatedValue = (convertedBalance * Math.pow(10, exponent)).toFixed(decimalsToKeep)
     return `<${truncatedValue}e-${exponent}`
   } else {
-    return balance
+    return convertedBalance.toFixed(decimalsToKeep)
   }
 }
 

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -122,8 +122,11 @@ function generateBalanceObject (formattedBalance, decimalsToKeep = 1) {
   var afterDecimal = balance.split('.')[1]
   var shortBalance = shortenBalance(balance, decimalsToKeep)
 
-  if (beforeDecimal === '0' && afterDecimal.substr(0, 5) === '00000') { balance = '<1.0e-5' }
-  balance = `${beforeDecimal}.${afterDecimal.slice(0, 3)}`
+  if (beforeDecimal === '0' && afterDecimal.substr(0, 5) === '00000') {
+    balance = '<1.0e-5'
+  } else if (beforeDecimal !== '0') {
+    balance = `${beforeDecimal}.${afterDecimal.slice(0, decimalsToKeep)}`
+  }
 
   return { balance, label, shortBalance }
 }


### PR DESCRIPTION
 in balances where the before decimal is >0
fixes #422 
<img width="114" alt="screen shot 2016-07-13 at 2 52 22 pm" src="https://cloud.githubusercontent.com/assets/11225267/16821105/73db3e7e-4909-11e6-83b5-4ce010399bb2.png">
