### PR TITLE
Identify token transactions by method names token data, and not just …

### DIFF
--- a/ui/app/components/pending-tx/confirm-send-token.js
+++ b/ui/app/components/pending-tx/confirm-send-token.js
@@ -86,6 +86,7 @@ function mapDispatchToProps (dispatch, ownProps) {
         amount: tokenAmountInHex,
         errors: { to: null, amount: null },
         editingTransactionId: id,
+        token: ownProps.token,
       }))
       dispatch(actions.showSendTokenPage())
     },

--- a/ui/app/components/pending-tx/index.js
+++ b/ui/app/components/pending-tx/index.js
@@ -63,14 +63,17 @@ PendingTx.prototype.componentWillMount = async function () {
       isFetching: false,
     })
   }
+  const tokenData = txParams && abiDecoder.decodeMethod(txParams.data)
+  const { name: tokenMethodName } = tokenData || {}
+  const isTokenTransaction = ['transfer', 'approve', 'transferFrom']
+    .find(possibleName => tokenMethodName === possibleName)
 
-  try {
+  if (isTokenTransaction) {
     const token = util.getContractAtAddress(txParams.to)
     const results = await Promise.all([
       token.symbol(),
       token.decimals(),
     ])
-
     const [ symbol, decimals ] = results
 
     if (symbol[0] && decimals[0]) {
@@ -83,11 +86,14 @@ PendingTx.prototype.componentWillMount = async function () {
       })
     } else {
       this.setState({
-        transactionType: TX_TYPES.SEND_ETHER,
+        transactionType: TX_TYPES.SEND_TOKEN,
+        tokenAddress: txParams.to,
+        tokenSymbol: null,
+        tokenDecimals: null,
         isFetching: false,
       })
     }
-  } catch (e) {
+  } else {
     this.setState({
       transactionType: TX_TYPES.SEND_ETHER,
       isFetching: false,

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -55,8 +55,9 @@ function getSelectedToken (state) {
   const tokens = state.metamask.tokens || []
   const selectedTokenAddress = state.metamask.selectedTokenAddress
   const selectedToken = tokens.filter(({ address }) => address === selectedTokenAddress)[0]
+  const sendToken = state.metamask.send.token
 
-  return selectedToken || null
+  return selectedToken || sendToken || null
 }
 
 function getSelectedTokenExchangeRate (state) {


### PR DESCRIPTION
Fixes #3554

Previous to this PR, we were failing to identify token transactions as **_token_** transactions if the token was not known to metamask. This PR ensures we correctly identify token transactions by basing the decision on decoded transaction data.