### PR TITLE
[NewUI] MM-40 Notification opens to most recent transation if unviewed.

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -126,6 +126,16 @@ module.exports = class TransactionController extends EventEmitter {
     }, {})
   }
 
+  markTransactionAsViewed(id) {
+    const { latestUnapprovedTx } = this.getState()
+    if (id === latestUnapprovedTx.id) {
+      this._updateLatestUnapprovedTx(id, true);
+    }
+  }
+  setLatestUnapprovedTx (id) {
+    this._updateLatestUnapprovedTx(id);
+  }
+
   updateTx (txMeta) {
     // create txMeta snapshot for history
     const txMetaForHistory = clone(txMeta)
@@ -172,7 +182,7 @@ module.exports = class TransactionController extends EventEmitter {
     this.once(`${txMeta.id}:rejected`, function (txId) {
       this.removeAllListeners(`${txMeta.id}:signed`)
     })
-
+    this.setLatestUnapprovedTx(txMeta.id)
     this.emit('updateBadge')
     this.emit(`${txMeta.id}:unapproved`, txMeta)
   }
@@ -440,5 +450,12 @@ module.exports = class TransactionController extends EventEmitter {
       metamaskNetworkId: this.getNetwork(),
     })
     this.memStore.updateState({ unapprovedTxs, selectedAddressTxList })
+  }
+
+  _updateLatestUnapprovedTx (transactionId, viewed = false) {
+    this.memStore.updateState({ latestUnapprovedTx: {
+      id: transactionId,
+      viewed,
+    } })
   }
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -317,6 +317,7 @@ module.exports = class MetamaskController extends EventEmitter {
       exportAccount: nodeify(keyringController.exportAccount, keyringController),
 
       // txController
+      markTransactionAsViewed: this.markTransactionAsViewed.bind(this),
       cancelTransaction: nodeify(txController.cancelTransaction, txController),
       updateAndApproveTransaction: nodeify(txController.updateAndApproveTransaction, txController),
 
@@ -646,5 +647,11 @@ module.exports = class MetamaskController extends EventEmitter {
     .then(() => {
       return Promise.resolve(rpcTarget)
     })
+  }
+
+// transactions
+  
+  markTransactionAsViewed(txId) {
+    this.txController.markTransactionAsViewed(txId)
   }
 }

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -128,6 +128,9 @@ var actions = {
   previousTx: previousTx,
   viewPendingTx: viewPendingTx,
   VIEW_PENDING_TX: 'VIEW_PENDING_TX',
+  SET_LATEST_UNAPPROVED_TX: 'SET_LATEST_UNAPPROVED_TX',
+  setLatestUnapprovedTx,
+  markTransactionAsViewed,
   // app messages
   confirmSeedWords: confirmSeedWords,
   showAccountDetail: showAccountDetail,
@@ -506,6 +509,13 @@ function cancelTx (txData) {
   }
 }
 
+function setLatestUnapprovedTx (latestUnapprovedTx) {
+  return {
+    type: actions.SET_LATEST_UNAPPROVED_TX,
+    tx: latestUnapprovedTx,
+  }
+}
+
 //
 // initialize screen
 //
@@ -701,6 +711,13 @@ function addToken (address, symbol, decimals) {
 function goBackToInitView () {
   return {
     type: actions.BACK_TO_INIT_MENU,
+  }
+}
+
+function markTransactionAsViewed (txId) {
+  return (dispatch) => {
+    log.debug(`background.markTransactionAsViewed`)
+    background.markTransactionAsViewed(txId)
   }
 }
 

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -49,6 +49,7 @@ function mapDispatchToProps (dispatch) {
     setCurrentCurrencyToUSD: () => dispatch(actions.setCurrentCurrency('USD')),
     backToAccountDetail: address => dispatch(actions.backToAccountDetail(address)),
     cancelTransaction: ({ id }) => dispatch(actions.cancelTx({ id })),
+    markTransactionAsViewed: (id) => dispatch(actions.markTransactionAsViewed(id)),
   }
 }
 
@@ -65,6 +66,9 @@ function PendingTx () {
 
 PendingTx.prototype.componentWillMount = function () {
   this.props.setCurrentCurrencyToUSD()
+  if (this.props.txData) {
+    this.props.markTransactionAsViewed(this.props.txData.id)
+  }
 }
 
 PendingTx.prototype.getTotal = function () {

--- a/ui/index.js
+++ b/ui/index.js
@@ -8,7 +8,6 @@ global.log = require('loglevel')
 
 module.exports = launchMetamaskUi
 
-
 log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn')
 
 function launchMetamaskUi (opts, cb) {
@@ -38,6 +37,7 @@ function startApp (metamaskState, accountManager, opts) {
 
   accountManager.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
+    store.dispatch(actions.setLatestUnapprovedTx(metamaskState.latestUnapprovedTx))
   })
 
   // start app


### PR DESCRIPTION
Functionality added with this PR:

- If the notification opens because of a new pending transaction, the confirmation screen with that transaction is shown.
- If the most recent pending transaction has already been viewed via the confirmation screen, then opening the extension manually will just show the default account details screen.

![notification](https://user-images.githubusercontent.com/7499938/30479813-668e48f8-99f1-11e7-9e00-556d972b4e21.gif)

(Note: the massive total value shown on opening the notification will be fixed after https://github.com/MetaMask/metamask-extension/pull/2103)
