### PR TITLE
Fix bug where decimals in gas inputs gave strange results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix bug where edited gas parameters would not take effect.
 - Trim currency list.
 - Fix event filter bug introduced by newer versions of Geth.
+- Fix bug where decimals in gas inputs could result in strange values.
 
 ## 3.6.4 2017-5-8
 

--- a/ui/app/components/hex-as-decimal-input.js
+++ b/ui/app/components/hex-as-decimal-input.js
@@ -139,7 +139,7 @@ HexAsDecimalInput.prototype.constructWarning = function () {
 }
 
 function hexify (decimalString) {
-  const hexBN = new BN(decimalString, 10)
+  const hexBN = new BN(decimalString.split('.')[0], 10)
   return '0x' + hexBN.toString('hex')
 }
 

--- a/ui/app/components/hex-as-decimal-input.js
+++ b/ui/app/components/hex-as-decimal-input.js
@@ -139,7 +139,7 @@ HexAsDecimalInput.prototype.constructWarning = function () {
 }
 
 function hexify (decimalString) {
-  const hexBN = new BN(decimalString.split('.')[0], 10)
+  const hexBN = new BN(parseInt(decimalString), 10)
   return '0x' + hexBN.toString('hex')
 }
 


### PR DESCRIPTION
Alex Miller reported that decimal inputs were giving strange results.  Until our BN input is ready, this will prevent that kind of bug from happening.