### PR TITLE
Allow user's specified nonce bypassing nextNonce validation

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -251,7 +251,7 @@ module.exports = class TransactionController extends EventEmitter {
       // add nonce to txParams
       const nonce = txMeta.nonceSpecified ? txMeta.txParams.nonce : nonceLock.nextNonce
       if (!txMeta.nonceSpecified && nonce > nonceLock.nextNonce) {
-        const message = `Specified nonce may not be larger than account's next valid nonce.`
+        const message = `Nonce may not be larger than account's next valid nonce.`
         throw new Error(message)
       }
       txMeta.txParams.nonce = ethUtil.addHexPrefix(nonce.toString(16))

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -250,7 +250,7 @@ module.exports = class TransactionController extends EventEmitter {
       nonceLock = await this.nonceTracker.getNonceLock(fromAddress)
       // add nonce to txParams
       const nonce = txMeta.nonceSpecified ? txMeta.txParams.nonce : nonceLock.nextNonce
-      if (nonce > nonceLock.nextNonce) {
+      if (!txMeta.nonceSpecified && nonce > nonceLock.nextNonce) {
         const message = `Specified nonce may not be larger than account's next valid nonce.`
         throw new Error(message)
       }


### PR DESCRIPTION
When sending two transactions in a row with different payload, nonce value is incremented relying on last confirmed transaction value and therefore pending transactions may replace each other. 

Specifying custom incremented nonce for each sequential transactions fails with error: 
`Specified nonce may not be larger than account's next valid nonce.`

This pull request allows to bypass validation for user specified nonce. 

Issues related to pull request - https://github.com/MetaMask/metamask-extension/issues/3154

Fixes #3154 