### PR TITLE
Specific methods for frequentRpcList

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -375,22 +375,6 @@ class PreferencesController {
   }
 
   /**
-   * Gets an updated rpc list from this.addToFrequentRpcList() and sets the `frequentRpcList` to this update list.
-   *
-   * @param {string} _url The the new rpc url to add to the updated list
-   * @param {bool} remove Remove selected url
-   * @returns {Promise<void>} Promise resolves with undefined
-   *
-   */
-  updateFrequentRpcList (_url, remove = false) {
-    return this.addToFrequentRpcList(_url, remove)
-      .then((rpcList) => {
-        this.store.updateState({ frequentRpcList: rpcList })
-        return Promise.resolve()
-      })
-  }
-
-  /**
    * Setter for the `currentAccountTab` property
    *
    * @param {string} currentAccountTab Specifies the new tab to be marked as current
@@ -405,24 +389,39 @@ class PreferencesController {
   }
 
   /**
-   * Returns an updated rpcList based on the passed url and the current list.
-   * The returned list will have a max length of 3. If the _url currently exists it the list, it will be moved to the
-   * end of the list. The current list is modified and returned as a promise.
+   * Adds custom RPC url to state.
    *
-   * @param {string} _url The rpc url to add to the frequentRpcList.
-   * @param {bool} remove Remove selected url
-   * @returns {Promise<array>} The updated frequentRpcList.
+   * @param {string} url The RPC url to add to frequentRpcList.
+   * @returns {Promise<array>} Promise resolving to updated frequentRpcList.
    *
    */
-  addToFrequentRpcList (_url, remove = false) {
+  addToFrequentRpcList (url) {
     const rpcList = this.getFrequentRpcList()
-    const index = rpcList.findIndex((element) => { return element === _url })
+    const index = rpcList.findIndex((element) => { return element === url })
     if (index !== -1) {
       rpcList.splice(index, 1)
     }
-    if (!remove && _url !== 'http://localhost:8545') {
-      rpcList.push(_url)
+    if (url !== 'http://localhost:8545') {
+      rpcList.push(url)
     }
+    this.store.updateState({ frequentRpcList: rpcList })
+    return Promise.resolve(rpcList)
+  }
+
+  /**
+   * Removes custom RPC url from state.
+   *
+   * @param {string} url The RPC url to remove from frequentRpcList.
+   * @returns {Promise<array>} Promise resolving to updated frequentRpcList.
+   *
+   */
+  removeFromFrequentRpcList (url) {
+    const rpcList = this.getFrequentRpcList()
+    const index = rpcList.findIndex((element) => { return element === url })
+    if (index !== -1) {
+      rpcList.splice(index, 1)
+    }
+    this.store.updateState({ frequentRpcList: rpcList })
     return Promise.resolve(rpcList)
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1458,7 +1458,7 @@ module.exports = class MetamaskController extends EventEmitter {
    */
   async setCustomRpc (rpcTarget) {
     this.networkController.setRpcTarget(rpcTarget)
-    await this.preferencesController.updateFrequentRpcList(rpcTarget)
+    await this.preferencesController.addToFrequentRpcList(rpcTarget)
     return rpcTarget
   }
 
@@ -1467,7 +1467,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * @param {string} rpcTarget - A RPC URL to delete.
    */
   async delCustomRpc (rpcTarget) {
-    await this.preferencesController.updateFrequentRpcList(rpcTarget, true)
+    await this.preferencesController.removeFromFrequentRpcList(rpcTarget)
   }
 
   /**

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -479,5 +479,24 @@ describe('preferences controller', function () {
       assert.equal(preferencesController.store.getState().seedWords, 'foo bar baz')
     })
   })
+
+  describe('on updateFrequentRpcList', function () {
+    it('should add custom RPC url to state', function () {
+      preferencesController.addToFrequentRpcList('rpc_url')
+      preferencesController.addToFrequentRpcList('http://localhost:8545')
+      assert.deepEqual(preferencesController.store.getState().frequentRpcList, ['rpc_url'])
+      preferencesController.addToFrequentRpcList('rpc_url')
+      assert.deepEqual(preferencesController.store.getState().frequentRpcList, ['rpc_url'])
+    })
+
+    it('should remove custom RPC url from state', function () {
+      preferencesController.addToFrequentRpcList('rpc_url')
+      assert.deepEqual(preferencesController.store.getState().frequentRpcList, ['rpc_url'])
+      preferencesController.removeFromFrequentRpcList('other_rpc_url')
+      preferencesController.removeFromFrequentRpcList('http://localhost:8545')
+      preferencesController.removeFromFrequentRpcList('rpc_url')
+      assert.deepEqual(preferencesController.store.getState().frequentRpcList, [])
+    })
+  })
 })
 


### PR DESCRIPTION
This PR creates specific methods to add and remove RPC urls of `frequentRpcList` in `PreferencesController`.