### PR TITLE
Fix inpage provider name regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Ensure MetaMask's inpage provider is named MetamaskInpageProvider to keep some sites from breaking.
+
 ## 4.1.2 2018-2-28
 
 - Actually includes all the fixes mentioned in 4.1.1 (sorry)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -407,7 +407,9 @@ function bundleTask(opts) {
       // loads map from browserify file
       .pipe(gulpif(debug, sourcemaps.init({ loadMaps: true })))
       // Minification
-      .pipe(gulpif(opts.isBuild, uglify()))
+      .pipe(gulpif(opts.isBuild, uglify({
+        mangle: {  reserved: [ 'MetamaskInpageProvider' ] },
+      })))
       // writes .map file
       .pipe(gulpif(debug, sourcemaps.write('./')))
       // write completed bundles

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "gulp-stylefmt": "^1.1.0",
     "gulp-stylelint": "^4.0.0",
     "gulp-uglify": "^3.0.0",
-    "gulp-uglify-es": "^1.0.0",
+    "gulp-uglify-es": "^1.0.1",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^5.0.0",
     "gulp-zip": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7348,9 +7348,9 @@ mersenne-twister@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
 
-metamascara@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/metamascara/-/metamascara-1.3.1.tgz#a84d6f20ef4ba401ce44eba120857ee1d680747b"
+metamascara@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/metamascara/-/metamascara-2.2.1.tgz#f97b87045a245e1bd2e1bcae7a3d4dcd4e17c02a"
   dependencies:
     iframe "^1.0.0"
     iframe-stream "^3.0.0"


### PR DESCRIPTION
Fixes #3372 by not minifying the name of our inpage provider, which some
people were using to identify MetaMask (not our preferred, supported
method of web3.currentProvider.isMetaMask).