### PR TITLE
Improve CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys: dependency-cache-firefox-
+          keys: dependency-cache-firefox-{{ .Revision }}
       - run:
           name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,9 +103,6 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
-          name: Install npm 6
-          command: sudo npm install -g npm@6
-      - run:
           name: Install deps via npm
           command: npm install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
           command: ./.circleci/scripts/firefox-download.sh
       - save_cache:
           key: dependency-cache-firefox-{{ .Revision }}
-          path:
+          paths:
             - firefox
 
   prep-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox-
       - run:
           name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           command: |
            # Only run npm install if the package-lock.json or package.json was changed
            CHANGED_FILES="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
-	         echo "$CHANGED_FILES" | grep --quiet "package.*json" && 
+	   echo "$CHANGED_FILES" | grep --quiet "package.*json" && 
            sudo npm install -g npm@6 &&
            npm install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,10 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+      - save_cache:
+          key: dependency-cache-{{ .Revision }}
+          paths:
+            - node_modules
 
   prep-deps-firefox:
     docker:
@@ -129,7 +133,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: build:dist
           command: npm run dist
@@ -148,7 +152,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: build:dist
           command: npm run doc
@@ -163,7 +167,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -182,7 +186,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Test
           command: npm run lint
@@ -193,7 +197,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Test
           command: npx nsp check
@@ -204,7 +208,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -225,7 +229,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -241,7 +245,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -262,7 +266,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -278,7 +282,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -295,7 +299,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - restore_cache:
@@ -322,7 +326,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - restore_cache:
@@ -345,7 +349,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: test:coverage
           command: npm run test:coverage
@@ -363,7 +367,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -382,7 +386,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -406,7 +410,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -425,7 +429,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           name: Install deps via npm
           command: npm install
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           command: |
            # Only run npm install if the package-lock.json or package.json was changed
            CHANGED_FILES="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
-	   echo "$CHANGED_FILES" | grep --quiet "package.*json" && 
+           echo "$CHANGED_FILES" | grep --quiet "package.*json" && 
            sudo npm install -g npm@6 &&
            npm install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,16 +101,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install deps via npm
           command: npm install
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
-      - save_cache:
-          key: dependency-cache-{{ .Revision }}
           paths:
             - node_modules
 
@@ -133,7 +129,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: build:dist
           command: npm run dist
@@ -152,7 +148,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: build:dist
           command: npm run doc
@@ -167,7 +163,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -186,7 +182,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Test
           command: npm run lint
@@ -197,7 +193,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Test
           command: npx nsp check
@@ -208,7 +204,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -229,7 +225,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -245,7 +241,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -266,7 +262,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -282,7 +278,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -299,7 +295,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - restore_cache:
@@ -326,7 +322,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - restore_cache:
@@ -349,7 +345,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: test:coverage
           command: npm run test:coverage
@@ -367,7 +363,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -386,7 +382,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -410,7 +406,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -429,7 +425,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,10 +105,10 @@ jobs:
       - run:
           name: Install deps via npm
           command: |
-          if [ ! -d node_modules ]; then
-            sudo npm install -g npm@$NPM_VERSION
-            npm ci
-          fi
+            if [ ! -d node_modules ]; then
+              sudo npm install -g npm@$NPM_VERSION
+              npm ci
+            fi
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,11 @@ jobs:
             if [ ! -d node_modules ]; then
               sudo npm install -g npm@6
               npm install
+              # If the package-lock.json has changed, die with an error
+              CHANGED_FILES="$(git diff --name-only package-lock.json)"
+              echo "$CHANGED_FILES" | grep --quiet "package-lock.json" && 
+              echo "Looks like package-lock.json has changed. Did you forget to include it on your PR?" && 
+              exit
             fi
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,16 +119,15 @@ jobs:
       - image: circleci/node:8.11.3-browsers
     steps:
       - checkout
-      - restore_cache:
-          keys: dependency-cache-firefox
+      # - restore_cache:
+      #    keys: dependency-cache-firefox-
       - run:
           name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh
       - save_cache:
-          key: dependency-cache-firefox
-          paths:
+          key: dependency-cache-firefox-{{ .Revision }}
+          path:
             - firefox
-            - firefox-58.0.tar.bz2
 
   prep-build:
     docker:
@@ -227,14 +226,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox
+          key: dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - restore_cache:
-          key: build-cache-{{ .Revision }}
       - run:
           name: test:e2e:firefox
           command: npm run test:e2e:firefox
