### PR TITLE
Fix bug where resetAccount does not clear network cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug where the "Reset account" feature would not clear the network cache.
+
 ## 4.4.0 Mon Mar 26 2018
 
 - Internationalization: Taiwanese, Thai, Slovenian

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -588,7 +588,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.txController.wipeTransactions(selectedAddress)
 
     const networkController = this.networkController
-    const oldType = networkController.getProvoderConfig().type
+    const oldType = networkController.getProviderConfig().type
     await networkController.setProviderType(oldType, true)
 
     return selectedAddress

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -49,7 +49,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * @constructor
-   * @param {Object} opts 
+   * @param {Object} opts
    */
    constructor (opts) {
     super()
@@ -296,8 +296,8 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * The metamask-state of the various controllers, made available to the UI
-   * 
-   * @returns {Object} status 
+   *
+   * @returns {Object} status
    */
   getState () {
     const wallet = this.configManager.getWallet()
@@ -335,8 +335,8 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * Returns an api-object which is consumed by the UI
-   * 
-   * @returns {Object} 
+   *
+   * @returns {Object}
    */
   getApi () {
     const keyringController = this.keyringController
@@ -365,7 +365,7 @@ module.exports = class MetamaskController extends EventEmitter {
       placeSeedWords: this.placeSeedWords.bind(this),
       verifySeedPhrase: nodeify(this.verifySeedPhrase, this),
       clearSeedWordCache: this.clearSeedWordCache.bind(this),
-      resetAccount: this.resetAccount.bind(this),
+      resetAccount: nodeify(this.resetAccount, this),
       importAccountWithStrategy: this.importAccountWithStrategy.bind(this),
 
       // vault management
@@ -426,14 +426,14 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * Creates a new Vault(?) and create a new keychain(?)
-   * 
+   *
    * A vault is ...
-   * 
+   *
    * A keychain is ...
-   * 
+   *
    *
    * @param  {} password
-   * 
+   *
    * @returns {} vault
    */
   async createNewVaultAndKeychain (password) {
@@ -479,9 +479,9 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * Retrieves the first Identiy from the passed Vault and selects the related address
-   * 
+   *
    * An Identity is ...
-   * 
+   *
    * @param  {} vault
    */
   selectFirstIdentity (vault) {
@@ -495,8 +495,8 @@ module.exports = class MetamaskController extends EventEmitter {
   //
 
   /**
-   * Adds a new account to ... 
-   * 
+   * Adds a new account to ...
+   *
    * @returns {} keyState
    */
   async addNewAccount () {
@@ -522,10 +522,10 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * Adds the current vault's seed words to the UI's state tree.
-   * 
+   *
    * Used when creating a first vault, to allow confirmation.
    * Also used when revealing the seed words in the confirmation view.
-   */ 
+   */
   placeSeedWords (cb) {
 
     this.verifySeedPhrase()
@@ -540,7 +540,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * Verifies the validity of the current vault's seed phrase.
-   * 
+   *
    * Validity: seed phrase restores the accounts belonging to the current vault.
    *
    * Called when the first account is created and on unlocking the vault.
@@ -571,27 +571,32 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * Remove the primary account seed phrase from the UI's state tree.
-   * 
+   *
    * The seed phrase remains available in the background process.
-   * 
+   *
    */
   clearSeedWordCache (cb) {
     this.configManager.setSeedWords(null)
     cb(null, this.preferencesController.getSelectedAddress())
   }
-  
+
   /**
    * ?
    */
-  resetAccount (cb) {
+  async resetAccount (cb) {
     const selectedAddress = this.preferencesController.getSelectedAddress()
     this.txController.wipeTransactions(selectedAddress)
-    cb(null, selectedAddress)
+
+    const networkController = this.networkController
+    const oldType = networkController.getProvoderConfig().type
+    await networkController.setProviderType(oldType, true)
+
+    return selectedAddress
   }
 
   /**
    * Imports an account ... ?
-   * 
+   *
    * @param  {} strategy
    * @param  {} args
    * @param  {} cb
@@ -634,9 +639,9 @@ module.exports = class MetamaskController extends EventEmitter {
   }
 
   // Prefixed Style Message Signing Methods:
-  
+
   /**
-   * 
+   *
    * @param  {} msgParams
    * @param  {} cb
    */
@@ -655,7 +660,7 @@ module.exports = class MetamaskController extends EventEmitter {
       }
     })
   }
-  
+
   /**
    * @param  {} msgParams
    */
@@ -676,7 +681,7 @@ module.exports = class MetamaskController extends EventEmitter {
       return this.getState()
     })
   }
-  
+
   /**
    * @param  {} msgParams
    */
@@ -697,13 +702,13 @@ module.exports = class MetamaskController extends EventEmitter {
         return this.getState()
       })
   }
-  
+
   // ---------------------------------------------------------------------------
   // Account Restauration
 
   /**
    * ?
-   * 
+   *
    * @param  {} migratorOutput
    */
   restoreOldVaultAccounts (migratorOutput) {
@@ -714,7 +719,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * ?
-   * 
+   *
    * @param  {} migratorOutput
    */
   restoreOldLostAccounts (migratorOutput) {
@@ -728,9 +733,9 @@ module.exports = class MetamaskController extends EventEmitter {
 
   /**
    * Import (lost) Accounts
-   * 
+   *
    * @param  {Object} {lostAccounts} @Array accounts <{ address, privateKey }>
-   * 
+   *
    * Uses the array's private keys to create a new Simple Key Pair keychain
    * and add it to the keyring controller.
    */
@@ -823,7 +828,7 @@ module.exports = class MetamaskController extends EventEmitter {
     if (cb && typeof cb === 'function') {
       cb(null, this.getState())
     }
-  }  
+  }
 
   cancelPersonalMessage (msgId, cb) {
     const messageManager = this.personalMessageManager
@@ -978,7 +983,7 @@ module.exports = class MetamaskController extends EventEmitter {
     const percentileNum = percentile(50, lowestPrices)
     const percentileNumBn = new BN(percentileNum)
     return '0x' + percentileNumBn.mul(GWEI_BN).toString(16)
-  }  
+  }
 
 //=============================================================================
 // CONFIG


### PR DESCRIPTION
Fixes #3439 

Sorry, it looks like my vim auto-linter removed a lot of trailing whitespace that was not caught in a previous JSDoc PR.

The important changes are [here](https://github.com/MetaMask/metamask-extension/pull/3760/files#diff-fd8e90928ae2cc670d306c0244a894d0L586).