### PR TITLE
Fix CORS issues in FireFox

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -58,10 +58,8 @@
     "storage",
     "clipboardWrite",
     "http://localhost:8545/",
-    "https://rinkeby.infura.io/metamask/",
-    "https://mainnet.infura.io/metamask/",
-    "https://ropsten.infura.io/metamask/",
-    "https://kovan.infura.io/metamask/"
+    "https://*.infura.io/",
+    "https://api.cryptonator.com"
     ],
   "web_accessible_resources": [
     "scripts/inpage.js"

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -58,8 +58,7 @@
     "storage",
     "clipboardWrite",
     "http://localhost:8545/",
-    "https://*.infura.io/",
-    "https://api.cryptonator.com"
+    "https://*.infura.io/"
     ],
   "web_accessible_resources": [
     "scripts/inpage.js"

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -57,7 +57,11 @@
   "permissions": [
     "storage",
     "clipboardWrite",
-    "http://localhost:8545/"
+    "http://localhost:8545/",
+    "https://rinkeby.infura.io/metamask/",
+    "https://mainnet.infura.io/metamask/",
+    "https://ropsten.infura.io/metamask/",
+    "https://kovan.infura.io/metamask/"
     ],
   "web_accessible_resources": [
     "scripts/inpage.js"


### PR DESCRIPTION
Fixes #1779

Looks like Firefox requires adding all HTTP addresses to `manifest.json`, so I added addresses for `rinkeby`, `kovan`, `ropsten` and `mainnet`.

Verified on:
https://dapp.acebusters.com
http://registrar.ens.domains/
