### PR TITLE
1102: Bypass CSP restrictions

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -151,20 +151,20 @@ function listenForProviderRequest () {
     switch (action) {
       case 'approve-provider-request':
         isEnabled = true
-        injectScript(`window.dispatchEvent(new CustomEvent('ethereumprovider', { detail: {}}))`)
+        window.postMessage({ type: 'ethereumprovider' }, '*')
         break
       case 'reject-provider-request':
-        injectScript(`window.dispatchEvent(new CustomEvent('ethereumprovider', { detail: { error: 'User rejected provider access' }}))`)
+        window.postMessage({ type: 'ethereumprovider', error: 'User rejected provider access' }, '*')
         break
       case 'answer-is-approved':
-        injectScript(`window.dispatchEvent(new CustomEvent('ethereumisapproved', { detail: { isApproved: ${isApproved}, caching: ${caching}}}))`)
+        window.postMessage({ type: 'ethereumisapproved', isApproved, caching }, '*')
         break
       case 'answer-is-unlocked':
-        injectScript(`window.dispatchEvent(new CustomEvent('metamaskisunlocked', { detail: { isUnlocked: ${isUnlocked}}}))`)
+        window.postMessage({ type: 'metamaskisunlocked', isUnlocked }, '*')
         break
       case 'metamask-set-locked':
         isEnabled = false
-        injectScript(`window.dispatchEvent(new CustomEvent('metamasksetlocked', { detail: {}}))`)
+        window.postMessage({ type: 'metamasksetlocked' }, '*')
         break
     }
   })

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -54,12 +54,12 @@ var inpageProvider = new MetamaskInpageProvider(metamaskStream)
 inpageProvider.setMaxListeners(100)
 
 // set up a listener for when MetaMask is locked
-onMessage('metamasksetlocked', ({ data: { type } }) => { isEnabled = false })
+onMessage('metamasksetlocked', () => { isEnabled = false })
 
 // augment the provider with its enable method
 inpageProvider.enable = function ({ force } = {}) {
   return new Promise((resolve, reject) => {
-    providerHandle = ({ data: { type, error } }) => {
+    providerHandle = ({ data: { error } }) => {
       if (typeof error !== 'undefined') {
         reject(error)
       } else {
@@ -119,16 +119,12 @@ inpageProvider._metamask = new Proxy({
    * @returns {Promise<boolean>} - Promise resolving to true if this domain has been previously approved
    */
   isApproved: function() {
-    return new Promise((resolve, reject) => {
-      isApprovedHandle = ({ data: { caching, isApproved, error, type } }) => {
-        if (typeof error !== 'undefined') {
-          reject(error)
+    return new Promise((resolve) => {
+      isApprovedHandle = ({ data: { caching, isApproved } }) => {
+        if (caching) {
+          resolve(!!isApproved)
         } else {
-          if (caching) {
-            resolve(!!isApproved)
-          } else {
-            resolve(false)
-          }
+          resolve(false)
         }
       }
       onMessage('ethereumisapproved', isApprovedHandle, true)
@@ -142,13 +138,9 @@ inpageProvider._metamask = new Proxy({
    * @returns {Promise<boolean>} - Promise resolving to true if MetaMask is currently unlocked
    */
   isUnlocked: function () {
-    return new Promise((resolve, reject) => {
-      isUnlockedHandle = ({ data: { isUnlocked, error, type } }) => {
-        if (typeof error !== 'undefined') {
-          reject(error)
-        } else {
-          resolve(!!isUnlocked)
-        }
+    return new Promise((resolve) => {
+      isUnlockedHandle = ({ data: { isUnlocked } }) => {
+        resolve(!!isUnlocked)
       }
       onMessage('metamaskisunlocked', isUnlockedHandle, true)
       window.postMessage({ type: 'METAMASK_IS_UNLOCKED' }, '*')


### PR DESCRIPTION
This pull request modifies the 1102 implementation to use `postMessage` to communicate between the `contentscript` and the `inpage` instead of injecting inline scripts that trigger events. This is because inline script execution requires downstream sites to configure their CSP policy accordingly, which seems overly restrictive on our part.

**Note:** This fixes the IDEX exchange issue encountered when using Firefox.