### PR TITLE
[NewUI] Hide fiat values on account details screen when eth/token value is 0.

### DIFF
--- a/ui/app/components/balance-component.js
+++ b/ui/app/components/balance-component.js
@@ -94,7 +94,8 @@ BalanceComponent.prototype.renderFiatValue = function (formattedBalance) {
 }
 
 BalanceComponent.prototype.renderFiatAmount = function (fiatDisplayNumber, fiatSuffix, fiatPrefix) {
-  if (fiatDisplayNumber === 'N/A') return null
+  const shouldNotRenderFiat = fiatDisplayNumber === 'N/A' || Number(fiatDisplayNumber) === 0
+  if (shouldNotRenderFiat) return null
 
   return h('div.fiat-amount', {
     style: {},

--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -86,7 +86,9 @@ TokenCell.prototype.render = function () {
       numberOfDecimals: 2,
       conversionRate: currentTokenToFiatRate,
     })
-    formattedFiat = `${currentTokenInFiat} ${currentCurrency.toUpperCase()}`
+    formattedFiat = currentTokenInFiat.toString() === '0'
+      ? ''
+      : `${currentTokenInFiat} ${currentCurrency.toUpperCase()}`
   }
 
   const showFiat = Boolean(currentTokenInFiat) && currentCurrency.toUpperCase() !== symbol

--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -170,6 +170,7 @@ TxListItem.prototype.getSendTokenTotal = async function () {
 TxListItem.prototype.render = function () {
   const {
     transactionStatus,
+    transactionAmount,
     onClick,
     transActionId,
     dateString,
@@ -177,6 +178,7 @@ TxListItem.prototype.render = function () {
     className,
   } = this.props
   const { total, fiatTotal } = this.state
+  const showFiatTotal = transactionAmount !== '0x0' && fiatTotal
 
   return h(`div${className || ''}`, {
     key: transActionId,
@@ -238,7 +240,7 @@ TxListItem.prototype.render = function () {
             }),
           }, total),
 
-          fiatTotal && h('span.tx-list-fiat-value', fiatTotal),
+          showFiatTotal && h('span.tx-list-fiat-value', fiatTotal),
 
         ]),
       ]),


### PR DESCRIPTION
This PR hides the fiat amounts on the account detail screen in cases where the eth/token amount is 0. This handles the case of an error in the api that gives us the conversion amount between eth/tokens and fiat, and therefore rendering 0 fiat even though eth/tokens amount is greater than 0.

<img width="544" alt="screen shot 2017-12-19 at 1 53 05 pm" src="https://user-images.githubusercontent.com/7499938/34170649-45b8dbe6-e4c6-11e7-8291-ffbe12b17767.png">
-
<img width="801" alt="screen shot 2017-12-19 at 1 46 04 pm" src="https://user-images.githubusercontent.com/7499938/34170650-45cee670-e4c6-11e7-8094-dc2064b04bf8.png">
-
<img width="359" alt="screen shot 2017-12-19 at 1 41 39 pm" src="https://user-images.githubusercontent.com/7499938/34170651-45e6e0c2-e4c6-11e7-98cb-ee40b1cab231.png">
-
<img width="359" alt="screen shot 2017-12-19 at 1 41 31 pm" src="https://user-images.githubusercontent.com/7499938/34170652-45ff80d2-e4c6-11e7-9655-9616fbf92571.png">
