### PR TITLE
Remove send button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Remove SEND token button until a better token sending form can be built, due to some precision issues.
+
 ## 3.8.0 2017-6-28
 
 - No longer stop rebroadcasting transactions

--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -31,9 +31,11 @@ TokenCell.prototype.render = function () {
 
       h('span', { style: { flex: '1 0 auto' } }),
 
+      /*
       h('button', {
         onClick: this.send.bind(this, address),
       }, 'SEND'),
+      */
 
     ])
   )


### PR DESCRIPTION
Some token precisions are not respected by TokenFactory, so it's not sufficient for a default send form. Removing for now.