### PR TITLE
[NewUI] MM-146 #1: Allow editing of send ether transaction.

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -115,6 +115,7 @@ var actions = {
   TRANSACTION_ERROR: 'TRANSACTION_ERROR',
   NEXT_TX: 'NEXT_TX',
   PREVIOUS_TX: 'PREV_TX',
+  EDIT_TX: 'EDIT_TX',
   signMsg: signMsg,
   cancelMsg: cancelMsg,
   signPersonalMsg,
@@ -129,10 +130,13 @@ var actions = {
   completedTx: completedTx,
   txError: txError,
   nextTx: nextTx,
+  editTx,
   previousTx: previousTx,
   cancelAllTx: cancelAllTx,
   viewPendingTx: viewPendingTx,
   VIEW_PENDING_TX: 'VIEW_PENDING_TX',
+  updateTransactionParams,
+  UPDATE_TRANSACTION_PARAMS: 'UPDATE_TRANSACTION_PARAMS',
   // send screen
   estimateGas,
   getGasPrice,
@@ -668,6 +672,8 @@ function updateAndApproveTx (txData) {
     log.debug(`actions calling background.updateAndApproveTx`)
     background.updateAndApproveTransaction(txData, (err) => {
       dispatch(actions.hideLoadingIndication())
+      dispatch(actions.updateTransactionParams(txData.id, txData.txParams))
+      dispatch(actions.clearSend())
       if (err) {
         dispatch(actions.txError(err))
         dispatch(actions.goHome())
@@ -682,6 +688,14 @@ function completedTx (id) {
   return {
     type: actions.COMPLETED_TX,
     value: id,
+  }
+}
+
+function updateTransactionParams (id, txParams) {
+  return {
+    type: actions.UPDATE_TRANSACTION_PARAMS,
+    id,
+    value: txParams,
   }
 }
 
@@ -945,6 +959,13 @@ function viewPendingTx (txId) {
 function previousTx () {
   return {
     type: actions.PREVIOUS_TX,
+  }
+}
+
+function editTx (txId) {
+  return {
+    type: actions.EDIT_TX,
+    value: txId,
   }
 }
 

--- a/ui/app/components/currency-input.js
+++ b/ui/app/components/currency-input.js
@@ -40,7 +40,7 @@ function sanitizeDecimal (val) {
 //  sanitizeValue('.200') -> '0.200'
 //  sanitizeValue('a.b.1.c,89.123') -> '0.189123'
 function sanitizeValue (value) {
-  let [,integer, point, decimal] = (/([^.]*)([.]?)([^.]*)/).exec(value)
+  let [, integer, point, decimal] = (/([^.]*)([.]?)([^.]*)/).exec(value)
 
   integer = sanitizeInteger(integer) || '0'
   decimal = sanitizeDecimal(decimal)

--- a/ui/app/components/pending-tx/confirm-send-ether.js
+++ b/ui/app/components/pending-tx/confirm-send-ether.js
@@ -40,16 +40,15 @@ function mapDispatchToProps (dispatch) {
       const {
         gas: gasLimit,
         gasPrice,
-        from,
         to,
-        value: amount
+        value: amount,
       } = txParams
       dispatch(actions.editTx(id))
-      dispatch(actions.updateGasLimit(gasLimit)),
-      dispatch(actions.updateGasPrice(gasPrice)),
-      dispatch(actions.updateSendTo(to)),
-      dispatch(actions.updateSendAmount(amount)),
-      dispatch(actions.updateSendErrors({ to: null, amount: null })),
+      dispatch(actions.updateGasLimit(gasLimit))
+      dispatch(actions.updateGasPrice(gasPrice))
+      dispatch(actions.updateSendTo(to))
+      dispatch(actions.updateSendAmount(amount))
+      dispatch(actions.updateSendErrors({ to: null, amount: null }))
       dispatch(actions.showSendPage())
     },
     cancelTransaction: ({ id }) => dispatch(actions.cancelTx({ id })),
@@ -176,7 +175,7 @@ ConfirmSendEther.prototype.getData = function () {
 }
 
 ConfirmSendEther.prototype.render = function () {
-  const { editTransaction, selectedAddress, currentCurrency, clearSend } = this.props
+  const { editTransaction, currentCurrency, clearSend } = this.props
   const txMeta = this.gatherTxMeta()
   const txParams = txMeta.txParams || {}
 
@@ -441,7 +440,7 @@ ConfirmSendEther.prototype.getFormEl = function () {
 ConfirmSendEther.prototype.gatherTxMeta = function () {
   const props = this.props
   const state = this.state
-  let txData = clone(state.txData) || clone(props.txData)
+  const txData = clone(state.txData) || clone(props.txData)
 
   if (props.send.editingTransactionId) {
     const {
@@ -450,7 +449,7 @@ ConfirmSendEther.prototype.gatherTxMeta = function () {
         amount: value,
         gasLimit: gas,
         gasPrice,
-      }
+      },
     } = props
     const { txParams: { from, to } } = txData
     txData.txParams = {

--- a/ui/app/components/send/send-utils.js
+++ b/ui/app/components/send/send-utils.js
@@ -7,7 +7,7 @@ const {
   calcTokenAmount,
 } = require('../../token-util')
 
-function isBalanceSufficient({
+function isBalanceSufficient ({
   amount = '0x0',
   gasTotal = '0x0',
   balance,
@@ -39,7 +39,7 @@ function isBalanceSufficient({
   return balanceIsSufficient
 }
 
-function isTokenBalanceSufficient({
+function isTokenBalanceSufficient ({
   amount = '0x0',
   tokenBalance,
   decimals,

--- a/ui/app/components/send/send-v2-container.js
+++ b/ui/app/components/send/send-v2-container.js
@@ -63,6 +63,7 @@ function mapDispatchToProps (dispatch) {
       dispatch(actions.signTokenTx(tokenAddress, toAddress, amount, txData))
     ),
     signTx: txParams => dispatch(actions.signTx(txParams)),
+    updateAndApproveTx: txParams => dispatch(actions.updateAndApproveTx(txParams)),
     setSelectedAddress: address => dispatch(actions.setSelectedAddress(address)),
     addToAddressBook: address => dispatch(actions.addToAddressBook(address)),
     updateGasTotal: newTotal => dispatch(actions.updateGasTotal(newTotal)),
@@ -76,5 +77,6 @@ function mapDispatchToProps (dispatch) {
     updateSendErrors: newError => dispatch(actions.updateSendErrors(newError)),
     goHome: () => dispatch(actions.goHome()),
     clearSend: () => dispatch(actions.clearSend()),
+    backToConfirmScreen: editingTransactionId => dispatch(actions.showConfTxPage({ id: editingTransactionId })),
   }
 }

--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -151,7 +151,7 @@ const subtractCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(a, aBase)).minus(b, bBase);
+  const value = (new BigNumber(a, aBase)).minus(b, bBase)
 
   return converter({
     value,
@@ -183,7 +183,7 @@ const conversionGreaterThan = (
 ) => {
   const firstValue = converter({ ...firstProps })
   const secondValue = converter({ ...secondProps })
-  
+
   return firstValue.gt(secondValue)
 }
 

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -33,6 +33,7 @@ function reduceMetamask (state, action) {
       amount: '0x0',
       memo: '',
       errors: {},
+      editingTransactionId: null,
     },
     coinOptions: {},
   }, state.metamask)
@@ -107,6 +108,14 @@ function reduceMetamask (state, action) {
         }
       }
       return newState
+
+    case actions.EDIT_TX:
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          editingTransactionId: action.value,
+        },
+      })
 
     case actions.SHOW_NEW_VAULT_SEED:
       return extend(metamaskState, {
@@ -260,6 +269,20 @@ function reduceMetamask (state, action) {
           memo: '',
           errors: {},
         },
+      })
+
+    case actions.UPDATE_TRANSACTION_PARAMS:
+      const { id, value } = action
+      let { selectedAddressTxList } = metamaskState
+      selectedAddressTxList = selectedAddressTxList.map(tx => {
+        if (tx.id === id) {
+          tx.txParams = value
+        }
+        return tx
+      })
+
+      return extend(metamaskState, {
+        selectedAddressTxList,
       })
 
     case actions.PAIR_UPDATE:

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -150,9 +150,9 @@ function reduceMetamask (state, action) {
     case actions.SAVE_ACCOUNT_LABEL:
       const account = action.value.account
       const name = action.value.label
-      var id = {}
+      const id = {}
       id[account] = extend(metamaskState.identities[account], { name })
-      var identities = extend(metamaskState.identities, id)
+      const identities = extend(metamaskState.identities, id)
       return extend(metamaskState, { identities })
 
     case actions.SET_CURRENT_FIAT:
@@ -272,10 +272,10 @@ function reduceMetamask (state, action) {
       })
 
     case actions.UPDATE_TRANSACTION_PARAMS:
-      const { id, value } = action
+      const { id: txId, value } = action
       let { selectedAddressTxList } = metamaskState
       selectedAddressTxList = selectedAddressTxList.map(tx => {
-        if (tx.id === id) {
+        if (tx.id === txId) {
           tx.txParams = value
         }
         return tx

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -93,6 +93,9 @@ SendTransactionScreen.prototype.componentWillMount = function () {
     updateGasTotal,
     from,
     tokenContract,
+    editingTransactionId,
+    gasPrice,
+    gasLimit,
   } = this.props
   const { symbol } = selectedToken || {}
 
@@ -102,22 +105,32 @@ SendTransactionScreen.prototype.componentWillMount = function () {
 
   const estimateGasParams = getParamsForGasEstimate(selectedAddress, symbol, data)
 
-  Promise
-    .all([
-      getGasPrice(),
-      estimateGas(estimateGasParams),
-      tokenContract && tokenContract.balanceOf(from.address)
-    ])
-    .then(([gasPrice, gas, usersToken]) => {
+  let newGasTotal
+  if (!editingTransactionId) {
+    Promise
+      .all([
+        getGasPrice(),
+        estimateGas(estimateGasParams),
+        tokenContract && tokenContract.balanceOf(from.address)
+      ])
+      .then(([gasPrice, gas, usersToken]) => {
 
-      const newGasTotal = multiplyCurrencies(gas, gasPrice, {
-        toNumericBase: 'hex',
-        multiplicandBase: 16,
-        multiplierBase: 16,
+        const newGasTotal = multiplyCurrencies(gas, gasPrice, {
+          toNumericBase: 'hex',
+          multiplicandBase: 16,
+          multiplierBase: 16,
+        })
+        updateGasTotal(newGasTotal)
+        this.updateSendTokenBalance(usersToken)
       })
-      updateGasTotal(newGasTotal)
-      this.updateSendTokenBalance(usersToken)
+  } else {
+    newGasTotal = multiplyCurrencies(gasLimit, gasPrice, {
+      toNumericBase: 'hex',
+      multiplicandBase: 16,
+      multiplierBase: 16,
     })
+    updateGasTotal(newGasTotal)
+  }
 }
 
 SendTransactionScreen.prototype.componentDidUpdate = function (prevProps) {
@@ -394,6 +407,7 @@ SendTransactionScreen.prototype.renderAmountRow = function () {
     errors,
     amount,
   } = this.props
+
   return h('div.send-v2__form-row', [
     
     h('div.send-v2__form-label', [
@@ -551,9 +565,12 @@ SendTransactionScreen.prototype.onSubmit = function (event) {
     gasPrice,
     signTokenTx,
     signTx,
+    updateAndApproveTx,
     selectedToken,
-    clearSend,
+    toAccounts,
+    editingTransactionId,
     errors: { amount: amountError, to: toError },
+    backToConfirmScreen,
   } = this.props
 
   const noErrors = !amountError && toError === null
@@ -563,6 +580,11 @@ SendTransactionScreen.prototype.onSubmit = function (event) {
   }
 
   this.addToAddressBookIfNew(to)
+
+  if (editingTransactionId) {
+    backToConfirmScreen(editingTransactionId)
+    return
+  }
 
   const txParams = {
     from,
@@ -575,8 +597,6 @@ SendTransactionScreen.prototype.onSubmit = function (event) {
     txParams.value = amount
     txParams.to = to
   }
-
-  clearSend()
 
   selectedToken
     ? signTokenTx(selectedToken.address, to, amount, txParams)

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -111,7 +111,7 @@ SendTransactionScreen.prototype.componentWillMount = function () {
       .all([
         getGasPrice(),
         estimateGas(estimateGasParams),
-        tokenContract && tokenContract.balanceOf(from.address)
+        tokenContract && tokenContract.balanceOf(from.address),
       ])
       .then(([gasPrice, gas, usersToken]) => {
 
@@ -365,7 +365,7 @@ SendTransactionScreen.prototype.validateAmount = function (value) {
   let amountError = null
 
   const sufficientBalance = isBalanceSufficient({
-    amount: selectedToken ?  '0x0' : amount,
+    amount: selectedToken ? '0x0' : amount,
     gasTotal,
     balance,
     primaryCurrency,
@@ -409,7 +409,7 @@ SendTransactionScreen.prototype.renderAmountRow = function () {
   } = this.props
 
   return h('div.send-v2__form-row', [
-    
+
     h('div.send-v2__form-label', [
       'Amount:',
       this.renderErrorMessage('amount'),
@@ -565,9 +565,7 @@ SendTransactionScreen.prototype.onSubmit = function (event) {
     gasPrice,
     signTokenTx,
     signTx,
-    updateAndApproveTx,
     selectedToken,
-    toAccounts,
     editingTransactionId,
     errors: { amount: amountError, to: toError },
     backToConfirmScreen,


### PR DESCRIPTION
This PR enables the user to click an "Edit" button on the confirmation screen for a send ether transaction, edit the transaction and then send the edited transaction.

![editbeforesend](https://user-images.githubusercontent.com/7499938/32561832-caa56450-c487-11e7-9f2d-dfb19b7ca58d.gif)
