### PR TITLE
deps - bump provider-engine 8.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "through2": "^2.0.1",
     "vreme": "^3.0.2",
     "web3": "ethereum/web3.js#260ac6e78a8ce4b2e13f5bb0fdb65f4088585876",
-    "web3-provider-engine": "^8.0.2",
+    "web3-provider-engine": "^8.0.5",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
This fixes the bug where a finalizing the tx (filling in data, signing, or submitting) triggered an error, it would block all further tx submissions
