### PR TITLE
remove unavailable goToBuyEtherView propType

### DIFF
--- a/mascara/src/app/first-time/index.js
+++ b/mascara/src/app/first-time/index.js
@@ -20,7 +20,6 @@ class FirstTimeFlow extends Component {
     seedWords: PropTypes.string,
     address: PropTypes.string,
     noActiveNotices: PropTypes.bool,
-    goToBuyEtherView: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -171,4 +170,3 @@ export default connect(
     openBuyEtherModal: () => dispatch(showModal({ name: 'DEPOSIT_ETHER'})),
   })
 )(FirstTimeFlow)
-


### PR DESCRIPTION
Got warning in chrome extension log:

```
Warning: Failed prop type: The prop `goToBuyEtherView` is marked as required in `t`, but its value is `undefined`. in t (created by Connect(t)) in Connect(t) (created by M) in div (created by M) in M (created by Connect(M)) in Connect(M) (created by b) in b (created by Connect(b)) in Connect(b) (created by c) in t (created by c) in c
```

Search `goToBuyEtherView` and it only shows in `mascara/src/app/index`'s `propTypes` definition, should be removed