### PR TITLE
Network controller refactor

### DIFF
--- a/app/scripts/controllers/network.js
+++ b/app/scripts/controllers/network.js
@@ -41,24 +41,6 @@ module.exports = class NetworkController extends EventEmitter {
     this.emit('networkDidChange')
   }
 
-  _setProvider (provider) {
-    // collect old block tracker events
-    const oldProvider = this._provider
-    let blockTrackerHandlers
-    if (oldProvider) {
-      // capture old block handlers
-      blockTrackerHandlers = oldProvider._blockTracker.proxyEventHandlers
-      // tear down
-      oldProvider.removeAllListeners()
-      oldProvider.stop()
-    }
-    // override block tracler
-    provider._blockTracker = createEventEmitterProxy(provider._blockTracker, blockTrackerHandlers)
-    // set as new provider
-    this._provider = provider
-    this._proxy.setTarget(provider)
-  }
-
   verifyNetwork () {
   // Check network when restoring connectivity:
     if (this.isNetworkLoading()) this.lookupNetwork()
@@ -110,6 +92,24 @@ module.exports = class NetworkController extends EventEmitter {
   getRpcAddressForType (type, provider = this.getProviderConfig()) {
     if (RPC_ADDRESS_LIST[type]) return RPC_ADDRESS_LIST[type]
     return provider && provider.rpcTarget ? provider.rpcTarget : DEFAULT_RPC
+  }
+
+  _setProvider (provider) {
+    // collect old block tracker events
+    const oldProvider = this._provider
+    let blockTrackerHandlers
+    if (oldProvider) {
+      // capture old block handlers
+      blockTrackerHandlers = oldProvider._blockTracker.proxyEventHandlers
+      // tear down
+      oldProvider.removeAllListeners()
+      oldProvider.stop()
+    }
+    // override block tracler
+    provider._blockTracker = createEventEmitterProxy(provider._blockTracker, blockTrackerHandlers)
+    // set as new provider
+    this._provider = provider
+    this._proxy.setTarget(provider)
   }
 
   _logBlock (block) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -232,8 +232,7 @@ module.exports = class MetamaskController extends EventEmitter {
       processTransaction: nodeify(async (txParams) => await this.txController.newUnapprovedTransaction(txParams), this),
       // old style msg signing
       processMessage: this.newUnsignedMessage.bind(this),
-
-      // new style msg signing
+      // personal_sign msg signing
       processPersonalMessage: this.newUnsignedPersonalMessage.bind(this),
     })
   }

--- a/test/unit/network-contoller-test.js
+++ b/test/unit/network-contoller-test.js
@@ -20,9 +20,9 @@ describe('# Network Controller', function () {
     describe('#provider', function () {
       it('provider should be updatable without reassignment', function () {
         networkController.initializeProvider(networkControllerProviderInit, dummyProviderConstructor)
-        const provider = networkController.provider
-        networkController.provider.setTarget({test: true, on: () => {}})
-        assert.ok(provider.test)
+        const proxy = networkController._proxy
+        proxy.setTarget({ test: true, on: () => {} })
+        assert.ok(proxy.test)
       })
     })
     describe('#getNetworkState', function () {


### PR DESCRIPTION
DRYs up `initializeProvider` and `switchNetwork`'s provider+blockTracker wrapping code into `_setProvider`