### PR TITLE
Soften accusatory language on phishing warning

### DIFF
--- a/app/scripts/phishing-detect.js
+++ b/app/scripts/phishing-detect.js
@@ -1,7 +1,7 @@
 window.onload = function () {
   if (window.location.pathname === '/phishing.html') {
     const {hostname} = parseHash()
-    document.getElementById('esdbLink').innerHTML = '<b>To read more about this scam, navigate to: <a href="https://etherscamdb.info/domain/' + hostname + '"> https://etherscamdb.info/domain/' + hostname + '</a></b>'
+    document.getElementById('esdbLink').innerHTML = '<b>To read more about this site and why it was blocked, navigate to: <a href="https://etherscamdb.info/domain/' + hostname + '"> https://etherscamdb.info/domain/' + hostname + '</a></b>'
   }
 }
 


### PR DESCRIPTION
We don't always know for sure that sites marked as phishers are
defiitely scams, and so we should avoid language that makes concrete
accusations.