### PR TITLE
Allow other extensions to connect

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -67,6 +67,7 @@
   "externally_connectable": {
     "matches": [
       "https://metamask.io/*"
-    ]
+    ],
+    "ids": ["*"]
   }
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -197,6 +197,7 @@ function setupController (initState, initLangCode) {
   // connect to other contexts
   //
   extension.runtime.onConnect.addListener(connectRemote)
+  extension.runtime.onConnectExternal.addListener(connectExternal)
 
   const metamaskInternalProcessHash = {
     [ENVIRONMENT_TYPE_POPUP]: true,
@@ -211,9 +212,9 @@ function setupController (initState, initLangCode) {
   function connectRemote (remotePort) {
     const processName = remotePort.name
     const isMetaMaskInternalProcess = metamaskInternalProcessHash[processName]
-    const portStream = new PortStream(remotePort)
 
     if (isMetaMaskInternalProcess) {
+      const portStream = new PortStream(remotePort)
       // communication with popup
       controller.isClientOpen = true
       controller.setupTrustedCommunication(portStream, 'MetaMask')
@@ -246,10 +247,15 @@ function setupController (initState, initLangCode) {
         })
       }
     } else {
-      // communication with page
-      const originDomain = urlUtil.parse(remotePort.sender.url).hostname
-      controller.setupUntrustedCommunication(portStream, originDomain)
+      connectExternal(remotePort)
     }
+  }
+
+  // communication with page or other extension
+  function connectExternal(remotePort) {
+    const originDomain = urlUtil.parse(remotePort.sender.url).hostname
+    const portStream = new PortStream(remotePort)
+    controller.setupUntrustedCommunication(portStream, originDomain)
   }
 
   //


### PR DESCRIPTION
As discussed in #940 this PR allows to connect to MetaMask from other extensions.

Resolves #940 