### PR TITLE
Promisify persistence of old vaults in migration code

### DIFF
--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -127,8 +127,9 @@ module.exports = class KeyringController extends EventEmitter {
       if (serialized && shouldMigrate) {
         const keyring = this.restoreKeyring(serialized)
         this.keyrings.push(keyring)
-        this.persistAllKeyrings()
         this.configManager.setSelectedAccount(keyring.getAccounts()[0])
+        return this.persistAllKeyrings()
+        .then(() => { return key })
       }
       return key
     })
@@ -274,13 +275,12 @@ module.exports = class KeyringController extends EventEmitter {
   }
 
   persistAllKeyrings () {
-    const serialized = this.keyrings.map((k) => {
+    const serialized = this.keyrings.map((keyring) => {
       return {
-        type: k.type,
-        data: k.serialize(),
+        type: keyring.type,
+        data: keyring.serialize(),
       }
     })
-
     return this.encryptor.encryptWithKey(this.key, serialized)
     .then((encryptedString) => {
       this.configManager.setVault(encryptedString)

--- a/test/integration/lib/keyring-controller-test.js
+++ b/test/integration/lib/keyring-controller-test.js
@@ -1,0 +1,46 @@
+var KeyringController = require('../../../app/scripts/keyring-controller')
+var ConfigManager = require('../../../app/scripts/lib/config-manager')
+
+var oldStyleVault = require('../mocks/oldVault.json')
+
+var STORAGE_KEY = 'metamask-config'
+var PASSWORD = '12345678'
+var FIRST_ADDRESS = '0x4dd5d356c5A016A220bCD69e82e5AF680a430d00'.toLowerCase()
+
+
+QUnit.module('Old Style Vaults', {
+  beforeEach: function () {
+    window.localStorage[STORAGE_KEY] = JSON.stringify(oldStyleVault)
+
+    this.configManager = new ConfigManager({
+      loadData: () => { return JSON.parse(window.localStorage[STORAGE_KEY]) },
+      setData: (data) => { window.localStorage[STORAGE_KEY] = JSON.stringify(data) },
+    })
+
+    this.keyringController = new KeyringController({
+      configManager: this.configManager,
+      getNetwork: () => { return '2' },
+    })
+
+    this.ethStore = {
+      addAccount: () => {},
+      removeAccount: () => {},
+    }
+
+    this.keyringController.setStore(this.ethStore)
+  }
+})
+
+QUnit.test('keyringController:isInitialized', function (assert) {
+  assert.ok(this.keyringController.getState().isInitialized)
+})
+
+QUnit.test('keyringController:submitPassword', function (assert) {
+  var done = assert.async()
+
+  this.keyringController.submitPassword(PASSWORD, (err, state) => {
+    assert.notOk(err)
+    assert.ok(state.identities[FIRST_ADDRESS])
+    done()
+  })
+})

--- a/test/integration/mocks/oldVault.json
+++ b/test/integration/mocks/oldVault.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "version": 4
+  },
+  "data": {
+    "fiatCurrency": "USD",
+    "isConfirmed": true,
+    "TOSHash": "a4f4e23f823a7ac51783e7ffba7914a911b09acdb97263296b7e14b527f80c5b",
+    "conversionRate": 9.47316629,
+    "conversionDate": 1479510994,
+    "wallet": "{\"encSeed\":{\"encStr\":\"a5tjKtDGlHkua+6Ta5s3wMFWPmsBqaPdMKGmqeI2z1kMbNs3V03HBaCptU7NtMra1DjHKbSNsUToxFUrmrvWBmUejamN16+l1CviwqASsv7kKzpot00/dfyyJgtZwwFP5Je+TAB1V231nRbPidOfeE1cDec5V8KTF8epl6qzsbA25pjeW76Dfw==\",\"nonce\":\"RzID6bAhWfGTSR74xdIh3RaT1+1sLk6F\"},\"ksData\":{\"m/44'/60'/0'/0\":{\"info\":{\"curve\":\"secp256k1\",\"purpose\":\"sign\"},\"encHdPathPriv\":{\"encStr\":\"6nlYAopRbmGcqerRZO08XwgeYaCJg9XRhh4oiYiVVdQtyNPdxvOI9TcE/mqvBiatMwBwA+TmsqTV6eZZe/VDZKYIGajKulQbScd0xQ71JhYfqqmzSG6EH2Pnzwa+aSAsfARgN1JJSaff2+p6wV6Zg5BUDtl72OGEIEfXhcUGwg==\",\"nonce\":\"Ee1KiDqtx7NvYToQUFvjEhKNinNQcXlK\"},\"hdIndex\":1,\"encPrivKeys\":{\"4dd5d356c5a016a220bcd69e82e5af680a430d00\":{\"key\":\"htGRGAH10lGF4M+fvioznmYVIUSWAzwp/yWSIo85psgZZwmCdJY72oyGanYsrFO8\",\"nonce\":\"PkP8XeZ+ok215rzEorvJu9nYTWzkOVr0\"}},\"addresses\":[\"4dd5d356c5a016a220bcd69e82e5af680a430d00\"]}},\"encHdRootPriv\":{\"encStr\":\"TAZAo71a+4IlAaoA66f0w4ts2f+V7ArTSUHRIrMltfAPXz7GfJBmKXNtHPORUYAjRiKqWK6FZnhKLf7Vcng2LG7VnDQwC4xPxzSRZzSEilnoY3V+zRY0HD7Wb/pndb4FliA/buZQmjohO4vezeX0hl70rJlPJEZTyYoWgxbxFA==\",\"nonce\":\"FlJOaLyBEHMaH5fEnYjdHc6nn18+WkRj\"},\"salt\":\"CmuCcWpbqpKUUv+1aE2ZwvQl7EIQ731uFibSq++vwtY=\",\"version\":2}",
+    "config": {
+      "provider": {
+        "type": "testnet"
+      },
+      "selectedAccount": "0x4dd5d356c5a016a220bcd69e82e5af680a430d00"
+    },
+    "showSeedWords": false,
+    "isEthConfirmed": true
+  }
+}


### PR DESCRIPTION
We were not waiting for our encryptor to persist our new vault from our migrated old vault, causing issues. This promisifies the call to persistence so that we wait for that task to complete.

Also, wrote a test to catch this issue.