### PR TITLE
edit decimal check in old-ui/

### DIFF
--- a/old-ui/app/add-suggested-token.js
+++ b/old-ui/app/add-suggested-token.js
@@ -172,7 +172,7 @@ AddSuggestedTokenScreen.prototype.validateInputs = function (opts) {
     msg += 'Address is invalid.'
   }
 
-  const validDecimals = decimals >= 0 && decimals < 36
+  const validDecimals = decimals >= 0 && decimals <= 36
   if (!validDecimals) {
     msg += 'Decimals must be at least 0, and not over 36. '
   }

--- a/old-ui/app/add-token.js
+++ b/old-ui/app/add-token.js
@@ -196,7 +196,7 @@ AddTokenScreen.prototype.validateInputs = function () {
     msg += 'Address is invalid.'
   }
 
-  const validDecimals = decimals >= 0 && decimals < 36
+  const validDecimals = decimals >= 0 && decimals <= 36
   if (!validDecimals) {
     msg += 'Decimals must be at least 0, and not over 36. '
   }

--- a/ui/app/components/pages/add-token/add-token.component.js
+++ b/ui/app/components/pages/add-token/add-token.component.js
@@ -206,7 +206,7 @@ class AddToken extends Component {
     const validDecimals = customDecimals !== null &&
       customDecimals !== '' &&
       customDecimals >= 0 &&
-      customDecimals < 36
+      customDecimals <= 36
     let customDecimalsError = null
 
     if (!validDecimals) {


### PR DESCRIPTION
I tried to add a custom token from my contract token that set decimals to 36 to a wallet by fill token address input by contract address. UI filled details about name and decimal automatically, but i got this error tell that **Decimals must be at least 0, and not over 36**. When I looked in github in **old-ui/app/add-suggested-token.js**. It uses < 36 to check decimal but on **app/scripts/controllers/preferences.js** check > 36 to throw, so I think It will be a little bug in UI.

![image](https://user-images.githubusercontent.com/26691764/44985434-942bce00-afaa-11e8-8511-5d67a89d94ab.png)


