### PR TITLE
node security - ignore known hoek advisory

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/566"]
+}


### PR DESCRIPTION
This allows us to ignore the known hoek advisory that does not affect us and get our PRs passing again