### PR TITLE
network - infura - hardcode net_version and eth_chainId

### DIFF
--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -29,32 +29,32 @@ function createInfuraClient ({ network }) {
 }
 
 function createNetworkAndChainIdMiddleware({ network }) {
-  let eth_chainId
-  let net_version
+  let chainId
+  let netId
 
   switch (network) {
     case 'mainnet':
-      net_version = '1'
-      eth_chainId = '0x01'
+      netId = '1'
+      chainId = '0x01'
       break
     case 'ropsten':
-      net_version = '3'
-      eth_chainId = '0x03'
+      netId = '3'
+      chainId = '0x03'
       break
     case 'rinkeby':
-      net_version = '4'
-      eth_chainId = '0x04'
+      netId = '4'
+      chainId = '0x04'
       break
     case 'kovan':
-      net_version = '42'
-      eth_chainId = '0x2a'
+      netId = '42'
+      chainId = '0x2a'
       break
     default:
       throw new Error(`createInfuraClient - unknown network "${network}"`)
   }
 
   return createScaffoldMiddleware({
-    eth_chainId,
-    net_version,
+    eth_chainId: chainId,
+    net_version: netId,
   })
 }

--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -1,4 +1,5 @@
 const mergeMiddleware = require('json-rpc-engine/src/mergeMiddleware')
+const createScaffoldMiddleware = require('json-rpc-engine/src/createScaffoldMiddleware')
 const createBlockReRefMiddleware = require('eth-json-rpc-middleware/block-ref')
 const createRetryOnEmptyMiddleware = require('eth-json-rpc-middleware/retryOnEmpty')
 const createBlockCacheMiddleware = require('eth-json-rpc-middleware/block-cache')
@@ -16,6 +17,7 @@ function createInfuraClient ({ network }) {
   const blockTracker = new BlockTracker({ provider: infuraProvider })
 
   const networkMiddleware = mergeMiddleware([
+    createNetworkAndChainIdMiddleware({ network }),
     createBlockCacheMiddleware({ blockTracker }),
     createInflightMiddleware(),
     createBlockReRefMiddleware({ blockTracker, provider: infuraProvider }),
@@ -24,4 +26,31 @@ function createInfuraClient ({ network }) {
     infuraMiddleware,
   ])
   return { networkMiddleware, blockTracker }
+}
+
+function createNetworkAndChainIdMiddleware({ network }) {
+  let eth_chainId
+  let net_version
+
+  switch (network) {
+    case 'mainnet':
+      net_version = '1'
+      eth_chainId = '0x01'
+      break
+    case 'ropsten':
+      net_version = '3'
+      eth_chainId = '0x03'
+      break
+    case 'kovan':
+      net_version = '42'
+      eth_chainId = '0x2a'
+      break
+    default:
+      throw new Error(`createInfuraClient - unknown network "${network}"`)
+  }
+
+  return createScaffoldMiddleware({
+    eth_chainId,
+    net_version,
+  })
 }

--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -41,6 +41,10 @@ function createNetworkAndChainIdMiddleware({ network }) {
       net_version = '3'
       eth_chainId = '0x03'
       break
+    case 'rinkeby':
+      net_version = '4'
+      eth_chainId = '0x04'
+      break
     case 'kovan':
       net_version = '42'
       eth_chainId = '0x2a'


### PR DESCRIPTION
Fixes #5664 

When using infura based networks, handle `net_version` and `eth_chainId` requests in the client via value set based on the selected network name (eg `"mainnet"` `"ropsten"`)

besides skipping unnecessary network requests, this supports `eth_chainId` ahead of infura releasing support for that method