### PR TITLE
i18n - Fix Slovenian translation

### DIFF
--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -1270,7 +1270,7 @@
     "message": "Dobrodošli v nov UI (Beta)"
   },
   "uiWelcomeMessage": {
-    "message": "Uporabljate nov uporabniškiu vmesnik."
+    "message": "Uporabljate nov uporabniški vmesnik."
   },
   "unapproved": {
     "message": "Neodobreno"


### PR DESCRIPTION
I fixed and added better Slovenian translation. Same as #5625 but for branch `eip-1102`.