### PR TITLE
Another e2e beta test fix

### DIFF
--- a/test/e2e/beta/contract-test/contract.js
+++ b/test/e2e/beta/contract-test/contract.js
@@ -38,17 +38,18 @@ const transferTokens = document.getElementById('transferTokens')
 const approveTokens = document.getElementById('approveTokens')
 
 deployButton.addEventListener('click', async function (event) {
+  document.getElementById('contractStatus').innerHTML = 'Deploying'
+
   var piggybank = await piggybankContract.new(
     {
       from: web3.eth.accounts[0],
       data: '0x608060405234801561001057600080fd5b5033600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506000808190555061023b806100686000396000f300608060405260043610610057576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680632e1a7d4d1461005c5780638da5cb5b1461009d578063d0e30db0146100f4575b600080fd5b34801561006857600080fd5b5061008760048036038101908080359060200190929190505050610112565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b26101d0565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6100fc6101f6565b6040518082815260200191505060405180910390f35b6000600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614151561017057600080fd5b8160008082825403925050819055503373ffffffffffffffffffffffffffffffffffffffff166108fc839081150290604051600060405180830381858888f193505050501580156101c5573d6000803e3d6000fd5b506000549050919050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60003460008082825401925050819055506000549050905600a165627a7a72305820f237db3ec816a52589d82512117bc85bc08d3537683ffeff9059108caf3e5d400029',
       gas: '4700000',
     }, function (e, contract) {
-      console.log(e, contract)
-      if (typeof contract.address !== 'undefined') {
+      if (e) {
+        throw e
+      } else if (typeof contract.address !== 'undefined') {
         console.log('Contract mined! address: ' + contract.address + ' transactionHash: ' + contract.transactionHash)
-
-        console.log(`contract`, contract)
 
         document.getElementById('contractStatus').innerHTML = 'Deployed'
 

--- a/test/e2e/beta/contract-test/contract.js
+++ b/test/e2e/beta/contract-test/contract.js
@@ -48,7 +48,8 @@ deployButton.addEventListener('click', async function (event) {
     }, function (e, contract) {
       if (e) {
         throw e
-      } else if (typeof contract.address !== 'undefined') {
+      }
+      if (typeof contract.address !== 'undefined') {
         console.log('Contract mined! address: ' + contract.address + ' transactionHash: ' + contract.transactionHash)
 
         document.getElementById('contractStatus').innerHTML = 'Deployed'

--- a/test/e2e/beta/contract-test/index.html
+++ b/test/e2e/beta/contract-test/index.html
@@ -11,7 +11,7 @@
       <button id="withdrawButton">Withdraw</button>
     </div>
     <div id="contractStatus" style="display: flex; font-size: 1rem;">
-      Not yet deployed
+      Not clicked
     </div>
   </div>
   <div style="display: flex; flex-flow: column;">

--- a/test/e2e/beta/from-import-beta-ui.spec.js
+++ b/test/e2e/beta/from-import-beta-ui.spec.js
@@ -89,7 +89,14 @@ describe('Using MetaMask with an existing account', function () {
         await driver.wait(until.stalenessOf(overlay))
       } catch (e) {}
 
-      const button = await findElement(driver, By.xpath("//button[contains(text(), 'Try it now')]"))
+      let button
+      try {
+        button = await findElement(driver, By.xpath("//button[contains(text(), 'Try it now')]"))
+      } catch (e) {
+        await loadExtension(driver, extensionId)
+        await delay(largeDelayMs)
+        button = await findElement(driver, By.xpath("//button[contains(text(), 'Try it now')]"))
+      }
       await button.click()
       await delay(regularDelayMs)
 

--- a/test/e2e/beta/helpers.js
+++ b/test/e2e/beta/helpers.js
@@ -122,12 +122,14 @@ async function closeAllWindowHandlesExcept (driver, exceptions, windowHandles) {
 }
 
 async function assertElementNotPresent (webdriver, driver, by) {
+  let dataTab
   try {
-    const dataTab = await findElement(driver, by, 4000)
-    if (dataTab) {
-      assert(false, 'Data tab should not be present')
-    }
+    dataTab = await findElement(driver, by, 4000)
   } catch (err) {
-    assert(err instanceof webdriver.error.NoSuchElementError)
+    console.log(err)
+    assert(err instanceof webdriver.error.NoSuchElementError || err instanceof webdriver.error.TimeoutError)
+  }
+  if (dataTab) {
+    assert(false, 'Data tab should not be present')
   }
 }

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -345,8 +345,8 @@ describe('MetaMask', function () {
       const passwordInputs = await driver.findElements(By.css('input'))
       await delay(regularDelayMs)
 
-      passwordInputs[0].sendKeys('correct horse battery staple')
-      passwordInputs[1].sendKeys('correct horse battery staple')
+      await passwordInputs[0].sendKeys('correct horse battery staple')
+      await passwordInputs[1].sendKeys('correct horse battery staple')
       await driver.findElement(By.css('.first-time-flow__button')).click()
       await delay(regularDelayMs)
     })
@@ -438,7 +438,7 @@ describe('MetaMask', function () {
       await driver.switchTo().window(windowHandles[2])
       await delay(regularDelayMs)
 
-      assertElementNotPresent(webdriver, driver, By.xpath(`//li[contains(text(), 'Data')]`))
+      await assertElementNotPresent(webdriver, driver, By.xpath(`//li[contains(text(), 'Data')]`))
 
       const confirmButton = await findElement(driver, By.xpath(`//button[contains(text(), 'Confirm')]`), 10000)
       await confirmButton.click()
@@ -515,15 +515,15 @@ describe('MetaMask', function () {
       await driver.switchTo().window(dapp)
       await delay(regularDelayMs)
 
-      let contractStatus = await driver.findElement(By.css('#contractStatus'))
-      await driver.wait(until.elementTextMatches(contractStatus, /Deployed/))
+      let contractStatus = await findElement(driver, By.css('#contractStatus'))
+      await driver.wait(until.elementTextMatches(contractStatus, /Deployed/), 10000)
 
       const depositButton = await findElement(driver, By.css('#depositButton'))
       await depositButton.click()
       await delay(largeDelayMs)
 
-      contractStatus = await driver.findElement(By.css('#contractStatus'))
-      await driver.wait(until.elementTextMatches(contractStatus, /Deposit\sinitiated/))
+      contractStatus = await findElement(driver, By.css('#contractStatus'))
+      await driver.wait(until.elementTextMatches(contractStatus, /Deposit\sinitiated/), 10000)
 
       await driver.switchTo().window(extension)
       await delay(largeDelayMs)
@@ -539,8 +539,8 @@ describe('MetaMask', function () {
       await configureGas.click()
       await delay(regularDelayMs)
 
-      const gasModal = await driver.findElement(By.css('span .modal'))
-      await driver.wait(until.elementLocated(By.css('.customize-gas__title')))
+      const gasModal = await findElement(driver, By.css('span .modal'))
+      await driver.wait(until.elementLocated(By.css('.customize-gas__title')), 10000)
 
       const [gasPriceInput, gasLimitInput] = await findElements(driver, By.css('.customize-gas-input'))
       await gasPriceInput.clear()

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -460,6 +460,11 @@ describe('MetaMask', function () {
       const transactions = await findElements(driver, By.css('.tx-list-item'))
       assert.equal(transactions.length, 2)
 
+      await findElement(driver, By.xpath(`//span[contains(text(), 'Submitted')]`))
+
+      const txStatuses = await findElements(driver, By.css('.tx-list-status'))
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Confirmed/))
+
       const txValues = await findElement(driver, By.css('.tx-list-value'))
       await driver.wait(until.elementTextMatches(txValues, /3\sETH/), 10000)
     })
@@ -509,6 +514,8 @@ describe('MetaMask', function () {
       const confirmButton = await findElement(driver, By.xpath(`//button[contains(text(), 'Confirm')]`))
       await confirmButton.click()
       await delay(regularDelayMs)
+
+      await findElement(driver, By.xpath(`//span[contains(text(), 'Submitted')]`))
 
       const txStatuses = await findElements(driver, By.css('.tx-list-status'))
       await driver.wait(until.elementTextMatches(txStatuses[0], /Confirmed/))

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -516,7 +516,7 @@ describe('MetaMask', function () {
       await delay(regularDelayMs)
 
       let contractStatus = await findElement(driver, By.css('#contractStatus'))
-      await driver.wait(until.elementTextMatches(contractStatus, /Deployed/), 10000)
+      await driver.wait(until.elementTextMatches(contractStatus, /Deployed/), 15000)
 
       const depositButton = await findElement(driver, By.css('#depositButton'))
       await depositButton.click()

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -88,7 +88,14 @@ describe('MetaMask', function () {
         await driver.wait(until.stalenessOf(overlay))
       } catch (e) {}
 
-      const button = await findElement(driver, By.xpath("//button[contains(text(), 'Try it now')]"))
+      let button
+      try {
+        button = await findElement(driver, By.xpath("//button[contains(text(), 'Try it now')]"))
+      } catch (e) {
+        await loadExtension(driver, extensionId)
+        await delay(largeDelayMs)
+        button = await findElement(driver, By.xpath("//button[contains(text(), 'Try it now')]"))
+      }
       await button.click()
       await delay(regularDelayMs)
 


### PR DESCRIPTION
~~Line 519 of https://github.com/MetaMask/metamask-extension/compare/e2e-tests-more-reliable?expand=1#diff-b00929238ad0453812af55a40336e889 was incorrectly matching the text on line 14 of test/e2e/beta/contract-test/index.html before the contract deploy was actually complete.~~

~~By updating the text on line 14 of test/e2e/beta/contract-test/index.html, these tests should now more consistently pass.~~

The previous description of the problem solved by this PR was incorrect. The updated description of this PR is:

This PR is an attempt to fix an inconsistently failing test in `metamask-beta-ui.spec.js`. The `'calls and confirms a contract method where ETH is sent'` test block fairly regularly, but not always, fails in firefox.

Currently the attempt to fix this is adding a missing `await` and improving the error handling within the method called on line 441: `await assertElementNotPresent(webdriver, driver, By.xpath(`//li[contains(text(), 'Data')]`))`

Further changes are made to just improve test debugging.

I will leave this PR open until we get the firefox tests constistently passing.