### PR TITLE
Transition home after tx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug where some transaction submission errors would show an empty screen.
+
 ## 3.9.8 2017-8-16
 
 - Reenable token list.

--- a/test/unit/actions/tx_test.js
+++ b/test/unit/actions/tx_test.js
@@ -53,7 +53,7 @@ describe('tx confirmation screen', function () {
           result = reducers(initialState, action)
           done()
         })
-        
+
       })
 
       it('should transition to the account detail view', function () {
@@ -63,91 +63,6 @@ describe('tx confirmation screen', function () {
       it('should have no unconfirmed txs remaining', function () {
         var count = getUnconfirmedTxCount(result)
         assert.equal(count, 0)
-      })
-    })
-
-    describe('sendTx', function () {
-      var result
-
-      describe('when there is an error', function () {
-        before(function (done) {
-          actions._setBackgroundConnection({
-            approveTransaction (txId, cb) { cb({message: 'An error!'}) },
-          })
-
-          actions.sendTx({id: firstTxId})(function (action) {
-            result = reducers(initialState, action)
-            done()
-          })
-        })
-
-        it('should stay on the page', function () {
-          assert.equal(result.appState.currentView.name, 'confTx')
-        })
-
-        it('should set errorMessage on the currentView', function () {
-          assert(result.appState.currentView.errorMessage)
-        })
-      })
-
-      describe('when there is success', function () {
-        it('should complete tx and go home', function () {
-          actions._setBackgroundConnection({
-            approveTransaction (txId, cb) { cb() },
-          })
-
-          var dispatchExpect = sinon.mock()
-          dispatchExpect.twice()
-
-          actions.sendTx({id: firstTxId})(dispatchExpect)
-        })
-      })
-    })
-
-    describe('when there are two pending txs', function () {
-      var firstTxId = 1457634084250832
-      var result, initialState
-      before(function (done) {
-        initialState = {
-          appState: {
-            currentView: {
-              name: 'confTx',
-            },
-          },
-          metamask: {
-            unapprovedTxs: {
-              '1457634084250832': {
-                id: firstTxId,
-                status: 'unconfirmed',
-                time: 1457634084250,
-              },
-              '1457634084250833': {
-                id: 1457634084250833,
-                status: 'unconfirmed',
-                time: 1457634084255,
-              },
-            },
-          },
-        }
-        freeze(initialState)
-
-        // Mocking a background connection:
-        actions._setBackgroundConnection({
-          approveTransaction (firstTxId, cb) { cb() },
-        })
-
-        actions.sendTx({id: firstTxId})(function (action) {
-          result = reducers(initialState, action)
-        })
-        done()
-      })
-
-      it('should stay on the confTx view', function () {
-        assert.equal(result.appState.currentView.name, 'confTx')
-      })
-
-      it('should transition to the first tx', function () {
-        assert.equal(result.appState.currentView.context, 0)
       })
     })
   })

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -97,7 +97,6 @@ var actions = {
   cancelMsg: cancelMsg,
   signPersonalMsg,
   cancelPersonalMsg,
-  sendTx: sendTx,
   signTx: signTx,
   updateAndApproveTx,
   cancelTx: cancelTx,
@@ -397,26 +396,13 @@ function signPersonalMsg (msgData) {
 
 function signTx (txData) {
   return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
     global.ethQuery.sendTransaction(txData, (err, data) => {
       dispatch(actions.hideLoadingIndication())
-      if (err) return dispatch(actions.displayWarning(err.message))
-      dispatch(actions.hideWarning())
+      if (err) dispatch(actions.displayWarning(err.message))
+      dispatch(this.goHome())
     })
-    dispatch(this.showConfTxPage())
-  }
-}
-
-function sendTx (txData) {
-  log.info(`actions - sendTx: ${JSON.stringify(txData.txParams)}`)
-  return (dispatch) => {
-    log.debug(`actions calling background.approveTransaction`)
-    background.approveTransaction(txData.id, (err) => {
-      if (err) {
-        dispatch(actions.txError(err))
-        return log.error(err.message)
-      }
-      dispatch(actions.completedTx(txData.id))
-    })
+    dispatch(actions.showConfTxPage())
   }
 }
 
@@ -428,6 +414,7 @@ function updateAndApproveTx (txData) {
       dispatch(actions.hideLoadingIndication())
       if (err) {
         dispatch(actions.txError(err))
+        dispatch(actions.goHome())
         return log.error(err.message)
       }
       dispatch(actions.completedTx(txData.id))


### PR DESCRIPTION
Fixes #1091.

Duplicating my explanation from there:

There are really two problems at play, one is simple (and I'm fixing), the other is a bit deeper, and requires some harder work.

Step 1 is that in case of error, we don't do anything, and so we see a spinner forever.
https://github.com/MetaMask/metamask-extension/blob/master/ui/app/actions.js#L430

To understand the second problem, you should refer to this line of our transaction manager:
https://github.com/MetaMask/metamask-extension/blob/master/app/scripts/controllers/transactions.js#L252

There you can see that if submitting a transaction fails, we set the tx as failed, and then return an error. The problem is that some errors are actually validation issues, where we actually want to just go back to editing the tx, and warn the user what was wrong.

A couple things I know these errors can be:

- Nonce is too low
- Gas limit is too high

Gas limits are a good validation, but nonce being too low isn't even something we have UI for, so in that case, we might want to, I don't know, detect it and adjust our nonce logic? Up for some discussion. No doubt there are a variety of possible errors here, different for different clients, which should be handled specifically.

That's a harder problem, so we can leave it for a longer term, may not even be worth doing. Maybe it's fine to fail a tx that fails a server-side validation, and leave the message in the failed tx message field.

Fixed this in a PR coming soon.

Also, confirmed we can remove `sendTx` from actions.