### PR TITLE
Resubmit approved transactions on new block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Develop Branch
 
+- Resubmit approved transactions on new block, to fix bug where an error can stick transactions in this state.
+
 ## 5.0.2 Friday November 9 2018
 
 - Fixed bug that caused accounts to update slowly to sites. #5717

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -82,7 +82,11 @@ class TransactionController extends EventEmitter {
       provider: this.provider,
       nonceTracker: this.nonceTracker,
       publishTransaction: (rawTx) => this.query.sendRawTransaction(rawTx),
-      getPendingTransactions: this.txStateManager.getPendingTransactions.bind(this.txStateManager),
+      getPendingTransactions: () => {
+        const pending = this.txStateManager.getPendingTransactions.bind(this.txStateManager)
+        const approved = this.txStateManager.getApprovedTransactions.bind(this.txStateManager)
+        return [...pending, ...approved]
+      }
       getCompletedTransactions: this.txStateManager.getConfirmedTransactions.bind(this.txStateManager),
     })
 

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -83,8 +83,8 @@ class TransactionController extends EventEmitter {
       nonceTracker: this.nonceTracker,
       publishTransaction: (rawTx) => this.query.sendRawTransaction(rawTx),
       getPendingTransactions: () => {
-        const pending = this.txStateManager.getPendingTransactions.bind(this.txStateManager)
-        const approved = this.txStateManager.getApprovedTransactions.bind(this.txStateManager)
+        const pending = this.txStateManager.getPendingTransactions()
+        const approved = this.txStateManager.getApprovedTransactions()
         return [...pending, ...approved]
       },
       approveTransaction: this.approveTransaction.bind(this),

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -86,7 +86,8 @@ class TransactionController extends EventEmitter {
         const pending = this.txStateManager.getPendingTransactions.bind(this.txStateManager)
         const approved = this.txStateManager.getApprovedTransactions.bind(this.txStateManager)
         return [...pending, ...approved]
-      }
+      },
+      approveTransaction: this.approveTransaction.bind(this),
       getCompletedTransactions: this.txStateManager.getConfirmedTransactions.bind(this.txStateManager),
     })
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -130,9 +130,12 @@ class PendingTransactionTracker extends EventEmitter {
     const txHash = txMeta.hash
     const txId = txMeta.id
 
+    // Only check submitted txs
+    if (txMeta.status !== 'submitted') return
+
     // extra check in case there was an uncaught error during the
     // signature and submission process
-    if (!txHash && txMeta.status === 'submitted') {
+    if (!txHash) {
       const noTxHashErr = new Error('We had an error while submitting this transaction, please try again.')
       noTxHashErr.name = 'NoTxHashError'
       this.emit('tx:failed', txId, noTxHashErr)

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -132,7 +132,7 @@ class PendingTransactionTracker extends EventEmitter {
 
     // extra check in case there was an uncaught error during the
     // signature and submission process
-    if (!txHash) {
+    if (!txHash && txMeta.status === 'submitted') {
       const noTxHashErr = new Error('We had an error while submitting this transaction, please try again.')
       noTxHashErr.name = 'NoTxHashError'
       this.emit('tx:failed', txId, noTxHashErr)

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -27,6 +27,7 @@ class PendingTransactionTracker extends EventEmitter {
     this.getPendingTransactions = config.getPendingTransactions
     this.getCompletedTransactions = config.getCompletedTransactions
     this.publishTransaction = config.publishTransaction
+    this.approveTransaction = config.approveTransaction
     this.confirmTransaction = config.confirmTransaction
   }
 
@@ -108,7 +109,7 @@ class PendingTransactionTracker extends EventEmitter {
     if (txBlockDistance <= Math.pow(2, retryCount) - 1) return
 
     // Only auto-submit already-signed txs:
-    if (!('rawTx' in txMeta)) return
+    if (!('rawTx' in txMeta)) return this.approveTransaction(txMeta.id)
 
     const rawTx = txMeta.rawTx
     const txHash = await this.publishTransaction(rawTx)

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -87,7 +87,7 @@ class TransactionStateManager extends EventEmitter {
     returns all txMetas who's status is approved for the current network
   */
   getApprovedTransactions(address) {
-    const opts = { status: 'submitted' }
+    const opts = { status: 'approved' }
     if (address) opts.from = address
     return this.getFilteredTxList(opts)
   }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -83,6 +83,17 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
+    @returns {array} the tx list whos status is approved if no address is provide
+    returns all txMetas who's status is approved for the current network
+  */
+  getApprovedTransactions(address) {
+    const opts = { status: 'submitted' }
+    if (address) opts.from = address
+    return this.getFilteredTxList(opts)
+  }
+
+  /**
+    @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
     @returns {array} the tx list whos status is submitted if no address is provide
     returns all txMetas who's status is submitted for the current network
   */

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -212,6 +212,7 @@ describe('PendingTransactionTracker', function () {
       pendingTxTracker.publishTransaction = async (rawTx) => {
         assert.equal(rawTx, txMeta.rawTx, 'Should pass the rawTx')
       }
+      pendingTxTracker.approveTransaction = async () => {}
       sinon.spy(pendingTxTracker, 'publishTransaction')
 
       txMetaToTestExponentialBackoff = Object.assign({}, txMeta, {
@@ -265,6 +266,18 @@ describe('PendingTransactionTracker', function () {
       })
 
       assert.equal(pendingTxTracker.publishTransaction.callCount, 1, 'Should call publish transaction')
+    })
+
+    it('should call opts.approveTransaction with the id if the tx is not signed', async () => {
+      const stubTx = {
+        id: 40,
+      }
+      const approveMock = sinon.stub(pendingTxTracker, 'approveTransaction')
+
+      pendingTxTracker._resubmitTx(stubTx)
+
+      assert.ok(approveMock.called)
+      approveMock.restore()
     })
   })
 

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -24,7 +24,7 @@ describe('PendingTransactionTracker', function () {
     }
     txMetaNoHash = {
       id: 2,
-      status: 'signed',
+      status: 'submitted',
       txParams: { from: '0x1678a085c290ebd122dc42cba69373b5953b831d'},
     }
 

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -313,7 +313,7 @@ describe('Transaction Controller', function () {
         assert.equal(params.gas, originalValue, 'gas unmodified')
         assert.equal(params.gasPrice, originalValue, 'gas price unmodified')
         assert.equal(result.hash, originalValue, `hash was set \n got: ${result.hash} \n expected: ${originalValue}`)
-        assert.equal(result.status, 'submitted' ,'Should have reached the submitted status.')
+        assert.equal(result.status, 'submitted', 'Should have reached the submitted status.')
         signStub.restore()
         pubStub.restore()
         done()

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -319,44 +319,6 @@ describe('Transaction Controller', function () {
         done()
       }).catch(done)
     })
-
-    it('continues operating after a listener throws', async function () {
-      this.timeout(15000)
-      const wrongValue = '0x05'
-
-      txController.addTx(txMeta)
-      providerResultStub.eth_gasPrice = wrongValue
-      providerResultStub.eth_estimateGas = '0x5209'
-
-      const signStub = sinon.stub(txController, 'signTransaction').callsFake(() => Promise.resolve())
-      const setStatusStub = sinon.stub(txController.txStateManager, 'setTxStatusSubmitted').throws()
-      const setStatusStub2 = sinon.stub(txController.txStateManager, 'setTxStatusFailed').throws()
-
-      const pubStub = sinon.stub(txController, 'publishTransaction').callsFake(() => {
-        txController.setTxHash('1', originalValue)
-        txController.txStateManager.setTxStatusSubmitted('1')
-      })
-
-      try {
-        await txController.approveTransaction(txMeta.id)
-      } catch (e) {
-        assert.ok(e, 'stub throws deliberately')
-      }
-      const result = txController.txStateManager.getTx(txMeta.id)
-      const params = result.txParams
-
-      assert.equal(params.gas, originalValue, 'gas unmodified')
-      assert.equal(params.gasPrice, originalValue, 'gas price unmodified')
-      assert.equal(result.hash, originalValue, `hash was set \n got: ${result.hash} \n expected: ${originalValue}`)
-      assert.equal(result.status, 'approved' ,'Should have only reached the approved status.')
-
-      // TODO: Add a way of detecting whether the Controller will continue trying to submit this transaction.
-
-      signStub.restore()
-      pubStub.restore()
-      setStatusStub.restore()
-      setStatusStub2.restore()
-    })
   })
 
   describe('#sign replay-protected tx', function () {

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -470,9 +470,11 @@ describe('Transaction Controller', function () {
         { id: 7, status: 'failed', metamaskNetworkId: currentNetworkId, txParams: {} },
       ])
     })
-    it('should show only submitted transactions as pending transasction', function () {
-      assert(txController.pendingTxTracker.getPendingTransactions().length, 1)
-      assert(txController.pendingTxTracker.getPendingTransactions()[0].status, 'submitted')
+    it('should show only submitted and approved transactions as pending transasction', function () {
+      assert(txController.pendingTxTracker.getPendingTransactions().length, 2)
+      const states = txController.pendingTxTracker.getPendingTransactions().map(tx => tx.status)
+      assert(states.includes('approved'), 'includes approved')
+      assert(states.includes('submitted'), 'includes submitted')
     })
   })
 })


### PR DESCRIPTION
May fix #4343 and related issues, where an error could leave transactions stranded in the approved state.