### PR TITLE
Hardware wallet fixes

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -800,7 +800,8 @@ module.exports = class MetamaskController extends EventEmitter {
     // Remove account from the preferences controller
     this.preferencesController.removeAddress(address)
     // Remove account from the account tracker controller
-    this.accountTracker.removeAccount(address)
+    this.accountTracker.removeAccount([address])
+
     // Remove account from the keyring
     await this.keyringController.removeAccount(address)
     return address

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -668,7 +668,9 @@ module.exports = class MetamaskController extends EventEmitter {
     this.preferencesController.setAddresses(newAccounts)
     newAccounts.forEach(address => {
       if (!oldAccounts.includes(address)) {
-        this.preferencesController.setAccountLabel(address, `${deviceName.toUpperCase()} ${parseInt(index, 10) + 1}`)
+        // Set the account label to Trezor 1 /  Ledger 1, etc
+        this.preferencesController.setAccountLabel(address, `${deviceName[0].toUpperCase()}${deviceName.slice(1)} ${parseInt(index, 10) + 1}`)
+        // Select the account
         this.preferencesController.setSelectedAddress(address)
       }
     })

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -573,7 +573,7 @@ describe('MetaMaskController', function () {
       assert(metamaskController.preferencesController.removeAddress.calledWith(addressToRemove))
     })
     it('should call accountTracker.removeAccount', async function () {
-      assert(metamaskController.accountTracker.removeAccount.calledWith(addressToRemove))
+      assert(metamaskController.accountTracker.removeAccount.calledWith([addressToRemove]))
     })
     it('should call keyringController.removeAccount', async function () {
       assert(metamaskController.keyringController.removeAccount.calledWith(addressToRemove))


### PR DESCRIPTION
- Fix account removal
- Change hardware wallet account label formatting (from TREZOR 1 to Trezor 1) to keep it consistent with the rest of the labels (we use Account 1 not ACCOUNT 1)