### PR TITLE
only check nonces of transactions who's from address match the txMeta

### DIFF
--- a/app/scripts/lib/pending-tx-tracker.js
+++ b/app/scripts/lib/pending-tx-tracker.js
@@ -178,7 +178,8 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
   }
 
   async _checkIfNonceIsTaken (txMeta) {
-    const completed = this.getCompletedTransactions()
+    const address = txMeta.txParams.from
+    const completed = this.getCompletedTransactions(address)
     const sameNonce = completed.filter((otherMeta) => {
       return otherMeta.txParams.nonce === txMeta.txParams.nonce
     })

--- a/test/unit/pending-tx-test.js
+++ b/test/unit/pending-tx-test.js
@@ -369,7 +369,7 @@ describe('PendingTransactionTracker', function () {
       }
     })
 
-    it('should return false', function (done) {
+    it('should return false if nonce has not been taken', function (done) {
       pendingTxTracker._checkIfNonceIsTaken({
         txParams: {
           from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
@@ -384,7 +384,7 @@ describe('PendingTransactionTracker', function () {
       .catch(done)
     })
 
-    it('should return true', function (done) {
+    it('should return true if nonce has been taken', function (done) {
       pendingTxTracker._checkIfNonceIsTaken({
         txParams: {
           from: '0x1678a085c290ebd122dc42cba69373b5953b831d',


### PR DESCRIPTION
fixes #2810 

the issue seemed to be that we were checking against all confirmed transactions instead of just the ones for that specific address 