### PR TITLE
Update vinyl-buffer to version 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "tape": "^4.5.1",
     "testem": "^1.10.3",
     "uglifyify": "^4.0.2",
-    "vinyl-buffer": "^1.0.0",
+    "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "watchify": "^3.9.0"
   },


### PR DESCRIPTION
When vinyl-source-stream was updated to v2.0.0, vinyl-buffer should have been updated to v1.0.1. Referenced here https://github.com/hughsk/vinyl-source-stream/issues/27