### PR TITLE
Make eth_sign deprecation warning more useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Make eth_sign deprecation warning less noisy
+- Add useful link to eth_sign deprecation warning.
 - Fix bug with network version serialization over synchronous RPC
 - Add MetaMask version to state logs.
 - Add the total amount of tokens when multiple tokens are added under the token list

--- a/ui/app/components/pending-msg.js
+++ b/ui/app/components/pending-msg.js
@@ -35,10 +35,21 @@ PendingMsg.prototype.render = function () {
         style: {
           margin: '10px',
         },
-      }, `Signing this message can have
+      }, [
+        `Signing this message can have
         dangerous side effects. Only sign messages from
         sites you fully trust with your entire account.
-        This dangerous method will be removed in a future version.`),
+        This dangerous method will be removed in a future version. `,
+        h('a', {
+          href: 'https://medium.com/metamask/the-new-secure-way-to-sign-data-in-your-browser-6af9dd2a1527',
+          style: { color: 'rgb(247, 134, 28)' },
+          onClick: (event) => {
+            event.preventDefault()
+            const url = 'https://medium.com/metamask/the-new-secure-way-to-sign-data-in-your-browser-6af9dd2a1527'
+            global.platform.openWindow({ url })
+          },
+        }, 'Read more here.'),
+      ]),
 
       // message details
       h(PendingTxDetails, state),


### PR DESCRIPTION
Link to descriptive article that demonstrates the new preferred method.