### PR TITLE
Add Kovan faucet instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Add link to Kovan Test Faucet instructions on buy view.
+
 ## 3.5.0 2017-3-27
 
 - Add better error messages for when a transaction fails on approval

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -623,6 +623,10 @@ module.exports = class MetamaskController extends EventEmitter {
       case '3':
         url = 'https://faucet.metamask.io/'
         break
+
+      case '42':
+        url = 'https://github.com/kovan-testnet/faucet'
+        break
     }
 
     if (url) extension.tabs.create({ url })

--- a/ui/app/components/buy-button-subview.js
+++ b/ui/app/components/buy-button-subview.js
@@ -121,15 +121,22 @@ BuyButtonSubview.prototype.formVersionSubview = function () {
       h('h3.text-transform-uppercase', {
         style: {
           width: '225px',
+          marginBottom: '15px',
         },
       }, 'In order to access this feature, please switch to the Main Network'),
-      (this.props.network === '3') ? h('h3.text-transform-uppercase', 'or:') : null,
+      ((this.props.network === '3') || (this.props.network === '42')) ? h('h3.text-transform-uppercase', 'or go to the') : null,
       (this.props.network === '3') ? h('button.text-transform-uppercase', {
         onClick: () => this.props.dispatch(actions.buyEth()),
         style: {
           marginTop: '15px',
         },
-      }, 'Go To Test Faucet') : null,
+      }, 'Ropsten Test Faucet') : null,
+      (this.props.network === '42') ? h('button.text-transform-uppercase', {
+        onClick: () => this.props.dispatch(actions.buyEth()),
+        style: {
+          marginTop: '15px',
+        },
+      }, 'Kovan Test Faucet') : null,
     ])
   }
 }


### PR DESCRIPTION
Just a quick addition of a button similar to our test faucet button on Ropsten: adds a similar button for Kovan, though it navigates to a repo that lists out instructions.