### PR TITLE
Remove log

### DIFF
--- a/app/scripts/lib/inpage-provider.js
+++ b/app/scripts/lib/inpage-provider.js
@@ -119,7 +119,6 @@ function remoteStoreWithLocalStorageCache (storageKey) {
   var store = new RemoteStore(initState)
   // cache the latest state locally
   store.subscribe(function (state) {
-    console.log('received state update %s of %s', storageKey, state)
     localStorage[storageKey] = JSON.stringify(state)
   })
 


### PR DESCRIPTION
I accidentally pushed over `dev` with [this commit](https://github.com/MetaMask/metamask-plugin/commit/98527c1c254fe2d438191c73053dcf3223062ef3).


The message was:

It seems `selectedAddress` was removed from the keyring-controller’s state, and is used to populate the injected current account.

I couldn't help myself, I dug around, I found a PR named [changed all instances of selectedAddress to selectedAccount](f5b0795) by @Zanibas.  Sorry, Kevin!  Had you actually changed all instances, this bug would not have happened.

Fixes #908