### PR TITLE
Fixes download file buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix Download State Logs button [#3791](https://github.com/MetaMask/metamask-extension/issues/3791)
+
 ## 4.5.3 Wed Apr 04 2018
 
 - Fix bug where checksum address are messing with balance issue [#3843](https://github.com/MetaMask/metamask-extension/issues/3843)

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -231,6 +231,7 @@ function exportAsFile (filename, data) {
     window.navigator.msSaveBlob(blob, filename)
   } else {
     const elem = window.document.createElement('a')
+    elem.target = "_blank"
     elem.href = window.URL.createObjectURL(blob)
     elem.download = filename
     document.body.appendChild(elem)

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -231,7 +231,7 @@ function exportAsFile (filename, data) {
     window.navigator.msSaveBlob(blob, filename)
   } else {
     const elem = window.document.createElement('a')
-    elem.target = "_blank"
+    elem.target = '_blank'
     elem.href = window.URL.createObjectURL(blob)
     elem.download = filename
     document.body.appendChild(elem)

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -271,6 +271,7 @@ function exportAsFile (filename, data) {
     window.navigator.msSaveBlob(blob, filename)
   } else {
     const elem = window.document.createElement('a')
+    elem.target = "_blank"
     elem.href = window.URL.createObjectURL(blob)
     elem.download = filename
     document.body.appendChild(elem)

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -271,7 +271,7 @@ function exportAsFile (filename, data) {
     window.navigator.msSaveBlob(blob, filename)
   } else {
     const elem = window.document.createElement('a')
-    elem.target = "_blank"
+    elem.target = '_blank'
     elem.href = window.URL.createObjectURL(blob)
     elem.download = filename
     document.body.appendChild(elem)


### PR DESCRIPTION
Add `target="_blank"` to exportAsFile element to open the file in a new tab and download.

Fixes #3791