### PR TITLE
Allow exporting seed words and private keys as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current Master
 
+- Add ability to export private keys as a file.
+- Add ability to export seed words as a file.
+
 ## 3.10.0 2017-9-11
 
 - Readded loose keyring label back into the account list.

--- a/ui/app/components/account-export.js
+++ b/ui/app/components/account-export.js
@@ -114,10 +114,10 @@ ExportAccountView.prototype.render = function () {
         onClick: () => this.props.dispatch(actions.backToAccountDetail(this.props.address)),
       }, 'Done'),
       h('button', {
-        onClick: () => exportAsFile(`MetaMask ${nickname} Private Key`, plainKey),
-        stlye: {
+        style: {
           marginLeft: '10px',
         },
+        onClick: () => exportAsFile(`MetaMask ${nickname} Private Key`, plainKey),
       }, 'Save as File'),
     ])
   }

--- a/ui/app/components/account-export.js
+++ b/ui/app/components/account-export.js
@@ -1,6 +1,7 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
+const exportAsFile = require('../util').exportAsFile
 const copyToClipboard = require('copy-to-clipboard')
 const actions = require('../actions')
 const ethUtil = require('ethereumjs-util')
@@ -113,7 +114,7 @@ ExportAccountView.prototype.render = function () {
         onClick: () => this.props.dispatch(actions.backToAccountDetail(this.props.address)),
       }, 'Done'),
       h('button', {
-        onClick: () => this.exportAsFile(`MetaMask ${nickname} Private Key`, plainKey),
+        onClick: () => exportAsFile(`MetaMask ${nickname} Private Key`, plainKey),
       }, 'Save as File'),
     ])
   }
@@ -125,19 +126,4 @@ ExportAccountView.prototype.onExportKeyPress = function (event) {
 
   const input = document.getElementById('exportAccount').value
   this.props.dispatch(actions.exportAccount(input, this.props.address))
-}
-
-ExportAccountView.prototype.exportAsFile = function (filename, data) {
-  // source: https://stackoverflow.com/a/33542499 by Ludovic Feltz
-  const blob = new Blob([data], {type: 'text/csv'})
-  if (window.navigator.msSaveOrOpenBlob) {
-    window.navigator.msSaveBlob(blob, filename)
-  } else {
-    const elem = window.document.createElement('a')
-    elem.href = window.URL.createObjectURL(blob)
-    elem.download = filename
-    document.body.appendChild(elem)
-    elem.click()
-    document.body.removeChild(elem)
-  }
 }

--- a/ui/app/components/account-export.js
+++ b/ui/app/components/account-export.js
@@ -115,6 +115,9 @@ ExportAccountView.prototype.render = function () {
       }, 'Done'),
       h('button', {
         onClick: () => exportAsFile(`MetaMask ${nickname} Private Key`, plainKey),
+        stlye: {
+          marginLeft: '10px',
+        },
       }, 'Save as File'),
     ])
   }

--- a/ui/app/keychains/hd/create-vault-complete.js
+++ b/ui/app/keychains/hd/create-vault-complete.js
@@ -3,6 +3,7 @@ const Component = require('react').Component
 const connect = require('react-redux').connect
 const h = require('react-hyperscript')
 const actions = require('../../actions')
+const exportAsFile = require('../../util').exportAsFile
 
 module.exports = connect(mapStateToProps)(CreateVaultCompleteScreen)
 
@@ -65,8 +66,17 @@ CreateVaultCompleteScreen.prototype.render = function () {
         style: {
           margin: '24px',
           fontSize: '0.9em',
+          marginBottom: '10px',
         },
       }, 'I\'ve copied it somewhere safe'),
+
+      h('button.primary', {
+        onClick: () => exportAsFile(`MetaMask Seed Words`, seed),
+        style: {
+          margin: '10px',
+          fontSize: '0.9em',
+        },
+      }, 'Save Seed Words As File'),
     ])
   )
 }

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -36,6 +36,7 @@ module.exports = {
   valueTable: valueTable,
   bnTable: bnTable,
   isHex: isHex,
+  exportAsFile: exportAsFile,
 }
 
 function valuesFor (obj) {
@@ -214,4 +215,19 @@ function readableDate (ms) {
 
 function isHex (str) {
   return Boolean(str.match(/^(0x)?[0-9a-fA-F]+$/))
+}
+
+function exportAsFile (filename, data) {
+  // source: https://stackoverflow.com/a/33542499 by Ludovic Feltz
+  const blob = new Blob([data], {type: 'text/csv'})
+  if (window.navigator.msSaveOrOpenBlob) {
+    window.navigator.msSaveBlob(blob, filename)
+  } else {
+    const elem = window.document.createElement('a')
+    elem.href = window.URL.createObjectURL(blob)
+    elem.download = filename
+    document.body.appendChild(elem)
+    elem.click()
+    document.body.removeChild(elem)
+  }
 }


### PR DESCRIPTION
Allows downloading of files for extra security (avoid clipboard sniffing) and convenience. Still does not implement #780 since we'd need to add to the module behavior.

![screenshot from 2017-09-11 16-50-38](https://user-images.githubusercontent.com/1840057/30301884-440759dc-9712-11e7-8ff8-eb5dd1755904.png)

![screenshot from 2017-09-11 16-53-05](https://user-images.githubusercontent.com/1840057/30301886-47eaeb0e-9712-11e7-8abc-b954f44d6089.png)
