### PR TITLE
sentry - message rewrite - guard against missing message

### DIFF
--- a/app/scripts/lib/setupRaven.js
+++ b/app/scripts/lib/setupRaven.js
@@ -66,7 +66,7 @@ function simplifyErrorMessages(report) {
 
 function rewriteErrorMessages(report, rewriteFn) {
   // rewrite top level message
-  report.message = rewriteFn(report.message)
+  if (report.message) report.message = rewriteFn(report.message)
   // rewrite each exception message
   if (report.exception && report.exception.values) {
     report.exception.values.forEach(item => {


### PR DESCRIPTION
This issue is preventing our sentry source urls from being rewritten, which fixes sourcemap support on sentry

should also fix the non descriptive 'Non-Error exception captured with keys: message, value'