### PR TITLE
Auto fail transactions that have been approved for over 12 hours

### DIFF
--- a/app/scripts/migrations/029.js
+++ b/app/scripts/migrations/029.js
@@ -18,9 +18,10 @@ module.exports = {
   version,
 
   migrate: failTxsThat(version, 'Stuck in approved state for too long.', (txMeta) => {
+    const isApproved = txMeta.status === 'approved'
     const createdTime = txMeta.submittedTime
     const now = Date.now()
-    return now - createdTime > unacceptableDelay
+    return isApproved && now - createdTime > unacceptableDelay
   }),
 }
 

--- a/app/scripts/migrations/029.js
+++ b/app/scripts/migrations/029.js
@@ -21,6 +21,6 @@ module.exports = {
     const createdTime = txMeta.submittedTime
     const now = Date.now()
     return now - createdTime > unacceptableDelay
-  })
+  }),
 }
 

--- a/app/scripts/migrations/029.js
+++ b/app/scripts/migrations/029.js
@@ -1,0 +1,26 @@
+// next version number
+const version = 29
+const failTxsThat = require('./fail-tx')
+
+// time
+const seconds = 1000
+const minutes = 60 * seconds
+const hours = 60 * minutes
+const unacceptableDelay = 12 * hours
+
+/*
+
+normalizes txParams on unconfirmed txs
+
+*/
+
+module.exports = {
+  version,
+
+  migrate: failTxsThat(version, 'Stuck in approved state for too long.', (txMeta) => {
+    const createdTime = txMeta.submittedTime
+    const now = Date.now()
+    return now - createdTime > unacceptableDelay
+  })
+}
+

