### PR TITLE
v3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fix bug that would sometimes display transactions as failed that could be successfully mined.
 
+## 3.10.2 2017-9-18
+
+rollback to 3.10.0 due to bug
+
 ## 3.10.1 2017-9-18
 
 - Add ability to export private keys as a file.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",


### PR DESCRIPTION
published `v3.10.2` as an emergency rollback to `v3.10.0`