### PR TITLE
Remove EAL google analytics link.

### DIFF
--- a/app/phishing.html
+++ b/app/phishing.html
@@ -43,7 +43,7 @@
       ga('create', 'UA-68598031-1', 'auto' {'allowLinker':true});
       ga('send', 'pageview');
       ga('require', 'linker');
-      ga('linker:autoLink', ['harrydenley.com', 'metamask.io'], false, true);
+      ga('linker:autoLink', ['metamask.io'], false, true);
     </script>
 
   </head>


### PR DESCRIPTION
Harry said he's not using this for Ether-Address-Lookup anymore, so removing it.