### PR TITLE
[NewUI-flat] SendV2 #10: Enable send functionality

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -137,6 +137,7 @@ var actions = {
   UPDATE_GAS_PRICE: 'UPDATE_GAS_PRICE',
   updateGasLimit,
   updateGasPrice,
+  setSelectedAddress,
   // app messages
   confirmSeedWords: confirmSeedWords,
   showAccountDetail: showAccountDetail,
@@ -696,6 +697,19 @@ function setSelectedToken (tokenAddress) {
   return {
     type: actions.SET_SELECTED_TOKEN,
     value: tokenAddress || null,
+  }
+}
+
+function setSelectedAddress (address) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    log.debug(`background.setSelectedAddress`)
+    background.setSelectedAddress(address, (err) => {
+      dispatch(actions.hideLoadingIndication())
+      if (err) {
+        return dispatch(actions.displayWarning(err.message))
+      }
+    })
   }
 }
 

--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -100,9 +100,9 @@ CurrencyDisplay.prototype.render = function () {
               this.setState({ value: newValue })
             }
           },
-          onBlur: event => this.handleChangeInHexWei(event.target.value.split(' ')[0]),
-          onKeyUp: event => resetCaretIfPastEnd(value || initValueToRender, event),
-          onClick: event => resetCaretIfPastEnd(value || initValueToRender, event),
+          onBlur: event => !readOnly && this.handleChangeInHexWei(event.target.value.split(' ')[0]),
+          onKeyUp: event => !readOnly && resetCaretIfPastEnd(value || initValueToRender, event),
+          onClick: event => !readOnly && resetCaretIfPastEnd(value || initValueToRender, event),
         }),
 
       ]),

--- a/ui/app/components/send/from-dropdown.js
+++ b/ui/app/components/send/from-dropdown.js
@@ -19,7 +19,14 @@ FromDropdown.prototype.getListItemIcon = function (currentAccount, selectedAccou
     : null
 }
 
-FromDropdown.prototype.renderDropdown = function (accounts, selectedAccount, closeDropdown) {
+FromDropdown.prototype.renderDropdown = function () {
+  const {
+    accounts,
+    selectedAccount,
+    closeDropdown,
+    onSelect,
+  } = this.props
+
   return h('div', {}, [
 
     h('div.send-v2__from-dropdown__close-area', {
@@ -30,7 +37,10 @@ FromDropdown.prototype.renderDropdown = function (accounts, selectedAccount, clo
 
       ...accounts.map(account => h(AccountListItem, {
         account, 
-        handleClick: () => console.log('Select identity'), 
+        handleClick: () => {
+          onSelect(account.address)
+          closeDropdown()
+        }, 
         icon: this.getListItemIcon(account, selectedAccount),
       }))
 
@@ -43,7 +53,6 @@ FromDropdown.prototype.render = function () {
   const {
     accounts,
     selectedAccount,
-    setFromField,
     openDropdown,
     closeDropdown,
     dropdownOpen,
@@ -57,7 +66,7 @@ FromDropdown.prototype.render = function () {
       icon: h(`i.fa.fa-caret-down.fa-lg`, { style: { color: '#dedede' } })
     }),
 
-    dropdownOpen && this.renderDropdown(accounts, selectedAccount, closeDropdown),
+    dropdownOpen && this.renderDropdown(),
 
   ])
     

--- a/ui/app/components/send/send-v2-container.js
+++ b/ui/app/components/send/send-v2-container.js
@@ -62,5 +62,10 @@ function mapDispatchToProps (dispatch) {
     estimateGas: params => dispatch(actions.estimateGas(params)),
     getGasPrice: () => dispatch(actions.getGasPrice()),
     updateTokenExchangeRate: token => dispatch(actions.updateTokenExchangeRate(token)),
+    signTokenTx: (tokenAddress, toAddress, amount, txData) => (
+      dispatch(actions.signTokenTx(tokenAddress, toAddress, amount, txData))
+    ),
+    signTx: txParams => dispatch(actions.signTx(txParams)),
+    setSelectedAddress: address => dispatch(actions.setSelectedAddress(address))
   }
 }

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -105,6 +105,7 @@ SendTransactionScreen.prototype.render = function () {
     selectedToken,
     showCustomizeGasModal,
     selectedAccount,
+    setSelectedAddress,
     primaryCurrency = 'ETH',
     gasLimit,
     gasPrice,
@@ -150,7 +151,7 @@ SendTransactionScreen.prototype.render = function () {
             dropdownOpen,
             accounts,
             selectedAccount,
-            setFromField: () => console.log('Set From Field'),
+            onSelect: address => setSelectedAddress(address),
             openDropdown: () => this.setState({ dropdownOpen: true }),
             closeDropdown: () => this.setState({ dropdownOpen: false }),
             conversionRate,
@@ -235,9 +236,43 @@ SendTransactionScreen.prototype.render = function () {
       // Buttons underneath card
       h('div.send-v2__footer', [
         h('button.send-v2__cancel-btn', {}, 'Cancel'),
-        h('button.send-v2__next-btn', {}, 'Next'),
+        h('button.send-v2__next-btn', {
+          onClick: event => this.onSubmit(event),
+        }, 'Next'),
       ]),
     ])
 
   )
+}
+
+SendTransactionScreen.prototype.onSubmit = function (event) {
+  event.preventDefault()
+  const {
+    to,
+    amount,
+  } = this.state
+  const {
+    gasLimit: gas,
+    gasPrice,
+    signTokenTx,
+    signTx,
+    selectedToken,
+    selectedAccount: { address: from },
+  } = this.props
+
+  const txParams = {
+    from,
+    value: '0',
+    gas,
+    gasPrice,
+  }
+
+  if (!selectedToken) {
+    txParams.value = amount
+    txParams.to = to
+  }
+
+  selectedToken
+    ? signTokenTx(selectedToken.address, to, amount, txParams)
+    : signTx(txParams)
 }


### PR DESCRIPTION
This PR modifies send-v2 and some of the components it uses to turn on the send functionality. The user can now send ether and tokens. The only remaining sendv2 pr is the addition of error handling.

Sending ether:

![sendingv2ether](https://user-images.githubusercontent.com/7499938/31591827-648e6f70-b1f1-11e7-8b3e-e6c304fcffb6.gif)

sending tokens:

![sendingv2-tokens](https://user-images.githubusercontent.com/7499938/31591858-ba239a5a-b1f1-11e7-82c7-1205abaff1c2.gif)
