### PR TITLE
Add team member documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To write tests that will be run in the browser using QUnit, add your test files 
 - [How to develop a live-reloading UI](./docs/ui-dev-mode.md)
 - [How to add a new translation to MetaMask](./docs/translating-guide.md)
 - [Publishing Guide](./docs/publishing.md)
+- [The MetaMask Team](./docs/team.md)
 - [How to develop an in-browser mocked UI](./docs/ui-mock-mode.md)
 - [How to live reload on local dependency changes](./docs/developing-on-deps.md)
 - [How to add new networks to the Provider Menu](./docs/adding-new-networks.md)

--- a/docs/team.md
+++ b/docs/team.md
@@ -55,7 +55,7 @@ Software Engineer
 
 The newest member of the team! Paul is currently being onboarded, and finding his niche within the team.
 
-## Laboratry Team Members
+## Laboratory Team Members
 
 These team members are working on projects that will benefit MetaMask, but are not directly working on the product itself.
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -55,6 +55,17 @@ Software Engineer
 
 The newest member of the team! Paul is currently being onboarded, and finding his niche within the team.
 
+## Laboratry Team Members
+
+These team members are working on projects that will benefit MetaMask, but are not directly working on the product itself.
+
+### Herman Junge
+
+@hermanjunge
+Software Engineer
+
+Herman is currently leading the Mustekala project, a JavaScript, IPFS-based Ethereum light client.
+
 ## Kyokan Team Members
 
 [Kyokan](http://kyokan.io/) is a consulting firm that has been working closely with the MetaMask team on the latest version of our user interface. Their team members are not members of ConsenSys LLC, but they contribute a lot to the project.

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,0 +1,62 @@
+# The Team
+
+Here is an overview of the current MetaMask team, and their primary roles and responsibilities, in the order they joined the team.
+
+This section will describe
+
+## Core Team Members
+
+The core team maintains aspects of the main product (the extension) and the core libraries (the MetaMask Controller, provider-engine, etc).
+
+### Aaron Davis
+
+@kumavis
+Founder / Technical Lead
+
+Especially in charge of connection to the blockchain. Wrote [provider-engine](https://github.com/MetaMask/provider-engine), and is currently working with @hermanjunge on our JavaScript light-client.
+
+### Dan Finlay
+
+@danfinlay
+Software Engineer / Product Lead
+
+Focused on the deliverable, user-valuable aspects of MetaMask, including usability and documentation. Coordinates efforts between different branches of the team, and integrations with other projects.
+
+### Frankie Pangilinan
+
+@frankiebee
+Software Engineer / Transaction Manager Lead
+
+Frankie contributes code throughout MetaMask, but has become especially specialized in the way MetaMask manages transactions. She is also the original lead of the [Mascara](https://github.com/MetaMask/mascara) project.
+
+### Kevin Serrano
+
+@Zanibas
+Software Engineer / Project Management Lead
+
+Kevin is a software engineer, but also spends a lot of his time keeping the team's administrative operations running smoothly.
+
+### Thomas Huang
+
+@tmashuang
+QA Engineer
+
+Thomas is the head of MetaMask Quality Assurance. He both takes the final pass of branches of code before we ship to production, and is also in charge of continuously improving our automated quality assurance process.
+
+### Christian Jeria
+
+@cjeria
+User Experience Designer
+
+Christian is the lead of MetaMask's user experience. He is continuously designing prototypes, testing them with users, and refining them with our developers for production.
+
+## Kyokan Team Members
+
+[Kyokan](http://kyokan.io/) is a consulting firm that has been working closely with the MetaMask team on the latest version of our user interface. Their team members are not members of ConsenSys LLC, but they contribute a lot to the project.
+
+- Daniel Tsui (@sdsui)
+- Chi Kei Chan (@chikeichan)
+- Dan Miller (@danjm)
+- David Yoo (@yookd)
+- Whymarrh Whitby (@whymarrh)
+

--- a/docs/team.md
+++ b/docs/team.md
@@ -50,6 +50,13 @@ User Experience Designer
 
 Christian is the lead of MetaMask's user experience. He is continuously designing prototypes, testing them with users, and refining them with our developers for production.
 
+### Paul Bouchon
+
+@bitpshr
+Software Engineer
+
+The newest member of the team! Paul is currently being onboarded, and finding his niche within the team.
+
 ## Kyokan Team Members
 
 [Kyokan](http://kyokan.io/) is a consulting firm that has been working closely with the MetaMask team on the latest version of our user interface. Their team members are not members of ConsenSys LLC, but they contribute a lot to the project.

--- a/docs/team.md
+++ b/docs/team.md
@@ -2,8 +2,6 @@
 
 Here is an overview of the current MetaMask team, and their primary roles and responsibilities, in the order they joined the team.
 
-This section will describe
-
 ## Core Team Members
 
 The core team maintains aspects of the main product (the extension) and the core libraries (the MetaMask Controller, provider-engine, etc).


### PR DESCRIPTION
To help exeternal contributors make sense of who is active on the
project, and who they should go to to ask certain questions.