### PR TITLE
Fix network name reference

### DIFF
--- a/ui/app/components/drop-menu-item.js
+++ b/ui/app/components/drop-menu-item.js
@@ -34,14 +34,15 @@ DropMenuItem.prototype.render = function () {
 DropMenuItem.prototype.activeNetworkRender = function () {
   let activeNetwork = this.props.activeNetworkRender
   let { provider } = this.props
+  let providerType = provider ? provider.type : null
   if (activeNetwork === undefined) return
 
   switch (this.props.label) {
     case 'Main Ethereum Network':
-      if (provider.type === 'mainnet') return h('.check', '✓')
+      if (providerType === 'mainnet') return h('.check', '✓')
       break
     case 'Ethereum Classic Network':
-      if (provider.type === 'classic') return h('.check', '✓')
+      if (providerType === 'classic') return h('.check', '✓')
       break
     case 'Morden Test Network':
       if (activeNetwork === '2') return h('.check', '✓')

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -13,7 +13,12 @@ function Network () {
 Network.prototype.render = function () {
   const props = this.props
   const networkNumber = props.network
-  const providerName = props.provider.type
+  let providerName
+  try {
+    providerName = props.provider.type
+  } catch (e) {
+    providerName = null
+  }
   let iconName, hoverText
 
   if (networkNumber === 'loading') {


### PR DESCRIPTION
When adding the classic network to the menu, I left a reference to a property that is not always existent, so we needed a fallback for it.
