### PR TITLE
[NewUI] Focus amount input when click anywhere in amount field container

### DIFF
--- a/ui/app/components/currency-input.js
+++ b/ui/app/components/currency-input.js
@@ -76,6 +76,7 @@ CurrencyInput.prototype.render = function () {
     className,
     placeholder,
     readOnly,
+    inputRef,
   } = this.props
 
   const inputSizeMultiplier = readOnly ? 1 : 1.2
@@ -89,5 +90,6 @@ CurrencyInput.prototype.render = function () {
     size: valueToRender.length * inputSizeMultiplier,
     readOnly,
     onChange: e => this.handleChange(e.target.value),
+    ref: inputRef, 
   })
 }

--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -81,6 +81,7 @@ CurrencyDisplay.prototype.render = function () {
     style: {
       borderColor: inError ? 'red' : null,
     },
+    onClick: () => this.currencyInput.focus(),
   }, [
 
     h('div.currency-display__primary-row', [
@@ -95,6 +96,7 @@ CurrencyDisplay.prototype.render = function () {
           onInputChange: newValue => {
             handleChange(this.getAmount(newValue))
           },
+          inputRef: input => { this.currencyInput = input; },
         }),
 
         h('span.currency-display__currency-symbol', primaryCurrency),


### PR DESCRIPTION
This PR ensures that the send amount input field is focused when the user clicks anywhere within the container.

![sendamountfocus](https://user-images.githubusercontent.com/7499938/32673691-aeed41b6-c62a-11e7-9e90-8e6055289654.gif)
