### PR TITLE
add a check for weather a tx is included in a block when jumping blocks

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -26,6 +26,7 @@ module.exports = class TransactionController extends EventEmitter {
     this.txProviderUtils = new TxProviderUtil(this.query)
     this.blockTracker.on('block', this.checkForTxInBlock.bind(this))
     this.blockTracker.on('block', this.resubmitPendingTxs.bind(this))
+    // provider-engine only exploses the 'block' event, not 'latest' for 'sync'
     this.provider._blockTracker.on('sync', this.queryPendingTxs.bind(this))
     this.signEthTx = opts.signTransaction
     this.nonceLock = Semaphore(1)
@@ -371,10 +372,12 @@ module.exports = class TransactionController extends EventEmitter {
   }
 
   queryPendingTxs ({oldBlock, newBlock}) {
+    // check pending transactions on start
     if (!oldBlock) {
       this._checkPendingTxs()
       return
     }
+    // if we synced by more than one block, check for missed pending transactions
     const diff = Number.parseInt(newBlock.number) - Number.parseInt(oldBlock.number)
     if (diff > 1) this._checkPendingTxs()
   }
@@ -453,6 +456,8 @@ module.exports = class TransactionController extends EventEmitter {
     this.txProviderUtils.publishTransaction(rawTx, cb)
   }
 
+  // checks the network for signed txs and
+  // if confirmed sets the tx status as 'confirmed'
   _checkPendingTxs () {
     var signedTxList = this.getFilteredTxList({status: 'submitted'})
     if (!signedTxList.length) return

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -26,6 +26,7 @@ module.exports = class TransactionController extends EventEmitter {
     this.txProviderUtils = new TxProviderUtil(this.query)
     this.blockTracker.on('block', this.checkForTxInBlock.bind(this))
     this.blockTracker.on('block', this.resubmitPendingTxs.bind(this))
+    this.provider._blockTracker.on('sync', this.queryPendingTxs.bind(this))
     this.signEthTx = opts.signTransaction
     this.nonceLock = Semaphore(1)
 
@@ -369,6 +370,15 @@ module.exports = class TransactionController extends EventEmitter {
     })
   }
 
+  queryPendingTxs ({oldBlock, newBlock}) {
+    if (!oldBlock) {
+      this._checkPendingTxs()
+      return
+    }
+    const diff = Number.parseInt(newBlock.number) - Number.parseInt(oldBlock.number)
+    if (diff > 1) this._checkPendingTxs()
+  }
+
   // PRIVATE METHODS
 
   //  Should find the tx in the tx list and
@@ -441,6 +451,37 @@ module.exports = class TransactionController extends EventEmitter {
     txMeta.retryCount++
     const rawTx = txMeta.rawTx
     this.txProviderUtils.publishTransaction(rawTx, cb)
+  }
+
+  _checkPendingTxs () {
+    var signedTxList = this.getFilteredTxList({status: 'submitted'})
+    if (!signedTxList.length) return
+    signedTxList.forEach((txMeta) => {
+      var txHash = txMeta.hash
+      var txId = txMeta.id
+      if (!txHash) {
+        const errReason = {
+          errCode: 'No hash was provided',
+          message: 'We had an error while submitting this transaction, please try again.',
+        }
+        return this.setTxStatusFailed(txId, errReason)
+      }
+      this.query.getTransactionByHash(txHash, (err, txParams) => {
+        if (err || !txParams) {
+          if (!txParams) return
+          txMeta.err = {
+            isWarning: true,
+            errorCode: err,
+            message: 'There was a problem loading this transaction.',
+          }
+          this.updateTx(txMeta)
+          return log.error(err)
+        }
+        if (txParams.blockNumber) {
+          this.setTxStatusConfirmed(txId)
+        }
+      })
+    })
   }
 
 }

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -19,6 +19,7 @@ describe('Transaction Controller', function () {
     txController = new TransactionController({
       networkStore: new ObservableStore(currentNetworkId),
       txHistoryLimit: 10,
+      provider: { _blockTracker: new EventEmitter()},
       blockTracker: new EventEmitter(),
       ethQuery: new EthQuery(new EventEmitter()),
       signTransaction: (ethTx) => new Promise((resolve) => {


### PR DESCRIPTION
this is for if for some reason you go offline with pending transactions or just get an update it will check for weather the tx is included in a block on the sync event 