### PR TITLE
Fix browser solidity error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove certain non-essential permissions from certain builds.
 - Add a check for when a tx is included in a block.
+- Fix bug where browser-solidity would sometimes warn of a contract creation error when there was none.
 - Minor modifications to network display.
 - Network now displays properly for pending transactions.
 - Implement replay attack protections allowed by EIP 155.

--- a/app/scripts/lib/tx-utils.js
+++ b/app/scripts/lib/tx-utils.js
@@ -20,7 +20,6 @@ module.exports = class txProviderUtils {
       if (err) return cb(err)
       async.waterfall([
         self.estimateTxGas.bind(self, txData, block.gasLimit),
-        self.checkForTxGasError.bind(self, txData),
         self.setTxGas.bind(self, txData, block.gasLimit),
       ], cb)
     })
@@ -38,22 +37,10 @@ module.exports = class txProviderUtils {
     this.query.estimateGas(txParams, cb)
   }
 
-  checkForTxGasError (txData, estimatedGasHex, cb) {
+  setTxGas (txData, blockGasLimitHex, estimatedGasHex, cb) {
     txData.estimatedGas = estimatedGasHex
-    // all gas used - must be an error
-    if (estimatedGasHex === txData.txParams.gas) {
-      txData.simulationFails = true
-    }
-    cb()
-  }
-
-  setTxGas (txData, blockGasLimitHex, cb) {
     const txParams = txData.txParams
-    // if OOG, nothing more to do
-    if (txData.simulationFails) {
-      cb()
-      return
-    }
+
     // if gasLimit was specified and doesnt OOG,
     // use original specified amount
     if (txData.gasLimitSpecified) {


### PR DESCRIPTION
Fixes #947 

Removes our current out of gas error detection from the tx approval view, so it should now be replaced with something more accurate.