### PR TITLE
[NewUI] Fix Settings/Info screen being visible on logout

### DIFF
--- a/ui/app/main-container.js
+++ b/ui/app/main-container.js
@@ -37,11 +37,7 @@ MainContainer.prototype.render = function () {
         break
       case 'config':
         log.debug('rendering config screen from unlock screen.')
-        contents = {
-          component: Settings,
-          key: 'config',
-        }
-        break
+        return h(Settings, {key: 'config'})
       default:
         log.debug('rendering locked screen')
         contents = {


### PR DESCRIPTION
Hi @danfinlay , was there previously a use case for showing the settings screen from the unlock/password prompt screen? I'm commenting out that code which fixes the issue of the Settings/Info screen being visible on logout.