### PR TITLE
Fix fox logo password following

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "inject-css": "^0.1.1",
     "jazzicon": "^1.1.3",
     "menu-droppo": "^1.1.0",
-    "metamask-logo": "^2.1.1",
+    "metamask-logo": "^2.1.2",
     "mississippi": "^1.2.0",
     "multiplex": "^6.7.0",
     "once": "^1.3.3",

--- a/ui/app/components/mascot.js
+++ b/ui/app/components/mascot.js
@@ -15,7 +15,7 @@ function Mascot () {
     width: 200,
     height: 200,
   })
-  if (!this.logo.webGLSupport) return
+
   this.refollowMouse = debounce(this.logo.setFollowMouse.bind(this.logo, true), 1000)
   this.unfollowMouse = this.logo.setFollowMouse.bind(this.logo, false)
 }
@@ -53,7 +53,6 @@ Mascot.prototype.handleAnimationEvents = function () {
 }
 
 Mascot.prototype.lookAt = function (target) {
-  if (!this.logo.webGLSupport) return
   this.unfollowMouse()
   this.logo.lookAt(target)
   this.refollowMouse()


### PR DESCRIPTION
The new lightweight svg logo was not following text quite right.

The new `lookAt` method was not using the same logic the module was using internally on mouse movement.

I simply used that logic and exposed it via the old (expected) API, and got it behaving the way I like.

Also removed some webGL checks I'd missed, that would create memory leaks in non-webGL compatible browsers.
