### PR TITLE
Update e2e test packages 📦

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1986,14 +1986,6 @@
                 }
             }
         },
-        "ansi-align": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-            "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-            "requires": {
-                "string-width": "^1.0.1"
-            }
-        },
         "ansi-colors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.0.1.tgz",
@@ -2317,11 +2309,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-        },
-        "as-array": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/as-array/-/as-array-2.0.0.tgz",
-            "integrity": "sha1-TwSAXYf4/OjlEbwhCPjl46KH1Uc="
         },
         "asap": {
             "version": "2.0.6",
@@ -3970,19 +3957,6 @@
             "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
             "dev": true
         },
-        "basic-auth": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-            "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
-        "basic-auth-connect": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-            "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
-        },
         "bcrypt-pbkdf": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -4250,29 +4224,6 @@
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.3.tgz",
             "integrity": "sha512-/gp96UlcFw5DbV2KQPCqTqi0Mb9gZRyDAHiDsGEH+4B/KOQjeoE5lM1PxlVX8DQDvfEfitmC1rW2Oy8fk/XBDg==",
             "dev": true
-        },
-        "boxen": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-            "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
-            "requires": {
-                "ansi-align": "^1.1.0",
-                "camelcase": "^2.1.0",
-                "chalk": "^1.1.1",
-                "cli-boxes": "^1.0.0",
-                "filled-array": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "repeating": "^2.0.0",
-                "string-width": "^1.0.1",
-                "widest-line": "^1.0.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-                }
-            }
         },
         "brace-expansion": {
             "version": "1.1.8",
@@ -5010,7 +4961,8 @@
         "capture-stack-trace": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-            "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+            "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+            "dev": true
         },
         "case-sensitive-paths-webpack-plugin": {
             "version": "2.1.2",
@@ -5083,11 +5035,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
             "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-        },
-        "char-spinner": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
-            "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE="
         },
         "character-entities": {
             "version": "1.2.1",
@@ -5311,11 +5258,6 @@
                 "exit": "0.1.2",
                 "glob": "^7.1.1"
             }
-        },
-        "cli-boxes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
         "cli-cursor": {
             "version": "2.1.0",
@@ -5810,14 +5752,6 @@
                 }
             }
         },
-        "compare-semver": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/compare-semver/-/compare-semver-1.1.0.tgz",
-            "integrity": "sha1-fAp5onu4C2xplERfgpWCWdPQIVM=",
-            "requires": {
-                "semver": "^5.0.1"
-            }
-        },
         "component-bind": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -5839,6 +5773,7 @@
             "version": "2.0.12",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
             "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+            "dev": true,
             "requires": {
                 "mime-db": ">= 1.30.0 < 2"
             }
@@ -5847,6 +5782,7 @@
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
             "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+            "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
                 "bytes": "3.0.0",
@@ -5882,46 +5818,16 @@
                 "proto-list": "~1.2.1"
             }
         },
-        "configstore": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-            "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-            "requires": {
-                "dot-prop": "^3.0.0",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.1",
-                "os-tmpdir": "^1.0.0",
-                "osenv": "^0.1.0",
-                "uuid": "^2.0.1",
-                "write-file-atomic": "^1.1.2",
-                "xdg-basedir": "^2.0.0"
-            }
-        },
         "connect": {
             "version": "3.6.6",
             "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
             "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+            "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.1.0",
                 "parseurl": "~1.3.2",
                 "utils-merge": "1.0.1"
-            }
-        },
-        "connect-query": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/connect-query/-/connect-query-1.0.0.tgz",
-            "integrity": "sha1-3kT1dyCdokBNH8BGktGkEY5YIRk=",
-            "requires": {
-                "qs": "~6.4.0"
-            },
-            "dependencies": {
-                "qs": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-                }
             }
         },
         "console-browserify": {
@@ -6085,6 +5991,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "dev": true,
             "requires": {
                 "capture-stack-trace": "^1.0.0"
             }
@@ -7475,14 +7382,6 @@
             "resolved": "https://registry.npmjs.org/dot-only-hunter/-/dot-only-hunter-1.0.3.tgz",
             "integrity": "sha1-9k0h7b5v8xFJlfEGGmGpNcMAIEs=",
             "dev": true
-        },
-        "dot-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-            "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-            "requires": {
-                "is-obj": "^1.0.0"
-            }
         },
         "dotenv": {
             "version": "5.0.1",
@@ -10399,14 +10298,6 @@
             "integrity": "sha512-h2avnhux4p3tXTA9xR7ntnQSFQdY4hAkyNj8wDXlVT2Die38JxVCInnrieuktdxzRevRWa3dBjN+SbQe1os0GQ==",
             "dev": true
         },
