### PR TITLE
Add note about callback param to sync method warning

### DIFF
--- a/app/scripts/lib/inpage-provider.js
+++ b/app/scripts/lib/inpage-provider.js
@@ -84,7 +84,7 @@ MetamaskInpageProvider.prototype.send = function (payload) {
     // throw not-supported Error
     default:
       var link = 'https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md#dizzy-all-async---think-of-metamask-as-a-light-client'
-      var message = `The MetaMask Web3 object does not support synchronous methods like ${payload.method}. See ${link} for details.`
+      var message = `The MetaMask Web3 object does not support synchronous methods like ${payload.method} without a callback parameter. See ${link} for details.`
       throw new Error(message)
 
   }


### PR DESCRIPTION
In response to [This StackExchange post](http://ethereum.stackexchange.com/questions/9385/send-transaction-using-metamask-injected-web-3) where our error message is confusing, since it lists a method we do actually support.

Added a note about needing a callback parameter.
