### PR TITLE
Fix gas editing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Fix bug where edited gas parameters would not take effect.
 - Trim currency list.
 - Fix event filter bug introduced by newer versions of Geth.
 

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "browserify": "^13.0.0",
     "chai": "^3.5.0",
     "clone": "^1.0.2",
-    "create-react-factory": "^0.2.1",
     "deep-freeze-strict": "^1.1.1",
     "del": "^2.2.0",
     "envify": "^4.0.0",

--- a/test/unit/components/pending-tx-test.js
+++ b/test/unit/components/pending-tx-test.js
@@ -9,7 +9,7 @@ const Factory = createReactFactory(PendingTx)
 const ReactTestUtils = require('react-addons-test-utils')
 const ethUtil = require('ethereumjs-util')
 
-describe.only('PendingTx', function () {
+describe('PendingTx', function () {
   let pendingTxComponent
 
   const identities = {

--- a/test/unit/components/pending-tx-test.js
+++ b/test/unit/components/pending-tx-test.js
@@ -54,7 +54,6 @@ describe('PendingTx', function () {
     const component = additions.renderIntoDocument(pendingTxComponent)
     renderer.render(pendingTxComponent)
     const result = renderer.getRenderOutput()
-    const form = result.props.children
     assert.equal(result.type, 'div', 'should create a div')
 
     try {
@@ -63,10 +62,10 @@ describe('PendingTx', function () {
         target: {
           value: 2,
           checkValidity() { return true },
-        }
+        },
       })
 
-      let form = additions.find(component, 'form')[0]
+      const form = additions.find(component, 'form')[0]
       form.checkValidity = () => true
       form.getFormEl = () => { return { checkValidity() { return true } } }
       ReactTestUtils.Simulate.submit(form, { preventDefault() {}, target: { checkValidity() {

--- a/test/unit/components/pending-tx-test.js
+++ b/test/unit/components/pending-tx-test.js
@@ -2,15 +2,10 @@ const assert = require('assert')
 const additions = require('react-testutils-additions')
 const h = require('react-hyperscript')
 const PendingTx = require('../../../ui/app/components/pending-tx')
-const createReactFactory = require('create-react-factory').createReactFactory
-const React = require('react')
-const shallow = require('react-test-renderer/shallow')
-const Factory = createReactFactory(PendingTx)
 const ReactTestUtils = require('react-addons-test-utils')
 const ethUtil = require('ethereumjs-util')
 
 describe('PendingTx', function () {
-  let pendingTxComponent
 
   const identities = {
     '0xfdea65c8e26263f6d9a1b5de9555d2931a33b826': {
@@ -38,7 +33,7 @@ describe('PendingTx', function () {
 
   it('should use updated values when edited.', function (done) {
 
-    const renderer = ReactTestUtils.createRenderer();
+    const renderer = ReactTestUtils.createRenderer()
     const newGasPrice = '0x77359400'
 
     const props = {
@@ -56,16 +51,14 @@ describe('PendingTx', function () {
     }
 
     const pendingTxComponent = h(PendingTx, props)
-    const component = additions.renderIntoDocument(pendingTxComponent);
+    const component = additions.renderIntoDocument(pendingTxComponent)
     renderer.render(pendingTxComponent)
     const result = renderer.getRenderOutput()
     const form = result.props.children
-    const children = form.props.children[form.props.children.length - 1]
     assert.equal(result.type, 'div', 'should create a div')
 
-    try{
-
-      const input = additions.find(component, '.cell.row input[type="number"]')[1]
+    try {
+      const input = additions.find(component, '.cell.row input[type='number']')[1]
       ReactTestUtils.Simulate.change(input, {
         target: {
           value: 2,
@@ -76,14 +69,14 @@ describe('PendingTx', function () {
       let form = additions.find(component, 'form')[0]
       form.checkValidity = () => true
       form.getFormEl = () => { return { checkValidity() { return true } } }
-      ReactTestUtils.Simulate.submit(form, { preventDefault() {}, target: { checkValidity() {return true} } })
+      ReactTestUtils.Simulate.submit(form, { preventDefault() {}, target: { checkValidity() {
+        return true
+      } } })
 
     } catch (e) {
-      console.log("WHAAAA")
+      console.log('WHAAAA')
       console.error(e)
     }
-
   })
-
 })
 

--- a/test/unit/components/pending-tx-test.js
+++ b/test/unit/components/pending-tx-test.js
@@ -58,7 +58,7 @@ describe('PendingTx', function () {
     assert.equal(result.type, 'div', 'should create a div')
 
     try {
-      const input = additions.find(component, '.cell.row input[type='number']')[1]
+      const input = additions.find(component, '.cell.row input[type="number"]')[1]
       ReactTestUtils.Simulate.change(input, {
         target: {
           value: 2,

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -3,6 +3,7 @@ const EventEmitter = require('events')
 const ethUtil = require('ethereumjs-util')
 const EthTx = require('ethereumjs-tx')
 const ObservableStore = require('obs-store')
+const clone = require('clone')
 const TransactionController = require('../../app/scripts/controllers/transactions')
 const noop = () => true
 const currentNetworkId = 42
@@ -184,8 +185,11 @@ describe('Transaction Controller', function () {
         },
       }
 
+      const updatedMeta = clone(txMeta)
+
       txController.addTx(txMeta)
-      txMeta.txParams.gasPrice = desiredGasPriced
+      updatedMeta.txParams.gasPrice = desiredGasPriced
+      txController.updateTx(updatedMeta)
       var result = txController.getTx('1')
       assert.equal(result.txParams.gasPrice, desiredGasPriced, 'gas price updated')
     })

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -9,7 +9,7 @@ const currentNetworkId = 42
 const otherNetworkId = 36
 const privKey = new Buffer('8718b9618a37d1fc78c436511fc6df3c8258d3250635bba617f33003270ec03e', 'hex')
 
-describe('Transaction Manager', function () {
+describe('Transaction Controller', function () {
   let txController
 
   beforeEach(function () {
@@ -170,6 +170,25 @@ describe('Transaction Manager', function () {
       var result = txController.getTx('1')
       assert.equal(result.hash, 'foo')
     })
+
+    it('updates gas price', function () {
+      const originalGasPrice = '0x01'
+      const desiredGasPriced = '0x02'
+
+      const txMeta = {
+        id: '1',
+        status: 'unapproved',
+        metamaskNetworkId: currentNetworkId,
+        txParams: {
+          gasPrice: originalGasPrice,
+        },
+      }
+
+      txController.addTx(txMeta)
+      txMeta.txParams.gasPrice = desiredGasPriced
+      var result = txController.getTx('1')
+      assert.equal(result.txParams.gasPrice, desiredGasPriced, 'gas price updated')
+    })
   })
 
   describe('#getUnapprovedTxList', function () {
@@ -234,4 +253,5 @@ describe('Transaction Manager', function () {
       })
     })
   })
+
 })

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -108,7 +108,7 @@ ConfirmTxScreen.prototype.render = function () {
           currentCurrency,
           // Actions
           buyEth: this.buyEth.bind(this, txParams.from || props.selectedAddress),
-          sendTransaction: this.sendTransaction.bind(this, txData),
+          sendTransaction: this.sendTransaction.bind(this),
           cancelTransaction: this.cancelTransaction.bind(this, txData),
           signMessage: this.signMessage.bind(this, txData),
           signPersonalMessage: this.signPersonalMessage.bind(this, txData),


### PR DESCRIPTION
Adding more gas updating tests.

Removed a `.only` call on one of unit test `describe` blocks, which prevented most of our unit tests from running.