### PR TITLE
Prevent batch request from opening multiple windows

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -184,9 +184,7 @@ function setupController (initState) {
 function triggerUi () {
   extension.tabs.query({ active: true }, (tabs) => {
     const currentlyActiveMetamaskTab = tabs.find(tab => openMetamaskTabsIDs[tab.id])
-    if (!popupIsOpen && !currentlyActiveMetamaskTab) notificationManager.showPopup((notification) => {
-      notifcationIsOpen = notification;
-    });
+    if (!popupIsOpen && !currentlyActiveMetamaskTab) notificationManager.showPopup();
     notifcationIsOpen = true;
   })
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -40,7 +40,7 @@ const isIE = !!document.documentMode
 const isEdge = !isIE && !!window.StyleMedia
 
 let popupIsOpen = false
-let notifcationIsOpen = false;
+let notificationIsOpen = false
 let openMetamaskTabsIDs = {}
 
 // state persistence
@@ -139,8 +139,8 @@ function setupController (initState) {
       }
       if (remotePort.name === 'notification') {
         endOfStream(portStream, () => {
-          notifcationIsOpen = false
-        });
+          notificationIsOpen = false
+        })
       }
     } else {
       // communication with page
@@ -184,8 +184,8 @@ function setupController (initState) {
 function triggerUi () {
   extension.tabs.query({ active: true }, (tabs) => {
     const currentlyActiveMetamaskTab = tabs.find(tab => openMetamaskTabsIDs[tab.id])
-    if (!popupIsOpen && !currentlyActiveMetamaskTab) notificationManager.showPopup();
-    notifcationIsOpen = true;
+    if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) notificationManager.showPopup()
+    notificationIsOpen = true
   })
 }
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -40,6 +40,7 @@ const isIE = !!document.documentMode
 const isEdge = !isIE && !!window.StyleMedia
 
 let popupIsOpen = false
+let notifcationIsOpen = false;
 let openMetamaskTabsIDs = {}
 
 // state persistence
@@ -136,6 +137,11 @@ function setupController (initState) {
           }
         })
       }
+      if (remotePort.name === 'notification') {
+        endOfStream(portStream, () => {
+          notifcationIsOpen = false
+        });
+      }
     } else {
       // communication with page
       const originDomain = urlUtil.parse(remotePort.sender.url).hostname
@@ -178,7 +184,10 @@ function setupController (initState) {
 function triggerUi () {
   extension.tabs.query({ active: true }, (tabs) => {
     const currentlyActiveMetamaskTab = tabs.find(tab => openMetamaskTabsIDs[tab.id])
-    if (!popupIsOpen && !currentlyActiveMetamaskTab) notificationManager.showPopup()
+    if (!popupIsOpen && !currentlyActiveMetamaskTab) notificationManager.showPopup((notification) => {
+      notifcationIsOpen = notification;
+    });
+    notifcationIsOpen = true;
   })
 }
 

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -9,7 +9,7 @@ class NotificationManager {
   // Public
   //
 
-  showPopup () {
+  showPopup (cb) {
     this._getPopup((err, popup) => {
       if (err) throw err
 
@@ -23,6 +23,9 @@ class NotificationManager {
           type: 'popup',
           width,
           height,
+        }, (win) => {
+          // naming of popup window and a popup in chrome extension sense is confusing
+          cb((win.type == 'popup'));
         })
       }
     })

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -45,7 +45,6 @@ class NotificationManager {
   _getPopup (cb) {
     this._getWindows((err, windows) => {
       if (err) throw err
-      console.log(windows);
       cb(null, this._getPopupIn(windows))
     })
   }
@@ -64,7 +63,6 @@ class NotificationManager {
   _getPopupIn (windows) {
     return windows ? windows.find((win) => {
       // Returns notification popup
-      console.log(win);
       return (win && win.type === 'popup')
     }) : null
   }

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -60,9 +60,7 @@ class NotificationManager {
 
   _getPopupIn (windows) {
     return windows ? windows.find((win) => {
-      return (win && win.type === 'popup' &&
-        win.height === height &&
-        win.width === width)
+      return (win && win.type === 'popup')
     }) : null
   }
 

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -9,29 +9,28 @@ class NotificationManager {
   // Public
   //
 
-  showPopup (cb) {
+  showPopup () {
     this._getPopup((err, popup) => {
       if (err) throw err
 
+      // Bring focus to chrome popup
       if (popup) {
-        // bring focus to existing popup
+        // bring focus to existing chrome popup
         extension.windows.update(popup.id, { focused: true })
       } else {
-        // create new popup
+        // create new notification popup
         extension.windows.create({
           url: 'notification.html',
           type: 'popup',
           width,
           height,
-        }, (win) => {
-          // naming of popup window and a popup in chrome extension sense is confusing
-          cb((win.type == 'popup'));
         })
       }
     })
   }
 
   closePopup () {
+    // closes notification popup
     this._getPopup((err, popup) => {
       if (err) throw err
       if (!popup) return
@@ -46,6 +45,7 @@ class NotificationManager {
   _getPopup (cb) {
     this._getWindows((err, windows) => {
       if (err) throw err
+      console.log(windows);
       cb(null, this._getPopupIn(windows))
     })
   }
@@ -63,6 +63,8 @@ class NotificationManager {
 
   _getPopupIn (windows) {
     return windows ? windows.find((win) => {
+      // Returns notification popup
+      console.log(win);
       return (win && win.type === 'popup')
     }) : null
   }

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -65,6 +65,7 @@ startPopup({ container, connectionStream }, (err, store) => {
 
 function closePopupIfOpen (windowType) {
   if (windowType !== 'notification') {
+    // should close only chrome popup
     notificationManager.closePopup()
   }
 }


### PR DESCRIPTION
There seems to an issue with the "popup" naming convention within the repo.
Currently, the chrome popup (plugin at the top right) and the notification popup (the issue I'm fixing) are both called "popup" in many different cases.

This creates confusion within the `notification-manager.js`. I've traced a route though `popup.js` to show the issue.

With regards to the main fix. It has been fixed but I have introduced a new bug (feature?) where all notification popups are closed when the chrome popup is opened. This isn't disastrous in anyway, but may not the intended flow for the extension.

There's two options:
1. Leave it as it is
2. Rework the naming convention and change how `notification-manager.js` checks for chrome popups vs notifcation popups

Please advise. I also would love it if someone else can test this version in their respective browser. I've tested on Chrome in Linux/macOS.

Fix #1666