### PR TITLE
Network indicator modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Remove certain non-essential permissions from certain builds.
 - Add a check for when a tx is included in a block.
+- Minor modifications to network display.
+- Network now displays properly for pending transactions.
 
 ## 2.14.1 2016-12-20
 

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -144,7 +144,7 @@ App.prototype.renderAppBar = function () {
           h('#network-spacer.flex-center', {
             style: {
               marginRight: '-72px',
-            }
+            },
           }, [
             h(NetworkIndicator, {
               network: this.props.network,

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -141,15 +141,21 @@ App.prototype.renderAppBar = function () {
             src: '/images/icon-128.png',
           }),
 
-          h(NetworkIndicator, {
-            network: this.props.network,
-            provider: this.props.provider,
-            onClick: (event) => {
-              event.preventDefault()
-              event.stopPropagation()
-              this.setState({ isNetworkMenuOpen: !isNetworkMenuOpen })
-            },
-          }),
+          h('#network-spacer.flex-center', {
+            style: {
+              marginRight: '-72px',
+            }
+          }, [
+            h(NetworkIndicator, {
+              network: this.props.network,
+              provider: this.props.provider,
+              onClick: (event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                this.setState({ isNetworkMenuOpen: !isNetworkMenuOpen })
+              },
+            }),
+          ]),
         ]),
 
         // metamask name

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -13,6 +13,7 @@ function Network () {
 Network.prototype.render = function () {
   const props = this.props
   const networkNumber = props.network
+  const style = props.style
   let providerName
   try {
     providerName = props.provider.type
@@ -46,11 +47,7 @@ Network.prototype.render = function () {
   }
 
   return (
-    h('#network_component.flex-center.pointer', {
-      style: {
-        marginRight: '-27px',
-        marginLeft: '-3px',
-      },
+    h('#network_component.pointer', {
       title: hoverText,
       onClick: (event) => this.props.onClick(event),
     }, [

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -13,7 +13,6 @@ function Network () {
 Network.prototype.render = function () {
   const props = this.props
   const networkNumber = props.network
-  const style = props.style
   let providerName
   try {
     providerName = props.provider.type

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -56,11 +56,11 @@ ConfirmTxScreen.prototype.render = function () {
         !isNotification ? h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
           onClick: this.goHome.bind(this),
         }) : null,
+        h('h2.page-subtitle', 'Confirm Transaction'),
         isNotification ? h(NetworkIndicator, {
           network: network,
           provider: provider,
         }) : null,
-        h('h2.page-subtitle', 'Confirm Transaction'),
       ]),
 
       h('h3', {

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -4,6 +4,7 @@ const ReactCSSTransitionGroup = require('react-addons-css-transition-group')
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 const actions = require('./actions')
+const NetworkIndicator = require('./components/network')
 const txHelper = require('../lib/tx-helper')
 const isPopupOrNotification = require('../../app/scripts/lib/is-popup-or-notification')
 const ethUtil = require('ethereumjs-util')
@@ -24,6 +25,7 @@ function mapStateToProps (state) {
     index: state.appState.currentView.context,
     warning: state.appState.warning,
     network: state.metamask.network,
+    provider: state.metamask.provider,
   }
 }
 
@@ -36,6 +38,7 @@ ConfirmTxScreen.prototype.render = function () {
   var state = this.props
 
   var network = state.network
+  var provider = state.provider
   var unconfTxs = state.unconfTxs
   var unconfMsgs = state.unconfMsgs
   var unconfTxList = txHelper(unconfTxs, unconfMsgs, network)
@@ -52,6 +55,10 @@ ConfirmTxScreen.prototype.render = function () {
       h('.section-title.flex-row.flex-center', [
         !isNotification ? h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
           onClick: this.goHome.bind(this),
+        }) : null,
+        isNotification ? h(NetworkIndicator, {
+          network: network,
+          provider: provider,
         }) : null,
         h('h2.page-subtitle', 'Confirm Transaction'),
       ]),

--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -165,9 +165,6 @@ textarea.twelve-word-phrase {
 }
 
 .network-name {
-  position: absolute;
-  top: 8px;
-  left: 60px;
   width: 5.2em;
   line-height: 9px;
   text-rendering: geometricPrecision;


### PR DESCRIPTION
Made the network indicator a bit more modular so it can be more easily used in other parts of the app, as well as added a network indicator in the tx confirmation. Solves #924.

Shows up in the notification.
![screenshot from 2017-01-04 15-10-11](https://cloud.githubusercontent.com/assets/1840057/21662665/f7b6abd8-d28f-11e6-9ab2-ed1fa0597626.png)

Hides itself in the popup.
![screenshot from 2017-01-04 15-10-22](https://cloud.githubusercontent.com/assets/1840057/21662668/fb4e20a0-d28f-11e6-8ce2-6f343afc1d34.png)