-        "fast-url-parser": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-            "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
-            "requires": {
-                "punycode": "^1.3.2"
-            }
-        },
         "fastparse": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
@@ -10579,11 +10470,6 @@
                 "repeat-element": "^1.1.2",
                 "repeat-string": "^1.5.2"
             }
-        },
-        "filled-array": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
-            "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
         },
         "finalhandler": {
             "version": "1.1.0",
@@ -10998,49 +10884,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/flat/-/flat-1.0.0.tgz",
             "integrity": "sha1-Ad/dW8vBScZrNe1AHh11PxqtjVk="
-        },
-        "flat-arguments": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/flat-arguments/-/flat-arguments-1.0.2.tgz",
-            "integrity": "sha1-m6p4Ct8FAfKC1ybJxqA426ROp28=",
-            "requires": {
-                "array-flatten": "^1.0.0",
-                "as-array": "^1.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isobject": "^3.0.0"
-            },
-            "dependencies": {
-                "as-array": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/as-array/-/as-array-1.0.0.tgz",
-                    "integrity": "sha1-KKbu6qVynx9OyiBH316d4avaDtE=",
-                    "requires": {
-                        "lodash.isarguments": "2.4.x",
-                        "lodash.isobject": "^2.4.1",
-                        "lodash.values": "^2.4.1"
-                    },
-                    "dependencies": {
-                        "lodash.isarguments": {
-                            "version": "2.4.1",
-                            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-2.4.1.tgz",
-                            "integrity": "sha1-STGpwIJTrfCRrnyhkiWKlzh27Mo="
-                        },
-                        "lodash.isobject": {
-                            "version": "2.4.1",
-                            "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                            "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-                            "requires": {
-                                "lodash._objecttypes": "~2.4.1"
-                            }
-                        }
-                    }
-                },
-                "lodash.isobject": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-                    "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
-                }
-            }
         },
         "flat-cache": {
             "version": "1.3.0",
@@ -12752,21 +12595,6 @@
                 "is-glob": "^2.0.0"
             }
         },
-        "glob-slash": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/glob-slash/-/glob-slash-1.0.0.tgz",
-            "integrity": "sha1-/lLvpDMjP3Si/mTHq7m8hIICq5U="
-        },
-        "glob-slasher": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glob-slasher/-/glob-slasher-1.0.1.tgz",
-            "integrity": "sha1-dHoOW7IiZC7hDT4FRD4QlJPLD44=",
-            "requires": {
-                "glob-slash": "^1.0.0",
-                "lodash.isobject": "^2.4.1",
-                "toxic": "^1.0.0"
-            }
-        },
         "glob-stream": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
