### PR TITLE
Adjust old UI css compatibility with new UI style changes

### DIFF
--- a/app/popup.html
+++ b/app/popup.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html style="width:350px; height:600px;">
+<html style="width:357px; height:600px;">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
     <title>MetaMask Plugin</title>
   </head>
-  <body style="width:350px; height:600px;">
+  <body style="width:357px; height:600px;">
     <div id="app-content"></div>
     <script src="./scripts/popup.js" type="text/javascript" charset="utf-8"></script>
   </body>

--- a/old-ui/app/components/account-dropdowns.js
+++ b/old-ui/app/components/account-dropdowns.js
@@ -268,6 +268,7 @@ class AccountDropdowns extends Component {
           'i.fa.fa-ellipsis-h',
           {
             style: {
+              margin: '0.5em',
               fontSize: '1.8em',
             },
             onClick: (event) => {

--- a/old-ui/app/config.js
+++ b/old-ui/app/config.js
@@ -32,7 +32,7 @@ ConfigScreen.prototype.render = function () {
   return (
     h('.flex-column.flex-grow', {
       style:{
-        maxHeight: '465px',
+        maxHeight: '585px',
         overflowY: 'auto',
       },
     }, [

--- a/old-ui/app/css/index.css
+++ b/old-ui/app/css/index.css
@@ -285,7 +285,7 @@ app sections
 }
 
 .unlock-screen #metamask-mascot-container {
-  margin-top: 24px;
+  margin-top: 80px;
 }
 
 .unlock-screen h1 {
@@ -443,7 +443,7 @@ input.large-input {
   flex-wrap: wrap;
   overflow-x: hidden;
   overflow-y: auto;
-  max-height: 465px;
+  max-height: 585px;
   flex-direction: inherit;
 }
 


### PR DESCRIPTION
Adjust css for classic ui compatibility with new ui styling.
Right side is the proposed changes.

![uat-oldui-compatibility-account-detail](https://user-images.githubusercontent.com/13376180/36279853-531e2ebc-124d-11e8-8c49-e34336bb8fd8.jpg)
![uat-oldui-compatibility-settings](https://user-images.githubusercontent.com/13376180/36279854-5340f744-124d-11e8-8002-96c6213e45eb.jpg)
![uat-oldui-compatibility](https://user-images.githubusercontent.com/13376180/36279855-5361aafc-124d-11e8-8c79-b219d7d04035.jpg)
![uat-oldui-compatiblity-login](https://user-images.githubusercontent.com/13376180/36279856-538444b8-124d-11e8-8044-7cf781b71159.jpg)