### PR TITLE
Remove morden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix broken reload detection.
 - Fix transaction forever cached-as-pending bug.
+- Removed Morden testnet provider from provider menu.
 
 ## 2.13.11 2016-11-23
 

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -1,6 +1,5 @@
 const MAINET_RPC_URL = 'https://mainnet.infura.io/metamask'
 const TESTNET_RPC_URL = 'https://ropsten.infura.io/metamask'
-const MORDEN_RPC_URL = 'https://morden.infura.io/metamask'
 const DEFAULT_RPC_URL = TESTNET_RPC_URL
 
 global.METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
@@ -11,6 +10,6 @@ module.exports = {
     default: DEFAULT_RPC_URL,
     mainnet: MAINET_RPC_URL,
     testnet: TESTNET_RPC_URL,
-    morden: MORDEN_RPC_URL,
+    morden: TESTNET_RPC_URL,
   },
 }

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -244,15 +244,6 @@ App.prototype.renderNetworkDropdown = function () {
     }),
 
     h(DropMenuItem, {
-      label: 'Morden Test Network',
-      closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
-      action: () => props.dispatch(actions.setProviderType('morden')),
-      icon: h('.menu-icon.red-dot'),
-      activeNetworkRender: props.network,
-      provider: props.provider,
-    }),
-
-    h(DropMenuItem, {
       label: 'Localhost 8545',
       closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
       action: () => props.dispatch(actions.setRpcTarget('http://localhost:8545')),

--- a/ui/app/components/drop-menu-item.js
+++ b/ui/app/components/drop-menu-item.js
@@ -44,9 +44,6 @@ DropMenuItem.prototype.activeNetworkRender = function () {
     case 'Ropsten Test Network':
       if (provider.type === 'testnet') return h('.check', '✓')
       break
-    case 'Morden Test Network':
-      if (provider.type === 'morden') return h('.check', '✓')
-      break
     case 'Localhost 8545':
       if (activeNetwork === 'http://localhost:8545') return h('.check', '✓')
       break

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -42,9 +42,6 @@ Network.prototype.render = function () {
   } else if (parseInt(networkNumber) === 3) {
     hoverText = 'Ropsten Test Network'
     iconName = 'ropsten-test-network'
-  } else if (parseInt(networkNumber) === 2) {
-    hoverText = 'Morden Test Network'
-    iconName = 'morden-test-network'
   } else {
     hoverText = 'Unknown Private Network'
     iconName = 'unknown-private-network'
@@ -78,15 +75,6 @@ Network.prototype.render = function () {
                   color: '#ff6666',
                 }},
               'Ropsten Test Net'),
-            ])
-          case 'morden-test-network':
-            return h('.network-indicator', [
-              h('.menu-icon.red-dot'),
-              h('.network-name', {
-                style: {
-                  color: '#ff6666',
-                }},
-              'Morden Test Net'),
             ])
           default:
             return h('.network-indicator', [

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -133,7 +133,7 @@ function currentProviderDisplay (metamaskState) {
 
     case 'testnet':
       title = 'Current Network'
-      value = 'Morden Test Network'
+      value = 'Ropsten Test Network'
       break
 
     default:


### PR DESCRIPTION
Removes morden Infura provider from provider menu.

Previous morden users will now be pointed at Ropsten.

Notification of the change will be added in another PR.