### PR TITLE
diagnostics - temporarily disable

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -46,7 +46,6 @@ const GWEI_BN = new BN('1000000000')
 const percentile = require('percentile')
 const seedPhraseVerifier = require('./lib/seed-phrase-verifier')
 const cleanErrorStack = require('./lib/cleanErrorStack')
-const DiagnosticsReporter = require('./lib/diagnostics-reporter')
 const log = require('loglevel')
 
 module.exports = class MetamaskController extends EventEmitter {
@@ -64,12 +63,6 @@ module.exports = class MetamaskController extends EventEmitter {
     this.opts = opts
     const initState = opts.initState || {}
     this.recordFirstTimeInfo(initState)
-
-    // metamask diagnostics reporter
-    this.diagnostics = opts.diagnostics || new DiagnosticsReporter({
-      firstTimeInfo: initState.firstTimeInfo,
-      version,
-    })
 
     // platform-specific api
     this.platform = opts.platform
@@ -92,7 +85,6 @@ module.exports = class MetamaskController extends EventEmitter {
     this.preferencesController = new PreferencesController({
       initState: initState.PreferencesController,
       initLangCode: opts.initLangCode,
-      diagnostics: this.diagnostics,
     })
 
     // currency controller


### PR DESCRIPTION
removing the diagnostics controller because
- it served its purpose diagnosing the identities-without-keys issue
- allow us to retool our diagnostics server without any traffic hitting it