### PR TITLE
Remove streaming subprovider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cleanup decimal bugs in our gas inputs.
 - Fix bug where submit button was enabled for invalid gas inputs.
 - Now enforce 95% of block's gasLimit to protect users.
+- Removing provider-engine from the inpage provider. This fixes some error handling inconsistencies introduced in 3.7.0.
 
 ## 3.7.0 2017-5-23
 


### PR DESCRIPTION
Since the polling leak seems to be coming from elsewhere, and new bugs came from this, I'm rolling back this change so that we can push the other improvements sooner and fix the bug at its true root.