### PR TITLE
Ethereum Classic Support

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -31,7 +31,7 @@ const diskStore = new LocalStorageStore({ storageKey: STORAGE_KEY })
 // initialization flow
 initialize().catch(console.error)
 
-async function initialize() {
+async function initialize () {
   const initState = await loadStateFromPersistence()
   await setupController(initState)
   console.log('MetaMask initialization complete.')

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -15,6 +15,6 @@ module.exports = {
     classic: CLASSIC_RPC_URL,
   },
   networkIdOverwrites: {
-    classic: 0x3d,
+    classic: '61',
   },
 }

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -2,6 +2,7 @@ const MAINET_RPC_URL = 'https://mainnet.infura.io/metamask'
 const ROPSTEN_RPC_URL = 'https://ropsten.infura.io/metamask'
 const KOVAN_RPC_URL = 'https://kovan.infura.io/metamask'
 const RINKEBY_RPC_URL = 'https://rinkeby.infura.io/metamask'
+const CLASSIC_RPC_URL = 'http://metamask.epool.io:9999/'
 
 global.METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
 
@@ -11,5 +12,6 @@ module.exports = {
     ropsten: ROPSTEN_RPC_URL,
     kovan: KOVAN_RPC_URL,
     rinkeby: RINKEBY_RPC_URL,
+    classic: CLASSIC_RPC_URL,
   },
 }

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -2,7 +2,7 @@ const MAINET_RPC_URL = 'https://mainnet.infura.io/metamask'
 const ROPSTEN_RPC_URL = 'https://ropsten.infura.io/metamask'
 const KOVAN_RPC_URL = 'https://kovan.infura.io/metamask'
 const RINKEBY_RPC_URL = 'https://rinkeby.infura.io/metamask'
-const CLASSIC_RPC_URL = 'http://metamask.epool.io:9999/'
+const CLASSIC_RPC_URL = 'https://mewapi.epool.io'
 
 global.METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
 
