### PR TITLE
Show transaction error message tooltips for statuses

### DIFF
--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -353,6 +353,7 @@ class TransactionStateManager extends EventEmitter {
     const txMeta = this.getTx(txId)
     txMeta.err = {
       message: err.toString(),
+      rpc: err.value,
       stack: err.stack,
     }
     this.updateTx(txMeta)

--- a/ui/app/components/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.component.js
@@ -128,6 +128,7 @@ export default class TransactionListItem extends PureComponent {
           <TransactionStatus
             className="transaction-list-item__status"
             status={transaction.status}
+            title={(transaction.err && transaction.err.rpc) ? transaction.err.rpc.message : null}
           />
           { this.renderPrimaryCurrency() }
           { this.renderSecondaryCurrency() }

--- a/ui/app/components/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.component.js
@@ -128,7 +128,11 @@ export default class TransactionListItem extends PureComponent {
           <TransactionStatus
             className="transaction-list-item__status"
             status={transaction.status}
-            title={(transaction.err && transaction.err.rpc) ? transaction.err.rpc.message : null}
+            title={
+              (transaction.err && transaction.err.rpc)
+                ? transaction.err.rpc.message
+                : transaction.err && transaction.err.message
+            }
           />
           { this.renderPrimaryCurrency() }
           { this.renderSecondaryCurrency() }

--- a/ui/app/components/transaction-status/transaction-status.component.js
+++ b/ui/app/components/transaction-status/transaction-status.component.js
@@ -28,16 +28,24 @@ const statusToTextHash = {
 }
 
 export default class TransactionStatus extends PureComponent {
+  static defaultProps = {
+    title: null,
+  }
+
   static propTypes = {
     status: PropTypes.string,
+    title: PropTypes.string,
     className: PropTypes.string,
   }
 
   render () {
-    const { className, status } = this.props
+    const { className, status, title } = this.props
 
     return (
-      <div className={classnames('transaction-status', className, statusToClassNameHash[status])}>
+      <div
+        className={classnames('transaction-status', className, statusToClassNameHash[status])}
+        title={title || status}
+      >
         { statusToTextHash[status] || status }
       </div>
     )


### PR DESCRIPTION
Fixes #3768

This PR updates the `TransactionStatus` component to accept an optional `title` prop and the `TransactionListItem` to use the transaction's error message as the title if it exists.

#### Pics or it didn't happen

In the best case a new `txMeta` will have the RPC error message directly on it:

<img width="448" alt="screen shot 2018-08-22 at 21 05 19" src="https://user-images.githubusercontent.com/1623628/44496846-ff8faa80-a650-11e8-9532-a99d84113d5d.png">

If there's no error we'll have just the status:

<img width="379" alt="screen shot 2018-08-22 at 21 22 34" src="https://user-images.githubusercontent.com/1623628/44497012-9fe5cf00-a651-11e8-9aea-77117f0976a3.png">

In the worst case, we're showing this monstrosity:

<img width="573" alt="screen shot 2018-08-22 at 21 22 22" src="https://user-images.githubusercontent.com/1623628/44497018-a5dbb000-a651-11e8-9dbc-2f68a2c9adfd.png">

Initially I didn't want to have `txMeta.err.message` in the title but in some (non-RPC) cases that's the best we've got and it contains useful information.