### PR TITLE
Update web3.js version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Add a check for improper Transaction data.
+- Inject up to date version of web3.js
 
 ## 2.13.5 2016-10-18
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "three.js": "^0.73.2",
     "through2": "^2.0.1",
     "vreme": "^3.0.2",
-    "web3": "ethereum/web3.js#260ac6e78a8ce4b2e13f5bb0fdb65f4088585876",
+    "web3": "ethereum/web3.js",
     "web3-provider-engine": "^8.1.5",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "three.js": "^0.73.2",
     "through2": "^2.0.1",
     "vreme": "^3.0.2",
-    "web3": "ethereum/web3.js",
+    "web3": "0.17.0-beta",
     "web3-provider-engine": "^8.1.5",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"


### PR DESCRIPTION
We've been pointed at a branch of web3 for a long time, but our special branch [was merged into web3.js a couple months ago](https://github.com/ethereum/web3.js/pull/489).
