### PR TITLE
Don't pass origin as an HTTP header

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -221,7 +221,6 @@ module.exports = class MetamaskController extends EventEmitter {
         eth_syncing: false,
         web3_clientVersion: `MetaMask/v${version}`,
       },
-      originHttpHeaderKey: 'X-Metamask-Origin',
       // account mgmt
       getAccounts: (cb) => {
         const isUnlocked = this.keyringController.memStore.getState().isUnlocked


### PR DESCRIPTION
Fixes #1779.

That issue seems to be caused by MetaMask demanding to send the `x-metamask-origin` header, and Ethereum nodes responding with CORS responses that disallow that header. I posted [a Wireshark dump](https://github.com/MetaMask/metamask-extension/issues/1779#issuecomment-333423169) in #1779 that illustrates the problem.

This is a different fix than #2138. In particular, this fix is compatible with the "Custom RPC" option; in general the extension needs to be able to make requests against arbitrary user-submitted Ethereum nodes, and they can't all be put in the manifest to be exempted from proper CORS checking.

On the other hand, this fix just removes the `x-metamask-origin` header, which presumably was added for a reason. However, since apparently neither Infura nor Parity send CORS responses allowing this header, I don't think it's really tenable to have MetaMask try and send it. If it's really needed for Infura, it should be sent only when Infura is the node provider, until non-Infura nodes can tolerate it.