### PR TITLE
Ensure account-tracker currentBlockNumber is set on first block update.

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -45,6 +45,9 @@ class AccountTracker {
     this._blockTracker = opts.blockTracker
     // blockTracker.currentBlock may be null
     this._currentBlockNumber = this._blockTracker.getCurrentBlock()
+    this._blockTracker.once('latest', blockNumber => {
+      this._currentBlockNumber = blockNumber
+    })
     // bind function for easier listener syntax
     this._updateForBlock = this._updateForBlock.bind(this)
   }


### PR DESCRIPTION
In `account-tracker.js`, the `syncWithAddresses` is called after unlocking. It calls `addAccounts`, which will update account balances if `this._currentBlockNumber` is truthy.

Prior to this PR, `this._currentBlockNumber` can still be null at the time of unlocking because the account-tracker adds a listener to the blockTracker after the first block update. It has to wait for the next `'latest'` block update, which can leave the user with an out of date or null balance for the duration of the blockTrackerers polling interval.

This PR ensures that `this._currentBlockNumber` gets set on the first block update, and therefore is (virtually always, I presume) set at the time of unlocking the account.