### PR TITLE
Add Infura Status Information to UI State

### DIFF
--- a/app/scripts/controllers/infura.js
+++ b/app/scripts/controllers/infura.js
@@ -1,0 +1,42 @@
+const ObservableStore = require('obs-store')
+const extend = require('xtend')
+
+// every ten minutes
+const POLLING_INTERVAL = 300000
+
+class InfuraController {
+
+  constructor (opts = {}) {
+    const initState = extend({
+      infuraNetworkStatus: {},
+    }, opts.initState)
+    this.store = new ObservableStore(initState)
+  }
+
+  //
+  // PUBLIC METHODS
+  //
+
+  // Responsible for retrieving the status of Infura's nodes. Can return either
+  // ok, degraded, or down.
+  checkInfuraNetworkStatus () {
+    return fetch('https://api.infura.io/v1/status/metamask')
+      .then(response => response.json())
+      .then((parsedResponse) => {
+        this.store.updateState({
+          infuraNetworkStatus: parsedResponse,
+        })
+      })
+  }
+
+  scheduleInfuraNetworkCheck() {
+    if (this.conversionInterval) {
+      clearInterval(this.conversionInterval)
+    }
+    this.conversionInterval = setInterval(() => {
+      this.checkInfuraNetworkStatus()
+    }, POLLING_INTERVAL)
+  }
+}
+
+module.exports = InfuraController

--- a/app/scripts/controllers/infura.js
+++ b/app/scripts/controllers/infura.js
@@ -29,7 +29,7 @@ class InfuraController {
       })
   }
 
