### PR TITLE
Remove default tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current Master
 
+- Reenable token list.
+- Remove default tokens.
+
 ## 3.9.7 2017-8-15
 
 - hotfix - disable token list

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -12,7 +12,7 @@ const ExportAccountView = require('./components/account-export')
 const ethUtil = require('ethereumjs-util')
 const EditableLabel = require('./components/editable-label')
 const TabBar = require('./components/tab-bar')
-// const TokenList = require('./components/token-list')
+const TokenList = require('./components/token-list')
 const AccountDropdowns = require('./components/account-dropdowns').AccountDropdowns
 
 module.exports = connect(mapStateToProps)(AccountDetailScreen)
@@ -255,34 +255,17 @@ AccountDetailScreen.prototype.tabSections = function () {
 
 AccountDetailScreen.prototype.tabSwitchView = function () {
   const props = this.props
-  const { address/*, network */} = props
-  const { currentAccountTab/*, tokens*/ } = this.props
+  const { address, network } = props
+  const { currentAccountTab, tokens } = this.props
 
   switch (currentAccountTab) {
     case 'tokens':
-      // return h(TokenList, {
-      //   userAddress: address,
-      //   network,
-      //   tokens,
-      //   addToken: () => this.props.dispatch(actions.showAddTokenPage()),
-      // })
-      return h('.hotFix', {
-        style: {
-          padding: '80px',
-        },
-      }, [
-      'Token lists are temporarily down. You can check you your token balances ',
-      h('span.hotFix', {
-          style: {
-            color: 'rgba(247, 134, 28, 1)',
-            cursor: 'pointer',
-          },
-          onClick: () => {
-            global.platform.openWindow({
-            url: `https://ethplorer.io/address/${address}`,
-          })
-          },
-        }, 'here')])
+      return h(TokenList, {
+        userAddress: address,
+        network,
+        tokens,
+        addToken: () => this.props.dispatch(actions.showAddTokenPage()),
+      })
     default:
       return this.transactionList()
   }

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -27,7 +27,24 @@ TokenList.prototype.render = function () {
 
   if (error) {
     log.error(error)
-    return this.message('There was a problem loading your token balances.')
+    return h('.hotFix', {
+      style: {
+        padding: '80px',
+      },
+    }, [
+      'We had trouble loading your token balances. You can view them ',
+      h('span.hotFix', {
+        style: {
+          color: 'rgba(247, 134, 28, 1)',
+          cursor: 'pointer',
+        },
+        onClick: () => {
+          global.platform.openWindow({
+          url: `https://ethplorer.io/address/${userAddress}`,
+        })
+        },
+      }, 'here'),
+    ])
   }
 
   const tokenViews = tokens.map((tokenData) => {

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -3,7 +3,6 @@ const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const TokenTracker = require('eth-token-tracker')
 const TokenCell = require('./token-cell.js')
-const normalizeAddress = require('eth-sig-util').normalize
 
 module.exports = TokenList
 
@@ -187,18 +186,5 @@ TokenList.prototype.updateBalances = function (tokens) {
 TokenList.prototype.componentWillUnmount = function () {
   if (!this.tracker) return
   this.tracker.stop()
-}
-
-function uniqueMergeTokens (tokensA, tokensB) {
-  const uniqueAddresses = []
-  const result = []
-  tokensA.concat(tokensB).forEach((token) => {
-    const normal = normalizeAddress(token.address)
-    if (!uniqueAddresses.includes(normal)) {
-      uniqueAddresses.push(normal)
-      result.push(token)
-    }
-  })
-  return result
 }
 

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -5,16 +5,6 @@ const TokenTracker = require('eth-token-tracker')
 const TokenCell = require('./token-cell.js')
 const normalizeAddress = require('eth-sig-util').normalize
 
-const defaultTokens = []
-const contracts = require('eth-contract-metadata')
-for (const address in contracts) {
-  const contract = contracts[address]
-  if (contract.erc20) {
-    contract.address = address
-    defaultTokens.push(contract)
-  }
-}
-
 module.exports = TokenList
 
 inherits(TokenList, Component)
@@ -153,7 +143,7 @@ TokenList.prototype.createFreshTokenTracker = function () {
   this.tracker = new TokenTracker({
     userAddress,
     provider: global.ethereumProvider,
-    tokens: uniqueMergeTokens(defaultTokens, this.props.tokens),
+    tokens: this.props.tokens,
     pollingInterval: 8000,
   })
 


### PR DESCRIPTION
Reverts yesterday's hot-fix that removed the token list entirely.
Instead removes the default token list, so that each user isn't checking the balance of every token every time, they need to manually specify.

We could maybe even add an "auto detect tokens" button at some point, which we could tuck away, and maybe run on account creation, but those are optimizations.

In the short term this should cut the bandwidth usage of the token view by a large factor for normal users. This is the same fix that was chosen by the MEW team to deal with the same problem when they had it.