### PR TITLE
the repeated getSelectedAddress() func  send.selectors.js is removed

### DIFF
--- a/ui/app/components/app/send/send.container.js
+++ b/ui/app/components/app/send/send.container.js
@@ -2,6 +2,10 @@ import { connect } from 'react-redux'
 import SendEther from './send.component'
 import { withRouter } from 'react-router-dom'
 import { compose } from 'recompose'
+const {
+  getSelectedAddress,
+} = require('../../../selectors/selectors')
+
 import {
   getAmountConversionRate,
   getBlockGasLimit,
@@ -12,7 +16,6 @@ import {
   getGasTotal,
   getPrimaryCurrency,
   getRecentBlocks,
-  getSelectedAddress,
   getSelectedToken,
   getSelectedTokenContract,
   getSelectedTokenToFiatRate,

--- a/ui/app/components/app/send/send.selectors.js
+++ b/ui/app/components/app/send/send.selectors.js
@@ -5,6 +5,7 @@ const {
 } = require('../../../helpers/utils/conversion-util')
 const {
   getMetaMaskAccounts,
+  getSelectedAddress
 } = require('../../../selectors/selectors')
 const {
   estimateGasPriceFromRecentBlocks,
@@ -33,7 +34,6 @@ const selectors = {
   getPrimaryCurrency,
   getRecentBlocks,
   getSelectedAccount,
-  getSelectedAddress,
   getSelectedIdentity,
   getSelectedToken,
   getSelectedTokenContract,
@@ -147,12 +147,6 @@ function getSelectedAccount (state) {
   const selectedAddress = getSelectedAddress(state)
 
   return accounts[selectedAddress]
-}
-
-function getSelectedAddress (state) {
-  const selectedAddress = state.metamask.selectedAddress || Object.keys(getMetaMaskAccounts(state))[0]
-
-  return selectedAddress
 }
 
 function getSelectedIdentity (state) {

--- a/ui/app/components/app/send/send.selectors.js
+++ b/ui/app/components/app/send/send.selectors.js
@@ -5,7 +5,7 @@ const {
 } = require('../../../helpers/utils/conversion-util')
 const {
   getMetaMaskAccounts,
-  getSelectedAddress
+  getSelectedAddress,
 } = require('../../../selectors/selectors')
 const {
   estimateGasPriceFromRecentBlocks,

--- a/ui/app/components/app/send/tests/send-container.test.js
+++ b/ui/app/components/app/send/tests/send-container.test.js
@@ -54,7 +54,7 @@ proxyquire('../send.container.js', {
   './send.utils.js': {
     calcGasTotal: (gasLimit, gasPrice) => gasLimit + gasPrice,
   },
-  
+
 })
 
 describe('send container', () => {

--- a/ui/app/components/app/send/tests/send-container.test.js
+++ b/ui/app/components/app/send/tests/send-container.test.js
@@ -35,7 +35,6 @@ proxyquire('../send.container.js', {
     getGasTotal: (s) => `mockGasTotal:${s}`,
     getPrimaryCurrency: (s) => `mockPrimaryCurrency:${s}`,
     getRecentBlocks: (s) => `mockRecentBlocks:${s}`,
-    getSelectedAddress: (s) => `mockSelectedAddress:${s}`,
     getSelectedToken: (s) => `mockSelectedToken:${s}`,
     getSelectedTokenContract: (s) => `mockTokenContract:${s}`,
     getSelectedTokenToFiatRate: (s) => `mockTokenToFiatRate:${s}`,
@@ -47,11 +46,15 @@ proxyquire('../send.container.js', {
     getTokenBalance: (s) => `mockTokenBalance:${s}`,
     getQrCodeData: (s) => `mockQrCodeData:${s}`,
   },
+  '../../../selectors/selectors': {
+    getSelectedAddress: (s) => `mockSelectedAddress:${s}`,
+  },
   '../../../store/actions': actionSpies,
   '../../../ducks/send/send.duck': duckActionSpies,
   './send.utils.js': {
     calcGasTotal: (gasLimit, gasPrice) => gasLimit + gasPrice,
   },
+  
 })
 
 describe('send container', () => {

--- a/ui/app/components/app/send/tests/send-selectors.test.js
+++ b/ui/app/components/app/send/tests/send-selectors.test.js
@@ -273,6 +273,7 @@ describe('send selectors', () => {
     })
   })
 
+
   describe('getSelectedIdentity()', () => {
     it('should return the identity object of the currently selected address', () => {
       assert.deepEqual(

--- a/ui/app/components/app/send/tests/send-selectors.test.js
+++ b/ui/app/components/app/send/tests/send-selectors.test.js
@@ -20,7 +20,6 @@ const {
   getPrimaryCurrency,
   getRecentBlocks,
   getSelectedAccount,
-  getSelectedAddress,
   getSelectedIdentity,
   getSelectedToken,
   getSelectedTokenContract,
@@ -270,15 +269,6 @@ describe('send selectors', () => {
           nonce: '0x0',
           address: '0xd85a4b6a394794842887b8284293d69163007bbb',
         }
-      )
-    })
-  })
-
-  describe('getSelectedAddress()', () => {
-    it('should', () => {
-      assert.equal(
-        getSelectedAddress(mockState),
-        '0xd85a4b6a394794842887b8284293d69163007bbb'
       )
     })
   })


### PR DESCRIPTION
- getSelectedAddress() is removed from send.selectors.js and was imported from selectors.js
- All other imports were also made from selectors.js