### PR TITLE
add POA.network support

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -2,6 +2,7 @@ const MAINET_RPC_URL = 'https://mainnet.infura.io/metamask'
 const ROPSTEN_RPC_URL = 'https://ropsten.infura.io/metamask'
 const KOVAN_RPC_URL = 'https://kovan.infura.io/metamask'
 const RINKEBY_RPC_URL = 'https://rinkeby.infura.io/metamask'
+const POA_RPC_URL = 'https://core.poa.network'
 const LOCALHOST_RPC_URL = 'http://localhost:8545'
 
 global.METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
@@ -13,10 +14,12 @@ module.exports = {
     ropsten: ROPSTEN_RPC_URL,
     kovan: KOVAN_RPC_URL,
     rinkeby: RINKEBY_RPC_URL,
+    poa: POA_RPC_URL,
   },
   networkNames: {
     3: 'Ropsten',
     4: 'Rinkeby',
     42: 'Kovan',
+    99: 'POA'
   },
 }

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -20,6 +20,6 @@ module.exports = {
     3: 'Ropsten',
     4: 'Rinkeby',
     42: 'Kovan',
-    99: 'POA'
+    99: 'POA',
   },
 }

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -18,6 +18,10 @@ function getBuyEthUrl ({ network, amount, address }) {
     case '42':
       url = 'https://github.com/kovan-testnet/faucet'
       break
+
+    case '99':
+      url = 'https://poa.network'
+      break
   }
   return url
 }

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -7,6 +7,7 @@ const MAINNET_RPC = MetamaskConfig.network.mainnet
 const ROPSTEN_RPC = MetamaskConfig.network.ropsten
 const KOVAN_RPC = MetamaskConfig.network.kovan
 const RINKEBY_RPC = MetamaskConfig.network.rinkeby
