### PR TITLE
Empty web3 accounts array when locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## Current Master
 
+- Properly remove addresses from web3 when locking MetaMask
+
 ## 3.6.1 2017-4-30
-
-- Made fox less nosy.
-
 
 - Fix bug where error was reported in debugger console when Chrome opened a new window.
 - Fix bug where block-tracker could stop polling for new blocks.

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -7,6 +7,7 @@ class PreferencesController {
   constructor (opts = {}) {
     const initState = extend({
       frequentRpcList: [],
+      lastAddress: '',
     }, opts.initState)
     this.store = new ObservableStore(initState)
   }
@@ -19,6 +20,18 @@ class PreferencesController {
     return new Promise((resolve, reject) => {
       const address = normalizeAddress(_address)
       this.store.updateState({ selectedAddress: address })
+      this.store.updateState({ lastAddress: address })
+      resolve()
+    })
+  }
+
+  restoreLastAddress () {
+    return this.setSelectedAddress(this.store.getState().lastAddress)
+  }
+
+  clearSelectedAddress () {
+    return new Promise((resolve, reject) => {
+      this.store.updateState({ selectedAddress: '' })
       resolve()
     })
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -424,6 +424,7 @@ module.exports = class MetamaskController extends EventEmitter {
   setLocked (cb) {
     this.keyringController.setLocked()
       .then((err, result) => {
+        if (err) { cb(err) }
         return this.preferencesController.clearSelectedAddress()
       }).then((err, result) => {
         cb(err, result)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -273,6 +273,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
       // PreferencesController
       setSelectedAddress: nodeify(preferencesController.setSelectedAddress).bind(preferencesController),
+      restoreLastAddress: nodeify(preferencesController.restoreLastAddress).bind(preferencesController),
       setDefaultRpc: nodeify(this.setDefaultRpc).bind(this),
       setCustomRpc: nodeify(this.setCustomRpc).bind(this),
 
@@ -280,7 +281,7 @@ module.exports = class MetamaskController extends EventEmitter {
       setAddressBook: nodeify(addressBookController.setAddressBook).bind(addressBookController),
 
       // KeyringController
-      setLocked: nodeify(keyringController.setLocked).bind(keyringController),
+      setLocked: this.setLocked.bind(this),
       createNewVaultAndKeychain: nodeify(keyringController.createNewVaultAndKeychain).bind(keyringController),
       createNewVaultAndRestore: nodeify(keyringController.createNewVaultAndRestore).bind(keyringController),
       addNewKeyring: nodeify(keyringController.addNewKeyring).bind(keyringController),
@@ -362,7 +363,11 @@ module.exports = class MetamaskController extends EventEmitter {
 
   submitPassword (password, cb) {
     return this.keyringController.submitPassword(password)
-    .then((newState) => { cb(null, newState) })
+    .then(() => {
+      return this.preferencesController.restoreLastAddress()
+    }).then(() => {
+      cb(null)
+    })
     .catch((reason) => { cb(reason) })
   }
 
@@ -415,6 +420,15 @@ module.exports = class MetamaskController extends EventEmitter {
   //
   // Identity Management
   //
+
+  setLocked (cb) {
+    this.keyringController.setLocked()
+      .then((err, result) => {
+        return this.preferencesController.clearSelectedAddress()
+      }).then((err, result) => {
+        cb(err, result)
+      })
+  }
 
   newUnapprovedTransaction (txParams, cb) {
     log.debug(`MetaMaskController newUnapprovedTransaction ${JSON.stringify(txParams)}`)

--- a/app/scripts/migrations/013.js
+++ b/app/scripts/migrations/013.js
@@ -1,0 +1,32 @@
+const version = 12
+
+/*
+
+This migration adds lastAddress to our controllers to maintain UI consistency.
+
+*/
+
+const clone = require('clone')
+
+module.exports = {
+  version,
+
+  migrate: function (originalVersionedData) {
+    const versionedData = clone(originalVersionedData)
+    versionedData.meta.version = version
+    try {
+      const state = versionedData.data
+      const newState = transformState(state)
+      versionedData.data = newState
+    } catch (err) {
+      console.warn(`MetaMask Migration #${version}` + err.stack)
+    }
+    return Promise.resolve(versionedData)
+  },
+}
+
+function transformState (state) {
+  const newState = state
+  newState.PreferencesController.lastAddress = newState.PreferencesController.selectedAddress
+  return newState
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -23,4 +23,5 @@ module.exports = [
   require('./010'),
   require('./011'),
   require('./012'),
+  require('./013'),
 ]

--- a/test/unit/migrations-test.js
+++ b/test/unit/migrations-test.js
@@ -16,6 +16,8 @@ const migration9 = require(path.join('..', '..', 'app', 'scripts', 'migrations',
 const migration10 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '010'))
 const migration11 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '011'))
 const migration12 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '012'))
+const migration13 = require(path.join('..', '..', 'app', 'scripts', 'migrations', '013'))
+
 
 
 const oldTestRpc = 'https://rawtestrpc.metamask.io/'
@@ -98,6 +100,10 @@ describe('wallet1 is migrated successfully', () => {
     }).then((twelfthResult) => {
       assert.equal(twelfthResult.data.NoticeController.noticesList[0].body, '', 'notices that have been read should have an empty body.')
       assert.equal(twelfthResult.data.NoticeController.noticesList[1].body, 'nonempty', 'notices that have not been read should not have an empty body.')
+
+      return migration13.migrate(twelfthResult)
+    }).then((thirteenthResult) => {
+      assert.equal(thirteenthResult.data.PreferencesController.lastAddress, thirteenthResult.data.PreferencesController.selectedAddress, 'lastAddress should be saved.')
     })
 
   })


### PR DESCRIPTION
Fixes #1363 by emptying web3 accounts when we lock MetaMask.

Outstanding issues that I need help on:
- Race condition in restoring the `selectedAddress` in time for when the unlock happens?
- Issue where if MetaMask locks due to an update, the accounts are not cleared in this instance.