### PR TITLE
Fix nondeterministic build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('zip', gulp.parallel('zip:chrome', 'zip:firefox'))
 // high level tasks
 
 gulp.task('dev', gulp.series('dev:js', 'copy', gulp.parallel('copy:watch', 'dev:reload')))
-gulp.task('build', gulp.series('clean', gulp.parallel('build:js', 'copy')))
+gulp.task('build', gulp.series('clean', 'build:js', 'copy'))
 gulp.task('dist', gulp.series('build', 'zip'))
 
 // task generators


### PR DESCRIPTION
We used to be able to copy static resources while we built js, but now part of the copy task is copying firefox built files into chrome, so they need to be done in order.

This could probably be optimized a bit more, but for now it builds reliably again.
