### PR TITLE
Add 10% price bump minimum to retry attempts.

### DIFF
--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -43,7 +43,9 @@ PendingTx.prototype.render = function () {
   let forceGasMin
   if (lastGasPrice) {
     const stripped = ethUtil.stripHexPrefix(lastGasPrice)
-    forceGasMin = new BN(stripped, 16).add(MIN_GAS_PRICE_BN)
+    const lastGas = new BN(stripped, 16)
+    const priceBump = lastGas.divn('10')
+    forceGasMin = lastGas.add(priceBump)
   }
 
   // Account Details


### PR DESCRIPTION
Turns out geth requires at least a 10% price bump to replace txs:
https://github.com/ethereum/go-ethereum/blob/9619a610248e9630968ba1d9be8e214b645c9c55/core/tx_pool.go#L133