### PR TITLE
[NewUI] Change min gas price to 0.1 GWEI

### DIFF
--- a/ui/app/components/customize-gas-modal/index.js
+++ b/ui/app/components/customize-gas-modal/index.js
@@ -2,6 +2,7 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const connect = require('react-redux').connect
+const ethUtil = require('ethereumjs-util')
 const actions = require('../../actions')
 const GasModalCard = require('./gas-modal-card')
 
@@ -224,7 +225,7 @@ CustomizeGasModal.prototype.render = function () {
           value: convertedGasPrice,
           min: MIN_GAS_PRICE_GWEI,
           // max: 1000,
-          step: 1,
+          step: MIN_GAS_PRICE_GWEI,
           onChange: value => this.convertAndSetGasPrice(value),
           title: 'Gas Price (GWEI)',
           copy: 'We calculate the suggested gas prices based on network success rates.',

--- a/ui/app/components/input-number.js
+++ b/ui/app/components/input-number.js
@@ -1,7 +1,12 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
-const { addCurrencies } = require('../conversion-util')
+const {
+  addCurrencies,
+  conversionGTE,
+  conversionLTE,
+  toNegative,
+} = require('../conversion-util')
 
 module.exports = InputNumber
 
@@ -17,8 +22,21 @@ InputNumber.prototype.setValue = function (newValue) {
 
   newValue = Number(fixed ? newValue.toFixed(4) : newValue)
 
-  if (newValue >= min && newValue <= max) {
+  const newValueGreaterThanMin = conversionGTE(
+    { value: newValue, fromNumericBase: 'dec' },
+    { value: min, fromNumericBase: 'hex' },
+  )
+
+  const newValueLessThanMax = conversionLTE(
+    { value: newValue, fromNumericBase: 'dec' },
+    { value: max, fromNumericBase: 'hex' },
+  )
+  if (newValueGreaterThanMin && newValueLessThanMax) {
     onChange(newValue)
+  } else if (!newValueGreaterThanMin) {
+    onChange(min)
+  } else if (!newValueLessThanMax) {
+    onChange(max)
   }
 }
 
@@ -29,7 +47,7 @@ InputNumber.prototype.render = function () {
     h('input.customize-gas-input', {
       placeholder,
       type: 'number',
-      value: value,
+      value,
       onChange: (e) => this.setValue(e.target.value),
     }),
     h('span.gas-tooltip-input-detail', {}, [unitLabel]),
@@ -39,7 +57,7 @@ InputNumber.prototype.render = function () {
       }),
       h('i.fa.fa-angle-down', {
         style: { cursor: 'pointer' },
-        onClick: () => this.setValue(addCurrencies(value, step * -1)),
+        onClick: () => this.setValue(addCurrencies(value, toNegative(step))),
       }),
     ]),
   ])

--- a/ui/app/components/pending-tx/confirm-deploy-contract.js
+++ b/ui/app/components/pending-tx/confirm-deploy-contract.js
@@ -10,9 +10,7 @@ const BN = ethUtil.BN
 const hexToBn = require('../../../../app/scripts/lib/hex-to-bn')
 const { conversionUtil } = require('../../conversion-util')
 
