### PR TITLE
Remove fix modal header height

### DIFF
--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -566,7 +566,6 @@
     padding: 30px;
     font-size: 22px;
     color: $nile-blue;
-    height: 79px;
   }
 
   &__message {
@@ -832,7 +831,6 @@
   padding: 30px;
   font-size: 22px;
   color: $nile-blue;
-  height: 79px;
 }
 
 .notification-modal-message {


### PR DESCRIPTION
Hello guys! 

This PR removes the fix header height on the modals that causes issues like this one:

<img width="358" alt="screen shot 2018-05-16 at 5 21 23 pm" src="https://user-images.githubusercontent.com/1247834/40148104-54550aec-593a-11e8-813e-9a5b8ae940ba.png">

After the fix:

<img width="357" alt="screen shot 2018-05-16 at 5 22 26 pm" src="https://user-images.githubusercontent.com/1247834/40148109-5bd13a70-593a-11e8-8530-367f6b19fd47.png">

Fixes #4272