### PR TITLE
Add account type assertion to PreferencesController#setAccountLabel

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -247,6 +247,7 @@ class PreferencesController {
    * @return {Promise<string>}
    */
   setAccountLabel (account, label) {
+    if (!account) throw new Error('setAccountLabel requires a valid address, got ' + String(account))
     const address = normalizeAddress(account)
     const {identities} = this.store.getState()
     identities[address] = identities[address] || {}


### PR DESCRIPTION
This PR adds a type check to `PreferencesController#setAccountLabel` to ensure we're setting a name for a valid account.