### PR TITLE
Update migration code for new hd wallet param name

### DIFF
--- a/app/scripts/lib/idStore-migrator.js
+++ b/app/scripts/lib/idStore-migrator.js
@@ -37,11 +37,11 @@ module.exports = class IdentityStoreMigrator {
 
   serializeVault () {
     const mnemonic = this.idStore._idmgmt.getSeed()
-    const n = this.idStore._getAddresses().length
+    const numberOfAccounts = this.idStore._getAddresses().length
 
     return {
       type: 'HD Key Tree',
-      data: { mnemonic, n },
+      data: { mnemonic, numberOfAccounts },
     }
   }
 


### PR DESCRIPTION
Fixes #821 
Fixes #822 

The hd keyring `n` parameter was renamed without being renamed in the migration code.