### PR TITLE
Added reset account feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Add a "reset account" feature to Settings
 - Add warning for importing some kinds of files.
 
 ## 3.13.8 2018-1-29

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -152,6 +152,10 @@ module.exports = class TransactionController extends EventEmitter {
     }
   }
 
+  wipeTransactions(){
+    this.txStateManager.wipeTransactions();
+  }
+
   // Adds a tx to the txlist
   addTx (txMeta) {
     this.txStateManager.addTx(txMeta)

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -152,8 +152,8 @@ module.exports = class TransactionController extends EventEmitter {
     }
   }
 
-  wipeTransactions(){
-    this.txStateManager.wipeTransactions();
+  wipeTransactions (address) {
+    this.txStateManager.wipeTransactions(address)
   }
 
   // Adds a tx to the txlist

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -221,6 +221,10 @@ module.exports = class TransactionStateManger extends EventEmitter {
     this._setTxStatus(txId, 'failed')
   }
 
+  wipeTransactions(){
+  	this._saveTxList([]);
+  }
+
 //
 //           PRIVATE METHODS
 //

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -221,10 +221,10 @@ module.exports = class TransactionStateManger extends EventEmitter {
     this._setTxStatus(txId, 'failed')
   }
 
-  wipeTransactions(){
-  	this._saveTxList([]);
+  wipeTransactions () {
+    this._saveTxList([]);
   }
-
+  
 //
 //           PRIVATE METHODS
 //

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -226,7 +226,7 @@ module.exports = class TransactionStateManger extends EventEmitter {
     const txs = this.getTxList()
 
     // Filter out the ones from the current account
-    const otherAccountTxs = txs.filter((txMeta) => txMeta.from !== address)
+    const otherAccountTxs = txs.filter((txMeta) => txMeta.txParams.from !== address)
 
     // Update state
     this._saveTxList(otherAccountTxs)

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -223,10 +223,11 @@ module.exports = class TransactionStateManger extends EventEmitter {
 
   wipeTransactions (address) {
     // network only tx
-    const txs = this.getTxList()
+    const txs = this.getFullTxList()
+    const network = this.getNetwork()
 
-    // Filter out the ones from the current account
-    const otherAccountTxs = txs.filter((txMeta) => txMeta.txParams.from !== address)
+    // Filter out the ones from the current account and network
+    const otherAccountTxs = txs.filter((txMeta) => !(txMeta.txParams.from === address && txMeta.metamaskNetworkId === network))
 
     // Update state
     this._saveTxList(otherAccountTxs)

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -221,10 +221,16 @@ module.exports = class TransactionStateManger extends EventEmitter {
     this._setTxStatus(txId, 'failed')
   }
 
-  wipeTransactions () {
-    this._saveTxList([]);
+  wipeTransactions (address) {
+    // network only tx
+    const txs = this.getTxList()
+
+    // Filter out the ones from the current account
+    const otherAccountTxs = txs.filter((txMeta) => txMeta.from !== address)
+
+    // Update state
+    this._saveTxList(otherAccountTxs)
   }
-  
 //
 //           PRIVATE METHODS
 //

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -348,6 +348,7 @@ module.exports = class MetamaskController extends EventEmitter {
       addNewAccount: nodeify(this.addNewAccount, this),
       placeSeedWords: this.placeSeedWords.bind(this),
       clearSeedWordCache: this.clearSeedWordCache.bind(this),
+      resetAccount: this.resetAccount.bind(this),
       importAccountWithStrategy: this.importAccountWithStrategy.bind(this),
 
       // vault management
@@ -603,6 +604,13 @@ module.exports = class MetamaskController extends EventEmitter {
     this.configManager.setSeedWords(null)
     cb(null, this.preferencesController.getSelectedAddress())
   }
+
+  
+  resetAccount(cb){
+    this.txController.wipeTransactions();
+    cb(null, this.preferencesController.getSelectedAddress())
+  }
+
 
   importAccountWithStrategy (strategy, args, cb) {
     accountImporter.importAccount(strategy, args)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -605,10 +605,10 @@ module.exports = class MetamaskController extends EventEmitter {
     cb(null, this.preferencesController.getSelectedAddress())
   }
 
-  
-  resetAccount(cb){
-    this.txController.wipeTransactions();
-    cb(null, this.preferencesController.getSelectedAddress())
+  resetAccount (cb) {
+    const selectedAddress = this.preferencesController.getSelectedAddress()
+    this.txController.wipeTransactions(selectedAddress)
+    cb(null, selectedAddress)
   }
 
 

--- a/test/unit/tx-state-manager-test.js
+++ b/test/unit/tx-state-manager-test.js
@@ -241,14 +241,15 @@ describe('TransactionStateManger', function () {
 
   describe('#wipeTransactions', function () {
     
-    const specificAddress = '0xaa';
+    const specificAddress = '0xaa'
+    const otherAddress = '0xbb'
 
     it('should remove only the transactions from a specific address', function () {
       
       const txMetas = [
-        { id: 0, status: 'unapproved', txParams: { from: specificAddress, to: '0xbb' }, metamaskNetworkId: currentNetworkId },
-        { id: 1, status: 'confirmed', txParams: { from: '0xbb', to: specificAddress }, metamaskNetworkId: currentNetworkId },
-        { id: 2, status: 'confirmed', txParams: { from: '0xcc', to: specificAddress }, metamaskNetworkId: currentNetworkId },
+        { id: 0, status: 'unapproved', txParams: { from: specificAddress, to: otherAddress }, metamaskNetworkId: currentNetworkId },
+        { id: 1, status: 'confirmed', txParams: { from: otherAddress, to: specificAddress }, metamaskNetworkId: currentNetworkId },
+        { id: 2, status: 'confirmed', txParams: { from: otherAddress, to: specificAddress }, metamaskNetworkId: currentNetworkId },
       ]
       txMetas.forEach((txMeta) => txStateManager.addTx(txMeta, noop))
 
@@ -257,18 +258,15 @@ describe('TransactionStateManger', function () {
       const transactionsFromCurrentAddress = txStateManager.getTxList().filter((txMeta) => txMeta.txParams.from === specificAddress)
       const transactionsFromOtherAddresses = txStateManager.getTxList().filter((txMeta) => txMeta.txParams.from !== specificAddress)
 
-      assert.equal(transactionsFromCurrentAddress.length, 0);
-      assert.equal(transactionsFromOtherAddresses.length, 2);
-
-
+      assert.equal(transactionsFromCurrentAddress.length, 0)
+      assert.equal(transactionsFromOtherAddresses.length, 2)
     })
 
     it('should not remove the transactions from other networks', function () {
-      
       const txMetas = [
-        { id: 0, status: 'unapproved', txParams: { from: specificAddress, to: '0xbb' }, metamaskNetworkId: currentNetworkId },
-        { id: 1, status: 'confirmed', txParams: { from: specificAddress, to: specificAddress }, metamaskNetworkId: otherNetworkId  },
-        { id: 2, status: 'confirmed', txParams: { from: specificAddress, to: specificAddress }, metamaskNetworkId: otherNetworkId },
+        { id: 0, status: 'unapproved', txParams: { from: specificAddress, to: otherAddress }, metamaskNetworkId: currentNetworkId },
+        { id: 1, status: 'confirmed', txParams: { from: specificAddress, to: otherAddress }, metamaskNetworkId: otherNetworkId },
+        { id: 2, status: 'confirmed', txParams: { from: specificAddress, to: otherAddress }, metamaskNetworkId: otherNetworkId },
       ]
       
       txMetas.forEach((txMeta) => txStateManager.addTx(txMeta, noop))
@@ -276,14 +274,10 @@ describe('TransactionStateManger', function () {
       txStateManager.wipeTransactions(specificAddress)
 
       const txsFromCurrentNetworkAndAddress = txStateManager.getTxList().filter((txMeta) => txMeta.txParams.from === specificAddress)
-      const txFromOtherNetworks= txStateManager.getFullTxList().filter((txMeta) => txMeta.metamaskNetworkId === otherNetworkId)
+      const txFromOtherNetworks = txStateManager.getFullTxList().filter((txMeta) => txMeta.metamaskNetworkId === otherNetworkId)
 
-      console.log('NETWORK TX LIST: ', txStateManager.getTxList());
-      console.log('FULL TX LIST: ', txStateManager.getFullTxList());
-
-      assert.equal(txsFromCurrentNetworkAndAddress.length, 0);
-      assert.equal(txFromOtherNetworks.length, 2);
-
+      assert.equal(txsFromCurrentNetworkAndAddress.length, 0)
+      assert.equal(txFromOtherNetworks.length, 2)
 
     })
   })

--- a/test/unit/tx-state-manager-test.js
+++ b/test/unit/tx-state-manager-test.js
@@ -238,4 +238,53 @@ describe('TransactionStateManger', function () {
       assert.equal(txStateManager.getFilteredTxList(filterParams).length, 5, `getFilteredTxList - ${JSON.stringify(filterParams)}`)
     })
   })
+
+  describe('#wipeTransactions', function () {
+    
+    const specificAddress = '0xaa';
+
+    it('should remove only the transactions from a specific address', function () {
+      
+      const txMetas = [
+        { id: 0, status: 'unapproved', txParams: { from: specificAddress, to: '0xbb' }, metamaskNetworkId: currentNetworkId },
+        { id: 1, status: 'confirmed', txParams: { from: '0xbb', to: specificAddress }, metamaskNetworkId: currentNetworkId },
+        { id: 2, status: 'confirmed', txParams: { from: '0xcc', to: specificAddress }, metamaskNetworkId: currentNetworkId },
+      ]
+      txMetas.forEach((txMeta) => txStateManager.addTx(txMeta, noop))
+
+      txStateManager.wipeTransactions(specificAddress)
+
+      const transactionsFromCurrentAddress = txStateManager.getTxList().filter((txMeta) => txMeta.txParams.from === specificAddress)
+      const transactionsFromOtherAddresses = txStateManager.getTxList().filter((txMeta) => txMeta.txParams.from !== specificAddress)
+
+      assert.equal(transactionsFromCurrentAddress.length, 0);
+      assert.equal(transactionsFromOtherAddresses.length, 2);
+
+
+    })
+
+    it('should not remove the transactions from other networks', function () {
+      
+      const txMetas = [
+        { id: 0, status: 'unapproved', txParams: { from: specificAddress, to: '0xbb' }, metamaskNetworkId: currentNetworkId },
+        { id: 1, status: 'confirmed', txParams: { from: specificAddress, to: specificAddress }, metamaskNetworkId: otherNetworkId  },
+        { id: 2, status: 'confirmed', txParams: { from: specificAddress, to: specificAddress }, metamaskNetworkId: otherNetworkId },
+      ]
+      
+      txMetas.forEach((txMeta) => txStateManager.addTx(txMeta, noop))
+
+      txStateManager.wipeTransactions(specificAddress)
+
+      const txsFromCurrentNetworkAndAddress = txStateManager.getTxList().filter((txMeta) => txMeta.txParams.from === specificAddress)
+      const txFromOtherNetworks= txStateManager.getFullTxList().filter((txMeta) => txMeta.metamaskNetworkId === otherNetworkId)
+
+      console.log('NETWORK TX LIST: ', txStateManager.getTxList());
+      console.log('FULL TX LIST: ', txStateManager.getFullTxList());
+
+      assert.equal(txsFromCurrentNetworkAndAddress.length, 0);
+      assert.equal(txFromOtherNetworks.length, 2);
+
+
+    })
+  })
 })

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -47,12 +47,14 @@ var actions = {
   addNewAccount,
   NEW_ACCOUNT_SCREEN: 'NEW_ACCOUNT_SCREEN',
   navigateToNewAccountScreen,
+  resetAccount,
   showNewVaultSeed: showNewVaultSeed,
   showInfoPage: showInfoPage,
   // seed recovery actions
   REVEAL_SEED_CONFIRMATION: 'REVEAL_SEED_CONFIRMATION',
   revealSeedConfirmation: revealSeedConfirmation,
   requestRevealSeed: requestRevealSeed,
+
   // unlock screen
   UNLOCK_IN_PROGRESS: 'UNLOCK_IN_PROGRESS',
   UNLOCK_FAILED: 'UNLOCK_FAILED',
@@ -306,6 +308,20 @@ function requestRevealSeed (password) {
       })
     })
   }
+}
+
+function resetAccount () {
+    return (dispatch) => {
+        background.resetAccount((err, account) => {
+            dispatch(actions.hideLoadingIndication())
+            if (err) {
+                dispatch(actions.displayWarning(err.message))
+            }
+
+            log.info('Transaction history reset for ' + account)
+            dispatch(actions.showAccountsPage())
+        })
+    }
 }
 
 function addNewKeyring (type, opts) {

--- a/ui/app/config.js
+++ b/ui/app/config.js
@@ -55,6 +55,7 @@ ConfigScreen.prototype.render = function () {
         h('.flex-space-around', {
           style: {
             padding: '20px',
+            overflow: 'auto',
           },
         }, [
 
@@ -140,6 +141,24 @@ ConfigScreen.prototype.render = function () {
                 state.dispatch(actions.revealSeedConfirmation())
               },
             }, 'Reveal Seed Words'),
+          ]),
+
+          h('hr.horizontal-line'),
+
+          h('div', {
+            style: {
+              marginTop: '20px',
+            },
+          }, [
+            h('button', {
+              style: {
+                alignSelf: 'center',
+              },
+              onClick (event) {
+                event.preventDefault()
+                state.dispatch(actions.resetAccount())
+              },
+            }, 'Reset Account'),
           ]),
 
         ]),


### PR DESCRIPTION
Fixes  #3147 

I've been following  #1999  because I'm just another dev affected by that issue very often, so after seeing the latest update on #3147, I've decided to give it a try and it looks like it works!

I've added a button in the settings view that will wipe all the transactions for that account.

There's not a good spot to place this new button, so I've added below "Reveal Seed Words" and it ends up rendering below the fold (that explains why I had to use overflow: auto)

Let me know if you want to make any changes to the code or UI.


You can see how it looks / works in the gif below:

<img src="https://media.giphy.com/media/l4pT84YnZtOTGxwAg/giphy.gif" />




