### PR TITLE
[NewUI] get token data in tx-list even if token has been removed

### DIFF
--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -21,9 +21,7 @@ const fuse = new Fuse(contractList, {
 })
 const actions = require('./actions')
 const ethUtil = require('ethereumjs-util')
-const abi = require('human-standard-token-abi')
-const Eth = require('ethjs-query')
-const EthContract = require('ethjs-contract')
+const { tokenInfoGetter } = require('./token-util')
 const R = require('ramda')
 
 const emptyAddr = '0x0000000000000000000000000000000000000000'
@@ -63,11 +61,7 @@ function AddTokenScreen () {
 }
 
 AddTokenScreen.prototype.componentWillMount = function () {
-  if (typeof global.ethereumProvider === 'undefined') return
-
-  this.eth = new Eth(global.ethereumProvider)
-  this.contract = new EthContract(this.eth)
-  this.TokenContract = this.contract(abi)
+  this.tokenInfoGetter = tokenInfoGetter()
 }
 
 AddTokenScreen.prototype.toggleToken = function (address, token) {
@@ -164,18 +158,11 @@ AddTokenScreen.prototype.validate = function () {
 }
 
 AddTokenScreen.prototype.attemptToAutoFillTokenParams = async function (address) {
-  const contract = this.TokenContract.at(address)
-
-  const results = await Promise.all([
-    contract.symbol(),
-    contract.decimals(),
-  ])
-
-  const [ symbol, decimals ] = results
+  const { symbol, decimals } = await this.tokenInfoGetter(address)
   if (symbol && decimals) {
     this.setState({
-      customSymbol: symbol[0],
-      customDecimals: decimals[0].toString(),
+      customSymbol: symbol,
+      customDecimals: decimals.toString(),
     })
   }
 }

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -9,6 +9,7 @@ const ShiftListItem = require('./shift-list-item')
 const { formatBalance, formatDate } = require('../util')
 const { showConfTxPage } = require('../actions')
 const classnames = require('classnames')
+const { tokenInfoGetter } = require('../token-util')
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(TxList)
 
@@ -28,6 +29,10 @@ function mapDispatchToProps (dispatch) {
 inherits(TxList, Component)
 function TxList () {
   Component.call(this)
+}
+
+TxList.prototype.componentWillMount = function () {
+  this.tokenInfoGetter = tokenInfoGetter()
 }
 
 TxList.prototype.render = function () {
@@ -99,6 +104,7 @@ TxList.prototype.renderTransactionListItem = function (transaction, conversionRa
     transactionAmount,
     transactionHash,
     conversionRate,
+    tokenInfoGetter: this.tokenInfoGetter,
   }
 
   const isUnapproved = transactionStatus === 'unapproved';

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -1,0 +1,36 @@
+const abi = require('human-standard-token-abi')
+const Eth = require('ethjs-query')
+const EthContract = require('ethjs-contract')
+
+const tokenInfoGetter = function () {
+  if (typeof global.ethereumProvider === 'undefined') return
+
+  const eth = new Eth(global.ethereumProvider)
+  const contract = new EthContract(eth)
+  const TokenContract = contract(abi)
+
+  const tokens = {}
+
+  return async (address) => {
+    if (tokens[address]) {
+      return tokens[address]
+    }
+
+    const contract = TokenContract.at(address)
+
+    const result = await Promise.all([
+      contract.symbol(),
+      contract.decimals(),
+    ])
+
+    const [ symbol = [], decimals = [] ] = result
+
+    tokens[address] = { symbol: symbol[0], decimals: decimals[0] }
+
+    return tokens[address]
+  }
+}
+
+module.exports = {
+  tokenInfoGetter,
+}


### PR DESCRIPTION
This PR fixes the following bug.
```
Reproduction steps:
1. Add a token
2. Send that token
3. Remove that token
The token list will now not know how to render the token sent
```
More specifically, before this PR a transaction of a token that had been removed from the wallet view list would have the text 'undefined' next to the amount of the transaction.

This PR fixes this by getting the token from the blockchain in case it is not available in state or from `eth-contract-metadata`

**BEFORE THIS PR**
<img width="714" alt="screen shot 2017-10-27 at 3 16 05 pm" src="https://user-images.githubusercontent.com/7499938/32117685-d4750f4c-bb29-11e7-95c1-dccc1b528aec.png">


**AFTER THIS PR**
<img width="664" alt="screen shot 2017-10-26 at 10 52 23 pm" src="https://user-images.githubusercontent.com/7499938/32117640-a9f5a06a-bb29-11e7-9215-5418c09bc86c.png">
