### PR TITLE
Implement NewUI Dropdown Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dist": "npm install && gulp dist",
     "test": "npm run lint && npm run test-unit && npm run test-integration",
     "test-unit": "METAMASK_ENV=test mocha --require test/helper.js --recursive \"test/unit/**/*.js\"",
+    "test-responsive": "METAMASK_ENV=test mocha --require test/helper.js --recursive \"test/unit/responsive/**/*.js\"",
     "test-integration": "npm run buildMock && npm run buildCiUnits && testem ci -P 2",
     "lint": "gulp lint",
     "buildCiUnits": "node test/integration/index.js",

--- a/test/unit/responsive/components/dropdown-test.js
+++ b/test/unit/responsive/components/dropdown-test.js
@@ -1,0 +1,51 @@
+var assert = require('assert');
+
+const additions = require('react-testutils-additions');
+const h = require('react-hyperscript');
+const ReactTestUtils = require('react-addons-test-utils');
+const sinon = require('sinon');
+const path = require('path');
+const Dropdown = require(path.join(__dirname, '..', '..', '..', '..', 'ui', 'responsive', 'app', 'components', 'dropdown.js')).Dropdown;
+const DropdownMenuItem = require(path.join(__dirname, '..', '..', '..', '..', 'ui', 'responsive', 'app', 'components', 'dropdown.js')).DropdownMenuItem;
+
+describe('Dropdown components', function () {
+  it('can render two items', function () {
+    const renderer = ReactTestUtils.createRenderer()
+
+    const onClickOutside = sinon.spy();
+    const closeMenu = sinon.spy();
+    const onClick = sinon.spy();
+
+    const dropdownComponent = h(Dropdown, {
+      isOpen: true,
+      zIndex: 11,
+      onClickOutside,
+      style: {
+        position: 'absolute',
+        right: 0,
+        top: '36px',
+      },
+      innerStyle: {},
+    }, [ // DROP MENU ITEMS
+      h('style', `
+        .drop-menu-item:hover { background:rgb(235, 235, 235); }
+        .drop-menu-item i { margin: 11px; }
+      `),
+
+      h(DropdownMenuItem, {
+        closeMenu,
+        onClick,
+      }, 'Item 1'),
+
+      h(DropdownMenuItem, {
+        closeMenu,
+        onClick,
+      }, 'Item 2'),
+    ])
+
+    const component = additions.renderIntoDocument(dropdownComponent);
+    renderer.render(dropdownComponent);
+    const items = additions.find(component, 'li');
+    assert.equal(items.length, 2);
+  });
+});

--- a/ui/responsive/app/components/dropdown.js
+++ b/ui/responsive/app/components/dropdown.js
@@ -21,7 +21,16 @@ class Dropdown extends Component {
           boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
         },
       },
-      children,
+      [
+        h(
+          'style',
+          `
+          li.dropdown-menu-item:hover { color:rgb(225, 225, 225); }
+          li.dropdown-menu-item { color: rgb(185, 185, 185); }
+          `
+        ),
+        ...children,
+      ],
     );
   }
 }
@@ -38,7 +47,7 @@ class DropdownMenuItem extends Component {
     const { onClick, closeMenu, children } = this.props;
 
     return h(
-      'li',
+      'li.dropdown-menu-item',
       {
         onClick,
         closeMenu,
@@ -48,7 +57,6 @@ class DropdownMenuItem extends Component {
           fontSize: '12px',
           fontStyle: 'normal',
           fontFamily: 'Montserrat Regular',
-          color: 'rgb(185, 185, 185)',
           cursor: 'pointer',
           display: 'flex',
           justifyContent: 'flex-start',

--- a/ui/responsive/app/components/dropdown.js
+++ b/ui/responsive/app/components/dropdown.js
@@ -1,0 +1,71 @@
+const Component = require('react').Component;
+const PropTypes = require('react').PropTypes;
+const h = require('react-hyperscript');
+const MenuDroppo = require('menu-droppo');
+
+class Dropdown extends Component {
+  render() {
+    const { isOpen, onClickOutside, style, children } = this.props;
+
+    return h(
+      MenuDroppo,
+      {
+        isOpen,
+        zIndex: 11,
+        onClickOutside,
+        style,
+        innerStyle: {
+          borderRadius: '4px',
+          padding: '8px 16px',
+          background: 'rgba(0, 0, 0, 0.8)',
+          boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
+        },
+      },
+      children,
+    );
+  }
+}
+
+Dropdown.propTypes = {
+  isOpen: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
+  children: PropTypes.node,
+  style: PropTypes.object.isRequired,  
+}
+
+class DropdownMenuItem extends Component {
+  render() {
+    const { onClick, closeMenu, children } = this.props;
+
+    return h(
+      'li',
+      {
+        onClick,
+        closeMenu,
+        style: {
+          listStyle: 'none',
+          padding: '8px 0px 8px 0px',
+          fontSize: '12px',
+          fontStyle: 'normal',
+          fontFamily: 'Montserrat Regular',
+          color: 'rgb(185, 185, 185)',
+          cursor: 'pointer',
+          display: 'flex',
+          justifyContent: 'flex-start',
+        },
+      },
+      children
+    );
+  }
+}
+
+DropdownMenuItem.propTypes = {
+  closeMenu: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};
+
+module.exports = {
+  Dropdown,
+  DropdownMenuItem,
+};


### PR DESCRIPTION
Rough Notes:
- Implements dropdown with new design
- `app.js` has no changes: this is only the reusable component. Will hook it up when implementing new views
- Adds tests, which includes a usage example (see `test/unit/responsive/components/dropdown-test.js`). 
- Added `test-responsive` script. Reason: `NewUI` tests don't work (cloning broke the relative paths): we will fix (for all other tests) in a future PR.
- Eyeballed a bunch of styles, if feedback/exact values from designer are available, please ping on Gitter!

![new-dropdown](https://user-images.githubusercontent.com/8230144/28155589-3ee26a9c-6764-11e7-8dc9-79452e36042a.gif)

@flyswatter let me know if you have any questions.