### PR TITLE
[Old-UI] Fix cancel button on buy eth screen.

### DIFF
--- a/old-ui/app/components/coinbase-form.js
+++ b/old-ui/app/components/coinbase-form.js
@@ -40,7 +40,7 @@ CoinbaseForm.prototype.render = function () {
       }, 'Continue to Coinbase'),
 
       h('button.btn-red', {
-        onClick: () => props.dispatch(actions.backTobuyView(props.accounts.address)),
+        onClick: () => props.dispatch(actions.goHome()),
       }, 'Cancel'),
     ]),
   ])


### PR DESCRIPTION
Fixes #3336 

![fix-cancel-buy-eth-old-ui](https://user-images.githubusercontent.com/7499938/36759656-b521935c-1bf2-11e8-9220-831458a49d62.gif)
