### PR TITLE
mascara - docker - bump to node7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:7
 MAINTAINER kumavis
 
 # setup app dir


### PR DESCRIPTION
this says that when we deploy our mascara cdn, we should use node v7 instead of node v6