### PR TITLE
Ensures that advanced tab gas limit reflects tx gas limit

### DIFF
--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -769,6 +769,22 @@ describe('MetaMask', function () {
       await driver.switchTo().window(popup)
       await delay(regularDelayMs)
 
+      const configureGas = await driver.wait(until.elementLocated(By.css('.confirm-detail-row__header-text--edit')), 10000)
+      await configureGas.click()
+      await delay(regularDelayMs)
+
+      const advancedTabButton = await driver.wait(until.elementLocated(By.xpath(`//li[contains(text(), 'Advanced')]`)), 10000)
+      await advancedTabButton.click()
+      await delay(tinyDelayMs)
+
+      const [gasPriceInput, gasLimitInput] = await findElements(driver, By.css('.advanced-tab__gas-edit-row__input'))
+      assert(gasPriceInput.getAttribute('value'), 20)
+      assert(gasLimitInput.getAttribute('value'), 4700000)
+
+      const saveButton = await findElement(driver, By.xpath(`//button[contains(text(), 'Save')]`))
+      await saveButton.click()
+      await delay(regularDelayMs)
+
       const confirmButton = await findElement(driver, By.xpath(`//button[contains(text(), 'Confirm')]`))
       await confirmButton.click()
       await delay(regularDelayMs)

--- a/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -76,7 +76,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const customGasTotal = calcGasTotal(customModalGasLimitInHex, customModalGasPriceInHex)
 
-  const gasButtonInfo = getRenderableBasicEstimateData(state)
+  const gasButtonInfo = getRenderableBasicEstimateData(state, customModalGasLimitInHex)
 
   const currentCurrency = getCurrentCurrency(state)
   const conversionRate = getConversionRate(state)
@@ -235,7 +235,7 @@ function getTxParams (state, transactionId) {
   const { txParams: pendingTxParams } = pendingTransaction || {}
   return txData.txParams || pendingTxParams || {
     from: send.from,
-    gas: send.gasLimit,
+    gas: send.gasLimit || '0x5208',
     gasPrice: send.gasPrice || getFastPriceEstimateInHexWEI(state, true),
     to: send.to,
     value: getSelectedToken(state) ? '0x0' : send.amount,

--- a/ui/app/ducks/gas.duck.js
+++ b/ui/app/ducks/gas.duck.js
@@ -29,7 +29,7 @@ const SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED = 'metamask/gas/SET_BASIC_PRICE_E
 const initState = {
   customData: {
     price: null,
-    limit: '0x5208',
+    limit: null,
   },
   basicEstimates: {
     average: null,

--- a/ui/app/ducks/tests/gas-duck.test.js
+++ b/ui/app/ducks/tests/gas-duck.test.js
@@ -98,7 +98,7 @@ describe('Gas Duck', () => {
   const initState = {
     customData: {
       price: null,
-      limit: '0x5208',
+      limit: null,
     },
     basicEstimates: {
       average: null,

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -221,11 +221,10 @@ function getGasPriceInHexWei (price) {
   )(price)
 }
 
-function getRenderableBasicEstimateData (state) {
+function getRenderableBasicEstimateData (state, gasLimit) {
   if (getBasicGasEstimateLoadingStatus(state)) {
     return []
   }
-  const gasLimit = state.metamask.send.gasLimit || getCustomGasLimit(state)
   const conversionRate = state.metamask.conversionRate
   const currentCurrency = getCurrentCurrency(state)
   const {
@@ -270,7 +269,7 @@ function getRenderableEstimateDataForSmallButtonsFromGWEI (state) {
   if (getBasicGasEstimateLoadingStatus(state)) {
     return []
   }
-  const gasLimit = state.metamask.send.gasLimit || getCustomGasLimit(state)
+  const gasLimit = state.metamask.send.gasLimit || getCustomGasLimit(state) || '0x5208'
   const conversionRate = state.metamask.conversionRate
   const currentCurrency = getCurrentCurrency(state)
   const {

--- a/ui/app/selectors/tests/custom-gas.test.js
+++ b/ui/app/selectors/tests/custom-gas.test.js
@@ -102,9 +102,6 @@ describe('custom-gas selectors', () => {
           metamask: {
             conversionRate: 255.71,
             currentCurrency: 'usd',
-            send: {
-              gasLimit: '0x5208',
-            },
           },
           gas: {
             basicEstimates: {
@@ -168,7 +165,7 @@ describe('custom-gas selectors', () => {
     it('should return renderable data about basic estimates', () => {
       tests.forEach(test => {
         assert.deepEqual(
-          getRenderableBasicEstimateData(test.mockState),
+          getRenderableBasicEstimateData(test.mockState, '0x5208'),
           test.expectedResult
         )
       })


### PR DESCRIPTION
Addresses the issue described here: https://www.reddit.com/r/Metamask/comments/a5ftb3/whats_with_this_new_update/ebmm14v/

We were defaulting the gas limit to 21000 in the initial state of the reducer, when a default only needs to be applied while mapping state to props if no other gas limit exists.

![gaslimitfix](https://user-images.githubusercontent.com/7499938/49878259-b468f580-fe01-11e8-925b-3341a458253b.gif)

This PR includes a failing test that catches this error and passes with these changes.