### PR TITLE
Check balance before showing cancel

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -884,6 +884,9 @@
   "noTransactions": {
     "message": "You have no transactions"
   },
+  "notEnoughGas": {
+    "message": "Not Enough Gas"
+  },
   "notFound": {
     "message": "Not Found"
   },

--- a/ui/app/components/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/transaction-list-item-details/transaction-list-item-details.component.js
@@ -19,11 +19,13 @@ export default class TransactionListItemDetails extends PureComponent {
     onRetry: PropTypes.func,
     showCancel: PropTypes.bool,
     showRetry: PropTypes.bool,
+    cancelDisabled: PropTypes.bool,
     transactionGroup: PropTypes.object,
   }
 
   state = {
     justCopied: false,
+    cancelDisabled: false,
   }
 
   handleEtherscanClick = () => {
@@ -61,10 +63,52 @@ export default class TransactionListItemDetails extends PureComponent {
     })
   }
 
+  renderCancel() {
+    const { t } = this.context
+    const {
+      showCancel,
+      cancelDisabled,
+    } = this.props
+
+    if (!showCancel) {
+      return null
+    }
+
+    return cancelDisabled
+      ? (
+        <Tooltip title={t('notEnoughGas')}>
+          <div>
+            <Button
+              type="raised"
+              onClick={this.handleCancel}
+              className="transaction-list-item-details__header-button"
+              disabled
+            >
+              { t('cancel') }
+            </Button>
+          </div>
+        </Tooltip>
+      )
+      : (
+        <Button
+          type="raised"
+          onClick={this.handleCancel}
+          className="transaction-list-item-details__header-button"
+        >
+          { t('cancel') }
+        </Button>
+      )
+  }
+
   render () {
     const { t } = this.context
     const { justCopied } = this.state
-    const { transactionGroup, showCancel, showRetry, onCancel, onRetry } = this.props
+    const {
+      transactionGroup,
+      showRetry,
+      onCancel,
+      onRetry,
+    } = this.props
     const { primaryTransaction: transaction } = transactionGroup
     const { txParams: { to, from } = {} } = transaction
 
@@ -84,17 +128,7 @@ export default class TransactionListItemDetails extends PureComponent {
                 </Button>
               )
             }
-            {
-              showCancel && (
-                <Button
-                  type="raised"
-                  onClick={this.handleCancel}
-                  className="transaction-list-item-details__header-button"
-                >
-                  { t('cancel') }
-                </Button>
-              )
-            }
+            { this.renderCancel() }
             <Tooltip title={justCopied ? t('copiedTransactionId') : t('copyTransactionId')}>
               <Button
                 type="raised"

--- a/ui/app/components/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.component.js
@@ -195,7 +195,8 @@ export default class TransactionListItem extends PureComponent {
                   onRetry={this.handleRetry}
                   showRetry={showRetry && methodData.done}
                   onCancel={this.handleCancel}
-                  showCancel={showCancel && hasEnoughCancelGas}
+                  showCancel={showCancel}
+                  cancelDisabled={!hasEnoughCancelGas}
                 />
               </div>
             )

--- a/ui/app/components/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.component.js
@@ -23,6 +23,7 @@ export default class TransactionListItem extends PureComponent {
     setSelectedToken: PropTypes.func,
     showCancelModal: PropTypes.func,
     showCancel: PropTypes.bool,
+    hasEnoughCancelGas: PropTypes.bool,
     showRetry: PropTypes.bool,
     token: PropTypes.object,
     tokenData: PropTypes.object,
@@ -137,6 +138,7 @@ export default class TransactionListItem extends PureComponent {
       nonceAndDate,
       primaryTransaction,
       showCancel,
+      hasEnoughCancelGas,
       showRetry,
       tokenData,
       transactionGroup,
@@ -193,7 +195,7 @@ export default class TransactionListItem extends PureComponent {
                   onRetry={this.handleRetry}
                   showRetry={showRetry && methodData.done}
                   onCancel={this.handleCancel}
-                  showCancel={showCancel}
+                  showCancel={showCancel && hasEnoughCancelGas}
                 />
               </div>
             )

--- a/ui/app/components/transaction-list-item/transaction-list-item.container.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { compose } from 'recompose'
+import ethUtil from 'ethereumjs-util'
 const BigNumber = require('bignumber.js')
 import withMethodData from '../../higher-order-components/with-method-data'
 import TransactionListItem from './transaction-list-item.component'
@@ -15,9 +16,8 @@ import {
   setCustomGasPriceForRetry,
   setCustomGasLimit,
 } from '../../ducks/gas.duck'
-import ethUtil from "ethereumjs-util"
-import {multiplyCurrencies} from "../../conversion-util"
-import {getSelectedAddress} from "../../selectors"
+import {multiplyCurrencies} from '../../conversion-util'
+import {getSelectedAddress} from '../../selectors'
 
 const mapStateToProps = state => {
   const { metamask: { knownMethodData, accounts } } = state


### PR DESCRIPTION
This PR adds a check to make sure that `selectedAccount` has enough balance to cover gas fee for cancel transaction. If `selectedAccountBalance` is less than the gas fee for canceling, it will not render the cancel button.

fixes #5927 