### PR TITLE
Fix rounding error in ether input on send screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix bug that prevented updating custom token details.
 - No longer mark long-pending transactions as failed, since we now have button to retry with higher gas.
+- Fix rounding error when specifying an ether amount that has too much precision.
 
 ## 3.13.3 2017-12-14
 

--- a/app/scripts/lib/tx-gas-utils.js
+++ b/app/scripts/lib/tx-gas-utils.js
@@ -26,7 +26,7 @@ module.exports = class txProvideUtil {
         err.message.includes('Transaction execution error.') ||
         err.message.includes('gas required exceeds allowance or always failing transaction')
       )
-      if ( simulationFailed ) {
+      if (simulationFailed) {
         txMeta.simulationFails = true
         return txMeta
       }

--- a/app/scripts/notice-controller.js
+++ b/app/scripts/notice-controller.js
@@ -77,7 +77,7 @@ module.exports = class NoticeController extends EventEmitter {
     return uniqBy(oldNotices.concat(newNotices), 'id')
   }
 
-  _filterNotices(notices) {
+  _filterNotices (notices) {
     return notices.filter((newNotice) => {
       if ('version' in newNotice) {
         const satisfied = semver.satisfies(this.version, newNotice.version)

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -201,6 +201,12 @@ describe('util', function () {
         var output = util.normalizeEthStringToWei(input)
         assert.equal(output.toString(10), ethInWei)
       })
+
+      it('should account for overflow numbers gracefully by dropping extra precision.', function () {
+        var input = '1.11111111111111111111'
+        var output = util.normalizeEthStringToWei(input)
+        assert.equal(output.toString(10), '1111111111111111111')
+      })
     })
 
     describe('#normalizeNumberToWei', function () {

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -207,6 +207,12 @@ describe('util', function () {
         var output = util.normalizeEthStringToWei(input)
         assert.equal(output.toString(10), '1111111111111111111')
       })
+
+      it('should not truncate very exact wei values that do not have extra precision.', function () {
+        var input = '1.100000000000000001'
+        var output = util.normalizeEthStringToWei(input)
+        assert.equal(output.toString(10), '1100000000000000001')
+      })
     })
 
     describe('#normalizeNumberToWei', function () {

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -247,16 +247,26 @@ SendTransactionScreen.prototype.onSubmit = function () {
   const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
   const nickname = state.nickname || ' '
   const input = document.querySelector('input[name="amount"]').value
+  const parts = input.split('')
 
-  if (isNaN(input)) {
+  let message
+
+  if (isNaN(input) || input === '') {
     message = 'Invalid ether value.'
     return this.props.dispatch(actions.displayWarning(message))
+  }
+
+  if (parts[1]) {
+    var decimal = parts[1]
+    if (decimal.length > 18) {
+      message = 'Ether amount is too precise.'
+      return this.props.dispatch(actions.displayWarning(message))
+    }
   }
 
   const value = util.normalizeEthStringToWei(input)
   const txData = document.querySelector('input[name="txData"]').value
   const balance = this.props.balance
-  let message
 
   if (value.gt(balance)) {
     message = 'Insufficient funds.'

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -247,6 +247,12 @@ SendTransactionScreen.prototype.onSubmit = function () {
   const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
   const nickname = state.nickname || ' '
   const input = document.querySelector('input[name="amount"]').value
+
+  if (isNaN(input)) {
+    message = 'Invalid ether value.'
+    return this.props.dispatch(actions.displayWarning(message))
+  }
+
   const value = util.normalizeEthStringToWei(input)
   const txData = document.querySelector('input[name="txData"]').value
   const balance = this.props.balance

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -193,6 +193,9 @@ function normalizeEthStringToWei (str) {
     while (decimal.length < 18) {
       decimal += '0'
     }
+    if (decimal.length > 18) {
+      decimal = decimal.slice(0, 18)
+    }
     const decimalBN = new ethUtil.BN(decimal, 10)
     eth = eth.add(decimalBN)
   }


### PR DESCRIPTION
Fixes #2782 by creating a front-end validation to prevent invalid inputs and an additional safeguard on the eth-to-wei conversion by truncating any extra precision. 