### PR TITLE
Suggest Yarn for Node >= 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ If you're a web dapp developer, we've got two types of guides for you:
 ## Building locally
 
  - Install [Node.js](https://nodejs.org/en/) version 6.3.1 or later.
- - Install local dependencies with `npm install`.
+ - Install dependencies:
+   - For node versions up to and including 9, install local dependencies with `npm install`.
+   - For node versions 10 and later, install [Yarn](https://yarnpkg.com/lang/en/docs/install/) and use `yarn install`.
  - Install gulp globally with `npm install -g gulp-cli`.
  - Build the project to the `./dist/` folder with `gulp build`.
  - Optionally, to rebuild on file changes, run `gulp dev`.


### PR DESCRIPTION

While I had success with `npm install` for node 9.5, with node 10.1, some dependencies didn't set up correctly and when I tried to run the tests I got:
```
Error: Cannot find module './build/Release/scrypt'
```
This was fixed with `yarn install`.