### PR TITLE
test - e2e - check for console errors after each test

### DIFF
--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -62,7 +62,7 @@ function mapStateToProps (state) {
     isInitialized: state.metamask.isInitialized,
     isUnlocked: state.metamask.isUnlocked,
     currentView: state.appState.currentView,
-    activeAddress: state.appState.activeAddress,
+    selectedAddress: state.metamask.selectedAddress,
     transForward: state.appState.transForward,
     isMascara: state.metamask.isMascara,
     isOnboarding: Boolean(!noActiveNotices || seedWords || !isInitialized),
@@ -197,7 +197,7 @@ App.prototype.renderAppBar = function () {
             style: {},
             enableAccountsSelector: true,
             identities: this.props.identities,
-            selected: this.props.currentView.context,
+            selected: this.props.selectedAddress,
             network: this.props.network,
             keyrings: this.props.keyrings,
           }, []),
@@ -588,7 +588,7 @@ App.prototype.renderPrimary = function () {
         },
       }, [
         h('i.fa.fa-arrow-left.fa-lg.cursor-pointer.color-orange', {
-          onClick: () => props.dispatch(actions.backToAccountDetail(props.activeAddress)),
+          onClick: () => props.dispatch(actions.backToAccountDetail(props.selectedAddress)),
           style: {
             marginLeft: '10px',
             marginTop: '50px',

--- a/old-ui/app/components/ens-input.js
+++ b/old-ui/app/components/ens-input.js
@@ -1,7 +1,6 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
-const extend = require('xtend')
 const debounce = require('debounce')
 const copyToClipboard = require('copy-to-clipboard')
 const ENS = require('ethjs-ens')
@@ -20,55 +19,61 @@ function EnsInput () {
 
 EnsInput.prototype.render = function () {
   const props = this.props
-  const opts = extend(props, {
-    list: 'addresses',
-    onChange: () => {
-      const network = this.props.network
-      const networkHasEnsSupport = getNetworkEnsSupport(network)
-      if (!networkHasEnsSupport) return
 
-      const recipient = document.querySelector('input[name="address"]').value
-      if (recipient.match(ensRE) === null) {
-        return this.setState({
-          loadingEns: false,
-          ensResolution: null,
-          ensFailure: null,
-        })
-      }
+  function onInputChange() {
+    const network = this.props.network
+    const networkHasEnsSupport = getNetworkEnsSupport(network)
+    if (!networkHasEnsSupport) return
 
-      this.setState({
-        loadingEns: true,
+    const recipient = document.querySelector('input[name="address"]').value
+    if (recipient.match(ensRE) === null) {
+      return this.setState({
+        loadingEns: false,
+        ensResolution: null,
+        ensFailure: null,
       })
-      this.checkName()
-    },
-  })
-  return h('div', {
-    style: { width: '100%' },
-  }, [
-    h('input.large-input', opts),
-    // The address book functionality.
-    h('datalist#addresses',
-      [
-        // Corresponds to the addresses owned.
-        Object.keys(props.identities).map((key) => {
-          const identity = props.identities[key]
-          return h('option', {
-            value: identity.address,
-            label: identity.name,
-            key: identity.address,
-          })
-        }),
-        // Corresponds to previously sent-to addresses.
-        props.addressBook.map((identity) => {
-          return h('option', {
-            value: identity.address,
-            label: identity.name,
-            key: identity.address,
-          })
-        }),
-      ]),
-    this.ensIcon(),
-  ])
+    }
+
+    this.setState({
+      loadingEns: true,
+    })
+    this.checkName()
+  }
+
+  return (
+    h('div', {
+      style: { width: '100%' },
+    }, [
+      h('input.large-input', {
+        name: props.name,
+        placeholder: props.placeholder,
+        list: 'addresses',
+        onChange: onInputChange.bind(this),
+      }),
+      // The address book functionality.
+      h('datalist#addresses',
+        [
+          // Corresponds to the addresses owned.
+          Object.keys(props.identities).map((key) => {
+            const identity = props.identities[key]
+            return h('option', {
+              value: identity.address,
+              label: identity.name,
+              key: identity.address,
+            })
+          }),
+          // Corresponds to previously sent-to addresses.
+          props.addressBook.map((identity) => {
+            return h('option', {
+              value: identity.address,
+              label: identity.name,
+              key: identity.address,
+            })
+          }),
+        ]),
+      this.ensIcon(),
+    ])
+  )
 }
 
 EnsInput.prototype.componentDidMount = function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -315,8 +315,10 @@ describe('Metamask popup page', function () {
       'Warning: Unknown prop `dataset` on ',
       // Third-party Favicon 404s show up as errors
       'favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)',
-      // React Minified build - known issue blocked by test build sys
+      // React Development build - known issue blocked by test build sys
       'Warning: It looks like you\'re using a minified copy of the development build of React.',
+      // Redux Development build - known issue blocked by test build sys
+      'This means that you are running a slower development build of Redux.',
     ]
     const browserLogs = await driver.manage().logs().get('browser')
     const errorEntries = browserLogs.filter(entry => !ignoredLogTypes.includes(entry.level.toString()))

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -310,7 +310,12 @@ describe('Metamask popup page', function () {
 
   async function checkBrowserForConsoleErrors() {
     const ignoredLogTypes = ['WARNING']
-    const ignoredErrorMessages = ['Warning: Unknown prop `dataset` on ']
+    const ignoredErrorMessages = [
+      // React throws error warnings on "dataset", but still sets the data-* properties correctly
+      'Warning: Unknown prop `dataset` on ',
+      // Third-party Favicon 404s show up as errors
+      'favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)',
+    ]
     const browserLogs = await driver.manage().logs().get('browser')
     const errorEntries = browserLogs.filter(entry => !ignoredLogTypes.includes(entry.level.toString()))
     const errorObjects = errorEntries.map(entry => entry.toJSON())

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -310,10 +310,13 @@ describe('Metamask popup page', function () {
 
   async function checkBrowserForConsoleErrors() {
     const ignoredLogTypes = ['WARNING']
+    const ignoredErrorMessages = ['Warning: Unknown prop `dataset` on ']
     const browserLogs = await driver.manage().logs().get('browser')
     const errorEntries = browserLogs.filter(entry => !ignoredLogTypes.includes(entry.level.toString()))
-    const errorEntryObjects = errorEntries.map(entry => entry.toJSON())
-    return errorEntryObjects
+    const errorObjects = errorEntries.map(entry => entry.toJSON())
+    // ignore all errors that contain a message in `ignoredErrorMessages`
+    const matchedErrorObjects = errorObjects.filter(entry => !ignoredErrorMessages.some(message => entry.message.includes(message)))
+    return matchedErrorObjects
   }
 
   async function verboseReportOnFailure (test) {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -30,12 +30,16 @@ describe('Metamask popup page', function () {
   })
 
   afterEach(async function () {
-    // check for console errors
-    const errors = await checkBrowserForConsoleErrors()
-    if (errors.length) {
-      const errorReports = errors.map(err => err.message)
-      const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
-      this.test.error(new Error(errorMessage))
+    // logs command not supported in firefox
+    // https://github.com/SeleniumHQ/selenium/issues/2910
+    if (process.env.SELENIUM_BROWSER === 'chrome') {
+      // check for console errors
+      const errors = await checkBrowserForConsoleErrors()
+      if (errors.length) {
+        const errorReports = errors.map(err => err.message)
+        const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
+        this.test.error(new Error(errorMessage))
+      }
     }
     // gather extra data if test failed
     if (this.currentTest.state === 'failed') {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -315,6 +315,8 @@ describe('Metamask popup page', function () {
       'Warning: Unknown prop `dataset` on ',
       // Third-party Favicon 404s show up as errors
       'favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)',
+      // React Minified build - known issue blocked by test build sys
+      'Warning: It looks like you\'re using a minified copy of the development build of React.',
     ]
     const browserLogs = await driver.manage().logs().get('browser')
     const errorEntries = browserLogs.filter(entry => !ignoredLogTypes.includes(entry.level.toString()))


### PR DESCRIPTION
After each test, it checks the browser console for errors (chrome only), and fails on errors.
Added a filter to ignore a few messages.

Some are fine to ignore:
- React throws error warnings on "dataset", but still sets the data-* properties correctly
- Third-party Favicon 404s show up as errors

Some shouldn't be ignored but fixing them is much larger scope that that of this PR:
- React Development build - known issue blocked by test build sys
- Redux Development build - known issue blocked by test build sys