### PR TITLE
Update Chinese naming on our language list

### DIFF
--- a/app/_locales/index.json
+++ b/app/_locales/index.json
@@ -17,6 +17,6 @@
   { "code": "tml", "name": "Tamil" },
   { "code": "tr", "name": "Turkish" },  
   { "code": "vi", "name": "Vietnamese" },
-  { "code": "zh_CN", "name": "Mandarin" },
-  { "code": "zh_TW", "name": "Taiwanese" }
+  { "code": "zh_CN", "name": "Chinese (Simplified)" },
+  { "code": "zh_TW", "name": "Chinese (Traditional)" }
 ]


### PR DESCRIPTION
I sincerely hope this is a non-controversial change. Changes `Mandarin` and `Taiwanese` to their more generalized `Chinese (Simplified)` and `Chinese (Traditional)` counterparts.