### PR TITLE
Dont render conf-tx if their are no txParams to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Fix Bug where you see a empty transaction flash by on the confirm transaction view.
 - Create visible difference in transaction history between a approved but not yet included in a block transaction and a transaction who has been confirmed.
 - Fix memory leak in RPC Cache
 - Override RPC commands eth_syncing and web3_clientVersion

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -43,9 +43,11 @@ ConfirmTxScreen.prototype.render = function () {
   var unconfMsgs = state.unconfMsgs
   var unconfTxList = txHelper(unconfTxs, unconfMsgs, network)
   var index = state.index !== undefined ? state.index : 0
-  var txData = unconfTxList[index] || {txParams: {}}
-  var txParams = txData.txParams || {}
+  var txData = unconfTxList[index] || {}
+  var txParams = txData.txParams
   var isNotification = isPopupOrNotification() === 'notification'
+  if (!txParams) return null
+
   return (
 
     h('.flex-column.flex-grow', [


### PR DESCRIPTION
Before maybe you saw a quick flash of a tx on the conf page that had no params this should fix that temporarily. However we should figure out a better solution sometime in the future. I think part of the cause is its trying to render the view before the state has updated and doesn't have the unconfTxList yet, and then re-rendering once the sate has updated. 