### PR TITLE
Adds getPendingNonce method to provider initialization in metamask-controller.

### DIFF
--- a/app/scripts/controllers/network/createMetamaskMiddleware.js
+++ b/app/scripts/controllers/network/createMetamaskMiddleware.js
@@ -38,6 +38,6 @@ function createPendingNonceMiddleware ({ getPendingNonce }) {
     const address = req.params[0]
     const blockRef = req.params[1]
     if (blockRef !== 'pending') return next()
-    req.result = await getPendingNonce(address)
+    res.result = await getPendingNonce(address)
   })
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -268,6 +268,7 @@ module.exports = class MetamaskController extends EventEmitter {
       // msg signing
       processEthSignMessage: this.newUnsignedMessage.bind(this),
       processPersonalMessage: this.newUnsignedPersonalMessage.bind(this),
+      getPendingNonce: this.getPendingNonce.bind(this),
     }
     const providerProxy = this.networkController.initializeProvider(providerOpts)
     return providerProxy
@@ -1360,6 +1361,19 @@ module.exports = class MetamaskController extends EventEmitter {
     const percentileNum = percentile(50, lowestPrices)
     const percentileNumBn = new BN(percentileNum)
     return '0x' + percentileNumBn.mul(GWEI_BN).toString(16)
+  }
+
+  /**
+   * Returns the nonce that will be associated with a transaction once approved
+   * @param address {string} - The hex string address for the transaction
+   * @returns Promise<number>
+   */
+  async getPendingNonce (address) {
+    const { nonceDetails, releaseLock} = await this.txController.nonceTracker.getNonceLock(address)
+    const pendingNonce = nonceDetails.params.highestSuggested
+
+    releaseLock()
+    return pendingNonce
   }
 
 //=============================================================================


### PR DESCRIPTION
Fixes #5306 

`app/scripts/controllers/network/createMetamaskMiddleware.js` expects a `getPendingNonce` method, but that was missing from the options passed to `initializeProvider` in `metamask-controller.js`

This PR adds `getPendingNonce`. It also fixes a bug in the `createPendingNonceMiddleware` function in `createMetamaskMiddleware.js`: the `result` was being added to the `createAsyncMiddleware` `req` and not the `res`. This was returning a `'JsonRpcEngine - response has no error or result for request:\n' + requestBody` error from https://github.com/kumavis/json-rpc-engine/blob/a931cbcc15b4f7fc2971bfdc694f6203e2afe2ec/src/index.js#L54

QA was done by creating a transaction on https://token.store/, which was one of the actions reported as broken by users that was caused by the missing `getPendingNonce` method.