### PR TITLE
[NewUI] Export private key modal back button

### DIFF
--- a/ui/app/components/modals/account-details-modal.js
+++ b/ui/app/components/modals/account-details-modal.js
@@ -19,6 +19,10 @@ function mapDispatchToProps (dispatch) {
   return {
     // Is this supposed to be used somewhere?
     showQrView: (selected, identity) => dispatch(actions.showQrView(selected, identity)),
+    showExportPrivateKeyModal: () => {
+      dispatch(actions.showModal({ name: 'EXPORT_PRIVATE_KEY' }))
+    },
+    hideModal: () => dispatch(actions.hideModal()),
   }
 }
 
@@ -33,7 +37,12 @@ module.exports = connect(mapStateToProps, mapDispatchToProps)(AccountDetailsModa
   // fonts of qr-header
 
 AccountDetailsModal.prototype.render = function () {
-  const { selectedIdentity, network } = this.props
+  const {
+    selectedIdentity,
+    network,
+    showExportPrivateKeyModal,
+    hideModal,
+  } = this.props
   const { name, address } = selectedIdentity
 
   return h(AccountModalContainer, {}, [
@@ -51,7 +60,11 @@ AccountDetailsModal.prototype.render = function () {
       }, [ 'View account on Etherscan' ]),
 
       // Holding on redesign for Export Private Key functionality
-      h('button.btn-clear', [ 'Export private key' ]),
+      h('button.btn-clear', {
+        onClick: () => {
+          showExportPrivateKeyModal()
+        },
+      }, [ 'Export private key' ]),
       
   ])
 }

