### PR TITLE
Fixed prohibited shortcut combination.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Current Master
 
+## 2.9.2 2016-08-24
+
+- Fixed shortcut bug from preventing installation.
+
+
 ## 2.9.1 2016-08-24
 
 - Added static image as fallback for when WebGL isn't supported.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -7,10 +7,10 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "windows": "Ctrl+Alt+M",
-        "mac": "Command+Alt+M",
-        "chromeos": "Ctrl+Alt+M",
-        "linux": "Ctrl+Alt+M"
+        "windows": "Alt+Shift+M",
+        "mac": "Alt+Shift+M",
+        "chromeos": "Search+M",
+        "linux": "Alt+Shift+M"
       }
     }
   },

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "manifest_version": 2,
   "description": "Ethereum Browser Extension",
   "commands": {


### PR DESCRIPTION
Did not realize that Ctrl+Alt was a prohibited combination...I did not read that well.

@flyswatter can we get an emergency bump for this? People can't even load the extension in this state.
