### PR TITLE
[NewUI]  Fix confirm token gas, and identicon sent to

### DIFF
--- a/ui/app/components/pending-tx/confirm-send-token.js
+++ b/ui/app/components/pending-tx/confirm-send-token.js
@@ -145,14 +145,14 @@ ConfirmSendToken.prototype.getData = function () {
   const { value } = params[0] || {}
   const txMeta = this.gatherTxMeta()
   const txParams = txMeta.txParams || {}
-
+  
   return {
     from: {
       address: txParams.from,
       name: identities[txParams.from].name,
     },
     to: {
-      address: txParams.to,
+      address: value,
       name: identities[value] ? identities[value].name : 'New Recipient',
     },
     memo: txParams.memo || '',
@@ -290,7 +290,7 @@ ConfirmSendToken.prototype.render = function () {
             h(
               Identicon,
               {
-                address: txParams.to,
+                address: toAddress,
                 diameter: 60,
               },
             ),

--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -147,16 +147,16 @@ const addCurrencies = (a, b, options = {}) => {
 
 const multiplyCurrencies = (a, b, options = {}) => {
   const {
-    toNumericBase,
-    numberOfDecimals,
     multiplicandBase,
     multiplierBase,
+    ...conversionOptions,
   } = options
+
   const value = (new BigNumber(a, multiplicandBase)).times(b, multiplierBase);
+
   return converter({
     value,
-    toNumericBase,
-    numberOfDecimals,
+    ...conversionOptions,
   })
 }
 

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -6,6 +6,7 @@ const selectors = {
   getSelectedAccount,
   getSelectedToken,
   getSelectedTokenExchangeRate,
+  getTokenExchangeRate,
   conversionRateSelector,
   transactionsSelector,
   accountsWithSendEtherInfoSelector,
@@ -57,7 +58,15 @@ function getSelectedTokenExchangeRate (state) {
   return tokenExchangeRate
 }
 
-function conversionRateSelector (state) {
+function getTokenExchangeRate (state, tokenSymbol) {
+  const pair = `${tokenSymbol.toLowerCase()}_eth`
+  const tokenExchangeRates = state.metamask.tokenExchangeRates
+  const { rate: tokenExchangeRate = 0 } = tokenExchangeRates[pair] || {}
+
+  return tokenExchangeRate
+}
+
+function conversionRateSelector (state) { 
   return state.metamask.conversionRate
 }
 


### PR DESCRIPTION
This PR fixes two issues:
- It correctly converts eth to token in the gas fields on the confirm screen
- It shows the correct identicon being sent to when sending a token, instead of the identicon for the token

Before:

<img width="391" alt="screen shot 2017-10-17 at 9 43 56 pm" src="https://user-images.githubusercontent.com/7499938/31735844-9f295504-b41d-11e7-9d80-d9722c133c3f.png">

After:

<img width="369" alt="screen shot 2017-10-18 at 3 55 35 pm" src="https://user-images.githubusercontent.com/7499938/31735853-a7c69fbe-b41d-11e7-9d99-5002ee119dc0.png">

