### PR TITLE
[NewUI] Fix "send 120 tokens" bug.

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -1,5 +1,6 @@
 const abi = require('human-standard-token-abi')
 const getBuyEthUrl = require('../../app/scripts/lib/buy-eth-url')
+const ethUtil = require('ethereumjs-util')
 
 var actions = {
   _setBackgroundConnection: _setBackgroundConnection,
@@ -641,7 +642,7 @@ function signTokenTx (tokenAddress, toAddress, amount, txData) {
   return dispatch => {
     dispatch(actions.showLoadingIndication())
     const token = global.eth.contract(abi).at(tokenAddress)
-    token.transfer(toAddress, amount, txData)
+    token.transfer(toAddress, ethUtil.addHexPrefix(amount), txData)
       .catch(err => {
         dispatch(actions.hideLoadingIndication())
         dispatch(actions.displayWarning(err.message))


### PR DESCRIPTION
This PR fixes the bug that was described as follows:
"Send Token -- Enter 120 token will turn to 78 on conf tx

- input 100, turn into 64
- input 120, turn into 78
- input 300, turn into 300
- input 314, turn into 314
- input 200, turn into 200

For some reason, it only happens on 100 and 120."

The bug happens when the hex representation of the amount of tokens sent only contains digits. The `token.transfer` method called in `signTokenTx` assumes that a number made of only the digits 0-9 is a decimal number, and it does not convert it from hex when creating the transaction. So when sending 100 or 120 tokens, and when the token has 0 decimals, the confirm screen shows the hex representation of these numbers, which are made of only 0-9 digits.

To confirm this assessment, consider the following results:
```
(120 * Math.pow(10, 0)).toString(16) // => "78"
(100 * Math.pow(10, 0)).toString(16) // => "64"
parseInt("78", 16) // => 120
parseInt("64", 16) // => 100
```

The fix for this bug is simply to append `'0x'` to the amount before it is sent. This is done at the action level at the time of the api call. The `ethUtil.addHexPrefix` method only adds the hex prefix if it is not already added.

