### PR TITLE
Update global refs

### DIFF
--- a/test/unit/extension-test.js
+++ b/test/unit/extension-test.js
@@ -18,9 +18,7 @@ describe('extension', function() {
       }
 
       it('returns the desired result', function() {
-        console.dir(Extension)
         const extension = new Extension()
-        console.dir(extension)
         const result = extension.extension.getURL()
         assert.equal(result, desiredResult)
       })


### PR DESCRIPTION
The `GLOBAL` variable is deprecated, so switching our test mocks over to the `global` namespace instead.
