### PR TITLE
Fix gh-pages job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,8 +299,8 @@ jobs:
       - run:
           name: github gh-pages docs publish
           command: >
-            git config user.name metamaskbot
-            git config user.email admin@metamask.io
+            git config user.name metamaskbot &&
+            git config user.email admin@metamask.io &&
             gh-pages -d docs/jsdocs
 
   test-unit:


### PR DESCRIPTION
If you look at https://circleci.com/gh/MetaMask/metamask-extension/55557 you'll see that the gh-pages publishing job is failing because the commands are not separated. This PR fixes that issue.

![screen shot 2018-09-25 at 2 31 24 pm](https://user-images.githubusercontent.com/1247834/46034866-b27b7a00-c0cf-11e8-9bf5-ffb114cc49ba.png)
