### PR TITLE
Add harbourair.com to injection block list

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -177,6 +177,7 @@ function blacklistedDomainCheck () {
     'cdn.shopify.com/s/javascripts/tricorder/xtld-read-only-frame.html',
     'adyen.com',
     'gravityforms.com',
+    'harbourair.com',
   ]
   var currentUrl = window.location.href
   var currentRegex


### PR DESCRIPTION
This site was getting unexpected results when MetaMask was installed.

https://consensys.zendesk.com/agent/tickets/2312