### PR TITLE
[NewUI] Clear selected token on network change

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -155,6 +155,7 @@ var actions = {
   UPDATE_TOKENS: 'UPDATE_TOKENS',
   setRpcTarget: setRpcTarget,
   setProviderType: setProviderType,
+  updateProviderType,
   // loading overlay
   SHOW_LOADING: 'SHOW_LOADING_INDICATION',
   HIDE_LOADING: 'HIDE_LOADING_INDICATION',
@@ -869,11 +870,17 @@ function setProviderType (type) {
         log.error(err)
         return dispatch(self.displayWarning('Had a problem changing networks!'))
       }
+      dispatch(actions.updateProviderType(type))
+      dispatch(actions.setSelectedToken())
     })
-    return {
-      type: actions.SET_PROVIDER_TYPE,
-      value: type,
-    }
+    
+  }
+}
+
+function updateProviderType(type) {
+  return {
+    type: actions.SET_PROVIDER_TYPE,
+    value: type,
   }
 }
 


### PR DESCRIPTION
This PR clears the selected token when a network is changed. Now, when changing a network, eth will always be selected.

![tokennetowrkchg](https://user-images.githubusercontent.com/7499938/31204426-603551f4-a946-11e7-88c8-475c1ede3b43.gif)