### PR TITLE
Fix styling of first-time-flow container

### DIFF
--- a/mascara/src/app/first-time/index.css
+++ b/mascara/src/app/first-time/index.css
@@ -17,7 +17,7 @@
   font-family: Roboto;
 }
 
-@media screen and (min-height: 576px) {
+@media screen and (min-height: 601px) {
   .first-time-flow {
     height: 100vh;
   }


### PR DESCRIPTION
Fixes #5482, refs #5340

This PR fixes the height of the first time flow container to both support the popup window and regular windows. This is a hack but it's (🤞) temporary.