### PR TITLE
[NewUI] Vertically centers the text of the new ui modal header.

### DIFF
--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -815,6 +815,7 @@
   width: 100%;
   display: flex;
   justify-content: center;
+  align-items: center;
   padding: 30px;
   font-size: 22px;
   color: $nile-blue;


### PR DESCRIPTION
Before:
<img width="426" alt="screen shot 2018-01-16 at 2 44 21 pm" src="https://user-images.githubusercontent.com/7499938/35004781-de0ed2c2-facb-11e7-92b9-93d69858deb1.png">

After:
<img width="352" alt="screen shot 2018-01-16 at 2 42 31 pm" src="https://user-images.githubusercontent.com/7499938/35004784-e1438078-facb-11e7-87cb-9ba01cd68fce.png">