### PR TITLE
Modify FAQ to be more visible.

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -341,7 +341,7 @@ App.prototype.renderDropdown = function () {
     }),
 
     h(DropMenuItem, {
-      label: 'Info',
+      label: 'Info/Help',
       closeMenu: () => this.setState({ isMainMenuOpen: !isOpen }),
       action: () => this.props.dispatch(actions.showInfoPage()),
       icon: h('i.fa.fa-question.fa-lg'),

--- a/ui/app/info.js
+++ b/ui/app/info.js
@@ -52,7 +52,7 @@ InfoScreen.prototype.render = function () {
 
           h('div', {
             style: {
-              marginBottom: '10px',
+              marginBottom: '5px',
             }},
             [
               h('div', [
@@ -87,7 +87,7 @@ InfoScreen.prototype.render = function () {
 
           h('hr', {
             style: {
-              margin: '20px 0 ',
+              margin: '10px 0 ',
               width: '7em',
             },
           }),
@@ -97,6 +97,13 @@ InfoScreen.prototype.render = function () {
               paddingLeft: '30px',
             }},
             [
+              h('div.fa.fa-github', [
+                h('a.info', {
+                  href: 'https://github.com/MetaMask/faq',
+                  target: '_blank',
+                  onClick (event) { this.navigateTo(event.target.href) },
+                }, 'Need Help? Read our FAQ!'),
+              ]),
               h('div', [
                 h('a', {
                   href: 'https://metamask.io/',
@@ -137,14 +144,6 @@ InfoScreen.prototype.render = function () {
                   style: { width: '85vw' },
                   onClick () { this.navigateTo('mailto:help@metamask.io?subject=Feedback') },
                 }, 'Email us!'),
-              ]),
-
-              h('div.fa.fa-github', [
-                h('a.info', {
-                  href: 'https://github.com/MetaMask/metamask-plugin/issues',
-                  target: '_blank',
-                  onClick (event) { this.navigateTo(event.target.href) },
-                }, 'Start a thread on GitHub'),
               ]),
             ]),
         ]),


### PR DESCRIPTION
In an effort to help reform our support systems, we're expanding and exposing our FAQ in as many ways as possible so that users have a better first line of defense for common questions.

This replaces our github link on the premises that we will include a link to submit an issue within the FAQ.