### PR TITLE
Restore npm install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ If you're a web dapp developer, we've got two types of guides for you:
 ## Building locally
 
  - Install [Node.js](https://nodejs.org/en/) version 8.11.3 and npm version 6.1.0
+   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
+   - Update npm to 6.1.0: ```npm install -g npm@6.1.0```
  - Install dependencies:
-   - If you are using nvm (recommended) running `nvm use` will automatically choose the right node version for you.
+ ```bash
+npm install
+ ```
  - Install gulp globally with `npm install -g gulp-cli`.
  - Build the project to the `./dist/` folder with `gulp build`.
  - Optionally, to rebuild on file changes, run `gulp dev`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you're a web dapp developer, we've got two types of guides for you:
 
  - Install [Node.js](https://nodejs.org/en/) version 8.11.3 and npm version 6.1.0
    - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
-   - Update npm to 6.1.0: ```npm install -g npm@6.1.0```
+   - Select npm 6.1.0: ```npm install -g npm@6.1.0```
  - Install dependencies: ```npm install```
  - Install gulp globally with `npm install -g gulp-cli`.
  - Build the project to the `./dist/` folder with `gulp build`.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ If you're a web dapp developer, we've got two types of guides for you:
  - Install [Node.js](https://nodejs.org/en/) version 8.11.3 and npm version 6.1.0
    - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
    - Update npm to 6.1.0: ```npm install -g npm@6.1.0```
- - Install dependencies:
- ```bash
-npm install
- ```
+ - Install dependencies: ```npm install```
  - Install gulp globally with `npm install -g gulp-cli`.
  - Build the project to the `./dist/` folder with `gulp build`.
  - Optionally, to rebuild on file changes, run `gulp dev`.


### PR DESCRIPTION
#### Changes
This moves the `nvm use` suggestion to immediately after the instruction to install an old node version.
This adds instructions for updating (or downgrading) npm, which aren't managed by by nvm use.
This restores the `npm install` instructions, removed in cde91fac1612aaae96c854e15062ea98fac5e262.

Reviewers @brunobar79 @danfinlay