### PR TITLE
Add personal_sign and personal_ecRecover support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
 ## Current Master
+
+- Add personal_sign and personal_ecRecover support.
 - net_version has been made synchronous.
 - Test suite for migrations expanded.
 - Network now changeable from lock screen.
-
 - Improve test coverage of eth.sign behavior, including a code example of verifying a signature.
 
 ## 3.2.2 2017-2-8

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "0.18.2",
-    "web3-provider-engine": "^8.5.0",
+    "web3-provider-engine": "^9.1.0",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
This does not add support to the `web3` API, but does add support to our provider, so the functionality is injected into the page, for any JS lib author to use, whoever adds it first, either `web3` or `ethjs` @SilentCicero.