### PR TITLE
Added adyen.com to blacklisted domains because postMessages are  bloc…

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -175,7 +175,7 @@ function blacklistedDomainCheck () {
     'dropbox.com',
     'webbyawards.com',
     'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
-    'adyen.com'
+    'adyen.com',
   ]
   var currentUrl = window.location.href
   var currentRegex

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -166,7 +166,7 @@ function documentElementCheck () {
 
 /**
  * Checks if the current domain is blacklisted
- * 
+ *
  * @returns {boolean} {@code true} if the current domain is blacklisted
  */
 function blacklistedDomainCheck () {
@@ -175,6 +175,7 @@ function blacklistedDomainCheck () {
     'dropbox.com',
     'webbyawards.com',
     'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
+    'adyen.com'
   ]
   var currentUrl = window.location.href
   var currentRegex


### PR DESCRIPTION
…king card encryption

Adyen is hosting iframes encrypting credit card data.
MetaMasks' postMessages seem to withhold card data from being encrypted, causing errors inside of our iframes. Thus causing anyone using MetaMask not being able to pay on effected websites using their credit cards.

Similar to https://github.com/MetaMask/metamask-extension/pull/4143