### PR TITLE
Fix firefox popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Popup new transactions in Firefox.
+
 ## 3.5.2 2017-3-28
 
 - Fix bug where gas estimate totals were sometimes wrong.

--- a/app/scripts/lib/extension.js
+++ b/app/scripts/lib/extension.js
@@ -11,4 +11,7 @@
  */
 
 const Extension = require('./extension-instance')
-module.exports = new Extension()
+const instance = new Extension()
+window.METAMASK_EXTENSION = instance
+module.exports = instance
+

--- a/app/scripts/lib/notifications.js
+++ b/app/scripts/lib/notifications.js
@@ -22,9 +22,11 @@ function show () {
       extension.windows.create({
         url: 'notification.html',
         type: 'popup',
-        focused: true,
         width,
         height,
+      })
+      .catch((reason) => {
+        log.error("failed to create poupup", reason)
       })
     }
   })

--- a/app/scripts/lib/notifications.js
+++ b/app/scripts/lib/notifications.js
@@ -26,7 +26,7 @@ function show () {
         height,
       })
       .catch((reason) => {
-        log.error("failed to create poupup", reason)
+        log.error('failed to create poupup', reason)
       })
     }
   })


### PR DESCRIPTION
Firefox popup was not popping up, because Firefox does not support the `focused` parameter when opening a new window, and we don't actually require it for Chrome either, new popups are at the foreground by default already.