### PR TITLE
[NewUI] Clear import error state

### DIFF
--- a/ui/app/accounts/import/private-key.js
+++ b/ui/app/accounts/import/private-key.js
@@ -17,6 +17,10 @@ function PrivateKeyImportView () {
   Component.call(this)
 }
 
+PrivateKeyImportView.prototype.componentWillUnmount = function () {
+  this.props.dispatch(actions.displayWarning(null))
+}
+
 PrivateKeyImportView.prototype.render = function () {
   const { error } = this.props
 

--- a/ui/app/components/account-menu/index.js
+++ b/ui/app/components/account-menu/index.js
@@ -32,6 +32,7 @@ function mapDispatchToProps (dispatch) {
     },
     lockMetamask: () => {
       dispatch(actions.lockMetamask())
+      dispatch(actions.displayWarning(null))
       dispatch(actions.toggleAccountMenu())
     },
     showConfigPage: () => {


### PR DESCRIPTION
This PR resolves the following bug:

```
1. Export your private key and copy it
2. Try to import account with the private key
3. Observe that there is an error message
4. Log out
5. Observe that same error message show up on login

-> Clear error message state on log out
-> Clear error message state on component unmount
```