### PR TITLE
No longer show network spinner on config screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- No longer show network loading indication on config screen, to allow selecting custom RPCs.
+
 ## 3.8.1 2017-6-30
 
 - Temporarily disabled loading popular tokens by default to improve performance.

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -66,7 +66,7 @@ function mapStateToProps (state) {
 App.prototype.render = function () {
   var props = this.props
   const { isLoading, loadingMessage, transForward, network } = props
-  const isLoadingNetwork = network === 'loading'
+  const isLoadingNetwork = network === 'loading' && props.currentView.name !== 'config'
   const loadMessage = loadingMessage || isLoadingNetwork ?
     'Searching for Network' : null
 


### PR DESCRIPTION
The config screen is used to select networks, so we must not block it with network loading indication.

Fixes #1720