### PR TITLE
[old-ui] Prevent user from switching network in old-ui notification

### DIFF
--- a/old-ui/app/components/network.js
+++ b/old-ui/app/components/network.js
@@ -23,14 +23,15 @@ Network.prototype.render = function () {
 
   if (networkNumber === 'loading') {
     return h('span.pointer', {
+      className: props.onClick && 'pointer',
       style: {
         display: 'flex',
         alignItems: 'center',
         flexDirection: 'row',
       },
-      onClick: (event) => this.props.onClick(event),
+      onClick: (event) => props.onClick && props.onClick(event),
     }, [
-      h('img', {
+      props.onClick && h('img', {
         title: 'Attempting to connect to blockchain.',
         style: {
           width: '27px',
@@ -60,9 +61,10 @@ Network.prototype.render = function () {
   }
 
   return (
-    h('#network_component.pointer', {
+    h('#network_component', {
+      className: props.onClick && 'pointer',
       title: hoverText,
-      onClick: (event) => this.props.onClick(event),
+      onClick: (event) => props.onClick && props.onClick(event),
     }, [
       (function () {
         switch (iconName) {
@@ -74,7 +76,7 @@ Network.prototype.render = function () {
                   color: '#039396',
                 }},
               'Main Network'),
-              h('i.fa.fa-caret-down.fa-lg'),
+              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
             ])
           case 'ropsten-test-network':
             return h('.network-indicator', [
@@ -84,7 +86,7 @@ Network.prototype.render = function () {
                   color: '#ff6666',
                 }},
               'Ropsten Test Net'),
-              h('i.fa.fa-caret-down.fa-lg'),
+              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
             ])
           case 'kovan-test-network':
             return h('.network-indicator', [
@@ -94,7 +96,7 @@ Network.prototype.render = function () {
                   color: '#690496',
                 }},
               'Kovan Test Net'),
-              h('i.fa.fa-caret-down.fa-lg'),
+              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
             ])
           case 'rinkeby-test-network':
             return h('.network-indicator', [
@@ -104,7 +106,7 @@ Network.prototype.render = function () {
                   color: '#e7a218',
                 }},
               'Rinkeby Test Net'),
-              h('i.fa.fa-caret-down.fa-lg'),
+              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
             ])
           default:
             return h('.network-indicator', [
@@ -120,7 +122,7 @@ Network.prototype.render = function () {
                   color: '#AEAEAE',
                 }},
               'Private Network'),
-              h('i.fa.fa-caret-down.fa-lg'),
+              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
             ])
         }
       })(),


### PR DESCRIPTION
This PR resolves issue 475091747 on sentry.io

`props.onclick` was undefined as no onclick method is passed to the network component when it is being used in the notification. (see `NetworkIndicator` on line 79 of `metamask-extension/old-ui/app/conf-tx.js`). I don't think we want to allow the user to switch networks in that case. So this PR resolves the issue by only calling `props.onClick` if defined and only presenting it as a clickable element if `props.onClick` is defined.

![noclick-netowkr-ntfcn](https://user-images.githubusercontent.com/7499938/36803537-62a82064-1c92-11e8-8ecf-1cad9a7bb1e8.gif)
![clickablenetworkmain](https://user-images.githubusercontent.com/7499938/36803542-64a44dd4-1c92-11e8-831b-462de9ef4d77.gif)
