### PR TITLE
Allow signature V values over 1 byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix occasional nonce tracking issue.
 - Fix bug where some events would not be emitted by web3.
+- Fix bug where an error would be thrown when composing signatures for networks with large ID values.
 
 ## 3.5.3 2017-4-24
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eth-query": "^1.0.3",
     "eth-sig-util": "^1.1.1",
     "eth-simple-keyring": "^1.1.1",
-    "ethereumjs-tx": "^1.2.5",
+    "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",
     "ethjs-ens": "^1.0.2",


### PR DESCRIPTION
By bumping ethereumjs-tx.

Helps mitigate #1341, but not by itself.