### PR TITLE
Fixes #4534

### DIFF
--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -65,7 +65,7 @@ PendingTx.prototype.render = function () {
 
   try {
     // default to 8MM gas limit
-    gasLimit = new BN(blockGasLimit || '8000000')
+    gasLimit = new BN(blockGasLimit || '0x7a1200', 16) // 0x7a1200 === 8000000
   } catch (e) {
     gasLimit = new BN('8000000')
   }

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -60,8 +60,16 @@ PendingTx.prototype.render = function () {
   // Gas
   const gas = txParams.gas
   const gasBn = hexToBn(gas)
-  // default to 8MM gas limit
-  const gasLimit = new BN(parseInt(blockGasLimit) || '8000000')
+
+  let gasLimit
+
+  try {
+    // default to 8MM gas limit
+    gasLimit = new BN(blockGasLimit || '8000000')
+  } catch (e) {
+    gasLimit = new BN('8000000')
+  }
+
   const safeGasLimitBN = this.bnMultiplyByFraction(gasLimit, 99, 100)
   const saferGasLimitBN = this.bnMultiplyByFraction(gasLimit, 98, 100)
   const safeGasLimit = safeGasLimitBN.toString(10)

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -65,7 +65,7 @@ PendingTx.prototype.render = function () {
 
   try {
     // default to 8MM gas limit
-    gasLimit = new BN(blockGasLimit || '0x7a1200', 16) // 0x7a1200 === 8000000
+    gasLimit = new BN(`${blockGasLimit || '7a1200'}`.replace('0x'), 16) // 7a1200 === 8000000
   } catch (e) {
     gasLimit = new BN('8000000')
   }


### PR DESCRIPTION
fix https://github.com/MetaMask/metamask-extension/issues/4534, that happen when blockGasLimit exceed 9007199254740992 and the problem is that metamask completly  freeze after that, forcing it to be reinstalled in extension panel.