### PR TITLE
keyring - simple - fix address generation

### DIFF
--- a/app/scripts/keyrings/simple.js
+++ b/app/scripts/keyrings/simple.js
@@ -35,12 +35,12 @@ class SimpleKeyring extends EventEmitter {
       newWallets.push(Wallet.generate())
     }
     this.wallets = this.wallets.concat(newWallets)
-    const hexWallets = newWallets.map(w => w.getAddress().toString('hex'))
+    const hexWallets = newWallets.map(w => ethUtil.bufferToHex(w.getAddress()))
     return Promise.resolve(hexWallets)
   }
 
   getAccounts () {
-    return Promise.resolve(this.wallets.map(w => w.getAddress().toString('hex')))
+    return Promise.resolve(this.wallets.map(w => ethUtil.bufferToHex(w.getAddress())))
   }
 
   // tx is an instance of the ethereumjs-transaction class.
@@ -70,7 +70,7 @@ class SimpleKeyring extends EventEmitter {
   /* PRIVATE METHODS */
 
   _getWalletForAccount (account) {
-    return this.wallets.find(w => w.getAddress().toString('hex') === account)
+    return this.wallets.find(w => ethUtil.bufferToHex(w.getAddress()) === account)
   }
 
 }

--- a/app/scripts/keyrings/simple.js
+++ b/app/scripts/keyrings/simple.js
@@ -54,6 +54,7 @@ class SimpleKeyring extends EventEmitter {
   // For eth_sign, we need to sign transactions:
   signMessage (withAccount, data) {
     const wallet = this._getWalletForAccount(withAccount)
+
     const message = ethUtil.removeHexPrefix(data)
     var privKey = wallet.getPrivateKey()
     var msgSig = ethUtil.ecsign(new Buffer(message, 'hex'), privKey)
@@ -70,7 +71,9 @@ class SimpleKeyring extends EventEmitter {
   /* PRIVATE METHODS */
 
   _getWalletForAccount (account) {
-    return this.wallets.find(w => ethUtil.bufferToHex(w.getAddress()) === account)
+    let wallet = this.wallets.find(w => ethUtil.bufferToHex(w.getAddress()) === account)
+    if (!wallet) throw new Error('Simple Keyring - Unable to find matching address.')
+    return wallet
   }
 
 }

--- a/test/unit/keyrings/simple-test.js
+++ b/test/unit/keyrings/simple-test.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const extend = require('xtend')
+const ethUtil = require('ethereumjs-util')
 const SimpleKeyring = require('../../../app/scripts/keyrings/simple')
 const TYPE_STR = 'Simple Key Pair'
 
@@ -72,14 +73,10 @@ describe('simple-keyring', function() {
     it('calls getAddress on each wallet', function(done) {
 
       // Push a mock wallet
-      const desiredOutput = 'foo'
+      const desiredOutput = '0x18a3462427bcc9133bb46e88bcbe39cd7ef0e761'
       keyring.wallets.push({
         getAddress() {
-          return {
-            toString() {
-              return desiredOutput
-            }
-          }
+          return ethUtil.toBuffer(desiredOutput)
         }
       })
 


### PR DESCRIPTION
This:
* fixes an issue where simple keyring could not get the wallet object for an address
* adds a more semantic error for looking up a wallet for an unrecognized address
* improves fixture data used in a test