@@ -12912,56 +12740,6 @@
             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
             "requires": {
                 "sparkles": "^1.0.0"
-            }
-        },
-        "got": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-            "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-            "requires": {
-                "create-error-class": "^3.0.1",
-                "duplexer2": "^0.1.4",
-                "is-redirect": "^1.0.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "lowercase-keys": "^1.0.0",
-                "node-status-codes": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "parse-json": "^2.1.0",
-                "pinkie-promise": "^2.0.0",
-                "read-all-stream": "^3.0.0",
-                "readable-stream": "^2.0.5",
-                "timed-out": "^3.0.0",
-                "unzip-response": "^1.0.2",
-                "url-parse-lax": "^1.0.0"
-            },
-            "dependencies": {
-                "duplexer2": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-                    "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-                    "requires": {
-                        "readable-stream": "^2.0.2"
-                    }
-                },
-                "prepend-http": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-                },
-                "timed-out": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-                    "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
-                },
-                "url-parse-lax": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-                    "requires": {
-                        "prepend-http": "^1.0.1"
-                    }
-                }
             }
         },
         "graceful-fs": {
@@ -14625,11 +14403,6 @@
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
             "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
         },
-        "home-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/home-dir/-/home-dir-1.0.0.tgz",
-            "integrity": "sha1-KRfrRL3JByztqUJXlUOEfjAX/k4="
-        },
         "home-or-tmp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -15888,11 +15661,6 @@
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
             "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
         },
-        "is-npm": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-        },
         "is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -15999,7 +15767,8 @@
         "is-redirect": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+            "dev": true
         },
         "is-regex": {
             "version": "1.0.4",
@@ -16030,7 +15799,8 @@
         "is-retry-allowed": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "dev": true
         },
         "is-root": {
             "version": "1.0.0",
@@ -16104,11 +15874,6 @@
             "requires": {
                 "unc-path-regex": "^0.1.2"
             }
-        },
-        "is-url": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
         },
         "is-utf8": {
             "version": "0.2.1",
@@ -16327,16 +16092,6 @@
                 "color": "^0.11.1",
                 "mersenne-twister": "^1.0.1",
                 "raphael": "^2.2.0"
-            }
-        },
-        "join-path": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/join-path/-/join-path-1.1.1.tgz",
-            "integrity": "sha1-EFNaEm0ky9Zff/zfFe8uYxB2tQU=",
-            "requires": {
-                "as-array": "^2.0.0",
-                "url-join": "0.0.1",
-                "valid-url": "^1"
             }
         },
         "js-base64": {
@@ -17716,19 +17471,6 @@
                 "es6-weak-map": "^2.0.1"
             }
         },
-        "latest-version": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-            "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-            "requires": {
-                "package-json": "^2.0.0"
-            }
-        },
-        "lazy-req": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-            "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
-        },
         "lazystream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -18394,16 +18136,6 @@
             "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
             "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
         },
-        "lodash._isnative": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-            "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
-        },
-        "lodash._objecttypes": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-            "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
-        },
         "lodash._reescape": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
@@ -18423,14 +18155,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
             "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-        },
-        "lodash._shimkeys": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-            "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-            "requires": {
-                "lodash._objecttypes": "~2.4.1"
-            }
         },
         "lodash.assign": {
             "version": "4.2.0",
@@ -18520,14 +18244,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.isobject": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-            "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-            "requires": {
-                "lodash._objecttypes": "~2.4.1"
-            }
         },
         "lodash.isplainobject": {
             "version": "4.0.6",
@@ -18629,26 +18345,6 @@
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
             "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
-        },
-        "lodash.values": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-            "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-            "requires": {
-                "lodash.keys": "~2.4.1"
-            },
-            "dependencies": {
-                "lodash.keys": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-                    "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-                    "requires": {
-                        "lodash._isnative": "~2.4.1",
-                        "lodash._shimkeys": "~2.4.1",
-                        "lodash.isobject": "~2.4.1"
-                    }
-                }
-            }
         },
         "log-driver": {
             "version": "1.2.5",
@@ -18948,7 +18644,8 @@
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+            "dev": true
         },
         "lru-cache": {
             "version": "4.1.1",
@@ -20163,18 +19860,6 @@
             "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
             "dev": true
         },
-        "morgan": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
-            "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
-            "requires": {
-                "basic-auth": "~2.0.0",
-                "debug": "2.6.9",
-                "depd": "~1.1.1",
-                "on-finished": "~2.3.0",
-                "on-headers": "~1.0.1"
-            }
-        },
         "mout": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
