### PR TITLE
Fix bug where reset account would not work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fix bug where account reset did not work with custom RPC providers.
+
 ## 4.7.4 Tue Jun 05 2018
 
 - Add diagnostic reporting for users with multiple HD keyrings

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -89,14 +89,21 @@ module.exports = class NetworkController extends EventEmitter {
       type: 'rpc',
       rpcTarget,
     }
-    this.providerStore.updateState(providerConfig)
-    this._switchNetwork(providerConfig)
+    this.providerConfig = providerConfig
   }
 
   async setProviderType (type) {
     assert.notEqual(type, 'rpc', `NetworkController - cannot call "setProviderType" with type 'rpc'. use "setRpcTarget"`)
     assert(INFURA_PROVIDER_TYPES.includes(type) || type === LOCALHOST, `NetworkController - Unknown rpc type "${type}"`)
     const providerConfig = { type }
+    this.providerConfig = providerConfig
+  }
+
+  resetConnection () {
+    this.providerConfig = this.getProviderConfig()
+  }
+
+  set providerConfig (providerConfig) {
     this.providerStore.updateState(providerConfig)
     this._switchNetwork(providerConfig)
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -628,10 +628,7 @@ module.exports = class MetamaskController extends EventEmitter {
   async resetAccount () {
     const selectedAddress = this.preferencesController.getSelectedAddress()
     this.txController.wipeTransactions(selectedAddress)
-
-    const networkController = this.networkController
-    const oldType = networkController.getProviderConfig().type
-    await networkController.setProviderType(oldType, true)
+    this.networkController.resetConnection()
 
     return selectedAddress
   }


### PR DESCRIPTION
Fixes #4462

Ensures that resetAccount() can work on non-stock providers.

I'm unclear how this was ever working, this code hasn't moved in months,
but users report it recently breaking. Maybe we only recently pushed it
to prod.