### PR TITLE
MM-25 account details modal

### DIFF
--- a/ui/app/components/modals/modal.js
+++ b/ui/app/components/modals/modal.js
@@ -54,11 +54,13 @@ const MODALS = {
       width: '95%',
       top: isPopupOrNotification() === 'popup' ? '52vh' : '36.5vh',
       boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
+      borderRadius: '4px',
     },
     laptopModalStyle: {
       width: '360px',
       top: 'calc(33% + 45px)',
       boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
+      borderRadius: '4px',
     },
   },
 

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -172,16 +172,19 @@
   justify-content: flex-start;
   align-items: center;
   position: relative;
-  padding: 5px 0;
+  padding: 5px 0 31px 0;
+  border: 1px solid $silver;
   border-radius: 4px;
+  font-family: 'Montserrat UltraLight';
 }
 
 .account-details-modal-wrapper .qr-header {
-  margin-top: 15px;
+  margin-top: 9px;
+  font-size: 20px;
 }
 
 .account-details-modal-wrapper .qr-wrapper {
-  margin-top: 15px;
+  margin-top: 5px;
 }
 
 .account-details-modal-wrapper .ellip-address-wrapper {
@@ -189,25 +192,34 @@
   justify-content: center;
   border: 1px solid $alto;
   padding: 5px 10px;
+  font-family: 'Montserrat Light';
+  margin-top: 7px;
+  width: 286px;
+}
+
+.account-details-modal-wrapper .qr-ellip-address {
+  width: 254px;
 }
 
 .account-details-modal-wrapper .btn-clear {
   min-height: 28px;
-  font-size: 1em;
+  font-size: 14px;
   border-color: $curious-blue;
   color: $curious-blue;
   border-radius: 2px;
   flex-basis: 100%;
   width: 75%;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  padding: 10px;
+  margin-top: 17px;
+  padding: 10px 22px;
+  height: 44px;
+  width: 235px;
+  font-family: 'Montserrat Light';
 }
 
 .account-details-modal-divider {
   width: 100%;
   height: 1px;
-  margin: 10px 0;
+  margin: 19px 0 8px 0;
   background-color: $alto;
 }
 
@@ -217,11 +229,11 @@
 
 .account-details-modal-close::after {
   content: '\00D7';
-  font-size: 1.5em;
-  color: $alto;
+  font-size: 40px;
+  color: $dusty-gray;
   position: absolute;
-  top: 5px;
-  right: 10px;
+  top: 10px;
+  right: 12px;
 }
 
 // New Account Modal

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -1,3 +1,7 @@
+.modal > div:focus {
+  outline: none !important;
+}
+
 // Buy Modal
 .buy-modal-content {
   flex-direction: column;

--- a/ui/app/css/itcss/settings/variables.scss
+++ b/ui/app/css/itcss/settings/variables.scss
@@ -30,6 +30,7 @@ $concrete: #f3f3f3;
 $tundora: #4d4d4d;
 $nile-blue: #1b344d;
 $scorpion: #5d5d5d;
+$silver: #cdcdcd;
 
 /*
   Z-Indicies


### PR DESCRIPTION
Touches up styling for account details modal. Removes chrome's blue highlight on focused modals.

<img width="1116" alt="screen shot 2017-09-06 at 8 57 47 am" src="https://user-images.githubusercontent.com/7499938/30109658-c4d352f8-92e1-11e7-8e50-3fbcebb7c9ea.png">

----

<img width="348" alt="screen shot 2017-09-06 at 8 58 00 am" src="https://user-images.githubusercontent.com/7499938/30109657-c4d33c32-92e1-11e7-8a51-7ada9cb105e0.png">
