### PR TITLE
metamask - append dapp origin domain to rpc request

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "0.19.1",
-    "web3-provider-engine": "^13.0.3",
-    "web3-stream-provider": "^2.0.6",
+    "web3-provider-engine": "^13.1.1",
+    "web3-stream-provider": "^3.0.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
this will infura track dapps using more than their fair share (e.g. EOS)