### PR TITLE
Fix temp Chrome profile path used for e2e tests

### DIFF
--- a/test/e2e/func.js
+++ b/test/e2e/func.js
@@ -21,7 +21,7 @@ function delay (time) {
 }
 
 function buildChromeWebDriver (extPath) {
-  const tmpProfile = path.join(os.tmpdir(), fs.mkdtempSync('mm-chrome-profile'));
+  const tmpProfile = fs.mkdtempSync(path.join(os.tmpdir(), 'mm-chrome-profile'))
   return new webdriver.Builder()
     .withCapabilities({
       chromeOptions: {


### PR DESCRIPTION
This PR updates the path to the temporary Chrome profile we use in the e2e tests. Previously we were littering the current working directory with the temp folders, a result of incorrectly using `fs.mkdtempSync`. This correctly passes the OS' temp dir as the prefix for `fs.mkdtempSync`.