### PR TITLE
Enable etherscan linking on Kovan transaction list items.

### DIFF
--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -28,7 +28,7 @@ TransactionListItem.prototype.render = function () {
 
   let isLinkable = false
   const numericNet = parseInt(network)
-  isLinkable = numericNet === 1 || numericNet === 3
+  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 42
 
   var isMsg = ('msgParams' in transaction)
   var isTx = ('txParams' in transaction)


### PR DESCRIPTION
As the title says--enabling kovan tx list items to now navigate to etherscan when linked.

Suggestions for not hardcoding this? Easy fix, but we could automate this part.