### PR TITLE
Ensure get-first-preferred-lang-code.js matches locale codes from loc…

### DIFF
--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -2,14 +2,16 @@ const extension = require('extensionizer')
 const promisify = require('pify')
 const allLocales = require('../../_locales/index.json')
 
-const existingLocaleCodes = allLocales.map(locale => locale.code.replace('_', '-'))
+const existingLocaleCodes = allLocales.map(locale => locale.code.toLowerCase().replace('_', '-'))
 
 async function getFirstPreferredLangCode () {
   const userPreferredLocaleCodes = await promisify(
     extension.i18n.getAcceptLanguages,
     { errorFirst: false }
   )()
-  const firstPreferredLangCode = userPreferredLocaleCodes.find(code => existingLocaleCodes.includes(code))
+  const firstPreferredLangCode = userPreferredLocaleCodes
+    .map(code => code.toLowerCase())
+    .find(code => existingLocaleCodes.includes(code))
   return firstPreferredLangCode || 'en'
 }
 

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -2,7 +2,7 @@ const extension = require('extensionizer')
 const promisify = require('pify')
 const allLocales = require('../../_locales/index.json')
 
-const existingLocaleCodes = allLocales.map(locale => locale.code)
+const existingLocaleCodes = allLocales.map(locale => locale.code.replace('_', '-'))
 
 async function getFirstPreferredLangCode () {
   const userPreferredLocaleCodes = await promisify(


### PR DESCRIPTION
…al directory names and chrome extension api.

For instance, if `extension.i18n.getAcceptLanguages()` returns `zh-CN`, it will now be correctly matched by our `zh_CN` directory.