### PR TITLE
Update hide-token-confirmation-modal.js to use new modalState schema

### DIFF
--- a/ui/app/components/modals/edit-account-name-modal.js
+++ b/ui/app/components/modals/edit-account-name-modal.js
@@ -9,7 +9,7 @@ const { getSelectedAccount } = require('../../selectors')
 function mapStateToProps (state) {
   return {
     selectedAccount: getSelectedAccount(state),
-    identity: state.appState.modal.modalState.identity,
+    identity: state.appState.modal.modalState.props.identity,
   }
 }
 

--- a/ui/app/components/modals/hide-token-confirmation-modal.js
+++ b/ui/app/components/modals/hide-token-confirmation-modal.js
@@ -9,7 +9,7 @@ const Identicon = require('../identicon')
 function mapStateToProps (state) {
   return {
     network: state.metamask.network,
-    token: state.appState.modal.modalState.token,
+    token: state.appState.modal.modalState.props.token,
   }
 }
 

--- a/ui/app/components/modals/shapeshift-deposit-tx-modal.js
+++ b/ui/app/components/modals/shapeshift-deposit-tx-modal.js
@@ -8,7 +8,7 @@ const AccountModalContainer = require('./account-modal-container')
 
 function mapStateToProps (state) {
   return {
-    Qr: state.appState.modal.modalState.Qr,
+    Qr: state.appState.modal.modalState.props.Qr,
   }
 }
 


### PR DESCRIPTION
The modalState schema in appState was updated in 41e38fe55. This update the hide-token-confirmation-modal to correctly use the new schema.

![fixhidetoken](https://user-images.githubusercontent.com/7499938/40938109-6a68bbd6-681b-11e8-890a-0b877aca11ff.gif)

Fixes #4443 