### PR TITLE
Fix export privkey modal password bugs

### DIFF
--- a/ui/app/components/modals/account-details-modal.js
+++ b/ui/app/components/modals/account-details-modal.js
@@ -61,7 +61,7 @@ AccountDetailsModal.prototype.render = function () {
 
   let exportPrivateKeyFeatureEnabled = true
   // This feature is disabled for hardware wallets
-  if (keyring.type.search('Hardware') !== -1) {
+  if (keyring && keyring.type.search('Hardware') !== -1) {
     exportPrivateKeyFeatureEnabled = false
   }
 


### PR DESCRIPTION
Refs #4964—the previously uncaught promise rejection here was logged to Sentry
Refs #5066

Fixes #4992

This PR fixes a two separate issues/bugs:

1. When a user enters their password incorrectly and then re-enters their password correctly the error message was still being displayed (508df54)
2. When the Keyring Controller dispatches state updates during unlock the keyrings can temporarily be emptied and the `AccountDetailsModal` will try to read a property from a missing keyring (ab6db4c)