### PR TITLE
Support for prefix wallet_watchAsset

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -104,7 +104,7 @@ class PreferencesController {
    * @param {Function} - end
    */
   async requestWatchAsset (req, res, next, end) {
-    if (req.method === 'metamask_watchAsset') {
+    if (req.method === 'metamask_watchAsset' || req.method === 'wallet_watchAsset') {
       const { type, options } = req.params
       switch (type) {
         case 'ERC20':

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -375,6 +375,11 @@ describe('preferences controller', function () {
       await preferencesController.requestWatchAsset(req, res, asy.next, asy.end)
       sandbox.assert.called(stubEnd)
       sandbox.assert.notCalled(stubNext)
+      req.method = 'wallet_watchAsset'
+      req.params.type = 'someasset'
+      await preferencesController.requestWatchAsset(req, res, asy.next, asy.end)
+      sandbox.assert.calledTwice(stubEnd)
+      sandbox.assert.notCalled(stubNext)
     })
     it('should through error if method is supported but asset type is not', async function () {
       req.method = 'metamask_watchAsset'


### PR DESCRIPTION
This PR adds support for `wallet_watchAsset` prefix to be used with `watchAsset` feature.