### PR TITLE
Disable the first time flow import button while isLoading is true.

### DIFF
--- a/mascara/src/app/first-time/import-seed-phrase-screen.js
+++ b/mascara/src/app/first-time/import-seed-phrase-screen.js
@@ -76,8 +76,9 @@ class ImportSeedPhraseScreen extends Component {
 
   render () {
     const { seedPhrase, password, confirmPassword } = this.state
-    const { warning } = this.props
-    const importDisabled = warning || !seedPhrase || !password || !confirmPassword
+    const { warning, isLoading } = this.props
+    const importDisabled = warning || !seedPhrase || !password || !confirmPassword || isLoading
+
     return (
       <div className="first-view-main-wrapper">
         <div className="first-view-main">
@@ -152,7 +153,7 @@ class ImportSeedPhraseScreen extends Component {
 }
 
 export default connect(
-  ({ appState: { warning } }) => ({ warning }),
+  ({ appState: { warning, isLoading } }) => ({ warning, isLoading }),
   dispatch => ({
     leaveImportSeedScreenState: () => {
       dispatch(unMarkPasswordForgotten())


### PR DESCRIPTION
Fixes #3696

This bug was resolved with 4.4.0. Specifically, the "Popup extension in new-ui uses new on-boarding designs" change. This is supported by looking at all the events that match 'Cannot read property type of undefined' in sentry: https://sentry.io/metamask/metamask/issues/482614027/events/. They are all from versions 4.3.0 or earlier.

Previously, it was possible to do the following:
(1) install the extension
(2) click "Try Beta Version" to open the app in full browser mode
(3) go to the "Import account from seed phrase screen."
(4) open the popup extension and click through the two notices
(5) fill out the seed phrase import form and click the submit button, and then click it again while the loading indicator is still showing (therefore causing two `createNewVaultAndRestore` actions to be in flight at the same time).

This made it possible for a `forceUpdateMetamaskState` call and `showAccountsPage` action to be dispatched and successfully resolved while a `background.createNewVaultAndRestore` call was not yet resolved, causing the user to arrive at the main page with an undefined keyring.

With 4.4.0, the user is unable to do (4) in the reproduction steps above. This then forces the user to the notices screen after the import screen, and prevents the undefined keyring error on the main screen.

**However, as an extra guard agains this bug emerging again after some future change, this PR ensures that the import button cannot be clicked while the `createNewVaultAndRestore` is still unresolved. Regardless of the bug, this is desirable.**