### PR TITLE
Update support links to zendesk

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Support
 
-If you're a user seeking support, [here is our support site](https://metamask.helpscoutdocs.com/).
+If you're a user seeking support, [here is our support site](https://metamask.zendesk.com/hc/en-us).
 
 ## Introduction
 

--- a/old-ui/app/accounts/import/index.js
+++ b/old-ui/app/accounts/import/index.js
@@ -59,7 +59,7 @@ AccountImportSubview.prototype.render = function () {
           },
           onClick: () => {
             global.platform.openWindow({
-              url: 'https://metamask.helpscoutdocs.com/article/17-what-are-loose-accounts',
+              url: 'https://metamask.zendesk.com/hc/en-us/articles/360015289592-What-Are-Loose-Accounts-',
             })
           },
         }, 'here.'),


### PR DESCRIPTION
There were two links still pointing to our old support site. This PR fixes it.