### PR TITLE
Wait for first metamask data to establish ping-pong stream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## Current Master
 
 - Increase default max gas to `100000` over the RPC's `estimateGas` response.
+- Fix bug where slow-loading dapps would sometimes trigger infinite reload loops.
 
 ## 2.13.4 2016-10-17
 
 - Add custom transaction fee field to send form.
 - Fix bug where web3 was being injected into XML files.
+- Fix bug where changing network would not reload current Dapps.
 
 ## 2.13.3 2016-10-4
 

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -43,7 +43,7 @@ reloadStream.once('data', triggerReload)
 var pingChannel = inpageProvider.multiStream.createStream('pingpong')
 var pingStream = new PingStream({ objectMode: true })
 // wait for first successful reponse
-metamaskStream.once('data', function(){
+metamaskStream.once('_data', function(){
   pingStream.pipe(pingChannel).pipe(pingStream)
 })
 endOfStream(pingStream, triggerReload)


### PR DESCRIPTION
Prevents infinite reload loops when dapps take too long to load.

Fixes #746.

Also added to the changelog of the previous version, noting the reload on provider change feature.
