### PR TITLE
bugfix - portstream - dont wrap cb in try catch

### DIFF
--- a/app/scripts/lib/port-stream.js
+++ b/app/scripts/lib/port-stream.js
@@ -51,11 +51,11 @@ PortDuplexStream.prototype._write = function (msg, encoding, cb) {
       // console.log('PortDuplexStream - sent message', msg)
       this._port.postMessage(msg)
     }
-    cb()
   } catch (err) {
     // console.error(err)
-    cb(new Error('PortDuplexStream - disconnected'))
+    return cb(new Error('PortDuplexStream - disconnected'))
   }
+  cb()
 }
 
 // util


### PR DESCRIPTION
Updates #960

This should take care of most of the cases with #960, but there could be more

We were accidentally wrapping the synchronous portion of the continuation (`cb`) in a try catch. This is why promises are usually superior.