### PR TITLE
[NewUI] Restore notification functionality

### DIFF
--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -15,6 +15,11 @@ function reduceApp (state, action) {
     name = 'accountDetail'
   }
 
+  if (hasUnconfActions) {
+    log.debug('pending txs detected, defaulting to conf-tx view.')
+    name = 'confTx'
+  }
+
   var defaultView = {
     name,
     detailView: null,

--- a/ui/index.js
+++ b/ui/index.js
@@ -36,6 +36,15 @@ function startApp (metamaskState, accountManager, opts) {
     networkVersion: opts.networkVersion,
   })
 
+  // if unconfirmed txs, start on txConf page
+  const unapprovedTxsAll = txHelper(metamaskState.unapprovedTxs, metamaskState.unapprovedMsgs, metamaskState.unapprovedPersonalMsgs, metamaskState.network)
+  const numberOfUnapprivedTx = unapprovedTxsAll.length
+  if (numberOfUnapprivedTx > 0) {
+    store.dispatch(actions.showConfTxPage({
+      id: unapprovedTxsAll[numberOfUnapprivedTx - 1].id,
+    }))
+  }
+
   accountManager.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
   })


### PR DESCRIPTION
Restores the notification functionality removed in https://github.com/MetaMask/metamask-extension/pull/2022

![notificationfunctionality](https://user-images.githubusercontent.com/7499938/30889683-c7388046-a302-11e7-85e4-5d90dface000.gif)
