### PR TITLE
[NewUI] Correct rendering of conversions when conversion rate is a token.

### DIFF
--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -6,7 +6,7 @@ const Identicon = require('./identicon')
 const prefixForNetwork = require('../../lib/etherscan-prefix-for-network')
 const selectors = require('../selectors')
 const actions = require('../actions')
-const { conversionUtil } = require('../conversion-util')
+const { conversionUtil, multiplyCurrencies } = require('../conversion-util')
 
 const TokenMenuDropdown = require('./dropdowns/token-menu-dropdown.js')
 
@@ -17,7 +17,7 @@ function mapStateToProps (state) {
     selectedTokenAddress: state.metamask.selectedTokenAddress,
     userAddress: selectors.getSelectedAddress(state),
     tokenExchangeRates: state.metamask.tokenExchangeRates,
-    ethToUSDRate: state.metamask.conversionRate,
+    conversionRate: state.metamask.conversionRate,
     sidebarOpen: state.appState.sidebarOpen,
   }
 }
@@ -61,7 +61,7 @@ TokenCell.prototype.render = function () {
     setSelectedToken,
     selectedTokenAddress,
     tokenExchangeRates,
-    ethToUSDRate,
+    conversionRate,
     hideSidebar,
     sidebarOpen,
     currentCurrency,
@@ -70,22 +70,26 @@ TokenCell.prototype.render = function () {
   
   const pair = `${symbol.toLowerCase()}_eth`;
 
-  let currentTokenToEthRate;
+  let currentTokenToFiatRate;
   let currentTokenInFiat;
-  let formattedUSD = ''
+  let formattedFiat = ''
 
   if (tokenExchangeRates[pair]) {
-    currentTokenToEthRate = tokenExchangeRates[pair].rate;
+    currentTokenToFiatRate = multiplyCurrencies(
+      tokenExchangeRates[pair].rate,
+      conversionRate
+    )
     currentTokenInFiat = conversionUtil(string, {
       fromNumericBase: 'dec',
       fromCurrency: symbol,
-      toCurrency: 'USD',
+      toCurrency: currentCurrency.toUpperCase(),
       numberOfDecimals: 2,
-      conversionRate: currentTokenToEthRate,
-      ethToUSDRate,
+      conversionRate: currentTokenToFiatRate,
     })
-    formattedUSD = `${currentTokenInFiat} ${currentCurrency.toUpperCase()}`;
+    formattedFiat = `${currentTokenInFiat} ${currentCurrency.toUpperCase()}`;
   }
+
+  const showFiat = Boolean(currentTokenInFiat) && currentCurrency.toUpperCase() !== symbol
  
   return (
     h('div.token-list-item', {
@@ -108,9 +112,9 @@ TokenCell.prototype.render = function () {
       h('h.token-list-item__balance-wrapper', null, [
         h('h3.token-list-item__token-balance', `${string || 0} ${symbol}`),
 
-        h('div.token-list-item__fiat-amount', {
+        showFiat && h('div.token-list-item__fiat-amount', {
           style: {},
-        }, formattedUSD),
+        }, formattedFiat),
       ]),
 
       h('i.fa.fa-ellipsis-h.fa-lg.token-list-item__ellipsis.cursor-pointer', {


### PR DESCRIPTION
The PR does the following:

1. Fixes a bug where selecting a token as a currency on the settings screen would prevent the user from opening the send screen. This occured when exchange rates had more than 15 significant digits, which was too many for the BigNumber library used in the `conversion-util`. The fix is to convert the conversion rate to a string before doing any multiplications with it.
2. Ensures that tokens are shown in the selected currency in the token list (wallet view) and transaction list (i.e. shown in addition to and below the number of tokens).
3. Prevents the value of the token from being shown in the selected currency if the selected currency is the token itself.

Succesful currency selection and sending:
![send-token-after-conversion-sigdig-fix](https://user-images.githubusercontent.com/7499938/32084240-7ee15c02-baa2-11e7-8001-1621f306e3c6.gif)

Various screen shots of the account details page when a token is selected as currency:

<img width="647" alt="screen shot 2017-10-26 at 10 51 55 pm" src="https://user-images.githubusercontent.com/7499938/32084262-a02bec88-baa2-11e7-8b11-82f9b51c439c.png">
-
<img width="646" alt="screen shot 2017-10-26 at 10 52 10 pm" src="https://user-images.githubusercontent.com/7499938/32084263-a043f576-baa2-11e7-9915-63d525360814.png">
-
<img width="664" alt="screen shot 2017-10-26 at 10 52 23 pm" src="https://user-images.githubusercontent.com/7499938/32084264-a05a6cac-baa2-11e7-85d9-f5a5d0c5cc9b.png">

**Results of QA testing:**

Sending ether, sending BAT with exchange rate and sending a custom token were all tested with ANT selected as the current currency.
Sending BAT was tested with BAT selected as the current currency.
Sending ether and sending BAT were tested with USD as the current currency.


