### PR TITLE
bump extenionizer version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7408,13 +7408,13 @@
       "resolved": "https://registry.npmjs.org/extension-link-enabler/-/extension-link-enabler-1.0.0.tgz",
       "integrity": "sha1-V7kZru7fOL6XJwuYmM7nimN+RvM=",
       "requires": {
-        "extensionizer": "1.0.0"
+        "extensionizer": "1.0.1"
       }
     },
     "extensionizer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/extensionizer/-/extensionizer-1.0.0.tgz",
-      "integrity": "sha1-AcIJu+ptnArLp3Epw6pKmpj8NTg="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/extensionizer/-/extensionizer-1.0.1.tgz",
+      "integrity": "sha512-UES5CSOYqshNsWFrpORcQR47+ph6UvQK25mguD44IyeMemt40CG+LTZrH1PgpGUHX3w7ACtNQnmM0J+qEe8G0Q=="
     },
     "external-editor": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "ethjs-query": "^0.3.4",
     "express": "^4.15.5",
     "extension-link-enabler": "^1.0.0",
-    "extensionizer": "^1.0.0",
+    "extensionizer": "^1.0.1",
     "fast-json-patch": "^2.0.4",
     "fast-levenshtein": "^2.0.6",
     "file-loader": "^1.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4762,7 +4762,7 @@ extension-link-enabler@^1.0.0:
   dependencies:
     extensionizer "^1.0.0"
 
-extensionizer@^1.0.0:
+extensionizer@^1.0.0, extensionizer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/extensionizer/-/extensionizer-1.0.1.tgz#504544239a7610ba8404b15c1832091a37768d09"
 


### PR DESCRIPTION
extenionizer@1.0.0 -> extenionizer@1.0.1 improves developer experience: see [this PR](https://github.com/MetaMask/extensionizer/pull/4)