### PR TITLE
Remove annoying console.log on each run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for alternative ENS TLDs (Ethereum Name Service Top-Level Domains).
 - Lower minimum gas price to 0.1 GWEI.
+- Remove web3 injection message from production (thanks to @ChainsawBaby)
 
 ## 3.11.2 2017-10-21
 

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -1,12 +1,17 @@
 /*global Web3*/
 cleanContextForImports()
 require('web3/dist/web3.min.js')
+const log = require('loglevel')
 const LocalMessageDuplexStream = require('post-message-stream')
 // const PingStream = require('ping-pong-stream/ping')
 // const endOfStream = require('end-of-stream')
 const setupDappAutoReload = require('./lib/auto-reload.js')
 const MetamaskInpageProvider = require('./lib/inpage-provider.js')
 restoreContextAfterImports()
+
+const METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
+window.log = log
+log.setDefaultLevel(METAMASK_DEBUG ? 'debug' : 'warn')
 
 
 //
@@ -28,9 +33,9 @@ var inpageProvider = new MetamaskInpageProvider(metamaskStream)
 
 var web3 = new Web3(inpageProvider)
 web3.setProvider = function () {
-  console.log('MetaMask - overrode web3.setProvider')
+  log.debug('MetaMask - overrode web3.setProvider')
 }
-console.log('MetaMask - injected web3')
+log.debug('MetaMask - injected web3')
 // export global web3, with usage-detection
 setupDappAutoReload(web3, inpageProvider.publicConfigStore)
 
@@ -65,4 +70,3 @@ function restoreContextAfterImports () {
     console.warn('MetaMask - global.define could not be overwritten.')
   }
 }
-


### PR DESCRIPTION
This has been annoying me for some time, and line 36 is completely not needed.