### PR TITLE
Show "Received" transaction

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -998,6 +998,9 @@
   "receive": {
     "message": "Receive"
   },
+  "receivedEther": {
+    "message": "Received Ether"
+  },
   "recipientAddress": {
     "message": "Recipient Address"
   },

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -16,7 +16,6 @@ const {
   TRANSACTION_TYPE_RETRY,
   TRANSACTION_TYPE_STANDARD,
   TRANSACTION_STATUS_APPROVED,
-  TRANSACTION_STATUS_CONFIRMED,
 } = require('./enums')
 
 const { hexToBn, bnToHex, BnMultiplyByFraction } = require('../../lib/util')
@@ -105,25 +104,6 @@ class TransactionController extends EventEmitter {
 
     // request state update to finalize initialization
     this._updatePendingTxsAfterFirstBlock()
-    const opt = {
-      from: "0xcf1de0b4d1e492080336909f70413a5f4e7eec62",
-      gas: "0x5208",
-      gasPrice: "0x5d21dba00",
-      nonce: "0x44",
-      to: "0xcf1de0b4d1e492080336909f70413a5f4e7eec62",
-      value: "0x2386f26fc10000",
-    }
-
-    setTimeout(() => {
-      // let txMeta = this.txStateManager.generateTxMeta({
-      //   txParams: opt,
-      //   type: TRANSACTION_TYPE_STANDARD,
-      //   status: TRANSACTION_STATUS_APPROVED,
-      // })
-      // this.addTx(txMeta)
-    }, 1000)
-    console.log(this.txStateManager.getFullTxList())
-    // this.addUnapprovedTransaction({})
   }
 
   /** @returns {number} the chainId*/
