### PR TITLE
ignore lodash vulnerability

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,7 @@
 {
   "exceptions": [
     "https://nodesecurity.io/advisories/566",
-    "https://nodesecurity.io/advisories/157"
+    "https://nodesecurity.io/advisories/157",
+    "https://nodesecurity.io/advisories/577"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8548,13 +8548,12 @@
             "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
             "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
             "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
                 "ethereumjs-util": "^5.1.1"
             },
             "dependencies": {
                 "ethereumjs-abi": {
                     "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
-                    "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                    "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
                     "requires": {
                         "bn.js": "^4.10.0",
                         "ethereumjs-util": "^5.0.0"
@@ -20200,7 +20199,7 @@
             "requires": {
                 "async": "^1.3.0",
                 "flat-arguments": "^1.0.0",
-                "lodash": "^4.17.5",
+                "lodash": "^3.10.0",
                 "minimist": "^1.1.0"
             },
             "dependencies": {
@@ -20210,7 +20209,7 @@
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 },
                 "lodash": {
-                    "version": "4.17.5",
+                    "version": "3.10.1",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                     "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                 }
@@ -30585,7 +30584,6 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
@@ -31609,7 +31607,6 @@
             "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
             "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
             "requires": {
-                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2": "*",
@@ -31618,7 +31615,7 @@
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
                 }
             }
         },
@@ -32117,8 +32114,7 @@
             "dev": true,
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+                "web3-core-helpers": "1.0.0-beta.34"
             },
             "dependencies": {
                 "underscore": {
@@ -32129,8 +32125,7 @@
                 },
                 "websocket": {
                     "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-                    "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-                    "dev": true,
+                    "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
                     "requires": {
                         "debug": "^2.2.0",
                         "nan": "^2.3.3",
@@ -33486,8 +33481,7 @@
         "yaeti": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-            "dev": true
+            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
         },
         "yallist": {
             "version": "2.1.2",


### PR DESCRIPTION
Because I manually bumped the package-lock.json to fix this vulnerability, every time it gets regenerated the change will be overriden and the test deps will fail again.

Since it's coming from superstatic and it's an internal tool we use for running the test suite it's safe to ignore it.


![screen shot 2018-07-03 at 1 55 57 pm](https://user-images.githubusercontent.com/1247834/42236442-d88c6158-7ec8-11e8-8fd1-94f1a6e62042.png)
