### PR TITLE
[NewUI] Use correct platform wrapper in popup.js

### DIFF
--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -4,12 +4,12 @@ const startPopup = require('./popup-core')
 const PortStream = require('./lib/port-stream.js')
 const isPopupOrNotification = require('./lib/is-popup-or-notification')
 const extension = require('extensionizer')
-const ExtensionPlatform = require('./platforms/extension')
+const WindowPlatform = require('./platforms/window')
 const NotificationManager = require('./lib/notification-manager')
 const notificationManager = new NotificationManager()
 
 // create platform global
-global.platform = new ExtensionPlatform()
+global.platform = new WindowPlatform()
 
 // inject css
 const css = MetaMaskUiCss()


### PR DESCRIPTION
_Note: It is unclear how this might affect the behaviour of the extension in production. In particular, need to determine if and how the extension is using `ExtensionPlatform` and whether this change will break any related behavour. So this is still a work in progress._

----

Before this PR you could witness the following behaviour if viewing the app in the browser window at either `popup.html` or `home.html`:
1. Select the dropdown in the top left
2. Click 'View account on etherscan'
3. Nothing happens.
4. Error in console says "Cannot read property 'create' of null"

Meanwhile, attempting to do the same through the extension would result in a successful opening of etherscan in a new tab.

The issue is with the `platform` property on the global object. In `app/scripts/popup.js` that property was assigned a new `ExtensionPlatform` object. The ExtensionPlatform constructor is defined in `app/scripts/platforms/extension.js`. It uses the https://github.com/MetaMask/extensionizer module to give easy access to the WebExtensions API. This is where the problem lies: the WebExtensions API is not available in the browser window.

Instead, we need a `WindowPlatform` object as defined in `app/scripts/platforms/window.js`. It has the same API as `ExtensionPlatform`, but itself accesses the browsers APIs via the window object (and not the `extensionizer`) module.

With the change in this PR, the `global.platform.openWindow` method (and therefore "View account on etherscan") work at `home.html`, `popup.html` and in the extension.

Further notes:
- `global.platform` is only every accessed for the `openWindow` method
