### PR TITLE
Modify forgot password flow to go back to init screen.

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -197,6 +197,7 @@ function createNewVaultAndRestore (password, seed) {
     background.createNewVaultAndRestore(password, seed, (err) => {
       dispatch(actions.hideLoadingIndication())
       if (err) return dispatch(actions.displayWarning(err.message))
+      dispatch(actions.showAccountsPage())
     })
   }
 }

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -90,7 +90,6 @@ App.prototype.render = function () {
           transitionLeaveTimeout: 300,
         }, [
           this.renderPrimary(),
-          this.renderBackToInitButton(),
         ]),
       ]),
     ])
@@ -335,39 +334,6 @@ App.prototype.renderBackButton = function (style, justArrow = false) {
       }, 'BACK'),
     ])
   )
-}
-
-App.prototype.renderBackToInitButton = function () {
-  var props = this.props
-  var button = null
-  if (!props.isDisclaimerConfirmed) return button
-
-  if (!props.isUnlocked) {
-    if (props.currentView.name === 'InitMenu') {
-      button = props.forgottenPassword ? h('.flex-row', {
-        key: 'rightArrow',
-        style: {
-          position: 'absolute',
-          bottom: '10px',
-          right: '15px',
-          fontSize: '21px',
-          fontFamily: 'Montserrat Light',
-          color: '#7F8082',
-          width: '77.578px',
-          alignItems: 'flex-end',
-        },
-      }, [
-        h('div.cursor-pointer', {
-          style: {
-            marginRight: '3px',
-          },
-          onClick: () => props.dispatch(actions.backToUnlockView()),
-        }, 'LOGIN'),
-        h('i.fa.fa-arrow-right.cursor-pointer'),
-      ]) : null
-    }
-  }
-  return button
 }
 
 App.prototype.renderPrimary = function () {

--- a/ui/app/first-time/init-menu.js
+++ b/ui/app/first-time/init-menu.js
@@ -21,6 +21,7 @@ function mapStateToProps (state) {
     // state from plugin
     currentView: state.appState.currentView,
     warning: state.appState.warning,
+    forgottenPassword: state.appState.forgottenPassword,
   }
 }
 
@@ -128,6 +129,17 @@ InitializeMenuScreen.prototype.renderMenu = function (state) {
         }, 'I already have a DEN that I would like to import'),
       ]),
 
+      state.forgottenPassword ? h('.flex-row.flex-center.flex-grow', [
+        h('p.pointer', {
+          onClick: this.backToUnlockView.bind(this),
+          style: {
+            fontSize: '0.8em',
+            color: 'rgb(247, 134, 28)',
+            textDecoration: 'underline',
+          },
+        }, 'I remember my password!'),
+      ]) : null,
+
     ])
   )
 }
@@ -145,6 +157,10 @@ InitializeMenuScreen.prototype.componentDidMount = function () {
 
 InitializeMenuScreen.prototype.showRestoreVault = function () {
   this.props.dispatch(actions.showRestoreVault())
+}
+
+InitializeMenuScreen.prototype.backToUnlockView = function () {
+  this.props.dispatch(actions.backToUnlockView())
 }
 
 InitializeMenuScreen.prototype.createNewVaultAndKeychain = function () {

--- a/ui/app/first-time/init-menu.js
+++ b/ui/app/first-time/init-menu.js
@@ -21,7 +21,7 @@ function mapStateToProps (state) {
     // state from plugin
     currentView: state.appState.currentView,
     warning: state.appState.warning,
-    forgottenPassword: state.appState.forgottenPassword,
+    forgottenPassword: state.metamask.isInitialized,
   }
 }
 
@@ -118,17 +118,6 @@ InitializeMenuScreen.prototype.renderMenu = function (state) {
         },
       }, 'Create'),
 
-      h('.flex-row.flex-center.flex-grow', [
-        h('p.pointer', {
-          onClick: this.showRestoreVault.bind(this),
-          style: {
-            fontSize: '0.8em',
-            color: 'rgb(247, 134, 28)',
-            textDecoration: 'underline',
-          },
-        }, 'I already have a DEN that I would like to import'),
-      ]),
-
       state.forgottenPassword ? h('.flex-row.flex-center.flex-grow', [
         h('p.pointer', {
           onClick: this.backToUnlockView.bind(this),
@@ -137,8 +126,19 @@ InitializeMenuScreen.prototype.renderMenu = function (state) {
             color: 'rgb(247, 134, 28)',
             textDecoration: 'underline',
           },
-        }, 'I remember my password!'),
+        }, 'Return to Login'),
       ]) : null,
+
+      h('.flex-row.flex-center.flex-grow', [
+        h('p.pointer', {
+          onClick: this.showRestoreVault.bind(this),
+          style: {
+            fontSize: '0.8em',
+            color: 'rgb(247, 134, 28)',
+            textDecoration: 'underline',
+          },
+        }, 'Import Existing DEN'),
+      ]),
 
     ])
   )

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -233,6 +233,7 @@ function reduceApp (state, action) {
         isLoading: false,
         warning: null,
         scrollToBottom: false,
+        forgottenPassword: false,
       })
 
     case actions.REVEAL_ACCOUNT:

--- a/ui/app/unlock.js
+++ b/ui/app/unlock.js
@@ -70,7 +70,7 @@ UnlockScreen.prototype.render = function () {
 
       h('.flex-row.flex-center.flex-grow', [
         h('p.pointer', {
-          onClick: () => this.props.dispatch(actions.showRestoreVault()),
+          onClick: () => this.props.dispatch(actions.goBackToInitView()),
           style: {
             fontSize: '0.8em',
             color: 'rgb(247, 134, 28)',
@@ -116,4 +116,3 @@ UnlockScreen.prototype.inputChanged = function (event) {
     y: boundingRect.top + coordinates.top - element.scrollTop,
   })
 }
-


### PR DESCRIPTION
We didn't need to rewrite a new function for showing the init screen again--we have a method for this. Alongside this, we also removed the 'back to login' button, primarily because it can't fit in the current view. We can add it back in (the way to get back from a lost password to the lock screen again is closing and re-opening the popup), but we'd have to make room for the button.

Fixes #865 