### PR TITLE
Reestablish old versions of eth-keyring-controller and eth-hd-keyring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2107,12 +2107,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "argsarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
-            "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs=",
-            "dev": true
-        },
         "arr-diff": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -4657,22 +4651,6 @@
                 "ieee754": "^1.1.4"
             }
         },
-        "buffer-alloc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-            "dev": true,
-            "requires": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
-            }
-        },
-        "buffer-alloc-unsafe": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "dev": true
-        },
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -4684,28 +4662,10 @@
             "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
             "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
         },
-        "buffer-fill": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-            "dev": true
-        },
-        "buffer-from": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-            "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-            "dev": true
-        },
         "buffer-more-ints": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
             "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw=",
-            "dev": true
-        },
-        "buffer-to-arraybuffer": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-            "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
             "dev": true
         },
         "buffer-xor": {
@@ -4748,25 +4708,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
             "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-        },
-        "bytewise": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-            "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-            "dev": true,
-            "requires": {
-                "bytewise-core": "^1.2.2",
-                "typewise": "^1.0.3"
-            }
-        },
-        "bytewise-core": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-            "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-            "dev": true,
-            "requires": {
-                "typewise-core": "^1.2"
-            }
         },
         "cacache": {
             "version": "10.0.4",
@@ -4848,27 +4789,6 @@
             "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
             "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
             "dev": true
-        },
-        "cachedown": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
-            "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
-            "dev": true,
-            "requires": {
-                "abstract-leveldown": "^2.4.1",
-                "lru-cache": "^3.2.0"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-                    "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "^1.0.1"
-                    }
-                }
-            }
         },
         "call-me-maybe": {
             "version": "1.0.1",
@@ -5934,16 +5854,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
-        "cors": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-            "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-            "dev": true,
-            "requires": {
-                "object-assign": "^4",
-                "vary": "^1"
-            }
-        },
         "corser": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -6546,12 +6456,6 @@
             "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
             "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
         },
-        "d64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
-            "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA=",
-            "dev": true
-        },
         "dargs": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
@@ -6650,30 +6554,6 @@
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
-        "decompress": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-            "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
-            "dev": true,
-            "requires": {
-                "decompress-tar": "^4.0.0",
-                "decompress-tarbz2": "^4.0.0",
-                "decompress-targz": "^4.0.0",
-                "decompress-unzip": "^4.0.1",
-                "graceful-fs": "^4.1.10",
-                "make-dir": "^1.0.0",
-                "pify": "^2.3.0",
-                "strip-dirs": "^2.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
-            }
-        },
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -6681,104 +6561,6 @@
             "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
-            }
-        },
-        "decompress-tar": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-            "dev": true,
-            "requires": {
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0",
-                "tar-stream": "^1.5.2"
-            }
-        },
-        "decompress-tarbz2": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-            "dev": true,
-            "requires": {
-                "decompress-tar": "^4.1.0",
-                "file-type": "^6.1.0",
-                "is-stream": "^1.1.0",
-                "seek-bzip": "^1.0.5",
-                "unbzip2-stream": "^1.0.9"
-            },
-            "dependencies": {
-                "file-type": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-                    "dev": true
-                }
-            }
-        },
-        "decompress-targz": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-            "dev": true,
-            "requires": {
-                "decompress-tar": "^4.1.1",
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0"
-            }
-        },
-        "decompress-unzip": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-            "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-            "dev": true,
-            "requires": {
-                "file-type": "^3.8.0",
-                "get-stream": "^2.2.0",
-                "pify": "^2.3.0",
-                "yauzl": "^2.4.2"
-            },
-            "dependencies": {
-                "fd-slicer": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-                    "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-                    "dev": true,
-                    "requires": {
-                        "pend": "~1.2.0"
-                    }
-                },
-                "file-type": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-                    "dev": true
-                },
-                "get-stream": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-                    "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-                    "dev": true,
-                    "requires": {
-                        "object-assign": "^4.0.1",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                },
-                "yauzl": {
-                    "version": "2.10.0",
-                    "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-                    "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-                    "dev": true,
-                    "requires": {
-                        "buffer-crc32": "~0.2.3",
-                        "fd-slicer": "~1.1.0"
-                    }
-                }
             }
         },
         "deep-diff": {
@@ -8258,7 +8040,7 @@
             }
         },
         "eth-contract-metadata": {
-            "version": "github:MetaMask/eth-contract-metadata#2da362052a312dc6c72a7eec116abf6284664f50",
+            "version": "github:MetaMask/eth-contract-metadata#f1a59032297fc00b9804de4674667f2955158757",
             "from": "github:MetaMask/eth-contract-metadata#master"
         },
         "eth-ens-namehash": {
@@ -8278,38 +8060,18 @@
             }
         },
         "eth-hd-keyring": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eth-hd-keyring/-/eth-hd-keyring-2.0.0.tgz",
-            "integrity": "sha512-lTeANNPNj/j08sWU7LUQZTsx9NUJaUsiOdVxeP0UI5kke7L+Sd7zJWBmCShudEVG8PkqKLE1KJo08o430sl6rw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/eth-hd-keyring/-/eth-hd-keyring-1.2.2.tgz",
+            "integrity": "sha1-rV9HkHRDapO0ObC5XHkJXCh5GII=",
             "requires": {
                 "bip39": "^2.2.0",
-                "eth-sig-util": "^2.0.1",
-                "ethereumjs-abi": "^0.6.5",
+                "eth-sig-util": "^1.4.2",
                 "ethereumjs-util": "^5.1.1",
                 "ethereumjs-wallet": "^0.6.0",
                 "events": "^1.1.1",
                 "xtend": "^4.0.1"
             },
             "dependencies": {
-                "eth-sig-util": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
-                    "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
-                    "requires": {
-                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                        "ethereumjs-util": "^5.1.1"
-                    },
-                    "dependencies": {
-                        "ethereumjs-abi": {
-                            "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                            "requires": {
-                                "bn.js": "^4.10.0",
-                                "ethereumjs-util": "^5.0.0"
-                            }
-                        }
-                    }
-                },
                 "ethereumjs-util": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -8384,17 +8146,17 @@
             }
         },
         "eth-keyring-controller": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eth-keyring-controller/-/eth-keyring-controller-4.0.0.tgz",
-            "integrity": "sha512-D3Uj0b97vzEl/zXvrwYjFUYsz5gB4tnl/iMWqOm8jsvaREuHHbxRkm3iU/LG4fT8NGwS+fG8sLRPNBPu2/wRsA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/eth-keyring-controller/-/eth-keyring-controller-3.3.0.tgz",
+            "integrity": "sha512-ZQtWxg0mNSAeQ9JcOaeTKaN5vfr+MbjRhSfeaF1VIWZsQgULpHrbjT6m94qiAFdh7ZngoR7OEpK9PATBH7JNYw==",
             "dev": true,
             "requires": {
                 "bip39": "^2.4.0",
                 "bluebird": "^3.5.0",
                 "browser-passworder": "^2.0.3",
-                "eth-hd-keyring": "^2.0.0",
+                "eth-hd-keyring": "^1.2.2",
                 "eth-sig-util": "^1.4.0",
-                "eth-simple-keyring": "^2.0.0",
+                "eth-simple-keyring": "^1.3.0",
                 "ethereumjs-util": "^5.1.2",
                 "loglevel": "^1.5.0",
                 "obs-store": "^2.4.1",
@@ -8439,21 +8201,6 @@
                         "xtend": "^4.0.1"
                     }
                 }
-            }
-        },
-        "eth-lib": {
-            "version": "0.1.27",
-            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
-            "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
-            "dev": true,
-            "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "keccakjs": "^0.2.1",
-                "nano-json-stream-parser": "^0.1.2",
-                "servify": "^0.1.12",
-                "ws": "^3.0.0",
-                "xhr-request-promise": "^0.1.2"
             }
         },
         "eth-method-registry": {
@@ -8609,40 +8356,18 @@
             }
         },
         "eth-simple-keyring": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-2.0.0.tgz",
-            "integrity": "sha512-4dMbkIy2k1qotDTjWINvXG+7tBmofp0YUhlXgcG0+I3w684V46+MAHEkBtD2Y09iEeIB07RDXrezKP9WxOpynA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-1.3.0.tgz",
+            "integrity": "sha512-KNB3WXHyY/NfUiVTllsGScJ8AFTR6OGcrjKn4oSYG+HIvhkOoBqMAJ94BR3zGTvzyg5rHywHwT4L2K4+ZPFp5Q==",
             "dev": true,
             "requires": {
-                "eth-sig-util": "^2.0.1",
-                "ethereumjs-abi": "^0.6.5",
+                "eth-sig-util": "^1.4.2",
                 "ethereumjs-util": "^5.1.1",
                 "ethereumjs-wallet": "^0.6.0",
                 "events": "^1.1.1",
                 "xtend": "^4.0.1"
             },
             "dependencies": {
-                "eth-sig-util": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
-                    "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
-                    "dev": true,
-                    "requires": {
-                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                        "ethereumjs-util": "^5.1.1"
-                    },
-                    "dependencies": {
-                        "ethereumjs-abi": {
-                            "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                            "dev": true,
-                            "requires": {
-                                "bn.js": "^4.10.0",
-                                "ethereumjs-util": "^5.0.0"
-                            }
-                        }
-                    }
-                },
                 "ethereumjs-util": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
@@ -9579,12 +9304,6 @@
                 "through": "~2.3.1"
             }
         },
-        "eventemitter3": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-            "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
-            "dev": true
-        },
         "events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -10412,12 +10131,6 @@
                 "flat": "~1.0.0"
             }
         },
-        "file-type": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-            "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-            "dev": true
-        },
         "file-uri-to-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -11076,12 +10789,6 @@
                 "null-check": "^1.0.0"
             }
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
-        },
         "fs-exists-sync": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
@@ -11196,12 +10903,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -11216,17 +10925,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -11337,12 +11049,14 @@
                 "inherits": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -11357,6 +11071,7 @@
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -11370,6 +11085,7 @@
                     "version": "2.2.4",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
                     "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -11474,7 +11190,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -11486,6 +11203,7 @@
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -11587,6 +11305,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -11806,10 +11525,1152 @@
                         "xtend": "~4.0.0"
                     }
                 },
