### PR TITLE
Update Shapeshift logo url and adjust list item contents

### DIFF
--- a/ui/app/components/shift-list-item.js
+++ b/ui/app/components/shift-list-item.js
@@ -52,12 +52,12 @@ ShiftListItem.prototype.render = function () {
       },
     }, [
       h('img', {
-        src: 'https://info.shapeshift.io/sites/default/files/logo.png',
+        src: 'https://shapeshift.io/logo.png',
         style: {
           height: '35px',
           width: '132px',
           position: 'absolute',
-          clip: 'rect(0px,23px,34px,0px)',
+          clip: 'rect(0px,30px,34px,0px)',
         },
       }),
     ]),
@@ -132,7 +132,6 @@ ShiftListItem.prototype.renderInfo = function () {
     case 'no_deposits':
       return h('.flex-column', {
         style: {
-          width: '200px',
           overflow: 'hidden',
         },
       }, [


### PR DESCRIPTION
Update ShapeShift logo url, reduce clipping of image, and remove width of shapeshift tx info.
Top of screenshot is the PR. Bottom is current with the updated url.
![screenshot from 2018-10-17 20-28-46](https://user-images.githubusercontent.com/13376180/47130168-36e39780-d24d-11e8-9ceb-a5053faa2306.png)
