### PR TITLE
View address of an added token

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -146,6 +146,9 @@
   "copy": {
     "message": "Copy"
   },
+  "copyContractAddress": {
+    "message": "Copy Contract Address"
+  },
   "copyToClipboard": {
     "message": "Copy to clipboard"
   },
@@ -954,6 +957,9 @@
   },
   "viewAccount": {
     "message": "View Account"
+  },
+  "viewOnEtherscan": {
+    "message": "View on Etherscan"
   },
   "visitWebSite": {
     "message": "Visit our web site"

--- a/ui/app/components/dropdowns/token-menu-dropdown.js
+++ b/ui/app/components/dropdowns/token-menu-dropdown.js
@@ -4,14 +4,20 @@ const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const connect = require('react-redux').connect
 const actions = require('../../actions')
-
+const genAccountLink = require('etherscan-link').createAccountLink
+const copyToClipboard = require('copy-to-clipboard')
 
 TokenMenuDropdown.contextTypes = {
   t: PropTypes.func,
 }
 
-module.exports = connect(null, mapDispatchToProps)(TokenMenuDropdown)
+module.exports = connect(mapStateToProps, mapDispatchToProps)(TokenMenuDropdown)
 
+function mapStateToProps (state) {
+  return {
+    network: state.metamask.network,
+  }
+}
 
 function mapDispatchToProps (dispatch) {
   return {
@@ -51,7 +57,21 @@ TokenMenuDropdown.prototype.render = function () {
             this.props.onClose()
           },
         }, this.context.t('hideToken')),
-
+        h('div.token-menu-dropdown__option', {
+          onClick: (e) => {
+            e.stopPropagation()
+            copyToClipboard(this.props.token.address)
+            this.props.onClose()
+          },
+        }, this.context.t('copyContractAddress')),
+        h('div.token-menu-dropdown__option', {
+          onClick: (e) => {
+            e.stopPropagation()
+            const url = genAccountLink(this.props.token.address, this.props.network)
+            global.platform.openWindow({ url })
+            this.props.onClose()
+          },
+        }, this.context.t('viewOnEtherscan')),
       ]),
     ]),
   ])

--- a/ui/app/components/dropdowns/token-menu-dropdown.js
+++ b/ui/app/components/dropdowns/token-menu-dropdown.js
@@ -6,6 +6,7 @@ const connect = require('react-redux').connect
 const actions = require('../../actions')
 const genAccountLink = require('etherscan-link').createAccountLink
 const copyToClipboard = require('copy-to-clipboard')
+const { Menu, Item, CloseArea } = require('./components/menu')
 
 TokenMenuDropdown.contextTypes = {
   t: PropTypes.func,
@@ -43,36 +44,34 @@ TokenMenuDropdown.prototype.onClose = function (e) {
 TokenMenuDropdown.prototype.render = function () {
   const { showHideTokenConfirmationModal } = this.props
 
-  return h('div.token-menu-dropdown', {}, [
-    h('div.token-menu-dropdown__close-area', {
+  return h(Menu, { className: 'token-menu-dropdown', isShowing: true }, [
+    h(CloseArea, {
       onClick: this.onClose,
     }),
-    h('div.token-menu-dropdown__container', {}, [
-      h('div.token-menu-dropdown__options', {}, [
-
-        h('div.token-menu-dropdown__option', {
-          onClick: (e) => {
-            e.stopPropagation()
-            showHideTokenConfirmationModal(this.props.token)
-            this.props.onClose()
-          },
-        }, this.context.t('hideToken')),
-        h('div.token-menu-dropdown__option', {
-          onClick: (e) => {
-            e.stopPropagation()
-            copyToClipboard(this.props.token.address)
-            this.props.onClose()
-          },
-        }, this.context.t('copyContractAddress')),
-        h('div.token-menu-dropdown__option', {
-          onClick: (e) => {
-            e.stopPropagation()
-            const url = genAccountLink(this.props.token.address, this.props.network)
-            global.platform.openWindow({ url })
-            this.props.onClose()
-          },
-        }, this.context.t('viewOnEtherscan')),
-      ]),
-    ]),
+    h(Item, {
+      onClick: (e) => {
+        e.stopPropagation()
+        showHideTokenConfirmationModal(this.props.token)
+        this.props.onClose()
+      },
+      text: this.context.t('hideToken'), 
+    }),
+    h(Item, {
+      onClick: (e) => {
+        e.stopPropagation()
+        copyToClipboard(this.props.token.address)
+        this.props.onClose()
+      },
+      text: this.context.t('copyContractAddress'), 
+    }),
+    h(Item, {
+      onClick: (e) => {
+        e.stopPropagation()
+        const url = genAccountLink(this.props.token.address, this.props.network)
+        global.platform.openWindow({ url })
+        this.props.onClose()
+      },
+      text: this.context.t('viewOnEtherscan'), 
+    }),
   ])
 }

--- a/ui/app/css/itcss/components/token-list.scss
+++ b/ui/app/css/itcss/components/token-list.scss
@@ -81,7 +81,6 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
 }
 
 .token-menu-dropdown {
-  height: 55px;
   width: 80%;
   border-radius: 4px;
   background-color: rgba(0, 0, 0, .82);

--- a/ui/app/css/itcss/components/token-list.scss
+++ b/ui/app/css/itcss/components/token-list.scss
@@ -82,11 +82,8 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
 
 .token-menu-dropdown {
   width: 80%;
-  border-radius: 4px;
-  background-color: rgba(0, 0, 0, .82);
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .5);
   position: absolute;
-  top: 60px;
+  top: 52px;
   right: 25px;
   z-index: 2000;
 


### PR DESCRIPTION
Fixes #4440 

Added the "Copy Contract Address" and "View on Etherscan" actions.
There were two similar items in messages.json, "Copy to clipboard" and "View account on Etherscan", but in my opinion they do not describe these actions properly, hence I added these also.

![image](https://user-images.githubusercontent.com/3006955/41498487-830ee46e-716f-11e8-9d8b-178eb3152583.png)
