### PR TITLE
build - correctly set METAMASK_ENV via envify

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -22,7 +22,7 @@ const EdgeEncryptor = require('./edge-encryptor')
 const getFirstPreferredLangCode = require('./lib/get-first-preferred-lang-code')
 
 const STORAGE_KEY = 'metamask-config'
-const METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
+const METAMASK_DEBUG = process.env.METAMASK_DEBUG
 
 window.log = log
 log.setDefaultLevel(METAMASK_DEBUG ? 'debug' : 'warn')
@@ -94,7 +94,7 @@ function setupController (initState, initLangCode) {
   //
   // MetaMask Controller
   //
-  
+
   const controller = new MetamaskController({
     // User confirmation callbacks:
     showUnconfirmedMessage: triggerUi,

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -13,7 +13,7 @@ const DEFAULT_RPC = 'rinkeby'
 const OLD_UI_NETWORK_TYPE = 'network'
 const BETA_UI_NETWORK_TYPE = 'networkBeta'
 
-global.METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
+global.METAMASK_DEBUG = process.env.METAMASK_DEBUG
 
 module.exports = {
   network: {

--- a/app/scripts/first-time-state.js
+++ b/app/scripts/first-time-state.js
@@ -1,6 +1,6 @@
 // test and development environment variables
 const env = process.env.METAMASK_ENV
-const METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
+const METAMASK_DEBUG = process.env.METAMASK_DEBUG
 
 //
 // The default state of MetaMask

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -9,7 +9,7 @@ const setupDappAutoReload = require('./lib/auto-reload.js')
 const MetamaskInpageProvider = require('./lib/inpage-provider.js')
 restoreContextAfterImports()
 
-const METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
+const METAMASK_DEBUG = process.env.METAMASK_DEBUG
 window.log = log
 log.setDefaultLevel(METAMASK_DEBUG ? 'debug' : 'warn')
 

--- a/app/scripts/lib/setupRaven.js
+++ b/app/scripts/lib/setupRaven.js
@@ -1,5 +1,5 @@
 const Raven = require('raven-js')
-const METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
+const METAMASK_DEBUG = process.env.METAMASK_DEBUG
 const extractEthjsErrorMessage = require('./extractEthjsErrorMessage')
 const PROD = 'https://3567c198f8a8412082d32655da2961d0@sentry.io/273505'
 const DEV = 'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "gulp dev:extension",
-    "mascara": "gulp dev:mascara & cross-env METAMASK_DEBUG=true node ./mascara/example/server",
+    "mascara": "gulp dev:mascara & node ./mascara/example/server",
     "dist": "gulp dist",
     "test": "npm run test:unit && npm run test:integration && npm run lint",
     "test:unit": "cross-env METAMASK_ENV=test mocha --exit --require babel-core/register --require test/helper.js --recursive \"test/unit/**/*.js\"",
@@ -61,7 +61,6 @@
         }
       ],
       "reactify",
-      "envify",
       "brfs"
     ]
   },

--- a/ui/app/store.js
+++ b/ui/app/store.js
@@ -4,7 +4,7 @@ const thunkMiddleware = require('redux-thunk').default
 const rootReducer = require('./reducers')
 const createLogger = require('redux-logger').createLogger
 
-global.METAMASK_DEBUG = 'GULP_METAMASK_DEBUG'
+global.METAMASK_DEBUG = process.env.METAMASK_DEBUG
 
 module.exports = configureStore
 


### PR DESCRIPTION
When i refactored + optimized the build system, I accidently moved minification before our environment var injection, and this broke setting METAMASK_ENV to prod.

Seems to only have a couple small side effects:
- default network for new users = Rinkeby
- logging is more verbose
- sentry reports go to the wrong sentry project