### PR TITLE
tx-gas-utils -  catch all errors from gas estimation

### DIFF
--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -30,14 +30,10 @@ class TxGasUtil {
     try {
       estimatedGasHex = await this.estimateTxGas(txMeta, block.gasLimit)
     } catch (err) {
-      const simulationFailed = (
-        err.message.includes('Transaction execution error.') ||
-        err.message.includes('gas required exceeds allowance or always failing transaction')
-      )
-      if (simulationFailed) {
-        txMeta.simulationFails = true
-        return txMeta
+      txMeta.simulationFails = {
+        reason: err.message,
       }
+      return txMeta
     }
     this.setTxGas(txMeta, block.gasLimit, estimatedGasHex)
     return txMeta


### PR DESCRIPTION
estimateGas can fail for reasons other than the two previously captured in "simulationFailed"

This change propagates that there was an error with the transaction to the UI but still allows the user to submit the transaction if they wish.

Fixes https://github.com/MetaMask/metamask-extension/issues/3519, uses txMeta to calculate gas in old-ui/app/components/pending-tx.js

Additional improvements are to pass on the actual errors to the UI. #4870