### PR TITLE
Fix badge number to include personal_sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a warning to JSON file import.
 - Fix bug where slowly mined txs would sometimes be incorrectly marked as failed.
+- Fix bug where badge count did not reflect personal_sign pending messages.
 
 ## 3.7.8 2017-6-12
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -116,13 +116,15 @@ function setupController (initState) {
   updateBadge()
   controller.txController.on('updateBadge', updateBadge)
   controller.messageManager.on('updateBadge', updateBadge)
+  controller.personalMessageManager.on('updateBadge', updateBadge)
 
   // plugin badge text
   function updateBadge () {
     var label = ''
     var unapprovedTxCount = controller.txController.unapprovedTxCount
     var unapprovedMsgCount = controller.messageManager.unapprovedMsgCount
-    var count = unapprovedTxCount + unapprovedMsgCount
+    var unapprovedPersonalMsgs = controller.personalMessageManager.unapprovedPersonalMsgCount
+    var count = unapprovedTxCount + unapprovedMsgCount + unapprovedPersonalMsgs
     if (count) {
       label = String(count)
     }


### PR DESCRIPTION
Fixes #1630 by allowing for personal_sign pending messages to be included in the # of pending items count in the MetaMask badge.