### PR TITLE
network - for infura networks use the infura block tracker provider

### DIFF
--- a/app/scripts/controllers/network.js
+++ b/app/scripts/controllers/network.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const EventEmitter = require('events')
 const createMetamaskProvider = require('web3-provider-engine/zero.js')
+const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider')
 const ObservableStore = require('obs-store')
 const ComposedStore = require('obs-store/lib/composed')
 const extend = require('xtend')
@@ -8,6 +9,7 @@ const EthQuery = require('eth-query')
 const createEventEmitterProxy = require('../lib/events-proxy.js')
 const RPC_ADDRESS_LIST = require('../config.js').network
 const DEFAULT_RPC = RPC_ADDRESS_LIST['rinkeby']
+const INFURA_PROVIDER_TYPES = ['ropsten', 'rinkeby', 'kovan', 'mainnet']
 
 module.exports = class NetworkController extends EventEmitter {
 
@@ -24,8 +26,13 @@ module.exports = class NetworkController extends EventEmitter {
 
   initializeProvider (_providerParams) {
     this._baseProviderParams = _providerParams
-    const rpcUrl = this.getCurrentRpcAddress()
-    this._configureStandardProvider({ rpcUrl })
+    const { type, rpcTarget } = this.providerStore.getState()
+    // map rpcTarget to rpcUrl
+    const opts = {
+      type,
+      rpcUrl: rpcTarget,
+    }
+    this._configureProvider(opts)
     this._proxy.on('block', this._logBlock.bind(this))
     this._proxy.on('error', this.verifyNetwork.bind(this))
     this.ethQuery = new EthQuery(this._proxy)
@@ -83,7 +90,7 @@ module.exports = class NetworkController extends EventEmitter {
     const rpcTarget = this.getRpcAddressForType(type)
     assert(rpcTarget, `NetworkController - unknown rpc address for type "${type}"`)
     this.providerStore.updateState({ type, rpcTarget })
-    this._switchNetwork({ rpcUrl: rpcTarget })
+    this._switchNetwork({ type })
   }
 
   getProviderConfig () {
@@ -99,14 +106,50 @@ module.exports = class NetworkController extends EventEmitter {
   // Private
   //
 
-  _switchNetwork (providerParams) {
+  _switchNetwork (opts) {
     this.setNetworkState('loading')
-    this._configureStandardProvider(providerParams)
+    this._configureProvider(opts)
     this.emit('networkDidChange')
   }
 
-  _configureStandardProvider (_providerParams) {
-    const providerParams = extend(this._baseProviderParams, _providerParams, {
+  _configureProvider (opts) {
+    // type-based rpc endpoints
+    const { type } = opts
+    if (type) {
+      // type-based infura rpc endpoints
+      const isInfura = INFURA_PROVIDER_TYPES.includes(type)
+      opts.rpcUrl = this.getRpcAddressForType(type)
+      if (isInfura) {
+        this._configureInfuraProvider(opts)
+      // other type-based rpc endpoints
+      } else {
+        this._configureStandardProvider(opts)
+      }
+    // url-based rpc endpoints
+    } else {
+      this._configureStandardProvider(opts)
+    }
+  }
+
+  _configureInfuraProvider (opts) {
+    console.log('_configureInfuraProvider', opts)
+    const blockTrackerProvider = createInfuraProvider({
+      network: opts.type,
+    })
+    const providerParams = extend(this._baseProviderParams, {
+      rpcUrl: opts.rpcUrl,
+      engineParams: {
+        pollingInterval: 8000,
+        blockTrackerProvider,
+      },
+    })
+    const provider = createMetamaskProvider(providerParams)
+    this._setProvider(provider)
+  }
+
+  _configureStandardProvider ({ rpcUrl }) {
+    const providerParams = extend(this._baseProviderParams, {
+      rpcUrl,
       engineParams: {
         pollingInterval: 8000,
       },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eth-contract-metadata": "^1.1.4",
     "eth-hd-keyring": "^1.2.1",
     "eth-json-rpc-filters": "^1.2.4",
+    "eth-json-rpc-infura": "^1.0.1",
     "eth-keyring-controller": "^2.1.2",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
@@ -152,7 +153,7 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "^0.20.1",
-    "web3-provider-engine": "^13.3.4",
+    "web3-provider-engine": "^13.4.0",
     "web3-stream-provider": "^3.0.1",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
This retargets our block poller for infura-based networks to their RESTful CDN endpoint. Less load for them, hopefully better response times globally.

works normally for other rpc-based network

relevant dep changes:
https://github.com/MetaMask/provider-engine/commit/c25156d618a1d9712d5f401ab67b6e93fbe3dddb
https://github.com/kumavis/eth-json-rpc-infura