### PR TITLE
migrations - report migrations errors to sentry with vault structure

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -20,6 +20,7 @@ const reportFailedTxToSentry = require('./lib/reportFailedTxToSentry')
 const setupMetamaskMeshMetrics = require('./lib/setupMetamaskMeshMetrics')
 const EdgeEncryptor = require('./edge-encryptor')
 const getFirstPreferredLangCode = require('./lib/get-first-preferred-lang-code')
+const getObjStructure = require('./lib/getObjStructure')
 
 const STORAGE_KEY = 'metamask-config'
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG
@@ -77,6 +78,16 @@ async function loadStateFromPersistence () {
                   diskStore.getState() ||
                   migrator.generateInitialState(firstTimeState)
 
+  // report migration errors to sentry
+  migrator.on('error', (err) => {
+    // get vault structure without secrets
+    const vaultStructure = getObjStructure(versionedData)
+    raven.captureException(err, {
+      // "extra" key is required by Sentry
+      extra: { vaultStructure },
+    })
+  })
+
   // migrate data
   versionedData = await migrator.migrateData(versionedData)
   if (!versionedData) {
@@ -84,7 +95,14 @@ async function loadStateFromPersistence () {
   }
 
   // write to disk
-  if (localStore.isSupported) localStore.set(versionedData)
+  if (localStore.isSupported) {
+    localStore.set(versionedData)
+  } else {
+    // throw in setTimeout so as to not block boot
+    setTimeout(() => {
+      throw new Error('MetaMask - Localstore not supported')
+    })
+  }
 
   // return just the data
   return versionedData.data

--- a/app/scripts/lib/getObjStructure.js
+++ b/app/scripts/lib/getObjStructure.js
@@ -1,0 +1,33 @@
+const clone = require('clone')
+
+module.exports = getObjStructure
+
+// This will create an object that represents the structure of the given object
+// it replaces all values with the result of their type
+
+// {
+//   "data": {
+//     "CurrencyController": {
+//       "conversionDate": "number",
+//       "conversionRate": "number",
+//       "currentCurrency": "string"
+//     }
+// }
+
+function getObjStructure(obj) {
+  const structure = clone(obj)
+  return deepMap(structure, (value) => {
+    return value === null ? 'null' : typeof value
+  })
+}
+
+function deepMap(target = {}, visit) {
+  Object.entries(target).forEach(([key, value]) => {
+    if (typeof value === 'object' && value !== null) {
+      target[key] = deepMap(value, visit)
+    } else {
+      target[key] = visit(value)
+    }
+  })
+  return target
+}

--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -29,9 +29,12 @@ class Migrator extends EventEmitter {
         // accept the migration as good
         versionedData = migratedData
       } catch (err) {
+        // rewrite error message to add context without clobbering stack
+        const originalErrorMessage = err.message
+        err.message = `MetaMask Migration Error #${migration.version}: ${originalErrorMessage}`
+        console.warn(err.stack)
         // emit error instead of throw so as to not break the run (gracefully fail)
-        const error = new Error(`MetaMask Migration Error #${migration.version}:\n${err.stack}`)
-        this.emit('error', error)
+        this.emit('error', err)
         // stop migrating and use state as is
         return versionedData
       }

--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -30,7 +30,7 @@ class Migrator extends EventEmitter {
         versionedData = migratedData
       } catch (err) {
         // emit error instead of throw so as to not break the run (gracefully fail)
-        const error = new Error(`MetaMask Migration Error #${version}:\n${err.stack}`)
+        const error = new Error(`MetaMask Migration Error #${migration.version}:\n${err.stack}`)
         this.emit('error', error)
         // stop migrating and use state as is
         return versionedData

--- a/app/scripts/migrations/024.js
+++ b/app/scripts/migrations/024.js
@@ -13,17 +13,13 @@ const clone = require('clone')
 module.exports = {
   version,
 
-  migrate: function (originalVersionedData) {
+  migrate: async function (originalVersionedData) {
     const versionedData = clone(originalVersionedData)
     versionedData.meta.version = version
-    try {
-      const state = versionedData.data
-      const newState = transformState(state)
-      versionedData.data = newState
-    } catch (err) {
-      console.warn(`MetaMask Migration #${version}` + err.stack)
-    }
-    return Promise.resolve(versionedData)
+    const state = versionedData.data
+    const newState = transformState(state)
+    versionedData.data = newState
+    return versionedData
   },
 }
 


### PR DESCRIPTION
- migrator now gracefully handles migration errors + emits errors as an eventemitter
- special sentry error reporting hook for migration failures
- report errors when extension.storage.local not supported
- update last migration (24) to fail instead of warn