### PR TITLE
Fix height of first-time-flow container

### DIFF
--- a/mascara/src/app/first-time/index.css
+++ b/mascara/src/app/first-time/index.css
@@ -8,6 +8,7 @@
 
 .first-time-flow {
   width: 100vw;
+  height: 100vh;
   background-color: #fff;
   overflow: auto;
   display: flex;


### PR DESCRIPTION
Refs #5298

This PR fixes the height of the `.first-time-flow` container which #5298 changed.

#### Before & after:

<img width="1224" src="https://user-images.githubusercontent.com/1623628/45936316-9a044600-bf8f-11e8-85ce-f818c56d08c6.png">
<img width="1224" src="https://user-images.githubusercontent.com/1623628/45936317-9a9cdc80-bf8f-11e8-949e-eb9dae197c61.png">
