### PR TITLE
[New-UI] Link user from pending tx-item to confirm screen

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -421,7 +421,7 @@ function signTx (txData) {
       if (err) return dispatch(actions.displayWarning(err.message))
       dispatch(actions.hideWarning())
     })
-    dispatch(actions.showConfTxPage())
+    dispatch(actions.showConfTxPage({}))
   }
 }
 
@@ -626,10 +626,11 @@ function showAccountsPage () {
   }
 }
 
-function showConfTxPage (transForward = true) {
+function showConfTxPage ({transForward = true, id}) {
   return {
     type: actions.SHOW_CONF_TX_PAGE,
-    transForward: transForward,
+    transForward,
+    id,
   }
 }
 

--- a/ui/app/components/buy-button-subview.js
+++ b/ui/app/components/buy-button-subview.js
@@ -245,7 +245,7 @@ BuyButtonSubview.prototype.navigateTo = function (url) {
 
 BuyButtonSubview.prototype.backButtonContext = function () {
   if (this.props.context === 'confTx') {
-    this.props.dispatch(actions.showConfTxPage(false))
+    this.props.dispatch(actions.showConfTxPage({transForward: false}))
   } else {
     this.props.dispatch(actions.goHome())
   }

--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -1,0 +1,92 @@
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const inherits = require('util').inherits
+const Identicon = require('./identicon')
+
+module.exports = TxListItem
+
+inherits(TxListItem, Component)
+function TxListItem () {
+  Component.call(this)
+}
+
+TxListItem.prototype.getAddressText = function (address) {
+  return address
+    ? `${address.slice(0, 10)}...${address.slice(-4)}`
+    : 'Contract Published'
+}
+
+TxListItem.prototype.render = function () {
+  const {
+    transactionStatus,
+    onClick,
+    transActionId,
+    dateString,
+    address,
+    transactionAmount,
+    className
+  } = this.props
+
+  return h(`div${className || ''}`, {
+    key: transActionId,
+    onClick: () => onClick && onClick(transActionId),
+  }, [
+    h(`div.flex-column.tx-list-item-wrapper`, {}, [
+
+      h('div.tx-list-date-wrapper', {
+        style: {},
+      }, [
+        h('span.tx-list-date', {}, [
+          dateString,
+        ]),
+      ]),
+
+      h('div.flex-row.tx-list-content-wrapper', {
+        style: {},
+      }, [
+
+        h('div.tx-list-identicon-wrapper', {
+          style: {},
+        }, [
+          h(Identicon, {
+            address,
+            diameter: 28,
+          }),
+        ]),
+
+        h('div.tx-list-account-and-status-wrapper', {}, [
+          h('div.tx-list-account-wrapper', {
+            style: {},
+          }, [
+            h('span.tx-list-account', {}, [
+              this.getAddressText(address),
+            ]),
+          ]),
+
+          h('div.tx-list-status-wrapper', {
+            style: {},
+          }, [
+            h('span.tx-list-status', {}, [
+              transactionStatus,
+            ]),
+          ]),
+        ]),
+
+        h('div.flex-column.tx-list-details-wrapper', {
+          style: {},
+        }, [
+
+          h('span.tx-list-value', {}, [
+            transactionAmount,
+          ]),
+
+          h('span.tx-list-fiat-value', {}, [
+            '+ $300 USD',
+          ]),
+
+        ]),
+      ]),
+    ]) // holding on icon from design
+  ])
+}
+

--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -1,6 +1,7 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
+const prefixForNetwork = require('../../lib/etherscan-prefix-for-network')
 const Identicon = require('./identicon')
 
 module.exports = TxListItem
@@ -24,7 +25,7 @@ TxListItem.prototype.render = function () {
     dateString,
     address,
     transactionAmount,
-    className
+    className,
   } = this.props
 
   return h(`div${className || ''}`, {
@@ -89,4 +90,3 @@ TxListItem.prototype.render = function () {
     ]) // holding on icon from design
   ])
 }
-

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -3,7 +3,7 @@ const connect = require('react-redux').connect
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const selectors = require('../selectors')
-const Identicon = require('./identicon')
+const TxListItem = require('./tx-list-item')
 const { formatBalance, formatDate } = require('../util')
 const { showConfTxPage } = require('../actions')
 
@@ -53,16 +53,6 @@ TxList.prototype.render = function () {
   ])
 }
 
