### PR TITLE
Make ropsten faucet button point at the correct url.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for the new, default Ropsten Test Network.
 - Fix bug that would cause MetaMask to occasionally lose its StreamProvider connection and drop requests.
 - Fix bug that would cause the Custom RPC menu item to not appear when Localhost 8545 was selected.
+- Point ropsten faucet button to actual faucet.
 
 ## 2.13.8 2016-11-16
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -341,7 +341,7 @@ module.exports = class MetamaskController {
     var network = this.state.network
     var url = `https://buy.coinbase.com/?code=9ec56d01-7e81-5017-930c-513daa27bb6a&amount=${amount}&address=${address}&crypto_currency=ETH`
 
-    if (network === '2') {
+    if (network === '3') {
       url = 'https://faucet.metamask.io/'
     }
 

--- a/ui/app/components/buy-button-subview.js
+++ b/ui/app/components/buy-button-subview.js
@@ -114,8 +114,8 @@ BuyButtonSubview.prototype.formVersionSubview = function () {
           width: '225px',
         },
       }, 'In order to access this feature please switch to the Main Network'),
-      h('h3.text-transform-uppercase', 'or:'),
-      this.props.network === '2' ? h('button.text-transform-uppercase', {
+      this.props.network === '3' ? h('h3.text-transform-uppercase', 'or:') : null,
+      this.props.network === '3' ? h('button.text-transform-uppercase', {
         onClick: () => this.props.dispatch(actions.buyEth()),
         style: {
           marginTop: '15px',


### PR DESCRIPTION
Same as the other PR--fixes #862 by fixing the faucet button on Ropsten to point at an actual faucet.