### PR TITLE
[NewUI] Restore display of all unconfirmed transactions.

### DIFF
--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -389,7 +389,7 @@ function reduceApp (state, action) {
       return extend(appState, {
         currentView: {
           name: 'confTx',
-          context: action.id ? indexForPending(state, action.id) : indexForLastPending(state),
+          context: action.id ? indexForPending(state, action.id) : 0,
         },
         transForward: action.transForward,
         warning: null,
@@ -409,36 +409,36 @@ function reduceApp (state, action) {
 
     case actions.COMPLETED_TX:
       log.debug('reducing COMPLETED_TX for tx ' + action.value)
-      // const otherUnconfActions = getUnconfActionList(state)
-      // .filter(tx => tx.id !== action.value)
-      // const hasOtherUnconfActions = otherUnconfActions.length > 0
+      const otherUnconfActions = getUnconfActionList(state)
+        .filter(tx => tx.id !== action.value)
+      const hasOtherUnconfActions = otherUnconfActions.length > 0
 
-      // if (hasOtherUnconfActions) {
-      //   log.debug('reducer detected txs - rendering confTx view')
-      //   return extend(appState, {
-      //     transForward: false,
-      //     currentView: {
-      //       name: 'confTx',
-      //       context: 0,
-      //     },
-      //     warning: null,
-      //   })
-      // } else {
-      log.debug('attempting to close popup')
-      return extend(appState, {
-        // indicate notification should close
-        shouldClose: true,
-        transForward: false,
-        warning: null,
-        currentView: {
-          name: 'accountDetail',
-          context: state.metamask.selectedAddress,
-        },
-        accountDetail: {
-          subview: 'transactions',
-        },
-      })
-      // }
+      if (hasOtherUnconfActions) {
+        log.debug('reducer detected txs - rendering confTx view')
+        return extend(appState, {
+          transForward: false,
+          currentView: {
+            name: 'confTx',
+            context: 0,
+          },
+          warning: null,
+        })
+      } else {
+        log.debug('attempting to close popup')
+        return extend(appState, {
+          // indicate notification should close
+          shouldClose: true,
+          transForward: false,
+          warning: null,
+          currentView: {
+            name: 'accountDetail',
+            context: state.metamask.selectedAddress,
+          },
+          accountDetail: {
+            subview: 'transactions',
+          },
+        })
+      }
 
     case actions.NEXT_TX:
       return extend(appState, {
@@ -679,6 +679,6 @@ function indexForPending (state, txId) {
   return index
 }
 
-function indexForLastPending (state) {
-  return getUnconfActionList(state).length
-}
+// function indexForLastPending (state) {
+//   return getUnconfActionList(state).length
+// }


### PR DESCRIPTION
Resolves two bugs:

1. "Clicking eth_sign twice without signing the first causes infinite spinner"
2. "Loading spinner shows when creating account while on send screen"

And meets the requirements detailed in this comment: https://github.com/MetaMask/metamask-extension/pull/2858#issuecomment-356140774

This is done by restoring the functionality currently on master. I believe that this is a sub-optimal user experience as the user is unable to see a list of their currently pending transactions. However, improving the UX can be resolved at a later time. For now resolving bugs in a way that meets requirements has priority.

Gif showing bug 1 (see above) resolved:
![ethsigntwice](https://user-images.githubusercontent.com/7499938/34968547-68fe80d6-fa44-11e7-81c5-73519c57650c.gif)

Gif showing bug 2 (see above) resolved:
![createaccountwhileonsend](https://user-images.githubusercontent.com/7499938/34968703-62a252fc-fa45-11e7-9d79-63840dbb150b.gif)

Gif showing how it works when there are lots of unconfirmed transactions:
![transactions_all](https://user-images.githubusercontent.com/7499938/34968479-0e633afe-fa44-11e7-8a2a-b63838125d37.gif)

Also tested to ensure no breaking changes:
- creating, adding and sending a token
- editing the sending of a transaction created by a dapp
- editing the sending of tokens
