### PR TITLE
identicon - set blockies height and width to identicon diameter

### DIFF
--- a/ui/app/components/identicon.js
+++ b/ui/app/components/identicon.js
@@ -105,9 +105,8 @@ IdenticonComponent.prototype.componentDidUpdate = function () {
 function _generateBlockie (container, address, diameter) {
   const img = new Image()
   img.src = toDataUrl(address)
-  const dia = !diameter || diameter < 50 ? 50 : diameter
-  img.height = dia * 1.25
-  img.width = dia * 1.25
+  img.height = diameter
+  img.width = diameter
   container.appendChild(img)
 }
 


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/3812

sets the diameter as shown in screenshots in issue. open to other solutions.