### PR TITLE
metamask controller - add tx watcher

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1,5 +1,6 @@
 const EventEmitter = require('events')
 const extend = require('xtend')
+const async = require('async')
 const promiseToCallback = require('promise-to-callback')
 const pipe = require('pump')
 const Dnode = require('dnode')
@@ -70,6 +71,16 @@ module.exports = class MetamaskController extends EventEmitter {
     this.ethStore = new EthStore({
       provider: this.provider,
       blockTracker: this.provider,
+    })
+
+    this.provider.on('block', (block) => {
+      const self = this
+      // console.log(block)
+      async.map(block.transactions, this.ethQuery.getTransactionByHash.bind(this.ethQuery), (err, transactions) => {
+        if (err) throw err
+        console.log(transactions)
+        transactions.forEach((tx) => self.inspectConfirmedTransaction(tx))
+      })
     })
 
     // key mgmt
@@ -237,6 +248,22 @@ module.exports = class MetamaskController extends EventEmitter {
         seedWords: this.configManager.getSeedWords(),
       }
     )
+  }
+
+  //
+  // notifications
+  //
+
+  inspectConfirmedTransaction (tx) {
+    this.keyringController.getAccounts().then((addresses) => {
+      addresses = addresses.map((addr) => '0x' + addr.toLowerCase())
+      console.log('addresses:', addresses)
+      let toAddress = (tx.to || '').toLowerCase()
+      if (addresses.indexOf(toAddress) !== -1) {
+        console.log('incomming tx!')
+        console.log(tx)
+      }
+    })
   }
 
   //


### PR DESCRIPTION
made this as an experiment - it looks for at the txs in each new block

we can use this to show notifications or something

couple annoying things:
- `eth-block-tracker` doesnt include tx bodies currently
- checking if we control an address is annoying, bc 0x prefixing and case sensitivity