### PR TITLE
deps - bump provider-engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "0.18.2",
-    "web3-provider-engine": "^10.0.1",
+    "web3-provider-engine": "^11.0.2",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
uses fetch instead of xhr, fixes a race condition in cache subp