### PR TITLE
[NewUI] Fix loose label being misaligned on accounts dropdown

### DIFF
--- a/ui/app/components/dropdowns/components/account-dropdowns.js
+++ b/ui/app/components/dropdowns/components/account-dropdowns.js
@@ -51,17 +51,20 @@ class AccountDropdowns extends Component {
             {
               marginTop: index === 0 ? '5px' : '',
               fontSize: '24px',
-              width: '260px',
             },
             menuItemStyles,
           ),
         },
         [
-          h('div.flex-row.flex-center', {}, [
-
+          h('div.flex-row.flex-center', {
+            style: {
+              flexGrow: '1',
+              padding: '0 8px',
+            },
+          }, [
             h('span', {
               style: {
-                flex: '1 1 0',
+                flex: '0',
                 minWidth: '20px',
                 minHeight: '30px',
               },
@@ -78,47 +81,48 @@ class AccountDropdowns extends Component {
               Identicon,
               {
                 address: identity.address,
-                diameter: 24,
+                diameter: 25,
                 style: {
-                  flex: '1 1 auto',
+                  flex: '0',
                   marginLeft: '10px',
                 },
               },
             ),
 
-            h('span.flex-column', {
-              style: {
-                flex: '10 10 auto',
-                width: '175px',
-                alignItems: 'flex-start',
-                justifyContent: 'center',
-                marginLeft: '10px',
-                position: 'relative',
-              },
-            }, [
-              this.indicateIfLoose(keyring),
-              h('span.account-dropdown-name', {
+            h('div.account-detail', {}, [
+              h('span.flex-column', {
                 style: {
-                  fontSize: '18px',
-                  maxWidth: '145px',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
+                  flex: '1 1 175px',
+                  alignItems: 'flex-start',
+                  justifyContent: 'center',
+                  marginLeft: '10px',
+                  position: 'relative',
                 },
-              }, identity.name || ''),
+              }, [
+                h('span.account-dropdown-name', {
+                  style: {
+                    fontSize: '18px',
+                    maxWidth: '145px',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  },
+                }, identity.name || ''),
 
-              h('span.account-dropdown-balance', {
-                style: {
-                  fontSize: '14px',
-                  fontFamily: 'Avenir',
-                  fontWeight: 500,
-                },
-              }, formattedBalance),
+                h('span.account-dropdown-balance', {
+                  style: {
+                    fontSize: '14px',
+                    fontFamily: 'Avenir',
+                    fontWeight: 500,
+                  },
+                }, formattedBalance),
+              ]),
+              this.indicateIfLoose(keyring),
             ]),
 
-            h('span', {
+            h('span.flex-center', {
               style: {
-                flex: '3 3 auto',
+                flex: '0 0 auto',
               },
             }, [
               h('span.account-dropdown-edit-button', {
@@ -159,7 +163,16 @@ class AccountDropdowns extends Component {
     try { // Sometimes keyrings aren't loaded yet:
       const type = keyring.type
       const isLoose = type !== 'HD Key Tree'
-      return isLoose ? h('.keyring-label', 'LOOSE') : null
+      return isLoose
+        ? h('.account-dropdown__loose-label', [
+            h('span', {
+              style: {
+                lineHeight: '10px',
+              },
+            },
+            'LOOSE'),
+          ])
+        : null
     } catch (e) { return }
   }
 

--- a/ui/app/components/dropdowns/components/dropdown.js
+++ b/ui/app/components/dropdowns/components/dropdown.js
@@ -20,7 +20,7 @@ class Dropdown extends Component {
 
     const innerStyleDefaults = extend({
       borderRadius: '4px',
-      padding: '8px 16px',
+      padding: '8px',
       background: 'rgba(0, 0, 0, 0.8)',
       boxShadow: 'rgba(0, 0, 0, 0.15) 0px 2px 2px 2px',
     }, innerStyle)

--- a/ui/app/components/wallet-view.js
+++ b/ui/app/components/wallet-view.js
@@ -129,7 +129,7 @@ WalletView.prototype.render = function () {
               top: '14px',
             },
             innerStyle: {
-              padding: '10px 16px',
+              padding: '10px',
             },
             useCssTransition: true,
             selected: selectedAddress,

--- a/ui/app/css/itcss/components/account-dropdown.scss
+++ b/ui/app/css/itcss/components/account-dropdown.scss
@@ -4,7 +4,7 @@
 
 .account-dropdown-balance {
   color: $dusty-gray;
-  line-height: 19px;
+  margin-top: 5px;
 }
 
 .account-dropdown-edit-button {
@@ -33,7 +33,7 @@
     margin-top: 4px;
     position: relative;
   }
-  
+
   &__account-name {
     font-size: 16px;
     margin-left: 8px;
@@ -62,4 +62,24 @@
   &__account-secondary-balance {
     color: $dusty-gray;
   }
+}
+
+.account-detail {
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.account-dropdown__loose-label {
+  z-index: 1;
+  font-size: 11px;
+  background: rgba(255, 0, 0, .8);
+  color: $white;
+  border-radius: 10px;
+  padding: 5px;
+  margin-right: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8051479/31595256-4e68e3e4-b208-11e7-8fb4-849a43001557.png)

After:
![image](https://user-images.githubusercontent.com/8051479/31595257-52a4cd92-b208-11e7-9410-d6b150c6c3c5.png)

Fixes #2338 . Also fixes account icons getting cut off.