--- a/ui/app/components/modals/account-modal-container.js
+++ b/ui/app/components/modals/account-modal-container.js
@@ -28,8 +28,13 @@ function AccountModalContainer () {
 module.exports = connect(mapStateToProps, mapDispatchToProps)(AccountModalContainer)
 
 AccountModalContainer.prototype.render = function () {
-  const { selectedIdentity, children } = this.props
-  console.log(`children`, children);
+  const {
+    selectedIdentity,
+    children,
+    showBackButton = false,
+    backButtonAction,
+  } = this.props
+
   return h('div', { style: { borderRadius: '4px' }}, [
     h('div.account-modal-container', [
 
@@ -41,6 +46,16 @@ AccountModalContainer.prototype.render = function () {
           diameter: 64,
           style: {},
         }),
+
+      ]),
+
+      showBackButton && h('div.account-modal-back', {
+        onClick: backButtonAction,
+      }, [
+
+        h('i.fa.fa-angle-left.fa-lg'),
+
+        h('span.account-modal-back__text', ' Back'),
 
       ]),
 

--- a/ui/app/components/modals/export-private-key-modal.js
+++ b/ui/app/components/modals/export-private-key-modal.js
@@ -14,12 +14,14 @@ function mapStateToProps (state) {
     privateKey: state.appState.accountDetail.privateKey,
     network: state.metamask.network,
     selectedIdentity: getSelectedIdentity(state),
+    previousModalState: state.appState.modal.previousModalState.name,
   }
 }
 
 function mapDispatchToProps (dispatch) {
   return {
     exportAccount: (password, address) => dispatch(actions.exportAccount(password, address)),
+    showAccountDetailModal: () => dispatch(actions.showModal({ name: 'ACCOUNT_DETAILS' })),
     hideModal: () => dispatch(actions.hideModal()),
   }
 }
@@ -86,10 +88,16 @@ ExportPrivateKeyModal.prototype.render = function () {
     network,
     privateKey,
     warning,
+    showAccountDetailModal,
+    hideModal,
+    previousModalState,
   } = this.props
   const { name, address } = selectedIdentity
 
-  return h(AccountModalContainer, {}, [
+  return h(AccountModalContainer, {
+    showBackButton: previousModalState === 'ACCOUNT_DETAILS',
+    backButtonAction: () => showAccountDetailModal(),
+  }, [
 
       h('span.account-name', name),
 

--- a/ui/app/components/modals/export-private-key-modal.js
+++ b/ui/app/components/modals/export-private-key-modal.js
@@ -31,11 +31,19 @@ function ExportPrivateKeyModal () {
   Component.call(this)
 
   this.state = {
-    password: ''
+    password: '',
+    privateKey: null,
   }
 }
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(ExportPrivateKeyModal)
+
+ExportPrivateKeyModal.prototype.exportAccountAndGetPrivateKey = function (password, address) {
+  const { exportAccount } = this.props
+
+  exportAccount(password, address)
+    .then(privateKey => this.setState({ privateKey }))
+}
 
 ExportPrivateKeyModal.prototype.renderPasswordLabel = function (privateKey) {
   return h('span.private-key-password-label', privateKey
@@ -68,15 +76,13 @@ ExportPrivateKeyModal.prototype.renderButton = function (className, onClick, lab
   }, label)
 }
 
-ExportPrivateKeyModal.prototype.renderButtons = function (privateKey, password, address) {
-  const { hideModal, exportAccount } = this.props
-
+ExportPrivateKeyModal.prototype.renderButtons = function (privateKey, password, address, hideModal) {
   return h('div.export-private-key-buttons', {}, [
     !privateKey && this.renderButton('btn-clear btn-cancel', () => hideModal(), 'Cancel'),
 
     (privateKey
       ? this.renderButton('btn-clear', () => hideModal(), 'Done')
-      : this.renderButton('btn-clear', () => exportAccount(this.state.password, address), 'Download')
+      : this.renderButton('btn-clear', () => this.exportAccountAndGetPrivateKey(this.state.password, address), 'Download')
     ),
 
   ])
@@ -86,13 +92,14 @@ ExportPrivateKeyModal.prototype.render = function () {
   const {
     selectedIdentity,
     network,
-    privateKey,
     warning,
     showAccountDetailModal,
     hideModal,
     previousModalState,
   } = this.props
   const { name, address } = selectedIdentity
+
+  const { privateKey } = this.state
 
   return h(AccountModalContainer, {
     showBackButton: previousModalState === 'ACCOUNT_DETAILS',
@@ -124,7 +131,7 @@ ExportPrivateKeyModal.prototype.render = function () {
         account.`
       ),
 
-      this.renderButtons(privateKey, this.state.password, address),
+      this.renderButtons(privateKey, this.state.password, address, hideModal),
       
   ])
 }

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -192,6 +192,21 @@
   }
 }
 
+.account-modal-back {
+  color: $dusty-gray;
+  position: absolute;
+  top: 13px;
+  left: 17px;
+  cursor: pointer;
+
+  &__text {
+    margin-top: 2px;
+    font-family: 'DIN OT';
+    font-size: 14px;
+    line-height: 18px;
+  }
+}
+
 .account-modal-close::after {
   content: '\00D7';
   font-size: 40px;

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -37,6 +37,9 @@ function reduceApp (state, action) {
       modalState: {
         name: null,
       },
+      previousModalState: {
+        name: null,
+      }
     },
     sidebarOpen: false,
     networkDropdownOpen: false,
@@ -82,6 +85,7 @@ function reduceApp (state, action) {
           state.appState.modal,
           { open: true },
           { modalState: action.payload },
+          { previousModalState: appState.modal.modalState},
         ),
       })
 
@@ -90,7 +94,8 @@ function reduceApp (state, action) {
         modal: Object.assign(
           state.appState.modal,
           { open: false },
-          { modalState: action.payload || state.appState.modal.modalState },
+          { modalState: { name: null } },
+          { previousModalState: appState.modal.modalState}, 
         ),
       })
 


### PR DESCRIPTION
Adds a back button to export private key that is only shown if export private key is accessed from the Account Details Modal (which is where the back button goes)

![exportback](https://user-images.githubusercontent.com/7499938/30866215-2eff6d48-a2b3-11e7-8b34-6364927f54d7.gif)
