### PR TITLE
Fix cache clearing reference for Opera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Current Master
 
+## 2.11.1 2016-09-12
+
+- Fix bug that prevented caches from being cleared in Opera.
+
 ## 2.11.0 2016-09-12
 
 - Fix bug where pending transactions from Test net (or other networks) show up In Main net.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -505,7 +505,7 @@ IdentityStore.prototype.purgeCache = function () {
   this._currentState.identities = {}
   let accounts
   try {
-    Object.keys(this._ethStore._currentState.accounts)
+    accounts = Object.keys(this._ethStore._currentState.accounts)
   } catch (e) {
     accounts = []
   }


### PR DESCRIPTION
For some reason Chrome didn't mind this awful bug, but Opera caught it.
