### PR TITLE
sentry - report failed txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Add ability to bypass gas estimation loading indicator.
+- Forward failed transactions to Sentry error reporting service
 
 ## 3.13.5 2018-1-16
 

--- a/app/scripts/setupRaven.js
+++ b/app/scripts/setupRaven.js
@@ -21,4 +21,6 @@ function setupRaven(opts) {
   Raven.config(ravenTarget, {
     release,
   }).install()
+
+  return Raven
 }


### PR DESCRIPTION
Errors are automatically reported to sentry -- other errors need to be manually submitted.
this forwards all failed txs' txMeta to sentry