### PR TITLE
[NewUI] Able to change send screen selections of to and from fields.

### DIFF
--- a/ui/app/components/send-token/index.js
+++ b/ui/app/components/send-token/index.js
@@ -181,7 +181,7 @@ SendTokenScreen.prototype.renderToAddressInput = function () {
         to: e.target.value,
         errors: {},
       }),
-      onFocus: () => to && this.setState({ to: '' }),
+      onFocus: event => to && event.target.select(),
     }),
     h('datalist#addresses', [
       // Corresponds to the addresses owned.

--- a/ui/app/components/send-token/index.js
+++ b/ui/app/components/send-token/index.js
@@ -181,6 +181,7 @@ SendTokenScreen.prototype.renderToAddressInput = function () {
         to: e.target.value,
         errors: {},
       }),
+      onFocus: () => to && this.setState({ to: '' }),
     }),
     h('datalist#addresses', [
       // Corresponds to the addresses owned.

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -123,7 +123,15 @@ SendTransactionScreen.prototype.renderFromInput = function (from, identities) {
         })
       },
       onBlur: () => this.setErrorsFor('from'),
-      onFocus: () => this.clearErrorsFor('from'),
+      onFocus: () => {
+        this.clearErrorsFor('from'),
+        this.state.newTx.from && this.setState({
+          newTx: {
+            ...this.state.newTx,
+            from: '',
+          },
+        })
+      },
     }),
 
     h('datalist#accounts', [
@@ -160,7 +168,15 @@ SendTransactionScreen.prototype.renderToInput = function (to, identities, addres
         })
       },
       onBlur: () => this.setErrorsFor('to'),
-      onFocus: () => this.clearErrorsFor('to'),
+      onFocus: () => {
+        this.clearErrorsFor('to')
+        this.state.newTx.to && this.setState({
+          newTx: {
+            ...this.state.newTx,
+            to: '',
+          },
+        })
+      },
     }),
 
     h('datalist#addresses', [

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -124,7 +124,7 @@ SendTransactionScreen.prototype.renderFromInput = function (from, identities) {
       },
       onBlur: () => this.setErrorsFor('from'),
       onFocus: event => {
-        this.clearErrorsFor('from'),
+        this.clearErrorsFor('from')
         this.state.newTx.from && event.target.select()
       },
     }),

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -123,14 +123,9 @@ SendTransactionScreen.prototype.renderFromInput = function (from, identities) {
         })
       },
       onBlur: () => this.setErrorsFor('from'),
-      onFocus: () => {
+      onFocus: event => {
         this.clearErrorsFor('from'),
-        this.state.newTx.from && this.setState({
-          newTx: {
-            ...this.state.newTx,
-            from: '',
-          },
-        })
+        this.state.newTx.from && event.target.select()
       },
     }),
 
@@ -168,14 +163,9 @@ SendTransactionScreen.prototype.renderToInput = function (to, identities, addres
         })
       },
       onBlur: () => this.setErrorsFor('to'),
-      onFocus: () => {
+      onFocus: event => {
         this.clearErrorsFor('to')
-        this.state.newTx.to && this.setState({
-          newTx: {
-            ...this.state.newTx,
-            to: '',
-          },
-        })
+        this.state.newTx.to && event.target.select()
       },
     }),
 


### PR DESCRIPTION
This PR updates the the way datalists are used in send and send token to allow the user to change their selection. The approach is to set the field back to empty if it is focused and already has a value.

![tofromchangeseleciton](https://user-images.githubusercontent.com/7499938/30736062-e4002e4a-9f5b-11e7-9b37-807bcc04df8b.gif)
