### PR TITLE
Fix condition where failing seed word checks would infinite-spin future attempts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix bug that prevented updating custom token details.
 - No longer mark long-pending transactions as failed, since we now have button to retry with higher gas.
 - Fix rounding error when specifying an ether amount that has too much precision.
+- Fix bug where incorrectly inputting seed phrase would prevent any future attempts from succeeding.
 
 ## 3.13.3 2017-12-14
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -513,10 +513,15 @@ module.exports = class MetamaskController extends EventEmitter {
 
   async createNewVaultAndRestore (password, seed) {
     const release = await this.createVaultMutex.acquire()
-    const vault = await this.keyringController.createNewVaultAndRestore(password, seed)
-    this.selectFirstIdentity(vault)
-    release()
-    return vault
+    try {
+      const vault = await this.keyringController.createNewVaultAndRestore(password, seed)
+      this.selectFirstIdentity(vault)
+      release()
+      return vault
+    } catch (err) {
+      release()
+      throw err
+    }
   }
 
   selectFirstIdentity (vault) {

--- a/test/unit/metamask-controller-test.js
+++ b/test/unit/metamask-controller-test.js
@@ -39,16 +39,18 @@ describe('MetaMaskController', function () {
 
     beforeEach(function () {
       sinon.spy(metamaskController.keyringController, 'createNewVaultAndKeychain')
+      sinon.spy(metamaskController.keyringController, 'createNewVaultAndRestore')
     })
 
     afterEach(function () {
       metamaskController.keyringController.createNewVaultAndKeychain.restore()
+      metamaskController.keyringController.createNewVaultAndRestore.restore()
     })
 
     describe('#createNewVaultAndKeychain', function () {
       it('can only create new vault on keyringController once', async function () {
-
         const selectStub = sinon.stub(metamaskController, 'selectFirstIdentity')
+
 
         const password = 'a-fake-password'
 
@@ -60,6 +62,22 @@ describe('MetaMaskController', function () {
         selectStub.reset()
       })
     })
+
+    describe('#createNewVaultAndRestore', function () {
+      it('should be able to call newVaultAndRestore despite a mistake.', async function () {
+        // const selectStub = sinon.stub(metamaskController, 'selectFirstIdentity')
+
+        const password = 'what-what-what'
+        const wrongSeed = 'debris dizzy just program just float decrease vacant alarm reduce speak stadiu'
+        const rightSeed = 'debris dizzy just program just float decrease vacant alarm reduce speak stadium'
+          const first = await metamaskController.createNewVaultAndRestore(password, wrongSeed)
+            .catch((e) => {
+              return
+            })
+          const second = await metamaskController.createNewVaultAndRestore(password, rightSeed)
+
+        assert(metamaskController.keyringController.createNewVaultAndRestore.calledTwice)
+      })
+    })
   })
 })
-

--- a/ui/app/keychains/hd/restore-vault.js
+++ b/ui/app/keychains/hd/restore-vault.js
@@ -149,4 +149,8 @@ RestoreVaultScreen.prototype.createNewVaultAndRestore = function () {
   this.warning = null
   this.props.dispatch(actions.displayWarning(this.warning))
   this.props.dispatch(actions.createNewVaultAndRestore(password, seed))
+  .catch((err) => {
+    log.error(err.message)
+  })
+
 }


### PR DESCRIPTION
Fixes #2812 by adjusting the semaphore logic to account for rejected promises. Now users should be able to fail at seed words as many times as they'd like!