### PR TITLE
metamask - selected accounts - dont reveal when locked

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -190,7 +190,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
   initPublicConfigStore () {
     // get init state
-    const publicConfigStore = new ObservableStore(this.store.getState())
+    const publicConfigStore = new ObservableStore()
 
     // memStore -> transform -> publicConfigStore
     this.on('update', (memState) => {


### PR DESCRIPTION
Fixes #1363 by emptying web3 accounts when we lock MetaMask.

Replaces https://github.com/MetaMask/metamask-plugin/pull/1371

We handle sync and async account lookups very differently so theres two fixes here.

sync -> publicConfig
async -> getAccounts