### PR TITLE
Empty vault - attempt recovery

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -174,8 +174,11 @@ function setupController (initState, initLangCode) {
   }
 
   function persistData(state) {
+    if (!state) {
+      throw new Error('MetaMask - updated state is missing', state)
+    }
     if (!state.data) {
-      throw new Error('MetaMask - updated state is missing data', state)
+      throw new Error('MetaMask - updated state does not have data', state)
     }
     if (localStore.isSupported) {
       localStore.set(state)

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -162,9 +162,9 @@ function setupController (initState, initLangCode) {
     asStream(controller.store),
     debounce(1000),
     storeTransform(versionifyData),
-    storeTransform(syncDataWithExtension),
+    storeTransform(persistData),
     (error) => {
-      log.error('pump hit error', error)
+      log.error('MetaMask - Persistence pipeline failed', error)
     }
   )
 
@@ -173,7 +173,10 @@ function setupController (initState, initLangCode) {
     return versionedData
   }
 
-  function syncDataWithExtension(state) {
+  function persistData(state) {
+    if (!state.data) {
+      throw new Error('MetaMask - updated state is missing data', state)
+    }
     if (localStore.isSupported) {
       localStore.set(state)
       .catch((err) => {


### PR DESCRIPTION
Updates #3919

- tries to recover empty vaults from localStorage (diskStore)
- reports to sentry when an empty vault was found and if recovery was possible or not
- disallows writing state with missing data