### PR TITLE
Improvement: Increase click area for arrows

### DIFF
--- a/ui/app/components/input-number.js
+++ b/ui/app/components/input-number.js
@@ -66,13 +66,16 @@ InputNumber.prototype.render = function () {
     }),
     h('span.gas-tooltip-input-detail', {}, [unitLabel]),
     h('div.gas-tooltip-input-arrows', {}, [
-      h('i.fa.fa-angle-up', {
+      h('div.gas-tooltip-input-arrow-wrapper', {
         onClick: () => this.setValue(addCurrencies(value, step, { toNumericBase: 'dec' })),
-      }),
-      h('i.fa.fa-angle-down', {
-        style: { cursor: 'pointer' },
+      }, [
+        h('i.fa.fa-angle-up'),
+      ]),
+      h('div.gas-tooltip-input-arrow-wrapper', {
         onClick: () => this.setValue(subtractCurrencies(value, step, { toNumericBase: 'dec' })),
-      }),
+      }, [
+        h('i.fa.fa-angle-down'),
+      ]),
     ]),
   ])
 }

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -888,10 +888,19 @@
       font-size: 18px;
       color: $tundora;
       right: 0px;
-      padding: 1px 4px;
+      padding: 0;
       display: flex;
       justify-content: space-around;
       align-items: center;
+    }
+
+    .gas-tooltip-input-arrow-wrapper {
+      align-items: center;
+      align-self: stretch;
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      justify-content: center;
     }
 
     input[type="number"]::-webkit-inner-spin-button {


### PR DESCRIPTION
Creates a wrapper div for the arrow buttons and places the onClick handler there. The wrapper div allows the click area to be much larger which fixes the issue of clicks appearing not to work. It also appeared buggy since cursor: pointer; was being applied to the container of both arrows, but the onClick area was only the actual icon.

This may fix #5163 