### PR TITLE
Clear unknown identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fixes issue where old nicknames were kept around causing errors.
+
 ## 4.7.2 Sun Jun 03 2018
 
 - Fix bug preventing users from logging in. Internally accounts and identities were out of sync.

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -28,6 +28,7 @@ class PreferencesController {
       featureFlags: {},
       currentLocale: opts.initLangCode,
       identities: {},
+      lostIdentities: {},
     }, opts.initState)
     this.store = new ObservableStore(initState)
   }
@@ -106,18 +107,19 @@ class PreferencesController {
    * @returns {Promise<string>} selectedAddress the selected address.
    */
   syncAddresses (addresses) {
-    const identities = this.store.getState().identities
+    let { identities, lostIdentities } = this.store.getState()
 
     Object.keys(identities).forEach((identity) => {
       if (!addresses.includes(identity)) {
         delete identities[identity]
+        lostIdentities[identity] = identities[identity]
 
         // TODO: Report the bug to Sentry including the now-lost identity.
         alert('Error 4486: MetaMask has encountered a very strange error. Please open a support issue immediately at support@metamask.io.')
       }
     })
 
-    this.store.updateState({ identities })
+    this.store.updateState({ identities, lostIdentities })
     this.addAddresses(addresses)
 
     let selected = this.getSelectedAddress()

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -2,6 +2,7 @@ const ObservableStore = require('obs-store')
 const normalizeAddress = require('eth-sig-util').normalize
 const extend = require('xtend')
 const notifier = require('../lib/bug-notifier')
+const log = require('loglevel')
 const { version } = require('../../manifest.json')
 
 class PreferencesController {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -127,7 +127,7 @@ class PreferencesController {
       }, 10)
 
       // Notify our servers:
-      const uri =
+      const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
       notifier.notify(uri, { accounts: Object.keys(lostIdentities) })
       .catch(log.error)
     }

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -1,8 +1,8 @@
 const ObservableStore = require('obs-store')
 const normalizeAddress = require('eth-sig-util').normalize
 const extend = require('xtend')
-const BugNotifier = require('../lib/bug-notifier')
-const notifier = new BugNotifier()
+const notifier = require('../lib/bug-notifier')
+const { version } = require('../../manifest.json')
 
 class PreferencesController {
 
@@ -130,7 +130,7 @@ class PreferencesController {
 
       // Notify our servers:
       const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
-      notifier.notify(uri, { accounts: Object.keys(newlyLost) })
+      notifier.notify(uri, { accounts: Object.keys(newlyLost), version })
       .catch(log.error)
 
       for (let key in newlyLost) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -126,11 +126,6 @@ class PreferencesController {
     // Identities are no longer present.
     if (Object.keys(newlyLost).length > 0) {
 
-      // timeout to prevent blocking the thread:
-      setTimeout(() => {
-        alert('Error 4486: MetaMask has encountered a very strange error. Please open a support issue immediately at support@metamask.io.')
-      }, 10)
-
       // Notify our servers:
       const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
       const firstTimeInfo = this.getFirstTimeInfo ? this.getFirstTimeInfo() : {}

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -111,15 +111,17 @@ class PreferencesController {
    */
   syncAddresses (addresses) {
     let { identities, lostIdentities } = this.store.getState()
+
+    let newlyLost = {}
     Object.keys(identities).forEach((identity) => {
       if (!addresses.includes(identity)) {
         delete identities[identity]
-        lostIdentities[identity] = identities[identity]
+        newlyLost[identity] = identities[identity]
       }
     })
 
     // Identities are no longer present.
-    if (Object.keys(lostIdentities).length > 0) {
+    if (Object.keys(newlyLost).length > 0) {
 
       // timeout to prevent blocking the thread:
       setTimeout(() => {
@@ -130,6 +132,10 @@ class PreferencesController {
       const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
       notifier.notify(uri, { accounts: Object.keys(lostIdentities) })
       .catch(log.error)
+
+      for (let key in newlyLost) {
+        lostIdentities[key] = newlyLost[key]
+      }
     }
 
     this.store.updateState({ identities, lostIdentities })

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -98,6 +98,37 @@ class PreferencesController {
     this.store.updateState({ identities })
   }
 
+  /*
+   * Synchronizes identity entries with known accounts.
+   * Removes any unknown identities, and returns the resulting selected address.
+   *
+   * @param {Array<string>} addresses known to the vault.
+   * @returns {Promise<string>} selectedAddress the selected address.
+   */
+  syncAddresses (addresses) {
+    const identities = this.store.getState().identities
+
+    Object.keys(identities).forEach((identity) => {
+      if (!addresses.includes(identity)) {
+        delete identities[identity]
+
+        // TODO: Report the bug to Sentry including the now-lost identity.
+        // TODO: Inform the user of the lost identity.
+      }
+    })
+
+    this.store.updateState({ identities })
+    this.addAddresses(addresses)
+
+    let selected = this.getSelectedAddress()
+    if (!addresses.includes(selected)) {
+      selected = addresses[0]
+      this.setSelectedAddress(selected)
+    }
+
+    return selected
+  }
+
   /**
    * Setter for the `selectedAddress` property
    *

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -146,6 +146,8 @@ class PreferencesController {
     this.store.updateState({ identities, lostIdentities })
     this.addAddresses(addresses)
 
+    // If the selected account is no longer valid,
+    // select an arbitrary other account:
     let selected = this.getSelectedAddress()
     if (!addresses.includes(selected)) {
       selected = addresses[0]

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -133,7 +133,13 @@ class PreferencesController {
       // Notify our servers:
       const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
       const firstTimeInfo = this.getFirstTimeInfo ? this.getFirstTimeInfo() : {}
-      notifier.notify(uri, { accounts: Object.keys(newlyLost), version, firstTimeInfo })
+      notifier.notify(uri, {
+        accounts: Object.keys(newlyLost),
+        metadata: {
+          version,
+          firstTimeInfo,
+        },
+      })
       .catch(log.error)
 
       for (let key in newlyLost) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -130,7 +130,7 @@ class PreferencesController {
 
       // Notify our servers:
       const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
-      notifier.notify(uri, { accounts: Object.keys(lostIdentities) })
+      notifier.notify(uri, { accounts: Object.keys(newlyLost) })
       .catch(log.error)
 
       for (let key in newlyLost) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -33,6 +33,8 @@ class PreferencesController {
       lostIdentities: {},
     }, opts.initState)
 
+    this.getFirstTimeInfo = opts.getFirstTimeInfo || null
+
     this.store = new ObservableStore(initState)
   }
 // PUBLIC METHODS
@@ -130,7 +132,8 @@ class PreferencesController {
 
       // Notify our servers:
       const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
-      notifier.notify(uri, { accounts: Object.keys(newlyLost), version })
+      const firstTimeInfo = this.getFirstTimeInfo ? this.getFirstTimeInfo() : {}
+      notifier.notify(uri, { accounts: Object.keys(newlyLost), version, firstTimeInfo })
       .catch(log.error)
 
       for (let key in newlyLost) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -119,8 +119,8 @@ class PreferencesController {
     let newlyLost = {}
     Object.keys(identities).forEach((identity) => {
       if (!addresses.includes(identity)) {
-        delete identities[identity]
         newlyLost[identity] = identities[identity]
+        delete identities[identity]
       }
     })
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -113,7 +113,7 @@ class PreferencesController {
         delete identities[identity]
 
         // TODO: Report the bug to Sentry including the now-lost identity.
-        // TODO: Inform the user of the lost identity.
+        alert('Error 4486: MetaMask has encountered a very strange error. Please open a support issue immediately at support@metamask.io.')
       }
     })
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -35,6 +35,7 @@ class PreferencesController {
     }, opts.initState)
 
     this.getFirstTimeInfo = opts.getFirstTimeInfo || null
+    this.notifier = opts.notifier || notifier
 
     this.store = new ObservableStore(initState)
   }
@@ -129,7 +130,7 @@ class PreferencesController {
       // Notify our servers:
       const uri = 'https://diagnostics.metamask.io/v1/orphanedAccounts'
       const firstTimeInfo = this.getFirstTimeInfo ? this.getFirstTimeInfo() : {}
-      notifier.notify(uri, {
+      this.notifier.notify(uri, {
         accounts: Object.keys(newlyLost),
         metadata: {
           version,

--- a/app/scripts/lib/4486-notifier.js
+++ b/app/scripts/lib/4486-notifier.js
@@ -1,0 +1,29 @@
+class BugNotifier {
+  notify (message) {
+
+    postData('http://example.com/answer', {answer: 42})
+      .then(data => console.log(data)) // JSON from `response.json()` call
+      .catch(error => console.error(error))
+  }
+}
+
+function postData(url, data) {
+  // Default options are marked with *
+  return fetch(url, {
+    body: JSON.stringify(data), // must match 'Content-Type' header
+    cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+    credentials: 'same-origin', // include, same-origin, *omit
+    headers: {
+      'user-agent': 'Mozilla/4.0 MDN Example',
+      'content-type': 'application/json'
+    },
+    method: 'POST', // *GET, POST, PUT, DELETE, etc.
+    mode: 'cors', // no-cors, cors, *same-origin
+    redirect: 'follow', // manual, *follow, error
+    referrer: 'no-referrer', // *client, no-referrer
+  })
+  .then(response => response.json()) // parses response to JSON
+}
+
+module.exports = BugNotifier
+

--- a/app/scripts/lib/bug-notifier.js
+++ b/app/scripts/lib/bug-notifier.js
@@ -1,14 +1,11 @@
 class BugNotifier {
   notify (uri, message) {
     return postData(uri, message)
-      .then(data => console.log(data)) // JSON from `response.json()` call
-      .catch(error => console.error(error))
   }
 }
 
 function postData(uri, data) {
-
-  return fetch(url, {
+  return fetch(uri, {
     body: JSON.stringify(data), // must match 'Content-Type' header
     credentials: 'same-origin', // include, same-origin, *omit
     headers: {
@@ -17,7 +14,6 @@ function postData(uri, data) {
     method: 'POST', // *GET, POST, PUT, DELETE, etc.
     mode: 'cors', // no-cors, cors, *same-origin
   })
-  .then(response => response.json()) // parses response to JSON
 }
 
 module.exports = BugNotifier

--- a/app/scripts/lib/bug-notifier.js
+++ b/app/scripts/lib/bug-notifier.js
@@ -1,26 +1,21 @@
 class BugNotifier {
-  notify (message) {
-
-    postData('http://example.com/answer', {answer: 42})
+  notify (uri, message) {
+    return postData(uri, message)
       .then(data => console.log(data)) // JSON from `response.json()` call
       .catch(error => console.error(error))
   }
 }
 
-function postData(url, data) {
-  // Default options are marked with *
+function postData(uri, data) {
+
   return fetch(url, {
     body: JSON.stringify(data), // must match 'Content-Type' header
-    cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
     credentials: 'same-origin', // include, same-origin, *omit
     headers: {
-      'user-agent': 'Mozilla/4.0 MDN Example',
       'content-type': 'application/json'
     },
     method: 'POST', // *GET, POST, PUT, DELETE, etc.
     mode: 'cors', // no-cors, cors, *same-origin
-    redirect: 'follow', // manual, *follow, error
-    referrer: 'no-referrer', // *client, no-referrer
   })
   .then(response => response.json()) // parses response to JSON
 }

--- a/app/scripts/lib/bug-notifier.js
+++ b/app/scripts/lib/bug-notifier.js
@@ -9,7 +9,7 @@ function postData(uri, data) {
     body: JSON.stringify(data), // must match 'Content-Type' header
     credentials: 'same-origin', // include, same-origin, *omit
     headers: {
-      'content-type': 'application/json'
+      'content-type': 'application/json',
     },
     method: 'POST', // *GET, POST, PUT, DELETE, etc.
     mode: 'cors', // no-cors, cors, *same-origin

--- a/app/scripts/lib/bug-notifier.js
+++ b/app/scripts/lib/bug-notifier.js
@@ -16,5 +16,7 @@ function postData(uri, data) {
   })
 }
 
-module.exports = BugNotifier
+const notifier = new BugNotifier()
+
+module.exports = notifier
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -356,7 +356,7 @@ module.exports = class MetamaskController extends EventEmitter {
       importAccountWithStrategy: nodeify(this.importAccountWithStrategy, this),
 
       // vault management
-      submitPassword: nodeify(keyringController.submitPassword, keyringController),
+      submitPassword: nodeify(this.submitPassword, this),
 
       // network management
       setProviderType: nodeify(networkController.setProviderType, networkController),
@@ -472,6 +472,22 @@ module.exports = class MetamaskController extends EventEmitter {
       release()
       throw err
     }
+  }
+
+  /*
+   * Submits the user's password and attempts to unlock the vault.
+   * Also synchronizes the preferencesController, to ensure its schema
+   * is up to date with known accounts once the vault is decrypted.
+   *
+   * @param {string} password - The user's password
+   * @returns {Promise<object>} - The keyringController update.
+   */
+  async submitPassword (password) {
+    await this.keyringController.submitPassword(password)
+    const accounts = await this.keyringController.getAccounts()
+
+    await this.preferencesController.syncAddresses(accounts)
+    return this.keyringController.fullUpdate()
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -85,6 +85,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.preferencesController = new PreferencesController({
       initState: initState.PreferencesController,
       initLangCode: opts.initLangCode,
+      getFirstTimeInfo: () => initState.firstTimeInfo,
     })
 
     // currency controller

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -45,7 +45,7 @@ describe('MetaMaskController', function () {
       encryptor: {
         encrypt: function (password, object) {
           this.object = object
-          return Promise.resolve()
+          return Promise.resolve('mock-encrypted')
         },
         decrypt: function () {
           return Promise.resolve(this.object)
@@ -60,6 +60,31 @@ describe('MetaMaskController', function () {
   afterEach(function () {
     nock.cleanAll()
     sandbox.restore()
+  })
+
+  describe('submitPassword', function () {
+    const password = 'password'
+
+    beforeEach(async function () {
+      await metamaskController.createNewVaultAndKeychain(password)
+    })
+
+    it('removes any identities that do not correspond to known accounts.', async function () {
+      const fakeAddress = '0xbad0'
+      metamaskController.preferencesController.addAddresses([fakeAddress])
+      await metamaskController.submitPassword(password)
+
+      const identities = Object.keys(metamaskController.preferencesController.store.getState().identities)
+      const addresses = await metamaskController.keyringController.getAccounts()
+
+      identities.forEach((identity) => {
+        assert.ok(addresses.includes(identity), `addresses should include all IDs: ${identity}`)
+      })
+
+      addresses.forEach((address) => {
+        assert.ok(identities.includes(address), `identities should include all Addresses: ${address}`)
+      })
+    })
   })
 
   describe('#getGasPrice', function () {
@@ -479,7 +504,7 @@ describe('MetaMaskController', function () {
     it('errors when signing a message', async function () {
       await metamaskController.signPersonalMessage(personalMessages[0].msgParams)
       assert.equal(metamaskPersonalMsgs[msgId].status, 'signed')
-      assert.equal(metamaskPersonalMsgs[msgId].rawSig, '0x6a1b65e2b8ed53cf398a769fad24738f9fbe29841fe6854e226953542c4b6a173473cb152b6b1ae5f06d601d45dd699a129b0a8ca84e78b423031db5baa734741b')      
+      assert.equal(metamaskPersonalMsgs[msgId].rawSig, '0x6a1b65e2b8ed53cf398a769fad24738f9fbe29841fe6854e226953542c4b6a173473cb152b6b1ae5f06d601d45dd699a129b0a8ca84e78b423031db5baa734741b')
     })
   })
 
@@ -513,7 +538,7 @@ describe('MetaMaskController', function () {
     })
 
     it('sets up controller dnode api for trusted communication', function (done) {
-      streamTest = createThoughStream((chunk, enc, cb) => { 
+      streamTest = createThoughStream((chunk, enc, cb) => {
         assert.equal(chunk.name, 'controller')
         cb()
         done()

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -72,6 +72,11 @@ describe('MetaMaskController', function () {
     it('removes any identities that do not correspond to known accounts.', async function () {
       const fakeAddress = '0xbad0'
       metamaskController.preferencesController.addAddresses([fakeAddress])
+      metamaskController.preferencesController.notifier = {
+        notify: async () => {
+          return true
+        },
+      }
       await metamaskController.submitPassword(password)
 
       const identities = Object.keys(metamaskController.preferencesController.store.getState().identities)


### PR DESCRIPTION
Addresses #4475, where entries in the identities object do not
necessarily have corresponding accounts in the vault.

On password submission, this change passes known accounts to the
preferencesController (responsible for nickname management), and removes
unknown entries.

Includes "TODO" notes for where we could log the issue to sentry or
notify the user.

Verified locally after reproducing the issue on my computer by adding an unknown "identity" to my vault by entering this code in the background console and then promptly reloading the background script:

```javascript
chrome.storage.local.get((state) => {
  state.data.PreferencesController.identities['0xb4dd96de450e9206b74678a0e0426d35dc934e3f'] = { address: '0xb4dd96de450e9206b74678a0e0426d35dc934e3f',
  name: 'Mystery Account' }
  state.data.PreferencesController.selectedAddress = '0xb4dd96de450e9206b74678a0e0426d35dc934e3f'
  chrome.storage.local.set(state)
})
```

Standing question: How did this happen in the first place?