### PR TITLE
[NewUI] Styling improvements for account dropdown.

### DIFF
--- a/ui/app/components/dropdowns/components/account-dropdowns.js
+++ b/ui/app/components/dropdowns/components/account-dropdowns.js
@@ -51,6 +51,7 @@ class AccountDropdowns extends Component {
             {
               marginTop: index === 0 ? '5px' : '',
               fontSize: '24px',
+              width: '260px',
             },
             menuItemStyles,
           ),
@@ -92,6 +93,7 @@ class AccountDropdowns extends Component {
                 alignItems: 'flex-start',
                 justifyContent: 'center',
                 marginLeft: '10px',
+                position: 'relative',
               },
             }, [
               this.indicateIfLoose(keyring),
@@ -104,7 +106,6 @@ class AccountDropdowns extends Component {
                   textOverflow: 'ellipsis',
                 },
               }, identity.name || ''),
-              h('span', { style: { marginLeft: '20px', fontSize: '24px' } }, isSelected ? h('.check', '✓') : null),
 
               h('span.account-dropdown-balance', {
                 style: {
@@ -202,17 +203,19 @@ class AccountDropdowns extends Component {
           },
           [
             h(
-              Identicon,
+              'div',
               {
                 style: {
-                  marginLeft: '10px',
+                  marginLeft: '8px',
+                  fontFamily: 'Montserrat UltraLight',
+                  fontSize: '30px',
                 },
-                diameter: 32,
               },
+              '+'
             ),
             h('span', {
               style: {
-                marginLeft: '20px',
+                marginLeft: '14px',
                 fontFamily: 'DIN OT',
                 fontSize: '16px',
                 lineHeight: '23px',
@@ -232,13 +235,13 @@ class AccountDropdowns extends Component {
           },
           [
             h(
-              Identicon,
+              'div',
               {
                 style: {
                   marginLeft: '10px',
                 },
-                diameter: 32,
               },
+              String.fromCharCode(10515)
             ),
             h('span', {
               style: {

--- a/ui/app/components/dropdowns/components/account-dropdowns.js
+++ b/ui/app/components/dropdowns/components/account-dropdowns.js
@@ -203,15 +203,12 @@ class AccountDropdowns extends Component {
           },
           [
             h(
-              'div',
+              'i.fa.fa-plus.fa-lg',
               {
                 style: {
                   marginLeft: '8px',
-                  fontFamily: 'Montserrat UltraLight',
-                  fontSize: '30px',
                 },
-              },
-              '+'
+              }
             ),
             h('span', {
               style: {
@@ -235,13 +232,12 @@ class AccountDropdowns extends Component {
           },
           [
             h(
-              'div',
+              'i.fa.fa-download.fa-lg',
               {
                 style: {
-                  marginLeft: '10px',
+                  marginLeft: '8px',
                 },
-              },
-              String.fromCharCode(10515)
+              }
             ),
             h('span', {
               style: {

--- a/ui/app/css/itcss/tools/utilities.scss
+++ b/ui/app/css/itcss/tools/utilities.scss
@@ -239,9 +239,8 @@ hr.horizontal-line {
   height: 20px;
   min-width: 20px;
   position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  top: 0px;
+  right: 5px;
   padding: 4px;
 }
 


### PR DESCRIPTION
- Remove Orange check mark
- Fix padding on hover
- Move "Loose" badge
- Icon update for Create Account and Import Account ( @chikeichan  these are not very good right now. I am not sure if there is an icon library we can/should use?)

<img width="498" alt="screen shot 2017-09-27 at 8 50 24 pm" src="https://user-images.githubusercontent.com/7499938/30943725-78b21c5e-a3cd-11e7-8a9a-00baa84064ed.png">

<img width="360" alt="screen shot 2017-09-27 at 10 27 01 pm" src="https://user-images.githubusercontent.com/7499938/30944525-12464fa2-a3d3-11e7-83e3-efe163aa917e.png">

