### PR TITLE
Kumavis refactor4

### DIFF
--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -31,14 +31,15 @@ class KeyringController extends EventEmitter {
   constructor (opts) {
     super()
     const initState = opts.initState || {}
+    this.keyringTypes = keyringTypes
     this.store = new ObservableStore(initState)
     this.memStore = new ObservableStore({
       keyrings: [],
+      keyringTypes: this.keyringTypes.map(krt => krt.type),
     })
     this.configManager = opts.configManager
     this.ethStore = opts.ethStore
     this.encryptor = encryptor
-    this.keyringTypes = keyringTypes
     this.keyrings = []
     this.identities = {} // Essentially a name hash
 
@@ -85,9 +86,8 @@ class KeyringController extends EventEmitter {
       // computed
       isInitialized: (!!wallet || !!state.vault),
       isUnlocked: (!!this.password),
-      // hard coded
-      keyringTypes: this.keyringTypes.map(krt => krt.type),
       // memStore
+      keyringTypes: memState.keyringTypes,
       identities: this.identities,
       keyrings: memState.keyrings,
       // messageManager

--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -2,7 +2,6 @@ const ethUtil = require('ethereumjs-util')
 const BN = ethUtil.BN
 const bip39 = require('bip39')
 const EventEmitter = require('events').EventEmitter
-const extend = require('xtend')
 const ObservableStore = require('obs-store')
 const filter = require('promise-filter')
 const encryptor = require('browser-passworder')
@@ -33,7 +32,9 @@ class KeyringController extends EventEmitter {
     super()
     const initState = opts.initState || {}
     this.store = new ObservableStore(initState)
-    this.memStore = new ObservableStore({})
+    this.memStore = new ObservableStore({
+      keyrings: [],
+    })
     this.configManager = opts.configManager
     this.ethStore = opts.ethStore
     this.encryptor = encryptor
@@ -80,7 +81,7 @@ class KeyringController extends EventEmitter {
     // old wallet
     const wallet = this.configManager.getWallet()
     const memState = this.memStore.getState()
-    return extend(memState, {
+    const result = {
       // computed
       isInitialized: (!!wallet || !!state.vault),
       isUnlocked: (!!this.password),
@@ -88,16 +89,15 @@ class KeyringController extends EventEmitter {
       keyringTypes: this.keyringTypes.map(krt => krt.type),
       // memStore
       identities: this.identities,
-      // configManager
-      seedWords: this.configManager.getSeedWords(),
-      isDisclaimerConfirmed: this.configManager.getConfirmedDisclaimer(),
-      currentFiat: this.configManager.getCurrentFiat(),
-      conversionRate: this.configManager.getConversionRate(),
-      conversionDate: this.configManager.getConversionDate(),
+      keyrings: memState.keyrings,
       // messageManager
       unconfMsgs: messageManager.unconfirmedMsgs(),
       messages: messageManager.getMsgList(),
-    })
+      // configManager
+      seedWords: this.configManager.getSeedWords(),
+      isDisclaimerConfirmed: this.configManager.getConfirmedDisclaimer(),
+    }
+    return result
   }
 
   // Create New Vault And Keychain

--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -78,13 +78,10 @@ class KeyringController extends EventEmitter {
   // in this class, but will need to be Promisified when we move our
   // persistence to an async model.
   getState () {
-    const state = this.store.getState()
     // old wallet
-    const wallet = this.configManager.getWallet()
     const memState = this.memStore.getState()
     const result = {
       // computed
-      isInitialized: (!!wallet || !!state.vault),
       isUnlocked: (!!this.password),
       // memStore
       keyringTypes: memState.keyringTypes,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -180,6 +180,9 @@ module.exports = class MetamaskController extends EventEmitter {
       {
         shapeShiftTxList: this.configManager.getShapeShiftTxList(),
         lostAccounts: this.configManager.getLostAccounts(),
+        currentFiat: this.configManager.getCurrentFiat(),
+        conversionRate: this.configManager.getConversionRate(),
+        conversionDate: this.configManager.getConversionDate(),
       }
     )
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -169,22 +169,19 @@ module.exports = class MetamaskController extends EventEmitter {
   //
 
   getState () {
-    return this.keyringController.getState()
-    .then((keyringControllerState) => {
-      return extend(
-        this.state,
-        this.ethStore.getState(),
-        this.configManager.getConfig(),
-        this.txManager.getState(),
-        keyringControllerState,
-        this.preferencesController.store.getState(),
-        this.noticeController.getState(),
-        {
-          shapeShiftTxList: this.configManager.getShapeShiftTxList(),
-          lostAccounts: this.configManager.getLostAccounts(),
-        }
-      )
-    })
+    return extend(
+      this.state,
+      this.ethStore.getState(),
+      this.configManager.getConfig(),
+      this.txManager.getState(),
+      this.keyringController.getState(),
+      this.preferencesController.store.getState(),
+      this.noticeController.getState(),
+      {
+        shapeShiftTxList: this.configManager.getShapeShiftTxList(),
+        lostAccounts: this.configManager.getLostAccounts(),
+      }
+    )
   }
 
   //
@@ -199,7 +196,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
     return {
       // etc
-      getState:              nodeify(this.getState.bind(this)),
+      getState:              (cb) => cb(null, this.getState()),
       setRpcTarget:          this.setRpcTarget.bind(this),
       setProviderType:       this.setProviderType.bind(this),
       useEtherscanProvider:  this.useEtherscanProvider.bind(this),
@@ -295,11 +292,8 @@ module.exports = class MetamaskController extends EventEmitter {
     )
   }
 
-  sendUpdate () {
-    this.getState()
-    .then((state) => {
-      this.emit('update', state)
-    })
+  sendUpdate () {  
+    this.emit('update', this.getState())
   }
 
   //

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -169,14 +169,21 @@ module.exports = class MetamaskController extends EventEmitter {
   //
 
   getState () {
+    const wallet = this.configManager.getWallet()
+    const vault = this.keyringController.store.getState().vault
+    const isInitialized = (!!wallet || !!vault)
     return extend(
+      {
+        isInitialized,
+      },
       this.state,
       this.ethStore.getState(),
-      this.configManager.getConfig(),
       this.txManager.getState(),
       this.keyringController.getState(),
       this.preferencesController.store.getState(),
       this.noticeController.getState(),
+      // config manager
+      this.configManager.getConfig(),
       {
         shapeShiftTxList: this.configManager.getShapeShiftTxList(),
         lostAccounts: this.configManager.getLostAccounts(),

--- a/mock-dev.js
+++ b/mock-dev.js
@@ -16,7 +16,6 @@ const extend = require('xtend')
 const render = require('react-dom').render
 const h = require('react-hyperscript')
 const pipe = require('mississippi').pipe
-const LocalStorageStore = require('obs-store/lib/localStorage')
 const Root = require('./ui/app/root')
 const configureStore = require('./ui/app/store')
 const actions = require('./ui/app/actions')
@@ -27,7 +26,6 @@ const firstTimeState = require('./app/scripts/first-time-state')
 const extension = require('./development/mockExtension')
 const noop = function () {}
 
-const STORAGE_KEY = 'metamask-config'
 
 //
 // Query String
@@ -56,26 +54,14 @@ const injectCss = require('inject-css')
 // MetaMask Controller
 //
 
-let dataStore = new LocalStorageStore({ storageKey: STORAGE_KEY })
-// initial state for first time users
-if (!dataStore.getState()) {
-  dataStore.putState(firstTimeState)
-}
-
 const controller = new MetamaskController({
   // User confirmation callbacks:
   showUnconfirmedMessage: noop,
   unlockAccountMessage: noop,
   showUnapprovedTx: noop,
   // initial state
-  initState: dataStore.getState(),
+  initState: firstTimeState,
 })
-
-// setup state persistence
-pipe(
-  controller.store,
-  dataStore
-)
 
 //
 // User Interface

--- a/test/unit/idStore-migration-test.js
+++ b/test/unit/idStore-migration-test.js
@@ -80,13 +80,4 @@ describe('IdentityStore to KeyringController migration', function() {
     })
   })
 
-  describe('entering a password', function() {
-    it('should identify an old wallet as an initialized keyring', function(done) {
-      keyringController.configManager.setWallet('something')
-      const state = keyringController.getState()
-      assert(state.isInitialized, 'old vault counted as initialized.')
-      assert(!state.lostAccounts, 'no lost accounts')
-      done()
-    })
-  })
 })

--- a/test/unit/idStore-migration-test.js
+++ b/test/unit/idStore-migration-test.js
@@ -83,15 +83,10 @@ describe('IdentityStore to KeyringController migration', function() {
   describe('entering a password', function() {
     it('should identify an old wallet as an initialized keyring', function(done) {
       keyringController.configManager.setWallet('something')
-      keyringController.getState()
-      .then((state) => {
-        assert(state.isInitialized, 'old vault counted as initialized.')
-        assert(!state.lostAccounts, 'no lost accounts')
-        done()
-      })
-      .catch((err) => {
-        done(err)
-      })
+      const state = keyringController.getState()
+      assert(state.isInitialized, 'old vault counted as initialized.')
+      assert(!state.lostAccounts, 'no lost accounts')
+      done()
     })
   })
 })

--- a/test/unit/keyring-controller-test.js
+++ b/test/unit/keyring-controller-test.js
@@ -104,7 +104,7 @@ describe('KeyringController', function() {
     it('should add the address to the identities hash', function() {
       const fakeAddress = '0x12345678'
       keyringController.createNickname(fakeAddress)
-      const identities = keyringController.identities
+      const identities = keyringController.memStore.getState().identities
       const identity = identities[fakeAddress]
       assert.equal(identity.address, fakeAddress)
     })
@@ -114,7 +114,9 @@ describe('KeyringController', function() {
     it ('sets the nickname', function(done) {
       const account = addresses[0]
       var nick = 'Test nickname'
-      keyringController.identities[ethUtil.addHexPrefix(account)] = {}
+      const identities = keyringController.memStore.getState().identities
+      identities[ethUtil.addHexPrefix(account)] = {}
+      keyringController.memStore.updateState({ identities })
       keyringController.saveAccountLabel(account, nick)
       .then((label) => {
         try {


### PR DESCRIPTION
slowly moving `ConfigManager` refs out of `KeyringController` into `MetamaskController`.

these two seemed to cause side effects in integration tests when moved.
```js
seedWords: this.configManager.getSeedWords(),
isDisclaimerConfirmed: this.configManager.getConfirmedDisclaimer(),
```
I think this has to do with some reliances on `fullUpdate()`

also removed persistence from the integration tests so now you can refresh them without side effects