### PR TITLE
Fix delegate call analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Add a check for improper Transaction data.
+- Fix bug that was sometimes preventing transactions from being sent.
 
 ## 2.13.5 2016-10-18
 

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -247,7 +247,7 @@ IdentityStore.prototype.addUnconfirmedTransaction = function (txParams, onTxDone
   // perform static analyis on the target contract code
   function analyzeForDelegateCall(cb){
     if (txParams.to) {
-      query.getCode(txParams.to, function (err, result) {
+      query.getCode(txParams.to, (err, result) => {
         if (err) return cb(err)
         var containsDelegateCall = this.checkForDelegateCall(result)
         txData.containsDelegateCall = containsDelegateCall


### PR DESCRIPTION
Fixed reference allowing transactions to be analyzed for delegate call again.

When I was creating a test case for the delegate call method previously, I moved a function outside of the scope breaking that function reference.

That code was then merged in while I was in Tahoe over a long weekend.
