### PR TITLE
Debounce was breaking in update

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "copy-to-clipboard": "^3.0.8",
     "css-loader": "^0.28.11",
     "currency-formatter": "^1.4.2",
-    "debounce": "^1.0.0",
+    "debounce": "1.1.0",
     "debounce-stream": "^2.0.0",
     "deep-extend": "^0.5.1",
     "detect-node": "^2.0.3",


### PR DESCRIPTION
As found in issue here: https://github.com/MetaMask/metamask-extension/issues/5064
Pinned the version at 1.1.0 until the new version with breaking changes can be intergrated.