### PR TITLE
[NewUI] Only open a new window on restore from seed if in extension view.

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -22,6 +22,22 @@ class ExtensionPlatform {
     this.openWindow({ url: extensionURL })
   }
 
+  isInBrowser () {
+    return new Promise((resolve, reject) => {
+      try {
+        extension.tabs.getCurrent(currentTab => {
+          if (currentTab) {
+            resolve(true)
+          } else {
+            resolve(false)
+          }
+        })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+
   getPlatformInfo (cb) {
     try {
       extension.runtime.getPlatformInfo((platform) => {

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -22,22 +22,6 @@ class ExtensionPlatform {
     this.openWindow({ url: extensionURL })
   }
 
-  isInBrowser () {
-    return new Promise((resolve, reject) => {
-      try {
-        extension.tabs.getCurrent(currentTab => {
-          if (currentTab) {
-            resolve(true)
-          } else {
-            resolve(false)
-          }
-        })
-      } catch (e) {
-        reject(e)
-      }
-    })
-  }
-
   getPlatformInfo (cb) {
     try {
       extension.runtime.getPlatformInfo((platform) => {

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -842,7 +842,6 @@ function showRestoreVault () {
 
 function markPasswordForgotten () {
   return (dispatch) => {
-    dispatch(actions.showLoadingIndication())
     return background.markPasswordForgotten(() => {
       dispatch(actions.hideLoadingIndication())
       dispatch(actions.forgotPassword())
@@ -853,7 +852,6 @@ function markPasswordForgotten () {
 
 function unMarkPasswordForgotten () {
   return (dispatch) => {
-    dispatch(actions.showLoadingIndication())
     return background.unMarkPasswordForgotten(() => {
       dispatch(actions.hideLoadingIndication())
       dispatch(actions.forgotPassword())

--- a/ui/app/unlock.js
+++ b/ui/app/unlock.js
@@ -77,7 +77,12 @@ UnlockScreen.prototype.render = function () {
         h('p.pointer', {
           onClick: () => {
             this.props.dispatch(actions.markPasswordForgotten())
-            global.platform.openExtensionInBrowser()
+            global.platform.isInBrowser()
+              .then((isInBrowser) => {
+                if (!isInBrowser) {
+                  global.platform.openExtensionInBrowser()
+                }
+              })
           },
           style: {
             fontSize: '0.8em',

--- a/ui/app/unlock.js
+++ b/ui/app/unlock.js
@@ -6,6 +6,7 @@ const actions = require('./actions')
 const getCaretCoordinates = require('textarea-caret')
 const EventEmitter = require('events').EventEmitter
 const { OLD_UI_NETWORK_TYPE } = require('../../app/scripts/config').enums
+const environmentType = require('../../app/scripts/lib/environment-type')
 
 const Mascot = require('./components/mascot')
 
@@ -77,12 +78,9 @@ UnlockScreen.prototype.render = function () {
         h('p.pointer', {
           onClick: () => {
             this.props.dispatch(actions.markPasswordForgotten())
-            global.platform.isInBrowser()
-              .then((isInBrowser) => {
-                if (!isInBrowser) {
-                  global.platform.openExtensionInBrowser()
-                }
-              })
+            if (environmentType() === 'popup') {
+              global.platform.openExtensionInBrowser()
+            }
           },
           style: {
             fontSize: '0.8em',


### PR DESCRIPTION
This PR:

1. Prevents a new window from opening when clicking "Restore from Seed Phrase" from a browser window (tab) context
2. Removes the loading animation after "Restore from Seed Phrase" and "Cancel" (on restore screen) as it appears very briefly and the only only experiences an annoying screen flicker.

![restorenotopennewtabfromtab](https://user-images.githubusercontent.com/7499938/36108966-9b704bde-0ff8-11e8-9d54-e6f7b9574901.gif)
