### PR TITLE
Removed hex prefix from private key export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix bug where chosen FIAT exchange rate does no persist when switching networks
 - Fix additional parameters that made MetaMask sometimes receive errors from Parity.
 - Fix bug where invalid transactions would still open the MetaMask popup.
+- Removed hex prefix from private key export, to increase compatibility with Geth, MyEtherWallet, and Jaxx.
 
 ## 2.13.1 2016-09-23
 

--- a/ui/app/components/account-export.js
+++ b/ui/app/components/account-export.js
@@ -3,6 +3,7 @@ const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const copyToClipboard = require('copy-to-clipboard')
 const actions = require('../actions')
+const ethUtil = require('ethereumjs-util')
 
 module.exports = ExportAccountView
 
@@ -61,7 +62,9 @@ ExportAccountView.prototype.render = function () {
 
   if (accountExported) {
     return h('div.privateKey', {
-
+      style: {
+        margin: '0 20px',
+      },
     }, [
       h('label', 'Your private key (click to copy):'),
       h('p.error.cursor-pointer', {
@@ -72,9 +75,9 @@ ExportAccountView.prototype.render = function () {
           width: '100%',
         },
         onClick: function (event) {
-          copyToClipboard(accountDetail.privateKey)
+          copyToClipboard(ethUtil.stripHexPrefix(accountDetail.privateKey))
         },
-      }, accountDetail.privateKey),
+      }, ethUtil.stripHexPrefix(accountDetail.privateKey)),
       h('button', {
         onClick: () => this.props.dispatch(actions.backToAccountDetail(this.props.address)),
       }, 'Done'),


### PR DESCRIPTION
For compatibility with Jaxx, MEW, and Geth.

Fixes #687 

Also improved formatting on private key export view.
