### PR TITLE
test - fix notice-controller test

### DIFF
--- a/test/unit/notice-controller-test.js
+++ b/test/unit/notice-controller-test.js
@@ -11,8 +11,6 @@ describe('notice-controller', function() {
 
   beforeEach(function() {
     // simple localStorage polyfill
-    window.localStorage = {}
-    if (window.localStorage.clear) window.localStorage.clear()
     let configManager = configManagerGen()
     noticeController = new NoticeController({
       configManager: configManager,
@@ -21,7 +19,7 @@ describe('notice-controller', function() {
 
   describe('notices', function() {
     describe('#getNoticesList', function() {
-      it('should return an empty array when new', function() {
+      it('should return an empty array when new', function(done) {
         var testList = [{
           id:0,
           read:false,
@@ -29,11 +27,12 @@ describe('notice-controller', function() {
         }]
         var result = noticeController.getNoticesList()
         assert.equal(result.length, 0)
+        done()
       })
     })
 
     describe('#setNoticesList', function() {
-      it('should set data appropriately', function () {
+      it('should set data appropriately', function (done) {
         var testList = [{
           id:0,
           read:false,
@@ -42,11 +41,12 @@ describe('notice-controller', function() {
         noticeController.setNoticesList(testList)
         var testListId = noticeController.getNoticesList()[0].id
         assert.equal(testListId, 0)
+        done()
       })
     })
 
     describe('#updateNoticeslist', function() {
-      it('should integrate the latest changes from the source', function() {
+      it('should integrate the latest changes from the source', function(done) {
         var testList = [{
           id:55,
           read:false,
@@ -57,26 +57,26 @@ describe('notice-controller', function() {
           var newList = noticeController.getNoticesList()
           assert.ok(newList[0].id === 55)
           assert.ok(newList[1])
+          done()
         })
       })
-      it('should not overwrite any existing fields', function () {
+      it('should not overwrite any existing fields', function (done) {
         var testList = [{
           id:0,
           read:false,
           title:"Futuristic Notice"
         }]
         noticeController.setNoticesList(testList)
-        noticeController.updateNoticesList().then(() => {
-          var newList = noticeController.getNoticesList()
-          assert.equal(newList[0].id, 0)
-          assert.equal(newList[0].title, "Futuristic Notice")
-          assert.equal(newList.length, 1)
-        })
+        var newList = noticeController.getNoticesList()
+        assert.equal(newList[0].id, 0)
+        assert.equal(newList[0].title, "Futuristic Notice")
+        assert.equal(newList.length, 1)
+        done()
       })
     })
 
     describe('#markNoticeRead', function () {
-      it('should mark a notice as read', function () {
+      it('should mark a notice as read', function (done) {
         var testList = [{
           id:0,
           read:false,
@@ -86,11 +86,12 @@ describe('notice-controller', function() {
         noticeController.markNoticeRead(testList[0])
         var newList = noticeController.getNoticesList()
         assert.ok(newList[0].read)
+        done()
       })
     })
 
     describe('#getLatestUnreadNotice', function () {
-      it('should retrieve the latest unread notice', function () {
+      it('should retrieve the latest unread notice', function (done) {
         var testList = [
           {id:0,read:true,title:"Past Notice"},
           {id:1,read:false,title:"Current Notice"},
@@ -99,8 +100,9 @@ describe('notice-controller', function() {
         noticeController.setNoticesList(testList)
         var latestUnread = noticeController.getLatestUnreadNotice()
         assert.equal(latestUnread.id, 2)
+        done()
       })
-      it('should return undefined if no unread notices exist.', function () {
+      it('should return undefined if no unread notices exist.', function (done) {
         var testList = [
           {id:0,read:true,title:"Past Notice"},
           {id:1,read:true,title:"Current Notice"},
@@ -109,6 +111,7 @@ describe('notice-controller', function() {
         noticeController.setNoticesList(testList)
         var latestUnread = noticeController.getLatestUnreadNotice()
         assert.ok(!latestUnread)
+        done()
       })
     })
   })


### PR DESCRIPTION
calling `updateNoticesList` was injecting the hard coded notices

also cleaned up some stuff and enforced the done callback usage