+                "accepts": {
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+                    "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+                    "dev": true,
+                    "requires": {
+                        "mime-types": "2.1.18",
+                        "negotiator": "0.6.1"
+                    }
+                },
+                "aes-js": {
+                    "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-0.2.4.tgz",
+                    "integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0=",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.1.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "any-promise": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+                    "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+                    "dev": true
+                },
+                "argsarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
+                    "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs=",
+                    "dev": true
+                },
+                "array-flatten": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                    "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+                    "dev": true
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                    "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                    "dev": true
+                },
+                "asn1.js": {
+                    "version": "4.10.1",
+                    "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+                    "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "inherits": "2.0.3",
+                        "minimalistic-assert": "1.0.1"
+                    }
+                },
+                "assert": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+                    "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+                    "requires": {
+                        "util": "0.10.3"
+                    }
+                },
+                "assert-match": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/assert-match/-/assert-match-1.1.1.tgz",
+                    "integrity": "sha512-c0QY2kpYVrH/jis6cCq9Mnt4/bIdGALDh1N8HY9ZARZedsMs5LSbgywxkjd5A1uNVLN0L8evANxBPxKiabVoZw==",
+                    "requires": {
+                        "assert": "1.4.1",
+                        "babel-runtime": "6.26.0",
+                        "es-to-primitive": "1.1.1",
+                        "lodash.merge": "4.6.1"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "assertion-error": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+                    "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+                    "dev": true
+                },
+                "async": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+                    "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "4.17.10"
+                    }
+                },
+                "async-eventemitter": {
+                    "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+                    "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+                    "dev": true,
+                    "requires": {
+                        "async": "2.6.1"
+                    }
+                },
+                "async-limiter": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+                    "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+                    "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+                    "dev": true
+                },
+                "babel-code-frame": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+                    "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "babel-core": {
+                    "version": "6.26.3",
+                    "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+                    "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "6.26.0",
+                        "babel-generator": "6.26.1",
+                        "babel-helpers": "6.24.1",
+                        "babel-messages": "6.23.0",
+                        "babel-register": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "convert-source-map": "1.5.1",
+                        "debug": "2.6.9",
+                        "json5": "0.5.1",
+                        "lodash": "4.17.10",
+                        "minimatch": "3.0.4",
+                        "path-is-absolute": "1.0.1",
+                        "private": "0.1.8",
+                        "slash": "1.0.0",
+                        "source-map": "0.5.7"
+                    }
+                },
+                "babel-generator": {
+                    "version": "6.26.1",
+                    "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+                    "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+                    "dev": true,
+                    "requires": {
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "detect-indent": "4.0.0",
+                        "jsesc": "1.3.0",
+                        "lodash": "4.17.10",
+                        "source-map": "0.5.7",
+                        "trim-right": "1.0.1"
+                    },
+                    "dependencies": {
+                        "jsesc": {
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+                            "dev": true
+                        }
+                    }
+                },
+                "babel-helper-builder-binary-assignment-operator-visitor": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+                    "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-explode-assignable-expression": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-call-delegate": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+                    "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-hoist-variables": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-define-map": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+                    "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "lodash": "4.17.10"
+                    }
+                },
+                "babel-helper-explode-assignable-expression": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+                    "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-function-name": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+                    "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-get-function-arity": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-get-function-arity": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+                    "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-hoist-variables": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+                    "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-optimise-call-expression": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+                    "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-regex": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+                    "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "lodash": "4.17.10"
+                    }
+                },
+                "babel-helper-remap-async-to-generator": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+                    "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helper-replace-supers": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+                    "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-optimise-call-expression": "6.24.1",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-helpers": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+                    "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-messages": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                    "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-check-es2015-constants": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+                    "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-syntax-async-functions": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+                    "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+                    "dev": true
+                },
+                "babel-plugin-syntax-exponentiation-operator": {
+                    "version": "6.13.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+                    "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+                    "dev": true
+                },
+                "babel-plugin-syntax-trailing-function-commas": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+                    "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+                    "dev": true
+                },
+                "babel-plugin-transform-async-to-generator": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+                    "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-remap-async-to-generator": "6.24.1",
+                        "babel-plugin-syntax-async-functions": "6.13.0",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-arrow-functions": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+                    "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-block-scoped-functions": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+                    "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-block-scoping": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+                    "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "lodash": "4.17.10"
+                    }
+                },
+                "babel-plugin-transform-es2015-classes": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+                    "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-define-map": "6.26.0",
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-helper-optimise-call-expression": "6.24.1",
+                        "babel-helper-replace-supers": "6.24.1",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-computed-properties": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+                    "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-destructuring": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+                    "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-duplicate-keys": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+                    "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-for-of": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+                    "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-function-name": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+                    "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-function-name": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-literals": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+                    "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-amd": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+                    "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-commonjs": {
+                    "version": "6.26.2",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+                    "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-transform-strict-mode": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-systemjs": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+                    "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-hoist-variables": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-modules-umd": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+                    "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-object-super": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+                    "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-replace-supers": "6.24.1",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-parameters": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+                    "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-call-delegate": "6.24.1",
+                        "babel-helper-get-function-arity": "6.24.1",
+                        "babel-runtime": "6.26.0",
+                        "babel-template": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-shorthand-properties": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+                    "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-spread": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+                    "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-sticky-regex": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+                    "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-regex": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-template-literals": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+                    "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-typeof-symbol": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+                    "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-es2015-unicode-regex": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+                    "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-regex": "6.26.0",
+                        "babel-runtime": "6.26.0",
+                        "regexpu-core": "2.0.0"
+                    }
+                },
+                "babel-plugin-transform-exponentiation-operator": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+                    "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+                        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+                        "babel-runtime": "6.26.0"
+                    }
+                },
+                "babel-plugin-transform-regenerator": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+                    "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-transform": "0.10.1"
+                    }
+                },
+                "babel-plugin-transform-strict-mode": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+                    "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0"
+                    }
+                },
+                "babel-preset-env": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+                    "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-check-es2015-constants": "6.22.0",
+                        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+                        "babel-plugin-transform-async-to-generator": "6.24.1",
+                        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+                        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+                        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+                        "babel-plugin-transform-es2015-classes": "6.24.1",
+                        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+                        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+                        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+                        "babel-plugin-transform-es2015-for-of": "6.23.0",
+                        "babel-plugin-transform-es2015-function-name": "6.24.1",
+                        "babel-plugin-transform-es2015-literals": "6.22.0",
+                        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+                        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+                        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+                        "babel-plugin-transform-es2015-object-super": "6.24.1",
+                        "babel-plugin-transform-es2015-parameters": "6.24.1",
+                        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+                        "babel-plugin-transform-es2015-spread": "6.22.0",
+                        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+                        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+                        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+                        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+                        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+                        "babel-plugin-transform-regenerator": "6.26.0",
+                        "browserslist": "3.2.8",
+                        "invariant": "2.2.4",
+                        "semver": "5.4.1"
+                    }
+                },
+                "babel-register": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+                    "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+                    "dev": true,
+                    "requires": {
+                        "babel-core": "6.26.3",
+                        "babel-runtime": "6.26.0",
+                        "core-js": "2.5.6",
+                        "home-or-tmp": "2.0.0",
+                        "lodash": "4.17.10",
+                        "mkdirp": "0.5.1",
+                        "source-map-support": "0.4.18"
+                    }
+                },
+                "babel-runtime": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+                    "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+                    "requires": {
+                        "core-js": "2.5.6",
+                        "regenerator-runtime": "0.11.1"
+                    }
+                },
+                "babel-template": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+                    "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-traverse": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "lodash": "4.17.10"
+                    }
+                },
+                "babel-traverse": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+                    "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "6.26.0",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "babylon": "6.18.0",
+                        "debug": "2.6.9",
+                        "globals": "9.18.0",
+                        "invariant": "2.2.4",
+                        "lodash": "4.17.10"
+                    }
+                },
+                "babel-types": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+                    "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.10",
+                        "to-fast-properties": "1.0.3"
+                    }
+                },
+                "babelify": {
+                    "version": "7.3.0",
+                    "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+                    "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
+                    "dev": true,
+                    "requires": {
+                        "babel-core": "6.26.3",
+                        "object-assign": "4.1.1"
+                    }
+                },
+                "babylon": {
+                    "version": "6.18.0",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+                    "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+                    "dev": true
+                },
+                "backoff": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+                    "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+                    "dev": true,
+                    "requires": {
+                        "precond": "0.2.3"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                },
+                "base-x": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
+                    "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w=",
+                    "dev": true
+                },
+                "base64-js": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+                    "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                    "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "bindings": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+                    "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+                    "dev": true
+                },
+                "bip39": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
+                    "integrity": "sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
+                    "dev": true,
+                    "requires": {
+                        "create-hash": "1.2.0",
+                        "pbkdf2": "3.0.16",
+                        "randombytes": "2.0.6",
+                        "safe-buffer": "5.1.2",
+                        "unorm": "1.4.1"
+                    }
+                },
+                "bip66": {
+                    "version": "1.1.5",
+                    "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+                    "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "bl": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+                    "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "1.0.34",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        }
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                    "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "bluebird": {
+                    "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+                    "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+                    "dev": true
+                },
                 "bn.js": {
                     "version": "4.11.6",
                     "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
                     "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                    "dev": true
+                },
+                "body-parser": {
+                    "version": "1.18.3",
+                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+                    "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.0.0",
+                        "content-type": "1.0.4",
+                        "debug": "2.6.9",
+                        "depd": "1.1.2",
+                        "http-errors": "1.6.3",
+                        "iconv-lite": "0.4.23",
+                        "on-finished": "2.3.0",
+                        "qs": "6.5.2",
+                        "raw-body": "2.3.3",
+                        "type-is": "1.6.16"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "brorand": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+                    "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+                    "dev": true
+                },
+                "browser-stdout": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+                    "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+                },
+                "browserify-aes": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+                    "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-xor": "1.0.3",
+                        "cipher-base": "1.0.4",
+                        "create-hash": "1.2.0",
+                        "evp_bytestokey": "1.0.3",
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "browserify-cipher": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+                    "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+                    "dev": true,
+                    "requires": {
+                        "browserify-aes": "1.2.0",
+                        "browserify-des": "1.0.1",
+                        "evp_bytestokey": "1.0.3"
+                    }
+                },
+                "browserify-des": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+                    "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+                    "dev": true,
+                    "requires": {
+                        "cipher-base": "1.0.4",
+                        "des.js": "1.0.0",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "browserify-rsa": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+                    "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "randombytes": "2.0.6"
+                    }
+                },
+                "browserify-sha3": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
+                    "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
+                    "dev": true,
+                    "requires": {
+                        "js-sha3": "0.3.1"
+                    }
+                },
+                "browserify-sign": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+                    "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "browserify-rsa": "4.0.1",
+                        "create-hash": "1.2.0",
+                        "create-hmac": "1.1.7",
+                        "elliptic": "6.4.0",
+                        "inherits": "2.0.3",
+                        "parse-asn1": "5.1.1"
+                    }
+                },
+                "browserslist": {
+                    "version": "3.2.8",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+                    "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "1.0.30000850",
+                        "electron-to-chromium": "1.3.47"
+                    }
+                },
+                "bs58": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
+                    "integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
+                    "dev": true,
+                    "requires": {
+                        "base-x": "1.1.0"
+                    }
+                },
+                "bs58check": {
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-1.3.4.tgz",
+                    "integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
+                    "dev": true,
+                    "requires": {
+                        "bs58": "3.1.0",
+                        "create-hash": "1.2.0"
+                    }
+                },
+                "buffer": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+                    "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "1.3.0",
+                        "ieee754": "1.1.11"
+                    }
+                },
+                "buffer-alloc": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
+                    "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+                    "dev": true,
+                    "requires": {
+                        "buffer-alloc-unsafe": "0.1.1",
+                        "buffer-fill": "0.1.1"
+                    }
+                },
+                "buffer-alloc-unsafe": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
+                    "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo=",
+                    "dev": true
+                },
+                "buffer-crc32": {
+                    "version": "0.2.13",
+                    "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+                    "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+                    "dev": true
+                },
+                "buffer-fill": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
+                    "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q==",
+                    "dev": true
+                },
+                "buffer-from": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+                    "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
+                    "dev": true
+                },
+                "buffer-to-arraybuffer": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+                    "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
+                    "dev": true
+                },
+                "buffer-xor": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+                    "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+                    "dev": true
+                },
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                    "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                    "dev": true
+                },
+                "bytes": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+                    "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+                    "dev": true
+                },
+                "bytewise": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+                    "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
+                    "dev": true,
+                    "requires": {
+                        "bytewise-core": "1.2.3",
+                        "typewise": "1.0.3"
+                    }
+                },
+                "bytewise-core": {
+                    "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+                    "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
+                    "dev": true,
+                    "requires": {
+                        "typewise-core": "1.2.0"
+                    }
+                },
+                "cachedown": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
+                    "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
+                    "dev": true,
+                    "requires": {
+                        "abstract-leveldown": "2.7.2",
+                        "lru-cache": "3.2.0"
+                    },
+                    "dependencies": {
+                        "abstract-leveldown": {
+                            "version": "2.7.2",
+                            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                            "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+                            "dev": true,
+                            "requires": {
+                                "xtend": "4.0.1"
+                            }
+                        }
+                    }
+                },
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000850",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000850.tgz",
+                    "integrity": "sha512-iHK48UR/InydhpPAzgSmsJXRAR925T0kwJhZ1wk0xRatpGMvi2f06LABg6HXfV4WW4P2wChzlcFa/TEmbTyXQA==",
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                     "dev": true
                 },
                 "chai": {
@@ -11821,6 +12682,393 @@
                         "assertion-error": "^1.0.1",
                         "deep-eql": "^0.1.3",
                         "type-detect": "^1.0.0"
+                    }
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "checkpoint-store": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+                    "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+                    "dev": true,
+                    "requires": {
+                        "functional-red-black-tree": "1.0.1"
+                    }
+                },
+                "cipher-base": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+                    "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    }
+                },
+                "clone": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                    "dev": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                    "dev": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                    "dev": true
+                },
+                "coinstring": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
+                    "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
+                    "dev": true,
+                    "requires": {
+                        "bs58": "2.0.1",
+                        "create-hash": "1.2.0"
+                    },
+                    "dependencies": {
+                        "bs58": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
+                            "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40=",
+                            "dev": true
+                        }
+                    }
+                },
+                "combined-stream": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                    "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                },
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "1.1.0",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
+                    },
+                    "dependencies": {
+                        "buffer-from": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+                            "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "content-disposition": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+                    "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+                    "dev": true
+                },
+                "content-type": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+                    "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+                    "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+                    "dev": true
+                },
+                "cookie": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                    "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+                    "dev": true
+                },
+                "cookie-signature": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                    "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+                    "dev": true
+                },
+                "core-js": {
+                    "version": "2.5.6",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+                    "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "dev": true
+                },
+                "cors": {
+                    "version": "2.8.4",
+                    "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+                    "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+                    "dev": true,
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "vary": "1.1.2"
+                    }
+                },
+                "create-ecdh": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+                    "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "elliptic": "6.4.0"
+                    }
+                },
+                "create-hash": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+                    "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+                    "dev": true,
+                    "requires": {
+                        "cipher-base": "1.0.4",
+                        "inherits": "2.0.3",
+                        "md5.js": "1.3.4",
+                        "ripemd160": "2.0.2",
+                        "sha.js": "2.4.11"
+                    }
+                },
+                "create-hmac": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+                    "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+                    "dev": true,
+                    "requires": {
+                        "cipher-base": "1.0.4",
+                        "create-hash": "1.2.0",
+                        "inherits": "2.0.3",
+                        "ripemd160": "2.0.2",
+                        "safe-buffer": "5.1.2",
+                        "sha.js": "2.4.11"
+                    }
+                },
+                "cross-fetch": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.1.tgz",
+                    "integrity": "sha1-lshZEE113vyWf7XbYkdOdUJrArA=",
+                    "dev": true,
+                    "requires": {
+                        "node-fetch": "2.1.2",
+                        "whatwg-fetch": "2.0.4"
+                    }
+                },
+                "crypto-browserify": {
+                    "version": "3.12.0",
+                    "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+                    "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+                    "dev": true,
+                    "requires": {
+                        "browserify-cipher": "1.0.1",
+                        "browserify-sign": "4.0.4",
+                        "create-ecdh": "4.0.3",
+                        "create-hash": "1.2.0",
+                        "create-hmac": "1.1.7",
+                        "diffie-hellman": "5.0.3",
+                        "inherits": "2.0.3",
+                        "pbkdf2": "3.0.16",
+                        "public-encrypt": "4.0.2",
+                        "randombytes": "2.0.6",
+                        "randomfill": "1.0.4"
+                    }
+                },
+                "d64": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
+                    "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA=",
+                    "dev": true
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                    "dev": true
+                },
+                "decode-uri-component": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+                    "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+                    "dev": true
+                },
+                "decompress": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+                    "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+                    "dev": true,
+                    "requires": {
+                        "decompress-tar": "4.1.1",
+                        "decompress-tarbz2": "4.1.1",
+                        "decompress-targz": "4.1.1",
+                        "decompress-unzip": "4.0.1",
+                        "graceful-fs": "4.1.11",
+                        "make-dir": "1.3.0",
+                        "pify": "2.3.0",
+                        "strip-dirs": "2.1.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                },
+                "decompress-response": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+                    "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+                    "dev": true,
+                    "requires": {
+                        "mimic-response": "1.0.0"
+                    }
+                },
+                "decompress-tar": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+                    "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+                    "dev": true,
+                    "requires": {
+                        "file-type": "5.2.0",
+                        "is-stream": "1.1.0",
+                        "tar-stream": "1.6.1"
+                    }
+                },
+                "decompress-tarbz2": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+                    "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+                    "dev": true,
+                    "requires": {
+                        "decompress-tar": "4.1.1",
+                        "file-type": "6.2.0",
+                        "is-stream": "1.1.0",
+                        "seek-bzip": "1.0.5",
+                        "unbzip2-stream": "1.2.5"
+                    },
+                    "dependencies": {
+                        "file-type": {
+                            "version": "6.2.0",
+                            "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+                            "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "decompress-targz": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+                    "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+                    "dev": true,
+                    "requires": {
+                        "decompress-tar": "4.1.1",
+                        "file-type": "5.2.0",
+                        "is-stream": "1.1.0"
+                    }
+                },
+                "decompress-unzip": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+                    "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+                    "dev": true,
+                    "requires": {
+                        "file-type": "3.9.0",
+                        "get-stream": "2.3.1",
+                        "pify": "2.3.0",
+                        "yauzl": "2.9.1"
+                    },
+                    "dependencies": {
+                        "file-type": {
+                            "version": "3.9.0",
+                            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+                            "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+                            "dev": true
+                        },
+                        "get-stream": {
+                            "version": "2.3.1",
+                            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+                            "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+                            "dev": true,
+                            "requires": {
+                                "object-assign": "4.1.1",
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
                     }
                 },
                 "deep-eql": {
@@ -11839,6 +13087,257 @@
                             "dev": true
                         }
                     }
+                },
+                "deep-equal": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+                    "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+                    "dev": true
+                },
+                "deferred-leveldown": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+                    "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+                    "dev": true,
+                    "requires": {
+                        "abstract-leveldown": "2.6.3"
+                    },
+                    "dependencies": {
+                        "abstract-leveldown": {
+                            "version": "2.6.3",
+                            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+                            "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+                            "dev": true,
+                            "requires": {
+                                "xtend": "4.0.1"
+                            }
+                        }
+                    }
+                },
+                "define-properties": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+                    "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+                    "dev": true,
+                    "requires": {
+                        "foreach": "2.0.5",
+                        "object-keys": "1.0.11"
+                    },
+                    "dependencies": {
+                        "object-keys": {
+                            "version": "1.0.11",
+                            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+                            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+                            "dev": true
+                        }
+                    }
+                },
+                "defined": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                    "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+                    "dev": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                    "dev": true
+                },
+                "depd": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+                    "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+                    "dev": true
+                },
+                "des.js": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                    "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "minimalistic-assert": "1.0.1"
+                    }
+                },
+                "destroy": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                    "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+                    "dev": true
+                },
+                "detect-indent": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+                    "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+                    "dev": true,
+                    "requires": {
+                        "repeating": "2.0.1"
+                    }
+                },
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+                },
+                "diffie-hellman": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+                    "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "miller-rabin": "4.0.1",
+                        "randombytes": "2.0.6"
+                    }
+                },
+                "dom-walk": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+                    "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+                    "dev": true
+                },
+                "drbg.js": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+                    "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+                    "dev": true,
+                    "requires": {
+                        "browserify-aes": "1.2.0",
+                        "create-hash": "1.2.0",
+                        "create-hmac": "1.1.7"
+                    }
+                },
+                "duplexer3": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                    "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+                    "dev": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                    "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "ee-first": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                    "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.47",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
+                    "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ=",
+                    "dev": true
+                },
+                "elliptic": {
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+                    "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "brorand": "1.1.0",
+                        "hash.js": "1.1.3",
+                        "hmac-drbg": "1.0.1",
+                        "inherits": "2.0.3",
+                        "minimalistic-assert": "1.0.1",
+                        "minimalistic-crypto-utils": "1.0.1"
+                    }
+                },
+                "encodeurl": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+                    "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+                    "dev": true
+                },
+                "encoding": {
+                    "version": "0.1.12",
+                    "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                    "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+                    "dev": true,
+                    "requires": {
+                        "iconv-lite": "0.4.23"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                    "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0"
+                    }
+                },
+                "errno": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+                    "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+                    "dev": true,
+                    "requires": {
+                        "prr": "1.0.1"
+                    }
+                },
+                "error-ex": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                    "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+                    "dev": true,
+                    "requires": {
+                        "is-arrayish": "0.2.1"
+                    }
+                },
+                "es-abstract": {
+                    "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+                    "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "1.1.1",
+                        "function-bind": "1.1.1",
+                        "has": "1.0.3",
+                        "is-callable": "1.1.3",
+                        "is-regex": "1.0.4"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                    "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+                    "requires": {
+                        "is-callable": "1.1.3",
+                        "is-date-object": "1.0.1",
+                        "is-symbol": "1.0.1"
+                    }
+                },
+                "escape-html": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                    "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                },
+                "esutils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                    "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+                    "dev": true
+                },
+                "etag": {
+                    "version": "1.8.1",
+                    "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+                    "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+                    "dev": true
                 },
                 "eth-block-tracker": {
                     "version": "3.0.1",
@@ -11874,16 +13373,229 @@
                         "json-rpc-engine": "^3.4.0",
                         "json-rpc-error": "^2.0.0",
                         "tape": "^4.8.0"
+                    }
+                },
+                "eth-json-rpc-middleware": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+                    "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
+                    "dev": true,
+                    "requires": {
+                        "async": "2.6.1",
+                        "eth-query": "2.1.2",
+                        "eth-tx-summary": "3.2.3",
+                        "ethereumjs-block": "1.7.1",
+                        "ethereumjs-tx": "1.3.4",
+                        "ethereumjs-util": "5.2.0",
+                        "ethereumjs-vm": "2.3.5",
+                        "fetch-ponyfill": "4.1.0",
+                        "json-rpc-engine": "3.7.3",
+                        "json-rpc-error": "2.0.0",
+                        "json-stable-stringify": "1.0.1",
+                        "promise-to-callback": "1.0.0",
+                        "tape": "4.9.0"
                     },
                     "dependencies": {
-                        "cross-fetch": {
-                            "version": "2.2.2",
-                            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz",
-                            "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
+                        "ethereum-common": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                            "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+                            "dev": true
+                        },
+                        "ethereumjs-block": {
+                            "version": "1.7.1",
+                            "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+                            "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
                             "dev": true,
                             "requires": {
-                                "node-fetch": "2.1.2",
-                                "whatwg-fetch": "2.0.4"
+                                "async": "2.6.1",
+                                "ethereum-common": "0.2.0",
+                                "ethereumjs-tx": "1.3.4",
+                                "ethereumjs-util": "5.2.0",
+                                "merkle-patricia-tree": "2.3.1"
+                            }
+                        }
+                    }
+                },
+                "eth-lib": {
+                    "version": "0.1.27",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+                    "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "elliptic": "6.4.0",
+                        "keccakjs": "0.2.1",
+                        "nano-json-stream-parser": "0.1.2",
+                        "servify": "0.1.12",
+                        "ws": "3.3.3",
+                        "xhr-request-promise": "0.1.2"
+                    },
+                    "dependencies": {
+                        "ws": {
+                            "version": "3.3.3",
+                            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                            "dev": true,
+                            "requires": {
+                                "async-limiter": "~1.0.0",
+                                "safe-buffer": "~5.1.0",
+                                "ultron": "~1.1.0"
+                            }
+                        }
+                    }
+                },
+                "eth-query": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+                    "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
+                    "dev": true,
+                    "requires": {
+                        "json-rpc-random-id": "1.0.1",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "eth-sig-util": {
+                    "version": "1.4.2",
+                    "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+                    "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
+                    "dev": true,
+                    "requires": {
+                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+                        "ethereumjs-util": "5.2.0"
+                    },
+                    "dependencies": {
+                        "ethereumjs-abi": {
+                            "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+                            "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+                            "dev": true,
+                            "requires": {
+                                "bn.js": "4.11.6",
+                                "ethereumjs-util": "5.2.0"
+                            }
+                        }
+                    }
+                },
+                "eth-tx-summary": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.3.tgz",
+                    "integrity": "sha512-1gZpA5fKarJOVSb5OUlPnhDQuIazqAkI61zlVvf5LdG47nEgw+/qhyZnuj3CUdE/TLTKuRzPLeyXLjaB4qWTRQ==",
+                    "dev": true,
+                    "requires": {
+                        "async": "2.6.1",
+                        "bn.js": "4.11.8",
+                        "clone": "2.1.1",
+                        "concat-stream": "1.6.2",
+                        "end-of-stream": "1.4.1",
+                        "eth-query": "2.1.2",
+                        "ethereumjs-block": "1.7.1",
+                        "ethereumjs-tx": "1.3.4",
+                        "ethereumjs-util": "5.2.0",
+                        "ethereumjs-vm": "2.3.4",
+                        "through2": "2.0.3",
+                        "treeify": "1.1.0",
+                        "web3-provider-engine": "13.8.0"
+                    },
+                    "dependencies": {
+                        "async-eventemitter": {
+                            "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                            "from": "async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                            "dev": true,
+                            "requires": {
+                                "async": "2.6.1"
+                            }
+                        },
+                        "bn.js": {
+                            "version": "4.11.8",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+                            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                            "dev": true
+                        },
+                        "eth-block-tracker": {
+                            "version": "2.3.1",
+                            "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
+                            "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
+                            "dev": true,
+                            "requires": {
+                                "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                                "eth-query": "2.1.2",
+                                "ethereumjs-tx": "1.3.4",
+                                "ethereumjs-util": "5.2.0",
+                                "ethjs-util": "0.1.4",
+                                "json-rpc-engine": "3.7.3",
+                                "pify": "2.3.0",
+                                "tape": "4.9.0"
+                            }
+                        },
+                        "ethereum-common": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                            "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+                            "dev": true
+                        },
+                        "ethereumjs-block": {
+                            "version": "1.7.1",
+                            "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+                            "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+                            "dev": true,
+                            "requires": {
+                                "async": "2.6.1",
+                                "ethereum-common": "0.2.0",
+                                "ethereumjs-tx": "1.3.4",
+                                "ethereumjs-util": "5.2.0",
+                                "merkle-patricia-tree": "2.3.1"
+                            }
+                        },
+                        "ethereumjs-vm": {
+                            "version": "2.3.4",
+                            "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
+                            "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
+                            "dev": true,
+                            "requires": {
+                                "async": "2.6.1",
+                                "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                                "ethereum-common": "0.2.0",
+                                "ethereumjs-account": "2.0.5",
+                                "ethereumjs-block": "1.7.1",
+                                "ethereumjs-util": "5.2.0",
+                                "fake-merkle-patricia-tree": "1.0.1",
+                                "functional-red-black-tree": "1.0.1",
+                                "merkle-patricia-tree": "2.3.1",
+                                "rustbn.js": "0.1.2",
+                                "safe-buffer": "5.1.2"
+                            }
+                        },
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        },
+                        "web3-provider-engine": {
+                            "version": "13.8.0",
+                            "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
+                            "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
+                            "dev": true,
+                            "requires": {
+                                "async": "2.6.1",
+                                "clone": "2.1.1",
+                                "eth-block-tracker": "2.3.1",
+                                "eth-sig-util": "1.4.2",
+                                "ethereumjs-block": "1.7.1",
+                                "ethereumjs-tx": "1.3.4",
+                                "ethereumjs-util": "5.2.0",
+                                "ethereumjs-vm": "2.3.4",
+                                "fetch-ponyfill": "4.1.0",
+                                "json-rpc-error": "2.0.0",
+                                "json-stable-stringify": "1.0.1",
+                                "promise-to-callback": "1.0.0",
+                                "readable-stream": "2.3.6",
+                                "request": "2.87.0",
+                                "semaphore": "1.1.0",
+                                "solc": "0.4.24",
+                                "tape": "4.9.0",
+                                "xhr": "2.5.0",
+                                "xtend": "4.0.1"
                             }
                         }
                     }
