### PR TITLE
deploy - docs - publish via npm script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ jobs:
           command: >
             git config user.name metamaskbot &&
             git config user.email admin@metamask.io &&
-            gh-pages -d docs/jsdocs
+            npm run publish-docs
 
   test-unit:
     docker:


### PR DESCRIPTION
fixes an issue where gh-pages is not globally installed as can be seen here https://circleci.com/gh/MetaMask/metamask-extension/64035
