### PR TITLE
Set `NODE_ENV` when generating bundler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -462,7 +462,9 @@ function generateBundler (opts, performBundle) {
   bundler.transform(envify({
     METAMASK_DEBUG: opts.devMode,
     NODE_ENV: opts.devMode ? 'development' : 'production',
-  }))
+  }), {
+    global: true,
+  })
 
   if (opts.watch) {
     bundler = watchify(bundler)


### PR DESCRIPTION
Unless there are some other implications I missed, this simple line should solve https://github.com/MetaMask/metamask-extension/issues/4115
