### PR TITLE
Reset Instructions Link

### DIFF
--- a/old-ui/app/config.js
+++ b/old-ui/app/config.js
@@ -288,7 +288,7 @@ ConfigScreen.prototype.render = function () {
             }, [
               'Resetting is for developer use only. ',
               h('a', {
-                href: 'http://metamask.helpscoutdocs.com/article/36-resetting-an-account',
+                href: 'https://metamask.zendesk.com/hc/en-us/articles/360015489231-Resetting-an-Account-Old-UI-',
                 target: '_blank',
               }, 'Read more.'),
             ]),


### PR DESCRIPTION
This repairs the "Read more" link to the reset instructions in the old UI.

Related: https://github.com/MetaMask/metamask-extension/issues/5727