### PR TITLE
inpage - temporarily disable ping stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Fix broken reload detection.
+- Temporarily disable extension reload detection causing infinite reload bug.
 - Fix transaction forever cached-as-pending bug.
 - Removed Morden testnet provider from provider menu.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Temporarily disable extension reload detection causing infinite reload bug.
+
 ## 2.14.0 2016-12-16
 
 - Removed Morden testnet provider from provider menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,16 @@
 ## Current Master
 
 - Temporarily disable extension reload detection causing infinite reload bug.
-- Fix transaction forever cached-as-pending bug.
+## 2.14.0 2016-12-16
+
 - Removed Morden testnet provider from provider menu.
+- Add support for notices.
+- Fix broken reload detection.
+- Fix transaction forever cached-as-pending bug.
 
 ## 2.13.11 2016-11-23
 
 - Add support for synchronous RPC method "eth_uninstallFilter".
-- Add support for notices.
-- Add support for working links.
 
 ## 2.13.10 2016-11-22
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "2.13.11",
+  "version": "2.14.0",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -2,8 +2,8 @@
 cleanContextForImports()
 require('web3/dist/web3.min.js')
 const LocalMessageDuplexStream = require('post-message-stream')
-const PingStream = require('ping-pong-stream/ping')
-const endOfStream = require('end-of-stream')
+// const PingStream = require('ping-pong-stream/ping')
+// const endOfStream = require('end-of-stream')
 const setupDappAutoReload = require('./lib/auto-reload.js')
 const MetamaskInpageProvider = require('./lib/inpage-provider.js')
 restoreContextAfterImports()
@@ -40,13 +40,14 @@ reloadStream.once('data', triggerReload)
 
 // setup ping timeout autoreload
 // LocalMessageDuplexStream does not self-close, so reload if pingStream fails
-var pingChannel = inpageProvider.multiStream.createStream('pingpong')
-var pingStream = new PingStream({ objectMode: true })
+// var pingChannel = inpageProvider.multiStream.createStream('pingpong')
+// var pingStream = new PingStream({ objectMode: true })
 // wait for first successful reponse
-metamaskStream.once('data', function(){
-  pingStream.pipe(pingChannel).pipe(pingStream)
-})
-endOfStream(pingStream, triggerReload)
+// disable pingStream until https://github.com/MetaMask/metamask-plugin/issues/746 is resolved more gracefully
+// metamaskStream.once('data', function(){
+//   pingStream.pipe(pingChannel).pipe(pingStream)
+// })
+// endOfStream(pingStream, triggerReload)
 
 // set web3 defaultAcount
 inpageProvider.publicConfigStore.subscribe(function (state) {


### PR DESCRIPTION
PingStream was finding false-positives for timeouts, causing issues.
This is a hot patch to disable it until a better solution is found.
See https://github.com/MetaMask/metamask-plugin/issues/746