@@ -11893,6 +13605,17 @@
                     "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
                     "integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU=",
                     "dev": true
+                },
+                "ethereumjs-account": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+                    "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
+                    "dev": true,
+                    "requires": {
+                        "ethereumjs-util": "5.2.0",
+                        "rlp": "2.0.0",
+                        "safe-buffer": "5.1.2"
+                    }
                 },
                 "ethereumjs-block": {
                     "version": "1.2.2",
@@ -12001,10 +13724,2487 @@
                         }
                     }
                 },
+                "ethereumjs-wallet": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz",
+                    "integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
+                    "dev": true,
+                    "requires": {
+                        "aes-js": "0.2.4",
+                        "bs58check": "1.3.4",
+                        "ethereumjs-util": "4.5.0",
+                        "hdkey": "0.7.1",
+                        "scrypt.js": "0.2.0",
+                        "utf8": "2.1.2",
+                        "uuid": "2.0.3"
+                    },
+                    "dependencies": {
+                        "ethereumjs-util": {
+                            "version": "4.5.0",
+                            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+                            "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                            "dev": true,
+                            "requires": {
+                                "bn.js": "4.11.6",
+                                "create-hash": "1.2.0",
+                                "keccakjs": "0.2.1",
+                                "rlp": "2.0.0",
+                                "secp256k1": "3.5.0"
+                            }
+                        }
+                    }
+                },
+                "ethjs-unit": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+                    "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "number-to-bn": "1.7.0"
+                    }
+                },
+                "ethjs-util": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.4.tgz",
+                    "integrity": "sha1-HItoeSV0RO9NPz+7rC3tEs2ZfZM=",
+                    "dev": true,
+                    "requires": {
+                        "is-hex-prefixed": "1.0.0",
+                        "strip-hex-prefix": "1.0.0"
+                    }
+                },
+                "eventemitter3": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+                    "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
+                    "dev": true
+                },
+                "evp_bytestokey": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+                    "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+                    "dev": true,
+                    "requires": {
+                        "md5.js": "1.3.4",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "express": {
+                    "version": "4.16.3",
+                    "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+                    "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+                    "dev": true,
+                    "requires": {
+                        "accepts": "1.3.5",
+                        "array-flatten": "1.1.1",
+                        "body-parser": "1.18.2",
+                        "content-disposition": "0.5.2",
+                        "content-type": "1.0.4",
+                        "cookie": "0.3.1",
+                        "cookie-signature": "1.0.6",
+                        "debug": "2.6.9",
+                        "depd": "1.1.2",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
+                        "finalhandler": "1.1.1",
+                        "fresh": "0.5.2",
+                        "merge-descriptors": "1.0.1",
+                        "methods": "1.1.2",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "path-to-regexp": "0.1.7",
+                        "proxy-addr": "2.0.3",
+                        "qs": "6.5.1",
+                        "range-parser": "1.2.0",
+                        "safe-buffer": "5.1.1",
+                        "send": "0.16.2",
+                        "serve-static": "1.13.2",
+                        "setprototypeof": "1.1.0",
+                        "statuses": "1.4.0",
+                        "type-is": "1.6.16",
+                        "utils-merge": "1.0.1",
+                        "vary": "1.1.2"
+                    },
+                    "dependencies": {
+                        "body-parser": {
+                            "version": "1.18.2",
+                            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+                            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+                            "dev": true,
+                            "requires": {
+                                "bytes": "3.0.0",
+                                "content-type": "1.0.4",
+                                "debug": "2.6.9",
+                                "depd": "1.1.2",
+                                "http-errors": "1.6.3",
+                                "iconv-lite": "0.4.19",
+                                "on-finished": "2.3.0",
+                                "qs": "6.5.1",
+                                "raw-body": "2.3.2",
+                                "type-is": "1.6.16"
+                            }
+                        },
+                        "iconv-lite": {
+                            "version": "0.4.19",
+                            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+                            "dev": true
+                        },
+                        "qs": {
+                            "version": "6.5.1",
+                            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                            "dev": true
+                        },
+                        "raw-body": {
+                            "version": "2.3.2",
+                            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+                            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+                            "dev": true,
+                            "requires": {
+                                "bytes": "3.0.0",
+                                "http-errors": "1.6.2",
+                                "iconv-lite": "0.4.19",
+                                "unpipe": "1.0.0"
+                            },
+                            "dependencies": {
+                                "depd": {
+                                    "version": "1.1.1",
+                                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+                                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+                                    "dev": true
+                                },
+                                "http-errors": {
+                                    "version": "1.6.2",
+                                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+                                    "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+                                    "dev": true,
+                                    "requires": {
+                                        "depd": "1.1.1",
+                                        "inherits": "2.0.3",
+                                        "setprototypeof": "1.0.3",
+                                        "statuses": "1.4.0"
+                                    }
+                                },
+                                "setprototypeof": {
+                                    "version": "1.0.3",
+                                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+                                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "safe-buffer": {
+                            "version": "5.1.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                            "dev": true
+                        },
+                        "statuses": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                    "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+                    "dev": true
+                },
+                "extsprintf": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                    "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+                    "dev": true
+                },
+                "fake-merkle-patricia-tree": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+                    "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+                    "dev": true,
+                    "requires": {
+                        "checkpoint-store": "1.1.0"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+                    "dev": true
+                },
+                "fast-json-stable-stringify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+                    "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+                    "dev": true
+                },
+                "fd-slicer": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                    "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+                    "dev": true,
+                    "requires": {
+                        "pend": "1.2.0"
+                    }
+                },
+                "fetch-ponyfill": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+                    "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
+                    "dev": true,
+                    "requires": {
+                        "node-fetch": "1.7.3"
+                    },
+                    "dependencies": {
+                        "node-fetch": {
+                            "version": "1.7.3",
+                            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+                            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+                            "dev": true,
+                            "requires": {
+                                "encoding": "0.1.12",
+                                "is-stream": "1.1.0"
+                            }
+                        }
+                    }
+                },
+                "file-type": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+                    "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+                    "dev": true
+                },
+                "finalhandler": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+                    "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "statuses": "1.4.0",
+                        "unpipe": "1.0.0"
+                    },
+                    "dependencies": {
+                        "statuses": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                            "dev": true
+                        }
+                    }
+                },
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "for-each": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+                    "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-function": "1.0.1"
+                    }
+                },
+                "foreach": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+                    "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+                    "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "2.1.18"
+                    }
+                },
+                "forwarded": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+                    "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+                    "dev": true
+                },
+                "fresh": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+                    "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+                    "dev": true
+                },
+                "fs-constants": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+                    "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+                    "dev": true
+                },
+                "fs-extra": {
+                    "version": "0.30.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                    "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "jsonfile": "2.4.0",
+                        "klaw": "1.3.1",
+                        "path-is-absolute": "1.0.1",
+                        "rimraf": "2.6.2"
+                    }
+                },
+                "fs-promise": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
+                    "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
+                    "dev": true,
+                    "requires": {
+                        "any-promise": "1.3.0",
+                        "fs-extra": "2.1.2",
+                        "mz": "2.7.0",
+                        "thenify-all": "1.6.0"
+                    },
+                    "dependencies": {
+                        "fs-extra": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+                            "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "jsonfile": "2.4.0"
+                            }
+                        }
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+                    "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2"
+                    }
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+                    "dev": true
+                },
+                "functional-red-black-tree": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+                    "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+                    "dev": true
+                },
+                "generic-pool": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz",
+                    "integrity": "sha1-+XGN7agvoSXtXEPjQcmiFadm2aM=",
+                    "dev": true
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                    "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "global": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+                    "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+                    "dev": true,
+                    "requires": {
+                        "min-document": "2.19.0",
+                        "process": "0.5.2"
+                    }
+                },
+                "globals": {
+                    "version": "9.18.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                    "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+                    "dev": true
+                },
+                "got": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+                    "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+                    "dev": true,
+                    "requires": {
+                        "decompress-response": "3.3.0",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-plain-obj": "1.1.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "isurl": "1.0.0",
+                        "lowercase-keys": "1.0.1",
+                        "p-cancelable": "0.3.0",
+                        "p-timeout": "1.2.1",
+                        "safe-buffer": "5.1.2",
+                        "timed-out": "4.0.1",
+                        "url-parse-lax": "1.0.0",
+                        "url-to-options": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                    "dev": true
+                },
+                "graceful-readlink": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                    "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                    "dev": true
+                },
+                "growl": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+                    "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "has": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                    "dev": true,
+                    "requires": {
+                        "function-bind": "1.1.1"
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+                },
+                "has-localstorage": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-localstorage/-/has-localstorage-1.0.1.tgz",
+                    "integrity": "sha1-/mJAbEdn+9bXhNrGkFkoEIuClxs=",
+                    "dev": true
+                },
+                "has-symbol-support-x": {
+                    "version": "1.4.2",
+                    "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+                    "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+                    "dev": true
+                },
+                "has-to-string-tag-x": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+                    "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbol-support-x": "1.4.2"
+                    }
+                },
+                "hash-base": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "hash.js": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+                    "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "minimalistic-assert": "1.0.1"
+                    }
+                },
+                "hdkey": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
+                    "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
+                    "dev": true,
+                    "requires": {
+                        "coinstring": "2.3.0",
+                        "secp256k1": "3.5.0"
+                    }
+                },
+                "he": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+                },
+                "heap": {
+                    "version": "0.2.6",
+                    "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+                    "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
+                    "dev": true
+                },
+                "hmac-drbg": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+                    "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+                    "dev": true,
+                    "requires": {
+                        "hash.js": "1.1.3",
+                        "minimalistic-assert": "1.0.1",
+                        "minimalistic-crypto-utils": "1.0.1"
+                    }
+                },
+                "home-or-tmp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+                    "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "hosted-git-info": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+                    "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+                    "dev": true
+                },
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "dev": true,
+                    "requires": {
+                        "depd": "1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": "1.5.0"
+                    }
+                },
+                "http-https": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+                    "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.14.2"
+                    }
+                },
+                "humble-localstorage": {
+                    "version": "1.4.2",
+                    "resolved": "https://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
+                    "integrity": "sha1-0Fqw1SbE7b3b98amDfb/WAUoNGk=",
+                    "dev": true,
+                    "requires": {
+                        "has-localstorage": "1.0.1",
+                        "localstorage-memory": "1.0.2"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": "2.1.2"
+                    }
+                },
+                "ieee754": {
+                    "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+                    "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+                    "dev": true
+                },
+                "immediate": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+                    "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                },
+                "invariant": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+                    "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "1.3.1"
+                    }
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                    "dev": true
+                },
+                "ipaddr.js": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+                    "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+                    "dev": true
+                },
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                    "dev": true
+                },
+                "is-builtin-module": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                    "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                    "dev": true,
+                    "requires": {
+                        "builtin-modules": "1.1.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+                    "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+                },
+                "is-date-object": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+                    "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+                },
+                "is-finite": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                    "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-fn": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+                    "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-function": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+                    "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+                    "dev": true
+                },
+                "is-hex-prefixed": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+                    "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+                    "dev": true
+                },
+                "is-natural-number": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+                    "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+                    "dev": true
+                },
+                "is-object": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+                    "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+                    "dev": true
+                },
+                "is-plain-obj": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                    "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+                    "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+                    "dev": true,
+                    "requires": {
+                        "has": "1.0.3"
+                    }
+                },
+                "is-retry-allowed": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                    "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                    "dev": true
+                },
+                "is-symbol": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+                    "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                    "dev": true
+                },
+                "is-utf8": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                    "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                    "dev": true
+                },
+                "isurl": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+                    "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+                    "dev": true,
+                    "requires": {
+                        "has-to-string-tag-x": "1.4.1",
+                        "is-object": "1.0.1"
+                    }
+                },
+                "js-scrypt": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/js-scrypt/-/js-scrypt-0.2.0.tgz",
+                    "integrity": "sha1-emK3AbRhbnCtDN5URiequ5nX/jk=",
+                    "dev": true,
+                    "requires": {
+                        "generic-pool": "2.0.4"
+                    }
+                },
+                "js-sha3": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
+                    "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                    "dev": true,
+                    "optional": true
+                },
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                },
+                "json-rpc-engine": {
+                    "version": "3.7.3",
+                    "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.7.3.tgz",
+                    "integrity": "sha512-+FO3UWu/wafh/+MZ6BXy0HZU+f5plwUn82FgxpC0scJkEh5snOjFrAAtqCITPDfvfLHRUFOG5pQDUx2pspfERQ==",
+                    "dev": true,
+                    "requires": {
+                        "async": "2.6.1",
+                        "babel-preset-env": "1.7.0",
+                        "babelify": "7.3.0",
+                        "clone": "2.1.1",
+                        "json-rpc-error": "2.0.0",
+                        "promise-to-callback": "1.0.0"
+                    }
+                },
+                "json-rpc-error": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
+                    "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "json-rpc-random-id": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+                    "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg=",
+                    "dev": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+                    "dev": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                    "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                    "dev": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true
+                },
+                "jsonfile": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
+                    }
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                    "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+                    "dev": true
+                },
+                "jsprim": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                    "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                    }
+                },
+                "keccak": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+                    "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                    "dev": true,
+                    "requires": {
+                        "bindings": "1.3.0",
+                        "inherits": "2.0.3",
+                        "nan": "2.10.0",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "keccakjs": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
+                    "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
+                    "dev": true,
+                    "requires": {
+                        "browserify-sha3": "0.0.1",
+                        "sha3": "1.2.2"
+                    }
+                },
+                "klaw": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+                    "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
+                    }
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "1.0.0"
+                    }
+                },
+                "level-codec": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+                    "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
+                    "dev": true
+                },
+                "level-errors": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+                    "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+                    "dev": true,
+                    "requires": {
+                        "errno": "0.1.7"
+                    }
+                },
+                "level-iterator-stream": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+                    "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "level-errors": "1.0.5",
+                        "readable-stream": "1.1.14",
+                        "xtend": "4.0.1"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "1.1.14",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        }
+                    }
+                },
+                "level-post": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+                    "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+                    "dev": true,
+                    "requires": {
+                        "ltgt": "2.2.1"
+                    }
+                },
+                "level-sublevel": {
+                    "version": "6.6.2",
+                    "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
+                    "integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
+                    "dev": true,
+                    "requires": {
+                        "bytewise": "1.1.0",
+                        "levelup": "0.19.1",
+                        "ltgt": "2.1.3",
+                        "pull-defer": "0.2.2",
+                        "pull-level": "2.0.4",
+                        "pull-stream": "3.6.8",
+                        "typewiselite": "1.0.0",
+                        "xtend": "4.0.1"
+                    },
+                    "dependencies": {
+                        "abstract-leveldown": {
+                            "version": "0.12.4",
+                            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+                            "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+                            "dev": true,
+                            "requires": {
+                                "xtend": "3.0.0"
+                            },
+                            "dependencies": {
+                                "xtend": {
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                                    "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "deferred-leveldown": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+                            "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+                            "dev": true,
+                            "requires": {
+                                "abstract-leveldown": "0.12.4"
+                            }
+                        },
+                        "levelup": {
+                            "version": "0.19.1",
+                            "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
+                            "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
+                            "dev": true,
+                            "requires": {
+                                "bl": "0.8.2",
+                                "deferred-leveldown": "0.2.0",
+                                "errno": "0.1.7",
+                                "prr": "0.0.0",
+                                "readable-stream": "1.0.34",
+                                "semver": "5.1.1",
+                                "xtend": "3.0.0"
+                            },
+                            "dependencies": {
+                                "xtend": {
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                                    "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "ltgt": {
+                            "version": "2.1.3",
+                            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+                            "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=",
+                            "dev": true
+                        },
+                        "prr": {
+                            "version": "0.0.0",
+                            "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                            "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "1.0.34",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        },
+                        "semver": {
+                            "version": "5.1.1",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+                            "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk=",
+                            "dev": true
+                        }
+                    }
+                },
+                "level-ws": {
+                    "version": "0.0.0",
+                    "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+                    "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "2.1.2"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "1.0.34",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "0.0.1",
+                                "string_decoder": "0.10.31"
+                            }
+                        },
+                        "xtend": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                            "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+                            "dev": true,
+                            "requires": {
+                                "object-keys": "0.4.0"
+                            }
+                        }
+                    }
+                },
+                "levelup": {
+                    "version": "1.3.9",
+                    "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+                    "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+                    "dev": true,
+                    "requires": {
+                        "deferred-leveldown": "1.2.2",
+                        "level-codec": "7.0.1",
+                        "level-errors": "1.0.5",
+                        "level-iterator-stream": "1.3.1",
+                        "prr": "1.0.1",
+                        "semver": "5.4.1",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                },
+                "localstorage-down": {
+                    "version": "0.6.7",
+                    "resolved": "https://registry.npmjs.org/localstorage-down/-/localstorage-down-0.6.7.tgz",
+                    "integrity": "sha1-0Hmak7MebF+lGI7AYkLrHM6dbRU=",
+                    "dev": true,
+                    "requires": {
+                        "abstract-leveldown": "0.12.3",
+                        "argsarray": "0.0.1",
+                        "buffer-from": "0.1.2",
+                        "d64": "1.0.0",
+                        "humble-localstorage": "1.4.2",
+                        "inherits": "2.0.3",
+                        "tiny-queue": "0.2.0"
+                    },
+                    "dependencies": {
+                        "abstract-leveldown": {
+                            "version": "0.12.3",
+                            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
+                            "integrity": "sha1-EWsexcdxDvei1XBnaLvbREC+EHA=",
+                            "dev": true,
+                            "requires": {
+                                "xtend": "3.0.0"
+                            }
+                        },
+                        "xtend": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                            "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+                            "dev": true
+                        }
+                    }
+                },
+                "localstorage-memory": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.2.tgz",
+                    "integrity": "sha1-zUqPIQ5V3VGckp9LTMgoKbWPmlE=",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+                    "dev": true
+                },
+                "lodash.assign": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+                    "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+                    "dev": true
+                },
+                "lodash.merge": {
+                    "version": "4.6.1",
+                    "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+                    "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+                },
+                "looper": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+                    "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew=",
+                    "dev": true
+                },
+                "loose-envify": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                    "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+                    "dev": true,
+                    "requires": {
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "lowercase-keys": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+                    "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+                    "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "1.0.2"
+                    }
+                },
+                "ltgt": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+                    "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+                    "dev": true
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+                    "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "3.0.0"
+                    }
+                },
+                "md5.js": {
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+                    "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+                    "dev": true,
+                    "requires": {
+                        "hash-base": "3.0.4",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "media-typer": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                    "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+                    "dev": true
+                },
+                "memdown": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+                    "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+                    "dev": true,
+                    "requires": {
+                        "abstract-leveldown": "2.7.2",
+                        "functional-red-black-tree": "1.0.1",
+                        "immediate": "3.2.3",
+                        "inherits": "2.0.3",
+                        "ltgt": "2.2.1",
+                        "safe-buffer": "5.1.2"
+                    },
+                    "dependencies": {
+                        "abstract-leveldown": {
+                            "version": "2.7.2",
+                            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                            "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+                            "dev": true,
+                            "requires": {
+                                "xtend": "4.0.1"
+                            }
+                        }
+                    }
+                },
+                "memorystream": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+                    "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+                    "dev": true
+                },
+                "merge-descriptors": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+                    "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+                    "dev": true
+                },
+                "merkle-patricia-tree": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
+                    "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
+                    "dev": true,
+                    "requires": {
+                        "async": "1.5.2",
+                        "ethereumjs-util": "5.2.0",
+                        "level-ws": "0.0.0",
+                        "levelup": "1.3.9",
+                        "memdown": "1.4.1",
+                        "readable-stream": "2.3.6",
+                        "rlp": "2.0.0",
+                        "semaphore": "1.1.0"
+                    },
+                    "dependencies": {
+                        "async": {
+                            "version": "1.5.2",
+                            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                            "dev": true
+                        }
+                    }
+                },
+                "methods": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+                    "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+                    "dev": true
+                },
+                "miller-rabin": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+                    "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "brorand": "1.1.0"
+                    }
+                },
+                "mime": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+                    "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+                    "dev": true
+                },
+                "mime-db": {
+                    "version": "1.33.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+                    "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.18",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+                    "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.33.0"
+                    }
+                },
+                "mimic-response": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+                    "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
+                    "dev": true
+                },
+                "min-document": {
+                    "version": "2.19.0",
+                    "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+                    "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+                    "dev": true,
+                    "requires": {
+                        "dom-walk": "0.1.1"
+                    }
+                },
+                "minimalistic-assert": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+                    "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+                    "dev": true
+                },
+                "minimalistic-crypto-utils": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+                    "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "requires": {
+                        "brace-expansion": "1.1.11"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "mkdirp-promise": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+                    "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+                    "dev": true,
+                    "requires": {
+                        "mkdirp": "0.5.1"
+                    }
+                },
+                "mocha": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
+                    "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+                    "requires": {
+                        "browser-stdout": "1.3.1",
+                        "commander": "2.11.0",
+                        "debug": "3.1.0",
+                        "diff": "3.5.0",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.2",
+                        "growl": "1.10.3",
+                        "he": "1.1.1",
+                        "minimatch": "3.0.4",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "4.4.0"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "2.11.0",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+                        },
+                        "debug": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "4.4.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                            "requires": {
+                                "has-flag": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "mock-fs": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
+                    "integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w==",
+                    "dev": true
+                },
+                "mout": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
+                    "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                },
+                "mz": {
+                    "version": "2.7.0",
+                    "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+                    "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+                    "dev": true,
+                    "requires": {
+                        "any-promise": "1.3.0",
+                        "object-assign": "4.1.1",
+                        "thenify-all": "1.6.0"
+                    }
+                },
+                "nan": {
+                    "version": "2.10.0",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+                    "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+                    "dev": true
+                },
+                "nano-json-stream-parser": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+                    "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
+                    "dev": true
+                },
+                "negotiator": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                    "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+                    "dev": true
+                },
                 "node-fetch": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
                     "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+                    "dev": true
