### PR TITLE
Display error when seed phrase is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix bug where slowly mined txs would sometimes be incorrectly marked as failed.
 - Fix bug where badge count did not reflect personal_sign pending messages.
 - Seed word confirmation wording is now scarier.
+- Fix error for invalid seed words.
 
 ## 3.7.8 2017-6-12
 

--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -87,7 +87,7 @@ class KeyringController extends EventEmitter {
     }
 
     if (!bip39.validateMnemonic(seed)) {
-      return Promise.reject('Seed phrase is invalid.')
+      return Promise.reject(new Error('Seed phrase is invalid.'))
     }
 
     this.clearKeyrings()


### PR DESCRIPTION
Fixes #1584 by converting a promise to return an error rather than a straight-up string. This allows the error for invalid seed phrases to render properly.