### PR TITLE
Phase out ethereumjs-util from encryptor module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix bug that would cause MetaMask to occasionally lose its StreamProvider connection and drop requests.
 - Fix bug that would cause the Custom RPC menu item to not appear when Localhost 8545 was selected.
 - Point ropsten faucet button to actual faucet.
+- Phase out ethereumjs-util from our encryptor module.
 
 ## 2.13.8 2016-11-16
 

--- a/app/scripts/lib/encryptor.js
+++ b/app/scripts/lib/encryptor.js
@@ -1,5 +1,3 @@
-var ethUtil = require('ethereumjs-util')
-
 module.exports = {
 
   // Simple encryption methods:
@@ -101,10 +99,10 @@ function keyFromPassword (password) {
 }
 
 function serializeBufferFromStorage (str) {
-  str = ethUtil.stripHexPrefix(str)
-  var buf = new Uint8Array(str.length / 2)
-  for (var i = 0; i < str.length; i += 2) {
-    var seg = str.substr(i, 2)
+  var stripStr = (str.slice(0, 2) === '0x') ? str.slice(2) : str
+  var buf = new Uint8Array(stripStr.length / 2)
+  for (var i = 0; i < stripStr.length; i += 2) {
+    var seg = stripStr.substr(i, 2)
     buf[i / 2] = parseInt(seg, 16)
   }
   return buf


### PR DESCRIPTION
Fixes #860 