### PR TITLE
Fix etherscan links on notifications

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -111,7 +111,7 @@ class ExtensionPlatform {
 
   _viewOnEtherScan (txId) {
     if (txId.startsWith('http://')) {
-      global.metamaskController.platform.openWindow({ url: txId })
+      this.openWindow({ url: txId })
     }
   }
 }


### PR DESCRIPTION
This broke since #5865 
Anyway, there's no need to call MMC to open a window.