### PR TITLE
[NewUI] Fix send of USD and backspacing amount to 0

### DIFF
--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -47,7 +47,7 @@ const toNormalizedDenomination = {
   WEI: bigNumber => bigNumber.div(BIG_NUMBER_WEI_MULTIPLIER)
 }
 const toSpecifiedDenomination = {
-  WEI: bigNumber => bigNumber.times(BIG_NUMBER_WEI_MULTIPLIER)
+  WEI: bigNumber => bigNumber.times(BIG_NUMBER_WEI_MULTIPLIER).round()
 }
 const baseChange = {
   hex: n => n.toString(16),
@@ -83,8 +83,8 @@ const whenPropApplySetterMap = (prop, setterMap) => whenPredSetWithPropAndSetter
 const converter = R.pipe(
   whenPropApplySetterMap('fromNumericBase', toBigNumber),
   whenPropApplySetterMap('fromDenomination', toNormalizedDenomination),
-  whenPropApplySetterMap('toDenomination', toSpecifiedDenomination),
   whenPredSetWithPropAndSetter(fromAndToCurrencyPropsNotEqual, 'conversionRate', convert),
+  whenPropApplySetterMap('toDenomination', toSpecifiedDenomination),
   whenPredSetWithPropAndSetter(R.prop('ethToUSDRate'), 'ethToUSDRate', convert),
   whenPredSetWithPropAndSetter(R.prop('numberOfDecimals'), 'numberOfDecimals', round),
   whenPropApplySetterMap('toNumericBase', baseChange),

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -230,12 +230,16 @@ SendTransactionScreen.prototype.renderAmountInput = function (activeCurrency) {
       placeholder: `0 ${activeCurrency}`,
       type: 'number',
       onChange: (event) => {
+        const amountToSend = event.target.value
+          ? this.getAmountToSend(event.target.value)
+          : '0x0'
+
         this.setState({
           newTx: Object.assign(
             this.state.newTx,
             {
               amount: event.target.value,
-              amountToSend: this.getAmountToSend(event.target.value),
+              amountToSend: amountToSend,
             }
           ),
         })


### PR DESCRIPTION
Fixes:
- usd transactions can now be successfully confirmed. Fix was to ensure that value is rounded to a whole number after converting to WEI. Depending on the conversion rate, sometimes USD to ETH conversions would give a number so precise that even the WEI value would have a decimal. This corrects that.
- entering an amount and then deleting it with backspace no longer causes an error

![saveusdfix](https://user-images.githubusercontent.com/7499938/30971434-6f88b5e6-a442-11e7-8366-514b446f05f2.gif)
