### PR TITLE
Consider HW Wallets for signTypedMessage

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -50,6 +50,7 @@ const seedPhraseVerifier = require('./lib/seed-phrase-verifier')
 const log = require('loglevel')
 const TrezorKeyring = require('eth-trezor-keyring')
 const LedgerBridgeKeyring = require('eth-ledger-bridge-keyring')
+const HW_WALLETS_KEYRINGS = [TrezorKeyring.type, LedgerBridgeKeyring.type]
 const EthQuery = require('eth-query')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
@@ -1021,15 +1022,14 @@ module.exports = class MetamaskController extends EventEmitter {
     log.info('MetaMaskController - eth_signTypedData')
     const msgId = msgParams.metamaskId
     const version = msgParams.version
-    const HW_WALLETS_KEYRINGS = [TrezorKeyring.type, LedgerBridgeKeyring.type]
     try {
       const cleanMsgParams = await this.typedMessageManager.approveMessage(msgParams)
       const address = sigUtil.normalize(cleanMsgParams.from)
       const keyring = await this.keyringController.getKeyringForAccount(address)
       let signature
-      // HW Wallet keyrings don't expose private keys so
-      // we need to handle it separately
-      if (HW_WALLETS_KEYRINGS.indexOf(keyring.type) === -1) {
+      // HW Wallet keyrings don't expose private keys
+      // so we need to handle it separately
+      if (!HW_WALLETS_KEYRINGS.includes(keyring.type)) {
         const wallet = keyring._getWalletForAccount(address)
         const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
         switch (version) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1041,7 +1041,7 @@ module.exports = class MetamaskController extends EventEmitter {
             break
         }
       } else {
-        signature = await keyring.signTypedData(address, cleanMsgParams.data);
+        signature = await keyring.signTypedData(address, cleanMsgParams.data)
       }
       this.typedMessageManager.setMsgStatusSigned(msgId, signature)
       return this.getState()


### PR DESCRIPTION
That feature it's not currently supported on Ledger or Trezor but the current implementation of signedTypedData was reading private keys from the keyring, which is a private method and not supported on the HW wallet keyrings.

This PR handles both scenarios separately and at least now we will fail with the right error message:
- `Not supported in this device`

Once the hw wallets gets support, we should have to just update the keyring without need of touching the extension.

Fixes #5319 


BEFORE: 
![screen shot 2018-11-20 at 12 48 04 pm](https://user-images.githubusercontent.com/1247834/48792774-234fa480-ecc3-11e8-85eb-3708dab7ef59.png)

AFTER:
![screen shot 2018-11-20 at 12 45 01 pm](https://user-images.githubusercontent.com/1247834/48792787-29de1c00-ecc3-11e8-85df-3be2018e75f7.png)

