### PR TITLE
Fix token values being undefined

### DIFF
--- a/ui/app/components/token-currency-display/token-currency-display.component.js
+++ b/ui/app/components/token-currency-display/token-currency-display.component.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import CurrencyDisplay from '../currency-display/currency-display.component'
 import { getTokenData } from '../../helpers/transactions.util'
-import { calcTokenAmount } from '../../token-util'
+import { getTokenValue, calcTokenAmount } from '../../token-util'
 
 export default class TokenCurrencyDisplay extends PureComponent {
   static propTypes = {
@@ -34,8 +34,8 @@ export default class TokenCurrencyDisplay extends PureComponent {
 
     let displayValue
 
-    if (tokenData.params && tokenData.params.length === 2) {
-      const tokenValue = tokenData.params[1].value
+    if (tokenData.params && tokenData.params.length) {
+      const tokenValue = getTokenValue(tokenData.params)
       const tokenAmount = calcTokenAmount(tokenValue, decimals)
       displayValue = `${tokenAmount} ${symbol}`
     }

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -111,3 +111,8 @@ export function calcTokenAmount (value, decimals) {
   const multiplier = Math.pow(10, Number(decimals || 0))
   return new BigNumber(String(value)).div(multiplier).toNumber()
 }
+
+export function getTokenValue (tokenParams = []) {
+  const valueData = tokenParams.find(param => param.name === '_value')
+  return valueData && valueData.value
+}


### PR DESCRIPTION
We were incorrectly assuming that the value of a token transfer method was always in `params[1]` from the `human-standard-token-abi`, when it's possible that the value is in `params[2]`. This PR explicitly looks through `params` for the `_value` name.