### PR TITLE
Add current block number and hash to the state.

### DIFF
--- a/app/scripts/lib/eth-store.js
+++ b/app/scripts/lib/eth-store.js
@@ -19,6 +19,8 @@ class EthereumStore extends ObservableStore {
     super({
       accounts: {},
       transactions: {},
+      currentBlockNumber: '0',
+      currentBlockHash: '',
     })
     this._provider = opts.provider
     this._query = new EthQuery(this._provider)
@@ -69,6 +71,8 @@ class EthereumStore extends ObservableStore {
   _updateForBlock (block) {
     const blockNumber = '0x' + block.number.toString('hex')
     this._currentBlockNumber = blockNumber
+    this.updateState({ currentBlockNumber: parseInt(blockNumber) })
+    this.updateState({ currentBlockHash: `0x${block.hash.toString('hex')}`})
     async.parallel([
       this._updateAccounts.bind(this),
       this._updateTransactions.bind(this, blockNumber),


### PR DESCRIPTION
Fixes #1227 by including current block number and hash in a state dump by including it in our state tree. The simplest solution, but it does add more muck to our state tree. I imagine we could write some conditional logic where our logState function is, but it'd be messy.

Will be good at least for now in debugging the nonce plague.