### PR TITLE
Get version from manifest instead of hard coding in New UI info page.

### DIFF
--- a/ui/app/settings.js
+++ b/ui/app/settings.js
@@ -333,6 +333,8 @@ class Settings extends Component {
   }
 
   renderInfoContent () {
+    const version = global.platform.getVersion()
+
     return (
       h('div.settings__content', [
         h('div.settings__content-row', [
@@ -340,7 +342,7 @@ class Settings extends Component {
             this.renderLogo(),
             h('div.settings__info-item', [
               h('div.settings__info-version-header', 'MetaMask Version'),
-              h('div.settings__info-version-number', '4.0.0'),
+              h('div.settings__info-version-number', version),
             ]),
             h('div.settings__info-item', [
               h(


### PR DESCRIPTION
<img width="1043" alt="screen shot 2018-01-19 at 4 24 14 pm" src="https://user-images.githubusercontent.com/7499938/35168921-3d670634-fd35-11e7-928e-144d7afe4eae.png">
