### PR TITLE
[New-UI] Confirm Screen restyle and connect to state

### DIFF
--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -142,7 +142,7 @@ PendingTx.prototype.render = function () {
   this.inputs = []
 
   return (
-    h('div.flex-column.flex-grow', {
+    h('div.flex-column.flex-grow.confirm-screen-container', {
       style: {
         // overflow: 'scroll',
         minWidth: '355px', // TODO: maxWidth TBD, use home.html
@@ -196,7 +196,7 @@ PendingTx.prototype.render = function () {
         h('h3.flex-center.confirm-screen-sending-to-message', {
           style: {
             textAlign: 'center',
-            fontSize: '12px',
+            fontSize: '16px',
           }
         }, [
           `You're sending to Recipient ...${endOfToAddress}`
@@ -234,9 +234,9 @@ PendingTx.prototype.render = function () {
               width: '50%',
             },
           }, [
-            h('div.confirm-screen-account-name', {}, fromName),
+            h('div.confirm-screen-row-info', {}, fromName),
 
-            h('div.confirm-screen-account-number', {}, `...${endOfFromAddress}`),
+            h('div.confirm-screen-row-detail', {}, `...${endOfFromAddress}`),
           ]),
         ]),
 
@@ -259,9 +259,9 @@ PendingTx.prototype.render = function () {
               width: '50%',
             },
           }, [
-            h('div.confirm-screen-account-name', {}, toName),
+            h('div.confirm-screen-row-info', {}, toName),
 
-            h('div.confirm-screen-account-number', {}, `...${endOfToAddress}`),
+            h('div.confirm-screen-row-detail', {}, `...${endOfToAddress}`),
           ]),
         ]),
 
@@ -284,9 +284,9 @@ PendingTx.prototype.render = function () {
               width: '50%',
             },
           }, [
-            h('div.confirm-screen-account-name', {}, `$${gasFeeInUSD} USD`),
+            h('div.confirm-screen-row-info', {}, `$${gasFeeInUSD} USD`),
 
-            h('div.confirm-screen-account-number', {}, `${gasFeeInETH} ETH`),
+            h('div.confirm-screen-row-detail', {}, `${gasFeeInETH} ETH`),
           ]),
         ]),
 
@@ -318,9 +318,9 @@ PendingTx.prototype.render = function () {
               width: '50%',
             },
           }, [
-            h('div.confirm-screen-account-name', {}, `$${totalInUSD} USD`),
+            h('div.confirm-screen-row-info', {}, `$${totalInUSD} USD`),
 
-            h('div.confirm-screen-account-number', {}, `${totalInETH} ETH`),
+            h('div.confirm-screen-row-detail', {}, `${totalInETH} ETH`),
           ]),
         ]),
 

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -34,15 +34,6 @@ const sectionDivider = h('div', {
   },
 })
 
-const contentDivider = h('div', {
-  style: {
-    marginLeft: '16px',
-    marginRight: '16px',
-    height: '1.4px',
-    background: '#E7E7E7',
-  },
-})
-
 module.exports = connect(mapStateToProps, mapDispatchToProps)(PendingTx)
 
 function mapStateToProps (state) {
@@ -212,8 +203,8 @@ PendingTx.prototype.render = function () {
           txParams.memo || 'Fake memo',
         ]),
 
-        // error message
-        props.error && h('span.error.flex-center', props.error),
+        // TODO: put this error message in the right place
+        // props.error && h('span.error.flex-center', props.error),
 
         sectionDivider,
 
@@ -240,7 +231,6 @@ PendingTx.prototype.render = function () {
           ]),
         ]),
 
-        contentDivider,
 
         h('section.flex-row.flex-center.confirm-screen-row', {
         }, [
@@ -265,7 +255,6 @@ PendingTx.prototype.render = function () {
           ]),
         ]),
 
-        contentDivider,
 
         h('section.flex-row.flex-center.confirm-screen-row', {
         }, [
@@ -290,7 +279,6 @@ PendingTx.prototype.render = function () {
           ]),
         ]),
 
