### PR TITLE
Don't show popup when sending tx from within metamask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Fix bug where provider menu did not allow switching to custom network from a custom network.
+- Sending a transaction from within MetaMask no longer triggers a popup.
 
 ## 2.10.0 2016-08-29
 

--- a/app/scripts/lib/notifications.js
+++ b/app/scripts/lib/notifications.js
@@ -9,11 +9,12 @@ module.exports = notifications
 window.METAMASK_NOTIFIER = notifications
 
 function show () {
-  getPopup((popup) => {
-    if (popup) {
-      return extension.windows.update(popup.id, { focused: true })
-    }
+  getWindows((windows) => {
 
+    if (windows.length > 0) {
+      const win = windows[0]
+      return extension.windows.update(win.id, { focused: true })
+    }
 
     extension.windows.create({
       url: 'notification.html',
@@ -25,20 +26,27 @@ function show () {
   })
 }
 
-function getPopup(cb) {
-
+function getWindows(cb) {
   // Ignore in test environment
   if (!extension.windows) {
-    return cb(null)
+    return cb()
   }
 
   extension.windows.getAll({}, (windows) => {
-    let popup = windows.find((win) => {
-      return win.type === 'popup'
-    })
-
-    cb(popup)
+    cb(null, windows)
   })
+}
+
+function getPopup(cb) {
+  getWindows((windows) => {
+    cb(getPopupIn(windows))
+  })
+}
+
+function getPopupIn(windows) {
+  return  windows ? windows.find((win) => {
+    return win.type === 'popup'
+  }) : null
 }
 
 function closePopup() {

--- a/app/scripts/lib/notifications.js
+++ b/app/scripts/lib/notifications.js
@@ -44,7 +44,7 @@ function getPopup(cb) {
 }
 
 function getPopupIn(windows) {
-  return  windows ? windows.find((win) => {
+  return windows ? windows.find((win) => {
     return win.type === 'popup'
   }) : null
 }

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -276,8 +276,6 @@ function signMsg (msgData) {
 
 function signTx (txData) {
   return (dispatch) => {
-    dispatch(actions.showLoadingIndication())
-
     web3.eth.sendTransaction(txData, (err, data) => {
       dispatch(actions.hideLoadingIndication())
 
@@ -285,6 +283,7 @@ function signTx (txData) {
       dispatch(actions.hideWarning())
       dispatch(actions.goHome())
     })
+    dispatch(this.showConfTxPage())
   }
 }
 

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -236,7 +236,6 @@ SendTransactionScreen.prototype.onSubmit = function () {
   }
 
   this.props.dispatch(actions.hideWarning())
-  this.props.dispatch(actions.showLoadingIndication())
 
   var txParams = {
     from: this.props.address,


### PR DESCRIPTION
Fixes #566 

If the popup is open and used to send a tx, rather than initiating an additional popup, the view simply transitions to the confirmation screen.
