### PR TITLE
Fix ether warning checkbox to reflect proper behavior.

### DIFF
--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -274,9 +274,13 @@ ConfigManager.prototype.getConfirmed = function () {
   return ('isConfirmed' in data) && data.isConfirmed
 }
 
-ConfigManager.prototype.setShouldntShowWarning = function (confirmed) {
+ConfigManager.prototype.setShouldntShowWarning = function () {
   var data = this.getData()
-  data.isEthConfirmed = confirmed
+  if (data.isEthConfirmed) {
+    data.isEthConfirmed = !data.isEthConfirmed
+  } else {
+    data.isEthConfirmed = true    
+  }
   this.setData(data)
 }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -243,7 +243,7 @@ module.exports = class MetamaskController {
 
   agreeToEthWarning (cb) {
     try {
-      this.configManager.setShouldntShowWarning(true)
+      this.configManager.setShouldntShowWarning()
       cb()
     } catch (e) {
       cb(e)

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -10,6 +10,7 @@ function reduceMetamask (state, action) {
   var metamaskState = extend({
     isInitialized: false,
     isUnlocked: false,
+    isEthConfirmed: false,
     currentDomain: 'example.com',
     rpcTarget: 'https://rawtestrpc.metamask.io/',
     identities: {},
@@ -33,7 +34,7 @@ function reduceMetamask (state, action) {
 
     case actions.AGREE_TO_ETH_WARNING:
       return extend(metamaskState, {
-        isEthConfirmed: true,
+        isEthConfirmed: !metamaskState.isEthConfirmed,
       })
 
     case actions.UNLOCK_METAMASK:


### PR DESCRIPTION
The previous behavior of the checkbox when wanting to hide the ether warning on each popup open (the one warning users not to store large amounts of ether) was to set a condition to true. The new behavior now reflects the actual state of the checkbox (though honestly, who goes back on a checkbox after they check it?)
