### PR TITLE
Manifest fix for firefox-specific field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a Warning screen about storing ETH
 - Add buy Button!
 - MetaMask now throws descriptive errors when apps try to use synchronous web3 methods.
+- Removed firefox-specific line in manifest.
 
 ## 2.6.2 2016-07-20
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -37,11 +37,6 @@
       "all_frames": false
     }
   ],
-  "applications": {
-    "gecko": {
-      "id": "MOZILLA_EXTENSION_ID"
-    }
-  },
   "permissions": [
     "notifications",
     "storage",


### PR DESCRIPTION
As specified--small change due to manifest.json not being completely standard across browsers.
