### PR TITLE
Decrease click area for AmountMaxButton on send screen

### DIFF
--- a/ui/app/components/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.js
+++ b/ui/app/components/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.js
@@ -34,21 +34,27 @@ export default class AmountMaxButton extends Component {
     })
   }
 
-  render () {
-    const { setMaxModeTo, maxModeOn } = this.props
+  onMaxClick = (event) => {
+    const { setMaxModeTo } = this.props
 
-    return (
-      <div
-        className="send-v2__amount-max"
-        onClick={(event) => {
-          event.preventDefault()
-          setMaxModeTo(true)
-          this.setMaxAmount()
-        }}
-      >
-        {!maxModeOn ? this.context.t('max') : ''}
-      </div>
-    )
+    event.preventDefault()
+    setMaxModeTo(true)
+    this.setMaxAmount()
+  }
+
+  render () {
+    return this.props.maxModeOn
+      ? null
+      : (
+        <div>
+          <span
+            className="send-v2__amount-max"
+            onClick={this.onMaxClick}
+          >
+            {this.context.t('max')}
+          </span>
+        </div>
+      )
   }
 
 }

--- a/ui/app/components/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
+++ b/ui/app/components/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
@@ -56,9 +56,8 @@ describe('AmountMaxButton Component', function () {
   })
 
   describe('render', () => {
-    it('should render a div with a send-v2__amount-max class', () => {
-      assert.equal(wrapper.find('.send-v2__amount-max').length, 1)
-      assert(wrapper.find('.send-v2__amount-max').is('div'))
+    it('should render an element with a send-v2__amount-max class', () => {
+      assert(wrapper.exists('.send-v2__amount-max'))
     })
 
     it('should call setMaxModeTo and setMaxAmount when the send-v2__amount-max div is clicked', () => {
@@ -77,9 +76,9 @@ describe('AmountMaxButton Component', function () {
       )
     })
 
-    it('should not render text when maxModeOn is true', () => {
+    it('should not render anything when maxModeOn is true', () => {
       wrapper.setProps({ maxModeOn: true })
-      assert.equal(wrapper.find('.send-v2__amount-max').text(), '')
+      assert.ok(!wrapper.exists('.send-v2__amount-max'))
     })
 
     it('should render the expected text when maxModeOn is false', () => {


### PR DESCRIPTION
Fixes #5469

This PR reduces the click area for the max button on the send screen to help reduce accidental clicks.

<details>
<summary><strong>Before & after screenshots<strong></summary>
<img width="1079" src="https://user-images.githubusercontent.com/1623628/46983875-0c62d480-d0bd-11e8-9cf9-ced40454f3b7.png">
<p>
<img width="1079" src="https://user-images.githubusercontent.com/1623628/46983876-0c62d480-d0bd-11e8-87cb-af044ec1044a.png">
</details>