### PR TITLE
Stop loading popular tokens by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Temporarily disabled loading popular tokens by default to improve performance.
+
 ## 3.8.0 2017-6-28
 
 - No longer stop rebroadcasting transactions

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -3,10 +3,11 @@ const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const TokenTracker = require('eth-token-tracker')
 const TokenCell = require('./token-cell.js')
-const contracts = require('eth-contract-metadata')
 const normalizeAddress = require('eth-sig-util').normalize
 
 const defaultTokens = []
+/*
+const contracts = require('eth-contract-metadata')
 for (const address in contracts) {
   const contract = contracts[address]
   if (contract.erc20) {
@@ -14,6 +15,7 @@ for (const address in contracts) {
     defaultTokens.push(contract)
   }
 }
+*/
 
 module.exports = TokenList
 


### PR DESCRIPTION
Improves performance by not pre-populating the token list with popular tokens.