### PR TITLE
Update the state when a new account is added

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -356,7 +356,25 @@ function navigateToNewAccountScreen () {
 
 function addNewAccount () {
   log.debug(`background.addNewAccount`)
-  return callBackgroundThenUpdate(background.addNewAccount)
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication('This may take a while, be patient.'))
+    log.debug(`background.addNewAccount`)
+    background.addNewAccount((err) => {
+      if (err) return dispatch(actions.displayWarning(err.message))
+      log.debug(`background.getState`)
+      background.getState((err, newState) => {
+        dispatch(actions.hideLoadingIndication())
+        if (err) {
+          return dispatch(actions.displayWarning(err.message))
+        }
+        dispatch(actions.updateMetamaskState(newState))
+        dispatch({
+          type: actions.SHOW_ACCOUNT_DETAIL,
+          value: newState.selectedAddress,
+        })
+      })
+    })
+  }
 }
 
 function showInfoPage () {


### PR DESCRIPTION
When a new account is added, the selected address in the prop in `AccountDropdowns` component is not updated since the new state is not passed to there. That is the reason why the check mark does not move when adding a new account.

This patch is to get the updated new state when an account is created and dispatch `SHOW_ACCOUNT_DETAIL` action with it.

Fixes: https://github.com/MetaMask/metamask-extension/issues/2349

<details><summary>Screen capture gif</summary>
<img src="https://user-images.githubusercontent.com/1716463/31854543-75ae5a5a-b69b-11e7-9d73-783d4ca4244f.gif">
</details>