### PR TITLE
Reenable Default Token List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current Master
 
+- Re-enable default token list.
+- Add origin header to dapp-bound requests to allow providers to throttle sites.
+
 ## 3.8.2 2017-7-3
 
 - No longer show network loading indication on config screen, to allow selecting custom RPCs.

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -6,7 +6,6 @@ const TokenCell = require('./token-cell.js')
 const normalizeAddress = require('eth-sig-util').normalize
 
 const defaultTokens = []
-/*
 const contracts = require('eth-contract-metadata')
 for (const address in contracts) {
   const contract = contracts[address]
@@ -15,7 +14,6 @@ for (const address in contracts) {
     defaultTokens.push(contract)
   }
 }
-*/
 
 module.exports = TokenList
 


### PR DESCRIPTION
Looks pretty clear to me now that the heavy traffic spike was not this feature, but was the EOS crowdsale. Now that we've mitigated their traffic spike, I think we can safely re-introduce this feature.