### PR TITLE
translate to Traditional Chinese, fix #3529

### DIFF
--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -1,0 +1,864 @@
+{
+  "accept": {
+    "message": "接受"
+  },
+  "account": {
+    "message": "帳戶"
+  },
+  "accountDetails": {
+    "message": "帳戶詳情"
+  },
+  "accountName": {
+    "message": "帳戶名稱"
+  },
+  "address": {
+    "message": "帳戶地址"
+  },
+  "addCustomToken": {
+    "message": "加入自訂代幣"
+  },
+  "addToken": {
+    "message": "加入代幣"
+  },
+  "addTokens": {
+    "message": "加入多筆代幣"
+  },
+  "amount": {
+    "message": "數額"
+  },
+  "amountPlusGas": {
+    "message": "數額 + Gas"
+  },
+  "appDescription": {
+    "message": "乙太坊瀏覽器擴充插件",
+    "description": "The description of the application"
+  },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
+  "approved": {
+    "message": "已同意"
+  },
+  "attemptingConnect": {
+    "message": "正在嘗試連接區塊鏈。"
+  },
+  "attributions": {
+    "message": "來源"
+  },
+  "available": {
+    "message": "可使用"
+  },
+  "back": {
+    "message": "上一頁"
+  },
+  "balance": {
+    "message": "餘額："
+  },
+  "balances": {
+    "message": "你的餘額："
+  },
+  "balanceIsInsufficientGas": {
+    "message": "當前餘額不足以支付 Gas"
+  },
+  "beta": {
+    "message": "BETA"
+  },
+  "betweenMinAndMax": {
+    "message": "必須大於等於 $1 並且小於等於 $2 。",
+    "description": "helper for inputting hex as decimal input"
+  },
+  "blockiesIdenticon": {
+    "message": "使用 Blockies Identicon"
+  },
+  "borrowDharma": {
+    "message": "透過 Dharma (Beta) 借用"
+  },
+  "builtInCalifornia": {
+    "message": "MetaMask 是在加州設計製造."
+  },
+  "buy": {
+    "message": "購買"
+  },
+  "buyCoinbase": {
+    "message": "在 Coinbase 上購買"
+  },
+  "buyCoinbaseExplainer": {
+    "message": "Coinbase 是世界上最流行的買賣比特幣，以太幣和萊特幣的交易所。"
+  },
+  "ok": {
+    "message": "Ok"
+  },
+  "cancel": {
+    "message": "取消"
+  },
+  "classicInterface": {
+    "message": "使用舊版界面"
+  },
+  "clickCopy": {
+    "message": "點擊複製"
+  },
+  "confirm": {
+    "message": "確認"
+  },
+  "confirmed": {
+    "message": "已確認"
+  },
+  "confirmContract": {
+    "message": "確認合約"
+  },
+  "confirmPassword": {
+    "message": "確認密碼"
+  },
+  "confirmTransaction": {
+    "message": "確認交易"
+  },
+  "continue": {
+    "message": "繼續"
+  },
+  "continueToCoinbase": {
+    "message": "繼續前往 Coinbase"
+  },
+  "contractDeployment": {
+    "message": "合約部署"
+  },
+  "conversionProgress": {
+    "message": "正在取得匯率"
+  },
+  "copiedButton": {
+    "message": "已複製"
+  },
+  "copiedClipboard": {
+    "message": "已複製到剪貼簿"
+  },
+  "copiedExclamation": {
+    "message": "已複製！"
+  },
+  "copiedSafe": {
+    "message": "我已經複製到某個安全的地方了"
+  },
+  "copy": {
+    "message": "複製"
+  },
+  "copyToClipboard": {
+    "message": "複製到剪貼簿"
+  },
+  "copyButton": {
+    "message": " 複製 "
+  },
+  "copyPrivateKey": {
+    "message": "7這是你的私鑰（點擊複製）"
+  },
+  "create": {
+    "message": "建立"
+  },
+  "createAccount": {
+    "message": "建立帳戶"
+  },
+  "createDen": {
+    "message": "建立"
+  },
+  "crypto": {
+    "message": "加密",
+    "description": "Exchange type (cryptocurrencies)"
+  },
+  "currentConversion": {
+    "message": "當前匯率"
+  },
+  "currentNetwork": {
+    "message": "當前網路"
+  },
+  "customGas": {
+    "message": "自訂 Gas"
+  },
+  "customize": {
+    "message": "自訂"
+  },
+  "customRPC": {
+    "message": "自訂 RPC"
+  },
+  "decimalsMustZerotoTen": {
+    "message": "小數點後位數至少為0, 最多為36."
+  },
+  "decimal": {
+    "message": "小數點精度"
+  },
+  "defaultNetwork": {
+    "message": "預設Ether交易網路為主網（Main Net）。"
+  },
+  "denExplainer": {
+    "message": "你的 DEN 是在你的 MetaMask 中的加密密碼儲存庫。"
+  },
+  "deposit": {
+    "message": "存入"
+  },
+  "depositBTC": {
+    "message": "將你的 BTC 存入到下面的地址："
+  },
+  "depositCoin": {
+    "message": "將你的 $1 存入到下面的地址",
+    "description": "Tells the user what coin they have selected to deposit with shapeshift"
+  },
+  "depositEth": {
+    "message": "存入 Eth"
+  },
+  "depositEther": {
+    "message": "存入 Ether"
+  },
+  "depositFiat": {
+    "message": "從法定貨幣存入"
+  },
+  "depositFromAccount": {
+    "message": "從其他帳戶存入"
+  },
+  "depositShapeShift": {
+    "message": "從 ShapeShift 存入"
+  },
+  "depositShapeShiftExplainer": {
+    "message": "如果你擁有其他加密貨幣，你可以直接交易並存入 Ether 到你的MetaMask錢包。不需要開帳戶。"
+  },
+  "details": {
+    "message": "詳情"
+  },
+  "directDeposit": {
+    "message": "直接存入"
+  },
+  "directDepositEther": {
+    "message": "直接存入 Ether"
+  },
+  "directDepositEtherExplainer": {
+    "message": "如果你已經擁有了一些Ether，使用直接存入功能是讓你的新錢包最快取得Ether的方式。"
+  },
+  "done": {
+    "message": "完成"
+  },
+  "downloadStatelogs": {
+    "message": "下載狀態紀錄"
+  },
+  "dropped": {
+    "message": "丟棄"
+  },
+  "edit": {
+    "message": "編輯"
+  },
+  "editAccountName": {
+    "message": "編輯帳戶名稱"
+  },
+  "emailUs": {
+    "message": "寄 Email 給我們!"
+  },
+  "encryptNewDen": {
+    "message": "加密你的新 DEN"
+  },
+  "enterPassword": {
+    "message": "請輸入密碼"
+  },
+  "enterPasswordConfirm": {
+    "message": "請再次輸入密碼確認"
+  },
+  "passwordNotLongEnough": {
+    "message": "您所輸入的密碼長度不足"
+  },
+  "passwordsDontMatch": {
+    "message": "您所輸入的密碼不一致"
+  },
+  "etherscanView": {
+    "message": "在 Etherscan 上查看帳戶"
+  },
+  "exchangeRate": {
+    "message": "匯率"
+  },
+  "exportPrivateKey": {
+    "message": "導出私鑰"
+  },
+  "exportPrivateKeyWarning": {
+    "message": "您需要自行負擔導出私鑰產生的風險"
+  },
+  "failed": {
+    "message": "失败"
+  },
+  "fiat": {
+    "message": "FIAT",
+    "description": "Exchange type"
+  },
+  "fileImportFail": {
+    "message": "檔案導入失敗？點擊這裡！",
+    "description": "Helps user import their account from a JSON file"
+  },
+  "from": {
+    "message": "來源地址"
+  },
+  "fromToSame": {
+    "message": "來源和目的地址不能一樣"
+  },
+  "fromShapeShift": {
+    "message": "來自 ShapeShift"
+  },
+  "gas": {
+    "message": "Gas",
+    "description": "Short indication of gas cost"
+  },
+  "gasFee": {
+    "message": "Gas 費用"
+  },
+  "gasLimit": {
+    "message": "Gas 上限"
+  },
+  "gasLimitCalculation": {
+    "message": "我們根據網路成功率算出建議的 Gas 上限。"
+  },
+  "gasLimitRequired": {
+    "message": "必需填寫 Gas 上限"
+  },
+  "gasLimitTooLow": {
+    "message": "Gas 上限至少為 21000"
+  },
+  "gasPrice": {
+    "message": "Gas 價格 (GWEI)"
+  },
+  "gasPriceCalculation": {
+    "message": "我們根據網路成功率算出建議的 Gas 價格"
+  },
+  "gasPriceRequired": {
+    "message": "必需填寫 Gas 價格"
+  },
+  "getEther": {
+    "message": "取得 Ether"
+  },
+  "getEtherFromFaucet": {
+    "message": "從水管取得$1 Ether",
+    "description": "Displays network name for Ether faucet"
+  },
+  "greaterThanMin": {
+    "message": "必須要大於等於 $1。",
+    "description": "helper for inputting hex as decimal input"
+  },
+  "here": {
+    "message": "這裡",
+    "description": "as in -click here- for more information (goes with troubleTokenBalances)"
+  },
+  "hereList": {
+    "message": "Here's a list!!!!"
+  },
+  "hide": {
+    "message": "隱藏"
+  },
+  "hideToken": {
+    "message": "隱藏代幣"
+  },
+  "hideTokenPrompt": {
+    "message": "隱藏代幣？"
+  },
+  "howToDeposit": {
+    "message": "你想怎麼存入 Ether？"
+  },
+  "holdEther": {
+    "message": "Metamask 讓您能保存 ether 和代幣, 並成為您接觸分散式應用程式的途徑."
+  },
+  "import": {
+    "message": "導入",
+    "description": "Button to import an account from a selected file"
+  },
+  "importAccount": {
+    "message": "導入帳戶"
+  },
+  "importAnAccount": {
+    "message": "導入一個帳戶"
+  },
+  "importDen": {
+    "message": "導入現成的 DEN"
+  },
+  "imported": {
+    "message": "已導入私鑰",
+    "description": "status showing that an account has been fully loaded into the keyring"
+  },
+  "infoHelp": {
+    "message": "說明 & 資訊"
+  },
+  "insufficientFunds": {
+    "message": "資金不足."
+  },
+  "insufficientTokens": {
+    "message": "代幣不足."
+  },
+  "invalidAddress": {
+    "message": "錯誤的地址"
+  },
+  "invalidAddressRecipient": {
+    "message": "接收地址錯誤"
+  },
+  "invalidGasParams": {
+    "message": "Gas 參數錯誤"
+  },
+  "invalidInput": {
+    "message": "輸入錯誤。"
+  },
+  "invalidRequest": {
+    "message": "無效的請求"
+  },
+  "invalidRPC": {
+    "message": "無效的 RPC URI"
+  },
+  "jsonFail": {
+    "message": "有東西出錯了. 請確認你的 JSON 檔案格式正確."
+  },
+  "jsonFile": {
+    "message": "JSON 檔案",
+    "description": "format for importing an account"
+  },
+  "kovan": {
+    "message": "Kovan 測試網路"
+  },
+  "knowledgeDataBase": {
+    "message": "查看我們的知識庫"
+  },
+  "max": {
+    "message": "Max"
+  },
+  "lessThanMax": {
+    "message": "必須小於等於 $1.",
+    "description": "helper for inputting hex as decimal input"
+  },
+  "likeToAddTokens": {
+    "message": "您確定要加入這些代幣嗎？"
+  },
+  "links": {
+    "message": "連結"
+  },
+  "limit": {
+    "message": "limit"
+  },
+  "loading": {
+    "message": "載入..."
+  },
+  "loadingTokens": {
+    "message": "載入代幣..."
+  },
+  "localhost": {
+    "message": "Localhost 8545"
+  },
+  "logout": {
+    "message": "登出"
+  },
+  "loose": {
+    "message": "loose"
+  },
+  "loweCaseWords": {
+    "message": "助憶詞僅包含小寫字元"
+  },
+  "mainnet": {
+    "message": "主乙太坊網路"
+  },
+  "message": {
+    "message": "訊息"
+  },
+  "metamaskDescription": {
+    "message": "MetaMask is a secure identity vault for Ethereum."
+  },
+  "min": {
+    "message": "最小"
+  },
+  "myAccounts": {
+    "message": "我的帳戶"
+  },
+  "mustSelectOne": {
+    "message": "必須選擇至少 1 代幣."
+  },
+  "needEtherInWallet": {
+    "message": "要使用 MetaMask 存取 DAPP時，您的錢包中需要有 Ether。"
+  },
+  "needImportFile": {
+    "message": "您必須選擇一個檔案來導入。",
+    "description": "User is important an account and needs to add a file to continue"
+  },
+  "needImportPassword": {
+    "message": "您必須為選擇好的檔案輸入密碼。",
+    "description": "Password and file needed to import an account"
+  },
+  "networks": {
+    "message": "網路"
+  },
+  "newAccount": {
+    "message": "新帳戶"
+  },
+  "newAccountNumberName": {
+    "message": "帳戶 $1",
+    "description": "Default name of next account to be created on create account screen"
+  },
+  "newContract": {
+    "message": "新合約"
+  },
+  "newPassword": {
+    "message": "新密碼（至少8個字）"
+  },
+  "newRecipient": {
+    "message": "新收款人"
+  },
+  "newRPC": {
+    "message": "New RPC URL"
+  },
+  "next": {
+    "message": "下一頁"
+  },
+  "noAddressForName": {
+    "message": "此 ENS 尚未指定地址。"
+  },
+  "noDeposits": {
+    "message": "尚未有存款"
+  },
+  "noTransactionHistory": {
+    "message": "尚未有交易紀錄。"
+  },
+  "noTransactions": {
+    "message": "尚未有交易"
+  },
+  "notStarted": {
+    "message": "尚未開始"
+  },
+  "oldUI": {
+    "message": "舊版界面"
+  },
+  "oldUIMessage": {
+    "message": "你已經切換到舊版界面。可以通過右上方下拉選單中的選項切換回新的使用者界面。"
+  },
+  "or": {
+    "message": "或",
+    "description": "choice between creating or importing a new account"
+  },
+  "passwordMismatch": {
+    "message": "密碼不一致",
+    "description": "in password creation process, the two new password fields did not match"
+  },
+  "passwordShort": {
+    "message": "密碼不夠長",
+    "description": "in password creation process, the password is not long enough to be secure"
+  },
+  "pastePrivateKey": {
+    "message": "請貼上你的私鑰串:",
+    "description": "For importing an account from a private key"
+  },
+  "pasteSeed": {
+    "message": "請貼上你的助憶詞！"
+  },
+  "personalAddressDetected": {
+    "message": "已偵測到個人地址. 請輸入代幣合約地址."
+  },
+  "pleaseReviewTransaction": {
+    "message": "請檢查你的交易。"
+  },
+  "privateKey": {
+    "message": "私鑰",
+    "description": "select this type of file to use to import an account"
+  },
+  "privateKeyWarning": {
+    "message": "注意：永遠不要公開這個私鑰。任何取得這把私鑰的人都可以竊取這個帳號中的任何資產。"
+  },
+  "privateNetwork": {
+    "message": "私有網路"
+  },
+  "qrCode": {
+    "message": "顯示 QR Code"
+  },
+  "readdToken": {
+    "message": "之後還可以透過帳戶選單中的“加入代幣”來加入此代幣。"
+  },
+  "readMore": {
+    "message": "了解更多。"
+  },
+  "readMore2": {
+    "message": "了解更多。"
+  },
+  "receive": {
+    "message": "接收"
+  },
+  "recipientAddress": {
+    "message": "接收地址"
+  },
+  "refundAddress": {
+    "message": "你的退款地址"
+  },
+  "rejected": {
+    "message": "拒絕"
+  },
+  "resetAccount": {
+    "message": "重置帳戶"
+  },
+  "restoreFromSeed": {
+    "message": "透過助憶詞重置"
+  },
+  "restoreVault": {
+    "message": "重置金庫"
+  },
+  "required": {
+    "message": "必填"
+  },
+  "retryWithMoreGas": {
+    "message": "改用更高的 Gas 價格重試"
+  },
+  "walletSeed": {
+    "message": "Wallet Seed"
+  },
+  "revealSeedWords": {
+    "message": "顯示助憶詞"
+  },
+  "revealSeedWordsWarning": {
+    "message": "別在公共場合回復你的助憶詞！這些詞可被用來竊取你的帳戶."
+  },
+  "revert": {
+    "message": "還原"
+  },
+  "rinkeby": {
+    "message": "Rinkeby 測試網路"
+  },
+  "ropsten": {
+    "message": "Ropsten 測試網路"
+  },
+  "currentRpc": {
+    "message": "當前的 RPC"
+  },
+  "connectingToMainnet": {
+    "message": "連線到主 Ethereum 網路"
+  },
+  "connectingToRopsten": {
+    "message": "連線到 Ropsten 測試網路"
+  },
+  "connectingToKovan": {
+    "message": "連線到 Kovan 測試網路"
+  },
+  "connectingToRinkeby": {
+    "message": "連線到 Rinkeby 測試網路"
+  },
+  "connectingToUnknown": {
+    "message": "連線到未知網路"
+  },
+  "sampleAccountName": {
+    "message": "例如：我的新帳戶",
+    "description": "Help user understand concept of adding a human-readable name to their account"
+  },
+  "save": {
+    "message": "儲存"
+  },
+  "saveAsFile": {
+    "message": "儲存檔案",
+    "description": "Account export process"
+  },
+  "saveSeedAsFile": {
+    "message": "將助憶詞儲存成檔案"
+  },
+  "search": {
+    "message": "搜尋"
+  },
+  "secretPhrase": {
+    "message": "在此輸入你的12個祕密助憶詞以回復金庫."
+  },
+  "newPassword8Chars": {
+    "message": "新密碼 (至少 8 個字元)"
+  },
+  "seedPhraseReq": {
+    "message": "助憶詞為 12 個詞語"
+  },
+  "select": {
+    "message": "選擇"
+  },
+  "selectCurrency": {
+    "message": "選擇幣別"
+  },
+  "selectService": {
+    "message": "選擇服務"
+  },
+  "selectType": {
+    "message": "選擇類型"
+  },
+  "send": {
+    "message": "發送"
+  },
+  "sendETH": {
+    "message": "發送 ETH"
+  },
+  "sendTokens": {
+    "message": "發送代幣"
+  },
+  "onlySendToEtherAddress": {
+    "message": "只發送 ETH 到乙太坊地址."
+  },
+  "sendTokensAnywhere": {
+    "message": "發送代幣給擁有乙太坊帳戶的任何人"
+  },
+  "settings": {
+    "message": "設定"
+  },
+  "info": {
+    "message": "資訊"
+  },
+  "shapeshiftBuy": {
+    "message": "從 Shapeshift 購買"
+  },
+  "showPrivateKeys": {
+    "message": "顯示私鑰"
+  },
+  "showQRCode": {
+    "message": "顯示 QR Code"
+  },
+  "sign": {
+    "message": "簽名"
+  },
+  "signMessage": {
+    "message": "簽署訊息"
+  },
+  "signNotice": {
+    "message": "簽署此訊息可能會產生危險的副作用。 \n只從你完全信任的網站上簽名。這種危險的方法;將在未來的版本中被移除。"
+  },
+  "sigRequest": {
+    "message": "請求簽署"
+  },
+  "sigRequested": {
+    "message": "已請求簽署"
+  },
+  "spaceBetween": {
+    "message": "there can only be a space between words"
+  },
+  "status": {
+    "message": "狀態"
+  },
+  "stateLogs": {
+    "message": "狀態紀錄"
+  },
+  "stateLogsDescription": {
+    "message": "狀態紀錄包含你的公開帳戶地址和已傳送的交易資訊."
+  },
+  "stateLogError": {
+    "message": "在取得狀態紀錄時發生錯誤."
+  },
+  "submit": {
+    "message": "送出"
+  },
+  "submitted": {
+    "message": "已送出"
+  },
+  "supportCenter": {
+    "message": "造訪我們的協助中心"
+  },
+  "symbolBetweenZeroTen": {
+    "message": "代號必須介於 0 到 10 字元間."
+  },
+  "takesTooLong": {
+    "message": "花費太長時間？"
+  },
+  "terms": {
+    "message": "使用條款"
+  },
+  "testFaucet": {
+    "message": "測試水管"
+  },
+  "to": {
+    "message": "目的帳號"
+  },
+  "toETHviaShapeShift": {
+    "message": "$1 ETH 透過 ShapeShift",
+    "description": "system will fill in deposit type in start of message"
+  },
+  "tokenAddress": {
+    "message": "代幣地址"
+  },
+  "tokenAlreadyAdded": {
+    "message": "已加入過此代幣。"
+  },
+  "tokenBalance": {
+    "message": "代幣餘額："
+  },
+  "tokenSelection": {
+    "message": "搜尋代幣或是從熱門代幣列表中選擇。"
+  },
+  "tokenSymbol": {
+    "message": "代幣代號"
+  },
+  "tokenWarning1": {
+    "message": "使用 MetaMask 帳戶追蹤你已購得的代幣。如果你使用不同的帳戶保存購得的代幣，那些代幣就不會出現在這裡。"
+  },
+  "total": {
+    "message": "總量"
+  },
+  "transactions": {
+    "message": "交易紀錄"
+  },
+  "transactionMemo": {
+    "message": "交易備註（選填）"
+  },
+  "transactionNumber": {
+    "message": "交易號碼"
+  },
+  "transfers": {
+    "message": "交易"
+  },
+  "troubleTokenBalances": {
+    "message": "無法取得代幣餘額。您k可以到這裡查看 ",
+    "description": "Followed by a link (here) to view token balances"
+  },
+  "twelveWords": {
+    "message": "這 12 個單詞是唯一回復你的 MetaMask 帳號的方法。\n將它們儲存到那些安全且隱密的地方吧。"
+  },
+  "typePassword": {
+    "message": "請輸入密碼"
+  },
+  "uiWelcome": {
+    "message": "歡迎使用新版界面 （Beta）"
+  },
+  "uiWelcomeMessage": {
+    "message": "你現在正在使用新的 Metamask 界面。試試諸如發送代幣等新功能，有任何問題請告知我們。"
+  },
+  "unapproved": {
+    "message": "未同意"
+  },
+  "unavailable": {
+    "message": "不可用"
+  },
+  "unknown": {
+    "message": "未知"
+  },
+  "unknownNetwork": {
+    "message": "未知私有網路"
+  },
+  "unknownNetworkId": {
+    "message": "未知網路 ID"
+  },
+  "uriErrorMsg": {
+    "message": "URIs 需要加入適當的 HTTP/HTTPS 前綴."
+  },
+  "usaOnly": {
+    "message": "僅限美國",
+    "description": "Using this exchange is limited to people inside the USA"
+  },
+  "usedByClients": {
+    "message": "可用於各種不同的客戶端"
+  },
+  "useOldUI": {
+    "message": "使用舊版界面"
+  },
+  "validFileImport": {
+    "message": "您必須選擇一個合法的檔案來導入."
+  },
+  "vaultCreated": {
+    "message": "已建立金庫"
+  },
+  "viewAccount": {
+    "message": "查看帳戶"
+  },
+  "visitWebSite": {
+    "message": "造訪我們的網站"
+  },
+  "warning": {
+    "message": "警告"
+  },
+  "welcomeBeta": {
+    "message": "歡迎到 MetaMask Beta"
+  },
+  "whatsThis": {
+    "message": "這是什麼？"
+  },
+  "yourSigRequested": {
+    "message": "正在請求你的簽署"
+  },
+  "youSign": {
+    "message": "正在簽署"
+  }
+}

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -147,7 +147,7 @@
     "message": " 複製 "
   },
   "copyPrivateKey": {
-    "message": "7這是你的私鑰（點擊複製）"
+    "message": "這是你的私鑰（點擊複製）"
   },
   "create": {
     "message": "建立"
@@ -413,7 +413,7 @@
     "message": "查看我們的知識庫"
   },
   "max": {
-    "message": "Max"
+    "message": "最大值"
   },
   "lessThanMax": {
     "message": "必須小於等於 $1.",
@@ -426,7 +426,7 @@
     "message": "連結"
   },
   "limit": {
-    "message": "limit"
+    "message": "上限"
   },
   "loading": {
     "message": "載入..."
@@ -441,7 +441,7 @@
     "message": "登出"
   },
   "loose": {
-    "message": "loose"
+    "message": "非Metamask帳號"
   },
   "loweCaseWords": {
     "message": "助憶詞僅包含小寫字元"
@@ -453,7 +453,7 @@
     "message": "訊息"
   },
   "metamaskDescription": {
-    "message": "MetaMask is a secure identity vault for Ethereum."
+    "message": "MetaMask 是Ethereum的安全身份識別金庫."
   },
   "min": {
     "message": "最小"
@@ -596,7 +596,7 @@
     "message": "改用更高的 Gas 價格重試"
   },
   "walletSeed": {
-    "message": "Wallet Seed"
+    "message": "錢包助憶詞"
   },
   "revealSeedWords": {
     "message": "顯示助憶詞"


### PR DESCRIPTION
As @hewigovens mentioned in #3529 , software usually hosts separate localization files for these 2 locales.

@kumavis @Orangem21 here's the traditional Chinese translation.
I refer `zh_CN` translation and added several missing strings from `en` message.json

