### PR TITLE
build - make gulp return non-zero error code on bundle fail

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -296,8 +296,6 @@ function bundleTask(opts) {
     return (
 
       bundler.bundle()
-      // log errors if they happen
-      .on('error', gutil.log.bind(gutil, 'Browserify Error'))
       // convert bundle stream to gulp vinyl stream
       .pipe(source(opts.filename))
       // inject variables into bundle


### PR DESCRIPTION
`npm run dist` returns zero exit code when there is a browserify bundle error. This is bad.

This PR fixes it. It still logs the error. see xample output below:

before:
```
╭─kumavis@xyzs-MacBook-Pro  ~/dev/metamask-mascara ‹node-v6.10.1›  (master) 
╰─$ npm run dist                                                                                                                                                                 1 ↵

> metamask-crx@0.0.0 dist /Users/kumavis/dev/metamask-mascara
> gulp dist --disableLiveReload

[13:54:06] Using gulpfile ~/dev/metamask-mascara/gulpfile.js
[13:54:06] Starting 'dist'...
[13:54:06] Starting 'build'...
[13:54:06] Starting 'clean'...
[13:54:06] Finished 'clean' after 154 ms
[13:54:06] Starting 'build:js'...
[13:54:06] Starting 'copy'...
[13:54:06] Starting 'build:js:inpage'...
[13:54:06] Starting 'build:js:contentscript'...
[13:54:06] Starting 'build:js:background'...
[13:54:06] Starting 'build:js:popup'...
[13:54:06] Starting 'copy:locales'...
[13:54:06] Starting 'copy:images'...
[13:54:06] Starting 'copy:fonts'...
[13:54:06] Starting 'copy:root'...
[13:54:11] Finished 'copy:root' after 4.85 s
[13:54:12] Finished 'copy:locales' after 6.07 s
[13:54:12] Finished 'copy:fonts' after 6.44 s
[13:54:20] Finished 'copy:images' after 14 s
[13:54:20] Starting 'manifest:production'...
[13:54:22] Finished 'manifest:production' after 1.84 s
[13:54:22] Starting 'manifest:chrome'...
[13:54:23] Finished 'manifest:chrome' after 1.07 s
[13:54:23] Starting 'manifest:opera'...
[13:54:24] Browserify Error { ReferenceError: Unknown plugin "transform-runtime" specified in "/Users/kumavis/dev/metamask-mascara/node_modules/eth-block-tracker/.babelrc" at 0, attempted to resolve relative to "/Users/kumavis/dev/metamask-mascara/node_modules/eth-block-tracker" while parsing file: /Users/kumavis/dev/metamask-mascara/node_modules/eth-block-tracker/bundle/index.js
    at /Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:180:17
    at Array.map (native)
    at Function.normalisePlugins (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:158:20)
    at OptionManager.mergeOptions (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:36)
    at OptionManager.init (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at Babelify._flush (/Users/kumavis/dev/metamask-mascara/node_modules/babelify/index.js:27:24)
    at Babelify.<anonymous> (_stream_transform.js:118:12)
  filename: '/Users/kumavis/dev/metamask-mascara/node_modules/eth-block-tracker/bundle/index.js',
  stream: 
   Labeled {
     _readableState: 
      ReadableState {
        objectMode: true,
        highWaterMark: 16,
        buffer: [Object],
        length: 0,
        pipes: [Object],
        pipesCount: 1,
        flowing: true,
        ended: false,
        endEmitted: false,
        reading: true,
        sync: false,
        needReadable: true,
        emittedReadable: false,
        readableListening: false,
        resumeScheduled: false,
        defaultEncoding: 'utf8',
        ranOut: false,
        awaitDrain: 0,
        readingMore: false,
        decoder: null,
        encoding: null },
     readable: true,
     domain: null,
     _events: 
      { end: [Object],
        error: [Object],
        data: [Function: ondata],
        _mutate: [Object] },
     _eventsCount: 4,
     _maxListeners: undefined,
     _writableState: 
      WritableState {
        objectMode: true,
        highWaterMark: 16,
        needDrain: false,
        ending: true,
        ended: true,
        finished: true,
        decodeStrings: true,
        defaultEncoding: 'utf8',
        length: 0,
        writing: false,
        corked: 0,
        sync: false,
        bufferProcessing: false,
        onwrite: [Function],
        writecb: null,
        writelen: 0,
        bufferedRequest: null,
        lastBufferedRequest: null,
        pendingcb: 0,
        prefinished: true,
        errorEmitted: false,
        bufferedRequestCount: 0,
        corkedRequestsFree: [Object] },
     writable: false,
     allowHalfOpen: true,
     _options: { objectMode: true },
     _wrapOptions: { objectMode: true },
     _streams: [ [Object] ],
     length: 1,
     label: 'deps' } }
[13:54:24] Finished 'manifest:opera' after 1.1 s
[13:54:24] Finished 'copy' after 18 s
[13:54:30] Finished 'build:js:inpage' after 24 s
[13:54:30] Finished 'build:js:contentscript' after 24 s
[13:54:41] Finished 'build:js:popup' after 35 s
[13:54:41] The following tasks did not complete: dist, build, <parallel>, build:js, build:js:background
[13:54:41] Did you forget to signal async completion?
╭─kumavis@xyzs-MacBook-Pro  ~/dev/metamask-mascara ‹node-v6.10.1›  (master) 
╰─$ echo $?     
0
```

now:
```
╭─kumavis@xyzs-MacBook-Pro  ~/dev/metamask-mascara ‹node-v6.10.1›  (master) 
╰─$ npm run dist

> metamask-crx@0.0.0 dist /Users/kumavis/dev/metamask-mascara
> gulp dist --disableLiveReload

[14:02:25] Using gulpfile ~/dev/metamask-mascara/gulpfile.js
[14:02:25] Starting 'dist'...
[14:02:25] Starting 'build'...
[14:02:25] Starting 'clean'...
[14:02:25] Finished 'clean' after 211 ms
[14:02:25] Starting 'build:js'...
[14:02:25] Starting 'copy'...
[14:02:25] Starting 'build:js:inpage'...
[14:02:25] Starting 'build:js:contentscript'...
[14:02:25] Starting 'build:js:background'...
[14:02:25] Starting 'build:js:popup'...
[14:02:25] Starting 'copy:locales'...
[14:02:25] Starting 'copy:images'...
[14:02:25] Starting 'copy:fonts'...
[14:02:25] Starting 'copy:root'...
[14:02:30] Finished 'copy:root' after 4.8 s
[14:02:31] Finished 'copy:locales' after 5.91 s
[14:02:32] Finished 'copy:fonts' after 6.16 s
[14:02:38] Finished 'copy:images' after 13 s
[14:02:38] Starting 'manifest:production'...
[14:02:40] Finished 'manifest:production' after 2.16 s
[14:02:40] Starting 'manifest:chrome'...
[14:02:41] Finished 'manifest:chrome' after 1.11 s
[14:02:41] Starting 'manifest:opera'...
[14:02:42] 'build:js:background' errored after 17 s
[14:02:42] ReferenceError: Unknown plugin "transform-runtime" specified in "/Users/kumavis/dev/metamask-mascara/node_modules/eth-block-tracker/.babelrc" at 0, attempted to resolve relative to "/Users/kumavis/dev/metamask-mascara/node_modules/eth-block-tracker" while parsing file: /Users/kumavis/dev/metamask-mascara/node_modules/eth-block-tracker/bundle/index.js
    at /Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:180:17
    at Array.map (native)
    at Function.normalisePlugins (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:158:20)
    at OptionManager.mergeOptions (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:36)
    at OptionManager.init (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/Users/kumavis/dev/metamask-mascara/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at Babelify._flush (/Users/kumavis/dev/metamask-mascara/node_modules/babelify/index.js:27:24)
    at Babelify.<anonymous> (_stream_transform.js:118:12)
[14:02:42] 'build:js' errored after 17 s
[14:02:42] 'build' errored after 17 s
[14:02:42] 'dist' errored after 17 s
[14:02:42] The following tasks did not complete: copy, build:js:inpage, build:js:contentscript, build:js:popup, manifest:opera
[14:02:42] Did you forget to signal async completion?

npm ERR! Darwin 16.4.0
npm ERR! argv "/Users/kumavis/.nvm/versions/node/v6.10.1/bin/node" "/Users/kumavis/.nvm/versions/node/v6.10.1/bin/npm" "run" "dist"
npm ERR! node v6.10.1
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! metamask-crx@0.0.0 dist: `gulp dist --disableLiveReload`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the metamask-crx@0.0.0 dist script 'gulp dist --disableLiveReload'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the metamask-crx package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     gulp dist --disableLiveReload
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs metamask-crx
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls metamask-crx
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/kumavis/dev/metamask-mascara/npm-debug.log
```