### PR TITLE
BugFix - infura rest api uri length limit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eth-block-tracker": "^2.3.0",
     "eth-contract-metadata": "^1.1.4",
     "eth-json-rpc-filters": "^1.2.5",
-    "eth-json-rpc-infura": "^2.0.5",
+    "eth-json-rpc-infura": "^2.0.7",
     "eth-keyring-controller": "^2.1.4",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",


### PR DESCRIPTION
Fixes #3030 

external changes:
https://github.com/kumavis/eth-json-rpc-infura/commit/dda1a84b43dcc18230293c1ec76b417ff5405ba0
infura rest api change to allow `eth_call` via POST (others already supported)