### PR TITLE
Account for 0x/empty string recipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Remove recipient field if application initializes a tx with an empty string, or 0x, and tx data. Throw an error with the same condition, but without tx data.
 - Throw an error if a application tries to submit a tx whose value is a decimal, and inform that it should be in wei.
 - Fix bug that prevented updating custom token details.
 - No longer mark long-pending transactions as failed, since we now have button to retry with higher gas.

--- a/app/scripts/lib/tx-gas-utils.js
+++ b/app/scripts/lib/tx-gas-utils.js
@@ -81,6 +81,7 @@ module.exports = class txProvideUtil {
   }
 
   async validateTxParams (txParams) {
+    this.validateRecipient(txParams)
     if ('value' in txParams) {
       const value = txParams.value.toString()
       if (value.includes('-')) {
@@ -91,5 +92,15 @@ module.exports = class txProvideUtil {
         throw new Error(`Invalid transaction value of ${txParams.value} number must be in wei`)
       }
     }
+  }
+  validateRecipient (txParams) {
+    if (txParams.to === '0x') {
+      if (txParams.data) {
+        delete txParams.to
+      } else {
+        throw new Error('Invalid recipient address')
+      }
+    }
+    return txParams
   }
 }

--- a/test/unit/tx-gas-util-test.js
+++ b/test/unit/tx-gas-util-test.js
@@ -1,0 +1,32 @@
+const assert = require('assert')
+const TxGasUtils = require('../../app/scripts/lib/tx-gas-utils')
+const { createStubedProvider } = require('../stub/provider')
+
+describe('Tx Gas Util', function () {
+  let txGasUtil, provider, providerResultStub
+  beforeEach(function () {
+    providerResultStub = {}
+    provider = createStubedProvider(providerResultStub)
+    txGasUtil = new TxGasUtils({
+      provider,
+    })
+  })
+
+  it('removes recipient for txParams with 0x when contract data is provided', function () {
+    const zeroRecipientandDataTxParams = {
+      from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
+      to: '0x',
+      data: 'bytecode',
+    }
+    const sanitizedTxParams = txGasUtil.validateRecipient(zeroRecipientandDataTxParams)
+    assert.deepEqual(sanitizedTxParams, { from: '0x1678a085c290ebd122dc42cba69373b5953b831d', data: 'bytecode' }, 'no recipient with 0x')
+  })
+
+  it('should error when recipient is 0x', function () {
+    const zeroRecipientTxParams = {
+      from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
+      to: '0x',
+    }
+    assert.throws(() => { txGasUtil.validateRecipient(zeroRecipientTxParams) }, Error, 'Invalid recipient address')
+  })
+})


### PR DESCRIPTION
Remove recipient field if application initializes a tx with an empty string, or 0x, and tx data. Throw an error with the same condition, but without tx data. Primarily for deploying contracts from MEW.
Added in `tx-gas-utils` but could have added to `app/scripts/lib/util`.
 Fixes #2621.
  
  