### PR TITLE
Fix ShapeShift purchases

### DIFF
--- a/old-ui/app/components/shapeshift-form.js
+++ b/old-ui/app/components/shapeshift-form.js
@@ -138,7 +138,7 @@ ShapeshiftForm.prototype.renderMain = function () {
             width: '229px',
             height: '82px',
           },
-        }, this.props.warning)
+        }, this.props.warning + '')
         : this.renderInfo(),
 
       this.renderRefundAddressForCoin(coin),

--- a/ui/app/components/shapeshift-form.js
+++ b/ui/app/components/shapeshift-form.js
@@ -55,6 +55,10 @@ function ShapeshiftForm () {
   }
 }
 
+ShapeshiftForm.prototype.getCoinPair = function () {
+  return `${this.state.depositCoin.toUpperCase()}_ETH`
+}
+
 ShapeshiftForm.prototype.componentWillMount = function () {
   this.props.shapeShiftSubview()
 }
@@ -120,14 +124,12 @@ ShapeshiftForm.prototype.renderMetadata = function (label, value) {
 }
 
 ShapeshiftForm.prototype.renderMarketInfo = function () {
-  const { depositCoin } = this.state
-  const coinPair = `${depositCoin}_eth`
   const { tokenExchangeRates } = this.props
   const {
     limit,
     rate,
     minimum,
-  } = tokenExchangeRates[coinPair] || {}
+  } = tokenExchangeRates[this.getCoinPair()] || {}
 
   return h('div.shapeshift-form__metadata', {}, [
 
@@ -172,10 +174,9 @@ ShapeshiftForm.prototype.renderQrCode = function () {
 
 ShapeshiftForm.prototype.render = function () {
   const { coinOptions, btnClass, warning } = this.props
-  const { depositCoin, errorMessage, showQrCode, depositAddress } = this.state
-  const coinPair = `${depositCoin}_eth`
+  const { errorMessage, showQrCode, depositAddress } = this.state
   const { tokenExchangeRates } = this.props
-  const token = tokenExchangeRates[coinPair]
+  const token = tokenExchangeRates[this.getCoinPair()]
 
   return h('div.shapeshift-form-wrapper', [
     showQrCode


### PR DESCRIPTION
There were a few issues involving ShapeShift purchases in both the old and new user interfaces.

The old user interface expected the `warning` prop that's passed down via Redux state when making a ShapeShift purchase to be a string. The associated `coinShiftRequest` action directly triggered an error action using the raw Error object returned from a failed ShapeShift HTTP request, causing the UI to silently blow up due to React's inability to render objects (which always bothered me, the renderer should at least fall back to `toString`, but whatever.)

The new user interface already gracefully handled request errors, but the ShapeShift form itself never rendered market information or enabled the purchase button despite successfully hitting ShapeShift's backend without issue. This issue was caused by inconsistent casing of coin pairs and prevented users from purchasing Ether using ShapeShift altogether.

This PR updates the old UI's `ShapeshiftForm` component to always render its `warning` prop as a string (using ugly but the most efficient syntax since this will be called every render cycle.) Rather than change the associated action itself to return an error string, it seemed safer and more future-proof to continue passing down the actual Error in state and allowing components to decide how to render it. This PR also updates the new UI's `ShapeshiftForm` component to retrieve market information and enable the purchase button agnostically of coin pair case.

Resolves #3688
Resolves #4120