### PR TITLE
Version 3.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+## 3.10.5 2017-9-27
+
 - Fix block gas limit estimation.
 
 ## 3.10.4 2017-9-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix block gas limit estimation.
+
 ## 3.10.4 2017-9-27
 
 - Fix bug that could mis-render token balances when very small. (Not actually included in 3.9.9)

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -52,7 +52,7 @@ module.exports = class TransactionController extends EventEmitter {
       provider: this.provider,
       nonceTracker: this.nonceTracker,
       getBalance: (address) => {
-        const account = this.accountTracker.getState().accounts[address]
+        const account = this.accountTracker.store.getState().accounts[address]
         if (!account) return
         return account.balance
       },

--- a/app/scripts/keyring-controller.js
+++ b/app/scripts/keyring-controller.js
@@ -568,7 +568,7 @@ class KeyringController extends EventEmitter {
   clearKeyrings () {
     let accounts
     try {
-      accounts = Object.keys(this.accountTracker.getState())
+      accounts = Object.keys(this.accountTracker.store.getState())
     } catch (e) {
       accounts = []
     }

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -11,6 +11,7 @@ const async = require('async')
 const EthQuery = require('eth-query')
 const ObservableStore = require('obs-store')
 const EventEmitter = require('events').EventEmitter
+const ethUtil = require('ethereumjs-util')
 function noop () {}
 
 
@@ -59,8 +60,9 @@ class AccountTracker extends EventEmitter {
   _updateForBlock (block) {
     const blockNumber = '0x' + block.number.toString('hex')
     this._currentBlockNumber = blockNumber
+    const currentBlockGasLimit = ethUtil.addHexPrefix(block.gasLimit.toString())
 
-    this.store.updateState({ currentBlockGasLimit: `0x${block.gasLimit.toString('hex')}` })
+    this.store.updateState({ currentBlockGasLimit })
 
     async.parallel([
       this._updateAccounts.bind(this),


### PR DESCRIPTION
Fix bug where block gas limit was incorrectly parsed.

Previous ethStore assumed non-hex-prefixed values, but we sometimes get hex-prefixed values. Using ethUtil to manage the safe hex prefixing of whatever is returned.

Yes I know the irony that @wanderer recently told Frankie to not use this method, but it has its uses, when the clients have inconsistent prefixing.