### PR TITLE
Improve gas estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Improve gas price suggestion to be closer to the lowest that will be accepted.
 - Throw an error if a application tries to submit a tx whose value is a decimal, and inform that it should be in wei.
 - Fix bug that prevented updating custom token details.
 - No longer mark long-pending transactions as failed, since we now have button to retry with higher gas.

--- a/app/scripts/controllers/blacklist.js
+++ b/app/scripts/controllers/blacklist.js
@@ -57,3 +57,4 @@ class BlacklistController {
 }
 
 module.exports = BlacklistController
+

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -32,6 +32,7 @@ module.exports = class TransactionController extends EventEmitter {
     this.provider = opts.provider
     this.blockTracker = opts.blockTracker
     this.signEthTx = opts.signTransaction
+    this.getGasPrice = opts.getGasPrice
 
     this.memStore = new ObservableStore({})
     this.query = new EthQuery(this.provider)
@@ -179,7 +180,7 @@ module.exports = class TransactionController extends EventEmitter {
     // ensure value
     txMeta.gasPriceSpecified = Boolean(txParams.gasPrice)
     txMeta.nonceSpecified = Boolean(txParams.nonce)
-    const gasPrice = txParams.gasPrice || await this.query.gasPrice()
+    const gasPrice = txParams.gasPrice || this.getGasPrice()
     txParams.gasPrice = ethUtil.addHexPrefix(gasPrice.toString(16))
     txParams.value = txParams.value || '0x0'
     // set gasLimit

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -180,7 +180,8 @@ module.exports = class TransactionController extends EventEmitter {
     // ensure value
     txMeta.gasPriceSpecified = Boolean(txParams.gasPrice)
     txMeta.nonceSpecified = Boolean(txParams.nonce)
-    const gasPrice = txParams.gasPrice || this.getGasPrice()
+    const gasPrice = txParams.gasPrice || this.getGasPrice ? this.getGasPrice()
+      : await this.query.gasPrice()
     txParams.gasPrice = ethUtil.addHexPrefix(gasPrice.toString(16))
     txParams.value = txParams.value || '0x0'
     // set gasLimit

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -489,9 +489,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
   getGasPrice () {
     const { recentBlocksController } = this
-    console.dir(recentBlocksController)
     const { recentBlocks } = recentBlocksController.store.getState()
-    console.dir(recentBlocks)
     const lowestPrices = recentBlocks.map((block) => {
       return block.transactions
       .sort((a, b) => {
@@ -499,7 +497,6 @@ module.exports = class MetamaskController extends EventEmitter {
       })[0]
     })
     .map(number => number.div(GWEI_BN).toNumber())
-    console.dir({ lowestPrices })
     return percentile(50, lowestPrices)
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -491,13 +491,20 @@ module.exports = class MetamaskController extends EventEmitter {
     const { recentBlocksController } = this
     const { recentBlocks } = recentBlocksController.store.getState()
     const lowestPrices = recentBlocks.map((block) => {
-      return block.transactions
+      if (!block.gasPrices) {
+        return new BN(0)
+      }
+      return block.gasPrices
+      .map(hexPrefix => hexPrefix.substr(2))
+      .map(hex => new BN(hex, 16))
       .sort((a, b) => {
         return a.gt(b) ? 1 : -1
       })[0]
     })
     .map(number => number.div(GWEI_BN).toNumber())
-    return percentile(50, lowestPrices)
+    const percentileNum = percentile(50, lowestPrices)
+    const percentileNumBn = new BN(percentileNum)
+    return '0x' + percentileNumBn.mul(GWEI_BN).toString(16)
   }
 
   //

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "obj-multiplex": "^1.0.0",
     "obs-store": "^3.0.0",
     "once": "^1.3.3",
+    "percentile": "^1.2.0",
     "ping-pong-stream": "^1.0.0",
     "pojo-migrator": "^2.1.0",
     "polyfill-crypto.getrandomvalues": "^1.0.0",

--- a/test/unit/metamask-controller-test.js
+++ b/test/unit/metamask-controller-test.js
@@ -55,8 +55,10 @@ describe('MetaMaskController', function () {
             getState: () => {
               return {
                 recentBlocks: [
-                  { transactions: [ new BN('50000000000'), new BN('100000000000') ] },
-                  { transactions: [ new BN('60000000000'), new BN('100000000000') ] },
+                  { gasPrices: [ '0x3b9aca00', '0x174876e800'] },
+                  { gasPrices: [ '0x3b9aca00', '0x174876e800'] },
+                  { gasPrices: [ '0x174876e800', '0x174876e800' ]},
+                  { gasPrices: [ '0x174876e800', '0x174876e800' ]},
                 ]
               }
             }
@@ -64,7 +66,7 @@ describe('MetaMaskController', function () {
         }
 
         const gasPrice = metamaskController.getGasPrice()
-        assert.equal(gasPrice, 50, 'accurately estimates 50th percentile accepted gas price')
+        assert.equal(gasPrice, '0x3b9aca00', 'accurately estimates 50th percentile accepted gas price')
 
         metamaskController.recentBlocksController = realRecentBlocksController
       })


### PR DESCRIPTION
Needs QA to be sure.

Replaces our client-dependent gas price estimation with an algorithm that uses recent successful transaction data to suggest a lower gas price.

Looks at last 20 blocks, looks at lowest mined tx for each, returns the lowest price that would be returned by 50% of those blocks.