### PR TITLE
Fix transaction confirmation ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Now redirects from known malicious sites faster.
 - Added a link to our new support page to the help screen.
+- Fixed bug where a new transaction would be shown over the current transaction, creating a possible timing attack against user confirmation.
 
 ## 3.9.0 2017-7-12
 

--- a/test/unit/tx-helper-test.js
+++ b/test/unit/tx-helper-test.js
@@ -1,0 +1,17 @@
+const assert = require('assert')
+const txHelper = require('../../ui/lib/tx-helper')
+
+describe('txHelper', function () {
+  it('always shows the oldest tx first', function () {
+    const metamaskNetworkId = 1
+    const txs = {
+      a: { metamaskNetworkId, time: 3 },
+      b: { metamaskNetworkId, time: 1 },
+      c: { metamaskNetworkId, time: 2 },
+    }
+
+    const sorted = txHelper(txs, null, null, metamaskNetworkId)
+    assert.equal(sorted[0].time, 1, 'oldest tx first')
+    assert.equal(sorted[2].time, 3, 'newest tx last')
+  })
+})

--- a/ui/lib/tx-helper.js
+++ b/ui/lib/tx-helper.js
@@ -12,6 +12,10 @@ module.exports = function (unapprovedTxs, unapprovedMsgs, personalMsgs, network)
   const personalValues = valuesFor(personalMsgs)
   log.debug(`tx helper found ${personalValues.length} unsigned personal messages`)
   allValues = allValues.concat(personalValues)
+  allValues = allValues.sort((a, b) => {
+    return a.time > b.time
+  })
 
-  return allValues.sort(txMeta => txMeta.time)
+  return allValues
 }
+


### PR DESCRIPTION
Newest tx or message will now always appear last, and a new tx proposed after the user has a confirmation box open will never change the confirmation to a different tx proposed.

Fixes #1637