### PR TITLE
[NewUI-flat] Shows all pending signature requests in tx list. (WIP - do not merge)

### DIFF
--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -51,19 +51,21 @@ TxListItem.prototype.getAddressText = function () {
   const {
     address,
     txParams = {},
+    isMsg,
   } = this.props
 
   const decodedData = txParams.data && abiDecoder.decodeMethod(txParams.data)
   const { name: txDataName, params = [] } = decodedData || {}
   const { value } = params[0] || {}
 
-  switch (txDataName) {
-    case 'transfer':
-      return `${value.slice(0, 10)}...${value.slice(-4)}`
-    default:
-      return address
-        ? `${address.slice(0, 10)}...${address.slice(-4)}`
-        : 'Contract Published'
+  if (txDataName === 'transfer') {
+    return `${value.slice(0, 10)}...${value.slice(-4)}`
+  } else if (isMsg) {
+    return 'Signature Requested'
+  } else if (address) {
+    return `${address.slice(0, 10)}...${address.slice(-4)}`
+  } else {
+    return 'Contract Published'
   }
 }
 

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -71,9 +71,9 @@ TxList.prototype.renderTransactionListItem = function (transaction, conversionRa
 
   const props = {
     dateString: formatDate(transaction.time),
-    address: transaction.txParams.to,
+    address: transaction.txParams && transaction.txParams.to,
     transactionStatus: transaction.status,
-    transactionAmount: transaction.txParams.value,
+    transactionAmount: transaction.txParams && transaction.txParams.value,
     transActionId: transaction.id,
     transactionHash: transaction.hash,
     transactionNetworkId: transaction.metamaskNetworkId,
@@ -101,6 +101,7 @@ TxList.prototype.renderTransactionListItem = function (transaction, conversionRa
     transactionHash,
     conversionRate,
     tokenInfoGetter: this.tokenInfoGetter,
+    isMsg: Boolean(transaction.msgParams && transaction.msgParams.from),
   }
 
   const isUnapproved = transactionStatus === 'unapproved'

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -107,12 +107,22 @@ function getCurrentAccountWithSendEtherInfo (state) {
 
 function transactionsSelector (state) {
   const { network, selectedTokenAddress } = state.metamask
+
   const unapprovedMsgs = valuesFor(state.metamask.unapprovedMsgs)
+  const unapprovedPersonalMsgs = valuesFor(state.metamask.unapprovedPersonalMsgs)
+  const unapprovedTypedMessages = valuesFor(state.metamask.unapprovedTypedMessages)
+  const allMessages = [
+    ...unapprovedMsgs,
+    ...unapprovedPersonalMsgs,
+    ...unapprovedTypedMessages,
+  ]
+
   const shapeShiftTxList = (network === '1') ? state.metamask.shapeShiftTxList : undefined
   const transactions = state.metamask.selectedAddressTxList || []
-  const txsToRender = !shapeShiftTxList ? transactions.concat(unapprovedMsgs) : transactions.concat(unapprovedMsgs, shapeShiftTxList)
+  const txsToRender = !shapeShiftTxList
+    ? transactions.concat(allMessages)
+    : transactions.concat(allMessages, shapeShiftTxList)
 
-  // console.log({txsToRender, selectedTokenAddress})
   return selectedTokenAddress
     ? txsToRender
       .filter(({ txParams: { to } }) => to === selectedTokenAddress)


### PR DESCRIPTION
This PR originally intended to fix the following bug:
"Clicking eth_sign twice without signing the first causes infinite spinner"

That bug occurs when there are two or more `unnapprovedMsgs` (i.e. `eth_sign` signature requests) and one is approved or cancelled. After approving or cancelling, the user is taken back to the account details page which attempts to render `unnapprovedMsgs` as a `tx-list-item`. It would break on that attempted render.

While discovering this, I discovered that there is code in both the new and old UI for rendering `unapprovedMsgs` in the tx-list.

Based on that discovery, this PR ensures that all unapproved msgs (eth_sign, sign_typed_data, etc.) are shown in the tx-list. After these msgs are confirmed or cancelled, they no longer appear in the list.

**_Before we merge we need to confirm whether this is desired UX._**

![signmessageintxlist](https://user-images.githubusercontent.com/7499938/34577306-4a0e8a78-f15b-11e7-9460-ceb06cf4b539.gif)
