### PR TITLE
[NewUI] Try beta link on unlock and privacy screens.

### DIFF
--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -456,11 +456,31 @@ App.prototype.renderPrimary = function () {
   // notices
   if (!props.noActiveNotices) {
     log.debug('rendering notice screen for unread notices.')
-    return h(NoticeScreen, {
-      notice: props.lastUnreadNotice,
-      key: 'NoticeScreen',
-      onConfirm: () => props.dispatch(actions.markNoticeRead(props.lastUnreadNotice)),
-    })
+    return h('div', [
+
+      h(NoticeScreen, {
+        notice: props.lastUnreadNotice,
+        key: 'NoticeScreen',
+        onConfirm: () => props.dispatch(actions.markNoticeRead(props.lastUnreadNotice)),
+      }),
+
+      !props.isInitialized && h('.flex-row.flex-center.flex-grow', [
+        h('p.pointer', {
+          onClick: () => {
+            global.platform.openExtensionInBrowser()
+            props.dispatch(actions.setFeatureFlag('betaUI', true, 'BETA_UI_NOTIFICATION_MODAL'))
+              .then(() => props.dispatch(actions.setNetworkEndpoints(BETA_UI_NETWORK_TYPE)))
+          },
+          style: {
+            fontSize: '0.8em',
+            color: '#aeaeae',
+            textDecoration: 'underline',
+            marginTop: '32px',
+          },
+        }, 'Try Beta Version'),
+      ]),
+
+    ])
   } else if (props.lostAccounts && props.lostAccounts.length > 0) {
     log.debug('rendering notice screen for lost accounts view.')
     return h(NoticeScreen, {

--- a/ui/app/unlock.js
+++ b/ui/app/unlock.js
@@ -5,6 +5,7 @@ const connect = require('react-redux').connect
 const actions = require('./actions')
 const getCaretCoordinates = require('textarea-caret')
 const EventEmitter = require('events').EventEmitter
+const { OLD_UI_NETWORK_TYPE } = require('../../app/scripts/config').enums
 
 const Mascot = require('./components/mascot')
 
@@ -85,6 +86,22 @@ UnlockScreen.prototype.render = function () {
           },
         }, 'Restore from seed phrase'),
       ]),
+
+      h('.flex-row.flex-center.flex-grow', [
+        h('p.pointer', {
+          onClick: () => {
+            this.props.dispatch(actions.setFeatureFlag('betaUI', false, 'OLD_UI_NOTIFICATION_MODAL'))
+              .then(() => this.props.dispatch(actions.setNetworkEndpoints(OLD_UI_NETWORK_TYPE)))
+          },
+          style: {
+            fontSize: '0.8em',
+            color: '#aeaeae',
+            textDecoration: 'underline',
+            marginTop: '32px',
+          },
+        }, 'Use classic interface'),
+      ]),
+      
     ])
   )
 }


### PR DESCRIPTION
Adds a link to switch between versions to the first privacy notice screen in old ui, and the unlock screen in new ui.

![use-classic](https://user-images.githubusercontent.com/7499938/36007799-8efd19f4-0d1e-11e8-88fd-5b4f8ae1d331.gif)
----
![old-first-to-beta](https://user-images.githubusercontent.com/7499938/36007800-8f109ec0-0d1e-11e8-94a4-029382c1c80b.gif)
