### PR TITLE
[NewUI] Fix issues with amount max

### DIFF
--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -36,6 +36,28 @@ CurrencyDisplay.prototype.getAmount = function (value) {
     : toHexWei(value)
 }
 
+CurrencyDisplay.prototype.getValueToRender = function () {
+  const { selectedToken, conversionRate, value } = this.props
+
+  const { decimals, symbol } = selectedToken || {}
+  const multiplier = Math.pow(10, Number(decimals || 0))
+
+  return selectedToken
+    ? conversionUtil(value, {
+      fromNumericBase: 'hex',
+      toCurrency: symbol,
+      conversionRate: multiplier,
+      invertConversionRate: true,
+    })
+    : conversionUtil(value, {
+      fromNumericBase: 'hex',
+      toNumericBase: 'dec',
+      fromDenomination: 'WEI',
+      numberOfDecimals: 6,
+      conversionRate,
+    })
+}
+
 CurrencyDisplay.prototype.render = function () {
   const {
     className = 'currency-display',
@@ -50,13 +72,7 @@ CurrencyDisplay.prototype.render = function () {
     handleChange,
   } = this.props
 
-  const valueToRender = conversionUtil(value, {
-    fromNumericBase: 'hex',
-    toNumericBase: 'dec',
-    fromDenomination: 'WEI',
-    numberOfDecimals: 6,
-    conversionRate,
-  })
+  const valueToRender = this.getValueToRender()
 
   const convertedValue = conversionUtil(valueToRender, {
     fromNumericBase: 'dec',

--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -11,11 +11,6 @@ function CurrencyDisplay () {
   Component.call(this)
 }
 
-function isValidInput (text) {
-  const re = /^([1-9]\d*|0)(\.|\.\d*)?$/
-  return re.test(text)
-}
-
 function toHexWei (value) {
   return conversionUtil(value, {
     fromNumericBase: 'dec',
@@ -68,7 +63,6 @@ CurrencyDisplay.prototype.render = function () {
     convertedCurrency,
     readOnly = false,
     inError = false,
-    value,
     handleChange,
   } = this.props
 
@@ -81,8 +75,6 @@ CurrencyDisplay.prototype.render = function () {
     numberOfDecimals: 2,
     conversionRate,
   })
-
-  const inputSizeMultiplier = readOnly ? 1 : 1.2
 
   return h('div', {
     className,

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -307,7 +307,6 @@ SendTransactionScreen.prototype.handleAmountChange = function (value) {
 SendTransactionScreen.prototype.setAmountToMax = function () {
   const {
     from: { balance },
-    gasTotal,
     updateSendAmount,
     updateSendErrors,
     updateGasPrice,
@@ -323,7 +322,7 @@ SendTransactionScreen.prototype.setAmountToMax = function () {
     ? multiplyCurrencies(tokenBalance, multiplier, {toNumericBase: 'hex'})
     : subtractCurrencies(
       ethUtil.addHexPrefix(balance),
-      ethUtil.addHexPrefix(gasTotal),
+      ethUtil.addHexPrefix(MIN_GAS_TOTAL),
       { toNumericBase: 'hex' }
     )
 

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -328,9 +328,11 @@ SendTransactionScreen.prototype.setAmountToMax = function () {
     )
 
   updateSendErrors({ amount: null })
-  updateGasPrice(MIN_GAS_PRICE_HEX)
-  updateGasLimit(MIN_GAS_LIMIT_HEX)
-  updateGasTotal(MIN_GAS_TOTAL)
+  if (!selectedToken) {
+    updateGasPrice(MIN_GAS_PRICE_HEX)
+    updateGasLimit(MIN_GAS_LIMIT_HEX)
+    updateGasTotal(MIN_GAS_TOTAL)
+  }
   updateSendAmount(maxAmount)
 }
 


### PR DESCRIPTION
This PR currency-display so that passed tokens are correctly converted given their decimal value (needed now that currency-display is delegating handling of the state of the input value to its parent).

It also changes the max amount of ether to be based on the minimum gas price. (Whether we want to do this or base it on estimated gas price is a separate question, and if the answer to that question changes the required behaviour, we will resolve in a future PR. This just adjusts send to follow the currently intended behaviour).

All fixes some lint errors.