### PR TITLE
Default to estimating 1 gwei for empty blocks.

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -492,7 +492,7 @@ module.exports = class MetamaskController extends EventEmitter {
     const { recentBlocks } = recentBlocksController.store.getState()
     const lowestPrices = recentBlocks.map((block) => {
       if (!block.gasPrices) {
-        return new BN(0)
+        return GWEI_BN
       }
       return block.gasPrices
       .map(hexPrefix => hexPrefix.substr(2))


### PR DESCRIPTION
To avoid estimating 0 gwei on low-traffic private networks.