### PR TITLE
Prevent Polling while MetaMask user is logged out

### DIFF
--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -17,7 +17,6 @@ class RecentBlocksController {
     this.store = new ObservableStore(initState)
 
     this.blockTracker.on('block', this.processBlock.bind(this))
-    this.backfill()
   }
 
   resetState () {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -286,9 +286,9 @@ module.exports = class MetamaskController extends EventEmitter {
       if (memState.isUnlocked && !this.blockTracker._isRunning) {
         this.recentBlocksController.resetState()
         this.recentBlocksController.backfill()
-        this.blockTracker.start();
+        this.blockTracker.start()
       } else if (!memState.isUnlocked && this.blockTracker._isRunning) {
-        this.blockTracker.stop();
+        this.blockTracker.stop()
       }
 
       const publicState = selectPublicState(memState)


### PR DESCRIPTION
Over at Infura we're looking for ways to relieve some load off our servers. I found that eth-block-tracker was polling for both logged in and logged out users. Instead, with this PR we're hoping to only initiate the polling only once the user is logged in and then terminate again once they're logged out. I've been running this version locally without any problems. 

In `metamask-controller.js` on line 286 I'm checking for auth & polling status, If there's a better place to drop this lmk. We could also remove the check for polling on line 106 if we can remove the line that kickstarts polling in [provider-engine](https://github.com/MetaMask/provider-engine/blob/006a94d4ad5c2a8a147d2a440495d0c3defab498/zero.js#L93).
