### PR TITLE
[NewUI] Edit account modal allows edits, not just replacements

### DIFF
--- a/ui/app/components/modals/edit-account-name-modal.js
+++ b/ui/app/components/modals/edit-account-name-modal.js
@@ -24,10 +24,11 @@ function mapDispatchToProps (dispatch) {
 }
 
 inherits(EditAccountNameModal, Component)
-function EditAccountNameModal () {
+function EditAccountNameModal (props) {
   Component.call(this)
+
   this.state = {
-    inputText: '',
+    inputText: props.identity.name,
   }
 }
 


### PR DESCRIPTION
Edit account modal shows and allows editing of name from props, not just placeholder.

![editaccountplaceholder](https://user-images.githubusercontent.com/7499938/31204699-96acd698-a947-11e7-8fc3-fd6595987c02.gif)
