### PR TITLE
Make token helpscout link open in new tab.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Current Master
+- Fix link for 'Learn More' in the Add Token Screen to open to a new tab.
 
 ## 4.5.3 Wed Apr 04 2018
 

--- a/ui/app/add-token.js
+++ b/ui/app/add-token.js
@@ -360,6 +360,7 @@ AddTokenScreen.prototype.renderTabs = function () {
           h('div.add-token__info-box__copy', this.context.t('keepTrackTokens')),
           h('a.add-token__info-box__copy--blue', {
             href: 'http://metamask.helpscoutdocs.com/article/16-managing-erc20-tokens',
+            target: '_blank',
           }, this.context.t('learnMore')),
         ]),
         h('div.add-token__input-container', [


### PR DESCRIPTION
Question: should we be using `target: '_blank'` to enable links in new tabs, or this behavior I saw somewhere else where we stop default behavior first?

```
          onClick (event) { global.platform.openWindow({ url: event.target.href }) },
        }, 'Read more.'),
```

In fact, I see places where we do this in both.