### PR TITLE
Mark tx as failed after tx with same nonce is mined

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -62,6 +62,7 @@ module.exports = class TransactionController extends EventEmitter {
       retryTimePeriod: 86400000, // Retry 3500 blocks, or about 1 day.
       publishTransaction: (rawTx) => this.query.sendRawTransaction(rawTx),
       getPendingTransactions: this.txStateManager.getPendingTransactions.bind(this.txStateManager),
+      getCompletedTransactions: this.txStateManager.getConfirmedTransactions.bind(this.txStateManager),
     })
 
     this.txStateManager.store.subscribe(() => this.emit('update:badge'))

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -46,6 +46,12 @@ module.exports = class TransactionStateManger extends EventEmitter {
     return this.getFilteredTxList(opts)
   }
 
+  getConfirmedTransactions (address) {
+    const opts = { status: 'confirmed' }
+    if (address) opts.from = address
+    return this.getFilteredTxList(opts)
+  }
+
   addTx (txMeta) {
     this.once(`${txMeta.id}:signed`, function (txId) {
       this.removeAllListeners(`${txMeta.id}:rejected`)

--- a/test/unit/pending-tx-test.js
+++ b/test/unit/pending-tx-test.js
@@ -48,6 +48,7 @@ describe('PendingTransactionTracker', function () {
         }
       },
       getPendingTransactions: () => {return []},
+      getCompletedTransactions: () => {return []},
       publishTransaction: () => {},
     })
   })
@@ -82,7 +83,7 @@ describe('PendingTransactionTracker', function () {
         nonce: '0x01',
       }, { count: 1 })[0]
 
-      stub = sinon.stub(pendingTxTracker, 'getPendingTransactions')
+      stub = sinon.stub(pendingTxTracker, 'getCompletedTransactions')
       .returns(txGen.txs)
 
       // THE EXPECTATION
@@ -97,7 +98,7 @@ describe('PendingTransactionTracker', function () {
       await pendingTxTracker._checkPendingTx(pending)
 
       // THE ASSERTION
-      return sinon.assert.calledWith(spy, pending.id, 'tx failed should be emitted')
+      assert.ok(spy.calledWith(pending.id), 'tx failed should be emitted')
     })
   })
 


### PR DESCRIPTION
When checking pending txs, check for successful txs with same nonce. If a successful tx with the same nonce exists, transition tx to the failed state.

Fixes #2294