### PR TITLE
Fix errors wtih msgs/txs blocking the UI

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -494,7 +494,7 @@ module.exports = class MetamaskController extends EventEmitter {
       // tells the listener that the message has been signed
       // and can be returned to the dapp
       this.messageManager.setMsgStatusSigned(msgId, rawSig)
-      return this.getState()
+      return cb(null, this.getState())
     })
   }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -363,12 +363,10 @@ function signMsg (msgData) {
     log.debug(`actions calling background.signMessage`)
     background.signMessage(msgData, (err, newState) => {
       log.debug('signMessage called back')
-      dispatch(actions.updateMetamaskState(newState))
       dispatch(actions.hideLoadingIndication())
-
+      dispatch(actions.updateMetamaskState(newState))
       if (err) log.error(err)
-      if (err) return dispatch(actions.displayWarning(err.message))
-
+      if (err) dispatch(actions.displayWarning(err.message))
       dispatch(actions.completedTx(msgData.metamaskId))
     })
   }
@@ -386,7 +384,7 @@ function signPersonalMsg (msgData) {
       dispatch(actions.hideLoadingIndication())
 
       if (err) log.error(err)
-      if (err) return dispatch(actions.displayWarning(err.message))
+      if (err) dispatch(actions.displayWarning(err.message))
 
       dispatch(actions.completedTx(msgData.metamaskId))
     })
@@ -397,8 +395,11 @@ function signTx (txData) {
   return (dispatch) => {
     web3.eth.sendTransaction(txData, (err, data) => {
       dispatch(actions.hideLoadingIndication())
-      if (err) return dispatch(actions.displayWarning(err.message))
-      dispatch(actions.hideWarning())
+      if (err) {
+        dispatch(actions.displayWarning(err.message))
+      } else {
+        dispatch(actions.hideWarning())
+      }
     })
     dispatch(this.showConfTxPage())
   }
@@ -411,7 +412,7 @@ function sendTx (txData) {
     background.approveTransaction(txData.id, (err) => {
       if (err) {
         dispatch(actions.txError(err))
-        return console.error(err.message)
+        console.error(err.message)
       }
       dispatch(actions.completedTx(txData.id))
     })
@@ -426,7 +427,7 @@ function updateAndApproveTx (txData) {
       dispatch(actions.hideLoadingIndication())
       if (err) {
         dispatch(actions.txError(err))
-        return console.error(err.message)
+        console.error(err.message)
       }
       dispatch(actions.completedTx(txData.id))
     })

--- a/ui/app/components/pending-msg.js
+++ b/ui/app/components/pending-msg.js
@@ -32,10 +32,8 @@ PendingMsg.prototype.render = function () {
         style: {
           margin: '10px',
         },
-      }, `Signing this message can have
-        dangerous side effects. Only sign messages from
-        sites you fully trust with your entire account.
-        This will be fixed in a future version.`),
+      }, `Only sign messages from
+        sites you fully trust with your entire account.`),
 
       // message details
       h(PendingTxDetails, state),
@@ -53,4 +51,3 @@ PendingMsg.prototype.render = function () {
 
   )
 }
-


### PR DESCRIPTION
Fixes #1254 by removing return statements from our warning renders. These end up blocking our UI from updating properly, since `actions.completedTx` is responsible for several UI changes, such as state management, deciding whether to close the popup or show another tx, etc. etc.