### PR TITLE
Add minor fixes, including account selection scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "inject-css": "^0.1.1",
     "jazzicon": "^1.2.0",
     "loglevel": "^1.4.1",
-    "menu-droppo": "1.1.6",
+    "menu-droppo": "2.0.0",
     "metamask-logo": "^2.1.2",
     "mississippi": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -206,7 +206,9 @@ App.prototype.renderNetworkDropdown = function () {
       left: '2px',
       top: '36px',
     },
-    innerStyle: {},
+    innerStyle: {
+      padding: '2px 16px 2px 0px',
+    },
   }, [
 
     h(

--- a/ui/app/components/account-dropdowns.js
+++ b/ui/app/components/account-dropdowns.js
@@ -59,6 +59,8 @@ class AccountDropdowns extends Component {
         style: {
           marginLeft: '-125px',
           minWidth: '180px',
+          overflowY: 'auto',
+          maxHeight: '300px',
         },
         isOpen: accountSelectorActive,
         onClickOutside: () => { this.setState({ accountSelectorActive: false }) },

--- a/ui/app/components/account-dropdowns.js
+++ b/ui/app/components/account-dropdowns.js
@@ -120,14 +120,6 @@ class AccountDropdowns extends Component {
           DropdownMenuItem,
           {
             closeMenu: () => {},
-            onClick: () => actions.showConfigPage(),
-          },
-          'Account Settings',
-        ),
-        h(
-          DropdownMenuItem,
-          {
-            closeMenu: () => {},
             onClick: () => {
               const { selected, network } = this.props
               const url = genAccountLink(selected, network)

--- a/ui/app/components/dropdown.js
+++ b/ui/app/components/dropdown.js
@@ -7,7 +7,7 @@ const noop = () => {}
 
 class Dropdown extends Component {
   render () {
-    const { isOpen, onClickOutside, style, children } = this.props
+    const { isOpen, onClickOutside, style, innerStyle, children } = this.props
 
     return h(
       MenuDroppo,
@@ -21,6 +21,7 @@ class Dropdown extends Component {
           padding: '8px 16px',
           background: 'rgba(0, 0, 0, 0.8)',
           boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
+          ...innerStyle,
         },
       },
       [


### PR DESCRIPTION
![dropdowns-for-master](https://user-images.githubusercontent.com/8230144/28640353-4ef7ef32-7200-11e7-8446-2c2a31d80306.gif)

- Bumps version of `menu-droppo`
- Went for adding `overflow-y` to only one dropdown (instead of a global change to the lib) because: 
---- Global settings and account options aren't likely to ever have too much content
---- Network dropdown might eventually, but we'd see that coming with plenty of time
(Open to readjusting if we need it global though!)
- Removed "Account Settings" from account options dropdown as discussed live