### PR TITLE
Fix currency checking for firefox

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -57,7 +57,8 @@
   "permissions": [
     "storage",
     "clipboardWrite",
-    "http://localhost:8545/"
+    "http://localhost:8545/",
+    "https://www.cryptonator.com/"
   ],
   "web_accessible_resources": [
     "scripts/inpage.js"


### PR DESCRIPTION
By adding cryptonator to our permitted CORS hosts.

Fixes #1285.

Will probably trigger additional permissions requests to our users.