### PR TITLE
Inject Script: Blacklist domains where not to inject script

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -96,7 +96,8 @@ function logStreamDisconnectWarning (remoteLabel, err) {
 }
 
 function shouldInjectWeb3 () {
-  return doctypeCheck() && suffixCheck() && documentElementCheck()
+  return doctypeCheck() && suffixCheck() 
+    && documentElementCheck() && !blacklistedDomainCheck()
 }
 
 function doctypeCheck () {
@@ -127,6 +128,20 @@ function documentElementCheck () {
     return documentElement.toLowerCase() === 'html'
   }
   return true
+}
+
+function blacklistedDomainCheck () {
+  var blacklistedDomains = ['uscourts.gov', 'dropbox.com']
+  var currentUrl = window.location.href
+  var currentRegex
+  for (let i = 0; i < blacklistedDomains.length; i++) {
+    const blacklistedDomain = blacklistedDomains[i].replace('.', '\\.')
+    currentRegex = new RegExp(`(?:https?:\\/\\/)(?:(?!${blacklistedDomain}).)*$`)
+    if (!currentRegex.test(currentUrl)) {
+      return true
+    }
+  }
+  return false
 }
 
 function redirectToPhishingWarning () {


### PR DESCRIPTION
Ref #3382 

Put a whitelist domain check where if the page url is in the list
of whitelisted domains, we shouldn't inject script in that web page.

PS: Currently I have hardcoded the list of domains. Can you please
clear how the data will be fetched from API? Is there (or will be) a 
particular endpoint that I need to fetch from, or that should be
configurable by the user while using the chrome extension? I will
update the PR accordingly.