### PR TITLE
Fix ui overlap

### DIFF
--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -123,8 +123,6 @@ AccountDetailScreen.prototype.render = function () {
               h('.flex-row', {
                 style: {
                   justifyContent: 'flex-end',
-                  position: 'relative',
-                  bottom: '15px',
                 },
               }, [
 


### PR DESCRIPTION
fixes #1006 
before:
![](https://cloud.githubusercontent.com/assets/1474978/21996247/1a7e130c-dbde-11e6-8dcd-113c586129f2.png)

after:
<img width="365" alt="screen shot 2017-01-26 at 2 53 53 pm" src="https://cloud.githubusercontent.com/assets/11225267/22353915/abda33a2-e3d7-11e6-86ab-96519761fc29.png">
<img width="401" alt="screen shot 2017-01-26 at 2 54 01 pm" src="https://cloud.githubusercontent.com/assets/11225267/22353916/abdc3508-e3d7-11e6-91c1-e8f5adf83d64.png">
