### PR TITLE
Use token decimals when calculating confirm screen token approval amount

### DIFF
--- a/ui/app/selectors/confirm-transaction.js
+++ b/ui/app/selectors/confirm-transaction.js
@@ -147,14 +147,20 @@ export const tokenAmountAndToAddressSelector = createSelector(
 
 export const approveTokenAmountAndToAddressSelector = createSelector(
   tokenDataParamsSelector,
-  params => {
+  tokenDecimalsSelector,
+  (params, tokenDecimals) => {
     let toAddress = ''
     let tokenAmount = 0
 
     if (params && params.length) {
       toAddress = params.find(param => param.name === TOKEN_PARAM_SPENDER).value
       const value = Number(params.find(param => param.name === TOKEN_PARAM_VALUE).value)
-      tokenAmount = roundExponential(value)
+
+      if (tokenDecimals) {
+        tokenAmount = calcTokenAmount(value, tokenDecimals)
+      }
+      
+      tokenAmount = roundExponential(tokenAmount)
     }
 
     return {


### PR DESCRIPTION
fixes #4984 

Before:
![image](https://user-images.githubusercontent.com/7499938/43846237-6db241de-9b08-11e8-93f1-59976f7bf81f.png)

After:
![image](https://user-images.githubusercontent.com/7499938/43846210-560dce54-9b08-11e8-80e8-6336b34a4895.png)
