### PR TITLE
Fix broken reference to host store.didUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug where host store would fail to receive updates.
+
 ## 2.7.1 2016-07-27
 
 - Fix bug where web3 would sometimes not be injected in time for the application.

--- a/app/scripts/lib/remote-store.js
+++ b/app/scripts/lib/remote-store.js
@@ -52,7 +52,7 @@ HostStore.prototype.set = function (key, value) {
 
 HostStore.prototype.createStream = function () {
   var dnode = Dnode({
-    update: this._didUpdate.bind(this),
+    // update: this._didUpdate.bind(this),
   })
   dnode.on('remote', this._didConnect.bind(this))
   return dnode


### PR DESCRIPTION
I'd returned this line because it seemed to fix Firefox compatibility, now it seems like that wasn't the case.  Removing it again.
