### PR TITLE
Remove cryptonator from chrome manifest file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 - Readded loose keyring label back into the account list.
+- Remove cryptonator from chrome permissions.
 
 ## 3.9.12 2017-9-6
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -57,9 +57,8 @@
   "permissions": [
     "storage",
     "clipboardWrite",
-    "http://localhost:8545/",
-    "https://api.cryptonator.com/"
-  ],
+    "http://localhost:8545/"
+    ],
   "web_accessible_resources": [
     "scripts/inpage.js"
   ],


### PR DESCRIPTION
Unnecessary permissions have been revoked! Reduce our attack vectors! Fixes #1938.