### PR TITLE
Fix ENS resolution issues

### DIFF
--- a/app/scripts/lib/ipfsContent.js
+++ b/app/scripts/lib/ipfsContent.js
@@ -5,7 +5,7 @@ module.exports = function (provider) {
     function ipfsContent (details) {
       const name = details.url.substring(7, details.url.length - 1)
       let clearTime = null
-      extension.tabs.getSelected(null, tab => {
+      extension.tabs.query({active: true}, tab => {
           extension.tabs.update(tab.id, { url: 'loading.html' })
 
           clearTime = setTimeout(() => {

--- a/app/scripts/lib/ipfsContent.js
+++ b/app/scripts/lib/ipfsContent.js
@@ -34,11 +34,11 @@ module.exports = function (provider) {
       return { cancel: true }
     }
 
-    extension.webRequest.onBeforeRequest.addListener(ipfsContent, {urls: ['*://*.eth/', '*://*.test/']})
+    extension.webRequest.onErrorOccurred.addListener(ipfsContent, {urls: ['*://*.eth/', '*://*.test/']})
 
     return {
       remove () {
-        extension.webRequest.onBeforeRequest.removeListener(ipfsContent)
+        extension.webRequest.onErrorOccurred.removeListener(ipfsContent)
       },
     }
 }


### PR DESCRIPTION
The functionality introduced in v4.9.0 to resolve .eth domains doesn't check if the user's DNS is able to resolve a .eth or .test address. Therefore the extension prevents the user to access these sites even though the DNS is returning an IP address.

Also, the current implementation doesn't work in Firefox (tested on version 61.0.1) as it relies on a deprecated method: tabs.getSelected

Fixes #5009
