### PR TITLE
Typo in "send" translation

### DIFF
--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -490,7 +490,7 @@
     "message": "Sélectionner un service"
   },
   "send": {
-    "message": "Envoyé"
+    "message": "Envoyer"
   },
   "sendTokens": {
     "message": "Envoyer des jetons"


### PR DESCRIPTION
**send** should be translated as **Envoyer** instead of _Envoyé_ (which mean sent, not _send_)