### PR TITLE
Tests - Improved provider stubbing with test-block-middleware

### DIFF
--- a/app/scripts/lib/tx-gas-utils.js
+++ b/app/scripts/lib/tx-gas-utils.js
@@ -12,7 +12,8 @@ its passed ethquery
 and used to do things like calculate gas of a tx.
 */
 
-module.exports = class txProvideUtil {
+module.exports = class TxGasUtil {
+  
   constructor (provider) {
     this.query = new EthQuery(provider)
   }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ensnare": "^1.0.0",
     "eslint-plugin-react": "^7.4.0",
     "eth-bin-to-ops": "^1.0.1",
+    "eth-block-tracker": "^2.3.0",
     "eth-contract-metadata": "^1.1.4",
     "eth-json-rpc-filters": "^1.2.5",
     "eth-json-rpc-infura": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "ensnare": "^1.0.0",
     "eslint-plugin-react": "^7.4.0",
     "eth-bin-to-ops": "^1.0.1",
-    "eth-block-tracker": "^2.2.0",
     "eth-contract-metadata": "^1.1.4",
     "eth-json-rpc-filters": "^1.2.5",
     "eth-json-rpc-infura": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "iframe-stream": "^3.0.0",
     "inject-css": "^0.1.1",
     "jazzicon": "^1.2.0",
-    "json-rpc-engine": "3.2.0",
+    "json-rpc-engine": "^3.5.0",
     "json-rpc-middleware-stream": "^1.0.1",
     "lodash.debounce": "^4.0.8",
     "lodash.memoize": "^4.1.2",

--- a/test/stub/provider.js
+++ b/test/stub/provider.js
@@ -1,11 +1,12 @@
 const JsonRpcEngine = require('json-rpc-engine')
 const scaffoldMiddleware = require('eth-json-rpc-middleware/scaffold')
+const TestBlockchain = require('eth-block-tracker/test/util/testBlockMiddleware')
 
 module.exports = {
   createEngineForTestData,
   providerFromEngine,
   scaffoldMiddleware,
-  createStubbedProvider,
+  createTestProviderTools,
 }
 
 
@@ -18,8 +19,13 @@ function providerFromEngine (engine) {
   return provider
 }
 
-function createStubbedProvider (resultStub) {
+function createTestProviderTools (opts = {}) {
   const engine = createEngineForTestData()
-  engine.push(scaffoldMiddleware(resultStub))
-  return providerFromEngine(engine)
+  const testBlockchain = new TestBlockchain()
+  // handle provided hooks
+  engine.push(scaffoldMiddleware(opts.scaffold || {}))
+  // handle block tracker methods
+  engine.push(testBlockchain.createMiddleware())
+  const provider = providerFromEngine(engine)
+  return { provider, engine, testBlockchain }
 }

--- a/test/stub/provider.js
+++ b/test/stub/provider.js
@@ -5,7 +5,7 @@ module.exports = {
   createEngineForTestData,
   providerFromEngine,
   scaffoldMiddleware,
-  createStubedProvider,
+  createStubbedProvider,
 }
 
 
@@ -18,7 +18,7 @@ function providerFromEngine (engine) {
   return provider
 }
 
-function createStubedProvider (resultStub) {
+function createStubbedProvider (resultStub) {
   const engine = createEngineForTestData()
   engine.push(scaffoldMiddleware(resultStub))
   return providerFromEngine(engine)

--- a/test/stub/provider.js
+++ b/test/stub/provider.js
@@ -5,7 +5,6 @@ module.exports = {
   createEngineForTestData,
   providerFromEngine,
   scaffoldMiddleware,
-  createEthJsQueryStub,
   createStubedProvider,
 }
 
@@ -17,18 +16,6 @@ function createEngineForTestData () {
 function providerFromEngine (engine) {
   const provider = { sendAsync: engine.handle.bind(engine) }
   return provider
-}
-
-function createEthJsQueryStub (stubProvider) {
-  return new Proxy({}, {
-    get: (obj, method) => {
-      return (...params) => {
-        return new Promise((resolve, reject) => {
-          stubProvider.sendAsync({ method: `eth_${method}`, params }, (err, ress) => resolve(ress.result))
-        })
-      }
-    },
-  })
 }
 
 function createStubedProvider (resultStub) {

--- a/test/unit/pending-tx-test.js
+++ b/test/unit/pending-tx-test.js
@@ -3,7 +3,7 @@ const ethUtil = require('ethereumjs-util')
 const EthTx = require('ethereumjs-tx')
 const ObservableStore = require('obs-store')
 const clone = require('clone')
-const { createStubbedProvider } = require('../stub/provider')
+const { createTestProviderTools } = require('../stub/provider')
 const PendingTransactionTracker = require('../../app/scripts/lib/pending-tx-tracker')
 const MockTxGen = require('../lib/mock-tx-gen')
 const sinon = require('sinon')
@@ -39,7 +39,7 @@ describe('PendingTransactionTracker', function () {
       txParams: { from: '0x1678a085c290ebd122dc42cba69373b5953b831d'},
     }
     providerResultStub = {}
-    provider = createStubbedProvider(providerResultStub)
+    provider = createTestProviderTools({ scaffold: providerResultStub }).provider
 
     pendingTxTracker = new PendingTransactionTracker({
       provider,

--- a/test/unit/pending-tx-test.js
+++ b/test/unit/pending-tx-test.js
@@ -3,7 +3,7 @@ const ethUtil = require('ethereumjs-util')
 const EthTx = require('ethereumjs-tx')
 const ObservableStore = require('obs-store')
 const clone = require('clone')
-const { createStubedProvider } = require('../stub/provider')
+const { createStubbedProvider } = require('../stub/provider')
 const PendingTransactionTracker = require('../../app/scripts/lib/pending-tx-tracker')
 const MockTxGen = require('../lib/mock-tx-gen')
 const sinon = require('sinon')
@@ -39,7 +39,7 @@ describe('PendingTransactionTracker', function () {
       txParams: { from: '0x1678a085c290ebd122dc42cba69373b5953b831d'},
     }
     providerResultStub = {}
-    provider = createStubedProvider(providerResultStub)
+    provider = createStubbedProvider(providerResultStub)
 
     pendingTxTracker = new PendingTransactionTracker({
       provider,

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -6,7 +6,7 @@ const ObservableStore = require('obs-store')
 const sinon = require('sinon')
 const TransactionController = require('../../app/scripts/controllers/transactions')
 const TxGasUtils = require('../../app/scripts/lib/tx-gas-utils')
-const { createStubbedProvider } = require('../stub/provider')
+const { createTestProviderTools } = require('../stub/provider')
 
 const noop = () => true
 const currentNetworkId = 42
@@ -15,11 +15,18 @@ const privKey = new Buffer('8718b9618a37d1fc78c436511fc6df3c8258d3250635bba617f3
 
 
 describe('Transaction Controller', function () {
-  let txController, provider, providerResultStub
+  let txController, provider, providerResultStub, testBlockchain
 
   beforeEach(function () {
-    providerResultStub = {}
-    provider = createStubbedProvider(providerResultStub)
+    providerResultStub = {
+      // 1 gwei
+      eth_gasPrice: '0x0de0b6b3a7640000',
+      // by default, all accounts are external accounts (not contracts)
+      eth_getCode: '0x',
+    }
+    const providerTools = createTestProviderTools({ scaffold: providerResultStub })
+    provider = providerTools.provider
+    testBlockchain = providerTools.testBlockchain
 
     txController = new TransactionController({
       provider,
@@ -153,15 +160,6 @@ describe('Transaction Controller', function () {
   })
 
   describe('#addUnapprovedTransaction', function () {
-    let addTxDefaults
-    beforeEach(() => {
-      addTxDefaults = txController.addTxDefaults
-      txController.addTxDefaults = function addTxDefaultsStub () { return Promise.resolve() }
-
-    })
-    afterEach(() => {
-      txController.addTxDefaults = addTxDefaults
-    })
 
     it('should add an unapproved transaction and return a valid txMeta', function (done) {
       txController.addUnapprovedTransaction({})

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -6,7 +6,7 @@ const ObservableStore = require('obs-store')
 const sinon = require('sinon')
 const TransactionController = require('../../app/scripts/controllers/transactions')
 const TxGasUtils = require('../../app/scripts/lib/tx-gas-utils')
-const { createStubedProvider } = require('../stub/provider')
+const { createStubbedProvider } = require('../stub/provider')
 
 const noop = () => true
 const currentNetworkId = 42
@@ -19,7 +19,7 @@ describe('Transaction Controller', function () {
 
   beforeEach(function () {
     providerResultStub = {}
-    provider = createStubedProvider(providerResultStub)
+    provider = createStubbedProvider(providerResultStub)
 
     txController = new TransactionController({
       provider,

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -217,7 +217,7 @@ describe('Transaction Controller', function () {
       var sample = {
         value: '0x01',
       }
-      txController.txProviderUtils.validateTxParams(sample).then(() => {
+      txController.txGasUtil.validateTxParams(sample).then(() => {
         done()
       }).catch(done)
     })
@@ -226,7 +226,7 @@ describe('Transaction Controller', function () {
       var sample = {
         value: '-0x01',
       }
-      txController.txProviderUtils.validateTxParams(sample)
+      txController.txGasUtil.validateTxParams(sample)
       .then(() => done('expected to thrown on negativity values but didn\'t'))
       .catch((err) => {
         assert.ok(err, 'error')

--- a/test/unit/tx-controller-test.js
+++ b/test/unit/tx-controller-test.js
@@ -1,11 +1,12 @@
 const assert = require('assert')
 const ethUtil = require('ethereumjs-util')
 const EthTx = require('ethereumjs-tx')
+const EthjsQuery = require('ethjs-query')
 const ObservableStore = require('obs-store')
 const sinon = require('sinon')
 const TransactionController = require('../../app/scripts/controllers/transactions')
 const TxGasUtils = require('../../app/scripts/lib/tx-gas-utils')
-const { createStubedProvider, createEthJsQueryStub } = require('../stub/provider')
+const { createStubedProvider } = require('../stub/provider')
 
 const noop = () => true
 const currentNetworkId = 42
@@ -30,10 +31,7 @@ describe('Transaction Controller', function () {
         resolve()
       }),
     })
-    txController.query = createEthJsQueryStub(provider)
-    txController.txGasUtil.query = createEthJsQueryStub(provider)
     txController.nonceTracker.getNonceLock = () => Promise.resolve({ nextNonce: 0, releaseLock: noop })
-    txController.txProviderUtils = new TxGasUtils(txController.provider)
   })
 
   describe('#getState', function () {

--- a/test/unit/tx-gas-util-test.js
+++ b/test/unit/tx-gas-util-test.js
@@ -1,12 +1,12 @@
 const assert = require('assert')
 const TxGasUtils = require('../../app/scripts/lib/tx-gas-utils')
-const { createStubbedProvider } = require('../stub/provider')
+const { createTestProviderTools } = require('../stub/provider')
 
 describe('Tx Gas Util', function () {
   let txGasUtil, provider, providerResultStub
   beforeEach(function () {
     providerResultStub = {}
-    provider = createStubbedProvider(providerResultStub)
+    provider = createTestProviderTools({ scaffold: providerResultStub }).provider
     txGasUtil = new TxGasUtils({
       provider,
     })

--- a/test/unit/tx-gas-util-test.js
+++ b/test/unit/tx-gas-util-test.js
@@ -1,12 +1,12 @@
 const assert = require('assert')
 const TxGasUtils = require('../../app/scripts/lib/tx-gas-utils')
-const { createStubedProvider } = require('../stub/provider')
+const { createStubbedProvider } = require('../stub/provider')
 
 describe('Tx Gas Util', function () {
   let txGasUtil, provider, providerResultStub
   beforeEach(function () {
     providerResultStub = {}
-    provider = createStubedProvider(providerResultStub)
+    provider = createStubbedProvider(providerResultStub)
     txGasUtil = new TxGasUtils({
       provider,
     })


### PR DESCRIPTION
All blockchain state lookups are stubbed at the lowest level: the provider

Adds a test utility `createTestProviderTools` that includes the the `test-block-middleware` used in the `eth-block-tracker` tests to create a `testBlockchain` that handles basic block querying and tx submission

other fixes and improvements