### PR TITLE
Hide seed words from UI State Dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Current Master
 
-- Remove seedWords from UI state dump.
 - Inject web3 into loaded iFrames.
 
 ## 3.5.1 2017-3-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Remove seedWords from UI state dump.
+
 ## 3.5.1 2017-3-27
 
 - Fix edge case where users were unable to enable the notice button if notices were short enough to not require a scrollbar.

--- a/ui/app/reducers.js
+++ b/ui/app/reducers.js
@@ -42,6 +42,10 @@ function rootReducer (state, action) {
 }
 
 window.logState = function () {
-  var stateString = JSON.stringify(window.METAMASK_CACHED_LOG_STATE, null, 2)
+  var stateString = JSON.stringify(window.METAMASK_CACHED_LOG_STATE, removeSeedWords, 2)
   console.log(stateString)
+}
+
+function removeSeedWords (key, value) {
+  return key === 'seedWords' ? undefined : value
 }


### PR DESCRIPTION
Fixes #1270. We could take a step further and just not store our seed words in the state tree and recalculate them each time, but currently unsure of how to call background functions without going through actions.