--- a/app/scripts/migrations/fail-tx.js
+++ b/app/scripts/migrations/fail-tx.js
@@ -22,7 +22,7 @@ function transformState (state, condition, reason) {
   if (TransactionController && TransactionController.transactions) {
     const transactions = TransactionController.transactions
 
-    newState.TransactionController.transactions = transactions.map((txMeta, _, txList) => {
+    newState.TransactionController.transactions = transactions.map((txMeta) => {
       if (!condition(txMeta)) {
         return txMeta
       }

--- a/app/scripts/migrations/fail-tx.js
+++ b/app/scripts/migrations/fail-tx.js
@@ -1,0 +1,41 @@
+const clone = require('clone')
+
+module.exports = function (version, reason, condition) {
+  return function (originalVersionedData) {
+    const versionedData = clone(originalVersionedData)
+    versionedData.meta.version = version
+    try {
+      const state = versionedData.data
+      const newState = transformState(state, condition, reason)
+      versionedData.data = newState
+    } catch (err) {
+      console.warn(`MetaMask Migration #${version}` + err.stack)
+    }
+    return Promise.resolve(versionedData)
+
+  }
+}
+
+function transformState (state, condition, reason) {
+  const newState = state
+  const { TransactionController } = newState
+  if (TransactionController && TransactionController.transactions) {
+    const transactions = newState.TransactionController.transactions
+
+    newState.TransactionController.transactions = transactions.map((txMeta, _, txList) => {
+      if (!condition(txMeta)) {
+        return txMeta
+      }
+
+      txMeta.status = 'failed'
+      txMeta.err = {
+        message: reason,
+        note: `Tx automatically failed by migration because ${reason}`,
+      }
+
+      return txMeta
+    })
+  }
+  return newState
+}
+

--- a/app/scripts/migrations/fail-tx.js
+++ b/app/scripts/migrations/fail-tx.js
@@ -20,7 +20,7 @@ function transformState (state, condition, reason) {
   const newState = state
   const { TransactionController } = newState
   if (TransactionController && TransactionController.transactions) {
-    const transactions = newState.TransactionController.transactions
+    const transactions = TransactionController.transactions
 
     newState.TransactionController.transactions = transactions.map((txMeta, _, txList) => {
       if (!condition(txMeta)) {

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -39,4 +39,5 @@ module.exports = [
   require('./026'),
   require('./027'),
   require('./028'),
+  require('./029'),
 ]

--- a/test/unit/migrations/029-test.js
+++ b/test/unit/migrations/029-test.js
@@ -9,24 +9,28 @@ const storage = {
         { 'status': 'approved', id: 1, submittedTime: 0 },
         { 'status': 'approved', id: 2, 'submittedTime': properTime },
         {'status': 'confirmed', id: 3, submittedTime: properTime},
-        {'status': 'submitted', id: 3, submittedTime: properTime},
+        {'status': 'submitted', id: 4, submittedTime: properTime},
+        { 'status': 'submitted', id: 5, 'submittedTime': 0 },
       ],
     },
   },
 }
 
-describe('storage is migrated successfully where transactions that are submitted have submittedTimes', () => {
+describe.only('storage is migrated successfully where transactions that are submitted have submittedTimes', () => {
   it('should auto fail transactions more than 12 hours old', (done) => {
     migration29.migrate(storage)
     .then((migratedData) => {
-      const [txMeta1, txMeta2, txMeta3] = migratedData.data.TransactionController.transactions
+      const txs = migratedData.data.TransactionController.transactions
+      const [txMeta1, txMeta2, txMeta3 ] = txs
       assert.equal(migratedData.meta.version, 29)
 
       assert.equal(txMeta1.status, 'failed', 'old tx is auto failed')
       assert(txMeta1.err.message.includes('too long'), 'error message assigned')
 
-      assert.notEqual(txMeta2.status, 'failed', 'newer tx is not auto failed')
-      assert.notEqual(txMeta3.status, 'failed', 'newer tx is not auto failed')
+      txs.forEach((tx) => {
+        if (tx.id === 1) return
+        assert.notEqual(tx.status, 'failed', 'other tx is not auto failed')
+      })
 
       done()
     }).catch(done)

--- a/test/unit/migrations/029-test.js
+++ b/test/unit/migrations/029-test.js
@@ -1,0 +1,34 @@
+const assert = require('assert')
+const migration29 = require('../../../app/scripts/migrations/029')
+const properTime = (new Date()).getTime()
+const storage = {
+  'meta': {},
+  'data': {
+    'TransactionController': {
+      'transactions': [
+        { 'status': 'approved', id: 1, submittedTime: 0 },
+        { 'status': 'approved', id: 2, 'submittedTime': properTime },
+        {'status': 'confirmed', id: 3, submittedTime: properTime},
+        {'status': 'submitted', id: 3, submittedTime: properTime},
+      ],
+    },
+  },
+}
+
+describe('storage is migrated successfully where transactions that are submitted have submittedTimes', () => {
+  it('should auto fail transactions more than 12 hours old', (done) => {
+    migration29.migrate(storage)
+    .then((migratedData) => {
+      const [txMeta1, txMeta2, txMeta3] = migratedData.data.TransactionController.transactions
+      assert.equal(migratedData.meta.version, 29)
+
+      assert.equal(txMeta1.status, 'failed', 'old tx is auto failed')
+      assert(txMeta1.err.message.includes('too long'), 'error message assigned')
+
+      assert.notEqual(txMeta2.status, 'failed', 'newer tx is not auto failed')
+      assert.notEqual(txMeta3.status, 'failed', 'newer tx is not auto failed')
+
+      done()
+    }).catch(done)
+  })
+})

--- a/test/unit/migrations/029-test.js
+++ b/test/unit/migrations/029-test.js
@@ -7,21 +7,21 @@ const storage = {
     'TransactionController': {
       'transactions': [
         { 'status': 'approved', id: 1, submittedTime: 0 },
-        { 'status': 'approved', id: 2, 'submittedTime': properTime },
-        {'status': 'confirmed', id: 3, submittedTime: properTime},
-        {'status': 'submitted', id: 4, submittedTime: properTime},
-        { 'status': 'submitted', id: 5, 'submittedTime': 0 },
+        { 'status': 'approved', id: 2, submittedTime: properTime },
+        { 'status': 'confirmed', id: 3, submittedTime: properTime },
+        { 'status': 'submitted', id: 4, submittedTime: properTime },
+        { 'status': 'submitted', id: 5, submittedTime: 0 },
       ],
     },
   },
 }
 
-describe.only('storage is migrated successfully where transactions that are submitted have submittedTimes', () => {
+describe('storage is migrated successfully where transactions that are submitted have submittedTimes', () => {
   it('should auto fail transactions more than 12 hours old', (done) => {
     migration29.migrate(storage)
     .then((migratedData) => {
       const txs = migratedData.data.TransactionController.transactions
-      const [txMeta1, txMeta2, txMeta3 ] = txs
+      const [ txMeta1 ] = txs
       assert.equal(migratedData.meta.version, 29)
 
       assert.equal(txMeta1.status, 'failed', 'old tx is auto failed')


### PR DESCRIPTION
Converts txs using a migration.

This migration uses a new helper function that generates tx-failing
migrations, and only requires a version, error message, and condition to
run on each transaction.

Mitigates a potential confusion/frustration with our new logic that auto-retries txs in the `approved` state.