### PR TITLE
Ensures token list amount is in its own row.

### DIFF
--- a/ui/app/css/itcss/components/token-list.scss
+++ b/ui/app/css/itcss/components/token-list.scss
@@ -34,6 +34,7 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
   &__fiat-amount {
     margin-top: .25%;
     font-size: 105%;
+    width: 100%;
     text-transform: uppercase;
 
     @media #{$wallet-balance-breakpoint-range} {


### PR DESCRIPTION
Fixes #4536 

Before:

<img width="278" alt="screen shot 2018-06-28 at 2 46 55 pm" src="https://user-images.githubusercontent.com/7499938/42049962-34221336-7ae2-11e8-8674-c6eb95183973.png">

After:

<img width="300" alt="screen shot 2018-06-28 at 2 45 19 pm" src="https://user-images.githubusercontent.com/7499938/42049967-39034ee2-7ae2-11e8-9664-20eef33cd858.png">
