### PR TITLE
Ensure that custom gas data in state gets set from inline advance gas…

### DIFF
--- a/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
@@ -27,10 +27,13 @@ import {
 } from '../../../../ducks/send.duck'
 import {
   resetCustomData,
+  setCustomGasPrice,
+  setCustomGasLimit,
 } from '../../../../ducks/gas.duck'
 import { getGasLoadingError, gasFeeIsInError, getGasButtonGroupShown } from './send-gas-row.selectors.js'
 import { showModal, setGasPrice, setGasLimit, setGasTotal } from '../../../../actions'
 import { getAdvancedInlineGasShown, getCurrentEthBalance } from '../../../../selectors'
+import { addHexPrefix } from 'ethereumjs-util'
 import SendGasRow from './send-gas-row.component'
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(SendGasRow)
@@ -79,11 +82,13 @@ function mapDispatchToProps (dispatch) {
     setGasPrice: (newPrice, gasLimit) => {
       newPrice = decGWEIToHexWEI(newPrice)
       dispatch(setGasPrice(newPrice))
+      dispatch(setCustomGasPrice(addHexPrefix(newPrice)))
       dispatch(setGasTotal(calcGasTotal(gasLimit, newPrice)))
     },
     setGasLimit: (newLimit, gasPrice) => {
       newLimit = decimalToHex(newLimit)
       dispatch(setGasLimit(newLimit))
+      dispatch(setCustomGasLimit(addHexPrefix(newLimit.toString(16))))
       dispatch(setGasTotal(calcGasTotal(newLimit, gasPrice)))
     },
     showGasButtonGroup: () => dispatch(showGasButtonGroup()),

--- a/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
+++ b/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
@@ -19,6 +19,8 @@ const sendDuckSpies = {
 
 const gasDuckSpies = {
   resetCustomData: sinon.spy(),
+  setCustomGasPrice: sinon.spy(),
+  setCustomGasLimit: sinon.spy(),
 }
 
 proxyquire('../send-gas-row.container.js', {
@@ -123,9 +125,10 @@ describe('send-gas-row container', () => {
     describe('setGasPrice()', () => {
       it('should dispatch an action', () => {
         mapDispatchToPropsObject.setGasPrice('mockNewPrice', 'mockLimit')
-        assert(dispatchSpy.calledTwice)
+        assert(dispatchSpy.calledThrice)
         assert(actionSpies.setGasPrice.calledOnce)
         assert.equal(actionSpies.setGasPrice.getCall(0).args[0], '0xmockNewPrice000')
+        assert.equal(gasDuckSpies.setCustomGasPrice.getCall(0).args[0], '0xmockNewPrice000')
         assert(actionSpies.setGasTotal.calledOnce)
         assert.equal(actionSpies.setGasTotal.getCall(0).args[0], 'mockLimit0xmockNewPrice000')
       })
@@ -134,9 +137,10 @@ describe('send-gas-row container', () => {
     describe('setGasLimit()', () => {
       it('should dispatch an action', () => {
         mapDispatchToPropsObject.setGasLimit('mockNewLimit', 'mockPrice')
-        assert(dispatchSpy.calledTwice)
+        assert(dispatchSpy.calledThrice)
         assert(actionSpies.setGasLimit.calledOnce)
         assert.equal(actionSpies.setGasLimit.getCall(0).args[0], '0xmockNewLimit')
+        assert.equal(gasDuckSpies.setCustomGasLimit.getCall(0).args[0], '0xmockNewLimit')
         assert(actionSpies.setGasTotal.calledOnce)
         assert.equal(actionSpies.setGasTotal.getCall(0).args[0], '0xmockNewLimitmockPrice')
       })


### PR DESCRIPTION
… controls on send screen.

This PR fixes a bug that could be seen by doing the following:
- toggle Advanced Gas Controls to true
- edit the gas limit directly on the send screen
- go to the confirm screen
- notice that gas limit is what you just set on the send screen (this is correct behaviour)
- click 'edit' and then the advanced tab
- the gas limit will be 21000

After this PR, the gas limit on the last step will be the expected value, what was set on the send screen.