### PR TITLE
Download State Logs with .json extension

### DIFF
--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -117,7 +117,7 @@ ConfigScreen.prototype.render = function () {
                   if (err) {
                     state.dispatch(actions.displayWarning('Error in retrieving state logs.'))
                   } else {
-                    exportAsFile('MetaMask State Logs', result)
+                    exportAsFile('MetaMask State Logs.json', result)
                   }
                 })
               },


### PR DESCRIPTION
That doesn't fix #2095, but at least makes downloaded files
syntax-highlighted when opened in editors