### PR TITLE
Improvement: Reposition customize gas error

### DIFF
--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -831,11 +831,13 @@
     &__error-message {
       display: block;
       position: absolute;
-      top: 4px;
-      right: 4px;
+      top: -18px;
+      right: 0;
       font-size: 12px;
       line-height: 12px;
       color: $red;
+      width: 100%;
+      text-align: center;
     }
 
     &__cancel {


### PR DESCRIPTION
This horizontally centers the error message above the footer. There was not sufficient space to have it inside the footer. Since there are new designs coming for this screen I kept this change minimal.

This fixes #4579 