### PR TITLE
notification-manager - remove promise listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug where error was reported in debugger console when Chrome opened a new window.
+
 ## 3.6.0 2017-4-25
 
 - Add Rinkeby Test Network to our network list.

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -24,9 +24,6 @@ class NotificationManager {
           width,
           height,
         })
-        .catch((reason) => {
-          log.error('failed to create poupup', reason)
-        })
       }
     })
   }


### PR DESCRIPTION
seems chrome changed their API?
MDN suggests that a Promise should be returned but getting `undefined`
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/windows/create

Chrome docs suggest its a callback API lolwut
https://developer.chrome.com/extensions/windows#method-create

so clearly the best idea is to remove logging so that we can rediscover the problem later in some subtle annoying fashion