### PR TITLE
new-ui - dont exclude `txParams.data` when editing and updating txParams

### DIFF
--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -571,9 +571,11 @@ SendTransactionScreen.prototype.getEditedTx = function () {
       data,
     })
   } else {
+    const data = unapprovedTxs[editingTransactionId].txParams.data
     Object.assign(editingTx.txParams, {
       value: ethUtil.addHexPrefix(amount),
       to: ethUtil.addHexPrefix(to),
+      data,
     })
   }
 


### PR DESCRIPTION
this a partial fix for issue #3554 
this just dosent null out the data field on gas edited transactions