-TxList.prototype.getAddressText = function (transaction) {
-  const {
-    txParams: { to },
-  } = transaction
-
-  return to
-    ? `${to.slice(0, 10)}...${to.slice(-4)}`
-    : 'Contract Published'
-}
-
 TxList.prototype.renderTranstions = function () {
   const { txsToRender } = this.props
 
@@ -92,70 +82,21 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
   } = props
   const { showConfTxPage } = this.props
 
-  return h('div.tx-list-item', {
-    key: transaction.id,
-  }, [
-    h('div.flex-column.tx-list-item__wrapper', {
-      onClick: () => transactionStatus === 'unapproved' && showConfTxPage({id: transActionId}),
-      style: {},
-    }, [
+  if (!address) return null
+    
+  const opts = {
+    transactionStatus,
+    transActionId,
+    dateString,
+    address,
+    transactionAmount,
+  }
 
-      h('div.tx-list-date-wrapper', {
-        style: {},
-      }, [
-        h('span.tx-list-date', {}, [
-          dateString,
-        ]),
-      ]),
+  if (transactionStatus === 'unapproved') {
+    opts.onClick = () => showConfTxPage({id: transActionId})
+    opts.className = '.tx-list-pending-item-container'
+  }
 
-      h('div.flex-row.tx-list-content-wrapper', {
-        style: {},
-      }, [
-
-        h('div.tx-list-identicon-wrapper', {
-          style: {},
-        }, [
-          h(Identicon, {
-            address,
-            diameter: 28,
-          }),
-        ]),
-
-        h('div.tx-list-account-and-status-wrapper', {}, [
-          h('div.tx-list-account-wrapper', {
-            style: {},
-          }, [
-            h('span.tx-list-account', {}, [
-              this.getAddressText(transaction),
-            ]),
-          ]),
-
-          h('div.tx-list-status-wrapper', {
-            style: {},
-          }, [
-            h('span.tx-list-status', {}, [
-              transactionStatus,
-            ]),
-          ]),
-        ]),
-
-        h('div.flex-column.tx-list-details-wrapper', {
-          style: {},
-        }, [
-
-          h('span.tx-list-value', {}, [
-            transactionAmount,
-          ]),
-
-          h('span.tx-list-fiat-value', {}, [
-            '+ $300 USD',
-          ]),
-
-        ]),
-
-      ]),
-    ]),
-
-  ])
+  return h(TxListItem, opts)
 }
 

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -102,6 +102,7 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
   if (transactionStatus === 'unapproved') {
     opts.onClick = () => showConfTxPage({id: transActionId})
     opts.className += '.tx-list-pending-item-container'
+    opt.transactionStatus = 'Not Started'
   }
   else if (transactionHash) {
     opts.onClick = () => this.view(transactionHash, transactionNetworkId)

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -5,13 +5,20 @@ const inherits = require('util').inherits
 const selectors = require('../selectors')
 const Identicon = require('./identicon')
 const { formatBalance, formatDate } = require('../util')
+const { showConfTxPage } = require('../actions')
 
-module.exports = connect(mapStateToProps)(TxList)
+module.exports = connect(mapStateToProps, mapDispatchToProps)(TxList)
 
 function mapStateToProps (state) {
   return {
     txsToRender: selectors.transactionsSelector(state),
     conversionRate: selectors.conversionRateSelector(state),
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    showConfTxPage: ({ id }) => dispatch(showConfTxPage({ id }))
   }
 }
 
@@ -22,7 +29,7 @@ function TxList () {
 
 TxList.prototype.render = function () {
 
-  // console.log('transactions to render', txsToRender)
+  const { txsToRender, showConfTxPage } = this.props
 
   return h('div.flex-column.tx-list-container', {}, [
 
@@ -73,18 +80,23 @@ TxList.prototype.renderTransactionListItem = function (transaction) {
     address: transaction.txParams.to,
     transactionStatus: transaction.status,
     transactionAmount: formatBalance(transaction.txParams.value, 6),
+    transActionId: transaction.id,
   }
+
   const {
     address,
     transactionStatus,
     transactionAmount,
     dateString,
+    transActionId,
   } = props
+  const { showConfTxPage } = this.props
 
   return h('div.tx-list-item', {
     key: transaction.id,
   }, [
     h('div.flex-column.tx-list-item__wrapper', {
+      onClick: () => transactionStatus === 'unapproved' && showConfTxPage({id: transActionId}),
       style: {},
     }, [
 

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -73,10 +73,10 @@
 
 .tx-list-pending-item-container {
   cursor: pointer;
-}
 
-.tx-list-pending-item-container:hover {
-  background: $alto;
+  &:hover {
+    background: rgba($alto, .2);
+  }
 }
 
 .tx-list-date-wrapper {

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -71,12 +71,17 @@
   }
 }
 
-.tx-list-pending-item-container {
+.tx-list-clickable {
   cursor: pointer;
 
   &:hover {
     background: rgba($alto, .2);
   }
+}
+
+.tx-list-pending-item-container {
+  cursor: pointer;
+  opacity: 0.5;
 }
 
 .tx-list-date-wrapper {

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -61,6 +61,22 @@
   flex: 0 0 70px;
   align-items: stretch;
   justify-content: flex-start;
+
+  @media screen and (max-width: $break-small) {
+    padding: 0 1.3em .95em;
+  }
+
+  @media screen and (min-width: $break-large) {
+    margin: 0 2.37em;
+  }
+}
+
+.tx-list-pending-item-container {
+  cursor: pointer;
+}
+
+.tx-list-pending-item-container:hover {
+  background: $alto;
 }
 
 .tx-list-date-wrapper {

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -14,10 +14,6 @@ function reduceApp (state, action) {
   if (selectedAddress) {
     name = 'accountDetail'
   }
-  if (hasUnconfActions) {
-    log.debug('pending txs detected, defaulting to conf-tx view.')
-    name = 'confTx'
-  }
 
   var defaultView = {
     name,

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -360,7 +360,7 @@ function reduceApp (state, action) {
       return extend(appState, {
         currentView: {
           name: 'confTx',
-          context: action.id && indexForPending(state, action.id) || 0,
+          context: action.id ? indexForPending(state, action.id) : 0,
         },
         transForward: action.transForward,
         warning: null,

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -360,7 +360,7 @@ function reduceApp (state, action) {
       return extend(appState, {
         currentView: {
           name: 'confTx',
-          context: 0,
+          context: action.id && indexForPending(state, action.id) || 0,
         },
         transForward: action.transForward,
         warning: null,

--- a/ui/index.js
+++ b/ui/index.js
@@ -36,12 +36,6 @@ function startApp (metamaskState, accountManager, opts) {
     networkVersion: opts.networkVersion,
   })
 
-  // if unconfirmed txs, start on txConf page
-  const unapprovedTxsAll = txHelper(metamaskState.unapprovedTxs, metamaskState.unapprovedMsgs, metamaskState.unapprovedPersonalMsgs, metamaskState.network)
-  if (unapprovedTxsAll.length > 0) {
-    store.dispatch(actions.showConfTxPage())
-  }
-
   accountManager.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
   })


### PR DESCRIPTION
This PR does the following:
- removes the code that automatically brings the user to the confirm page if there are any pending transactions
- creates a "tx-list-item" component to be used for rendering the transactions in the main list
- creates a link to the confirm page from pending transactions on the main list.
- Makes a design change here to help the user understand and navigate the clicking of pending transactions to get to the confirm page. See the below screenshot:

![main-screen-pending-tx](https://user-images.githubusercontent.com/7499938/30081341-5d58b0d0-9261-11e7-9adc-c62fb48105c0.gif)

