### PR TITLE
EIP-1102: Transitionary API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#4606](https://github.com/MetaMask/metamask-extension/pull/4606): Add new metamask_watchAsset method.
 - [#5189](https://github.com/MetaMask/metamask-extension/pull/5189): Fix bug where Ropsten loading message is shown when connecting to Kovan.
+- [#5256](https://github.com/MetaMask/metamask-extension/pull/5256): Add mock EIP-1102 support
 
 ## 4.9.3 Wed Aug 15 2018
 

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -22,6 +22,15 @@ var metamaskStream = new LocalMessageDuplexStream({
 // compose the inpage provider
 var inpageProvider = new MetamaskInpageProvider(metamaskStream)
 
+// Augment the provider with its enable method
+inpageProvider.enable = function () {
+  return new Promise((resolve) => {
+    resolve(inpageProvider.send({ method: 'eth_accounts' }).result)
+  })
+}
+
+window.ethereum = inpageProvider
+
 //
 // setup web3
 //

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -23,9 +23,19 @@ var metamaskStream = new LocalMessageDuplexStream({
 var inpageProvider = new MetamaskInpageProvider(metamaskStream)
 
 // Augment the provider with its enable method
-inpageProvider.enable = function () {
-  return new Promise((resolve) => {
-    resolve(inpageProvider.send({ method: 'eth_accounts' }).result)
+inpageProvider.enable = function (options = {}) {
+  return new Promise((resolve, reject) => {
+    if (options.mockRejection) {
+      reject('User rejected account access')
+    } else {
+      inpageProvider.sendAsync({ method: 'eth_accounts', params: [] }, (error, response) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(response.result)
+        }
+      })
+    }
   })
 }
 


### PR DESCRIPTION
This pull request adds a transitionary EIP-1102 API so dapps can begin preemptively calling it. Specifically, this pull request does the following:

1. Assigns the provider to `window.ethereum`
2. Adds a `provider#enable` method

**Note:** User-rejection can be tested by passing an object into the `enable` method with a `mockRejection` property set to `true`:

```js
ethereum.enable({ mockRejection: true })
```