### PR TITLE
Hide app header when a provider request is pending

### DIFF
--- a/ui/app/components/app-header/app-header.component.js
+++ b/ui/app/components/app-header/app-header.component.js
@@ -23,6 +23,7 @@ export default class AppHeader extends PureComponent {
     toggleAccountMenu: PropTypes.func,
     selectedAddress: PropTypes.string,
     isUnlocked: PropTypes.bool,
+    providerRequests: PropTypes.array,
   }
 
   static contextTypes = {
@@ -40,12 +41,23 @@ export default class AppHeader extends PureComponent {
       : hideNetworkDropdown()
   }
 
+  /**
+   * Returns whether or not the user is in the middle of a confirmation prompt
+   *
+   * This accounts for both tx confirmations as well as provider approvals
+   *
+   * @returns {boolean}
+   */
   isConfirming () {
-    const { location } = this.props
+    const { location, providerRequests } = this.props
+    const confirmTxRouteMatch = matchPath(location.pathname, {
+      exact: false,
+      path: CONFIRM_TRANSACTION_ROUTE,
+    })
+    const isConfirmingTx = Boolean(confirmTxRouteMatch)
+    const hasPendingProviderApprovals = Array.isArray(providerRequests) && providerRequests.length > 0
 
-    return Boolean(matchPath(location.pathname, {
-      path: CONFIRM_TRANSACTION_ROUTE, exact: false,
-    }))
+    return isConfirmingTx || hasPendingProviderApprovals
   }
 
   renderAccountMenu () {

--- a/ui/app/components/app-header/app-header.container.js
+++ b/ui/app/components/app-header/app-header.container.js
@@ -11,6 +11,7 @@ const mapStateToProps = state => {
   const {
     network,
     provider,
+    providerRequests,
     selectedAddress,
     isUnlocked,
   } = metamask
@@ -19,6 +20,7 @@ const mapStateToProps = state => {
     networkDropdownOpen,
     network,
     provider,
+    providerRequests,
     selectedAddress,
     isUnlocked,
   }


### PR DESCRIPTION
This PR hides the app header when we're showing a Connect Request screen (in addition to when we're showing tx confirmations).

**Before:**

<img width="403" src="https://user-images.githubusercontent.com/1623628/49022920-9b5d1500-f170-11e8-8f03-37673f156900.png">


**After:**

<img width="655" src="https://user-images.githubusercontent.com/1623628/49022950-aadc5e00-f170-11e8-9126-0ee6ab9e8c98.png">