+                },
+                "normalize-package-data": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                    "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "2.6.0",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.4.1",
+                        "validate-npm-package-license": "3.0.3"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                    "dev": true
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                },
+                "object-inspect": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
+                    "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
+                    "dev": true
+                },
+                "object-keys": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                    "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+                    "dev": true
+                },
+                "oboe": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
+                    "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
+                    "dev": true,
+                    "requires": {
+                        "http-https": "1.0.0"
+                    }
+                },
+                "on-finished": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                    "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+                    "dev": true,
+                    "requires": {
+                        "ee-first": "1.1.1"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                    "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                    "dev": true,
+                    "requires": {
+                        "lcid": "1.0.0"
+                    }
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                    "dev": true
+                },
+                "p-cancelable": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+                    "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+                    "dev": true
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                    "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+                    "dev": true
+                },
+                "p-timeout": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+                    "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+                    "dev": true,
+                    "requires": {
+                        "p-finally": "1.0.0"
+                    }
+                },
+                "parse-asn1": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+                    "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+                    "dev": true,
+                    "requires": {
+                        "asn1.js": "4.10.1",
+                        "browserify-aes": "1.2.0",
+                        "create-hash": "1.2.0",
+                        "evp_bytestokey": "1.0.3",
+                        "pbkdf2": "3.0.16"
+                    }
+                },
+                "parse-headers": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+                    "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+                    "dev": true,
+                    "requires": {
+                        "for-each": "0.3.2",
+                        "trim": "0.0.1"
+                    }
+                },
+                "parse-json": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
+                },
+                "parseurl": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+                    "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                },
+                "path-parse": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                    "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+                    "dev": true
+                },
+                "path-to-regexp": {
+                    "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                },
+                "pbkdf2": {
+                    "version": "3.0.16",
+                    "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+                    "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+                    "dev": true,
+                    "requires": {
+                        "create-hash": "1.2.0",
+                        "create-hmac": "1.1.7",
+                        "ripemd160": "2.0.2",
+                        "safe-buffer": "5.1.2",
+                        "sha.js": "2.4.11"
+                    }
+                },
+                "pend": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+                    "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                },
+                "pinkie": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                    "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                    "dev": true
+                },
+                "pinkie-promise": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                    "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie": "2.0.4"
+                    }
+                },
+                "precond": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                    "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
+                    "dev": true
+                },
+                "prepend-file": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/prepend-file/-/prepend-file-1.3.1.tgz",
+                    "integrity": "sha1-g7FuC0rBkB/OiNvZRaIvTMgd9Xk=",
+                    "dev": true,
+                    "requires": {
+                        "tmp": "0.0.31"
+                    }
+                },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+                    "dev": true
+                },
+                "private": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+                    "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+                    "dev": true
+                },
+                "process": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+                    "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "promise-to-callback": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+                    "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-fn": "1.0.0",
+                        "set-immediate-shim": "1.0.1"
+                    }
+                },
+                "proxy-addr": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+                    "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+                    "dev": true,
+                    "requires": {
+                        "forwarded": "0.1.2",
+                        "ipaddr.js": "1.6.0"
+                    }
+                },
+                "prr": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+                    "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+                    "dev": true
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+                    "dev": true
+                },
+                "public-encrypt": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+                    "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "browserify-rsa": "4.0.1",
+                        "create-hash": "1.2.0",
+                        "parse-asn1": "5.1.1",
+                        "randombytes": "2.0.6"
+                    }
+                },
+                "pull-cat": {
+                    "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+                    "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs=",
+                    "dev": true
+                },
+                "pull-defer": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
+                    "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM=",
+                    "dev": true
+                },
+                "pull-level": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+                    "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+                    "dev": true,
+                    "requires": {
+                        "level-post": "1.0.7",
+                        "pull-cat": "1.1.11",
+                        "pull-live": "1.0.1",
+                        "pull-pushable": "2.2.0",
+                        "pull-stream": "3.6.8",
+                        "pull-window": "2.1.4",
+                        "stream-to-pull-stream": "1.7.2"
+                    }
+                },
+                "pull-live": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+                    "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+                    "dev": true,
+                    "requires": {
+                        "pull-cat": "1.1.11",
+                        "pull-stream": "3.6.8"
+                    }
+                },
+                "pull-pushable": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+                    "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE=",
+                    "dev": true
+                },
+                "pull-stream": {
+                    "version": "3.6.8",
+                    "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.8.tgz",
+                    "integrity": "sha512-wQUIptQBcM0rFsUhZoEpOT3vUn73DtTGVq3NQ86c4T7iMOSprDzeKWYq2ksXnbwiuExTKvt+8G9fzNLFQuiO+A==",
+                    "dev": true
+                },
+                "pull-window": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+                    "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+                    "dev": true,
+                    "requires": {
+                        "looper": "2.0.0"
+                    }
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "query-string": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+                    "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+                    "dev": true,
+                    "requires": {
+                        "decode-uri-component": "0.2.0",
+                        "object-assign": "4.1.1",
+                        "strict-uri-encode": "1.1.0"
+                    }
+                },
+                "randombytes": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+                    "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "randomfill": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+                    "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+                    "dev": true,
+                    "requires": {
+                        "randombytes": "2.0.6",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "randomhex": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
+                    "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
+                    "dev": true
+                },
+                "range-parser": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                    "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+                    "dev": true
+                },
+                "raw-body": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+                    "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.0.0",
+                        "http-errors": "1.6.3",
+                        "iconv-lite": "0.4.23",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "1.1.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    },
+                    "dependencies": {
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "dev": true
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "5.1.2"
+                            }
+                        }
+                    }
+                },
+                "regenerate": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+                    "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+                    "dev": true
+                },
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+                },
+                "regenerator-transform": {
+                    "version": "0.10.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+                    "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.26.0",
+                        "babel-types": "6.26.0",
+                        "private": "0.1.8"
+                    }
+                },
+                "regexpu-core": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+                    "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "1.4.0",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
+                    }
+                },
+                "regjsgen": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                    "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+                    "dev": true
+                },
+                "regjsparser": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                    "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+                    "dev": true,
+                    "requires": {
+                        "jsesc": "0.5.0"
+                    }
+                },
+                "repeating": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                    "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                    "dev": true,
+                    "requires": {
+                        "is-finite": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.87.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+                    "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.7.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.0.3",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.18",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.2",
+                        "tough-cookie": "2.3.4",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.2.1"
+                    },
+                    "dependencies": {
+                        "uuid": {
+                            "version": "3.2.1",
+                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+                            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                    "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+                    "dev": true
+                },
+                "require-from-string": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+                    "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+                    "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "1.0.5"
+                    }
+                },
+                "resumer": {
+                    "version": "0.0.0",
+                    "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+                    "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+                    "dev": true,
+                    "requires": {
+                        "through": "2.3.8"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "ripemd160": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+                    "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+                    "dev": true,
+                    "requires": {
+                        "hash-base": "3.0.4",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "rlp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
+                    "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A=",
+                    "dev": true
+                },
+                "rustbn.js": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
+                    "integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg==",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+                    "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                    "dev": true
+                },
+                "scrypt": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
+                    "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+                    "dev": true,
+                    "requires": {
+                        "nan": "2.10.0"
+                    }
+                },
+                "scrypt.js": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+                    "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
+                    "dev": true,
+                    "requires": {
+                        "scrypt": "6.0.3",
+                        "scryptsy": "1.2.1"
+                    }
+                },
+                "scryptsy": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+                    "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+                    "dev": true,
+                    "requires": {
+                        "pbkdf2": "3.0.16"
+                    }
+                },
+                "secp256k1": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+                    "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+                    "dev": true,
+                    "requires": {
+                        "bindings": "1.3.0",
+                        "bip66": "1.1.5",
+                        "bn.js": "4.11.6",
+                        "create-hash": "1.2.0",
+                        "drbg.js": "1.0.1",
+                        "elliptic": "6.4.0",
+                        "nan": "2.10.0",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "seedrandom": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+                    "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
+                    "dev": true
+                },
+                "seek-bzip": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                    "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+                    "dev": true,
+                    "requires": {
+                        "commander": "2.8.1"
+                    }
+                },
+                "semaphore": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+                    "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+                    "dev": true
+                },
+                "send": {
+                    "version": "0.16.2",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+                    "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "depd": "1.1.2",
+                        "destroy": "1.0.4",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
+                        "fresh": "0.5.2",
+                        "http-errors": "1.6.3",
+                        "mime": "1.4.1",
+                        "ms": "2.0.0",
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.2.0",
+                        "statuses": "1.4.0"
+                    },
+                    "dependencies": {
+                        "statuses": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                            "dev": true
+                        }
+                    }
+                },
+                "serve-static": {
+                    "version": "1.13.2",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+                    "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+                    "dev": true,
+                    "requires": {
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "parseurl": "1.3.2",
+                        "send": "0.16.2"
+                    }
+                },
+                "servify": {
+                    "version": "0.1.12",
+                    "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+                    "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+                    "dev": true,
+                    "requires": {
+                        "body-parser": "1.18.3",
+                        "cors": "2.8.4",
+                        "express": "4.16.3",
+                        "request": "2.87.0",
+                        "xhr": "2.5.0"
+                    }
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                    "dev": true
+                },
+                "set-immediate-shim": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                    "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+                    "dev": true
+                },
+                "setimmediate": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+                    "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+                    "dev": true
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+                    "dev": true
+                },
+                "sha.js": {
+                    "version": "2.4.11",
+                    "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+                    "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "sha3": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
+                    "integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
+                    "dev": true,
+                    "requires": {
+                        "nan": "2.10.0"
+                    }
+                },
+                "shebang-loader": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/shebang-loader/-/shebang-loader-0.0.1.tgz",
+                    "integrity": "sha1-pAAEldRMzu++xjQ157FphWn6Uuw=",
+                    "dev": true
+                },
+                "simple-concat": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+                    "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+                    "dev": true
+                },
+                "simple-get": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+                    "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+                    "dev": true,
+                    "requires": {
+                        "decompress-response": "3.3.0",
+                        "once": "1.4.0",
+                        "simple-concat": "1.0.0"
+                    }
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
                     "dev": true
                 },
                 "solc": {
@@ -12044,6 +16244,355 @@
                         }
                     }
                 },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.4.18",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.5.7"
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+                    "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+                    "dev": true,
+                    "requires": {
+                        "spdx-expression-parse": "3.0.0",
+                        "spdx-license-ids": "3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+                    "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                    "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "2.1.0",
+                        "spdx-license-ids": "3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+                    "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+                    "dev": true
+                },
+                "sshpk": {
+                    "version": "1.14.2",
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+                    "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+                    "dev": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "safer-buffer": "2.1.2",
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+                    "dev": true
+                },
+                "stream-to-pull-stream": {
+                    "version": "1.7.2",
+                    "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
+                    "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
+                    "dev": true,
+                    "requires": {
+                        "looper": "3.0.0",
+                        "pull-stream": "3.6.8"
+                    },
+                    "dependencies": {
+                        "looper": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+                            "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k=",
+                            "dev": true
+                        }
+                    }
+                },
+                "strict-uri-encode": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+                    "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string.prototype.trim": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+                    "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "1.1.2",
+                        "es-abstract": "1.12.0",
+                        "function-bind": "1.1.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                },
+                "strip-dirs": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+                    "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+                    "dev": true,
+                    "requires": {
+                        "is-natural-number": "4.0.1"
+                    }
+                },
+                "strip-hex-prefix": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+                    "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+                    "dev": true,
+                    "requires": {
+                        "is-hex-prefixed": "1.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                },
+                "swarm-js": {
+                    "version": "0.1.37",
+                    "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
+                    "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "3.5.1",
+                        "buffer": "5.1.0",
+                        "decompress": "4.2.0",
+                        "eth-lib": "0.1.27",
+                        "fs-extra": "2.1.2",
+                        "fs-promise": "2.0.3",
+                        "got": "7.1.0",
+                        "mime-types": "2.1.18",
+                        "mkdirp-promise": "5.0.1",
+                        "mock-fs": "4.5.0",
+                        "setimmediate": "1.0.5",
+                        "tar.gz": "1.0.7",
+                        "xhr-request-promise": "0.1.2"
+                    },
+                    "dependencies": {
+                        "fs-extra": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+                            "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "jsonfile": "2.4.0"
+                            }
+                        }
+                    }
+                },
+                "tape": {
+                    "version": "4.9.0",
+                    "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
+                    "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
+                    "dev": true,
+                    "requires": {
+                        "deep-equal": "1.0.1",
+                        "defined": "1.0.0",
+                        "for-each": "0.3.2",
+                        "function-bind": "1.1.1",
+                        "glob": "7.1.2",
+                        "has": "1.0.3",
+                        "inherits": "2.0.3",
+                        "minimist": "1.2.0",
+                        "object-inspect": "1.5.0",
+                        "resolve": "1.5.0",
+                        "resumer": "0.0.0",
+                        "string.prototype.trim": "1.1.2",
+                        "through": "2.3.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                            "dev": true
+                        }
+                    }
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-stream": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+                    "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+                    "dev": true,
+                    "requires": {
+                        "bl": "1.2.2",
+                        "buffer-alloc": "1.1.0",
+                        "end-of-stream": "1.4.1",
+                        "fs-constants": "1.0.0",
+                        "readable-stream": "2.3.6",
+                        "to-buffer": "1.1.1",
+                        "xtend": "4.0.1"
+                    },
+                    "dependencies": {
+                        "bl": {
+                            "version": "1.2.2",
+                            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+                            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+                            "dev": true,
+                            "requires": {
+                                "readable-stream": "2.3.6",
+                                "safe-buffer": "5.1.2"
+                            }
+                        }
+                    }
+                },
+                "tar.gz": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
+                    "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "2.11.0",
+                        "commander": "2.8.1",
+                        "fstream": "1.0.11",
+                        "mout": "0.11.1",
+                        "tar": "2.2.1"
+                    },
+                    "dependencies": {
+                        "bluebird": {
+                            "version": "2.11.0",
+                            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+                            "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+                            "dev": true
+                        }
+                    }
+                },
+                "temp": {
+                    "version": "0.8.3",
+                    "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+                    "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+                    "dev": true,
+                    "requires": {
+                        "os-tmpdir": "1.0.2",
+                        "rimraf": "2.2.8"
+                    },
+                    "dependencies": {
+                        "rimraf": {
+                            "version": "2.2.8",
+                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                            "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                            "dev": true
+                        }
+                    }
+                },
+                "thenify": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+                    "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+                    "dev": true,
+                    "requires": {
+                        "any-promise": "1.3.0"
+                    }
+                },
+                "thenify-all": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+                    "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+                    "dev": true,
+                    "requires": {
+                        "thenify": "3.3.0"
+                    }
+                },
+                "through": {
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                    "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "timed-out": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                    "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+                    "dev": true
+                },
+                "tiny-queue": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.0.tgz",
+                    "integrity": "sha1-xJ/LXIdVW+G0pd9+uHEB1beLydw=",
+                    "dev": true
+                },
                 "tmp": {
                     "version": "0.0.31",
                     "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
@@ -12053,11 +16602,258 @@
                         "os-tmpdir": "~1.0.1"
                     }
                 },
