### PR TITLE
Update eslint to catch unused argument variables, except for the _ placeholder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -133,7 +133,7 @@
     "no-unneeded-ternary": [2, { "defaultAssignment": false }],
     "no-unreachable": 2,
     "no-unsafe-finally": 2,
-    "no-unused-vars": [2, { "vars": "all", "args": "none" }],
+    "no-unused-vars": [2, { "vars": "all", "argsIgnorePattern": "^_$", "args": "all" }],
     "no-useless-call": 2,
     "no-useless-computed-key": 2,
     "no-useless-constructor": 2,

--- a/app/scripts/controllers/balance.js
+++ b/app/scripts/controllers/balance.js
@@ -68,7 +68,7 @@ class BalanceController {
   _registerUpdates () {
     const update = this.updateBalance.bind(this)
 
-    this.txController.on('tx:status-update', (txId, status) => {
+    this.txController.on('tx:status-update', (_, status) => {
       switch (status) {
         case 'submitted':
         case 'confirmed':

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -155,7 +155,7 @@ class PreferencesController {
    *
    */
   setSelectedAddress (_address) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const address = normalizeAddress(_address)
       this.store.updateState({ selectedAddress: address })
       resolve()
@@ -198,7 +198,7 @@ class PreferencesController {
     const newEntry = { address, symbol, decimals }
 
     const tokens = this.store.getState().tokens
-    const previousEntry = tokens.find((token, index) => {
+    const previousEntry = tokens.find((token) => {
       return token.address === address
     })
     const previousIndex = tokens.indexOf(previousEntry)
@@ -279,7 +279,7 @@ class PreferencesController {
    *
    */
   setCurrentAccountTab (currentAccountTab) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.store.updateState({ currentAccountTab })
       resolve()
     })

--- a/app/scripts/controllers/shapeshift.js
+++ b/app/scripts/controllers/shapeshift.js
@@ -136,7 +136,7 @@ class ShapeshiftController {
    * @param {ShapeShiftTx} tx The tx to remove
    *
    */
-  removeShapeShiftTx (tx) {
+  removeShapeShiftTx () {
     const { shapeShiftTxList } = this.store.getState()
     const index = shapeShiftTxList.indexOf(index)
     if (index !== -1) {

--- a/app/scripts/controllers/transactions/nonce-tracker.js
+++ b/app/scripts/controllers/transactions/nonce-tracker.js
@@ -84,7 +84,7 @@ class NonceTracker {
     const blockTracker = this._getBlockTracker()
     const currentBlock = blockTracker.getCurrentBlock()
     if (currentBlock) return currentBlock
-    return await new Promise((reject, resolve) => {
+    return await new Promise((_, resolve) => {
       blockTracker.once('latest', resolve)
     })
   }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -113,10 +113,10 @@ class TransactionStateManager extends EventEmitter {
     @returns {object} the txMeta
   */
   addTx (txMeta) {
-    this.once(`${txMeta.id}:signed`, function (txId) {
+    this.once(`${txMeta.id}:signed`, function () {
       this.removeAllListeners(`${txMeta.id}:rejected`)
     })
-    this.once(`${txMeta.id}:rejected`, function (txId) {
+    this.once(`${txMeta.id}:rejected`, function () {
       this.removeAllListeners(`${txMeta.id}:signed`)
     })
     // initialize history

--- a/app/scripts/controllers/user-actions.js
+++ b/app/scripts/controllers/user-actions.js
@@ -4,7 +4,7 @@ const TypedMessageManager = require('./lib/typed-message-manager')
 
 class UserActionController {
 
-  constructor (opts = {}) {
+  constructor () {
 
     this.messageManager = new MessageManager()
     this.personalMessageManager = new PersonalMessageManager()

--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -47,7 +47,7 @@ ConfigManager.prototype.setPasswordForgotten = function (passwordForgottenState)
   this.setData(data)
 }
 
-ConfigManager.prototype.getPasswordForgotten = function (passwordForgottenState) {
+ConfigManager.prototype.getPasswordForgotten = function () {
   const data = this.getData()
   return data.forgottenPassword
 }

--- a/app/scripts/lib/createErrorMiddleware.js
+++ b/app/scripts/lib/createErrorMiddleware.js
@@ -52,8 +52,8 @@ function sanitizeRPCError (error, override) {
  * @param {MiddlewareConfig} [config={override:true}] - Middleware configuration
  * @returns {Function} json-rpc-engine middleware function
  */
-function createErrorMiddleware ({ override = true } = {}) {
-  return (req, res, next) => {
+function createErrorMiddleware () {
+  return (_, res, next) => {
     next(done => {
       const { error } = res
       if (!error) { return done() }

--- a/app/scripts/lib/createProviderMiddleware.js
+++ b/app/scripts/lib/createProviderMiddleware.js
@@ -6,7 +6,7 @@ module.exports = createProviderMiddleware
  * @param {{ provider: Object }} config Configuration containing current Web3 provider
  */
 function createProviderMiddleware ({ provider }) {
-  return (req, res, next, end) => {
+  return (req, res, _, end) => {
     provider.sendAsync(req, (err, _res) => {
       if (err) return end(err)
       res.result = _res.result

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -34,7 +34,7 @@ module.exports = class MessageManager extends EventEmitter {
    * @property {array} messages Holds all messages that have been created by this MessageManager
    *
    */
-  constructor (opts) {
+  constructor () {
     super()
     this.memStore = new ObservableStore({
       unapprovedMsgs: {},

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -36,7 +36,7 @@ module.exports = class PersonalMessageManager extends EventEmitter {
    * @property {array} messages Holds all messages that have been created by this PersonalMessageManager
    *
    */
-  constructor (opts) {
+  constructor () {
     super()
     this.memStore = new ObservableStore({
       unapprovedPersonalMsgs: {},

--- a/app/scripts/lib/port-stream.js
+++ b/app/scripts/lib/port-stream.js
@@ -64,7 +64,7 @@ PortDuplexStream.prototype._read = noop
  * @param {string} encoding Encoding to use when writing payload
  * @param {Function} cb Called when writing is complete or an error occurs
  */
-PortDuplexStream.prototype._write = function (msg, encoding, cb) {
+PortDuplexStream.prototype._write = function (msg, _, cb) {
   try {
     if (Buffer.isBuffer(msg)) {
       var data = msg.toJSON()

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -35,7 +35,7 @@ module.exports = class TypedMessageManager extends EventEmitter {
    * @property {array} messages Holds all messages that have been created by this TypedMessage
    *
    */
-  constructor (opts) {
+  constructor () {
     super()
     this.memStore = new ObservableStore({
       unapprovedTypedMessages: {},

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -233,7 +233,7 @@ module.exports = class MetamaskController extends EventEmitter {
       static: {
         eth_syncing: false,
         web3_clientVersion: `MetaMask/v${version}`,
-        eth_sendTransaction: (payload, next, end) => {
+        eth_sendTransaction: (payload, _, end) => {
           const origin = payload.origin
           const txParams = payload.params[0]
           nodeify(this.txController.newUnapprovedTransaction, this.txController)(txParams, { origin }, end)
@@ -935,7 +935,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * @param {string} txId - The ID of the transaction to speed up.
    * @param {Function} cb - The callback function called with a full state update.
    */
-  async retryTransaction (txId, cb) {
+  async retryTransaction (txId) {
     await this.txController.retryTransaction(txId)
     const state = await this.getState()
     return state

--- a/app/scripts/migrations/024.js
+++ b/app/scripts/migrations/024.js
@@ -27,7 +27,7 @@ function transformState (state) {
   const newState = state
   if (!newState.TransactionController) return newState
   const transactions = newState.TransactionController.transactions
-  newState.TransactionController.transactions = transactions.map((txMeta, _, txList) => {
+  newState.TransactionController.transactions = transactions.map((txMeta) => {
     if (
       txMeta.status === 'unapproved' &&
       txMeta.txParams &&

--- a/app/scripts/migrations/025.js
+++ b/app/scripts/migrations/025.js
@@ -43,7 +43,7 @@ function normalizeTxParams (txParams) {
   // functions that handle normalizing of that key in txParams
   const whiteList = {
     from: from => ethUtil.addHexPrefix(from).toLowerCase(),
-    to: to => ethUtil.addHexPrefix(txParams.to).toLowerCase(),
+    to: () => ethUtil.addHexPrefix(txParams.to).toLowerCase(),
     nonce: nonce => ethUtil.addHexPrefix(nonce),
     value: value => ethUtil.addHexPrefix(value),
     data: data => ethUtil.addHexPrefix(data),

--- a/development/backGroundConnectionModifiers.js
+++ b/development/backGroundConnectionModifiers.js
@@ -1,20 +1,20 @@
 module.exports = {
   'confirm sig requests': {
-    signMessage: (msgData, cb) => {
+    signMessage: (_, cb) => {
       const stateUpdate = {
         unapprovedMsgs: {},
         unapprovedMsgCount: 0,
       }
       return cb(null, stateUpdate)
     },
-    signPersonalMessage: (msgData, cb) => {
+    signPersonalMessage: (_, cb) => {
       const stateUpdate = {
         unapprovedPersonalMsgs: {},
         unapprovedPersonalMsgsCount: 0,
       }
       return cb(null, stateUpdate)
     },
-    signTypedMessage: (msgData, cb) => {
+    signTypedMessage: (_, cb) => {
       const stateUpdate = {
         unapprovedTypedMessages: {},
         unapprovedTypedMessagesCount: 0,

--- a/gentests.js
+++ b/gentests.js
@@ -48,11 +48,11 @@ async function start (fileRegEx, testGenerator) {
 }
 */
 
-async function startContainer (fileRegEx, testGenerator) {
+async function startContainer (fileRegEx) {
   const fileNames = await getAllFileNames('./ui/app')
   const sFiles = fileNames.filter(name => name.match(fileRegEx))
 
-  async.each(sFiles, async (sFile, cb) => {
+  async.each(sFiles, async (sFile) => {
     console.log(`sFile`, sFile)
     const [, sRootPath, sPath] = sFile.match(/^(.+\/)([^/]+)$/)
 
@@ -91,7 +91,7 @@ async function startContainer (fileRegEx, testGenerator) {
           const proxyquireObject = ('{\n  ' + result
             .match(/import\s{[\s\S]+?}\sfrom\s.+/g)
             .map(s => s.replace(/\n/g, ''))
-            .map((s, i) => {
+            .map((s) => {
               const proxyKeys = s.match(/{.+}/)[0].match(/\w+/g)
               return '\'' + s.match(/'(.+)'/)[1] + '\': { ' + (proxyKeys.length > 1
                   ? '\n    ' + proxyKeys.join(': () => {},\n    ') + ': () => {},\n '

--- a/mascara/server/util.js
+++ b/mascara/server/util.js
@@ -8,7 +8,7 @@ module.exports = {
 
 
 function serveBundle (server, path, bundle) {
-  server.get(path, function (req, res) {
+  server.get(path, function (_, res) {
     res.setHeader('Content-Type', 'application/javascript; charset=UTF-8')
     res.send(bundle.latest)
   })

--- a/mascara/src/background.js
+++ b/mascara/src/background.js
@@ -58,7 +58,7 @@ async function loadStateFromPersistence () {
   return migratedData.data
 }
 
-async function setupController (initState, client) {
+async function setupController (initState) {
 
   //
   // MetaMask Controller

--- a/mascara/test/helpers.js
+++ b/mascara/test/helpers.js
@@ -1,5 +1,5 @@
 export default function wait (time) {
-  return new Promise(function (resolve, reject) {
+  return new Promise(function (resolve) {
     setTimeout(function () {
       resolve()
     }, time * 3 || 1500)

--- a/old-ui/app/accounts/import/index.js
+++ b/old-ui/app/accounts/import/index.js
@@ -16,7 +16,7 @@ const menuItems = [
 
 module.exports = connect(mapStateToProps)(AccountImportSubview)
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {
     menuItems,
   }
@@ -37,7 +37,7 @@ AccountImportSubview.prototype.render = function () {
     h('div', [
       h('.section-title.flex-row.flex-center', [
         h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: (event) => {
+          onClick: () => {
             props.dispatch(actions.goHome())
           },
         }),

--- a/old-ui/app/accounts/import/seed.js
+++ b/old-ui/app/accounts/import/seed.js
@@ -5,7 +5,7 @@ const connect = require('react-redux').connect
 
 module.exports = connect(mapStateToProps)(SeedImportSubview)
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 

--- a/old-ui/app/add-token.js
+++ b/old-ui/app/add-token.js
@@ -43,7 +43,7 @@ AddTokenScreen.prototype.render = function () {
       // subtitle and nav
       h('.section-title.flex-row.flex-center', [
         h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: (event) => {
+          onClick: () => {
             props.dispatch(actions.goHome())
           },
         }),
@@ -150,7 +150,7 @@ AddTokenScreen.prototype.render = function () {
             style: {
               alignSelf: 'center',
             },
-            onClick: (event) => {
+            onClick: () => {
               const valid = this.validateInputs()
               if (!valid) return
 

--- a/old-ui/app/components/account-export.js
+++ b/old-ui/app/components/account-export.js
@@ -106,7 +106,7 @@ ExportAccountView.prototype.render = function () {
           webkitUserSelect: 'text',
           maxWidth: '275px',
         },
-        onClick: function (event) {
+        onClick: function () {
           copyToClipboard(ethUtil.stripHexPrefix(accountDetail.privateKey))
         },
       }, plainKey),

--- a/old-ui/app/components/account-panel.js
+++ b/old-ui/app/components/account-panel.js
@@ -69,7 +69,7 @@ AccountPanel.prototype.render = function () {
   )
 }
 
-function balanceOrFaucetingIndication (account, isFauceting) {
+function balanceOrFaucetingIndication (account) {
   // Temporarily deactivating isFauceting indication
   // because it shows fauceting for empty restored accounts.
   if (/* isFauceting*/ false) {

--- a/old-ui/app/components/bn-as-decimal-input.js
+++ b/old-ui/app/components/bn-as-decimal-input.js
@@ -109,7 +109,7 @@ BnAsDecimalInput.prototype.render = function () {
   )
 }
 
-BnAsDecimalInput.prototype.setValid = function (message) {
+BnAsDecimalInput.prototype.setValid = function () {
   this.setState({ invalid: null })
 }
 

--- a/old-ui/app/components/custom-radio-list.js
+++ b/old-ui/app/components/custom-radio-list.js
@@ -30,7 +30,7 @@ RadioList.prototype.render = function () {
           marginRight: '5px',
         },
       },
-        labels.map((lable, i) => {
+        labels.map((lable) => {
           let isSelcted = (this.state !== null)
           isSelcted = isSelcted ? (this.state.selected === lable) : (defaultFocus === lable)
           return h(isSelcted ? activeClass : inactiveClass, {

--- a/old-ui/app/components/ens-input.js
+++ b/old-ui/app/components/ens-input.js
@@ -117,7 +117,7 @@ EnsInput.prototype.lookupEnsName = function () {
   })
 }
 
-EnsInput.prototype.componentDidUpdate = function (prevProps, prevState) {
+EnsInput.prototype.componentDidUpdate = function (_, prevState) {
   const state = this.state || {}
   const ensResolution = state.ensResolution
   // If an address is sent without a nickname, meaning not from ENS or from
@@ -141,7 +141,7 @@ EnsInput.prototype.ensIcon = function (recipient) {
   }, this.ensIconContents(recipient))
 }
 
-EnsInput.prototype.ensIconContents = function (recipient) {
+EnsInput.prototype.ensIconContents = function () {
   const { loadingEns, ensFailure, ensResolution } = this.state || { ensResolution: ZERO_ADDRESS}
 
   if (loadingEns) {

--- a/old-ui/app/components/hex-as-decimal-input.js
+++ b/old-ui/app/components/hex-as-decimal-input.js
@@ -102,7 +102,7 @@ HexAsDecimalInput.prototype.render = function () {
   )
 }
 
-HexAsDecimalInput.prototype.setValid = function (message) {
+HexAsDecimalInput.prototype.setValid = function () {
   this.setState({ invalid: null })
 }
 
@@ -143,7 +143,7 @@ function hexify (decimalString) {
   return '0x' + hexBN.toString('hex')
 }
 
-function decimalize (input, toEth) {
+function decimalize (input) {
   if (input === '') {
     return ''
   } else {

--- a/old-ui/app/components/token-cell.js
+++ b/old-ui/app/components/token-cell.js
@@ -50,7 +50,7 @@ TokenCell.prototype.send = function (address, event) {
   }
 }
 
-TokenCell.prototype.view = function (address, userAddress, network, event) {
+TokenCell.prototype.view = function (address, userAddress, network) {
   const url = etherscanLinkFor(address, userAddress, network)
   if (url) {
     navigateTo(url)

--- a/old-ui/app/components/transaction-list-item.js
+++ b/old-ui/app/components/transaction-list-item.js
@@ -184,7 +184,7 @@ function domainField (txParams) {
   ])
 }
 
-function recipientField (txParams, transaction, isTx, isMsg) {
+function recipientField (txParams, transaction, _, isMsg) {
   let message
 
   if (isMsg) {

--- a/old-ui/app/config.js
+++ b/old-ui/app/config.js
@@ -120,7 +120,7 @@ ConfigScreen.prototype.render = function () {
               style: {
                 alignSelf: 'center',
               },
-              onClick (event) {
+              onClick () {
                 window.logStateString((err, result) => {
                   if (err) {
                     state.dispatch(actions.displayWarning('Error in retrieving state logs.'))

--- a/old-ui/app/info.js
+++ b/old-ui/app/info.js
@@ -6,7 +6,7 @@ const actions = require('../../ui/app/actions')
 
 module.exports = connect(mapStateToProps)(InfoScreen)
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 
@@ -29,7 +29,7 @@ InfoScreen.prototype.render = function () {
       // subtitle and nav
       h('.section-title.flex-row.flex-center', [
         h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-          onClick: (event) => {
+          onClick: () => {
             state.dispatch(actions.goHome())
           },
         }),

--- a/old-ui/app/new-keychain.js
+++ b/old-ui/app/new-keychain.js
@@ -5,7 +5,7 @@ const connect = require('react-redux').connect
 
 module.exports = connect(mapStateToProps)(NewKeychain)
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 

--- a/old-ui/app/settings.js
+++ b/old-ui/app/settings.js
@@ -6,7 +6,7 @@ const actions = require('../../ui/app/actions')
 
 module.exports = connect(mapStateToProps)(AppSettingsPage)
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 

--- a/old-ui/app/template.js
+++ b/old-ui/app/template.js
@@ -5,7 +5,7 @@ const connect = require('react-redux').connect
 
 module.exports = connect(mapStateToProps)(COMPONENTNAME)
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 

--- a/old-ui/app/unlock.js
+++ b/old-ui/app/unlock.js
@@ -90,7 +90,7 @@ UnlockScreen.prototype.componentDidMount = function () {
   document.getElementById('password-box').focus()
 }
 
-UnlockScreen.prototype.onSubmit = function (event) {
+UnlockScreen.prototype.onSubmit = function () {
   const input = document.getElementById('password-box')
   const password = input.value
   this.props.dispatch(actions.tryUnlockMetamask(password))

--- a/old-ui/example.js
+++ b/old-ui/example.js
@@ -91,7 +91,7 @@ accountManager.setSelectedAccount = function (address, cb) {
   this._didUpdate()
 }
 
-accountManager.signTransaction = function (txParams, cb) {
+accountManager.signTransaction = function () {
   alert('signing tx....')
 }
 

--- a/test/e2e/beta/contract-test/contract.js
+++ b/test/e2e/beta/contract-test/contract.js
@@ -33,7 +33,7 @@ const deployButton = document.getElementById('deployButton')
 const depositButton = document.getElementById('depositButton')
 const withdrawButton = document.getElementById('withdrawButton')
 
-deployButton.addEventListener('click', async function (event) {
+deployButton.addEventListener('click', async function () {
 
     var piggybank = await piggybankContract.new(
        {
@@ -47,13 +47,13 @@ deployButton.addEventListener('click', async function (event) {
 
           console.log(`contract`, contract)
 
-          depositButton.addEventListener('click', function (event) {
+          depositButton.addEventListener('click', function () {
            contract.deposit({ from: web3.eth.accounts[0], value: '0x29a2241af62c0000' }, function (result) {
              console.log(result)
            })
           })
 
-          withdrawButton.addEventListener('click', function (event) {
+          withdrawButton.addEventListener('click', function () {
            contract.withdraw('0xde0b6b3a7640000', { from: web3.eth.accounts[0] }, function (result) {
              console.log(result)
            })

--- a/test/integration/lib/add-token.js
+++ b/test/integration/lib/add-token.js
@@ -17,7 +17,7 @@ QUnit.test('successful add token flow', (assert) => {
     })
 })
 
-async function runAddTokenFlowTest (assert, done) {
+async function runAddTokenFlowTest (assert) {
   const selectState = await queryAsync($, 'select')
   selectState.val('add token')
   reactTriggerChange(selectState[0])

--- a/test/integration/lib/confirm-sig-requests.js
+++ b/test/integration/lib/confirm-sig-requests.js
@@ -13,7 +13,7 @@ QUnit.test('successful confirmation of sig requests', (assert) => {
   })
 })
 
-async function runConfirmSigRequestsTest (assert, done) {
+async function runConfirmSigRequestsTest (assert) {
   const selectState = await queryAsync($, 'select')
   selectState.val('confirm sig requests')
   reactTriggerChange(selectState[0])

--- a/test/integration/lib/currency-localization.js
+++ b/test/integration/lib/currency-localization.js
@@ -15,7 +15,7 @@ QUnit.test('renders localized currency', (assert) => {
   })
 })
 
-async function runCurrencyLocalizationTest (assert, done) {
+async function runCurrencyLocalizationTest (assert) {
   console.log('*** start runCurrencyLocalizationTest')
   const selectState = await queryAsync($, 'select')
   selectState.val('currency localization')

--- a/test/integration/lib/mascara-first-time.js
+++ b/test/integration/lib/mascara-first-time.js
@@ -5,7 +5,7 @@ const {
   queryAsync,
 } = require('../../lib/util')
 
-async function runFirstTimeUsageTest (assert, done) {
+async function runFirstTimeUsageTest (assert) {
   await timeout(4000)
 
   const app = await queryAsync($, '#app-content')
@@ -58,7 +58,7 @@ async function runFirstTimeUsageTest (assert, done) {
   await timeout()
   const selectPhrase = text => {
     const option = $('.backup-phrase__confirm-seed-option')
-      .filter((i, d) => d.textContent === text)[0]
+      .filter((_, d) => d.textContent === text)[0]
     $(option).click()
   }
 

--- a/test/integration/lib/send-new-ui.js
+++ b/test/integration/lib/send-new-ui.js
@@ -52,7 +52,7 @@ async function customizeGas (assert, price, limit, ethFee, usdFee) {
   )
 }
 
-async function runSendFlowTest (assert, done) {
+async function runSendFlowTest (assert) {
   console.log('*** start runSendFlowTest')
   const selectState = await queryAsync($, 'select')
   selectState.val('send new ui')

--- a/test/integration/lib/tx-list-items.js
+++ b/test/integration/lib/tx-list-items.js
@@ -14,7 +14,7 @@ QUnit.test('renders list items successfully', (assert) => {
   })
 })
 
-async function runTxListItemsTest (assert, done) {
+async function runTxListItemsTest (assert) {
   console.log('*** start runTxListItemsTest')
   const selectState = await queryAsync($, 'select')
   selectState.val('tx list items')

--- a/test/lib/mock-encryptor.js
+++ b/test/lib/mock-encryptor.js
@@ -4,12 +4,12 @@ let cacheVal
 
 module.exports = {
 
-  encrypt (password, dataObj) {
+  encrypt (_, dataObj) {
     cacheVal = dataObj
     return Promise.resolve(mockHex)
   },
 
-  decrypt (password, text) {
+  decrypt () {
     return Promise.resolve(cacheVal || {})
   },
 
@@ -21,7 +21,7 @@ module.exports = {
     return this.decrypt(key, text)
   },
 
-  keyFromPassword (password) {
+  keyFromPassword () {
     return Promise.resolve(mockKey)
   },
 

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -6,7 +6,7 @@ module.exports = {
 }
 
 function timeout (time) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     setTimeout(resolve, time || 1500)
   })
 }

--- a/test/unit/actions/tx_test.js
+++ b/test/unit/actions/tx_test.js
@@ -44,8 +44,8 @@ describe('tx confirmation screen', function () {
     describe('cancelTx', function () {
       before(function (done) {
         actions._setBackgroundConnection({
-          approveTransaction (txId, cb) { cb('An error!') },
-          cancelTransaction (txId, cb) { cb() },
+          approveTransaction (_, cb) { cb('An error!') },
+          cancelTransaction (_, cb) { cb() },
           clearSeedWordCache (cb) { cb() },
         })
 

--- a/test/unit/app/controllers/currency-controller-test.js
+++ b/test/unit/app/controllers/currency-controller-test.js
@@ -62,7 +62,7 @@ describe('currency-controller', function () {
 
 
         var promise = new Promise(
-          function (resolve, reject) {
+          function (resolve) {
             currencyController.setCurrentCurrency('jpy')
             currencyController.updateConversionRate().then(function () {
               resolve()

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -43,7 +43,7 @@ describe('MetaMaskController', function () {
       showUnapprovedTx: noop,
       showUnconfirmedMessage: noop,
       encryptor: {
-        encrypt: function (password, object) {
+        encrypt: function (_, object) {
           this.object = object
           return Promise.resolve('mock-encrypted')
         },
@@ -134,7 +134,7 @@ describe('MetaMaskController', function () {
   describe('#createNewVaultAndRestore', function () {
     it('should be able to call newVaultAndRestore despite a mistake.', async function () {
       const password = 'what-what-what'
-      await metamaskController.createNewVaultAndRestore(password, TEST_SEED.slice(0, -1)).catch((e) => null)
+      await metamaskController.createNewVaultAndRestore(password, TEST_SEED.slice(0, -1)).catch(() => null)
       await metamaskController.createNewVaultAndRestore(password, TEST_SEED)
 
       assert(metamaskController.keyringController.createNewVaultAndRestore.calledTwice)
@@ -372,7 +372,7 @@ describe('MetaMaskController', function () {
 
     it('should clear config seed phrase', function () {
       metamaskController.configManager.setSeedWords('test words')
-      metamaskController.clearSeedWordCache((err, result) => {
+      metamaskController.clearSeedWordCache((err) => {
         if (err) console.log(err)
       })
       const getConfigSeed = metamaskController.configManager.getSeedWords()
@@ -523,7 +523,7 @@ describe('MetaMaskController', function () {
     it('sets up phishing stream for untrusted communication ', async function () {
       await metamaskController.blacklistController.updatePhishingList()
 
-      streamTest = createThoughStream((chunk, enc, cb) => {
+      streamTest = createThoughStream((chunk, _, cb) => {
         assert.equal(chunk.name, 'phishing')
         assert.equal(chunk.data.hostname, phishingUrl)
          cb()
@@ -541,7 +541,7 @@ describe('MetaMaskController', function () {
     })
 
     it('sets up controller dnode api for trusted communication', function (done) {
-      streamTest = createThoughStream((chunk, enc, cb) => {
+      streamTest = createThoughStream((chunk, _, cb) => {
         assert.equal(chunk.name, 'controller')
         cb()
         done()

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -102,7 +102,7 @@ describe('PendingTransactionTracker', function () {
     it('should emit \'tx:failed\' if the txMeta does not have a hash', function (done) {
       const block = Proxy.revocable({}, {}).revoke()
       pendingTxTracker.getPendingTransactions = () => [txMetaNoHash]
-      pendingTxTracker.once('tx:failed', (txId, err) => {
+      pendingTxTracker.once('tx:failed', (txId) => {
         assert(txId, txMetaNoHash.id, 'should pass txId')
         done()
       })
@@ -146,7 +146,7 @@ describe('PendingTransactionTracker', function () {
 
   describe('#_checkPendingTx', function () {
     it('should emit \'tx:failed\' if the txMeta does not have a hash', function (done) {
-      pendingTxTracker.once('tx:failed', (txId, err) => {
+      pendingTxTracker.once('tx:failed', (txId) => {
         assert(txId, txMetaNoHash.id, 'should pass txId')
         done()
       })
@@ -184,7 +184,7 @@ describe('PendingTransactionTracker', function () {
       pendingTxTracker.getPendingTransactions = () => txList
       pendingTxTracker._checkPendingTx = (tx) => { tx.resolve(tx) }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
 
       pendingTxTracker._checkPendingTxs()
@@ -208,7 +208,7 @@ describe('PendingTransactionTracker', function () {
       pendingTxTracker.getPendingTransactions = () => txList
       pendingTxTracker._resubmitTx = async (tx) => { tx.resolve(tx) }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
       pendingTxTracker.resubmitPendingTxs(blockStub)
     })
@@ -234,7 +234,7 @@ describe('PendingTransactionTracker', function () {
         throw new Error(knownErrors.pop())
       }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
 
       pendingTxTracker.resubmitPendingTxs(blockStub)
@@ -250,9 +250,9 @@ describe('PendingTransactionTracker', function () {
       })
 
       pendingTxTracker.getPendingTransactions = () => txList
-      pendingTxTracker._resubmitTx = async (tx) => { throw new TypeError('im some real error') }
+      pendingTxTracker._resubmitTx = async () => { throw new TypeError('im some real error') }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
 
       pendingTxTracker.resubmitPendingTxs(blockStub)

--- a/test/unit/app/controllers/transactions/tx-gas-util-test.js
+++ b/test/unit/app/controllers/transactions/tx-gas-util-test.js
@@ -11,7 +11,7 @@ describe('txUtils', function () {
 
   before(function () {
     txUtils = new TxUtils(new Proxy({}, {
-      get: (obj, name) => {
+      get: () => {
         return () => {}
       },
     }))

--- a/test/unit/app/controllers/transactions/tx-state-history-helper-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-history-helper-test.js
@@ -29,7 +29,7 @@ describe('Transaction state history helper', function () {
 
   describe('#migrateFromSnapshotsToDiffs', function () {
     it('migrates history to diffs and can recover original values', function () {
-      testVault.data.TransactionController.transactions.forEach((tx, index) => {
+      testVault.data.TransactionController.transactions.forEach((tx) => {
         const newHistory = txStateHistoryHelper.migrateFromSnapshotsToDiffs(tx.history)
         newHistory.forEach((newEntry, index) => {
           if (index === 0) {

--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -56,7 +56,7 @@ describe('TransactionStateManager', function () {
     it('should emit a rejected event to signal the exciton of callback', (done) => {
       const tx = { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }
       txStateManager.addTx(tx)
-      const noop = function (err, txId) {
+      const noop = function (err) {
           if (err) {
             console.log('Error: ', err)
           }

--- a/test/unit/app/edge-encryptor-test.js
+++ b/test/unit/app/edge-encryptor-test.js
@@ -83,7 +83,7 @@ describe('EdgeEncryptor', function () {
       edgeEncryptor.encrypt(password, data)
         .then(function (encryptedData) {
           edgeEncryptor.decrypt('wrong password', encryptedData)
-          .then(function (decryptedData) {
+          .then(function () {
             assert.fail('could decrypt with wrong password')
             done()
           })

--- a/test/unit/components/pending-tx-test.js
+++ b/test/unit/components/pending-tx-test.js
@@ -42,7 +42,7 @@ describe('PendingTx', function () {
   const props = {
     txData,
     computedBalances,
-    sendTransaction: (txMeta, event) => {
+    sendTransaction: (txMeta) => {
       // Assert changes:
       const result = ethUtil.addHexPrefix(txMeta.txParams.gasPrice)
       assert.notEqual(result, gasPrice, 'gas price should change')

--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -61,7 +61,7 @@ describe('Migrator', () => {
     const migrator = new Migrator({ migrations: [{ version: 1, migrate: async () => { throw new Error('test') } } ] })
     migrator.on('error', () => done())
     migrator.migrateData({ meta: {version: 0} })
-    .then((migratedData) => {
+    .then(() => {
     }).catch(done)
   })
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -706,7 +706,7 @@ function signTypedMsg (msgData) {
 function signTx (txData) {
   return (dispatch) => {
     dispatch(actions.showLoadingIndication())
-    global.ethQuery.sendTransaction(txData, (err, data) => {
+    global.ethQuery.sendTransaction(txData, (err) => {
       dispatch(actions.hideLoadingIndication())
       if (err) return dispatch(actions.displayWarning(err.message))
       dispatch(actions.hideWarning())
@@ -1032,7 +1032,7 @@ function cancelTypedMsg (msgData) {
 function cancelTx (txData) {
   return dispatch => {
     log.debug(`background.cancelTransaction`)
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       background.cancelTransaction(txData.id, () => {
         dispatch(actions.clearSend())
         dispatch(actions.completedTx(txData.id))
@@ -1489,7 +1489,7 @@ function retryTransaction (txId) {
 function setProviderType (type) {
   return (dispatch) => {
     log.debug(`background.setProviderType`, type)
-    background.setProviderType(type, (err, result) => {
+    background.setProviderType(type, (err) => {
       if (err) {
         log.error(err)
         return dispatch(self.displayWarning('Had a problem changing networks!'))
@@ -1511,7 +1511,7 @@ function updateProviderType (type) {
 function setRpcTarget (newRpc) {
   return (dispatch) => {
     log.debug(`background.setRpcTarget: ${newRpc}`)
-    background.setCustomRpc(newRpc, (err, result) => {
+    background.setCustomRpc(newRpc, (err) => {
       if (err) {
         log.error(err)
         return dispatch(self.displayWarning('Had a problem changing networks!'))
@@ -1525,7 +1525,7 @@ function setRpcTarget (newRpc) {
 function addToAddressBook (recipient, nickname = '') {
   log.debug(`background.addToAddressBook`)
   return (dispatch) => {
-    background.setAddressBook(recipient, nickname, (err, result) => {
+    background.setAddressBook(recipient, nickname, (err) => {
       if (err) {
         log.error(err)
         return dispatch(self.displayWarning('Address book failed to update'))
@@ -1758,7 +1758,7 @@ function pairUpdate (coin) {
   }
 }
 
-function shapeShiftSubview (network) {
+function shapeShiftSubview () {
   var pair = 'btc_eth'
   return (dispatch) => {
     dispatch(actions.showSubLoadingIndication())
@@ -1794,7 +1794,7 @@ function coinShiftRquest (data, marketData) {
 }
 
 function buyWithShapeShift (data) {
-  return dispatch => new Promise((resolve, reject) => {
+  return () => new Promise((resolve, reject) => {
     shapeShiftRequest('shift', { method: 'POST', data}, (response) => {
       if (response.error) {
         return reject(response.error)
@@ -1841,7 +1841,7 @@ function shapeShiftRequest (query, options, cb) {
   !options ? options = {} : null
   options.method ? method = options.method : method = 'GET'
 
-  var requestListner = function (request) {
+  var requestListner = function () {
     try {
       queryResponse = JSON.parse(this.responseText)
       cb ? cb(queryResponse) : null

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -365,7 +365,7 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch, ownProps) {
+function mapDispatchToProps (dispatch) {
   return {
     dispatch,
     hideSidebar: () => dispatch(actions.hideSidebar()),

--- a/ui/app/components/account-export.js
+++ b/ui/app/components/account-export.js
@@ -112,7 +112,7 @@ ExportAccountView.prototype.render = function () {
           webkitUserSelect: 'text',
           maxWidth: '275px',
         },
-        onClick: function (event) {
+        onClick: function () {
           copyToClipboard(ethUtil.stripHexPrefix(accountDetail.privateKey))
         },
       }, plainKey),

--- a/ui/app/components/account-panel.js
+++ b/ui/app/components/account-panel.js
@@ -69,7 +69,7 @@ AccountPanel.prototype.render = function () {
   )
 }
 
-function balanceOrFaucetingIndication (account, isFauceting) {
+function balanceOrFaucetingIndication (account) {
   // Temporarily deactivating isFauceting indication
   // because it shows fauceting for empty restored accounts.
   if (/* isFauceting*/ false) {

--- a/ui/app/components/bn-as-decimal-input.js
+++ b/ui/app/components/bn-as-decimal-input.js
@@ -116,7 +116,7 @@ BnAsDecimalInput.prototype.render = function () {
   )
 }
 
-BnAsDecimalInput.prototype.setValid = function (message) {
+BnAsDecimalInput.prototype.setValid = function () {
   this.setState({ invalid: null })
 }
 

--- a/ui/app/components/custom-radio-list.js
+++ b/ui/app/components/custom-radio-list.js
@@ -30,7 +30,7 @@ RadioList.prototype.render = function () {
           marginRight: '5px',
         },
       },
-        labels.map((lable, i) => {
+        labels.map((lable) => {
           let isSelcted = (this.state !== null)
           isSelcted = isSelcted ? (this.state.selected === lable) : (defaultFocus === lable)
           return h(isSelcted ? activeClass : inactiveClass, {

--- a/ui/app/components/ens-input.js
+++ b/ui/app/components/ens-input.js
@@ -142,7 +142,7 @@ EnsInput.prototype.ensIcon = function (recipient) {
   }, this.ensIconContents(recipient))
 }
 
-EnsInput.prototype.ensIconContents = function (recipient) {
+EnsInput.prototype.ensIconContents = function () {
   const { loadingEns, ensFailure, ensResolution, toError } = this.state || { ensResolution: ZERO_ADDRESS }
 
   if (toError) return

--- a/ui/app/components/hex-as-decimal-input.js
+++ b/ui/app/components/hex-as-decimal-input.js
@@ -109,7 +109,7 @@ HexAsDecimalInput.prototype.render = function () {
   )
 }
 
-HexAsDecimalInput.prototype.setValid = function (message) {
+HexAsDecimalInput.prototype.setValid = function () {
   this.setState({ invalid: null })
 }
 
@@ -150,7 +150,7 @@ function hexify (decimalString) {
   return '0x' + hexBN.toString('hex')
 }
 
-function decimalize (input, toEth) {
+function decimalize (input) {
   if (input === '') {
     return ''
   } else {

--- a/ui/app/components/modals/deposit-ether-modal.js
+++ b/ui/app/components/modals/deposit-ether-modal.js
@@ -41,7 +41,7 @@ function mapDispatchToProps (dispatch) {
 }
 
 inherits(DepositEtherModal, Component)
-function DepositEtherModal (props, context) {
+function DepositEtherModal (_, context) {
   Component.call(this)
 
   // need to set after i18n locale has loaded

--- a/ui/app/components/modals/export-private-key-modal.js
+++ b/ui/app/components/modals/export-private-key-modal.js
@@ -84,7 +84,7 @@ ExportPrivateKeyModal.prototype.renderButton = function (className, onClick, lab
   }, label)
 }
 
-ExportPrivateKeyModal.prototype.renderButtons = function (privateKey, password, address, hideModal) {
+ExportPrivateKeyModal.prototype.renderButtons = function (privateKey, _, address, hideModal) {
   return h('div.export-private-key-buttons', {}, [
     !privateKey && this.renderButton(
       'btn-default btn--large export-private-key__button export-private-key__button--cancel',

--- a/ui/app/components/modals/transaction-confirmed/transaction-confirmed.component.js
+++ b/ui/app/components/modals/transaction-confirmed/transaction-confirmed.component.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const TransactionConfirmed = (props, context) => {
+const TransactionConfirmed = (_, context) => {
   const { t } = context
 
   return (

--- a/ui/app/components/modals/welcome-beta/welcome-beta.component.js
+++ b/ui/app/components/modals/welcome-beta/welcome-beta.component.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const TransactionConfirmed = (props, context) => {
+const TransactionConfirmed = (_, context) => {
   const { t } = context
 
   return (

--- a/ui/app/components/pages/create-account/import-account/seed.js
+++ b/ui/app/components/pages/create-account/import-account/seed.js
@@ -11,7 +11,7 @@ SeedImportSubview.contextTypes = {
 module.exports = connect(mapStateToProps)(SeedImportSubview)
 
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 

--- a/ui/app/components/pages/settings/settings.js
+++ b/ui/app/components/pages/settings/settings.js
@@ -218,7 +218,7 @@ class Settings extends Component {
         h('div.settings__content-item', [
           h('div.settings__content-item-col', [
             h('button.btn-primary.btn--large.settings__button', {
-              onClick (event) {
+              onClick () {
                 window.logStateString((err, result) => {
                   if (err) {
                     this.state.dispatch(actions.displayWarning(this.context.t('stateLogError')))

--- a/ui/app/components/pending-tx/confirm-send-token.js
+++ b/ui/app/components/pending-tx/confirm-send-token.js
@@ -210,7 +210,7 @@ ConfirmSendToken.prototype.componentWillMount = function () {
   const { tokenContract, selectedAddress } = this.props
   tokenContract && tokenContract
     .balanceOf(selectedAddress)
-    .then(usersToken => {
+    .then(() => {
     })
   this.updateComponentSendErrors({})
 }

--- a/ui/app/components/pending-tx/index.js
+++ b/ui/app/components/pending-tx/index.js
@@ -61,7 +61,7 @@ PendingTx.prototype.componentDidMount = function () {
   this.setTokenData()
 }
 
-PendingTx.prototype.componentDidUpdate = function (prevProps, prevState) {
+PendingTx.prototype.componentDidUpdate = function (_, prevState) {
   if (prevState.isFetching) {
     this.setTokenData()
   }

--- a/ui/app/components/send/currency-display.js
+++ b/ui/app/components/send/currency-display.js
@@ -98,7 +98,7 @@ CurrencyDisplay.prototype.handleChange = function (newVal) {
   this.props.onChange(this.getAmount(newVal))
 }
 
-CurrencyDisplay.prototype.getInputWidth = function (valueToRender, readOnly) {
+CurrencyDisplay.prototype.getInputWidth = function (valueToRender) {
   const valueString = String(valueToRender)
   const valueLength = valueString.length || 1
   const decimalPointDeficit = valueString.match(/\./) ? -0.5 : 0

--- a/ui/app/components/send/to-autocomplete.js
+++ b/ui/app/components/send/to-autocomplete.js
@@ -82,7 +82,7 @@ ToAutoComplete.prototype.handleInputEvent = function (event = {}, cb) {
   cb && cb(event.target.value)
 }
 
-ToAutoComplete.prototype.componentDidUpdate = function (nextProps, nextState) {
+ToAutoComplete.prototype.componentDidUpdate = function (nextProps) {
   if (this.props.to !== nextProps.to) {
     this.handleInputEvent()
   }

--- a/ui/app/components/send_/account-list-item/tests/account-list-item-container.test.js
+++ b/ui/app/components/send_/account-list-item/tests/account-list-item-container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../account-list-item.container.js', {
   'react-redux': {
-    connect: (ms, md) => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/components/send_/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-container.test.js
+++ b/ui/app/components/send_/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../send-row-error-message.container.js', {
   'react-redux': {
-    connect: (ms, md) => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/components/send_/send.selectors.js
+++ b/ui/app/components/send_/send.selectors.js
@@ -244,7 +244,7 @@ function getSendToAccounts (state) {
   const addressBookAccounts = getAddressBook(state)
   const allAccounts = [...fromAccounts, ...addressBookAccounts]
   // TODO: figure out exactly what the below returns and put a descriptive variable name on it
-  return Object.entries(allAccounts).map(([key, account]) => account)
+  return Object.entries(allAccounts).map(([, account]) => account)
 }
 
 function getTokenBalance (state) {

--- a/ui/app/components/send_/tests/send-container.test.js
+++ b/ui/app/components/send_/tests/send-container.test.js
@@ -23,7 +23,7 @@ proxyquire('../send.container.js', {
     },
   },
   'react-router-dom': { withRouter: () => {} },
-  'recompose': { compose: (arg1, arg2) => () => arg2() },
+  'recompose': { compose: (_, arg2) => () => arg2() },
   './send.selectors': {
     getAmountConversionRate: (s) => `mockAmountConversionRate:${s}`,
     getBlockGasLimit: (s) => `mockBlockGasLimit:${s}`,

--- a/ui/app/components/send_/tests/send-utils.test.js
+++ b/ui/app/components/send_/tests/send-utils.test.js
@@ -17,8 +17,8 @@ const {
 } = require('../send.constants')
 
 const stubs = {
-  addCurrencies: sinon.stub().callsFake((a, b, obj) => a + b),
-  conversionUtil: sinon.stub().callsFake((val, obj) => parseInt(val, 16)),
+  addCurrencies: sinon.stub().callsFake((a, b) => a + b),
+  conversionUtil: sinon.stub().callsFake((val) => parseInt(val, 16)),
   conversionGTE: sinon.stub().callsFake((obj1, obj2) => obj1.value >= obj2.value),
   multiplyCurrencies: sinon.stub().callsFake((a, b) => `${a}x${b}`),
   calcTokenAmount: sinon.stub().callsFake((a, d) => 'calc:' + a + d),

--- a/ui/app/components/token-cell.js
+++ b/ui/app/components/token-cell.js
@@ -142,7 +142,7 @@ TokenCell.prototype.send = function (address, event) {
   }
 }
 
-TokenCell.prototype.view = function (address, userAddress, network, event) {
+TokenCell.prototype.view = function (address, userAddress, network) {
   const url = etherscanLinkFor(address, userAddress, network)
   if (url) {
     navigateTo(url)

--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -41,7 +41,7 @@ const convert = R.invoker(1, 'times')
 const round = R.invoker(2, 'round')(R.__, BigNumber.ROUND_HALF_DOWN)
 const roundDown = R.invoker(2, 'round')(R.__, BigNumber.ROUND_DOWN)
 const invertConversionRate = conversionRate => () => new BigNumber(1.0).div(conversionRate)
-const decToBigNumberViaString = n => R.pipe(String, toBigNumber['dec'])
+const decToBigNumberViaString = () => R.pipe(String, toBigNumber['dec'])
 
 // Setter Maps
 const toBigNumber = {

--- a/ui/app/new-keychain.js
+++ b/ui/app/new-keychain.js
@@ -5,7 +5,7 @@ const connect = require('react-redux').connect
 
 module.exports = connect(mapStateToProps)(NewKeychain)
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 

--- a/ui/app/select-app.js
+++ b/ui/app/select-app.js
@@ -36,7 +36,7 @@ function SelectedApp () {
   Component.call(this)
 }
 
-SelectedApp.prototype.componentWillReceiveProps = function (nextProps) {
+SelectedApp.prototype.componentWillReceiveProps = function () {
   // Code commented out until we begin auto adding users to NewUI
   const {
     // isUnlocked,

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -258,7 +258,7 @@ function bnMultiplyByFraction (targetBN, numerator, denominator) {
   return targetBN.mul(numBN).div(denomBN)
 }
 
-function getTxFeeBn (gas, gasPrice = MIN_GAS_PRICE_BN.toString(16), blockGasLimit) {
+function getTxFeeBn (gas, gasPrice = MIN_GAS_PRICE_BN.toString(16)) {
   const gasBn = hexToBn(gas)
   const gasPriceBn = hexToBn(gasPrice)
   const txFeeBn = gasBn.mul(gasPriceBn)
@@ -287,7 +287,7 @@ function exportAsFile (filename, data) {
 }
 
 function allNull (obj) {
-  return Object.entries(obj).every(([key, value]) => value === null)
+  return Object.entries(obj).every(([, value]) => value === null)
 }
 
 function getTokenAddressFromTokenObject (token) {

--- a/ui/example.js
+++ b/ui/example.js
@@ -91,7 +91,7 @@ accountManager.setSelectedAccount = function (address, cb) {
   this._didUpdate()
 }
 
-accountManager.signTransaction = function (txParams, cb) {
+accountManager.signTransaction = function () {
   alert('signing tx....')
 }
 


### PR DESCRIPTION
A small update to eslint. We will start having errors for unused arguments, but will still allow `_` as a placeholder for an arg that will intentionally be unused? in