### PR TITLE
Hide the password in the private key retrieval screen.

### DIFF
--- a/ui/app/components/account-export.js
+++ b/ui/app/components/account-export.js
@@ -52,6 +52,7 @@ ExportAccountView.prototype.render = function () {
           }, [
             h('p.error', warning),
             h('input#exportAccount.sizing-input', {
+              type: 'password',
               placeholder: 'confirm password',
               onKeyPress: this.onExportKeyPress.bind(this),
               style: {


### PR DESCRIPTION
Caught by @tmashuang since our private key screen didn't properly hide our password! It was because we shifted from an "I understand" prompt to a password prompt. 