+                "to-buffer": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+                    "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.3.4",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+                    "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "treeify": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+                    "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+                    "dev": true
+                },
+                "trim": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+                    "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+                    "dev": true
+                },
+                "trim-right": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                    "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+                    "dev": true
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                    "dev": true,
+                    "optional": true
+                },
                 "type-detect": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
                     "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
                     "dev": true
+                },
+                "type-is": {
+                    "version": "1.6.16",
+                    "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+                    "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+                    "dev": true,
+                    "requires": {
+                        "media-typer": "0.3.0",
+                        "mime-types": "2.1.18"
+                    }
+                },
+                "typedarray": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                    "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+                    "dev": true
+                },
+                "typedarray-to-buffer": {
+                    "version": "3.1.5",
+                    "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+                    "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+                    "dev": true,
+                    "requires": {
+                        "is-typedarray": "1.0.0"
+                    }
+                },
+                "typewise": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+                    "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
+                    "dev": true,
+                    "requires": {
+                        "typewise-core": "1.2.0"
+                    }
+                },
+                "typewise-core": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+                    "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=",
+                    "dev": true
+                },
+                "typewiselite": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+                    "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4=",
+                    "dev": true
+                },
+                "ultron": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+                    "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+                    "dev": true
+                },
+                "unbzip2-stream": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
+                    "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+                    "dev": true,
+                    "requires": {
+                        "buffer": "3.6.0",
+                        "through": "2.3.8"
+                    },
+                    "dependencies": {
+                        "base64-js": {
+                            "version": "0.0.8",
+                            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                            "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+                            "dev": true
+                        },
+                        "buffer": {
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+                            "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+                            "dev": true,
+                            "requires": {
+                                "base64-js": "0.0.8",
+                                "ieee754": "1.1.11",
+                                "isarray": "1.0.0"
+                            }
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "dev": true
+                        }
+                    }
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+                    "dev": true
+                },
+                "unorm": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+                    "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+                    "dev": true
+                },
+                "unpipe": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                    "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+                    "dev": true
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "1.0.4"
+                    }
+                },
+                "url-set-query": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+                    "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
+                    "dev": true
+                },
+                "url-to-options": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+                    "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+                    "dev": true
+                },
+                "utf8": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+                    "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "requires": {
+                        "inherits": "2.0.1"
+                    },
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                            "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                        }
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                    "dev": true
+                },
+                "utils-merge": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+                    "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+                    "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+                    "dev": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+                    "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "3.0.0",
+                        "spdx-expression-parse": "3.0.0"
+                    }
+                },
+                "vary": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+                    "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+                    "dev": true
+                },
+                "verror": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                    "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                    }
                 },
                 "web3": {
                     "version": "1.0.0-beta.34",
@@ -12071,6 +16867,206 @@
                         "web3-eth-personal": "1.0.0-beta.34",
                         "web3-net": "1.0.0-beta.34",
                         "web3-shh": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-bzz": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
+                    "dev": true,
+                    "requires": {
+                        "got": "7.1.0",
+                        "swarm-js": "0.1.37",
+                        "underscore": "1.8.3"
+                    }
+                },
+                "web3-core": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
+                    "dev": true,
+                    "requires": {
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-core-method": "1.0.0-beta.34",
+                        "web3-core-requestmanager": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-core-helpers": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
+                    "dev": true,
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-eth-iban": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-core-method": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
+                    "dev": true,
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-core-promievent": "1.0.0-beta.34",
+                        "web3-core-subscriptions": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-core-promievent": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
+                    "dev": true,
+                    "requires": {
+                        "any-promise": "1.3.0",
+                        "eventemitter3": "1.1.1"
+                    }
+                },
+                "web3-core-requestmanager": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
+                    "dev": true,
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-providers-http": "1.0.0-beta.34",
+                        "web3-providers-ipc": "1.0.0-beta.34",
+                        "web3-providers-ws": "1.0.0-beta.34"
+                    }
+                },
+                "web3-core-subscriptions": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
+                    "dev": true,
+                    "requires": {
+                        "eventemitter3": "1.1.1",
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.34"
+                    }
+                },
+                "web3-eth": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
+                    "dev": true,
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core": "1.0.0-beta.34",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-core-method": "1.0.0-beta.34",
+                        "web3-core-subscriptions": "1.0.0-beta.34",
+                        "web3-eth-abi": "1.0.0-beta.34",
+                        "web3-eth-accounts": "1.0.0-beta.34",
+                        "web3-eth-contract": "1.0.0-beta.34",
+                        "web3-eth-iban": "1.0.0-beta.34",
+                        "web3-eth-personal": "1.0.0-beta.34",
+                        "web3-net": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-eth-abi": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-eth-accounts": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
+                    "dev": true,
+                    "requires": {
+                        "any-promise": "1.3.0",
+                        "crypto-browserify": "3.12.0",
+                        "eth-lib": "0.2.7",
+                        "scrypt.js": "0.2.0",
+                        "underscore": "1.8.3",
+                        "uuid": "2.0.1",
+                        "web3-core": "1.0.0-beta.34",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-core-method": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    },
+                    "dependencies": {
+                        "eth-lib": {
+                            "version": "0.2.7",
+                            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                            "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                            "dev": true,
+                            "requires": {
+                                "bn.js": "4.11.6",
+                                "elliptic": "6.4.0",
+                                "xhr-request-promise": "0.1.2"
+                            }
+                        },
+                        "uuid": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                            "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-eth-contract": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
+                    "dev": true,
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core": "1.0.0-beta.34",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-core-method": "1.0.0-beta.34",
+                        "web3-core-promievent": "1.0.0-beta.34",
+                        "web3-core-subscriptions": "1.0.0-beta.34",
+                        "web3-eth-abi": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-eth-iban": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-eth-personal": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
+                    "dev": true,
+                    "requires": {
+                        "web3-core": "1.0.0-beta.34",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "web3-core-method": "1.0.0-beta.34",
+                        "web3-net": "1.0.0-beta.34",
+                        "web3-utils": "1.0.0-beta.34"
+                    }
+                },
+                "web3-net": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
+                    "dev": true,
+                    "requires": {
+                        "web3-core": "1.0.0-beta.34",
+                        "web3-core-method": "1.0.0-beta.34",
                         "web3-utils": "1.0.0-beta.34"
                     }
                 },
