### PR TITLE
Allow injection in IFrames + dynamic IFrames

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -51,7 +51,7 @@
         "scripts/contentscript.js"
       ],
       "run_at": "document_start",
-      "all_frames": false
+      "all_frames": true
     }
   ],
   "permissions": [

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -73,6 +73,6 @@ function isAllowedSuffix (testCase) {
   if (doctype) {
     return doctype.name === 'html'
   } else {
-    return false
+    return true
   }
 }


### PR DESCRIPTION
When working with DAPPS that open Iframes - web3 is not injected there. These small changes fix this, and inject a web3 instance in every iframe that gets opened on page-start , and also on dynamically generated iframes.

We needed this for out TrellEth project 

https://twitter.com/sponnet/status/845100360540794880
https://press.swarm.city/meet-trelleth-73affcb82d02#.zhzcq2nhq
https://github.com/trelleth 

I hope this could get modified in the main MetaMask product. It would open up much possibilities !