### PR TITLE
Set account-detail-screen height as 500px for Firefox

### DIFF
--- a/ui/app/css/index.css
+++ b/ui/app/css/index.css
@@ -439,6 +439,7 @@ input.large-input {
 /* account detail screen */
 
 .account-detail-section {
+  height: 500px;
   display: flex;
   flex-wrap: wrap;
   overflow-y: auto;


### PR DESCRIPTION
Sets the account-detail-screen height as 500px for Firefox. Will introduce an issue with screens that have a different text size other than 100%.