### PR TITLE
Add tests showing recovering public key from signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Improve test coverage of eth.sign behavior, including a code example of verifying a signature.
+
 ## 3.2.2 2017-2-8
 
 - Revert eth.sign behavior to the previous one with a big warning.  We will be gradually implementing the new behavior over the coming time. https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign

--- a/app/scripts/keyrings/hd.js
+++ b/app/scripts/keyrings/hd.js
@@ -112,9 +112,11 @@ class HdKeyring extends EventEmitter {
 
 
   _getWalletForAccount (account) {
+    const targetAddress = sigUtil.normalize(account)
     return this.wallets.find((w) => {
       const address = w.getAddress().toString('hex')
-      return ((address === account) || (sigUtil.normalize(address) === account))
+      return ((address === targetAddress) ||
+              (sigUtil.normalize(address) === targetAddress))
     })
   }
 }

--- a/app/scripts/keyrings/simple.js
+++ b/app/scripts/keyrings/simple.js
@@ -88,7 +88,8 @@ class SimpleKeyring extends EventEmitter {
   /* PRIVATE METHODS */
 
   _getWalletForAccount (account) {
-    let wallet = this.wallets.find(w => ethUtil.bufferToHex(w.getAddress()) === account)
+    const address = sigUtil.normalize(account)
+    let wallet = this.wallets.find(w => ethUtil.bufferToHex(w.getAddress()) === address)
     if (!wallet) throw new Error('Simple Keyring - Unable to find matching address.')
     return wallet
   }


### PR DESCRIPTION
Fixes #1104 

Turns out this was working ok, but there were a few problems:

1. we did not have any good reproducible examples of recovering an address from a signature.
2. we failed to identify that the reporting user was expecting the geth-style prefixing, right after we'd reverted that behavior.
3. the reporting user did not cast the `v` parameter as an `int` (probably copied from this also incorrect and popular [stackexchange post](https://ethereum.stackexchange.com/questions/2660/how-can-i-verify-a-signature-with-the-web3-javascript-api).

As a bonus bug, our sign method was also intolerant for non-hex-prefixed addresses, so I made it more flexible here, too.