### PR TITLE
EIP-1102: Update publicConfig store with approval

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -147,11 +147,15 @@ function listenForProviderRequest () {
     }
   })
 
-  extension.runtime.onMessage.addListener(({ action = '', isApproved, caching, isUnlocked }) => {
+  extension.runtime.onMessage.addListener(({ action = '', isApproved, caching, isUnlocked, selectedAddress }) => {
     switch (action) {
       case 'approve-provider-request':
         isEnabled = true
-        window.postMessage({ type: 'ethereumprovider' }, '*')
+        window.postMessage({ type: 'ethereumprovider', selectedAddress }, '*')
+        break
+      case 'approve-legacy-provider-request':
+        isEnabled = true
+        window.postMessage({ type: 'ethereumproviderlegacy', selectedAddress }, '*')
         break
       case 'reject-provider-request':
         window.postMessage({ type: 'ethereumprovider', error: 'User rejected provider access' }, '*')

--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -88,7 +88,10 @@ class ProviderApprovalController {
   _handlePrivacyRequest () {
     const privacyMode = this.preferencesController.getFeatureFlags().privacyMode
     if (!privacyMode) {
-      this.platform && this.platform.sendMessage({ action: 'approve-provider-request' }, { active: true })
+      this.platform && this.platform.sendMessage({
+        action: 'approve-legacy-provider-request',
+        selectedAddress: this.publicConfigStore.getState().selectedAddress,
+      }, { active: true })
       this.publicConfigStore.emit('update', this.publicConfigStore.getState())
     }
   }
@@ -101,7 +104,10 @@ class ProviderApprovalController {
   approveProviderRequest (origin) {
     this.closePopup && this.closePopup()
     const requests = this.store.getState().providerRequests || []
-    this.platform && this.platform.sendMessage({ action: 'approve-provider-request' }, { active: true })
+    this.platform && this.platform.sendMessage({
+      action: 'approve-provider-request',
+      selectedAddress: this.publicConfigStore.getState().selectedAddress,
+    }, { active: true })
     this.publicConfigStore.emit('update', this.publicConfigStore.getState())
     const providerRequests = requests.filter(request => request.origin !== origin)
     this.store.updateState({ providerRequests })

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -56,45 +56,31 @@ inpageProvider.setMaxListeners(100)
 // set up a listener for when MetaMask is locked
 onMessage('metamasksetlocked', () => { isEnabled = false })
 
+// set up a listener for privacy mode responses
+onMessage('ethereumproviderlegacy', ({ data: { selectedAddress } }) => {
+  isEnabled = true
+  inpageProvider.publicConfigStore.updateState({ selectedAddress })
+}, true)
+
 // augment the provider with its enable method
 inpageProvider.enable = function ({ force } = {}) {
   return new Promise((resolve, reject) => {
-    providerHandle = ({ data: { error } }) => {
+    providerHandle = ({ data: { error, selectedAddress } }) => {
       if (typeof error !== 'undefined') {
         reject(error)
       } else {
         window.removeEventListener('message', providerHandle)
-        // wait for the publicConfig store to populate with an account
-        const publicConfig = new Promise((resolve) => {
-          const { selectedAddress } = inpageProvider.publicConfigStore.getState()
-          inpageProvider._metamask.isUnlocked().then(unlocked => {
-            if (!unlocked || selectedAddress) {
-              resolve()
-            } else {
-              inpageProvider.publicConfigStore.on('update', ({ selectedAddress }) => {
-                selectedAddress && resolve()
-              })
-            }
-          })
-        })
+        inpageProvider.publicConfigStore.updateState({ selectedAddress })
 
         // wait for the background to update with an account
-        const ethAccounts = new Promise((resolveAccounts, rejectAccounts) => {
-          inpageProvider.sendAsync({ method: 'eth_accounts', params: [] }, (error, response) => {
-            if (error) {
-              rejectAccounts(error)
-            } else {
-              resolveAccounts(response.result)
-            }
-          })
-        })
-
-        Promise.all([ethAccounts, publicConfig])
-          .then(([selectedAddress]) => {
+        inpageProvider.sendAsync({ method: 'eth_accounts', params: [] }, (error, response) => {
+          if (error) {
+            reject(error)
+          } else {
             isEnabled = true
-            resolve(selectedAddress)
-          })
-          .catch(reject)
+            resolve(response.result)
+          }
+        })
       }
     }
     onMessage('ethereumprovider', providerHandle, true)


### PR DESCRIPTION
This pull request fixes a race condition when switching to "privacy mode" in certain scenarios. Specifically, these changes update the logic used to update the in-page `publicConfigStore` after approval (both after an `enable` call and after a "privacy mode" settings check initiated on load.) In both cases, an update to the `publicConfigStore` was triggered from the background context from the `ProviderApprovalController`, but this would sometimes happen before in-page listeners were set up. To fix this, instead of hoping the `publicConfigStore` would update at the right time, we don't rely on this at all anymore. Instead, we shuffle the `selectedAddress` along with the approval response and manually update the store directly.

**To reproduce the original issue:**

1. Before pulling this branch, disable "privacy mode".
2. Unlock MetaMask.
3. Refresh any webpage and log `web3.eth.accounts` in the console as soon as possible.
4. Note that it's empty in "privacy mode" with an unlocked MetaMask.

To verify this fix, the exact same steps can be used but with this branch built and deployed.

Resolves #5716