### PR TITLE
Fix error display in confirmation screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 - Show a warning when a transaction fails during simulation.
 - Fix bug where 20% of gas estimate was not being added properly.
+- Render error messages in our confirmation screen more gracefully.
 
 ## 2.13.7 2016-11-8
 

--- a/app/scripts/lib/idStore.js
+++ b/app/scripts/lib/idStore.js
@@ -248,7 +248,7 @@ IdentityStore.prototype.addUnconfirmedTransaction = function (txParams, onTxDone
   function analyzeForDelegateCall(cb){
     if (txParams.to) {
       query.getCode(txParams.to, (err, result) => {
-        if (err) return cb(err)
+        if (err) return cb(err.message || err)
         var containsDelegateCall = self.checkForDelegateCall(result)
         txData.containsDelegateCall = containsDelegateCall
         cb()
@@ -264,7 +264,7 @@ IdentityStore.prototype.addUnconfirmedTransaction = function (txParams, onTxDone
     var gasLimit = '0x3b9aca00'
     estimationParams.gas = gasLimit
     query.estimateGas(estimationParams, function(err, result){
-      if (err) return cb(err)
+      if (err) return cb(err.message || err)
       if (result === estimationParams.gas) {
         txData.simulationFails = true
         query.getBlockByNumber('latest', true, function(err, block){
@@ -282,7 +282,7 @@ IdentityStore.prototype.addUnconfirmedTransaction = function (txParams, onTxDone
   }
 
   function didComplete (err) {
-    if (err) return cb(err)
+    if (err) return cb(err.message || err)
     configManager.addTx(txData)
     // signal update
     self._didUpdate()

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -212,7 +212,6 @@ module.exports = class MetamaskController {
 
   newUnsignedTransaction (txParams, onTxDoneCb) {
     const idStore = this.idStore
-
     let err = this.enforceTxValidations(txParams)
     if (err) return onTxDoneCb(err)
     idStore.addUnconfirmedTransaction(txParams, onTxDoneCb, (err, txData) => {


### PR DESCRIPTION
Fixes the elusive #756....perhaps. We'll need testing to be sure, but I'm pushing a PR early just to start discussion.

Basically, what's happening is that if a full error is pushed into our provider engine through callbacks, provider engine will provide an error within an error when attempting to display the error in MetaMask.

This is rectified by conditionally by either printing error.message, or plain error if that doesn't exist (and is most likely a plain string).

@flyswatter how can we test this? I would need a faulty contract like in the thread to reproduce and confirm.