### PR TITLE
set an id to the metamask notification popup

### DIFF
--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -28,6 +28,7 @@ class NotificationManager {
       } else {
         // create new notification popup
         extension.windows.create({
+          id: 'metamask-popup',
           url: 'notification.html',
           type: 'popup',
           width,
@@ -93,7 +94,7 @@ class NotificationManager {
   _getPopupIn (windows) {
     return windows ? windows.find((win) => {
       // Returns notification popup
-      return (win && win.type === 'popup')
+      return (win && win.type === 'popup' && win.id === 'metamask-popup')
     }) : null
   }
 

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -28,11 +28,12 @@ class NotificationManager {
       } else {
         // create new notification popup
         extension.windows.create({
-          id: 'metamask-popup',
           url: 'notification.html',
           type: 'popup',
           width,
           height,
+        }).then((currentPopup) => {
+          this._popupId = currentPopup.id
         })
       }
     })
@@ -85,7 +86,7 @@ class NotificationManager {
   }
 
   /**
-   * Given an array of windows, returns the first that has a 'popup' type, or null if no such window exists.
+   * Given an array of windows, returns the 'popup' that has been opened by MetaMask, or null if no such window exists.
    *
    * @private
    * @param {array} windows An array of objects containing data about the open MetaMask extension windows.
@@ -94,7 +95,7 @@ class NotificationManager {
   _getPopupIn (windows) {
     return windows ? windows.find((win) => {
       // Returns notification popup
-      return (win && win.type === 'popup' && win.id === 'metamask-popup')
+      return (win && win.type === 'popup' && win.id === this._popupId)
     }) : null
   }
 


### PR DESCRIPTION
Fixes #4553 

This simple patch solve my issue.

I've added an id to the opened MetaMask popup window and check that id when MetaMask want to close any popup windows.
So if you have opened a popup with window.open MetaMask won't close it and won't lose any progress you have done inside your popup.