### PR TITLE
Only show the customize gas modal if the estimateGas call is not loading

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -175,6 +175,8 @@ var actions = {
   CLEAR_SEND: 'CLEAR_SEND',
   OPEN_FROM_DROPDOWN: 'OPEN_FROM_DROPDOWN',
   CLOSE_FROM_DROPDOWN: 'CLOSE_FROM_DROPDOWN',
+  GAS_LOADING_STARTED: 'GAS_LOADING_STARTED',
+  GAS_LOADING_FINISHED: 'GAS_LOADING_FINISHED',
   setGasLimit,
   setGasPrice,
   updateGasData,
@@ -190,6 +192,8 @@ var actions = {
   updateSendErrors,
   clearSend,
   setSelectedAddress,
+  gasLoadingStarted,
+  gasLoadingFinished,
   // app messages
   confirmSeedWords: confirmSeedWords,
   showAccountDetail: showAccountDetail,
@@ -740,8 +744,9 @@ function updateGasData ({
   to,
   value,
 }) {
-  const estimatedGasPrice = estimateGasPriceFromRecentBlocks(recentBlocks)
   return (dispatch) => {
+    dispatch(actions.gasLoadingStarted())
+    const estimatedGasPrice = estimateGasPriceFromRecentBlocks(recentBlocks)
     return Promise.all([
       Promise.resolve(estimatedGasPrice),
       estimateGas({
@@ -762,11 +767,25 @@ function updateGasData ({
     .then((gasEstimate) => {
       dispatch(actions.setGasTotal(gasEstimate))
       dispatch(updateSendErrors({ gasLoadingError: null }))
+      dispatch(actions.gasLoadingFinished())
     })
     .catch(err => {
       log.error(err)
       dispatch(updateSendErrors({ gasLoadingError: 'gasLoadingError' }))
+      dispatch(actions.gasLoadingFinished())
     })
+  }
+}
+
+function gasLoadingStarted () {
+  return {
+    type: actions.GAS_LOADING_STARTED,
+  }
+}
+
+function gasLoadingFinished () {
+  return {
+    type: actions.GAS_LOADING_FINISHED,
   }
 }
 

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -62,6 +62,7 @@ function reduceApp (state, action) {
     warning: null,
     buyView: {},
     isMouseUser: false,
+    gasIsLoading: false,
   }, state.appState)
 
   switch (action.type) {
@@ -674,6 +675,16 @@ function reduceApp (state, action) {
       return extend(appState, {
         isMouseUser: action.value,
       })
+
+    case actions.GAS_LOADING_STARTED:
+      return extend(appState, {
+        gasIsLoading: true,
+      })
+
+    case actions.GAS_LOADING_FINISHED:
+      return extend(appState, {
+        gasIsLoading: false,
+      }) 
 
     default:
       return appState

--- a/ui/app/selectors.js
+++ b/ui/app/selectors.js
@@ -16,6 +16,7 @@ const selectors = {
   transactionsSelector,
   accountsWithSendEtherInfoSelector,
   getCurrentAccountWithSendEtherInfo,
+  getGasIsLoading,
   getGasPrice,
   getGasLimit,
   getForceGasMin,
@@ -115,6 +116,10 @@ function transactionsSelector (state) {
       .sort((a, b) => b.time - a.time)
     : txsToRender
       .sort((a, b) => b.time - a.time)
+}
+
+function getGasIsLoading (state) {
+  return state.appState.gasIsLoading
 }
 
 function getGasPrice (state) {


### PR DESCRIPTION
This PR ensures that the customize gas modal will only render once gas has finished estimating. Previous to this, users could see an incorrect estimate in the customize gas modal if they take the following steps when sending a token:
(1) Edit the amount input from 0 to some number > 0, or from a number > 0 to 0
(2) Immediately open the gas customization modal

If they were to then save this incorrect estimation and create a transaction, they could experience an out of gas error.