### PR TITLE
[new-ui] add token - check for logo url before trying to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix "Add Token" screen referencing missing token logo urls
+
 ## 4.1.0 2018-2-27
 
 - Report failed txs to Sentry with more specific message

--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -240,7 +240,7 @@ AddTokenScreen.prototype.renderTokenList = function () {
         }, [
           h('div.add-token__token-icon', {
             style: {
-              backgroundImage: `url(images/contract/${logo})`,
+              backgroundImage: logo && `url(images/contract/${logo})`,
             },
           }),
           h('div.add-token__token-data', [


### PR DESCRIPTION
this is likely causing the `p0` corrupted extensions

Updates #3354