### PR TITLE
Fix setState warnings in components using TokenTracker

### DIFF
--- a/ui/app/components/token-balance.js
+++ b/ui/app/components/token-balance.js
@@ -98,6 +98,10 @@ TokenBalance.prototype.componentDidUpdate = function (nextProps) {
 }
 
 TokenBalance.prototype.updateBalance = function (tokens = []) {
+  if (!this.tracker.running) {
+    return
+  }
+
   const [{ string, symbol }] = tokens
 
   this.setState({

--- a/ui/app/components/token-balance.js
+++ b/ui/app/components/token-balance.js
@@ -110,5 +110,7 @@ TokenBalance.prototype.updateBalance = function (tokens = []) {
 TokenBalance.prototype.componentWillUnmount = function () {
   if (!this.tracker) return
   this.tracker.stop()
+  this.tracker.removeListener('update', this.balanceUpdater)
+  this.tracker.removeListener('error', this.showError)
 }
 

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -158,6 +158,9 @@ TokenList.prototype.componentDidUpdate = function (nextProps) {
 }
 
 TokenList.prototype.updateBalances = function (tokens) {
+  if (!this.tracker.running) {
+    return
+  }
   this.setState({ tokens, isLoading: false })
 }
 

--- a/ui/app/components/token-list.js
+++ b/ui/app/components/token-list.js
@@ -164,6 +164,8 @@ TokenList.prototype.updateBalances = function (tokens) {
 TokenList.prototype.componentWillUnmount = function () {
   if (!this.tracker) return
   this.tracker.stop()
+  this.tracker.removeListener('update', this.balanceUpdater)
+  this.tracker.removeListener('error', this.showError)
 }
 
 // function uniqueMergeTokens (tokensA, tokensB = []) {

--- a/ui/app/helpers/with-token-tracker.js
+++ b/ui/app/helpers/with-token-tracker.js
@@ -75,6 +75,9 @@ const withTokenTracker = WrappedComponent => {
     }
 
     updateBalance (tokens = []) {
+      if (!this.tracker.running) {
+        return
+      }
       const [{ string, symbol }] = tokens
       this.setState({ string, symbol, error: null })
     }


### PR DESCRIPTION
Fixes #4415

This PR fixes the `setState` warnings/errors that occur when components using a TokenTracker instance try to update the balance after the component has been unmounted.