### PR TITLE
Parity compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add a link to the transaction in history that goes to https://metamask.github.io/eth-tx-viz
 too help visualize transactions and to where they are going.
 - Show "Buy Ether" button and warning on tx confirmation when sender balance is insufficient
+- Change behavior that prevented Parity client compatibility, where we included a request site origin on rpc calls.
 
 ## 2.12.1 2016-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Current Master
 
+## 2.13.0 2016-09-18
+
+- Add Parity compatibility, fixing Geth dependency issues.
 - Add a link to the transaction in history that goes to https://metamask.github.io/eth-tx-viz
 too help visualize transactions and to where they are going.
 - Show "Buy Ether" button and warning on tx confirmation when sender balance is insufficient
-- Change behavior that prevented Parity client compatibility, where we included a request site origin on rpc calls.
 
 ## 2.12.1 2016-09-14
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -75,6 +75,10 @@ module.exports = class MetamaskController {
   }
 
   onRpcRequest (stream, originDomain, request) {
+
+    /* Commented out for Parity compliance
+     * Parity does not permit additional keys, like `origin`,
+     * and Infura is not currently filtering this key out.
     var payloads = Array.isArray(request) ? request : [request]
     payloads.forEach(function (payload) {
       // Append origin to rpc payload
@@ -86,6 +90,7 @@ module.exports = class MetamaskController {
         payload.params.push({ origin: originDomain })
       }
     })
+    */
 
     // handle rpc request
     this.provider.sendAsync(request, function onPayloadHandled (err, response) {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "through2": "^2.0.1",
     "vreme": "^3.0.2",
     "web3": "ethereum/web3.js#260ac6e78a8ce4b2e13f5bb0fdb65f4088585876",
-    "web3-provider-engine": "^8.0.5",
+    "web3-provider-engine": "^8.0.6",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
- Drop origin key from requests for Parity compatibility
- Bump web3 provider engine version for Parity compliance

Note this bumps provider engine to a version that does not exist right now. This should fail the test suite, which should be manually re-run once provider-engine is updated.
