### PR TITLE
[NewUI] Only create account from the modal, not on menu click

### DIFF
--- a/ui/app/components/dropdowns/components/account-dropdowns.js
+++ b/ui/app/components/dropdowns/components/account-dropdowns.js
@@ -162,11 +162,11 @@ class AccountDropdowns extends Component {
           DropdownMenuItem,
           {
             closeMenu: () => {},
-            onClick: () => actions.addNewAccount(),
             style: Object.assign(
               {},
               menuItemStyles,
             ),
+            onClick: () => actions.showNewAccountModal(),
           },
           [
             h(
@@ -184,9 +184,6 @@ class AccountDropdowns extends Component {
                 fontFamily: 'DIN OT',
                 fontSize: '16px',
                 lineHeight: '23px',
-              },
-              onClick: () => {
-                actions.showNewAccountModal()
               },
             }, 'Create Account'),
           ],

--- a/ui/app/components/modals/new-account-modal.js
+++ b/ui/app/components/modals/new-account-modal.js
@@ -19,6 +19,10 @@ function mapDispatchToProps (dispatch) {
     hideModal: () => {
       dispatch(actions.hideModal())
     },
+    createAccount: () => {
+      dispatch(actions.addNewAccount())
+      dispatch(actions.hideModal())
+    },
   }
 }
 
@@ -60,7 +64,9 @@ NewAccountModal.prototype.render = function () {
       ]),
 
       h('div.new-account-modal-content.button', {}, [
-        h('button.btn-clear', {}, [
+        h('button.btn-clear', {
+          onClick: this.props.createAccount
+        }, [
           'SAVE',
         ]),
       ]),

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -284,6 +284,7 @@
   top: 25px;
   right: 17.5px;
   font-family: sans-serif;
+  cursor: pointer;
 }
 
 .new-account-modal-content {


### PR DESCRIPTION
Prior to this PR, new account were created whenever 'Create Account' was clicked in the account selection dropdown.

This PR fixes this so that account creation only happens from the modal, when 'Save' is clicked.

![addaccountfrommodal](https://user-images.githubusercontent.com/7499938/30489961-4035bbe2-9a13-11e7-8a75-ec2250196443.gif)
