### PR TITLE
Notice fix for when notices are short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix edge case where users were unable to enable the notice button if notices were short enough to not require a scrollbar.
+
 ## 3.5.0 2017-3-27
 
 - Add better error messages for when a transaction fails on approval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+## 3.5.1 2017-3-27
+
 - Fix edge case where users were unable to enable the notice button if notices were short enough to not require a scrollbar.
 
 ## 3.5.0 2017-3-27

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/ui/app/components/notice.js
+++ b/ui/app/components/notice.js
@@ -92,6 +92,7 @@ Notice.prototype.render = function () {
         },
       }, [
         h(ReactMarkdown, {
+          className: 'notice-box',
           source: body,
           skipHtml: true,
         }),
@@ -114,6 +115,8 @@ Notice.prototype.render = function () {
 Notice.prototype.componentDidMount = function () {
   var node = findDOMNode(this)
   linker.setupListener(node)
+  if (document.getElementsByClassName('notice-box')[0].clientHeight < 310) { this.setState({disclaimerDisabled: false}) }
+
 }
 
 Notice.prototype.componentWillUnmount = function () {


### PR DESCRIPTION
If notices were really short, there would be no way for a user to enable the button (our logic triggered on scroll actions). This adds an action to check after mounting whether the notice has a height less than our current notice window.