### PR TITLE
sentry - add detection for Brave Browser

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -27,7 +27,6 @@ const EdgeEncryptor = require('./edge-encryptor')
 const getFirstPreferredLangCode = require('./lib/get-first-preferred-lang-code')
 const getObjStructure = require('./lib/getObjStructure')
 const ipfsContent = require('./lib/ipfsContent.js')
-const assert = require('assert')
 
 const {
   ENVIRONMENT_TYPE_POPUP,
@@ -47,7 +46,6 @@ global.METAMASK_NOTIFIER = notificationManager
 // setup sentry error reporting
 const releaseVersion = platform.getVersion()
 const raven = setupRaven({ releaseVersion })
-assert.equal('test', 'notest')
 
 // browser check if it is Edge - https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
 // Internet Explorer 6-11

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -27,6 +27,7 @@ const EdgeEncryptor = require('./edge-encryptor')
 const getFirstPreferredLangCode = require('./lib/get-first-preferred-lang-code')
 const getObjStructure = require('./lib/getObjStructure')
 const ipfsContent = require('./lib/ipfsContent.js')
+const assert = require('assert')
 
 const {
   ENVIRONMENT_TYPE_POPUP,
@@ -44,8 +45,9 @@ const notificationManager = new NotificationManager()
 global.METAMASK_NOTIFIER = notificationManager
 
 // setup sentry error reporting
-const release = platform.getVersion()
-const raven = setupRaven({ release })
+const releaseVersion = platform.getVersion()
+const raven = setupRaven({ releaseVersion })
+assert.equal('test', 'notest')
 
 // browser check if it is Edge - https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
 // Internet Explorer 6-11

--- a/app/scripts/lib/setupRaven.js
+++ b/app/scripts/lib/setupRaven.js
@@ -28,7 +28,6 @@ function setupRaven (opts) {
       const report = opts.data
 
       try {
-        console.log('testing opts in transport sentry')
         // handle error-like non-error exceptions
         rewriteErrorLikeExceptions(report)
         // simplify certain complex error messages (e.g. Ethjs)

--- a/app/scripts/lib/setupRaven.js
+++ b/app/scripts/lib/setupRaven.js
@@ -8,8 +8,10 @@ module.exports = setupRaven
 
 // Setup raven / sentry remote error reporting
 function setupRaven (opts) {
-  const { release } = opts
+  const { releaseVersion } = opts
   let ravenTarget
+  // detect brave
+  const isBrave = Boolean(window.chrome.ipcRenderer)
 
   if (METAMASK_DEBUG) {
     console.log('Setting up Sentry Remote Error Reporting: DEV')
@@ -20,10 +22,13 @@ function setupRaven (opts) {
   }
 
   const client = Raven.config(ravenTarget, {
-    release,
+    releaseVersion,
     transport: function (opts) {
+      opts.data.extra.isBrave = isBrave
       const report = opts.data
+
       try {
+        console.log('testing opts in transport sentry')
         // handle error-like non-error exceptions
         rewriteErrorLikeExceptions(report)
         // simplify certain complex error messages (e.g. Ethjs)


### PR DESCRIPTION
- from Brave team: `window.chrome.ipcRenderer` is defined and can be used to identify Brave in background script
- adds flag to Sentry report to help detect chrome vs brave issues