### PR TITLE
[NewUI] Confirm screen shows amount plus gas in total field

### DIFF
--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -114,6 +114,16 @@ const conversionUtil = (value, {
   value,
 });
 
+const addCurrencies = (a, b, { toNumericBase, numberOfDecimals }) => {
+  const value = (new BigNumber(a)).add(b);
+  return converter({
+    value,
+    toNumericBase,
+    numberOfDecimals,
+  })
+}
+
 module.exports = {
   conversionUtil,
+  addCurrencies,
 }


### PR DESCRIPTION
The confirm screen showed the same value in the large text at top and in the "Total (Amount + Gas)" row at bottom. The value being displayed was the `amount`.

This PR corrects the `amount + gas` value at bottom show that it shows the sum, and properly represents the total.

<img width="528" alt="screen shot 2017-09-20 at 11 27 28 am" src="https://user-images.githubusercontent.com/7499938/30647840-1eb72fe0-9df7-11e7-9a00-a068cf37f355.png">
