### PR TITLE
Add support page link to help page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Now redirects from known malicious sites faster.
+- Added a link to our new support page to the help screen.
 
 ## 3.9.0 2017-7-12
 

--- a/ui/app/info.js
+++ b/ui/app/info.js
@@ -97,11 +97,17 @@ InfoScreen.prototype.render = function () {
               paddingLeft: '30px',
             }},
             [
+              h('div.fa.fa-support', [
+                h('a.info', {
+                  href: 'http://metamask.consensyssupport.happyfox.com',
+                  target: '_blank',
+                }, 'Visit our Support Center'),
+              ]),
               h('div.fa.fa-github', [
                 h('a.info', {
-                  href: 'https://github.com/MetaMask/faq',
+                  href: 'https://github.com/MetaMask/metamask-extension/issues/new',
                   target: '_blank',
-                }, 'Need Help? Read our FAQ!'),
+                }, 'Found a bug? Report it!'),
               ]),
               h('div', [
                 h('a', {


### PR DESCRIPTION
Also adjust github link to be a new bug link, which goes to the new issue page.

![screen shot 2017-07-17 at 9 58 26 am](https://user-images.githubusercontent.com/542863/28279799-8337cdc0-6ad6-11e7-87ec-7227b093cf46.png)