### PR TITLE
Remove dot-only-hunter package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8490,12 +8490,6 @@
         "domelementtype": "1"
       }
     },
-    "dot-only-hunter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dot-only-hunter/-/dot-only-hunter-1.0.3.tgz",
-      "integrity": "sha1-9k0h7b5v8xFJlfEGGmGpNcMAIEs=",
-      "dev": true
-    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,6 @@
     "css-loader": "^0.28.11",
     "deep-freeze-strict": "^1.1.1",
     "del": "^3.0.0",
-    "dot-only-hunter": "^1.0.3",
     "envify": "^4.0.0",
     "enzyme": "^3.4.4",
     "enzyme-adapter-react-15": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "publish-docs": "gh-pages -d docs/jsdocs",
     "test": "npm run test:unit && npm run test:integration && npm run lint",
     "watch:test:unit": "nodemon --exec \"npm run test:unit\" ./test ./app ./ui",
-    "test:unit": "cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive \"test/unit/**/*.js\" \"ui/app/**/*.test.js\" && dot-only-hunter",
+    "test:unit": "cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive \"test/unit/**/*.js\" \"ui/app/**/*.test.js\"",
     "test:single": "cross-env METAMASK_ENV=test mocha --require test/helper.js",
     "test:integration": "npm run test:integration:build && npm run test:flat && npm run test:mascara",
     "test:integration:build": "gulp build:scss",


### PR DESCRIPTION
Refs #4374, #4674, #4712

This PR removes the dot-only-hunter package from the project because:

1. It isn't currently configured correctly (it doesn't work, as detailed below)
2. The ESLint configuration includes `mocha/no-exclusive-test` which catches exclusive tests

### By example

I had the following exclusive test:

```diff
diff --git a/ui/app/components/send/send-content/send-to-row/tests/send-to-row-container.test.js b/ui/app/components/send/send-content/send-to-row/tests/send-to-row-container.test.js
index dfce7652f..6b7b41b4b 100644
--- a/ui/app/components/send/send-content/send-to-row/tests/send-to-row-container.test.js
+++ b/ui/app/components/send/send-content/send-to-row/tests/send-to-row-container.test.js
@@ -36,7 +36,7 @@ proxyquire('../send-to-row.container.js', {
   '../../../../ducks/send.duck': duckActionSpies,
 })
 
-describe('send-to-row container', () => {
+describe.only('send-to-row container', () => {
 
   describe('mapStateToProps()', () => {
 
```

Running `npm run test:unit` shows the following at the bottom:

```
Hunting inside 'test' for tests with `.only`...
All good!

```

While running `npm run test:lint` shows the following (truncated for brevity):

```

> metamask-crx@0.0.0 lint metamask-extension
> eslint .


ui/app/components/send/send-content/send-to-row/tests/send-to-row-container.test.js
  39:10  error  Unexpected exclusive mocha test  mocha/no-exclusive-tests

✖ 4 problems (1 error, 3 warnings)
  0 errors, 2 warnings potentially fixable with the `--fix` option.

npm ERR! [...]
```

### `dot-only-hunter` configuration

For the curious, `dot-only-hunter` doesn't work because by default it recursively searches a directory named "test" which we don't have.

```bash
$ npx dot-only-hunter test/
```
```
Hunting inside 'test/' for tests with `.only`...
All good!
```
```bash
$ npx dot-only-hunter ui/
```
```
Hunting inside 'ui/' for tests with `.only`...
ui/app/components/send/send-content/send-to-row/tests/send-to-row-container.test.js:39:describe.only('send-to-row container', () => {
Whoops! Found `.only` in your tests.
```