### PR TITLE
[NewUI-flat] Correct rounding in currency display.

### DIFF
--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -68,13 +68,14 @@ CurrencyDisplay.prototype.render = function () {
 
   const valueToRender = this.getValueToRender()
 
-  const convertedValue = conversionUtil(valueToRender, {
+  let convertedValue = conversionUtil(valueToRender, {
     fromNumericBase: 'dec',
     fromCurrency: primaryCurrency,
     toCurrency: convertedCurrency,
     numberOfDecimals: 2,
     conversionRate,
   })
+  convertedValue = Number(convertedValue).toFixed(2)
 
   return h('div', {
     className,

--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -37,7 +37,7 @@ const BIG_NUMBER_GWEI_MULTIPLIER = new BigNumber('1000000000')
 
 // Individual Setters
 const convert = R.invoker(1, 'times')
-const round = R.invoker(2, 'round')(R.__, BigNumber.ROUND_DOWN)
+const round = R.invoker(2, 'round')(R.__, BigNumber.ROUND_HALF_DOWN)
 const invertConversionRate = conversionRate => () => new BigNumber(1.0).div(conversionRate)
 const decToBigNumberViaString = n => R.pipe(String, toBigNumber['dec'])
 


### PR DESCRIPTION
This PR makes the rounding of fiat values less than 0.01  in currency display consistent with master: if ` value < 0.005` then '0.00' is shown, else 0.01 is shown.

![currencydisplayrounding](https://user-images.githubusercontent.com/7499938/32655565-aab44672-c5e8-11e7-93a2-0270bd7ad0fc.gif)