-        contentDivider,
 
         h('section.flex-row.flex-center.confirm-screen-total-box ', {}, [
           h('div', {

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -103,11 +103,12 @@ PendingTx.prototype.render = function () {
 
   const txFeeBn = gasBn.mul(gasPriceBn)
 
-  const valueBn = hexToBn(txParams.value)
-  const maxCost = txFeeBn.add(valueBn)
+  const amountBn = hexToBn(txParams.value)
 
-  const balanceBn = hexToBn(balance)
-  const insufficientBalance = balanceBn.lt(maxCost)
+  // TODO: insufficient balance should be handled on send screen
+  // const maxCost = txFeeBn.add(amountBn)
+  // const balanceBn = hexToBn(balance)
+  // const insufficientBalance = balanceBn.lt(maxCost)
 
   const fromName = identities[txParams.from].name;
   const toName = identities[txParams.to].name;
@@ -128,12 +129,12 @@ PendingTx.prototype.render = function () {
     conversionRate,
   })
 
-  const totalInUSD = conversionUtil(hexToBn('0xa1'), {
+  const totalInUSD = conversionUtil(amountBn, {
     fromFormat: 'BN',
     toCurrency: 'USD',
     conversionRate,
   })
-  const totalInETH = conversionUtil(hexToBn('0xa1'), {
+  const totalInETH = conversionUtil(amountBn, {
     fromFormat: 'BN',
     toCurrency: 'ETH',
     conversionRate,

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -82,7 +82,6 @@ PendingTx.prototype.render = function () {
   const { blockGasLimit, conversionRate, identities } = props
 
   const txMeta = this.gatherTxMeta()
-  console.log(`txMeta`, txMeta);
   const txParams = txMeta.txParams || {}
 
   // Account Details
@@ -103,11 +102,12 @@ PendingTx.prototype.render = function () {
 
   const txFeeBn = gasBn.mul(gasPriceBn)
 
-  const valueBn = hexToBn(txParams.value)
-  const maxCost = txFeeBn.add(valueBn)
+  const amountBn = hexToBn(txParams.value)
 
-  const balanceBn = hexToBn(balance)
-  const insufficientBalance = balanceBn.lt(maxCost)
+  // TODO: insufficient balance should be handled on send screen
+  // const maxCost = txFeeBn.add(amountBn)
+  // const balanceBn = hexToBn(balance)
+  // const insufficientBalance = balanceBn.lt(maxCost)
 
   const fromName = identities[txParams.from].name;
   const toName = identities[txParams.to].name;
@@ -128,12 +128,12 @@ PendingTx.prototype.render = function () {
     conversionRate,
   })
 
-  const totalInUSD = conversionUtil(hexToBn('0xa1'), {
+  const totalInUSD = conversionUtil(amountBn, {
     fromFormat: 'BN',
     toCurrency: 'USD',
     conversionRate,
   })
-  const totalInETH = conversionUtil(hexToBn('0xa1'), {
+  const totalInETH = conversionUtil(amountBn, {
     fromFormat: 'BN',
     toCurrency: 'ETH',
     conversionRate,

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -25,14 +25,6 @@ const MIN_GAS_PRICE_BN = MIN_GAS_PRICE_GWEI_BN.mul(GWEI_FACTOR)
 //   divider
 //   contentBox
 //   actionButtons
-const sectionDivider = h('div', {
-  style: {
-    height: '1px',
-    background: '#E7E7E7',
-    margin: 0,
-    marginTop: '18px',
-  },
-})
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(PendingTx)
 
@@ -199,14 +191,12 @@ PendingTx.prototype.render = function () {
           'USD',
         ]),
 
-        h('h3.flex-center.confirm-screen-send-memo', {}, [
-          txParams.memo || 'Fake memo',
-        ]),
+        h('div.flex-center.confirm-memo-wrapper', {}, h(
+          'h3.confirm-screen-send-memo', {}, txParams.memo || 'Fake memo'
+        )),
 
         // TODO: put this error message in the right place
         // props.error && h('span.error.flex-center', props.error),
-
-        sectionDivider,
 
         h('section.flex-row.flex-center.confirm-screen-row', {
         }, [

--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -1,0 +1,50 @@
+const {
+  numericBalance,
+  parseBalance,
+  formatBalance,
+  normalizeToWei,
+  valueTable,
+} = require('./util')
+const hexToBn = require('../../app/scripts/lib/hex-to-bn')
+const { BN } = require('ethereumjs-util')
+const GWEI_MULTIPLIER = normalizeToWei(hexToBn(valueTable.gwei.toString(16)), 'gwei');
+
+const conversionUtil = (value, {
+  fromCurrency,
+  toCurrency,
+  fromFormat,
+  toFormat,
+  precision = 2,
+  conversionRate,
+}) => {
+  let result;
+  
+  if (fromFormat === 'BN') {
+    if (fromCurrency !== 'GWEI') {
+      result = normalizeToWei(value, 'gwei')
+    }
+    else {
+      result = value
+    }
+
+    result = result.toString(16)
+    result = formatBalance(result, 9)
+    result = result.split(' ')
+    result = Number(result[0]) * 1000000000
+  }
+
+  if (fromCurrency === 'GWEI') {
+    result = result / 1000000000
+  }
+
+  if (toCurrency === 'USD') {
+    result = result * conversionRate
+    result = result.toFixed(precision)
+  }
+
+  return result
+};
+
+module.exports = {
+  conversionUtil,
+}

--- a/ui/app/css/itcss/components/confirm.scss
+++ b/ui/app/css/itcss/components/confirm.scss
@@ -207,3 +207,7 @@ section .confirm-screen-account-number,
 #pending-tx-form {
   flex: 1 0 auto;
 }
+
+.confirm-screen-row + .confirm-screen-row {
+  border-top: 1px solid #E7E7E7;
+}

--- a/ui/app/css/itcss/components/confirm.scss
+++ b/ui/app/css/itcss/components/confirm.scss
@@ -1,0 +1,194 @@
+.confirm-screen-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-width: 320px;
+  min-height: 753px;
+  z-index: 100;
+  top: 5%;
+  font-family: 'DIN NEXT';
+  margin-left: 3.5%;
+  margin-right: 3.5%;
+  background: $white;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .08);
+  padding-top: 20px;
+  padding-bottom: 31px;
+
+  @media screen and (max-width: $break-small) {
+    margin-top: 33px;
+  }
+
+  @media screen and (min-width: $break-large) {
+    width: 498px;
+  }
+}
+
+.confirm-screen-wrapper > h3,
+.confirm-screen-wrapper > div,
+.confirm-screen-wrapper > section {
+  margin-left: 23px; 
+  margin-right: 23px;
+}
+
+.confirm-screen-wrapper > .confirm-screen-total-box {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.confirm-screen-wrapper > .confirm-screen-header {
+  @media screen and (max-width: $break-small) {
+    margin-left: 8px;
+  }
+}
+
+.confirm-screen-header {
+  font-size: 26px;
+  position: relative;
+
+  @media screen and (max-width: $break-small) {
+   font-size: 22px;
+  }
+}
+
+.confirm-screen-title {
+  @media screen and (max-width: $break-small) {
+   margin-left: 22px;
+   margin-right: 8px;
+  }
+}
+
+.confirm-screen-back-button {
+  background: $white;
+  border: 1px solid $dusty-gray;
+  left: 0;
+  position: absolute;
+  text-align: center;
+  color: $black;
+  padding: 6px 13px 7px 12px;
+  border-radius: 2px;
+  height: 30px;
+  width: 54px;
+
+  @media screen and (max-width: $break-small) {
+   margin-right: 12px;
+  }
+}
+
+.confirm-screen-account-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.confirm-screen-account-name {
+  font-size: 16px;
+  line-height: 24px;
+  color: $scorpion;
+  text-align: center;
+}
+
+.confirm-screen-account-number {
+  font-size: 10px;
+  line-height: 16px;
+  color: $dusty-gray;
+  text-align: center;
+}
+
+.confirm-screen-identicons {
+  margin-top: 48px;
+
+  i {
+    align-self: start;
+    margin: 20px 14px 0 14px;
+  }
+}
+
+.confirm-screen-sending-to-message {
+  text-align: center;
+  font-size: 16px;
+  margin-top: 50px;
+}
+
+.confirm-screen-send-amount {
+  font-size: 64px;
+  color: $scorpion;
+  margin-top: 26px;
+  line-height: 76px; 
+  text-align: center;
+  font-family: 'DIN NEXT Light';
+}
+
+.confirm-screen-send-amount-currency {
+  font-size: 20px;
+  line-height: 20px;
+  margin-top: 16px;
+  text-align: center;
+}
+
+.confirm-screen-send-memo {
+  color: $dusty-gray;
+  font-size: 16px;
+  line-height: 24px;
+  text-align: center;
+  margin-top: 21px;
+}
+
+.confirm-screen-label {
+  font-size: 18px; 
+  line-height: 25px;
+  color: $scorpion;
+  text-align: left;
+}
+
+section .confirm-screen-account-name,
+section .confirm-screen-account-number {
+  text-align: left;
+}
+
+.confirm-screen-row {
+  margin-top: 15px;
+  margin-bottom: 11.5px;
+}
+
+.confirm-screen-total-box {
+  background-color: $wild-sand;
+  border-radius: 8px;
+  margin-left: 10px;
+  margin-right: 10px;
+  padding: 22px 14px 22px;
+  margin-bottom: 10px;
+  margin-top: 13px;
+}
+
+.confirm-screen-confirm-button {
+  height: 62px;
+  width: 216.88px;
+  border-radius: 2px;
+  background-color: #02C9B1;
+  font-size: 16px;
+  color: $white;
+  text-align: center;
+  font-family: 'DIN NEXT';
+  padding-top: 15px;
+  padding-bottom: 15px;
+  margin-top: 23px;
+  border-width: 0;
+  box-shadow: none;
+}
+
+.btn-light.confirm-screen-cancel-button {
+  height: 62px;
+  width: 216.88px;
+  background: none;
+  border: none;
+  opacity: 1;
+  width: 8em;
+  font-family: 'DIN NEXT';
+  border-width: 0;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  font-size: 16px;
+  box-shadow: none;
+}
+
+#pending-tx-form {
+  flex: 1 0 auto;
+}

--- a/ui/app/css/itcss/components/confirm.scss
+++ b/ui/app/css/itcss/components/confirm.scss
@@ -42,6 +42,10 @@
   margin-right: 10px;
 }
 
+.confirm-screen-wrapper > .confirm-memo-wrapper {
+  margin: 0;
+}
+
 .confirm-screen-wrapper > .confirm-screen-header {
   @media screen and (max-width: $break-small) {
     margin-left: 8px;
@@ -130,12 +134,18 @@
   text-align: center;
 }
 
+.confirm-memo-wrapper {
+  width: 100%;
+  border-bottom: 1px solid $gallery;
+}
+
 .confirm-screen-send-memo {
   color: $dusty-gray;
   font-size: 16px;
   line-height: 24px;
   text-align: center;
   margin-top: 21px;
+  margin-bottom: 18px;
 }
 
 .confirm-screen-label {
@@ -209,5 +219,5 @@ section .confirm-screen-account-number,
 }
 
 .confirm-screen-row + .confirm-screen-row {
-  border-top: 1px solid #E7E7E7;
+  border-top: 1px solid $gallery;
 }

--- a/ui/app/css/itcss/components/confirm.scss
+++ b/ui/app/css/itcss/components/confirm.scss
@@ -1,3 +1,15 @@
+.confirm-screen-container {
+  position: absolute;
+
+  @media screen and (max-width: 575px) {
+    margin-top: 35px;
+  }
+
+  @media screen and (min-width: 576px) {
+    margin-top: 6.9vh;
+  }
+}
+
 .confirm-screen-wrapper {
   display: flex;
   flex-direction: column;
@@ -12,10 +24,6 @@
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .08);
   padding-top: 20px;
   padding-bottom: 31px;
-
-  @media screen and (max-width: $break-small) {
-    margin-top: 33px;
-  }
 
   @media screen and (min-width: $break-large) {
     width: 498px;
@@ -78,7 +86,7 @@
   flex-direction: column;
 }
 
-.confirm-screen-account-name {
+.confirm-screen-account-name, .confirm-screen-row-info {
   font-size: 16px;
   line-height: 24px;
   color: $scorpion;
@@ -104,14 +112,14 @@
 .confirm-screen-sending-to-message {
   text-align: center;
   font-size: 16px;
-  margin-top: 50px;
+  margin-top: 30px;
 }
 
 .confirm-screen-send-amount {
   font-size: 64px;
   color: $scorpion;
-  margin-top: 26px;
-  line-height: 76px; 
+  margin-top: 12px;
+  line-height: 60px; 
   text-align: center;
   font-family: 'DIN NEXT Light';
 }
@@ -119,7 +127,6 @@
 .confirm-screen-send-amount-currency {
   font-size: 20px;
   line-height: 20px;
-  margin-top: 16px;
   text-align: center;
 }
 
@@ -139,13 +146,21 @@
 }
 
 section .confirm-screen-account-name,
-section .confirm-screen-account-number {
+section .confirm-screen-account-number,
+.confirm-screen-row-info,
+.confirm-screen-row-detail {
   text-align: left;
 }
 
 .confirm-screen-row {
   margin-top: 15px;
   margin-bottom: 11.5px;
+}
+
+.confirm-screen-row-detail {
+  font-size: 12px;
+  line-height: 16px;
+  color: $dusty-gray;
 }
 
 .confirm-screen-total-box {

--- a/ui/app/css/itcss/components/index.scss
+++ b/ui/app/css/itcss/components/index.scss
@@ -14,6 +14,8 @@
 
 @import './send.scss';
 
+@import './confirm.scss';
+
 // Balances
 @import './hero-balance.scss';
 

--- a/ui/app/css/itcss/settings/typography.scss
+++ b/ui/app/css/itcss/settings/typography.scss
@@ -50,6 +50,20 @@
 }
 
 @font-face {
+  font-family: 'DIN NEXT';
+  src: url('/fonts/DIN NEXT/DIN NEXT W01 Regular.otf') format('opentype');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'DIN NEXT Light';
+  src: url('/fonts/DIN NEXT/DIN NEXT W10 Light.otf') format('opentype');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
   font-family: 'Lato';
   src: url('/fonts/Lato/Lato-Regular.ttf') format('truetype');
   font-weight: 400;

--- a/ui/app/css/itcss/settings/variables.scss
+++ b/ui/app/css/itcss/settings/variables.scss
@@ -30,6 +30,7 @@ $concrete: #f3f3f3;
 $tundora: #4d4d4d;
 $nile-blue: #1b344d;
 $scorpion: #5d5d5d;
+$caribbean-green: #02C9B1;
 
 /*
   Z-Indicies


### PR DESCRIPTION
This PR implements the layout for the confirm screen, which is now connected to state.

![send-to-confirm](https://user-images.githubusercontent.com/7499938/30110397-969eedea-92e4-11e7-8e2b-3e105ab35e49.gif)


----
<img width="1101" alt="screen shot 2017-09-05 at 4 09 31 pm" src="https://user-images.githubusercontent.com/7499938/30076806-b6ab33e0-9254-11e7-8818-889b50b77266.png">

<img width="1054" alt="screen shot 2017-09-05 at 4 09 40 pm" src="https://user-images.githubusercontent.com/7499938/30076804-b6a75478-9254-11e7-99b5-097059ded1fd.png">
----
<img width="351" alt="screen shot 2017-09-05 at 4 09 51 pm" src="https://user-images.githubusercontent.com/7499938/30076805-b6aad31e-9254-11e7-9123-2a97dba6d0e2.png">
<img width="344" alt="screen shot 2017-09-05 at 4 09 57 pm" src="https://user-images.githubusercontent.com/7499938/30076807-b6acc570-9254-11e7-9a0d-dbfc8af20538.png">





