### PR TITLE
Fixes the cancel button in the buy screen to take the user home.

### DIFF
--- a/ui/app/components/coinbase-form.js
+++ b/ui/app/components/coinbase-form.js
@@ -40,7 +40,7 @@ CoinbaseForm.prototype.render = function () {
       }, 'Continue to Coinbase'),
 
       h('button.btn-red', {
-        onClick: () => props.dispatch(actions.backTobuyView(props.accounts.address)),
+        onClick: () => props.dispatch(actions.goHome()),
       }, 'Cancel'),
     ]),
   ])


### PR DESCRIPTION
`ui/app/components/coinbase-form.js` is trying to dispatch a `backTobuyView` action. But no such action exists. This causes the 'Cancel' button on the buy screen to do nothing.

This PR fixes that by dispatching the `goHome` action on the click of the cancel button.

![fixolduibuycancelbutton](https://user-images.githubusercontent.com/7499938/33775976-934bd408-dc1a-11e7-824e-d3b3ded4d3ca.gif)

