### PR TITLE
EIP-1193: standard provider API

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -158,7 +158,7 @@ function listenForProviderRequest () {
         window.postMessage({ type: 'ethereumproviderlegacy', selectedAddress }, '*')
         break
       case 'reject-provider-request':
-        window.postMessage({ type: 'ethereumprovider', error: 'User rejected provider access' }, '*')
+        window.postMessage({ type: 'ethereumprovider', error: 'User denied account authorization' }, '*')
         break
       case 'answer-is-approved':
         window.postMessage({ type: 'ethereumisapproved', isApproved, caching }, '*')
@@ -170,6 +170,11 @@ function listenForProviderRequest () {
         isEnabled = false
         window.postMessage({ type: 'metamasksetlocked' }, '*')
         break
+      case 'ethereum-ping-success':
+        window.postMessage({ type: 'ethereumpingsuccess' }, '*')
+        break
+      case 'ethereum-ping-error':
+        window.postMessage({ type: 'ethereumpingerror' }, '*')
     }
   })
 }

--- a/app/scripts/controllers/network/createBlockTracker.js
+++ b/app/scripts/controllers/network/createBlockTracker.js
@@ -1,0 +1,15 @@
+const BlockTracker = require('eth-block-tracker')
+
+/**
+ * Creates a block tracker that sends platform events on success and failure
+ */
+module.exports = function createBlockTracker (args, platform) {
+  const blockTracker = new BlockTracker(args)
+  blockTracker.on('latest', () => {
+    platform.sendMessage({ action: 'ethereum-ping-success' })
+  })
+  blockTracker.on('error', () => {
+    platform.sendMessage({ action: 'ethereum-ping-error' })
+  })
+  return blockTracker
+}