-  scheduleInfuraNetworkCheck() {
+  scheduleInfuraNetworkCheck () {
     if (this.conversionInterval) {
       clearInterval(this.conversionInterval)
     }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -15,6 +15,7 @@ const CurrencyController = require('./controllers/currency')
 const NoticeController = require('./notice-controller')
 const ShapeShiftController = require('./controllers/shapeshift')
 const AddressBookController = require('./controllers/address-book')
+const InfuraController = require('./controllers/infura')
 const MessageManager = require('./lib/message-manager')
 const PersonalMessageManager = require('./lib/personal-message-manager')
 const TransactionController = require('./controllers/transactions')
@@ -44,8 +45,8 @@ module.exports = class MetamaskController extends EventEmitter {
     this.store = new ObservableStore(initState)
 
     // network store
-
     this.networkController = new NetworkController(initState.NetworkController)
+
     // config manager
     this.configManager = new ConfigManager({
       store: this.store,
@@ -62,6 +63,13 @@ module.exports = class MetamaskController extends EventEmitter {
     })
     this.currencyController.updateConversionRate()
     this.currencyController.scheduleConversionInterval()
+
+    // infura controller
+    this.infuraController = new InfuraController({
+      initState: initState.InfuraController,
+    })
+    this.infuraController.scheduleInfuraNetworkCheck()
+
 
     // rpc provider
     this.provider = this.initializeProvider()
@@ -147,6 +155,9 @@ module.exports = class MetamaskController extends EventEmitter {
     this.networkController.store.subscribe((state) => {
       this.store.updateState({ NetworkController: state })
     })
+    this.infuraController.store.subscribe((state) => {
+      this.store.updateState({ InfuraController: state })
+    })
 
     // manual mem state subscriptions
     this.networkController.store.subscribe(this.sendUpdate.bind(this))
@@ -160,6 +171,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.currencyController.store.subscribe(this.sendUpdate.bind(this))
     this.noticeController.memStore.subscribe(this.sendUpdate.bind(this))
     this.shapeshiftController.store.subscribe(this.sendUpdate.bind(this))
+    this.infuraController.store.subscribe(this.sendUpdate.bind(this))
   }
 
   //
@@ -237,6 +249,7 @@ module.exports = class MetamaskController extends EventEmitter {
       this.addressBookController.store.getState(),
       this.currencyController.store.getState(),
       this.noticeController.memStore.getState(),
+      this.infuraController.store.getState(),
       // config manager
       this.configManager.getConfig(),
       this.shapeshiftController.store.getState(),

--- a/test/unit/infura-controller-test.js
+++ b/test/unit/infura-controller-test.js
@@ -1,5 +1,5 @@
 // polyfill fetch
-global.fetch = global.fetch || function () {return Promise.resolve({
+global.fetch = function () {return Promise.resolve({
     json: () => { return Promise.resolve({"mainnet": "ok", "ropsten": "degraded", "kovan": "down", "rinkeby": "ok"}) },
   })
 }
@@ -20,7 +20,6 @@ describe('infura-controller', function () {
         infuraController.checkInfuraNetworkStatus()
           .then(() => {
             const networkStatus = infuraController.store.getState().infuraNetworkStatus
-            const networkStatus2 = infuraController.store.getState()
             assert.equal(Object.keys(networkStatus).length, 4)
             assert.equal(networkStatus.mainnet, 'ok')
             assert.equal(networkStatus.ropsten, 'degraded')

--- a/test/unit/infura-controller-test.js
+++ b/test/unit/infura-controller-test.js
@@ -1,0 +1,34 @@
+// polyfill fetch
+global.fetch = global.fetch || require('isomorphic-fetch')
+
+const assert = require('assert')
+const nock = require('nock')
+const InfuraController = require('../../app/scripts/controllers/infura')
+
+describe('infura-controller', function () {
+  var infuraController
+
+  beforeEach(function () {
+    infuraController = new InfuraController()
+  })
+
+  describe('network status queries', function () {
+    describe('#checkInfuraNetworkStatus', function () {
+      it('should return an object reflecting the network statuses', function () {
+        this.timeout(15000)
+        nock('https://api.infura.io')
+          .get('/v1/status/metamask')
+          .reply(200, '{"mainnet": "ok", "ropsten": "degraded", "kovan": "down", "rinkeby": "ok"}')
+
+        infuraController.checkInfuraNetworkStatus()
+          .then(() => {
+            const networkStatus = infuraController.store.getState().infuraNetworkStatus
+            assert.equal(Object.keys(networkStatus).length, 4)
+            assert.equal(networkStatus.mainnet, 'ok')
+            assert.equal(networkStatus.ropsten, 'degraded')
+            assert.equal(networkStatus.kovan, 'down')
+          })
+      })
+    })
+  })
+})

--- a/test/unit/infura-controller-test.js
+++ b/test/unit/infura-controller-test.js
@@ -1,8 +1,9 @@
 // polyfill fetch
-global.fetch = global.fetch || require('isomorphic-fetch')
-
+global.fetch = global.fetch || function () {return Promise.resolve({
+    json: () => { return Promise.resolve({"mainnet": "ok", "ropsten": "degraded", "kovan": "down", "rinkeby": "ok"}) },
+  })
+}
 const assert = require('assert')
-const nock = require('nock')
 const InfuraController = require('../../app/scripts/controllers/infura')
 
 describe('infura-controller', function () {
@@ -14,20 +15,20 @@ describe('infura-controller', function () {
 
   describe('network status queries', function () {
     describe('#checkInfuraNetworkStatus', function () {
-      it('should return an object reflecting the network statuses', function () {
+      it('should return an object reflecting the network statuses', function (done) {
         this.timeout(15000)
-        nock('https://api.infura.io')
-          .get('/v1/status/metamask')
-          .reply(200, '{"mainnet": "ok", "ropsten": "degraded", "kovan": "down", "rinkeby": "ok"}')
-
         infuraController.checkInfuraNetworkStatus()
           .then(() => {
             const networkStatus = infuraController.store.getState().infuraNetworkStatus
+            const networkStatus2 = infuraController.store.getState()
             assert.equal(Object.keys(networkStatus).length, 4)
             assert.equal(networkStatus.mainnet, 'ok')
             assert.equal(networkStatus.ropsten, 'degraded')
             assert.equal(networkStatus.kovan, 'down')
           })
+          .then(() => done())
+          .catch(done)
+
       })
     })
   })


### PR DESCRIPTION
Places foundations in the background to provide UI for users when Infura's services are degraded or down. Will provide an immediate benefit of logs revealing whether infura was dealing with network issues while the user encountered problems.

Also created a new infura controller to account for the various APIs we'll use in the future.