### PR TITLE
Fix account and network dropdowns in confirm screen

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -1,7 +1,7 @@
 const { Component } = require('react')
 const PropTypes = require('prop-types')
 const connect = require('react-redux').connect
-const { Route, Switch, withRouter, matchPath } = require('react-router-dom')
+const { Route, Switch, withRouter } = require('react-router-dom')
 const { compose } = require('recompose')
 const h = require('react-hyperscript')
 const actions = require('./actions')
@@ -83,15 +83,6 @@ class App extends Component {
     )
   }
 
-  renderAppHeader () {
-    const { location } = this.props
-    const isInitializing = matchPath(location.pathname, {
-      path: INITIALIZE_ROUTE, exact: false,
-    })
-
-    return isInitializing ? null : h(AppHeader)
-  }
-
   render () {
     const {
       isLoading,
@@ -128,7 +119,7 @@ class App extends Component {
         // global modal
         h(Modal, {}, []),
 
-        this.renderAppHeader(),
+        h(AppHeader),
 
         // sidebar
         this.renderSidebar(),

--- a/ui/app/components/pending-tx/confirm-send-ether.js
+++ b/ui/app/components/pending-tx/confirm-send-ether.js
@@ -28,6 +28,10 @@ const currencies = require('currency-formatter/currencies')
 
 const { MIN_GAS_PRICE_HEX } = require('../send/send-constants')
 const { SEND_ROUTE, DEFAULT_ROUTE } = require('../../routes')
+const {
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_NOTIFICATION,
+} = require('../../../../app/scripts/lib/enums')
 
 ConfirmSendEther.contextTypes = {
   t: PropTypes.func,
@@ -293,6 +297,14 @@ ConfirmSendEther.prototype.editTransaction = function (txMeta) {
   history.push(SEND_ROUTE)
 }
 
+ConfirmSendEther.prototype.renderNetworkDisplay = function () {
+  const windowType = window.METAMASK_UI_TYPE
+
+  return (windowType === ENVIRONMENT_TYPE_NOTIFICATION || windowType === ENVIRONMENT_TYPE_POPUP)
+    ? h(NetworkDisplay)
+    : null
+}
+
 ConfirmSendEther.prototype.render = function () {
   const {
     currentCurrency,
@@ -358,7 +370,7 @@ ConfirmSendEther.prototype.render = function () {
               visibility: !txMeta.lastGasPrice ? 'initial' : 'hidden',
             },
           }, 'Edit'),
-          window.METAMASK_UI_TYPE === 'notification' && h(NetworkDisplay),
+          this.renderNetworkDisplay(),
         ]),
         h('.page-container__title', title),
         h('.page-container__subtitle', subtitle),

--- a/ui/app/css/itcss/components/account-menu.scss
+++ b/ui/app/css/itcss/components/account-menu.scss
@@ -23,6 +23,10 @@
   &__icon {
     margin-left: 20px;
     cursor: pointer;
+
+    &--disabled {
+      cursor: initial;
+    }
   }
 
   &__header {

--- a/ui/app/css/itcss/components/header.scss
+++ b/ui/app/css/itcss/components/header.scss
@@ -82,10 +82,6 @@
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-
-    .identicon {
-      cursor: pointer;
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #4233 

@cjeria 
Disables network and account selector in full screen mode.
Hides the app header bar in pop-up mode. Shows the network indicator only similarly to how it's currently being handled in notification mode.

![image](https://user-images.githubusercontent.com/8051479/40024995-02820136-5785-11e8-8859-89391c5c4df7.png)

