### PR TITLE
Make docs links consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,13 @@
 # MetaMask Browser Extension
 [![Build Status](https://circleci.com/gh/MetaMask/metamask-extension.svg?style=shield&circle-token=a1ddcf3cd38e29267f254c9c59d556d513e3a1fd)](https://circleci.com/gh/MetaMask/metamask-extension) [![Coverage Status](https://coveralls.io/repos/github/MetaMask/metamask-extension/badge.svg?branch=master)](https://coveralls.io/github/MetaMask/metamask-extension?branch=master) [![Stories in Ready](https://badge.waffle.io/MetaMask/metamask-extension.png?label=in%20progress&title=waffle.io)](https://waffle.io/MetaMask/metamask-extension)
 
-## Support
+You can find the latest version of MetaMask on [our official website](https://metamask.io/).  For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/hc/en-us).
 
-If you're a user seeking support, [here is our support site](https://metamask.zendesk.com/hc/en-us).
+For up to the minute news, follow our [Twitter](https://twitter.com/metamask_io) or [Medium](https://medium.com/metamask) pages.
 
-## Introduction
+To learn how to develop MetaMask-compatible applications, visit our [Developer Docs](https://metamask.github.io/metamask-docs/).
 
-[Mission Statement](./MISSION.md)
-
-[Documentation](https://metamask.github.io/metamask-docs/)
-
-[Internal Code Documentation](./docs#documentation)
-
-## Developing Compatible Dapps
-
-If you're a web dapp developer, we've got two types of guides for you:
-
-### New Dapp Developers
-
-- We recommend this [Learning Solidity](https://karl.tech/learning-solidity-part-1-deploy-a-contract/) tutorial series by Karl Floersch.
-- We wrote a (slightly outdated now) gentle introduction on [Developing Dapps with Truffle and MetaMask](https://medium.com/metamask/developing-ethereum-dapps-with-truffle-and-metamask-aa8ad7e363ba).
-
-### Current Dapp Developers
-
-- If you have a Dapp, and you want to ensure compatibility, [here is our guide on building MetaMask-compatible Dapps](https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md)
+To learn how to contribute to the MetaMask project itself, visit our [Internal Docs](https://github.com/MetaMask/metamask-extension/tree/develop/docs).
 
 ## Building locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,14 @@
 # Documentation
 
+These docs relate to how to contribute to the MetaMask project itself.
+
+You can find the latest version of MetaMask on [our official website](https://metamask.io/).
+
+For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/hc/en-us).
+
+For up to the minute news, follow our [Twitter](https://twitter.com/metamask_io) or [Medium](https://medium.com/metamask) pages.
+
+To learn how to develop MetaMask-compatible applications, visit our [Developer Docs](https://metamask.github.io/metamask-docs/).
 
 - [How to add custom build to Chrome](./add-to-chrome.md)
 - [How to add custom build to Firefox](./add-to-firefox.md)


### PR DESCRIPTION
So our various docs pages inter-link consistently per https://github.com/MetaMask/metamask-docs/issues/1