### PR TITLE
fix typo in transaction.js

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -3,7 +3,7 @@ const ObservableStore = require('obs-store')
 const ethUtil = require('ethereumjs-util')
 const Transaction = require('ethereumjs-tx')
 const EthQuery = require('ethjs-query')
-const TransactionStateManger = require('../lib/tx-state-manager')
+const TransactionStateManager = require('../lib/tx-state-manager')
 const TxGasUtil = require('../lib/tx-gas-utils')
 const PendingTransactionTracker = require('../lib/pending-tx-tracker')
 const createId = require('../lib/random-id')
@@ -38,7 +38,7 @@ module.exports = class TransactionController extends EventEmitter {
     this.query = new EthQuery(this.provider)
     this.txGasUtil = new TxGasUtil(this.provider)
 
-    this.txStateManager = new TransactionStateManger({
+    this.txStateManager = new TransactionStateManager({
       initState: opts.initState,
       txHistoryLimit: opts.txHistoryLimit,
       getNetwork: this.getNetwork.bind(this),

--- a/app/scripts/lib/tx-state-manager.js
+++ b/app/scripts/lib/tx-state-manager.js
@@ -4,7 +4,7 @@ const ObservableStore = require('obs-store')
 const ethUtil = require('ethereumjs-util')
 const txStateHistoryHelper = require('./tx-state-history-helper')
 
-module.exports = class TransactionStateManger extends EventEmitter {
+module.exports = class TransactionStateManager extends EventEmitter {
   constructor ({ initState, txHistoryLimit, getNetwork }) {
     super()
 

--- a/test/unit/message-manager-test.js
+++ b/test/unit/message-manager-test.js
@@ -1,11 +1,11 @@
 const assert = require('assert')
-const MessageManger = require('../../app/scripts/lib/message-manager')
+const MessageManager = require('../../app/scripts/lib/message-manager')
 
 describe('Message Manager', function () {
   let messageManager
 
   beforeEach(function () {
-    messageManager = new MessageManger()
+    messageManager = new MessageManager()
   })
 
   describe('#getMsgList', function () {

--- a/test/unit/tx-state-manager-test.js
+++ b/test/unit/tx-state-manager-test.js
@@ -5,7 +5,7 @@ const TxStateManager = require('../../app/scripts/lib/tx-state-manager')
 const txStateHistoryHelper = require('../../app/scripts/lib/tx-state-history-helper')
 const noop = () => true
 
-describe('TransactionStateManger', function () {
+describe('TransactionStateManager', function () {
   let txStateManager
   const currentNetworkId = 42
   const otherNetworkId = 2


### PR DESCRIPTION
Fixed a typo in `app/scripts/controllers/transactions.js`.

Before: `TransactionStateManger`
After: `TransactionStateManager`

This is my first PR so please let me know what else I need to add.