### PR TITLE
Add test coverage dir to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@ dist/**
 builds/**
 test-builds/**
 docs/**
+coverage/
 
 development/bundle.js
 development/states.js


### PR DESCRIPTION
This PR adds the unit test coverage directory to the ESLint ignore list.