### PR TITLE
Fix block polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Current Master
 
+## 3.6.1 2017-4-25
+
 - Fix bug where error was reported in debugger console when Chrome opened a new window.
+- Fix bug where block-tracker could stop polling for new blocks.
 
 ## 3.6.0 2017-4-25
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -341,9 +341,7 @@ module.exports = class MetamaskController extends EventEmitter {
         console.error('Error in RPC response:\n', response.error)
       }
       if (request.isMetamaskInternal) return
-      if (global.METAMASK_DEBUG) {
-        console.log(`RPC (${originDomain}):`, request, '->', response)
-      }
+      log.info(`RPC (${originDomain}):`, request, '->', response)
     }
   }
 
@@ -591,9 +589,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
   // Log blocks
   logBlock (block) {
-    if (global.METAMASK_DEBUG) {
-      console.log(`BLOCK CHANGED: #${block.number.toString('hex')} 0x${block.hash.toString('hex')}`)
-    }
+    log.info(`BLOCK CHANGED: #${block.number.toString('hex')} 0x${block.hash.toString('hex')}`)
     this.verifyNetwork()
   }
 
@@ -682,9 +678,7 @@ module.exports = class MetamaskController extends EventEmitter {
         this.setNetworkState('loading')
         return
       }
-      if (global.METAMASK_DEBUG) {
-        console.log('web3.getNetwork returned ' + network)
-      }
+      log.info('web3.getNetwork returned ' + network)
       this.setNetworkState(network)
     })
   }

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "0.18.2",
-    "web3-provider-engine": "^12.0.2",
+    "web3-provider-engine": "^12.0.3",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
When there was a parsing error, eth-block-tracker would not resume block polling.

Merged into eth-block-tracker here:
https://github.com/MetaMask/eth-block-tracker/pull/18

Merged into provider-engine here:
https://github.com/MetaMask/provider-engine/pull/144

Also bumps the version for a faster fix & deploy.