### PR TITLE
Bugfix: bump version of metamask-inpage-provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20868,11 +20868,11 @@
       }
     },
     "metamask-inpage-provider": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/metamask-inpage-provider/-/metamask-inpage-provider-1.0.0.tgz",
-      "integrity": "sha512-8ouTHzBuMb5DlsJstb3ikeA53zKk01ebcXEy3vHzg48MBO8sqHyFII37KYBkzkZ+ZkvouhmxMVCO+n8qo1oTmQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/metamask-inpage-provider/-/metamask-inpage-provider-1.1.1.tgz",
+      "integrity": "sha512-I7P8mny3e03dwzt0SFsXOmoj1eEz5GpUGiBIAJ4fyXUpx92JkII5ekq/MNkf5muktoJod9cWjDF03//+/DCD2A==",
       "requires": {
-        "json-rpc-engine": "^3.7.3",
+        "json-rpc-engine": "^3.7.4",
         "json-rpc-middleware-stream": "^1.0.1",
         "loglevel": "^1.6.1",
         "obj-multiplex": "^1.0.0",
@@ -20880,28 +20880,6 @@
         "pump": "^3.0.0"
       },
       "dependencies": {
-        "babelify": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-          "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-          "requires": {
-            "babel-core": "^6.0.14",
-            "object-assign": "^4.0.0"
-          }
-        },
-        "json-rpc-engine": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.7.3.tgz",
-          "integrity": "sha512-+FO3UWu/wafh/+MZ6BXy0HZU+f5plwUn82FgxpC0scJkEh5snOjFrAAtqCITPDfvfLHRUFOG5pQDUx2pspfERQ==",
-          "requires": {
-            "async": "^2.0.1",
-            "babel-preset-env": "^1.3.2",
-            "babelify": "^7.3.0",
-            "clone": "^2.1.1",
-            "json-rpc-error": "^2.0.0",
-            "promise-to-callback": "^1.0.0"
-          }
-        },
         "loglevel": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "lodash.uniqby": "^4.7.0",
     "loglevel": "^1.4.1",
     "metamascara": "^2.0.0",
-    "metamask-inpage-provider": "^1.0.0",
+    "metamask-inpage-provider": "^1.1.1",
     "metamask-logo": "^2.1.4",
     "mkdirp": "^0.5.1",
     "multihashes": "^0.4.12",


### PR DESCRIPTION
This pull request bumps the version of metamask-inpage-provider, which in turn uses an updated version of json-rpc-engine.

**Note:** To test that this fully fixes the ForkDelta / EtherDelta issue (thanks to @danjm for these instructions):
1. checkout `bugfix-inpage-version`
2. delete `node_modules, reinstall npm packages, and reload metamask
3. start metamask and login
4. open https://etherdelta.com/
5. if it is working, you will see https://gyazo.com/5d817a4f37936d38022e707128af65d6, if it is not working you will see an infinite spinner, and a couple errors in the console, including
    ```
    "DOMException: Failed to execute 'postMessage' on 'Window': function(){for(var u={},a=[],i=0,l=this.length;i<l;++i)u.hasOwnProperty(this[i])||(a.push(this[i]),u[this[i]]=1);return a} could not be cloned."
    ```