@@ -195,7 +175,7 @@ class TransactionController extends EventEmitter {
     // validate
     const normalizedTxParams = txUtils.normalizeTxParams(txParams)
     // Assert the from address is the selected address
-    if (![normalizedTxParams.from, normalizedTxParams.to].includes(this.getSelectedAddress())) {
+    if (normalizedTxParams.from !== this.getSelectedAddress()) {
       throw new Error(`Transaction from address isn't valid for this account`)
     }
     txUtils.validateTxParams(normalizedTxParams)

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -16,6 +16,7 @@ const {
   TRANSACTION_TYPE_RETRY,
   TRANSACTION_TYPE_STANDARD,
   TRANSACTION_STATUS_APPROVED,
+  TRANSACTION_STATUS_CONFIRMED,
 } = require('./enums')
 
 const { hexToBn, bnToHex, BnMultiplyByFraction } = require('../../lib/util')
@@ -104,6 +105,25 @@ class TransactionController extends EventEmitter {
 
     // request state update to finalize initialization
     this._updatePendingTxsAfterFirstBlock()
+    const opt = {
+      from: "0xcf1de0b4d1e492080336909f70413a5f4e7eec62",
+      gas: "0x5208",
+      gasPrice: "0x5d21dba00",
+      nonce: "0x44",
+      to: "0xcf1de0b4d1e492080336909f70413a5f4e7eec62",
+      value: "0x2386f26fc10000",
+    }
+
+    setTimeout(() => {
+      // let txMeta = this.txStateManager.generateTxMeta({
+      //   txParams: opt,
+      //   type: TRANSACTION_TYPE_STANDARD,
+      //   status: TRANSACTION_STATUS_APPROVED,
+      // })
+      // this.addTx(txMeta)
+    }, 1000)
+    console.log(this.txStateManager.getFullTxList())
+    // this.addUnapprovedTransaction({})
   }
 
   /** @returns {number} the chainId*/
@@ -175,7 +195,7 @@ class TransactionController extends EventEmitter {
     // validate
     const normalizedTxParams = txUtils.normalizeTxParams(txParams)
     // Assert the from address is the selected address
-    if (normalizedTxParams.from !== this.getSelectedAddress()) {
+    if (![normalizedTxParams.from, normalizedTxParams.to].includes(this.getSelectedAddress())) {
       throw new Error(`Transaction from address isn't valid for this account`)
     }
     txUtils.validateTxParams(normalizedTxParams)
@@ -617,9 +637,11 @@ class TransactionController extends EventEmitter {
     this.pendingTxTracker.updatePendingTxs()
     const unapprovedTxs = this.txStateManager.getUnapprovedTxList()
     const selectedAddressTxList = this.txStateManager.getFilteredTxList({
-      from: this.getSelectedAddress(),
+      keys: ['from', 'to'],
+      values: [this.getSelectedAddress(), this.getSelectedAddress()],
       metamaskNetworkId: this.getNetwork(),
     })
+
     this.memStore.updateState({ unapprovedTxs, selectedAddressTxList })
   }
 }

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -615,10 +615,11 @@ class TransactionController extends EventEmitter {
   */
   _updateMemstore () {
     this.pendingTxTracker.updatePendingTxs()
+    const selectedAddress = this.getSelectedAddress()
     const unapprovedTxs = this.txStateManager.getUnapprovedTxList()
-    const selectedAddressTxList = this.txStateManager.getFilteredTxList({
+    let selectedAddressTxList = this.txStateManager.getFilteredTxList({
       keys: ['from', 'to'],
-      values: [this.getSelectedAddress(), this.getSelectedAddress()],
+      values: [selectedAddress, selectedAddress],
       metamaskNetworkId: this.getNetwork(),
     })
 

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -277,7 +277,7 @@ class TransactionStateManager extends EventEmitter {
         const value = values[i]
         ret = ret.concat(this.getTxsByMetaData(key, value, filteredTxList))
       })
-      filteredTxList = ret
+      filteredTxList = [...(new Set(ret))]
     }
 
     Object.keys(rest).forEach((key) => {

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -241,6 +241,13 @@ class TransactionStateManager extends EventEmitter {
     status: 'signed',<br>
     err: undefined,<br>
   }<br></code>
+  <br>To filter by multiple keys<br>
+  let <code>thingsToLookFor = {<br>
+    keys: ['from', 'to'],<br>
+    values: ['0x0..', '0x0..'],<br>
+    status: 'signed',<br>
+    err: undefined,<br>
+  }<br></code>
   @param [initialList=this.getTxList()]
   @returns a {array} of txMeta with all
   options matching
@@ -261,7 +268,19 @@ class TransactionStateManager extends EventEmitter {
   */
   getFilteredTxList (opts, initialList) {
     let filteredTxList = initialList
-    Object.keys(opts).forEach((key) => {
+
+    const { keys, values, ...rest } = opts
+
+    if (keys && values) {
+      let ret = []
+      keys.forEach((key, i) => {
+        const value = values[i]
+        ret = ret.concat(this.getTxsByMetaData(key, value, filteredTxList))
+      })
+      filteredTxList = ret
+    }
+
+    Object.keys(rest).forEach((key) => {
       filteredTxList = this.getTxsByMetaData(key, opts[key], filteredTxList)
     })
     return filteredTxList

--- a/ui/app/components/transaction-action/transaction-action.component.js
+++ b/ui/app/components/transaction-action/transaction-action.component.js
@@ -13,6 +13,7 @@ export default class TransactionAction extends PureComponent {
     className: PropTypes.string,
     transaction: PropTypes.object,
     methodData: PropTypes.object,
+    selectedAddress: PropTypes.string,
   }
 
   state = {
@@ -29,7 +30,7 @@ export default class TransactionAction extends PureComponent {
 
   async getTransactionAction () {
     const { transactionAction } = this.state
-    const { transaction, methodData } = this.props
+    const { transaction, methodData, selectedAddress } = this.props
     const { data, done } = methodData
     const { name = '' } = data
 
@@ -37,7 +38,7 @@ export default class TransactionAction extends PureComponent {
       return
     }
 
-    const actionKey = await getTransactionActionKey(transaction, data)
+    const actionKey = await getTransactionActionKey(transaction, data, selectedAddress)
     const action = actionKey
       ? this.context.t(actionKey)
       : camelCaseToCapitalize(name)

--- a/ui/app/components/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.component.js
@@ -130,7 +130,7 @@ export default class TransactionListItem extends PureComponent {
       )
   }
 
-  renderReceive () {
+  render () {
     const {
       assetImages,
       transaction,
@@ -139,12 +139,23 @@ export default class TransactionListItem extends PureComponent {
       primaryTransaction,
       showCancel,
       showRetry,
+      tokenData,
       transactionGroup,
       selectedAddress,
     } = this.props
     const { txParams = {} } = transaction
     const { showTransactionDetails } = this.state
-    const fromAddress = txParams.from
+    const isDeposit = txParams.to === selectedAddress
+
+    let address
+
+    if (isDeposit) {
+      address = txParams.from
+    } else {
+      address = tokenData
+        ? tokenData.params && tokenData.params[0] && tokenData.params[0].value || txParams.to
+        : txParams.to
+    }
 
     return (
       <div className="transaction-list-item">
@@ -154,9 +165,9 @@ export default class TransactionListItem extends PureComponent {
         >
           <Identicon
             className="transaction-list-item__identicon"
-            address={fromAddress}
+            address={address}
             diameter={34}
-            image={assetImages[fromAddress]}
+            image={assetImages[address]}
           />
           <TransactionAction
             transaction={transaction}
@@ -179,87 +190,8 @@ export default class TransactionListItem extends PureComponent {
                 : primaryTransaction.err && primaryTransaction.err.message
             )}
           />
-          { this.renderPrimaryCurrency(true) }
-          { this.renderSecondaryCurrency(true) }
-        </div>
-        <div className={classnames('transaction-list-item__expander', {
-          'transaction-list-item__expander--show': showTransactionDetails,
-        })}>
-          {
-            showTransactionDetails && (
-              <div className="transaction-list-item__details-container">
-                <TransactionListItemDetails
-                  transactionGroup={transactionGroup}
-                  onRetry={this.handleRetry}
-                  showRetry={showRetry && methodData.done}
-                  onCancel={this.handleCancel}
-                  showCancel={showCancel}
-                />
-              </div>
-            )
-          }
-        </div>
-      </div>
-    )
-  }
-
-  render () {
-    const {
-      assetImages,
-      transaction,
-      methodData,
-      nonceAndDate,
-      primaryTransaction,
-      showCancel,
-      showRetry,
-      tokenData,
-      transactionGroup,
-      selectedAddress,
-    } = this.props
-    const { txParams = {} } = transaction
-    const { showTransactionDetails } = this.state
-    const toAddress = tokenData
-      ? tokenData.params && tokenData.params[0] && tokenData.params[0].value || txParams.to
-      : txParams.to
-
-    if (txParams.to === selectedAddress) {
-      return this.renderReceive()
-    }
-
-    return (
-      <div className="transaction-list-item">
-        <div
-          className="transaction-list-item__grid"
-          onClick={this.handleClick}
-        >
-          <Identicon
-            className="transaction-list-item__identicon"
-            address={toAddress}
-            diameter={34}
-            image={assetImages[toAddress]}
-          />
-          <TransactionAction
-            transaction={transaction}
-            methodData={methodData}
-            className="transaction-list-item__action"
-          />
-          <div
-            className="transaction-list-item__nonce"
-            title={nonceAndDate}
-          >
-            { nonceAndDate }
-          </div>
-          <TransactionStatus
-            className="transaction-list-item__status"
-            statusKey={getStatusKey(primaryTransaction)}
-            title={(
-              (primaryTransaction.err && primaryTransaction.err.rpc)
-                ? primaryTransaction.err.rpc.message
-                : primaryTransaction.err && primaryTransaction.err.message
-            )}
-          />
-          { this.renderPrimaryCurrency() }
-          { this.renderSecondaryCurrency() }
+          { this.renderPrimaryCurrency(isDeposit) }
+          { this.renderSecondaryCurrency(isDeposit) }
         </div>
         <div className={classnames('transaction-list-item__expander', {
           'transaction-list-item__expander--show': showTransactionDetails,

--- a/ui/app/components/transaction-list-item/transaction-list-item.container.js
+++ b/ui/app/components/transaction-list-item/transaction-list-item.container.js
@@ -16,9 +16,10 @@ import {
 } from '../../ducks/gas.duck'
 
 const mapStateToProps = state => {
-  const { metamask: { knownMethodData } } = state
+  const { metamask: { knownMethodData, selectedAddress } } = state
   return {
     knownMethodData,
+    selectedAddress,
   }
 }
 

--- a/ui/app/components/transaction-list/transaction-list.component.js
+++ b/ui/app/components/transaction-list/transaction-list.component.js
@@ -98,7 +98,7 @@ export default class TransactionList extends PureComponent {
       ) : (
         <TransactionListItem
           transactionGroup={transactionGroup}
-          key={`${transactionGroup.nonce}:${index}:${selectedAddress}`}
+          key={`${transactionGroup.nonce || transactions[0].id}:${index}:${selectedAddress}`}
           showRetry={isPendingTx && this.shouldShowRetry(transactionGroup, index === 0)}
           showCancel={isPendingTx && this.shouldShowCancel(transactionGroup)}
           token={selectedToken}

--- a/ui/app/components/transaction-list/transaction-list.component.js
+++ b/ui/app/components/transaction-list/transaction-list.component.js
@@ -20,6 +20,7 @@ export default class TransactionList extends PureComponent {
     selectedToken: PropTypes.object,
     updateNetworkNonce: PropTypes.func,
     assetImages: PropTypes.object,
+    selectedAddress: PropTypes.string,
   }
 
   componentDidMount () {
@@ -85,7 +86,7 @@ export default class TransactionList extends PureComponent {
   }
 
   renderTransaction (transactionGroup, index, isPendingTx = false) {
-    const { selectedToken, assetImages } = this.props
+    const { selectedToken, assetImages, selectedAddress } = this.props
     const { transactions = [] } = transactionGroup
 
     return transactions[0].key === TRANSACTION_TYPE_SHAPESHIFT
@@ -97,7 +98,7 @@ export default class TransactionList extends PureComponent {
       ) : (
         <TransactionListItem
           transactionGroup={transactionGroup}
-          key={`${transactionGroup.nonce}:${index}`}
+          key={`${transactionGroup.nonce}:${index}:${selectedAddress}`}
           showRetry={isPendingTx && this.shouldShowRetry(transactionGroup, index === 0)}
           showCancel={isPendingTx && this.shouldShowCancel(transactionGroup)}
           token={selectedToken}

--- a/ui/app/components/transaction-list/transaction-list.container.js
+++ b/ui/app/components/transaction-list/transaction-list.container.js
@@ -45,11 +45,11 @@ const mapDispatchToProps = dispatch => {
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { selectedAddress, ...restStateProps } = stateProps
+  const { selectedAddress } = stateProps
   const { updateNetworkNonce, ...restDispatchProps } = dispatchProps
 
   return {
-    ...restStateProps,
+    ...stateProps,
     ...restDispatchProps,
     ...ownProps,
     updateNetworkNonce: () => updateNetworkNonce(selectedAddress),

--- a/ui/app/components/transaction-list/transaction-list.container.js
+++ b/ui/app/components/transaction-list/transaction-list.container.js
@@ -11,11 +11,29 @@ import { selectedTokenSelector } from '../../selectors/tokens'
 import { updateNetworkNonce } from '../../actions'
 
 const mapStateToProps = state => {
+  const selectedAddress = getSelectedAddress(state)
   return {
     completedTransactions: nonceSortedCompletedTransactionsSelector(state),
+    // completedTransactions: nonceSortedCompletedTransactionsSelector({
+    //   ...state,
+    //   metamask: {
+    //     ...state.metamask,
+    //     selectedAddressTxList: (state.metamask.selectedAddressTxList).map((txMeta) => {
+    //       return txMeta.txParams.to === selectedAddress
+    //         ? {
+    //           ...txMeta,
+    //           txParams: {
+    //             ...txMeta.txParams,
+    //             nonce: undefined,
+    //           },
+    //         }
+    //         : txMeta
+    //     }),
+    //   },
+    // }),
     pendingTransactions: nonceSortedPendingTransactionsSelector(state),
     selectedToken: selectedTokenSelector(state),
-    selectedAddress: getSelectedAddress(state),
+    selectedAddress,
     assetImages: getAssetImages(state),
   }
 }

--- a/ui/app/components/transaction-list/transaction-list.container.js
+++ b/ui/app/components/transaction-list/transaction-list.container.js
@@ -11,29 +11,11 @@ import { selectedTokenSelector } from '../../selectors/tokens'
 import { updateNetworkNonce } from '../../actions'
 
 const mapStateToProps = state => {
-  const selectedAddress = getSelectedAddress(state)
   return {
     completedTransactions: nonceSortedCompletedTransactionsSelector(state),
-    // completedTransactions: nonceSortedCompletedTransactionsSelector({
-    //   ...state,
-    //   metamask: {
-    //     ...state.metamask,
-    //     selectedAddressTxList: (state.metamask.selectedAddressTxList).map((txMeta) => {
-    //       return txMeta.txParams.to === selectedAddress
-    //         ? {
-    //           ...txMeta,
-    //           txParams: {
-    //             ...txMeta.txParams,
-    //             nonce: undefined,
-    //           },
-    //         }
-    //         : txMeta
-    //     }),
-    //   },
-    // }),
     pendingTransactions: nonceSortedPendingTransactionsSelector(state),
     selectedToken: selectedTokenSelector(state),
-    selectedAddress,
+    selectedAddress: getSelectedAddress(state),
     assetImages: getAssetImages(state),
   }
 }

--- a/ui/app/constants/transactions.js
+++ b/ui/app/constants/transactions.js
@@ -13,6 +13,7 @@ export const TOKEN_METHOD_APPROVE = 'approve'
 export const TOKEN_METHOD_TRANSFER_FROM = 'transferfrom'
 
 export const SEND_ETHER_ACTION_KEY = 'sentEther'
+export const RECEIVE_ETHER_ACTION_KEY = 'receivedEther'
 export const DEPLOY_CONTRACT_ACTION_KEY = 'contractDeployment'
 export const APPROVE_ACTION_KEY = 'approve'
 export const SEND_TOKEN_ACTION_KEY = 'sentTokens'

--- a/ui/app/helpers/transactions.util.js
+++ b/ui/app/helpers/transactions.util.js
@@ -19,6 +19,7 @@ import {
   SIGNATURE_REQUEST_KEY,
   CONTRACT_INTERACTION_KEY,
   CANCEL_ATTEMPT_ACTION_KEY,
+  RECEIVE_ETHER_ACTION_KEY,
 } from '../constants/transactions'
 
 import { addCurrencies } from '../conversion-util'
@@ -75,9 +76,10 @@ export function getFourBytePrefix (data = '') {
  * Returns the action of a transaction as a key to be passed into the translator.
  * @param {Object} transaction - txData object
  * @param {Object} methodData - Data returned from eth-method-registry
+ * @param {Object} selectedAddress - address currently selected
  * @returns {string|undefined}
  */
-export async function getTransactionActionKey (transaction, methodData) {
+export async function getTransactionActionKey (transaction, methodData, selectedAddress) {
   const { txParams: { data, to } = {}, msgParams, type } = transaction
 
   if (type === 'cancel') {
@@ -90,6 +92,10 @@ export async function getTransactionActionKey (transaction, methodData) {
 
   if (isConfirmDeployContract(transaction)) {
     return DEPLOY_CONTRACT_ACTION_KEY
+  }
+
+  if (to === selectedAddress) {
+    return RECEIVE_ETHER_ACTION_KEY
   }
 
   if (data) {


### PR DESCRIPTION
This adds the following:
- Filter `selectedAddressTxList` by both `from` and `to` attribute
- Add `received` state to `TransactionListItem`

This will show received tx that are initiated by the extension. The method of which to query tx outside of metamask is still undecided. 

*Question*
- Current completed transaction list is sorted by nonce. Is there a reason for this? Since incoming tx will not follow the same sort order as outgoing tx, the list now appears unsorted. This would be a lot easier if the list is sorted by timestamp. @danjm @cjeria 


<img width="899" alt="screen shot 2019-01-31 at 10 20 17 pm" src="https://user-images.githubusercontent.com/8507735/52106208-bdc34280-25a6-11e9-8687-46b4942359c5.png">
