### PR TITLE
Bugfix for #5708: Fix inpage listener throwing

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -30,8 +30,8 @@ console.warn('ATTENTION: In an effort to improve user privacy, MetaMask ' +
  * @param {boolean} remove - removes this handler after being triggered
  */
 function onMessage(messageType, handler, remove) {
-  window.addEventListener('message', function ({ data: { type } }) {
-    if (type !== messageType) { return }
+  window.addEventListener('message', function ({ data }) {
+    if (!data || data.type !== messageType) { return }
     remove && window.removeEventListener('message', handler)
     handler.apply(window, arguments)
   })


### PR DESCRIPTION
Fixes #5708.

In `onMessage` introduced in #5693, the `data` field of the message is now checked before accessing its `type` field. Previously, the listener would throw an error for any message that didn't contain a `data` field.