### PR TITLE
[NewUI] Show loading on conf-tx until the pending tx is available.

### DIFF
--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -97,6 +97,7 @@ function currentTxView (opts) {
       return h(PendingPersonalMsg, opts)
     }
   }
+  return h(Loading, { isLoading: true })
 }
 
 ConfirmTxScreen.prototype.buyEth = function (address, event) {


### PR DESCRIPTION
This PR ensures that the correct information is shown on the confirm screen. Loading is shown until the most recent pending tx is available.

![sendconfirmloading](https://user-images.githubusercontent.com/7499938/30444235-c99e47f8-995c-11e7-8687-37c93b3e9d59.gif)


