### PR TITLE
Force main container wrapper height to fill remaining space

### DIFF
--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -215,7 +215,8 @@ $wallet-view-bg: $alabaster;
   }
 
   .main-container-wrapper {
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     width: 100%;
   }
 }


### PR DESCRIPTION
This PR updates the styling for the `.main-container-wrapper` we use to contain all the content, removing the 100% height rule and replacing it with `flex: 1`+`min-height: 0` to work around a flexbox quirk where a child won't fill up the remaining space properly in some cases.<sup>\[vague\]</sup>

Before & after:

<img width="1680" alt="" src="https://user-images.githubusercontent.com/1623628/49487748-63179f80-f81e-11e8-80bd-3343989ba9a0.png">
<img width="1680" alt="" src="https://user-images.githubusercontent.com/1623628/49487747-63179f80-f81e-11e8-92dd-c6c37cdc4daf.png">