@@ -20374,29 +20059,6 @@
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
                     "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                }
-            }
-        },
-        "nash": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/nash/-/nash-2.0.4.tgz",
-            "integrity": "sha1-y5ZHkc79N21Zz6zYAQknRhaqFdI=",
-            "requires": {
-                "async": "^1.3.0",
-                "flat-arguments": "^1.0.0",
-                "lodash": "^3.10.0",
-                "minimist": "^1.1.0"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-                },
-                "lodash": {
-                    "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                 }
             }
         },
@@ -20713,7 +20375,8 @@
         "node-status-codes": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-            "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+            "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+            "dev": true
         },
         "node-uuid": {
             "version": "1.4.8",
@@ -22591,7 +22254,8 @@
         "on-headers": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+            "dev": true
         },
         "once": {
             "version": "1.4.0",
@@ -22899,17 +22563,6 @@
                 "ip": "^1.1.5",
                 "netmask": "^1.0.6",
                 "thunkify": "^2.1.2"
-            }
-        },
-        "package-json": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
-            "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-            "requires": {
-                "got": "^5.0.0",
-                "registry-auth-token": "^3.0.1",
-                "registry-url": "^3.0.3",
-                "semver": "^5.1.0"
             }
         },
         "pako": {
@@ -25665,6 +25318,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "optional": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -25675,7 +25329,8 @@
                 "deep-extend": {
                     "version": "0.6.0",
                     "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-                    "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+                    "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                    "optional": true
                 }
             }
         },
@@ -26248,6 +25903,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
             "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+            "dev": true,
             "requires": {
                 "pinkie-promise": "^2.0.0",
                 "readable-stream": "^2.0.0"
@@ -26578,23 +26234,6 @@
                 "regenerate": "^1.2.1",
                 "regjsgen": "^0.2.0",
                 "regjsparser": "^0.1.4"
-            }
-        },
-        "registry-auth-token": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-            "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-            "requires": {
-                "rc": "^1.1.6",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "registry-url": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-            "requires": {
-                "rc": "^1.0.1"
             }
         },
         "regjsgen": {
@@ -27125,27 +26764,6 @@
             "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
             "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
         },
-        "router": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/router/-/router-1.3.2.tgz",
-            "integrity": "sha1-v6oWiIpSg9XuQNmZ2nqfoVKWpgw=",
-            "requires": {
-                "array-flatten": "2.1.1",
-                "debug": "2.6.9",
-                "methods": "~1.1.2",
-                "parseurl": "~1.3.2",
-                "path-to-regexp": "0.1.7",
-                "setprototypeof": "1.1.0",
-                "utils-merge": "1.0.1"
-            },
-            "dependencies": {
-                "array-flatten": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-                    "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
-                }
-            }
-        },
         "rst-selector-parser": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -27155,11 +26773,6 @@
                 "lodash.flattendeep": "^4.4.0",
                 "nearley": "^2.7.10"
             }
