### PR TITLE
fix mascara example uses incorrect asset paths

### DIFF
--- a/mascara/proxy/index.html
+++ b/mascara/proxy/index.html
@@ -15,6 +15,6 @@
 
 <body>
   Hello! I am the MetaMask iframe.
-  <script src="./proxy.js"></script>
+  <script src="../proxy.js"></script>
 </body>
 </html>

--- a/mascara/src/proxy.js
+++ b/mascara/src/proxy.js
@@ -4,7 +4,7 @@ const SwStream = require('sw-stream/lib/sw-stream.js')
 
 const keepAliveDelay = Math.floor(Math.random() * (30000 - 1000)) + 1000
 const background = new SwController({
-  fileName: './scripts/background.js',
+  fileName: '../background.js',
   keepAlive: true,
   keepAliveInterval: 30000,
   keepAliveDelay,
@@ -13,7 +13,7 @@ const background = new SwController({
 const pageStream = createParentStream()
 background.on('ready', () => {
   const swStream = SwStream({
-    serviceWorker: background.controller,
+    serviceWorker: background.getWorker(),
     context: 'dapp',
   })
   pageStream.pipe(swStream).pipe(pageStream)

--- a/mascara/ui/index.html
+++ b/mascara/ui/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="app-content"></div>
-    <script src="./scripts/ui.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./ui.js" type="text/javascript" charset="utf-8"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "sw-stream": "^2.0.2",
     "swappable-obj-proxy": "^1.1.0",
     "textarea-caret": "^3.0.1",
+    "uglifyify": "^5.0.1",
     "valid-url": "^1.0.9",
     "web3": "^0.20.1",
     "web3-stream-provider": "^3.0.1",


### PR DESCRIPTION
- Fix asset paths
- Fix incorrect method call for SwController's serviceWorker
- Add missing dependency (uglifyify)