### PR TITLE
Improve transaction retry method

### DIFF
--- a/app/scripts/lib/pending-tx-tracker.js
+++ b/app/scripts/lib/pending-tx-tracker.js
@@ -118,7 +118,7 @@ module.exports = class PendingTransactionTracker extends EventEmitter {
       // ignore resubmit warnings, return early
       if (isKnownTx) return
       // encountered real error - transition to error state
-      txMeta.warning = {
+      txMeta.err = {
         error: errorMessage,
         message: 'There was an error when resubmitting this transaction.',
       }

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -208,6 +208,23 @@ module.exports = class TransactionStateManger extends EventEmitter {
 
   // should update the status of the tx to 'confirmed'.
   setTxStatusConfirmed (txId) {
+    const tx = this.getTx(txId)
+
+    // Clear any warnings:
+    tx.warning = undefined
+    this.updateTx(tx)
+
+    // Mark same-nonces as failed:
+    this.getTxList()
+    .filter(txMeta => txMeta.txParams.nonce === tx.txParams.nonce)
+    .filter(txMeta => txMeta.id !== tx.id)
+    .forEach((txMeta) => {
+      txMeta.err = {
+        message: 'Another transaction with this nonce was mined.',
+      }
+      this._setTxStatus(txMeta.id, 'failed')
+    })
+
     this._setTxStatus(txId, 'confirmed')
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -620,9 +620,9 @@ module.exports = class MetamaskController extends EventEmitter {
   //
 
   async retryTransaction (txId, cb) {
-    await this.txController.retryTransaction(txId)
+    const txMeta = await this.txController.retryTransaction(txId)
     const state = await this.getState()
-    return state
+    return { txMeta, state }
   }
 
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -763,12 +763,13 @@ function markAccountsFound () {
 function retryTransaction (txId) {
   log.debug(`background.retryTransaction`)
   return (dispatch) => {
-    background.retryTransaction(txId, (err, newState) => {
+    background.retryTransaction(txId, (err, results) => {
+      const { state, txMeta } = results
       if (err) {
         return dispatch(actions.displayWarning(err.message))
       }
-      dispatch(actions.updateMetamaskState(newState))
-      dispatch(actions.viewPendingTx(txId))
+      dispatch(actions.updateMetamaskState(state))
+      dispatch(actions.viewPendingTx(txMeta.id))
     })
   }
 }

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -30,8 +30,9 @@ function TransactionListItem () {
 
 TransactionListItem.prototype.showRetryButton = function () {
   const { transaction = {} } = this.props
-  const { status, time } = transaction
-  return status === 'submitted' && Date.now() - time > 30000
+  const { status, submitTime, time } = transaction
+  const earliest = submitTime || time
+  return status === 'submitted' && ((Date.now() - earliest) > 30000)
 }
 
 TransactionListItem.prototype.render = function () {


### PR DESCRIPTION
Fixes #3011

When the "Retry with higher gas" button is clicked, we now create a
duplicate transaction of that one, so users can more clearly see which
transaction is successful, and if they cancel the retry, it does not
appear to cancel the original transaction.

`Pending-tx-tracker` is now responsible for marking same-nonced txs as
failed when a tx is confirmed as mined.

Unified the tx submission under `pendingTxTracker.submitTx`, to avoid
duplicating its very specific error handling. Renamed `resubmitPendingTx`
to `submitTx` to reflect this more generic purpose.

Moved the tx submission error handling into that method, so it can be
called from outside without duplicating its unique error handling.

### Unrelated:

We now record the time of the first successful tx submission, and use
that to show the retry button, to avoid too-soon "waiting?" buttons.