### PR TITLE
Remove trailing periods and whitespace

### DIFF
--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -244,7 +244,7 @@ SendTransactionScreen.prototype.recipientDidChange = function (recipient, nickna
 
 SendTransactionScreen.prototype.onSubmit = function () {
   const state = this.state || {}
-  const recipient = state.recipient || document.querySelector('input[name="address"]').value
+  const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
   const nickname = state.nickname || ' '
   const input = document.querySelector('input[name="amount"]').value
   const value = util.normalizeEthStringToWei(input)


### PR DESCRIPTION
Remove trailing periods and whitespace when users copy and paste address with them. Fixes #1643 