### PR TITLE
[NewUI] Update max amount behaviour

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -149,6 +149,7 @@ var actions = {
   UPDATE_SEND_AMOUNT: 'UPDATE_SEND_AMOUNT',
   UPDATE_SEND_MEMO: 'UPDATE_SEND_MEMO',
   UPDATE_SEND_ERRORS: 'UPDATE_SEND_ERRORS',
+  UPDATE_MAX_MODE: 'UPDATE_MAX_MODE',
   UPDATE_SEND: 'UPDATE_SEND',
   CLEAR_SEND: 'CLEAR_SEND',
   updateGasLimit,
@@ -160,6 +161,7 @@ var actions = {
   updateSendAmount,
   updateSendMemo,
   updateSendErrors,
+  setMaxModeTo,
   updateSend,
   clearSend,
   setSelectedAddress,
@@ -631,6 +633,13 @@ function updateSendErrors (error) {
   return {
     type: actions.UPDATE_SEND_ERRORS,
     value: error,
+  }
+}
+
+function setMaxModeTo (bool) {
+  return {
+    type: actions.UPDATE_MAX_MODE,
+    value: bool,
   }
 }
 

--- a/ui/app/components/send/send-v2-container.js
+++ b/ui/app/components/send/send-v2-container.js
@@ -78,5 +78,6 @@ function mapDispatchToProps (dispatch) {
     goHome: () => dispatch(actions.goHome()),
     clearSend: () => dispatch(actions.clearSend()),
     backToConfirmScreen: editingTransactionId => dispatch(actions.showConfTxPage({ id: editingTransactionId })),
+    setMaxModeTo: bool => dispatch(actions.setMaxModeTo(bool)),
   }
 }

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -33,6 +33,7 @@ function reduceMetamask (state, action) {
       amount: '0x0',
       memo: '',
       errors: {},
+      maxModeOn: false,
       editingTransactionId: null,
     },
     coinOptions: {},
@@ -254,6 +255,14 @@ function reduceMetamask (state, action) {
             ...metamaskState.send.errors,
             ...action.value,
           },
+        },
+      })
+
+    case actions.UPDATE_MAX_MODE:
+      return extend(metamaskState, {
+        send: {
+          ...metamaskState.send,
+          maxModeOn: action.value,
         },
       })
 

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -24,6 +24,7 @@ const selectors = {
   getSendAmount,
   getSelectedTokenToFiatRate,
   getSelectedTokenContract,
+  getSendMaxModeState,
 }
 
 module.exports = selectors
@@ -133,6 +134,10 @@ function getSendFrom (state) {
 
 function getSendAmount (state) {
   return state.metamask.send.amount
+}
+
+function getSendMaxModeState (state) {
+  return state.metamask.send.maxModeOn
 }
 
 function getCurrentCurrency (state) {

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -13,8 +13,6 @@ const GasFeeDisplay = require('./components/send/gas-fee-display-v2')
 
 const {
   MIN_GAS_TOTAL,
-  MIN_GAS_PRICE_HEX,
-  MIN_GAS_LIMIT_HEX,
 } = require('./components/send/send-constants')
 
 const {
@@ -313,8 +311,9 @@ SendTransactionScreen.prototype.renderToRow = function () {
 
 SendTransactionScreen.prototype.handleAmountChange = function (value) {
   const amount = value
-  const { updateSendAmount } = this.props
+  const { updateSendAmount, setMaxModeTo } = this.props
 
+  setMaxModeTo(false)
   this.validateAmount(amount)
   updateSendAmount(amount)
 }
@@ -324,11 +323,9 @@ SendTransactionScreen.prototype.setAmountToMax = function () {
     from: { balance },
     updateSendAmount,
     updateSendErrors,
-    updateGasPrice,
-    updateGasLimit,
-    updateGasTotal,
     tokenBalance,
     selectedToken,
+    gasTotal,
   } = this.props
   const { decimals } = selectedToken || {}
   const multiplier = Math.pow(10, Number(decimals || 0))
@@ -337,16 +334,12 @@ SendTransactionScreen.prototype.setAmountToMax = function () {
     ? multiplyCurrencies(tokenBalance, multiplier, {toNumericBase: 'hex'})
     : subtractCurrencies(
       ethUtil.addHexPrefix(balance),
-      ethUtil.addHexPrefix(MIN_GAS_TOTAL),
+      ethUtil.addHexPrefix(gasTotal),
       { toNumericBase: 'hex' }
     )
 
   updateSendErrors({ amount: null })
-  if (!selectedToken) {
-    updateGasPrice(MIN_GAS_PRICE_HEX)
-    updateGasLimit(MIN_GAS_LIMIT_HEX)
-    updateGasTotal(MIN_GAS_TOTAL)
-  }
+
   updateSendAmount(maxAmount)
 }
 
@@ -407,19 +400,22 @@ SendTransactionScreen.prototype.renderAmountRow = function () {
     amountConversionRate,
     errors,
     amount,
+    setMaxModeTo,
+    maxModeOn,
   } = this.props
 
   return h('div.send-v2__form-row', [
 
-    h('div.send-v2__form-label', [
+     h('div.send-v2__form-label', [
       'Amount:',
       this.renderErrorMessage('amount'),
       !errors.amount && h('div.send-v2__amount-max', {
         onClick: (event) => {
           event.preventDefault()
+          setMaxModeTo(true)
           this.setAmountToMax()
         },
-      }, [ 'Max' ]),
+      }, [ !maxModeOn ? 'Max' : '' ]),
     ]),
 
     h('div.send-v2__form-field', [


### PR DESCRIPTION
Matched specs from slack conversation:

danjm:
> Hmmm... okay, thanks. In an effort to clarified the desired behaviour, I'm going to explain how I think this will work in a couple scenarios based on what you wrote.

> For the sake of clarifying desired behaviour, I won't worry about the complexity of computing gas limit at the moment; below I assume that in either of the scenario's you mention - simple send or sending to a smart contract - we'll be able to calculate gas price/limit when needed.

> (1) User has yet to enter send amount or edit ('customize') gas. User clicks "Max". We calculate the minimum possible (* see note 1 below) gas price and limit, and set send amount based on that. We also set a "Max" flag to true. If the user edits gas at any point, the send amount is adjusted automatically, so that it is always the maximum amount given the user's custom gas price/limit.

> (2) User has yet to click "Max". User enters send amount and then customizes gas. Then the user clicks "Max". Gas should not change and should remain at the level the user set it to. Send amount should be set to the greatest possible amount given the user's custom gas. Editing gas adjusts amount as described in scenario (1) above.

> (3) In either scenario, if the max flag is on and then the user edits the amount, the max flag is turned off.

> Note 1: Or, instead of "minimum possible", would you prefer that we use an "estimated safe" / "recommended" gas price / limit.

> danfinlay: I actually don’t think this button can set a static value. I think it has to set a Boolean flag that we persist in the background, so that if the user adjusts their gas price or gas limit in the next screen, we can account for that. While it’s very easy to calculate the gas needed for a simple send, so gas limit should be easy most of the time, and gas price needs to stay user defined above.

> That doesn’t even begin to touch on the complexity Show more…
Thread in #team-metamask-uatNov 7th at 10:30 PM


> danfinlay [9 days ago] 
> This is mostly correct, and I agree with note 1. Case 1 should result in auto filling gas params based on default suggestions, and setting the remaining as value. Case 2 is clever, could probably be a second story. Case 3 is correct.