### PR TITLE
1102: Update publicConfigStore on next turn

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -59,7 +59,9 @@ onMessage('metamasksetlocked', () => { isEnabled = false })
 // set up a listener for privacy mode responses
 onMessage('ethereumproviderlegacy', ({ data: { selectedAddress } }) => {
   isEnabled = true
-  inpageProvider.publicConfigStore.updateState({ selectedAddress })
+  setTimeout(() => {
+    inpageProvider.publicConfigStore.updateState({ selectedAddress })
+  }, 0)
 }, true)
 
 // augment the provider with its enable method
@@ -70,7 +72,9 @@ inpageProvider.enable = function ({ force } = {}) {
         reject(error)
       } else {
         window.removeEventListener('message', providerHandle)
-        inpageProvider.publicConfigStore.updateState({ selectedAddress })
+        setTimeout(() => {
+          inpageProvider.publicConfigStore.updateState({ selectedAddress })
+        }, 0)
 
         // wait for the background to update with an account
         inpageProvider.sendAsync({ method: 'eth_accounts', params: [] }, (error, response) => {


### PR DESCRIPTION
This pull request fixes an odd issue that only presented itself in production builds. Specifically, both privacy mode and legacy mode trigger a manual update to the inpage provider's `publicConfigStore`. In production builds, when privacy mode is disabled and a page first loads, this manual update sporadically happened too soon, causing the `selectedAddress` to get correctly set then incorrectly overwritten with `undefined`.

This fix pushes the manual `publicConfigStore` updates to the next turn, guaranteeing that all previously-triggered updates occur before the manually-triggered update that's ultimately required to se the `selectedAddress`. We don't need to add any timeout to the `setTimeout` call because pushing the operation to the next turn already guarantees correct ordering.

Resolves #5716
Resolves #5628