### PR TITLE
Network IO Optimization: Lazy AccountTracker

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -43,10 +43,24 @@ class AccountTracker {
     this._provider = opts.provider
     this._query = pify(new EthQuery(this._provider))
     this._blockTracker = opts.blockTracker
-    // subscribe to latest block
-    this._blockTracker.on('latest', this._updateForBlock.bind(this))
     // blockTracker.currentBlock may be null
     this._currentBlockNumber = this._blockTracker.getCurrentBlock()
+    // bind function for easier listener syntax
+    this._updateForBlock = this._updateForBlock.bind(this)
+  }
+
+  start () {
+    // remove first to avoid double add
+    this._blockTracker.removeListener('latest', this._updateForBlock)
+    // add listener
+    this._blockTracker.addListener('latest', this._updateForBlock)
+    // fetch account balances
+    this._updateAccounts()
+  }
+
+  stop () {
+    // remove listener
+    this._blockTracker.removeListener('latest', this._updateForBlock)
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1444,6 +1444,7 @@ module.exports = class MetamaskController extends EventEmitter {
     }
   }
 
+  // TODO: Replace isClientOpen methods with `controllerConnectionChanged` events.
   /**
    * A method for recording whether the MetaMask user interface is open or not.
    * @private

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -131,6 +131,14 @@ module.exports = class MetamaskController extends EventEmitter {
       provider: this.provider,
       blockTracker: this.blockTracker,
     })
+    // start and stop polling for balances based on activeControllerConnections
+    this.on('controllerConnectionChanged', (activeControllerConnections) => {
+      if (activeControllerConnections > 0) {
+        this.accountTracker.start()
+      } else {
+        this.accountTracker.stop()
+      }
+    })
 
     // key mgmt
     const additionalKeyrings = [TrezorKeyring, LedgerBridgeKeyring]


### PR DESCRIPTION
This is an alternate to https://github.com/MetaMask/metamask-extension/pull/5119

By tracking the number of active ControllerConnections and emitting an event on change, we have a good hook for when there are UIs open pointing at metamask. Using this hook, we tell the account tracker to start and stop polling for account ether balances.

This approach allows us to retain the last known account balance while we fetch an update. This is an improvement over my previous approach of migrating the account controller to the ui, which would not provide the stale value. 

A further improvement that could be made: mark the block number of this balance lookup in the accountTracker state -- this would help the UI show the stale balance while indicating that it is stale (e.g. showing the value greyed out) 