@@ -264,7 +259,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox
+          key: dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -365,7 +360,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox
+          key: dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -408,7 +403,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox
+          key: dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,15 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install deps via npm
-          command: npm install
+          command: |
+          if [ ! -d node_modules ]; then
+            sudo npm install -g npm@$NPM_VERSION
+            npm ci
+          fi
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
-            - ./node_modules
+            - node_modules
 
   prep-deps-firefox:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,8 @@ jobs:
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: test:e2e:firefox
           command: npm run test:e2e:firefox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           command: |
             if [ ! -d node_modules ]; then
               sudo npm install -g npm@6
-              npm ci
+              npm install
             fi
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh
       - save_cache:
-          key: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox-
           paths:
             - firefox
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install npm 6
-          command: npm install -g npm@6
+          command: sudo npm install -g npm@6
       - run:
           name: Install deps via npm
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-        keys: dependency-cache-firefox-
+          keys: dependency-cache-firefox-
       - run:
           name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,8 @@ jobs:
       - image: circleci/node:8.11.3-browsers
     steps:
       - checkout
-      # - restore_cache:
-      #    keys: dependency-cache-firefox-
+      - restore_cache:
+        keys: dependency-cache-firefox-
       - run:
           name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,10 @@ jobs:
       - run:
           name: Install deps via npm
           command: |
-           sudo npm install -g npm@6
+           # Only run npm install if the package-lock.json or package.json was changed
+           CHANGED_FILES="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+	         echo "$CHANGED_FILES" | grep --quiet "package.*json" && 
+           sudo npm install -g npm@6 &&
            npm install
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ jobs:
           key: dependency-cache-firefox
           paths:
             - firefox
+            - firefox-58.0.tar.bz2
 
   prep-build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox-{{ .Revision }}
       - run:
           name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          keys:
