### PR TITLE
issue#1929 fixed

### DIFF
--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -272,6 +272,10 @@ SendTransactionScreen.prototype.onSubmit = function () {
     return this.props.dispatch(actions.displayWarning(message))
   }
 
+  if(this.props.address==recipient){
+    alert("Warning the Recipient Address is same as Sender Address")
+  }
+
   if (!isHex(ethUtil.stripHexPrefix(txData)) && txData) {
     message = 'Transaction data must be hex string.'
     return this.props.dispatch(actions.displayWarning(message))


### PR DESCRIPTION
Fixes #1929 

shows alert message with the text "Warning the Recipient Address is same as Sender Address" when user tries to send eth to himself

![screenshot from 2017-11-07 23-06-06](https://user-images.githubusercontent.com/19390504/32508472-74358d2e-c410-11e7-9b57-37039ef38c23.png)
