### PR TITLE
[NewUI] Disable Send-v2 next button when form is in error

### DIFF
--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -652,7 +652,8 @@
   }
 
   &__next-btn,
-  &__cancel-btn {
+  &__cancel-btn,
+  &__next-btn__disabled {
     width: 163px;
     text-align: center;
     height: 55px;
@@ -667,14 +668,15 @@
     border: 1px solid;
   }
 
+  &__next-btn,
+  &__next-btn__disabled {
+    color: $curious-blue;
+    border-color: $curious-blue;
+  }
+
   &__next-btn__disabled {
     opacity: .5;
     cursor: auto;
-  }
-
-  &__next-btn {
-    color: $curious-blue;
-    border-color: $curious-blue;
   }
 
   &__cancel-btn {

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -382,7 +382,14 @@ SendTransactionScreen.prototype.renderForm = function () {
 }
 
 SendTransactionScreen.prototype.renderFooter = function () {
-  const { goHome, clearSend } = this.props
+  const {
+    goHome,
+    clearSend,
+    errors: { amount: amountError, to: toError }
+  } = this.props
+  
+  const noErrors = amountError === null && toError === null
+  const errorClass = noErrors ? '' : '__disabled'
 
   return h('div.send-v2__footer', [
     h('button.send-v2__cancel-btn', {
@@ -391,8 +398,8 @@ SendTransactionScreen.prototype.renderFooter = function () {
         goHome()
       },
     }, 'Cancel'),
-    h('button.send-v2__next-btn', {
-      onClick: event => this.onSubmit(event),
+    h(`button.send-v2__next-btn${errorClass}`, {
+      onClick: event => noErrors && this.onSubmit(event),
     }, 'Next'),
   ])
 }


### PR DESCRIPTION
This PR adds code to disable the "Next" button on the send screen before required fields are filled out or when a field is in error.

![sendv2-next-disabled](https://user-images.githubusercontent.com/7499938/31907240-d3460208-b80d-11e7-9d14-9680318b015d.gif)
