### PR TITLE
Add ability to copy addresses from tx confirmation view

### DIFF
--- a/ui/app/components/copyable.js
+++ b/ui/app/components/copyable.js
@@ -24,9 +24,6 @@ Copyable.prototype.render = function () {
   return h(Tooltip, {
     title: copied ? 'Copied!' : 'Copy',
     position: 'bottom',
-    style: {
-      cursor: 'pointer',
-    },
   }, h('span', {
     style: {
       cursor: 'pointer',

--- a/ui/app/components/copyable.js
+++ b/ui/app/components/copyable.js
@@ -1,0 +1,49 @@
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const inherits = require('util').inherits
+
+const Tooltip = require('./tooltip')
+const copyToClipboard = require('copy-to-clipboard')
+
+module.exports = Copyable
+
+inherits(Copyable, Component)
+function Copyable () {
+  Component.call(this)
+  this.state = {
+    copied: false,
+  }
+}
+
+Copyable.prototype.render = function () {
+  const props = this.props
+  const state = this.state
+  const { value, children } = props
+  const { copied } = state
+
+  return h(Tooltip, {
+    title: copied ? 'Copied!' : 'Copy',
+    position: 'bottom',
+    style: {
+      cursor: 'pointer',
+    },
+  }, h('span', {
+    style: {
+      cursor: 'pointer',
+    },
+    onClick: (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      copyToClipboard(value)
+      this.debounceRestore()
+    },
+  }, children))
+}
+
+Copyable.prototype.debounceRestore = function () {
+  this.setState({ copied: true })
+  clearTimeout(this.timeout)
+  this.timeout = setTimeout(() => {
+    this.setState({ copied: false })
+  }, 850)
+}

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -9,8 +9,7 @@ const BN = ethUtil.BN
 const hexToBn = require('../../../app/scripts/lib/hex-to-bn')
 
 const MiniAccountPanel = require('./mini-account-panel')
-const Tooltip = require('./tooltip')
-const copyToClipboard = require('copy-to-clipboard')
+const Copyable = require('./copyable')
 const EthBalance = require('./eth-balance')
 const util = require('../util')
 const addressSummary = util.addressSummary
@@ -96,18 +95,11 @@ PendingTx.prototype.render = function () {
                 },
               }, identity.name),
 
-              h(Tooltip, {
-                title: 'Copy address',
-                position: 'bottom',
+              h(Copyable, {
+                value: ethUtil.toChecksumAddress(address),
               }, [
                 h('span.font-small', {
-                  onClick: (event) => {
-                    event.preventDefault()
-                    event.stopPropagation()
-                    copyToClipboard(ethUtil.toChecksumAddress(address))
-                  },
                   style: {
-                    cursor: 'pointer',
                     fontFamily: 'Montserrat Light, Montserrat, sans-serif',
                   },
                 }, addressSummary(address, 6, 4, false)),
@@ -343,18 +335,11 @@ PendingTx.prototype.miniAccountPanelForRecipient = function () {
         },
       }, nameForAddress(txParams.to, props.identities)),
 
-      h(Tooltip, {
-        title: 'Copy address',
-        position: 'bottom',
+      h(Copyable, {
+        value: ethUtil.toChecksumAddress(txParams.to),
       }, [
         h('span.font-small', {
-          onClick: (event) => {
-            event.preventDefault()
-            event.stopPropagation()
-            copyToClipboard(ethUtil.toChecksumAddress(txParams.to))
-          },
           style: {
-            cursor: 'pointer',
             fontFamily: 'Montserrat Light, Montserrat, sans-serif',
           },
         }, addressSummary(txParams.to, 6, 4, false)),

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -9,6 +9,8 @@ const BN = ethUtil.BN
 const hexToBn = require('../../../app/scripts/lib/hex-to-bn')
 
 const MiniAccountPanel = require('./mini-account-panel')
+const Tooltip = require('./tooltip')
+const copyToClipboard = require('copy-to-clipboard')
 const EthBalance = require('./eth-balance')
 const util = require('../util')
 const addressSummary = util.addressSummary
@@ -93,11 +95,23 @@ PendingTx.prototype.render = function () {
                   fontFamily: 'Montserrat Bold, Montserrat, sans-serif',
                 },
               }, identity.name),
-              h('span.font-small', {
-                style: {
-                  fontFamily: 'Montserrat Light, Montserrat, sans-serif',
-                },
-              }, addressSummary(address, 6, 4, false)),
+
+              h(Tooltip, {
+                title: 'Copy address',
+                position: 'bottom',
+              }, [
+                h('span.font-small', {
+                  onClick: (event) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    copyToClipboard(ethUtil.toChecksumAddress(address))
+                  },
+                  style: {
+                    cursor: 'pointer',
+                    fontFamily: 'Montserrat Light, Montserrat, sans-serif',
+                  },
+                }, addressSummary(address, 6, 4, false)),
+              ]),
 
               h('span.font-small', {
                 style: {
@@ -322,16 +336,30 @@ PendingTx.prototype.miniAccountPanelForRecipient = function () {
       imageSeed: txParams.to,
       picOrder: 'left',
     }, [
+
       h('span.font-small', {
         style: {
           fontFamily: 'Montserrat Bold, Montserrat, sans-serif',
         },
       }, nameForAddress(txParams.to, props.identities)),
-      h('span.font-small', {
-        style: {
-          fontFamily: 'Montserrat Light, Montserrat, sans-serif',
-        },
-      }, addressSummary(txParams.to, 6, 4, false)),
+
+      h(Tooltip, {
+        title: 'Copy address',
+        position: 'bottom',
+      }, [
+        h('span.font-small', {
+          onClick: (event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            copyToClipboard(ethUtil.toChecksumAddress(txParams.to))
+          },
+          style: {
+            cursor: 'pointer',
+            fontFamily: 'Montserrat Light, Montserrat, sans-serif',
+          },
+        }, addressSummary(txParams.to, 6, 4, false)),
+      ]),
+
     ])
   } else {
     return h(MiniAccountPanel, {


### PR DESCRIPTION
Adds new "copyable" component that allows any elements to be wrapped to include:

- a tool tip that changes/debounces its "copy/copied" label when clicked.
- a customizable copyable value.
- pointer cursor style.

Fixes #1539