### PR TITLE
Fix port stream end bug

### DIFF
--- a/app/scripts/lib/port-stream.js
+++ b/app/scripts/lib/port-stream.js
@@ -30,8 +30,7 @@ PortDuplexStream.prototype._onMessage = function (msg) {
 
 PortDuplexStream.prototype._onDisconnect = function () {
   try {
-    // this.end()
-    this.emit('close')
+    this.push(null)
   } catch (err) {
     this.emit('error', err)
   }


### PR DESCRIPTION
Emitting `end` or `close` was not ending the stream.

Pushing a null packet also closes a stream, so I did that instead.

Fixes #616 
