### PR TITLE
Add first version of phishing site warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Now detects and blocks known phishing sites.
 - No longer validate nonce client-side in retry loop.
 - Fix bug where insufficient balance error was sometimes shown on successful transactions.
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -52,6 +52,12 @@
       ],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "run_at": "document_end",
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["scripts/blacklister.js"],
+      "css": ["css/blacklister.css"]
     }
   ],
   "permissions": [

--- a/app/scripts/blacklister.js
+++ b/app/scripts/blacklister.js
@@ -1,0 +1,13 @@
+const blacklistedDomains = require('etheraddresslookup/blacklists/domains.json')
+
+function detectBlacklistedDomain() {
+  var strCurrentTab = window.location.hostname
+  if (blacklistedDomains && blacklistedDomains.includes(strCurrentTab)) {
+    window.location.href = 'https://metamask.io/phishing.html'
+  }
+}
+
+window.addEventListener('load', function() {
+  detectBlacklistedDomain()
+})
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 8.0.0
+    version: 8.1.4
 dependencies:
   pre:
     - "npm i -g testem"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -172,6 +172,7 @@ gulp.task('default', ['lint'], function () {
 const jsFiles = [
   'inpage',
   'contentscript',
+  'blacklister',
   'background',
   'popup',
 ]

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eth-sig-util": "^1.1.1",
     "eth-simple-keyring": "^1.1.1",
     "eth-token-tracker": "^1.1.2",
-    "etheraddresslookup": "github:407H/EtherAddressLookup",
+    "etheraddresslookup": "github:409H/EtherAddressLookup",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npm run dev",
     "dev": "gulp dev --debug",
     "disc": "gulp disc --debug",
-    "dist": "npm install && gulp dist",
+    "dist": "rm -rf node_modules/etheraddresslookup && npm install && gulp dist",
     "test": "npm run lint && npm run test-unit && npm run test-integration",
     "test-unit": "METAMASK_ENV=test mocha --require test/helper.js --recursive \"test/unit/**/*.js\"",
     "test-integration": "npm run buildMock && npm run buildCiUnits && testem ci -P 2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eth-sig-util": "^1.1.1",
     "eth-simple-keyring": "^1.1.1",
     "eth-token-tracker": "^1.1.2",
-    "etheraddresslookup": "github:flyswatter/EtherAddressLookup#AddPackageJson",
+    "etheraddresslookup": "github:407H/EtherAddressLookup",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eth-sig-util": "^1.1.1",
     "eth-simple-keyring": "^1.1.1",
     "eth-token-tracker": "^1.1.2",
+    "etheraddresslookup": "github:flyswatter/EtherAddressLookup#AddPackageJson",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",


### PR DESCRIPTION
Links to my own blacklist for now, since I added a package.json for easy importing.

We can point at the main 408H repository once this is merged:
https://github.com/409H/EtherAddressLookup/pull/24

Redirects detected phishing sites [here](https://metamask.io/phishing.html).

Eventually will be cool to regularly re-query the blacklist from the extension, so that we don't have to push an update to update the blacklist.

Fixes #1767.