### PR TITLE
Show the retry button on latest tx of earliest nonce.

### DIFF
--- a/old-ui/app/components/transaction-list-item.js
+++ b/old-ui/app/components/transaction-list-item.js
@@ -36,7 +36,7 @@ TransactionListItem.prototype.showRetryButton = function () {
     return false
   }
 
-  let currentTxIsLatest = false
+  let currentTxSharesEarliestNonce = false
   const currentNonce = txParams.nonce
   const currentNonceTxs = transactions.filter(tx => tx.txParams.nonce === currentNonce)
   const currentNonceSubmittedTxs = currentNonceTxs.filter(tx => tx.status === 'submitted')
@@ -45,14 +45,14 @@ TransactionListItem.prototype.showRetryButton = function () {
   const currentTxIsLatestWithNonce = lastSubmittedTxWithCurrentNonce &&
     lastSubmittedTxWithCurrentNonce.id === transaction.id
   if (currentSubmittedTxs.length > 0) {
-    const lastTx = currentSubmittedTxs.reduce((tx1, tx2) => {
+    const earliestSubmitted = currentSubmittedTxs.reduce((tx1, tx2) => {
       if (tx1.submittedTime < tx2.submittedTime) return tx1
       return tx2
     })
-    currentTxIsLatest = lastTx.id === transaction.id
+    currentTxSharesEarliestNonce = currentNonce === earliestSubmitted.txParams.nonce
   }
 
-  return currentTxIsLatestWithNonce && Date.now() - submittedTime > 30000 && currentTxIsLatest
+  return currentTxSharesEarliestNonce && currentTxIsLatestWithNonce && Date.now() - submittedTime > 30000
 }
 
 TransactionListItem.prototype.render = function () {

--- a/ui/app/components/tx-list-item.js
+++ b/ui/app/components/tx-list-item.js
@@ -213,7 +213,7 @@ TxListItem.prototype.showRetryButton = function () {
   if (!txParams) {
     return false
   }
-  let currentTxIsLatest = false
+  let currentTxSharesEarliestNonce = false
   const currentNonce = txParams.nonce
   const currentNonceTxs = selectedAddressTxList.filter(tx => tx.txParams.nonce === currentNonce)
   const currentNonceSubmittedTxs = currentNonceTxs.filter(tx => tx.status === 'submitted')
@@ -222,14 +222,14 @@ TxListItem.prototype.showRetryButton = function () {
   const currentTxIsLatestWithNonce = lastSubmittedTxWithCurrentNonce &&
     lastSubmittedTxWithCurrentNonce.id === transactionId
   if (currentSubmittedTxs.length > 0) {
-    const lastTx = currentSubmittedTxs.reduce((tx1, tx2) => {
+    const earliestSubmitted = currentSubmittedTxs.reduce((tx1, tx2) => {
       if (tx1.submittedTime < tx2.submittedTime) return tx1
       return tx2
     })
-    currentTxIsLatest = lastTx.id === transactionId
+    currentTxSharesEarliestNonce = currentNonce === earliestSubmitted.txParams.nonce
   }
 
-  return currentTxIsLatestWithNonce && Date.now() - transactionSubmittedTime > 30000 && currentTxIsLatest
+  return currentTxSharesEarliestNonce && currentTxIsLatestWithNonce && Date.now() - transactionSubmittedTime > 30000
 }
 
 TxListItem.prototype.setSelectedToken = function (tokenAddress) {


### PR DESCRIPTION
Fixes a minor issue with the logic for when retry buttons should be displayed on transactions.

The retry button is now only ever shown on the latest submitted transaction that shares a nonce with the earliest submitted transaction.

For example:
- I creates Tx 1A, then creates Tx 2A.
- both take too long, so the retry button will appear on Tx 1A
- I retry Tx 2A first and create Tx 2B. The retry button will still only appear on Tx 1A
- I now retry Tx 1A to create Tx 1B. Once Tx 1B takes too long, the retry button will appear on Tx 1B.

![peek 2018-07-31 16-59](https://user-images.githubusercontent.com/7499938/43482725-0a200e46-94e4-11e8-9cb9-f6c881161ffa.gif)
