### PR TITLE
[NewUI] Hide UI toggle in mascara

### DIFF
--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -405,7 +405,7 @@ App.prototype.renderDropdown = function () {
 
     h(DropdownMenuItem, {
       closeMenu: () => this.setState({ isMainMenuOpen: !isOpen }),
-      onClick: () => { this.props.dispatch(actions.setFeatureFlag('betaUI', true)) },
+      onClick: () => { this.props.dispatch(actions.setFeatureFlag('betaUI', true, 'BETA_UI_NOTIFICATION_MODAL')) },
     }, 'Try Beta!'),
   ])
 }

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -1523,10 +1523,7 @@ function updateTokenExchangeRate (token = '') {
   }
 }
 
-function setFeatureFlag (feature, activated) {
-  const notificationType = activated
-    ? 'BETA_UI_NOTIFICATION_MODAL'
-    : 'OLD_UI_NOTIFICATION_MODAL'
+function setFeatureFlag (feature, activated, notificationType) {
   return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve, reject) => {
@@ -1537,7 +1534,7 @@ function setFeatureFlag (feature, activated) {
           reject(err)
         }
         dispatch(actions.updateFeatureFlags(updatedFeatureFlags))
-        dispatch(actions.showModal({ name: notificationType }))
+        notificationType && dispatch(actions.showModal({ name: notificationType }))
         resolve(updatedFeatureFlags)
       })
     })

--- a/ui/app/select-app.js
+++ b/ui/app/select-app.js
@@ -18,26 +18,29 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    setFeatureFlagToBeta: notificationModal => dispatch(setFeatureFlag('betaUI', true, notificationModal)),
+    setFeatureFlagWithModal: () => dispatch(setFeatureFlag('betaUI', true, 'BETA_UI_NOTIFICATION_MODAL')),
+    setFeatureFlagWithoutModal: () => dispatch(setFeatureFlag('betaUI', true)),
   }
 }
 module.exports = connect(mapStateToProps, mapDispatchToProps)(SelectedApp)
 
 inherits(SelectedApp, Component)
 function SelectedApp () {
-	this.state = {
-		autoAdd: false,
-	}
 	Component.call(this)
 }
 
 SelectedApp.prototype.componentWillReceiveProps = function (nextProps) {
-	const { isUnlocked, setFeatureFlagToBeta, isMascara } = this.props
-	const notificationModal = isMascara ? null : 'BETA_UI_NOTIFICATION_MODAL'
+	const {
+		isUnlocked,
+		setFeatureFlagWithModal,
+		setFeatureFlagWithoutModal,
+		isMascara,
+	} = this.props
 
-	if (!isUnlocked && nextProps.isUnlocked && (nextProps.autoAdd || isMascara)) {
-		this.setState({ autoAdd: nextProps.autoAdd })
-		setFeatureFlagToBeta(notificationModal)
+	if (isMascara) {
+		setFeatureFlagWithoutModal()
+	} else if (!isUnlocked && nextProps.isUnlocked && (nextProps.autoAdd)) {
+		setFeatureFlagWithModal()
 	}
 }
 

--- a/ui/app/select-app.js
+++ b/ui/app/select-app.js
@@ -12,12 +12,13 @@ function mapStateToProps (state) {
 		betaUI: state.metamask.featureFlags.betaUI,
 		autoAdd: autoAddToBetaUI(state),
 		isUnlocked: state.metamask.isUnlocked,
+		isMascara: state.metamask.isMascara,
 	}
 }
 
 function mapDispatchToProps (dispatch) {
   return {
-    setFeatureFlagToBeta: () => dispatch(setFeatureFlag('betaUI', true)),
+    setFeatureFlagToBeta: notificationModal => dispatch(setFeatureFlag('betaUI', true, notificationModal)),
   }
 }
 module.exports = connect(mapStateToProps, mapDispatchToProps)(SelectedApp)
@@ -31,16 +32,17 @@ function SelectedApp () {
 }
 
 SelectedApp.prototype.componentWillReceiveProps = function (nextProps) {
-	const { isUnlocked, setFeatureFlagToBeta } = this.props
+	const { isUnlocked, setFeatureFlagToBeta, isMascara } = this.props
+	const notificationModal = isMascara ? null : 'BETA_UI_NOTIFICATION_MODAL'
 
-	if (!isUnlocked && nextProps.isUnlocked && nextProps.autoAdd) {
+	if (!isUnlocked && nextProps.isUnlocked && (nextProps.autoAdd || isMascara)) {
 		this.setState({ autoAdd: nextProps.autoAdd })
-		setFeatureFlagToBeta()
+		setFeatureFlagToBeta(notificationModal)
 	}
 }
 
 SelectedApp.prototype.render = function () {
-  const { betaUI } = this.props
-  const Selected = betaUI ? App : OldApp
+  const { betaUI, isMascara } = this.props
+  const Selected = betaUI || isMascara ? App : OldApp
   return h(Selected)
 }

--- a/ui/app/settings.js
+++ b/ui/app/settings.js
@@ -250,7 +250,7 @@ class Settings extends Component {
   }
 
   renderSettingsContent () {
-    const { warning } = this.props
+    const { warning, isMascara } = this.props
 
     return (
       h('div.settings__content', [
@@ -261,7 +261,7 @@ class Settings extends Component {
         this.renderNewRpcUrl(),
         this.renderStateLogs(),
         this.renderSeedWords(),
-        this.renderOldUI(),
+        !isMascara && this.renderOldUI(),
       ])
     )
   }
@@ -386,12 +386,14 @@ Settings.propTypes = {
   setFeatureFlagToBeta: PropTypes.func,
   warning: PropTypes.string,
   goHome: PropTypes.func,
+  isMascara: PropTypes.bool,
 }
 
 const mapStateToProps = state => {
   return {
     metamask: state.metamask,
     warning: state.appState.warning,
+    isMascara: state.metamask.isMascara,
   }
 }
 
@@ -403,7 +405,7 @@ const mapDispatchToProps = dispatch => {
     displayWarning: warning => dispatch(actions.displayWarning(warning)),
     revealSeedConfirmation: () => dispatch(actions.revealSeedConfirmation()),
     setUseBlockie: value => dispatch(actions.setUseBlockie(value)),
-    setFeatureFlagToBeta: () => dispatch(actions.setFeatureFlag('betaUI', false)),
+    setFeatureFlagToBeta: () => dispatch(actions.setFeatureFlag('betaUI', false, 'OLD_UI_NOTIFICATION_MODAL')),
   }
 }
 


### PR DESCRIPTION
Hides the UI toggles when in mascara.

Use old UI button hidden in mascara:

<img width="1167" alt="screen shot 2017-12-18 at 11 50 54 pm" src="https://user-images.githubusercontent.com/7499938/34139392-21ba8644-e44f-11e7-8bba-cde9cb7c63b8.png">
----
UI toggling still works in extension:

![dec18-autoaddnewui-onlogin](https://user-images.githubusercontent.com/7499938/34139408-35db6904-e44f-11e7-98f0-e130c098f068.gif)
-
![dec18oldui-newui-toggle](https://user-images.githubusercontent.com/7499938/34139409-35ee2454-e44f-11e7-9741-79ea1232c9c2.gif)

