### PR TITLE
metamask controller - start of using composed obs-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "mkdirp": "^0.5.1",
     "multiplex": "^6.7.0",
     "number-to-bn": "^1.7.0",
-    "obs-store": "^2.3.1",
+    "obs-store": "^2.4.1",
     "once": "^1.3.3",
     "ping-pong-stream": "^1.0.0",
     "pojo-migrator": "^2.1.0",


### PR DESCRIPTION
This is the start of a small refactor to remove our manual subscriptions for `MetamaskController`'s `diskStore` and `memStore`. This is not complete for two reasons:
- [ ] we still create our `memStore` from non-obs-store objects.
- [ ] configManager wants to consume the `diskStore` before its ready

Ideally, `memStore` should also use the hierarchical `composed` store, instead of the current flat merge store, but that would break the API as consumed by the ui.
