### PR TITLE
Fix a possible seed phrase bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Fix bug where a user could be shown two different seed phrases.
 - Detect when multiple web3 extensions are active, and provide useful error.
 
 ## 3.12.0 2017-10-25

--- a/test/unit/metamask-controller-test.js
+++ b/test/unit/metamask-controller-test.js
@@ -27,6 +27,24 @@ describe('MetaMaskController', function () {
 
   describe('Metamask Controller', function () {
     assert(metamaskController)
+
+    describe('#createNewVaultAndKeychain', function () {
+      it('can only create new vault on keyringController once', async function () {
+
+        const selectStub = sinon.stub(metamaskController, 'selectFirstIdentity')
+
+        const expectation = sinon.mock(metamaskController.keyringController)
+          .expects('createNewVaultAndKeychain').once()
+
+        const password = 'a-fake-password'
+
+        const first = await metamaskController.createNewVaultAndKeychain(password)
+        const second = await metamaskController.createNewVaultAndKeychain(password)
+
+        expectation.verify()
+        selectStub.reset()
+      })
+    })
   })
 })
 

--- a/test/unit/metamask-controller-test.js
+++ b/test/unit/metamask-controller-test.js
@@ -13,12 +13,10 @@ describe('MetaMaskController', function () {
     platform: {},
     encryptor: {
       encrypt: function(password, object) {
-        console.log('encrypting ', object)
         this.object = object
         return Promise.resolve()
       },
       decrypt: function () {
-        console.log('decrypting')
         return Promise.resolve(this.object)
       }
     },
@@ -55,11 +53,7 @@ describe('MetaMaskController', function () {
         const password = 'a-fake-password'
 
         const first = await metamaskController.createNewVaultAndKeychain(password)
-        console.log('FIRST ONE RETURNED:')
-        console.dir(first)
         const second = await metamaskController.createNewVaultAndKeychain(password)
-        console.log('SECOND ONE RETURNED:')
-        console.dir(second)
 
         assert(metamaskController.keyringController.createNewVaultAndKeychain.calledOnce)
 

--- a/test/unit/metamask-controller-test.js
+++ b/test/unit/metamask-controller-test.js
@@ -11,6 +11,17 @@ describe('MetaMaskController', function () {
     unlockAccountMessage: noop,
     showUnapprovedTx: noop,
     platform: {},
+    encryptor: {
+      encrypt: function(password, object) {
+        console.log('encrypting ', object)
+        this.object = object
+        return Promise.resolve()
+      },
+      decrypt: function () {
+        console.log('decrypting')
+        return Promise.resolve(this.object)
+      }
+    },
     // initial state
     initState: clone(firstTimeState),
   })
@@ -28,20 +39,30 @@ describe('MetaMaskController', function () {
   describe('Metamask Controller', function () {
     assert(metamaskController)
 
+    beforeEach(function () {
+      sinon.spy(metamaskController.keyringController, 'createNewVaultAndKeychain')
+    })
+
+    afterEach(function () {
+      metamaskController.keyringController.createNewVaultAndKeychain.restore()
+    })
+
     describe('#createNewVaultAndKeychain', function () {
       it('can only create new vault on keyringController once', async function () {
 
         const selectStub = sinon.stub(metamaskController, 'selectFirstIdentity')
 
-        const expectation = sinon.mock(metamaskController.keyringController)
-          .expects('createNewVaultAndKeychain').once()
-
         const password = 'a-fake-password'
 
         const first = await metamaskController.createNewVaultAndKeychain(password)
+        console.log('FIRST ONE RETURNED:')
+        console.dir(first)
         const second = await metamaskController.createNewVaultAndKeychain(password)
+        console.log('SECOND ONE RETURNED:')
+        console.dir(second)
 
-        expectation.verify()
+        assert(metamaskController.keyringController.createNewVaultAndKeychain.calledOnce)
+
         selectStub.reset()
       })
     })

--- a/ui/app/first-time/init-menu.js
+++ b/ui/app/first-time/init-menu.js
@@ -8,6 +8,8 @@ const actions = require('../actions')
 const Tooltip = require('../components/tooltip')
 const getCaretCoordinates = require('textarea-caret')
 
+let isSubmitting = false
+
 module.exports = connect(mapStateToProps)(InitializeMenuScreen)
 
 inherits(InitializeMenuScreen, Component)
@@ -164,7 +166,10 @@ InitializeMenuScreen.prototype.createNewVaultAndKeychain = function () {
     return
   }
 
-  this.props.dispatch(actions.createNewVaultAndKeychain(password))
+  if (!isSubmitting) {
+    isSubmitting = true
+    this.props.dispatch(actions.createNewVaultAndKeychain(password))
+  }
 }
 
 InitializeMenuScreen.prototype.inputChanged = function (event) {


### PR DESCRIPTION
Fixes a valid solution to #2577

Based on observations by @seesemichaelj [in this comment](https://github.com/MetaMask/metamask-extension/issues/2577#issuecomment-345469455).

- Prevents multiple keyrings from being created with the `createFirstVaultAndKeychain` method.
- Prevents multiple submissions on the first time screen.
- Includes test that could fail if the method was called twice, although it does not simulate the kind of specific slowdown that caused this issue, although I manually reproduced it (try first commit if curious, hold down enter on password confirmation).

This fix should be followed by a thorough updating of our codebase to ensure that form views only submit once, to avoid weird issues where an event listener is fired multiple times.

Opening for discussion, and if we conclude this really is the bug we were looking for (which it looks like!), we'll be awarding the related bounties. Taking a little time to rub our eyes in disbelief, the proper ceremonies may be carried out after this week (Thanksgiving week, our team is spending a lot of family time).