### PR TITLE
Improve gas price estimation by backfilling recent-blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Further improve gas price estimation.
+
 ## 3.13.4 2018-1-9
 
 - Remove recipient field if application initializes a tx with an empty string, or 0x, and tx data. Throw an error with the same condition, but without tx data.

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -1,11 +1,13 @@
 const ObservableStore = require('obs-store')
 const extend = require('xtend')
+const BN = require('ethereumjs-util').BN
 
 class RecentBlocksController {
 
   constructor (opts = {}) {
-    const { blockTracker } = opts
+    const { blockTracker, ethQuery } = opts
     this.blockTracker = blockTracker
+    this.ethQuery = ethQuery
     this.historyLength = opts.historyLength || 40
 
     const initState = extend({
@@ -14,6 +16,7 @@ class RecentBlocksController {
     this.store = new ObservableStore(initState)
 
     this.blockTracker.on('block', this.processBlock.bind(this))
+    this.backfill()
   }
 
   resetState () {
@@ -23,12 +26,7 @@ class RecentBlocksController {
   }
 
   processBlock (newBlock) {
-    const block = extend(newBlock, {
-      gasPrices: newBlock.transactions.map((tx) => {
-        return tx.gasPrice
-      }),
-    })
-    delete block.transactions
+    const block = this.mapTransactionsToPrices(newBlock)
 
     const state = this.store.getState()
     state.recentBlocks.push(block)
@@ -39,6 +37,73 @@ class RecentBlocksController {
 
     this.store.updateState(state)
   }
+
+  backfillBlock (newBlock) {
+    const block = this.mapTransactionsToPrices(newBlock)
+
+    const state = this.store.getState()
+
+    if (state.recentBlocks.length < this.historyLength) {
+      state.recentBlocks.unshift(block)
+    }
+
+    this.store.updateState(state)
+  }
+
+  mapTransactionsToPrices (newBlock) {
+    const block = extend(newBlock, {
+      gasPrices: newBlock.transactions.map((tx) => {
+        return tx.gasPrice
+      }),
+    })
+    delete block.transactions
+    return block
+  }
+
+  async backfill() {
+    this.blockTracker.once('block', async (block) => {
+      let blockNum = block.number
+      let recentBlocks
+      let state = this.store.getState()
+      recentBlocks = state.recentBlocks
+
+      while (recentBlocks.length < this.historyLength) {
+        try {
+          let blockNumBn = new BN(blockNum.substr(2), 16)
+          const newNum = blockNumBn.subn(1).toString(10)
+          const newBlock = await this.getBlockByNumber(newNum)
+
+          if (newBlock) {
+            this.backfillBlock(newBlock)
+            blockNum = newBlock.number
+          }
+
+          state = this.store.getState()
+          recentBlocks = state.recentBlocks
+        } catch (e) {
+          log.error(e)
+        }
+        await this.wait()
+      }
+    })
+  }
+
+  async wait () {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 100)
+    })
+  }
+
+  async getBlockByNumber (number) {
+    const bn = new BN(number)
+    return new Promise((resolve, reject) => {
+      this.ethQuery.getBlockByNumber('0x' + bn.toString(16), true, (err, block) => {
+        if (err) reject(err)
+        resolve(block)
+      })
+    })
+  }
+
 }
 
 module.exports = RecentBlocksController

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -1,13 +1,14 @@
 const ObservableStore = require('obs-store')
 const extend = require('xtend')
 const BN = require('ethereumjs-util').BN
+const EthQuery = require('eth-query')
 
 class RecentBlocksController {
 
   constructor (opts = {}) {
-    const { blockTracker, ethQuery } = opts
+    const { blockTracker, provider } = opts
     this.blockTracker = blockTracker
-    this.ethQuery = ethQuery
+    this.ethQuery = new EthQuery(provider)
     this.historyLength = opts.historyLength || 40
 
     const initState = extend({

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -94,12 +94,14 @@ module.exports = class MetamaskController extends EventEmitter {
     this.provider = this.initializeProvider()
     this.blockTracker = this.provider._blockTracker
 
-    this.recentBlocksController = new RecentBlocksController({
-      blockTracker: this.blockTracker,
-    })
-
     // eth data query tools
     this.ethQuery = new EthQuery(this.provider)
+
+    this.recentBlocksController = new RecentBlocksController({
+      blockTracker: this.blockTracker,
+      ethQuery: this.ethQuery,
+    })
+
     // account tracker watches balances, nonces, and any code at their address.
     this.accountTracker = new AccountTracker({
       provider: this.provider,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5,7 +5,6 @@ const Dnode = require('dnode')
 const ObservableStore = require('obs-store')
 const asStream = require('obs-store/lib/asStream')
 const AccountTracker = require('./lib/account-tracker')
-const EthQuery = require('eth-query')
 const RpcEngine = require('json-rpc-engine')
 const debounce = require('debounce')
 const createEngineStream = require('json-rpc-middleware-stream/engineStream')
@@ -94,12 +93,9 @@ module.exports = class MetamaskController extends EventEmitter {
     this.provider = this.initializeProvider()
     this.blockTracker = this.provider._blockTracker
 
-    // eth data query tools
-    this.ethQuery = new EthQuery(this.provider)
-
     this.recentBlocksController = new RecentBlocksController({
       blockTracker: this.blockTracker,
-      ethQuery: this.ethQuery,
+      provider: this.provider,
     })
 
     // account tracker watches balances, nonces, and any code at their address.
@@ -142,7 +138,6 @@ module.exports = class MetamaskController extends EventEmitter {
       signTransaction: this.keyringController.signTransaction.bind(this.keyringController),
       provider: this.provider,
       blockTracker: this.blockTracker,
-      ethQuery: this.ethQuery,
       getGasPrice: this.getGasPrice.bind(this),
     })
     this.txController.on('newUnapprovedTx', opts.showUnapprovedTx.bind(opts))


### PR DESCRIPTION
When first initializing, recent-block controller now back-fills up to
its desired history length. This makes estimated gas prices reflect a
longer recent history, even when first switching to a new network.

Fixes #2925