### PR TITLE
i18n - Updated Dutch translation for main network name 

### DIFF
--- a/app/_locales/nl/messages.json
+++ b/app/_locales/nl/messages.json
@@ -435,7 +435,7 @@
     "message": "back-up woorden hebben alleen kleine letters"
   },
   "mainnet": {
-    "message": "belangrijkste Ethereum-netwerk"
+    "message": "Main Netwerk"
   },
   "message": {
     "message": "Bericht"


### PR DESCRIPTION
Current translation translates to 'most important Ethereum-network'. 'Main' is totally acceptable to use in Dutch.