### PR TITLE
Use latest balanc3 api for prices

### DIFF
--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -39,7 +39,7 @@ class TokenRatesController {
    */
   async fetchExchangeRate (address) {
     try {
-      const response = await fetch(`https://metamask.dev.balanc3.net/prices?from=${address}&to=ETH&autoConversion=false&summaryOnly=true`)
+      const response = await fetch(`https://metamask.balanc3.net/prices?from=${address}&to=ETH&autoConversion=false&summaryOnly=true`)
       const json = await response.json()
       return json && json.length ? json[0].averagePrice : 0
     } catch (error) { }


### PR DESCRIPTION
This will allow us to deploy again, uses the production-ready price API from the Balanc3 team.