### PR TITLE
[NewUI-flat] SendV2 #11: Error handling

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -934,7 +934,7 @@ function setRpcTarget (newRpc) {
 }
 
 // Calls the addressBookController to add a new address.
-function addToAddressBook (recipient, nickname) {
+function addToAddressBook (recipient, nickname = '') {
   log.debug(`background.addToAddressBook`)
   return (dispatch) => {
     background.setAddressBook(recipient, nickname, (err, result) => {

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -140,6 +140,7 @@ var actions = {
   UPDATE_SEND_TO: 'UPDATE_SEND_TO',
   UPDATE_SEND_AMOUNT: 'UPDATE_SEND_AMOUNT',
   UPDATE_SEND_MEMO: 'UPDATE_SEND_MEMO',
+  UPDATE_SEND_ERRORS: 'UPDATE_SEND_ERRORS',
   updateGasLimit,
   updateGasPrice,
   updateGasTotal,
@@ -147,6 +148,7 @@ var actions = {
   updateSendTo,
   updateSendAmount,
   updateSendMemo,
+  updateSendErrors,
   setSelectedAddress,
   // app messages
   confirmSeedWords: confirmSeedWords,
@@ -550,6 +552,14 @@ function updateSendMemo (memo) {
   return {
     type: actions.UPDATE_SEND_MEMO,
     value: memo,
+  }
+}
+
+function updateSendErrors (error) {
+  console.log(`updateSendErrors error`, error);
+  return {
+    type: actions.UPDATE_SEND_ERRORS,
+    value: error,
   }
 }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -135,8 +135,18 @@ var actions = {
   getGasPrice,
   UPDATE_GAS_LIMIT: 'UPDATE_GAS_LIMIT',
   UPDATE_GAS_PRICE: 'UPDATE_GAS_PRICE',
+  UPDATE_GAS_TOTAL: 'UPDATE_GAS_TOTAL',
+  UPDATE_SEND_FROM: 'UPDATE_SEND_FROM',
+  UPDATE_SEND_TO: 'UPDATE_SEND_TO',
+  UPDATE_SEND_AMOUNT: 'UPDATE_SEND_AMOUNT',
+  UPDATE_SEND_MEMO: 'UPDATE_SEND_MEMO',
   updateGasLimit,
   updateGasPrice,
+  updateGasTotal,
+  updateSendFrom,
+  updateSendTo,
+  updateSendAmount,
+  updateSendMemo,
   setSelectedAddress,
   // app messages
   confirmSeedWords: confirmSeedWords,
@@ -507,6 +517,42 @@ function updateGasPrice (gasPrice) {
     value: gasPrice,
   }
 }
+
+function updateGasTotal (gasTotal) {
+  return {
+    type: actions.UPDATE_GAS_TOTAL,
+    value: gasTotal,
+  }
+}
+
+function updateSendFrom (from) {
+  return {
+    type: actions.UPDATE_SEND_FROM,
+    value: from,
+  }
+}
+
+function updateSendTo (to) {
+  return {
+    type: actions.UPDATE_SEND_TO,
+    value: to,
+  }
+}
+
+function updateSendAmount (amount) {
+  return {
+    type: actions.UPDATE_SEND_AMOUNT,
+    value: amount,
+  }
+}
+
+function updateSendMemo (memo) {
+  return {
+    type: actions.UPDATE_SEND_MEMO,
+    value: memo,
+  }
+}
+
 
 function sendTx (txData) {
   log.info(`actions - sendTx: ${JSON.stringify(txData.txParams)}`)

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -351,20 +351,22 @@ App.prototype.renderPrimary = function () {
     case 'sendTransaction':
       log.debug('rendering send tx screen')
 
-      const SendComponentToRender = checkFeatureToggle('send-v2')
-        ? SendTransactionScreen2
-        : SendTransactionScreen
+      // Going to leave this here until we are ready to delete SendTransactionScreen v1
+      // const SendComponentToRender = checkFeatureToggle('send-v2')
+      //   ? SendTransactionScreen2
+      //   : SendTransactionScreen
 
-      return h(SendComponentToRender, {key: 'send-transaction'})
+      return h(SendTransactionScreen2, {key: 'send-transaction'})
 
     case 'sendToken':
       log.debug('rendering send token screen')
 
-      const SendTokenComponentToRender = checkFeatureToggle('send-v2')
-        ? SendTransactionScreen2
-        : SendTokenScreen
+      // Going to leave this here until we are ready to delete SendTransactionScreen v1
+      // const SendTokenComponentToRender = checkFeatureToggle('send-v2')
+      //   ? SendTransactionScreen2
+      //   : SendTokenScreen
 
-      return h(SendTokenComponentToRender, {key: 'sendToken'})
+      return h(SendTransactionScreen2, {key: 'sendToken'})
 
     case 'newKeychain':
       log.debug('rendering new keychain screen')

--- a/ui/app/components/customize-gas-modal/index.js
+++ b/ui/app/components/customize-gas-modal/index.js
@@ -5,7 +5,7 @@ const connect = require('react-redux').connect
 const actions = require('../../actions')
 const GasModalCard = require('./gas-modal-card')
 
-const { conversionUtil } = require('../../conversion-util')
+const { conversionUtil, multiplyCurrencies } = require('../../conversion-util')
 
 const {
   getGasPrice,
@@ -26,6 +26,7 @@ function mapDispatchToProps (dispatch) {
     hideModal: () => dispatch(actions.hideModal()),
     updateGasPrice: newGasPrice => dispatch(actions.updateGasPrice(newGasPrice)),
     updateGasLimit: newGasLimit => dispatch(actions.updateGasLimit(newGasLimit)),
+    updateGasTotal: newGasTotal => dispatch(actions.updateGasTotal(newGasTotal)),
   }
 }
 
@@ -46,10 +47,18 @@ CustomizeGasModal.prototype.save = function (gasPrice, gasLimit) {
     updateGasPrice,
     updateGasLimit,
     hideModal,
+    updateGasTotal
   } = this.props
+
+  const newGasTotal = multiplyCurrencies(gasLimit, gasPrice, {
+    toNumericBase: 'hex',
+    multiplicandBase: 16,
+    multiplierBase: 16,
+  })
 
   updateGasPrice(gasPrice)
   updateGasLimit(gasLimit)
+  updateGasTotal(newGasTotal)
   hideModal()
 }
 

--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -28,16 +28,12 @@ function resetCaretIfPastEnd (value, event) {
   }
 }
 
-CurrencyDisplay.prototype.handleChangeInHexWei = function (value) {
-  const { handleChange } = this.props
-
-  const valueInHexWei = conversionUtil(value, {
+function toHexWei (value) {
+  return conversionUtil(value, {
     fromNumericBase: 'dec',
     toNumericBase: 'hex',
     toDenomination: 'WEI',
   })
-
-  handleChange(valueInHexWei)
 }
 
 CurrencyDisplay.prototype.render = function () {
@@ -51,7 +47,10 @@ CurrencyDisplay.prototype.render = function () {
     convertedPrefix = '',
     placeholder = '0',
     readOnly = false,
+    inError = false,
     value: initValue,
+    handleChange,
+    validate,
   } = this.props
   const { value } = this.state
 
@@ -73,6 +72,9 @@ CurrencyDisplay.prototype.render = function () {
 
   return h('div', {
     className,
+    style: {
+      borderColor: inError ? 'red' : null,
+    },
   }, [
 
     h('div.currency-display__primary-row', [
@@ -100,8 +102,13 @@ CurrencyDisplay.prototype.render = function () {
               this.setState({ value: newValue })
             }
           },
-          onBlur: event => !readOnly && this.handleChangeInHexWei(event.target.value.split(' ')[0]),
-          onKeyUp: event => !readOnly && resetCaretIfPastEnd(value || initValueToRender, event),
+          onBlur: event => !readOnly && handleChange(toHexWei(event.target.value.split(' ')[0])),
+          onKeyUp: event => {
+            if (!readOnly) {
+              validate(toHexWei(value || initValueToRender))
+              resetCaretIfPastEnd(value || initValueToRender, event)
+            }
+          },
           onClick: event => !readOnly && resetCaretIfPastEnd(value || initValueToRender, event),
         }),
 

--- a/ui/app/components/send/from-dropdown.js
+++ b/ui/app/components/send/from-dropdown.js
@@ -38,7 +38,7 @@ FromDropdown.prototype.renderDropdown = function () {
       ...accounts.map(account => h(AccountListItem, {
         account, 
         handleClick: () => {
-          onSelect(account.address)
+          onSelect(account)
           closeDropdown()
         }, 
         icon: this.getListItemIcon(account, selectedAccount),

--- a/ui/app/components/send/gas-fee-display-v2.js
+++ b/ui/app/components/send/gas-fee-display-v2.js
@@ -1,9 +1,7 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
-const CurrencyDisplay = require('./currency-display');
-
-const { multiplyCurrencies } = require('../../conversion-util')
+const CurrencyDisplay = require('./currency-display')
 
 module.exports = GasFeeDisplay
 
@@ -15,24 +13,17 @@ function GasFeeDisplay () {
 GasFeeDisplay.prototype.render = function () {
   const {
     conversionRate,
-    gasLimit,
-    gasPrice,
+    gasTotal,
     onClick,
   } = this.props
 
-  const readyToRender = Boolean(gasLimit && gasPrice)
-
   return h('div', [
 
-    readyToRender
+    gasTotal
       ? h(CurrencyDisplay, {
         primaryCurrency: 'ETH',
         convertedCurrency: 'USD',
-        value: multiplyCurrencies(gasLimit, gasPrice, {
-          toNumericBase: 'hex',
-          multiplicandBase: 16,
-          multiplierBase: 16,
-        }),
+        value: gasTotal,
         conversionRate,
         convertedPrefix: '$',
         readOnly: true,

--- a/ui/app/components/send/send-v2-container.js
+++ b/ui/app/components/send/send-v2-container.js
@@ -15,6 +15,7 @@ const {
   getGasPrice,
   getGasLimit,
   getAddressBook,
+  getSendFrom,
 } = require('../../selectors')
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(SendEther)
@@ -46,16 +47,15 @@ function mapStateToProps (state) {
   }
 
   return {
-    selectedAccount: getCurrentAccountWithSendEtherInfo(state),
+    ...state.metamask.send,
+    from: getSendFrom(state) || getCurrentAccountWithSendEtherInfo(state),
     fromAccounts,
     toAccounts: [...fromAccounts, ...getAddressBook(state)],
     conversionRate,
     selectedToken,
     primaryCurrency,
     data,
-    tokenToUSDRate,
-    gasPrice: getGasPrice(state),
-    gasLimit: getGasLimit(state),
+    amountConversionRate: selectedToken ? tokenToUSDRate : conversionRate,
   }
 }
 
@@ -71,5 +71,10 @@ function mapDispatchToProps (dispatch) {
     signTx: txParams => dispatch(actions.signTx(txParams)),
     setSelectedAddress: address => dispatch(actions.setSelectedAddress(address)),
     addToAddressBook: address => dispatch(actions.addToAddressBook(address)),
+    updateGasTotal: newTotal => dispatch(actions.updateGasTotal(newTotal)),
+    updateSendFrom: newFrom => dispatch(actions.updateSendFrom(newFrom)),
+    updateSendTo: newTo => dispatch(actions.updateSendTo(newTo)),
+    updateSendAmount: newAmount => dispatch(actions.updateSendAmount(newAmount)),
+    updateSendMemo: newMemo => dispatch(actions.updateSendMemo(newMemo)),
   }
 }

--- a/ui/app/components/send/send-v2-container.js
+++ b/ui/app/components/send/send-v2-container.js
@@ -77,5 +77,6 @@ function mapDispatchToProps (dispatch) {
     updateSendAmount: newAmount => dispatch(actions.updateSendAmount(newAmount)),
     updateSendMemo: newMemo => dispatch(actions.updateSendMemo(newMemo)),
     updateSendErrors: newError => dispatch(actions.updateSendErrors(newError)),
+    goHome: () => dispatch(actions.goHome()),
   }
 }

--- a/ui/app/components/send/send-v2-container.js
+++ b/ui/app/components/send/send-v2-container.js
@@ -76,5 +76,6 @@ function mapDispatchToProps (dispatch) {
     updateSendTo: newTo => dispatch(actions.updateSendTo(newTo)),
     updateSendAmount: newAmount => dispatch(actions.updateSendAmount(newAmount)),
     updateSendMemo: newMemo => dispatch(actions.updateSendMemo(newMemo)),
+    updateSendErrors: newError => dispatch(actions.updateSendErrors(newError)),
   }
 }

--- a/ui/app/components/send/send-v2-container.js
+++ b/ui/app/components/send/send-v2-container.js
@@ -14,13 +14,15 @@ const {
   getSelectedAddress,
   getGasPrice,
   getGasLimit,
+  getAddressBook,
 } = require('../../selectors')
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(SendEther)
 
 function mapStateToProps (state) {
-  const selectedAddress = getSelectedAddress(state);
-  const selectedToken = getSelectedToken(state);
+  const fromAccounts = accountsWithSendEtherInfoSelector(state)
+  const selectedAddress = getSelectedAddress(state)
+  const selectedToken = getSelectedToken(state)
   const tokenExchangeRates = state.metamask.tokenExchangeRates
   const selectedTokenExchangeRate = getSelectedTokenExchangeRate(state)
   const conversionRate = conversionRateSelector(state)
@@ -45,7 +47,8 @@ function mapStateToProps (state) {
 
   return {
     selectedAccount: getCurrentAccountWithSendEtherInfo(state),
-    accounts: accountsWithSendEtherInfoSelector(state),
+    fromAccounts,
+    toAccounts: [...fromAccounts, ...getAddressBook(state)],
     conversionRate,
     selectedToken,
     primaryCurrency,
@@ -66,6 +69,7 @@ function mapDispatchToProps (dispatch) {
       dispatch(actions.signTokenTx(tokenAddress, toAddress, amount, txData))
     ),
     signTx: txParams => dispatch(actions.signTx(txParams)),
-    setSelectedAddress: address => dispatch(actions.setSelectedAddress(address))
+    setSelectedAddress: address => dispatch(actions.setSelectedAddress(address)),
+    addToAddressBook: address => dispatch(actions.addToAddressBook(address)),
   }
 }

--- a/ui/app/components/send/to-autocomplete.js
+++ b/ui/app/components/send/to-autocomplete.js
@@ -11,7 +11,7 @@ function ToAutoComplete () {
 }
 
 ToAutoComplete.prototype.render = function () {
-  const { to, accounts, onChange } = this.props
+  const { to, accounts, onChange, inError } = this.props
 
   return h('div.send-v2__to-autocomplete', [
 
@@ -19,15 +19,15 @@ ToAutoComplete.prototype.render = function () {
       name: 'address',
       list: 'addresses',
       placeholder: 'Recipient Address',
+      className: inError ? `send-v2__error-border` : '', 
       value: to,
       onChange,
-      // onBlur: () => {
-      //   this.setErrorsFor('to')
-      // },
       onFocus: event => {
-        // this.clearErrorsFor('to')
         to && event.target.select()
       },
+      style: {
+        borderColor: inError ? 'red' : null,
+      }
     }),
 
     h('datalist#addresses', [

--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -157,14 +157,11 @@ const multiplyCurrencies = (a, b, options = {}) => {
 }
 
 const conversionGreaterThan = (
-  { value, fromNumericBase },
-  { value: compareToValue, fromNumericBase: compareToBase },
+  { ...firstProps },
+  { ...secondProps  },
 ) => {
-  const firstValue = converter({ value, fromNumericBase })
-  const secondValue = converter({
-    value: compareToValue,
-    fromNumericBase: compareToBase,
-  })
+  const firstValue = converter({ ...firstProps })
+  const secondValue = converter({ ...secondProps })
   return firstValue.gt(secondValue)
 }
 

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -497,6 +497,17 @@
     width: 287px;
   }
 
+  &__error {
+    font-size: 12px;
+    line-height: 12px;
+    left: 8px;
+    color: $red;
+  }
+
+  &__error-border {
+    color: $red;
+  }
+
   &__form {
     display: flex;
     flex-direction: column;

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -24,6 +24,11 @@ function reduceMetamask (state, action) {
     send: {
       gasLimit: null,
       gasPrice: null,
+      gasTotal: null,
+      from: '',
+      to: '',
+      amount: '0x0',
+      memo: '',
     },
   }, state.metamask)
 
@@ -157,6 +162,7 @@ function reduceMetamask (state, action) {
         tokens: action.newTokens,
       })
 
+    // metamask.send
     case actions.UPDATE_GAS_LIMIT:
       return extend(metamaskState, {
         send: {
@@ -176,6 +182,46 @@ function reduceMetamask (state, action) {
     case actions.TOGGLE_ACCOUNT_MENU:
       return extend(metamaskState, {
         isAccountMenuOpen: !metamaskState.isAccountMenuOpen,
+      })
+
+    case actions.UPDATE_GAS_TOTAL:
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          gasTotal: action.value,
+        },
+      })
+
+    case actions.UPDATE_SEND_FROM:
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          from: action.value,
+        },
+      })
+
+    case actions.UPDATE_SEND_TO:
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          to: action.value,
+        },
+      })
+
+    case actions.UPDATE_SEND_AMOUNT:
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          amount: action.value,
+        },
+      })
+
+    case actions.UPDATE_SEND_MEMO:
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          memo: action.value,
+        },
       })
 
     default:

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -29,6 +29,7 @@ function reduceMetamask (state, action) {
       to: '',
       amount: '0x0',
       memo: '',
+      errors: {},
     },
   }, state.metamask)
 
@@ -221,6 +222,21 @@ function reduceMetamask (state, action) {
         send: {
           ...metamaskState.send,
           memo: action.value,
+        },
+      })
+
+    case actions.UPDATE_SEND_ERRORS:
+      console.log(123, {
+        ...metamaskState.send.errors,
+        ...action.value,
+      })
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          errors: {
+            ...metamaskState.send.errors,
+            ...action.value,
+          }
         },
       })
 

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -12,6 +12,7 @@ const selectors = {
   getCurrentAccountWithSendEtherInfo,
   getGasPrice,
   getGasLimit,
+  getAddressBook,
 }
 
 module.exports = selectors
@@ -57,6 +58,10 @@ function getSelectedTokenExchangeRate (state) {
 
 function conversionRateSelector (state) {
   return state.metamask.conversionRate
+}
+
+function getAddressBook (state) {
+  return state.metamask.addressBook
 }
 
 function accountsWithSendEtherInfoSelector (state) {

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -13,6 +13,7 @@ const selectors = {
   getGasPrice,
   getGasLimit,
   getAddressBook,
+  getSendFrom,
 }
 
 module.exports = selectors
@@ -106,4 +107,8 @@ function getGasPrice (state) {
 
 function getGasLimit (state) {
   return state.metamask.send.gasLimit
+}
+
+function getSendFrom (state) {
+  return state.metamask.send.from
 }

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -28,6 +28,9 @@ function SendTransactionScreen () {
     memo: '',
     dropdownOpen: false,
   }
+
+  this.handleToChange = this.handleToChange.bind(this)
+  this.handleAmountChange = this.handleAmountChange.bind(this)
 }
 
 SendTransactionScreen.prototype.componentWillMount = function () {
@@ -97,149 +100,203 @@ SendTransactionScreen.prototype.renderCopy = function () {
   ])
 }
 
-SendTransactionScreen.prototype.render = function () {
+SendTransactionScreen.prototype.renderHeader = function () {
+  return h('div', [
+    h('div.send-v2__header', {}, [
+
+      this.renderHeaderIcon(),
+
+      h('div.send-v2__arrow-background', [
+        h('i.fa.fa-lg.fa-arrow-circle-right.send-v2__send-arrow-icon'),
+      ]),
+
+      h('div.send-v2__header-tip'),
+
+    ]),
+
+    this.renderTitle(),
+
+    this.renderCopy(),
+  ])
+}
+
+SendTransactionScreen.prototype.renderFromRow = function () {
   const {
     accounts,
     conversionRate,
-    tokenToUSDRate,
-    selectedToken,
-    showCustomizeGasModal,
     selectedAccount,
     setSelectedAddress,
+  } = this.props
+
+  const { dropdownOpen } = this.state
+
+  return h('div.send-v2__form-row', [
+
+    h('div.send-v2__form-label', 'From:'),
+
+    h(FromDropdown, {
+      dropdownOpen,
+      accounts,
+      selectedAccount,
+      onSelect: address => setSelectedAddress(address),
+      openDropdown: () => this.setState({ dropdownOpen: true }),
+      closeDropdown: () => this.setState({ dropdownOpen: false }),
+      conversionRate,
+    }),
+
+  ])
+}
+
+SendTransactionScreen.prototype.handleToChange = function (event) {
+  const to = event.target.value
+
+  this.setState({
+    ...this.state,
+    to,
+  })
+}
+
+SendTransactionScreen.prototype.renderToRow = function () {
+  const { accounts } = this.props
+  const { to } = this.state
+
+  return h('div.send-v2__form-row', [
+
+    h('div.send-v2__form-label', 'To:'),
+
+    h(ToAutoComplete, {
+      to,
+      accounts,
+      onChange: this.handleToChange,
+    }),
+
+  ])
+}
+
+SendTransactionScreen.prototype.handleAmountChange = function (value) {
+  const amount = value
+
+  this.setState({
+    ...this.state,
+    amount,
+  })
+}
+
+SendTransactionScreen.prototype.renderAmountRow = function () {
+  const {
+    conversionRate,
+    tokenToUSDRate,
+    selectedToken,
     primaryCurrency = 'ETH',
+  } = this.props
+
+  const { amount } = this.state
+
+  const amountConversionRate = selectedToken ? tokenToUSDRate : conversionRate
+
+  return h('div.send-v2__form-row', [
+
+    h('div.send-v2__form-label', 'Amount:'),
+
+    h(CurrencyDisplay, {
+      primaryCurrency,
+      convertedCurrency: 'USD',
+      value: amount,
+      conversionRate: amountConversionRate,
+      convertedPrefix: '$',
+      handleChange: this.handleAmountChange
+    }),        
+
+  ])
+}
+
+SendTransactionScreen.prototype.renderGasRow = function () {
+  const {
+    conversionRate,
+    showCustomizeGasModal,
     gasLimit,
     gasPrice,
   } = this.props
 
-  const {
-    dropdownOpen,
-    to,
-    amount,
-    // gasLimit,
-    // gasPrice,
-    memo,
-  } = this.state
+  return h('div.send-v2__form-row', [
 
-  const amountConversionRate = selectedToken ? tokenToUSDRate : conversionRate
+    h('div.send-v2__form-label', 'Gas fee:'),
 
+    h(GasFeeDisplay, {
+      gasLimit,
+      gasPrice,
+      conversionRate,
+      onClick: showCustomizeGasModal,
+    }),
+
+    h('div.send-v2__sliders-icon-container', {
+      onClick: showCustomizeGasModal,
+    }, [
+      h('i.fa.fa-sliders.send-v2__sliders-icon'),
+    ])          
+
+  ])
+}
+
+SendTransactionScreen.prototype.renderMemoRow = function () {
+  const { memo } = this.state
+
+  return h('div.send-v2__form-row', [
+
+    h('div.send-v2__form-label', 'Transaction Memo:'),
+
+    h(MemoTextArea, {
+      memo,
+      onChange: (event) => {
+        this.setState({
+          ...this.state,
+          memo: event.target.value,
+        })
+      },
+    }),
+
+  ])
+}
+
+SendTransactionScreen.prototype.renderForm = function () {
+  return h('div.send-v2__form', {}, [
+
+    this.renderFromRow(),
+
+    this.renderToRow(),
+
+    this.renderAmountRow(),
+
+    this.renderGasRow(),
+
+    this.renderMemoRow(),
+
+  ])
+}
+
+SendTransactionScreen.prototype.renderFooter = function () {
+  const { goHome } = this.props
+
+  return h('div.send-v2__footer', [
+    h('button.send-v2__cancel-btn', {
+      onClick: goHome,
+    }, 'Cancel'),
+    h('button.send-v2__next-btn', {
+      onClick: event => this.onSubmit(event),
+    }, 'Next'),
+  ])
+}
+
+SendTransactionScreen.prototype.render = function () {
   return (
 
     h('div.send-v2__container', [
-      h('div.send-v2__header', {}, [
 
-        this.renderHeaderIcon(),
+      this.renderHeader(),
 
-        h('div.send-v2__arrow-background', [
-          h('i.fa.fa-lg.fa-arrow-circle-right.send-v2__send-arrow-icon'),
-        ]),
+      this.renderForm(),
 
-        h('div.send-v2__header-tip'),
-
-      ]),
-
-      this.renderTitle(),
-
-      this.renderCopy(),
-
-      h('div.send-v2__form', {}, [
-
-        h('div.send-v2__form-row', [
-
-          h('div.send-v2__form-label', 'From:'),
-
-          h(FromDropdown, {
-            dropdownOpen,
-            accounts,
-            selectedAccount,
-            onSelect: address => setSelectedAddress(address),
-            openDropdown: () => this.setState({ dropdownOpen: true }),
-            closeDropdown: () => this.setState({ dropdownOpen: false }),
-            conversionRate,
-          }),
-
-        ]),
-
-        h('div.send-v2__form-row', [
-
-          h('div.send-v2__form-label', 'To:'),
-
-          h(ToAutoComplete, {
-            to,
-            accounts,
-            onChange: (event) => {
-              this.setState({
-                ...this.state,
-                to: event.target.value,
-              })
-            },
-          }),
-
-        ]),
-
-        h('div.send-v2__form-row', [
-
-          h('div.send-v2__form-label', 'Amount:'),
-
-          h(CurrencyDisplay, {
-            primaryCurrency,
-            convertedCurrency: 'USD',
-            value: amount,
-            conversionRate: amountConversionRate,
-            convertedPrefix: '$',
-            handleChange: (value) => {
-              this.setState({
-                ...this.state,
-                amount: value,
-              })
-            }
-          }),          
-
-        ]),
-
-        h('div.send-v2__form-row', [
-
-          h('div.send-v2__form-label', 'Gas fee:'),
-
-          h(GasFeeDisplay, {
-            gasLimit,
-            gasPrice,
-            conversionRate,
-            onClick: showCustomizeGasModal,
-          }),
-
-          h('div.send-v2__sliders-icon-container', {
-            onClick: showCustomizeGasModal,
-          }, [
-            h('i.fa.fa-sliders.send-v2__sliders-icon'),
-          ])          
-
-        ]),
-
-        h('div.send-v2__form-row', [
-
-          h('div.send-v2__form-label', 'Transaction Memo:'),
-
-          h(MemoTextArea, {
-            memo,
-            onChange: (event) => {
-              this.setState({
-                ...this.state,
-                memo: event.target.value,
-              })
-            },
-          }),
-
-        ]),
-
-      ]),
-
-      // Buttons underneath card
-      h('div.send-v2__footer', [
-        h('button.send-v2__cancel-btn', {}, 'Cancel'),
-        h('button.send-v2__next-btn', {
-          onClick: event => this.onSubmit(event),
-        }, 'Next'),
-      ]),
+      this.renderFooter(),
     ])
 
   )

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -122,7 +122,7 @@ SendTransactionScreen.prototype.renderHeader = function () {
 
 SendTransactionScreen.prototype.renderFromRow = function () {
   const {
-    accounts,
+    fromAccounts,
     conversionRate,
     selectedAccount,
     setSelectedAddress,
@@ -136,7 +136,7 @@ SendTransactionScreen.prototype.renderFromRow = function () {
 
     h(FromDropdown, {
       dropdownOpen,
-      accounts,
+      accounts: fromAccounts,
       selectedAccount,
       onSelect: address => setSelectedAddress(address),
       openDropdown: () => this.setState({ dropdownOpen: true }),
@@ -157,7 +157,7 @@ SendTransactionScreen.prototype.handleToChange = function (event) {
 }
 
 SendTransactionScreen.prototype.renderToRow = function () {
-  const { accounts } = this.props
+  const { toAccounts } = this.props
   const { to } = this.state
 
   return h('div.send-v2__form-row', [
@@ -166,7 +166,7 @@ SendTransactionScreen.prototype.renderToRow = function () {
 
     h(ToAutoComplete, {
       to,
-      accounts,
+      accounts: toAccounts,
       onChange: this.handleToChange,
     }),
 
@@ -302,6 +302,14 @@ SendTransactionScreen.prototype.render = function () {
   )
 }
 
+SendTransactionScreen.prototype.addToAddressBookIfNew = function (newAddress) {
+  const { toAccounts, addToAddressBook } = this.props
+  if (!toAccounts.find(({ address }) => newAddress === address)) {
+    // TODO: nickname, i.e. addToAddressBook(recipient, nickname)
+    addToAddressBook(newAddress)
+  }
+}
+
 SendTransactionScreen.prototype.onSubmit = function (event) {
   event.preventDefault()
   const {
@@ -315,7 +323,10 @@ SendTransactionScreen.prototype.onSubmit = function (event) {
     signTx,
     selectedToken,
     selectedAccount: { address: from },
+    toAccounts,
   } = this.props
+
+  this.addToAddressBookIfNew(to)
 
   const txParams = {
     from,


### PR DESCRIPTION
This PR ultimately adds error handling for the 'to' and 'amount' fields. In addition it:

- Breaks send-v2 down into renderable functions.
- Get addressBook accounts in send-v2
- Moves all of send state to metamask state.

This PR includes code from 4 branches and can be broken down if needed

![errorhandling-33](https://user-images.githubusercontent.com/7499938/31687468-e7572974-b363-11e7-8cfb-47925b726a1e.gif)
