### PR TITLE
End json-rpc-engine stack on error

### DIFF
--- a/app/scripts/lib/createErrorMiddleware.js
+++ b/app/scripts/lib/createErrorMiddleware.js
@@ -59,6 +59,7 @@ function createErrorMiddleware ({ override = true } = {}) {
       if (!error) { return done() }
       sanitizeRPCError(error)
       log.error(`MetaMask - RPC Error: ${error.message}`, error)
+      done()
     })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -1500,8 +1500,7 @@
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
         },
         "chai": {
           "version": "3.5.0",
@@ -8014,7 +8013,6 @@
       "dependencies": {
         "async-eventemitter": {
           "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-          "from": "async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
           "requires": {
             "async": "2.6.0"
           }
@@ -8174,16 +8172,16 @@
       "integrity": "sha512-NNlVB/TBc8p9CblwECjPlUR+7MNQKiBa7tEFxIzZ9MjjNCEYPWDXTm0vJZzuDtVmFxYwIA53UD0QEn0QNxWNEQ==",
       "dev": true,
       "requires": {
-        "bip39": "^2.4.0",
-        "bluebird": "^3.5.0",
-        "browser-passworder": "^2.0.3",
-        "eth-hd-keyring": "^1.2.2",
-        "eth-sig-util": "^1.4.0",
-        "eth-simple-keyring": "^1.2.2",
-        "ethereumjs-util": "^5.1.2",
-        "loglevel": "^1.5.0",
-        "obs-store": "^2.4.1",
-        "promise-filter": "^1.1.0"
+        "bip39": "2.4.0",
+        "bluebird": "3.5.1",
+        "browser-passworder": "2.0.3",
+        "eth-hd-keyring": "1.2.2",
+        "eth-sig-util": "1.4.2",
+        "eth-simple-keyring": "1.2.2",
+        "ethereumjs-util": "5.2.0",
+        "loglevel": "1.6.0",
+        "obs-store": "2.4.1",
+        "promise-filter": "1.1.0"
       },
       "dependencies": {
         "babelify": {
@@ -8268,7 +8266,6 @@
       "dependencies": {
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "4.11.8",
             "ethereumjs-util": "5.1.3"
@@ -8296,11 +8293,11 @@
       "integrity": "sha512-uQVBYshHUOaXVoat1BpLA/QNMCr4hgdFBgwIB7rRmQ+m3vQQAseUsOM+biPDYzq6end+6LjcccElLpQaIZe6dg==",
       "dev": true,
       "requires": {
-        "eth-sig-util": "^1.4.2",
-        "ethereumjs-util": "^5.1.1",
-        "ethereumjs-wallet": "^0.6.0",
-        "events": "^1.1.1",
-        "xtend": "^4.0.1"
+        "eth-sig-util": "1.4.2",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-wallet": "0.6.0",
+        "events": "1.1.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -8502,7 +8499,7 @@
         "eth-query": "2.1.2",
         "ethereumjs-block": "1.7.0",
         "ethereumjs-tx": "1.3.3",
-        "ethereumjs-util": "^5.0.1",
+        "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
         "ethereumjs-vm": "2.3.5",
         "through2": "2.0.3",
         "treeify": "1.1.0",
@@ -8651,7 +8648,7 @@
         "async": "2.6.0",
         "ethereum-common": "0.2.0",
         "ethereumjs-tx": "1.3.3",
-        "ethereumjs-util": "^5.0.0",
+        "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
         "merkle-patricia-tree": "2.3.0"
       }
     },
@@ -8661,7 +8658,7 @@
       "integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
       "requires": {
         "ethereum-common": "0.0.18",
-        "ethereumjs-util": "^5.0.0"
+        "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9"
       },
       "dependencies": {
         "ethereum-common": {
@@ -8673,7 +8670,6 @@
     },
     "ethereumjs-util": {
       "version": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
-      "from": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
       "requires": {
         "bn.js": "4.11.8",
         "create-hash": "1.1.3",
@@ -9111,7 +9107,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -11827,7 +11823,6 @@
     },
     "gulp": {
       "version": "github:gulpjs/gulp#71c094a51c7972d26f557899ddecab0210ef3776",
-      "from": "github:gulpjs/gulp#4.0",
       "requires": {
         "glob-watcher": "4.0.0",
         "gulp-cli": "2.0.1",
@@ -18210,7 +18205,7 @@
       "integrity": "sha512-LKd2OoIT9Re/OG38zXbd5pyHIk2IfcOUczCwkYXl5iJIbufg9nqpweh66VfPwMkUlrEvc7YVvtQdmSrB9V9TkQ==",
       "requires": {
         "async": "1.5.2",
-        "ethereumjs-util": "^5.0.0",
+        "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
         "level-ws": "0.0.0",
         "levelup": "1.3.9",
         "memdown": "1.4.1",
@@ -31232,8 +31227,7 @@
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         }
       }
     },
@@ -31714,7 +31708,6 @@
         },
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-          "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
           "requires": {
             "debug": "2.6.9",
             "nan": "2.8.0",


### PR DESCRIPTION
This PR fixes a bug introduced by the error reporting middleware where the json-rpc-engine stack wasn't properly ended if an error occurred, preventing downstream `catch` statements from being called.

Resolves #4431 
Resolves #4441