### PR TITLE
Update Balanc3 API

### DIFF
--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -14,8 +14,9 @@ class TokenRatesController {
    *
    * @param {Object} [config] - Options to configure controller
    */
-  constructor ({ interval = DEFAULT_INTERVAL, preferences } = {}) {
+  constructor ({ interval = DEFAULT_INTERVAL, currency, preferences } = {}) {
     this.store = new ObservableStore()
+    this.currency = currency
     this.preferences = preferences
     this.interval = interval
   }
@@ -26,11 +27,12 @@ class TokenRatesController {
   async updateExchangeRates () {
     if (!this.isActive) { return }
     const contractExchangeRates = {}
-    const pairs = this._tokens.map(token => `pairs[]=${token.address}/ETH`)
+    const nativeCurrency = this.currency ? this.currency.getState().nativeCurrency.toUpperCase() : 'ETH'
+    const pairs = this._tokens.map(token => `pairs[]=${token.address}/${nativeCurrency}`)
     const query = pairs.join('&')
     if (this._tokens.length > 0) {
       try {
-        const response = await fetch(`https://exchanges.demo.balanc3.net/pie?${query}&autoConversion=true`)
+        const response = await fetch(`https://exchanges.balanc3.net/pie?${query}&autoConversion=true`)
         const { prices = [] } = await response.json()
         prices.forEach(({ pair, price }) => {
           contractExchangeRates[pair.split('/')[0]] = typeof price === 'number' ? price : 0

--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -26,30 +26,20 @@ class TokenRatesController {
   async updateExchangeRates () {
     if (!this.isActive) { return }
     const contractExchangeRates = {}
-    // copy array to ensure its not modified during iteration
-    const tokens = this._tokens.slice()
-    for (const token of tokens) {
-      if (!token) return log.error(`TokenRatesController - invalid tokens state:\n${JSON.stringify(tokens, null, 2)}`)
-      const address = token.address
-      contractExchangeRates[address] = await this.fetchExchangeRate(address)
+    const pairs = this._tokens.map(token => `pairs[]=${token.address}/ETH`)
+    const query = pairs.join('&')
+    if (this._tokens.length > 0) {
+      try {
+        const response = await fetch(`https://exchanges.demo.balanc3.net/pie?${query}&autoConversion=true`)
+        const { prices = [] } = await response.json()
+        prices.forEach(({ pair, price }) => {
+          contractExchangeRates[pair.split('/')[0]] = typeof price === 'number' ? price : 0
+        })
+      } catch (error) {
+        log.warn(`MetaMask - TokenRatesController exchange rate fetch failed.`, error)
+      }
     }
     this.store.putState({ contractExchangeRates })
-  }
-
-  /**
-   * Fetches a token exchange rate by address
-   *
-   * @param {String} address - Token contract address
-   */
-  async fetchExchangeRate (address) {
-    try {
-      const response = await fetch(`https://metamask.balanc3.net/prices?from=${address}&to=ETH&autoConversion=false&summaryOnly=true`)
-      const json = await response.json()
-      return json && json.length ? json[0].averagePrice : 0
-    } catch (error) {
-      log.warn(`MetaMask - TokenRatesController exchange rate fetch failed for ${address}.`, error)
-      return 0
-    }
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -117,6 +117,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
     // token exchange rate tracker
     this.tokenRatesController = new TokenRatesController({
+      currency: this.currencyController.store,
       preferences: this.preferencesController.store,
     })
 

--- a/test/unit/app/controllers/token-rates-controller.js
+++ b/test/unit/app/controllers/token-rates-controller.js
@@ -17,13 +17,4 @@ describe('TokenRatesController', () => {
     assert.strictEqual(stub.getCall(0).args[1], 1337)
     stub.restore()
   })
-
-  it('should fetch each token rate based on address', async () => {
-    const controller = new TokenRatesController()
-    controller.isActive = true
-    controller.fetchExchangeRate = address => address
-    controller.tokens = [{ address: 'foo' }, { address: 'bar' }]
-    await controller.updateExchangeRates()
-    assert.deepEqual(controller.store.getState().contractExchangeRates, { foo: 'foo', bar: 'bar' })
-  })
 })


### PR DESCRIPTION
This pull request updates the Balanc3 URL used by the TokenRatesController to fetch token-to-ETH exchange rates. The controller now uses a bulk pricing endpoint that allows all exchange rates to be fetched in a single HTTP request.

Resolves #5741 
Resolves #5062