### PR TITLE
Version 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+## 3.6.5 2017-5-17
+
 - Fix bug where edited gas parameters would not take effect.
 - Trim currency list.
 - Fix event filter bug introduced by newer versions of Geth.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",


### PR DESCRIPTION
- Fix bug where edited gas parameters would not take effect.
- Trim currency list.
- Fix event filter bug introduced by newer versions of Geth.
- Fix bug where decimals in gas inputs could result in strange values.