### PR TITLE
Add network-indicator classname to network loading spinner

### DIFF
--- a/ui/app/components/network.js
+++ b/ui/app/components/network.js
@@ -22,7 +22,7 @@ Network.prototype.render = function () {
   let iconName, hoverText
 
   if (networkNumber === 'loading') {
-    return h('span.pointer', {
+    return h('span.pointer.network-indicator', {
       style: {
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
Adds the network-indicator class to network loading spinner.