### PR TITLE
Upgrade obs-store and fix memory leaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21822,9 +21822,9 @@
       }
     },
     "obs-store": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/obs-store/-/obs-store-3.0.0.tgz",
-      "integrity": "sha512-ZHK0fwDZEecEvdiqQGnxrEshbqibVgsq4aIIe/5PIT8fGGprTTuGw1RXLMy5G1VN/KtnmEP6+n+aLH7BYuYCVA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/obs-store/-/obs-store-3.0.2.tgz",
+      "integrity": "sha512-GzBr7KM2TYWoJSlF3sVo1cMIOeyxgXpEdegXLZyYONRpunFHsBdKwOba0ki17kN2stLaEwTNolJChGHafqM7Fw==",
       "requires": {
         "babel-preset-es2015": "^6.22.0",
         "babelify": "^7.3.0",
@@ -21835,7 +21835,7 @@
       "dependencies": {
         "babelify": {
           "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
             "babel-core": "^6.0.14",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "multiplex": "^6.7.0",
     "number-to-bn": "^1.7.0",
     "obj-multiplex": "^1.0.0",
-    "obs-store": "^3.0.0",
+    "obs-store": "^3.0.2",
     "percentile": "^1.2.0",
     "pify": "^3.0.0",
     "ping-pong-stream": "^1.0.0",


### PR DESCRIPTION
This PR discovers and addresses two event emitter memory leaks:
* In the main metamask controller whenever the menu is opened
* When setting up the public config store whenever a new tab is opened

The memory usage before fixing these was not as high as the original issue stated but when I analyzed the heap dumps periodically, there were many objects not being garbage collected (old event emitters). And, I was not able to run the tests for very long but I do see a reduction in the live javascript memory and it's staying consistently low over time.

This fixes #4074