### PR TITLE
ci - dont need global install of test utils

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,6 @@
 machine:
   node:
     version: 8.1.4
-dependencies:
-  pre:
-    - "npm i -g testem"
-    - "npm i -g mocha"
 test:
   override:
     - "npm run ci"


### PR DESCRIPTION
npm scripts will use `node_modules` for cli tools - kinda magical
should save us ~40s of ci time per run