### PR TITLE
Add apparent phishing address to block list

### DIFF
--- a/app/scripts/controllers/transactions/lib/recipient-blacklist-checker.js
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist-checker.js
@@ -1,4 +1,4 @@
-const Config = require('./recipient-blacklist-config.json')
+const Config = require('./recipient-blacklist.js')
 
 /** @module*/
 module.exports = {

--- a/app/scripts/controllers/transactions/lib/recipient-blacklist-config.json
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist-config.json
@@ -1,6 +1,8 @@
 {
   "blacklist": [
+    // IDEX phisher
     "0x9bcb0A9d99d815Bb87ee3191b1399b1Bcc46dc77",
+    // Ganache default seed phrases
     "0x627306090abab3a6e1400e9345bc60c78a8bef57",
     "0xf17f52151ebef6c7334fad080c5704d77216b732",
     "0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef",

--- a/app/scripts/controllers/transactions/lib/recipient-blacklist-config.json
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist-config.json
@@ -1,5 +1,6 @@
 {
   "blacklist": [
+    "0x9bcb0A9d99d815Bb87ee3191b1399b1Bcc46dc77",
     "0x627306090abab3a6e1400e9345bc60c78a8bef57",
     "0xf17f52151ebef6c7334fad080c5704d77216b732",
     "0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef",

--- a/app/scripts/controllers/transactions/lib/recipient-blacklist.js
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "blacklist": [
     // IDEX phisher
     "0x9bcb0A9d99d815Bb87ee3191b1399b1Bcc46dc77",

--- a/app/scripts/controllers/transactions/lib/recipient-blacklist.js
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist.js
@@ -1,17 +1,17 @@
 module.exports = {
-  "blacklist": [
+  'blacklist': [
     // IDEX phisher
-    "0x9bcb0A9d99d815Bb87ee3191b1399b1Bcc46dc77",
+    '0x9bcb0A9d99d815Bb87ee3191b1399b1Bcc46dc77',
     // Ganache default seed phrases
-    "0x627306090abab3a6e1400e9345bc60c78a8bef57",
-    "0xf17f52151ebef6c7334fad080c5704d77216b732",
-    "0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef",
-    "0x821aea9a577a9b44299b9c15c88cf3087f3b5544",
-    "0x0d1d4e623d10f9fba5db95830f7d3839406c6af2",
-    "0x2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e",
-    "0x2191ef87e392377ec08e7c08eb105ef5448eced5",
-    "0x0f4f2ac550a1b4e2280d04c21cea7ebd822934b5",
-    "0x6330a553fc93768f612722bb8c2ec78ac90b3bbc",
-    "0x5aeda56215b167893e80b4fe645ba6d5bab767de"
-  ]
+    '0x627306090abab3a6e1400e9345bc60c78a8bef57',
+    '0xf17f52151ebef6c7334fad080c5704d77216b732',
+    '0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef',
+    '0x821aea9a577a9b44299b9c15c88cf3087f3b5544',
+    '0x0d1d4e623d10f9fba5db95830f7d3839406c6af2',
+    '0x2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e',
+    '0x2191ef87e392377ec08e7c08eb105ef5448eced5',
+    '0x0f4f2ac550a1b4e2280d04c21cea7ebd822934b5',
+    '0x6330a553fc93768f612722bb8c2ec78ac90b3bbc',
+    '0x5aeda56215b167893e80b4fe645ba6d5bab767de',
+  ],
 }


### PR DESCRIPTION
In [this reddit post](https://www.reddit.com/r/Metamask/comments/8r3nsu/help_me_please_somebody_stole_my_ethers/) a user suggests they got some ether stolen after visiting IDEX. Their ether was sent to [this address](https://etherscan.io/address/0x9bcb0a9d99d815bb87ee3191b1399b1bcc46dc77), which is full of comments of people telling similar stories of being phished on IDEX. I think we can safely block this, and probably safe some people some money.