### PR TITLE
Fix ERC20 token value decoding

### DIFF
--- a/ui/app/components/token-currency-display/token-currency-display.component.js
+++ b/ui/app/components/token-currency-display/token-currency-display.component.js
@@ -35,7 +35,7 @@ export default class TokenCurrencyDisplay extends PureComponent {
 
     let displayValue
 
-    if (tokenData.params && tokenData.params.length) {
+    if (tokenData && tokenData.params && tokenData.params.length) {
       const tokenValue = getTokenValue(tokenData.params)
       displayValue = calcTokenAmount(tokenValue, decimals).toString()
     }


### PR DESCRIPTION
When MetaMask user calls non-standard ERC20 methods such as `mint`
`getTokenData` cannot decode tx data
`tokenData` will be `undefined`
Uncaught error will break the UI

This PR adds defensive code to avoid error