### PR TITLE
[NewUI-flat] Fixes add token search.

### DIFF
--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -105,6 +105,7 @@ AddTokenScreen.prototype.tokenAddressDidChange = function (e) {
 }
 
 AddTokenScreen.prototype.checkExistingAddresses = function (address) {
+  if (!address) return false
   const tokensList = this.props.tokens
   const matchesAddress = existingToken => {
     return existingToken.address.toLowerCase() === address.toLowerCase()

--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -7,7 +7,9 @@ const Fuse = require('fuse.js')
 const contractMap = require('eth-contract-metadata')
 const TokenBalance = require('./components/token-balance')
 const Identicon = require('./components/identicon')
-const contractList = Object.entries(contractMap).map(([ _, tokenData]) => tokenData)
+const contractList = Object.entries(contractMap)
+  .map(([ _, tokenData]) => tokenData)
+  .filter(tokenData => Boolean(tokenData.erc20))
 const fuse = new Fuse(contractList, {
     shouldSort: true,
     threshold: 0.45,


### PR DESCRIPTION
This PR fixes two issues in add token search: the first prevents rendering of search results with less than 6 matches, the second shows contracts that in https://github.com/MetaMask/eth-contract-metadata/ but are not erc20 in search results

Searching "an" before 89573533b8da75138bddffbadbaeff6f9eb68001:

![brokenaddtoken](https://user-images.githubusercontent.com/7499938/31825488-fa7fddfe-b58c-11e7-9354-b6f8fa9de361.gif)

Searching "an" after 89573533b8da75138bddffbadbaeff6f9eb68001:

![addtokenfixed](https://user-images.githubusercontent.com/7499938/31825516-0e8d4fde-b58d-11e7-88d8-31824a22b421.gif)

Searching "en" before b25c73a866140e362ea27d455101d07ccf1a56e6:

<img width="451" alt="screen shot 2017-10-20 at 12 00 00 pm" src="https://user-images.githubusercontent.com/7499938/31826151-da9fca9c-b58e-11e7-8295-669aa2531e16.png">

Searching "en" after b25c73a866140e362ea27d455101d07ccf1a56e6:

<img width="473" alt="screen shot 2017-10-20 at 12 00 41 pm" src="https://user-images.githubusercontent.com/7499938/31826174-e7e8d61c-b58e-11e7-954b-e5481a496708.png">


