### PR TITLE
[NewUI-flat] Add needed iterator in tx-list and path to account in selectors.

### DIFF
--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -50,7 +50,11 @@ TxList.prototype.renderTransaction = function () {
   const { txsToRender, conversionRate } = this.props
   return txsToRender.length
     ? txsToRender.map((transaction, i) => this.renderTransactionListItem(transaction, conversionRate))
-    : [h('div.tx-list-item.tx-list-item--empty', [ 'No Transactions' ])]
+    : [h(
+        'div.tx-list-item.tx-list-item--empty',
+        { key: 'tx-list-none' },
+        [ 'No Transactions' ],
+      )]
 }
 
 // TODO: Consider moving TxListItem into a separate component
@@ -88,6 +92,7 @@ TxList.prototype.renderTransactionListItem = function (transaction, conversionRa
     txParams: transaction.txParams,
     transactionStatus,
     transActionId,
+    key: transActionId,
     dateString,
     address,
     transactionAmount,

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -13,7 +13,7 @@ module.exports = selectors
 
 function getSelectedAddress (state) {
   // TODO: accounts is not defined. Is it needed?
-  const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
+  const selectedAddress = state.metamask.selectedAddress || Object.keys(state.metamask.accounts)[0]
 
   return selectedAddress
 }


### PR DESCRIPTION
The undefined `accounts` variable in `selectors.js` throw an error... perhaps only when first signing up and logging in to the app.

The missing key in the tx-list causes a warning in the console that I finally found annoying enough to fix.