### PR TITLE
Fix drizzle tests

### DIFF
--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -7,7 +7,7 @@ sleep 5
 cd test/e2e/beta/
 rm -rf drizzle-test
 mkdir drizzle-test && cd drizzle-test
-sudo npm install -g truffle
+npm install -g truffle
 truffle unbox drizzle
 echo "Deploying contracts for Drizzle test..."
 truffle compile && truffle migrate

--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -7,10 +7,10 @@ sleep 5
 cd test/e2e/beta/
 rm -rf drizzle-test
 mkdir drizzle-test && cd drizzle-test
-sudo npm install --unsafe-perm -g truffle
-sudo truffle unbox drizzle
+npm install --unsafe-perm truffle
+../../../../node_modules/.bin/truffle unbox drizzle
 echo "Deploying contracts for Drizzle test..."
-sudo truffle compile && sudo truffle migrate
+../../../../node_modules/.bin/truffle compile && ../../../../node_modules/.bin/truffle migrate
 BROWSER=none npm start >> /dev/null 2>&1 &
 cd ../../../../
 mocha test/e2e/beta/drizzle.spec

--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -7,7 +7,7 @@ sleep 5
 cd test/e2e/beta/
 rm -rf drizzle-test
 mkdir drizzle-test && cd drizzle-test
-npm install --unsafe-perm truffle
+npm install truffle
 ../../../../node_modules/.bin/truffle unbox drizzle
 echo "Deploying contracts for Drizzle test..."
 ../../../../node_modules/.bin/truffle compile && ../../../../node_modules/.bin/truffle migrate

--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -7,7 +7,7 @@ sleep 5
 cd test/e2e/beta/
 rm -rf drizzle-test
 mkdir drizzle-test && cd drizzle-test
-npm install -g truffle
+sudo npm install --unsafe-perm -g truffle
 truffle unbox drizzle
 echo "Deploying contracts for Drizzle test..."
 truffle compile && truffle migrate

--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -8,9 +8,9 @@ cd test/e2e/beta/
 rm -rf drizzle-test
 mkdir drizzle-test && cd drizzle-test
 sudo npm install --unsafe-perm -g truffle
-truffle unbox drizzle
+sudo truffle unbox drizzle
 echo "Deploying contracts for Drizzle test..."
-truffle compile && truffle migrate
+sudo truffle compile && sudo truffle migrate
 BROWSER=none npm start >> /dev/null 2>&1 &
 cd ../../../../
 mocha test/e2e/beta/drizzle.spec


### PR DESCRIPTION
The main change is to not install truffle globally, which requires sudo and introduces some other problems, and calling it from node_modules/.bin/truffle instead