### PR TITLE
guard adainst raven erroring

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -261,7 +261,11 @@ function setupController (initState, initLangCode) {
   controller.txController.on(`tx:status-update`, (txId, status) => {
     if (status !== 'failed') return
     const txMeta = controller.txController.txStateManager.getTx(txId)
-    reportFailedTxToSentry({ raven, txMeta })
+    try {
+      reportFailedTxToSentry({ raven, txMeta })
+    } catch (e) {
+      console.error(e)
+    }
   })
 
   // setup state persistence

--- a/app/scripts/lib/setupRaven.js
+++ b/app/scripts/lib/setupRaven.js
@@ -24,19 +24,20 @@ function setupRaven(opts) {
     transport: function(opts) {
       const report = opts.data
       // simplify certain complex error messages
-      report.exception.values.forEach(item => {
-        let errorMessage = item.value
-        // simplify ethjs error messages
-        errorMessage = extractEthjsErrorMessage(errorMessage)
-        // simplify 'Transaction Failed: known transaction'
-        if (errorMessage.indexOf('Transaction Failed: known transaction') === 0) {
-          // cut the hash from the error message
-          errorMessage = 'Transaction Failed: known transaction'
-        }
-        // finalize
-        item.value = errorMessage
-      })
-
+      if (report.exception && report.exception.values) {
+        report.exception.values.forEach(item => {
+          let errorMessage = item.value
+          // simplify ethjs error messages
+          errorMessage = extractEthjsErrorMessage(errorMessage)
+          // simplify 'Transaction Failed: known transaction'
+          if (errorMessage.indexOf('Transaction Failed: known transaction') === 0) {
+            // cut the hash from the error message
+            errorMessage = 'Transaction Failed: known transaction'
+          }
+          // finalize
+          item.value = errorMessage
+        })
+      }
       // modify report urls
       rewriteReportUrls(report)
       // make request normally
@@ -52,11 +53,13 @@ function rewriteReportUrls(report) {
   // update request url
   report.request.url = toMetamaskUrl(report.request.url)
   // update exception stack trace
-  report.exception.values.forEach(item => {
-    item.stacktrace.frames.forEach(frame => {
-      frame.filename = toMetamaskUrl(frame.filename)
+  if (report.exception && report.exception.values) {
+    report.exception.values.forEach(item => {
+      item.stacktrace.frames.forEach(frame => {
+        frame.filename = toMetamaskUrl(frame.filename)
+      })
     })
-  })
+  }
 }
 
 function toMetamaskUrl(origUrl) {


### PR DESCRIPTION
if you get an error in a listener when a tx fails for example a post fails we listen to the fail event on the txController and in response try to post to century in the catch on approval and that fails it exits the catch before the release lock for the nonce can be called the subsequent transaction will hang for ever because the previous nonce was never released this fixes raven fails by try catching them. in the listener on the txController   