### PR TITLE
Export state logs instead of copying to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add ability to export private keys as a file.
 - Add ability to export seed words as a file.
+- Changed state logs to a file download than a clipboard copy.
 
 ## 3.10.0 2017-9-11
 

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -5,7 +5,8 @@ const connect = require('react-redux').connect
 const actions = require('./actions')
 const currencies = require('./conversion.json').rows
 const validUrl = require('valid-url')
-const copyToClipboard = require('copy-to-clipboard')
+const exportAsFile = require('./util').exportAsFile
+
 
 module.exports = connect(mapStateToProps)(ConfigScreen)
 
@@ -110,9 +111,9 @@ ConfigScreen.prototype.render = function () {
                 alignSelf: 'center',
               },
               onClick (event) {
-                copyToClipboard(window.logState())
+                exportAsFile('MetaMask State Logs', window.logState())
               },
-            }, 'Copy State Logs'),
+            }, 'Download State Logs'),
           ]),
 
           h('hr.horizontal-line'),


### PR DESCRIPTION
Way better formatting and will be easier on support.