### PR TITLE
lower input z-index to prevent overlap - follow up style fix to #5242

### DIFF
--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -622,14 +622,14 @@
     position: relative;
 
     &__down-caret {
-      z-index: 1051;
+      z-index: 1026;
       position: absolute;
       top: 18px;
       right: 12px;
     }
 
     &__qr-code {
-      z-index: 1051;
+      z-index: 1026;
       position: absolute;
       top: 13px;
       right: 33px;
@@ -649,7 +649,7 @@
 
   &__to-autocomplete, &__memo-text-area, &__hex-data {
     &__input {
-      z-index: 1050;
+      z-index: 1025;
       position: relative;
       height: 54px;
       width: 100%;


### PR DESCRIPTION
This is a follow up to my last PR #5242. After turning on hex-data for sending transactions I noticed that this input was rendering above the dropdown as can be seen here:
<img width="363" alt="screen shot 2018-09-13 at 7 07 14 pm" src="https://user-images.githubusercontent.com/3892981/45521143-b1228700-b78a-11e8-89e3-e8fc1124294c.png">

Changing the z-index to 1025 instead of 1050 fixes the issue:
<img width="362" alt="screen shot 2018-09-13 at 7 19 52 pm" src="https://user-images.githubusercontent.com/3892981/45521152-bda6df80-b78a-11e8-8bf9-a3fd50bf7c78.png">

There are basically three layers here: The 'close-dropdown' layer which covers the entire extension at z-index 1000. The (recently added) inputs layer at 1025 which makes inputs right-click-able. And the actual dropdown layer on top at 1050.

My apologies for not testing thoroughly enough on the last PR. I double checked that right clicks are working properly in hex data input now also and everything else seems good.


