### PR TITLE
[DO NOT MERGE] Add very simple subscription support

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "lodash.uniqby": "^4.7.0",
     "loglevel": "^1.4.1",
     "metamascara": "^2.0.0",
-    "metamask-inpage-provider": "^1.1.1",
+    "metamask-inpage-provider": "MetaMask/metamask-inpage-provider#hacky-subscriptions",
     "metamask-logo": "^2.1.4",
     "mkdirp": "^0.5.1",
     "multihashes": "^0.4.12",


### PR DESCRIPTION
*Posted to validate fix, do not merge until affected dev confirms.*

While MetaMask never officially supported subscriptions, we added a
subscription subprovider to our provider-engine, which people began
building on.

We have since moved to json-rpc-engine, which lacks this subprovider. We
thought this would be fine, since we never officially supported it, but
apparently even Drizzle was building its UI framework on this API
expectation, so we decided breaking was unacceptable.

Rather than completely engineer a new subscription subprovider for
json-rpc-engine, or add websocket support (yet), I came up with a very
simple way of integrating our old support into the new inpage-provider.

Should have the added benefit of automatic memory management,
potentially solving memory leaks related to the old subscription
support.

Likely fixes #5425, pushing as a PR so we can provide the build to those
affected devs and see if this fixes their issue.

Relevant code changes visible [here in metamask-inpage-provider](https://github.com/MetaMask/metamask-inpage-provider/pull/3).

I did my own validation & bug reproduction using [this test repo](https://github.com/danfinlay/issue-5425-repro) that I composed based on [this comment](https://github.com/MetaMask/metamask-extension/issues/5425#issuecomment-427292798).