### PR TITLE
Add margin to "go to test faucet" button and show more of the address…

### DIFF
--- a/ui/app/components/buy-button-subview.js
+++ b/ui/app/components/buy-button-subview.js
@@ -110,6 +110,9 @@ BuyButtonSubview.prototype.formVersionSubview = function () {
       h('h3.text-transform-uppercase', 'or:'),
       this.props.network === '2' ? h('button.text-transform-uppercase', {
         onClick: () => this.props.dispatch(actions.buyEth()),
+        style: {
+          marginTop: '15px',
+        },
       }, 'Go To Test Faucet') : null,
     ])
   }

--- a/ui/app/components/qr-code.js
+++ b/ui/app/components/qr-code.js
@@ -41,7 +41,11 @@ QrCodeView.prototype.render = function () {
       },
     }),
     h('.flex-row', [
-      h('h3.ellip-address', Qr.data),
+      h('h3.ellip-address', {
+        style: {
+          width: '247px',
+        },
+      }, Qr.data),
       h(CopyButton, {
         value: Qr.data,
       }),


### PR DESCRIPTION
… on qr code page
<img width="387" alt="screen shot 2016-08-14 at 9 40 09 am" src="https://cloud.githubusercontent.com/assets/11225267/17655861/f9f0a180-6267-11e6-8edf-f631b00883b1.png">
<img width="370" alt="screen shot 2016-08-14 at 9 41 13 pm" src="https://cloud.githubusercontent.com/assets/11225267/17655860/f9ef733c-6267-11e6-8d1e-60abae82c58e.png">
