### PR TITLE
Fix memory leak in setupPublicConfig

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -455,13 +455,11 @@ module.exports = class MetamaskController extends EventEmitter {
   }
 
   setupPublicConfig (outStream) {
-    pump(
-      this.publicConfigStore,
-      outStream,
-      (err) => {
-        if (err) log.error(err)
-      }
-    )
+    this.publicConfigStore.pipe(outStream)
+
+    outStream.on('finish', () => {
+      this.publicConfigStore.unpipe(outStream)
+    })
   }
 
   privateSendUpdate () {


### PR DESCRIPTION
Fixes #2122 

Metamask (v3.12.0) becomes too slow to be usable after navigating enough pages. I did some digging and have found the root cause. 

In `metamask-controller.js`: `publicConfigStore` is a singleton.

The following code is causing the memory leak:
```js
  setupPublicConfig (outStream) {
    pump(
      this.publicConfigStore,
      outStream,
      (err) => {
        if (err) log.error(err)
      }
    )
  }
```

Everytime, I visit a page, it triggers that function, and everytime I refresh it is supposed to kill all the streams through the `pump` library.

Here's the pump function:

```js
var pump = function () {
  var streams = Array.prototype.slice.call(arguments)
  var callback = isFn(streams[streams.length - 1] || noop) && streams.pop() || noop

  if (Array.isArray(streams[0])) streams = streams[0]
  if (streams.length < 2) throw new Error('pump requires two streams per minimum')

  var error
  var destroys = streams.map(function (stream, i) {
    var reading = i < streams.length - 1
    var writing = i > 0
    return destroyer(stream, reading, writing, function (err) {
      if (!error) error = err
      if (err) destroys.forEach(call)
      if (reading) return
      destroys.forEach(call)
      callback(error)
    })
  })

  return streams.reduce(pipe)
}
```

For each stream, including publicConfigStore, we execute destroyer on it.

Destroyer does the following:

```js
var destroyer = function (stream, reading, writing, callback) {
  callback = once(callback)

  var closed = false
  // ADD LISTENER
  stream.on('close', function () {
    closed = true
  })

  // ADD LISTENERS
  eos(stream, {readable: reading, writable: writing}, function (err) {
    if (err) return callback(err)
    closed = true
    callback()
  })

  // ... more stuff
```
Each stream entering this function adds a `.on('close')` listener and all the listeners added by `eos`.

So everytime a page load, we have `publicConfigStore` being passed down to `pump`, which is passed down to destroyer that adds a bunch of listeners to it. 

Since publicConfigStore is a singleton, its  number of listeners keeps growing endlessly and since it is always referenced, the GC will never clean it.

I am not super familiar with streams, this PR is just a dummy fix. You might want to come up with a solution that fits your patterns better. cc @kumavis @danfinlay

P.S. I am developper at [ZenHub.com](https://zenhub.com), it's like Waffle but better and integrated in GitHub UI. You might want to give a look into it, it is free :)