### PR TITLE
re-approve approved transactions on block with out having pending transactions 

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -545,10 +545,11 @@ class TransactionController extends EventEmitter {
 
     function updateSubscription () {
       const pendingTxs = txStateManager.getPendingTransactions()
-      if (!listenersAreActive && pendingTxs.length > 0) {
+      const approvedTxs = txStateManager.getApprovedTransactions()
+      if (!listenersAreActive && pendingTxs.length > 0 && approvedTxs.length > 0) {
         blockTracker.on('latest', latestBlockHandler)
         listenersAreActive = true
-      } else if (listenersAreActive && !pendingTxs.length) {
+      } else if (listenersAreActive && !pendingTxs.length && !approvedTxs.length) {
         blockTracker.removeListener('latest', latestBlockHandler)
         listenersAreActive = false
       }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -71,7 +71,7 @@ class TransactionStateManager extends EventEmitter {
   }
 
   /**
-    @returns {array} the tx list whos status is unapproved
+    @returns {object} the tx list whos status is unapproved
   */
   getUnapprovedTxList () {
     const txList = this.getTxsByMetaData('status', 'unapproved')


### PR DESCRIPTION
before this PR the behavior was if you had no pending transactions then their were no listeners on the block tracker trying to resubmit/re-approve tx's 

this PR will check in the start up of the txController for approved transactions/pennding and call `resubmitPendingTxs` and will ensure that any tx-status:update change will attempt to re-approve approved transactions.