### PR TITLE
Ensure txParams are prefixed with 0x when sending.

### DIFF
--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -635,6 +635,10 @@ SendTransactionScreen.prototype.onSubmit = function (event) {
       txParams.to = to
     }
 
+    Object.keys(txParams).forEach(key => {
+      txParams[key] = ethUtil.addHexPrefix(txParams[key])
+    })
+
     selectedToken
       ? signTokenTx(selectedToken.address, to, amount, txParams)
       : signTx(txParams)


### PR DESCRIPTION
Makes the send component consistent with the validation added in https://github.com/MetaMask/metamask-extension/commit/21fbaed97