### PR TITLE
Skip drizzle tests until issue with ci is determined

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ workflows:
           requires:
             - prep-deps-npm
             - prep-build
-      - test-e2e-beta-drizzle:
-          requires:
-            - prep-deps-npm
-            - prep-build
+      # - test-e2e-beta-drizzle:
+      #     requires:
+      #       - prep-deps-npm
+      #       - prep-build
       - test-unit:
           requires:
             - prep-deps-npm
@@ -54,7 +54,7 @@ workflows:
             - test-mozilla-lint
             - test-e2e-beta-chrome
             - test-e2e-beta-firefox
-            - test-e2e-beta-drizzle
+            # - test-e2e-beta-drizzle
             - test-integration-flat-chrome
             - test-integration-flat-firefox
       - job-screens:
@@ -176,19 +176,19 @@ jobs:
           name: Test
           command: sudo npm install -g npm@6 && npm audit
 
-  test-e2e-beta-drizzle:
-    docker:
-      - image: circleci/node:8.11.3-browsers
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: test:e2e:drizzle:beta
-          command: npm run test:e2e:drizzle:beta
-      - store_artifacts:
-          path: test-artifacts
-          destination: test-artifacts
+  # test-e2e-beta-drizzle:
+  #   docker:
+  #     - image: circleci/node:8.11.3-browsers
+  #   steps:
+  #     - checkout
+  #     - attach_workspace:
+  #         at: .
+  #     - run:
+  #         name: test:e2e:drizzle:beta
+  #         command: npm run test:e2e:drizzle:beta
+  #     - store_artifacts:
+  #         path: test-artifacts
+  #         destination: test-artifacts
   test-e2e-beta-chrome:
     docker:
       - image: circleci/node:8.11.3-browsers


### PR DESCRIPTION
Hold off on drizzle test until issue with ci
- [x] `gyp WARN EACCES user "root" does not have permission to access the dev dir "/root/.node-gyp/8.11.3"` 
Can be resolved with adding `sudo npm install -g truffle --unsafe-perm` line 9 in run-drizzle.sh

- [x] Next issue is with 
`Error: Errors found in browser console:`
`http://127.0.0.1:3000/static/js/bundle.js 99432:20 "Contract ComplexStorage not found on network ID: 1546373425748"`
`http://127.0.0.1:3000/static/js/bundle.js 99432:20 "uncaught at root"`
Seems to be an issue with `truffle compile && truffle migrate` not running when ganache is open. Haven't confirmed if Ganache is actually open in background of ci, but extension seems to be connected to it.

