### PR TITLE
Improve UI gas calculation logic

### DIFF
--- a/app/scripts/lib/hex-to-bn.js
+++ b/app/scripts/lib/hex-to-bn.js
@@ -1,0 +1,7 @@
+const ethUtil = require('ethereumjs-util')
+const BN = ethUtil.BN
+
+module.exports = function hexToBn (hex) {
+  return new BN(ethUtil.stripHexPrefix(hex), 16)
+}
+

--- a/app/scripts/transaction-manager.js
+++ b/app/scripts/transaction-manager.js
@@ -79,8 +79,9 @@ module.exports = class TransactionManager extends EventEmitter {
       fullTxList.splice(index, 1)
     }
     fullTxList.push(txMeta)
-
     this._saveTxList(fullTxList)
+    this.emit('update')
+
     this.once(`${txMeta.id}:signed`, function (txId) {
       this.removeAllListeners(`${txMeta.id}:rejected`)
     })

--- a/app/scripts/transaction-manager.js
+++ b/app/scripts/transaction-manager.js
@@ -4,6 +4,7 @@ const extend = require('xtend')
 const Semaphore = require('semaphore')
 const ObservableStore = require('obs-store')
 const ethUtil = require('ethereumjs-util')
+const EthQuery = require('eth-query')
 const TxProviderUtil = require('./lib/tx-utils')
 const createId = require('./lib/random-id')
 
@@ -19,6 +20,7 @@ module.exports = class TransactionManager extends EventEmitter {
     this.txHistoryLimit = opts.txHistoryLimit
     this.provider = opts.provider
     this.blockTracker = opts.blockTracker
+    this.query = new EthQuery(this.provider)
     this.txProviderUtils = new TxProviderUtil(this.provider)
     this.blockTracker.on('block', this.checkForTxInBlock.bind(this))
     this.signEthTx = opts.signTransaction
@@ -329,7 +331,7 @@ module.exports = class TransactionManager extends EventEmitter {
         }
         return this.setTxStatusFailed(txId, errReason)
       }
