### PR TITLE
Version 3.10.8 - Fix Currency Conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Current Master
 
+## 3.10.8 2017-9-28
+
+- Fixed usage of new currency fetching API.
+
 ## 3.10.7 2017-9-28
 
 - Fixed bug where sometimes the current account was not correctly set and exposed to web apps.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MetaMask",
   "short_name": "Metamask",
-  "version": "3.10.7",
+  "version": "3.10.8",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "Ethereum Browser Extension",

--- a/app/scripts/controllers/currency.js
+++ b/app/scripts/controllers/currency.js
@@ -45,7 +45,7 @@ class CurrencyController {
 
   updateConversionRate () {
     const currentCurrency = this.getCurrentCurrency()
-    return fetch(`https://api.infura.io/v1/ticker/eth${currentCurrency}`)
+    return fetch(`https://api.infura.io/v1/ticker/eth${currentCurrency.toLowerCase()}`)
     .then(response => response.json())
     .then((parsedResponse) => {
       this.setConversionRate(Number(parsedResponse.bid))


### PR DESCRIPTION
In our conversion to the new Infura API, somehow we were sending upper-cased conversions to their lower-case sensitive API.

Fixes the first part of #2240