@@ -13,5 +13,8 @@ module.exports = {
     kovan: KOVAN_RPC_URL,
     rinkeby: RINKEBY_RPC_URL,
     classic: CLASSIC_RPC_URL,
+  },
+  networkIdOverwrites: {
+    classic: 0x3d,
   },
 }

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -207,12 +207,7 @@ module.exports = class TransactionManager extends EventEmitter {
 
   getChainId () {
     const networkState = this.networkStore.getState()
-    var getChainId
-    if (networkState.chain) {
-      getChainId = networkState.chain
-    } else {
-      getChainId = parseInt(networkState.network)
-    }
+    const getChainId = parseInt(networkState.network)
     if (Number.isNaN(getChainId)) {
       return 0
     } else {

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -207,7 +207,12 @@ module.exports = class TransactionManager extends EventEmitter {
 
   getChainId () {
     const networkState = this.networkStore.getState()
-    const getChainId = parseInt(networkState.network)
+    var getChainId
+    if (networkState.chain) {
+      getChainId = networkState.chain
+    } else {
+      getChainId = parseInt(networkState.network)
+    }
     if (Number.isNaN(getChainId)) {
       return 0
     } else {

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -388,7 +388,6 @@ module.exports = class TransactionController extends EventEmitter {
     this.emit(`${txMeta.id}:${status}`, txId)
     if (status === 'submitted' || status === 'rejected') {
       this.emit(`${txMeta.id}:finished`, txMeta)
-
     }
     this.updateTx(txMeta)
     this.emit('updateBadge')

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -18,6 +18,11 @@ function getBuyEthUrl ({ network, amount, address }) {
     case '42':
       url = 'https://github.com/kovan-testnet/faucet'
       break
+
+    case '61':
+      url = 'https://poloniex.com/exchange#btc_etc'
+      break
+
   }
   return url
 }

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -7,6 +7,7 @@ const ROPSTEN_RPC = MetamaskConfig.network.ropsten
 const KOVAN_RPC = MetamaskConfig.network.kovan
 const RINKEBY_RPC = MetamaskConfig.network.rinkeby
 const CLASSIC_RPC = MetamaskConfig.network.classic
+const CLASSIC_OVERWRITE = MetamaskConfig.networkIdOverwrites.classic
 
 /* The config-manager is a convenience object
  * wrapping a pojo-migrator.
@@ -160,6 +161,18 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
 
     default:
       return provider && provider.rpcTarget ? provider.rpcTarget : RINKEBY_RPC
+  }
+}
+
+ConfigManager.prototype.getNetworkIdOverwrite = function () {
+  var provider = this.getProvider()
+  if (!provider) return null
+  switch (provider.type) {
+    case 'classic':
+      return CLASSIC_OVERWRITE
+
+    default:
+      return null
   }
 }
 

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -8,7 +8,6 @@ const ROPSTEN_RPC = MetamaskConfig.network.ropsten
 const KOVAN_RPC = MetamaskConfig.network.kovan
 const RINKEBY_RPC = MetamaskConfig.network.rinkeby
 const CLASSIC_RPC = MetamaskConfig.network.classic
-const CLASSIC_OVERWRITE = MetamaskConfig.networkIdOverwrites.classic
 
 /* The config-manager is a convenience object
  * wrapping a pojo-migrator.
@@ -161,18 +160,6 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
 
     default:
       return provider && provider.rpcTarget ? provider.rpcTarget : RINKEBY_RPC
-  }
-}
-
-ConfigManager.prototype.getNetworkIdOverwrite = function () {
-  var provider = this.getProvider()
-  if (!provider) return null
-  switch (provider.type) {
-    case 'classic':
-      return CLASSIC_OVERWRITE
-
-    default:
-      return null
   }
 }
 

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -6,6 +6,7 @@ const MAINNET_RPC = MetamaskConfig.network.mainnet
 const ROPSTEN_RPC = MetamaskConfig.network.ropsten
 const KOVAN_RPC = MetamaskConfig.network.kovan
 const RINKEBY_RPC = MetamaskConfig.network.rinkeby
+const CLASSIC_RPC = MetamaskConfig.network.classic
 
 /* The config-manager is a convenience object
  * wrapping a pojo-migrator.
@@ -153,6 +154,9 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
 
     case 'rinkeby':
       return RINKEBY_RPC
+
+    case 'classic':
+      return CLASSIC_RPC
 
     default:
       return provider && provider.rpcTarget ? provider.rpcTarget : RINKEBY_RPC

--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -14,8 +14,8 @@ class Migrator {
   async migrateData (versionedData = this.generateInitialState()) {
     const pendingMigrations = this.migrations.filter(migrationIsPending)
 
-    for (let index in pendingMigrations) {
-      let migration = pendingMigrations[index]
+    for (const index in pendingMigrations) {
+      const migration = pendingMigrations[index]
       versionedData = await migration.migrate(versionedData)
       if (!versionedData.data) throw new Error('Migrator - migration returned empty data')
       if (versionedData.version !== undefined && versionedData.meta.version !== migration.version) throw new Error('Migrator - Migration did not update version number correctly')

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -663,7 +663,13 @@ module.exports = class MetamaskController extends EventEmitter {
   }
 
   setNetworkState (network) {
-    return this.networkStore.updateState({ network })
+    var provider = this.configManager.getProvider();
+    if (!provider || provider.type !== 'classic') {
+      return this.networkStore.updateState({ network })
+    } else {
+      return this.networkStore.updateState({ network: network,
+                                             chain: 0x3d });
+    }
   }
 
   isNetworkLoading () {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -663,13 +663,7 @@ module.exports = class MetamaskController extends EventEmitter {
   }
 
   setNetworkState (network) {
-    var provider = this.configManager.getProvider();
-    if (!provider || provider.type !== 'classic') {
-      return this.networkStore.updateState({ network })
-    } else {
-      return this.networkStore.updateState({ network: network,
-                                             chain: 0x3d });
-    }
+    return this.networkStore.updateState({ network })
   }
 
   isNetworkLoading () {
@@ -687,7 +681,12 @@ module.exports = class MetamaskController extends EventEmitter {
         return
       }
       log.info('web3.getNetwork returned ' + network)
-      this.setNetworkState(network)
+      const overwrite = this.configManager.getNetworkIdOverwrite()
+      if (overwrite) {
+        this.setNetworkState(overwrite)
+      } else {
+        this.setNetworkState(network)
+      }
     })
   }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -871,8 +871,7 @@ function pairUpdate (coin) {
 }
 
 function shapeShiftSubview (network) {
-  var pair
-  network === 'classic' ? pair = 'btc_etc' : pair = 'btc_eth'
+  var pair = 'btc_eth'
 
   return (dispatch) => {
     dispatch(actions.showSubLoadingIndication())

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -871,7 +871,8 @@ function pairUpdate (coin) {
 }
 
 function shapeShiftSubview (network) {
-  var pair = 'btc_eth'
+  var pair
+  network === 'classic' ? pair = 'btc_etc' : pair = 'btc_eth'
 
   return (dispatch) => {
     dispatch(actions.showSubLoadingIndication())

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -274,6 +274,15 @@ App.prototype.renderNetworkDropdown = function () {
     }),
 
     h(DropMenuItem, {
+      label: 'Ethereum Classic Network',
+      closeMenu: () => this.setState({ isNetworkMenuOpen: false}),
+      action: () => props.dispatch(actions.setProviderType('classic')),
+      icon: h('.menu-icon.hollow-diamond'),
+      activeNetworkRender: props.network,
+      provider: props.provider,
+    }),
+
+    h(DropMenuItem, {
       label: 'Localhost 8545',
       closeMenu: () => this.setState({ isNetworkMenuOpen: false }),
       action: () => props.dispatch(actions.setDefaultRpcTarget(rpcList)),

--- a/ui/app/components/drop-menu-item.js
+++ b/ui/app/components/drop-menu-item.js
@@ -50,6 +50,9 @@ DropMenuItem.prototype.activeNetworkRender = function () {
     case 'Rinkeby Test Network':
       if (providerType === 'rinkeby') return h('.check', '✓')
       break
+    case 'Ethereum Classic Network':
+      if (providerType === 'classic') return h('.check', '✓')
+      break
     case 'Localhost 8545':
       if (activeNetwork === 'http://localhost:8545') return h('.check', '✓')
       break

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -46,6 +46,9 @@ Network.prototype.render = function () {
   } else if (providerName === 'rinkeby') {
     hoverText = 'Rinkeby Test Network'
     iconName = 'rinkeby-test-network'
+  } else if (providerName === 'classic') {
+    hoverText = 'Ethereum Classic Network'
+    iconName = 'classic-network'
   } else {
     hoverText = 'Unknown Private Network'
     iconName = 'unknown-private-network'
@@ -93,6 +96,15 @@ Network.prototype.render = function () {
                   color: '#e7a218',
                 }},
               'Rinkeby Test Net'),
+            ])
+          case 'classic-network':
+            return h('.network-indicator', [
+              h('.menu-icon.hollow-diamond'),
+              h('.network-name', {
+                style: {
+                  color: '#039396',
+                }},
+              'Etherum Classic'),
             ])
           default:
             return h('.network-indicator', [

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -28,7 +28,7 @@ TransactionListItem.prototype.render = function () {
 
   let isLinkable = false
   const numericNet = parseInt(network)
-  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 4 || numericNet === 42
+  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 4 || numericNet === 42 || numericNet == 61
 
   var isMsg = ('msgParams' in transaction)
   var isTx = ('txParams' in transaction)

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -28,7 +28,7 @@ TransactionListItem.prototype.render = function () {
 
   let isLinkable = false
   const numericNet = parseInt(network)
-  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 4 || numericNet === 42 || numericNet == 61
+  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 4 || numericNet === 42 || numericNet === 61
 
   var isMsg = ('msgParams' in transaction)
   var isTx = ('txParams' in transaction)

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -171,6 +171,10 @@ function currentProviderDisplay (metamaskState) {
       value = 'Rinkeby Test Network'
       break
 
+    case 'classic':
+      title = 'Current Network'
+      value = 'Ethereum Classic Network'
+
     default:
       title = 'Current RPC'
       value = metamaskState.provider.rpcTarget

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -174,6 +174,7 @@ function currentProviderDisplay (metamaskState) {
     case 'classic':
       title = 'Current Network'
       value = 'Ethereum Classic Network'
+      break
 
     default:
       title = 'Current RPC'

--- a/ui/lib/account-link.js
+++ b/ui/lib/account-link.js
@@ -17,6 +17,9 @@ module.exports = function (address, network) {
     case 42: // kovan test net
       link = `http://kovan.etherscan.io/address/${address}`
       break
+    case 61: // classic net
+      link = `https://gastracker.io/addr/${address}`
+      break
     default:
       link = ''
       break

--- a/ui/lib/explorer-link.js
+++ b/ui/lib/explorer-link.js
@@ -14,6 +14,8 @@ module.exports = function (hash, network) {
     case 42: // kovan test net
       prefix = 'kovan.'
       break
+    case 61: // classic net
+      return `https://gastracker.io/tx/${hash}`
     default:
       prefix = ''
   }


### PR DESCRIPTION
For ETC users who want to test this out, [here](https://drive.google.com/drive/folders/0B9jwlWGMea63Zkp0UTlEN0Fnem8?usp=sharing) are the builds. Most of the function works except address/transaction explorer links and buy-eth link.

To fix the address/transaction links, however, there's some complications:

* Ethereum and Ethereum Classic uses the same `networkId = 1`
* Ethereum doesn't have a `chainId`. Ethereum Classic has `chainId = 0x3d`.
* The current transaction signing process in metamask confuses `networkId` with `chainId`. `chainId` is set to always equal to `networkId`, if I get this correct.
* UI links dispatch based on the `networkId`.

So I think there's some small refactoring needed...