### PR TITLE
1102: Use meta title if it exists

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -302,6 +302,11 @@ function getSiteName (window) {
     return siteName.content
   }
 
+  const metaTitle = document.querySelector('head > meta[name="title"]')
+  if (metaTitle) {
+    return metaTitle.content
+  }
+
   return document.title
 }
 


### PR DESCRIPTION
This pull request updates the logic used to grab a dapp's title for the approval dialog. We now use `<meta name="title">` if it exists before ultimately falling back to `<title>`, the latter of which is commonly used for dynamic content.

Resolves #5698