### PR TITLE
Use Parity on-chain registry only when is needed

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -19,6 +19,7 @@ class PreferencesController {
    * @property {boolean} store.useBlockie The users preference for blockie identicons within the UI
    * @property {object} store.featureFlags A key-boolean map, where keys refer to features and booleans to whether the
    * user wishes to see that feature
+   * @property {object} store.knownMethodData Contains all data methods known by the user
    * @property {string} store.currentLocale The preferred language locale key
    * @property {string} store.selectedAddress A hex string that matches the currently selected address in the app
    *
@@ -36,6 +37,7 @@ class PreferencesController {
         betaUI: true,
         skipAnnounceBetaUI: true,
       },
+      knownMethodData: {},
       currentLocale: opts.initLangCode,
       identities: {},
       lostIdentities: {},
@@ -96,6 +98,18 @@ class PreferencesController {
     const newEntry = { address, symbol, decimals, image }
     suggested[address] = newEntry
     this.store.updateState({ suggestedTokens: suggested })
+  }
+
+  /**
+   * Add new dataMethod to state, to avoid requesting this information again through Infura
+   *
+   * @param {string} fourBytePrefix Four-byte method signature
+   * @param {string} dataMethod Corresponding data method
+   */
+  addKnownMethodData (fourBytePrefix, dataMethod) {
+    const knownMethodData = this.store.getState().knownMethodData
+    knownMethodData[fourBytePrefix] = dataMethod
+    this.store.updateState({ knownMethodData })
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -101,14 +101,14 @@ class PreferencesController {
   }
 
   /**
-   * Add new dataMethod to state, to avoid requesting this information again through Infura
+   * Add new methodData to state, to avoid requesting this information again through Infura
    *
    * @param {string} fourBytePrefix Four-byte method signature
-   * @param {string} dataMethod Corresponding data method
+   * @param {string} methodData Corresponding data method
    */
-  addKnownMethodData (fourBytePrefix, dataMethod) {
+  addKnownMethodData (fourBytePrefix, methodData) {
     const knownMethodData = this.store.getState().knownMethodData
-    knownMethodData[fourBytePrefix] = dataMethod
+    knownMethodData[fourBytePrefix] = methodData
     this.store.updateState({ knownMethodData })
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -425,6 +425,7 @@ module.exports = class MetamaskController extends EventEmitter {
       setAccountLabel: nodeify(preferencesController.setAccountLabel, preferencesController),
       setFeatureFlag: nodeify(preferencesController.setFeatureFlag, preferencesController),
       setPreference: nodeify(preferencesController.setPreference, preferencesController),
+      addKnownMethodData: nodeify(preferencesController.addKnownMethodData, preferencesController),
 
       // BlacklistController
       whitelistPhishingDomain: this.whitelistPhishingDomain.bind(this),

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -236,6 +236,7 @@ var actions = {
   removeToken,
   updateTokens,
   removeSuggestedTokens,
+  addKnownMethodData,
   UPDATE_TOKENS: 'UPDATE_TOKENS',
   setRpcTarget: setRpcTarget,
   delRpcTarget: delRpcTarget,
@@ -1490,7 +1491,6 @@ const backgroundSetLocked = () => {
       if (error) {
         return reject(error)
       }
-
       resolve()
     })
   })
@@ -1718,6 +1718,12 @@ function removeSuggestedTokens () {
     })
     .then(() => updateMetamaskStateFromBackground())
     .then(suggestedTokens => dispatch(actions.updateMetamaskState({...suggestedTokens})))
+  }
+}
+
+function addKnownMethodData (fourBytePrefix, dataMethod) {
+  return (dispatch) => {
+    background.addKnownMethodData(fourBytePrefix, dataMethod)
   }
 }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -1721,9 +1721,9 @@ function removeSuggestedTokens () {
   }
 }
 
