### PR TITLE
info.js  Remove width element to fix email layout

### DIFF
--- a/ui/app/info.js
+++ b/ui/app/info.js
@@ -138,7 +138,6 @@ InfoScreen.prototype.render = function () {
               h('div.fa.fa-envelope', [
                 h('a.info', {
                   target: '_blank',
-                  style: { width: '85vw' },
                   href: 'mailto:help@metamask.io?subject=Feedback',
                 }, 'Email us!'),
               ]),


### PR DESCRIPTION
This should fix the bug with email layout:

![screenshot from 2018-01-04 17-07-35](https://user-images.githubusercontent.com/8781107/34567191-475ad644-f172-11e7-9e69-8287c66df920.png)

But I haven't tested it, because I couldn't find a way to edit extension HTML from FF.