### PR TITLE
fixed currency-display

### DIFF
--- a/ui/app/components/currency-display/currency-display.container.js
+++ b/ui/app/components/currency-display/currency-display.container.js
@@ -3,16 +3,17 @@ import CurrencyDisplay from './currency-display.component'
 import { getValueFromWeiHex, formatCurrency } from '../../helpers/confirm-transaction/util'
 
 const mapStateToProps = state => {
-  const { metamask: { currentCurrency, conversionRate } } = state
+  const { metamask: { nativeCurrency, currentCurrency, conversionRate } } = state
 
   return {
     currentCurrency,
     conversionRate,
+    nativeCurrency,
   }
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { currentCurrency, conversionRate, ...restStateProps } = stateProps
+  const { nativeCurrency, currentCurrency, conversionRate, ...restStateProps } = stateProps
   const {
     value,
     numberOfDecimals = 2,
@@ -24,7 +25,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 
   const toCurrency = currency || currentCurrency
   const convertedValue = getValueFromWeiHex({
-    value, toCurrency, conversionRate, numberOfDecimals, toDenomination: denomination,
+    value, fromCurrency: nativeCurrency, toCurrency, conversionRate, numberOfDecimals, toDenomination: denomination,
   })
   const displayValue = formatCurrency(convertedValue, toCurrency)
   const suffix = hideLabel ? undefined : toCurrency.toUpperCase()

--- a/ui/app/components/currency-display/tests/currency-display.container.test.js
+++ b/ui/app/components/currency-display/tests/currency-display.container.test.js
@@ -20,12 +20,14 @@ describe('CurrencyDisplay container', () => {
         metamask: {
           conversionRate: 280.45,
           currentCurrency: 'usd',
+          nativeCurrency: 'ETH',
         },
       }
 
       assert.deepEqual(mapStateToProps(mockState), {
         conversionRate: 280.45,
         currentCurrency: 'usd',
+        nativeCurrency: 'ETH',
       })
     })
   })
@@ -35,6 +37,7 @@ describe('CurrencyDisplay container', () => {
       const mockStateProps = {
         conversionRate: 280.45,
         currentCurrency: 'usd',
+        nativeCurrency: 'ETH',
       }
 
       const tests = [
@@ -43,40 +46,49 @@ describe('CurrencyDisplay container', () => {
             value: '0x2386f26fc10000',
             numberOfDecimals: 2,
             currency: 'usd',
+            nativeCurrency: 'ETH',
           },
           result: {
             displayValue: '$2.80',
             suffix: 'USD',
+            nativeCurrency: 'ETH',
           },
         },
         {
           props: {
             value: '0x2386f26fc10000',
+            currency: 'usd',
+            nativeCurrency: 'ETH',
           },
           result: {
             displayValue: '$2.80',
             suffix: 'USD',
+            nativeCurrency: 'ETH',
           },
         },
         {
           props: {
             value: '0x1193461d01595930',
             currency: 'ETH',
+            nativeCurrency: 'ETH',
             numberOfDecimals: 3,
           },
           result: {
             displayValue: '1.266',
             suffix: 'ETH',
+            nativeCurrency: 'ETH',
           },
         },
         {
           props: {
             value: '0x1193461d01595930',
             currency: 'ETH',
+            nativeCurrency: 'ETH',
             numberOfDecimals: 3,
             hideLabel: true,
           },
           result: {
+            nativeCurrency: 'ETH',
             displayValue: '1.266',
             suffix: undefined,
           },
@@ -85,10 +97,12 @@ describe('CurrencyDisplay container', () => {
           props: {
             value: '0x3b9aca00',
             currency: 'ETH',
+            nativeCurrency: 'ETH',
             denomination: 'GWEI',
             hideLabel: true,
           },
           result: {
+            nativeCurrency: 'ETH',
             displayValue: '1',
             suffix: undefined,
           },
@@ -97,10 +111,12 @@ describe('CurrencyDisplay container', () => {
           props: {
             value: '0x3b9aca00',
             currency: 'ETH',
+            nativeCurrency: 'ETH',
             denomination: 'WEI',
             hideLabel: true,
           },
           result: {
+            nativeCurrency: 'ETH',
             displayValue: '1000000000',
             suffix: undefined,
           },
@@ -109,10 +125,12 @@ describe('CurrencyDisplay container', () => {
           props: {
             value: '0x3b9aca00',
             currency: 'ETH',
+            nativeCurrency: 'ETH',
             numberOfDecimals: 100,
             hideLabel: true,
           },
           result: {
+            nativeCurrency: 'ETH',
             displayValue: '1e-9',
             suffix: undefined,
           },


### PR DESCRIPTION
partial revert commit 99acde4fb83bd9df5fe28825006558b1c0c4acbc

* [x] call `getValueFromWeiHex()` with `fromCurrency=nativeCurrency`

~~~diff
@@ -24,7 +25,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {

   const toCurrency = currency || currentCurrency
   const convertedValue = getValueFromWeiHex({
-    value, toCurrency, conversionRate, numberOfDecimals, toDenomination: denomination,
+    value, fromCurrency: nativeCurrency, toCurrency, conversionRate, numberOfDecimals, toDenomination: denomination,
   })
   const displayValue = formatCurrency(convertedValue, toCurrency)
   const suffix = hideLabel ? undefined : toCurrency.toUpperCase()
~~~
