### PR TITLE
Exponentional backoff on transaction retry in pending-tx-tracker

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -72,6 +72,12 @@ module.exports = class TransactionController extends EventEmitter {
     })
     this.pendingTxTracker.on('tx:failed', this.txStateManager.setTxStatusFailed.bind(this.txStateManager))
     this.pendingTxTracker.on('tx:confirmed', this.txStateManager.setTxStatusConfirmed.bind(this.txStateManager))
+    this.pendingTxTracker.on('tx:block-update', (txMeta, latestBlockNumber) => {
+      if (!txMeta.firstRetryBlockNumber) {
+        txMeta.firstRetryBlockNumber = latestBlockNumber
+        this.txStateManager.updateTx(txMeta, 'transactions/pending-tx-tracker#event: tx:retry')
+      }
+    })
     this.pendingTxTracker.on('tx:retry', (txMeta) => {
       if (!('retryCount' in txMeta)) txMeta.retryCount = 0
       txMeta.retryCount++

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -75,7 +75,7 @@ module.exports = class TransactionController extends EventEmitter {
     this.pendingTxTracker.on('tx:block-update', (txMeta, latestBlockNumber) => {
       if (!txMeta.firstRetryBlockNumber) {
         txMeta.firstRetryBlockNumber = latestBlockNumber
-        this.txStateManager.updateTx(txMeta, 'transactions/pending-tx-tracker#event: tx:retry')
+        this.txStateManager.updateTx(txMeta, 'transactions/pending-tx-tracker#event: tx:block-update')
       }
     })
     this.pendingTxTracker.on('tx:retry', (txMeta) => {

--- a/app/scripts/lib/pending-tx-tracker.js
+++ b/app/scripts/lib/pending-tx-tracker.js
@@ -112,7 +112,7 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
       return this.emit('tx:failed', txMeta.id, err)
     }
 
-    const firstRetryBlockNumber = txMeta.firstRetryBlockNumber
+    const firstRetryBlockNumber = txMeta.firstRetryBlockNumber || latestBlockNumber
     const txBlockDistance = Number.parseInt(latestBlockNumber, 16) - Number.parseInt(firstRetryBlockNumber, 16)
 
     const retryCount = txMeta.retryCount || 0

--- a/app/scripts/lib/pending-tx-tracker.js
+++ b/app/scripts/lib/pending-tx-tracker.js
@@ -69,7 +69,7 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
     const pending = this.getPendingTransactions()
     // only try resubmitting if their are transactions to resubmit
     if (!pending.length) return
-    pending.forEach((txMeta) => this._resubmitTx(txMeta).catch((err) => {
+    pending.forEach((txMeta) => this._resubmitTx(txMeta, block.number).catch((err) => {
       /*
       Dont marked as failed if the error is a "known" transaction warning
       "there is already a transaction with the same sender-nonce

--- a/test/unit/pending-tx-test.js
+++ b/test/unit/pending-tx-test.js
@@ -206,6 +206,7 @@ describe('PendingTransactionTracker', function () {
   })
 
   describe('#resubmitPendingTxs', function () {
+    const blockStub = { number: '0x0' };
     beforeEach(function () {
     const txMeta2 = txMeta3 = txMeta
     txList = [txMeta, txMeta2, txMeta3].map((tx) => {
@@ -223,7 +224,7 @@ describe('PendingTransactionTracker', function () {
       Promise.all(txList.map((tx) => tx.processed))
       .then((txCompletedList) => done())
       .catch(done)
-      pendingTxTracker.resubmitPendingTxs()
+      pendingTxTracker.resubmitPendingTxs(blockStub)
     })
     it('should not emit \'tx:failed\' if the txMeta throws a known txError', function (done) {
       knownErrors =[
@@ -250,7 +251,7 @@ describe('PendingTransactionTracker', function () {
       .then((txCompletedList) => done())
       .catch(done)
 
-      pendingTxTracker.resubmitPendingTxs()
+      pendingTxTracker.resubmitPendingTxs(blockStub)
     })
     it('should emit \'tx:warning\' if it encountered a real error', function (done) {
       pendingTxTracker.once('tx:warning', (txMeta, err) => {
@@ -268,7 +269,7 @@ describe('PendingTransactionTracker', function () {
       .then((txCompletedList) => done())
       .catch(done)
 
-      pendingTxTracker.resubmitPendingTxs()
+      pendingTxTracker.resubmitPendingTxs(blockStub)
     })
   })
   describe('#_resubmitTx', function () {


### PR DESCRIPTION
Reduces the amount of requests made to infura by exponentially increasing the number of blocks to wait before each request retry.

@frankiebee If we want to base the decision on whether to retry on blocks, I believe we'll have to add a property to `txMeta`. That is done here.

Another option is to base the decision on time since the tx was created, we wouldn't need to add any extra property to `txMeta`. A switch to that approach would be quite straightforward.

Also, this PR only limits retrys on the basis of the current number of 'successful tries' (i.e. `txMeta.retryCount`), and not the number of times that `this.publishTransaction(rawTx)` has been called. I know infura is handling retries as well, but should we keep track of unsuccessful calls to `this.publishTransaction(rawTx)` as well, and limit retries based on that number?