### PR TITLE
i787 High gas bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Fix gas estimation bug.
 - Fix github link on info page to point at current repository.
 
 ## 2.13.6 2016-10-26

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -287,11 +287,11 @@ IdentityStore.prototype.checkForDelegateCall = function (codeHex) {
   }
 }
 
-IdentityStore.prototype.addGasBuffer = function (gasHex) {
-  var gas = new BN(gasHex, 16)
-  var buffer = new BN('100000', 10)
-  var result = gas.add(buffer)
-  return ethUtil.addHexPrefix(result.toString(16))
+const gasBuffer = new BN('100000', 10)
+IdentityStore.prototype.addGasBuffer = function (gas) {
+  const bnGas = new BN(ethUtil.stripHexPrefix(gas), 16)
+  const correct = bnGas.add(gasBuffer)
+  return ethUtil.addHexPrefix(correct.toString(16))
 }
 
 // comes from metamask ui

--- a/test/unit/idStore-test.js
+++ b/test/unit/idStore-test.js
@@ -169,20 +169,18 @@ describe('IdentityStore', function() {
 
       const gas = '0x04ee59' // Actual estimated gas example
       const tooBigOutput = '0x80674f9' // Actual bad output
-      const bnGas = new BN(gas, 16)
+      const bnGas = new BN(ethUtil.stripHexPrefix(gas), 16)
       const correctBuffer = new BN('100000', 10)
       const correct = bnGas.add(correctBuffer)
 
       const tooBig = new BN(tooBigOutput, 16)
-      console.log(`Pure estimate is ${bnGas.toString(10)}`)
-      console.log(`Too big is ${tooBig.toString(10)}`)
-      console.log(`Buffer should be ${correctBuffer.toString(10)}`)
-      console.log(`correct should be ${correct.toString(10)}`)
       const result = idStore.addGasBuffer(gas)
-      const bnResult = new BN(result, 16)
+      const bnResult = new BN(ethUtil.stripHexPrefix(result), 16)
 
-      console.log(`Result was ${bnResult.toString(10)}`)
-      assert.equal(result, correct.toString(16), 'add the right amount')
+      assert.equal(result.indexOf('0x'), 0, 'included hex prefix')
+      assert(bnResult.gt(bnGas), 'Estimate increased in value.')
+      assert.equal(bnResult.sub(bnGas).toString(10), '100000', 'added 100k gas')
+      assert.equal(result, '0x' + correct.toString(16), 'Added the right amount')
       assert.notEqual(result, tooBigOutput, 'not that bad estimate')
     })
   })


### PR DESCRIPTION
Our gas price buffering logic had a bug, because bn.js has inconsistent behavior when using hex-prefixed input.  The issue has been opened with them here:
indutny/bn.js#151

We've corrected our usage in the meantime.

I've also added this fix to the MultiVault branch for when we merge that to master.

Fixes #787 

