### PR TITLE
Fix popup closing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current Master
 
+- Fixed bug where opening MetaMask could close a non-metamask popup.
+- Fixed memory leak that caused occasional crashes.
+
 ## 2.11.1 2016-09-12
 
 - Fix bug that prevented caches from being cleared in Opera.


### PR DESCRIPTION
Only close popups that seem to be MetaMask's

We only get these attributes to work with:

```
alwaysOnTop: false
focused: false
height: 500
id: 1231
incognito: false
left: -2556
state: "normal"
top: -733
type: "popup"
width: 360
```

I'm checking type, width, and height of our popup to verify it's ours, that should make this effectively a non issue.

If we ever want to make this even more stable we could set up the cross-process communication to relay the ID, but I think that would be overkill for now.

Fixes #646
