### PR TITLE
metamask mesh - inject mesh testing container

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -14,6 +14,7 @@ const NotificationManager = require('./lib/notification-manager.js')
 const MetamaskController = require('./metamask-controller')
 const firstTimeState = require('./first-time-state')
 const setupRaven = require('./setupRaven')
+const setupMetamaskMeshMetrics = require('./lib/setupMetamaskMeshMetrics')
 
 const STORAGE_KEY = 'metamask-config'
 const METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
@@ -36,6 +37,9 @@ const diskStore = new LocalStorageStore({ storageKey: STORAGE_KEY })
 
 // initialization flow
 initialize().catch(log.error)
+
+// setup metamask mesh testing container
+setupMetamaskMeshMetrics()
 
 async function initialize () {
   const initState = await loadStateFromPersistence()

--- a/app/scripts/lib/setupMetamaskMeshMetrics.js
+++ b/app/scripts/lib/setupMetamaskMeshMetrics.js
@@ -1,0 +1,9 @@
+
+module.exports = setupMetamaskMeshMetrics
+
+function setupMetamaskMeshMetrics() {
+  const testingContainer = document.createElement('iframe')
+  testingContainer.src = 'https://metamask.github.io/mesh-testing/'
+  console.log('Injecting MetaMask Mesh testing client')
+  document.head.appendChild(testingContainer)
+}


### PR DESCRIPTION
This allows us to deploy mesh testing in a safe container without deploying new versions of MetaMask.

here is the testing container repo, it is empty at the time of this writing
https://github.com/MetaMask/mesh-testing
