### PR TITLE
Emphasize auto-updating in announcement

### DIFF
--- a/development/announcer.js
+++ b/development/announcer.js
@@ -7,6 +7,6 @@ var changelog = fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md')).toSt
 
 var log = changelog.split(version)[1].split('##')[0].trim()
 
-let msg = `*MetaMask ${version}* now published to the Chrome Store! It should be available over the next hour!\n${log}`
+let msg = `*MetaMask ${version}* now published to the Chrome Store! It should auto-update over the next hour!\n${log}`
 
 console.log(msg)


### PR DESCRIPTION
Helps avoid issues like #703 by emphasizing uninstalling is not required.
