### PR TITLE
Fix height of first-time-flow container, again

### DIFF
--- a/mascara/src/app/first-time/index.css
+++ b/mascara/src/app/first-time/index.css
@@ -8,7 +8,6 @@
 
 .first-time-flow {
   width: 100vw;
-  height: 100vh;
   background-color: #fff;
   overflow: auto;
   display: flex;
@@ -16,6 +15,12 @@
   flex: 1 0 auto;
   font-weight: 400;
   font-family: Roboto;
+}
+
+@media screen and (min-height: 576px) {
+  .first-time-flow {
+    height: 100vh;
+  }
 }
 
 .alpha-warning__container {


### PR DESCRIPTION
This PR reimplements #5328 in a way that doesn't squish the container's contents on smaller screens.

**Before & after:**

<img width="1224" src="https://user-images.githubusercontent.com/1623628/45981718-9674cb80-c030-11e8-8411-2b0848a13c48.png">
<img width="1224" src="https://user-images.githubusercontent.com/1623628/45981719-9674cb80-c030-11e8-87f1-741f3ad8aea4.png">
