### PR TITLE
[NewUI] Client side error handling for from, to and amount fields in send.js

### DIFF
--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -123,7 +123,20 @@ const addCurrencies = (a, b, { toNumericBase, numberOfDecimals }) => {
   })
 }
 
+const conversionGreaterThan = (
+  { value, fromNumericBase },
+  { value: compareToValue, fromNumericBase: compareToBase },
+) => {
+  const firstValue = converter({ value, fromNumericBase })
+  const secondValue = converter({
+    value: compareToValue,
+    fromNumericBase: compareToBase,
+  })
+  return firstValue.gt(secondValue)
+}
+
 module.exports = {
   conversionUtil,
   addCurrencies,
+  conversionGreaterThan,
 }

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -104,6 +104,16 @@
       color: $red;
     }
   }
+
+  .send-screen-input-wrapper__error-message {
+    display: block;
+    position: absolute;
+    bottom: 4px;
+    font-size: 12px;
+    line-height: 12px;
+    left: 8px;
+    color: $red;
+  }
 }
 
 .send-screen-input {
@@ -294,6 +304,11 @@
   &__cancel-button {
     width: 163px;
     text-align: center;
+  }
+
+  &__send-button__disabled {
+    opacity: 0.5;
+    cursor: auto;
   }
 }
 

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -55,6 +55,7 @@ module.exports = {
   getContractAtAddress,
   exportAsFile: exportAsFile,
   isInvalidChecksumAddress,
+  allNull,
 }
 
 function valuesFor (obj) {
@@ -272,4 +273,8 @@ function exportAsFile (filename, data) {
     elem.click()
     document.body.removeChild(elem)
   }
+}
+
+function allNull (obj) {
+  return Object.entries(obj).every(([key, value]) => value === null)
 }


### PR DESCRIPTION
Adds client side error handling for the from, to and amount fields in send.js. Error handling follows the logic:
- Do not show error when field is not dirty
 - Show error on change
 - Hide error when input is active/focus (this prevents the input to show error as user type)
 - Disable submit button if form is not valid

![sendwitherrors](https://user-images.githubusercontent.com/7499938/30728867-c02a508e-9f35-11e7-96e0-1f67d9d6bca9.gif)