+            - dependency-cache-{{ checksum "package-lock.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - dependency-cache-
       - run:
           name: Install deps via npm
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,15 +108,8 @@ jobs:
       - run:
           name: Install deps via npm
           command: |
-            if [ ! -d node_modules ]; then
-              sudo npm install -g npm@6
-              npm install
-              # If the package-lock.json has changed, die with an error
-              CHANGED_FILES="$(git diff --name-only package-lock.json)"
-              echo "$CHANGED_FILES" | grep --quiet "package-lock.json" && 
-              echo "Looks like package-lock.json has changed. Did you forget to include it on your PR?" && 
-              exit
-            fi
+           sudo npm install -g npm@6
+           npm install
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,16 +103,15 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
+          name: Install npm 6
+          command: npm install -g npm@6
+      - run:
           name: Install deps via npm
           command: npm install
       - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          key: dependency-cache-{{ checksum "package.json" }}
           paths:
-            - node_modules
-      - save_cache:
-          key: dependency-cache-{{ .Revision }}
-          paths:
-            - node_modules
+            - ./node_modules
 
   prep-deps-firefox:
     docker:
@@ -133,7 +132,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: build:dist
           command: npm run dist
@@ -152,7 +151,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: build:dist
           command: npm run doc
@@ -167,7 +166,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -186,7 +185,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Test
           command: npm run lint
@@ -197,7 +196,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Test
           command: npx nsp check
@@ -208,7 +207,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -229,7 +228,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -245,7 +244,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -266,7 +265,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -282,7 +281,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - run:
@@ -299,7 +298,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - restore_cache:
@@ -326,7 +325,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           key: build-cache-{{ .Revision }}
       - restore_cache:
@@ -349,7 +348,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: test:coverage
           command: npm run test:coverage
@@ -367,7 +366,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -386,7 +385,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -410,7 +409,7 @@ jobs:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory
@@ -429,7 +428,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get Scss Cache key
           # this allows us to checksum against a whole directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           name: Install deps via npm
           command: |
             if [ ! -d node_modules ]; then
-              sudo npm install -g npm@$NPM_VERSION
+              sudo npm install -g npm@6
               npm ci
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,8 @@ jobs:
           command: ./.circleci/scripts/firefox-install.sh
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
+      - restore_cache:
+          key: build-cache-{{ .Revision }}
       - run:
           name: test:e2e:firefox
           command: npm run test:e2e:firefox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,11 +119,13 @@ jobs:
       - image: circleci/node:8.11.3-browsers
     steps:
       - checkout
+      - restore_cache:
+          keys: dependency-cache-firefox
       - run:
-          name: Download Firefox
+          name: Download Firefox If needed
           command: ./.circleci/scripts/firefox-download.sh
       - save_cache:
-          key: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox
           paths:
             - firefox
 
@@ -224,7 +226,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -261,7 +263,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -362,7 +364,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -405,7 +407,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-firefox-{{ .Revision }}
+          key: dependency-cache-firefox
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,13 +106,9 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - dependency-cache-
       - run:
-          name: Install deps via npm
+          name: Install npm 6 + deps via npm
           command: |
-           # Only run npm install if the package-lock.json or package.json was changed
-           CHANGED_FILES="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
-           echo "$CHANGED_FILES" | grep --quiet "package.*json" && 
-           sudo npm install -g npm@6 &&
-           npm install
+           sudo npm install -g npm@6.1.0 && npm install
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/scripts/firefox-download.sh
+++ b/.circleci/scripts/firefox-download.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
+FIREFOX_BINARY="firefox-58.0.tar.bz2"
+echo "Checking if firefox was already downloaded"
+if [ -e $FIREFOX_BINARY ]
+then
+    echo "$FIREFOX_BINARY found. No need to download"
+else
+    echo "Downloading firefox..."
+    wget "https://ftp.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/$FIREFOX_BINARY" \
+    && tar xjf "$FIREFOX_BINARY"
+    echo "firefox download complete"
+fi
 
-echo "Downloading firefox..."
-wget https://ftp.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/firefox-58.0.tar.bz2 \
-&& tar xjf firefox-58.0.tar.bz2
-echo "firefox download complete"

--- a/.circleci/scripts/firefox-download.sh
+++ b/.circleci/scripts/firefox-download.sh
@@ -5,7 +5,7 @@ then
     echo "Firefox found. No need to download"
 else
     FIREFOX_VERSION="61.0.1"
-    FIREFOX_BINARY="firefox-${!FIREFOX_VERSION}.tar.bz2"
+    FIREFOX_BINARY="firefox-$FIREFOX_VERSION.tar.bz2"
     echo "Downloading firefox..."
     wget "https://ftp.mozilla.org/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/$FIREFOX_BINARY" \
     && tar xjf "$FIREFOX_BINARY"

--- a/.circleci/scripts/firefox-download.sh
+++ b/.circleci/scripts/firefox-download.sh
@@ -4,9 +4,10 @@ if [ -d "firefox" ]
 then
     echo "Firefox found. No need to download"
 else
-    FIREFOX_BINARY="firefox-61.0.1.tar.bz2"
+    FIREFOX_VERSION="61.0.1"
+    FIREFOX_BINARY="firefox-${!FIREFOX_VERSION}.tar.bz2"
     echo "Downloading firefox..."
-    wget "https://ftp.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/$FIREFOX_BINARY" \
+    wget "https://ftp.mozilla.org/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/$FIREFOX_BINARY" \
     && tar xjf "$FIREFOX_BINARY"
     echo "firefox download complete"
 fi

--- a/.circleci/scripts/firefox-download.sh
+++ b/.circleci/scripts/firefox-download.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-FIREFOX_BINARY="firefox-58.0.tar.bz2"
 echo "Checking if firefox was already downloaded"
-if [ -e $FIREFOX_BINARY ]
+if [ -d "firefox" ]
 then
-    echo "$FIREFOX_BINARY found. No need to download"
+    echo "Firefox found. No need to download"
 else
+    FIREFOX_BINARY="firefox-61.0.1.tar.bz2"
     echo "Downloading firefox..."
     wget "https://ftp.mozilla.org/pub/firefox/releases/58.0/linux-x86_64/en-US/$FIREFOX_BINARY" \
     && tar xjf "$FIREFOX_BINARY"
     echo "firefox download complete"
 fi
-

--- a/.circleci/scripts/firefox-install.sh
+++ b/.circleci/scripts/firefox-install.sh
@@ -2,7 +2,7 @@
 
 echo "Installing firefox..."
 sudo rm -r /opt/firefox
-sudo mv firefox /opt/firefox58
+sudo mv firefox /opt/firefox61
 sudo mv /usr/bin/firefox /usr/bin/firefox-old
-sudo ln -s /opt/firefox58/firefox /usr/bin/firefox
+sudo ln -s /opt/firefox61/firefox /usr/bin/firefox
 echo "Firefox installed."


### PR DESCRIPTION
- Use npm 6
- Correct usage of the cache based on checksum "package-lock.json" instead of .Revision
- Defaulting to last cached version when no cache hit
- Caching Firefox instead of downloading the binary every time
- Upgrade to Firefox 61.0.1 (Hopefully this leads to more stable builds!)

This results in -2 to 3 minutes faster builds

Before: https://circleci.com/workflow-run/cf7ff164-7390-40ba-942e-4baff60b8d6e
After: https://circleci.com/workflow-run/0a568f9b-c07a-4c35-8c91-f5c7540b0918
