### PR TITLE
Fix assertion of missing child component

### DIFF
--- a/ui/app/components/send/send-content/tests/send-content-component.test.js
+++ b/ui/app/components/send/send-content/tests/send-content-component.test.js
@@ -44,7 +44,7 @@ describe('SendContent Component', function () {
       assert(PageContainerContentChild.childAt(1).is(SendToRow))
       assert(PageContainerContentChild.childAt(2).is(SendAmountRow))
       assert(PageContainerContentChild.childAt(3).is(SendGasRow))
-      assert.equal(PageContainerContentChild.childAt(4).html(), null)
+      assert.equal(PageContainerContentChild.childAt(4).exists(), false)
     })
   })
 })


### PR DESCRIPTION
Refs #5091 and #5138

This PR fixes a small issue with the way we were using Enzyme's [`.html()`](http://airbnb.io/enzyme/docs/api/ShallowWrapper/html.html)—we were calling `.html()` on a missing child and expecting it to return `null` where it instead throws an error.