### PR TITLE
pending tx tracker fix - dont error on retry fail

### DIFF
--- a/app/scripts/lib/pending-tx-tracker.js
+++ b/app/scripts/lib/pending-tx-tracker.js
@@ -89,7 +89,6 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
         // other
         || errorMessage.includes('gateway timeout')
         || errorMessage.includes('nonce too low')
-        || txMeta.retryCount > 1
       )
       // ignore resubmit warnings, return early
       if (isKnownTx) return


### PR DESCRIPTION
this is in the resubmit function so its always a retry -- dont need to check `retryCount`