### PR TITLE
Begin adding Ropsten support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Add support for the new, default Ropsten Test Network.
 - Fix bug that would cause MetaMask to occasionally lose its StreamProvider connection and drop requests.
 
 ## 2.13.8 2016-11-16

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -1,5 +1,6 @@
 const MAINET_RPC_URL = 'https://mainnet.infura.io/metamask'
-const TESTNET_RPC_URL = 'https://morden.infura.io/metamask'
+const TESTNET_RPC_URL = 'https://ropsten.infura.io/metamask'
+const MORDEN_RPC_URL = 'https://morden.infura.io/metamask'
 const DEFAULT_RPC_URL = TESTNET_RPC_URL
 
 global.METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
@@ -10,5 +11,6 @@ module.exports = {
     default: DEFAULT_RPC_URL,
     mainnet: MAINET_RPC_URL,
     testnet: TESTNET_RPC_URL,
+    morden: MORDEN_RPC_URL,
   },
 }

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -5,6 +5,7 @@ const rp = require('request-promise')
 
 const TESTNET_RPC = MetamaskConfig.network.testnet
 const MAINNET_RPC = MetamaskConfig.network.mainnet
+const MORDEN_RPC = MetamaskConfig.network.morden
 const txLimit = 40
 
 /* The config-manager is a convenience object
@@ -147,6 +148,9 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
 
     case 'testnet':
       return TESTNET_RPC
+
+    case 'morden':
+      return MORDEN_RPC
 
     default:
       return provider && provider.rpcTarget ? provider.rpcTarget : TESTNET_RPC

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -235,9 +235,18 @@ App.prototype.renderNetworkDropdown = function () {
     }),
 
     h(DropMenuItem, {
-      label: 'Morden Test Network',
+      label: 'Ropsten Test Network',
       closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
       action: () => props.dispatch(actions.setProviderType('testnet')),
+      icon: h('.menu-icon.red-dot'),
+      activeNetworkRender: props.network,
+      provider: props.provider,
+    }),
+
+    h(DropMenuItem, {
+      label: 'Morden Test Network',
+      closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
+      action: () => props.dispatch(actions.setProviderType('morden')),
       icon: h('.menu-icon.red-dot'),
       activeNetworkRender: props.network,
       provider: props.provider,

--- a/ui/app/components/drop-menu-item.js
+++ b/ui/app/components/drop-menu-item.js
@@ -41,8 +41,11 @@ DropMenuItem.prototype.activeNetworkRender = function () {
     case 'Main Ethereum Network':
       if (providerType === 'mainnet') return h('.check', '✓')
       break
-    case 'Morden Test Network':
+    case 'Ropsten Test Network':
       if (provider.type === 'testnet') return h('.check', '✓')
+      break
+    case 'Morden Test Network':
+      if (provider.type === 'morden') return h('.check', '✓')
       break
     case 'Localhost 8545':
       if (activeNetwork === 'http://localhost:8545') return h('.check', '✓')

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -36,6 +36,12 @@ Network.prototype.render = function () {
   } else if (providerName === 'mainnet') {
     hoverText = 'Main Ethereum Network'
     iconName = 'ethereum-network'
+  } else if (providerName === 'testnet') {
+    hoverText = 'Ropsten Test Network'
+    iconName = 'ropsten-test-network'
+  } else if (parseInt(networkNumber) === 3) {
+    hoverText = 'Ropsten Test Network'
+    iconName = 'ropsten-test-network'
   } else if (parseInt(networkNumber) === 2) {
     hoverText = 'Morden Test Network'
     iconName = 'morden-test-network'
@@ -43,6 +49,7 @@ Network.prototype.render = function () {
     hoverText = 'Unknown Private Network'
     iconName = 'unknown-private-network'
   }
+
   return (
     h('#network_component.flex-center.pointer', {
       style: {
@@ -62,6 +69,15 @@ Network.prototype.render = function () {
                   color: '#039396',
                 }},
               'Ethereum Main Net'),
+            ])
+          case 'ropsten-test-network':
+            return h('.network-indicator', [
+              h('.menu-icon.red-dot'),
+              h('.network-name', {
+                style: {
+                  color: '#ff6666',
+                }},
+              'Ropsten Test Net'),
             ])
           case 'morden-test-network':
             return h('.network-indicator', [

--- a/ui/app/css/lib.css
+++ b/ui/app/css/lib.css
@@ -213,7 +213,7 @@ hr.horizontal-line {
   background: rgb(0, 163, 68);
   border-radius: 20px;
 }
-.morden-icon {
+.testnet-icon {
   background: #2465E1;
 }
 

--- a/ui/lib/account-link.js
+++ b/ui/lib/account-link.js
@@ -9,6 +9,9 @@ module.exports = function(address, network) {
     case 2: // morden test net
       link = `http://testnet.etherscan.io/address/${address}`
       break
+    case 3: // ropsten test net
+      link = ''
+      break
     default:
       link = ''
       break


### PR DESCRIPTION
Ropsten links will still not work until Etherscan publishes their ropsten link format.

At that time we will need to update ui/lib/account-link.js

Otherwise, fixes #831 

![screen shot 2016-11-21 at 10 43 24 am](https://cloud.githubusercontent.com/assets/542863/20496432/fa462e92-afd9-11e6-8ff9-19227615d002.png)
