### PR TITLE
Add rpc key to i18n messages

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -676,6 +676,9 @@
   "ropsten": {
     "message": "Ropsten Test Network"
   },
+  "rpc": {
+    "message": "Custom RPC"
+  },
   "currentRpc": {
     "message": "Current RPC"
   },


### PR DESCRIPTION
Fixes #3960 
Adds the `rpc` key to messages. A fallback has already been added to `i18n-helper.getMessage` for unidentified keys so the previous blank screen crash should no longer happen.