### PR TITLE
Add boolean for specified gas price

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -169,6 +169,7 @@ module.exports = class TransactionController extends EventEmitter {
   async addTxDefaults (txMeta) {
     const txParams = txMeta.txParams
     // ensure value
+    txMeta.gasPriceSpecified = Boolean(txParams.gasPrice)
     const gasPrice = txParams.gasPrice || await this.query.gasPrice()
     txParams.gasPrice = ethUtil.addHexPrefix(gasPrice.toString(16))
     txParams.value = txParams.value || '0x0'


### PR DESCRIPTION
To help us deduce whether gas price comes from eth.query or from the original transaction opts.