### PR TITLE
Harden Drizzle test runner script

### DIFF
--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+set -o pipefail
+
 export PATH="$PATH:./node_modules/.bin"
 
 npm run ganache:start -- -b 2 >> /dev/null 2>&1 &

--- a/test/e2e/beta/run-drizzle.sh
+++ b/test/e2e/beta/run-drizzle.sh
@@ -4,17 +4,28 @@ set -e
 set -u
 set -o pipefail
 
-export PATH="$PATH:./node_modules/.bin"
-
 npm run ganache:start -- -b 2 >> /dev/null 2>&1 &
+npm_run_ganache_start_pid=$!
 sleep 5
-cd test/e2e/beta/
-rm -rf drizzle-test
-mkdir drizzle-test && cd drizzle-test
-npm install truffle
-../../../../node_modules/.bin/truffle unbox drizzle
+
+pushd "$(mktemp -d)"
+npm install --no-package-lock truffle
+truffle="$(npm bin)/truffle"
+$truffle unbox drizzle
 echo "Deploying contracts for Drizzle test..."
-../../../../node_modules/.bin/truffle compile && ../../../../node_modules/.bin/truffle migrate
+$truffle compile
+$truffle migrate
+
 BROWSER=none npm start >> /dev/null 2>&1 &
-cd ../../../../
-mocha test/e2e/beta/drizzle.spec
+npm_start_pid=$!
+
+popd
+if ! mocha test/e2e/beta/drizzle.spec
+then
+    test_status=1
+fi
+
+! kill -15 $npm_run_ganache_start_pid
+! kill -15 $npm_start_pid
+! wait $npm_run_ganache_start_pid $npm_start_pid
+exit ${test_status:-}


### PR DESCRIPTION
This PR updates the Bash script we're using to kick off the Drizzle tests, adding more error handling and cleaning up a few of the assumptions in the file. We no longer assume the location of the npm `.bin` directory and we're cleaning up after ourselves now when possible.