### PR TITLE
Bump token-tracker to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current Master
 
+- Fix precision bug in token balances.
+- Cache token symbol and precisions to reduce network load.
+
 ## 3.8.0 2017-6-28
 
 - No longer stop rebroadcasting transactions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix precision bug in token balances.
 - Cache token symbol and precisions to reduce network load.
+- Transpile some newer JavaScript, restores compatibility with some older browsers.
 
 ## 3.8.0 2017-6-28
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eth-query": "^2.1.2",
     "eth-sig-util": "^1.1.1",
     "eth-simple-keyring": "^1.1.1",
-    "eth-token-tracker": "^1.1.1",
+    "eth-token-tracker": "^1.1.2",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eth-query": "^2.1.2",
     "eth-sig-util": "^1.1.1",
     "eth-simple-keyring": "^1.1.1",
-    "eth-token-tracker": "^1.0.9",
+    "eth-token-tracker": "^1.1.1",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",


### PR DESCRIPTION
- Includes a critical decimal-handling fix.
- Reduces number of symbol and precision queries after initial load.
- Adds compile step to restore compat w/ older Firefoxes.