### PR TITLE
[NewUI] Activate info page

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -993,7 +993,7 @@ function setProviderType (type) {
       dispatch(actions.updateProviderType(type))
       dispatch(actions.setSelectedToken())
     })
-    
+
   }
 }
 

--- a/ui/app/components/account-menu/index.js
+++ b/ui/app/components/account-menu/index.js
@@ -38,6 +38,10 @@ function mapDispatchToProps (dispatch) {
       dispatch(actions.showConfigPage())
       dispatch(actions.toggleAccountMenu())
     },
+    showInfoPage: () => {
+      dispatch(actions.showInfoPage())
+      dispatch(actions.toggleAccountMenu())
+    },
     showNewAccountModal: () => {
       dispatch(actions.showModal({ name: 'NEW_ACCOUNT' }))
       dispatch(actions.toggleAccountMenu())
@@ -57,6 +61,7 @@ AccountMenu.prototype.render = function () {
     showImportPage,
     lockMetamask,
     showConfigPage,
+    showInfoPage,
   } = this.props
 
   return h(Menu, { className: 'account-menu', isShowing: isAccountMenuOpen }, [
@@ -83,6 +88,7 @@ AccountMenu.prototype.render = function () {
     }),
     h(Divider),
     h(Item, {
+      onClick: showInfoPage,
       icon: h('img', { src: 'images/mm-info-icon.svg' }),
       text: 'Info & Help',
     }),


### PR DESCRIPTION
The info component and its action were already defined but they were not called from the `account-menu`.

Fixes: https://github.com/MetaMask/metamask-extension/issues/2444