### PR TITLE
fix #1398, prevent injecting xml without xml suffix

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -96,7 +96,7 @@ function logStreamDisconnectWarning (remoteLabel, err) {
 }
 
 function shouldInjectWeb3 () {
-  return doctypeCheck() || suffixCheck()
+  return doctypeCheck() && suffixCheck() && documentElementCheck()
 }
 
 function doctypeCheck () {
@@ -104,7 +104,7 @@ function doctypeCheck () {
   if (doctype) {
     return doctype.name === 'html'
   } else {
-    return false
+    return true
   }
 }
 
@@ -117,6 +117,14 @@ function suffixCheck () {
     if (currentRegex.test(currentUrl)) {
       return false
     }
+  }
+  return true
+}
+
+function documentElementCheck () {
+  var documentElement = document.documentElement.nodeName
+  if (documentElement) {
+    return documentElement.toLowerCase() === 'html'
   }
   return true
 }


### PR DESCRIPTION
Problematic example: https://c.storage.googleapis.com/

Using `document.documentElement` as suggested in https://github.com/MetaMask/metamask-extension/issues/1398#issuecomment-325214629

Not sure if this is the proper way to fix it, since `shouldInjectWeb3()` using `||` between the checks already seems strange to me