### PR TITLE
Add Max GasLimit Ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Now when switching networks the extension does not restart
 - Cleanup decimal bugs in our gas inputs.
 - Fix bug where submit button was enabled for invalid gas inputs.
+- Now enforce 95% of block's gasLimit to protect users.
 
 ## 3.7.0 2017-5-23
 

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -47,6 +47,7 @@ PendingTx.prototype.render = function () {
   // Gas
   const gas = txParams.gas
   const gasBn = hexToBn(gas)
+  const safeGasLimit = parseInt(txMeta.blockGasLimit)
 
   // Gas Price
   const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_BN.toString(16)
@@ -159,6 +160,7 @@ PendingTx.prototype.render = function () {
                   scale: 0,
                   // The hard lower limit for gas.
                   min: MIN_GAS_LIMIT_BN.toString(10),
+                  max: safeGasLimit,
                   suffix: 'UNITS',
                   style: {
                     position: 'relative',


### PR DESCRIPTION
Adds a maximum limit of 95% of the current block's gas limit, to protect users.

![untitled](https://cloud.githubusercontent.com/assets/1840057/26429687/2a8c7288-409d-11e7-9b6a-5bb9afb8a6f7.png)
