### PR TITLE
Build - reduce browser support to explicit browser versions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,22 @@
 {
-  "presets": [["env", { "targets": { "browsers": [">0.25%", "not ie 11", "not op_mini all"] } } ], "react", "stage-0"],
-  "plugins": ["transform-runtime", "transform-async-to-generator", "transform-class-properties"]
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            ">0.25%",
+            "not ie 11",
+            "not op_mini all"
+          ]
+        },
+        "debug": true
+      }
+    ],
+    "stage-0",
+    "react"
+  ],
+  "plugins": [
+    "transform-class-properties"
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -5,18 +5,24 @@
       {
         "targets": {
           "browsers": [
-            ">0.25%",
-            "not ie 11",
-            "not op_mini all"
+            "chrome 55",
+            "firefox 53",
+            "opera 42",
+            "edge 17",
           ]
         },
         "debug": true
       }
     ],
     "stage-0",
-    "react"
+    "react",
   ],
   "plugins": [
-    "transform-class-properties"
+    "transform-class-properties",
+    // from previous babel-preset-env target browser config,
+    // required to complete transpile
+    "transform-es2015-parameters",
+    "transform-es2015-computed-properties",
+    "transform-es2015-spread",
   ]
 }

--- a/development/sourcemap-validator.js
+++ b/development/sourcemap-validator.js
@@ -17,7 +17,7 @@ start().catch(console.error)
 
 async function start () {
   const targetFiles = [`inpage.js`, `contentscript.js`, `ui.js`, `background.js`]
-  for (buildName of targetFiles) {
+  for (let buildName of targetFiles) {
     await validateSourcemapForFile({ buildName })
   }
 }
@@ -69,11 +69,10 @@ async function validateSourcemapForFile({ buildName }) {
       // warn if source content is missing
       if (!result.source) {
         console.warn(`!! missing source for position: ${JSON.stringify(position)}`)
-        // const buildLine = buildLines[position.line-1]
         console.warn(`   origin in build:`)
-        console.warn(`   ${buildLines[position.line-2]}`)
-        console.warn(`-> ${buildLines[position.line-1]}`)
-        console.warn(`   ${buildLines[position.line-0]}`)
+        console.warn(`   ${buildLines[position.line - 2]}`)
+        console.warn(`-> ${buildLines[position.line - 1]}`)
+        console.warn(`   ${buildLines[position.line - 0]}`)
         return
       }
       const sourceContent = consumer.sourceContentFor(result.source)

--- a/development/sourcemap-validator.js
+++ b/development/sourcemap-validator.js
@@ -1,6 +1,9 @@
 const fs = require('fs')
 const { SourceMapConsumer } = require('source-map')
 const path = require('path')
+const pify = require('pify')
+const fsAsync = pify(fs)
+
 //
 // Utility to help check if sourcemaps are working
 //
@@ -9,39 +12,85 @@ const path = require('path')
 // if not working it may error or print minified garbage
 //
 
-start()
+start().catch(console.error)
 
 
 async function start () {
-  const rawBuild = fs.readFileSync(path.join(__dirname, '/../dist/chrome/', 'inpage.js')
-  , 'utf8')
-  const rawSourceMap = fs.readFileSync(path.join(__dirname, '/../dist/sourcemaps/', 'inpage.js.map'), 'utf8')
+  const targetFiles = [`inpage.js`, `contentscript.js`, `ui.js`, `background.js`]
+  for (buildName of targetFiles) {
+    await validateSourcemapForFile({ buildName })
+  }
+}
+
+async function validateSourcemapForFile({ buildName }) {
+  console.log(`build "${buildName}"`)
+  const platform = `chrome`
+  // load build and sourcemaps
+  let rawBuild
+  try {
+    const filePath = path.join(__dirname, `/../dist/${platform}/`, `${buildName}`)
+    rawBuild = await fsAsync.readFile(filePath, 'utf8')
+  } catch (err) {}
+  if (!rawBuild) {
+    throw new Error(`SourcemapValidator - failed to load source file for "${buildName}"`)
+  }
+  // attempt to load in dist mode
+  let rawSourceMap
+  try {
+    const filePath = path.join(__dirname, `/../dist/sourcemaps/`, `${buildName}.map`)
+    rawSourceMap = await fsAsync.readFile(filePath, 'utf8')
+  } catch (err) {}
+  // attempt to load in dev mode
+  try {
+    const filePath = path.join(__dirname, `/../dist/${platform}/`, `${buildName}.map`)
+    rawSourceMap = await fsAsync.readFile(filePath, 'utf8')
+  } catch (err) {}
+  if (!rawSourceMap) {
+    throw new Error(`SourcemapValidator - failed to load sourcemaps for "${buildName}"`)
+  }
+
   const consumer = await new SourceMapConsumer(rawSourceMap)
 
-  console.log('hasContentsOfAllSources:', consumer.hasContentsOfAllSources(), '\n')
-  console.log('sources:')
-  consumer.sources.map((sourcePath) => console.log(sourcePath))
+  const hasContentsOfAllSources = consumer.hasContentsOfAllSources()
+  if (!hasContentsOfAllSources) console.warn('SourcemapValidator - missing content of some sources...')
 
-  console.log('\nexamining "new Error" statements:\n')
-  const sourceLines = rawBuild.split('\n')
-  sourceLines.map(line => indicesOf('new Error', line))
-  .forEach((errorIndices, lineIndex) => {
-    // if (errorIndex === null) return console.log('line does not contain "new Error"')
-    errorIndices.forEach((errorIndex) => {
-      const position = { line: lineIndex + 1, column: errorIndex }
+  console.log(`  sampling from ${consumer.sources.length} files`)
+  let sampleCount = 0
+
+  const buildLines = rawBuild.split('\n')
+  const targetString = 'new Error'
+  // const targetString = 'null'
+  const matchesPerLine = buildLines.map(line => indicesOf(targetString, line))
+  matchesPerLine.forEach((matchIndices, lineIndex) => {
+    matchIndices.forEach((matchColumn) => {
+      sampleCount++
+      const position = { line: lineIndex + 1, column: matchColumn }
       const result = consumer.originalPositionFor(position)
-      if (!result.source) return console.warn(`!! missing source for position: ${position}`)
-      // filter out deps distributed minified without sourcemaps
-      if (result.source === 'node_modules/browserify/node_modules/browser-pack/_prelude.js') return // minified mess
-      if (result.source === 'node_modules/web3/dist/web3.min.js') return // minified mess
+      // warn if source content is missing
+      if (!result.source) {
+        console.warn(`!! missing source for position: ${JSON.stringify(position)}`)
+        // const buildLine = buildLines[position.line-1]
+        console.warn(`   origin in build:`)
+        console.warn(`   ${buildLines[position.line-2]}`)
+        console.warn(`-> ${buildLines[position.line-1]}`)
+        console.warn(`   ${buildLines[position.line-0]}`)
+        return
+      }
       const sourceContent = consumer.sourceContentFor(result.source)
       const sourceLines = sourceContent.split('\n')
       const line = sourceLines[result.line - 1]
-      console.log(`\n========================== ${result.source} ====================================\n`)
-      console.log(line)
-      console.log(`\n==============================================================================\n`)
+      // this sometimes includes the whole line though we tried to match somewhere in the middle
+      const portion = line.slice(result.column)
+      const isMaybeValid = portion.includes(targetString)
+      if (!isMaybeValid) {
+        console.error('Sourcemap seems invalid:')
+        console.log(`\n========================== ${result.source} ====================================\n`)
+        console.log(line)
+        console.log(`\n==============================================================================\n`)
+      }
     })
   })
+  console.log(`  checked ${sampleCount} samples`)
 }
 
 function indicesOf (substring, string) {

--- a/package.json
+++ b/package.json
@@ -53,30 +53,7 @@
   },
   "browserify": {
     "transform": [
-      [
-        "babelify",
-        {
-          "presets": [
-            [
-              "env",
-              {
-                "browsers": [
-                  ">0.25%",
-                  "not ie 11",
-                  "not op_mini all"
-                ],
-                "debug": true
-              }
-            ],
-            "stage-0"
-          ]
-        },
-        {
-          "plugins": [
-            "transform-class-properties"
-          ]
-        }
-      ],
+      "babelify",
       "reactify",
       "brfs"
     ]

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
                   ">0.25%",
                   "not ie 11",
                   "not op_mini all"
-                ]
+                ],
+                "debug": true
               }
             ],
             "stage-0"


### PR DESCRIPTION
- improves sourcemap validation tool
- fixes the browser target reference (previously was ignored)
- explicitly sets the browser target reference instead of indirect percentage based figure
```
            "chrome 55",
            "firefox 53",
            "opera 42",
            "edge 17",
```
( note: seems that opera reference is not supported at this version of `preset-env` )


```
  transform-class-properties
  check-es2015-constants {}
  transform-es2015-arrow-functions {}
  transform-es2015-block-scoped-functions {}
  transform-es2015-block-scoping {}
  transform-es2015-classes {}
  transform-es2015-computed-properties {}
  transform-es2015-destructuring {}
  transform-es2015-duplicate-keys {}
  transform-es2015-for-of {}
  transform-es2015-function-name {}
  transform-es2015-literals {}
  transform-es2015-object-super {}
  transform-es2015-parameters {}
  transform-es2015-shorthand-properties {}
  transform-es2015-spread {}
  transform-es2015-sticky-regex {}
  transform-es2015-template-literals {}
  transform-es2015-typeof-symbol {}
  transform-es2015-unicode-regex {}
  transform-regenerator {}
  transform-exponentiation-operator {}
  transform-async-to-generator {}
  syntax-trailing-function-commas {}
```

after:
```
  transform-class-properties
  transform-es2015-parameters
  transform-es2015-computed-properties
  transform-es2015-spread
  transform-es2015-destructuring {"edge":"17"}
  transform-es2015-function-name {"edge":"17"}
  syntax-trailing-function-commas {"chrome":"55"}
```