### PR TITLE
[WIP] Enable syncing of vault/preferences between multiple browsers

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -47,11 +47,10 @@ async function initialize () {
 async function loadStateFromPersistence () {
   // migrations
   const migrator = new Migrator({ migrations })
-  // fetch from extension store
-  const extensionData = await extensionStore.fetch() // TODO: handle possible exceptions (https://developer.chrome.com/apps/runtime#property-lastError)
   // read from disk
   let versionedData = diskStore.getState() || migrator.generateInitialState(firstTimeState)
-  // merge extension and versioned data
+  // fetch from extension store and merge in data
+  const extensionData = await extensionStore.fetch() // TODO: handle possible exceptions (https://developer.chrome.com/apps/runtime#property-lastError)
   versionedData = { ...versionedData, ...extensionData }
   // migrate data
   versionedData = await migrator.migrateData(versionedData)

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -50,8 +50,12 @@ async function loadStateFromPersistence () {
   // read from disk
   let versionedData = diskStore.getState() || migrator.generateInitialState(firstTimeState)
   // fetch from extension store and merge in data
-  const extensionData = await extensionStore.fetch() // TODO: handle possible exceptions (https://developer.chrome.com/apps/runtime#property-lastError)
-  versionedData = { ...versionedData, ...extensionData }
+
+  if (extensionStore.isSupported && extensionStore.isEnabled) {
+    const extensionData = await extensionStore.fetch() // TODO: handle possible exceptions (https://developer.chrome.com/apps/runtime#property-lastError)
+    versionedData = { ...versionedData, ...extensionData }
+  }
+
   // migrate data
   versionedData = await migrator.migrateData(versionedData)
   // write to disk
@@ -92,7 +96,9 @@ function setupController (initState) {
   }
 
   function syncDataWithExtension(state) {
-    extensionStore.sync(state) // TODO: handle possible exceptions (https://developer.chrome.com/apps/runtime#property-lastError)
+    if (extensionStore.isSupported && extensionStore.isEnabled) {
+      extensionStore.sync(state) // TODO: handle possible exceptions (https://developer.chrome.com/apps/runtime#property-lastError)
+    }
     return state
   }
 

--- a/app/scripts/lib/extension-store.js
+++ b/app/scripts/lib/extension-store.js
@@ -1,11 +1,24 @@
 const extension = require('extensionizer')
 
 const KEYS_TO_SYNC = ['KeyringController', 'PreferencesController']
+const FIREFOX_SYNC_DISABLED_MESSAGE = 'Please set webextensions.storage.sync.enabled to true in about:config'
+
+const handleDisabledSyncAndResolve = (resolve, toResolve) => {
+  // Firefox 52 has sync available on extension.storage, but it is disabled by default
+  const lastError = extension.runtime.lastError
+  if (lastError && lastError.message.includes(FIREFOX_SYNC_DISABLED_MESSAGE)) {
+    resolve({})
+  } else {
+    resolve(toResolve)
+  }
+}
 
 module.exports = class ExtensionStore {
   async fetch() {
     return new Promise((resolve) => {
-      extension.storage.sync.get(KEYS_TO_SYNC, data => resolve(data))
+      extension.storage.sync.get(KEYS_TO_SYNC, (data) => {
+        handleDisabledSyncAndResolve(resolve, data)
+      })
     })
   }
   async sync(state) {
@@ -14,7 +27,9 @@ module.exports = class ExtensionStore {
       return result
     }, {})
     return new Promise((resolve) => {
-      extension.storage.sync.set(dataToSync, () => resolve())
+      extension.storage.sync.set(dataToSync, () => {
+        handleDisabledSyncAndResolve(resolve)
+      })
     })
   }
 }

--- a/app/scripts/lib/extension-store.js
+++ b/app/scripts/lib/extension-store.js
@@ -14,6 +14,10 @@ const handleDisabledSyncAndResolve = (resolve, toResolve) => {
 }
 
 module.exports = class ExtensionStore {
+  constructor() {
+    this.isSupported = !!(extension.storage.sync)
+    this.isEnabled = true // TODO: get value from user settings
+  }
   async fetch() {
     return new Promise((resolve) => {
       extension.storage.sync.get(KEYS_TO_SYNC, (data) => {

--- a/app/scripts/lib/extension-store.js
+++ b/app/scripts/lib/extension-store.js
@@ -1,0 +1,20 @@
+const extension = require('extensionizer')
+
+const KEYS_TO_SYNC = ['KeyringController', 'PreferencesController']
+
+module.exports = class ExtensionStore {
+  async fetch() {
+    return new Promise((resolve) => {
+      extension.storage.sync.get(KEYS_TO_SYNC, data => resolve(data))
+    })
+  }
+  async sync(state) {
+    const dataToSync = KEYS_TO_SYNC.reduce((result, key) => {
+      result[key] = state.data[key]
+      return result
+    }, {})
+    return new Promise((resolve) => {
+      extension.storage.sync.set(dataToSync, () => resolve())
+    })
+  }
+}

--- a/test/unit/extension-store-test.js
+++ b/test/unit/extension-store-test.js
@@ -1,0 +1,29 @@
+const assert = require('assert')
+
+const ExtensionStore = require('../../app/scripts/lib/extension-store')
+
+describe('Extension Store', function () {
+  let extensionStore
+
+  beforeEach(function () {
+    extensionStore = new ExtensionStore()
+  })
+
+  describe('#fetch', function () {
+    it('should return a promise', function () {
+
+    })
+    it('after promise resolution, should have loaded the proper data from the extension', function () {
+
+    })
+  })
+
+  describe('#sync', function () {
+    it('should return a promise', function () {
+
+    })
+    it('after promise resolution, should have synced the proper data from the extension', function () {
+
+    })
+  })
+})


### PR DESCRIPTION
This PR is to address issue #1459. Implementation details will be added to this PR, but for now, the linked issue has good amount of info.

Incomplete list of TODOS:
- [ ] Decide if enforcing strict rate-limiting due [to extension's own limits](https://developer.chrome.com/apps/storage#property-sync) is worth added complexity.
- [ ] Add  ExtensionStore onChange listener to update in mem store as updates to extension store come in
- [ ] Add error handling when calling extensionStore methods
- [ ] Add actually spec coverage (by actually being able to run specs locally)
- [x] Gracefully fallback to only localStorage for incompatible browsers (Opera, Firefox versions 52 and lower)
- [ ] Add isEnabled flag (with a default of false) and corresponding settings option
  