### PR TITLE
Bump provider and check for the tx in the block that provider engine gives us

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -338,12 +338,13 @@ module.exports = class TransactionController extends EventEmitter {
 
   //  checks if a signed tx is in a block and
   // if included sets the tx status as 'confirmed'
-  checkForTxInBlock () {
+  checkForTxInBlock (block) {
     var signedTxList = this.getFilteredTxList({status: 'submitted'})
     if (!signedTxList.length) return
     signedTxList.forEach((txMeta) => {
       var txHash = txMeta.hash
       var txId = txMeta.id
+
       if (!txHash) {
         const errReason = {
           errCode: 'No hash was provided',
@@ -351,20 +352,9 @@ module.exports = class TransactionController extends EventEmitter {
         }
         return this.setTxStatusFailed(txId, errReason)
       }
-      this.query.getTransactionByHash(txHash, (err, txParams) => {
-        if (err || !txParams) {
-          if (!txParams) return
-          txMeta.err = {
-            isWarning: true,
-            errorCode: err,
-            message: 'There was a problem loading this transaction.',
-          }
-          this.updateTx(txMeta)
-          return log.error(err)
-        }
-        if (txParams.blockNumber) {
-          this.setTxStatusConfirmed(txId)
-        }
+
+      block.transactions.forEach((tx) => {
+        if (tx.hash === txHash) this.setTxStatusConfirmed(txId)
       })
     })
   }

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "0.18.2",
-    "web3-provider-engine": "^12.2.4",
+    "web3-provider-engine": "^13.0.0",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "0.18.2",
-    "web3-provider-engine": "^13.0.0",
+    "web3-provider-engine": "^13.0.1",
     "web3-stream-provider": "^2.0.6",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Bump provider and check for the tx in the block that provider engine gives us
this allows for synchronous lookups of pending --> confirmed rather then asking again if a tx is in a block.   