### PR TITLE
Add explicit selectedAddress assertion to the wallet view

### DIFF
--- a/ui/app/components/wallet-view.js
+++ b/ui/app/components/wallet-view.js
@@ -36,7 +36,6 @@ function mapStateToProps (state) {
     tokens: state.metamask.tokens,
     keyrings: state.metamask.keyrings,
     selectedAddress: selectors.getSelectedAddress(state),
-    selectedIdentity: selectors.getSelectedIdentity(state),
     selectedAccount: selectors.getSelectedAccount(state),
     selectedTokenAddress: state.metamask.selectedTokenAddress,
   }
@@ -99,12 +98,12 @@ WalletView.prototype.render = function () {
   const {
     responsiveDisplayClassname,
     selectedAddress,
-    selectedIdentity,
     keyrings,
     showAccountDetailModal,
     sidebarOpen,
     hideSidebar,
     history,
+    identities,
   } = this.props
   // temporary logs + fake extra wallets
   // console.log('walletview, selectedAccount:', selectedAccount)
@@ -116,8 +115,7 @@ WalletView.prototype.render = function () {
   }
 
   const keyring = keyrings.find((kr) => {
-    return kr.accounts.includes(selectedAddress) ||
-      kr.accounts.includes(selectedIdentity.address)
+    return kr.accounts.includes(selectedAddress)
   })
 
   const type = keyring.type
@@ -149,7 +147,7 @@ WalletView.prototype.render = function () {
         h('span.account-name', {
           style: {},
         }, [
-          selectedIdentity.name,
+          identities[selectedAddress].name,
         ]),
 
         h('button.btn-clear.wallet-view__details-button.allcaps', this.context.t('details')),

--- a/ui/app/components/wallet-view.js
+++ b/ui/app/components/wallet-view.js
@@ -111,6 +111,10 @@ WalletView.prototype.render = function () {
 
   const checksummedAddress = checksumAddress(selectedAddress)
 
+  if (!selectedAddress) {
+    throw new Error('selectedAddress should not be ' + String(selectedAddress))
+  }
+
   const keyring = keyrings.find((kr) => {
     return kr.accounts.includes(selectedAddress) ||
       kr.accounts.includes(selectedIdentity.address)


### PR DESCRIPTION
This PR adds an explicit assertion to the wallet view that `selectedAddress` not be falsy lest we get undefined back when we search the keyring list and see a TypeError when reading properties from the keyring.