### PR TITLE
Improve ux for low gas price set

### DIFF
--- a/development/states/send-edit.json
+++ b/development/states/send-edit.json
@@ -197,6 +197,7 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
+    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/development/states/send-new-ui.json
+++ b/development/states/send-new-ui.json
@@ -139,7 +139,8 @@
   "send": {
     "fromDropdownOpen": false,
     "toDropdownOpen": false,
-    "errors": {}
+    "errors": {},
+    "gasButtonGroupShown": true
   },
   "confirmTransaction": {
     "txData": {},
@@ -179,6 +180,7 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
+    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -69,6 +69,7 @@ describe('MetaMask', function () {
 
   beforeEach(async function () {
     await driver.executeScript(
+      'window.origFetch = window.fetch.bind(window);' +
       'window.fetch = ' +
       '(...args) => { ' +
       'if (args[0] === "https://ethgasstation.info/json/ethgasAPI.json") { return ' +
@@ -77,7 +78,7 @@ describe('MetaMask', function () {
       'Promise.resolve({ json: () => Promise.resolve(JSON.parse(\'' + fetchMockResponses.ethGasPredictTable + '\')) }); } else if ' +
       '(args[0] === "https://dev.blockscale.net/api/gasexpress.json") { return ' +
       'Promise.resolve({ json: () => Promise.resolve(JSON.parse(\'' + fetchMockResponses.gasExpress + '\')) }); } ' +
-      'return window.fetch(...args); }'
+      'return window.origFetch(...args); }'
     )
   })
 

--- a/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
+++ b/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
@@ -102,11 +102,15 @@
       }
     }
 
-    &__insufficient-balance {
+    &__error-text {
       font-size: 12px;
       color: red;
     }
 
+    &__warning-text {
+      font-size: 12px;
+      color: orange;
+    }
 
     &__input-wrapper {
       position: relative;
@@ -126,6 +130,10 @@
 
     &__input--error {
        border: 1px solid $red;
+    }
+
+    &__input--warning {
+       border: 1px solid $orange;
     }
 
     &__input-arrows {
@@ -167,6 +175,10 @@
 
     &__input-arrows--error {
       border: 1px solid $red;
+    }
+
+    &__input-arrows--warning {
+      border: 1px solid $orange;
     }
 
     input[type="number"]::-webkit-inner-spin-button {

--- a/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
@@ -355,7 +355,7 @@ describe('AdvancedTabContent Component', function () {
         labelKey: 'gasPrice',
         insufficientBalance: false,
         customPriceIsSafe: true,
-        value: 1
+        value: 1,
       })
       assert.equal(gasInputError.isInError, false)
     })

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -35,6 +35,9 @@ export default class GasModalPageContainer extends Component {
       PropTypes.string,
       PropTypes.number,
     ]),
+    customPriceIsSafe: PropTypes.bool,
+    isSpeedUp: PropTypes.bool,
+    disableSave: PropTypes.bool,
   }
 
   state = {}
@@ -69,6 +72,8 @@ export default class GasModalPageContainer extends Component {
     currentTimeEstimate,
     insufficientBalance,
     gasEstimatesLoading,
+    customPriceIsSafe,
+    isSpeedUp,
   }) {
     const { transactionFee } = this.props
     return (
@@ -83,6 +88,8 @@ export default class GasModalPageContainer extends Component {
         gasChartProps={gasChartProps}
         insufficientBalance={insufficientBalance}
         gasEstimatesLoading={gasEstimatesLoading}
+        customPriceIsSafe={customPriceIsSafe}
+        isSpeedUp={isSpeedUp}
       />
     )
   }
@@ -153,6 +160,7 @@ export default class GasModalPageContainer extends Component {
       onSubmit,
       customModalGasPriceInHex,
       customModalGasLimitInHex,
+      disableSave,
       ...tabProps
     } = this.props
 
@@ -162,7 +170,7 @@ export default class GasModalPageContainer extends Component {
           title={this.context.t('customGas')}
           subtitle={this.context.t('customGasSubTitle')}
           tabsComponent={this.renderTabs(infoRowProps, tabProps)}
-          disabled={tabProps.insufficientBalance}
+          disabled={disableSave}
           onCancel={() => cancelAndClose()}
           onClose={() => cancelAndClose()}
           onSubmit={() => {

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -40,6 +40,7 @@ import {
   getEstimatedGasTimes,
   getRenderableBasicEstimateData,
   getBasicGasEstimateBlockTime,
+  isCustomPriceSafe,
 } from '../../../selectors/custom-gas'
 import {
   submittedPendingTransactionsSelector,
@@ -107,6 +108,7 @@ const mapStateToProps = (state, ownProps) => {
     newTotalFiat,
     currentTimeEstimate: getRenderableTimeEstimate(customGasPrice, gasPrices, estimatedTimes),
     blockTime: getBasicGasEstimateBlockTime(state),
+    customPriceIsSafe: isCustomPriceSafe(state),
     gasPriceButtonGroupProps: {
       buttonDataLoading,
       defaultActiveButtonIndex: getDefaultActiveButtonIndex(gasButtonInfo, customModalGasPriceInHex),
@@ -167,7 +169,7 @@ const mapDispatchToProps = dispatch => {
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { gasPriceButtonGroupProps, isConfirm, isSpeedUp, txId } = stateProps
+  const { gasPriceButtonGroupProps, isConfirm, txId, isSpeedUp, insufficientBalance, customGasPrice } = stateProps
   const {
     updateCustomGasPrice: dispatchUpdateCustomGasPrice,
     hideGasButtonGroup: dispatchHideGasButtonGroup,
@@ -208,6 +210,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         dispatchHideSidebar()
       }
     },
+    disableSave: insufficientBalance || (isSpeedUp && customGasPrice === 0),
   }
 }
 

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -78,6 +78,7 @@ describe('GasModalPageContainer Component', function () {
       customGasPriceInHex={'mockCustomGasPriceInHex'}
       customGasLimitInHex={'mockCustomGasLimitInHex'}
       insufficientBalance={false}
+      disableSave={false}
     />, { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } })
   })
 

--- a/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -75,6 +75,7 @@ describe('gas-modal-page-container container', () => {
         gas: {
           basicEstimates: {
             blockTime: 12,
+            safeLow: 2,
           },
           customData: {
             limit: 'aaaaaaaa',
@@ -107,9 +108,10 @@ describe('gas-modal-page-container container', () => {
         blockTime: 12,
         customModalGasLimitInHex: 'aaaaaaaa',
         customModalGasPriceInHex: 'ffffffff',
+        customPriceIsSafe: true,
         gasChartProps: {
           'currentPrice': 4.294967295,
-          estimatedTimes: ['31', '62', '93', '124'],
+          estimatedTimes: [31, 62, 93, 124],
           estimatedTimesMax: '31',
           gasPrices: [3, 4, 5, 6],
           gasPricesMax: 6,

--- a/ui/app/components/transaction-list-item/transaction-list-item.container.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.container.js
@@ -11,7 +11,7 @@ import { formatDate } from '../../util'
 import {
   fetchBasicGasAndTimeEstimates,
   fetchGasEstimates,
-  setCustomGasPrice,
+  setCustomGasPriceForRetry,
   setCustomGasLimit,
 } from '../../ducks/gas.duck'
 
@@ -21,7 +21,7 @@ const mapDispatchToProps = dispatch => {
     fetchGasEstimates: (blockTime) => dispatch(fetchGasEstimates(blockTime)),
     setSelectedToken: tokenAddress => dispatch(setSelectedToken(tokenAddress)),
     retryTransaction: (transaction, gasPrice) => {
-      dispatch(setCustomGasPrice(gasPrice || transaction.txParams.gasPrice))
+      dispatch(setCustomGasPriceForRetry(gasPrice || transaction.txParams.gasPrice))
       dispatch(setCustomGasLimit(transaction.txParams.gas))
       dispatch(showSidebar({
         transitionName: 'sidebar-left',

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -2,6 +2,7 @@ import { pipe, partialRight } from 'ramda'
 import {
   conversionUtil,
   multiplyCurrencies,
+  conversionGreaterThan,
 } from '../conversion-util'
 import {
   getCurrentCurrency,
@@ -38,6 +39,8 @@ const selectors = {
   getRenderableBasicEstimateData,
   getRenderableEstimateDataForSmallButtonsFromGWEI,
   priceEstimateToWei,
+  getSafeLowEstimate,
+  isCustomPriceSafe,
 }
 
 module.exports = selectors
@@ -94,6 +97,39 @@ function getDefaultActiveButtonIndex (gasButtonInfo, customGasPriceInHex, gasPri
   return gasButtonInfo.findIndex(({ priceInHexWei }) => {
     return priceInHexWei === addHexPrefix(customGasPriceInHex || gasPrice)
   })
+}
+
+function getSafeLowEstimate (state) {
+  const {
+    gas: {
+      basicEstimates: {
+        safeLow,
+      },
+    },
+  } = state
+
+  return safeLow
+}
+
+function isCustomPriceSafe (state) {
+  const safeLow = getSafeLowEstimate(state)
+  const customGasPrice = getCustomGasPrice(state)
+
+  if (!customGasPrice) {
+    return true
+  }
+
+  const customPriceSafe = conversionGreaterThan(
+    {
+      value: customGasPrice,
+      fromNumericBase: 'hex',
+      fromDenomination: 'WEI',
+      toDenomination: 'GWEI',
+    },
+    { value: safeLow, fromNumericBase: 'dec' }
+  )
+
+  return customPriceSafe
 }
 
 function getBasicGasEstimateBlockTime (state) {


### PR DESCRIPTION
Fixes #5782 according to the plan described here https://github.com/MetaMask/metamask-extension/pull/5786#issuecomment-440274730

> if the original tx price was greater than 0, continue to force retries to be priced at 110% of the original tx price
> if a user is ever setting the gas price to below our recommended minimum, we should show a warning
> if a user is retrying a transaction that had a gas price of 0, then we:
> - autofill gas price with our recommended gas price
> - still allow the user to set it as low as they wish
> - prevent them from sending a retry transaction with 0 gas price, and show an error message in that case

Below demonstrates the new behaviours for a user trying to speed up a transaction with a 0 gas price:

![peek 2018-11-30 12-35](https://user-images.githubusercontent.com/7499938/49300354-91068800-f49c-11e8-8601-109d8263b19c.gif)
