### PR TITLE
UI - aesthetic freshening up with some gradient action

### DIFF
--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -93,7 +93,7 @@ AccountDetailScreen.prototype.render = function () {
 
               // What is shown when not editing + edit text:
               h('label.editing-label', [h('.edit-text', 'edit')]),
-              h('h2.font-medium.color-forest', {name: 'edit'}, identity && identity.name),
+              h('h2.font-medium.color-white', {name: 'edit'}, identity && identity.name),
             ]),
             h('.flex-row', {
               style: {
@@ -105,7 +105,7 @@ AccountDetailScreen.prototype.render = function () {
 
               // address
 
-              h('div', {
+              h('.color-white', {
                 style: {
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -116,7 +116,6 @@ AccountDetailScreen.prototype.render = function () {
                   textRendering: 'geometricPrecision',
                   marginTop: '10px',
                   marginBottom: '15px',
-                  color: '#AEAEAE',
                 },
               }, checksumAddress),
 
@@ -137,12 +136,11 @@ AccountDetailScreen.prototype.render = function () {
                 h(Tooltip, {
                   title: 'QR Code',
                 }, [
-                  h('i.fa.fa-qrcode.pointer.pop-hover', {
+                  h('i.fa.fa-qrcode.pointer.pop-hover.color-white', {
                     onClick: () => props.dispatch(actions.showQrView(selected, identity ? identity.name : '')),
                     style: {
                       fontSize: '18px',
                       position: 'relative',
-                      color: 'rgb(247, 134, 28)',
                       top: '5px',
                       marginLeft: '3px',
                       marginRight: '3px',
@@ -159,7 +157,7 @@ AccountDetailScreen.prototype.render = function () {
                       alignItems: 'center',
                     },
                   }, [
-                    h('img.cursor-pointer.color-orange', {
+                    h('img.cursor-pointer', {
                       src: 'images/key-32.png',
                       onClick: () => this.requestAccountExport(selected),
                       style: {
@@ -171,7 +169,7 @@ AccountDetailScreen.prototype.render = function () {
               ]),
             ]),
 
-            // account ballence
+            // account balance
 
           ]),
         ]),
@@ -192,21 +190,25 @@ AccountDetailScreen.prototype.render = function () {
             },
           }),
 
-          h('button', {
+          h('button.border-only', {
             onClick: () => props.dispatch(actions.buyEthView(selected)),
             style: {
               marginBottom: '20px',
               marginRight: '8px',
               position: 'absolute',
               left: '219px',
+              borderColor: 'white',
+              boxShadow: 'none',
             },
           }, 'BUY'),
 
-          h('button', {
+          h('button.border-only', {
             onClick: () => props.dispatch(actions.showSendPage()),
             style: {
               marginBottom: '20px',
               marginRight: '8px',
+              borderColor: 'white',
+              boxShadow: 'none',
             },
           }, 'SEND'),
 
@@ -220,7 +222,11 @@ AccountDetailScreen.prototype.render = function () {
         transitionEnterTimeout: 300,
         transitionLeaveTimeout: 300,
       }, [
-        this.subview(),
+        h('div', {
+          style: {
+            background: '#F7F7F7',
+          },
+        }, this.subview()),
       ]),
 
     ])

--- a/ui/app/accounts/import/index.js
+++ b/ui/app/accounts/import/index.js
@@ -35,6 +35,8 @@ AccountImportSubview.prototype.render = function () {
   return (
     h('div', {
       style: {
+        height: '100%',
+        background: '#E4E4E4',
       },
     }, [
       h('div', {

--- a/ui/app/accounts/index.js
+++ b/ui/app/accounts/index.js
@@ -51,14 +51,13 @@ AccountsScreen.prototype.render = function () {
         h('h2.page-subtitle', 'Select Account'),
       ]),
 
-      h('hr.horizontal-line'),
-
       // identity selection
       h('section.identity-section', {
         style: {
           height: '418px',
           overflowY: 'auto',
           overflowX: 'hidden',
+          background: '#F7F7F7',
         },
       },
         [

--- a/ui/app/accounts/index.js
+++ b/ui/app/accounts/index.js
@@ -44,7 +44,7 @@ AccountsScreen.prototype.render = function () {
     h('.accounts-section.flex-grow', [
 
       // subtitle and nav
-      h('.section-title.flex-center', [
+      h('.section-title.flex-center.color-white', [
         h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
           onClick: this.goHome.bind(this),
         }),

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -69,7 +69,7 @@ App.prototype.render = function () {
 
   return (
 
-    h('.flex-column.flex-grow.full-height', {
+    h('.app-root.flex-column.flex-grow.full-height', {
       style: {
         // Windows was showing a vertical scroll bar:
         overflow: 'hidden',
@@ -121,7 +121,6 @@ App.prototype.renderAppBar = function () {
         style: {
           alignItems: 'center',
           visibility: props.isUnlocked ? 'visible' : 'none',
-          background: props.isUnlocked ? 'white' : 'none',
           height: '36px',
           position: 'relative',
           zIndex: 10,
@@ -135,14 +134,6 @@ App.prototype.renderAppBar = function () {
             alignItems: 'center',
           },
         }, [
-
-          // mini logo
-          h('img', {
-            height: 24,
-            width: 24,
-            src: '/images/icon-128.png',
-          }),
-
           h('#network-spacer.flex-center', {
             style: {
               marginRight: '-72px',
@@ -197,7 +188,7 @@ App.prototype.renderAppBar = function () {
             barHeight: 2,
             padding: 0,
             isOpen: state.isMainMenuOpen,
-            color: 'rgb(247,146,30)',
+            color: 'white',
             onClick: (event) => {
               event.preventDefault()
               event.stopPropagation()

--- a/ui/app/components/account-info-link.js
+++ b/ui/app/components/account-info-link.js
@@ -30,7 +30,7 @@ AccountInfoLink.prototype.render = function () {
     h(Tooltip, {
       title,
     }, [
-      h('i.fa.fa-info-circle.cursor-pointer.color-orange', {
+      h('i.fa.fa-info-circle.cursor-pointer.color-white', {
         style: {
           margin: '5px',
         },

--- a/ui/app/components/buy-button-subview.js
+++ b/ui/app/components/buy-button-subview.js
@@ -37,6 +37,7 @@ BuyButtonSubview.prototype.render = function () {
     h('.buy-eth-section.flex-column', {
       style: {
         alignItems: 'center',
+        background: '#F7F7F7',
       },
     }, [
              // back button

--- a/ui/app/components/copyButton.js
+++ b/ui/app/components/copyButton.js
@@ -34,7 +34,7 @@ CopyButton.prototype.render = function () {
     h(Tooltip, {
       title: message,
     }, [
-      h('i.fa.fa-clipboard.cursor-pointer.color-white', {
+      h('i.fa.fa-clipboard.cursor-pointer', {
         style: {
           margin: '5px',
         },

--- a/ui/app/components/copyButton.js
+++ b/ui/app/components/copyButton.js
@@ -34,7 +34,7 @@ CopyButton.prototype.render = function () {
     h(Tooltip, {
       title: message,
     }, [
-      h('i.fa.fa-clipboard.cursor-pointer.color-orange', {
+      h('i.fa.fa-clipboard.cursor-pointer.color-white', {
         style: {
           margin: '5px',
         },

--- a/ui/app/components/eth-balance.js
+++ b/ui/app/components/eth-balance.js
@@ -22,7 +22,7 @@ EthBalanceComponent.prototype.render = function () {
 
   return (
 
-    h('.ether-balance.ether-balance-amount', {
+    h('.ether-balance.color-white', {
       style,
     }, [
       h('div', {
@@ -76,7 +76,7 @@ EthBalanceComponent.prototype.renderBalance = function (value) {
         }, incoming ? `+${balance}` : balance),
         h('div', {
           style: {
-            color: ' #AEAEAE',
+            color: 'white',
             fontSize: '12px',
             marginLeft: '5px',
           },

--- a/ui/app/components/eth-balance.js
+++ b/ui/app/components/eth-balance.js
@@ -22,7 +22,7 @@ EthBalanceComponent.prototype.render = function () {
 
   return (
 
-    h('.ether-balance.color-white', {
+    h('.ether-balance', {
       style,
     }, [
       h('div', {
@@ -68,15 +68,14 @@ EthBalanceComponent.prototype.renderBalance = function (value) {
           textRendering: 'geometricPrecision',
         },
       }, [
-        h('div', {
+        h('.wallet-balance-value', {
           style: {
             width: '100%',
             textAlign: 'right',
           },
         }, incoming ? `+${balance}` : balance),
-        h('div', {
+        h('.wallet-balance-unit', {
           style: {
-            color: 'white',
             fontSize: '12px',
             marginLeft: '5px',
           },

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -63,7 +63,7 @@ Network.prototype.render = function () {
               h('.menu-icon.diamond'),
               h('.network-name', {
                 style: {
-                  color: '#039396',
+                  color: 'white',
                 }},
               'Ethereum Main Net'),
             ])
@@ -72,7 +72,7 @@ Network.prototype.render = function () {
               h('.menu-icon.red-dot'),
               h('.network-name', {
                 style: {
-                  color: '#ff6666',
+                  color: 'white',
                 }},
               'Ropsten Test Net'),
             ])
@@ -81,7 +81,7 @@ Network.prototype.render = function () {
               h('.menu-icon.hollow-diamond'),
               h('.network-name', {
                 style: {
-                  color: '#690496',
+                  color: 'white',
                 }},
               'Kovan Test Net'),
             ])
@@ -90,7 +90,7 @@ Network.prototype.render = function () {
               h('.menu-icon.golden-square'),
               h('.network-name', {
                 style: {
-                  color: '#e7a218',
+                  color: 'white',
                 }},
               'Rinkeby Test Net'),
             ])
@@ -99,13 +99,13 @@ Network.prototype.render = function () {
               h('i.fa.fa-question-circle.fa-lg', {
                 style: {
                   margin: '10px',
-                  color: 'rgb(125, 128, 130)',
+                  color: 'white',
                 },
               }),
 
               h('.network-name', {
                 style: {
-                  color: '#AEAEAE',
+                  color: 'white',
                 }},
               'Private Network'),
             ])

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -53,70 +53,77 @@ ConfirmTxScreen.prototype.render = function () {
 
   return (
 
-    h('.flex-column.flex-grow', [
+    h('.conf-tx-section', {
+      style: {
+        height: '100%',
+        background: '#F4F4F4',
+      }
+    }, [
+    
+      h('.flex-column.flex-grow', [
+        // subtitle and nav
+        h('.section-title.flex-row.flex-center', [
+          !isNotification ? h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
+            onClick: this.goHome.bind(this),
+          }) : null,
+          h('h2.page-subtitle', 'Confirm Transaction'),
+          isNotification ? h(NetworkIndicator, {
+            network: network,
+            provider: provider,
+          }) : null,
+        ]),
 
-      // subtitle and nav
-      h('.section-title.flex-row.flex-center', [
-        !isNotification ? h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: this.goHome.bind(this),
-        }) : null,
-        h('h2.page-subtitle', 'Confirm Transaction'),
-        isNotification ? h(NetworkIndicator, {
-          network: network,
-          provider: provider,
-        }) : null,
-      ]),
-
-      h('h3', {
-        style: {
-          alignSelf: 'center',
-          display: unconfTxList.length > 1 ? 'block' : 'none',
-        },
-      }, [
-        h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
+        h('h3', {
           style: {
-            display: props.index === 0 ? 'none' : 'inline-block',
+            alignSelf: 'center',
+            display: unconfTxList.length > 1 ? 'block' : 'none',
           },
-          onClick: () => props.dispatch(actions.previousTx()),
-        }),
-        ` ${props.index + 1} of ${unconfTxList.length} `,
-        h('i.fa.fa-arrow-right.fa-lg.cursor-pointer', {
-          style: {
-            display: props.index + 1 === unconfTxList.length ? 'none' : 'inline-block',
-          },
-          onClick: () => props.dispatch(actions.nextTx()),
-        }),
-      ]),
+        }, [
+          h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
+            style: {
+              display: props.index === 0 ? 'none' : 'inline-block',
+            },
+            onClick: () => props.dispatch(actions.previousTx()),
+          }),
+          ` ${props.index + 1} of ${unconfTxList.length} `,
+          h('i.fa.fa-arrow-right.fa-lg.cursor-pointer', {
+            style: {
+              display: props.index + 1 === unconfTxList.length ? 'none' : 'inline-block',
+            },
+            onClick: () => props.dispatch(actions.nextTx()),
+          }),
+        ]),
 
-      warningIfExists(props.warning),
+        warningIfExists(props.warning),
 
-      h(ReactCSSTransitionGroup, {
-        className: 'css-transition-group',
-        transitionName: 'main',
-        transitionEnterTimeout: 300,
-        transitionLeaveTimeout: 300,
-      }, [
+        h(ReactCSSTransitionGroup, {
+          className: 'css-transition-group',
+          transitionName: 'main',
+          transitionEnterTimeout: 300,
+          transitionLeaveTimeout: 300,
+        }, [
 
-        currentTxView({
-          // Properties
-          txData: txData,
-          key: txData.id,
-          selectedAddress: props.selectedAddress,
-          accounts: props.accounts,
-          identities: props.identities,
-          conversionRate,
-          currentCurrency,
-          // Actions
-          buyEth: this.buyEth.bind(this, txParams.from || props.selectedAddress),
-          sendTransaction: this.sendTransaction.bind(this),
-          cancelTransaction: this.cancelTransaction.bind(this, txData),
-          signMessage: this.signMessage.bind(this, txData),
-          signPersonalMessage: this.signPersonalMessage.bind(this, txData),
-          cancelMessage: this.cancelMessage.bind(this, txData),
-          cancelPersonalMessage: this.cancelPersonalMessage.bind(this, txData),
-        }),
+          currentTxView({
+            // Properties
+            txData: txData,
+            key: txData.id,
+            selectedAddress: props.selectedAddress,
+            accounts: props.accounts,
+            identities: props.identities,
+            conversionRate,
+            currentCurrency,
+            // Actions
+            buyEth: this.buyEth.bind(this, txParams.from || props.selectedAddress),
+            sendTransaction: this.sendTransaction.bind(this),
+            cancelTransaction: this.cancelTransaction.bind(this, txData),
+            signMessage: this.signMessage.bind(this, txData),
+            signPersonalMessage: this.signPersonalMessage.bind(this, txData),
+            cancelMessage: this.cancelMessage.bind(this, txData),
+            cancelPersonalMessage: this.cancelPersonalMessage.bind(this, txData),
+          }),
 
-      ]),
+        ]),
+      ])
     ])
   )
 }

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -26,87 +26,95 @@ ConfigScreen.prototype.render = function () {
   var warning = state.warning
 
   return (
-    h('.flex-column.flex-grow', [
+    h('.config-section', {
+      style: {
+        height: '100%',
+        background: '#F4F4F4',
+      }
+    }, [
 
-      // subtitle and nav
-      h('.section-title.flex-row.flex-center', [
-        h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: (event) => {
-            state.dispatch(actions.goHome())
-          },
-        }),
-        h('h2.page-subtitle', 'Settings'),
-      ]),
+      h('.flex-column.flex-grow', [
 
-      h('.error', {
-        style: {
-          display: warning ? 'block' : 'none',
-          padding: '0 20px',
-          textAlign: 'center',
-        },
-      }, warning),
+        // subtitle and nav
+        h('.section-title.flex-row.flex-center', [
+          h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
+            onClick: (event) => {
+              state.dispatch(actions.goHome())
+            },
+          }),
+          h('h2.page-subtitle', 'Settings'),
+        ]),
 
-      // conf view
-      h('.flex-column.flex-justify-center.flex-grow.select-none', [
-        h('.flex-space-around', {
+        h('.error', {
           style: {
-            padding: '20px',
+            display: warning ? 'block' : 'none',
+            padding: '0 20px',
+            textAlign: 'center',
           },
-        }, [
+        }, warning),
 
-          currentProviderDisplay(metamaskState),
-
-          h('div', { style: {display: 'flex'} }, [
-            h('input#new_rpc', {
-              placeholder: 'New RPC URL',
-              style: {
-                width: 'inherit',
-                flex: '1 0 auto',
-                height: '30px',
-                margin: '8px',
-              },
-              onKeyPress (event) {
-                if (event.key === 'Enter') {
-                  var element = event.target
-                  var newRpc = element.value
-                  rpcValidation(newRpc, state)
-                }
-              },
-            }),
-            h('button', {
-              style: {
-                alignSelf: 'center',
-              },
-              onClick (event) {
-                event.preventDefault()
-                var element = document.querySelector('input#new_rpc')
-                var newRpc = element.value
-                rpcValidation(newRpc, state)
-              },
-            }, 'Save'),
-          ]),
-          h('hr.horizontal-line'),
-          currentConversionInformation(metamaskState, state),
-          h('hr.horizontal-line'),
-
-          h('div', {
+        // conf view
+        h('.flex-column.flex-justify-center.flex-grow.select-none', [
+          h('.flex-space-around', {
             style: {
-              marginTop: '20px',
+              padding: '20px',
             },
           }, [
-            h('button', {
-              style: {
-                alignSelf: 'center',
-              },
-              onClick (event) {
-                event.preventDefault()
-                state.dispatch(actions.revealSeedConfirmation())
-              },
-            }, 'Reveal Seed Words'),
-          ]),
 
+            currentProviderDisplay(metamaskState),
+
+            h('div', { style: {display: 'flex'} }, [
+              h('input#new_rpc', {
+                placeholder: 'New RPC URL',
+                style: {
+                  width: 'inherit',
+                  flex: '1 0 auto',
+                  height: '30px',
+                  margin: '8px',
+                },
+                onKeyPress (event) {
+                  if (event.key === 'Enter') {
+                    var element = event.target
+                    var newRpc = element.value
+                    rpcValidation(newRpc, state)
+                  }
+                },
+              }),
+              h('button', {
+                style: {
+                  alignSelf: 'center',
+                },
+                onClick (event) {
+                  event.preventDefault()
+                  var element = document.querySelector('input#new_rpc')
+                  var newRpc = element.value
+                  rpcValidation(newRpc, state)
+                },
+              }, 'Save'),
+            ]),
+            h('hr.horizontal-line'),
+            currentConversionInformation(metamaskState, state),
+            h('hr.horizontal-line'),
+
+            h('div', {
+              style: {
+                marginTop: '20px',
+              },
+            }, [
+              h('button', {
+                style: {
+                  alignSelf: 'center',
+                },
+                onClick (event) {
+                  event.preventDefault()
+                  state.dispatch(actions.revealSeedConfirmation())
+                },
+              }, 'Reveal Seed Words'),
+            ]),
+
+          ]),
         ]),
-      ]),
+      ])
     ])
   )
 }

--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -134,7 +134,7 @@ button.btn-thin {
 h2.page-subtitle {
   font-family: 'Montserrat Regular';
   text-transform: uppercase;
-  color: #AEAEAE;
+  color: white;
   font-size: 1em;
   margin: 12px;
 }

--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -112,6 +112,15 @@ button.btn-thin {
   font-size: 13px;
 }
 
+.app-root {
+  /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#308dff+0,60d6f7+65,60d6f7+65,d7f7f6+100 */
+  background: #308dff; /* Old browsers */
+  background: -moz-linear-gradient(-45deg, #308dff 0%, #60d6f7 65%, #60d6f7 65%, #d7f7f6 100%); /* FF3.6-15 */
+  background: -webkit-linear-gradient(-45deg, #308dff 0%,#60d6f7 65%,#60d6f7 65%,#d7f7f6 100%); /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(135deg, #308dff 0%,#60d6f7 65%,#60d6f7 65%,#d7f7f6 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#308dff', endColorstr='#d7f7f6',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */}
+}
+
 .app-header {
   padding: 6px 8px;
 }
@@ -119,7 +128,7 @@ button.btn-thin {
 .app-header h1 {
   font-family: 'Montserrat Regular';
   text-transform: uppercase;
-  color: #AEAEAE;
+  color: white;
 }
 
 h2.page-subtitle {
@@ -461,10 +470,6 @@ input.large-input {
 }
 
 /* Ether Balance Widget */
-
-.ether-balance-amount {
-  color: #F7861C;
-}
 
 .ether-balance-label {
   color: #ABA9AA;

--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -134,7 +134,6 @@ button.btn-thin {
 h2.page-subtitle {
   font-family: 'Montserrat Regular';
   text-transform: uppercase;
-  color: white;
   font-size: 1em;
   margin: 12px;
 }

--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -479,6 +479,18 @@ input.large-input {
   font-size: 12px;
 }
 
+.send-screen {
+
+}
+
+.send-screen .wallet-balance-value {
+  color: #ABA9AA;
+}
+
+.send-screen .wallet-balance-unit {
+  color: #AEAEAE;
+}
+
 /* Ether Balance Widget */
 
 .ether-balance-label {

--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -411,25 +411,23 @@ input.large-input {
 
 /* account detail screen */
 
-.account-detail-section {
-
-}
-.name-label{
-
+.account-data-subsection .wallet-balance-value {
+  color: white;
 }
 
-.unapproved-tx-icon {
-  height: 16px;
-  width: 16px;
-  background: rgb(47, 174, 244);
-  border-color: #AEAEAE;
-  border-radius: 13px;
+.account-data-subsection .wallet-balance-unit {
+  color: white;
+}
+
+.account-data-subsection .copy-button {
+  color: white;
 }
 
 .edit-text {
   height: 100%;
   visibility: hidden;
 }
+
 .editing-label {
   display: flex;
   justify-content: flex-start;
@@ -439,9 +437,21 @@ input.large-input {
   text-rendering: geometricPrecision;
   color: #F7861C;
 }
+
 .name-label:hover .edit-text {
   visibility: visible;
 }
+
+/* tx history */
+
+.unapproved-tx-icon {
+  height: 16px;
+  width: 16px;
+  background: rgb(47, 174, 244);
+  border-color: #AEAEAE;
+  border-radius: 13px;
+}
+
 /* tx confirm */
 
 .unconftx-section input[type=password] {

--- a/ui/app/css/lib.css
+++ b/ui/app/css/lib.css
@@ -4,11 +4,20 @@
   color: #F7861C;
 }
 
+.color-white {
+  color: white;
+}
+
 .color-forest {
   color: #0A5448;
 }
 
 /* lib */
+
+.border-only {
+  background: none;
+  border: solid 1px;
+}
 
 .full-width {
   width: 100%;

--- a/ui/app/info.js
+++ b/ui/app/info.js
@@ -20,135 +20,143 @@ InfoScreen.prototype.render = function () {
   const version = global.platform.getVersion()
 
   return (
-    h('.flex-column.flex-grow', [
+    h('.info-section', {
+      style: {
+        height: '100%',
+        background: '#F4F4F4',
+      }
+    }, [
+    
+      h('.flex-column.flex-grow', [
 
-      // subtitle and nav
-      h('.section-title.flex-row.flex-center', [
-        h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: (event) => {
-            state.dispatch(actions.goHome())
-          },
-        }),
-        h('h2.page-subtitle', 'Info'),
-      ]),
+        // subtitle and nav
+        h('.section-title.flex-row.flex-center', [
+          h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
+            onClick: (event) => {
+              state.dispatch(actions.goHome())
+            },
+          }),
+          h('h2.page-subtitle', 'Info'),
+        ]),
 
-      // main view
-      h('.flex-column.flex-justify-center.flex-grow.select-none', [
-        h('.flex-space-around', {
-          style: {
-            padding: '20px',
-          },
-        }, [
-          // current version number
+        // main view
+        h('.flex-column.flex-justify-center.flex-grow.select-none', [
+          h('.flex-space-around', {
+            style: {
+              padding: '20px',
+            },
+          }, [
+            // current version number
 
-          h('.info.info-gray', [
-            h('div', 'Metamask'),
+            h('.info.info-gray', [
+              h('div', 'Metamask'),
+              h('div', {
+                style: {
+                  marginBottom: '10px',
+                },
+              }, `Version: ${version}`),
+            ]),
+
             h('div', {
               style: {
                 marginBottom: '10px',
+              }},
+              [
+                h('div', [
+                  h('a', {
+                    href: 'https://metamask.io/privacy.html',
+                    target: '_blank',
+                    onClick (event) { this.navigateTo(event.target.href) },
+                  }, [
+                    h('div.info', 'Privacy Policy'),
+                  ]),
+                ]),
+                h('div', [
+                  h('a', {
+                    href: 'https://metamask.io/terms.html',
+                    target: '_blank',
+                    onClick (event) { this.navigateTo(event.target.href) },
+                  }, [
+                    h('div.info', 'Terms of Use'),
+                  ]),
+                ]),
+                h('div', [
+                  h('a', {
+                    href: 'https://metamask.io/attributions.html',
+                    target: '_blank',
+                    onClick (event) { this.navigateTo(event.target.href) },
+                  }, [
+                    h('div.info', 'Attributions'),
+                  ]),
+                ]),
+              ]
+            ),
+
+            h('hr', {
+              style: {
+                margin: '20px 0 ',
+                width: '7em',
               },
-            }, `Version: ${version}`),
+            }),
+
+            h('div', {
+              style: {
+                paddingLeft: '30px',
+              }},
+              [
+                h('div', [
+                  h('a', {
+                    href: 'https://metamask.io/',
+                    target: '_blank',
+                    onClick (event) { this.navigateTo(event.target.href) },
+                  }, [
+                    h('img.icon-size', {
+                      src: 'images/icon-128.png',
+                      style: {
+                        // IE6-9
+                        filter: 'grayscale(100%)',
+                        // Microsoft Edge and Firefox 35+
+                        WebkitFilter: 'grayscale(100%)',
+                      },
+                    }),
+                    h('div.info', 'Visit our web site'),
+                  ]),
+                ]),
+                h('div.fa.fa-slack', [
+                  h('a.info', {
+                    href: 'http://slack.metamask.io',
+                    target: '_blank',
+                    onClick (event) { this.navigateTo(event.target.href) },
+                  }, 'Join the conversation on Slack'),
+                ]),
+
+                h('div.fa.fa-twitter', [
+                  h('a.info', {
+                    href: 'https://twitter.com/metamask_io',
+                    target: '_blank',
+                    onClick (event) { this.navigateTo(event.target.href) },
+                  }, 'Follow us on Twitter'),
+                ]),
+
+                h('div.fa.fa-envelope', [
+                  h('a.info', {
+                    target: '_blank',
+                    style: { width: '85vw' },
+                    onClick () { this.navigateTo('mailto:help@metamask.io?subject=Feedback') },
+                  }, 'Email us!'),
+                ]),
+
+                h('div.fa.fa-github', [
+                  h('a.info', {
+                    href: 'https://github.com/MetaMask/metamask-plugin/issues',
+                    target: '_blank',
+                    onClick (event) { this.navigateTo(event.target.href) },
+                  }, 'Start a thread on GitHub'),
+                ]),
+              ]),
           ]),
-
-          h('div', {
-            style: {
-              marginBottom: '10px',
-            }},
-            [
-              h('div', [
-                h('a', {
-                  href: 'https://metamask.io/privacy.html',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, [
-                  h('div.info', 'Privacy Policy'),
-                ]),
-              ]),
-              h('div', [
-                h('a', {
-                  href: 'https://metamask.io/terms.html',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, [
-                  h('div.info', 'Terms of Use'),
-                ]),
-              ]),
-              h('div', [
-                h('a', {
-                  href: 'https://metamask.io/attributions.html',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, [
-                  h('div.info', 'Attributions'),
-                ]),
-              ]),
-            ]
-          ),
-
-          h('hr', {
-            style: {
-              margin: '20px 0 ',
-              width: '7em',
-            },
-          }),
-
-          h('div', {
-            style: {
-              paddingLeft: '30px',
-            }},
-            [
-              h('div', [
-                h('a', {
-                  href: 'https://metamask.io/',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, [
-                  h('img.icon-size', {
-                    src: 'images/icon-128.png',
-                    style: {
-                      // IE6-9
-                      filter: 'grayscale(100%)',
-                      // Microsoft Edge and Firefox 35+
-                      WebkitFilter: 'grayscale(100%)',
-                    },
-                  }),
-                  h('div.info', 'Visit our web site'),
-                ]),
-              ]),
-              h('div.fa.fa-slack', [
-                h('a.info', {
-                  href: 'http://slack.metamask.io',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, 'Join the conversation on Slack'),
-              ]),
-
-              h('div.fa.fa-twitter', [
-                h('a.info', {
-                  href: 'https://twitter.com/metamask_io',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, 'Follow us on Twitter'),
-              ]),
-
-              h('div.fa.fa-envelope', [
-                h('a.info', {
-                  target: '_blank',
-                  style: { width: '85vw' },
-                  onClick () { this.navigateTo('mailto:help@metamask.io?subject=Feedback') },
-                }, 'Email us!'),
-              ]),
-
-              h('div.fa.fa-github', [
-                h('a.info', {
-                  href: 'https://github.com/MetaMask/metamask-plugin/issues',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, 'Start a thread on GitHub'),
-              ]),
-            ]),
         ]),
-      ]),
+      ])
     ])
   )
 }

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -56,171 +56,178 @@ SendTransactionScreen.prototype.render = function () {
 
   return (
 
-    h('.send-screen.flex-column.flex-grow', [
+    h('.send-screen', {
+      style: {
+        height: '100%',
+        background: '#F7F7F7',
+      },
+    }, [
+      h('.flex-column.flex-grow', [
 
-      //
-      // Sender Profile
-      //
+        //
+        // Sender Profile
+        //
 
-      h('.account-data-subsection.flex-row.flex-grow', {
-        style: {
-          margin: '0 20px',
-        },
-      }, [
-
-        // header - identicon + nav
-        h('.flex-row.flex-space-between', {
+        h('.account-data-subsection.flex-row.flex-grow', {
           style: {
-            marginTop: '15px',
+            margin: '0 20px',
           },
         }, [
-          // back button
-          h('i.fa.fa-arrow-left.fa-lg.cursor-pointer.color-orange', {
-            onClick: this.back.bind(this),
-          }),
 
-          // large identicon
-          h('.identicon-wrapper.flex-column.flex-center.select-none', [
-            h(Identicon, {
-              diameter: 62,
-              address: address,
-            }),
-          ]),
-
-          // invisible place holder
-          h('i.fa.fa-users.fa-lg.invisible', {
+          // header - identicon + nav
+          h('.flex-row.flex-space-between', {
             style: {
-              marginTop: '28px',
-            },
-          }),
-
-        ]),
-
-        // account label
-
-        h('.flex-column', {
-          style: {
-            marginTop: '10px',
-            alignItems: 'flex-start',
-          },
-        }, [
-          h('h2.font-medium.color-forest.flex-center', {
-            style: {
-              paddingTop: '8px',
-              marginBottom: '8px',
-            },
-          }, identity && identity.name),
-
-          // address and getter actions
-          h('.flex-row.flex-center', {
-            style: {
-              marginBottom: '8px',
+              marginTop: '15px',
             },
           }, [
+            // back button
+            h('i.fa.fa-arrow-left.fa-lg.cursor-pointer.color-orange', {
+              onClick: this.back.bind(this),
+            }),
 
-            h('div', {
+            // large identicon
+            h('.identicon-wrapper.flex-column.flex-center.select-none', [
+              h(Identicon, {
+                diameter: 62,
+                address: address,
+              }),
+            ]),
+
+            // invisible place holder
+            h('i.fa.fa-users.fa-lg.invisible', {
               style: {
-                lineHeight: '16px',
+                marginTop: '28px',
               },
-            }, addressSummary(address)),
-
-          ]),
-
-          // balance
-          h('.flex-row.flex-center', [
-
-            h(EthBalance, {
-              value: account && account.balance,
-              conversionRate,
-              currentCurrency,
             }),
 
           ]),
+
+          // account label
+
+          h('.flex-column', {
+            style: {
+              marginTop: '10px',
+              alignItems: 'flex-start',
+            },
+          }, [
+            h('h2.font-medium.color-forest.flex-center', {
+              style: {
+                paddingTop: '8px',
+                marginBottom: '8px',
+              },
+            }, identity && identity.name),
+
+            // address and getter actions
+            h('.flex-row.flex-center', {
+              style: {
+                marginBottom: '8px',
+              },
+            }, [
+
+              h('div', {
+                style: {
+                  lineHeight: '16px',
+                },
+              }, addressSummary(address)),
+
+            ]),
+
+            // balance
+            h('.flex-row.flex-center', [
+
+              h(EthBalance, {
+                value: account && account.balance,
+                conversionRate,
+                currentCurrency,
+              }),
+
+            ]),
+          ]),
         ]),
-      ]),
 
-      //
-      // Required Fields
-      //
+        //
+        // Required Fields
+        //
 
-      h('h3.flex-center.text-transform-uppercase', {
-        style: {
-          background: '#EBEBEB',
-          color: '#AEAEAE',
-          marginTop: '15px',
-          marginBottom: '16px',
-        },
-      }, [
-        'Send Transaction',
-      ]),
-
-      // error message
-      props.error && h('span.error.flex-center', props.error),
-
-      // 'to' field
-      h('section.flex-row.flex-center', [
-        h(EnsInput, {
-          name: 'address',
-          placeholder: 'Recipient Address',
-          onChange: this.recipientDidChange.bind(this),
-          network,
-          identities,
-          addressBook,
-        }),
-      ]),
-
-      // 'amount' and send button
-      h('section.flex-row.flex-center', [
-
-        h('input.large-input', {
-          name: 'amount',
-          placeholder: 'Amount',
-          type: 'number',
+        h('h3.flex-center.text-transform-uppercase', {
           style: {
-            marginRight: '6px',
+            background: '#EBEBEB',
+            color: '#AEAEAE',
+            marginTop: '15px',
+            marginBottom: '16px',
           },
-          dataset: {
-            persistentFormId: 'tx-amount',
-          },
-        }),
+        }, [
+          'Send Transaction',
+        ]),
 
-        h('button.primary', {
-          onClick: this.onSubmit.bind(this),
+        // error message
+        props.error && h('span.error.flex-center', props.error),
+
+        // 'to' field
+        h('section.flex-row.flex-center', [
+          h(EnsInput, {
+            name: 'address',
+            placeholder: 'Recipient Address',
+            onChange: this.recipientDidChange.bind(this),
+            network,
+            identities,
+            addressBook,
+          }),
+        ]),
+
+        // 'amount' and send button
+        h('section.flex-row.flex-center', [
+
+          h('input.large-input', {
+            name: 'amount',
+            placeholder: 'Amount',
+            type: 'number',
+            style: {
+              marginRight: '6px',
+            },
+            dataset: {
+              persistentFormId: 'tx-amount',
+            },
+          }),
+
+          h('button.primary', {
+            onClick: this.onSubmit.bind(this),
+            style: {
+              textTransform: 'uppercase',
+            },
+          }, 'Send'),
+
+        ]),
+
+        //
+        // Optional Fields
+        //
+        h('h3.flex-center.text-transform-uppercase', {
           style: {
-            textTransform: 'uppercase',
+            background: '#EBEBEB',
+            color: '#AEAEAE',
+            marginTop: '16px',
+            marginBottom: '16px',
           },
-        }, 'Send'),
+        }, [
+          'Transaction Data (optional)',
+        ]),
 
-      ]),
-
-      //
-      // Optional Fields
-      //
-      h('h3.flex-center.text-transform-uppercase', {
-        style: {
-          background: '#EBEBEB',
-          color: '#AEAEAE',
-          marginTop: '16px',
-          marginBottom: '16px',
-        },
-      }, [
-        'Transaction Data (optional)',
-      ]),
-
-      // 'data' field
-      h('section.flex-column.flex-center', [
-        h('input.large-input', {
-          name: 'txData',
-          placeholder: '0x01234',
-          style: {
-            width: '100%',
-            resize: 'none',
-          },
-          dataset: {
-            persistentFormId: 'tx-data',
-          },
-        }),
-      ]),
+        // 'data' field
+        h('section.flex-column.flex-center', [
+          h('input.large-input', {
+            name: 'txData',
+            placeholder: '0x01234',
+            style: {
+              width: '100%',
+              resize: 'none',
+            },
+            dataset: {
+              persistentFormId: 'tx-data',
+            },
+          }),
+        ]),
+      ])
     ])
   )
 }


### PR DESCRIPTION
just had a little fun taking xtian's idea and implementing it minimally

status: **WIP**

needs:
- [ ] de-orange hard-colored icons
- [ ] improved consistency in header/subheader background (opaque or transparent)
- [ ] grey background for various remaining screens (export key, etc)
- [ ] introduce new "user secret" value as an anti-phishing mechanism
- [ ] create gradient generating fn (from "user secret" value)
- [ ] figure out how to smoothly update background when user secret is unlocked
- [ ] QA

xtian's sketch:
![image](https://cloud.githubusercontent.com/assets/1474978/26766602/0277c120-494a-11e7-91f4-b53693617e6d.png)

as implemented:
![image](https://cloud.githubusercontent.com/assets/1474978/26766611/329970c4-494a-11e7-9780-301151123d69.png)

![image](https://cloud.githubusercontent.com/assets/1474978/26766613/37dbac28-494a-11e7-8757-1f3938fca94f.png)

![image](https://cloud.githubusercontent.com/assets/1474978/26766615/44da8f52-494a-11e7-8441-78082a2de89b.png)

![image](https://cloud.githubusercontent.com/assets/1474978/26766616/48722418-494a-11e7-9915-18ea75c7dd73.png)
