### PR TITLE
CI/Loading gas modal fix

### DIFF
--- a/test/e2e/beta/metamask-beta-responsive-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-responsive-ui.spec.js
@@ -278,6 +278,7 @@ describe('MetaMask', function () {
 
       const inputValue = await inputAmount.getAttribute('value')
       assert.equal(inputValue, '1')
+      await delay(regularDelayMs)
     })
 
     it('opens and closes the gas modal', async function () {

--- a/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
+++ b/ui/app/components/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
@@ -196,7 +196,7 @@ export default class AdvancedTabContent extends Component {
           <div className="advanced-tab__fee-chart__title">{ t('liveGasPricePredictions') }</div>
           {!gasEstimatesLoading
             ? <GasPriceChart {...gasChartProps} updateCustomGasPrice={updateCustomGasPrice} />
-            : <Loading />
+            : <Loading height={'165px'}/>
           }
           <div className="advanced-tab__fee-chart__speed-buttons">
             <span>{ t('slower') }</span>

--- a/ui/app/components/loading-screen/loading-screen.component.js
+++ b/ui/app/components/loading-screen/loading-screen.component.js
@@ -11,7 +11,11 @@ class LoadingScreen extends Component {
 
   render () {
     return (
-      h('.loading-overlay', [
+      h('.loading-overlay', {
+        style: {
+          height: this.props.height,
+        },
+      }, [
         h('.loading-overlay__container', [
           h(Spinner, {
             color: '#F7C06C',
@@ -26,6 +30,7 @@ class LoadingScreen extends Component {
 
 LoadingScreen.propTypes = {
   loadingMessage: PropTypes.string,
+  height: PropTypes.string,
 }
 
 module.exports = LoadingScreen


### PR DESCRIPTION
Loading overlay blocks the gas modal when there aren't enough recentBlock information to load the graph. Which is interfering with the CI test on line https://github.com/MetaMask/metamask-extension/blob/a14b106afa067a97278a88474c1450d201fe2385/test/e2e/beta/metamask-beta-responsive-ui.spec.js#L284

Note: After doing the loading modal, I realized we could have just change the test to click the Close button instead of the Save button, which is smaller than this PR. Still proposing this PR in case the loading modal being 100% height is an issue.

Before: 
![screenshot from 2019-01-24 21-08-10](https://user-images.githubusercontent.com/13376180/51726607-1467d400-201d-11e9-9e36-1b8686420e6f.png)
![screenshot from 2019-01-24 21-08-29](https://user-images.githubusercontent.com/13376180/51726610-16319780-201d-11e9-896e-569ee95ff4f1.png)

After: 
![screenshot from 2019-01-24 21-10-47](https://user-images.githubusercontent.com/13376180/51726623-1e89d280-201d-11e9-935d-2c0a1ab636e1.png)
![screenshot from 2019-01-24 21-11-10](https://user-images.githubusercontent.com/13376180/51726625-20ec2c80-201d-11e9-8d0e-71c0d0850b4d.png)