-        },
-        "rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         },
         "run-async": {
             "version": "2.3.0",
@@ -27552,14 +27165,6 @@
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
             "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "semver-diff": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-            "requires": {
-                "semver": "^5.0.3"
-            }
         },
         "semver-greatest-satisfied-range": {
             "version": "1.1.0",
@@ -28010,7 +27615,8 @@
         "slide": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+            "dev": true
         },
         "smart-buffer": {
             "version": "1.1.15",
@@ -28857,6 +28463,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
             "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+            "dev": true,
             "requires": {
                 "strip-ansi": "^3.0.0"
             }
@@ -29558,63 +29165,6 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "superstatic": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-5.0.2.tgz",
-            "integrity": "sha1-186TKe4w2qp2KwHUO1SNC3MGulQ=",
-            "requires": {
-                "as-array": "^2.0.0",
-                "async": "^1.5.2",
-                "basic-auth-connect": "^1.0.0",
-                "chalk": "^1.1.3",
-                "char-spinner": "^1.0.1",
-                "compare-semver": "^1.0.0",
-                "compression": "^1.7.0",
-                "connect": "^3.6.2",
-                "connect-query": "^1.0.0",
-                "destroy": "^1.0.4",
-                "fast-url-parser": "^1.1.3",
-                "fs-extra": "^0.30.0",
-                "glob": "^7.1.2",
-                "glob-slasher": "^1.0.1",
-                "home-dir": "^1.0.0",
-                "is-url": "^1.2.2",
-                "join-path": "^1.1.1",
-                "lodash": "^4.17.4",
-                "mime-types": "^2.1.16",
-                "minimatch": "^3.0.4",
-                "morgan": "^1.8.2",
-                "nash": "^2.0.4",
-                "on-finished": "^2.2.0",
-                "on-headers": "^1.0.0",
-                "path-to-regexp": "^1.7.0",
-                "router": "^1.3.1",
-                "rsvp": "^3.6.2",
-                "string-length": "^1.0.0",
-                "try-require": "^1.0.0",
-                "update-notifier": "^1.0.3"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "path-to-regexp": {
-                    "version": "1.7.0",
-                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-                    "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-                    "requires": {
-                        "isarray": "0.0.1"
                     }
                 }
             }
@@ -30481,14 +30031,6 @@
                 "punycode": "^1.4.1"
             }
         },
-        "toxic": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toxic/-/toxic-1.0.1.tgz",
-            "integrity": "sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==",
-            "requires": {
-                "lodash": "^4.17.10"
-            }
-        },
         "tr46": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
@@ -30621,11 +30163,6 @@
                     }
                 }
             }
-        },
-        "try-require": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/try-require/-/try-require-1.2.1.tgz",
-            "integrity": "sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I="
         },
         "tslib": {
             "version": "1.9.2",
@@ -31144,28 +30681,14 @@
         "unzip-response": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-            "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+            "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+            "dev": true
         },
         "upath": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
             "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
             "dev": true
-        },
-        "update-notifier": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
-            "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-            "requires": {
-                "boxen": "^0.6.0",
-                "chalk": "^1.0.0",
-                "configstore": "^2.0.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^2.0.0",
-                "lazy-req": "^1.1.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^2.0.0"
-            }
         },
         "upper-case": {
             "version": "1.1.3",
@@ -31208,11 +30731,6 @@
                     "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
                 }
             }
-        },
-        "url-join": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-            "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
         },
         "url-loader": {
             "version": "0.6.2",
@@ -33309,14 +32827,6 @@
                 "string-width": "^1.0.2"
             }
         },
-        "widest-line": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-            "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-            "requires": {
-                "string-width": "^1.0.1"
-            }
-        },
         "window-size": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -33442,6 +32952,7 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
             "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "imurmurhash": "^0.1.4",
@@ -33474,14 +32985,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
             "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
