### PR TITLE
Allow changing custom RPCs from lock screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Allow sending to ENS names in send form on Ropsten.
+- Can now change network to custom RPC URL from lock screen.
 
 ## 3.4.0 2017-3-8
 

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -400,6 +400,10 @@ App.prototype.renderPrimary = function () {
         log.debug('rendering restore vault screen')
         return h(HDRestoreVaultScreen, {key: 'HDRestoreVaultScreen'})
 
+      case 'config':
+        log.debug('rendering config screen from unlock screen.')
+        return h(ConfigScreen, {key: 'config'})
+
       default:
         log.debug('rendering locked screen')
         return h(UnlockScreen, {key: 'locked'})

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -266,7 +266,7 @@ App.prototype.renderNetworkDropdown = function () {
     this.renderCustomOption(props.provider),
     this.renderCommonRpc(rpcList, props.provider),
 
-    props.isUnlocked && h(DropMenuItem, {
+    h(DropMenuItem, {
       label: 'Custom RPC',
       closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
       action: () => this.props.dispatch(actions.showConfigPage()),


### PR DESCRIPTION
As requested, fixes #1206 by allowing custom RPC changes from the lock screen. This takes us to the config page directly.

Attempting to access seed words or go back will return users back to the lock screen.