### PR TITLE
Fix reopening bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Fixed bug that would prevent the plugin from reopening on the first try after receiving a new transaction while locked.
+- Fixed bug that would render 0 ETH as a non-exact amount.
 
 ## 2.6.1 2016-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fixed bug that would prevent the plugin from reopening on the first try after receiving a new transaction while locked.
+
 ## 2.6.1 2016-07-13
 
 - Fix tool tips on Eth balance to show the 6 decimals

--- a/ui/app/components/pending-tx-details.js
+++ b/ui/app/components/pending-tx-details.js
@@ -28,7 +28,8 @@ PTXP.render = function () {
   var txParams = txData.txParams || {}
   var address = txParams.from || props.selectedAddress
   var identity = props.identities[address] || { address: address }
-  var balance = props.accounts[address].balance
+  var account = props.accounts[address]
+  var balance = account ? account.balance : '0x0'
 
   var gasCost = new BN(ethUtil.stripHexPrefix(txParams.gas || txData.estimatedGas), 16)
   var gasPrice = new BN(ethUtil.stripHexPrefix(txParams.gasPrice || '0x4a817c800'), 16)

--- a/ui/app/reducers.js
+++ b/ui/app/reducers.js
@@ -7,6 +7,8 @@ const reduceIdentities = require('./reducers/identities')
 const reduceMetamask = require('./reducers/metamask')
 const reduceApp = require('./reducers/app')
 
+window.METAMASK_CACHED_LOG_STATE = null
+
 module.exports = rootReducer
 
 function rootReducer (state, action) {
@@ -35,5 +37,11 @@ function rootReducer (state, action) {
 
   state.appState = reduceApp(state, action)
 
+  window.METAMASK_CACHED_LOG_STATE = state
   return state
+}
+
+window.logState = function() {
+  var stateString = JSON.stringify(window.METAMASK_CACHED_LOG_STATE, null, 2)
+  console.log(stateString)
 }

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -173,7 +173,7 @@ SendTransactionScreen.prototype.render = function () {
           marginBottom: 16,
         },
       }, [
-        'Tranasactional Data (optional)',
+        'Transactional Data (optional)',
       ]),
 
       // 'data' field

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -123,7 +123,11 @@ function generateBalanceObject (formattedBalance, decimalsToKeep = 1) {
   var shortBalance = shortenBalance(balance, decimalsToKeep)
 
   if (beforeDecimal === '0' && afterDecimal.substr(0, 5) === '00000') {
-    balance = '<1.0e-5'
+    if (afterDecimal == 0) {
+      balance = '0'
+    } else {
+      balance = '<1.0e-5'
+    }
   } else if (beforeDecimal !== '0') {
     balance = `${beforeDecimal}.${afterDecimal.slice(0, decimalsToKeep)}`
   }

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -123,6 +123,7 @@ function generateBalanceObject (formattedBalance, decimalsToKeep = 1) {
   var shortBalance = shortenBalance(balance, decimalsToKeep)
 
   if (beforeDecimal === '0' && afterDecimal.substr(0, 5) === '00000') {
+    // eslint-disable-next-line eqeqeq
     if (afterDecimal == 0) {
       balance = '0'
     } else {

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -96,7 +96,7 @@ function formatBalance (balance, decimalsToKeep) {
   var parsed = parseBalance(balance)
   var beforeDecimal = parsed[0]
   var afterDecimal = parsed[1]
-  var formatted
+  var formatted = 'None'
   if (decimalsToKeep === undefined) {
     if (beforeDecimal === '0') {
       if (afterDecimal !== '0') {

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -96,7 +96,7 @@ function formatBalance (balance, decimalsToKeep) {
   var parsed = parseBalance(balance)
   var beforeDecimal = parsed[0]
   var afterDecimal = parsed[1]
-  var formatted = 'None'
+  var formatted
   if (decimalsToKeep === undefined) {
     if (beforeDecimal === '0') {
       if (afterDecimal !== '0') {


### PR DESCRIPTION
Fixes #445.

This was a bug with the lock screen trying to transition to a view with account metadata even though when locked, metamask does not have account metadata loaded yet.

My solution for now is to tolerate transitioning to a transaction while some data is loading.

To make it easier to diagnose bugs like this in the future, I've added a global `logState()` function to the UI, so someone can easily dump the current UI state from the UI console.
