### PR TITLE
Update the Phishing Warning notice text to not use inline URLs

### DIFF
--- a/notices/archive/notice_4.md
+++ b/notices/archive/notice_4.md
@@ -2,5 +2,4 @@ Dear MetaMask Users,
 
 There have been several instances of high-profile legitimate websites such as BTC Manager and Games Workshop that have had their websites temporarily compromised. This involves showing a fake MetaMask window on the page asking for user's seed phrases. MetaMask will never open itself to ask you for your seed phrase, and users are encouraged to report these instances immediately to either [our phishing blacklist](https://github.com/MetaMask/eth-phishing-detect/issues) or our support email at [support@metamask.io](mailto:support@metamask.io).
 
-Please read our full article on this ongoing issue at [https://medium.com/metamask/new-phishing-strategy-becoming-common-1b1123837168](https://medium.com/metamask/new-phishing-strategy-becoming-common-1b1123837168). 
-
+[Please read our full article on this ongoing issue over at Medium.](https://medium.com/metamask/new-phishing-strategy-becoming-common-1b1123837168)


### PR DESCRIPTION
This PR makes the Phishing Warning text not have a raw link right at the end of a sentence since it could introduce possible copy-and-paste errors.