### PR TITLE
Add Token Validations and Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 - Readded loose keyring label back into the account list.
+- Add info on token contract addresses.
+- Add validation preventing users from inputting their own addresses as token tracking addresses.
 
 ## 3.9.12 2017-9-6
 

--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -74,6 +74,7 @@ AddTokenScreen.prototype.render = function () {
               h('a', {
                 style: { fontWeight: 'bold', paddingRight: '10px'},
                 href: 'https://consensyssupport.happyfox.com/staff/kb/article/24-what-is-a-token-contract-address',
+                target: '_blank',
               }, [
                 h('span', 'Token Contract Address  '),
                 h('i.fa.fa-question-circle'),

--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -3,6 +3,8 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 const actions = require('./actions')
+const Tooltip = require('./components/tooltip.js')
+
 
 const ethUtil = require('ethereumjs-util')
 const abi = require('human-standard-token-abi')
@@ -15,6 +17,7 @@ module.exports = connect(mapStateToProps)(AddTokenScreen)
 
 function mapStateToProps (state) {
   return {
+    identities: state.metamask.identities,
   }
 }
 
@@ -64,15 +67,24 @@ AddTokenScreen.prototype.render = function () {
         }, [
 
           h('div', [
-            h('span', {
-              style: { fontWeight: 'bold', paddingRight: '10px'},
-            }, 'Token Address'),
+            h(Tooltip, {
+              position: 'top',
+              title: 'The contract of the actual token contract. Click for more info.',
+            }, [
+              h('a', {
+                style: { fontWeight: 'bold', paddingRight: '10px'},
+                href: 'https://consensyssupport.happyfox.com/staff/kb/article/24-what-is-a-token-contract-address',
+              }, [
+                h('span', 'Token Contract Address  '),
+                h('i.fa.fa-question-circle'),
+              ]),
+            ]),
           ]),
 
           h('section.flex-row.flex-center', [
             h('input#token-address', {
               name: 'address',
-              placeholder: 'Token Address',
+              placeholder: 'Token Contract Address',
               onChange: this.tokenAddressDidChange.bind(this),
               style: {
                 width: 'inherit',
@@ -171,7 +183,9 @@ AddTokenScreen.prototype.tokenAddressDidChange = function (event) {
 AddTokenScreen.prototype.validateInputs = function () {
   let msg = ''
   const state = this.state
+  const identitiesList = Object.keys(this.props.identities)
   const { address, symbol, decimals } = state
+  const standardAddress = ethUtil.addHexPrefix(address).toLowerCase()
 
   const validAddress = ethUtil.isValidAddress(address)
   if (!validAddress) {
@@ -189,7 +203,12 @@ AddTokenScreen.prototype.validateInputs = function () {
     msg += 'Symbol must be between 0 and 10 characters.'
   }
 
-  const isValid = validAddress && validDecimals
+  const ownAddress = identitiesList.includes(standardAddress)
+  if (ownAddress) {
+    msg = 'Personal address detected. Input the token contact address.'
+  }
+
+  const isValid = validAddress && validDecimals && !ownAddress
 
   if (!isValid) {
     this.setState({
@@ -216,4 +235,3 @@ AddTokenScreen.prototype.attemptToAutoFillTokenParams = async function (address)
     this.setState({ symbol: symbol[0], decimals: decimals[0].toString() })
   }
 }
-

--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -206,7 +206,7 @@ AddTokenScreen.prototype.validateInputs = function () {
 
   const ownAddress = identitiesList.includes(standardAddress)
   if (ownAddress) {
-    msg = 'Personal address detected. Input the token contact address.'
+    msg = 'Personal address detected. Input the token contract address.'
   }
 
   const isValid = validAddress && validDecimals && !ownAddress


### PR DESCRIPTION
Wrote a support article to explain to users. Please edit as necessary.
https://consensyssupport.happyfox.com/staff/kb/article/24-what-is-a-token-contract-address

First round of validations that at least checks if they're pasting their own address rather than the token's contract address.

![screenshot from 2017-09-07 18-02-44](https://user-images.githubusercontent.com/1840057/30191634-fea11b4e-93f6-11e7-98c6-853cb0b80ca6.png)
