### PR TITLE
Temporarily reversal of json-rpc-engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "iframe-stream": "^3.0.0",
     "inject-css": "^0.1.1",
     "jazzicon": "^1.2.0",
-    "json-rpc-engine": "^3.2.0",
+    "json-rpc-engine": "3.2.0",
     "json-rpc-middleware-stream": "^1.0.1",
     "loglevel": "^1.4.1",
     "metamascara": "^1.3.1",


### PR DESCRIPTION
Fixes two issues in production, temporarily reversal until we can find better fixes for:

- Transactions unable to be rejected.
- Disconnected provider whenever an error in the provider occurs.

So that people at this hackathon can use MetaMask.