### PR TITLE
Help debug stalled txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Add Transaction Number (nonce) to transaction list.
+
 ## 3.6.5 2017-5-17
 
 - Fix bug where edited gas parameters would not take effect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Add Transaction Number (nonce) to transaction list.
+- Label the pending tx icon with a tooltip.
 
 ## 3.6.5 2017-5-17
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",
     "multiplex": "^6.7.0",
+    "number-to-bn": "^1.7.0",
     "obs-store": "^2.3.1",
     "once": "^1.3.3",
     "ping-pong-stream": "^1.0.0",

--- a/ui/app/components/transaction-list-item-icon.js
+++ b/ui/app/components/transaction-list-item-icon.js
@@ -36,13 +36,12 @@ TransactionIcon.prototype.render = function () {
       return h(Tooltip, {
         title: 'Pending',
         position: 'bottom',
-      },
-      [
+      }, [
         h('i.fa.fa-ellipsis-h', {
           style: {
             fontSize: '27px',
           },
-        })
+        }),
       ])
   }
 

--- a/ui/app/components/transaction-list-item-icon.js
+++ b/ui/app/components/transaction-list-item-icon.js
@@ -1,6 +1,7 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
+const Tooltip = require('./tooltip')
 
 const Identicon = require('./identicon')
 
@@ -32,11 +33,17 @@ TransactionIcon.prototype.render = function () {
       })
 
     case 'submitted':
-      return h('i.fa.fa-ellipsis-h', {
-        style: {
-          fontSize: '27px',
-        },
-      })
+      return h(Tooltip, {
+        title: 'Pending',
+        position: 'bottom',
+      },
+      [
+        h('i.fa.fa-ellipsis-h', {
+          style: {
+            fontSize: '27px',
+          },
+        })
+      ])
   }
 
   if (isMsg) {

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -8,7 +8,7 @@ const explorerLink = require('../../lib/explorer-link')
 const CopyButton = require('./copyButton')
 const vreme = new (require('vreme'))
 const Tooltip = require('./tooltip')
-const BN = require('ethereumjs-util').BN
+const numberToBN = require('number-to-bn')
 
 const TransactionIcon = require('./transaction-list-item-icon')
 const ShiftListItem = require('./shift-list-item')
@@ -40,7 +40,7 @@ TransactionListItem.prototype.render = function () {
     txParams = transaction.msgParams
   }
 
-  const nonce = txParams.nonce ? (new BN(txParams.nonce.substr(2))).toString(10) : ''
+  const nonce = txParams.nonce ? numberToBN(txParams.nonce).toString(10) : ''
 
   const isClickable = ('hash' in transaction && isLinkable) || isPending
   return (

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -75,8 +75,7 @@ TransactionListItem.prototype.render = function () {
       h(Tooltip, {
         title: 'Transaction Number',
         position: 'bottom',
-      },
-      [
+      }, [
         h('span', {
           style: {
             display: 'flex',
@@ -88,7 +87,6 @@ TransactionListItem.prototype.render = function () {
           },
         }, nonce),
       ]),
-
 
       h('.flex-column', {style: {width: '200px', overflow: 'hidden'}}, [
         domainField(txParams),

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -8,6 +8,7 @@ const explorerLink = require('../../lib/explorer-link')
 const CopyButton = require('./copyButton')
 const vreme = new (require('vreme'))
 const Tooltip = require('./tooltip')
+const BN = require('ethereumjs-util').BN
 
 const TransactionIcon = require('./transaction-list-item-icon')
 const ShiftListItem = require('./shift-list-item')
@@ -39,6 +40,8 @@ TransactionListItem.prototype.render = function () {
     txParams = transaction.msgParams
   }
 
+  const nonce = (new BN(txParams.nonce.substr(2))).toString(10)
+
   const isClickable = ('hash' in transaction && isLinkable) || isPending
   return (
     h(`.transaction-list-item.flex-row.flex-space-between${isClickable ? '.pointer' : ''}`, {
@@ -68,6 +71,24 @@ TransactionListItem.prototype.render = function () {
           h(TransactionIcon, { txParams, transaction, isTx, isMsg }),
         ]),
       ]),
+
+      h(Tooltip, {
+        title: 'Transaction Number',
+        position: 'bottom',
+      },
+      [
+        h('span', {
+          style: {
+            display: 'flex',
+            cursor: 'normal',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '10px',
+          },
+        }, nonce),
+      ]),
+
 
       h('.flex-column', {style: {width: '200px', overflow: 'hidden'}}, [
         domainField(txParams),

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -40,7 +40,7 @@ TransactionListItem.prototype.render = function () {
     txParams = transaction.msgParams
   }
 
-  const nonce = (new BN(txParams.nonce.substr(2))).toString(10)
+  const nonce = txParams.nonce ? (new BN(txParams.nonce.substr(2))).toString(10) : ''
 
   const isClickable = ('hash' in transaction && isLinkable) || isPending
   return (


### PR DESCRIPTION
Added a few stylistic changes to the tx list to make it easier to debug users' stalled txs:
- Show nonce in tx list
- Add tooltip to pending tx icon (people have been confused by it) for until we have a better icon.

<img width="400" alt="screen shot 2017-05-21 at 2 14 56 pm" src="https://cloud.githubusercontent.com/assets/542863/26287453/8e565816-3e30-11e7-8992-835ef695748a.png">
<img width="360" alt="screen shot 2017-05-21 at 2 14 50 pm" src="https://cloud.githubusercontent.com/assets/542863/26287454/8e592d70-3e30-11e7-990c-8f009c11a0b9.png">
