### PR TITLE
Modify Keyring protocol to always return promises for public methods

### DIFF
--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -281,7 +281,7 @@ module.exports = class KeyringController extends EventEmitter {
   }
 
   persistAllKeyrings () {
-    Promise.all(this.keyrings.map((keyring) => {
+    return Promise.all(this.keyrings.map((keyring) => {
       return Promise.all([keyring.type, keyring.serialize()])
       .then((serializedKeyringArray) => {
         // Label the output values on each serialized Keyring:
@@ -314,13 +314,14 @@ module.exports = class KeyringController extends EventEmitter {
     const { type, data } = serialized
     const Keyring = this.getKeyringClassForType(type)
     const keyring = new Keyring()
-    keyring.deserialize(data)
+    return keyring.deserialize(data)
     .then(() => {
       return keyring.getAccounts()
     })
     .then((accounts) => {
       this.setupAccounts(accounts)
       this.keyrings.push(keyring)
+      return keyring
     })
   }
 

--- a/app/scripts/keyrings/hd.js
+++ b/app/scripts/keyrings/hd.js
@@ -21,10 +21,10 @@ class HdKeyring extends EventEmitter {
   }
 
   serialize () {
-    return {
+    return Promise.resolve({
       mnemonic: this.mnemonic,
       numberOfAccounts: this.wallets.length,
-    }
+    })
   }
 
   deserialize (opts = {}) {
@@ -40,6 +40,8 @@ class HdKeyring extends EventEmitter {
     if ('numberOfAccounts' in opts) {
       this.addAccounts(opts.numberOfAccounts)
     }
+
+    return Promise.resolve()
   }
 
   addAccounts (numberOfAccounts = 1) {
@@ -55,11 +57,12 @@ class HdKeyring extends EventEmitter {
       newWallets.push(wallet)
       this.wallets.push(wallet)
     }
-    return newWallets.map(w => w.getAddress().toString('hex'))
+    const hexWallets = newWallets.map(w => w.getAddress().toString('hex'))
+    return Promise.resolve(hexWallets)
   }
 
   getAccounts () {
-    return this.wallets.map(w => w.getAddress().toString('hex'))
+    return Promise.resolve(this.wallets.map(w => w.getAddress().toString('hex')))
   }
 
   // tx is an instance of the ethereumjs-transaction class.
@@ -67,7 +70,7 @@ class HdKeyring extends EventEmitter {
     const wallet = this._getWalletForAccount(address)
     var privKey = wallet.getPrivateKey()
     tx.sign(privKey)
-    return tx
+    return Promise.resolve(tx)
   }
 
   // For eth_sign, we need to sign transactions:
@@ -77,12 +80,12 @@ class HdKeyring extends EventEmitter {
     var privKey = wallet.getPrivateKey()
     var msgSig = ethUtil.ecsign(new Buffer(message, 'hex'), privKey)
     var rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
-    return rawMsgSig
+    return Promise.resolve(rawMsgSig)
   }
 
   exportAccount (address) {
     const wallet = this._getWalletForAccount(address)
-    return wallet.getPrivateKey().toString('hex')
+    return Promise.resolve(wallet.getPrivateKey().toString('hex'))
   }
 
 

--- a/app/scripts/keyrings/simple.js
+++ b/app/scripts/keyrings/simple.js
@@ -8,10 +8,6 @@ class SimpleKeyring extends EventEmitter {
 
   /* PUBLIC METHODS */
 
-  static type () {
-    return type
-  }
-
   constructor (opts) {
     super()
     this.type = type
@@ -20,7 +16,7 @@ class SimpleKeyring extends EventEmitter {
   }
 
   serialize () {
-    return this.wallets.map(w => w.getPrivateKey().toString('hex'))
+    return Promise.resolve(this.wallets.map(w => w.getPrivateKey().toString('hex')))
   }
 
   deserialize (wallets = []) {
@@ -29,6 +25,7 @@ class SimpleKeyring extends EventEmitter {
       const wallet = Wallet.fromPrivateKey(b)
       return wallet
     })
+    return Promise.resolve()
   }
 
   addAccounts (n = 1) {
@@ -37,11 +34,12 @@ class SimpleKeyring extends EventEmitter {
       newWallets.push(Wallet.generate())
     }
     this.wallets = this.wallets.concat(newWallets)
-    return newWallets.map(w => w.getAddress().toString('hex'))
+    const hexWallets = newWallets.map(w => w.getAddress().toString('hex'))
+    return Promise.resolve(hexWallets)
   }
 
   getAccounts () {
-    return this.wallets.map(w => w.getAddress().toString('hex'))
+    return Promise.resolve(this.wallets.map(w => w.getAddress().toString('hex')))
   }
 
   // tx is an instance of the ethereumjs-transaction class.
@@ -49,7 +47,7 @@ class SimpleKeyring extends EventEmitter {
     const wallet = this._getWalletForAccount(address)
     var privKey = wallet.getPrivateKey()
     tx.sign(privKey)
-    return tx
+    return Promise.resolve(tx)
   }
 
   // For eth_sign, we need to sign transactions:
@@ -59,12 +57,12 @@ class SimpleKeyring extends EventEmitter {
     var privKey = wallet.getPrivateKey()
     var msgSig = ethUtil.ecsign(new Buffer(message, 'hex'), privKey)
     var rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
-    return rawMsgSig
+    return Promise.resolve(rawMsgSig)
   }
 
   exportAccount (address) {
     const wallet = this._getWalletForAccount(address)
-    return wallet.getPrivateKey().toString('hex')
+    return Promise.resolve(wallet.getPrivateKey().toString('hex'))
   }
 
 

--- a/test/unit/keyring-controller-test.js
+++ b/test/unit/keyring-controller-test.js
@@ -77,8 +77,15 @@ describe('KeyringController', function() {
       keyringController.restoreKeyring(mockSerialized)
       .then((keyring) => {
         assert.equal(keyring.wallets.length, 1, 'one wallet restored')
-        assert.equal(keyring.getAccounts()[0], addresses[0])
+        return keyring.getAccounts()
+      })
+      .then((accounts) => {
+        assert.equal(accounts[0], addresses[0])
         mock.verify()
+        done()
+      })
+      .catch((reason) => {
+        assert.ifError(reason)
         done()
       })
     })

--- a/test/unit/keyrings/hd-test.js
+++ b/test/unit/keyrings/hd-test.js
@@ -16,15 +16,18 @@ describe('hd-keyring', function() {
     keyring = new HdKeyring()
   })
 
-  describe('constructor', function() {
+  describe('constructor', function(done) {
     keyring = new HdKeyring({
       mnemonic: sampleMnemonic,
       numberOfAccounts: 2,
     })
 
     const accounts = keyring.getAccounts()
-    assert.equal(accounts[0], firstAcct)
-    assert.equal(accounts[1], secondAcct)
+    .then((accounts) => {
+      assert.equal(accounts[0], firstAcct)
+      assert.equal(accounts[1], secondAcct)
+      done()
+    })
   })
 
   describe('Keyring.type', function() {
@@ -44,49 +47,62 @@ describe('hd-keyring', function() {
 
   describe('#serialize empty wallets.', function() {
     it('serializes a new mnemonic', function() {
-      const output = keyring.serialize()
-      assert.equal(output.numberOfAccounts, 0)
-      assert.equal(output.mnemonic, null)
+      keyring.serialize()
+      .then((output) => {
+        assert.equal(output.numberOfAccounts, 0)
+        assert.equal(output.mnemonic, null)
+      })
     })
   })
 
   describe('#deserialize a private key', function() {
-    it('serializes what it deserializes', function() {
+    it('serializes what it deserializes', function(done) {
       keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1
       })
-      assert.equal(keyring.wallets.length, 1, 'restores two accounts')
-      keyring.addAccounts(1)
+      .then(() => {
+        assert.equal(keyring.wallets.length, 1, 'restores two accounts')
+        keyring.addAccounts(1)
 
-      const accounts = keyring.getAccounts()
-      assert.equal(accounts[0], firstAcct)
-      assert.equal(accounts[1], secondAcct)
-      assert.equal(accounts.length, 2)
+        const accounts = keyring.getAccounts()
+        assert.equal(accounts[0], firstAcct)
+        assert.equal(accounts[1], secondAcct)
+        assert.equal(accounts.length, 2)
 
-      const serialized = keyring.serialize()
-      assert.equal(serialized.mnemonic, sampleMnemonic)
+        keyring.serialize()
+        .then((serialized) => {
+          assert.equal(serialized.mnemonic, sampleMnemonic)
+          done()
+        })
+      })
     })
   })
 
   describe('#addAccounts', function() {
     describe('with no arguments', function() {
-      it('creates a single wallet', function() {
+      it('creates a single wallet', function(done) {
         keyring.addAccounts()
-        assert.equal(keyring.wallets.length, 1)
+        .then(() => {
+          assert.equal(keyring.wallets.length, 1)
+          done()
+        })
       })
     })
 
     describe('with a numeric argument', function() {
-      it('creates that number of wallets', function() {
+      it('creates that number of wallets', function(done) {
         keyring.addAccounts(3)
-        assert.equal(keyring.wallets.length, 3)
+        .then(() => {
+          assert.equal(keyring.wallets.length, 3)
+          done()
+        })
       })
     })
   })
 
   describe('#getAccounts', function() {
-    it('calls getAddress on each wallet', function() {
+    it('calls getAddress on each wallet', function(done) {
 
       // Push a mock wallet
       const desiredOutput = 'foo'
@@ -101,8 +117,11 @@ describe('hd-keyring', function() {
       })
 
       const output = keyring.getAccounts()
-      assert.equal(output[0], desiredOutput)
-      assert.equal(output.length, 1)
+      .then((output) => {
+        assert.equal(output[0], desiredOutput)
+        assert.equal(output.length, 1)
+        done()
+      })
     })
   })
 })

--- a/test/unit/keyrings/hd-test.js
+++ b/test/unit/keyrings/hd-test.js
@@ -57,24 +57,26 @@ describe('hd-keyring', function() {
 
   describe('#deserialize a private key', function() {
     it('serializes what it deserializes', function(done) {
+      console.log('deserializing ' + sampleMnemonic)
       keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1
       })
       .then(() => {
+        console.dir(keyring)
         assert.equal(keyring.wallets.length, 1, 'restores two accounts')
-        keyring.addAccounts(1)
-
-        const accounts = keyring.getAccounts()
+        return keyring.addAccounts(1)
+      }).then(() => {
+        return keyring.getAccounts()
+      }).then((accounts) => {
         assert.equal(accounts[0], firstAcct)
         assert.equal(accounts[1], secondAcct)
         assert.equal(accounts.length, 2)
 
-        keyring.serialize()
-        .then((serialized) => {
-          assert.equal(serialized.mnemonic, sampleMnemonic)
-          done()
-        })
+        return keyring.serialize()
+      }).then((serialized) => {
+        assert.equal(serialized.mnemonic, sampleMnemonic)
+        done()
       })
     })
   })

--- a/test/unit/keyrings/simple-test.js
+++ b/test/unit/keyrings/simple-test.js
@@ -28,19 +28,23 @@ describe('simple-keyring', function() {
   })
 
   describe('#serialize empty wallets.', function() {
-    it('serializes an empty array', function() {
-      const output = keyring.serialize()
-      assert.deepEqual(output, [])
+    it('serializes an empty array', function(done) {
+      keyring.serialize()
+      .then((output) => {
+        assert.deepEqual(output, [])
+        done()
+      })
     })
   })
 
   describe('#deserialize a private key', function() {
     it('serializes what it deserializes', function() {
       keyring.deserialize([privKeyHex])
-      assert.equal(keyring.wallets.length, 1, 'has one wallet')
-
-      const serialized = keyring.serialize()
-      assert.equal(serialized[0], privKeyHex)
+      .then(() => {
+        assert.equal(keyring.wallets.length, 1, 'has one wallet')
+        const serialized = keyring.serialize()
+        assert.equal(serialized[0], privKeyHex)
+      })
     })
   })
 
@@ -48,20 +52,24 @@ describe('simple-keyring', function() {
     describe('with no arguments', function() {
       it('creates a single wallet', function() {
         keyring.addAccounts()
-        assert.equal(keyring.wallets.length, 1)
+        .then(() => {
+          assert.equal(keyring.wallets.length, 1)
+        })
       })
     })
 
     describe('with a numeric argument', function() {
       it('creates that number of wallets', function() {
         keyring.addAccounts(3)
-        assert.equal(keyring.wallets.length, 3)
+        .then(() => {
+          assert.equal(keyring.wallets.length, 3)
+        })
       })
     })
   })
 
   describe('#getAccounts', function() {
-    it('calls getAddress on each wallet', function() {
+    it('calls getAddress on each wallet', function(done) {
 
       // Push a mock wallet
       const desiredOutput = 'foo'
@@ -75,9 +83,12 @@ describe('simple-keyring', function() {
         }
       })
 
-      const output = keyring.getAccounts()
-      assert.equal(output[0], desiredOutput)
-      assert.equal(output.length, 1)
+      keyring.getAccounts()
+      .then((output) => {
+        assert.equal(output[0], desiredOutput)
+        assert.equal(output.length, 1)
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes #844 

Converts the Keyring API over to one where all public methods (other than the constructor) return promises, and so are able to resolve asynchronously.

This will be important for remote signing strategies, so it's good that we caught this early.