### PR TITLE
CI - remove node security test as blocker for prerelease builds + screenshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,6 @@ workflows:
       - all-tests-pass:
           requires:
             - test-lint
-            - test-deps
             - test-unit
             - test-e2e-chrome
             - test-e2e-firefox


### PR DESCRIPTION
We will still see the failures in the PR. This does not change GitHub PR merge requirements (currently not required).