@@ -12101,6 +17097,109 @@
                         "ws": "^5.1.1",
                         "xhr": "^2.2.0",
                         "xtend": "^4.0.1"
+                    },
+                    "dependencies": {
+                        "ws": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.0.tgz",
+                            "integrity": "sha512-c18dMeW+PEQdDFzkhDsnBAlS4Z8KGStBQQUcQ5mf7Nf689jyGk0594L+i9RaQuf4gog6SvWLJorz2NfSaqxZ7w==",
+                            "dev": true,
+                            "requires": {
+                                "async-limiter": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "web3-providers-http": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
+                    "dev": true,
+                    "requires": {
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "xhr2": "0.1.4"
+                    }
+                },
+                "web3-providers-ipc": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
+                    "dev": true,
+                    "requires": {
+                        "oboe": "2.1.3",
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.34"
+                    }
+                },
+                "web3-providers-ws": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
+                    "dev": true,
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.34",
+                        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+                    },
+                    "dependencies": {
+                        "websocket": {
+                            "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                            "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                            "dev": true,
+                            "requires": {
+                                "debug": "2.6.9",
+                                "nan": "2.10.0",
+                                "typedarray-to-buffer": "3.1.5",
+                                "yaeti": "0.0.6"
+                            }
+                        }
+                    }
+                },
+                "web3-shh": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
+                    "dev": true,
+                    "requires": {
+                        "web3-core": "1.0.0-beta.34",
+                        "web3-core-method": "1.0.0-beta.34",
+                        "web3-core-subscriptions": "1.0.0-beta.34",
+                        "web3-net": "1.0.0-beta.34"
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.0.0-beta.34",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+                    "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "eth-lib": "0.1.27",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randomhex": "0.1.5",
+                        "underscore": "1.8.3",
+                        "utf8": "2.1.1"
+                    },
+                    "dependencies": {
+                        "utf8": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+                            "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "websocket": {
+                    "version": "1.0.26",
+                    "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
+                    "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "nan": "2.10.0",
+                        "typedarray-to-buffer": "3.1.5",
+                        "yaeti": "0.0.6"
                     }
                 },
                 "whatwg-fetch": {
@@ -12109,14 +17208,100 @@
                     "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
                     "dev": true
                 },
