### PR TITLE
EIP-1102: Add deprecation message

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -9,6 +9,11 @@ restoreContextAfterImports()
 
 log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
+console.warn('BREAKING CHANGE: In an effort to improve user privacy, MetaMask will ' +
+'stop exposing user accounts to dapps by default. Dapps must call provider.enable() ' +
+'in order to view and use accounts. Please see https://bit.ly/2QQHXvF for complete ' +
+'information and up-to-date example code.')
+
 //
 // setup plugin communication
 //
@@ -52,6 +57,7 @@ if (typeof window.web3 !== 'undefined') {
      or MetaMask and another web3 extension. Please remove one
      and try again.`)
 }
+
 var web3 = new Web3(inpageProvider)
 web3.setProvider = function () {
   log.debug('MetaMask - overrode web3.setProvider')

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -10,9 +10,9 @@ restoreContextAfterImports()
 log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
 console.warn('ATTENTION: In an effort to improve user privacy, MetaMask will ' +
-'stop exposing user accounts to dapps by default. Dapps must call provider.enable() ' +
-'in order to view and use accounts. Please see https://bit.ly/2QQHXvF for complete ' +
-'information and up-to-date example code.')
+'stop exposing user accounts to dapps by default beginning November 2nd, 2018. ' +
+'Dapps should call provider.enable() in order to view and use accounts. Please see ' +
+'https://bit.ly/2QQHXvF for complete information and up-to-date example code.')
 
 //
 // setup plugin communication

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -9,7 +9,7 @@ restoreContextAfterImports()
 
 log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
-console.warn('BREAKING CHANGE: In an effort to improve user privacy, MetaMask will ' +
+console.warn('ATTENTION: In an effort to improve user privacy, MetaMask will ' +
 'stop exposing user accounts to dapps by default. Dapps must call provider.enable() ' +
 'in order to view and use accounts. Please see https://bit.ly/2QQHXvF for complete ' +
 'information and up-to-date example code.')

--- a/app/scripts/lib/auto-reload.js
+++ b/app/scripts/lib/auto-reload.js
@@ -2,18 +2,12 @@ module.exports = setupDappAutoReload
 
 function setupDappAutoReload (web3, observable) {
   // export web3 as a global, checking for usage
-  let hasBeenWarned = false
   let reloadInProgress = false
   let lastTimeUsed
   let lastSeenNetwork
 
   global.web3 = new Proxy(web3, {
     get: (_web3, key) => {
-      // show warning once on web3 access
-      if (!hasBeenWarned && key !== 'currentProvider') {
-        console.warn('MetaMask: web3 will be deprecated in the near future in favor of the ethereumProvider \nhttps://github.com/MetaMask/faq/blob/master/detecting_metamask.md#web3-deprecation')
-        hasBeenWarned = true
-      }
       // get the time of use
       lastTimeUsed = Date.now()
       // return value normally


### PR DESCRIPTION
This pull request adds a deprecation message that displays as soon as MetaMask is injected with verbiage around the upcoming 1102 change. We should land this soon (as part of the 4.12.0 release if possible) so developers who may not follow our Medium / Twitter know about the change.

@bdresser how's the tone of this message? I think we should make it as friendly as possible.