### PR TITLE
[Part-1] Fix/dropdown toggle

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -308,7 +308,11 @@ App.prototype.renderDropdown = function () {
     isOpen: isOpen,
     zIndex: 11,
     onClickOutside: (event) => {
-      this.setState({ isMainMenuOpen: !isOpen })
+      const { classList } = event.target
+      const isNotToggleElement = !classList.contains('sandwich-expando')
+      if (isNotToggleElement) {
+        this.setState({ isMainMenuOpen: false })
+      }
     },
     style: {
       position: 'absolute',

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -198,7 +198,17 @@ App.prototype.renderNetworkDropdown = function () {
   return h(Dropdown, {
     isOpen,
     onClickOutside: (event) => {
-      this.setState({ isNetworkMenuOpen: !isOpen })
+      const { classList } = event.target
+      const isNotToggleElement = [
+        classList.contains('menu-icon'),
+        classList.contains('network-name'),
+        classList.contains('network-indicator'),
+      ].filter(bool => bool).length === 0;
+      // classes from three constituent nodes of the toggle element
+
+      if (isNotToggleElement) {
+        this.setState({ isNetworkMenuOpen: false })
+      }
     },
     zIndex: 11,
     style: {

--- a/ui/app/components/account-dropdowns.js
+++ b/ui/app/components/account-dropdowns.js
@@ -17,6 +17,8 @@ class AccountDropdowns extends Component {
       accountSelectorActive: false,
       optionsMenuActive: false,
     }
+    this.accountSelectorToggleClassName = 'fa-angle-down';
+    this.optionsMenuToggleClassName = 'fa-ellipsis-h';
   }
 
   renderAccounts () {
@@ -63,7 +65,13 @@ class AccountDropdowns extends Component {
           maxHeight: '300px',
         },
         isOpen: accountSelectorActive,
-        onClickOutside: () => { this.setState({ accountSelectorActive: false }) },
+        onClickOutside: (event) => {
+          const { classList } = event.target
+          const isNotToggleElement = !classList.contains(this.accountSelectorToggleClassName)
+          if (accountSelectorActive && isNotToggleElement) {
+            this.setState({ accountSelectorActive: false })
+          }
+        },
       },
       [
         ...this.renderAccounts(),
@@ -115,7 +123,13 @@ class AccountDropdowns extends Component {
           minWidth: '180px',
         },
         isOpen: optionsMenuActive,
-        onClickOutside: () => { this.setState({ optionsMenuActive: false }) },
+        onClickOutside: () => {
+          const { classList } = event.target
+          const isNotToggleElement = !classList.contains(this.optionsMenuToggleClassName)
+          if (optionsMenuActive && isNotToggleElement) {
+            this.setState({ optionsMenuActive: false })
+          }
+        },
       },
       [
         h(


### PR DESCRIPTION
**This PR is being made to `NewUI` and is intended to support QA of  #1835**

Given how are dropdowns are implemented: `onClickOutside` needs to account for the toggle element. Before, if the toggle element was clicked: the global listener would still fire, a net result of two toggle events firing.  
![](https://user-images.githubusercontent.com/8230144/28737408-35f2eb1e-73a3-11e7-9de7-c76ee59ca1ed.gif)


This PR fixes that.
![newui-dropdown-fixes](https://user-images.githubusercontent.com/8230144/28739291-a4104a46-73ae-11e7-8c96-0602ff182de6.gif)

Architectural comment: if dropdown functionality will ever become more complex, we'll save time by moving all dropdown state over to redux; benefits include full-time travel/replayability, and more granular control over which events affect re-renders of the dropdown components. 

This would be my preference long-term. For now, suggesting we go with this solution to get the branches merged.