### PR TITLE
Bump up EventEmitter listener warning threshold count to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Bump limit for EventEmitter listeners before warning.
+
 ## 3.13.7 2018-1-22
 
 - Add ability to bypass gas estimation loading indicator.

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -43,6 +43,8 @@ module.exports = class MetamaskController extends EventEmitter {
   constructor (opts) {
     super()
 
+    this.defaultMaxListeners = 20
+
     this.sendUpdate = debounce(this.privateSendUpdate.bind(this), 200)
 
     this.opts = opts


### PR DESCRIPTION
As the title says above, to cut down on the number of errors we see in console. Not setting to 0 just in case we actually have an event emitter listener avalanche. 