### PR TITLE
Add batch reject to confirm screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -790,6 +790,9 @@
   "rejectTxsN": {
     "message": "Reject $1 transactions"
   },
+  "rejectTxsDescription": {
+    "message": "You are about to batch reject $1 transactions."
+  },
   "rejected": {
     "message": "Rejected"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -784,6 +784,12 @@
   "refundAddress": {
     "message": "Your Refund Address"
   },
+  "reject": {
+    "message": "Reject"
+  },
+  "rejectTxsN": {
+    "message": "Reject $1 transactions"
+  },
   "rejected": {
     "message": "Rejected"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -787,6 +787,9 @@
   "reject": {
     "message": "Reject"
   },
+  "rejectAll": {
+    "message": "Reject All"
+  },
   "rejectTxsN": {
     "message": "Reject $1 transactions"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -128,6 +128,9 @@
   "cancellationGasFee": {
     "message": "Cancellation Gas Fee"
   },
+  "cancelN": {
+    "message": "Cancel all $1 transactions"
+  },
   "classicInterface": {
     "message": "Use classic interface"
   },

--- a/ui/app/components/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/confirm-page-container/confirm-page-container.component.js
@@ -41,7 +41,9 @@ export default class ConfirmPageContainer extends Component {
     assetImage: PropTypes.string,
     summaryComponent: PropTypes.node,
     warning: PropTypes.string,
+    unapprovedTxCount: PropTypes.number,
     // Footer
+    onCancelAll: PropTypes.func,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func,
     disabled: PropTypes.bool,
@@ -67,10 +69,12 @@ export default class ConfirmPageContainer extends Component {
       summaryComponent,
       detailsComponent,
       dataComponent,
+      onCancelAll,
       onCancel,
       onSubmit,
       identiconAddress,
       nonce,
+      unapprovedTxCount,
       assetImage,
       warning,
     } = this.props
@@ -116,7 +120,13 @@ export default class ConfirmPageContainer extends Component {
           submitText={this.context.t('confirm')}
           submitButtonType="confirm"
           disabled={disabled}
-        />
+        >
+          {unapprovedTxCount > 1 && (
+            <a onClick={() => onCancelAll()}>
+              {this.context.t('cancelN', [unapprovedTxCount])}
+            </a>
+          )}
+        </PageContainerFooter>
       </div>
     )
   }

--- a/ui/app/components/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/confirm-page-container/confirm-page-container.component.js
@@ -116,6 +116,7 @@ export default class ConfirmPageContainer extends Component {
         }
         <PageContainerFooter
           onCancel={() => onCancel()}
+          cancelText={this.context.t('reject')}
           onSubmit={() => onSubmit()}
           submitText={this.context.t('confirm')}
           submitButtonType="confirm"
@@ -123,7 +124,7 @@ export default class ConfirmPageContainer extends Component {
         >
           {unapprovedTxCount > 1 && (
             <a onClick={() => onCancelAll()}>
-              {this.context.t('cancelN', [unapprovedTxCount])}
+              {this.context.t('rejectTxsN', [unapprovedTxCount])}
             </a>
           )}
         </PageContainerFooter>

--- a/ui/app/components/modals/modal.js
+++ b/ui/app/components/modals/modal.js
@@ -28,6 +28,7 @@ import ConfirmCustomizeGasModal from './customize-gas'
 import CancelTransaction from './cancel-transaction'
 import WelcomeBeta from './welcome-beta'
 import TransactionDetails from './transaction-details'
+import RejectTransactions from './reject-transactions'
 
 const modalContainerBaseStyle = {
   transform: 'translate3d(-50%, 0, 0px)',
@@ -367,6 +368,19 @@ const MODALS = {
 
   TRANSACTION_DETAILS: {
     contents: h(TransactionDetails),
+    mobileModalStyle: {
+      ...modalContainerMobileStyle,
+    },
+    laptopModalStyle: {
+      ...modalContainerLaptopStyle,
+    },
+    contentStyle: {
+      borderRadius: '8px',
+    },
+  },
+
+  REJECT_TRANSACTIONS: {
+    contents: h(RejectTransactions),
     mobileModalStyle: {
       ...modalContainerMobileStyle,
     },

--- a/ui/app/components/modals/reject-transactions/index.js
+++ b/ui/app/components/modals/reject-transactions/index.js
@@ -1,0 +1,1 @@
+export { default } from './reject-transactions.container'

--- a/ui/app/components/modals/reject-transactions/index.scss
+++ b/ui/app/components/modals/reject-transactions/index.scss
@@ -1,0 +1,6 @@
+.reject-transactions {
+  &__description {
+    text-align: center;
+    font-size: .875rem;
+  }
+}

--- a/ui/app/components/modals/reject-transactions/reject-transactions.component.js
+++ b/ui/app/components/modals/reject-transactions/reject-transactions.component.js
@@ -30,7 +30,7 @@ export default class RejectTransactionsModal extends PureComponent {
         onClose={hideModal}
         onSubmit={this.onSubmit}
         onCancel={hideModal}
-        submitText={t('reject')}
+        submitText={t('rejectAll')}
         cancelText={t('cancel')}
         submitType="secondary"
       >

--- a/ui/app/components/modals/reject-transactions/reject-transactions.component.js
+++ b/ui/app/components/modals/reject-transactions/reject-transactions.component.js
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types'
+import React, { PureComponent } from 'react'
+import Modal from '../../modal'
+
+export default class RejectTransactionsModal extends PureComponent {
+  static contextTypes = {
+    t: PropTypes.func.isRequired,
+  }
+
+  static propTypes = {
+    onSubmit: PropTypes.func.isRequired,
+    hideModal: PropTypes.func.isRequired,
+    unapprovedTxCount: PropTypes.number.isRequired,
+  }
+
+  onSubmit = async () => {
+    const { onSubmit, hideModal } = this.props
+
+    await onSubmit()
+    hideModal()
+  }
+
+  render () {
+    const { t } = this.context
+    const { hideModal, unapprovedTxCount } = this.props
+
+    return (
+      <Modal
+        headerText={t('rejectTxsN', [unapprovedTxCount])}
+        onClose={hideModal}
+        onSubmit={this.onSubmit}
+        onCancel={hideModal}
+        submitText={t('reject')}
+        cancelText={t('cancel')}
+        submitType="secondary"
+      >
+        <div>
+          <div className="reject-transactions__description">
+            { t('rejectTxsDescription', [unapprovedTxCount]) }
+          </div>
+        </div>
+      </Modal>
+    )
+  }
+}

--- a/ui/app/components/modals/reject-transactions/reject-transactions.container.js
+++ b/ui/app/components/modals/reject-transactions/reject-transactions.container.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux'
+import { compose } from 'recompose'
+import RejectTransactionsModal from './reject-transactions.component'
+import withModalProps from '../../../higher-order-components/with-modal-props'
+
+const mapStateToProps = (state, ownProps) => {
+  const { unapprovedTxCount } = ownProps
+
+  return {
+    unapprovedTxCount,
+  }
+}
+
+export default compose(
+  withModalProps,
+  connect(mapStateToProps),
+)(RejectTransactionsModal)

--- a/ui/app/components/page-container/index.scss
+++ b/ui/app/components/page-container/index.scss
@@ -52,29 +52,29 @@
     .btn-confirm {
       font-size: 1rem;
     }
-  }
 
-  &__footer-header {
-    display: flex;
-    flex-flow: row;
-    justify-content: center;
-    padding: 16px;
-    flex: 0 0 auto;
-  }
+    header {
+      display: flex;
+      flex-flow: row;
+      justify-content: center;
+      padding: 16px;
+      flex: 0 0 auto;
+    }
 
-  &__footer-footer {
-    display: flex;
-    flex-flow: row;
-    justify-content: space-around;
-    padding: 0 16px 16px;
-    flex: 0 0 auto;
+    footer {
+      display: flex;
+      flex-flow: row;
+      justify-content: space-around;
+      padding: 0 16px 16px;
+      flex: 0 0 auto;
 
-    a, a:hover {
-      text-decoration: none;
-      cursor: pointer;
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      color: #2f9ae0;
+      a, a:hover {
+        text-decoration: none;
+        cursor: pointer;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        color: #2f9ae0;
+      }
     }
   }
 

--- a/ui/app/components/page-container/index.scss
+++ b/ui/app/components/page-container/index.scss
@@ -43,15 +43,38 @@
 
   &__footer {
     display: flex;
-    flex-flow: row;
+    flex-flow: column;
     justify-content: center;
     border-top: 1px solid $geyser;
-    padding: 16px;
     flex: 0 0 auto;
 
     .btn-default,
     .btn-confirm {
       font-size: 1rem;
+    }
+  }
+
+  &__footer-header {
+    display: flex;
+    flex-flow: row;
+    justify-content: center;
+    padding: 16px;
+    flex: 0 0 auto;
+  }
+
+  &__footer-footer {
+    display: flex;
+    flex-flow: row;
+    justify-content: space-around;
+    padding: 0 16px 16px;
+    flex: 0 0 auto;
+
+    a, a:hover {
+      text-decoration: none;
+      cursor: pointer;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      color: #2f9ae0;
     }
   }
 

--- a/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
@@ -32,7 +32,7 @@ export default class PageContainerFooter extends Component {
     return (
       <div className="page-container__footer">
 
-        <div className="page-container__footer-header">
+        <header>
           <Button
             type="default"
             large
@@ -51,12 +51,12 @@ export default class PageContainerFooter extends Component {
           >
             { submitText || this.context.t('next') }
           </Button>
-        </div>
+        </header>
 
         {children && (
-          <div className="page-container__footer-footer">
+          <footer>
             {children}
-          </div>
+          </footer>
         )}
 
       </div>

--- a/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/app/components/page-container/page-container-footer/page-container-footer.component.js
@@ -5,6 +5,7 @@ import Button from '../../button'
 export default class PageContainerFooter extends Component {
 
   static propTypes = {
+    children: PropTypes.node,
     onCancel: PropTypes.func,
     cancelText: PropTypes.string,
     onSubmit: PropTypes.func,
@@ -19,6 +20,7 @@ export default class PageContainerFooter extends Component {
 
   render () {
     const {
+      children,
       onCancel,
       cancelText,
       onSubmit,
@@ -30,24 +32,32 @@ export default class PageContainerFooter extends Component {
     return (
       <div className="page-container__footer">
 
-        <Button
-          type="default"
-          large
-          className="page-container__footer-button"
-          onClick={e => onCancel(e)}
-        >
-          { cancelText || this.context.t('cancel') }
-        </Button>
+        <div className="page-container__footer-header">
+          <Button
+            type="default"
+            large
+            className="page-container__footer-button"
+            onClick={e => onCancel(e)}
+          >
+            { cancelText || this.context.t('cancel') }
+          </Button>
 
-        <Button
-          type={submitButtonType || 'primary'}
-          large
-          className="page-container__footer-button"
-          disabled={disabled}
-          onClick={e => onSubmit(e)}
-        >
-          { submitText || this.context.t('next') }
-        </Button>
+          <Button
+            type={submitButtonType || 'primary'}
+            large
+            className="page-container__footer-button"
+            disabled={disabled}
+            onClick={e => onSubmit(e)}
+          >
+            { submitText || this.context.t('next') }
+          </Button>
+        </div>
+
+        {children && (
+          <div className="page-container__footer-footer">
+            {children}
+          </div>
+        )}
 
       </div>
     )

--- a/ui/app/components/page-container/page-container-footer/tests/page-container-footer.component.test.js
+++ b/ui/app/components/page-container/page-container-footer/tests/page-container-footer.component.test.js
@@ -25,7 +25,7 @@ describe('Page Footer', () => {
     assert.equal(wrapper.find('.page-container__footer').length, 1)
   })
 
-  it('should render a page-container__footer-footer class when given children', () => {
+  it('should render a footer inside page-container__footer when given children', () => {
     const wrapper = shallow(
       <PageFooter>
         <div>Works</div>
@@ -33,7 +33,7 @@ describe('Page Footer', () => {
       { context: { t: sinon.spy((k) => `[${k}]`) } }
     )
 
-    assert.equal(wrapper.find('.page-container__footer-footer').length, 1)
+    assert.equal(wrapper.find('.page-container__footer footer').length, 1)
   })
 
   it('renders two button components', () => {

--- a/ui/app/components/page-container/page-container-footer/tests/page-container-footer.component.test.js
+++ b/ui/app/components/page-container/page-container-footer/tests/page-container-footer.component.test.js
@@ -25,6 +25,17 @@ describe('Page Footer', () => {
     assert.equal(wrapper.find('.page-container__footer').length, 1)
   })
 
+  it('should render a page-container__footer-footer class when given children', () => {
+    const wrapper = shallow(
+      <PageFooter>
+        <div>Works</div>
+      </PageFooter>,
+      { context: { t: sinon.spy((k) => `[${k}]`) } }
+    )
+
+    assert.equal(wrapper.find('.page-container__footer-footer').length, 1)
+  })
+
   it('renders two button components', () => {
     assert.equal(wrapper.find(Button).length, 2)
   })
@@ -65,5 +76,4 @@ describe('Page Footer', () => {
       assert.equal(onSubmit.callCount, 1)
     })
   })
-
 })

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -22,6 +22,7 @@ export default class ConfirmTransactionBase extends Component {
     // Redux props
     balance: PropTypes.string,
     cancelTransaction: PropTypes.func,
+    cancelAllTransactions: PropTypes.func,
     clearConfirmTransaction: PropTypes.func,
     clearSend: PropTypes.func,
     conversionRate: PropTypes.number,
@@ -49,6 +50,7 @@ export default class ConfirmTransactionBase extends Component {
     toName: PropTypes.string,
     transactionStatus: PropTypes.string,
     txData: PropTypes.object,
+    unapprovedTxCount: PropTypes.number,
     // Component props
     action: PropTypes.string,
     contentComponent: PropTypes.node,
@@ -249,6 +251,16 @@ export default class ConfirmTransactionBase extends Component {
     onEdit({ txData, tokenData, tokenProps })
   }
 
+  handleCancelAll () {
+    const { cancelAllTransactions, history, clearConfirmTransaction } = this.props
+
+    cancelAllTransactions()
+      .then(() => {
+        clearConfirmTransaction()
+        history.push(DEFAULT_ROUTE)
+      })
+  }
+
   handleCancel () {
     const { onCancel, txData, cancelTransaction, history, clearConfirmTransaction } = this.props
 
@@ -314,6 +326,7 @@ export default class ConfirmTransactionBase extends Component {
       nonce,
       assetImage,
       warning,
+      unapprovedTxCount,
     } = this.props
     const { submitting, submitError } = this.state
 
@@ -337,6 +350,7 @@ export default class ConfirmTransactionBase extends Component {
         dataComponent={this.renderData()}
         contentComponent={contentComponent}
         nonce={nonce}
+        unapprovedTxCount={unapprovedTxCount}
         assetImage={assetImage}
         identiconAddress={identiconAddress}
         errorMessage={errorMessage || submitError}
@@ -344,6 +358,7 @@ export default class ConfirmTransactionBase extends Component {
         warning={warning}
         disabled={!propsValid || !valid || submitting}
         onEdit={() => this.handleEdit()}
+        onCancelAll={() => this.handleCancelAll()}
         onCancel={() => this.handleCancel()}
         onSubmit={() => this.handleSubmit()}
       />

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -44,6 +44,7 @@ export default class ConfirmTransactionBase extends Component {
     sendTransaction: PropTypes.func,
     showCustomizeGasModal: PropTypes.func,
     showTransactionConfirmedModal: PropTypes.func,
+    showRejectTransactionsConfirmationModal: PropTypes.func,
     toAddress: PropTypes.string,
     tokenData: PropTypes.object,
     tokenProps: PropTypes.object,
@@ -252,13 +253,22 @@ export default class ConfirmTransactionBase extends Component {
   }
 
   handleCancelAll () {
-    const { cancelAllTransactions, history, clearConfirmTransaction } = this.props
+    const {
+      cancelAllTransactions,
+      clearConfirmTransaction,
+      history,
+      showRejectTransactionsConfirmationModal,
+      unapprovedTxCount,
+    } = this.props
 
-    cancelAllTransactions()
-      .then(() => {
+    showRejectTransactionsConfirmationModal({
+      unapprovedTxCount,
+      async onSubmit () {
+        await cancelAllTransactions()
         clearConfirmTransaction()
         history.push(DEFAULT_ROUTE)
-      })
+      },
+    })
   }
 
   handleCancel () {

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -111,6 +111,9 @@ const mapDispatchToProps = dispatch => {
     updateGasAndCalculate: ({ gasLimit, gasPrice }) => {
       return dispatch(updateGasAndCalculate({ gasLimit, gasPrice }))
     },
+    showRejectTransactionsConfirmationModal: ({ onSubmit, unapprovedTxCount }) => {
+      return dispatch(showModal({ name: 'REJECT_TRANSACTIONS', onSubmit, unapprovedTxCount }))
+    },
     cancelTransaction: ({ id }) => dispatch(cancelTx({ id })),
     cancelAllTransactions: (txList) => dispatch(cancelTxs(txList)),
     sendTransaction: txData => dispatch(updateAndApproveTx(txData)),

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -8,7 +8,7 @@ import {
   clearConfirmTransaction,
   updateGasAndCalculate,
 } from '../../../ducks/confirm-transaction.duck'
-import { clearSend, cancelTx, updateAndApproveTx, showModal } from '../../../actions'
+import { clearSend, cancelTx, cancelTxs, updateAndApproveTx, showModal } from '../../../actions'
 import {
   INSUFFICIENT_FUNDS_ERROR_KEY,
   GAS_LIMIT_TOO_LOW_ERROR_KEY,
@@ -17,7 +17,7 @@ import { getHexGasTotal } from '../../../helpers/confirm-transaction/util'
 import { isBalanceSufficient } from '../../send/send.utils'
 import { conversionGreaterThan } from '../../../conversion-util'
 import { MIN_GAS_LIMIT_DEC } from '../../send/send.constants'
-import { addressSlicer } from '../../../util'
+import { addressSlicer, valuesFor } from '../../../util'
 
 const casedContractMap = Object.keys(contractMap).reduce((acc, base) => {
   return {
@@ -53,6 +53,7 @@ const mapStateToProps = (state, props) => {
     selectedAddress,
     selectedAddressTxList,
     assetImages,
+    unapprovedTxs,
   } = metamask
   const assetImage = assetImages[txParamsToAddress]
   const { balance } = accounts[selectedAddress]
@@ -66,6 +67,8 @@ const mapStateToProps = (state, props) => {
 
   const transaction = R.find(({ id }) => id === transactionId)(selectedAddressTxList)
   const transactionStatus = transaction ? transaction.status : ''
+
+  const unapprovedTxCount = valuesFor(unapprovedTxs).length
 
   return {
     balance,
@@ -90,6 +93,8 @@ const mapStateToProps = (state, props) => {
     transactionStatus,
     nonce,
     assetImage,
+    unapprovedTxs,
+    unapprovedTxCount,
   }
 }
 
@@ -107,6 +112,7 @@ const mapDispatchToProps = dispatch => {
       return dispatch(updateGasAndCalculate({ gasLimit, gasPrice }))
     },
     cancelTransaction: ({ id }) => dispatch(cancelTx({ id })),
+    cancelAllTransactions: (txList) => dispatch(cancelTxs(txList)),
     sendTransaction: txData => dispatch(updateAndApproveTx(txData)),
   }
 }
@@ -156,8 +162,9 @@ const getValidateEditGas = ({ balance, conversionRate, txData }) => {
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { balance, conversionRate, txData } = stateProps
+  const { balance, conversionRate, txData, unapprovedTxs } = stateProps
   const {
+    cancelAllTransactions: dispatchCancelAllTransactions,
     showCustomizeGasModal: dispatchShowCustomizeGasModal,
     updateGasAndCalculate: dispatchUpdateGasAndCalculate,
     ...otherDispatchProps
@@ -174,6 +181,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       onSubmit: txData => dispatchUpdateGasAndCalculate(txData),
       validate: validateEditGas,
     }),
+    cancelAllTransactions: () => dispatchCancelAllTransactions(valuesFor(unapprovedTxs)),
   }
 }
 

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -53,6 +53,7 @@ const mapStateToProps = (state, props) => {
     selectedAddress,
     selectedAddressTxList,
     assetImages,
+    network,
     unapprovedTxs,
   } = metamask
   const assetImage = assetImages[txParamsToAddress]
@@ -68,7 +69,11 @@ const mapStateToProps = (state, props) => {
   const transaction = R.find(({ id }) => id === transactionId)(selectedAddressTxList)
   const transactionStatus = transaction ? transaction.status : ''
 
-  const unapprovedTxCount = valuesFor(unapprovedTxs).length
+  const currentNetworkUnapprovedTxs = R.filter(
+    ({ metamaskNetworkId }) => metamaskNetworkId === network,
+    valuesFor(unapprovedTxs),
+  )
+  const unapprovedTxCount = currentNetworkUnapprovedTxs.length
 
   return {
     balance,


### PR DESCRIPTION
Closes #4970

This PR adds a "Reject All" option to the confirm screen for transactions when there are multiple transactions pending. (#5307 was the original version of this PR but with an incorrect title and description.) This PR also rewords the secondary button on the confirm screen to be "reject" instead of "cancel" to avoid confusing it with cancelling a transaction.

#### The confirm screen when there are more than 1 tx

<img width="472" src="https://user-images.githubusercontent.com/1623628/45938539-7ba94500-bfa5-11e8-904a-f4acc58e04fd.png">
<img width="472" src="https://user-images.githubusercontent.com/1623628/45938586-dd69af00-bfa5-11e8-8bfc-77ecc48d194d.png">


#### The confirm screen when there's only 1 tx (for reference)

<img width="472" src="https://user-images.githubusercontent.com/1623628/45938538-7ba94500-bfa5-11e8-8b4d-b9b1f6f20054.png">

#### Todo:

- [x] Only show the reject all option when there's more than 1 tx pending
- [x] Awaiting merge of #5282
- [x] Solicit design feedback (@cjeria)
- [x] Update other confirm screens to match