### PR TITLE
Blacklist problematic shopify iFrame

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -174,6 +174,7 @@ function blacklistedDomainCheck () {
     'uscourts.gov',
     'dropbox.com',
     'webbyawards.com',
+    'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
   ]
   var currentUrl = window.location.href
   var currentRegex


### PR DESCRIPTION
Addresses #3526 

**What’s the problem?**
The script at https://cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html will call `addEventListener` on the window for the `message` event. If it receives a message, it will call `postMessage` on the source of the event. Ultimately, this leads to an infinite loop.

**Offending snippet from `xtld-read-only-frame.html`**
```javascript
window.addEventListener("message", function(t) {
  e.tokenForOrigin() && t.source.postMessage(JSON.stringify({
    event: "trekkie:xtldToken:v1",
    uniqToken: e.tokenForOrigin()
  }), t.origin)
})
```

**Scenario**
1. MetaMask starts up and is injected into `xtld-read-only-frame.html`.
2. Once metamask is injected, `port-duplex-stream` immediately sends a “SYN” message event to the `xtld-read-only-frame iframe.html` window.
3. `xtld-read-only-frame.html` gets this event, and calls `postMessage` on the source of the event
4. The source of the event _is_ the very same window. Therefore `xtld-read-only-frame.html` calls `postMessage` on its own window.
5. This triggers an infinite loop which ultimately crashes FireFox.

This happens on both Chrome and FireFox, however; the performance is much worse in FireFox. It may be due to some internal performance difference with the “message” event, or window.postMessage.

**Solution**
Add `https://cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html` to the blacklist.

We could add the entire `cdn.shopify.com` to the blacklist, but upon some research it seems that they may allow users to upload content to this CDN, which means we probably want to be more selective and only block this specific page.