### PR TITLE
Add new eth-lightwallet salting to vault.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - MetaMask logo now renders as super lightweight SVG, improving compatibility and performance.
 - Now showing loading indication during vault unlocking, to clarify behavior for users who are experience slow unlocks.
 - Now only initially creates one wallet when restoring a vault, to reduce some users' confusion.
+- Improved the security of vault encryption by ensuring passwords are always uniquely salted.
 
 ## 2.10.2 2016-09-02
 

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -494,7 +494,7 @@ IdentityStore.prototype._createFirstWallet = function (derivedKey) {
   keyStore.generateNewAddress(derivedKey, 1)
   this.configManager.setWallet(keyStore.serialize())
   var addresses = keyStore.getAddresses()
-  this._ethStore.addAccount(addresses[0])
+  this._ethStore.addAccount(ethUtil.addHexPrefix(addresses[0]))
 }
 
 // get addresses and normalize address hexString

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -464,6 +464,11 @@ IdentityStore.prototype._createIdmgmt = function (password, seedPhrase, entropy,
     keyStore.keyFromPassword(password, (err, derivedKey) => {
       if (err) return cb(err)
 
+      this._ethStore._currentState = {
+        accounts: {},
+        transactions: {},
+      }
+
       keyStore.addHdDerivationPath(this.hdPathString, derivedKey, {curve: 'secp256k1', purpose: 'sign'})
 
       this._createFirstWallet(derivedKey)

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -75,7 +75,6 @@ IdentityStore.prototype.recoverFromSeed = function (password, seed, cb) {
     if (err) return cb(err)
 
     this._loadIdentities()
-    this._didUpdate()
     cb(null, this.getState())
   })
 }
@@ -394,7 +393,6 @@ IdentityStore.prototype._loadIdentities = function () {
   var addresses = this._getAddresses()
   addresses.forEach((address, i) => {
     // // add to ethStore
-    this._ethStore.addAccount(address)
     // add to identities
     const defaultLabel = 'Wallet ' + (i + 1)
     const nickname = configManager.nicknameForWallet(address)
@@ -413,7 +411,6 @@ IdentityStore.prototype.saveAccountLabel = function (account, label, cb) {
   configManager.setNicknameForWallet(account, label)
   this._loadIdentities()
   cb(null, label)
-  this._didUpdate()
 }
 
 // mayBeFauceting
@@ -481,8 +478,6 @@ IdentityStore.prototype._createIdmgmt = function (password, seedPhrase, entropy,
       })
 
       cb()
-      this._loadIdentities()
-      this._didUpdate()
     })
   })
 }
@@ -497,9 +492,9 @@ IdentityStore.prototype._createFirstWallet = function (derivedKey) {
   const keyStore = this._keyStore
   keyStore.setDefaultHdDerivationPath(this.hdPathString)
   keyStore.generateNewAddress(derivedKey, 1)
+  this.configManager.setWallet(keyStore.serialize())
   var addresses = keyStore.getAddresses()
   this._ethStore.addAccount(addresses[0])
-  this.configManager.setWallet(keyStore.serialize())
 }
 
 // get addresses and normalize address hexString

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -59,6 +59,7 @@ IdentityStore.prototype.createNewVault = function (password, entropy, cb) {
     this.configManager.setShowSeedWords(true)
     var seedWords = this._idmgmt.getSeed()
 
+
     cb(null, seedWords)
   })
 }
@@ -124,7 +125,7 @@ IdentityStore.prototype.getSelectedAddress = function () {
   return configManager.getSelectedAccount()
 }
 
