### PR TITLE
Fix provider menu selection indication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Current Master
 
 - Add a check for improper Transaction data.
+- Fix bug where custom provider selection could show duplicate items.
+- Fix bug where connecting to a local morden node would make two providers appear selected.
 
 ## 2.13.5 2016-10-18
 

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -240,6 +240,7 @@ App.prototype.renderNetworkDropdown = function () {
       action: () => props.dispatch(actions.setProviderType('testnet')),
       icon: h('.menu-icon.red-dot'),
       activeNetworkRender: props.network,
+      provider: props.provider,
     }),
 
     h(DropMenuItem, {
@@ -248,13 +249,6 @@ App.prototype.renderNetworkDropdown = function () {
       action: () => props.dispatch(actions.setRpcTarget('http://localhost:8545')),
       icon: h('i.fa.fa-question-circle.fa-lg'),
       activeNetworkRender: props.provider.rpcTarget,
-    }),
-
-    h(DropMenuItem, {
-      label: 'Custom RPC',
-      closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
-      action: () => this.props.dispatch(actions.showConfigPage()),
-      icon: h('i.fa.fa-question-circle.fa-lg'),
     }),
 
     this.renderCustomOption(props.provider.rpcTarget),
@@ -508,7 +502,12 @@ App.prototype.toggleMetamaskActive = function () {
 App.prototype.renderCustomOption = function (rpcTarget) {
   switch (rpcTarget) {
     case undefined:
-      return null
+      return h(DropMenuItem, {
+        label: 'Custom RPC',
+        closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
+        action: () => this.props.dispatch(actions.showConfigPage()),
+        icon: h('i.fa.fa-question-circle.fa-lg'),
+      })
 
     case 'http://localhost:8545':
       return h(DropMenuItem, {

--- a/ui/app/components/drop-menu-item.js
+++ b/ui/app/components/drop-menu-item.js
@@ -42,7 +42,7 @@ DropMenuItem.prototype.activeNetworkRender = function () {
       if (providerType === 'mainnet') return h('.check', '✓')
       break
     case 'Morden Test Network':
-      if (activeNetwork === '2') return h('.check', '✓')
+      if (provider.type === 'testnet') return h('.check', '✓')
       break
     case 'Localhost 8545':
       if (activeNetwork === 'http://localhost:8545') return h('.check', '✓')


### PR DESCRIPTION
- Fix bug where custom provider selection could show duplicate items.
- Fix bug where connecting to a local morden node would make two providers appear selected.

<img width="379" alt="screen shot 2016-10-25 at 2 15 06 pm" src="https://cloud.githubusercontent.com/assets/542863/19704755/ce68ee1c-9abd-11e6-87d1-c5983d5cb80b.png">

Fixes #761
