### PR TITLE
Set autoConversion off for token/eth conversion

### DIFF
--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -33,7 +33,7 @@ class TokenRatesController {
     const query = pairs.join('&')
     if (this._tokens.length > 0) {
       try {
-        const response = await fetch(`https://exchanges.balanc3.net/pie?${query}&autoConversion=true`)
+        const response = await fetch(`https://exchanges.balanc3.net/pie?${query}&autoConversion=false`)
         const { prices = [] } = await response.json()
         prices.forEach(({ pair, price }) => {
           const address = pair.split('/')[0]


### PR DESCRIPTION
Alternative for https://github.com/MetaMask/metamask-extension/pull/5965.
Closes #5960 

On certain tokens (eg FirstBlood, Cypto20) would sometimes return the USD price for ETH pairing. This will turn off the USD price for tokens. 

From the Balanc3 team: 
>Obviously it's worth noting that if you turn autoconversion off then only trades for the actual pair will be displayed which means that some granularity will be lost for the price (edited) 
In extreme cases, that means there will not be a price for pair (we do not display prices for the `/pie` endpoint if the most recent available price is older than 1 day)