### PR TITLE
Prevent users from adding custom token if decimals is an empty string.

### DIFF
--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -143,7 +143,10 @@ AddTokenScreen.prototype.validate = function () {
       errors.customAddress = t('invalidAddress')
     }
 
-    const validDecimals = customDecimals !== null && customDecimals >= 0 && customDecimals < 36
+    const validDecimals = customDecimals !== null
+      && customDecimals !== ''
+      && customDecimals >= 0
+      && customDecimals < 36
     if (!validDecimals) {
       errors.customDecimals = t('decimalsMustZerotoTen')
     }


### PR DESCRIPTION
Fixes #3692 