+                "which-module": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+                    "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+                    "dev": true
+                },
+                "window-size": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+                    "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                },
                 "ws": {
                     "version": "5.2.2",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
                     "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-                    "dev": true,
                     "requires": {
                         "async-limiter": "~1.0.0"
                     }
+                },
+                "xhr": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+                    "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+                    "dev": true,
+                    "requires": {
+                        "global": "4.3.2",
+                        "is-function": "1.0.1",
+                        "parse-headers": "2.0.1",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "xhr-request": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+                    "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-to-arraybuffer": "0.0.5",
+                        "object-assign": "4.1.1",
+                        "query-string": "5.1.1",
+                        "simple-get": "2.8.1",
+                        "timed-out": "4.0.1",
+                        "url-set-query": "1.0.0",
+                        "xhr": "2.5.0"
+                    }
+                },
+                "xhr-request-promise": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
+                    "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+                    "dev": true,
+                    "requires": {
+                        "xhr-request": "1.1.0"
+                    }
+                },
+                "xhr2": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+                    "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
+                    "dev": true
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                    "dev": true
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+                    "dev": true
+                },
+                "yaeti": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+                    "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "7.1.0",
@@ -12158,6 +17343,16 @@
                     "requires": {
                         "camelcase": "^3.0.0",
                         "lodash.assign": "^4.0.6"
+                    }
+                },
+                "yauzl": {
+                    "version": "2.9.1",
+                    "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+                    "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+                    "dev": true,
+                    "requires": {
+                        "buffer-crc32": "0.2.13",
+                        "fd-slicer": "1.0.1"
                     }
                 }
             }
@@ -12300,12 +17495,6 @@
             "requires": {
                 "is-property": "^1.0.0"
             }
-        },
-        "generic-pool": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz",
-            "integrity": "sha1-+XGN7agvoSXtXEPjQcmiFadm2aM=",
-            "dev": true
         },
         "get-caller-file": {
             "version": "1.0.2",
@@ -14229,12 +19418,6 @@
                 "sparkles": "^1.0.0"
             }
         },
-        "has-localstorage": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-localstorage/-/has-localstorage-1.0.1.tgz",
-            "integrity": "sha1-/mJAbEdn+9bXhNrGkFkoEIuClxs=",
-            "dev": true
-        },
         "has-symbol-support-x": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
@@ -14371,12 +19554,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true
-        },
-        "heap": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-            "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
             "dev": true
         },
         "hipchat-notifier": {
@@ -14727,12 +19904,6 @@
                 }
             }
         },
-        "http-https": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-            "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-            "dev": true
-        },
         "http-parser-js": {
             "version": "0.4.9",
             "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
@@ -14932,16 +20103,6 @@
                         "is-plain-obj": "^1.0.0"
                     }
                 }
-            }
-        },
-        "humble-localstorage": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
-            "integrity": "sha1-0Fqw1SbE7b3b98amDfb/WAUoNGk=",
-            "dev": true,
-            "requires": {
-                "has-localstorage": "^1.0.1",
-                "localstorage-memory": "^1.0.1"
             }
         },
         "hyphenate-style-name": {
@@ -15664,12 +20825,6 @@
                 "xtend": "^4.0.0"
             }
         },
-        "is-natural-number": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-            "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-            "dev": true
-        },
         "is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -16129,15 +21284,6 @@
             "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.0.tgz",
             "integrity": "sha1-fPLLaYGWaEeQNQ0MTKB/Su2ewX4=",
             "dev": true
-        },
-        "js-scrypt": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/js-scrypt/-/js-scrypt-0.2.0.tgz",
-            "integrity": "sha1-emK3AbRhbnCtDN5URiequ5nX/jk=",
-            "dev": true,
-            "requires": {
-                "generic-pool": "~2.0.4"
-            }
         },
         "js-sha3": {
             "version": "0.3.1",
@@ -17620,133 +22766,6 @@
                 }
             }
         },
-        "level-post": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-            "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-            "dev": true,
-            "requires": {
-                "ltgt": "^2.1.2"
-            }
-        },
-        "level-sublevel": {
-            "version": "6.6.5",
-            "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
-            "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
-            "dev": true,
-            "requires": {
-                "bytewise": "~1.1.0",
-                "levelup": "~0.19.0",
-                "ltgt": "~2.1.1",
-                "pull-defer": "^0.2.2",
-                "pull-level": "^2.0.3",
-                "pull-stream": "^3.6.8",
-                "typewiselite": "~1.0.0",
-                "xtend": "~4.0.0"
-            },
-            "dependencies": {
-                "abstract-leveldown": {
-                    "version": "0.12.4",
-                    "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-                    "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-                    "dev": true,
-                    "requires": {
-                        "xtend": "~3.0.0"
-                    },
-                    "dependencies": {
-                        "xtend": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                            "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-                            "dev": true
-                        }
-                    }
-                },
-                "bl": {
-                    "version": "0.8.2",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-                    "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "~1.0.26"
-                    }
-                },
-                "deferred-leveldown": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-                    "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-                    "dev": true,
-                    "requires": {
-                        "abstract-leveldown": "~0.12.1"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "levelup": {
-                    "version": "0.19.1",
-                    "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-                    "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-                    "dev": true,
-                    "requires": {
-                        "bl": "~0.8.1",
-                        "deferred-leveldown": "~0.2.0",
-                        "errno": "~0.1.1",
-                        "prr": "~0.0.0",
-                        "readable-stream": "~1.0.26",
-                        "semver": "~5.1.0",
-                        "xtend": "~3.0.0"
-                    },
-                    "dependencies": {
-                        "xtend": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                            "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-                            "dev": true
-                        }
-                    }
-                },
-                "ltgt": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-                    "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=",
-                    "dev": true
-                },
-                "prr": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-                    "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "semver": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-                    "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk=",
-                    "dev": true
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
         "level-ws": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
@@ -18021,44 +23040,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/locale-currency/-/locale-currency-0.0.1.tgz",
             "integrity": "sha1-yeFaIv9XW0tLuUekv5KsI2vR/ps="
-        },
-        "localstorage-down": {
-            "version": "0.6.7",
-            "resolved": "https://registry.npmjs.org/localstorage-down/-/localstorage-down-0.6.7.tgz",
-            "integrity": "sha1-0Hmak7MebF+lGI7AYkLrHM6dbRU=",
-            "dev": true,
-            "requires": {
-                "abstract-leveldown": "0.12.3",
-                "argsarray": "0.0.1",
-                "buffer-from": "^0.1.1",
-                "d64": "^1.0.0",
-                "humble-localstorage": "^1.4.2",
-                "inherits": "^2.0.1",
-                "tiny-queue": "0.2.0"
-            },
-            "dependencies": {
-                "abstract-leveldown": {
-                    "version": "0.12.3",
-                    "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
-                    "integrity": "sha1-EWsexcdxDvei1XBnaLvbREC+EHA=",
-                    "dev": true,
-                    "requires": {
-                        "xtend": "~3.0.0"
-                    }
-                },
-                "xtend": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                    "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
-                    "dev": true
-                }
-            }
-        },
-        "localstorage-memory": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/localstorage-memory/-/localstorage-memory-1.0.2.tgz",
-            "integrity": "sha1-zUqPIQ5V3VGckp9LTMgoKbWPmlE=",
-            "dev": true
         },
         "locate-path": {
             "version": "2.0.0",
@@ -18625,12 +23606,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-        },
-        "looper": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-            "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew=",
-            "dev": true
         },
         "loose-envify": {
             "version": "1.3.1",
@@ -19740,15 +24715,6 @@
                 }
             }
         },
-        "mkdirp-promise": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
-            "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
-            "dev": true,
-            "requires": {
-                "mkdirp": "*"
-            }
-        },
         "mocha": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
@@ -19811,12 +24777,6 @@
             "integrity": "sha1-cjqTEOfXN9e3fHpmghI3QlsDLUg=",
             "dev": true
         },
-        "mock-fs": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
-            "integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w==",
-            "dev": true
-        },
         "module-deps": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.0.0.tgz",
@@ -19872,12 +24832,6 @@
             "version": "2.22.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
             "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
-            "dev": true
-        },
-        "mout": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-            "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
             "dev": true
         },
         "move-concurrently": {
@@ -20002,12 +24956,6 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
             "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-        },
-        "nano-json-stream-parser": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-            "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-            "dev": true
         },
         "nanomatch": {
             "version": "1.2.9",
@@ -22223,15 +27171,6 @@
                 "es-abstract": "^1.6.1",
                 "function-bind": "^1.1.0",
                 "has": "^1.0.1"
-            }
-        },
-        "oboe": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
-            "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
-            "dev": true,
-            "requires": {
-                "http-https": "^1.0.0"
             }
         },
         "obs-store": {
@@ -24625,26 +29564,6 @@
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
-        "prepend-file": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/prepend-file/-/prepend-file-1.3.1.tgz",
-            "integrity": "sha1-g7FuC0rBkB/OiNvZRaIvTMgd9Xk=",
-            "dev": true,
-            "requires": {
-                "tmp": "0.0.31"
-            },
-            "dependencies": {
-                "tmp": {
-                    "version": "0.0.31",
-                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-                    "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-                    "dev": true,
-                    "requires": {
-                        "os-tmpdir": "~1.0.1"
-                    }
-                }
-            }
-        },
         "prepend-http": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -24905,64 +29824,6 @@
                 "create-hash": "^1.1.0",
                 "parse-asn1": "^5.0.0",
                 "randombytes": "^2.0.1"
-            }
-        },
-        "pull-cat": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-            "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs=",
-            "dev": true
-        },
-        "pull-defer": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
-            "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM=",
-            "dev": true
-        },
-        "pull-level": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-            "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-            "dev": true,
-            "requires": {
-                "level-post": "^1.0.7",
-                "pull-cat": "^1.1.9",
-                "pull-live": "^1.0.1",
-                "pull-pushable": "^2.0.0",
-                "pull-stream": "^3.4.0",
-                "pull-window": "^2.1.4",
-                "stream-to-pull-stream": "^1.7.1"
-            }
-        },
-        "pull-live": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-            "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
-            "dev": true,
-            "requires": {
-                "pull-cat": "^1.1.9",
-                "pull-stream": "^3.4.0"
-            }
-        },
-        "pull-pushable": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-            "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE=",
-            "dev": true
-        },
-        "pull-stream": {
-            "version": "3.6.8",
-            "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.8.tgz",
-            "integrity": "sha512-wQUIptQBcM0rFsUhZoEpOT3vUn73DtTGVq3NQ86c4T7iMOSprDzeKWYq2ksXnbwiuExTKvt+8G9fzNLFQuiO+A==",
-            "dev": true
-        },
-        "pull-window": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-            "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
-            "dev": true,
-            "requires": {
-                "looper": "^2.0.0"
             }
         },
         "pump": {
@@ -25292,12 +30153,6 @@
                 "randombytes": "^2.0.5",
                 "safe-buffer": "^5.1.0"
             }
-        },
-        "randomhex": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
-            "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-            "dev": true
         },
         "range-parser": {
             "version": "1.2.0",
@@ -27121,32 +31976,6 @@
                 "safe-buffer": "^5.1.0"
             }
         },
-        "seedrandom": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-            "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
-            "dev": true
-        },
-        "seek-bzip": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-            "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
-            "dev": true,
-            "requires": {
-                "commander": "~2.8.1"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-readlink": ">= 1.0.0"
-                    }
-                }
-            }
-        },
         "selenium-webdriver": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
@@ -27244,19 +32073,6 @@
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.2",
                 "send": "0.16.1"
