### PR TITLE
 Allow updating token details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug that prevented updating custom token details.
+
 ## 3.13.3 2017-12-14
 
 - Show tokens that are held that have no balance.

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -26,23 +26,23 @@ class PreferencesController {
     return this.store.getState().selectedAddress
   }
 
-  addToken (rawAddress, symbol, decimals) {
+  async addToken (rawAddress, symbol, decimals) {
     const address = normalizeAddress(rawAddress)
     const newEntry = { address, symbol, decimals }
 
     const tokens = this.store.getState().tokens
-    const previousIndex = tokens.find((token, index) => {
+    const previousEntry = tokens.find((token, index) => {
       return token.address === address
     })
+    const previousIndex = tokens.indexOf(previousEntry)
 
-    if (previousIndex) {
+    if (previousEntry) {
       tokens[previousIndex] = newEntry
     } else {
       tokens.push(newEntry)
     }
 
     this.store.updateState({ tokens })
-    return Promise.resolve()
   }
 
   getTokens () {

--- a/test/unit/preferences-controller-test.js
+++ b/test/unit/preferences-controller-test.js
@@ -1,0 +1,48 @@
+const assert = require('assert')
+const PreferencesController = require('../../app/scripts/controllers/preferences')
+
+describe('preferences controller', function () {
+  let preferencesController
+
+  before(() => {
+    preferencesController = new PreferencesController()
+  })
+
+  describe('addToken', function () {
+    it('should add that token to its state', async function () {
+      const address = '0xabcdef1234567'
+      const symbol = 'ABBR'
+      const decimals = 5
+
+      await preferencesController.addToken(address, symbol, decimals)
+
+      const tokens = preferencesController.getTokens()
+      assert.equal(tokens.length, 1, 'one token added')
+
+      const added = tokens[0]
+      assert.equal(added.address, address, 'set address correctly')
+      assert.equal(added.symbol, symbol, 'set symbol correctly')
+      assert.equal(added.decimals, decimals, 'set decimals correctly')
+    })
+
+    it('should allow updating a token value', async function () {
+      const address = '0xabcdef1234567'
+      const symbol = 'ABBR'
+      const decimals = 5
+
+      await preferencesController.addToken(address, symbol, decimals)
+
+      const newDecimals = 6
+      await preferencesController.addToken(address, symbol, newDecimals)
+
+      const tokens = preferencesController.getTokens()
+      assert.equal(tokens.length, 1, 'one token added')
+
+      const added = tokens[0]
+      assert.equal(added.address, address, 'set address correctly')
+      assert.equal(added.symbol, symbol, 'set symbol correctly')
+      assert.equal(added.decimals, newDecimals, 'updated decimals correctly')
+    })
+  })
+})
+


### PR DESCRIPTION
Fixes #2173, a bug that prevented users from updating a custom token's details.

After this, users will be able to correct incorrectly entered token details (like decimals) by re-adding that token using the usual add-token screen.