### PR TITLE
Add some tests to tx-state-history-helper

### DIFF
--- a/test/unit/tx-state-history-helper-test.js
+++ b/test/unit/tx-state-history-helper-test.js
@@ -1,0 +1,26 @@
+const assert = require('assert')
+const clone = require('clone')
+const txStateHistoryHelper = require('../../app/scripts/lib/tx-state-history-helper')
+
+describe('deepCloneFromTxMeta', function () {
+  it('should clone deep', function () {
+    const input = {
+      foo: {
+        bar: {
+          bam: 'baz'
+        }
+      }
+    }
+    const output = txStateHistoryHelper.snapshotFromTxMeta(input)
+    assert('foo' in output, 'has a foo key')
+    assert('bar' in output.foo, 'has a bar key')
+    assert('bam' in output.foo.bar, 'has a bar key')
+    assert.equal(output.foo.bar.bam, 'baz', 'has a baz value')
+  })
+
+  it('should remove the history key', function () {
+    const input = { foo: 'bar', history: 'remembered' }
+    const output = txStateHistoryHelper.snapshotFromTxMeta(input)
+    assert(typeof output.history, 'undefined', 'should remove history')
+  })
+})


### PR DESCRIPTION
I believe this Fixes #1974 by adding a test that confirms we are performing a deep merge on first history item construction.

Was there a reason we suspected this wasn't the case, or was this just to add an assurance?