### PR TITLE
Fixes conversion status for tokens without conversion rates (#4661)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -584,6 +584,9 @@
   "noDeposits": {
     "message": "No deposits received"
   },
+  "noConversionRateAvailable":{
+    "message": "No Conversion Rate Available"
+  },
   "noTransactionHistory": {
     "message": "No transaction history."
   },

--- a/ui/app/components/send/currency-display/currency-display.js
+++ b/ui/app/components/send/currency-display/currency-display.js
@@ -75,6 +75,10 @@ CurrencyDisplay.prototype.getValueToRender = function ({ selectedToken, conversi
 CurrencyDisplay.prototype.getConvertedValueToRender = function (nonFormattedValue) {
   const { primaryCurrency, convertedCurrency, conversionRate } = this.props
 
+  if (conversionRate == 0 || conversionRate == null || converstionRate == undefined && nonFormattedValue != 0) {
+    return null
+  }
+
   let convertedValue = conversionUtil(nonFormattedValue, {
     fromNumericBase: 'dec',
     fromCurrency: primaryCurrency,
@@ -83,19 +87,13 @@ CurrencyDisplay.prototype.getConvertedValueToRender = function (nonFormattedValu
     conversionRate,
   })
 
-  if (conversionRate == 0 && nonFormattedValue != 0) {
-    convertedValue = null
-    return convertedValue
-  }
-  else {
-    convertedValue == Number(convertedValue).toFixed(2)
-    const upperCaseCurrencyCode = convertedCurrency.toUpperCase()
-    return currencies.find(currency => currency.code === upperCaseCurrencyCode)
-      ? currencyFormatter.format(Number(convertedValue), {
-        code: upperCaseCurrencyCode,
-      })
+  convertedValue == Number(convertedValue).toFixed(2)
+  const upperCaseCurrencyCode = convertedCurrency.toUpperCase()
+  return currencies.find(currency => currency.code === upperCaseCurrencyCode)
+    ? currencyFormatter.format(Number(convertedValue), {
+      code: upperCaseCurrencyCode,
+    })
       : convertedValue
-    }
   }
 
 CurrencyDisplay.prototype.handleChange = function (newVal) {
@@ -110,6 +108,19 @@ CurrencyDisplay.prototype.getInputWidth = function (valueToRender, readOnly) {
   return (valueLength + decimalPointDeficit + 0.75) + 'ch'
 }
 
+CurrencyDisplay.prototype.onlyRenderConversions = function (convertedValueToRender) {
+  const{
+    convertedBalanceClassName = 'currency-display__converted-value',
+    convertedCurrency,
+  } = this.props
+    
+    return h('div', {
+    className: convertedBalanceClassName,
+    }, convertedValueToRender == null
+      ? 'No Conversion Rate'
+      : `${convertedValueToRender} ${convertedCurrency.toUpperCase()}`
+)
+  }
 
 CurrencyDisplay.prototype.render = function () {
   const {
@@ -126,19 +137,6 @@ CurrencyDisplay.prototype.render = function () {
   const { valueToRender } = this.state
 
   const convertedValueToRender = this.getConvertedValueToRender(valueToRender)
-
-  function onlyRenderConversions() {
-    if (convertedValueToRender == null) {
-      return h('div', {
-        className: convertedBalanceClassName,
-      }, 'No Conversion Rate')
-    }
-    else {
-      return h('div', {
-        className: convertedBalanceClassName,
-      }, `${convertedValueToRender} ${convertedCurrency.toUpperCase()}`)
-    }
-  }
 
   return h('div', {
     className,
@@ -176,7 +174,7 @@ CurrencyDisplay.prototype.render = function () {
 
       ]),
 
-    ]), onlyRenderConversions(),
+    ]), this.onlyRenderConversions(convertedValueToRender),
 
   ])
 

--- a/ui/app/components/send/currency-display/currency-display.js
+++ b/ui/app/components/send/currency-display/currency-display.js
@@ -80,13 +80,13 @@ CurrencyDisplay.prototype.getValueToRender = function ({ selectedToken, conversi
 CurrencyDisplay.prototype.getConvertedValueToRender = function (nonFormattedValue) {
   const { primaryCurrency, convertedCurrency, conversionRate } = this.props
 
-  if (conversionRate == 0 || conversionRate == null || conversionRate == undefined) {
-    if (nonFormattedValue != 0) {
+  if (conversionRate === 0 || conversionRate === null || conversionRate === undefined) {
+    if (nonFormattedValue !== 0) {
       return null
     }
   }
 
-  const convertedValue = conversionUtil(nonFormattedValue, {
+  let convertedValue = conversionUtil(nonFormattedValue, {
     fromNumericBase: 'dec',
     fromCurrency: primaryCurrency,
     toCurrency: convertedCurrency,
@@ -94,7 +94,7 @@ CurrencyDisplay.prototype.getConvertedValueToRender = function (nonFormattedValu
     conversionRate,
   })
 
-  convertedValue == Number(convertedValue).toFixed(2)
+  convertedValue = Number(convertedValue).toFixed(2)
   const upperCaseCurrencyCode = convertedCurrency.toUpperCase()
   return currencies.find(currency => currency.code === upperCaseCurrencyCode)
     ? currencyFormatter.format(Number(convertedValue), {
@@ -132,9 +132,7 @@ CurrencyDisplay.prototype.render = function () {
   const {
     className = 'currency-display',
     primaryBalanceClassName = 'currency-display__input',
-    convertedBalanceClassName = 'currency-display__converted-value',
     primaryCurrency,
-    convertedCurrency,
     readOnly = false,
     inError = false,
     onBlur,

--- a/ui/app/components/send/currency-display/currency-display.js
+++ b/ui/app/components/send/currency-display/currency-display.js
@@ -82,16 +82,21 @@ CurrencyDisplay.prototype.getConvertedValueToRender = function (nonFormattedValu
     numberOfDecimals: 2,
     conversionRate,
   })
-  convertedValue = Number(convertedValue).toFixed(2)
 
-  const upperCaseCurrencyCode = convertedCurrency.toUpperCase()
-
-  return currencies.find(currency => currency.code === upperCaseCurrencyCode)
-    ? currencyFormatter.format(Number(convertedValue), {
-      code: upperCaseCurrencyCode,
-    })
-    : convertedValue
-}
+  if (conversionRate == 0 && nonFormattedValue != 0) {
+    convertedValue = null
+    return convertedValue
+  }
+  else {
+    convertedValue == Number(convertedValue).toFixed(2)
+    const upperCaseCurrencyCode = convertedCurrency.toUpperCase()
+    return currencies.find(currency => currency.code === upperCaseCurrencyCode)
+      ? currencyFormatter.format(Number(convertedValue), {
+        code: upperCaseCurrencyCode,
+      })
+      : convertedValue
+    }
+  }
 
 CurrencyDisplay.prototype.handleChange = function (newVal) {
   this.setState({ valueToRender: removeLeadingZeroes(newVal) })
@@ -104,6 +109,7 @@ CurrencyDisplay.prototype.getInputWidth = function (valueToRender, readOnly) {
   const decimalPointDeficit = valueString.match(/\./) ? -0.5 : 0
   return (valueLength + decimalPointDeficit + 0.75) + 'ch'
 }
+
 
 CurrencyDisplay.prototype.render = function () {
   const {
@@ -120,6 +126,19 @@ CurrencyDisplay.prototype.render = function () {
   const { valueToRender } = this.state
 
   const convertedValueToRender = this.getConvertedValueToRender(valueToRender)
+
+  function onlyRenderConversions() {
+    if (convertedValueToRender == null) {
+      return h('div', {
+        className: convertedBalanceClassName,
+      }, 'No Conversion Rate')
+    }
+    else {
+      return h('div', {
+        className: convertedBalanceClassName,
+      }, `${convertedValueToRender} ${convertedCurrency.toUpperCase()}`)
+    }
+  }
 
   return h('div', {
     className,
@@ -157,11 +176,7 @@ CurrencyDisplay.prototype.render = function () {
 
       ]),
 
-    ]),
-
-    h('div', {
-      className: convertedBalanceClassName,
-    }, `${convertedValueToRender} ${convertedCurrency.toUpperCase()}`),
+    ]), onlyRenderConversions(),
 
   ])
 

--- a/ui/app/components/send/currency-display/currency-display.js
+++ b/ui/app/components/send/currency-display/currency-display.js
@@ -6,6 +6,11 @@ const { removeLeadingZeroes } = require('../send.utils')
 const currencyFormatter = require('currency-formatter')
 const currencies = require('currency-formatter/currencies')
 const ethUtil = require('ethereumjs-util')
+const PropTypes = require('prop-types')
+
+CurrencyDisplay.contextTypes = {
+  t: PropTypes.func,
+}
 
 module.exports = CurrencyDisplay
 
@@ -75,11 +80,13 @@ CurrencyDisplay.prototype.getValueToRender = function ({ selectedToken, conversi
 CurrencyDisplay.prototype.getConvertedValueToRender = function (nonFormattedValue) {
   const { primaryCurrency, convertedCurrency, conversionRate } = this.props
 
-  if (conversionRate == 0 || conversionRate == null || converstionRate == undefined && nonFormattedValue != 0) {
-    return null
+  if (conversionRate == 0 || conversionRate == null || conversionRate == undefined) {
+    if (nonFormattedValue != 0) {
+      return null
+    }
   }
 
-  let convertedValue = conversionUtil(nonFormattedValue, {
+  const convertedValue = conversionUtil(nonFormattedValue, {
     fromNumericBase: 'dec',
     fromCurrency: primaryCurrency,
     toCurrency: convertedCurrency,
@@ -109,15 +116,14 @@ CurrencyDisplay.prototype.getInputWidth = function (valueToRender, readOnly) {
 }
 
 CurrencyDisplay.prototype.onlyRenderConversions = function (convertedValueToRender) {
-  const{
+  const {
     convertedBalanceClassName = 'currency-display__converted-value',
     convertedCurrency,
   } = this.props
-    
     return h('div', {
     className: convertedBalanceClassName,
     }, convertedValueToRender == null
-      ? 'No Conversion Rate'
+      ? this.context.t('noConversionRateAvailable')
       : `${convertedValueToRender} ${convertedCurrency.toUpperCase()}`
 )
   }


### PR DESCRIPTION
Two Possible Screen options: 
1. "No Conversion Rate" is displayed
<img width="349" alt="screen shot 2018-07-11 at 2 46 50 pm" src="https://user-images.githubusercontent.com/30504811/42593889-a0235566-851b-11e8-8d21-6851a811a14f.png">
2. Nothing is displayed but we'd need to adjust the size of the box
<img width="351" alt="screen shot 2018-07-11 at 2 49 00 pm" src="https://user-images.githubusercontent.com/30504811/42593894-a2e74848-851b-11e8-9201-d245f6f0a295.png">