-function addKnownMethodData (fourBytePrefix, dataMethod) {
+function addKnownMethodData (fourBytePrefix, methodData) {
   return (dispatch) => {
-    background.addKnownMethodData(fourBytePrefix, dataMethod)
+    background.addKnownMethodData(fourBytePrefix, methodData)
   }
 }
 

--- a/ui/app/components/transaction-list-item/transaction-list-item.container.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.container.js
@@ -3,7 +3,7 @@ import { withRouter } from 'react-router-dom'
 import { compose } from 'recompose'
 import withMethodData from '../../higher-order-components/with-method-data'
 import TransactionListItem from './transaction-list-item.component'
-import { setSelectedToken, showModal, showSidebar } from '../../actions'
+import { setSelectedToken, showModal, showSidebar, addKnownMethodData } from '../../actions'
 import { hexToDecimal } from '../../helpers/conversions.util'
 import { getTokenData } from '../../helpers/transactions.util'
 import { increaseLastGasPrice } from '../../helpers/confirm-transaction/util'
@@ -15,11 +15,19 @@ import {
   setCustomGasLimit,
 } from '../../ducks/gas.duck'
 
+const mapStateToProps = state => {
+  const { metamask: { knownMethodData } } = state
+  return {
+    knownMethodData,
+  }
+}
+
 const mapDispatchToProps = dispatch => {
   return {
     fetchBasicGasAndTimeEstimates: () => dispatch(fetchBasicGasAndTimeEstimates()),
     fetchGasEstimates: (blockTime) => dispatch(fetchGasEstimates(blockTime)),
     setSelectedToken: tokenAddress => dispatch(setSelectedToken(tokenAddress)),
+    addKnownMethodData: (fourBytePrefix, methodData) => dispatch(addKnownMethodData(fourBytePrefix, methodData)),
     retryTransaction: (transaction, gasPrice) => {
       dispatch(setCustomGasPriceForRetry(gasPrice || transaction.txParams.gasPrice))
       dispatch(setCustomGasLimit(transaction.txParams.gas))
@@ -64,6 +72,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 
 export default compose(
   withRouter,
-  connect(null, mapDispatchToProps, mergeProps),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   withMethodData,
 )(TransactionListItem)

--- a/ui/app/helpers/transactions.util.js
+++ b/ui/app/helpers/transactions.util.js
@@ -60,6 +60,18 @@ export function isConfirmDeployContract (txData = {}) {
 }
 
 /**
+ * Returns four-byte method signature from data
+ *
+ * @param {string} data - The hex data (@code txParams.data) of a transaction
+ * @returns {string} - The four-byte method signature
+ */
+export function getFourBytePrefix (data = '') {
+  const prefixedData = ethUtil.addHexPrefix(data)
+  const fourBytePrefix = prefixedData.slice(0, 10)
+  return fourBytePrefix
+}
+
+/**
  * Returns the action of a transaction as a key to be passed into the translator.
  * @param {Object} transaction - txData object
  * @param {Object} methodData - Data returned from eth-method-registry

--- a/ui/app/higher-order-components/with-method-data/with-method-data.component.js
+++ b/ui/app/higher-order-components/with-method-data/with-method-data.component.js
@@ -37,7 +37,7 @@ export default function withMethodData (WrappedComponent) {
             methodData = knownMethodData[fourBytePrefix]
           } else {
             methodData = await getMethodData(data)
-            if (!methodData.isEmpty()) {
+            if (!Object.entries(methodData).length === 0) {
               addKnownMethodData(fourBytePrefix, methodData)
             }
           }

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -54,6 +54,7 @@ function reduceMetamask (state, action) {
     preferences: {
       useNativeCurrencyAsPrimaryCurrency: true,
     },
+    knownMethodData: {},
   }, state.metamask)
 
   switch (action.type) {


### PR DESCRIPTION
Right now we look up functions signatures using Parity on-chain registry every time the transaction list is rendered, for each transaction without exception.

This PR adds to state `knownMethodData` object with the objective to avoid unnecessary calls to Infura. If I have 10 txs of method data `Transfer` we just need to query the contract for the needed method data once, not 10 times nor 10 times each time the txs list is rendered.

This is hopefully going to reduce the load to Infura.