### PR TITLE
Fix token balance precision rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Fix bug where some transaction submission errors would show an empty screen.
+- Fix bug that could mis-render token balances when very small.
 
 ## 3.9.8 2017-8-16
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eth-query": "^2.1.2",
     "eth-sig-util": "^1.2.2",
     "eth-simple-keyring": "^1.1.1",
-    "eth-token-tracker": "^1.1.2",
+    "eth-token-tracker": "^1.1.3",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",


### PR DESCRIPTION
Fixes a bug where balances under 1 token could be mis-rendered by fixing it [here](https://github.com/MetaMask/eth-token-tracker/pull/9) then updating us to `eth-token-tracker@1.1.3`.

Fixes #1912