### PR TITLE
Version 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+## 3.7.0 2017-5-23
+
 - Add Transaction Number (nonce) to transaction list.
 - Label the pending tx icon with a tooltip.
 - Fix bug where website filters would pile up and not deallocate when leaving a site.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.6.5",
+  "version": "3.7.0",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -12,7 +12,7 @@ const denodeify = require('denodeify')
 const RETRY_LIMIT = 200
 const RESUBMIT_INTERVAL = 10000 // Ten seconds
 
-module.exports = class TransactionManager extends EventEmitter {
+module.exports = class TransactionController extends EventEmitter {
   constructor (opts) {
     super()
     this.store = new ObservableStore(extend({
@@ -448,7 +448,8 @@ module.exports = class TransactionManager extends EventEmitter {
     const rawTx = txMeta.rawTx
     this.txProviderUtils.publishTransaction(rawTx, cb)
   }
+
 }
 
 
-const warn = () => console.warn('warn was used no cb provided')
+const warn = () => log.warn('warn was used no cb provided')


### PR DESCRIPTION
- Add Transaction Number (nonce) to transaction list.
- Label the pending tx icon with a tooltip.
- Fix bug where website filters would pile up and not deallocate when leaving a site.
- Continually resubmit pending txs for a period of time to ensure successful broadcast.
- ENS names will no longer resolve to their owner if no resolver is set. Resolvers must be explicitly set and configured.