+const POA_RPC = MetamaskConfig.network.poa
 
 /* The config-manager is a convenience object
  * wrapping a pojo-migrator.
@@ -153,6 +154,9 @@ ConfigManager.prototype.getCurrentRpcAddress = function () {
 
     case 'rinkeby':
       return RINKEBY_RPC
+
+    case 'poa':
+      return POA_RPC
 
     default:
       return provider && provider.rpcTarget ? provider.rpcTarget : RINKEBY_RPC

--- a/app/scripts/lib/tx-gas-utils.js
+++ b/app/scripts/lib/tx-gas-utils.js
@@ -26,7 +26,7 @@ module.exports = class txProvideUtil {
         err.message.includes('Transaction execution error.') ||
         err.message.includes('gas required exceeds allowance or always failing transaction')
       )
-      if ( simulationFailed ) {
+      if (simulationFailed) {
         txMeta.simulationFails = true
         return txMeta
       }

--- a/app/scripts/notice-controller.js
+++ b/app/scripts/notice-controller.js
@@ -77,7 +77,7 @@ module.exports = class NoticeController extends EventEmitter {
     return uniqBy(oldNotices.concat(newNotices), 'id')
   }
 
-  _filterNotices(notices) {
+  _filterNotices (notices) {
     return notices.filter((newNotice) => {
       if ('version' in newNotice) {
         const satisfied = semver.satisfies(this.version, newNotice.version)

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -185,6 +185,8 @@ AccountDetailScreen.prototype.render = function () {
             value: account && account.balance,
             conversionRate,
             currentCurrency,
+            network: network,
+            showFiat: parseInt(network) !== 99,
             style: {
               lineHeight: '7px',
               marginTop: '10px',
@@ -196,6 +198,7 @@ AccountDetailScreen.prototype.render = function () {
           h('button', {
             onClick: () => props.dispatch(actions.buyEthView(selected)),
             style: { marginRight: '10px' },
+            disabled:  network === '99',
           }, 'BUY'),
 
           h('button', {

--- a/ui/app/account-detail.js
+++ b/ui/app/account-detail.js
@@ -198,7 +198,7 @@ AccountDetailScreen.prototype.render = function () {
           h('button', {
             onClick: () => props.dispatch(actions.buyEthView(selected)),
             style: { marginRight: '10px' },
-            disabled:  network === '99',
+            disabled: network === '99',
           }, 'BUY'),
 
           h('button', {

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -332,7 +332,7 @@ App.prototype.renderNetworkDropdown = function () {
           fontSize: '18px',
         },
       },
-      [ 
+      [
         h('.blue-triangle.menu-icon'),
         'POA Network',
         providerType === 'poa' ? h('.check', '✓') : null,

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -325,6 +325,23 @@ App.prototype.renderNetworkDropdown = function () {
     h(
       DropdownMenuItem,
       {
+        key: 'poa',
+        closeMenu: () => this.setState({ isNetworkMenuOpen: !isOpen }),
+        onClick: () => props.dispatch(actions.setProviderType('poa')),
+        style: {
+          fontSize: '18px',
+        },
+      },
+      [ 
+        h('.blue-triangle.menu-icon'),
+        'POA Network',
+        providerType === 'poa' ? h('.check', '✓') : null,
+      ]
+    ),
+
+    h(
+      DropdownMenuItem,
+      {
         key: 'default',
         closeMenu: () => this.setState({ isNetworkMenuOpen: !isOpen }),
         onClick: () => props.dispatch(actions.setProviderType('localhost')),
@@ -640,6 +657,8 @@ App.prototype.getNetworkName = function () {
     name = 'Kovan Test Network'
   } else if (providerName === 'rinkeby') {
     name = 'Rinkeby Test Network'
+  } else if (providerName === 'poa') {
+    name = 'POA Network'
   } else {
     name = 'Unknown Private Network'
   }

--- a/ui/app/components/account-dropdowns.js
+++ b/ui/app/components/account-dropdowns.js
@@ -162,7 +162,7 @@ class AccountDropdowns extends Component {
   }
 
   renderAccountOptions () {
-    const { actions } = this.props
+    const { actions, network } = this.props
     const { optionsMenuActive } = this.state
 
     return h(
@@ -187,12 +187,12 @@ class AccountDropdowns extends Component {
           {
             closeMenu: () => {},
             onClick: () => {
-              const { selected, network } = this.props
-              const url = genAccountLink(selected, network)
+              const { selected } = this.props
+              const url = network === '99' ? `https://core-explorer.poa.network/account/${selected}` : genAccountLink(selected, network)
               global.platform.openWindow({ url })
             },
           },
-          'View account on Etherscan',
+          network === '99' ? 'View account on explorer' : 'View account on Etherscan',
         ),
         h(
           DropdownMenuItem,

--- a/ui/app/components/account-dropdowns.js
+++ b/ui/app/components/account-dropdowns.js
@@ -2,7 +2,7 @@ const Component = require('react').Component
 const PropTypes = require('react').PropTypes
 const h = require('react-hyperscript')
 const actions = require('../actions')
-const genAccountLink = require('etherscan-link').createAccountLink
+const {createAccountLink} = require('./create-link')
 const connect = require('react-redux').connect
 const Dropdown = require('./dropdown').Dropdown
 const DropdownMenuItem = require('./dropdown').DropdownMenuItem
@@ -19,6 +19,18 @@ class AccountDropdowns extends Component {
     }
     this.accountSelectorToggleClassName = 'accounts-selector'
     this.optionsMenuToggleClassName = 'fa-ellipsis-h'
+  }
+
+  generateLabel(chainId) {
+    switch (chainId) {
+      case '1':
+      case '3':
+      case '4':
+      case '42':
+        return 'View account on Etherscan'
+      case '99':
+        return 'View account on explorer'
+    }
   }
 
   renderAccounts () {
@@ -188,11 +200,11 @@ class AccountDropdowns extends Component {
             closeMenu: () => {},
             onClick: () => {
               const { selected } = this.props
-              const url = network === '99' ? `https://core-explorer.poa.network/account/${selected}` : genAccountLink(selected, network)
+              const url = createAccountLink(selected, network)
               global.platform.openWindow({ url })
             },
           },
-          network === '99' ? 'View account on explorer' : 'View account on Etherscan',
+          this.generateLabel(network),
         ),
         h(
           DropdownMenuItem,

--- a/ui/app/components/buy-button-subview.js
+++ b/ui/app/components/buy-button-subview.js
@@ -169,6 +169,23 @@ BuyButtonSubview.prototype.primarySubview = function () {
       ])
     )
 
+    case '99':
+      return (
+        h('div.flex-column', {
+          style: {
+            alignItems: 'center',
+            margin: '20px 50px',
+          },
+        }, [
+          h('button.text-transform-uppercase', {
+            onClick: () => this.props.dispatch(actions.buyEth({ network })),
+            style: {
+              marginTop: '15px',
+            },
+          }, 'POA Network'),
+      ])
+    )
+
     default:
       return (
         h('h2.error', 'Unknown network ID')

--- a/ui/app/components/create-link.js
+++ b/ui/app/components/create-link.js
@@ -1,0 +1,25 @@
+const genAccountLink = require('etherscan-link').createAccountLink
+const explorerLink = require('etherscan-link').createExplorerLink
+
+exports.createAccountLink = (accountId, chainId) => {
+  switch (chainId) {
+    case '1':
+    case '3':
+    case '4':
+    case '42':
+      return genAccountLink(accountId, chainId)
+    case '99':
+      return `https://core-explorer.poa.network/account/${accountId}`
+  }
+}
+exports.createExplorerLink = (hash, chainId) => {
+  switch (chainId) {
+    case '1':
+    case '3':
+    case '4':
+    case '42':
+      return explorerLink(hash, parseInt(chainId))
+    case '99':
+      return `https://core-explorer.poa.network/tx/${hash}`
+  }
+}

--- a/ui/app/components/eth-balance.js
+++ b/ui/app/components/eth-balance.js
@@ -18,7 +18,8 @@ EthBalanceComponent.prototype.render = function () {
   let { value } = props
   const { style, width } = props
   var needsParse = this.props.needsParse !== undefined ? this.props.needsParse : true
-  value = value ? formatBalance(value, 6, needsParse) : '...'
+  var network = this.props.network
+  value = value ? formatBalance(value, 6, needsParse, network) : '...'
 
   return (
 

--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -54,6 +54,9 @@ Network.prototype.render = function () {
   } else if (providerName === 'rinkeby') {
     hoverText = 'Rinkeby Test Network'
     iconName = 'rinkeby-test-network'
+  } else if (providerName === 'poa') {
+    hoverText = 'POA Network'
+    iconName = 'poa-network'
   } else {
     hoverText = 'Unknown Private Network'
     iconName = 'unknown-private-network'
@@ -104,6 +107,16 @@ Network.prototype.render = function () {
                   color: '#e7a218',
                 }},
               'Rinkeby Test Net'),
+              h('i.fa.fa-caret-down.fa-lg'),
+            ])
+          case 'poa-network':
+            return h('.network-indicator', [
+              h('.menu-icon.blue-triangle'),
+              h('.network-name', {
+                style: {
+                  color: '#676f8a',
+                }},
+              'POA Network'),
               h('i.fa.fa-caret-down.fa-lg'),
             ])
           default:

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -32,7 +32,7 @@ function PendingTx () {
 
 PendingTx.prototype.render = function () {
   const props = this.props
-  const { currentCurrency, blockGasLimit } = props
+  const { network, currentCurrency, blockGasLimit } = props
 
   const conversionRate = props.conversionRate
   const txMeta = this.gatherTxMeta()
@@ -135,6 +135,8 @@ PendingTx.prototype.render = function () {
                   currentCurrency,
                   inline: true,
                   labelColor: '#F7861C',
+                  network: network,
+                  showFiat: parseInt(network) !== 99,
                 }),
               ]),
             ]),
@@ -170,7 +172,7 @@ PendingTx.prototype.render = function () {
             // in the way that gas and gasLimit currently are.
             h('.row', [
               h('.cell.label', 'Amount'),
-              h(EthBalance, { value: txParams.value, currentCurrency, conversionRate }),
+              h(EthBalance, { value: txParams.value, currentCurrency, conversionRate, network: network, showFiat: parseInt(network) !== 99 }),
             ]),
 
             // Gas Limit (customizable)
@@ -223,7 +225,7 @@ PendingTx.prototype.render = function () {
             // Max Transaction Fee (calculated)
             h('.cell.row', [
               h('.cell.label', 'Max Transaction Fee'),
-              h(EthBalance, { value: txFeeBn.toString(16), currentCurrency, conversionRate }),
+              h(EthBalance, { value: txFeeBn.toString(16), currentCurrency, conversionRate, network: network, showFiat: parseInt(network) !== 99 }),
             ]),
 
             h('.cell.row', {
@@ -247,6 +249,8 @@ PendingTx.prototype.render = function () {
                   inline: true,
                   labelColor: 'black',
                   fontSize: '16px',
+                  network: network,
+                  showFiat: parseInt(network) !== 99,
                 }),
               ]),
             ]),

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -5,7 +5,7 @@ const connect = require('react-redux').connect
 
 const EthBalance = require('./eth-balance')
 const addressSummary = require('../util').addressSummary
-const explorerLink = require('etherscan-link').createExplorerLink
+const {createExplorerLink} = require('./create-link')
 const CopyButton = require('./copyButton')
 const vreme = new (require('vreme'))()
 const Tooltip = require('./tooltip')
@@ -67,7 +67,7 @@ TransactionListItem.prototype.render = function () {
         }
         event.stopPropagation()
         if (!transaction.hash || !isLinkable) return
-        var url = parseInt(network) === 99 ? `https://core-explorer.poa.network/tx/${transaction.hash}` : explorerLink(transaction.hash, parseInt(network))
+        const url = createExplorerLink(transaction.hash, network)
         global.platform.openWindow({ url })
       },
       style: {

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -44,7 +44,7 @@ TransactionListItem.prototype.render = function () {
 
   let isLinkable = false
   const numericNet = parseInt(network)
-  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 4 || numericNet === 42
+  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 4 || numericNet === 42 || numericNet === 99
 
   var isMsg = ('msgParams' in transaction)
   var isTx = ('txParams' in transaction)
@@ -67,7 +67,7 @@ TransactionListItem.prototype.render = function () {
         }
         event.stopPropagation()
         if (!transaction.hash || !isLinkable) return
-        var url = explorerLink(transaction.hash, parseInt(network))
+        var url = parseInt(network) === 99 ? `https://core-explorer.poa.network/tx/${transaction.hash}` : explorerLink(transaction.hash, parseInt(network))
         global.platform.openWindow({ url })
       },
       style: {
@@ -116,6 +116,7 @@ TransactionListItem.prototype.render = function () {
           width: '55px',
           shorten: true,
           showFiat: false,
+          network: network,
           style: {fontSize: '15px'},
         }) : h('.flex-column'),
       ]),

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -102,6 +102,7 @@ ConfirmTxScreen.prototype.render = function () {
         selectedAddress: props.selectedAddress,
         accounts: props.accounts,
         identities: props.identities,
+        network: props.network,
         conversionRate,
         currentCurrency,
         blockGasLimit,

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -208,6 +208,10 @@ function currentProviderDisplay (metamaskState) {
       value = 'Rinkeby Test Network'
       break
 
+    case 'poa':
+      title = 'Current Network'
+      value = 'POA Network'
+
     default:
       title = 'Current RPC'
       value = metamaskState.provider.rpcTarget

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -211,7 +211,7 @@ function currentProviderDisplay (metamaskState) {
     case 'poa':
       title = 'Current Network'
       value = 'POA Network'
-
+      break
     default:
       title = 'Current RPC'
       value = metamaskState.provider.rpcTarget

--- a/ui/app/css/lib.css
+++ b/ui/app/css/lib.css
@@ -195,6 +195,12 @@ hr.horizontal-line {
   background: #EBB33F;
 }
 
+div.blue-triangle {
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 12px solid #3ab9fe;
+}
+
 .pending-dot {
   background: red;
   left: 14px;

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -133,6 +133,8 @@ SendTransactionScreen.prototype.render = function () {
               value: account && account.balance,
               conversionRate,
               currentCurrency,
+              network: network,
+              showFiat: parseInt(network) !== 99,
             }),
 
           ]),

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -102,24 +102,32 @@ function parseBalance (balance) {
 
 // Takes wei hex, returns an object with three properties.
 // Its "formatted" property is what we generally use to render values.
-function formatBalance (balance, decimalsToKeep, needsParse = true) {
+function formatBalance (balance, decimalsToKeep, needsParse = true, network = null) {
   var parsed = needsParse ? parseBalance(balance) : balance.split('.')
   var beforeDecimal = parsed[0]
   var afterDecimal = parsed[1]
   var formatted = 'None'
+  var suffix = 'ETH'
+
+  switch (network) {
+    case '99':
+      suffix = 'POA'
+      break
+  }
+
   if (decimalsToKeep === undefined) {
     if (beforeDecimal === '0') {
       if (afterDecimal !== '0') {
         var sigFigs = afterDecimal.match(/^0*(.{2})/) // default: grabs 2 most significant digits
         if (sigFigs) { afterDecimal = sigFigs[0] }
-        formatted = '0.' + afterDecimal + ' ETH'
+        formatted = '0.' + afterDecimal + ' ' + suffix
       }
     } else {
-      formatted = beforeDecimal + '.' + afterDecimal.slice(0, 3) + ' ETH'
+      formatted = beforeDecimal + '.' + afterDecimal.slice(0, 3) + ' ' + suffix
     }
   } else {
     afterDecimal += Array(decimalsToKeep).join('0')
-    formatted = beforeDecimal + '.' + afterDecimal.slice(0, decimalsToKeep) + ' ETH'
+    formatted = beforeDecimal + '.' + afterDecimal.slice(0, decimalsToKeep) + ' ' + suffix
   }
   return formatted
 }


### PR DESCRIPTION
We would really like to provide an easy way for our users to use POA network in metamask so they can switch to POA network.
Poa.network is the compliant EIP155 network.
MEW already supports it.
https://myetherwallet.com
https://github.com/kvhnuke/etherwallet/pull/1427

Please let us know if there is anything else that we need to add in this PR.

@kumavis @danfinlay 