### PR TITLE
[NewUI] Enables functionality for export private keys

### DIFF
--- a/ui/app/components/readonly-input.js
+++ b/ui/app/components/readonly-input.js
@@ -14,13 +14,17 @@ ReadOnlyInput.prototype.render = function () {
     wrapperClass = '',
     inputClass = '',
     value,
+    textarea,
   } = this.props
 
+  const inputType = textarea ? 'textarea' : 'input'
+
   return h('div', {className: wrapperClass}, [
-    h('input', {
+    h(inputType, {
       className: inputClass,
       value,
       readOnly: true,
+      onFocus: event => event.target.select(),
     }),
   ])
 }

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -283,11 +283,16 @@
   flex-direction: column;
 }
 
-.private-key-password-label {
+.private-key-password-label, .private-key-password-error {
   color: $scorpion;
   font-size: 14px;
   line-height: 18px;
   margin-bottom: 10px;
+}
+
+.private-key-password-error {
+  color: $crimson;
+  margin-bottom: 0;
 }
 
 .private-key-password-input {
@@ -331,6 +336,27 @@
     border-color: $dusty-gray;
     color: $scorpion;
   }
+}
+
+.private-key-password-display-wrapper {
+  height: 80px;
+  width: 291px;
+  border: 1px solid $silver; 
+  border-radius: 2px;
+}
+
+.private-key-password-display-textarea {
+  color: $crimson;
+  font-family: "DIN OT"; 
+  font-size: 16px; 
+  line-height: 21px;
+  border: none;
+  height: 75px;
+  width: 253px;
+  overflow: hidden;
+  resize: none;
+  padding: 9px 13px 8px;
+  text-transform: uppercase;
 }
 
 


### PR DESCRIPTION
The user can enter their password and then copy their key.

@chikeichan Should "Download" be the text on the button before the password is entered? Or something else?

![exportactions](https://user-images.githubusercontent.com/7499938/30862037-349009c2-a2a7-11e7-8875-dea9f037d1df.gif)
