### PR TITLE
High GasLimit Validation Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add ability to export seed words as a file.
 - Changed state logs to a file download than a clipboard copy.
 - Fix link to support center.
+- Warn users when a dapp proposes a high gas limit (90% of blockGasLimit or higher)
 
 ## 3.10.0 2017-9-11
 

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -296,7 +296,7 @@ PendingTx.prototype.render = function () {
             }, 'Insufficient balance for transaction')
           : null,
 
-          (dangerousGasLimit && gasLimitSpecified) ?
+          (dangerousGasLimit && !gasLimitSpecified) ?
             h('span.error', {
               style: {
                 fontSize: '0.9em',

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -53,6 +53,7 @@ PendingTx.prototype.render = function () {
   const gasBn = hexToBn(gas)
   const gasLimit = new BN(parseInt(blockGasLimit))
   const safeGasLimitBN = this.bnMultiplyByFraction(gasLimit, 19, 20)
+  const saferGasLimitBN = this.bnMultiplyByFraction(gasLimit, 18, 20)
   const safeGasLimit = safeGasLimitBN.toString(10)
 
   // Gas Price
@@ -67,7 +68,7 @@ PendingTx.prototype.render = function () {
 
   const balanceBn = hexToBn(balance)
   const insufficientBalance = balanceBn.lt(maxCost)
-  const dangerousGasLimit = gasBn.gte(safeGasLimitBN)
+  const dangerousGasLimit = gasBn.gte(saferGasLimitBN)
   const gasLimitSpecified = txMeta.gasLimitSpecified
   const buyDisabled = insufficientBalance || !this.state.valid || !isValidAddress || this.state.submitting
   const showRejectAll = props.unconfTxListLength > 1

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -52,7 +52,8 @@ PendingTx.prototype.render = function () {
   const gas = txParams.gas
   const gasBn = hexToBn(gas)
   const gasLimit = new BN(parseInt(blockGasLimit))
-  const safeGasLimit = this.bnMultiplyByFraction(gasLimit, 19, 20).toString(10)
+  const safeGasLimitBN = this.bnMultiplyByFraction(gasLimit, 19, 20)
+  const safeGasLimit = safeGasLimitBN.toString(10)
 
   // Gas Price
   const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_BN.toString(16)
@@ -66,6 +67,8 @@ PendingTx.prototype.render = function () {
 
   const balanceBn = hexToBn(balance)
   const insufficientBalance = balanceBn.lt(maxCost)
+  const dangerousGasLimit = gasBn.gte(safeGasLimitBN)
+  const gasLimitSpecified = txMeta.gasLimitSpecified
   const buyDisabled = insufficientBalance || !this.state.valid || !isValidAddress || this.state.submitting
   const showRejectAll = props.unconfTxListLength > 1
 
@@ -263,33 +266,44 @@ PendingTx.prototype.render = function () {
             text-transform: uppercase;
           }
         `),
+        h('.cell.row', {
+          style: {
+            textAlign: 'center',
+          },
+        }, [
+          txMeta.simulationFails ?
+            h('.error', {
+              style: {
+                fontSize: '0.9em',
+              },
+            }, 'Transaction Error. Exception thrown in contract code.')
+          : null,
 
-        txMeta.simulationFails ?
-          h('.error', {
-            style: {
-              marginLeft: 50,
-              fontSize: '0.9em',
-            },
-          }, 'Transaction Error. Exception thrown in contract code.')
-        : null,
+          !isValidAddress ?
+            h('.error', {
+              style: {
+                fontSize: '0.9em',
+              },
+            }, 'Recipient address is invalid. Sending this transaction will result in a loss of ETH.')
+          : null,
 
-        !isValidAddress ?
-          h('.error', {
-            style: {
-              marginLeft: 50,
-              fontSize: '0.9em',
-            },
-          }, 'Recipient address is invalid. Sending this transaction will result in a loss of ETH.')
-        : null,
+          insufficientBalance ?
+            h('span.error', {
+              style: {
+                fontSize: '0.9em',
+              },
+            }, 'Insufficient balance for transaction')
+          : null,
 
-        insufficientBalance ?
-          h('span.error', {
-            style: {
-              marginLeft: 50,
-              fontSize: '0.9em',
-            },
-          }, 'Insufficient balance for transaction')
-        : null,
+          (dangerousGasLimit && gasLimitSpecified) ?
+            h('span.error', {
+              style: {
+                fontSize: '0.9em',
+              },
+            }, 'Gas limit set dangerously high. Approving this transaction is likely to fail.')
+          : null,
+        ]),
+
 
         // send + cancel
         h('.flex-row.flex-space-around.conf-buttons', {


### PR DESCRIPTION
- Warn users when their gasLimit is 90% or higher of the current gasBlockLimit.
- Only warn users when this value is specified by the dapp.

The reasoning behind this is that the majority of successful transactions will never be close to the blockGasLimit. We only get high estimations when the transaction usually fails. If we can provide counterexamples to this, please do--not aware of any transactions being so pricey AND successful.