### PR TITLE
Add full address display for resolved ENS name in send view

### DIFF
--- a/ui/app/components/send/to-autocomplete/to-autocomplete.js
+++ b/ui/app/components/send/to-autocomplete/to-autocomplete.js
@@ -93,6 +93,7 @@ ToAutoComplete.prototype.componentDidUpdate = function (nextProps, nextState) {
 ToAutoComplete.prototype.render = function () {
   const {
     to,
+    toEns,
     dropdownOpen,
     onChange,
     inError,
@@ -104,7 +105,7 @@ ToAutoComplete.prototype.render = function () {
     h(`input.send-v2__to-autocomplete__input${qrScanner ? '.with-qr' : ''}`, {
       placeholder: this.context.t('recipientAddress'),
       className: inError ? `send-v2__error-border` : '',
-      value: to,
+      value: typeof toEns === 'string' ? toEns : to,
       onChange: event => onChange(event.target.value),
       onFocus: event => this.handleInputEvent(event),
       style: {


### PR DESCRIPTION
- Closes #5524

Adds text below send-to input showing resolved ENS address after confirmed resolution, with tooltip on hover in case of truncation:

![screen shot 2018-10-21 at 11 36 41 am](https://user-images.githubusercontent.com/879755/47270855-afd14080-d526-11e8-8105-431ebebd6558.png)

I would like to add tests but not clear on how to stub pre-determined ENS resolutions in the current setup, any advice would be appreciated!
