### PR TITLE
Update watchAsset ERC20 validation

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -583,8 +583,8 @@ class PreferencesController {
    */
   _validateERC20AssetParams (opts) {
     const { rawAddress, symbol, decimals } = opts
-    if (!rawAddress || !symbol || !decimals) throw new Error(`Cannot suggest token without address, symbol, and decimals`)
-    if (!(symbol.length < 6)) throw new Error(`Invalid symbol ${symbol} more than five characters`)
+    if (!rawAddress || !symbol || typeof decimals === 'undefined') throw new Error(`Cannot suggest token without address, symbol, and decimals`)
+    if (!(symbol.length < 7)) throw new Error(`Invalid symbol ${symbol} more than six characters`)
     const numDecimals = parseInt(decimals, 10)
     if (isNaN(numDecimals) || numDecimals > 36 || numDecimals < 0) {
       throw new Error(`Invalid decimals ${decimals} must be at least 0, and not over 36`)

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -456,28 +456,28 @@ describe('preferences controller', function () {
     it('should validate ERC20 asset correctly', async function () {
       const validateSpy = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpy({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC', decimals: 0}) } catch (e) {}
-      assert.equal(validateSpy.threw(), false, 'correct opts')
+      assert.equal(validateSpy.threw(), false, 'correct options object')
       const validateSpyAddress = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpyAddress({symbol: 'ABC', decimals: 0}) } catch (e) {}
-      assert.equal(validateSpyAddress.threw(), true, 'opts no address')
+      assert.equal(validateSpyAddress.threw(), true, 'options object with no address')
       const validateSpySymbol = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpySymbol({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', decimals: 0}) } catch (e) {}
-      assert.equal(validateSpySymbol.threw(), true, 'opts no symbol')
+      assert.equal(validateSpySymbol.threw(), true, 'options object with no symbol')
       const validateSpyDecimals = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpyDecimals({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC'}) } catch (e) {}
-      assert.equal(validateSpyDecimals.threw(), true, 'opts no decimals')
+      assert.equal(validateSpyDecimals.threw(), true, 'options object with no decimals')
       const validateSpyInvalidSymbol = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpyInvalidSymbol({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 0}) } catch (e) {}
-      assert.equal(validateSpyInvalidSymbol.threw(), true, 'opts no decimals')
+      assert.equal(validateSpyInvalidSymbol.threw(), true, 'options object with invalid symbol')
       const validateSpyInvalidDecimals1 = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpyInvalidDecimals1({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: -1}) } catch (e) {}
-      assert.equal(validateSpyInvalidDecimals1.threw(), true, 'decimals less than zero')
+      assert.equal(validateSpyInvalidDecimals1.threw(), true, 'options object with decimals less than zero')
       const validateSpyInvalidDecimals2 = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpyInvalidDecimals2({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 38}) } catch (e) {}
-      assert.equal(validateSpyInvalidDecimals2.threw(), true, 'decimals more than 36')
+      assert.equal(validateSpyInvalidDecimals2.threw(), true, 'options object with decimals more than 36')
       const validateSpyInvalidAddress = sandbox.spy(preferencesController._validateERC20AssetParams)
       try { validateSpyInvalidAddress({rawAddress: '0x123', symbol: 'ABC', decimals: 0}) } catch (e) {}
-      assert.equal(validateSpyInvalidAddress.threw(), true, 'address invalid')
+      assert.equal(validateSpyInvalidAddress.threw(), true, 'options object with address invalid')
     })
   })
 

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -453,6 +453,32 @@ describe('preferences controller', function () {
       const assetImages = preferencesController.getAssetImages()
       assert.ok(assetImages[address], `set image correctly`)
     })
+    it('should validate ERC20 asset correctly', async function () {
+      const validateSpy = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpy({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC', decimals: 0}) } catch (e) {}
+      assert.equal(validateSpy.threw(), false, 'correct opts')
+      const validateSpyAddress = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpyAddress({symbol: 'ABC', decimals: 0}) } catch (e) {}
+      assert.equal(validateSpyAddress.threw(), true, 'opts no address')
+      const validateSpySymbol = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpySymbol({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', decimals: 0}) } catch (e) {}
+      assert.equal(validateSpySymbol.threw(), true, 'opts no symbol')
+      const validateSpyDecimals = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpyDecimals({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC'}) } catch (e) {}
+      assert.equal(validateSpyDecimals.threw(), true, 'opts no decimals')
+      const validateSpyInvalidSymbol = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpyInvalidSymbol({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 0}) } catch (e) {}
+      assert.equal(validateSpyInvalidSymbol.threw(), true, 'opts no decimals')
+      const validateSpyInvalidDecimals1 = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpyInvalidDecimals1({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: -1}) } catch (e) {}
+      assert.equal(validateSpyInvalidDecimals1.threw(), true, 'decimals less than zero')
+      const validateSpyInvalidDecimals2 = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpyInvalidDecimals2({rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 38}) } catch (e) {}
+      assert.equal(validateSpyInvalidDecimals2.threw(), true, 'decimals more than 36')
+      const validateSpyInvalidAddress = sandbox.spy(preferencesController._validateERC20AssetParams)
+      try { validateSpyInvalidAddress({rawAddress: '0x123', symbol: 'ABC', decimals: 0}) } catch (e) {}
+      assert.equal(validateSpyInvalidAddress.threw(), true, 'address invalid')
+    })
   })
 
   describe('setPasswordForgotten', function () {


### PR DESCRIPTION
This PR updates and adds tests for ERC20 token validation used for watchAsset feature.

Resolves #5647