### PR TITLE
Bump version on eth-simple-keyring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Fix bug where web3 API was sometimes injected after the page loaded.
+- Fix bug where imported accounts could not use new eth_signTypedData method.
 
 ## 3.11.0 2017-10-11
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eth-query": "^2.1.2",
     "eth-rpc-client": "^1.1.3",
     "eth-sig-util": "^1.4.0",
-    "eth-simple-keyring": "^1.1.1",
+    "eth-simple-keyring": "^1.2.0",
     "eth-token-tracker": "^1.1.4",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",


### PR DESCRIPTION
Fixes bug where imported accounts could not use the new `signTypedData` method.