### PR TITLE
Version 4.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Current Develop Branch
 
+## 4.13.0
+
+- A rollback release, equivalent to `v4.11.1` to be deployed in the case that `v4.12.0` is found to have bugs.
+
 ## 4.11.1 Tuesday September 25 2018
 
 - Adds Ledger support.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "4.11.1",
+  "version": "4.13.0",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "__MSG_appDescription__",


### PR DESCRIPTION
To be force pushed over `master` and published in the case there is a critical bug found in `v4.12.x`.