### PR TITLE
Avoid 2,660 requests / hour to Infura

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9793,12 +9793,13 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -9882,12 +9883,13 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -10059,12 +10061,14 @@
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "dev": true,
           "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "dev": true,
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -10669,12 +10673,13 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -18914,11 +18919,21 @@
             "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "dev": true,
               "requires": {
+                "debug": "^2.2.0",
                 "nan": "^2.3.3",
                 "typedarray-to-buffer": "^3.1.2",
                 "yaeti": "^0.0.6"
@@ -34115,6 +34130,11 @@
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
       "dev": true
     },
+    "single-call-balance-checker-abi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/single-call-balance-checker-abi/-/single-call-balance-checker-abi-1.0.0.tgz",
+      "integrity": "sha512-T5fRBJHmGEMe76JFGB36gcZnOh1ip2S7Qsp7cwmwrfMRjadxTe02zJHtXERpnQf2yvSqNWRxvae5f6e8v4rhng=="
+    },
     "sinon": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.0.tgz",
@@ -38327,6 +38347,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
       "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
       "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -38335,7 +38356,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "semaphore": "^1.0.5",
     "semver": "^5.4.1",
     "shallow-copy": "0.0.1",
+    "single-call-balance-checker-abi": "^1.0.0",
     "sw-controller": "^1.0.3",
     "sw-stream": "^2.0.2",
     "swappable-obj-proxy": "^1.1.0",


### PR DESCRIPTION
The `DetectTokensController` has been querying every single ERC20 contract in the `eth-contract-metadata ` package (134 in total) every 3 minutes to see if the selectedAddress has a positive balance and start watching that token.

That can be done in a single call by querying a [smart contract]( https://github.com/wbobeirne/eth-balance-checker/blob/master/contracts/BalanceChecker.sol). The entire approach is described [here](https://medium.com/@wbobeirne/get-all-eth-token-balances-for-multiple-addresses-in-a-single-node-call-4d0bcd1e5625).  Note that instead of using the package mentioned in the article I just published the ABI of that contract as an npm module and query the contract directly because that package has a some dependencies that we don't want to bring in (truffle for ex.)

So instead of 134 requests / 3 minutes, we're doing 1, which results in 2,660 requests less made to Infura per hour.

I've submitted a similar PR to GABA: https://github.com/MetaMask/gaba/pull/55

Also, because we were firing those 134 requests as soon as the user logs in (or every 3 minutes) and most browsers can do no more than 10 requests in parallel, it was most likely to be causing a bottleneck and potentially making  the UI responsive, so  I wouldn't be surprised if this is related to #6017 