### PR TITLE
Add test for suspected nonce bug

### DIFF
--- a/app/scripts/lib/nonce-tracker.js
+++ b/app/scripts/lib/nonce-tracker.js
@@ -31,14 +31,13 @@ class NonceTracker {
     const networkNonceResult = await this._getNetworkNextNonce(address)
     const highestLocallyConfirmed = this._getHighestLocallyConfirmed(address)
     const nextNetworkNonce = networkNonceResult.nonce
-    const highestLocalNonce = highestLocallyConfirmed
-    const highestSuggested = Math.max(nextNetworkNonce, highestLocalNonce)
+    const highestSuggested = Math.max(nextNetworkNonce, highestLocallyConfirmed)
 
     const pendingTxs = this.getPendingTransactions(address)
     const localNonceResult = this._getHighestContinuousFrom(pendingTxs, highestSuggested) || 0
 
     nonceDetails.params = {
-      highestLocalNonce,
+      highestLocallyConfirmed,
       highestSuggested,
       nextNetworkNonce,
     }

--- a/test/unit/nonce-tracker-test.js
+++ b/test/unit/nonce-tracker-test.js
@@ -33,6 +33,25 @@ describe('Nonce Tracker', function () {
       })
     })
 
+    describe.only('issue 3670', function () {
+      beforeEach(function () {
+        const txGen = new MockTxGen()
+        pendingTxs = txGen.generate({ status: 'submitted' }, {
+          fromNonce: 6,
+          count: 3,
+        })
+        nonceTracker = generateNonceTrackerWith(pendingTxs, [], '0x6')
+      })
+
+      it('should return 9', async function () {
+        this.timeout(15000)
+        const nonceLock = await nonceTracker.getNonceLock('0x7d3517b0d011698406d6e0aed8453f0be2697926')
+        console.log(JSON.stringify(nonceLock, null, 2))
+        assert.equal(nonceLock.nextNonce, '9', `nonce should be 9 got ${nonceLock.nextNonce}`)
+        await nonceLock.releaseLock()
+      })
+    })
+
     describe('with no previous txs', function () {
       beforeEach(function () {
         nonceTracker = generateNonceTrackerWith([], [])

--- a/test/unit/nonce-tracker-test.js
+++ b/test/unit/nonce-tracker-test.js
@@ -33,7 +33,25 @@ describe('Nonce Tracker', function () {
       })
     })
 
-    describe.only('issue 3670', function () {
+    describe('sentry issue 476304902', function () {
+      beforeEach(function () {
+        const txGen = new MockTxGen()
+        pendingTxs = txGen.generate({ status: 'submitted' }, {
+          fromNonce: 3,
+          count: 29,
+        })
+        nonceTracker = generateNonceTrackerWith(pendingTxs, [], '0x3')
+      })
+
+      it('should return 9', async function () {
+        this.timeout(15000)
+        const nonceLock = await nonceTracker.getNonceLock('0x7d3517b0d011698406d6e0aed8453f0be2697926')
+        assert.equal(nonceLock.nextNonce, '32', `nonce should be 32 got ${nonceLock.nextNonce}`)
+        await nonceLock.releaseLock()
+      })
+    })
+
+    describe('issue 3670', function () {
       beforeEach(function () {
         const txGen = new MockTxGen()
         pendingTxs = txGen.generate({ status: 'submitted' }, {
@@ -46,7 +64,6 @@ describe('Nonce Tracker', function () {
       it('should return 9', async function () {
         this.timeout(15000)
         const nonceLock = await nonceTracker.getNonceLock('0x7d3517b0d011698406d6e0aed8453f0be2697926')
-        console.log(JSON.stringify(nonceLock, null, 2))
         assert.equal(nonceLock.nextNonce, '9', `nonce should be 9 got ${nonceLock.nextNonce}`)
         await nonceLock.releaseLock()
       })


### PR DESCRIPTION
I went through both of the issues linked in #3670, and wrote test cases for both of them, and confirmed that in both cases, the nonce seems to be calculated correctly.

I think the confusion was because we had a `highestLocalNonce` variable which was actually equal to `highestLocally_Confirmed_Nonce`. To help clarify, I've renamed that variable, to make these logs easier to understand.

In both cases, the errors (`replacement transaction underpriced`) could also be explained by either another computer having submitted a pending transaction to the pool, or maybe the mysterious behavior we're getting where this kind of error is thrown on the first submission.

I am suspicious that #3670 is actually a duplicate of #3669.