### PR TITLE
Update UI state on ethStore updates

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -60,6 +60,8 @@ module.exports = class MetamaskController {
     this.idStoreMigrator = new IdStoreMigrator({
       configManager: this.configManager,
     })
+
+    this.ethStore.on('update', this.sendUpdate.bind(this))
   }
 
   getState () {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -163,8 +163,12 @@ module.exports = class MetamaskController {
   }
 
   sendUpdate () {
-    this.listeners.forEach((remote) => {
-      remote.sendUpdate(this.getState())
+    this.getState()
+    .then((state) => {
+
+      this.listeners.forEach((remote) => {
+        remote.sendUpdate(state)
+      })
     })
   }
 


### PR DESCRIPTION
UI was remarkably not relying on ethStore for updates, so things like account balances were frozen until user activity.

Fixes #963