### PR TITLE
Add better logger

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
 
   "globals": {
     "document": false,
+    "log": true,
     "navigator": false,
     "web3": true,
     "window": false

--- a/mock-dev.js
+++ b/mock-dev.js
@@ -28,6 +28,7 @@ const noop = function () {}
 
 const log = require('loglevel')
 window.log = log
+log.setLevel('info')
 
 //
 // Query String

--- a/mock-dev.js
+++ b/mock-dev.js
@@ -26,6 +26,8 @@ const firstTimeState = require('./app/scripts/first-time-state')
 const extension = require('./development/mockExtension')
 const noop = function () {}
 
+const log = require('loglevel')
+window.log = log
 
 //
 // Query String

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "iframe-stream": "^1.0.2",
     "inject-css": "^0.1.1",
     "jazzicon": "^1.2.0",
+    "loglevel": "^1.4.1",
     "menu-droppo": "^1.1.0",
     "metamask-logo": "^2.1.2",
     "mississippi": "^1.2.0",

--- a/ui-dev.js
+++ b/ui-dev.js
@@ -25,6 +25,7 @@ const Selector = require('./development/selector')
 // logger
 const log = require('loglevel')
 window.log = log
+log.setLevel('info')
 
 // Query String
 const qs = require('qs')

--- a/ui-dev.js
+++ b/ui-dev.js
@@ -22,6 +22,10 @@ const configureStore = require('./development/uiStore')
 const states = require('./development/states')
 const Selector = require('./development/selector')
 
+// logger
+const log = require('loglevel')
+window.log = log
+
 // Query String
 const qs = require('qs')
 let queryString = qs.parse(window.location.href.split('#')[1])

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -351,12 +351,14 @@ App.prototype.renderPrimary = function () {
 
   // notices
   if (!props.noActiveNotices && !global.METAMASK_DEBUG) {
+    log.debug('rendering notice screen for unread notices.')
     return h(NoticeScreen, {
       notice: props.lastUnreadNotice,
       key: 'NoticeScreen',
       onConfirm: () => props.dispatch(actions.markNoticeRead(props.lastUnreadNotice)),
     })
   } else if (props.lostAccounts && props.lostAccounts.length > 0) {
+    log.debug('rendering notice screen for lost accounts view.')
     return h(NoticeScreen, {
       notice: generateLostAccountsNotice(props.lostAccounts),
       key: 'LostAccountsNotice',
@@ -365,18 +367,22 @@ App.prototype.renderPrimary = function () {
   }
 
   if (props.seedWords) {
+    log.debug('rendering seed words')
     return h(HDCreateVaultComplete, {key: 'HDCreateVaultComplete'})
   }
 
   // show initialize screen
   if (!props.isInitialized || props.forgottenPassword) {
     // show current view
+    log.debug('rendering an initialize screen')
     switch (props.currentView.name) {
 
       case 'restoreVault':
+        log.debug('rendering restore vault screen')
         return h(HDRestoreVaultScreen, {key: 'HDRestoreVaultScreen'})
 
       default:
+        log.debug('rendering menu screen')
         return h(InitializeMenuScreen, {key: 'menuScreenInit'})
     }
   }
@@ -386,9 +392,11 @@ App.prototype.renderPrimary = function () {
     switch (props.currentView.name) {
 
       case 'restoreVault':
+        log.debug('rendering restore vault screen')
         return h(HDRestoreVaultScreen, {key: 'HDRestoreVaultScreen'})
 
       default:
+        log.debug('rendering locked screen')
         return h(UnlockScreen, {key: 'locked'})
     }
   }
@@ -397,36 +405,47 @@ App.prototype.renderPrimary = function () {
   switch (props.currentView.name) {
 
     case 'accounts':
+      log.debug('rendering accounts screen')
       return h(AccountsScreen, {key: 'accounts'})
 
     case 'accountDetail':
+      log.debug('rendering account detail screen')
       return h(AccountDetailScreen, {key: 'account-detail'})
 
     case 'sendTransaction':
+      log.debug('rendering send tx screen')
       return h(SendTransactionScreen, {key: 'send-transaction'})
 
     case 'newKeychain':
+      log.debug('rendering new keychain screen')
       return h(NewKeyChainScreen, {key: 'new-keychain'})
 
     case 'confTx':
+      log.debug('rendering confirm tx screen')
       return h(ConfirmTxScreen, {key: 'confirm-tx'})
 
     case 'config':
+      log.debug('rendering config screen')
       return h(ConfigScreen, {key: 'config'})
 
     case 'import-menu':
+      log.debug('rendering import screen')
       return h(Import, {key: 'import-menu'})
 
     case 'reveal-seed-conf':
+      log.debug('rendering reveal seed confirmation screen')
       return h(RevealSeedConfirmation, {key: 'reveal-seed-conf'})
 
     case 'info':
+      log.debug('rendering info screen')
       return h(InfoScreen, {key: 'info'})
 
     case 'buyEth':
+      log.debug('rendering buy ether screen')
       return h(BuyView, {key: 'buyEthView'})
 
     case 'qr':
+      log.debug('rendering show qr screen')
       return h('div', {
         style: {
           position: 'absolute',
@@ -454,6 +473,7 @@ App.prototype.renderPrimary = function () {
       ])
 
     default:
+      log.debug('rendering default, account detail screen')
       return h(AccountDetailScreen, {key: 'account-detail'})
   }
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -8,6 +8,7 @@ module.exports = launchApp
 
 const log = require('loglevel')
 window.log = log
+log.setLevel('warn')
 
 function launchApp (opts) {
   var accountManager = opts.accountManager

--- a/ui/index.js
+++ b/ui/index.js
@@ -6,6 +6,9 @@ const configureStore = require('./app/store')
 const txHelper = require('./lib/tx-helper')
 module.exports = launchApp
 
+const log = require('loglevel')
+window.log = log
+
 function launchApp (opts) {
   var accountManager = opts.accountManager
   actions._setBackgroundConnection(accountManager)


### PR DESCRIPTION
I've added a new utility called [loglevel](https://github.com/pimterry/loglevel) to the project under the global name `log`.

This allows us to declare a log level by calling the function `log.setLevel(LEVEL)`, where `LEVEL` is a string equal to one of:
- trace
- debug
- info
- warn
- error

The console will then print only logs of that level or lower (on this list), printed with calls like `log.info('an info log')`.

That way, we can add tons of little `info` or `debug` logs all over the project, and easily enable that log level when it comes time to figure out what's going on.

I've added our first uses of this logger to `ui/app/app.js` to `log.debug` the routing logic, which I used to quickly isolate why `ui-dev` mode was broken (fix coming soon).