### PR TITLE
Render personal_sign messages as utf-8 text

### DIFF
--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -112,7 +112,7 @@ module.exports = class PersonalMessageManager extends EventEmitter{
     try {
       const stripped = ethUtil.stripHexPrefix(data)
       if (stripped.match(hexRe)) {
-        return stripped
+        return ethUtil.addHexPrefix(stripped)
       }
     } catch (e) {
       log.debug(`Message was not hex encoded, interpreting as utf8.`)

--- a/test/unit/components/binary-renderer-test.js
+++ b/test/unit/components/binary-renderer-test.js
@@ -1,0 +1,25 @@
+var assert = require('assert')
+var BinaryRenderer = require('../../../ui/app/components/binary-renderer')
+
+describe('BinaryRenderer', function() {
+
+  let binaryRenderer
+  const message = 'Hello, world!'
+  const buffer = new Buffer(message, 'utf8')
+  const hex = buffer.toString('hex')
+
+  beforeEach(function() {
+    binaryRenderer = new BinaryRenderer()
+  })
+
+  it('recovers message', function() {
+    const result = binaryRenderer.hexToText(hex)
+    assert.equal(result, message)
+  })
+
+
+  it('recovers message with hex prefix', function() {
+    const result = binaryRenderer.hexToText('0x' + hex)
+    assert.equal(result, message)
+  })
+})

--- a/test/unit/personal-message-manager-test.js
+++ b/test/unit/personal-message-manager-test.js
@@ -97,13 +97,13 @@ describe('Personal Message Manager', function() {
     it('tolerates a hex prefix', function() {
       var input = '0x12'
       var output = messageManager.normalizeMsgData(input)
-      assert.equal(output, '12', 'un modified')
+      assert.equal(output, '0x12', 'un modified')
     })
 
     it('tolerates normal hex', function() {
       var input = '12'
       var output = messageManager.normalizeMsgData(input)
-      assert.equal(output, '12', 'adds prefix')
+      assert.equal(output, '0x12', 'adds prefix')
     })
   })
 

--- a/test/unit/personal-message-manager-test.js
+++ b/test/unit/personal-message-manager-test.js
@@ -90,20 +90,20 @@ describe('Personal Message Manager', function() {
   describe('#normalizeMsgData', function() {
     it('converts text to a utf8 buffer', function() {
       var input = 'hello'
-      var output = messageManager.normalizeMsgdata(input)
-      assert.equal(output, '68656c6c6f', 'predictably hex encoded')
+      var output = messageManager.normalizeMsgData(input)
+      assert.equal(output, '0x68656c6c6f', 'predictably hex encoded')
     })
 
     it('tolerates a hex prefix', function() {
       var input = '0x12'
-      var output = messageManager.normalizeMsgdata(input)
-      assert.equal(output, '12', 'prefix stripped')
+      var output = messageManager.normalizeMsgData(input)
+      assert.equal(output, '12', 'un modified')
     })
 
     it('tolerates normal hex', function() {
       var input = '12'
-      var output = messageManager.normalizeMsgdata(input)
-      assert.equal(output, '12', 'not modified')
+      var output = messageManager.normalizeMsgData(input)
+      assert.equal(output, '12', 'adds prefix')
     })
   })
 

--- a/test/unit/personal-message-manager-test.js
+++ b/test/unit/personal-message-manager-test.js
@@ -4,7 +4,7 @@ const EventEmitter = require('events')
 
 const PersonalMessageManager = require('../../app/scripts/lib/personal-message-manager')
 
-describe('Transaction Manager', function() {
+describe('Personal Message Manager', function() {
   let messageManager
 
   beforeEach(function() {
@@ -86,4 +86,25 @@ describe('Transaction Manager', function() {
       assert.equal(messageManager.getMsg('2').status, 'approved')
     })
   })
+
+  describe('#normalizeMsgData', function() {
+    it('converts text to a utf8 buffer', function() {
+      var input = 'hello'
+      var output = messageManager.normalizeMsgdata(input)
+      assert.equal(output, '68656c6c6f', 'predictably hex encoded')
+    })
+
+    it('tolerates a hex prefix', function() {
+      var input = '0x12'
+      var output = messageManager.normalizeMsgdata(input)
+      assert.equal(output, '12', 'prefix stripped')
+    })
+
+    it('tolerates normal hex', function() {
+      var input = '12'
+      var output = messageManager.normalizeMsgdata(input)
+      assert.equal(output, '12', 'not modified')
+    })
+  })
+
 })

--- a/ui/app/components/binary-renderer.js
+++ b/ui/app/components/binary-renderer.js
@@ -1,0 +1,43 @@
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const inherits = require('util').inherits
+const ethUtil = require('ethereumjs-util')
+
+module.exports = BinaryRenderer
+
+inherits(BinaryRenderer, Component)
+function BinaryRenderer () {
+  Component.call(this)
+}
+
+BinaryRenderer.prototype.render = function () {
+  const props = this.props
+  const { value } = props
+  const text = this.hexToText(value)
+
+  return (
+    h('textarea.font-small', {
+      readOnly: true,
+      style: {
+        width: '315px',
+        maxHeight: '210px',
+        resize: 'none',
+        border: 'none',
+        background: 'white',
+        padding: '3px',
+      },
+      defaultValue: text,
+    })
+  )
+}
+
+BinaryRenderer.prototype.hexToText = function (hex) {
+  try {
+    const stripped = ethUtil.stripHexPrefix(hex)
+    const buff = Buffer.from(stripped, 'hex')
+    return buff.toString('utf8')
+  } catch (e) {
+    return hex
+  }
+}
+

--- a/ui/app/components/pending-personal-msg-details.js
+++ b/ui/app/components/pending-personal-msg-details.js
@@ -22,7 +22,6 @@ PendingMsgDetails.prototype.render = function () {
   var account = state.accounts[address] || { address: address }
 
   var { data } = msgParams
-  console.dir({ msgParams })
 
   return (
     h('div', {

--- a/ui/app/components/pending-personal-msg-details.js
+++ b/ui/app/components/pending-personal-msg-details.js
@@ -3,6 +3,7 @@ const h = require('react-hyperscript')
 const inherits = require('util').inherits
 
 const AccountPanel = require('./account-panel')
+const BinaryRenderer = require('./binary-renderer')
 
 module.exports = PendingMsgDetails
 
@@ -21,6 +22,7 @@ PendingMsgDetails.prototype.render = function () {
   var account = state.accounts[address] || { address: address }
 
   var { data } = msgParams
+  console.dir({ msgParams })
 
   return (
     h('div', {
@@ -41,18 +43,7 @@ PendingMsgDetails.prototype.render = function () {
       // message data
       h('div', [
         h('label.font-small', { style: { display: 'block' } }, 'MESSAGE'),
-        h('textarea.font-small', {
-          readOnly: true,
-          style: {
-            width: '315px',
-            maxHeight: '210px',
-            resize: 'none',
-            border: 'none',
-            background: 'white',
-            padding: '3px',
-          },
-          defaultValue: data,
-        }),
+        h(BinaryRenderer, { value: data }),
       ]),
 
     ])


### PR DESCRIPTION
Calls to `personal_sign` are now:

- When hex encoded, preserved as hex encoded, but displayed as utf-8 text.
- When not hex encoded, decoded as utf-8 text as hex for signing.
- The messages proposed for signing are displayed as UTF-8 text.
- When the message cannot be rendered as UTF-8 text, it is displayed as hexadecimal.

![screen shot 2017-03-06 at 2 58 55 pm](https://cloud.githubusercontent.com/assets/542863/23634276/3f4e18d2-027e-11e7-91c1-282339427e18.png)

Fixes #1173