### PR TITLE
Prevent injections on XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug where web3 was being injected into XML files.
+
 ## 2.13.3 2016-10-4
 
 - Fix bug where log queries were filtered out.

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -69,6 +69,18 @@ function setupStreams(){
 }
 
 function shouldInjectWeb3(){
-  var shouldInject = (window.location.href.indexOf('.pdf') === -1)
-  return shouldInject
+  return isAllowedSuffix(window.location.href)
+}
+
+function isAllowedSuffix(testCase) {
+  var prohibitedTypes = ['xml','pdf']
+  var currentUrl = window.location.href
+  var currentRegex
+  for (let i = 0; i < prohibitedTypes.length; i++) {
+    currentRegex = new RegExp(`\.${prohibitedTypes[i]}$`)
+    if (currentRegex.test(currentUrl)) {
+      return false
+    }
+  }
+  return true
 }

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -73,7 +73,7 @@ function shouldInjectWeb3(){
 }
 
 function isAllowedSuffix(testCase) {
-  var prohibitedTypes = ['xml','pdf']
+  var prohibitedTypes = ['xml', 'pdf']
   var currentUrl = window.location.href
   var currentRegex
   for (let i = 0; i < prohibitedTypes.length; i++) {


### PR DESCRIPTION
Fixes #735, but is only a stopgap solution until we can resolve the issue of 'how do we determine what pages should get an web3 injection?'
