### PR TITLE
Allow users to bypass phishing warning

### DIFF
--- a/app/phishing.html
+++ b/app/phishing.html
@@ -25,6 +25,7 @@
       a {
         color: white;
         cursor: pointer;
+        text-decoration: underline;
       }
     </style>
 

--- a/app/phishing.html
+++ b/app/phishing.html
@@ -3,7 +3,7 @@
 <html>
 
   <head>
-    <title>Dangerous Website Warning</title>
+    <title>Ethereum Phishing Detection - MetMask</title>
 
     <style>
       body {
@@ -57,7 +57,11 @@
       <p>This is because the site tested positive on the <a href="https://github.com/metamask/eth-phishing-detect">Ethereum Phishing Detector</a>. This includes outright malicious websites and legitimate websites that have been compromised by a malicious actor.</p>
       <p id="esdbLink"></p>
       <p>You can turn MetaMask off to interact with this site, but it is advised not to.</p>
-      <p>If you think this domain is incorrectly flagged or if a blocked legitimate website has resolved its security issues, <a href="https://github.com/metamask/eth-phishing-detect/issues/new">please file an issue</a>.</p>
+      <p>
+        If you think this domain is incorrectly flagged or if a blocked legitimate website has resolved its security issues,
+        <a href="https://github.com/metamask/eth-phishing-detect/issues/new">please file an issue</a>. If you believe this website
+        is safe and understand the risks involved, you can <a id="unsafe-continue">visit this unsafe website at your own risk</a>.
+      </p>
 
     </div>
   </body>

--- a/app/phishing.html
+++ b/app/phishing.html
@@ -24,6 +24,7 @@
 
       a {
         color: white;
+        cursor: pointer;
       }
     </style>
 

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const pump = require('pump')
+const querystring = require('querystring')
 const LocalMessageDuplexStream = require('post-message-stream')
 const PongStream = require('ping-pong-stream/pong')
 const ObjectMultiplex = require('obj-multiplex')
@@ -199,5 +200,8 @@ function blacklistedDomainCheck () {
 function redirectToPhishingWarning () {
   console.log('MetaMask - routing to Phishing Warning component')
   const extensionURL = extension.runtime.getURL('phishing.html')
-  window.location.href = extensionURL + '#' + window.location.hostname
+  window.location.href = `${extensionURL}#${querystring.stringify({
+    hostname: window.location.hostname,
+    href: window.location.href,
+  })}`
 }

--- a/app/scripts/controllers/blacklist.js
+++ b/app/scripts/controllers/blacklist.js
@@ -29,6 +29,7 @@ class BlacklistController {
   constructor (opts = {}) {
     const initState = extend({
       phishing: PHISHING_DETECTION_CONFIG,
+      whitelist: [],
     }, opts.initState)
     this.store = new ObservableStore(initState)
     // phishing detector
@@ -36,6 +37,21 @@ class BlacklistController {
     this._setupPhishingDetector(initState.phishing)
     // polling references
     this._phishingUpdateIntervalRef = null
+  }
+
+  /**
+   * Adds the given hostname to the runtime whitelist
+   * @param {string} hostname the hostname to whitelist
+   */
+  whitelistDomain (hostname) {
+    if (!hostname) {
+      return
+    }
+
+    const { whitelist } = this.store.getState()
+    this.store.updateState({
+      whitelist: [...new Set([hostname, ...whitelist])],
+    })
   }
 
   /**
@@ -48,6 +64,12 @@ class BlacklistController {
    */
   checkForPhishing (hostname) {
     if (!hostname) return false
+
+    const { whitelist } = this.store.getState()
+    if (whitelist.some((e) => e === hostname)) {
+      return false
+    }
+
     const { result } = this._phishingDetector.check(hostname)
     return result
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -387,6 +387,9 @@ module.exports = class MetamaskController extends EventEmitter {
       setAccountLabel: nodeify(preferencesController.setAccountLabel, preferencesController),
       setFeatureFlag: nodeify(preferencesController.setFeatureFlag, preferencesController),
 
+      // BlacklistController
+      whitelistPhishingDomain: this.whitelistPhishingDomain.bind(this),
+
       // AddressController
       setAddressBook: nodeify(addressBookController.setAddressBook, addressBookController),
 
@@ -1540,5 +1543,13 @@ module.exports = class MetamaskController extends EventEmitter {
         next()
       }
     }
+  }
+
+  /**
+   * Adds a domain to the {@link BlacklistController} whitelist
+   * @param {string} hostname the domain to whitelist
+   */
+  whitelistPhishingDomain (hostname) {
+    return this.blacklistController.whitelistDomain(hostname)
   }
 }

--- a/app/scripts/phishing-detect.js
+++ b/app/scripts/phishing-detect.js
@@ -1,5 +1,59 @@
 window.onload = function() {
   if (window.location.pathname === '/phishing.html') {
-      document.getElementById('esdbLink').innerHTML = '<b>To read more about this scam, navigate to: <a href="https://etherscamdb.info/domain/' + window.location.hash.substring(1) + '"> https://etherscamdb.info/domain/' + window.location.hash.substring(1) + '</a></b>'
+    const {hostname} = parseHash()
+    document.getElementById('esdbLink').innerHTML = '<b>To read more about this scam, navigate to: <a href="https://etherscamdb.info/domain/' + hostname + '"> https://etherscamdb.info/domain/' + hostname + '</a></b>'
   }
+}
+
+const querystring = require('querystring')
+const dnode = require('dnode')
+const { EventEmitter } = require('events')
+const PortStream = require('extension-port-stream')
+const extension = require('extensionizer')
+const setupMultiplex = require('./lib/stream-utils.js').setupMultiplex
+const { getEnvironmentType } = require('./lib/util')
+const ExtensionPlatform = require('./platforms/extension')
+
+document.addEventListener('DOMContentLoaded', start)
+
+function start () {
+  const windowType = getEnvironmentType(window.location.href)
+
+  global.platform = new ExtensionPlatform()
+  global.METAMASK_UI_TYPE = windowType
+
+  const extensionPort = extension.runtime.connect({ name: windowType })
+  const connectionStream = new PortStream(extensionPort)
+  const mx = setupMultiplex(connectionStream)
+  setupControllerConnection(mx.createStream('controller'), (err, metaMaskController) => {
+    if (err) {
+      return
+    }
+
+    const suspect = parseHash()
+    const unsafeContinue = () => {
+      window.location.href = suspect.href
+    }
+    const continueLink = document.getElementById('unsafe-continue')
+    continueLink.addEventListener('click', () => {
+      metaMaskController.whitelistPhishingDomain(suspect.hostname)
+      unsafeContinue()
+    })
+  })
+}
+
+function setupControllerConnection (connectionStream, cb) {
+  const eventEmitter = new EventEmitter()
+  const accountManagerDnode = dnode({
+    sendUpdate (state) {
+      eventEmitter.emit('update', state)
+    },
+  })
+  connectionStream.pipe(accountManagerDnode).pipe(connectionStream)
+  accountManagerDnode.once('remote', (accountManager) => cb(null, accountManager))
+}
+
+function parseHash () {
+  const hash = window.location.hash.substring(1)
+  return querystring.parse(hash)
 }

--- a/test/unit/app/controllers/blacklist-controller-test.js
+++ b/test/unit/app/controllers/blacklist-controller-test.js
@@ -8,6 +8,16 @@ describe('blacklist controller', function () {
     blacklistController = new BlacklistController()
   })
 
+  describe('whitelistDomain', function () {
+    it('should add hostname to the runtime whitelist', function () {
+      blacklistController.whitelistDomain('foo.com')
+      assert.deepEqual(blacklistController.store.getState().whitelist, ['foo.com'])
+
+      blacklistController.whitelistDomain('bar.com')
+      assert.deepEqual(blacklistController.store.getState().whitelist, ['bar.com', 'foo.com'])
+    })
+  })
+
   describe('checkForPhishing', function () {
     it('should not flag whitelisted values', function () {
       const result = blacklistController.checkForPhishing('www.metamask.io')
@@ -35,6 +45,11 @@ describe('blacklist controller', function () {
     })
     it('should not flag the mascara-faucet domain', function () {
       const result = blacklistController.checkForPhishing('zero-faucet.metamask.io')
+      assert.equal(result, false)
+    })
+    it('should not flag whitelisted domain', function () {
+      blacklistController.whitelistDomain('metamask.com')
+      const result = blacklistController.checkForPhishing('metamask.com')
       assert.equal(result, false)
     })
   })


### PR DESCRIPTION
Closes #2784

This PR updates the phishing warning page with a link that allows the user to bypass the blacklist.

A few notes:

- I think it's important that the whitelist isn't permanent as there's no way for the user to reset the whitelist _yet_
- The whitelist is for hostnames (`window.location.hostname`s) which is consistent with eth-phishing-detect