### PR TITLE
[NewUI] Shapeshift deposit tx in list with deposit modal

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -1151,7 +1151,10 @@ function reshowQrCode (data, coin) {
       ]
 
       dispatch(actions.hideLoadingIndication())
-      return dispatch(actions.showQrView(data, message))
+      return dispatch(actions.showModal({
+        name: 'SHAPESHIFT_DEPOSIT_TX',
+        Qr: { data, message },
+      }))
     })
   }
 }

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -26,7 +26,6 @@ const InfoScreen = require('./info')
 const Loading = require('./components/loading')
 const NetworkIndicator = require('./components/network')
 const BuyView = require('./components/buy-button-subview')
-const QrView = require('./components/qr-code')
 const HDCreateVaultComplete = require('./keychains/hd/create-vault-complete')
 const HDRestoreVaultScreen = require('./keychains/hd/restore-vault')
 const RevealSeedConfirmation = require('./keychains/hd/recover-seed/confirmation')
@@ -72,7 +71,6 @@ function mapStateToProps (state) {
     lastUnreadNotice: state.metamask.lastUnreadNotice,
     lostAccounts: state.metamask.lostAccounts,
     frequentRpcList: state.metamask.frequentRpcList || [],
-    Qr: state.appState.Qr,
 
     // state needed to get account dropdown temporarily rendering from app bar
     identities,
@@ -371,37 +369,6 @@ App.prototype.renderPrimary = function () {
     case 'buyEth':
       log.debug('rendering buy ether screen')
       return h(BuyView, {key: 'buyEthView'})
-
-    case 'qr':
-      log.debug('rendering show qr screen')
-      return h('div', {
-        style: {
-          position: 'absolute',
-          height: '100%',
-          top: '0px',
-          left: '0px',
-        },
-      }, [
-        h('i.fa.fa-arrow-left.fa-lg.cursor-pointer.color-orange', {
-          onClick: () => props.dispatch(actions.backToAccountDetail(props.activeAddress)),
-          style: {
-            marginLeft: '10px',
-            marginTop: '50px',
-          },
-        }),
-        h('div', {
-          style: {
-            position: 'absolute',
-            left: '44px',
-            width: '285px',
-          },
-        }, [
-          h(QrView, {
-            key: 'qr',
-            Qr: props.Qr,
-          }),
-        ]),
-      ])
 
     default:
       log.debug('rendering default, account detail screen')

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -72,6 +72,7 @@ function mapStateToProps (state) {
     lastUnreadNotice: state.metamask.lastUnreadNotice,
     lostAccounts: state.metamask.lostAccounts,
     frequentRpcList: state.metamask.frequentRpcList || [],
+    Qr: state.appState.Qr,
 
     // state needed to get account dropdown temporarily rendering from app bar
     identities,
@@ -395,7 +396,10 @@ App.prototype.renderPrimary = function () {
             width: '285px',
           },
         }, [
-          h(QrView, {key: 'qr'}),
+          h(QrView, {
+            key: 'qr',
+            Qr: props.Qr,
+          }),
         ]),
       ])
 

