### PR TITLE
Wraps calls to symbol() and decimals() in try catch (Fixes #4107)

### DIFF
--- a/ui/app/components/pages/add-token.js
+++ b/ui/app/components/pages/add-token.js
@@ -192,7 +192,7 @@ AddTokenScreen.prototype.attemptToAutoFillTokenParams = async function (address)
   if (symbol && decimals) {
     this.setState({
       customSymbol: symbol,
-      customDecimals: decimals.toString(),
+      customDecimals: decimals,
       autoFilled: true,
     })
   }

--- a/ui/app/components/pending-tx/index.js
+++ b/ui/app/components/pending-tx/index.js
@@ -8,7 +8,7 @@ const abiDecoder = require('abi-decoder')
 abiDecoder.addABI(abi)
 const inherits = require('util').inherits
 const actions = require('../../actions')
-const util = require('../../util')
+const { getSymbolAndDecimals } = require('../../token-util')
 const ConfirmSendEther = require('./confirm-send-ether')
 const ConfirmSendToken = require('./confirm-send-token')
 const ConfirmDeployContract = require('./confirm-deploy-contract')
@@ -26,6 +26,7 @@ function mapStateToProps (state) {
   const {
     conversionRate,
     identities,
+    tokens: existingTokens,
   } = state.metamask
   const accounts = state.metamask.accounts
   const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
@@ -33,6 +34,7 @@ function mapStateToProps (state) {
     conversionRate,
     identities,
     selectedAddress,
+    existingTokens,
   }
 }
 
@@ -66,6 +68,7 @@ PendingTx.prototype.componentDidUpdate = function (prevProps, prevState) {
 }
 
 PendingTx.prototype.setTokenData = async function () {
+  const { existingTokens } = this.props
   const txMeta = this.gatherTxMeta()
   const txParams = txMeta.txParams || {}
 
@@ -89,19 +92,14 @@ PendingTx.prototype.setTokenData = async function () {
   }
 
   if (isTokenTransaction) {
-    const token = util.getContractAtAddress(txParams.to)
-    const results = await Promise.all([
-      token.symbol(),
-      token.decimals(),
-    ])
-    const [ symbol, decimals ] = results
+    const { symbol, decimals } = await getSymbolAndDecimals(txParams.to, existingTokens)
 
-    if (symbol[0] && decimals[0]) {
+    if (symbol && decimals) {
       this.setState({
         transactionType: TX_TYPES.SEND_TOKEN,
         tokenAddress: txParams.to,
-        tokenSymbol: symbol[0],
-        tokenDecimals: decimals[0],
+        tokenSymbol: symbol,
+        tokenDecimals: decimals,
         isFetching: false,
       })
     } else {

--- a/ui/app/components/pending-tx/index.js
+++ b/ui/app/components/pending-tx/index.js
@@ -94,23 +94,13 @@ PendingTx.prototype.setTokenData = async function () {
   if (isTokenTransaction) {
     const { symbol, decimals } = await getSymbolAndDecimals(txParams.to, existingTokens)
 
-    if (symbol && decimals) {
-      this.setState({
-        transactionType: TX_TYPES.SEND_TOKEN,
-        tokenAddress: txParams.to,
-        tokenSymbol: symbol,
-        tokenDecimals: decimals,
-        isFetching: false,
-      })
-    } else {
-      this.setState({
-        transactionType: TX_TYPES.SEND_TOKEN,
-        tokenAddress: txParams.to,
-        tokenSymbol: null,
-        tokenDecimals: null,
-        isFetching: false,
-      })
-    }
+    this.setState({
+      transactionType: TX_TYPES.SEND_TOKEN,
+      tokenAddress: txParams.to,
+      tokenSymbol: symbol,
+      tokenDecimals: decimals,
+      isFetching: false,
+    })
   } else {
     this.setState({
       transactionType: TX_TYPES.SEND_ETHER,

--- a/ui/app/send-v2.js
+++ b/ui/app/send-v2.js
@@ -493,7 +493,7 @@ SendTransactionScreen.prototype.renderFooter = function () {
     history,
   } = this.props
 
-  const missingTokenBalance = selectedToken && !tokenBalance
+  const missingTokenBalance = selectedToken && (tokenBalance === null || tokenBalance === undefined)
   const noErrors = !amountError && toError === null
 
   return h('div.page-container__footer', [

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -17,10 +17,7 @@ function tokenInfoGetter () {
 async function getSymbolAndDecimals (tokenAddress, existingTokens = []) {
   const existingToken = existingTokens.find(({ address }) => tokenAddress === address)
   if (existingToken) {
-    return {
-      symbol: existingToken.symbol,
-      decimals: existingToken.decimals,
-    }
+    return existingToken
   }
   
   let result = []

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -38,8 +38,8 @@ async function getSymbolAndDecimals (tokenAddress, existingTokens = []) {
   const [ symbol = [], decimals = [] ] = result
 
   return {
-    symbol: symbol[0],
-    decimals: decimals[0],
+    symbol: symbol[0] || null,
+    decimals: decimals[0] && decimals[0].toString() || null,
   }
 }
 

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -1,14 +1,6 @@
-const abi = require('human-standard-token-abi')
-const Eth = require('ethjs-query')
-const EthContract = require('ethjs-contract')
+const util = require('./util')
 
-const tokenInfoGetter = function () {
-  if (typeof global.ethereumProvider === 'undefined') return
-
-  const eth = new Eth(global.ethereumProvider)
-  const contract = new EthContract(eth)
-  const TokenContract = contract(abi)
-
+function tokenInfoGetter () {
   const tokens = {}
 
   return async (address) => {
@@ -16,18 +8,38 @@ const tokenInfoGetter = function () {
       return tokens[address]
     }
 
-    const contract = TokenContract.at(address)
-
-    const result = await Promise.all([
-      contract.symbol(),
-      contract.decimals(),
-    ])
-
-    const [ symbol = [], decimals = [] ] = result
-
-    tokens[address] = { symbol: symbol[0], decimals: decimals[0] }
+    tokens[address] = await getSymbolAndDecimals(address)
 
     return tokens[address]
+  }
+}
+
+async function getSymbolAndDecimals (tokenAddress, existingTokens = []) {
+  const existingToken = existingTokens.find(({ address }) => tokenAddress === address)
+  if (existingToken) {
+    return {
+      symbol: existingToken.symbol,
+      decimals: existingToken.decimals,
+    }
+  }
+  
+  let result = []
+  try {
+    const token = util.getContractAtAddress(tokenAddress)
+
+    result = await Promise.all([
+      token.symbol(),
+      token.decimals(),
+    ])
+  } catch (err) {
+    console.log(`symbol() and decimal() calls for token at address ${tokenAddress} resulted in error:`, err)
+  }
+
+  const [ symbol = [], decimals = [] ] = result
+
+  return {
+    symbol: symbol[0],
+    decimals: decimals[0],
   }
 }
 
@@ -42,4 +54,5 @@ function calcTokenAmount (value, decimals) {
 module.exports = {
   tokenInfoGetter,
   calcTokenAmount,
+  getSymbolAndDecimals,
 }


### PR DESCRIPTION
Fixes #4107

Includes a change to `send-v2.js` unrelated to the bug, but helpful for testing the bug. That change allows the user to send 0 tokens, which we want regardless.

![sendtokenswithoutsymboldecimals](https://user-images.githubusercontent.com/7499938/39388634-2063de58-4a5c-11e8-9431-36139af73e3d.gif)
