### PR TITLE
Add optional showPopup parameter to .enable()

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -128,6 +128,7 @@ function listenForProviderRequest () {
         extension.runtime.sendMessage({
           action: 'init-provider-request',
           force: data.force,
+          showPopup: data.showPopup,
           origin: source.location.hostname,
           siteImage: getSiteIcon(source),
           siteTitle: getSiteName(source),

--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -62,11 +62,11 @@ class ProviderApprovalController {
       this.approveProviderRequest(origin)
       return
     }
-    if(showPopup) {
+    if (showPopup) {
       this.openPopup && this.openPopup()
     } else {
       this.rejectProviderRequest(origin)
-      return      
+      return
     }
   }
 

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -65,7 +65,7 @@ onMessage('ethereumproviderlegacy', ({ data: { selectedAddress } }) => {
 }, true)
 
 // augment the provider with its enable method
-inpageProvider.enable = function ({ force } = {}) {
+inpageProvider.enable = function ({ force, showPopup } = {}) {
   return new Promise((resolve, reject) => {
     providerHandle = ({ data: { error, selectedAddress } }) => {
       if (typeof error !== 'undefined') {
@@ -88,7 +88,7 @@ inpageProvider.enable = function ({ force } = {}) {
       }
     }
     onMessage('ethereumprovider', providerHandle, true)
-    window.postMessage({ type: 'ETHEREUM_ENABLE_PROVIDER', force }, '*')
+    window.postMessage({ type: 'ETHEREUM_ENABLE_PROVIDER', force, showPopup }, '*')
   })
 }
 


### PR DESCRIPTION
This is a rough start at addressing Issue #6022.  I believe it still needs work and testing, but can't do more at this moment so I'll share the start and explanation in the hopes someone might be able to pick up and progress further.

Tracing:
----

I see the `provider` getting an `enable` function with a `{force}` parameter [here](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/inpage.js#L67).  

That function [sends](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/inpage.js#L91) a `ETHEREUM_ENABLE_PROVIDER` message to the window along with the `force` parameter.

That message is [caught](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/contentscript.js#L117) and [forwarded](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/contentscript.js#L128) as `init-provider-request` which is [caught](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L32) and passed to [`_handleProviderRequest`](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L49) with the `force` parameter.  

A [key line](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L59) seems to be https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L59

which if true, returns [approval](https://github.com/MetaMask/metamask-extension/blob/eec7fcebd528a70b5c8a3571c5b802ced889e626/app/scripts/controllers/provider-approval.js#L101) and otherwise opens a popup. So it seems the "force" parameter is used to force a popup even when it might not otherwise be needed.  The parameter requested here is in some ways the opposite of that.

In [`_handleProviderRequest`](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L49) the only onward options are to grant quick approval or open a popup, with no quick denial option.  One way to implement this request might be to add such an onward option in an `else` block following the [`openPopup` line](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L63) after wrapping that line in an `if(popup)` block. 

As a side note, `openPopup` is passed in [here](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/metamask-controller.js#L235) from [here](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/background.js#L260), apparently defined [here](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/background.js#L458), which just opens a previously defined notification popup.

That onward option *might* make use of [`_handleIsApproved`](https://github.com/MetaMask/metamask-extension/blob/eec7fcebd528a70b5c8a3571c5b802ced889e626/app/scripts/controllers/provider-approval.js#L66) which sends an `answer-is-approved` message along with a boolean `isApproved` parameter.  That message gets [caught](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/contentscript.js#L163) and [forwarded](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/contentscript.js#L164) as `ethereumisapproved` with the boolean,  This message is [caught](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/inpage.js#L120) and passed to [`isApprovedHandle`](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/inpage.js#L113).  A better strategy is probably to use [`rejectProviderRequest`](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L119) in a similar manner to the use of [`approveProviderRequest`](https://github.com/MetaMask/metamask-extension/blob/0ad77970762ac5389e264ce70f633dddd8d58844/app/scripts/controllers/provider-approval.js#L101).

This pull request uses that latter strategy; see new lines 65-70 of [this commit](https://github.com/MetaMask/metamask-extension/commit/8dee1edde6229e72889889259613394074e1b130#diff-2cecef7b138cca58d13810de6d1191aeR65).  The [other](https://github.com/MetaMask/metamask-extension/commit/ac431887fd0d16dc2b72792d68f517cb8097ef62) [commits](https://github.com/MetaMask/metamask-extension/commit/0c2a762fc079ba038a170b7bee887d3fa4d602dd) are just trying to get the parameter value passed through to the place where it can be used.
