### PR TITLE
Fix eth.sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+## 3.0.1 2017-1-17
+
 - Fixed bug that prevented eth.sign from working.
 
 ## 3.0.0 2017-1-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fixed bug that prevented eth.sign from working.
+
 ## 3.0.0 2017-1-16
 
 - Fix seed word account generation (https://medium.com/metamask/metamask-3-migration-guide-914b79533cdd#.t4i1qmmsz).

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -397,6 +397,7 @@ module.exports = class KeyringController extends EventEmitter {
       }).then((rawSig) => {
         cb(null, rawSig)
         approvalCb(null, true)
+        messageManager.confirmMsg(msgId)
         return rawSig
       })
     } catch (e) {

--- a/app/scripts/keyrings/hd.js
+++ b/app/scripts/keyrings/hd.js
@@ -76,7 +76,7 @@ class HdKeyring extends EventEmitter {
   // For eth_sign, we need to sign transactions:
   signMessage (withAccount, data) {
     const wallet = this._getWalletForAccount(withAccount)
-    const message = ethUtil.removeHexPrefix(data)
+    const message = ethUtil.stripHexPrefix(data)
     var privKey = wallet.getPrivateKey()
     var msgSig = ethUtil.ecsign(new Buffer(message, 'hex'), privKey)
     var rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -41,12 +41,13 @@ ConfirmTxScreen.prototype.render = function () {
   var provider = state.provider
   var unconfTxs = state.unconfTxs
   var unconfMsgs = state.unconfMsgs
+
   var unconfTxList = txHelper(unconfTxs, unconfMsgs, network)
-  var index = state.index !== undefined ? state.index : 0
+  var index = state.index !== undefined && unconfTxList[index] ? state.index : 0
   var txData = unconfTxList[index] || {}
-  var txParams = txData.txParams
+  var txParams = txData.params || {}
   var isNotification = isPopupOrNotification() === 'notification'
-  if (!txParams) return null
+  if (unconfTxList.length === 0) return null
 
   return (
 
@@ -116,15 +117,19 @@ ConfirmTxScreen.prototype.render = function () {
 }
 
 function currentTxView (opts) {
-  if ('txParams' in opts.txData) {
+  const { txData } = opts
+  const { txParams, msgParams } = txData
+
+  if (txParams) {
     // This is a pending transaction
     return h(PendingTx, opts)
-  } else if ('msgParams' in opts.txData) {
+  } else if (msgParams) {
     // This is a pending message to sign
     return h(PendingMsg, opts)
   }
 }
 ConfirmTxScreen.prototype.checkBalanceAgainstTx = function (txData) {
+  if (!txData.txParams) return false
   var state = this.props
   var address = txData.txParams.from || state.selectedAccount
   var account = state.accounts[address]


### PR DESCRIPTION
We broke this in the `3.0.0` release, because we haven't done a good job QA'ing `eth.sign`.

We now have a new automated test in place to keep it working, and I'll put more in place soon.

Fixes #1014