### PR TITLE
Add predictive address functionality to recipient field in send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Allow sending to ENS names in send form on Ropsten.
+- Added an address book functionality that remembers the last 15 unique addresses sent to.
 
 ## 3.4.0 2017-3-8
 

--- a/app/scripts/controllers/address-book.js
+++ b/app/scripts/controllers/address-book.js
@@ -39,12 +39,12 @@ class AddressBookController {
   // upper limit to the number of addresses.
   _addToAddressBook (address, name) {
     let addressBook = this._getAddressBook()
-    let index = addressBook.findIndex((element) => { return element.address === address || element.name === name })
+    let index = addressBook.findIndex((element) => { return element.address.toLowerCase() === address.toLowerCase() || element.name === name })
     if (index !== -1) {
       addressBook.splice(index, 1)
     }
     addressBook.push({
-      address,
+      address: address,
       name,
     })
     return Promise.resolve(addressBook)

--- a/app/scripts/controllers/address-book.js
+++ b/app/scripts/controllers/address-book.js
@@ -3,6 +3,10 @@ const extend = require('xtend')
 
 class AddressBookController {
 
+
+  // Controller in charge of managing the address book functionality from the
+  // recipients field on the send screen. Manages a history of all saved
+  // addresses and all currently owned addresses.
   constructor (opts = {}) {
     const initState = extend({
       addressBook: [],
@@ -14,8 +18,9 @@ class AddressBookController {
   // PUBLIC METHODS
   //
 
+  // Sets a new address book in store by accepting a new address and nickname.
   setAddressBook (address, name) {
-    return this.addToAddressBook(address, name)
+    return this._addToAddressBook(address, name)
     .then((addressBook) => {
       this.store.updateState({
         addressBook,
@@ -24,8 +29,16 @@ class AddressBookController {
     })
   }
 
-  addToAddressBook (address, name) {
-    let addressBook = this.getAddressBook()
+  //
+  // PRIVATE METHODS
+  //
+
+
+  // Performs the logic to add the address and name into the address book. The
+  // pushed object is an object of two fields. Current behavior does not set an
+  // upper limit to the number of addresses.
+  _addToAddressBook (address, name) {
+    let addressBook = this._getAddressBook()
     let index = addressBook.findIndex((element) => { return element.address === address || element.name === name })
     if (index !== -1) {
       addressBook.splice(index, 1)
@@ -37,7 +50,9 @@ class AddressBookController {
     return Promise.resolve(addressBook)
   }
 
-  getAddressBook () {
+  // Internal method to get the address book. Current persistence behavior
+  // should not require that this method be called from the UI directly.
+  _getAddressBook () {
     return this.store.getState().addressBook
   }
 

--- a/app/scripts/controllers/address-book.js
+++ b/app/scripts/controllers/address-book.js
@@ -1,0 +1,46 @@
+const ObservableStore = require('obs-store')
+const extend = require('xtend')
+
+class AddressBookController {
+
+  constructor (opts = {}) {
+    const initState = extend({
+      addressBook: [],
+    }, opts.initState)
+    this.store = new ObservableStore(initState)
+  }
+
+  //
+  // PUBLIC METHODS
+  //
+
+  setAddressList (address, name) {
+    return this.addToAddressList(address, name)
+    .then((addressBook) => {
+      this.store.updateState({
+        addressBook,
+      })
+      return Promise.resolve()
+    })
+  }
+
+  addToAddressList (address, name) {
+    let addressBook = this.getAddressList()
+    let index = addressBook.findIndex((element) => { return element.address === address })
+    if (index !== -1) {
+      addressBook.splice(index, 1)
+    }
+    addressBook.push({
+      address,
+      name,
+    })
+    return Promise.resolve(addressBook)
+  }
+
+  getAddressList () {
+    return this.store.getState().addressBook
+  }
+
+}
+
+module.exports = AddressBookController

--- a/app/scripts/controllers/address-book.js
+++ b/app/scripts/controllers/address-book.js
@@ -50,7 +50,11 @@ class AddressBookController {
     // trigger this condition if we've seen this address before--may need to update nickname.
     } else if (addressBookIndex !== -1) {
       addressBook.splice(addressBookIndex, 1)
+    } else if (addressBook.length > 15) {
+      addressBook.shift()
     }
+
+
     addressBook.push({
       address: address,
       name,

--- a/app/scripts/controllers/address-book.js
+++ b/app/scripts/controllers/address-book.js
@@ -14,8 +14,8 @@ class AddressBookController {
   // PUBLIC METHODS
   //
 
-  setAddressList (address, name) {
-    return this.addToAddressList(address, name)
+  setAddressBook (address, name) {
+    return this.addToAddressBook(address, name)
     .then((addressBook) => {
       this.store.updateState({
         addressBook,
@@ -24,9 +24,9 @@ class AddressBookController {
     })
   }
 
-  addToAddressList (address, name) {
-    let addressBook = this.getAddressList()
-    let index = addressBook.findIndex((element) => { return element.address === address })
+  addToAddressBook (address, name) {
+    let addressBook = this.getAddressBook()
+    let index = addressBook.findIndex((element) => { return element.address === address || element.name === name })
     if (index !== -1) {
       addressBook.splice(index, 1)
     }
@@ -37,7 +37,7 @@ class AddressBookController {
     return Promise.resolve(addressBook)
   }
 
-  getAddressList () {
+  getAddressBook () {
     return this.store.getState().addressBook
   }
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -5,7 +5,9 @@ const extend = require('xtend')
 class PreferencesController {
 
   constructor (opts = {}) {
-    const initState = extend({ frequentRpcList: [] }, opts.initState)
+    const initState = extend({
+      frequentRpcList: [],
+    }, opts.initState)
     this.store = new ObservableStore(initState)
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -51,11 +51,6 @@ module.exports = class MetamaskController extends EventEmitter {
       initState: initState.PreferencesController,
     })
 
-    // address book controller
-    this.addressBookController = new AddressBookController({
-      initState: initState.AddressBookController,
-    })
-
     // currency controller
     this.currencyController = new CurrencyController({
       initState: initState.CurrencyController,
@@ -85,6 +80,11 @@ module.exports = class MetamaskController extends EventEmitter {
       this.preferencesController.setSelectedAddress(address)
       autoFaucet(address)
     })
+
+    // address book controller
+    this.addressBookController = new AddressBookController({
+      initState: initState.AddressBookController,
+    }, this.keyringController)
 
     // tx mgmt
     this.txManager = new TxManager({

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -251,6 +251,7 @@ module.exports = class MetamaskController extends EventEmitter {
     const preferencesController = this.preferencesController
     const txManager = this.txManager
     const noticeController = this.noticeController
+    const addressBookController = this.addressBookController
 
     return {
       // etc
@@ -277,6 +278,9 @@ module.exports = class MetamaskController extends EventEmitter {
       setSelectedAddress:        nodeify(preferencesController.setSelectedAddress).bind(preferencesController),
       setDefaultRpc:             nodeify(this.setDefaultRpc).bind(this),
       setCustomRpc:              nodeify(this.setCustomRpc).bind(this),
+
+      // AddressController
+      setAddressBook:           nodeify(addressBookController.setAddressBook).bind(addressBookController),
 
       // KeyringController
       setLocked:                 nodeify(keyringController.setLocked).bind(keyringController),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -15,6 +15,7 @@ const PreferencesController = require('./controllers/preferences')
 const CurrencyController = require('./controllers/currency')
 const NoticeController = require('./notice-controller')
 const ShapeShiftController = require('./controllers/shapeshift')
+const AddressBookController = require('./controllers/address-book')
 const MessageManager = require('./lib/message-manager')
 const PersonalMessageManager = require('./lib/personal-message-manager')
 const TxManager = require('./transaction-manager')
@@ -48,6 +49,11 @@ module.exports = class MetamaskController extends EventEmitter {
     // preferences controller
     this.preferencesController = new PreferencesController({
       initState: initState.PreferencesController,
+    })
+
+    // address book controller
+    this.addressBookController = new AddressBookController({
+      initState: initState.AddressBookController,
     })
 
     // currency controller
@@ -124,6 +130,9 @@ module.exports = class MetamaskController extends EventEmitter {
     this.preferencesController.store.subscribe((state) => {
       this.store.updateState({ PreferencesController: state })
     })
+    this.addressBookController.store.subscribe((state) => {
+      this.store.updateState({ AddressBookController: state })
+    })
     this.currencyController.store.subscribe((state) => {
       this.store.updateState({ CurrencyController: state })
     })
@@ -142,6 +151,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.personalMessageManager.memStore.subscribe(this.sendUpdate.bind(this))
     this.keyringController.memStore.subscribe(this.sendUpdate.bind(this))
     this.preferencesController.store.subscribe(this.sendUpdate.bind(this))
+    this.addressBookController.store.subscribe(this.sendUpdate.bind(this))
     this.currencyController.store.subscribe(this.sendUpdate.bind(this))
     this.noticeController.memStore.subscribe(this.sendUpdate.bind(this))
     this.shapeshiftController.store.subscribe(this.sendUpdate.bind(this))
@@ -219,6 +229,7 @@ module.exports = class MetamaskController extends EventEmitter {
       this.personalMessageManager.memStore.getState(),
       this.keyringController.memStore.getState(),
       this.preferencesController.store.getState(),
+      this.addressBookController.store.getState(),
       this.currencyController.store.getState(),
       this.noticeController.memStore.getState(),
       // config manager

--- a/test/unit/address-book-controller.js
+++ b/test/unit/address-book-controller.js
@@ -23,6 +23,13 @@ describe('address-book-controller', function() {
         assert.equal(addressBook[0].address, '0x01234', 'incorrect addresss')
         assert.equal(addressBook[0].name, 'test', 'incorrect nickname')
       })
+
+      it('should reject duplicates.', function () {
+        addressBookController.setAddressBook('0x01234', 'test')
+        addressBookController.setAddressBook('0x01234', 'test')
+        var addressBook = addressBookController._getAddressBook()
+        assert.equal(addressBook.length, 1, 'incorrect address book length.')
+      })
     })
   })
 })

--- a/test/unit/address-book-controller.js
+++ b/test/unit/address-book-controller.js
@@ -1,0 +1,28 @@
+const assert = require('assert')
+const extend = require('xtend')
+const AddressBookController = require('../../app/scripts/controllers/address-book')
+
+describe('address-book-controller', function() {
+  var addressBookController
+
+  beforeEach(function() {
+    addressBookController = new AddressBookController()
+  })
+
+  describe('addres book management', function () {
+    describe('#_getAddressBook', function () {
+      it('should be empty by default.', function () {
+        assert.equal(addressBookController._getAddressBook().length, 0)
+      })
+    })
+    describe('#setAddressBook', function () {
+      it('should properly set a new address.', function () {
+        addressBookController.setAddressBook('0x01234', 'test')
+        var addressBook = addressBookController._getAddressBook()
+        assert.equal(addressBook.length, 1, 'incorrect address book length.')
+        assert.equal(addressBook[0].address, '0x01234', 'incorrect addresss')
+        assert.equal(addressBook[0].name, 'test', 'incorrect nickname')
+      })
+    })
+  })
+})

--- a/test/unit/address-book-controller.js
+++ b/test/unit/address-book-controller.js
@@ -2,11 +2,27 @@ const assert = require('assert')
 const extend = require('xtend')
 const AddressBookController = require('../../app/scripts/controllers/address-book')
 
+const mockKeyringController = {
+  memStore: {
+    getState: function () {
+      return {
+        identities: {
+          '0x0aaa' : {
+            address: '0x0aaa',
+            name: 'owned',
+          }
+        }
+      }
+    }
+  }
+}
+
+
 describe('address-book-controller', function() {
   var addressBookController
 
   beforeEach(function() {
-    addressBookController = new AddressBookController()
+    addressBookController = new AddressBookController({}, mockKeyringController)
   })
 
   describe('addres book management', function () {
@@ -29,6 +45,11 @@ describe('address-book-controller', function() {
         addressBookController.setAddressBook('0x01234', 'test')
         var addressBook = addressBookController._getAddressBook()
         assert.equal(addressBook.length, 1, 'incorrect address book length.')
+      })
+      it('should not add any identities that are under user control', function () {
+        addressBookController.setAddressBook('0x0aaa', ' ')
+        var addressBook = addressBookController._getAddressBook()
+        assert.equal(addressBook.length, 0, 'incorrect address book length.')
       })
     })
   })

--- a/test/unit/currency-controller-test.js
+++ b/test/unit/currency-controller-test.js
@@ -7,7 +7,7 @@ const rp = require('request-promise')
 const nock = require('nock')
 const CurrencyController = require('../../app/scripts/controllers/currency')
 
-describe('config-manager', function() {
+describe('currency-controller', function() {
   var currencyController
 
   beforeEach(function() {

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -75,6 +75,8 @@ var actions = {
   // account detail screen
   SHOW_SEND_PAGE: 'SHOW_SEND_PAGE',
   showSendPage: showSendPage,
+  ADD_TO_ADDRESS_BOOK: 'ADD_TO_ADDRESS_BOOK',
+  addToAddressBook: addToAddressBook,
   REQUEST_ACCOUNT_EXPORT: 'REQUEST_ACCOUNT_EXPORT',
   requestExportAccount: requestExportAccount,
   EXPORT_ACCOUNT: 'EXPORT_ACCOUNT',
@@ -691,6 +693,18 @@ function setRpcTarget (newRpc) {
       if (err) {
         log.error(err)
         return dispatch(self.displayWarning('Had a problem changing networks!'))
+      }
+    })
+  }
+}
+
+function addToAddressBook (recipient, nickname) {
+  log.debug(`background.addToAddressBook`)
+  return (dispatch) => {
+    background.setAddressBook(recipient, nickname, (err, result) => {
+      if (err) {
+        log.error(err)
+        return dispatch(self.displayWarning('Address book failed to update'))
       }
     })
   }

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -698,6 +698,7 @@ function setRpcTarget (newRpc) {
   }
 }
 
+// Calls the addressBookController to add a new address. 
 function addToAddressBook (recipient, nickname) {
   log.debug(`background.addToAddressBook`)
   return (dispatch) => {

--- a/ui/app/components/ens-input.js
+++ b/ui/app/components/ens-input.js
@@ -59,6 +59,12 @@ EnsInput.prototype.render = function () {
             label: identity.name,
           })
         }),
+        props.addressBook.map((identity) => {
+          return h('option', {
+            value: identity.address,
+            label: identity.name,
+          })
+        }),
       ]),
     this.ensIcon(),
   ])
@@ -94,11 +100,13 @@ EnsInput.prototype.lookupEnsName = function () {
       this.setState({
         loadingEns: false,
         ensResolution: address,
+        nickname: recipient.trim(),
         hoverText: address + '\nClick to Copy',
       })
     }
   })
   .catch((reason) => {
+    log.error(reason)
     return this.setState({
       loadingEns: false,
       ensFailure: true,
@@ -109,10 +117,11 @@ EnsInput.prototype.lookupEnsName = function () {
 
 EnsInput.prototype.componentDidUpdate = function (prevProps, prevState) {
   const state = this.state || {}
-  const { ensResolution } = state
+  const ensResolution = state.ensResolution
+  const nickname = state.nickname || ' '
   if (ensResolution && this.props.onChange &&
       ensResolution !== prevState.ensResolution) {
-    this.props.onChange(ensResolution)
+    this.props.onChange(ensResolution, nickname)
   }
 }
 

--- a/ui/app/components/ens-input.js
+++ b/ui/app/components/ens-input.js
@@ -21,6 +21,7 @@ function EnsInput () {
 EnsInput.prototype.render = function () {
   const props = this.props
   const opts = extend(props, {
+    list: 'addresses',
     onChange: () => {
       const network = this.props.network
       let resolverAddress = networkResolvers[network]
@@ -46,6 +47,15 @@ EnsInput.prototype.render = function () {
     style: { width: '100%' },
   }, [
     h('input.large-input', opts),
+    h('datalist',
+      {
+        id: 'addresses',
+      },
+      [
+        Object.keys(props.identities).map((key) => {
+          return h('option', props.identities[key].address)
+        }),
+      ]),
     this.ensIcon(),
   ])
 }

--- a/ui/app/components/ens-input.js
+++ b/ui/app/components/ens-input.js
@@ -47,11 +47,13 @@ EnsInput.prototype.render = function () {
     style: { width: '100%' },
   }, [
     h('input.large-input', opts),
+    // The address book functionality.
     h('datalist',
       {
         id: 'addresses',
       },
       [
+        // Corresponds to the addresses owned.
         Object.keys(props.identities).map((key) => {
           let identity = props.identities[key]
           return h('option', {
@@ -59,6 +61,7 @@ EnsInput.prototype.render = function () {
             label: identity.name,
           })
         }),
+        // Corresponds to previously sent-to addresses.
         props.addressBook.map((identity) => {
           return h('option', {
             value: identity.address,
@@ -118,6 +121,8 @@ EnsInput.prototype.lookupEnsName = function () {
 EnsInput.prototype.componentDidUpdate = function (prevProps, prevState) {
   const state = this.state || {}
   const ensResolution = state.ensResolution
+  // If an address is sent without a nickname, meaning not from ENS or from
+  // the user's own accounts, a default of a one-space string is used.
   const nickname = state.nickname || ' '
   if (ensResolution && this.props.onChange &&
       ensResolution !== prevState.ensResolution) {

--- a/ui/app/components/ens-input.js
+++ b/ui/app/components/ens-input.js
@@ -53,7 +53,11 @@ EnsInput.prototype.render = function () {
       },
       [
         Object.keys(props.identities).map((key) => {
-          return h('option', props.identities[key].address)
+          let identity = props.identities[key]
+          return h('option', {
+            value: identity.address,
+            label: identity.name,
+          })
         }),
       ]),
     this.ensIcon(),

--- a/ui/app/components/ens-input.js
+++ b/ui/app/components/ens-input.js
@@ -48,10 +48,7 @@ EnsInput.prototype.render = function () {
   }, [
     h('input.large-input', opts),
     // The address book functionality.
-    h('datalist',
-      {
-        id: 'addresses',
-      },
+    h('datalist#addresses',
       [
         // Corresponds to the addresses owned.
         Object.keys(props.identities).map((key) => {

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -19,6 +19,7 @@ function reduceMetamask (state, action) {
     noActiveNotices: true,
     lastUnreadNotice: undefined,
     frequentRpcList: [],
+    addressBook: [],
   }, state.metamask)
 
   switch (action.type) {

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -20,6 +20,7 @@ function mapStateToProps (state) {
     identities: state.metamask.identities,
     warning: state.appState.warning,
     network: state.metamask.network,
+    addressBook: state.metamask.addressBook,
   }
 
   result.error = result.warning && result.warning.split('.')[0]
@@ -45,6 +46,7 @@ SendTransactionScreen.prototype.render = function () {
   var identity = state.identity
   var network = state.network
   var identities = state.identities
+  var addressBook = state.addressBook
 
   return (
 
@@ -155,6 +157,7 @@ SendTransactionScreen.prototype.render = function () {
           onChange: this.recipientDidChange.bind(this),
           network,
           identities,
+          addressBook,
         }),
       ]),
 
@@ -224,13 +227,17 @@ SendTransactionScreen.prototype.back = function () {
   this.props.dispatch(actions.backToAccountDetail(address))
 }
 
-SendTransactionScreen.prototype.recipientDidChange = function (recipient) {
-  this.setState({ recipient })
+SendTransactionScreen.prototype.recipientDidChange = function (recipient, nickname) {
+  this.setState({
+    recipient: recipient,
+    nickname: nickname,
+  })
 }
 
 SendTransactionScreen.prototype.onSubmit = function () {
   const state = this.state || {}
   const recipient = state.recipient || document.querySelector('input[name="address"]').value
+  const nickname = state.nickname || ' '
   const input = document.querySelector('input[name="amount"]').value
   const value = util.normalizeEthStringToWei(input)
   const txData = document.querySelector('input[name="txData"]').value
@@ -258,6 +265,8 @@ SendTransactionScreen.prototype.onSubmit = function () {
   }
 
   this.props.dispatch(actions.hideWarning())
+
+  this.props.dispatch(actions.addToAddressBook(recipient, nickname))
 
   var txParams = {
     from: this.props.address,

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -44,6 +44,7 @@ SendTransactionScreen.prototype.render = function () {
   var account = state.account
   var identity = state.identity
   var network = state.network
+  var identities = state.identities
 
   return (
 
@@ -153,6 +154,7 @@ SendTransactionScreen.prototype.render = function () {
           placeholder: 'Recipient Address',
           onChange: this.recipientDidChange.bind(this),
           network,
+          identities,
         }),
       ]),
 


### PR DESCRIPTION
Fixes #1165 by adding auto-complete functionality to addresses! It even works with .eth resolvers! Yay!
![screenshot from 2017-03-09 15-12-56](https://cloud.githubusercontent.com/assets/1840057/23774893/eb6a79d6-04da-11e7-96cd-20085f019e64.png)

Needs discussion is:
- How should we determine which addresses stay in the address book long-term?
- Styling issues (the arrow to show the entire address book and the .eth icon overlap)
- How many addresses to show?