### PR TITLE
Integrate gas buttons with the send screen.

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -70,6 +70,9 @@
   "available": {
     "message": "Available"
   },
+  "average": {
+    "message": "Average"
+  },
   "back": {
     "message": "Back"
   },
@@ -357,6 +360,9 @@
   },
   "failed": {
     "message": "Failed"
+  },
+  "fast": {
+    "message": "Fast"
   },
   "feeChartTitle": {
     "message": "Live Transaction Fee Predictions"
@@ -887,6 +893,9 @@
   "save": {
     "message": "Save"
   },
+  "slow": {
+    "message": "Slow"
+  },
   "speedUpTitle": {
     "message": "Speed Up Transaction"
   },
@@ -1117,6 +1126,9 @@
   },
   "transactionError": {
     "message": "Transaction Error. Exception thrown in contract code."
+  },
+  "transactionFee": {
+    "message": "Transaction Fee"
   },
   "transactionMemo": {
     "message": "Transaction memo (optional)"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -20,6 +20,9 @@
   "address": {
     "message": "Address"
   },
+  "advancedOptions": {
+    "message": "Advanced Options"
+  },
   "addCustomToken": {
     "message": "Add custom token"
   },

--- a/ui/app/components/button-group/button-group.component.js
+++ b/ui/app/components/button-group/button-group.component.js
@@ -10,6 +10,7 @@ export default class ButtonGroup extends PureComponent {
     children: PropTypes.array,
     className: PropTypes.string,
     style: PropTypes.object,
+    newActiveButtonIndex: PropTypes.number,
   }
 
   static defaultProps = {
@@ -23,9 +24,10 @@ export default class ButtonGroup extends PureComponent {
       : this.props.defaultActiveButtonIndex,
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate (_, prevState) {
+    // Provides an API for dynamically updating the activeButtonIndex
     if (typeof this.props.newActiveButtonIndex === 'number' && prevState.activeButtonIndex !== this.props.newActiveButtonIndex) {
-      this.setState({ activeButtonIndex: prevProps.newActiveButtonIndex })
+      this.setState({ activeButtonIndex: this.props.newActiveButtonIndex })
     }
   }
 

--- a/ui/app/components/button-group/button-group.component.js
+++ b/ui/app/components/button-group/button-group.component.js
@@ -23,6 +23,12 @@ export default class ButtonGroup extends PureComponent {
       : this.props.defaultActiveButtonIndex,
   }
 
+  componentDidUpdate (prevProps, prevState) {
+    if (typeof this.props.newActiveButtonIndex === 'number' && prevState.activeButtonIndex !== this.props.newActiveButtonIndex) {
+      this.setState({ activeButtonIndex: prevProps.newActiveButtonIndex })
+    }
+  }
+
   handleButtonClick (activeButtonIndex) {
     this.setState({ activeButtonIndex })
   }

--- a/ui/app/components/button-group/tests/button-group-component.test.js
+++ b/ui/app/components/button-group/tests/button-group-component.test.js
@@ -35,6 +35,20 @@ describe('ButtonGroup Component', function () {
     ButtonGroup.prototype.renderButtons.resetHistory()
   })
 
+  describe('componentDidUpdate', () => {
+    it('should set the activeButtonIndex to the updated newActiveButtonIndex', () => {
+      assert.equal(wrapper.state('activeButtonIndex'), 1)
+      wrapper.setProps({ newActiveButtonIndex: 2 })
+      assert.equal(wrapper.state('activeButtonIndex'), 2)
+    })
+
+    it('should not set the activeButtonIndex to an updated newActiveButtonIndex that is not a number', () => {
+      assert.equal(wrapper.state('activeButtonIndex'), 1)
+      wrapper.setProps({ newActiveButtonIndex: null })
+      assert.equal(wrapper.state('activeButtonIndex'), 1)
+    })
+  })
+
   describe('handleButtonClick', () => {
     it('should set the activeButtonIndex', () => {
       assert.equal(wrapper.state('activeButtonIndex'), 1)

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -92,23 +92,24 @@ export default class GasModalPageContainer extends Component {
     hideBasic,
     ...advancedTabProps
   }) {
+    let tabsToRender = [
+      { name: 'basic', content: this.renderBasicTabContent(gasPriceButtonGroupProps) },
+      { name: 'advanced', content: this.renderAdvancedTabContent(advancedTabProps) },
+    ]
+
+    if (hideBasic) {
+      tabsToRender = tabsToRender.slice(1)
+    }
+
     return (
       <Tabs>
-        {hideBasic
-          ? null
-          : <Tab name={this.context.t('basic')}>
+        {tabsToRender.map(({ name, content }, i) => <Tab name={this.context.t(name)} key={`gas-modal-tab-${i}`}>
             <div className="gas-modal-content">
-              { this.renderBasicTabContent(gasPriceButtonGroupProps) }
+              { content }
               { this.renderInfoRows(originalTotalFiat, originalTotalEth, newTotalFiat, newTotalEth) }
             </div>
           </Tab>
-        }
-        <Tab name={this.context.t('advanced')}>
-          <div className="gas-modal-content">
-            { this.renderAdvancedTabContent(advancedTabProps) }
-            { this.renderInfoRows(originalTotalFiat, originalTotalEth, newTotalFiat, newTotalEth) }
-          </div>
-        </Tab>
+        )}
       </Tabs>
     )
   }

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -89,16 +89,20 @@ export default class GasModalPageContainer extends Component {
   },
   {
     gasPriceButtonGroupProps,
+    hideBasic,
     ...advancedTabProps
   }) {
     return (
       <Tabs>
-        <Tab name={this.context.t('basic')}>
-          <div className="gas-modal-content">
-            { this.renderBasicTabContent(gasPriceButtonGroupProps) }
-            { this.renderInfoRows(originalTotalFiat, originalTotalEth, newTotalFiat, newTotalEth) }
-          </div>
-        </Tab>
+        {hideBasic
+          ? null
+          : <Tab name={this.context.t('basic')}>
+            <div className="gas-modal-content">
+              { this.renderBasicTabContent(gasPriceButtonGroupProps) }
+              { this.renderInfoRows(originalTotalFiat, originalTotalEth, newTotalFiat, newTotalEth) }
+            </div>
+          </Tab>
+        }
         <Tab name={this.context.t('advanced')}>
           <div className="gas-modal-content">
             { this.renderAdvancedTabContent(advancedTabProps) }

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -11,6 +11,9 @@ import {
   setCustomGasLimit,
 } from '../../../ducks/gas.duck'
 import {
+  hideGasButtonGroup,
+} from '../../../ducks/send.duck'
+import {
   updateGasAndCalculate,
 } from '../../../ducks/confirm-transaction.duck'
 import {
@@ -59,7 +62,10 @@ const mapStateToProps = state => {
 
   const newTotalFiat = addHexWEIsToRenderableFiat(value, customGasTotal, currentCurrency, conversionRate)
 
+  const hideBasic = state.appState.modal.modalState.props.hideBasic
+
   return {
+    hideBasic,
     isConfirm: isConfirm(state),
     customGasPriceInHex,
     customGasLimitInHex,
@@ -95,6 +101,7 @@ const mapDispatchToProps = dispatch => {
     updateConfirmTxGasAndCalculate: (gasLimit, gasPrice) => {
       return dispatch(updateGasAndCalculate({ gasLimit, gasPrice }))
     },
+    hideGasButtonGroup: () => dispatch(hideGasButtonGroup()),
   }
 }
 
@@ -102,6 +109,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const { gasPriceButtonGroupProps, isConfirm } = stateProps
   const {
     updateCustomGasPrice: dispatchUpdateCustomGasPrice,
+    hideGasButtonGroup: dispatchHideGasButtonGroup,
     setGasData: dispatchSetGasData,
     updateConfirmTxGasAndCalculate: dispatchUpdateConfirmTxGasAndCalculate,
     ...otherDispatchProps
@@ -111,7 +119,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...stateProps,
     ...otherDispatchProps,
     ...ownProps,
-    onSubmit: isConfirm ? dispatchUpdateConfirmTxGasAndCalculate : dispatchSetGasData,
+    onSubmit: isConfirm ? dispatchUpdateConfirmTxGasAndCalculate : (newLimit, newPrice) => {
+      dispatchSetGasData(newLimit, newPrice)
+      dispatchHideGasButtonGroup()
+    },
     gasPriceButtonGroupProps: {
       ...gasPriceButtonGroupProps,
       handleGasPriceSelection: dispatchUpdateCustomGasPrice,

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -119,10 +119,12 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...stateProps,
     ...otherDispatchProps,
     ...ownProps,
-    onSubmit: isConfirm ? dispatchUpdateConfirmTxGasAndCalculate : (newLimit, newPrice) => {
-      dispatchSetGasData(newLimit, newPrice)
-      dispatchHideGasButtonGroup()
-    },
+    onSubmit: isConfirm
+      ? dispatchUpdateConfirmTxGasAndCalculate
+      : (newLimit, newPrice) => {
+        dispatchSetGasData(newLimit, newPrice)
+        dispatchHideGasButtonGroup()
+      },
     gasPriceButtonGroupProps: {
       ...gasPriceButtonGroupProps,
       handleGasPriceSelection: dispatchUpdateCustomGasPrice,

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -161,6 +161,19 @@ describe('GasModalPageContainer Component', function () {
       assert.deepEqual(GP.renderInfoRows.getCall(0).args, ['mockOriginalTotalFiat', 'mockOriginalTotalEth', 'mockNewTotalFiat', 'mockNewTotalEth'])
       assert.deepEqual(GP.renderInfoRows.getCall(1).args, ['mockOriginalTotalFiat', 'mockOriginalTotalEth', 'mockNewTotalFiat', 'mockNewTotalEth'])
     })
+
+    it('should not render the basic tab if hideBasic is true', () => {
+      const renderTabsResult = wrapper.instance().renderTabs(mockInfoRowProps, {
+        gasPriceButtonGroupProps: mockGasPriceButtonGroupProps,
+        otherProps: 'mockAdvancedTabProps',
+        hideBasic: true,
+      })
+
+      const renderedTabs = shallow(renderTabsResult)
+      const tabs = renderedTabs.find(Tab)
+      assert.equal(tabs.length, 1)
+      assert.equal(tabs.at(0).props().name, 'advanced')
+    })
   })
 
   describe('renderInfoRow', () => {

--- a/ui/app/components/gas-customization/gas-price-button-group/gas-price-button-group.component.js
+++ b/ui/app/components/gas-customization/gas-price-button-group/gas-price-button-group.component.js
@@ -27,7 +27,7 @@ export default class GasPriceButtonGroup extends Component {
   }
 
   renderButtonContent ({
-    label,
+    labelKey,
     feeInPrimaryCurrency,
     feeInSecondaryCurrency,
     timeEstimate,
@@ -36,7 +36,7 @@ export default class GasPriceButtonGroup extends Component {
     showCheck,
   }) {
     return (<div>
-      { label && <div className={`${className}__label`}>{ label }</div> }
+      { labelKey && <div className={`${className}__label`}>{ this.context.t(labelKey) }</div> }
       { feeInPrimaryCurrency && <div className={`${className}__primary-currency`}>{ feeInPrimaryCurrency }</div> }
       { feeInSecondaryCurrency && <div className={`${className}__secondary-currency`}>{ feeInSecondaryCurrency }</div> }
       { timeEstimate && <div className={`${className}__time-estimate`}>{ timeEstimate }</div> }
@@ -57,9 +57,7 @@ export default class GasPriceButtonGroup extends Component {
         onClick={() => handleGasPriceSelection(priceInHexWei)}
         key={`gas-price-button-${index}`}
       >
-        {buttonDataLoading
-          ? 'Loading...'
-          : this.renderButtonContent(renderableGasInfo, buttonContentPropsAndFlags)}
+        {this.renderButtonContent(renderableGasInfo, buttonContentPropsAndFlags)}
       </Button>
     )
   }
@@ -68,18 +66,23 @@ export default class GasPriceButtonGroup extends Component {
     const {
       gasButtonInfo,
       defaultActiveButtonIndex = 1,
+      newActiveButtonIndex,
       noButtonActiveByDefault = false,
+      buttonDataLoading,
       ...buttonPropsAndFlags
     } = this.props
 
     return (
-      <ButtonGroup
-        className={buttonPropsAndFlags.className}
-        defaultActiveButtonIndex={defaultActiveButtonIndex}
-        noButtonActiveByDefault={noButtonActiveByDefault}
-      >
-        { gasButtonInfo.map((obj, index) => this.renderButton(obj, buttonPropsAndFlags, index)) }
-      </ButtonGroup>
+      !buttonDataLoading
+        ? <ButtonGroup
+          className={buttonPropsAndFlags.className}
+          defaultActiveButtonIndex={defaultActiveButtonIndex}
+          newActiveButtonIndex={newActiveButtonIndex}
+          noButtonActiveByDefault={noButtonActiveByDefault}
+        >
+          { gasButtonInfo.map((obj, index) => this.renderButton(obj, buttonPropsAndFlags, index)) }
+        </ButtonGroup>
+        : <div className={`${buttonPropsAndFlags.className}__loading-container`}>Loading...</div>
     )
   }
 }

--- a/ui/app/components/gas-customization/gas-price-button-group/gas-price-button-group.component.js
+++ b/ui/app/components/gas-customization/gas-price-button-group/gas-price-button-group.component.js
@@ -22,6 +22,7 @@ export default class GasPriceButtonGroup extends Component {
     defaultActiveButtonIndex: PropTypes.number,
     gasButtonInfo: PropTypes.arrayOf(PropTypes.shape(GAS_OBJECT_PROPTYPES_SHAPE)),
     handleGasPriceSelection: PropTypes.func,
+    newActiveButtonIndex: PropTypes.number,
     noButtonActiveByDefault: PropTypes.bool,
     showCheck: PropTypes.bool,
   }
@@ -82,7 +83,7 @@ export default class GasPriceButtonGroup extends Component {
         >
           { gasButtonInfo.map((obj, index) => this.renderButton(obj, buttonPropsAndFlags, index)) }
         </ButtonGroup>
-        : <div className={`${buttonPropsAndFlags.className}__loading-container`}>Loading...</div>
+        : <div className={`${buttonPropsAndFlags.className}__loading-container`}>{ this.context.t('loading') }</div>
     )
   }
 }

--- a/ui/app/components/gas-customization/gas-price-button-group/index.scss
+++ b/ui/app/components/gas-customization/gas-price-button-group/index.scss
@@ -18,6 +18,9 @@
     height: 15.4px;
   }
 
+  &__loading-container {
+    height: 130px;
+  }
 
   .button-group__button, .button-group__button--active {
     height: 130px;
@@ -54,6 +57,70 @@
         display: flex;
         color: $curious-blue;
         margin-top: 8px
+      }
+    }
+  }
+}
+
+.gas-price-button-group--small {
+  display: flex;
+  justify-content: stretch;
+  max-width: 260px;
+
+  &__button-fiat-price {
+    font-size: 13px;
+  }
+
+  &__button-label {
+    font-size: 16px;
+  }
+
+  &__label {
+    font-weight: 500;
+  }
+
+  &__primary-currency {
+    font-size: 12px;
+  }
+
+  &__secondary-currency {
+    font-size: 12px;
+  }
+
+  &__loading-container {
+    height: 78px;
+  }
+
+  .button-group__button, .button-group__button--active {
+    height: 78px;
+    background: white;
+    color: $scorpion;
+    padding-top: 9px;
+    padding-left: 8.5px;
+
+    div {
+      display: flex;
+      flex-flow: column;
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
+
+    i {
+      &:last-child {
+        display: none;
+      }
+    }
+  }
+
+  .button-group__button--active {
+    color: $white;
+    background: $dodger-blue;
+
+    i {
+      &:last-child {
+        display: flex;
+        color: $curious-blue;
+        margin-top: 10px
       }
     }
   }

--- a/ui/app/components/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
+++ b/ui/app/components/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import assert from 'assert'
-import { shallow } from 'enzyme'
+import shallow from '../../../../../lib/shallow-with-context'
 import sinon from 'sinon'
 import GasPriceButtonGroup from '../gas-price-button-group.component'
 
@@ -36,7 +36,6 @@ const mockGasPriceButtonGroupProps = {
 }
 
 const mockButtonPropsAndFlags = Object.assign({}, {
-  buttonDataLoading: mockGasPriceButtonGroupProps.buttonDataLoading,
   className: mockGasPriceButtonGroupProps.className,
   handleGasPriceSelection: mockGasPriceButtonGroupProps.handleGasPriceSelection,
   showCheck: mockGasPriceButtonGroupProps.showCheck,
@@ -87,11 +86,18 @@ describe('GasPriceButtonGroup Component', function () {
       )
     }
 
-    it('should called this.renderButton 3 times, with the correct args', () => {
+    it('should call this.renderButton 3 times, with the correct args', () => {
       assert.equal(GasPriceButtonGroup.prototype.renderButton.callCount, 3)
       renderButtonArgsTest(0, mockButtonPropsAndFlags)
       renderButtonArgsTest(1, mockButtonPropsAndFlags)
       renderButtonArgsTest(2, mockButtonPropsAndFlags)
+    })
+
+    it('should show loading if buttonDataLoading', () => {
+      wrapper.setProps({ buttonDataLoading: true })
+      assert(wrapper.is('div'))
+      assert(wrapper.hasClass('gas-price-button-group__loading-container'))
+      assert.equal(wrapper.text(), 'loading')
     })
   })
 
@@ -147,29 +153,18 @@ describe('GasPriceButtonGroup Component', function () {
         ]
       )
     })
-
-    it('should not call renderButtonContent if buttonDataLoading is true and should show a loading indicator', () => {
-      GasPriceButtonGroup.prototype.renderButtonContent.resetHistory()
-      const renderButtonResult = GasPriceButtonGroup.prototype.renderButton(
-        Object.assign({}, mockGasPriceButtonGroupProps.gasButtonInfo[0]),
-        Object.assign({}, mockButtonPropsAndFlags, {buttonDataLoading: true})
-      )
-      wrappedRenderButtonResult = shallow(renderButtonResult)
-      assert.equal(GasPriceButtonGroup.prototype.renderButtonContent.callCount, 0)
-      assert.equal(wrappedRenderButtonResult.childAt(0).text(), 'Loading...')
-    })
   })
 
   describe('renderButtonContent', () => {
-    it('should render a label if passed a label', () => {
-      const renderButtonContentResult = GasPriceButtonGroup.prototype.renderButtonContent({
-        label: 'mockLabel',
+    it('should render a label if passed a labelKey', () => {
+      const renderButtonContentResult = wrapper.instance().renderButtonContent({
+        labelKey: 'mockLabelKey',
       }, {
         className: 'someClass',
       })
       const wrappedRenderButtonContentResult = shallow(renderButtonContentResult)
       assert.equal(wrappedRenderButtonContentResult.childAt(0).children().length, 1)
-      assert.equal(wrappedRenderButtonContentResult.find('.someClass__label').text(), 'mockLabel')
+      assert.equal(wrappedRenderButtonContentResult.find('.someClass__label').text(), 'mockLabelKey')
     })
 
     it('should render a feeInPrimaryCurrency if passed a feeInPrimaryCurrency', () => {
@@ -215,8 +210,8 @@ describe('GasPriceButtonGroup Component', function () {
     })
 
     it('should render all elements if all args passed', () => {
-      const renderButtonContentResult = GasPriceButtonGroup.prototype.renderButtonContent({
-        label: 'mockLabel',
+      const renderButtonContentResult = wrapper.instance().renderButtonContent({
+        labelKey: 'mockLabel',
         feeInPrimaryCurrency: 'mockFeeInPrimaryCurrency',
         feeInSecondaryCurrency: 'mockFeeInSecondaryCurrency',
         timeEstimate: 'mockTimeEstimate',

--- a/ui/app/components/page-container/page-container.component.js
+++ b/ui/app/components/page-container/page-container.component.js
@@ -58,7 +58,8 @@ export default class PageContainer extends PureComponent {
 
   renderActiveTabContent () {
     const { tabsComponent } = this.props
-    const { children } = tabsComponent.props
+    let { children } = tabsComponent.props
+    children = children.filter(child => child)
     const { activeTabIndex } = this.state
 
     return children[activeTabIndex]

--- a/ui/app/components/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
+++ b/ui/app/components/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
@@ -11,7 +11,7 @@ export default class GasFeeDisplay extends Component {
     convertedCurrency: PropTypes.string,
     gasLoadingError: PropTypes.bool,
     gasTotal: PropTypes.string,
-    onClick: PropTypes.func,
+    showGasButtonGroup: PropTypes.func,
   };
 
   static contextTypes = {
@@ -22,7 +22,6 @@ export default class GasFeeDisplay extends Component {
     const {
       conversionRate,
       gasTotal,
-      onClick,
       primaryCurrency = 'ETH',
       convertedCurrency,
       gasLoadingError,
@@ -53,7 +52,7 @@ export default class GasFeeDisplay extends Component {
           className="gas-fee-reset"
           onClick={showGasButtonGroup}
         >
-          Reset
+          { this.context.t('reset') }
         </button>
       </div>
     )

--- a/ui/app/components/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
+++ b/ui/app/components/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
@@ -26,6 +26,7 @@ export default class GasFeeDisplay extends Component {
       primaryCurrency = 'ETH',
       convertedCurrency,
       gasLoadingError,
+      showGasButtonGroup,
     } = this.props
 
     return (
@@ -49,11 +50,10 @@ export default class GasFeeDisplay extends Component {
               </div>
         }
         <button
-          className="sliders-icon-container"
-          onClick={onClick}
-          disabled={!gasTotal && !gasLoadingError}
+          className="gas-fee-reset"
+          onClick={showGasButtonGroup}
         >
-          <i className="fa fa-sliders sliders-icon" />
+          Reset
         </button>
       </div>
     )

--- a/ui/app/components/send/send-content/send-gas-row/gas-fee-display/test/gas-fee-display.component.test.js
+++ b/ui/app/components/send/send-content/send-gas-row/gas-fee-display/test/gas-fee-display.component.test.js
@@ -17,9 +17,9 @@ describe('SendGasRow Component', function () {
     wrapper = shallow(<GasFeeDisplay
       conversionRate={20}
       gasTotal={'mockGasTotal'}
-      onClick={propsMethodSpies.showCustomizeGasModal}
       primaryCurrency={'mockPrimaryCurrency'}
       convertedCurrency={'mockConvertedCurrency'}
+      showGasButtonGroup={propsMethodSpies.showCustomizeGasModal}
     />, {context: {t: str => str + '_t'}})
   })
 
@@ -43,13 +43,19 @@ describe('SendGasRow Component', function () {
       assert.equal(value, 'mockGasTotal')
     })
 
-    it('should render the Button with the correct props', () => {
+    it('should render the reset button with the correct props', () => {
       const {
         onClick,
+        className,
       } = wrapper.find('button').props()
+      assert.equal(className, 'gas-fee-reset')
       assert.equal(propsMethodSpies.showCustomizeGasModal.callCount, 0)
       onClick()
       assert.equal(propsMethodSpies.showCustomizeGasModal.callCount, 1)
+    })
+
+    it('should render the reset button with the correct text', () => {
+      assert.equal(wrapper.find('button').text(), 'reset_t')
     })
   })
 })

--- a/ui/app/components/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/components/send/send-content/send-gas-row/send-gas-row.component.js
@@ -13,6 +13,9 @@ export default class SendGasRow extends Component {
     gasLoadingError: PropTypes.bool,
     gasTotal: PropTypes.string,
     showCustomizeGasModal: PropTypes.func,
+    gasPriceButtonGroupProps: PropTypes.object,
+    showGasButtonGroup: PropTypes.func,
+    gasButtonGroupShown: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -29,7 +32,7 @@ export default class SendGasRow extends Component {
       showCustomizeGasModal,
       gasPriceButtonGroupProps,
       gasButtonGroupShown,
-      showGasButtonGroup
+      showGasButtonGroup,
     } = this.props
 
     return (
@@ -43,10 +46,10 @@ export default class SendGasRow extends Component {
             <GasPriceButtonGroup
               className="gas-price-button-group--small"
               showCheck={false}
-              {...this.props.gasPriceButtonGroupProps}
+              {...gasPriceButtonGroupProps}
             />
             <div className="advanced-gas-options-btn" onClick={() => showCustomizeGasModal()}>
-              Advanced Options
+              { this.context.t('advancedOptions') }
             </div>
           </div>
         : <GasFeeDisplay

--- a/ui/app/components/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/components/send/send-content/send-gas-row/send-gas-row.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import SendRowWrapper from '../send-row-wrapper/'
 import GasFeeDisplay from './gas-fee-display/gas-fee-display.component'
+import GasPriceButtonGroup from '../../../gas-customization/gas-price-button-group'
 
 export default class SendGasRow extends Component {
 
@@ -26,21 +27,37 @@ export default class SendGasRow extends Component {
       gasTotal,
       gasFeeError,
       showCustomizeGasModal,
+      gasPriceButtonGroupProps,
+      gasButtonGroupShown,
+      showGasButtonGroup
     } = this.props
 
     return (
       <SendRowWrapper
-        label={`${this.context.t('gasFee')}:`}
+        label={`${this.context.t('transactionFee')}:`}
         showError={gasFeeError}
         errorType={'gasFee'}
       >
-        <GasFeeDisplay
-          conversionRate={conversionRate}
-          convertedCurrency={convertedCurrency}
-          gasLoadingError={gasLoadingError}
-          gasTotal={gasTotal}
-          onClick={() => showCustomizeGasModal()}
-        />
+        {gasButtonGroupShown
+         ? <div>
+            <GasPriceButtonGroup
+              className="gas-price-button-group--small"
+              showCheck={false}
+              {...this.props.gasPriceButtonGroupProps}
+            />
+            <div className="advanced-gas-options-btn" onClick={() => showCustomizeGasModal()}>
+              Advanced Options
+            </div>
+          </div>
+        : <GasFeeDisplay
+            conversionRate={conversionRate}
+            convertedCurrency={convertedCurrency}
+            gasLoadingError={gasLoadingError}
+            gasTotal={gasTotal}
+            showGasButtonGroup={showGasButtonGroup}
+            onClick={() => showCustomizeGasModal()}
+          />}
+
       </SendRowWrapper>
     )
   }

--- a/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
@@ -3,25 +3,64 @@ import {
     getConversionRate,
     getCurrentCurrency,
     getGasTotal,
+    getGasPrice,
 } from '../../send.selectors.js'
-import { getGasLoadingError, gasFeeIsInError } from './send-gas-row.selectors.js'
-import { showModal } from '../../../../actions'
+import{
+  getBasicGasEstimateLoadingStatus,
+  getRenderableEstimateDataForSmallButtons,
+  getDefaultActiveButtonIndex
+} from '../../../../selectors/custom-gas'
+import{
+  showGasButtonGroup
+} from '../../../../ducks/send.duck'
+import { getGasLoadingError, gasFeeIsInError, getGasButtonGroupShown } from './send-gas-row.selectors.js'
+import { showModal, setGasPrice } from '../../../../actions'
 import SendGasRow from './send-gas-row.component'
 
-export default connect(mapStateToProps, mapDispatchToProps)(SendGasRow)
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(SendGasRow)
 
 function mapStateToProps (state) {
+  const gasButtonInfo = getRenderableEstimateDataForSmallButtons(state)
+  const activeButtonIndex = getDefaultActiveButtonIndex(gasButtonInfo, getGasPrice(state))
+
   return {
     conversionRate: getConversionRate(state),
     convertedCurrency: getCurrentCurrency(state),
     gasTotal: getGasTotal(state),
     gasFeeError: gasFeeIsInError(state),
     gasLoadingError: getGasLoadingError(state),
+    gasPriceButtonGroupProps: {
+      buttonDataLoading: getBasicGasEstimateLoadingStatus(state),
+      defaultActiveButtonIndex: 1,
+      newActiveButtonIndex: activeButtonIndex > -1 ? activeButtonIndex : null,
+      gasButtonInfo,
+    },
+    gasButtonGroupShown: getGasButtonGroupShown(state),
   }
 }
 
 function mapDispatchToProps (dispatch) {
   return {
-    showCustomizeGasModal: () => dispatch(showModal({ name: 'CUSTOMIZE_GAS' })),
+    showCustomizeGasModal: () => dispatch(showModal({ name: 'CUSTOMIZE_GAS', hideBasic: true })),
+    setGasPrice: newPrice => dispatch(setGasPrice(newPrice)),
+    showGasButtonGroup: () => dispatch(showGasButtonGroup())
+  }
+}
+
+function mergeProps (stateProps, dispatchProps, ownProps) {
+  const { gasPriceButtonGroupProps } = stateProps
+  const {
+    setGasPrice: dispatchSetGasPrice,
+    ...otherDispatchProps
+  } = dispatchProps
+
+  return {
+    ...stateProps,
+    ...otherDispatchProps,
+    ...ownProps,
+    gasPriceButtonGroupProps: {
+      ...gasPriceButtonGroupProps,
+      handleGasPriceSelection: dispatchSetGasPrice,
+    },
   }
 }

--- a/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
@@ -5,13 +5,13 @@ import {
     getGasTotal,
     getGasPrice,
 } from '../../send.selectors.js'
-import{
+import {
   getBasicGasEstimateLoadingStatus,
   getRenderableEstimateDataForSmallButtons,
-  getDefaultActiveButtonIndex
+  getDefaultActiveButtonIndex,
 } from '../../../../selectors/custom-gas'
-import{
-  showGasButtonGroup
+import {
+  showGasButtonGroup,
 } from '../../../../ducks/send.duck'
 import { getGasLoadingError, gasFeeIsInError, getGasButtonGroupShown } from './send-gas-row.selectors.js'
 import { showModal, setGasPrice } from '../../../../actions'
@@ -43,7 +43,7 @@ function mapDispatchToProps (dispatch) {
   return {
     showCustomizeGasModal: () => dispatch(showModal({ name: 'CUSTOMIZE_GAS', hideBasic: true })),
     setGasPrice: newPrice => dispatch(setGasPrice(newPrice)),
-    showGasButtonGroup: () => dispatch(showGasButtonGroup())
+    showGasButtonGroup: () => dispatch(showGasButtonGroup()),
   }
 }
 

--- a/ui/app/components/send/send-content/send-gas-row/send-gas-row.selectors.js
+++ b/ui/app/components/send/send-content/send-gas-row/send-gas-row.selectors.js
@@ -1,6 +1,7 @@
 const selectors = {
   gasFeeIsInError,
   getGasLoadingError,
+  getGasButtonGroupShown,
 }
 
 module.exports = selectors
@@ -11,4 +12,8 @@ function getGasLoadingError (state) {
 
 function gasFeeIsInError (state) {
   return Boolean(state.send.errors.gasFee)
+}
+
+function getGasButtonGroupShown (state) {
+  return state.send.gasButtonGroupShown
 }

--- a/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
+++ b/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
@@ -6,6 +6,7 @@ import SendGasRow from '../send-gas-row.component.js'
 
 import SendRowWrapper from '../../send-row-wrapper/send-row-wrapper.component'
 import GasFeeDisplay from '../gas-fee-display/gas-fee-display.component'
+import GasPriceButtonGroup from '../../../../gas-customization/gas-price-button-group'
 
 const propsMethodSpies = {
   showCustomizeGasModal: sinon.spy(),
@@ -21,7 +22,13 @@ describe('SendGasRow Component', function () {
       gasFeeError={'mockGasFeeError'}
       gasLoadingError={false}
       gasTotal={'mockGasTotal'}
+      showGasButtonGroup={'mockShowGasPriceButtonGroup'}
+      gasButtonGroupShown={false}
       showCustomizeGasModal={propsMethodSpies.showCustomizeGasModal}
+      gasPriceButtonGroupProps={{
+        someGasPriceButtonGroupProp: 'foo',
+        anotherGasPriceButtonGroupProp: 'bar',
+      }}
     />, { context: { t: str => str + '_t' } })
   })
 
@@ -41,7 +48,7 @@ describe('SendGasRow Component', function () {
         errorType,
       } = wrapper.find(SendRowWrapper).props()
 
-      assert.equal(label, 'gasFee_t:')
+      assert.equal(label, 'transactionFee_t:')
       assert.equal(showError, 'mockGasFeeError')
       assert.equal(errorType, 'gasFee')
     })
@@ -57,13 +64,41 @@ describe('SendGasRow Component', function () {
         gasLoadingError,
         gasTotal,
         onClick,
+        showGasButtonGroup,
       } = wrapper.find(SendRowWrapper).childAt(0).props()
       assert.equal(conversionRate, 20)
       assert.equal(convertedCurrency, 'mockConvertedCurrency')
       assert.equal(gasLoadingError, false)
       assert.equal(gasTotal, 'mockGasTotal')
+      assert.equal(showGasButtonGroup, 'mockShowGasPriceButtonGroup')
       assert.equal(propsMethodSpies.showCustomizeGasModal.callCount, 0)
       onClick()
+      assert.equal(propsMethodSpies.showCustomizeGasModal.callCount, 1)
+    })
+
+    it('should render the GasPriceButtonGroup if gasButtonGroupShown is true', () => {
+      wrapper.setProps({ gasButtonGroupShown: true })
+      const rendered = wrapper.find(SendRowWrapper).childAt(0)
+      assert.equal(rendered.children().length, 2)
+
+      const gasPriceButtonGroup = rendered.childAt(0)
+      assert(gasPriceButtonGroup.is(GasPriceButtonGroup))
+      assert(gasPriceButtonGroup.hasClass('gas-price-button-group--small'))
+      assert.equal(gasPriceButtonGroup.props().showCheck, false)
+      assert.equal(gasPriceButtonGroup.props().someGasPriceButtonGroupProp, 'foo')
+      assert.equal(gasPriceButtonGroup.props().anotherGasPriceButtonGroupProp, 'bar')
+    })
+
+    it('should render an advanced options button if gasButtonGroupShown is true', () => {
+      wrapper.setProps({ gasButtonGroupShown: true })
+      const rendered = wrapper.find(SendRowWrapper).childAt(0)
+      assert.equal(rendered.children().length, 2)
+
+      const advancedOptionsButton = rendered.childAt(1)
+      assert.equal(advancedOptionsButton.text(), 'advancedOptions_t')
+
+      assert.equal(propsMethodSpies.showCustomizeGasModal.callCount, 0)
+      advancedOptionsButton.props().onClick()
       assert.equal(propsMethodSpies.showCustomizeGasModal.callCount, 1)
     })
   })

--- a/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
+++ b/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
@@ -4,16 +4,23 @@ import sinon from 'sinon'
 
 let mapStateToProps
 let mapDispatchToProps
+let mergeProps
 
 const actionSpies = {
   showModal: sinon.spy(),
+  setGasPrice: sinon.spy(),
+}
+
+const sendDuckSpies = {
+  showGasButtonGroup: sinon.spy(),
 }
 
 proxyquire('../send-gas-row.container.js', {
   'react-redux': {
-    connect: (ms, md) => {
+    connect: (ms, md, mp) => {
       mapStateToProps = ms
       mapDispatchToProps = md
+      mergeProps = mp
       return () => ({})
     },
   },
@@ -21,12 +28,20 @@ proxyquire('../send-gas-row.container.js', {
     getConversionRate: (s) => `mockConversionRate:${s}`,
     getCurrentCurrency: (s) => `mockConvertedCurrency:${s}`,
     getGasTotal: (s) => `mockGasTotal:${s}`,
+    getGasPrice: (s) => `mockGasPrice:${s}`,
   },
   './send-gas-row.selectors.js': {
     getGasLoadingError: (s) => `mockGasLoadingError:${s}`,
     gasFeeIsInError: (s) => `mockGasFeeError:${s}`,
+    getGasButtonGroupShown: (s) => `mockGetGasButtonGroupShown:${s}`,
   },
   '../../../../actions': actionSpies,
+  '../../../../selectors/custom-gas': {
+    getBasicGasEstimateLoadingStatus: (s) => `mockBasicGasEstimateLoadingStatus:${s}`,
+    getRenderableEstimateDataForSmallButtons: (s) => `mockGasButtonInfo:${s}`,
+    getDefaultActiveButtonIndex: (gasButtonInfo, gasPrice) => gasButtonInfo.length + gasPrice.length,
+  },
+  '../../../../ducks/send.duck': sendDuckSpies,
 })
 
 describe('send-gas-row container', () => {
@@ -40,6 +55,13 @@ describe('send-gas-row container', () => {
         gasTotal: 'mockGasTotal:mockState',
         gasFeeError: 'mockGasFeeError:mockState',
         gasLoadingError: 'mockGasLoadingError:mockState',
+        gasPriceButtonGroupProps: {
+          buttonDataLoading: `mockBasicGasEstimateLoadingStatus:mockState`,
+          defaultActiveButtonIndex: 1,
+          newActiveButtonIndex: 49,
+          gasButtonInfo: `mockGasButtonInfo:mockState`,
+        },
+        gasButtonGroupShown: `mockGetGasButtonGroupShown:mockState`,
       })
     })
 
@@ -60,11 +82,66 @@ describe('send-gas-row container', () => {
         assert(dispatchSpy.calledOnce)
         assert.deepEqual(
           actionSpies.showModal.getCall(0).args[0],
-          { name: 'CUSTOMIZE_GAS' }
+          { name: 'CUSTOMIZE_GAS', hideBasic: true }
         )
       })
     })
 
+    describe('setGasPrice()', () => {
+      it('should dispatch an action', () => {
+        mapDispatchToPropsObject.setGasPrice('mockNewPrice')
+        assert(dispatchSpy.calledOnce)
+        assert(actionSpies.setGasPrice.calledOnce)
+        assert.equal(actionSpies.setGasPrice.getCall(0).args[0], 'mockNewPrice')
+      })
+    })
+
+    describe('showGasButtonGroup()', () => {
+      it('should dispatch an action', () => {
+        mapDispatchToPropsObject.showGasButtonGroup()
+        assert(dispatchSpy.calledOnce)
+        assert(sendDuckSpies.showGasButtonGroup.calledOnce)
+      })
+    })
+
+  })
+
+  describe('mergeProps', () => {
+    let stateProps
+    let dispatchProps
+    let ownProps
+
+    beforeEach(() => {
+      stateProps = {
+        gasPriceButtonGroupProps: {
+          someGasPriceButtonGroupProp: 'foo',
+          anotherGasPriceButtonGroupProp: 'bar',
+        },
+        someOtherStateProp: 'baz',
+      }
+      dispatchProps = {
+        setGasPrice: sinon.spy(),
+        someOtherDispatchProp: sinon.spy(),
+      }
+      ownProps = { someOwnProp: 123 }
+    })
+
+    it('should return the expected props when isConfirm is true', () => {
+      const result = mergeProps(stateProps, dispatchProps, ownProps)
+
+      assert.equal(result.someOtherStateProp, 'baz')
+      assert.equal(result.gasPriceButtonGroupProps.someGasPriceButtonGroupProp, 'foo')
+      assert.equal(result.gasPriceButtonGroupProps.anotherGasPriceButtonGroupProp, 'bar')
+      assert.equal(result.someOwnProp, 123)
+
+      assert.equal(dispatchProps.setGasPrice.callCount, 0)
+      result.gasPriceButtonGroupProps.handleGasPriceSelection()
+      assert.equal(dispatchProps.setGasPrice.callCount, 1)
+
+      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 0)
+      result.someOtherDispatchProp()
+      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 1)
+    })
   })
 
 })

--- a/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-selectors.test.js
+++ b/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-selectors.test.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import {
   gasFeeIsInError,
   getGasLoadingError,
+  getGasButtonGroupShown,
 } from '../send-gas-row.selectors.js'
 
 describe('send-gas-row selectors', () => {
@@ -43,6 +44,18 @@ describe('send-gas-row selectors', () => {
       }
 
       assert.equal(gasFeeIsInError(state), false)
+    })
+  })
+
+  describe('getGasButtonGroupShown()', () => {
+    it('should return send.gasButtonGroupShown', () => {
+      const state = {
+        send: {
+          gasButtonGroupShown: 'foobar',
+        },
+      }
+
+      assert.equal(getGasButtonGroupShown(state), 'foobar')
     })
   })
 

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -578,7 +578,7 @@
     font-family: Roboto;
     font-size: 16px;
     line-height: 22px;
-    width: 88px;
+    width: 112px;
     font-weight: 400;
   }
 
@@ -620,6 +620,7 @@
 
   &__to-autocomplete {
     position: relative;
+    max-width: 260px;
 
     &__down-caret {
       position: absolute;
@@ -678,6 +679,7 @@
       display: flex;
       align-items: center;
     }
+
   }
 
   &__sliders-icon-container {
@@ -896,6 +898,15 @@
       display: none;
     }
   }
+
+}
+
+.advanced-gas-options-btn {
+  display: flex;
+  justify-content: flex-end;
+  font-size: 14px;
+  color: #2f9ae0;
+  cursor: pointer;
 }
 
 .sliders-icon-container {
@@ -912,6 +923,23 @@
   top: 14px;
   cursor: pointer;
   font-size: 1em;
+}
+
+.gas-fee-reset {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  border-radius: 4px;
+  background-color: #fff;
+  position: absolute;
+  right: 12px;
+  top: 14px;
+  cursor: pointer;
+  font-size: 1em;
+  font-size: 14px;
+  color: #2f9ae0;
+  font-family: Roboto;
 }
 
 .sliders-icon {

--- a/ui/app/ducks/send.duck.js
+++ b/ui/app/ducks/send.duck.js
@@ -7,11 +7,14 @@ const OPEN_TO_DROPDOWN = 'metamask/send/OPEN_TO_DROPDOWN'
 const CLOSE_TO_DROPDOWN = 'metamask/send/CLOSE_TO_DROPDOWN'
 const UPDATE_SEND_ERRORS = 'metamask/send/UPDATE_SEND_ERRORS'
 const RESET_SEND_STATE = 'metamask/send/RESET_SEND_STATE'
+const SHOW_GAS_BUTTON_GROUP = 'metamask/send/SHOW_GAS_BUTTON_GROUP'
+const HIDE_GAS_BUTTON_GROUP = 'metamask/send/HIDE_GAS_BUTTON_GROUP'
 
 // TODO: determine if this approach to initState is consistent with conventional ducks pattern
 const initState = {
   fromDropdownOpen: false,
   toDropdownOpen: false,
+  gasButtonGroupShown: true,
   errors: {},
 }
 
@@ -43,6 +46,14 @@ export default function reducer ({ send: sendState = initState }, action = {}) {
           ...action.value,
         },
       })
+    case SHOW_GAS_BUTTON_GROUP:
+      return extend(newState, {
+        gasButtonGroupShown: true,
+      })
+    case HIDE_GAS_BUTTON_GROUP:
+      return extend(newState, {
+        gasButtonGroupShown: false,
+      })
     case RESET_SEND_STATE:
       return extend({}, initState)
     default:
@@ -65,6 +76,14 @@ export function openToDropdown () {
 
 export function closeToDropdown () {
   return { type: CLOSE_TO_DROPDOWN }
+}
+
+export function showGasButtonGroup () {
+  return { type: SHOW_GAS_BUTTON_GROUP }
+}
+
+export function hideGasButtonGroup () {
+  return { type: HIDE_GAS_BUTTON_GROUP }
 }
 
 export function updateSendErrors (errorObject) {

--- a/ui/app/ducks/tests/send-duck.test.js
+++ b/ui/app/ducks/tests/send-duck.test.js
@@ -6,6 +6,8 @@ import SendReducer, {
   openToDropdown,
   closeToDropdown,
   updateSendErrors,
+  showGasButtonGroup,
+  hideGasButtonGroup,
 } from '../send.duck.js'
 
 describe('Send Duck', () => {
@@ -18,6 +20,7 @@ describe('Send Duck', () => {
     fromDropdownOpen: false,
     toDropdownOpen: false,
     errors: {},
+    gasButtonGroupShown: true,
   }
   const OPEN_FROM_DROPDOWN = 'metamask/send/OPEN_FROM_DROPDOWN'
   const CLOSE_FROM_DROPDOWN = 'metamask/send/CLOSE_FROM_DROPDOWN'
@@ -25,6 +28,8 @@ describe('Send Duck', () => {
   const CLOSE_TO_DROPDOWN = 'metamask/send/CLOSE_TO_DROPDOWN'
   const UPDATE_SEND_ERRORS = 'metamask/send/UPDATE_SEND_ERRORS'
   const RESET_SEND_STATE = 'metamask/send/RESET_SEND_STATE'
+  const SHOW_GAS_BUTTON_GROUP = 'metamask/send/SHOW_GAS_BUTTON_GROUP'
+  const HIDE_GAS_BUTTON_GROUP = 'metamask/send/HIDE_GAS_BUTTON_GROUP'
 
   describe('SendReducer()', () => {
     it('should initialize state', () => {
@@ -85,6 +90,24 @@ describe('Send Duck', () => {
       )
     })
 
+    it('should set gasButtonGroupShown to true when receiving a SHOW_GAS_BUTTON_GROUP action', () => {
+      assert.deepEqual(
+        SendReducer(Object.assign({}, mockState, { gasButtonGroupShown: false }), {
+          type: SHOW_GAS_BUTTON_GROUP,
+        }),
+        Object.assign({gasButtonGroupShown: true}, mockState.send)
+      )
+    })
+
+    it('should set gasButtonGroupShown to false when receiving a HIDE_GAS_BUTTON_GROUP action', () => {
+      assert.deepEqual(
+        SendReducer(mockState, {
+          type: HIDE_GAS_BUTTON_GROUP,
+        }),
+        Object.assign({gasButtonGroupShown: false}, mockState.send)
+      )
+    })
+
     it('should extend send.errors with the value of a UPDATE_SEND_ERRORS action', () => {
       const modifiedMockState = Object.assign({}, mockState, {
         send: {
@@ -142,6 +165,20 @@ describe('Send Duck', () => {
     assert.deepEqual(
       closeToDropdown(),
       { type: CLOSE_TO_DROPDOWN }
+    )
+  })
+
+  describe('showGasButtonGroup', () => {
+    assert.deepEqual(
+      showGasButtonGroup(),
+      { type: SHOW_GAS_BUTTON_GROUP }
+    )
+  })
+
+  describe('hideGasButtonGroup', () => {
+    assert.deepEqual(
+      hideGasButtonGroup(),
+      { type: HIDE_GAS_BUTTON_GROUP }
     )
   })
 

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -63,9 +63,7 @@ function getAveragePriceEstimateInHexWEI (state) {
 }
 
 function getDefaultActiveButtonIndex (gasButtonInfo, customGasPriceInHex, gasPrice) {
-  console.log('gasButtonInfo', gasButtonInfo)
   return gasButtonInfo.findIndex(({ priceInHexWei }) => {
-    console.log('priceInHexWei', priceInHexWei, '|', customGasPriceInHex)
     return priceInHexWei === addHexPrefix(customGasPriceInHex || gasPrice)
   })
 }
@@ -208,10 +206,6 @@ function getRenderableEstimateDataForSmallButtons (state) {
         safeLow,
         average,
         fast,
-        blockTime,
-        safeLowWait,
-        avgWait,
-        fastWait,
       },
     },
   } = state

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -25,6 +25,7 @@ const selectors = {
   getCustomGasLimit,
   getCustomGasPrice,
   getCustomGasTotal,
+  getRenderableEstimateDataForSmallButtons,
   getRenderableBasicEstimateData,
   getBasicGasEstimateLoadingStatus,
   getAveragePriceEstimateInHexWEI,
@@ -33,6 +34,8 @@ const selectors = {
 }
 
 module.exports = selectors
+
+const NUMBER_OF_DECIMALS_SM_BTNS = 5
 
 function getCustomGasErrors (state) {
   return state.gas.errors
@@ -60,7 +63,9 @@ function getAveragePriceEstimateInHexWEI (state) {
 }
 
 function getDefaultActiveButtonIndex (gasButtonInfo, customGasPriceInHex, gasPrice) {
+  console.log('gasButtonInfo', gasButtonInfo)
   return gasButtonInfo.findIndex(({ priceInHexWei }) => {
+    console.log('priceInHexWei', priceInHexWei, '|', customGasPriceInHex)
     return priceInHexWei === addHexPrefix(customGasPriceInHex || gasPrice)
   })
 }
@@ -74,22 +79,23 @@ function apiEstimateModifiedToGWEI (estimate) {
   })
 }
 
-function basicPriceEstimateToETHTotal (estimate, gasLimit) {
+function basicPriceEstimateToETHTotal (estimate, gasLimit, numberOfDecimals = 9) {
   return conversionUtil(calcGasTotal(gasLimit, estimate), {
     fromNumericBase: 'hex',
     toNumericBase: 'dec',
     fromDenomination: 'GWEI',
-    numberOfDecimals: 9,
+    numberOfDecimals,
   })
 }
 
-function getRenderableEthFee (estimate, gasLimit) {
+function getRenderableEthFee (estimate, gasLimit, numberOfDecimals = 9) {
   return pipe(
     apiEstimateModifiedToGWEI,
-    partialRight(basicPriceEstimateToETHTotal, [gasLimit]),
+    partialRight(basicPriceEstimateToETHTotal, [gasLimit, numberOfDecimals]),
     formatETHFee
   )(estimate, gasLimit)
 }
+
 
 function getRenderableConvertedCurrencyFee (estimate, gasLimit, convertedCurrency, conversionRate) {
   return pipe(
@@ -184,6 +190,49 @@ function getRenderableBasicEstimateData (state) {
       feeInPrimaryCurrency: getRenderableConvertedCurrencyFee(safeLow, gasLimit, currentCurrency, conversionRate),
       feeInSecondaryCurrency: getRenderableEthFee(safeLow, gasLimit),
       timeEstimate: getRenderableTimeEstimate(safeLowWait, blockTime),
+      priceInHexWei: getGasPriceInHexWei(safeLow),
+    },
+  ]
+}
+
+function getRenderableEstimateDataForSmallButtons (state) {
+  if (getBasicGasEstimateLoadingStatus(state)) {
+    return []
+  }
+  const gasLimit = state.metamask.send.gasLimit || getCustomGasLimit(state)
+  const conversionRate = state.metamask.conversionRate
+  const currentCurrency = getCurrentCurrency(state)
+  const {
+    gas: {
+      basicEstimates: {
+        safeLow,
+        average,
+        fast,
+        blockTime,
+        safeLowWait,
+        avgWait,
+        fastWait,
+      },
+    },
+  } = state
+
+  return [
+    {
+      labelKey: 'fast',
+      feeInSecondaryCurrency: getRenderableConvertedCurrencyFee(fast, gasLimit, currentCurrency, conversionRate),
+      feeInPrimaryCurrency: getRenderableEthFee(fast, gasLimit, NUMBER_OF_DECIMALS_SM_BTNS),
+      priceInHexWei: getGasPriceInHexWei(fast),
+    },
+    {
+      labelKey: 'average',
+      feeInSecondaryCurrency: getRenderableConvertedCurrencyFee(average, gasLimit, currentCurrency, conversionRate),
+      feeInPrimaryCurrency: getRenderableEthFee(average, gasLimit, NUMBER_OF_DECIMALS_SM_BTNS),
+      priceInHexWei: getGasPriceInHexWei(average),
+    },
+    {
+      labelKey: 'slow',
+      feeInSecondaryCurrency: getRenderableConvertedCurrencyFee(safeLow, gasLimit, currentCurrency, conversionRate),
+      feeInPrimaryCurrency: getRenderableEthFee(safeLow, gasLimit, NUMBER_OF_DECIMALS_SM_BTNS),
       priceInHexWei: getGasPriceInHexWei(safeLow),
     },
   ]

--- a/ui/app/selectors/tests/custom-gas.test.js
+++ b/ui/app/selectors/tests/custom-gas.test.js
@@ -7,6 +7,7 @@ const {
   getCustomGasPrice,
   getCustomGasTotal,
   getRenderableBasicEstimateData,
+  getRenderableEstimateDataForSmallButtons,
 } = proxyquire('../custom-gas', {})
 
 describe('custom-gas selectors', () => {
@@ -130,6 +131,104 @@ describe('custom-gas selectors', () => {
       tests.forEach(test => {
         assert.deepEqual(
           getRenderableBasicEstimateData(test.mockState),
+          test.expectedResult
+        )
+      })
+    })
+
+  })
+
+  describe('getRenderableEstimateDataForSmallButtons()', () => {
+    const tests = [
+      {
+        expectedResult: [
+          {
+            feeInSecondaryCurrency: '$0.05',
+            feeInPrimaryCurrency: '0.00021 ETH',
+            labelKey: 'fast',
+            priceInHexWei: '0x2540be400',
+          },
+          {
+            feeInSecondaryCurrency: '$0.03',
+            feeInPrimaryCurrency: '0.0001 ETH',
+            labelKey: 'average',
+            priceInHexWei: '0x12a05f200',
+          },
+          {
+            feeInSecondaryCurrency: '$0.01',
+            feeInPrimaryCurrency: '0.00005 ETH',
+            labelKey: 'slow',
+            priceInHexWei: '0x9502f900',
+          },
+        ],
+        mockState: {
+          metamask: {
+            conversionRate: 255.71,
+            currentCurrency: 'usd',
+            send: {
+              gasLimit: '0x5208',
+            },
+          },
+          gas: {
+            basicEstimates: {
+              blockTime: 14.16326530612245,
+              safeLow: 25,
+              safeLowWait: 6.6,
+              average: 50,
+              avgWait: 3.3,
+              fast: 100,
+              fastWait: 0.5,
+            },
+          },
+        },
+      },
+      {
+        expectedResult: [
+          {
+            feeInSecondaryCurrency: '$1.07',
+            feeInPrimaryCurrency: '0.00042 ETH',
+            labelKey: 'fast',
+            priceInHexWei: '0x4a817c800',
+          },
+          {
+            feeInSecondaryCurrency: '$0.54',
+            feeInPrimaryCurrency: '0.00021 ETH',
+            labelKey: 'average',
+            priceInHexWei: '0x2540be400',
+          },
+          {
+            feeInSecondaryCurrency: '$0.27',
+            feeInPrimaryCurrency: '0.0001 ETH',
+            labelKey: 'slow',
+            priceInHexWei: '0x12a05f200',
+          },
+        ],
+        mockState: {
+          metamask: {
+            conversionRate: 2557.1,
+            currentCurrency: 'usd',
+            send: {
+              gasLimit: '0x5208',
+            },
+          },
+          gas: {
+            basicEstimates: {
+              blockTime: 14.16326530612245,
+              safeLow: 50,
+              safeLowWait: 13.2,
+              average: 100,
+              avgWait: 6.6,
+              fast: 200,
+              fastWait: 1.0,
+            },
+          },
+        },
+      },
+    ]
+    it('should return renderable data about basic estimates appropriate for buttons with less info', () => {
+      tests.forEach(test => {
+        assert.deepEqual(
+          getRenderableEstimateDataForSmallButtons(test.mockState),
           test.expectedResult
         )
       })


### PR DESCRIPTION
Integrates gas buttons to the send screen

Wait for https://github.com/MetaMask/metamask-extension/pull/5253 to be merged before review

To do:

- [x] Unit tests
- [x] A few small refactors to improve code clarity and simplicity in `mapStateToProps`

Preview:

![screenshot from 2018-09-13 10-11-47](https://user-images.githubusercontent.com/7499938/45503975-1bbfcc80-b763-11e8-849d-d8f6aa7482e9.png)
----
![screenshot from 2018-09-13 10-11-57](https://user-images.githubusercontent.com/7499938/45503978-1bbfcc80-b763-11e8-97ff-0fc6138633fd.png)
