### PR TITLE
Set max retry limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Fix nonce calculation bug that would sometimes generate very wrong nonces.
+- Give up resubmitting a transaction after 3500 blocks.
 
 ## 3.9.10 2017-8-23
 

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -40,6 +40,10 @@ module.exports = class TransactionController extends EventEmitter {
           err: undefined,
         })
       },
+      giveUpOnTransaction: (txId) => {
+        const msg = `Gave up submitting after 3500 blocks un-mined.`
+        this.setTxStatusFailed(txId, msg)
+      },
     })
     this.query = new EthQuery(this.provider)
     this.txProviderUtil = new TxProviderUtil(this.provider)


### PR DESCRIPTION
Set transaction state to failed after 3500 blocks of retrying.

Should help mitigate the effects of stray pending transactions from bad-nonce errors in the past, like today's.