### PR TITLE
Improve popup behavior for tx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Fix bug where chosen FIAT exchange rate does no persist when switching networks
+- Fix additional parameters that made MetaMask sometimes receive errors from Parity.
 
 ## 2.13.1 2016-09-23
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -203,26 +203,15 @@ module.exports = class MetamaskController {
 
   newUnsignedTransaction (txParams, onTxDoneCb) {
     const idStore = this.idStore
-    var state = idStore.getState()
 
     let err = this.enforceTxValidations(txParams)
     if (err) return onTxDoneCb(err)
 
-    // It's locked
-    if (!state.isUnlocked) {
-
-      // Allow the environment to define an unlock message.
-      this.opts.unlockAccountMessage()
-      idStore.addUnconfirmedTransaction(txParams, onTxDoneCb, noop)
-
-    // It's unlocked
-    } else {
-      idStore.addUnconfirmedTransaction(txParams, onTxDoneCb, (err, txData) => {
-        if (err) return onTxDoneCb(err)
-        this.sendUpdate()
-        this.opts.showUnconfirmedTx(txParams, txData, onTxDoneCb)
-      })
-    }
+    idStore.addUnconfirmedTransaction(txParams, onTxDoneCb, (err, txData) => {
+      if (err) return onTxDoneCb(err)
+      this.sendUpdate()
+      this.opts.showUnconfirmedTx(txParams, txData, onTxDoneCb)
+    })
   }
 
   enforceTxValidations (txParams) {
@@ -353,4 +342,3 @@ module.exports = class MetamaskController {
   }
 }
 
-function noop () {}


### PR DESCRIPTION
When we receive an invalid params error, we no longer open the popup, which would then just show the account view (since it had no txs to confirm).