-      this.txProviderUtils.query.getTransactionByHash(txHash, (err, txParams) => {
+      this.query.getTransactionByHash(txHash, (err, txParams) => {
         if (err || !txParams) {
           if (!txParams) return
           txMeta.err = {

--- a/ui/app/accounts/index.js
+++ b/ui/app/accounts/index.js
@@ -11,7 +11,7 @@ module.exports = connect(mapStateToProps)(AccountsScreen)
 
 function mapStateToProps (state) {
   const pendingTxs = valuesFor(state.metamask.unapprovedTxs)
-  .filter(tx => tx.txParams.metamaskNetworkId === state.metamask.network)
+  .filter(txMeta => txMeta.metamaskNetworkId === state.metamask.network)
   const pendingMsgs = valuesFor(state.metamask.unapprovedMsgs)
   const pending = pendingTxs.concat(pendingMsgs)
 

--- a/ui/app/accounts/index.js
+++ b/ui/app/accounts/index.js
@@ -11,7 +11,7 @@ module.exports = connect(mapStateToProps)(AccountsScreen)
 
 function mapStateToProps (state) {
   const pendingTxs = valuesFor(state.metamask.unapprovedTxs)
-  .filter(tx => tx.txParams.metamaskNetworkId === state.metamask.network)
+  .filter(tx => tx.metamaskNetworkId === state.metamask.network)
   const pendingMsgs = valuesFor(state.metamask.unapprovedMsgs)
   const pending = pendingTxs.concat(pendingMsgs)
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -421,6 +421,7 @@ function updateAndApproveTx (txData) {
   return (dispatch) => {
     log.debug(`actions calling background.updateAndApproveTx`)
     background.updateAndApproveTransaction(txData, (err) => {
+      dispatch(actions.hideLoadingIndication())
       if (err) {
         dispatch(actions.txError(err))
         return console.error(err.message)

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -7,8 +7,6 @@ const actions = require('./actions')
 const NetworkIndicator = require('./components/network')
 const txHelper = require('../lib/tx-helper')
 const isPopupOrNotification = require('../../app/scripts/lib/is-popup-or-notification')
-const ethUtil = require('ethereumjs-util')
-const BN = ethUtil.BN
 
 const PendingTx = require('./components/pending-tx')
 const PendingMsg = require('./components/pending-msg')
@@ -104,9 +102,6 @@ ConfirmTxScreen.prototype.render = function () {
           selectedAddress: props.selectedAddress,
           accounts: props.accounts,
           identities: props.identities,
-          insufficientBalance: this.checkBalanceAgainstTx(txData),
-          // State actions
-          onTxChange: this.onTxChange.bind(this),
           // Actions
           buyEth: this.buyEth.bind(this, txParams.from || props.selectedAddress),
           sendTransaction: this.sendTransaction.bind(this, txData),
@@ -145,37 +140,14 @@ function currentTxView (opts) {
   }
 }
 
-ConfirmTxScreen.prototype.checkBalanceAgainstTx = function (txData) {
-  if (!txData.txParams) return false
-  var props = this.props
-  var address = txData.txParams.from || props.selectedAddress
-  var account = props.accounts[address]
-  var balance = account ? account.balance : '0x0'
-  var maxCost = new BN(txData.maxCost, 16)
-
-  var balanceBn = new BN(ethUtil.stripHexPrefix(balance), 16)
-  return maxCost.gt(balanceBn)
-}
-
 ConfirmTxScreen.prototype.buyEth = function (address, event) {
   this.stopPropagation(event)
   this.props.dispatch(actions.buyEthView(address))
 }
 
-// Allows the detail view to update the gas calculations,
-// for manual gas controls.
-ConfirmTxScreen.prototype.onTxChange = function (txData) {
-  log.debug(`conf-tx onTxChange triggered with ${JSON.stringify(txData)}`)
-  this.setState({ txData })
-}
-
-// Must default to any local state txData,
-// to allow manual override of gas calculations.
 ConfirmTxScreen.prototype.sendTransaction = function (txData, event) {
   this.stopPropagation(event)
-  const state = this.state || {}
-  const txMeta = state.txData
-  this.props.dispatch(actions.updateAndApproveTx(txMeta || txData))
+  this.props.dispatch(actions.updateAndApproveTx(txData))
 }
 
 ConfirmTxScreen.prototype.cancelTransaction = function (txData, event) {

--- a/ui/lib/tx-helper.js
+++ b/ui/lib/tx-helper.js
@@ -4,7 +4,7 @@ module.exports = function (unapprovedTxs, unapprovedMsgs, personalMsgs, network)
   log.debug('tx-helper called with params:')
   log.debug({ unapprovedTxs, unapprovedMsgs, personalMsgs, network })
 
-  const txValues = network ? valuesFor(unapprovedTxs).filter(tx => tx.txParams.metamaskNetworkId === network) : valuesFor(unapprovedTxs)
+  const txValues = network ? valuesFor(unapprovedTxs).filter(tx => tx.metamaskNetworkId === network) : valuesFor(unapprovedTxs)
   log.debug(`tx helper found ${txValues.length} unapproved txs`)
   const msgValues = valuesFor(unapprovedMsgs)
   log.debug(`tx helper found ${msgValues.length} unsigned messages`)

--- a/ui/lib/tx-helper.js
+++ b/ui/lib/tx-helper.js
@@ -4,7 +4,7 @@ module.exports = function (unapprovedTxs, unapprovedMsgs, personalMsgs, network)
   log.debug('tx-helper called with params:')
   log.debug({ unapprovedTxs, unapprovedMsgs, personalMsgs, network })
 
-  const txValues = network ? valuesFor(unapprovedTxs).filter(tx => tx.metamaskNetworkId === network) : valuesFor(unapprovedTxs)
+  const txValues = network ? valuesFor(unapprovedTxs).filter(txMeta => txMeta.metamaskNetworkId === network) : valuesFor(unapprovedTxs)
   log.debug(`tx helper found ${txValues.length} unapproved txs`)
   const msgValues = valuesFor(unapprovedMsgs)
   log.debug(`tx helper found ${msgValues.length} unsigned messages`)
@@ -13,5 +13,5 @@ module.exports = function (unapprovedTxs, unapprovedMsgs, personalMsgs, network)
   log.debug(`tx helper found ${personalValues.length} unsigned personal messages`)
   allValues = allValues.concat(personalValues)
 
-  return allValues.sort(tx => tx.time)
+  return allValues.sort(txMeta => txMeta.time)
 }


### PR DESCRIPTION
DO NOT MERGE UNTIL @kumavis ADDS A BIT.  WON'T WORK UNTIL THEN.

- Now striping hex prefixed gas values, which could cause mis-estimation.
- Unified calculation logic to be entirely functional and easier to reason about.
- Greatly simplified how the pending-tx form keeps updated form state.
- Removed tons of dead code related to when we had this view split into a few components.

Still needs a commit from @kumavis to ensure the background passes in a txMeta.txParams.gasPrice value.

Mostly fixes #1274, except doesn't yet prevent exceeding block gas limit.