### PR TITLE
feat: optionally display personal_sign data as hex

### DIFF
--- a/old-ui/app/components/binary-renderer.js
+++ b/old-ui/app/components/binary-renderer.js
@@ -13,8 +13,9 @@ function BinaryRenderer () {
 
 BinaryRenderer.prototype.render = function () {
   const props = this.props
-  const { value, style } = props
-  const text = this.hexToText(value)
+  const { value, style, encoding } = props
+
+  const text = encoding === 'hex' ? value : this.hexToText(value)
 
   const defaultStyle = extend({
     width: '315px',

--- a/old-ui/app/components/pending-personal-msg-details.js
+++ b/old-ui/app/components/pending-personal-msg-details.js
@@ -21,7 +21,7 @@ PendingMsgDetails.prototype.render = function () {
   var identity = state.identities[address] || { address: address }
   var account = state.accounts[address] || { address: address }
 
-  var { data } = msgParams
+  var { data, encoding } = msgParams
 
   return (
     h('div', {
@@ -47,6 +47,7 @@ PendingMsgDetails.prototype.render = function () {
       }, [
         h('label.font-small', { style: { display: 'block' } }, 'MESSAGE'),
         h(BinaryRenderer, {
+          encoding,
           value: data,
           style: {
             height: '215px',

--- a/ui/app/components/signature-request.js
+++ b/ui/app/components/signature-request.js
@@ -170,10 +170,15 @@ SignatureRequest.prototype.renderBody = function () {
   let notice = this.context.t('youSign') + ':'
 
   const { txData } = this.props
-  const { type, msgParams: { data } } = txData
+  const { type, msgParams: { data, encoding } } = txData
 
   if (type === 'personal_sign') {
-    rows = [{ name: this.context.t('message'), value: this.msgHexToText(data) }]
+    const name = this.context.t('message')
+    if (encoding === 'hex') {
+      rows = [{ name, value: data }]
+    } else {
+      rows = [{ name, value: this.msgHexToText(data) }]
+    }
   } else if (type === 'eth_signTypedData') {
     rows = data
   } else if (type === 'eth_sign') {


### PR DESCRIPTION
Allows developers to specify the display encoding of a personal_sign request in the RPC call. Fixes #3931.

For example, requesting users to sign a sha3 hash with personal_sign would result in ugly UTF-8 renderings of hex data. Developers can now sign this data using `web3.personal.sign('0xabcdef', web3.eth.coinbase, { encoding: 'hex' }, callback)` and the data will be displayed as hex.

I attempted to add a test case in the `confirm-sig-requests.js` integration test, but I was having difficulty getting the request I added in the `development/states/confirm-sig-requests.json` file to appear in the final test. Maybe someone can point me in the right direction?