### PR TITLE
Allow sourcemap uploads to sentry for empty version

### DIFF
--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -3,7 +3,6 @@ const pify = require('pify')
 const exec = pify(require('child_process').exec, { multiArgs: true })
 const VERSION = require('../dist/chrome/manifest.json').version
 
-
 start().catch(console.error)
 
 async function start () {
@@ -16,7 +15,7 @@ async function start () {
   // abort if versions exists
   if (versionAlreadyExists) {
     console.log(`Version "${VERSION}" already exists on Sentry, skipping version creation`)
-  }else{
+  } else {
      // create sentry release
     console.log(`creating Sentry release for "${VERSION}"...`)
     await exec(`sentry-cli releases --org 'metamask' --project 'metamask' new ${VERSION}`)
@@ -33,7 +32,7 @@ async function start () {
     console.log(`uploading sourcemaps Sentry release "${VERSION}"...`)
     await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} upload-sourcemaps ./dist/sourcemaps/ --url-prefix 'sourcemaps'`)
     console.log('all done!')
-  }else{
+  } else {
     console.log(`Version "${VERSION}" already has artifacts on Sentry, skipping sourcemap upload`)
   }
 }

--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -24,7 +24,7 @@ async function start () {
     await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} delete --all`)
   }
 
-  // check if version exists or not
+  // check if version has artifacts or not
   const versionHasArtifacts = versionAlreadyExists && await checkIfVersionHasArtifacts()
   if(!versionHasArtifacts){
     // upload sentry source and sourcemaps
@@ -54,6 +54,7 @@ async function checkIfVersionExists () {
 
 async function checkIfVersionHasArtifacts () {
   const artifacts = await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} list`);
+  // When there's no artifacts, we get a response from the shell like this ['', '']
   return artifacts[0] && artifacts[0].length > 0
 }
 

--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -15,7 +15,7 @@ async function start () {
   const versionAlreadyExists = await checkIfVersionExists()
   // abort if versions exists
   if (versionAlreadyExists) {
-    console.log(`Version "${VERSION}" already exists on Sentry, aborting version creation`)
+    console.log(`Version "${VERSION}" already exists on Sentry, skipping version creation`)
   }else{
      // create sentry release
     console.log(`creating Sentry release for "${VERSION}"...`)
@@ -34,7 +34,7 @@ async function start () {
     await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} upload-sourcemaps ./dist/sourcemaps/ --url-prefix 'sourcemaps'`)
     console.log('all done!')
   }else{
-    console.log(`Version "${VERSION}" already has artifacts on Sentry, aborting sourcemap upload`)
+    console.log(`Version "${VERSION}" already has artifacts on Sentry, skipping sourcemap upload`)
   }
 }
 

--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -3,6 +3,7 @@ const pify = require('pify')
 const exec = pify(require('child_process').exec, { multiArgs: true })
 const VERSION = require('../dist/chrome/manifest.json').version
 
+
 start().catch(console.error)
 
 async function start () {
@@ -14,21 +15,27 @@ async function start () {
   const versionAlreadyExists = await checkIfVersionExists()
   // abort if versions exists
   if (versionAlreadyExists) {
-    console.log(`Version "${VERSION}" already exists on Sentry, aborting sourcemap upload.`)
-    return
+    console.log(`Version "${VERSION}" already exists on Sentry, aborting version creation`)
+  }else{
+     // create sentry release
+    console.log(`creating Sentry release for "${VERSION}"...`)
+    await exec(`sentry-cli releases --org 'metamask' --project 'metamask' new ${VERSION}`)
+    console.log(`removing any existing files from Sentry release "${VERSION}"...`)
+    await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} delete --all`)
   }
 
-  // create sentry release
-  console.log(`creating Sentry release for "${VERSION}"...`)
-  await exec(`sentry-cli releases --org 'metamask' --project 'metamask' new ${VERSION}`)
-  console.log(`removing any existing files from Sentry release "${VERSION}"...`)
-  await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} delete --all`)
-  // upload sentry source and sourcemaps
-  console.log(`uploading source files Sentry release "${VERSION}"...`)
-  await exec(`for FILEPATH in ./dist/chrome/*.js; do [ -e $FILEPATH ] || continue; export FILE=\`basename $FILEPATH\` && echo uploading $FILE && sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} upload $FILEPATH metamask/$FILE; done;`)
-  console.log(`uploading sourcemaps Sentry release "${VERSION}"...`)
-  await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} upload-sourcemaps ./dist/sourcemaps/ --url-prefix 'sourcemaps'`)
-  console.log('all done!')
+  // check if version exists or not
+  const versionHasArtifacts = versionAlreadyExists && await checkIfVersionHasArtifacts()
+  if(!versionHasArtifacts){
+    // upload sentry source and sourcemaps
+    console.log(`uploading source files Sentry release "${VERSION}"...`)
+    await exec(`for FILEPATH in ./dist/chrome/*.js; do [ -e $FILEPATH ] || continue; export FILE=\`basename $FILEPATH\` && echo uploading $FILE && sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} upload $FILEPATH metamask/$FILE; done;`)
+    console.log(`uploading sourcemaps Sentry release "${VERSION}"...`)
+    await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} upload-sourcemaps ./dist/sourcemaps/ --url-prefix 'sourcemaps'`)
+    console.log('all done!')
+  }else{
+    console.log(`Version "${VERSION}" already has artifacts on Sentry, aborting sourcemap upload`)
+  }
 }
 
 async function checkIfAuthWorks () {
@@ -43,6 +50,11 @@ async function checkIfVersionExists () {
     await exec(`sentry-cli releases --org 'metamask' --project 'metamask' info ${VERSION}`)
   })
   return versionAlreadyExists
+}
+
+async function checkIfVersionHasArtifacts () {
+  const artifacts = await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} list`);
+  return artifacts[0] && artifacts[0].length > 0
 }
 
 async function doesNotFail (asyncFn) {

--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -25,7 +25,7 @@ async function start () {
 
   // check if version has artifacts or not
   const versionHasArtifacts = versionAlreadyExists && await checkIfVersionHasArtifacts()
-  if(!versionHasArtifacts){
+  if (!versionHasArtifacts) {
     // upload sentry source and sourcemaps
     console.log(`uploading source files Sentry release "${VERSION}"...`)
     await exec(`for FILEPATH in ./dist/chrome/*.js; do [ -e $FILEPATH ] || continue; export FILE=\`basename $FILEPATH\` && echo uploading $FILE && sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} upload $FILEPATH metamask/$FILE; done;`)
@@ -52,7 +52,7 @@ async function checkIfVersionExists () {
 }
 
 async function checkIfVersionHasArtifacts () {
-  const artifacts = await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} list`);
+  const artifacts = await exec(`sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} list`)
   // When there's no artifacts, we get a response from the shell like this ['', '']
   return artifacts[0] && artifacts[0].length > 0
 }


### PR DESCRIPTION
Problem: 

For some reason that's unknown to me, we have versions created on sentry that have no artifacts.
Our current sentry script will skip the upload if it detects a sentry version was already created.

This PR modifies the script to allow the upload of sourcemaps if the version exists but it has no artifacts.

BTW, Just used it to upload the sourcemaps to 4.12.0 since it was already created but had no artifacts.