-            }
-        },
-        "servify": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
-            "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
-            "dev": true,
-            "requires": {
-                "body-parser": "^1.16.0",
-                "cors": "^2.8.1",
-                "express": "^4.14.0",
-                "request": "^2.79.0",
-                "xhr": "^2.3.3"
             }
         },
         "set-blocking": {
@@ -27368,12 +32184,6 @@
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
-        },
-        "shebang-loader": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/shebang-loader/-/shebang-loader-0.0.1.tgz",
-            "integrity": "sha1-pAAEldRMzu++xjQ157FphWn6Uuw=",
-            "dev": true
         },
         "shebang-regex": {
             "version": "1.0.0",
@@ -27546,23 +32356,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
-        "simple-concat": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-            "dev": true
-        },
-        "simple-get": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-            "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-            "dev": true,
-            "requires": {
-                "decompress-response": "^3.3.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
         },
         "sinon": {
             "version": "5.0.0",
@@ -28491,24 +33284,6 @@
                 }
             }
         },
-        "stream-to-pull-stream": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
-            "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
-            "dev": true,
-            "requires": {
-                "looper": "^3.0.0",
-                "pull-stream": "^3.2.3"
-            },
-            "dependencies": {
-                "looper": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-                    "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k=",
-                    "dev": true
-                }
-            }
-        },
         "streamroller": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
@@ -28650,15 +33425,6 @@
             "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
             "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
             "dev": true
-        },
-        "strip-dirs": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-            "dev": true,
-            "requires": {
-                "is-natural-number": "^4.0.1"
-            }
         },
         "strip-eof": {
             "version": "1.0.0",
@@ -29363,91 +34129,6 @@
                 }
             }
         },
-        "swarm-js": {
-            "version": "0.1.37",
-            "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
-            "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
-            "dev": true,
-            "requires": {
-                "bluebird": "^3.5.0",
-                "buffer": "^5.0.5",
-                "decompress": "^4.0.0",
-                "eth-lib": "^0.1.26",
-                "fs-extra": "^2.1.2",
-                "fs-promise": "^2.0.0",
-                "got": "^7.1.0",
-                "mime-types": "^2.1.16",
-                "mkdirp-promise": "^5.0.1",
-                "mock-fs": "^4.1.0",
-                "setimmediate": "^1.0.5",
-                "tar.gz": "^1.0.5",
-                "xhr-request-promise": "^0.1.2"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-                    "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^2.1.0"
-                    }
-                },
-                "got": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-                    "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-                    "dev": true,
-                    "requires": {
-                        "decompress-response": "^3.2.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-plain-obj": "^1.1.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "isurl": "^1.0.0-alpha5",
-                        "lowercase-keys": "^1.0.0",
-                        "p-cancelable": "^0.3.0",
-                        "p-timeout": "^1.1.1",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "url-parse-lax": "^1.0.0",
-                        "url-to-options": "^1.0.1"
-                    }
-                },
-                "p-cancelable": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-                    "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-                    "dev": true
-                },
-                "p-timeout": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-                    "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-                    "dev": true,
-                    "requires": {
-                        "p-finally": "^1.0.0"
-                    }
-                },
-                "prepend-http": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-                    "dev": true
-                },
-                "url-parse-lax": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-                    "dev": true,
-                    "requires": {
-                        "prepend-http": "^1.0.1"
-                    }
-                }
-            }
-        },
         "symbol-observable": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
@@ -29603,42 +34284,6 @@
                 "block-stream": "*",
                 "fstream": "^1.0.2",
                 "inherits": "2"
-            }
-        },
-        "tar-stream": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-            "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
-            "dev": true,
-            "requires": {
-                "bl": "^1.0.0",
-                "buffer-alloc": "^1.1.0",
-                "end-of-stream": "^1.0.0",
-                "fs-constants": "^1.0.0",
-                "readable-stream": "^2.3.0",
-                "to-buffer": "^1.1.0",
-                "xtend": "^4.0.0"
-            }
-        },
-        "tar.gz": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
-            "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
-            "dev": true,
-            "requires": {
-                "bluebird": "^2.9.34",
-                "commander": "^2.8.1",
-                "fstream": "^1.0.8",
-                "mout": "^0.11.0",
-                "tar": "^2.1.1"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-                    "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-                    "dev": true
-                }
             }
         },
         "temp": {
@@ -29933,12 +34578,6 @@
             "dev": true,
             "optional": true
         },
-        "tiny-queue": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.0.tgz",
-            "integrity": "sha1-xJ/LXIdVW+G0pd9+uHEB1beLydw=",
-            "dev": true
-        },
         "tinycolor2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
@@ -29972,12 +34611,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
-        },
-        "to-buffer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-            "dev": true
         },
         "to-fast-properties": {
             "version": "1.0.3",
@@ -30302,36 +34935,6 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
-        "typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
-            "requires": {
-                "is-typedarray": "^1.0.0"
-            }
-        },
-        "typewise": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-            "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-            "dev": true,
-            "requires": {
-                "typewise-core": "^1.2.0"
-            }
-        },
-        "typewise-core": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-            "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=",
-            "dev": true
-        },
-        "typewiselite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-            "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4=",
-            "dev": true
-        },
         "ua-parser-js": {
             "version": "0.7.17",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
@@ -30488,35 +35091,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
             "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4="
-        },
-        "unbzip2-stream": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
-            "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
-            "dev": true,
-            "requires": {
-                "buffer": "^3.0.1",
-                "through": "^2.3.6"
-            },
-            "dependencies": {
-                "base64-js": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-                    "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
-                    "dev": true
-                },
-                "buffer": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-                    "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
-                    "dev": true,
-                    "requires": {
-                        "base64-js": "0.0.8",
-                        "ieee754": "^1.1.4",
-                        "isarray": "^1.0.0"
-                    }
-                }
-            }
         },
         "unc-path-regex": {
             "version": "0.1.2",
@@ -30870,12 +35444,6 @@
             "requires": {
                 "prepend-http": "^2.0.0"
             }
-        },
-        "url-set-query": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-            "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-            "dev": true
         },
         "url-to-options": {
             "version": "1.0.1",
@@ -31311,7 +35879,6 @@
             "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
             "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
             "requires": {
-                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2": "*",
@@ -31320,358 +35887,8 @@
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
                 }
-            }
-        },
-        "web3-bzz": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
-            "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
-            "dev": true,
-            "requires": {
-                "got": "7.1.0",
-                "swarm-js": "0.1.37",
-                "underscore": "1.8.3"
-            },
-            "dependencies": {
-                "got": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-                    "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-                    "dev": true,
-                    "requires": {
-                        "decompress-response": "^3.2.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-plain-obj": "^1.1.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "isurl": "^1.0.0-alpha5",
-                        "lowercase-keys": "^1.0.0",
-                        "p-cancelable": "^0.3.0",
-                        "p-timeout": "^1.1.1",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "url-parse-lax": "^1.0.0",
-                        "url-to-options": "^1.0.1"
-                    }
-                },
-                "p-cancelable": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-                    "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-                    "dev": true
-                },
-                "p-timeout": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-                    "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-                    "dev": true,
-                    "requires": {
-                        "p-finally": "^1.0.0"
-                    }
-                },
-                "prepend-http": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-                    "dev": true
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                },
-                "url-parse-lax": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-                    "dev": true,
-                    "requires": {
-                        "prepend-http": "^1.0.1"
-                    }
-                }
-            }
-        },
-        "web3-core": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
-            "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
-            "dev": true,
-            "requires": {
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-requestmanager": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            }
-        },
-        "web3-core-helpers": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
-            "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
-            "dev": true,
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-eth-iban": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-core-method": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
-            "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
-            "dev": true,
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-promievent": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-core-promievent": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
-            "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
-            "dev": true,
-            "requires": {
-                "any-promise": "1.3.0",
-                "eventemitter3": "1.1.1"
-            },
-            "dependencies": {
-                "any-promise": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-                    "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-core-requestmanager": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
-            "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
-            "dev": true,
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-providers-http": "1.0.0-beta.34",
-                "web3-providers-ipc": "1.0.0-beta.34",
-                "web3-providers-ws": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-core-subscriptions": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
-            "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
-            "dev": true,
-            "requires": {
-                "eventemitter3": "1.1.1",
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-eth": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
-            "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
-            "dev": true,
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-eth-abi": "1.0.0-beta.34",
-                "web3-eth-accounts": "1.0.0-beta.34",
-                "web3-eth-contract": "1.0.0-beta.34",
-                "web3-eth-iban": "1.0.0-beta.34",
-                "web3-eth-personal": "1.0.0-beta.34",
-                "web3-net": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-eth-abi": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
-            "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
-            "dev": true,
-            "requires": {
-                "bn.js": "4.11.6",
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.6",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-                    "dev": true
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-eth-accounts": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
-            "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
-            "dev": true,
-            "requires": {
-                "any-promise": "1.3.0",
-                "crypto-browserify": "3.12.0",
-                "eth-lib": "0.2.7",
-                "scrypt.js": "0.2.0",
-                "underscore": "1.8.3",
-                "uuid": "2.0.1",
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "any-promise": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-                    "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-                    "dev": true
-                },
-                "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-                    "dev": true,
-                    "requires": {
-                        "bn.js": "^4.11.6",
-                        "elliptic": "^6.4.0",
-                        "xhr-request-promise": "^0.1.2"
-                    }
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                },
-                "uuid": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                    "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-eth-contract": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
-            "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
-            "dev": true,
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-promievent": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-eth-abi": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-eth-iban": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
-            "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
-            "dev": true,
-            "requires": {
-                "bn.js": "4.11.6",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.6",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-eth-personal": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
-            "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
-            "dev": true,
-            "requires": {
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-net": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            }
-        },
-        "web3-net": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
-            "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
-            "dev": true,
-            "requires": {
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
             }
         },
         "web3-provider-engine": {
@@ -31775,126 +35992,12 @@
                 }
             }
         },
-        "web3-providers-http": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
-            "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
-            "dev": true,
-            "requires": {
-                "web3-core-helpers": "1.0.0-beta.34",
-                "xhr2": "0.1.4"
-            },
-            "dependencies": {
-                "xhr2": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-                    "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-providers-ipc": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
-            "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
-            "dev": true,
-            "requires": {
-                "oboe": "2.1.3",
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
-            }
-        },
-        "web3-providers-ws": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
-            "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
-            "dev": true,
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                },
-                "websocket": {
-                    "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-                    "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-                    "dev": true,
-                    "requires": {
-                        "debug": "^2.2.0",
-                        "nan": "^2.3.3",
-                        "typedarray-to-buffer": "^3.1.2",
-                        "yaeti": "^0.0.6"
-                    }
-                }
-            }
-        },
-        "web3-shh": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
-            "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
-            "dev": true,
-            "requires": {
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-net": "1.0.0-beta.34"
-            }
-        },
         "web3-stream-provider": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/web3-stream-provider/-/web3-stream-provider-3.0.1.tgz",
             "integrity": "sha1-9aWTqO7+gI+F61+x80Tlg4BQ+BQ=",
             "requires": {
                 "readable-stream": "^2.0.5"
-            }
-        },
-        "web3-utils": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
-            "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
-            "dev": true,
-            "requires": {
-                "bn.js": "4.11.6",
-                "eth-lib": "0.1.27",
-                "ethjs-unit": "0.1.6",
-                "number-to-bn": "1.7.0",
-                "randomhex": "0.1.5",
-                "underscore": "1.8.3",
-                "utf8": "2.1.1"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.6",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-                    "dev": true
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                },
-                "utf8": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-                    "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
-                    "dev": true
-                }
             }
         },
         "webidl-conversions": {
@@ -32823,18 +36926,6 @@
                 }
             }
         },
-        "websocket": {
-            "version": "1.0.26",
-            "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
-            "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
-            "dev": true,
-            "requires": {
-                "debug": "^2.2.0",
-                "nan": "^2.3.3",
-                "typedarray-to-buffer": "^3.1.2",
-                "yaeti": "^0.0.6"
-            }
-        },
         "websocket-driver": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -33079,30 +37170,6 @@
                 "xtend": "^4.0.0"
             }
         },
-        "xhr-request": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
-            "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
-            "dev": true,
-            "requires": {
-                "buffer-to-arraybuffer": "^0.0.5",
-                "object-assign": "^4.1.1",
-                "query-string": "^5.0.1",
-                "simple-get": "^2.7.0",
-                "timed-out": "^4.0.1",
-                "url-set-query": "^1.0.0",
-                "xhr": "^2.0.4"
-            }
-        },
-        "xhr-request-promise": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
-            "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
-            "dev": true,
-            "requires": {
-                "xhr-request": "^1.0.1"
-            }
-        },
         "xhr2": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
@@ -33169,12 +37236,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
             "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-        },
-        "yaeti": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-            "dev": true
         },
         "yallist": {
             "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     ]
   },
   "dependencies": {
-    "@material-ui/core": "^1.0.0",
+    "@material-ui/core": "1.0.0",
     "abi-decoder": "^1.0.9",
     "asmcrypto.js": "0.22.0",
     "async": "^2.5.0",
@@ -105,7 +105,7 @@
     "eth-bin-to-ops": "^1.0.1",
     "eth-contract-metadata": "github:MetaMask/eth-contract-metadata#master",
     "eth-ens-namehash": "^2.0.8",
-    "eth-hd-keyring": "^2.0.0",
+    "eth-hd-keyring": "^1.2.0",
     "eth-json-rpc-filters": "^1.2.6",
     "eth-json-rpc-infura": "^3.0.0",
     "eth-method-registry": "^1.0.0",
@@ -244,7 +244,7 @@
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-react": "^7.4.0",
     "eth-json-rpc-middleware": "^1.6.0",
-    "eth-keyring-controller": "^4.0.0",
+    "eth-keyring-controller": "^3.3.0",
     "file-loader": "^1.1.11",
     "fs-promise": "^2.0.3",
     "ganache-cli": "^6.1.0",


### PR DESCRIPTION
This pull request reestablishes previous versions of `eth-keyring-controller` and `eth-hd-keyring` that were prematurely bumped in de21a492655579b03da2b779058cfce1a3a2c9d3.

Resolves #4975 