### PR TITLE
Added new modular private key import system

### DIFF
--- a/app/scripts/account-import-strategies/index.js
+++ b/app/scripts/account-import-strategies/index.js
@@ -1,0 +1,37 @@
+const Wallet = require('ethereumjs-wallet')
+const importers = require('ethereumjs-wallet/thirdparty')
+const ethUtil = require('ethereumjs-util')
+
+const accountImporter = {
+
+  importAccount(strategy, args) {
+    try {
+      const importer = this.strategies[strategy]
+      const wallet = importer.apply(null, args)
+      const privateKeyHex = walletToPrivateKey(wallet)
+      return Promise.resolve(privateKeyHex)
+    } catch (e) {
+      return Promise.reject(e)
+    }
+  },
+
+  strategies: {
+    'Private Key': (privateKey) => {
+      const stripped = ethUtil.stripHexPrefix(privateKey)
+      const buffer = new Buffer(stripped, 'hex')
+      return Wallet.fromPrivateKey(buffer)
+    },
+    'JSON File': (input, password) => {
+      const wallet = importers.fromEtherWallet(input, password)
+      return walletToPrivateKey(wallet)
+    },
+  },
+
+}
+
+function walletToPrivateKey (wallet) {
+  const privateKeyBuffer = wallet.getPrivateKey()
+  return ethUtil.bufferToHex(privateKeyBuffer)
+}
+
+module.exports = accountImporter

--- a/ui/app/accounts/import/private-key.js
+++ b/ui/app/accounts/import/private-key.js
@@ -2,7 +2,6 @@ const inherits = require('util').inherits
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
-const type = 'Simple Key Pair'
 const actions = require('../../actions')
 
 module.exports = connect(mapStateToProps)(PrivateKeyImportView)
@@ -64,6 +63,6 @@ PrivateKeyImportView.prototype.createKeyringOnEnter = function (event) {
 PrivateKeyImportView.prototype.createNewKeychain = function () {
   const input = document.getElementById('private-key-box')
   const privateKey = input.value
-  this.props.dispatch(actions.addNewKeyring(type, [ privateKey ]))
+  this.props.dispatch(actions.importNewAccount('Private Key', [ privateKey ]))
 }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -43,6 +43,7 @@ var actions = {
   createNewVaultAndRestore: createNewVaultAndRestore,
   createNewVaultInProgress: createNewVaultInProgress,
   addNewKeyring,
+  importNewAccount,
   addNewAccount,
   NEW_ACCOUNT_SCREEN: 'NEW_ACCOUNT_SCREEN',
   navigateToNewAccountScreen,
@@ -260,6 +261,21 @@ function addNewKeyring (type, opts) {
       if (err) return dispatch(actions.displayWarning(err.message))
       dispatch(actions.updateMetamaskState(newState))
       dispatch(actions.showAccountsPage())
+    })
+  }
+}
+
+function importNewAccount (strategy, args) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    background.importAccountWithStrategy(strategy, args, (err, newState) => {
+      dispatch(actions.hideLoadingIndication())
+      if (err) return dispatch(actions.displayWarning(err.message))
+      dispatch(actions.updateMetamaskState(newState))
+      dispatch({
+        type: actions.SHOW_ACCOUNT_DETAIL,
+        value: newState.selectedAccount,
+      })
     })
   }
 }


### PR DESCRIPTION
Now any strategy for importing a private key that can be described as a pure function can be very easily turned into a MetaMask import strategy.

I've created a generic and reusable UI action called `importNewAccount(strategy, args)`.

The `strategy` is a unique string that maps to an import function in `app/scripts/account-import-strategies/index.js`, and the `args` will be passed to the member of the `strategies` array whose key matches the strategy string.

Strategies return private key hex strings, and are used by the metamask-controller to create a new keyring, and select that new account, before calling back.

This also implements @frankiebee's idea of showing the imported account when it's been imported (my oversight!).

This commit only moves us to this architecture, keeping feature parity for private key import, but has some untested code for importing geth-style JSON files as well!

I started implementing JSON file importing, but it turns out there are so many types of JSON files to import right now, that it's going to take some serious rigor to make that feature do what people would hope.