### PR TITLE
Revert "Ci - introduce a build job"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ workflows:
     jobs:
       - prep-deps-npm
       - prep-deps-firefox
-      - build:
-          requires:
-            - prep-deps-npm
       - prep-scss:
           requires:
             - prep-deps-npm
@@ -203,17 +200,3 @@ jobs:
       - run:
           name: test:integration:mascara
           command: npm run test:mascara
-
-  build:
-    docker:
-      - image: circleci/node:8-browsers
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: build:dist
-          command: npm run dist
-      - run:
-          name: build:debug
-          command: find dist/ -type f -exec md5sum {} \; | sort -k 2


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#3665 because that PR seems to have made our tests less deterministic.