### PR TITLE
Fix markup for inline instances of PageContainers

### DIFF
--- a/ui/app/components/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/app/components/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -90,35 +90,31 @@ export default class ConfirmAddSuggestedToken extends Component {
           </div>
         </div>
         <div className="page-container__footer">
-          <Button
-            type="default"
-            large
-            className="page-container__footer-button"
-            onClick={() => {
-              removeSuggestedTokens()
-              .then(() => {
-                history.push(DEFAULT_ROUTE)
-              })
-          }}
-          >
-            { this.context.t('cancel') }
-          </Button>
-          <Button
-            type="primary"
-            large
-            className="page-container__footer-button"
-            onClick={() => {
-              addToken(pendingToken)
-                .then(() => {
-                  removeSuggestedTokens()
-                  .then(() => {
-                    history.push(DEFAULT_ROUTE)
-                  })
-                })
-            }}
-          >
-            { this.context.t('addToken') }
-          </Button>
+          <header>
+            <Button
+              type="default"
+              large
+              className="page-container__footer-button"
+              onClick={() => {
+                removeSuggestedTokens()
+                  .then(() => history.push(DEFAULT_ROUTE))
+              }}
+            >
+              { this.context.t('cancel') }
+            </Button>
+            <Button
+              type="primary"
+              large
+              className="page-container__footer-button"
+              onClick={() => {
+                addToken(pendingToken)
+                  .then(() => removeSuggestedTokens())
+                  .then(() => history.push(DEFAULT_ROUTE))
+              }}
+            >
+              { this.context.t('addToken') }
+            </Button>
+          </header>
         </div>
       </div>
     )

--- a/ui/app/components/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/app/components/pages/confirm-add-token/confirm-add-token.component.js
@@ -86,28 +86,30 @@ export default class ConfirmAddToken extends Component {
           </div>
         </div>
         <div className="page-container__footer">
-          <Button
-            type="default"
-            large
-            className="page-container__footer-button"
-            onClick={() => history.push(ADD_TOKEN_ROUTE)}
-          >
-            { this.context.t('back') }
-          </Button>
-          <Button
-            type="primary"
-            large
-            className="page-container__footer-button"
-            onClick={() => {
-              addTokens(pendingTokens)
-                .then(() => {
-                  clearPendingTokens()
-                  history.push(DEFAULT_ROUTE)
-                })
-            }}
-          >
-            { this.context.t('addTokens') }
-          </Button>
+          <header>
+            <Button
+              type="default"
+              large
+              className="page-container__footer-button"
+              onClick={() => history.push(ADD_TOKEN_ROUTE)}
+            >
+              { this.context.t('back') }
+            </Button>
+            <Button
+              type="primary"
+              large
+              className="page-container__footer-button"
+              onClick={() => {
+                addTokens(pendingTokens)
+                  .then(() => {
+                    clearPendingTokens()
+                    history.push(DEFAULT_ROUTE)
+                  })
+              }}
+            >
+              { this.context.t('addTokens') }
+            </Button>
+          </header>
         </div>
       </div>
     )

--- a/ui/app/components/pages/keychains/reveal-seed.js
+++ b/ui/app/components/pages/keychains/reveal-seed.js
@@ -108,19 +108,21 @@ class RevealSeedPage extends Component {
   renderPasswordPromptFooter () {
     return (
       h('.page-container__footer', [
-        h(Button, {
-          type: 'default',
-          large: true,
-          className: 'page-container__footer-button',
-          onClick: () => this.props.history.push(DEFAULT_ROUTE),
-        }, this.context.t('cancel')),
-        h(Button, {
-          type: 'primary',
-          large: true,
-          className: 'page-container__footer-button',
-          onClick: event => this.handleSubmit(event),
-          disabled: this.state.password === '',
-        }, this.context.t('next')),
+        h('header', [
+          h(Button, {
+            type: 'default',
+            large: true,
+            className: 'page-container__footer-button',
+            onClick: () => this.props.history.push(DEFAULT_ROUTE),
+          }, this.context.t('cancel')),
+          h(Button, {
+            type: 'primary',
+            large: true,
+            className: 'page-container__footer-button',
+            onClick: event => this.handleSubmit(event),
+            disabled: this.state.password === '',
+          }, this.context.t('next')),
+        ]),
       ])
     )
   }


### PR DESCRIPTION
This PR fixes the markup for screens that had inline copies of the `PageContainer` markup, which changed in #5329 to accommodate more elements in the footer.

<details>
<summary>Before & after <strong>Add Tokens</strong></summary>
<img width="992" alt="screen shot 2018-10-05 at 18 06 53" src="https://user-images.githubusercontent.com/1623628/46559767-e45cbf80-c8cb-11e8-8d8e-d0e840a31a9b.png">
<img width="992" alt="screen shot 2018-10-05 at 18 20 43" src="https://user-images.githubusercontent.com/1623628/46559768-e4f55600-c8cb-11e8-8f68-ef563f831e1c.png">
</details>
<p>
<details>
<summary>Before & after <strong>Seed Phrase</strong></summary>
<img width="992" alt="screen shot 2018-10-05 at 18 06 26" src="https://user-images.githubusercontent.com/1623628/46559766-e45cbf80-c8cb-11e8-849c-e90454065431.png">
<img width="992" alt="screen shot 2018-10-05 at 18 20 51" src="https://user-images.githubusercontent.com/1623628/46559769-e4f55600-c8cb-11e8-8509-5fc9c68e2549.png">
</details>