### PR TITLE
transactions - ensure err is defined when setting tx failed

### DIFF
--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -361,13 +361,15 @@ class TransactionStateManager extends EventEmitter {
     @param err {erroObject} - error object
   */
   setTxStatusFailed (txId, err) {
+    const error = !err ? new Error('Internal metamask failure') : err
+
     const txMeta = this.getTx(txId)
     txMeta.err = {
-      message: err.toString(),
-      rpc: err.value,
-      stack: err.stack,
+      message: error.toString(),
+      rpc: error.value,
+      stack: error.stack,
     }
-    this.updateTx(txMeta)
+    this.updateTx(txMeta, 'transactions:tx-state-manager#fail - add error')
     this._setTxStatus(txId, 'failed')
   }
 


### PR DESCRIPTION
so @brunobar79 instead of what we discussed i did this so that we dont mess with sentry logs because they need the error before the fail event which is fired during the status change 