### PR TITLE
Fix return value of migration 26 when missing KC or PC

### DIFF
--- a/app/scripts/migrations/026.js
+++ b/app/scripts/migrations/026.js
@@ -27,7 +27,7 @@ module.exports = {
 
 function transformState (state) {
   if (!state.KeyringController || !state.PreferencesController) {
-    return
+    return state
   }
 
   if (!state.KeyringController.walletNicknames) {


### PR DESCRIPTION
This PR fixes the return value of migration 26 when the state is missing the KeyringController (KC) or the PreferencesController (PC) keys. The transform was previously returning `undefined` where the old state needs to be returned.