### PR TITLE
Inject web3 in iFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Inject web3 into loaded iFrames.
+
 ## 3.5.1 2017-3-27
 
 - Fix edge case where users were unable to enable the notice button if notices were short enough to not require a scrollbar.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -51,7 +51,7 @@
         "scripts/contentscript.js"
       ],
       "run_at": "document_start",
-      "all_frames": false
+      "all_frames": true
     }
   ],
   "permissions": [

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -73,6 +73,6 @@ function isAllowedSuffix (testCase) {
   if (doctype) {
     return doctype.name === 'html'
   } else {
-    return false
+    return true
   }
 }


### PR DESCRIPTION
Re-submission of #1259 because CircleCI doesn't seem to be able to run off a foreign remote?  Maybe it's a security practice.

Also bumped the changelog.

Fixes #1223