### PR TITLE
[NewUI] Prevents new tx from active tab from opening popup

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -30,6 +30,7 @@ const release = platform.getVersion()
 const raven = setupRaven({ release })
 
 let popupIsOpen = false
+let openMetamaskTabsIDs = {}
 
 // state persistence
 const diskStore = new LocalStorageStore({ storageKey: STORAGE_KEY })
@@ -113,9 +114,15 @@ function setupController (initState) {
       popupIsOpen = popupIsOpen || (remotePort.name === 'popup')
       controller.setupTrustedCommunication(portStream, 'MetaMask')
       // record popup as closed
+      if (remotePort.sender.url.match(/home.html$/)) {
+        openMetamaskTabsIDs[remotePort.sender.tab.id] = true
+      }
       if (remotePort.name === 'popup') {
         endOfStream(portStream, () => {
           popupIsOpen = false
+          if (remotePort.sender.url.match(/home.html$/)) {
+            openMetamaskTabsIDs[remotePort.sender.tab.id] = false
+          }
         })
       }
     } else {
@@ -158,7 +165,10 @@ function setupController (initState) {
 
 // popup trigger
 function triggerUi () {
-  if (!popupIsOpen) notificationManager.showPopup()
+  extension.tabs.query({ active: true }, (tabs) => {
+    const currentlyActiveMetamaskTab = tabs.find(tab => openMetamaskTabsIDs[tab.id])
+    if (!popupIsOpen && !currentlyActiveMetamaskTab) notificationManager.showPopup()
+  })
 }
 
 // On first install, open a window to MetaMask website to how-it-works.


### PR DESCRIPTION
Resolves #3292

Explanation:

`background.js` only allows a new popup to open when a new tx is created if its `popupIsOpen` variable is false. This variable is set to false when the extension as opened in the top right corner is closed. If metamask is opened in a browser tab from the top right extension, `popupIsOpen` will be set to false even though metamask is open. Then sending a tx from this browser tab will therefore create a new popup window (via the `triggerUI()` function in `background.js`

This PR tracks the tabs in which metamask is open, and at the time of a new tx being created, checks if any of these is active. If so, it prevents the notification popup from opening even if `popupIsOpen` is false.

Before screenshot:

![openpopupfromtab-before](https://user-images.githubusercontent.com/7499938/36498219-35155ff6-1718-11e8-9192-2c8bd8ab056b.gif)

After screenshot:

![openpopupfromtab-after](https://user-images.githubusercontent.com/7499938/36498226-3b90cbea-1718-11e8-8a8c-568cf3b95a31.gif)

Screenshot to so that txs from an external dapp still open the notification popup:

![popupfromdappstillworks](https://user-images.githubusercontent.com/7499938/36498251-4dbcdd2c-1718-11e8-98eb-5e1144e21355.gif)

