### PR TITLE
Update drizzle-test job

### DIFF
--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-set -u
-set -o pipefail
-
 export PATH="$PATH:./node_modules/.bin"
 
 npm run ganache:start -- -b 2 >> /dev/null 2>&1 &


### PR DESCRIPTION
Removing error flags from drizzle setup because when there's a dep. vulnerability npm install  will exit with a non-zero code and it will make the entire job fail when it shouldn't. Removing this flags solves this issue.