### PR TITLE
Add "Cancel All" button to confirm screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -116,6 +116,9 @@
   "cancel": {
     "message": "Cancel"
   },
+  "cancelAll": {
+    "message": "Cancel All"
+  },
   "classicInterface": {
     "message": "Use classic interface"
   },

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -167,6 +167,7 @@ var actions = {
   updateTransaction,
   updateAndApproveTx,
   cancelTx: cancelTx,
+  cancelTxs,
   completedTx: completedTx,
   txError: txError,
   nextTx: nextTx,
@@ -1299,6 +1300,47 @@ function cancelTx (txData) {
   }
 }
 
+/**
+ * Cancels all of the given transactions
+ * @param {Array<object>} txDataList a list of tx data objects
+ * @return {function(*): Promise<void>}
+ */
+function cancelTxs (txDataList) {
+  return async (dispatch, getState) => {
+    dispatch(actions.showLoadingIndication())
+    const txIds = txDataList.map(({id}) => id)
+    const cancellations = txIds.map((id) => new Promise((resolve, reject) => {
+      background.cancelTransaction(id, (err) => {
+        if (err) {
+          return reject(err)
+        }
+
+        resolve()
+      })
+    }))
+
+    await Promise.all(cancellations)
+    const newState = await updateMetamaskStateFromBackground()
+    dispatch(actions.updateMetamaskState(newState))
+    dispatch(actions.clearSend())
+
+    txIds.forEach((id) => {
+      dispatch(actions.completedTx(id))
+    })
+
+    dispatch(actions.hideLoadingIndication())
+
+    if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION) {
+      return global.platform.closeCurrentWindow()
+    }
+  }
+}
+
+/**
+ * @deprecated
+ * @param {Array<object>} txsData
+ * @return {Function}
+ */
 function cancelAllTx (txsData) {
   return (dispatch) => {
     txsData.forEach((txData, i) => {

--- a/ui/app/components/button/button.component.js
+++ b/ui/app/components/button/button.component.js
@@ -18,7 +18,12 @@ const typeHash = {
 }
 
 export default class Button extends Component {
+  static defaultProps = {
+    buttonRef: () => {},
+  }
+
   static propTypes = {
+    buttonRef: PropTypes.func,
     type: PropTypes.string,
     large: PropTypes.bool,
     className: PropTypes.string,
@@ -26,10 +31,11 @@ export default class Button extends Component {
   }
 
   render () {
-    const { type, large, className, ...buttonProps } = this.props
+    const { buttonRef, type, large, className, ...buttonProps } = this.props
 
     return (
       <button
+        ref={buttonRef}
         className={classnames(
           'button',
           typeHash[type],

--- a/ui/app/components/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/confirm-page-container/confirm-page-container.component.js
@@ -42,6 +42,7 @@ export default class ConfirmPageContainer extends Component {
     summaryComponent: PropTypes.node,
     warning: PropTypes.string,
     // Footer
+    onCancelAll: PropTypes.func,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func,
     disabled: PropTypes.bool,
@@ -67,6 +68,7 @@ export default class ConfirmPageContainer extends Component {
       summaryComponent,
       detailsComponent,
       dataComponent,
+      onCancelAll,
       onCancel,
       onSubmit,
       identiconAddress,
@@ -111,8 +113,10 @@ export default class ConfirmPageContainer extends Component {
           )
         }
         <PageContainerFooter
+          onAlternate={() => onCancelAll()}
           onCancel={() => onCancel()}
           onSubmit={() => onSubmit()}
+          alternateText={this.context.t('cancelAll')}
           submitText={this.context.t('confirm')}
           submitButtonType="confirm"
           disabled={disabled}

--- a/ui/app/components/page-container/index.scss
+++ b/ui/app/components/page-container/index.scss
@@ -46,8 +46,19 @@
     flex-flow: row;
     justify-content: center;
     border-top: 1px solid $geyser;
-    padding: 16px;
+    padding: 16px 16px 16px 0;
     flex: 0 0 auto;
+
+    > div {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: end;
+      width: 100%;
+      height: 100%;
+      overflow-x: scroll;
+      padding-left: 16px;
+    }
 
     .btn-default,
     .btn-confirm {

--- a/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
@@ -30,7 +30,7 @@ export default class PageContainerFooter extends Component {
     this.nextBtnRef = e
   }
 
-  componentDidMount () {
+  componentDidUpdate () {
     if (this.nextBtnRef) {
       this.nextBtnRef.scrollIntoView()
     }

--- a/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
@@ -4,7 +4,14 @@ import Button from '../../button'
 
 export default class PageContainerFooter extends Component {
 
+  static defaultProps = {
+    alternateText: null,
+    onAlternate: null,
+  }
+
   static propTypes = {
+    alternateText: PropTypes.string,
+    onAlternate: PropTypes.func,
     onCancel: PropTypes.func,
     cancelText: PropTypes.string,
     onSubmit: PropTypes.func,
@@ -17,8 +24,22 @@ export default class PageContainerFooter extends Component {
     t: PropTypes.func,
   }
 
+  nextBtnRef = null
+
+  setNextBtnRef = (e) => {
+    this.nextBtnRef = e
+  }
+
+  componentDidMount () {
+    if (this.nextBtnRef) {
+      this.nextBtnRef.scrollIntoView()
+    }
+  }
+
   render () {
     const {
+      alternateText,
+      onAlternate,
       onCancel,
       cancelText,
       onSubmit,
@@ -29,26 +50,38 @@ export default class PageContainerFooter extends Component {
 
     return (
       <div className="page-container__footer">
-
-        <Button
-          type="default"
-          large
-          className="page-container__footer-button"
-          onClick={e => onCancel(e)}
-        >
-          { cancelText || this.context.t('cancel') }
-        </Button>
-
-        <Button
-          type={submitButtonType || 'primary'}
-          large
-          className="page-container__footer-button"
-          disabled={disabled}
-          onClick={e => onSubmit(e)}
-        >
-          { submitText || this.context.t('next') }
-        </Button>
-
+        <div>
+          {
+            alternateText && onAlternate && (
+              <Button
+                type="default"
+                large
+                className="page-container__footer-button"
+                onClick={onAlternate}
+              >
+                { alternateText }
+              </Button>
+            )
+          }
+          <Button
+            type="default"
+            large
+            className="page-container__footer-button"
+            onClick={onCancel}
+          >
+            { cancelText || this.context.t('cancel') }
+          </Button>
+          <Button
+            buttonRef={this.setNextBtnRef}
+            type={submitButtonType || 'primary'}
+            large
+            className="page-container__footer-button"
+            disabled={disabled}
+            onClick={onSubmit}
+          >
+            { submitText || this.context.t('next') }
+          </Button>
+        </div>
       </div>
     )
   }

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -21,6 +21,7 @@ export default class ConfirmTransactionBase extends Component {
     // Redux props
     balance: PropTypes.string,
     cancelTransaction: PropTypes.func,
+    cancelAllTransactions: PropTypes.func,
     clearConfirmTransaction: PropTypes.func,
     clearSend: PropTypes.func,
     conversionRate: PropTypes.number,
@@ -248,6 +249,16 @@ export default class ConfirmTransactionBase extends Component {
     onEdit({ txData, tokenData, tokenProps })
   }
 
+  handleCancelAll () {
+    const { cancelAllTransactions, history, clearConfirmTransaction } = this.props
+
+    cancelAllTransactions()
+      .then(() => {
+        clearConfirmTransaction()
+        history.push(DEFAULT_ROUTE)
+      })
+  }
+
   handleCancel () {
     const { onCancel, txData, cancelTransaction, history, clearConfirmTransaction } = this.props
 
@@ -309,6 +320,7 @@ export default class ConfirmTransactionBase extends Component {
       identiconAddress,
       summaryComponent,
       contentComponent,
+      onCancelAll,
       onEdit,
       nonce,
       assetImage,
@@ -343,6 +355,7 @@ export default class ConfirmTransactionBase extends Component {
         warning={warning}
         disabled={!propsValid || !valid || submitting}
         onEdit={() => this.handleEdit()}
+        onCancelAll={() => this.handleCancelAll()}
         onCancel={() => this.handleCancel()}
         onSubmit={() => this.handleSubmit()}
       />

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -8,7 +8,7 @@ import {
   clearConfirmTransaction,
   updateGasAndCalculate,
 } from '../../../ducks/confirm-transaction.duck'
-import { clearSend, cancelTx, updateAndApproveTx, showModal } from '../../../actions'
+import { clearSend, cancelTx, cancelTxs, updateAndApproveTx, showModal } from '../../../actions'
 import {
   INSUFFICIENT_FUNDS_ERROR_KEY,
   GAS_LIMIT_TOO_LOW_ERROR_KEY,
@@ -17,7 +17,7 @@ import { getHexGasTotal } from '../../../helpers/confirm-transaction/util'
 import { isBalanceSufficient } from '../../send/send.utils'
 import { conversionGreaterThan } from '../../../conversion-util'
 import { MIN_GAS_LIMIT_DEC } from '../../send/send.constants'
-import { addressSlicer } from '../../../util'
+import { addressSlicer, valuesFor } from '../../../util'
 
 const casedContractMap = Object.keys(contractMap).reduce((acc, base) => {
   return {
@@ -53,6 +53,7 @@ const mapStateToProps = (state, props) => {
     selectedAddress,
     selectedAddressTxList,
     assetImages,
+    unapprovedTxs,
   } = metamask
   const assetImage = assetImages[txParamsToAddress]
   const { balance } = accounts[selectedAddress]
@@ -90,6 +91,7 @@ const mapStateToProps = (state, props) => {
     transactionStatus,
     nonce,
     assetImage,
+    unapprovedTxs,
   }
 }
 
@@ -107,6 +109,7 @@ const mapDispatchToProps = dispatch => {
       return dispatch(updateGasAndCalculate({ gasLimit, gasPrice }))
     },
     cancelTransaction: ({ id }) => dispatch(cancelTx({ id })),
+    cancelAllTransactions: (txList) => dispatch(cancelTxs(txList)),
     sendTransaction: txData => dispatch(updateAndApproveTx(txData)),
   }
 }
@@ -156,8 +159,9 @@ const getValidateEditGas = ({ balance, conversionRate, txData }) => {
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { balance, conversionRate, txData } = stateProps
+  const { balance, conversionRate, txData, unapprovedTxs } = stateProps
   const {
+    cancelAllTransactions: dispatchCancelAllTransactions,
     showCustomizeGasModal: dispatchShowCustomizeGasModal,
     updateGasAndCalculate: dispatchUpdateGasAndCalculate,
     ...otherDispatchProps
@@ -174,6 +178,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       onSubmit: txData => dispatchUpdateGasAndCalculate(txData),
       validate: validateEditGas,
     }),
+    cancelAllTransactions: () => dispatchCancelAllTransactions(valuesFor(unapprovedTxs)),
   }
 }
 


### PR DESCRIPTION
Closes #4970

This PR adds a "Cancel All" button to the confirm screen for transactions that will cancel all of the pending transactions.

To-do:

- [ ] Is this a usable design? (Probably not, I'm open to ideas.)
- [ ] Only show the 3rd option when there's more than 1 tx pending