### PR TITLE
Update Firefox version for e2e tests

### DIFF
--- a/.circleci/scripts/firefox-install
+++ b/.circleci/scripts/firefox-install
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-FIREFOX_VERSION='61.0.2'
+FIREFOX_VERSION='62.0'
 FIREFOX_BINARY="firefox-${FIREFOX_VERSION}.tar.bz2"
 FIREFOX_BINARY_URL="https://ftp.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/${FIREFOX_BINARY}"
 FIREFOX_PATH='/opt/firefox'


### PR DESCRIPTION
This PR updates the Firefox version used in the e2e tests to 62.0