### PR TITLE
Fix document extension check when injecting web3

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -135,17 +135,22 @@ function doctypeCheck () {
 }
 
 /**
- * Checks the current document extension
+ * Returns whether or not the extension (suffix) of the current document is prohibited
  *
- * @returns {boolean} {@code true} if the current extension is not prohibited
+ * This checks {@code window.location.pathname} against a set of file extensions
+ * that should not have web3 injected into them. This check is indifferent of query parameters
+ * in the location.
+ *
+ * @returns {boolean} whether or not the extension of the current document is prohibited
  */
 function suffixCheck () {
-  var prohibitedTypes = ['xml', 'pdf']
-  var currentUrl = window.location.href
-  var currentRegex
+  const prohibitedTypes = [
+    /\.xml$/,
+    /\.pdf$/,
+  ]
+  const currentUrl = window.location.pathname
   for (let i = 0; i < prohibitedTypes.length; i++) {
-    currentRegex = new RegExp(`\\.${prohibitedTypes[i]}$`)
-    if (currentRegex.test(currentUrl)) {
+    if (prohibitedTypes[i].test(currentUrl)) {
       return false
     }
   }


### PR DESCRIPTION
Fixes #2006

This PR updates the suffix check we do on URLs when deciding whether or not to inject web3—the check now uses `window.location.pathname` instead of `window.location.href` which means that it is no longer troubled by query parameters.