-IdentityStore.prototype.setSelectedAddress = function (address, cb) {
+IdentityStore.prototype.setSelectedAddressSync = function (address) {
   const configManager = this.configManager
   if (!address) {
     var addresses = this._getAddresses()
@@ -132,7 +133,12 @@ IdentityStore.prototype.setSelectedAddress = function (address, cb) {
   }
 
   configManager.setSelectedAccount(address)
-  if (cb) return cb(null, address)
+  return address
+}
+
+IdentityStore.prototype.setSelectedAddress = function (address, cb) {
+  const resultAddress = this.setSelectedAddressSync(address)
+  if (cb) return cb(null, resultAddress)
 }
 
 IdentityStore.prototype.revealAccount = function (cb) {
@@ -476,6 +482,8 @@ IdentityStore.prototype._createIdmgmt = function (password, seedPhrase, entropy,
         derivedKey: derivedKey,
         configManager: this.configManager,
       })
+
+      this.setSelectedAddressSync()
 
       cb()
     })

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -2,6 +2,7 @@ var assert = require('assert')
 var IdentityStore = require('../../app/scripts/lib/idStore')
 var configManagerGen = require('../lib/mock-config-manager')
 const ethUtil = require('ethereumjs-util')
+const async = require('async')
 
 describe('IdentityStore', function() {
 
@@ -65,6 +66,29 @@ describe('IdentityStore', function() {
     let accounts = []
     let idStore
 
+    var assertions = [
+      {
+        seed: 'picnic injury awful upper eagle junk alert toss flower renew silly vague',
+        account: '0x5d8de92c205279c10e5669f797b853ccef4f739a',
+      },
+      {
+        seed: 'radar blur cabbage chef fix engine embark joy scheme fiction master release',
+        account: '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9',
+      },
+      {
+         seed: 'phone coyote caught pattern found table wedding list tumble broccoli chief swing',
+        account: '0xb0e868f24bc7fec2bce2efc2b1c344d7569cd9d2',
+      },
+      {
+        seed: 'recycle tag bird palace blue village anxiety census cook soldier example music',
+        account: '0xab34a45920afe4af212b96ec51232aaa6a33f663',
+      },
+      {
+        seed: 'half glimpse tape cute harvest sweet bike voyage actual floor poet lazy',
+        account: '0x28e9044597b625ac4beda7250011670223de43b2',
+      }
+    ]
+
     before(function() {
       window.localStorage = {} // Hacking localStorage support into JSDom
 
@@ -80,36 +104,21 @@ describe('IdentityStore', function() {
       accounts = []
     })
 
-    it('should return the expected first account', function (done) {
-      let seedWords =  'picnic injury awful upper eagle junk alert toss flower renew silly vague'
-      let firstAccount = '0x5d8de92c205279c10e5669f797b853ccef4f739a'
+    it('should enforce seed compliance with TestRPC', function (done) {
+      const tests = assertions.map((assertion) => {
+        return function (cb) {
+          idStore.recoverFromSeed(password, assertion.seed, (err) => {
+            assert.ifError(err)
 
-      idStore.recoverFromSeed(password, seedWords, (err) => {
-        assert.ifError(err)
-
-        assert.equal(accounts[0], firstAccount)
-        done()
+            console.log('comparing %s to %s', accounts[0], assertion.account)
+            assert.equal(accounts[0], assertion.account)
+            cb()
+          })
+        }
       })
-    })
 
-    it('should return the expected second account', function (done) {
-      const secondSeed = 'radar blur cabbage chef fix engine embark joy scheme fiction master release'
-      const secondAcct = '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9'
-
-      idStore.recoverFromSeed(password, secondSeed, (err) => {
+      async.series(tests, function(err, results) {
         assert.ifError(err)
-        assert.equal(accounts[0], secondAcct)
-        done()
-      })
-    })
-
-    it('should return the expected third account', function (done) {
-      const thirdSeed = 'phone coyote caught pattern found table wedding list tumble broccoli chief swing'
-      const thirdAcct = '0xb0e868f24bc7fec2bce2efc2b1c344d7569cd9d2'
-
-      idStore.recoverFromSeed(password, thirdSeed, (err) => {
-        assert.ifError(err)
-        assert.equal(accounts[0], thirdAcct)
         done()
       })
     })

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -73,7 +73,7 @@ describe('IdentityStore', function() {
       },
       {
         seed: 'radar blur cabbage chef fix engine embark joy scheme fiction master release',
-        account: '0xe15D894BeCB0354c501AE69429B05143679F39e0',
+        account: '0xe15d894becb0354c501ae69429b05143679f39e0',
       },
       {
          seed: 'phone coyote caught pattern found table wedding list tumble broccoli chief swing',
@@ -90,10 +90,6 @@ describe('IdentityStore', function() {
       {
         seed: 'flavor tiger carpet motor angry hungry document inquiry large critic usage liar',
         account: '0xb571be96558940c4e9292e1999461aa7499fb6cd',
-      },
-      {
-        seed: 'this is a twelve word phrase seven eight nine ten eleven twelve',
-        account: '0x814e8ec0c3647e140b8e09228fc374b2a867fe48',
       },
     ]
 
@@ -115,10 +111,13 @@ describe('IdentityStore', function() {
     it('should enforce seed compliance with TestRPC', function (done) {
       const tests = assertions.map((assertion) => {
         return function (cb) {
+          accounts = []
           idStore.recoverFromSeed(password, assertion.seed, (err) => {
             assert.ifError(err)
 
-            assert.equal(accounts[0], assertion.account)
+            var received = accounts[0].toLowerCase()
+            var expected = assertion.account.toLowerCase()
+            assert.equal(received, expected)
             cb()
           })
         }

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -83,8 +83,19 @@ describe('IdentityStore', function() {
         assert.ifError(err)
 
         let newKeystore = idStore._idmgmt.keyStore
+
         assert.equal(accounts[0], firstAccount)
-        done()
+
+        accounts = []
+        const secondSeed = 'radar blur cabbage chef fix engine embark joy scheme fiction master release'
+        const secondAcct = '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9'
+
+        idStore.recoverFromSeed(password, secondSeed, (err) => {
+
+          let accounts = idStore._getAddresses()
+          assert.equal(accounts[0], secondAcct)
+          done()
+        })
       })
     })
   })

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -73,7 +73,7 @@ describe('IdentityStore', function() {
       },
       {
         seed: 'radar blur cabbage chef fix engine embark joy scheme fiction master release',
-        account: '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9',
+        account: '0xe15D894BeCB0354c501AE69429B05143679F39e0',
       },
       {
          seed: 'phone coyote caught pattern found table wedding list tumble broccoli chief swing',

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var IdentityStore = require('../../app/scripts/lib/idStore')
 var configManagerGen = require('../lib/mock-config-manager')
+const ethUtil = require('ethereumjs-util')
 
 describe('IdentityStore', function() {
 
@@ -18,7 +19,7 @@ describe('IdentityStore', function() {
       idStore = new IdentityStore({
         configManager: configManagerGen(),
         ethStore: {
-          addAccount(acct) { accounts.push(acct) },
+          addAccount(acct) { accounts.push(ethUtil.addHexPrefix(acct)) },
         },
       })
 
@@ -39,7 +40,7 @@ describe('IdentityStore', function() {
         idStore = new IdentityStore({
           configManager: configManagerGen(),
           ethStore: {
-            addAccount(acct) { newAccounts.push(acct) },
+            addAccount(acct) { newAccounts.push(ethUtil.addHexPrefix(acct)) },
           },
         })
       })
@@ -62,6 +63,9 @@ describe('IdentityStore', function() {
     let firstAccount = '0x5d8de92c205279c10e5669f797b853ccef4f739a'
     const salt = 'lightwalletSalt'
 
+    const secondSeed = 'radar blur cabbage chef fix engine embark joy scheme fiction master release'
+    const secondAcct = '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9'
+
     let password = 'secret!'
     let accounts = []
     let idStore
@@ -72,9 +76,13 @@ describe('IdentityStore', function() {
       idStore = new IdentityStore({
         configManager: configManagerGen(),
         ethStore: {
-          addAccount(acct) { accounts.push('0x' + acct) },
+          addAccount(acct) { accounts.push(ethUtil.addHexPrefix(acct)) },
         },
       })
+    })
+
+    beforeEach(function() {
+      accounts = []
     })
 
     it('should return the expected first account', function (done) {
@@ -87,15 +95,23 @@ describe('IdentityStore', function() {
         assert.equal(accounts[0], firstAccount)
 
         accounts = []
-        const secondSeed = 'radar blur cabbage chef fix engine embark joy scheme fiction master release'
-        const secondAcct = '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9'
-
         idStore.recoverFromSeed(password, secondSeed, (err) => {
 
           let accounts = idStore._getAddresses()
           assert.equal(accounts[0], secondAcct)
           done()
         })
+      })
+    })
+
+    it('should return the expected second account', function (done) {
+      idStore.recoverFromSeed(password, secondSeed, (err) => {
+        assert.ifError(err)
+
+        let newKeystore = idStore._idmgmt.keyStore
+
+        assert.equal(accounts[0], firstAccount)
+        done()
       })
     })
   })

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -128,5 +128,23 @@ describe('IdentityStore', function() {
         done()
       })
     })
+
+    it('should allow restoring and unlocking again', function (done) {
+      const assertion = assertions[0]
+      idStore.recoverFromSeed(password, assertion.seed, (err) => {
+        assert.ifError(err)
+
+        var received = accounts[0].toLowerCase()
+        var expected = assertion.account.toLowerCase()
+        assert.equal(received, expected)
+
+
+        idStore.submitPassword(password, function(err, account) {
+          assert.ifError(err)
+          assert.equal(account, expected)
+          done()
+        })
+      })
+    })
   })
 })

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -86,7 +86,15 @@ describe('IdentityStore', function() {
       {
         seed: 'half glimpse tape cute harvest sweet bike voyage actual floor poet lazy',
         account: '0x28e9044597b625ac4beda7250011670223de43b2',
-      }
+      },
+      {
+        seed: 'flavor tiger carpet motor angry hungry document inquiry large critic usage liar',
+        account: '0xb571be96558940c4e9292e1999461aa7499fb6cd',
+      },
+      {
+        seed: 'this is a twelve word phrase seven eight nine ten eleven twelve',
+        account: '0x814e8ec0c3647e140b8e09228fc374b2a867fe48',
+      },
     ]
 
     before(function() {

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -23,6 +23,7 @@ describe('IdentityStore', function() {
       })
 
       idStore.createNewVault(password, entropy, (err, seeds) => {
+        assert.ifError(err, 'createNewVault threw error')
         seedWords = seeds
         originalKeystore = idStore._idmgmt.keyStore
         done()
@@ -59,6 +60,7 @@ describe('IdentityStore', function() {
   describe('#recoverFromSeed BIP44 compliance', function() {
     let seedWords =  'picnic injury awful upper eagle junk alert toss flower renew silly vague'
     let firstAccount = '0x5d8de92c205279c10e5669f797b853ccef4f739a'
+    const salt = 'lightwalletSalt'
 
     let password = 'secret!'
     let accounts = []
@@ -70,7 +72,7 @@ describe('IdentityStore', function() {
       idStore = new IdentityStore({
         configManager: configManagerGen(),
         ethStore: {
-          addAccount(acct) { accounts.push(acct) },
+          addAccount(acct) { accounts.push('0x' + acct) },
         },
       })
     })

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -118,7 +118,6 @@ describe('IdentityStore', function() {
           idStore.recoverFromSeed(password, assertion.seed, (err) => {
             assert.ifError(err)
 
-            console.log('comparing %s to %s', accounts[0], assertion.account)
             assert.equal(accounts[0], assertion.account)
             cb()
           })

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -59,12 +59,7 @@ describe('IdentityStore', function() {
   })
 
   describe('#recoverFromSeed BIP44 compliance', function() {
-    let seedWords =  'picnic injury awful upper eagle junk alert toss flower renew silly vague'
-    let firstAccount = '0x5d8de92c205279c10e5669f797b853ccef4f739a'
-    const salt = 'lightwalletSalt'
-
-    const secondSeed = 'radar blur cabbage chef fix engine embark joy scheme fiction master release'
-    const secondAcct = '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9'
+   const salt = 'lightwalletSalt'
 
     let password = 'secret!'
     let accounts = []
@@ -86,31 +81,35 @@ describe('IdentityStore', function() {
     })
 
     it('should return the expected first account', function (done) {
+      let seedWords =  'picnic injury awful upper eagle junk alert toss flower renew silly vague'
+      let firstAccount = '0x5d8de92c205279c10e5669f797b853ccef4f739a'
 
       idStore.recoverFromSeed(password, seedWords, (err) => {
         assert.ifError(err)
 
-        let newKeystore = idStore._idmgmt.keyStore
-
         assert.equal(accounts[0], firstAccount)
-
-        accounts = []
-        idStore.recoverFromSeed(password, secondSeed, (err) => {
-
-          let accounts = idStore._getAddresses()
-          assert.equal(accounts[0], secondAcct)
-          done()
-        })
+        done()
       })
     })
 
     it('should return the expected second account', function (done) {
+      const secondSeed = 'radar blur cabbage chef fix engine embark joy scheme fiction master release'
+      const secondAcct = '0xac39b311dceb2a4b2f5d8461c1cdaf756f4f7ae9'
+
       idStore.recoverFromSeed(password, secondSeed, (err) => {
         assert.ifError(err)
+        assert.equal(accounts[0], secondAcct)
+        done()
+      })
+    })
 
-        let newKeystore = idStore._idmgmt.keyStore
+    it('should return the expected third account', function (done) {
+      const thirdSeed = 'phone coyote caught pattern found table wedding list tumble broccoli chief swing'
+      const thirdAcct = '0xb0e868f24bc7fec2bce2efc2b1c344d7569cd9d2'
 
-        assert.equal(accounts[0], firstAccount)
+      idStore.recoverFromSeed(password, thirdSeed, (err) => {
+        assert.ifError(err)
+        assert.equal(accounts[0], thirdAcct)
         done()
       })
     })

--- a/ui/app/accounts/account-list-item.js
+++ b/ui/app/accounts/account-list-item.js
@@ -7,14 +7,14 @@ const EthBalance = require('../components/eth-balance')
 const CopyButton = require('../components/copyButton')
 const Identicon = require('../components/identicon')
 
-module.exports = NewComponent
+module.exports = AccountListItem
 
-inherits(NewComponent, Component)
-function NewComponent () {
+inherits(AccountListItem, Component)
+function AccountListItem () {
   Component.call(this)
 }
 
-NewComponent.prototype.render = function () {
+AccountListItem.prototype.render = function () {
   const identity = this.props.identity
   var isSelected = this.props.selectedAddress === identity.address
   var account = this.props.accounts[identity.address]
@@ -23,9 +23,6 @@ NewComponent.prototype.render = function () {
   return (
     h(`.accounts-list-option.flex-row.flex-space-between.pointer.hover-white${selectedClass}`, {
       key: `account-panel-${identity.address}`,
-      style: {
-        flex: '1 0 auto',
-      },
       onClick: (event) => this.props.onShowDetail(identity.address, event),
     }, [
 
@@ -73,7 +70,7 @@ NewComponent.prototype.render = function () {
   )
 }
 
-NewComponent.prototype.pendingOrNot = function () {
+AccountListItem.prototype.pendingOrNot = function () {
   const pending = this.props.pending
   if (pending.length === 0) return null
   return h('.pending-dot', pending.length)

--- a/ui/app/accounts/index.js
+++ b/ui/app/accounts/index.js
@@ -84,7 +84,7 @@ AccountsScreen.prototype.render = function () {
             })
           }),
 
-          h('hr.horizontal-line', {key: 'horizontal-line1'}),
+          h('hr.horizontal-line'),
           h('div.footer.hover-white.pointer', {
             key: 'reveal-account-bar',
             onClick: () => {
@@ -92,7 +92,6 @@ AccountsScreen.prototype.render = function () {
             },
             style: {
               display: 'flex',
-              flex: '1 0 auto',
               height: '40px',
               paddint: '10px',
               justifyContent: 'center',
@@ -101,6 +100,7 @@ AccountsScreen.prototype.render = function () {
           }, [
             h('i.fa.fa-plus.fa-lg', {key: ''}),
           ]),
+          h('hr.horizontal-line'),
         ]),
 
       unconfTxList.length ? (

--- a/ui/app/components/shapeshift-form.js
+++ b/ui/app/components/shapeshift-form.js
@@ -69,7 +69,7 @@ ShapeshiftForm.prototype.renderMain = function () {
         h('input#fromCoin.buy-inputs.ex-coins', {
           type: 'text',
           list: 'coinList',
-          dataset: {
+          dataSet: {
             persistentFormId: 'input-coin',
           },
           style: {
@@ -165,7 +165,7 @@ ShapeshiftForm.prototype.renderMain = function () {
       h('input#fromCoinAddress.buy-inputs', {
         type: 'text',
         placeholder: `Your ${coin} Refund Address`,
-        dataset: {
+        dataSet: {
           persistentFormId: 'refund-address',
         },
         style: {

--- a/ui/app/first-time/restore-vault.js
+++ b/ui/app/first-time/restore-vault.js
@@ -41,7 +41,7 @@ RestoreVaultScreen.prototype.render = function () {
       // wallet seed entry
       h('h3', 'Wallet Seed'),
       h('textarea.twelve-word-phrase.letter-spacey', {
-        dataset: {
+        dataSet: {
           persistentFormId: 'wallet-seed',
         },
         placeholder: 'Enter your secret twelve word phrase here to restore your vault.',
@@ -52,7 +52,7 @@ RestoreVaultScreen.prototype.render = function () {
         type: 'password',
         id: 'password-box',
         placeholder: 'New Password (min 8 chars)',
-        dataset: {
+        dataSet: {
           persistentFormId: 'password',
         },
         style: {
@@ -67,7 +67,7 @@ RestoreVaultScreen.prototype.render = function () {
         id: 'password-box-confirm',
         placeholder: 'Confirm Password',
         onKeyPress: this.onMaybeCreate.bind(this),
-        dataset: {
+        dataSet: {
           persistentFormId: 'password-confirmation',
         },
         style: {

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -138,7 +138,7 @@ SendTransactionScreen.prototype.render = function () {
         h('input.large-input', {
           name: 'address',
           placeholder: 'Recipient Address',
-          dataset: {
+          dataSet: {
             persistentFormId: 'recipient-address',
           },
         }),
@@ -154,7 +154,7 @@ SendTransactionScreen.prototype.render = function () {
           style: {
             marginRight: 6,
           },
-          dataset: {
+          dataSet: {
             persistentFormId: 'tx-amount',
           },
         }),
@@ -192,7 +192,7 @@ SendTransactionScreen.prototype.render = function () {
             width: '100%',
             resize: 'none',
           },
-          dataset: {
+          dataSet: {
             persistentFormId: 'tx-data',
           },
         }),


### PR DESCRIPTION
eth-lightwallet was previously not salting vault passwords, potentially making it easier to crack them once obtained.

This branch incorporates the API changes to allow us to take advantage of the new salting logic.

This is still throwing deprecation warnings, but that's actually a bug in eth-lightwallet I wrote, [I've submitted a PR for that here](https://github.com/ConsenSys/eth-lightwallet/pull/116).

Fixes #555
