### PR TITLE
Add developer faq to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # MetaMask Plugin [![Build Status](https://circleci.com/gh/MetaMask/metamask-plugin.svg?style=shield&circle-token=a1ddcf3cd38e29267f254c9c59d556d513e3a1fd)](https://circleci.com/gh/MetaMask/metamask-plugin)
 
+## Developing Compatible Dapps
+
+If you're a web dapp developer, we've got two types of guides for you:
+
+- If you've never built a Dapp before, we've got a gentle introduction on [Developing Dapps with Truffle and MetaMask](https://blog.metamask.io/developing-for-metamask-with-truffle/).
+- If you have a Dapp, and you want to ensure compatibility, [here is our guide on building MetaMask-compatible Dapps](https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md)
+
 ## Building locally
 
  - Install [Node.js](https://nodejs.org/en/) version 6.3.1 or later.


### PR DESCRIPTION
We get a lot of slack users who ask basic questions like these.

A dev in our slack channel suggested throwing these links at the top of our main repo readme.

Sounded reasonable enough to me!
