### PR TITLE
Assure that seed words are placed into state tree upon request.

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -386,7 +386,7 @@ module.exports = class MetamaskController extends EventEmitter {
     .then((serialized) => {
       const seedWords = serialized.mnemonic
       this.configManager.setSeedWords(seedWords)
-      cb()
+      cb(null, seedWords)
     })
   }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -273,8 +273,10 @@ function requestRevealSeed (password) {
         return dispatch(actions.displayWarning(err.message))
       }
       log.debug(`background.placeSeedWords`)
-      background.placeSeedWords((err) => {
+      background.placeSeedWords((err, result) => {
         if (err) return dispatch(actions.displayWarning(err.message))
+        dispatch(actions.hideLoadingIndication())
+        dispatch(actions.showNewVaultSeed(result))
       })
     })
   }

--- a/ui/app/keychains/hd/recover-seed/confirmation.js
+++ b/ui/app/keychains/hd/recover-seed/confirmation.js
@@ -18,11 +18,8 @@ function mapStateToProps (state) {
   }
 }
 
-RevealSeedConfirmation.prototype.confirmationPhrase = 'I understand'
-
 RevealSeedConfirmation.prototype.render = function () {
   const props = this.props
-  const state = this.state
 
   return (
 
@@ -64,31 +61,13 @@ RevealSeedConfirmation.prototype.render = function () {
           },
         }),
 
-        h(`h4${state && state.confirmationWrong ? '.error' : ''}`, {
-          style: {
-            marginTop: '12px',
-          },
-        }, `Enter the phrase "${this.confirmationPhrase}" to proceed.`),
-
-        // confirm confirmation
-        h('input.large-input.letter-spacey', {
-          type: 'text',
-          id: 'confirm-box',
-          placeholder: this.confirmationPhrase,
-          onKeyPress: this.checkConfirmation.bind(this),
-          style: {
-            width: 260,
-            marginTop: 16,
-          },
-        }),
-
         h('.flex-row.flex-space-between', {
           style: {
             marginTop: 30,
             width: '50%',
           },
         }, [
-// cancel
+          // cancel
           h('button.primary', {
             onClick: this.goHome.bind(this),
           }, 'CANCEL'),
@@ -134,15 +113,6 @@ RevealSeedConfirmation.prototype.checkConfirmation = function (event) {
 }
 
 RevealSeedConfirmation.prototype.revealSeedWords = function () {
-  this.setState({ confirmationWrong: false })
-
-  const confirmBox = document.getElementById('confirm-box')
-  const confirmation = confirmBox.value
-  if (confirmation !== this.confirmationPhrase) {
-    confirmBox.value = ''
-    return this.setState({ confirmationWrong: true })
-  }
-
   var password = document.getElementById('password-box').value
   this.props.dispatch(actions.requestRevealSeed(password))
 }

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -94,6 +94,7 @@ function reduceMetamask (state, action) {
       return extend(metamaskState, {
         isUnlocked: true,
         isInitialized: false,
+        seedWords: action.value,
       })
 
     case actions.CLEAR_SEED_WORD_CACHE:


### PR DESCRIPTION
Does not necessarily address #1267 but it was an issue that was detected because of it. The state was not updating properly due to our seed words not being introduced directly into our state tree after a user requests seed words. This fixes that issue.