### PR TITLE
Provider - Use Infura rest api for infura networks

### DIFF
--- a/app/scripts/controllers/network.js
+++ b/app/scripts/controllers/network.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const EventEmitter = require('events')
 const createMetamaskProvider = require('web3-provider-engine/zero.js')
+const SubproviderFromProvider = require('web3-provider-engine/subproviders/web3.js')
 const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider')
 const ObservableStore = require('obs-store')
 const ComposedStore = require('obs-store/lib/composed')
@@ -133,15 +134,17 @@ module.exports = class NetworkController extends EventEmitter {
 
   _configureInfuraProvider (opts) {
     log.info('_configureInfuraProvider', opts)
-    const blockTrackerProvider = createInfuraProvider({
+    const infuraProvider = createInfuraProvider({
       network: opts.type,
     })
+    const infuraSubprovider = new SubproviderFromProvider(infuraProvider)
     const providerParams = extend(this._baseProviderParams, {
       rpcUrl: opts.rpcUrl,
       engineParams: {
         pollingInterval: 8000,
-        blockTrackerProvider,
+        blockTrackerProvider: infuraProvider,
       },
+      dataSubprovider: infuraSubprovider,
     })
     const provider = createMetamaskProvider(providerParams)
     this._setProvider(provider)

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -180,8 +180,10 @@ module.exports = class TransactionController extends EventEmitter {
     // ensure value
     txMeta.gasPriceSpecified = Boolean(txParams.gasPrice)
     txMeta.nonceSpecified = Boolean(txParams.nonce)
-    const gasPrice = txParams.gasPrice || this.getGasPrice ? this.getGasPrice()
-      : await this.query.gasPrice()
+    let gasPrice = txParams.gasPrice
+    if (!gasPrice) {
+      gasPrice = this.getGasPrice ? this.getGasPrice() : await this.query.gasPrice()
+    }
     txParams.gasPrice = ethUtil.addHexPrefix(gasPrice.toString(16))
     txParams.value = txParams.value || '0x0'
     // set gasLimit

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eth-contract-metadata": "^1.1.4",
     "eth-hd-keyring": "^1.2.1",
     "eth-json-rpc-filters": "^1.2.4",
-    "eth-json-rpc-infura": "^2.0.3",
+    "eth-json-rpc-infura": "^2.0.5",
     "eth-keyring-controller": "^2.1.2",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eth-contract-metadata": "^1.1.4",
     "eth-hd-keyring": "^1.2.1",
     "eth-json-rpc-filters": "^1.2.4",
-    "eth-json-rpc-infura": "^1.0.2",
+    "eth-json-rpc-infura": "^2.0.3",
     "eth-keyring-controller": "^2.1.2",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
@@ -154,7 +154,7 @@
     "valid-url": "^1.0.9",
     "vreme": "^3.0.2",
     "web3": "^0.20.1",
-    "web3-provider-engine": "^13.4.0",
+    "web3-provider-engine": "^13.5.0",
     "web3-stream-provider": "^3.0.1",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Needs QA and approval of go-live before partial rollout.
I used it and it seems to work great. Quite speedy responses on `eth_call`.

Infura may make a breaking change on their end.