### PR TITLE
Update GasBlockLimits on every new block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Update gasLimit params with every new block seen.
+
 ## 3.7.4 2017-6-2
 
 - Fix bug with inflight cache that caused some block lookups to return bad values (affected OasisDex).

--- a/app/scripts/lib/eth-store.js
+++ b/app/scripts/lib/eth-store.js
@@ -21,6 +21,7 @@ class EthereumStore extends ObservableStore {
       transactions: {},
       currentBlockNumber: '0',
       currentBlockHash: '',
+      currentBlockGasLimit: '',
     })
     this._provider = opts.provider
     this._query = new EthQuery(this._provider)
@@ -73,6 +74,7 @@ class EthereumStore extends ObservableStore {
     this._currentBlockNumber = blockNumber
     this.updateState({ currentBlockNumber: parseInt(blockNumber) })
     this.updateState({ currentBlockHash: `0x${block.hash.toString('hex')}`})
+    this.updateState({ currentBlockGasLimit: `0x${block.gasLimit.toString('hex')}` })
     async.parallel([
       this._updateAccounts.bind(this),
       this._updateTransactions.bind(this, blockNumber),

--- a/app/scripts/lib/tx-utils.js
+++ b/app/scripts/lib/tx-utils.js
@@ -21,19 +21,10 @@ module.exports = class txProviderUtils {
     this.query.getBlockByNumber('latest', true, (err, block) => {
       if (err) return cb(err)
       async.waterfall([
-        self.setBlockGasLimit.bind(self, txMeta, block.gasLimit),
         self.estimateTxGas.bind(self, txMeta, block.gasLimit),
         self.setTxGas.bind(self, txMeta, block.gasLimit),
       ], cb)
     })
-  }
-
-  setBlockGasLimit (txMeta, blockGasLimitHex, cb) {
-    const blockGasLimitBN = hexToBn(blockGasLimitHex)
-    const saferGasLimitBN = BnMultiplyByFraction(blockGasLimitBN, 19, 20)
-    txMeta.blockGasLimit = bnToHex(saferGasLimitBN)
-    cb()
-    return
   }
 
   estimateTxGas (txMeta, blockGasLimitHex, cb) {

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -32,7 +32,7 @@ function PendingTx () {
 
 PendingTx.prototype.render = function () {
   const props = this.props
-  const { currentCurrency } = props
+  const { currentCurrency, blockGasLimit } = props
 
   const conversionRate = props.conversionRate
   const txMeta = this.gatherTxMeta()
@@ -47,7 +47,8 @@ PendingTx.prototype.render = function () {
   // Gas
   const gas = txParams.gas
   const gasBn = hexToBn(gas)
-  const safeGasLimit = parseInt(txMeta.blockGasLimit)
+  const gasLimit = new BN(parseInt(blockGasLimit))
+  const safeGasLimit = this.bnMultiplyByFraction(gasLimit, 19, 20).toString(10)
 
   // Gas Price
   const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_BN.toString(16)
@@ -432,6 +433,12 @@ PendingTx.prototype.verifyGasParams = function () {
 
 PendingTx.prototype._notZeroOrEmptyString = function (obj) {
   return obj !== '' && obj !== '0x0'
+}
+
+PendingTx.prototype.bnMultiplyByFraction = function (targetBN, numerator, denominator) {
+  const numBN = new BN(numerator)
+  const denomBN = new BN(denominator)
+  return targetBN.mul(numBN).div(denomBN)
 }
 
 function forwardCarrat () {

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -29,6 +29,7 @@ function mapStateToProps (state) {
     provider: state.metamask.provider,
     conversionRate: state.metamask.conversionRate,
     currentCurrency: state.metamask.currentCurrency,
+    blockGasLimit: state.metamask.currentBlockGasLimit,
   }
 }
 
@@ -40,7 +41,7 @@ function ConfirmTxScreen () {
 ConfirmTxScreen.prototype.render = function () {
   const props = this.props
   const { network, provider, unapprovedTxs, currentCurrency,
-    unapprovedMsgs, unapprovedPersonalMsgs, conversionRate } = props
+    unapprovedMsgs, unapprovedPersonalMsgs, conversionRate, blockGasLimit } = props
 
   var unconfTxList = txHelper(unapprovedTxs, unapprovedMsgs, unapprovedPersonalMsgs, network)
 
@@ -106,6 +107,7 @@ ConfirmTxScreen.prototype.render = function () {
           identities: props.identities,
           conversionRate,
           currentCurrency,
+          blockGasLimit,
           // Actions
           buyEth: this.buyEth.bind(this, txParams.from || props.selectedAddress),
           sendTransaction: this.sendTransaction.bind(this),


### PR DESCRIPTION
This helps mitigate problems as seen in #1528 so that we query for new blockGasLimits every time a new block arrives!