### PR TITLE
Show invalid seed phrase error when importing new account

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -510,6 +510,9 @@
   "invalidRPC": {
     "message": "Invalid RPC URI"
   },
+  "invalidSeedPhrase": {
+    "message": "Invalid seed phrase"
+  },
   "jsonFail": {
     "message": "Something went wrong. Please make sure your JSON file is properly formatted."
   },

--- a/mascara/src/app/first-time/import-seed-phrase-screen.js
+++ b/mascara/src/app/first-time/import-seed-phrase-screen.js
@@ -1,3 +1,4 @@
+import {validateMnemonic} from 'bip39'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
@@ -39,8 +40,12 @@ class ImportSeedPhraseScreen extends Component {
   handleSeedPhraseChange (seedPhrase) {
     let seedPhraseError = null
 
-    if (seedPhrase && this.parseSeedPhrase(seedPhrase).split(' ').length !== 12) {
-      seedPhraseError = this.context.t('seedPhraseReq')
+    if (seedPhrase) {
+      if (this.parseSeedPhrase(seedPhrase).split(' ').length !== 12) {
+        seedPhraseError = this.context.t('seedPhraseReq')
+      } else if (!validateMnemonic(seedPhrase)) {
+        seedPhraseError = this.context.t('invalidSeedPhrase')
+      }
     }
 
     this.setState({ seedPhrase, seedPhraseError })


### PR DESCRIPTION
Fixes #4931

This PR adds an error message to the onboarding flow indicating if a user is trying to import an invalid seed phrase.

<img width="1232" alt="screen shot 2018-08-07 at 02 14 01" src="https://user-images.githubusercontent.com/1623628/43754875-9bd73668-99e7-11e8-9a76-0f40cc6dcfdc.png">
