### PR TITLE
increase z-index of send-to input field to allow for right-click past…

### DIFF
--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -622,12 +622,14 @@
     position: relative;
 
     &__down-caret {
+      z-index: 1051;
       position: absolute;
       top: 18px;
       right: 12px;
     }
 
     &__qr-code {
+      z-index: 1051;
       position: absolute;
       top: 13px;
       right: 33px;
@@ -647,6 +649,8 @@
 
   &__to-autocomplete, &__memo-text-area, &__hex-data {
     &__input {
+      z-index: 1050;
+      position: relative;
       height: 54px;
       width: 100%;
       border: 1px solid $alto;


### PR DESCRIPTION
Fixes #5198 

_(copy pasted from commit comment)_
Prior to this change, the send-v2__from-dropdown__close-area (used to dismiss the "to dropdown" that appears after the input is given focus) was rendered over top of the input field making it so the right click was intercepted by the div. 

By increasing the z-index of this input all right clicks are simply registered on the input component directly and all standard options appear similar to the amount input below (copy, paste, etc).

**Tests:** No test added. This was a stylistic change and testing the functionality of the HTML context menu seems like overkill.