-        },
-        "xdg-basedir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-            "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-            "requires": {
-                "os-homedir": "^1.0.0"
-            }
         },
         "xhr": {
             "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8397,13 +8397,12 @@
                     "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
                     "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
                     "requires": {
-                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                         "ethereumjs-util": "^5.1.1"
                     },
                     "dependencies": {
                         "ethereumjs-abi": {
                             "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                             "requires": {
                                 "bn.js": "^4.10.0",
                                 "ethereumjs-util": "^5.0.0"
@@ -8728,14 +8727,12 @@
                     "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
                     "dev": true,
                     "requires": {
-                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                         "ethereumjs-util": "^5.1.1"
                     },
                     "dependencies": {
                         "ethereumjs-abi": {
                             "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                            "dev": true,
+                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                             "requires": {
                                 "bn.js": "^4.10.0",
                                 "ethereumjs-util": "^5.0.0"
@@ -8747,7 +8744,6 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
                     "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-                    "dev": true,
                     "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
@@ -30695,7 +30691,6 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
@@ -31719,7 +31714,6 @@
             "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
             "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
             "requires": {
-                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2": "*",
@@ -31728,7 +31722,7 @@
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
                 }
             }
         },
@@ -32227,8 +32221,7 @@
             "dev": true,
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+                "web3-core-helpers": "1.0.0-beta.34"
             },
             "dependencies": {
                 "underscore": {
@@ -32239,8 +32232,7 @@
                 },
                 "websocket": {
                     "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-                    "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-                    "dev": true,
+                    "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
                     "requires": {
                         "debug": "^2.2.0",
                         "nan": "^2.3.3",
@@ -33596,8 +33588,7 @@
         "yaeti": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-            "dev": true
+            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
         },
         "yallist": {
             "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8296,12 +8296,13 @@
                     "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
                     "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
                     "requires": {
+                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                         "ethereumjs-util": "^5.1.1"
                     },
                     "dependencies": {
                         "ethereumjs-abi": {
                             "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                             "requires": {
                                 "bn.js": "^4.10.0",
                                 "ethereumjs-util": "^5.0.0"
@@ -8579,12 +8580,13 @@
             "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
             "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
             "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                 "ethereumjs-util": "^5.1.1"
             },
             "dependencies": {
                 "ethereumjs-abi": {
                     "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                    "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                    "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                     "requires": {
                         "bn.js": "^4.10.0",
                         "ethereumjs-util": "^5.0.0"
@@ -8626,12 +8628,14 @@
                     "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
                     "dev": true,
                     "requires": {
+                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                         "ethereumjs-util": "^5.1.1"
                     },
                     "dependencies": {
                         "ethereumjs-abi": {
                             "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                            "dev": true,
                             "requires": {
                                 "bn.js": "^4.10.0",
                                 "ethereumjs-util": "^5.0.0"
@@ -8643,6 +8647,7 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
                     "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                    "dev": true,
                     "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
@@ -10387,6 +10392,12 @@
                     }
                 }
             }
+        },
+        "file-size": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/file-size/-/file-size-0.0.5.tgz",
+            "integrity": "sha1-BX1Dw6Ptc12j+Q1gUqs4Dx5tXjs=",
+            "dev": true
         },
         "file-tree": {
             "version": "1.0.0",
@@ -28263,6 +28274,70 @@
                 }
             }
         },
+        "static-server": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/static-server/-/static-server-2.2.1.tgz",
+            "integrity": "sha512-j5eeW6higxYNmXMIT8iHjsdiViTpQDthg7o+SHsRtqdbxscdHqBHXwrXjHC8hL3F0Tsu34ApUpDkwzMBPBsrLw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^0.5.1",
+                "commander": "^2.3.0",
+                "file-size": "0.0.5",
+                "mime": "^1.2.11",
+                "opn": "^5.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                    "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^1.1.0",
+                        "escape-string-regexp": "^1.0.0",
+                        "has-ansi": "^0.1.0",
+                        "strip-ansi": "^0.3.0",
+                        "supports-color": "^0.2.0"
+                    }
+                },
+                "has-ansi": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^0.2.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^0.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+                    "dev": true
+                }
+            }
+        },
         "statuses": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -30228,6 +30303,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
@@ -31232,6 +31308,7 @@
             "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
             "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
             "requires": {
+                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2": "*",
@@ -31240,7 +31317,7 @@
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
                 }
             }
         },
