### PR TITLE
Fix e2e tests for adding custom RPC endpoints

### DIFF
--- a/test/e2e/beta/helpers.js
+++ b/test/e2e/beta/helpers.js
@@ -126,7 +126,6 @@ async function assertElementNotPresent (webdriver, driver, by) {
   try {
     dataTab = await findElement(driver, by, 4000)
   } catch (err) {
-    console.log(err)
     assert(err instanceof webdriver.error.NoSuchElementError || err instanceof webdriver.error.TimeoutError)
   }
   if (dataTab) {

--- a/test/e2e/beta/helpers.js
+++ b/test/e2e/beta/helpers.js
@@ -128,7 +128,5 @@ async function assertElementNotPresent (webdriver, driver, by) {
   } catch (err) {
     assert(err instanceof webdriver.error.NoSuchElementError || err instanceof webdriver.error.TimeoutError)
   }
-  if (dataTab) {
-    assert(false, 'Data tab should not be present')
-  }
+  assert.ok(!dataTab, 'Found element that should not be present')
 }

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -1030,7 +1030,7 @@ describe('MetaMask', function () {
     ]
 
     customRpcUrls.forEach(customRpcUrl => {
-      it('creates custom RPC: ' + customRpcUrl, async () => {
+      it(`creates custom RPC: ${customRpcUrl}`, async () => {
         const networkDropdown = await findElement(driver, By.css('.network-name'))
         await networkDropdown.click()
         await delay(regularDelayMs)

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -1059,25 +1059,15 @@ describe('MetaMask', function () {
       await delay(largeDelayMs * 2)
     })
 
-    it('finds 3 recent RPCs in history', async () => {
+    it('finds all recent RPCs in history', async () => {
       const networkDropdown = await findElement(driver, By.css('.network-name'))
       await networkDropdown.click()
       await delay(regularDelayMs)
 
-      // oldest selected RPC is not found
-      await assertElementNotPresent(webdriver, driver, By.xpath(`//span[contains(text(), '${customRpcUrls[0]}')]`))
-
       // only recent 3 are found and in correct order (most recent at the top)
       const customRpcs = await findElements(driver, By.xpath(`//span[contains(text(), 'https://mainnet.infura.io/')]`))
 
-      assert.equal(customRpcs.length, 3)
-
-      for (let i = 0; i < customRpcs.length; i++) {
-        const linkText = await customRpcs[i].getText()
-        const rpcUrl = customRpcUrls[customRpcUrls.length - i - 1]
-
-        assert.notEqual(linkText.indexOf(rpcUrl), -1)
-      }
+      assert.equal(customRpcs.length, customRpcUrls.length)
     })
   })
 })


### PR DESCRIPTION
Refs #5267

This PR updates the e2e tests for adding custom RPC endpoints now that the list is unbounded.

I've also cleaned up the code around the tests since there was a good bit of noise masking the underlying error when the e2e tests failed here. The commits list should walk through the changes.