### PR TITLE
Convert alert to a log.error

### DIFF
--- a/app/scripts/popup-core.js
+++ b/app/scripts/popup-core.js
@@ -50,7 +50,7 @@ function setupControllerConnection (connectionStream, cb) {
 
 function setupApp (err, accountManager) {
   if (err) {
-    alert(err.stack)
+    log.error(err.stack)
     throw err
   }
 

--- a/app/scripts/popup-core.js
+++ b/app/scripts/popup-core.js
@@ -51,7 +51,7 @@ function setupControllerConnection (connectionStream, cb) {
 function setupApp (err, accountManager) {
   var container = document.getElementById('app-content')
   if (err) {
-    container.innerHTML = '<div class="critical-error">The MetaMask app failed to load: please restart MetaMask</div>'
+    container.innerHTML = '<div class="critical-error">The MetaMask app failed to load: please open and close MetaMask again to restart.</div>'
     container.style.height = '80px'
     log.error(err.stack)
     throw err

--- a/app/scripts/popup-core.js
+++ b/app/scripts/popup-core.js
@@ -49,12 +49,14 @@ function setupControllerConnection (connectionStream, cb) {
 }
 
 function setupApp (err, accountManager) {
+  var container = document.getElementById('app-content')
   if (err) {
+    container.innerHTML = '<div class="critical-error">The MetaMask app failed to load: please restart MetaMask</div>'
+    container.style.height = '80px'
     log.error(err.stack)
     throw err
   }
 
-  var container = document.getElementById('app-content')
 
   MetaMaskUi({
     container: container,

--- a/ui/app/css/lib.css
+++ b/ui/app/css/lib.css
@@ -256,3 +256,9 @@ hr.horizontal-line {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.critical-error {
+  text-align: center;
+  margin-top: 20px;
+  color: red;
+}


### PR DESCRIPTION
Real simple fixes #1065: should be the last alert removed except for the one in chromereload, but I think that one can stay.