-const MIN_GAS_PRICE_GWEI_BN = new BN(1)
-const GWEI_FACTOR = new BN(1e9)
-const MIN_GAS_PRICE_BN = MIN_GAS_PRICE_GWEI_BN.mul(GWEI_FACTOR)
+const { MIN_GAS_PRICE_HEX } = require('../send/send-constants')
 
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(ConfirmDeployContract)
@@ -166,7 +164,7 @@ ConfirmDeployContract.prototype.getGasFee = function () {
   const gasBn = hexToBn(gas)
 
   // Gas Price
-  const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_BN.toString(16)
+  const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_HEX
   const gasPriceBn = hexToBn(gasPrice)
 
   const txFeeBn = gasBn.mul(gasPriceBn)

--- a/ui/app/components/pending-tx/confirm-send-ether.js
+++ b/ui/app/components/pending-tx/confirm-send-ether.js
@@ -10,9 +10,7 @@ const BN = ethUtil.BN
 const hexToBn = require('../../../../app/scripts/lib/hex-to-bn')
 const { conversionUtil, addCurrencies } = require('../../conversion-util')
 
-const MIN_GAS_PRICE_GWEI_BN = new BN(1)
-const GWEI_FACTOR = new BN(1e9)
-const MIN_GAS_PRICE_BN = MIN_GAS_PRICE_GWEI_BN.mul(GWEI_FACTOR)
+const { MIN_GAS_PRICE_HEX } = require('../send/send-constants')
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(ConfirmSendEther)
 
@@ -93,7 +91,7 @@ ConfirmSendEther.prototype.getGasFee = function () {
 //   const safeGasLimit = safeGasLimitBN.toString(10)
 
   // Gas Price
-  const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_BN.toString(16)
+  const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_HEX
   const gasPriceBn = hexToBn(gasPrice)
 
   const txFeeBn = gasBn.mul(gasPriceBn)

--- a/ui/app/components/pending-tx/confirm-send-token.js
+++ b/ui/app/components/pending-tx/confirm-send-token.js
@@ -17,9 +17,7 @@ const {
   addCurrencies,
 } = require('../../conversion-util')
 
-const MIN_GAS_PRICE_GWEI_BN = new BN(1)
-const GWEI_FACTOR = new BN(1e9)
-const MIN_GAS_PRICE_BN = MIN_GAS_PRICE_GWEI_BN.mul(GWEI_FACTOR)
+const { MIN_GAS_PRICE_HEX } = require('../send/send-constants')
 
 const {
   getSelectedTokenExchangeRate,
@@ -99,7 +97,7 @@ ConfirmSendToken.prototype.getGasFee = function () {
   const { decimals } = token
 
   const gas = txParams.gas
-  const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_BN.toString(16)
+  const gasPrice = txParams.gasPrice || MIN_GAS_PRICE_HEX
   const gasTotal = multiplyCurrencies(gas, gasPrice, {
     multiplicandBase: 16,
     multiplierBase: 16,

--- a/ui/app/components/send/send-constants.js
+++ b/ui/app/components/send/send-constants.js
@@ -1,20 +1,19 @@
+const ethUtil = require('ethereumjs-util')
 const Identicon = require('../identicon')
-const { multiplyCurrencies } = require('../../conversion-util')
+const { conversionUtil, multiplyCurrencies } = require('../../conversion-util')
 
-const MIN_GAS_PRICE_GWEI = '1'
-const GWEI_FACTOR = '1e9'
-const MIN_GAS_PRICE_HEX = multiplyCurrencies(GWEI_FACTOR, MIN_GAS_PRICE_GWEI, {
-	multiplicandBase: 16,
-	multiplierBase: 16,
-  toNumericBase: 'hex',
-})
-const MIN_GAS_PRICE_DEC = multiplyCurrencies(GWEI_FACTOR, MIN_GAS_PRICE_GWEI, {
-  multiplicandBase: 16,
-  multiplierBase: 16,
-  toNumericBase: 'dec',
-})
+const MIN_GAS_PRICE_HEX = (100000000).toString(16)
+const MIN_GAS_PRICE_DEC = '100000000'
 const MIN_GAS_LIMIT_HEX = (21000).toString(16)
 const MIN_GAS_LIMIT_DEC = 21000
+
+const MIN_GAS_PRICE_GWEI = ethUtil.addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
+  fromDenomination: 'WEI',
+  toDenomination: 'GWEI',
+  fromNumericBase: 'hex',
+  toNumericBase: 'hex',
+}))
+
 const MIN_GAS_TOTAL = multiplyCurrencies(MIN_GAS_LIMIT_HEX, MIN_GAS_PRICE_HEX, {
   toNumericBase: 'hex',
   multiplicandBase: 16,

--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -51,7 +51,7 @@ const toNormalizedDenomination = {
 }
 const toSpecifiedDenomination = {
   WEI: bigNumber => bigNumber.times(BIG_NUMBER_WEI_MULTIPLIER).round(),
-  GWEI: bigNumber => bigNumber.times(BIG_NUMBER_GWEI_MULTIPLIER).round(),
+  GWEI: bigNumber => bigNumber.times(BIG_NUMBER_GWEI_MULTIPLIER).round(1),
 }
 const baseChange = {
   hex: n => n.toString(16),
@@ -169,9 +169,34 @@ const conversionGreaterThan = (
   return firstValue.gt(secondValue)
 }
 
+const conversionGTE = (
+  { ...firstProps },
+  { ...secondProps  },
+) => {
+  const firstValue = converter({ ...firstProps })
+  const secondValue = converter({ ...secondProps })
+  return firstValue.greaterThanOrEqualTo(secondValue)
+}
+
+const conversionLTE = (
+  { ...firstProps },
+  { ...secondProps  },
+) => {
+  const firstValue = converter({ ...firstProps })
+  const secondValue = converter({ ...secondProps })
+  return firstValue.lessThanOrEqualTo(secondValue)
+}
+
+const toNegative = (n, options = {}) => {
+  return multiplyCurrencies(n, -1, options)
+}
+
 module.exports = {
   conversionUtil,
   addCurrencies,
   multiplyCurrencies,
   conversionGreaterThan,
+  conversionGTE,
+  conversionLTE,
+  toNegative,
 }


### PR DESCRIPTION
This PR allows the sending of gas prices with 0.1 GWEI. This makes NewUI-flat consistent with master after https://github.com/MetaMask/metamask-extension/commit/2489caddd4f42339a98cf0be767ad9cd003ad40c

![mingaspricegweicustomizer](https://user-images.githubusercontent.com/7499938/32063980-2eedfe20-ba53-11e7-8cc0-8125e0a410d8.gif)

----

![mingasprice0p1gwei](https://user-images.githubusercontent.com/7499938/32064000-38c2f374-ba53-11e7-8de6-49635ba60938.gif)

