### PR TITLE
Cast arguments for new Bignumbers() to string.

### DIFF
--- a/ui/app/conversion-util.js
+++ b/ui/app/conversion-util.js
@@ -46,7 +46,7 @@ const decToBigNumberViaString = n => R.pipe(String, toBigNumber['dec'])
 // Setter Maps
 const toBigNumber = {
   hex: n => new BigNumber(stripHexPrefix(n), 16),
-  dec: n => new BigNumber(n, 10),
+  dec: n => new BigNumber(String(n), 10),
   BN: n => new BigNumber(n.toString(16), 16),
 }
 const toNormalizedDenomination = {
@@ -154,7 +154,7 @@ const subtractCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(a, aBase)).minus(b, bBase)
+  const value = (new BigNumber(String(a), aBase)).minus(b, bBase)
 
   return converter({
     value,

--- a/ui/app/helpers/confirm-transaction/util.js
+++ b/ui/app/helpers/confirm-transaction/util.js
@@ -141,7 +141,7 @@ export function hasUnconfirmedTransactions (state) {
 
 export function roundExponential (value) {
   const PRECISION = 4
-  const bigNumberValue = new BigNumber(value)
+  const bigNumberValue = new BigNumber(String(value))
 
   // In JS, numbers with exponentials greater than 20 get displayed as an exponential.
   return bigNumberValue.e > 20 ? Number(bigNumberValue.toPrecision(PRECISION)) : value

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -44,7 +44,7 @@ async function getSymbolAndDecimals (tokenAddress, existingTokens = []) {
 
 function calcTokenAmount (value, decimals) {
   const multiplier = Math.pow(10, Number(decimals || 0))
-  return new BigNumber(value).div(multiplier).toNumber()
+  return new BigNumber(String(value)).div(multiplier).toNumber()
 }
 
 


### PR DESCRIPTION
Due an unexpected issue in our current version of bignumber.js (https://github.com/MikeMcl/bignumber.js/issues/148), `new Bignumber(x)` where x's significant digits were greater than 15 and x is not a string were throwing an error.

It seems that all our instances of `new Bignumber(x)` that were getting hit by numbers with that many significant digits were already casting args to strings, except for the new approve screen.

This PR updates all cases of `new Bignumber(x)` where x was not being converted to a string.

For a before and after test. Before:
- Run the app on `develop`, switch to mainnet and go to https://dai.makerdao.com/
- Click the 'Denied' toggle next to `MKRWipe/Shut` on the right side of the screen
- try to customize gas
- Gas will not update. check the console to see bignumber errors like that linked above

After:
- Run the app on this PRs branch and then follow the above steps
- Gas should correctly update
- submit the transaction (you can approve 0 MKR)
- the transaction should successfully confirm