### PR TITLE
Improve checks for closing info page on app installation in e2e beta tests.

### DIFF
--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -100,15 +100,21 @@ describe('MetaMask', function () {
       await delay(regularDelayMs)
 
       // Close all other tabs
-      let [oldUi, infoPage, newUi] = await driver.getAllWindowHandles()
-      newUi = newUi || infoPage
+      let [oldUi, tab1, tab2] = await driver.getAllWindowHandles()
       await driver.switchTo().window(oldUi)
       await driver.close()
-      if (infoPage !== newUi) {
-        await driver.switchTo().window(infoPage)
+
+      await driver.switchTo().window(tab1)
+      const tab1Url = await driver.getCurrentUrl()
+      if (tab1Url.match(/metamask.io/)) {
+        await driver.switchTo().window(tab1)
         await driver.close()
+        await driver.switchTo().window(tab2)
+      } else if (tab2) {
+        await driver.switchTo().window(tab2)
+        await driver.close()
+        await driver.switchTo().window(tab1)
       }
-      await driver.switchTo().window(newUi)
       await delay(regularDelayMs)
 
       const continueBtn = await findElement(driver, By.css('.welcome-screen__button'))


### PR DESCRIPTION
When our e2e beta tests run, it seems that sometimes the info page is opened on installation, and sometimes not. Perhaps is some sort of caching issue in the test environment. Also, it is unclear if the order of window handles returned by webdriver are deterministic.

This causes occasional failures at the `'selects the new UI option'` test.

For now, this PR just ensures that the info page is closed if present, and that the app is not accidentally closed in the `'selects the new UI option'` test step.