### PR TITLE
Make PreferencesController#setSelectedAddress explicitly synchronous

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -151,15 +151,10 @@ class PreferencesController {
    * Setter for the `selectedAddress` property
    *
    * @param {string} _address A new hex address for an account
-   * @returns {Promise<void>} Promise resolves with undefined
-   *
    */
   setSelectedAddress (_address) {
-    return new Promise((resolve, reject) => {
-      const address = normalizeAddress(_address)
-      this.store.updateState({ selectedAddress: address })
-      resolve()
-    })
+    const selectedAddress = normalizeAddress(_address)
+    this.store.updateState({ selectedAddress })
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -371,7 +371,7 @@ module.exports = class MetamaskController extends EventEmitter {
       setCustomRpc: nodeify(this.setCustomRpc, this),
 
       // PreferencesController
-      setSelectedAddress: nodeify(preferencesController.setSelectedAddress, preferencesController),
+      setSelectedAddress: preferencesController.setSelectedAddress.bind(preferencesController),
       addToken: nodeify(preferencesController.addToken, preferencesController),
       removeToken: nodeify(preferencesController.removeToken, preferencesController),
       setCurrentAccountTab: nodeify(preferencesController.setCurrentAccountTab, preferencesController),
@@ -500,7 +500,7 @@ module.exports = class MetamaskController extends EventEmitter {
       await this.diagnostics.reportMultipleKeyrings(nonSimpleKeyrings)
     }
 
-    await this.preferencesController.syncAddresses(accounts)
+    this.preferencesController.syncAddresses(accounts)
     return this.keyringController.fullUpdate()
   }
 
@@ -653,7 +653,7 @@ module.exports = class MetamaskController extends EventEmitter {
     const allAccounts = await this.keyringController.getAccounts()
     this.preferencesController.setAddresses(allAccounts)
     // set new account as selected
-    await this.preferencesController.setSelectedAddress(accounts[0])
+    this.preferencesController.setSelectedAddress(accounts[0])
   }
 
   // ---------------------------------------------------------------------------

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -75,7 +75,7 @@ describe('preferences controller', function () {
 
   describe('getTokens', function () {
     it('should return an empty list initially', async function () {
-      await preferencesController.setSelectedAddress('0x7e57e2')
+      preferencesController.setSelectedAddress('0x7e57e2')
 
       const tokens = preferencesController.getTokens()
       assert.equal(tokens.length, 0, 'empty list of tokens')
@@ -88,7 +88,7 @@ describe('preferences controller', function () {
       const symbol = 'ABBR'
       const decimals = 5
 
-      await preferencesController.setSelectedAddress('0x7e57e2')
+      preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken(address, symbol, decimals)
 
       const tokens = preferencesController.getTokens()
@@ -105,7 +105,7 @@ describe('preferences controller', function () {
       const symbol = 'ABBR'
       const decimals = 5
 
-      await preferencesController.setSelectedAddress('0x7e57e2')
+      preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken(address, symbol, decimals)
 
       const newDecimals = 6
@@ -125,11 +125,11 @@ describe('preferences controller', function () {
       const symbol = 'ABBR'
       const decimals = 5
 
-      await preferencesController.setSelectedAddress('0x7e57e2')
+      preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken(address, symbol, decimals)
       assert.equal(preferencesController.getTokens().length, 1, 'one token added for 1st address')
 
-      await preferencesController.setSelectedAddress('0xda22le')
+      preferencesController.setSelectedAddress('0xda22le')
       await preferencesController.addToken(address, symbol, decimals)
       assert.equal(preferencesController.getTokens().length, 1, 'one token added for 2nd address')
     })
@@ -137,7 +137,7 @@ describe('preferences controller', function () {
 
   describe('removeToken', function () {
     it('should remove the only token from its state', async function () {
-      await preferencesController.setSelectedAddress('0x7e57e2')
+      preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken('0xa', 'A', 5)
       await preferencesController.removeToken('0xa')
 
@@ -146,7 +146,7 @@ describe('preferences controller', function () {
     })
 
     it('should remove a token from its state', async function () {
-      await preferencesController.setSelectedAddress('0x7e57e2')
+      preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken('0xa', 'A', 4)
       await preferencesController.addToken('0xb', 'B', 5)
       await preferencesController.removeToken('0xa')


### PR DESCRIPTION
Context: In looking into why the selectedAddress is sometimes `undefined`, @alextsg noticed that the `PreferencesController#syncAddresses` method wasn't awaiting the promise returned from `PreferencesController#setSelectedAddress` which lead to the realization that it's not asynchronous, despite us awaiting it in a few places.

This PR removes the synchronous promise returned from `PreferencesController#syncAddresses` making it explicitly synchronous.