### PR TITLE
add help link to eth_sign warning

### DIFF
--- a/ui/app/components/signature-request.js
+++ b/ui/app/components/signature-request.js
@@ -178,7 +178,14 @@ SignatureRequest.prototype.renderBody = function () {
     rows = data
   } else if (type === 'eth_sign') {
     rows = [{ name: this.context.t('message'), value: data }]
-    notice = this.context.t('signNotice')
+    notice = [this.context.t('signNotice'),
+      h('span.request-signature__help-link', {
+        onClick: () => {
+          global.platform.openWindow({
+            url: 'https://consensys.zendesk.com/hc/en-us/articles/360004427792',
+          })
+        },
+    }, this.context.t('learnMore'))]
   }
 
   return h('div.request-signature__body', {}, [

--- a/ui/app/css/itcss/components/request-signature.scss
+++ b/ui/app/css/itcss/components/request-signature.scss
@@ -183,6 +183,12 @@
     padding: 6px 18px 15px;
   }
 
+  &__help-link {
+    cursor: pointer;
+    text-decoration: underline;
+    color: $curious-blue;
+  }
+
   &__footer {
     width: 100%;
     display: flex;


### PR DESCRIPTION
adds a link to our support site at the end of the `eth_sign` warning