### PR TITLE
How it works now displays only on install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix bug where pending transactions from Test net (or other networks) show up In Main net.
 - Add fiat conversion values to more views.
-- On fresh install, open a new tab with the MetaMask Introduction video.
+- On fresh install, open a new tab with the MetaMask Introduction video. Does not open on update.
 - Block negative values from transactions.
 - Fixed a memory leak.
 - MetaMask logo now renders as super lightweight SVG, improving compatibility and performance.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -37,8 +37,10 @@ function showUnconfirmedTx (txParams, txData, onTxDoneCb) {
 
 // On first install, open a window to MetaMask website to how-it-works.
 
-extension.runtime.onInstalled.addListener(function (object) {
-  extension.tabs.create({url: 'https://metamask.io/#how-it-works'})
+extension.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === 'install') {
+    extension.tabs.create({url: 'https://metamask.io/#how-it-works'})
+  }
 })
 
 //


### PR DESCRIPTION
Fixes #623 by checking whether or not an "onInstalled" event is caused by a fresh install or an "update" event, which is triggered by actual updates or by switching networks. This is because our network switch calls `chrome.runtime.reload`, which causes behavior similar to updating.
