### PR TITLE
 Adds new gas customization modal container (without content)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -29,11 +29,17 @@
   "addAcquiredTokens": {
     "message": "Add the tokens you've acquired using MetaMask"
   },
+  "advanced": {
+    "message": "Advanced"
+  },
   "amount": {
     "message": "Amount"
   },
   "amountPlusGas": {
     "message": "Amount + Gas"
+  },
+  "amountPlusTxFee": {
+    "message": "Amount + TX Fee"
   },
   "appDescription": {
     "message": "Ethereum Browser Extension",
@@ -69,6 +75,9 @@
   },
   "balanceIsInsufficientGas": {
     "message": "Insufficient balance for current gas total"
+  },
+  "basic": {
+    "message": "Basic"
   },
   "beta": {
     "message": "BETA"
@@ -215,6 +224,9 @@
   },
   "customGas": {
     "message": "Customize Gas"
+  },
+  "customGasSubTitle": {
+    "message": "Increasing fee may decrease processing times, but it is not guaranteed."
   },
   "customToken": {
     "message": "Custom Token"
@@ -629,6 +641,9 @@
   "newRPC": {
     "message": "New RPC URL"
   },
+  "newTotal": {
+    "message": "New Total"
+  },
   "next": {
     "message": "Next"
   },
@@ -668,6 +683,9 @@
   },
   "origin": {
     "message": "Origin"
+  },
+  "originalTotal": {
+    "message": "Original Total"
   },
   "password": {
     "message": "Password"

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -16,24 +16,26 @@ export default class GasModalPageContainer extends Component {
 
   renderBasicTabContent () {
     return (
-      <div className="basic-tab"/>
+      <div className="gas-modal-content__basic-tab"/>
     )
   }
 
   renderAdvancedTabContent () {
     return (
-      <div className="advanced-tab"/>
+      <div className="gas-modal-content__advanced-tab"/>
     )
   }
 
   renderInfoRow (className, totalLabelKey, fiatTotal, cryptoTotal) {
     return (
       <div className={className}>
-        <div className="total-info">
-          <span className="total-label">{`${this.context.t(totalLabelKey)}:`}</span><span className="total-value">{fiatTotal}</span>
+        <div className={`${className}__total-info`}>
+          <span className={`${className}__total-info__total-label`}>{`${this.context.t(totalLabelKey)}:`}</span>
+          <span className={`${className}__total-info__total-value`}>{fiatTotal}</span>
         </div>
-        <div className="sum-info">
-          <span className="sum-label">{`${this.context.t('amountPlusTxFee')}`}</span><span className="sum-value">{cryptoTotal}</span>
+        <div className={`${className}__sum-info`}>
+          <span className={`${className}__sum-info__sum-label`}>{`${this.context.t('amountPlusTxFee')}`}</span>
+          <span className={`${className}__sum-info__sum-value`}>{cryptoTotal}</span>
         </div>
       </div>
     )
@@ -43,8 +45,8 @@ export default class GasModalPageContainer extends Component {
     return (
       <div className="gas-modal-content">
         { mainTabContent() }
-        { this.renderInfoRow('info-row--fade', 'originalTotal', '$20.02 USD', '0.06685 ETH') }
-        { this.renderInfoRow('info-row', 'newTotal', '$20.02 USD', '0.06685 ETH') }
+        { this.renderInfoRow('gas-modal-content__info-row--fade', 'originalTotal', '$20.02 USD', '0.06685 ETH') }
+        { this.renderInfoRow('gas-modal-content__info-row', 'newTotal', '$20.02 USD', '0.06685 ETH') }
       </div>
     )
   }

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -68,7 +68,7 @@ export default class GasModalPageContainer extends Component {
     return (
       <PageContainer
         title={this.context.t('customGas')}
-        subtitle={this.context.t('customGasSpeedUp')}
+        subtitle={this.context.t('customGasSubTitle')}
         tabsComponent={this.renderTabs()}
         disabled={false}
         onCancel={() => hideModal()}

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -1,0 +1,79 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import PageContainer from '../../page-container'
+import { Tabs, Tab } from '../../tabs'
+
+export default class GasModalPageContainer extends Component {
+  static contextTypes = {
+    t: PropTypes.func,
+  }
+
+  static propTypes = {
+    hideModal: PropTypes.func,
+  }
+
+  state = {}
+
+  renderBasicTabContent () {
+    return (
+      <div className="basic-tab"/>
+    )
+  }
+
+  renderAdvancedTabContent () {
+    return (
+      <div className="advanced-tab"/>
+    )
+  }
+
+  renderInfoRow (className, totalLabelKey, fiatTotal, cryptoTotal) {
+    return (
+      <div className={className}>
+        <div className="total-info">
+          <span className="total-label">{`${this.context.t(totalLabelKey)}:`}</span><span className="total-value">{fiatTotal}</span>
+        </div>
+        <div className="sum-info">
+          <span className="sum-label">{`${this.context.t('amountPlusTxFee')}`}</span><span className="sum-value">{cryptoTotal}</span>
+        </div>
+      </div>
+    )
+  }
+
+  renderTabContent (mainTabContent) {
+    return (
+      <div className="gas-modal-content">
+        { mainTabContent() }
+        { this.renderInfoRow('info-row--fade', 'originalTotal', '$20.02 USD', '0.06685 ETH') }
+        { this.renderInfoRow('info-row', 'newTotal', '$20.02 USD', '0.06685 ETH') }
+      </div>
+    )
+  }
+
+  renderTabs () {
+    return (
+      <Tabs>
+        <Tab name={this.context.t('basic')}>
+          { this.renderTabContent(this.renderBasicTabContent) }
+        </Tab>
+        <Tab name={this.context.t('advanced')}>
+          { this.renderTabContent(this.renderAdvancedTabContent) }
+        </Tab>
+      </Tabs>
+    )
+  }
+
+  render () {
+    const { hideModal } = this.props
+
+    return (
+      <PageContainer
+        title={this.context.t('customGas')}
+        subtitle={this.context.t('customGasSpeedUp')}
+        tabsComponent={this.renderTabs()}
+        disabled={false}
+        onCancel={() => hideModal()}
+        onClose={() => hideModal()}
+      />
+    )
+  }
+}

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import GasModalPageContainer from './gas-modal-page-container.component'
+import { hideModal } from '../../../actions'
+
+const mapDispatchToProps = dispatch => {
+  return {
+    hideModal: () => dispatch(hideModal()),
+  }
+}
+
+export default connect(null, mapDispatchToProps)(GasModalPageContainer)

--- a/ui/app/components/gas-customization/gas-modal-page-container/index.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/index.js
@@ -1,0 +1,1 @@
+export { default } from './gas-modal-page-container.container'

--- a/ui/app/components/gas-customization/gas-modal-page-container/index.scss
+++ b/ui/app/components/gas-customization/gas-modal-page-container/index.scss
@@ -1,13 +1,13 @@
 .gas-modal-content {
-  .basic-tab {
+  &__basic-tab {
     height: 219px;
   }
 
-  .advanced-tab {
+  &__advanced-tab {
     height: 475px;
   }
 
-  .info-row, .info-row--fade {
+  &__info-row, &__info-row--fade {
     width: 100%;
     background: $polar;
     padding: 15px 21px;
@@ -15,35 +15,35 @@
     flex-flow: column;
     color: $scorpion;
 
-    .total-info, .sum-info {
+    &__total-info, &__sum-info {
       display: flex;
       flex-flow: row;
       justify-content: space-between;
     }
 
-    .total-info {
-      .total-label {
+    &__total-info {
+      &__total-label {
         font-size: 16px;
       }
 
-      .total-value {
+      &__total-value {
         font-size: 16px;
         font-weight: bold;
       }
     }
 
-    .sum-info {
-      .sum-label {
+    &__sum-info {
+      &__sum-label {
         font-size: 12px;
       }
 
-      .sum-value {
+      &__sum-value {
         font-size: 14px;
       }
     }
   }
 
-  .info-row--fade {
+  &__info-row--fade {
     background: white;
     color: $dusty-gray;
   }

--- a/ui/app/components/gas-customization/gas-modal-page-container/index.scss
+++ b/ui/app/components/gas-customization/gas-modal-page-container/index.scss
@@ -1,0 +1,50 @@
+.gas-modal-content {
+  .basic-tab {
+    height: 219px;
+  }
+
+  .advanced-tab {
+    height: 475px;
+  }
+
+  .info-row, .info-row--fade {
+    width: 100%;
+    background: $polar;
+    padding: 15px 21px;
+    display: flex;
+    flex-flow: column;
+    color: $scorpion;
+
+    .total-info, .sum-info {
+      display: flex;
+      flex-flow: row;
+      justify-content: space-between;
+    }
+
+    .total-info {
+      .total-label {
+        font-size: 16px;
+      }
+
+      .total-value {
+        font-size: 16px;
+        font-weight: bold;
+      }
+    }
+
+    .sum-info {
+      .sum-label {
+        font-size: 12px;
+      }
+
+      .sum-value {
+        font-size: 14px;
+      }
+    }
+  }
+
+  .info-row--fade {
+    background: white;
+    color: $dusty-gray;
+  }
+}

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -36,7 +36,7 @@ describe('GasModalPageContainer Component', function () {
         disabled,
       } = wrapper.find(PageContainer).props()
       assert.equal(title, 'customGas')
-      assert.equal(subtitle, 'customGasSpeedUp')
+      assert.equal(subtitle, 'customGasSubTitle')
       assert.equal(disabled, false)
     })
 
@@ -112,8 +112,8 @@ describe('GasModalPageContainer Component', function () {
 
       const renderTabContentResult = wrapper.instance().renderTabContent(() => <span>Mock content</span>)
       const renderedTabContent = shallow(renderTabContentResult)
-      assert.equal(renderedTabContent.childAt(1).text(), 'info-row--fade,originalTotal,$20.02 USD,0.06685 ETH')
-      assert.equal(renderedTabContent.childAt(2).text(), 'info-row,newTotal,$20.02 USD,0.06685 ETH')
+      assert.equal(renderedTabContent.childAt(1).text(), 'gas-modal-content__info-row--fade,originalTotal,$20.02 USD,0.06685 ETH')
+      assert.equal(renderedTabContent.childAt(2).text(), 'gas-modal-content__info-row,newTotal,$20.02 USD,0.06685 ETH')
 
       GP.renderInfoRow.restore()
     })
@@ -128,8 +128,8 @@ describe('GasModalPageContainer Component', function () {
       const firstChild = renderedInfoRow.childAt(0)
       const secondhild = renderedInfoRow.childAt(1)
 
-      assert.equal(firstChild.props().className, 'total-info')
-      assert.equal(secondhild.props().className, 'sum-info')
+      assert.equal(firstChild.props().className, 'mockClassName__total-info')
+      assert.equal(secondhild.props().className, 'mockClassName__sum-info')
 
       assert.equal(firstChild.childAt(0).text(), 'mockLabelKey:')
       assert.equal(firstChild.childAt(1).text(), 'mockFiatAmount')
@@ -142,7 +142,7 @@ describe('GasModalPageContainer Component', function () {
     it('should render', () => {
       const renderBasicTabContentResult = wrapper.instance().renderBasicTabContent()
       const renderedBasicTabContent = shallow(renderBasicTabContentResult)
-      assert.equal(renderedBasicTabContent.props().className, 'basic-tab')
+      assert.equal(renderedBasicTabContent.props().className, 'gas-modal-content__basic-tab')
     })
   })
 
@@ -150,7 +150,7 @@ describe('GasModalPageContainer Component', function () {
     it('should render', () => {
       const renderAdvancedTabContentResult = wrapper.instance().renderAdvancedTabContent()
       const renderedAdvancedTabContent = shallow(renderAdvancedTabContentResult)
-      assert.equal(renderedAdvancedTabContent.props().className, 'advanced-tab')
+      assert.equal(renderedAdvancedTabContent.props().className, 'gas-modal-content__advanced-tab')
     })
   })
 })

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -1,0 +1,156 @@
+import React from 'react'
+import assert from 'assert'
+import { shallow } from 'enzyme'
+import sinon from 'sinon'
+import GasModalPageContainer from '../gas-modal-page-container.component.js'
+
+import PageContainer from '../../../page-container'
+import { Tab } from '../../../tabs'
+
+const propsMethodSpies = {
+  hideModal: sinon.spy(),
+}
+
+describe('GasModalPageContainer Component', function () {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallow(<GasModalPageContainer
+      hideModal={propsMethodSpies.hideModal}
+    />, { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } })
+  })
+
+  afterEach(() => {
+    propsMethodSpies.hideModal.resetHistory()
+  })
+
+  describe('render', () => {
+    it('should render a PageContainer compenent', () => {
+      assert.equal(wrapper.find(PageContainer).length, 1)
+    })
+
+    it('should pass correct props to PageContainer', () => {
+      const {
+        title,
+        subtitle,
+        disabled,
+      } = wrapper.find(PageContainer).props()
+      assert.equal(title, 'customGas')
+      assert.equal(subtitle, 'customGasSpeedUp')
+      assert.equal(disabled, false)
+    })
+
+    it('should pass the correct onCancel and onClose methods to PageContainer', () => {
+      const {
+        onCancel,
+        onClose,
+      } = wrapper.find(PageContainer).props()
+      assert.equal(propsMethodSpies.hideModal.callCount, 0)
+      onCancel()
+      assert.equal(propsMethodSpies.hideModal.callCount, 1)
+      onClose()
+      assert.equal(propsMethodSpies.hideModal.callCount, 2)
+    })
+
+    it('should pass the correct renderTabs property to PageContainer', () => {
+      sinon.stub(GasModalPageContainer.prototype, 'renderTabs').returns('mockTabs')
+      const renderTabsWrapperTester = shallow(<GasModalPageContainer />, { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } })
+      const { tabsComponent } = renderTabsWrapperTester.find(PageContainer).props()
+      assert.equal(tabsComponent, 'mockTabs')
+      GasModalPageContainer.prototype.renderTabs.restore()
+    })
+  })
+
+  describe('renderTabs', () => {
+    it('should render a Tabs component with "Basic" and "Advanced" tabs', () => {
+      const renderTabsResult = wrapper.instance().renderTabs()
+      const renderedTabs = shallow(renderTabsResult)
+      assert.equal(renderedTabs.props().className, 'tabs')
+
+      const tabs = renderedTabs.find(Tab)
+      assert.equal(tabs.length, 2)
+
+      assert.equal(tabs.at(0).props().name, 'basic')
+      assert.equal(tabs.at(1).props().name, 'advanced')
+
+      assert.equal(tabs.at(0).childAt(0).props().className, 'gas-modal-content')
+      assert.equal(tabs.at(1).childAt(0).props().className, 'gas-modal-content')
+    })
+
+    it('should render the expected children of each tab', () => {
+      const GP = GasModalPageContainer.prototype
+      sinon.spy(GP, 'renderTabContent')
+      assert.equal(GP.renderTabContent.callCount, 0)
+
+      wrapper.instance().renderTabs()
+
+      assert.equal(GP.renderTabContent.callCount, 2)
+
+      assert.deepEqual(GP.renderTabContent.firstCall.args, [wrapper.instance().renderBasicTabContent])
+      assert.deepEqual(GP.renderTabContent.secondCall.args, [wrapper.instance().renderAdvancedTabContent])
+
+      GP.renderTabContent.restore()
+    })
+  })
+
+  describe('renderTabContent', () => {
+    it('should render a root gas-modal-content div', () => {
+      const renderTabContentResult = wrapper.instance().renderTabContent(() => {})
+      const renderedTabContent = shallow(renderTabContentResult)
+      assert.equal(renderedTabContent.props().className, 'gas-modal-content')
+    })
+
+    it('should render the element returned by the passed func as its first child', () => {
+      const renderTabContentResult = wrapper.instance().renderTabContent(() => <span>Mock content</span>)
+      const renderedTabContent = shallow(renderTabContentResult)
+      assert(renderedTabContent.childAt(0).equals(<span>Mock content</span>))
+    })
+
+    it('should render the element results of renderInfoRow calls as second and third childs', () => {
+      const GP = GasModalPageContainer.prototype
+      sinon.stub(GP, 'renderInfoRow').callsFake((...args) => args.join(','))
+
+      const renderTabContentResult = wrapper.instance().renderTabContent(() => <span>Mock content</span>)
+      const renderedTabContent = shallow(renderTabContentResult)
+      assert.equal(renderedTabContent.childAt(1).text(), 'info-row--fade,originalTotal,$20.02 USD,0.06685 ETH')
+      assert.equal(renderedTabContent.childAt(2).text(), 'info-row,newTotal,$20.02 USD,0.06685 ETH')
+
+      GP.renderInfoRow.restore()
+    })
+  })
+
+  describe('renderInfoRow', () => {
+    it('should render a div with the passed className and two children, each with the expected text', () => {
+      const renderInfoRowResult = wrapper.instance().renderInfoRow('mockClassName', 'mockLabelKey', 'mockFiatAmount', 'mockCryptoAmount')
+      const renderedInfoRow = shallow(renderInfoRowResult)
+      assert.equal(renderedInfoRow.props().className, 'mockClassName')
+
+      const firstChild = renderedInfoRow.childAt(0)
+      const secondhild = renderedInfoRow.childAt(1)
+
+      assert.equal(firstChild.props().className, 'total-info')
+      assert.equal(secondhild.props().className, 'sum-info')
+
+      assert.equal(firstChild.childAt(0).text(), 'mockLabelKey:')
+      assert.equal(firstChild.childAt(1).text(), 'mockFiatAmount')
+      assert.equal(secondhild.childAt(0).text(), 'amountPlusTxFee')
+      assert.equal(secondhild.childAt(1).text(), 'mockCryptoAmount')
+    })
+  })
+
+  describe('renderBasicTabContent', () => {
+    it('should render', () => {
+      const renderBasicTabContentResult = wrapper.instance().renderBasicTabContent()
+      const renderedBasicTabContent = shallow(renderBasicTabContentResult)
+      assert.equal(renderedBasicTabContent.props().className, 'basic-tab')
+    })
+  })
+
+  describe('renderAdvancedTabContent', () => {
+    it('should render', () => {
+      const renderAdvancedTabContentResult = wrapper.instance().renderAdvancedTabContent()
+      const renderedAdvancedTabContent = shallow(renderAdvancedTabContentResult)
+      assert.equal(renderedAdvancedTabContent.props().className, 'advanced-tab')
+    })
+  })
+})

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -1,0 +1,44 @@
+import assert from 'assert'
+import proxyquire from 'proxyquire'
+import sinon from 'sinon'
+
+// let mapStateToProps
+let mapDispatchToProps
+
+const actionSpies = {
+  hideModal: sinon.spy(),
+}
+
+proxyquire('../gas-modal-page-container.container.js', {
+  'react-redux': {
+    connect: (ms, md) => {
+      // mapStateToProps = ms
+      mapDispatchToProps = md
+      return () => ({})
+    },
+  },
+  '../../../actions': actionSpies,
+})
+
+describe('gas-modal-page-container container', () => {
+
+  describe('mapDispatchToProps()', () => {
+    let dispatchSpy
+    let mapDispatchToPropsObject
+
+    beforeEach(() => {
+      dispatchSpy = sinon.spy()
+      mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
+    })
+
+    describe('hideModal()', () => {
+      it('should dispatch a hideModal action', () => {
+        mapDispatchToPropsObject.hideModal()
+        assert(dispatchSpy.calledOnce)
+        assert(actionSpies.hideModal.calledOnce)
+      })
+    })
+
+  })
+
+})

--- a/ui/app/components/index.scss
+++ b/ui/app/components/index.scss
@@ -19,3 +19,5 @@
 @import './sender-to-recipient/index';
 
 @import './tabs/index';
+
+@import './gas-customization/gas-modal-page-container/index'

--- a/ui/app/components/modals/modal.js
+++ b/ui/app/components/modals/modal.js
@@ -17,7 +17,6 @@ const ExportPrivateKeyModal = require('./export-private-key-modal')
 const NewAccountModal = require('./new-account-modal')
 const ShapeshiftDepositTxModal = require('./shapeshift-deposit-tx-modal.js')
 const HideTokenConfirmationModal = require('./hide-token-confirmation-modal')
-const CustomizeGasModal = require('../customize-gas-modal')
 const NotifcationModal = require('./notification-modal')
 const ConfirmResetAccount = require('./confirm-reset-account')
 const ConfirmRemoveAccount = require('./confirm-remove-account')
@@ -25,7 +24,7 @@ const TransactionConfirmed = require('./transaction-confirmed')
 const WelcomeBeta = require('./welcome-beta')
 const Notification = require('./notification')
 
-import ConfirmCustomizeGasModal from './customize-gas'
+import ConfirmCustomizeGasModal from '../gas-customization/gas-modal-page-container'
 
 const modalContainerBaseStyle = {
   transform: 'translate3d(-50%, 0, 0px)',
@@ -283,30 +282,6 @@ const MODALS = {
 
   CUSTOMIZE_GAS: {
     contents: [
-      h(CustomizeGasModal),
-    ],
-    mobileModalStyle: {
-      width: '100vw',
-      height: '100vh',
-      top: '0',
-      transform: 'none',
-      left: '0',
-      right: '0',
-      margin: '0 auto',
-    },
-    laptopModalStyle: {
-      width: '720px',
-      height: '377px',
-      top: '80px',
-      transform: 'none',
-      left: '0',
-      right: '0',
-      margin: '0 auto',
-    },
-  },
-
-  CONFIRM_CUSTOMIZE_GAS: {
-    contents: [
       h(ConfirmCustomizeGasModal),
     ],
     mobileModalStyle: {
@@ -319,13 +294,16 @@ const MODALS = {
       margin: '0 auto',
     },
     laptopModalStyle: {
-      width: '720px',
-      height: '377px',
+      width: 'auto',
+      height: '0px',
       top: '80px',
+      left: '0px',
       transform: 'none',
-      left: '0',
-      right: '0',
       margin: '0 auto',
+      position: 'relative',
+    },
+    contentStyle: {
+      borderRadius: '8px',
     },
   },
 

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -99,7 +99,7 @@ const mapDispatchToProps = dispatch => {
       return dispatch(showModal({ name: 'TRANSACTION_CONFIRMED', onHide }))
     },
     showCustomizeGasModal: ({ txData, onSubmit, validate }) => {
-      return dispatch(showModal({ name: 'CONFIRM_CUSTOMIZE_GAS', txData, onSubmit, validate }))
+      return dispatch(showModal({ name: 'CUSTOMIZE_GAS', txData, onSubmit, validate }))
     },
     updateGasAndCalculate: ({ gasLimit, gasPrice }) => {
       return dispatch(updateGasAndCalculate({ gasLimit, gasPrice }))

--- a/ui/app/css/itcss/settings/variables.scss
+++ b/ui/app/css/itcss/settings/variables.scss
@@ -56,6 +56,7 @@ $zumthor: #edf7ff;
 $ecstasy: #f7861c;
 $linen: #fdf4f4;
 $oslo-gray: #8C8E94;
+$polar: #fafcfe;
 
 /*
   Z-Indicies


### PR DESCRIPTION
Fixes MetaMask/metamask-ui#4

This PR is compared against https://github.com/MetaMask/metamask-extension/tree/new-gas-customize-feature-branch. That branch, for now, has commits from https://github.com/MetaMask/metamask-extension/pull/4830. Those commits will be removed once that PR is merged to master.

![screencast from 07-31-2018 12_02_35 am](https://user-images.githubusercontent.com/7499938/43434325-bfe5c71e-9455-11e8-806a-aec53471df90.gif)

