### PR TITLE
Update wording on export private key modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -798,7 +798,7 @@
     "description": "select this type of file to use to import an account"
   },
   "privateKeyWarning": {
-    "message": "Warning: Never disclose this key. Anyone with your private keys can take steal any assets held in your account."
+    "message": "Warning: Never disclose this key. Anyone with your private keys can steal any assets held in your account."
   },
   "privateNetwork": {
     "message": "Private Network"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1189,7 +1189,7 @@
     "message": "These 12 words are the only way to restore your MetaMask accounts.\nSave them somewhere safe and secret."
   },
   "typePassword": {
-    "message": "Type Your Password"
+    "message": "Type your MetaMask password"
   },
   "uiWelcome": {
     "message": "Welcome to the New UI (Beta)"


### PR DESCRIPTION
Fixes #5314

This PR updates the wording on the export private key modal, to clarify that the password we are using the MetaMask password.

**Before & after:**

<img width="773" alt="screen shot 2018-10-16 at 17 04 16" src="https://user-images.githubusercontent.com/1623628/47043187-8f406980-d167-11e8-934d-7da32bc1603b.png">