--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -7,14 +7,14 @@ const createInflightMiddleware = require('eth-json-rpc-middleware/inflight-cache
 const createBlockTrackerInspectorMiddleware = require('eth-json-rpc-middleware/block-tracker-inspector')
 const providerFromMiddleware = require('eth-json-rpc-middleware/providerFromMiddleware')
 const createInfuraMiddleware = require('eth-json-rpc-infura')
-const BlockTracker = require('eth-block-tracker')
+const createBlockTracker = require('./createBlockTracker')
 
 module.exports = createInfuraClient
 
-function createInfuraClient ({ network }) {
+function createInfuraClient ({ network, platform }) {
   const infuraMiddleware = createInfuraMiddleware({ network })
   const infuraProvider = providerFromMiddleware(infuraMiddleware)
-  const blockTracker = new BlockTracker({ provider: infuraProvider })
+  const blockTracker = createBlockTracker({ provider: infuraProvider }, platform)
 
   const networkMiddleware = mergeMiddleware([
     createNetworkAndChainIdMiddleware({ network }),

--- a/app/scripts/controllers/network/createJsonRpcClient.js
+++ b/app/scripts/controllers/network/createJsonRpcClient.js
@@ -5,14 +5,14 @@ const createBlockCacheMiddleware = require('eth-json-rpc-middleware/block-cache'
 const createInflightMiddleware = require('eth-json-rpc-middleware/inflight-cache')
 const createBlockTrackerInspectorMiddleware = require('eth-json-rpc-middleware/block-tracker-inspector')
 const providerFromMiddleware = require('eth-json-rpc-middleware/providerFromMiddleware')
-const BlockTracker = require('eth-block-tracker')
+const createBlockTracker = require('./createBlockTracker')
 
 module.exports = createJsonRpcClient
 
-function createJsonRpcClient ({ rpcUrl }) {
+function createJsonRpcClient ({ rpcUrl, platform }) {
   const fetchMiddleware = createFetchMiddleware({ rpcUrl })
   const blockProvider = providerFromMiddleware(fetchMiddleware)
-  const blockTracker = new BlockTracker({ provider: blockProvider })
+  const blockTracker = createBlockTracker({ provider: blockProvider }, platform)
 
   const networkMiddleware = mergeMiddleware([
     createBlockRefRewriteMiddleware({ blockTracker }),

--- a/app/scripts/controllers/network/createLocalhostClient.js
+++ b/app/scripts/controllers/network/createLocalhostClient.js
@@ -3,14 +3,14 @@ const createFetchMiddleware = require('eth-json-rpc-middleware/fetch')
 const createBlockRefRewriteMiddleware = require('eth-json-rpc-middleware/block-ref-rewrite')
 const createBlockTrackerInspectorMiddleware = require('eth-json-rpc-middleware/block-tracker-inspector')
 const providerFromMiddleware = require('eth-json-rpc-middleware/providerFromMiddleware')
-const BlockTracker = require('eth-block-tracker')
+const createBlockTracker = require('./createBlockTracker')
 
 module.exports = createLocalhostClient
 
-function createLocalhostClient () {
+function createLocalhostClient ({ platform }) {
   const fetchMiddleware = createFetchMiddleware({ rpcUrl: 'http://localhost:8545/' })
   const blockProvider = providerFromMiddleware(fetchMiddleware)
-  const blockTracker = new BlockTracker({ provider: blockProvider, pollingInterval: 1000 })
+  const blockTracker = createBlockTracker({ provider: blockProvider, pollingInterval: 1000 }, platform)
 
   const networkMiddleware = mergeMiddleware([
     createBlockRefRewriteMiddleware({ blockTracker }),

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -37,8 +37,9 @@ const defaultNetworkConfig = {
 
 module.exports = class NetworkController extends EventEmitter {
 
-  constructor (opts = {}) {
+  constructor (opts = {}, platform) {
     super()
+    this.platform = platform
 
     // parse options
     const providerConfig = opts.provider || defaultProviderConfig
@@ -180,7 +181,7 @@ module.exports = class NetworkController extends EventEmitter {
 
   _configureInfuraProvider ({ type }) {
     log.info('NetworkController - configureInfuraProvider', type)
-    const networkClient = createInfuraClient({ network: type })
+    const networkClient = createInfuraClient({ network: type, platform: this.platform })
     this._setNetworkClient(networkClient)
     // setup networkConfig
     var settings = {
@@ -191,13 +192,13 @@ module.exports = class NetworkController extends EventEmitter {
 
   _configureLocalhostProvider () {
     log.info('NetworkController - configureLocalhostProvider')
-    const networkClient = createLocalhostClient()
+    const networkClient = createLocalhostClient({ platform: this.platform })
     this._setNetworkClient(networkClient)
   }
 
   _configureStandardProvider ({ rpcUrl, chainId, ticker, nickname }) {
     log.info('NetworkController - configureStandardProvider', rpcUrl)
-    const networkClient = createJsonRpcClient({ rpcUrl })
+    const networkClient = createJsonRpcClient({ rpcUrl, platform: this.platform })
     // hack to add a 'rpc' network with chainId
     networks.networkList['rpc'] = {
       chainId: chainId,

--- a/app/scripts/inpage-beta.js
+++ b/app/scripts/inpage-beta.js
@@ -1,0 +1,84 @@
+/*global ethereum */
+const EventEmitter = require('events')
+
+/**
+ * This class exposes the standard Ethereum provider API as per
+ * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md
+ */
+class EthereumProvider extends EventEmitter {
+  _isConnected
+
+  constructor () {
+    super()
+    this._onMessage('ethereumpingerror', this._onClose.bind(this))
+    this._onMessage('ethereumpingsuccess', this._onConnect.bind(this))
+    window.addEventListener('load', () => {
+      this._subscribe()
+      this._ping()
+    })
+  }
+
+  _onMessage (type, handler) {
+    window.addEventListener('message', function ({ data }) {
+      if (!data || data.type !== type) return
+      handler.apply(this, arguments)
+    })
+  }
+
+  _onClose () {
+    (this._isConnected === undefined || this._isConnected) && this.emit('close', {
+      code: 1011,
+      reason: 'Network connection error',
+    })
+    this._isConnected = false
+  }
+
+  _onConnect () {
+    !this._isConnected && this.emit('connect')
+    this._isConnected = true
+  }
+
+  async _ping () {
+    try {
+      await this.send('eth_blockNumber')
+      window.postMessage({ type: 'ethereumpingsuccess' }, '*')
+    } catch (error) {
+      window.postMessage({ type: 'ethereumpingerror' }, '*')
+    }
+  }
+
+  _subscribe () {
+    ethereum.on('networkChanged', data => { this.emit('networkChanged', data) })
+    ethereum.on('accountsChanged', data => { this.emit('accountsChanged', data) })
+    ethereum.on('data', (error, { method, params }) => {
+      if (!error && method === 'eth_subscription') {
+        this.emit('notification', params.result)
+      }
+    })
+  }
+
+  /**
+   * Initiate an RPC method call
+   *
+   * @param {string} method - RPC method name to call
+   * @param {string[]} params - Array of RPC method parameters
+   * @returns {Promise<*>} Promise resolving to the result if successful
+   */
+  send (method, params = []) {
+    if (method === 'eth_requestAccounts') return ethereum.enable()
+
+    return new Promise((resolve, reject) => {
+      try {
+        ethereum.sendAsync({ method, params, beta: true }, (error, response) => {
+          error = error || response.error
+          error ? reject(error) : resolve(response)
+        })
+      } catch (error) {
+        // Per EIP-1193, send should never throw, only reject its Promise. Here
+        // we swallow thrown errors, which is safe since we handle them above.
+      }
+    })
+  }
+}
+
+window.ethereumBeta = new EthereumProvider()

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -5,6 +5,7 @@ const log = require('loglevel')
 const LocalMessageDuplexStream = require('post-message-stream')
 const setupDappAutoReload = require('./lib/auto-reload.js')
 const MetamaskInpageProvider = require('metamask-inpage-provider')
+require('./inpage-beta')
 
 let isEnabled = false
 let warned = false
@@ -16,11 +17,12 @@ restoreContextAfterImports()
 
 log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
-console.warn('ATTENTION: In an effort to improve user privacy, MetaMask ' +
-'stopped exposing user accounts to dapps if "privacy mode" is enabled on ' +
-'November 2nd, 2018. Dapps should now call provider.enable() in order to view and use ' +
-'accounts. Please see https://bit.ly/2QQHXvF for complete information and up-to-date ' +
-'example code.')
+console.warn(`
+ATTENTION: MetaMask and other dapp browsers are beginning to move to a standard provider API.
+This new API is available today at window.ethereumBeta for testing. It can be used directly,
+or with web3 version <web3_version> available at <web3_link>. Please see for <blog_link> 
+or more information.
+`)
 
 /**
  * Adds a postMessage listener for a specific message type
@@ -69,7 +71,10 @@ inpageProvider.enable = function ({ force } = {}) {
   return new Promise((resolve, reject) => {
     providerHandle = ({ data: { error, selectedAddress } }) => {
       if (typeof error !== 'undefined') {
-        reject(error)
+        reject({
+          message: error,
+          code: 4001,
+        })
       } else {
         window.removeEventListener('message', providerHandle)
         setTimeout(() => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -86,7 +86,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.createVaultMutex = new Mutex()
 
     // network store
-    this.networkController = new NetworkController(initState.NetworkController)
+    this.networkController = new NetworkController(initState.NetworkController, this.platform)
 
     // preferences controller
     this.preferencesController = new PreferencesController({


### PR DESCRIPTION
This pull request adds a new inpage adapter that exposes a provider API that conforms to [EIP-1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md).

**Note:** An 1193-compatible version of web3 will be released soon. We should wait until that's ready 
(cc @nivida) so we can update the console log in this PR to link to that version of web3 for testing. We should also draft a blog that explains why this provider API is a good thing and that it should mark the end of major breaking changes.