### PR TITLE
[NewUI] Fixes width of from and to dropdowns in extension and on mobile views.

### DIFF
--- a/ui/app/components/send/to-autocomplete.js
+++ b/ui/app/components/send/to-autocomplete.js
@@ -94,7 +94,7 @@ ToAutoComplete.prototype.render = function () {
     inError,
   } = this.props
 
-  return h('div.to-autocomplete', {}, [
+  return h('div.send-v2__to-autocomplete', {}, [
 
     h('input.send-v2__to-autocomplete__input', {
       placeholder: 'Recipient Address',

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -577,6 +577,7 @@
     line-height: 16px;
     font-size: 12px;
     color: $tundora;
+    position: relative;
 
     &__close-area {
       position: fixed;
@@ -591,7 +592,7 @@
       z-index: 1050;
       position: absolute;
       height: 220px;
-      width: 240px;
+      width: 100%;
       border: 1px solid $geyser;
       border-radius: 4px;
       background-color: $white;


### PR DESCRIPTION
The to and from dropdown on the send screen were overflowing out of the window when viewing the app through the extension or on various mobile views. This PR fixes that.

<img width="559" alt="screen shot 2017-10-30 at 8 07 39 pm" src="https://user-images.githubusercontent.com/7499938/32199195-79ef3b2e-bdae-11e7-9cfc-cbcbdd322409.png">
----
<img width="448" alt="screen shot 2017-10-30 at 8 07 47 pm" src="https://user-images.githubusercontent.com/7499938/32199197-7a0aa6e8-bdae-11e7-8ab0-06176c8802c9.png">
----
<img width="355" alt="screen shot 2017-10-30 at 8 07 58 pm" src="https://user-images.githubusercontent.com/7499938/32199198-7a1f8e32-bdae-11e7-871b-45dbfddabe74.png">
