### PR TITLE
New gas customize final fixes

### DIFF
--- a/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
+import Loading from '../../../loading-screen'
 import GasPriceChart from '../../gas-price-chart'
 
 export default class AdvancedTabContent extends Component {
@@ -13,6 +14,7 @@ export default class AdvancedTabContent extends Component {
     updateCustomGasLimit: PropTypes.func,
     customGasPrice: PropTypes.number,
     customGasLimit: PropTypes.number,
+    gasEstimatesLoading: PropTypes.bool,
     millisecondsRemaining: PropTypes.number,
     totalFee: PropTypes.string,
     timeRemaining: PropTypes.string,
@@ -98,6 +100,7 @@ export default class AdvancedTabContent extends Component {
       insufficientBalance,
       totalFee,
       gasChartProps,
+      gasEstimatesLoading,
     } = this.props
 
     return (
@@ -112,7 +115,10 @@ export default class AdvancedTabContent extends Component {
               insufficientBalance
           ) }
           <div className="advanced-tab__fee-chart__title">Live Gas Price Predictions</div>
-          <GasPriceChart {...gasChartProps} updateCustomGasPrice={updateCustomGasPrice} />
+          {!gasEstimatesLoading
+            ? <GasPriceChart {...gasChartProps} updateCustomGasPrice={updateCustomGasPrice} />
+            : <Loading />
+          }
           <div className="advanced-tab__fee-chart__speed-buttons">
             <span>Slower</span>
             <span>Faster</span>

--- a/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon'
 import AdvancedTabContent from '../advanced-tab-content.component.js'
 
 import GasPriceChart from '../../../gas-price-chart'
+import Loading from '../../../../loading-screen'
 
 const propsMethodSpies = {
   updateCustomGasPrice: sinon.spy(),
@@ -57,6 +58,22 @@ describe('AdvancedTabContent Component', function () {
       assert(feeChartDiv.childAt(0).hasClass('advanced-tab__gas-edit-rows'))
       assert(feeChartDiv.childAt(1).hasClass('advanced-tab__fee-chart__title'))
       assert(feeChartDiv.childAt(2).is(GasPriceChart))
+      assert(feeChartDiv.childAt(3).hasClass('advanced-tab__fee-chart__speed-buttons'))
+    })
+
+    it('should render a loading component instead of the chart if gasEstimatesLoading is true', () => {
+      wrapper.setProps({ gasEstimatesLoading: true })
+      const advancedTabChildren = wrapper.children()
+      assert.equal(advancedTabChildren.length, 2)
+
+      assert(advancedTabChildren.at(0).hasClass('advanced-tab__transaction-data-summary'))
+      assert(advancedTabChildren.at(1).hasClass('advanced-tab__fee-chart'))
+
+      const feeChartDiv = advancedTabChildren.at(1)
+
+      assert(feeChartDiv.childAt(0).hasClass('advanced-tab__gas-edit-rows'))
+      assert(feeChartDiv.childAt(1).hasClass('advanced-tab__fee-chart__title'))
+      assert(feeChartDiv.childAt(2).is(Loading))
       assert(feeChartDiv.childAt(3).hasClass('advanced-tab__fee-chart__speed-buttons'))
     })
 

--- a/ui/app/components/gas-customization/gas-modal-page-container/basic-tab-content/basic-tab-content.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/basic-tab-content/basic-tab-content.component.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import Loading from '../../../loading-screen'
 import GasPriceButtonGroup from '../../gas-price-button-group'
 
 export default class BasicTabContent extends Component {
@@ -12,15 +13,20 @@ export default class BasicTabContent extends Component {
   }
 
   render () {
+    const { gasPriceButtonGroupProps } = this.props
+
     return (
       <div className="basic-tab-content">
         <div className="basic-tab-content__title">Estimated Processing Times</div>
         <div className="basic-tab-content__blurb">Select a higher gas fee to accelerate the processing of your transaction.*</div>
-        <GasPriceButtonGroup
-          className="gas-price-button-group--alt"
-          showCheck={true}
-          {...this.props.gasPriceButtonGroupProps}
-        />
+        {!gasPriceButtonGroupProps.loading
+            ? <GasPriceButtonGroup
+              className="gas-price-button-group--alt"
+              showCheck={true}
+              {...gasPriceButtonGroupProps}
+            />
+            : <Loading />
+        }
         <div className="basic-tab-content__footer-blurb">* Accelerating a transaction by using a higher gas price increases its chances of getting processed by the network faster, but it is not always guaranteed.</div>
       </div>
     )

--- a/ui/app/components/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme'
 import BasicTabContent from '../basic-tab-content.component'
 
 import GasPriceButtonGroup from '../../../gas-price-button-group/'
+import Loading from '../../../../loading-screen'
 
 const mockGasPriceButtonGroupProps = {
   buttonDataLoading: false,
@@ -60,12 +61,22 @@ describe('BasicTabContent Component', function () {
         noButtonActiveByDefault,
         showCheck,
       } = wrapper.find(GasPriceButtonGroup).props()
+      assert.equal(wrapper.find(GasPriceButtonGroup).length, 1)
       assert.equal(buttonDataLoading, mockGasPriceButtonGroupProps.buttonDataLoading)
       assert.equal(className, mockGasPriceButtonGroupProps.className)
       assert.equal(noButtonActiveByDefault, mockGasPriceButtonGroupProps.noButtonActiveByDefault)
       assert.equal(showCheck, mockGasPriceButtonGroupProps.showCheck)
       assert.deepEqual(gasButtonInfo, mockGasPriceButtonGroupProps.gasButtonInfo)
       assert.equal(JSON.stringify(handleGasPriceSelection), JSON.stringify(mockGasPriceButtonGroupProps.handleGasPriceSelection))
+    })
+
+    it('should render a loading component instead of the GasPriceButtonGroup if gasPriceButtonGroupProps.loading is true', () => {
+      wrapper.setProps({
+        gasPriceButtonGroupProps: { ...mockGasPriceButtonGroupProps, loading: true },
+      })
+
+      assert.equal(wrapper.find(GasPriceButtonGroup).length, 0)
+      assert.equal(wrapper.find(Loading).length, 1)
     })
   })
 })

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -68,6 +68,7 @@ export default class GasModalPageContainer extends Component {
     gasChartProps,
     currentTimeEstimate,
     insufficientBalance,
+    gasEstimatesLoading,
   }) {
     const { transactionFee } = this.props
     return (
@@ -81,6 +82,7 @@ export default class GasModalPageContainer extends Component {
         totalFee={newTotalFiat}
         gasChartProps={gasChartProps}
         insufficientBalance={insufficientBalance}
+        gasEstimatesLoading={gasEstimatesLoading}
       />
     )
   }

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -32,6 +32,7 @@ import {
   formatTimeEstimate,
   getFastPriceEstimateInHexWEI,
   getBasicGasEstimateLoadingStatus,
+  getGasEstimatesLoadingStatus,
   getCustomGasLimit,
   getCustomGasPrice,
   getDefaultActiveButtonIndex,
@@ -65,6 +66,8 @@ import { getAdjacentGasPrices, extrapolateY } from '../gas-price-chart/gas-price
 const mapStateToProps = (state, ownProps) => {
   const { transaction = {} } = ownProps
   const buttonDataLoading = getBasicGasEstimateLoadingStatus(state)
+  const gasEstimatesLoading = getGasEstimatesLoadingStatus(state)
+
   const { gasPrice: currentGasPrice, gas: currentGasLimit, value } = getTxParams(state, transaction.id)
   const customModalGasPriceInHex = getCustomGasPrice(state) || currentGasPrice
   const customModalGasLimitInHex = getCustomGasLimit(state) || currentGasLimit
@@ -127,6 +130,7 @@ const mapStateToProps = (state, ownProps) => {
     isSpeedUp: transaction.status === 'submitted',
     txId: transaction.id,
     insufficientBalance,
+    gasEstimatesLoading,
   }
 }
 

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -232,6 +232,7 @@ describe('GasModalPageContainer Component', function () {
         customGasLimit: 456,
         newTotalFiat: '$0.30',
         currentTimeEstimate: '1 min 31 sec',
+        gasEstimatesLoading: 'mockGasEstimatesLoading',
       })
       const advancedTabContentProps = renderAdvancedTabContentResult.props
       assert.equal(advancedTabContentProps.updateCustomGasPrice(), 'mockConvertThenUpdateCustomGasPrice')
@@ -240,6 +241,7 @@ describe('GasModalPageContainer Component', function () {
       assert.equal(advancedTabContentProps.customGasLimit, 456)
       assert.equal(advancedTabContentProps.timeRemaining, '1 min 31 sec')
       assert.equal(advancedTabContentProps.totalFee, '$0.30')
+      assert.equal(advancedTabContentProps.gasEstimatesLoading, 'mockGasEstimatesLoading')
     })
   })
 

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -80,6 +80,7 @@ describe('gas-modal-page-container container', () => {
             limit: 'aaaaaaaa',
             price: 'ffffffff',
           },
+          gasEstimatesLoading: false,
           priceAndTimeEstimates: [
             { gasprice: 3, expectedTime: '31' },
             { gasprice: 4, expectedTime: '62' },
@@ -118,6 +119,7 @@ describe('gas-modal-page-container container', () => {
           defaultActiveButtonIndex: 'mockRenderableBasicEstimateData:4ffffffff',
           gasButtonInfo: 'mockRenderableBasicEstimateData:4',
         },
+        gasEstimatesLoading: false,
         hideBasic: true,
         infoRowProps: {
           originalTotalFiat: '637.41',

--- a/ui/app/components/gas-customization/gas-price-chart/gas-price-chart.component.js
+++ b/ui/app/components/gas-customization/gas-price-chart/gas-price-chart.component.js
@@ -33,16 +33,19 @@ export default class GasPriceChart extends Component {
     updateCustomGasPrice,
   }) {
     const chart = generateChart(gasPrices, estimatedTimes, gasPricesMax, estimatedTimesMax)
-
     setTimeout(function () {
       setTickPosition('y', 0, -5, 8)
       setTickPosition('y', 1, -3, -5)
-      setTickPosition('x', 0, 3, 15)
+      setTickPosition('x', 0, 3)
       setTickPosition('x', 1, 3, -8)
 
-      // TODO: Confirm the below constants work with all data sets and screen sizes
+      const { x: domainX } = getCoordinateData('.domain')
+      const { x: yAxisX } = getCoordinateData('.c3-axis-y-label')
+      const { x: tickX } = getCoordinateData('.c3-axis-x .tick')
+
+      d3.select('.c3-axis-x .tick').attr('transform', 'translate(' + (domainX - tickX) / 2 + ', 0)')
       d3.select('.c3-axis-x-label').attr('transform', 'translate(0,-15)')
-      d3.select('.c3-axis-y-label').attr('transform', 'translate(52, 2) rotate(-90)')
+      d3.select('.c3-axis-y-label').attr('transform', 'translate(' + (domainX - yAxisX - 12) + ', 2) rotate(-90)')
       d3.select('.c3-xgrid-focus line').attr('y2', 98)
 
       d3.select('.c3-chart').on('mouseout', () => {

--- a/ui/app/components/gas-customization/gas-price-chart/gas-price-chart.utils.js
+++ b/ui/app/components/gas-customization/gas-price-chart/gas-price-chart.utils.js
@@ -12,6 +12,7 @@ export function handleMouseMove ({ xMousePos, chartXStart, chartWidth, gasPrices
 
   if (currentPosValue === null && newTimeEstimate === null) {
     hideDataUI(chart, '#overlayed-circle')
+    return
   }
 
   const indexOfNewCircle = estimatedTimes.length + 1
@@ -162,7 +163,13 @@ export function setSelectedCircle ({
 }) {
   const numberOfValues = chart.internal.data.xs.data1.length
   const { x: lowerX, y: lowerY } = getCoordinateData(`.c3-circle-${closestLowerValueIndex}`)
-  const { x: higherX, y: higherY } = getCoordinateData(`.c3-circle-${closestHigherValueIndex}`)
+  let { x: higherX, y: higherY } = getCoordinateData(`.c3-circle-${closestHigherValueIndex}`)
+
+  if (lowerX === higherX) {
+    const { x: higherXAdjusted, y: higherYAdjusted } = getCoordinateData(`.c3-circle-${closestHigherValueIndex + 1}`)
+    higherY = higherYAdjusted
+    higherX = higherXAdjusted
+  }
 
   const currentX = lowerX + (higherX - lowerX) * (newPrice - closestLowerValue) / (closestHigherValue - closestLowerValue)
   const newTimeEstimate = extrapolateY({ higherY, lowerY, higherX, lowerX, xForExtrapolation: currentX })
@@ -203,13 +210,13 @@ export function generateChart (gasPrices, estimatedTimes, gasPricesMax, estimate
     axis: {
       x: {
         min: gasPrices[0],
-        max: gasPricesMaxPadded,
+        max: gasPricesMax,
         tick: {
-          values: [Math.floor(gasPrices[0]), Math.ceil(gasPricesMaxPadded)],
+          values: [Math.floor(gasPrices[0]), Math.ceil(gasPricesMax)],
           outer: false,
           format: function (val) { return val + ' GWEI' },
         },
-        padding: {left: gasPricesMaxPadded / 50, right: gasPricesMaxPadded / 50},
+        padding: {left: gasPricesMax / 50, right: gasPricesMax / 50},
         label: {
           text: 'Gas Price ($)',
           position: 'outer-center',

--- a/ui/app/components/gas-customization/gas-price-chart/tests/gas-price-chart.component.test.js
+++ b/ui/app/components/gas-customization/gas-price-chart/tests/gas-price-chart.component.test.js
@@ -136,7 +136,7 @@ describe('GasPriceChart Component', function () {
       assert.equal(gasPriceChartUtilsSpies.setTickPosition.callCount, 4)
       assert.deepEqual(gasPriceChartUtilsSpies.setTickPosition.getCall(0).args, ['y', 0, -5, 8])
       assert.deepEqual(gasPriceChartUtilsSpies.setTickPosition.getCall(1).args, ['y', 1, -3, -5])
-      assert.deepEqual(gasPriceChartUtilsSpies.setTickPosition.getCall(2).args, ['x', 0, 3, 15])
+      assert.deepEqual(gasPriceChartUtilsSpies.setTickPosition.getCall(2).args, ['x', 0, 3])
       assert.deepEqual(gasPriceChartUtilsSpies.setTickPosition.getCall(3).args, ['x', 1, 3, -8])
     })
 

--- a/ui/app/components/modals/modal.js
+++ b/ui/app/components/modals/modal.js
@@ -4,6 +4,7 @@ const inherits = require('util').inherits
 const connect = require('react-redux').connect
 const FadeModal = require('boron').FadeModal
 const actions = require('../../actions')
+const { resetCustomData: resetCustomGasData } = require('../../ducks/gas.duck')
 const isMobileView = require('../../../lib/is-mobile-view')
 const { getEnvironmentType } = require('../../../../app/scripts/lib/util')
 const { ENVIRONMENT_TYPE_POPUP } = require('../../../../app/scripts/lib/enums')
@@ -317,6 +318,10 @@ const MODALS = {
     contentStyle: {
       borderRadius: '8px',
     },
+    customOnHideOpts: {
+      action: resetCustomGasData,
+      args: [],
+    },
   },
 
   TRANSACTION_CONFIRMED: {
@@ -392,8 +397,11 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    hideModal: () => {
+    hideModal: (customOnHideOpts) => {
       dispatch(actions.hideModal())
+      if (customOnHideOpts.action) {
+        dispatch(customOnHideOpts.action(...customOnHideOpts.args))
+      }
     },
     hideWarning: () => {
       dispatch(actions.hideWarning())
@@ -425,7 +433,7 @@ Modal.prototype.render = function () {
         if (modal.onHide) {
           modal.onHide(this.props)
         }
-        this.onHide()
+        this.onHide(modal.customOnHideOpts)
       },
       ref: (ref) => {
         this.modalRef = ref
@@ -447,11 +455,11 @@ Modal.prototype.componentWillReceiveProps = function (nextProps) {
   }
 }
 
-Modal.prototype.onHide = function () {
+Modal.prototype.onHide = function (customOnHideOpts) {
   if (this.props.onHideCallback) {
     this.props.onHideCallback()
   }
-  this.props.hideModal()
+  this.props.hideModal(customOnHideOpts)
 }
 
 Modal.prototype.hide = function () {

--- a/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/components/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -348,7 +348,7 @@ export default class ConfirmTransactionBase extends Component {
       />
     )
   }
-  
+
   handleNextTx (txId) {
     const { history, clearConfirmTransaction } = this.props
     if (txId) {

--- a/ui/app/ducks/tests/gas-duck.test.js
+++ b/ui/app/ducks/tests/gas-duck.test.js
@@ -45,10 +45,25 @@ describe('Gas Duck', () => {
     speed: 'mockSpeed',
   }
   const mockPredictTableResponse = [
+    { expectedTime: 400, expectedWait: 40, gasprice: 0.25, somethingElse: 'foobar' },
+    { expectedTime: 200, expectedWait: 20, gasprice: 0.5, somethingElse: 'foobar' },
     { expectedTime: 100, expectedWait: 10, gasprice: 1, somethingElse: 'foobar' },
+    { expectedTime: 75, expectedWait: 7.5, gasprice: 1.5, somethingElse: 'foobar' },
     { expectedTime: 50, expectedWait: 5, gasprice: 2, somethingElse: 'foobar' },
+    { expectedTime: 35, expectedWait: 4.5, gasprice: 3, somethingElse: 'foobar' },
+    { expectedTime: 34, expectedWait: 4.4, gasprice: 3.1, somethingElse: 'foobar' },
+    { expectedTime: 25, expectedWait: 4.2, gasprice: 3.5, somethingElse: 'foobar' },
     { expectedTime: 20, expectedWait: 4, gasprice: 4, somethingElse: 'foobar' },
+    { expectedTime: 19, expectedWait: 3.9, gasprice: 4.1, somethingElse: 'foobar' },
+    { expectedTime: 15, expectedWait: 3, gasprice: 7, somethingElse: 'foobar' },
+    { expectedTime: 14, expectedWait: 2.9, gasprice: 7.1, somethingElse: 'foobar' },
+    { expectedTime: 12, expectedWait: 2.5, gasprice: 8, somethingElse: 'foobar' },
     { expectedTime: 10, expectedWait: 2, gasprice: 10, somethingElse: 'foobar' },
+    { expectedTime: 9, expectedWait: 1.9, gasprice: 10.1, somethingElse: 'foobar' },
+    { expectedTime: 5, expectedWait: 1, gasprice: 15, somethingElse: 'foobar' },
+    { expectedTime: 4, expectedWait: 0.9, gasprice: 15.1, somethingElse: 'foobar' },
+    { expectedTime: 2, expectedWait: 0.8, gasprice: 17, somethingElse: 'foobar' },
+    { expectedTime: 1.1, expectedWait: 0.6, gasprice: 19.9, somethingElse: 'foobar' },
     { expectedTime: 1, expectedWait: 0.5, gasprice: 20, somethingElse: 'foobar' },
   ]
   const fetchStub = sinon.stub().callsFake((url) => new Promise(resolve => {
@@ -382,35 +397,13 @@ describe('Gas Duck', () => {
         [{ type: SET_API_ESTIMATES_LAST_RETRIEVED, value: 2000000 }]
       )
 
-      assert.deepEqual(
-        mockDistpatch.getCall(2).args,
-        [{
-          type: SET_PRICE_AND_TIME_ESTIMATES,
-          value: [
-            {
-              expectedTime: '25',
-              expectedWait: 5,
-              gasprice: 2,
-            },
-            {
-              expectedTime: '20',
-              expectedWait: 4,
-              gasprice: 4,
-            },
-            {
-              expectedTime: '10',
-              expectedWait: 2,
-              gasprice: 10,
-            },
-            {
-              expectedTime: '2.5',
-              expectedWait: 0.5,
-              gasprice: 20,
-            },
-          ],
+      const { type: thirdDispatchCallType, value: priceAndTimeEstimateResult } = mockDistpatch.getCall(2).args[0]
+      assert.equal(thirdDispatchCallType, SET_PRICE_AND_TIME_ESTIMATES)
+      assert(priceAndTimeEstimateResult.length < mockPredictTableResponse.length * 3 - 2)
+      assert(!priceAndTimeEstimateResult.find(d => d.expectedTime > 100))
+      assert(!priceAndTimeEstimateResult.find((d, i, a) => a[a + 1] && d.expectedTime > a[a + 1].expectedTime))
+      assert(!priceAndTimeEstimateResult.find((d, i, a) => a[a + 1] && d.gasprice > a[a + 1].gasprice))
 
-        }]
-      )
       assert.deepEqual(
         mockDistpatch.getCall(3).args,
         [{ type: GAS_ESTIMATE_LOADING_FINISHED }]

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -33,6 +33,7 @@ const selectors = {
   getDefaultActiveButtonIndex,
   getEstimatedGasPrices,
   getEstimatedGasTimes,
+  getGasEstimatesLoadingStatus,
   getPriceAndTimeEstimates,
   getRenderableBasicEstimateData,
   getRenderableEstimateDataForSmallButtonsFromGWEI,
@@ -61,6 +62,10 @@ function getCustomGasTotal (state) {
 
 function getBasicGasEstimateLoadingStatus (state) {
   return state.gas.basicEstimateIsLoading
+}
+
+function getGasEstimatesLoadingStatus (state) {
+  return state.gas.gasEstimatesLoading
 }
 
 function getPriceAndTimeEstimates (state) {


### PR DESCRIPTION
This PR fixes a few outstanding issues with the gas customization feature:
- Add loading spinners when waiting for APIs in the gas customization modal
- Statistically handles skewed data coming from the predict table api by way of removing outliers
- pads data from the predict table api with random points that fit within extrapolations between that api's points. This allows for a smoother experience using the graph.
- fixes an issue where the graph was highlighting non existent points at the margins
- ensures that custom gas data is reset when the gas modal closes