### PR TITLE
[New-UI] Account Details Modal: style, close button, address input

### DIFF
--- a/ui/app/components/modals/account-details-modal.js
+++ b/ui/app/components/modals/account-details-modal.js
@@ -57,7 +57,9 @@ AccountDetailsModal.prototype.render = function () {
 
       ]),
 
-      h('div.account-details-modal-close', {}),
+      h('div.account-details-modal-close', {
+        onClick: this.props.hideModal,
+      }),
 
       h(QrView, {
         Qr: {

--- a/ui/app/components/modals/modal.js
+++ b/ui/app/components/modals/modal.js
@@ -54,11 +54,13 @@ const MODALS = {
       width: '95%',
       top: isPopupOrNotification() === 'popup' ? '52vh' : '36.5vh',
       boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
+      borderRadius: '4px',
     },
     laptopModalStyle: {
       width: '360px',
       top: 'calc(33% + 45px)',
       boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
+      borderRadius: '4px',
     },
   },
 

--- a/ui/app/components/qr-code.js
+++ b/ui/app/components/qr-code.js
@@ -52,7 +52,7 @@ QrCodeView.prototype.render = function () {
           width: '247px',
         },
         value: Qr.data,
-        readonly: 'readonly',
+        readonly: true,
       }),
       // h(CopyButton, {
       //   value: Qr.data,

--- a/ui/app/components/qr-code.js
+++ b/ui/app/components/qr-code.js
@@ -47,11 +47,13 @@ QrCodeView.prototype.render = function () {
       },
     }),
     h('.div.ellip-address-wrapper', [
-      h('span.qr-ellip-address', {
+      h('input.qr-ellip-address', {
         style: {
           width: '247px',
         },
-      }, Qr.data),
+        value: Qr.data,
+        readonly: 'readonly',
+      }),
       // h(CopyButton, {
       //   value: Qr.data,
       // }),

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -172,16 +172,19 @@
   justify-content: flex-start;
   align-items: center;
   position: relative;
-  padding: 5px 0;
+  padding: 5px 0 31px 0;
+  border: 1px solid $silver;
   border-radius: 4px;
+  font-family: 'Montserrat UltraLight';
 }
 
 .account-details-modal-wrapper .qr-header {
-  margin-top: 15px;
+  margin-top: 9px;
+  font-size: 20px;
 }
 
 .account-details-modal-wrapper .qr-wrapper {
-  margin-top: 15px;
+  margin-top: 5px;
 }
 
 .account-details-modal-wrapper .ellip-address-wrapper {
@@ -189,25 +192,34 @@
   justify-content: center;
   border: 1px solid $alto;
   padding: 5px 10px;
+  font-family: 'Montserrat Light';
+  margin-top: 7px;
+  width: 286px;
+}
+
+.account-details-modal-wrapper .qr-ellip-address {
+  width: 254px;
 }
 
 .account-details-modal-wrapper .btn-clear {
   min-height: 28px;
-  font-size: 1em;
+  font-size: 14px;
   border-color: $curious-blue;
   color: $curious-blue;
   border-radius: 2px;
   flex-basis: 100%;
   width: 75%;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  padding: 10px;
+  margin-top: 17px;
+  padding: 10px 22px;
+  height: 44px;
+  width: 235px;
+  font-family: 'Montserrat Light';
 }
 
 .account-details-modal-divider {
   width: 100%;
   height: 1px;
-  margin: 10px 0;
+  margin: 19px 0 8px 0;
   background-color: $alto;
 }
 
@@ -217,11 +229,11 @@
 
 .account-details-modal-close::after {
   content: '\00D7';
-  font-size: 1.5em;
-  color: $alto;
+  font-size: 40px;
+  color: $dusty-gray;
   position: absolute;
-  top: 5px;
-  right: 10px;
+  top: 10px;
+  right: 12px;
 }
 
 // New Account Modal

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -203,6 +203,9 @@
 
 .account-details-modal-wrapper .qr-ellip-address {
   width: 254px;
+  border: none;
+  font-family: 'Montserrat Light';
+  font-size: 14px;
 }
 
 .account-details-modal-wrapper .btn-clear {

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -1,3 +1,7 @@
+.modal > div:focus {
+  outline: none !important;
+}
+
 // Buy Modal
 .buy-modal-content {
   flex-direction: column;

--- a/ui/app/css/itcss/settings/variables.scss
+++ b/ui/app/css/itcss/settings/variables.scss
@@ -30,6 +30,7 @@ $concrete: #f3f3f3;
 $tundora: #4d4d4d;
 $nile-blue: #1b344d;
 $scorpion: #5d5d5d;
+$silver: #cdcdcd;
 
 /*
   Z-Indicies


### PR DESCRIPTION
This PR:

- Improves the styling of the account details modal
- enables the close functionality of the 'x' in the top right
- converts the address field in the account details modal to a readonly input so that the address can be selected

![accoutndetailsmodal3](https://user-images.githubusercontent.com/7499938/30115617-da8da544-92f5-11e7-99e7-8fedd6e3975b.gif)
  