### PR TITLE
Throw if ENS Resolver isn't set up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add Transaction Number (nonce) to transaction list.
 - Label the pending tx icon with a tooltip.
 - Fix bug where website filters would pile up and not deallocate when leaving a site.
+- ENS names will no longer resolve to their owner if no resolver is set. Resolvers must be explicitly set and configured.
 
 ## 3.6.5 2017-5-17
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",
-    "ethjs-ens": "^1.0.2",
+    "ethjs-ens": "^2.0.0",
     "express": "^4.14.0",
     "extension-link-enabler": "^1.0.0",
     "extensionizer": "^1.0.0",


### PR DESCRIPTION
Instead of resolving to name owners, which can encourage inconsistent usage of ENS.

Fixes #1427.