### PR TITLE
Fixed Vivek's bug

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -488,7 +488,7 @@ class TransactionController extends EventEmitter {
         txMeta.loadingDefaults = false
         this.txStateManager.updateTx(txMeta, 'transactions: gas estimation for tx on boot')
       }).catch((error) => {
-        txMeta.loadingDefaults = false
+        tx.loadingDefaults = false
         this.txStateManager.setTxStatusFailed(tx.id, error)
       })
     })

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -195,7 +195,7 @@ class TransactionController extends EventEmitter {
     } catch (error) {
       log.warn(error)
       txMeta.loadingDefaults = false
-      this.txStateManager.updateTx(txMeta)
+      this.txStateManager.updateTx(txMeta, 'Failed to calculate gas defaults.')
       throw error
     }
 
@@ -492,7 +492,7 @@ class TransactionController extends EventEmitter {
         this.txStateManager.updateTx(txMeta, 'transactions: gas estimation for tx on boot')
       }).catch((error) => {
         tx.loadingDefaults = false
-        this.txStateManager.updateTx(tx)
+        this.txStateManager.updateTx(tx, 'failed to estimate gas during boot cleanup.')
         this.txStateManager.setTxStatusFailed(tx.id, error)
       })
     })

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -192,9 +192,12 @@ class TransactionController extends EventEmitter {
     } catch (error) {
       log.warn(error)
       this.txStateManager.setTxStatusFailed(txMeta.id, error)
+      txMeta.loadingDefaults = false
       throw error
     }
+
     txMeta.loadingDefaults = false
+
     // save txMeta
     this.txStateManager.updateTx(txMeta)
 
@@ -485,6 +488,7 @@ class TransactionController extends EventEmitter {
         txMeta.loadingDefaults = false
         this.txStateManager.updateTx(txMeta, 'transactions: gas estimation for tx on boot')
       }).catch((error) => {
+        txMeta.loadingDefaults = false
         this.txStateManager.setTxStatusFailed(tx.id, error)
       })
     })
@@ -588,6 +592,7 @@ class TransactionController extends EventEmitter {
       metamaskNetworkId: this.getNetwork(),
     })
     this.memStore.updateState({ unapprovedTxs, selectedAddressTxList })
+    this._onBootCleanUp()
   }
 }
 


### PR DESCRIPTION
Fixes #5850

What was happening:

It seems that his MetaMask had crashed while some new transactions had
been loading defaults. He probably had a network connectivity issue to
Infura (which we are working with Infura to address).

As a result of this network cutout, his three unapproved transactions
were not marked failed, and were not marked as `loadingDefaults =
false`, as their gas prices had not yet been estimated.

Normally this behavior is supposed to clean itself up when the
transaction controller starts up, via the
`TransactionController._onBootCleanUp()` function, but in this case,
during unlock, that function was unable to do its job because when it
requested the transaction list, the current network was in the `loading`
state, making it proceed as if there were no pending transactions.

Since we had `unapproved` transactions stuck in the `loadingDefaults` state, this triggered the loading spinner permanently on the confirmation screen.

To fix this, I am doing two things:
- Setting transactions to loadingDefaults = false in more catch blocks.
- Calling `onBootCleanUp()` when the network store's status changes, so
that it will re-trigger when network loading completes.