### PR TITLE
Prevent calling setState in TxListItem after unmount

### DIFF
--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -54,6 +54,8 @@ function TxListItem () {
     fiatTotal: null,
     isTokenTx: null,
   }
+
+  this.unmounted = false
 }
 
 TxListItem.prototype.componentDidMount = async function () {
@@ -67,7 +69,14 @@ TxListItem.prototype.componentDidMount = async function () {
     ? await this.getSendTokenTotal()
     : this.getSendEtherTotal()
 
+  if (this.unmounted) {
+    return
+  }
   this.setState({ total, fiatTotal, isTokenTx })
+}
+
+TxListItem.prototype.componentWillUnmount = function () {
+  this.unmounted = true
 }
 
 TxListItem.prototype.getAddressText = function () {


### PR DESCRIPTION
Refs #4733, fixes #4415

This PR fixes the setState warnings/errors that occur when the `TxListItem` component calls `setState` after it has been unmounted and the `this.getSendTokenTotal()` promise resolves.