### PR TITLE
Account transition fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Popup new transactions in Firefox.
+- Fix transition issue from account detail screen.
 
 ## 3.5.2 2017-3-28
 

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -60,7 +60,7 @@ AccountDetailScreen.prototype.render = function () {
         // header - identicon + nav
         h('div', {
           style: {
-            marginTop: '20px',
+            paddingTop: '20px',
             display: 'flex',
             justifyContent: 'flex-start',
             alignItems: 'flex-start',

--- a/ui/app/accounts/index.js
+++ b/ui/app/accounts/index.js
@@ -97,7 +97,7 @@ AccountsScreen.prototype.render = function () {
             style: {
               display: 'flex',
               height: '40px',
-              paddint: '10px',
+              padding: '10px',
               justifyContent: 'center',
               alignItems: 'center',
             },


### PR DESCRIPTION
Fixes #670 for the most part, broken off from another PR for modularity.

Why this works is because css transitions do not work well when you change margins. Changing this to padding makes everything a lot smoother.