### PR TITLE
Version 2.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Current Master
 
+## 2.13.2 2016-10-4
+
 - Fix bug where chosen FIAT exchange rate does no persist when switching networks
 - Fix additional parameters that made MetaMask sometimes receive errors from Parity.
+- Fix bug where invalid transactions would still open the MetaMask popup.
 
 ## 2.13.1 2016-09-23
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "through2": "^2.0.1",
     "vreme": "^3.0.2",
     "web3": "ethereum/web3.js#260ac6e78a8ce4b2e13f5bb0fdb65f4088585876",
-    "web3-provider-engine": "^8.0.7",
+    "web3-provider-engine": "^8.1.0",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Fixes #679 by bumping provider-engine to include param sanitization.
