### PR TITLE
[NewUI-flat] Remove old version of method left after merge

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -902,15 +902,6 @@ function addToAddressBook (recipient, nickname) {
   }
 }
 
-function setProviderType (type) {
-  log.debug(`background.setProviderType`)
-  background.setProviderType(type)
-  return {
-    type: actions.SET_PROVIDER_TYPE,
-    value: type,
-  }
-}
-
 function useEtherscanProvider () {
   log.debug(`background.useEtherscanProvider`)
   background.useEtherscanProvider()


### PR DESCRIPTION
After the merge in https://github.com/MetaMask/metamask-extension/commit/bd99bc2e88b44b13ca818fbba478bd74eef222e3#diff-0aa0e3817f82f374f3674ab6a143f7b0, there were two `setProviderType()` methods in `actions.js`, causing the switching of networks to break.

This PR fixes this by removing the old `setProviderType`