### PR TITLE
Bug fix: eth domain matching is too broad

### DIFF
--- a/app/scripts/lib/ipfsContent.js
+++ b/app/scripts/lib/ipfsContent.js
@@ -5,6 +5,8 @@ module.exports = function (provider) {
     function ipfsContent (details) {
       const name = details.url.substring(7, details.url.length - 1)
       let clearTime = null
+      if (/^.+\.eth$/.test(name) === false) return
+
       extension.tabs.query({active: true}, tab => {
           extension.tabs.update(tab.id, { url: 'loading.html' })
 


### PR DESCRIPTION
## Scenario
The "eth" on the domain will be resolution.

## Solution
Should only resolution when the tld is `.eth`

## Reference
Refer to the comment: https://github.com/MetaMask/metamask-extension/pull/5234#issuecomment-420377571