### PR TITLE
Save popup window ID to check when closing the popup

### DIFF
--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -17,7 +17,7 @@ class NotificationManager {
     * @param {Object} created popup window object.
     */
    _onCreated(popUpInfo) {
-    this._popUpId = popUpInfo.id;
+    this._popUpId = popUpInfo.id
    }
 
   /**
@@ -40,9 +40,9 @@ class NotificationManager {
           type: 'popup',
           width,
           height,
-        });
+        })
 
-        popUp.then(this._onCreated);
+        popUp.then(this._onCreated)
       }
     })
   }

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -12,6 +12,14 @@ class NotificationManager {
    *
    */
 
+   /**
+    * A success callback for when popup window is created. Saves the popup window ID in an instance variable.
+    * @param {Object} created popup window object.
+    */
+   _onCreated(popUpInfo) {
+    this._popUpId = popUpInfo.id;
+   }
+
   /**
    * Either brings an existing MetaMask notification window into focus, or creates a new notification window. New
    * notification windows are given a 'popup' type.
@@ -27,12 +35,14 @@ class NotificationManager {
         extension.windows.update(popup.id, { focused: true })
       } else {
         // create new notification popup
-        extension.windows.create({
+        let popUp = extension.windows.create({
           url: 'notification.html',
           type: 'popup',
           width,
           height,
-        })
+        });
+
+        popUp.then(this._onCreated);
       }
     })
   }
@@ -93,7 +103,7 @@ class NotificationManager {
   _getPopupIn (windows) {
     return windows ? windows.find((win) => {
       // Returns notification popup
-      return (win && win.type === 'popup')
+      return (win && win.type === 'popup' && win.id === this._popUpId)
     }) : null
   }
 

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -1,4 +1,5 @@
 const extension = require('extensionizer')
+const log = require('loglevel')
 const height = 620
 const width = 360
 

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -42,7 +42,7 @@ class NotificationManager {
           height,
         })
 
-        popUp.then(this._onCreated)
+        popUp.then(this._onCreated, (err) => log.error('Error occured while creating a popup window', err))
       }
     })
   }
@@ -53,11 +53,7 @@ class NotificationManager {
    */
   closePopup () {
     // closes notification popup
-    this._getPopup((err, popup) => {
-      if (err) throw err
-      if (!popup) return
-      extension.windows.remove(popup.id, console.error)
-    })
+    extension.windows.remove(this._popUpId, console.error)
   }
 
   /**


### PR DESCRIPTION
Saving the popup window id from the window object passed to the resolve callback of the Promise returned by `windows.create()`.

We can go a step further and remove the looping over windows array and straightaway close the window with that has the saved ID (please advise if this can be done).

Fixes #4553