### PR TITLE
Fix conf tx balance logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Fix rendering bug where the Confirm transaction view would lets you approve transactions when the account has insufficient balance.
 - Add ability to import accounts in JSON file format (used by Mist, Geth, MyEtherWallet, and more!)
 ## 3.1.1 2017-1-20
 

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -134,9 +134,9 @@ ConfirmTxScreen.prototype.checkBalanceAgainstTx = function (txData) {
   var address = txData.txParams.from || state.selectedAccount
   var account = state.accounts[address]
   var balance = account ? account.balance : '0x0'
-  var maxCost = new BN(txData.maxCost)
+  var maxCost = new BN(txData.maxCost, 16)
 
-  var balanceBn = new BN(ethUtil.stripHexPrefix(balance), 10)
+  var balanceBn = new BN(ethUtil.stripHexPrefix(balance), 16)
   return maxCost.gt(balanceBn)
 }
 

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -136,7 +136,7 @@ ConfirmTxScreen.prototype.checkBalanceAgainstTx = function (txData) {
   var balance = account ? account.balance : '0x0'
   var maxCost = new BN(txData.maxCost)
 
-  var balanceBn = new BN(ethUtil.stripHexPrefix(balance), 16)
+  var balanceBn = new BN(ethUtil.stripHexPrefix(balance), 10)
   return maxCost.gt(balanceBn)
 }
 


### PR DESCRIPTION
Fix issue where ConfTx view lets you approve txs when the account has insufficient balance
related to issue #1047 