### PR TITLE
Add download seed phrase link to new UI

### DIFF
--- a/mascara/src/app/first-time/index.css
+++ b/mascara/src/app/first-time/index.css
@@ -340,6 +340,19 @@
   min-width: 0;
 }
 
+.backup-phrase__tips-text--link {
+  color: #2f9ae0;
+  cursor: pointer;
+}
+
+.backup-phrase__tips-text--link:hover {
+  color: #2f9ae0;
+}
+
+.backup-phrase__tips-text--strong {
+  font-weight: bold;
+}
+
 @media only screen and (max-width: 768px) {
   .backup-phrase__content-wrapper {
     flex-direction: column;

--- a/mascara/src/app/first-time/seed-screen.js
+++ b/mascara/src/app/first-time/seed-screen.js
@@ -111,7 +111,7 @@ class BackupPhraseScreen extends Component {
         <div className="backup-phrase__tips">
           <div className="backup-phrase__tips-text">Tips:</div>
           <div className="backup-phrase__tips-text">
-            Store this phrase in a password manager like 1password.
+            Store this phrase in a password manager like 1Password.
           </div>
           <div className="backup-phrase__tips-text">
             Write this phrase on a piece of paper and store in a secure location. If you want even more security, write it down on multiple pieces of paper and store each in 2 - 3 different locations.

--- a/mascara/src/app/first-time/seed-screen.js
+++ b/mascara/src/app/first-time/seed-screen.js
@@ -5,6 +5,7 @@ import classnames from 'classnames'
 import { withRouter } from 'react-router-dom'
 import { compose } from 'recompose'
 import Identicon from '../../../../ui/app/components/identicon'
+import {exportAsFile} from '../../../../ui/app/util'
 import Breadcrumbs from './breadcrumbs'
 import LoadingScreen from './loading-screen'
 import { DEFAULT_ROUTE, INITIALIZE_CONFIRM_SEED_ROUTE } from '../../../../ui/app/routes'
@@ -65,6 +66,12 @@ class BackupPhraseScreen extends Component {
     }
   }
 
+  exportSeedWords = () => {
+    const { seedWords } = this.props
+
+    exportAsFile('MetaMask Secret Backup Phrase', seedWords, 'text/plain')
+  }
+
   renderSecretWordsContainer () {
     const { isShowingSecret } = this.state
 
@@ -118,6 +125,13 @@ class BackupPhraseScreen extends Component {
           </div>
           <div className="backup-phrase__tips-text">
             Memorize this phrase.
+          </div>
+          <div className="backup-phrase__tips-text">
+            <strong>
+              <a className="backup-phrase__tips-text--link backup-phrase__tips-text--strong" onClick={this.exportSeedWords}>
+                Download this Secret Backup Phrase
+              </a>
+            </strong> and keep it stored safely on an external encrypted hard drive or storage medium.
           </div>
         </div>
         <div className="backup-phrase__next-button">

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -271,9 +271,9 @@ function getContractAtAddress (tokenAddress) {
   return global.eth.contract(abi).at(tokenAddress)
 }
 
-function exportAsFile (filename, data) {
+function exportAsFile (filename, data, type = 'text/csv') {
   // source: https://stackoverflow.com/a/33542499 by Ludovic Feltz
-  const blob = new Blob([data], {type: 'text/csv'})
+  const blob = new Blob([data], {type})
   if (window.navigator.msSaveOrOpenBlob) {
     window.navigator.msSaveBlob(blob, filename)
   } else {


### PR DESCRIPTION
Closes #4883

This PR adds a link to download the seed phrase when onboarding in the new UI:

<img width="1232" src="https://user-images.githubusercontent.com/1623628/44060940-ef470c76-9f30-11e8-9a94-b6ca42cfbb67.png">

