### PR TITLE
Fix translations whose substitutions params were not in arrays.

### DIFF
--- a/ui/app/accounts/new-account/create-form.js
+++ b/ui/app/accounts/new-account/create-form.js
@@ -14,7 +14,7 @@ class NewAccountCreateForm extends Component {
 
     this.state = {
       newAccountName: '',
-      defaultAccountName: t('newAccountNumberName', newAccountNumber),
+      defaultAccountName: t('newAccountNumberName', [newAccountNumber]),
     }
   }
 

--- a/ui/app/components/shapeshift-form.js
+++ b/ui/app/components/shapeshift-form.js
@@ -143,7 +143,7 @@ ShapeshiftForm.prototype.renderQrCode = function () {
   return h('div.shapeshift-form', {}, [
 
     h('div.shapeshift-form__deposit-instruction', [
-      t('depositCoin', depositCoin.toUpperCase()),
+      t('depositCoin', [depositCoin.toUpperCase()]),
     ]),
 
     h('div', depositAddress),


### PR DESCRIPTION
These translations are failing on master because i18n.js expects the substitution params to be in an array.