--- a/ui/app/components/modals/account-modal-container.js
+++ b/ui/app/components/modals/account-modal-container.js
@@ -30,10 +30,14 @@ module.exports = connect(mapStateToProps, mapDispatchToProps)(AccountModalContai
 AccountModalContainer.prototype.render = function () {
   const {
     selectedIdentity,
-    children,
     showBackButton = false,
     backButtonAction,
   } = this.props
+  let { children } = this.props
+
+  if (children.constructor !== Array) {
+    children = [children]
+  }
 
   return h('div', { style: { borderRadius: '4px' }}, [
     h('div.account-modal-container', [

--- a/ui/app/components/modals/modal.js
+++ b/ui/app/components/modals/modal.js
@@ -13,6 +13,7 @@ const AccountDetailsModal = require('./account-details-modal')
 const EditAccountNameModal = require('./edit-account-name-modal')
 const ExportPrivateKeyModal = require('./export-private-key-modal')
 const NewAccountModal = require('./new-account-modal')
+const ShapeshiftDepositTxModal = require('./shapeshift-deposit-tx-modal.js')
 
 const accountModalStyle = {
   mobileModalStyle: {
@@ -105,6 +106,13 @@ const MODALS = {
   EXPORT_PRIVATE_KEY: {
     contents: [
       h(ExportPrivateKeyModal, {}, []),
+    ],
+    ...accountModalStyle,
+  },
+
+  SHAPESHIFT_DEPOSIT_TX: {
+    contents: [
+      h(ShapeshiftDepositTxModal),
     ],
     ...accountModalStyle,
   },

--- a/ui/app/components/modals/shapeshift-deposit-tx-modal.js
+++ b/ui/app/components/modals/shapeshift-deposit-tx-modal.js
@@ -1,0 +1,40 @@
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const inherits = require('util').inherits
+const connect = require('react-redux').connect
+const actions = require('../../actions')
+const QrView = require('../qr-code')
+const AccountModalContainer = require('./account-modal-container')
+
+function mapStateToProps (state) {
+  return {
+    Qr: state.appState.modal.modalState.Qr,
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    hideModal: () => {
+      dispatch(actions.hideModal())
+    },
+  }
+}
+
+inherits(ShapeshiftDepositTxModal, Component)
+function ShapeshiftDepositTxModal () {
+  Component.call(this)
+
+}
+
+module.exports = connect(mapStateToProps, mapDispatchToProps)(ShapeshiftDepositTxModal)
+
+ShapeshiftDepositTxModal.prototype.render = function () {
+  const { Qr } = this.props
+
+  return h(AccountModalContainer, {
+  }, [
+    h('div', {}, [
+      h(QrView, {key: 'qr', Qr}),
+    ])
+  ])
+}

--- a/ui/app/components/shift-list-item.js
+++ b/ui/app/components/shift-list-item.js
@@ -29,7 +29,7 @@ function ShiftListItem () {
 
 ShiftListItem.prototype.render = function () {
   return (
-    h('.transaction-list-item.flex-row', {
+    h('div.tx-list-item.tx-list-clickable', {
       style: {
         paddingTop: '20px',
         paddingBottom: '20px',

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -57,7 +57,7 @@ TxList.prototype.renderTransaction = function () {
 TxList.prototype.renderTransactionListItem = function (transaction, conversionRate) {
   // console.log({transaction})
   // refer to transaction-list.js:line 58
-  const shapeshiftProps = {};
+
   if (transaction.key === 'shapeshift') {
     return h(ShiftListItem, transaction)
   }

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -5,6 +5,7 @@ const inherits = require('util').inherits
 const prefixForNetwork = require('../../lib/etherscan-prefix-for-network')
 const selectors = require('../selectors')
 const TxListItem = require('./tx-list-item')
+const ShiftListItem = require('./shift-list-item')
 const { formatBalance, formatDate } = require('../util')
 const { showConfTxPage } = require('../actions')
 
@@ -56,8 +57,9 @@ TxList.prototype.renderTransaction = function () {
 TxList.prototype.renderTransactionListItem = function (transaction, conversionRate) {
   // console.log({transaction})
   // refer to transaction-list.js:line 58
+  const shapeshiftProps = {};
   if (transaction.key === 'shapeshift') {
-    return null
+    return h(ShiftListItem, transaction)
   }
 
   const props = {

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -17,6 +17,13 @@
   color: #5B5D67;
 }
 
+.qr-ellip-address, .ellip-address {
+  width: 247px;
+  border: none;
+  font-family: 'Montserrat Light';
+  font-size: 14px;
+}
+
 @media screen and (max-width: 575px) {
   .buy-modal-content-title-wrapper {
     justify-content: space-around;
@@ -248,13 +255,6 @@
     font-family: 'Montserrat Light';
     margin-top: 7px;
     width: 286px;
-  }
-
-  .qr-ellip-address, .ellip-address {
-    width: 247px;
-    border: none;
-    font-family: 'Montserrat Light';
-    font-size: 14px;
   }
 
   .btn-clear {


### PR DESCRIPTION
After this PR we are again showing shapeshift deposit transactions in the tx list. A modal with deposit transaction information can be opened from the transaction in the list.

**NOTE: the transaction in the list is styled in the same way it is styled in the old UI. If this needs to change, we can resolve it with another PR. There are some UX / design decisions that will have to be made before we can do so.**

![shpshfttxmodal](https://user-images.githubusercontent.com/7499938/31024013-41fc5386-a518-11e7-8dde-09aeb7fe4511.gif)
