### PR TITLE
Lower i18n-helper#getMessage log level from error to warning

### DIFF
--- a/ui/i18n-helper.js
+++ b/ui/i18n-helper.js
@@ -13,7 +13,7 @@ const getMessage = (locale, key, substitutions) => {
     return null
   }
   if (!locale[key]) {
-    log.error(`Translator - Unable to find value for key "${key}"`)
+    log.warn(`Translator - Unable to find value for key "${key}"`)
     return null
   }
   const entry = locale[key]


### PR DESCRIPTION
This PR lowers the log level of missing translating values from error to warnings. Previously this would distract from/obscure real errors in the console.