### PR TITLE
Fix loading screen height

### DIFF
--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -152,7 +152,7 @@ class App extends Component {
 
         h(AccountMenu),
 
-        h('div.main-container', [
+        h('div.main-container-wrapper', [
           (isLoading || isLoadingNetwork) && h(Loading, {
             loadingMessage: loadMessage,
           }),

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -152,12 +152,14 @@ class App extends Component {
 
         h(AccountMenu),
 
-        (isLoading || isLoadingNetwork) && h(Loading, {
-          loadingMessage: loadMessage,
-        }),
+        h('div.main-container', [
+          (isLoading || isLoadingNetwork) && h(Loading, {
+            loadingMessage: loadMessage,
+          }),
 
-        // content
-        this.renderRoutes(),
+          // content
+          this.renderRoutes(),
+        ]),
       ])
     )
   }

--- a/ui/app/components/page-container/index.scss
+++ b/ui/app/components/page-container/index.scss
@@ -182,5 +182,7 @@
     max-height: 82vh;
     min-height: 570px;
     flex: 0 0 auto;
+    margin-right: auto;
+    margin-left: auto;
   }
 }

--- a/ui/app/components/pages/unlock-page/index.scss
+++ b/ui/app/components/pages/unlock-page/index.scss
@@ -14,6 +14,7 @@
     align-self: stretch;
     justify-content: center;
     flex: 1 0 auto;
+    height: 100vh;
   }
 
   &__mascot-container {

--- a/ui/app/css/itcss/components/loading-overlay.scss
+++ b/ui/app/css/itcss/components/loading-overlay.scss
@@ -8,17 +8,8 @@
   align-items: center;
   flex: 1 1 auto;
   width: 100%;
+  height: 100%;
   background: rgba(255, 255, 255, .8);
-
-  @media screen and (max-width: 575px) {
-    margin-top: 66px;
-    height: calc(100% - 66px);
-  }
-
-  @media screen and (min-width: 576px) {
-    margin-top: 75px;
-    height: calc(100% - 75px);
-  }
 
   &__container {
     position: absolute;

--- a/ui/app/css/itcss/components/loading-overlay.scss
+++ b/ui/app/css/itcss/components/loading-overlay.scss
@@ -20,13 +20,6 @@
     height: calc(100% - 75px);
   }
 
-  &--full-screen {
-    position: fixed;
-    height: 100vh;
-    width: 100vw;
-    margin-top: 0;
-  }
-
   &__container {
     position: absolute;
     top: 33%;

--- a/ui/app/css/itcss/components/loading-overlay.scss
+++ b/ui/app/css/itcss/components/loading-overlay.scss
@@ -1,6 +1,6 @@
 .loading-overlay {
   left: 0;
-  z-index: 256;
+  z-index: 51;
   position: absolute;
   flex-direction: column;
   display: flex;

--- a/ui/app/css/itcss/components/loading-overlay.scss
+++ b/ui/app/css/itcss/components/loading-overlay.scss
@@ -1,6 +1,6 @@
 .loading-overlay {
   left: 0;
-  z-index: 50;
+  z-index: 256;
   position: absolute;
   flex-direction: column;
   display: flex;

--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -22,6 +22,12 @@ $wallet-view-bg: $alabaster;
   display: none;
 }
 
+.main-container-wrapper {
+  display: flex;
+  width: 100vw;
+  justify-content: center;
+}
+
 //Account and transaction details
 .account-and-transaction-details {
   display: flex;
@@ -218,6 +224,10 @@ $wallet-view-bg: $alabaster;
     width: 100%;
     overflow-y: auto;
     background-color: $white;
+  }
+
+  .main-container-wrapper {
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
This PR fixes #5287 by having the loading screen fill 100% of its container's height. #4417 had moved the loading screen down by the height of the app bar to allow users to switch networks but the app bar doesn't always have a fixed height—this PR introduces a 2nd container to work around the need for a fixed margin at the top of the loading screen.

**Screenshot of the confirm screen when loading**

<img width="472" src="https://user-images.githubusercontent.com/1623628/45774021-802cd100-bc26-11e8-8f73-6550848ee86f.png">

**Screenshot of the full-screen view not blocking the app bar (as per #4417)**

<img width="1224" src="https://user-images.githubusercontent.com/1623628/45774022-802cd100-bc26-11e8-98ad-cdc1da6c247f.png">
