### PR TITLE
Migration #015 set txs Failed

### DIFF
--- a/app/scripts/migrations/015.js
+++ b/app/scripts/migrations/015.js
@@ -1,0 +1,38 @@
+const version = 15
+
+/*
+
+This migration sets transactions with the 'Gave up submitting tx.' err message
+to a 'failed' stated
+
+*/
+
+const clone = require('clone')
+
+module.exports = {
+  version,
+
+  migrate: function (originalVersionedData) {
+    const versionedData = clone(originalVersionedData)
+    versionedData.meta.version = version
+    try {
+      const state = versionedData.data
+      const newState = transformState(state)
+      versionedData.data = newState
+    } catch (err) {
+      console.warn(`MetaMask Migration #${version}` + err.stack)
+    }
+    return Promise.resolve(versionedData)
+  },
+}
+
+function transformState (state) {
+  const newState = state
+  const transactions = newState.TransactionController.transactions
+  newState.TransactionController.transactions = transactions.map((txMeta) => {
+    if (!txMeta.err) return txMeta
+    else if (txMeta.err.message === 'Gave up submitting tx.') txMeta.status = 'failed'
+    return txMeta
+  })
+  return newState
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -25,4 +25,5 @@ module.exports = [
   require('./012'),
   require('./013'),
   require('./014'),
+  require('./015'),
 ]


### PR DESCRIPTION
Create a migration for setting tx's with the message 'Gave up submitting tx.' as failed as apart of the new nonce-trackers requirements  

