### PR TITLE
[NewUI] Fixes regression in confirm-send-token

### DIFF
--- a/ui/app/components/pending-tx/confirm-send-token.js
+++ b/ui/app/components/pending-tx/confirm-send-token.js
@@ -36,6 +36,7 @@ function mapStateToProps (state, ownProps) {
   const {
     conversionRate,
     identities,
+    currentCurrency,
   } = state.metamask
   const accounts = state.metamask.accounts
   const selectedAddress = getSelectedAddress(state)
@@ -47,6 +48,7 @@ function mapStateToProps (state, ownProps) {
     selectedAddress,
     tokenExchangeRate,
     tokenData: tokenData || {},
+    currentCurrency: currentCurrency.toUpperCase(),
   }
 }
 
@@ -101,7 +103,7 @@ ConfirmSendToken.prototype.getGasFee = function () {
     multiplierBase: 16,
   })
 
-  const FIAT = conversionUtil(txFeeBn, {
+  const FIAT = conversionUtil(gasTotal, {
     fromNumericBase: 'BN',
     toNumericBase: 'dec',
     fromDenomination: 'WEI',
@@ -223,7 +225,7 @@ ConfirmSendToken.prototype.renderTotalPlusGas = function () {
 
         h('div.confirm-screen-section-column', [
           h('div.confirm-screen-row-info', `${fiatAmount + fiatGas} ${currentCurrency}`),
-          h('div.confirm-screen-row-detail', `${tokenAmount + tokenGas} ${symbol}`),
+          h('div.confirm-screen-row-detail', `${tokenTotal} ${symbol}`),
         ]),
       ])
     )


### PR DESCRIPTION
There are changes that were made in https://github.com/MetaMask/metamask-extension/pull/2394/files that are not in NewUI-flat

<img width="362" alt="screen shot 2017-10-20 at 6 15 44 pm" src="https://user-images.githubusercontent.com/7499938/31841133-bd1205d8-b5c2-11e7-913b-6207905ca922.png">
