### PR TITLE
Improvement: Allow enter to submit password form

### DIFF
--- a/mascara/src/app/first-time/create-password-screen.js
+++ b/mascara/src/app/first-time/create-password-screen.js
@@ -63,7 +63,9 @@ class CreatePasswordScreen extends Component {
     return password === confirmPassword
   }
 
-  createAccount = () => {
+  createAccount = (event) => {
+    event.preventDefault()
+
     if (!this.isValid()) {
       return
     }
@@ -127,7 +129,7 @@ class CreatePasswordScreen extends Component {
               It allows you to hold ether & tokens, and interact with decentralized applications.
             </div>
           </div>}
-          <div className="create-password">
+          <form className="create-password">
             <div className="create-password__title">
               Create Password
             </div>
@@ -188,7 +190,7 @@ class CreatePasswordScreen extends Component {
             </a>
             { */ }
             <Breadcrumbs total={3} currentIndex={0} />
-          </div>
+          </form>
         </div>
       </div>
     )


### PR DESCRIPTION
This changes the create-password div into a form so that pressing the Enter key works as requested.

This fixes #5231