### PR TITLE
move removeLeadingZeroes to utils, add test

### DIFF
--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -2,6 +2,7 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
 const { conversionUtil, multiplyCurrencies } = require('../../conversion-util')
+const { removeLeadingZeroes } = require('../send_/send.utils')
 const currencyFormatter = require('currency-formatter')
 const currencies = require('currency-formatter/currencies')
 const ethUtil = require('ethereumjs-util')
@@ -90,10 +91,6 @@ CurrencyDisplay.prototype.getConvertedValueToRender = function (nonFormattedValu
       code: upperCaseCurrencyCode,
     })
     : convertedValue
-}
-
-function removeLeadingZeroes (str) {
-  return str.replace(/^0*(?=\d)/, '')
 }
 
 CurrencyDisplay.prototype.handleChange = function (newVal) {

--- a/ui/app/components/send_/send.utils.js
+++ b/ui/app/components/send_/send.utils.js
@@ -32,6 +32,7 @@ module.exports = {
   getToAddressForGasUpdate,
   isBalanceSufficient,
   isTokenBalanceSufficient,
+  removeLeadingZeroes,
 }
 
 function calcGasTotal (gasLimit, gasPrice) {
@@ -272,4 +273,8 @@ function estimateGasPriceFromRecentBlocks (recentBlocks) {
 
 function getToAddressForGasUpdate (...addresses) {
   return [...addresses, ''].find(str => str !== undefined && str !== null).toLowerCase()
+}
+
+function removeLeadingZeroes (str) {
+  return str.replace(/^0*(?=\d)/, '')
 }

--- a/ui/app/components/send_/send.utils.test.js
+++ b/ui/app/components/send_/send.utils.test.js
@@ -1,0 +1,30 @@
+import assert from 'assert'
+import { removeLeadingZeroes } from './send.utils'
+
+
+describe('send utils', () => {
+  describe('removeLeadingZeroes()', () => {
+    it('should remove leading zeroes from int when user types', () => {
+      assert.equal(removeLeadingZeroes('0'), '0')
+      assert.equal(removeLeadingZeroes('1'), '1')
+      assert.equal(removeLeadingZeroes('00'), '0')
+      assert.equal(removeLeadingZeroes('01'), '1')
+    })
+
+    it('should remove leading zeroes from int when user copy/paste', () => {
+      assert.equal(removeLeadingZeroes('001'), '1')
+    })
+
+    it('should remove leading zeroes from float when user types', () => {
+      assert.equal(removeLeadingZeroes('0.'), '0.')
+      assert.equal(removeLeadingZeroes('0.0'), '0.0')
+      assert.equal(removeLeadingZeroes('0.00'), '0.00')
+      assert.equal(removeLeadingZeroes('0.001'), '0.001')
+      assert.equal(removeLeadingZeroes('0.10'), '0.10')
+    })
+
+    it('should remove leading zeroes from float when user copy/paste', () => {
+      assert.equal(removeLeadingZeroes('00.1'), '0.1')
+    })
+  })
+})


### PR DESCRIPTION
this commit fixes #4665
however `input[type=number]` can accept string like "-+000.1eE-+10" which is not covered by curret implementatiuon