### PR TITLE
Make seed confirmation wording scarier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add a warning to JSON file import.
 - Fix bug where slowly mined txs would sometimes be incorrectly marked as failed.
 - Fix bug where badge count did not reflect personal_sign pending messages.
+- Seed word confirmation wording is now scarier.
 
 ## 3.7.8 2017-6-12
 

--- a/ui/app/keychains/hd/create-vault-complete.js
+++ b/ui/app/keychains/hd/create-vault-complete.js
@@ -54,7 +54,7 @@ CreateVaultCompleteScreen.prototype.render = function () {
           textAlign: 'center',
         },
       }, [
-        h('span.error', 'These 12 words can restore all of your MetaMask accounts for this vault.\nSave them somewhere safe and secret.'),
+        h('span.error', 'These 12 words are the only way to restore your MetaMask accounts.\nSave them somewhere safe and secret.'),
       ]),
 
       h('textarea.twelve-word-phrase', {


### PR DESCRIPTION
During the Status launch, I think I talked to two different people who decided to uninstall MetaMask and then wanted us to restore their accounts.

Time to make the seed word confirmation scarier, before we require typing it back as further confirmation.