### PR TITLE
Remove engine restrictions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
Looks like this turned out to be a bad idea, I'm removing it and might replace it with a less restrictive preinstall script that will just check your local version and die if it's wrong, rather than restricting packages