### PR TITLE
Update all balances on password unlock

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -555,6 +555,7 @@ module.exports = class MetamaskController extends EventEmitter {
     }
 
     await this.preferencesController.syncAddresses(accounts)
+    await this.balancesController.updateAllBalances()
     return this.keyringController.fullUpdate()
   }
 


### PR DESCRIPTION
Some users reported stale account balances. Balances were only updating on network change and new blocks, so this was a point in the code where an inconsistency could emerge. Not sure it causes the bug, but it doesn't hurt to update an extra time.