### PR TITLE
fix formatting of 32-byte strings in personal_sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 5.0.4 Thu Nov 29 2018
 
+- [#5878](https://github.com/MetaMask/metamask-extension/pull/5878): Formats 32-length byte strings passed to personal_sign as hex, rather than UTF8.
 - [#5840](https://github.com/MetaMask/metamask-extension/pull/5840): transactions/tx-gas-utils - add the acctual response for eth_getCode for NO_CONTRACT_ERROR's && add a debug object to simulationFailed
 - [#5848](https://github.com/MetaMask/metamask-extension/pull/5848): Soften accusatory language on phishing warning
 - [#5835](https://github.com/MetaMask/metamask-extension/pull/5835): Open full-screen UI on install

--- a/ui/app/components/signature-request.js
+++ b/ui/app/components/signature-request.js
@@ -164,7 +164,7 @@ SignatureRequest.prototype.msgHexToText = function (hex) {
   try {
     const stripped = ethUtil.stripHexPrefix(hex)
     const buff = Buffer.from(stripped, 'hex')
-    return buff.toString('utf8')
+    return buff.length === 32 ? hex : buff.toString('utf8')
   } catch (e) {
     return hex
   }


### PR DESCRIPTION
Addresses #5473 and #3931. Formats 32-length byte strings passed to `personal_sign` as utf8 so that they are correctly displayed to users in the UI.

In my opinion, it would be ideal for hex-encoded arguments passed to `personal_sign` to simply be displayed in the native bytes representation, and for non-hex-encoded arguments to be cast to utf8 bytes, but that's just my opinion. 