### PR TITLE
Modify logic for injection conditions.

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -69,14 +69,10 @@ function shouldInjectWeb3 () {
 }
 
 function isAllowedSuffix (testCase) {
-  var prohibitedTypes = ['xml', 'pdf']
-  var currentUrl = window.location.href
-  var currentRegex
-  for (let i = 0; i < prohibitedTypes.length; i++) {
-    currentRegex = new RegExp(`\.${prohibitedTypes[i]}$`)
-    if (currentRegex.test(currentUrl)) {
-      return false
-    }
+  const doctype = window.document.doctype
+  if (doctype) {
+    return doctype.name === 'html'
+  } else {
+    return false
   }
-  return true
 }


### PR DESCRIPTION
Our previous implementation only checked the href for a .xml suffix. We check the doctype instead in this case. @kumavis mentions there may be race conditions. Haven't seen any so far, but if there are concerns, please place them here.

Fixes #1237 