### PR TITLE
Fix currency settings retention

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -621,7 +621,7 @@ module.exports = class MetamaskController extends EventEmitter {
       this.currencyController.updateConversionRate()
       const data = {
         conversionRate: this.currencyController.getConversionRate(),
-        currentFiat: this.currencyController.getCurrentCurrency(),
+        currentCurrency: this.currencyController.getCurrentCurrency(),
         conversionDate: this.currencyController.getConversionDate(),
       }
       cb(null, data)

--- a/app/scripts/migrations/010.js
+++ b/app/scripts/migrations/010.js
@@ -2,7 +2,7 @@ const version = 10
 
 /*
 
-This migration breaks out the CurrencyController substate
+This migration breaks out the ShapeShiftController substate
 
 */
 

--- a/app/scripts/migrations/011.js
+++ b/app/scripts/migrations/011.js
@@ -2,7 +2,7 @@ const version = 11
 
 /*
 
-This migration breaks out the CurrencyController substate
+This migration removes the discaimer state from our app, which was integrated into our notices.
 
 */
 

--- a/development/states/account-detail-with-shapeshift-tx.json
+++ b/development/states/account-detail-with-shapeshift-tx.json
@@ -1,6 +1,6 @@
 {
   "metamask": {
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.06608791,
     "conversionDate": 1470421024,
     "isInitialized": true,

--- a/development/states/account-detail-with-transaction-history.json
+++ b/development/states/account-detail-with-transaction-history.json
@@ -1,6 +1,6 @@
 {
   "metamask": {
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.06608791,
     "conversionDate": 1470421024,
     "isInitialized": true,

--- a/development/states/account-detail.json
+++ b/development/states/account-detail.json
@@ -1,6 +1,6 @@
 {
   "metamask": {
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.06608791,
     "conversionDate": 1470421024,
     "isInitialized": true,

--- a/development/states/account-list-with-imported.json
+++ b/development/states/account-list-with-imported.json
@@ -14,7 +14,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 10.19458075,
     "conversionDate": 1484696373,
     "noActiveNotices": true,

--- a/development/states/accounts-loose.json
+++ b/development/states/accounts-loose.json
@@ -30,7 +30,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 0,
     "conversionDate": "N/A",
     "noActiveNotices": true,

--- a/development/states/accounts.json
+++ b/development/states/accounts.json
@@ -41,7 +41,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.84461814,
     "conversionDate": 1476226414,
     "accounts": {

--- a/development/states/compilation-bug.json
+++ b/development/states/compilation-bug.json
@@ -41,7 +41,7 @@
         "simulationFails": true
       }
     },
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 7.69158136,
     "conversionDate": 1482279663,
     "noActiveNotices": true,

--- a/development/states/conf-tx.json
+++ b/development/states/conf-tx.json
@@ -48,7 +48,7 @@
         "gasPrice": "4a817c800"
       }
     },
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 12.7200827,
     "conversionDate": 1487363041,
     "noActiveNotices": true,

--- a/development/states/config.json
+++ b/development/states/config.json
@@ -1,6 +1,6 @@
 {
   "metamask": {
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.06608791,
     "conversionDate": 1470421024,
     "isInitialized": true,

--- a/development/states/first-time.json
+++ b/development/states/first-time.json
@@ -6,7 +6,7 @@
     "identities": {},
     "frequentRpcList": [],
     "unapprovedTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 12.7527416,
     "conversionDate": 1487624341,
     "noActiveNotices": false,

--- a/development/states/import-private-key-warning.json
+++ b/development/states/import-private-key-warning.json
@@ -10,7 +10,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 10.1219126,
     "conversionDate": 1484695442,
     "noActiveNotices": true,

--- a/development/states/import-private-key.json
+++ b/development/states/import-private-key.json
@@ -10,7 +10,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 10.10788584,
     "conversionDate": 1484694362,
     "noActiveNotices": true,

--- a/development/states/locked.json
+++ b/development/states/locked.json
@@ -6,7 +6,7 @@
     "rpcTarget": "https://rawtestrpc.metamask.io/",
     "identities": {},
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.4379398,
     "conversionDate": 1473358355,
     "accounts": {},

--- a/development/states/lost-accounts.json
+++ b/development/states/lost-accounts.json
@@ -1,6 +1,6 @@
 {
   "metamask": {
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "lostAccounts": [
       "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
       "0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b"

--- a/development/states/new-account.json
+++ b/development/states/new-account.json
@@ -14,7 +14,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 10.92067835,
     "conversionDate": 1478282884,
     "network": null,

--- a/development/states/notice.json
+++ b/development/states/notice.json
@@ -9,7 +9,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 8.3533002,
     "conversionDate": 1481671082,
     "noActiveNotices": false,

--- a/development/states/pending-signature.json
+++ b/development/states/pending-signature.json
@@ -22,7 +22,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.02269525,
     "conversionDate": 1472076963,
     "accounts": {

--- a/development/states/pending-tx-insufficient.json
+++ b/development/states/pending-tx-insufficient.json
@@ -31,7 +31,7 @@
         "maxCost": "de234b52e4a0800"
       }
     },
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 12.59854817,
     "conversionDate": 1487662141,
     "noActiveNotices": true,

--- a/development/states/personal-sign.json
+++ b/development/states/personal-sign.json
@@ -18,7 +18,7 @@
       }
     },
     "unapprovedTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 13.2126613,
     "conversionDate": 1487888522,
     "noActiveNotices": true,

--- a/development/states/private-network.json
+++ b/development/states/private-network.json
@@ -16,7 +16,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 9.52855776,
     "conversionDate": 1479756513,
     "accounts": {

--- a/development/states/restore-vault.json
+++ b/development/states/restore-vault.json
@@ -6,7 +6,7 @@
     "rpcTarget": "https://rawtestrpc.metamask.io/",
     "identities": {},
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 0,
     "conversionDate": "N/A",
     "accounts": {},

--- a/development/states/send.json
+++ b/development/states/send.json
@@ -22,7 +22,7 @@
       }
     },
     "unapprovedTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 16.88200327,
     "conversionDate": 1489013762,
     "noActiveNotices": true,

--- a/development/states/shapeshift.json
+++ b/development/states/shapeshift.json
@@ -22,7 +22,7 @@
       }
     },
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 11.21274318,
     "conversionDate": 1472159644,
     "accounts": {

--- a/development/states/terms-and-conditions.json
+++ b/development/states/terms-and-conditions.json
@@ -5,7 +5,7 @@
     "rpcTarget": "https://rawtestrpc.metamask.io/",
     "identities": {},
     "unconfTxs": {},
-    "currentFiat": "USD",
+    "currentCurrency": "USD",
     "conversionRate": 8.18703468,
     "conversionDate": 1481755832,
     "network": "3",

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -71,7 +71,7 @@ var actions = {
   SHOW_CONF_TX_PAGE: 'SHOW_CONF_TX_PAGE',
   SHOW_CONF_MSG_PAGE: 'SHOW_CONF_MSG_PAGE',
   SET_CURRENT_FIAT: 'SET_CURRENT_FIAT',
-  setCurrentFiat: setCurrentFiat,
+  setCurrentCurrency: setCurrentCurrency,
   // account detail screen
   SHOW_SEND_PAGE: 'SHOW_SEND_PAGE',
   showSendPage: showSendPage,
@@ -328,10 +328,10 @@ function showInfoPage () {
   }
 }
 
-function setCurrentFiat (currencyCode) {
+function setCurrentCurrency (currencyCode) {
   return (dispatch) => {
     dispatch(this.showLoadingIndication())
-    log.debug(`background.setCurrentFiat`)
+    log.debug(`background.setCurrentCurrency`)
     background.setCurrentCurrency(currencyCode, (err, data) => {
       dispatch(this.hideLoadingIndication())
       if (err) {
@@ -341,7 +341,7 @@ function setCurrentFiat (currencyCode) {
       dispatch({
         type: this.SET_CURRENT_FIAT,
         value: {
-          currentFiat: data.currentFiat,
+          currentCurrency: data.currentCurrency,
           conversionRate: data.conversionRate,
           conversionDate: data.conversionDate,
         },

--- a/ui/app/components/fiat-value.js
+++ b/ui/app/components/fiat-value.js
@@ -9,7 +9,7 @@ module.exports = connect(mapStateToProps)(FiatValue)
 function mapStateToProps (state) {
   return {
     conversionRate: state.metamask.conversionRate,
-    currentFiat: state.metamask.currentFiat,
+    currentCurrency: state.metamask.currentCurrency,
   }
 }
 
@@ -34,7 +34,7 @@ FiatValue.prototype.render = function () {
     fiatTooltipNumber = 'Unknown'
   }
 
-  var fiatSuffix = props.currentFiat
+  var fiatSuffix = props.currentCurrency
 
   return fiatDisplay(fiatDisplayNumber, fiatSuffix)
 }

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -125,19 +125,19 @@ function rpcValidation (newRpc, state) {
 }
 
 function currentConversionInformation (metamaskState, state) {
-  var currentFiat = metamaskState.currentFiat
+  var currentCurrency = metamaskState.currentCurrency
   var conversionDate = metamaskState.conversionDate
   return h('div', [
     h('span', {style: { fontWeight: 'bold', paddingRight: '10px'}}, 'Current Conversion'),
     h('span', {style: { fontWeight: 'bold', paddingRight: '10px', fontSize: '13px'}}, `Updated ${Date(conversionDate)}`),
-    h('select#currentFiat', {
+    h('select#currentCurrency', {
       onChange (event) {
         event.preventDefault()
-        var element = document.getElementById('currentFiat')
-        var newFiat = element.value
-        state.dispatch(actions.setCurrentFiat(newFiat))
+        var element = document.getElementById('currentCurrency')
+        var newCurrency = element.value
+        state.dispatch(actions.setCurrentCurrency(newCurrency))
       },
-      defaultValue: currentFiat,
+      defaultValue: currentCurrency,
     }, currencies.map((currency) => {
       return h('option', {key: currency.code, value: currency.code}, `${currency.code} - ${currency.name}`)
     })

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -13,9 +13,6 @@ function reduceMetamask (state, action) {
     rpcTarget: 'https://rawtestrpc.metamask.io/',
     identities: {},
     unapprovedTxs: {},
-    currentFiat: 'USD',
-    conversionRate: 0,
-    conversionDate: 'N/A',
     noActiveNotices: true,
     lastUnreadNotice: undefined,
     frequentRpcList: [],
@@ -126,7 +123,7 @@ function reduceMetamask (state, action) {
 
     case actions.SET_CURRENT_FIAT:
       return extend(metamaskState, {
-        currentFiat: action.value.currentFiat,
+        currentCurrency: action.value.currentCurrency,
         conversionRate: action.value.conversionRate,
         conversionDate: action.value.conversionDate,
       })


### PR DESCRIPTION
In our latest migration for currency controller, we neglected to rename variables in our code even though we changed the naming convention on our back-end store. This fixes our app to properly refer to these variables. Fixes #1211 