@@ -31739,7 +31816,8 @@
             "dev": true,
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34"
+                "web3-core-helpers": "1.0.0-beta.34",
+                "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
             },
             "dependencies": {
                 "underscore": {
@@ -31750,7 +31828,8 @@
                 },
                 "websocket": {
                     "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-                    "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                    "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+                    "dev": true,
                     "requires": {
                         "debug": "^2.2.0",
                         "nan": "^2.3.3",
@@ -33091,7 +33170,8 @@
         "yaeti": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+            "dev": true
         },
         "yallist": {
             "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,16 +5116,16 @@
             "dev": true
         },
         "chromedriver": {
-            "version": "2.36.0",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.36.0.tgz",
-            "integrity": "sha512-Lq2HrigCJ4RVdIdCmchenv1rVrejNSJ7EUCQojycQo12ww3FedQx4nb+GgTdqMhjbOMTqq5+ziaiZlrEN2z1gQ==",
+            "version": "2.41.0",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.41.0.tgz",
+            "integrity": "sha512-6O9HxvrSuHqmRlIgMzi0/05GsDNHqs8kaF5gNTIyaZNwRzb/RBUWH1xNNXKNxyhXSnGSalH8hWsKP5mc/npSQQ==",
             "dev": true,
             "requires": {
                 "del": "^3.0.0",
-                "extract-zip": "^1.6.5",
+                "extract-zip": "^1.6.7",
                 "kew": "^0.7.0",
                 "mkdirp": "^0.5.1",
-                "request": "^2.83.0"
+                "request": "^2.87.0"
             }
         },
         "cipher-base": {
@@ -9839,30 +9839,33 @@
             }
         },
         "extract-zip": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-            "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+            "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.0",
+                "concat-stream": "1.6.2",
                 "debug": "2.6.9",
-                "mkdirp": "0.5.0",
+                "mkdirp": "0.5.1",
                 "yauzl": "2.4.1"
             },
             "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                "buffer-from": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+                    "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
                     "dev": true
                 },
-                "mkdirp": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "0.0.8"
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -198,7 +198,6 @@
     "semaphore": "^1.0.5",
     "semver": "^5.4.1",
     "shallow-copy": "0.0.1",
-    "superstatic": "^5.0.2",
     "sw-controller": "^1.0.3",
     "sw-stream": "^2.0.2",
     "textarea-caret": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -307,6 +307,7 @@
     "shell-parallel": "^1.0.3",
     "sinon": "^5.0.0",
     "source-map": "^0.7.2",
+    "static-server": "^2.2.1",
     "style-loader": "^0.21.0",
     "stylelint-config-standard": "^18.2.0",
     "tape": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "brfs": "^1.6.1",
     "browserify": "^16.1.1",
     "chai": "^4.1.0",
-    "chromedriver": "2.36.0",
+    "chromedriver": "^2.41.0",
     "clipboardy": "^1.2.3",
     "compression": "^1.7.1",
     "coveralls": "^3.0.0",

--- a/test/e2e/beta/run-all.sh
+++ b/test/e2e/beta/run-all.sh
@@ -6,5 +6,5 @@ set -o pipefail
 
 export PATH="$PATH:./node_modules/.bin"
 
-shell-parallel -s 'npm run ganache:start' -x 'sleep 5 && superstatic test/e2e/beta/contract-test/ --port 8080 --host 127.0.0.1' -x 'sleep 5 && mocha test/e2e/beta/metamask-beta-ui.spec'
-shell-parallel -s 'npm run ganache:start -- -d'  -x 'sleep 5 && superstatic test/e2e/beta/contract-test/ --port 8080 --host 127.0.0.1' -x 'sleep 5 && mocha test/e2e/beta/from-import-beta-ui.spec'
+shell-parallel -s 'npm run ganache:start' -x 'sleep 5 && static-server test/e2e/beta/contract-test/ --port 8080' -x 'sleep 5 && mocha test/e2e/beta/metamask-beta-ui.spec'
+shell-parallel -s 'npm run ganache:start -- -d'  -x 'sleep 5 && static-server test/e2e/beta/contract-test/ --port 8080' -x 'sleep 5 && mocha test/e2e/beta/from-import-beta-ui.spec'


### PR DESCRIPTION
Closes #4923
Closes #4946

This PR updates Chromedriver and replaces [superstatic](https://www.npmjs.com/package/superstatic) for [static-server](https://www.npmjs.com/package/static-server). There's a lot of churn in the lockfile due to Git URLs unfortunately.