### PR TITLE
Fix styling of error message in import accounts

### DIFF
--- a/ui/app/accounts/import/json.js
+++ b/ui/app/accounts/import/json.js
@@ -60,7 +60,7 @@ JsonImportSubview.prototype.render = function () {
         },
       }, 'Import'),
 
-      error ? h('span.warning', error) : null,
+      error ? h('span.error', error) : null,
     ])
   )
 }
@@ -95,4 +95,3 @@ JsonImportSubview.prototype.createNewKeychain = function () {
 
   this.props.dispatch(actions.importNewAccount('JSON File', [ fileContents, password ]))
 }
-

--- a/ui/app/accounts/import/private-key.js
+++ b/ui/app/accounts/import/private-key.js
@@ -48,7 +48,7 @@ PrivateKeyImportView.prototype.render = function () {
         },
       }, 'Import'),
 
-      error ? h('span.warning', error) : null,
+      error ? h('span.error', error) : null,
     ])
   )
 }
@@ -65,4 +65,3 @@ PrivateKeyImportView.prototype.createNewKeychain = function () {
   const privateKey = input.value
   this.props.dispatch(actions.importNewAccount('Private Key', [ privateKey ]))
 }
-


### PR DESCRIPTION
Fixes #1193 by changing a couple classes from `warning` to `error`.