### PR TITLE
Set default width for notice screens

### DIFF
--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -456,7 +456,11 @@ App.prototype.renderPrimary = function () {
   // notices
   if (!props.noActiveNotices) {
     log.debug('rendering notice screen for unread notices.')
-    return h('div', [
+    return h('div', {
+      style: {
+        width: '360px',
+      },
+    }, [
 
       h(NoticeScreen, {
         notice: props.lastUnreadNotice,


### PR DESCRIPTION
Before: 
<img width="357" alt="screen shot 2018-02-20 at 12 41 01 pm" src="https://user-images.githubusercontent.com/13376180/36448195-a6cdb4a0-163b-11e8-9ca9-30d8899a2d5f.png">


After: 
<img width="357" alt="screen shot 2018-02-20 at 12 38 06 pm" src="https://user-images.githubusercontent.com/13376180/36448201-ae0bac5e-163b-11e8-99b0-2d772ec51ff3.png">
