### PR TITLE
Do not mark slowly mined txs as failed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Add a warning to JSON file import.
+- Fix bug where slowly mined txs would sometimes be incorrectly marked as failed.
 
 ## 3.7.8 2017-6-12
 

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -25,10 +25,10 @@ module.exports = class TransactionController extends EventEmitter {
     this.query = opts.ethQuery
     this.txProviderUtils = new TxProviderUtil(this.query)
     this.blockTracker.on('block', this.checkForTxInBlock.bind(this))
-    this.blockTracker.on('latest', this.resubmitPendingTxs.bind(this))
+    this.provider._blockTracker.on('latest', this.resubmitPendingTxs.bind(this))
     this.signEthTx = opts.signTransaction
     this.nonceLock = Semaphore(1)
-
+    this.ethStore = opts.ethStore
     // memstore is computed from a few different stores
     this._updateMemstore()
     this.store.subscribe(() => this._updateMemstore())
@@ -411,26 +411,31 @@ module.exports = class TransactionController extends EventEmitter {
     const pending = this.getTxsByMetaData('status', 'submitted')
     // only try resubmitting if their are transactions to resubmit
     if (!pending.length) return
-    const resubmit = denodeify(this.resubmitTx.bind(this))
+    const resubmit = denodeify(this._resubmitTx.bind(this))
     Promise.all(pending.map(txMeta => resubmit(txMeta)))
     .catch((reason) => {
       log.info('Problem resubmitting tx', reason)
     })
   }
 
-  resubmitTx (txMeta, cb) {
-    // Increment a try counter.
-    if (!('retryCount' in txMeta)) {
-      txMeta.retryCount = 0
-    }
+  _resubmitTx (txMeta, cb) {
+    const address = txMeta.txParams.from
+    const balance = this.ethStore.getState().accounts[address].balance
+    const nonce = Number.parseInt(this.ethStore.getState().accounts[address].nonce)
+    const txNonce = Number.parseInt(txMeta.txParams.nonce)
+    const gtBalance = Number.parseInt(txMeta.txParams.value) > Number.parseInt(balance)
+    if (!('retryCount' in txMeta)) txMeta.retryCount = 0
 
+    // if the value of the transaction is greater then the balance
+    // or the nonce of the transaction is lower then the accounts nonce
+    // dont resubmit the tx
+    if (gtBalance || txNonce < nonce) return cb()
     // Only auto-submit already-signed txs:
-    if (!('rawTx' in txMeta)) {
-      return cb()
-    }
+    if (!('rawTx' in txMeta)) return cb()
 
     if (txMeta.retryCount > RETRY_LIMIT) return
 
+    // Increment a try counter.
     txMeta.retryCount++
     const rawTx = txMeta.rawTx
     this.txProviderUtils.publishTransaction(rawTx, cb)

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -27,7 +27,7 @@ module.exports = class TransactionController extends EventEmitter {
     this.blockTracker.on('block', this.checkForTxInBlock.bind(this))
     // provider-engine only exploses the 'block' event, not 'latest' for 'sync'
     this.provider._blockTracker.on('sync', this.queryPendingTxs.bind(this))
-    this.provider._blockTracker.on('latest', this.resubmitPendingTxs.bind(this))
+    this.blockTracker.on('latest', this.resubmitPendingTxs.bind(this))
     this.signEthTx = opts.signTransaction
     this.nonceLock = Semaphore(1)
     this.ethStore = opts.ethStore

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -429,10 +429,7 @@ module.exports = class TransactionController extends EventEmitter {
       return cb()
     }
 
-    if (txMeta.retryCount > RETRY_LIMIT) {
-      const message = 'Gave up submitting tx ' + txMeta.hash
-      return log.warning(message)
-    }
+    if (txMeta.retryCount > RETRY_LIMIT) return
 
     txMeta.retryCount++
     const rawTx = txMeta.rawTx

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -98,6 +98,7 @@ module.exports = class MetamaskController extends EventEmitter {
       provider: this.provider,
       blockTracker: this.provider,
       ethQuery: this.ethQuery,
+      ethStore: this.ethStore,
     })
 
     // notices

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eth-bin-to-ops": "^1.0.1",
     "eth-contract-metadata": "^1.0.0",
     "eth-hd-keyring": "^1.1.1",
-    "eth-query": "^2.1.1",
+    "eth-query": "^2.1.2",
     "eth-sig-util": "^1.1.1",
     "eth-simple-keyring": "^1.1.1",
     "ethereumjs-tx": "^1.3.0",

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -19,6 +19,7 @@ describe('Transaction Controller', function () {
     txController = new TransactionController({
       networkStore: new ObservableStore(currentNetworkId),
       txHistoryLimit: 10,
+      provider: { _blockTracker: new EventEmitter() },
       blockTracker: new EventEmitter(),
       ethQuery: new EthQuery(new EventEmitter()),
       signTransaction: (ethTx) => new Promise((resolve) => {


### PR DESCRIPTION
Fixes #1567

Also seems to fix #1556

Also improves resubmit performance by only resubmitting on `latest`.