### PR TITLE
Do not mark a retry tx failed that has been broadcast successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug that would sometimes display transactions as failed that could be successfully mined.
+
 ## 3.10.1 2017-9-18
 
 - Add ability to export private keys as a file.

--- a/app/scripts/lib/pending-tx-tracker.js
+++ b/app/scripts/lib/pending-tx-tracker.js
@@ -76,6 +76,9 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
       Dont marked as failed if the error is a "known" transaction warning
       "there is already a transaction with the same sender-nonce
       but higher/same gas price"
+
+      Also don't mark as failed if it has ever been broadcast successfully.
+      A successful broadcast means it may still be mined.
       */
       const errorMessage = err.message.toLowerCase()
       const isKnownTx = (
@@ -88,6 +91,7 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
         // other
         || errorMessage.includes('gateway timeout')
         || errorMessage.includes('nonce too low')
+        || txMeta.retryCount > 1
       )
       // ignore resubmit warnings, return early
       if (isKnownTx) return
@@ -117,10 +121,12 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
     // Only auto-submit already-signed txs:
     if (!('rawTx' in txMeta)) return
 
-    // Increment a try counter.
-    txMeta.retryCount++
     const rawTx = txMeta.rawTx
-    return await this.publishTransaction(rawTx)
+    const txHash = await this.publishTransaction(rawTx)
+
+    // Increment successful tries:
+    txMeta.retryCount++
+    return txHash
   }
 
   async _checkPendingTx (txMeta) {


### PR DESCRIPTION
Fixes #2115

If a tx has been braodcast, the only failures we should accept are:
- Never mined
- On chain failure

We had a section of code that would mark a tx failed during any unknown error during a retry.

Now no retry > 1 will ever mark a tx failed, since it has been broadcast, and may be mined.

Requesting review from @frankiebee since she's done the most work on the `pending-tx-tracker`. No rush, I know what you're doing right now, I don't expect a review before Wed/Thursday.