### PR TITLE
Update "Learn more" link on 1102 connect screen

### DIFF
--- a/ui/app/components/provider-page-container/provider-page-container-content/provider-page-container-content.component.js
+++ b/ui/app/components/provider-page-container/provider-page-container-content/provider-page-container-content.component.js
@@ -59,7 +59,13 @@ export default class ProviderPageContainerContent extends PureComponent {
           <p>
             {t('providerRequestInfo')}
             <br/>
-            <a href="#">{t('learnMore')}.</a>
+            <a
+              href="https://medium.com/metamask/introducing-privacy-mode-42549d4870fa"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('learnMore')}.
+            </a>
           </p>
         </section>
         <section className="secure-badge">


### PR DESCRIPTION
This PR updates the "Learn more" link we're showing on the 1102 screen