### PR TITLE
[NewUI] Fix margin styling for name and address in old account detail section.

### DIFF
--- a/old-ui/app/account-detail.js
+++ b/old-ui/app/account-detail.js
@@ -162,6 +162,7 @@ AccountDetailScreen.prototype.render = function () {
                   textRendering: 'geometricPrecision',
                   marginTop: '15px',
                   marginBottom: '15px',
+                  marginLeft: '15px',
                   color: '#AEAEAE',
                 },
               }, checksumAddress),

--- a/old-ui/app/css/index.css
+++ b/old-ui/app/css/index.css
@@ -442,10 +442,10 @@ input.large-input {
   flex-wrap: wrap;
   overflow-y: auto;
   flex-direction: inherit;
+}
 
-  .name-label {
-    margin-left: 15px;
-  }
+.account-detail-section .name-label {
+  margin-left: 15px;
 }
 
 .grow-tenx {


### PR DESCRIPTION
Fixes the alignment of the account address (below the account name) from this:

<img width="320" alt="screen shot 2017-12-08 at 3 19 44 pm" src="https://user-images.githubusercontent.com/7499938/34237096-621676c6-e5d5-11e7-9c33-6c7ee22596dc.png">

To this:

<img width="325" alt="screen shot 2017-12-08 at 12 42 42 pm" src="https://user-images.githubusercontent.com/7499938/34237104-6d6578d8-e5d5-11e7-9510-f584acdfa997.png">
