### PR TITLE
Version 3.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Current Master
 
+## 3.6.3 2017-5-8
+
+- Fix bug that could stop newer versions of Geth from working with MetaMask.
+
 ## 3.6.2 2017-5-8
 
 - Input gas price in Gwei.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",


### PR DESCRIPTION
Fixes new geth incompatibility by building in new eth-block-tracker.