### PR TITLE
[NewUI] Fixes shapeshift txs so that they render in tx list.

### DIFF
--- a/ui/app/components/shift-list-item.js
+++ b/ui/app/components/shift-list-item.js
@@ -29,40 +29,35 @@ function ShiftListItem () {
 }
 
 ShiftListItem.prototype.render = function () {
-  const { selectedAddress, receivingAddress } = this.props
-  return (
-    selectedAddress === receivingAddress
-      ? h('div.tx-list-item.tx-list-clickable', {
+  return h('div.tx-list-item.tx-list-clickable', {
+    style: {
+      paddingTop: '20px',
+      paddingBottom: '20px',
+      justifyContent: 'space-around',
+      alignItems: 'center',
+    },
+  }, [
+    h('div', {
+      style: {
+        width: '0px',
+        position: 'relative',
+        bottom: '19px',
+      },
+    }, [
+      h('img', {
+        src: 'https://info.shapeshift.io/sites/default/files/logo.png',
         style: {
-          paddingTop: '20px',
-          paddingBottom: '20px',
-          justifyContent: 'space-around',
-          alignItems: 'center',
+          height: '35px',
+          width: '132px',
+          position: 'absolute',
+          clip: 'rect(0px,23px,34px,0px)',
         },
-      }, [
-        h('div', {
-          style: {
-            width: '0px',
-            position: 'relative',
-            bottom: '19px',
-          },
-        }, [
-          h('img', {
-            src: 'https://info.shapeshift.io/sites/default/files/logo.png',
-            style: {
-              height: '35px',
-              width: '132px',
-              position: 'absolute',
-              clip: 'rect(0px,23px,34px,0px)',
-            },
-          }),
-        ]),
+      }),
+    ]),
 
-        this.renderInfo(),
-        this.renderUtilComponents(),
-      ])
-      : null
-  )
+    this.renderInfo(),
+    this.renderUtilComponents(),
+  ])
 }
 
 function formatDate (date) {

--- a/ui/app/components/tx-list.js
+++ b/ui/app/components/tx-list.js
@@ -50,6 +50,7 @@ TxList.prototype.render = function () {
 
 TxList.prototype.renderTransaction = function () {
   const { txsToRender, conversionRate } = this.props
+
   return txsToRender.length
     ? txsToRender.map((transaction, i) => this.renderTransactionListItem(transaction, conversionRate, i))
     : [h(
@@ -65,11 +66,7 @@ TxList.prototype.renderTransactionListItem = function (transaction, conversionRa
   // refer to transaction-list.js:line 58
 
   if (transaction.key === 'shapeshift') {
-    return h('div', {
-      key: `shapeshift${index}`,
-    }, [
-      h(ShiftListItem, transaction),
-    ])
+    return h(ShiftListItem, { ...transaction, key: `shapeshift${index}` })
   }
 
   const props = {


### PR DESCRIPTION
Previously, shapeshift txs were not appearing in the tx list. Also, once that issue was fixed there was a styling error where each shapeshift tx had a margin at bottom.

<img width="1092" alt="screen shot 2018-02-08 at 11 01 51 am" src="https://user-images.githubusercontent.com/7499938/35978857-5da27820-0cc1-11e8-9e62-e930e315c362.png">
