### PR TITLE
Require redux-logger of 2.10.2 and up

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-tooltip-component": "^0.3.0",
     "readable-stream": "^2.1.2",
     "redux": "^3.0.5",
-    "redux-logger": "^2.3.1",
+    "redux-logger": "^2.8.1",
     "redux-thunk": "^1.0.2",
     "request-promise": "^4.1.1",
     "sandwich-expando": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-tooltip-component": "^0.3.0",
     "readable-stream": "^2.1.2",
     "redux": "^3.0.5",
-    "redux-logger": "^2.8.1",
+    "redux-logger": "^2.10.2",
     "redux-thunk": "^1.0.2",
     "request-promise": "^4.1.1",
     "sandwich-expando": "^1.0.5",


### PR DESCRIPTION
In order to fix a weird error found by @frankiebee where 2.3.1 wasn't cutting it in our build.