### PR TITLE
Show disabled cursor in .network-disabled state

### DIFF
--- a/ui/app/css/itcss/components/network.scss
+++ b/ui/app/css/itcss/components/network.scss
@@ -1,6 +1,6 @@
 .network-component--disabled {
   // border-color: transparent !important;
-  cursor: default;
+  cursor: not-allowed;
 
   .fa-caret-down {
     opacity: 0;


### PR DESCRIPTION
This PR updates the cursor we show on the network selector when its in a disabled state. Gif attached.

![](https://user-images.githubusercontent.com/1623628/49022685-06f2b280-f170-11e8-98e8-33a294fb8961.gif)
