### PR TITLE
Handle Promise rejections when importing accounts

### DIFF
--- a/mascara/src/app/first-time/import-account-screen.js
+++ b/mascara/src/app/first-time/import-account-screen.js
@@ -71,10 +71,12 @@ class ImportAccountScreen extends Component {
       case OPTIONS.JSON_FILE:
         return importNewAccount('JSON File', [ jsonFile, password ])
           .then(next)
+          .catch()
       case OPTIONS.PRIVATE_KEY:
       default:
         return importNewAccount('Private Key', [ privateKey ])
           .then(next)
+          .catch()
     }
   }
 

--- a/mascara/src/app/first-time/import-account-screen.js
+++ b/mascara/src/app/first-time/import-account-screen.js
@@ -70,13 +70,15 @@ class ImportAccountScreen extends Component {
     switch (this.state.selectedOption) {
       case OPTIONS.JSON_FILE:
         return importNewAccount('JSON File', [ jsonFile, password ])
-          .then(next)
+          // JS runtime requires caught rejections but failures are handled by Redux
           .catch()
+          .then(next)
       case OPTIONS.PRIVATE_KEY:
       default:
         return importNewAccount('Private Key', [ privateKey ])
-          .then(next)
+          // JS runtime requires caught rejections but failures are handled by Redux
           .catch()
+          .then(next)
     }
   }
 

--- a/old-ui/app/accounts/import/json.js
+++ b/old-ui/app/accounts/import/json.js
@@ -95,7 +95,7 @@ class JsonImportSubview extends Component {
       return this.props.displayWarning(message)
     }
 
-    this.props.importNewAccount([ fileContents, password ])
+    this.props.importNewAccount([ fileContents, password ]).catch()
   }
 }
 

--- a/old-ui/app/accounts/import/json.js
+++ b/old-ui/app/accounts/import/json.js
@@ -95,7 +95,9 @@ class JsonImportSubview extends Component {
       return this.props.displayWarning(message)
     }
 
-    this.props.importNewAccount([ fileContents, password ]).catch()
+    this.props.importNewAccount([ fileContents, password ])
+      // JS runtime requires caught rejections but failures are handled by Redux
+      .catch()
   }
 }
 

--- a/old-ui/app/accounts/import/private-key.js
+++ b/old-ui/app/accounts/import/private-key.js
@@ -63,5 +63,7 @@ PrivateKeyImportView.prototype.createKeyringOnEnter = function (event) {
 PrivateKeyImportView.prototype.createNewKeychain = function () {
   const input = document.getElementById('private-key-box')
   const privateKey = input.value
-  this.props.dispatch(actions.importNewAccount('Private Key', [ privateKey ])).catch()
+  this.props.dispatch(actions.importNewAccount('Private Key', [ privateKey ]))
+    // JS runtime requires caught rejections but failures are handled by Redux
+    .catch()
 }

--- a/old-ui/app/accounts/import/private-key.js
+++ b/old-ui/app/accounts/import/private-key.js
@@ -63,5 +63,5 @@ PrivateKeyImportView.prototype.createKeyringOnEnter = function (event) {
 PrivateKeyImportView.prototype.createNewKeychain = function () {
   const input = document.getElementById('private-key-box')
   const privateKey = input.value
-  this.props.dispatch(actions.importNewAccount('Private Key', [ privateKey ]))
+  this.props.dispatch(actions.importNewAccount('Private Key', [ privateKey ])).catch()
 }

--- a/ui/app/components/pages/create-account/import-account/json.js
+++ b/ui/app/components/pages/create-account/import-account/json.js
@@ -104,7 +104,7 @@ class JsonImportSubview extends Component {
       return this.props.displayWarning(message)
     }
 
-    this.props.importNewJsonAccount([ fileContents, password ])
+    this.props.importNewJsonAccount([ fileContents, password ]).catch()
   }
 }
 

--- a/ui/app/components/pages/create-account/import-account/json.js
+++ b/ui/app/components/pages/create-account/import-account/json.js
@@ -104,7 +104,9 @@ class JsonImportSubview extends Component {
       return this.props.displayWarning(message)
     }
 
-    this.props.importNewJsonAccount([ fileContents, password ]).catch()
+    this.props.importNewJsonAccount([ fileContents, password ])
+      // JS runtime requires caught rejections but failures are handled by Redux 
+      .catch()
   }
 }
 

--- a/ui/app/components/pages/create-account/import-account/private-key.js
+++ b/ui/app/components/pages/create-account/import-account/private-key.js
@@ -92,4 +92,5 @@ PrivateKeyImportView.prototype.createNewKeychain = function () {
 
   importNewAccount('Private Key', [ privateKey ])
     .then(() => history.push(DEFAULT_ROUTE))
+    .catch()
 }

--- a/ui/app/components/pages/create-account/import-account/private-key.js
+++ b/ui/app/components/pages/create-account/import-account/private-key.js
@@ -91,6 +91,7 @@ PrivateKeyImportView.prototype.createNewKeychain = function () {
   const { importNewAccount, history } = this.props
 
   importNewAccount('Private Key', [ privateKey ])
-    .then(() => history.push(DEFAULT_ROUTE))
+    // JS runtime requires caught rejections but failures are handled by Redux 
     .catch()
+    .then(() => history.push(DEFAULT_ROUTE))
 }


### PR DESCRIPTION
This PR catches Promise rejections from the action used to import a new account (see the associated Sentry report [here](https://sentry.io/metamask/metamask/issues/505549706/?query=is:unresolved)). Thrown errors during account import are already dispatched to Redux and shown on the UI in each component that uses the action, so rejections in the components themselves just needed to be no-ops to appease the JS runtime.

Resolves #4141 