### PR TITLE
Fixes #6073 : implement class for sign footer button

### DIFF
--- a/ui/app/components/signature-request.js
+++ b/ui/app/components/signature-request.js
@@ -272,6 +272,7 @@ SignatureRequest.prototype.renderFooter = function () {
     h(Button, {
       type: 'primary',
       large: true,
+      className: 'request-signature__footer__sign-button',
       onClick: event => {
         sign(event).then(() => {
           this.props.clearConfirmTransaction()


### PR DESCRIPTION
Added a class name of 'request-signature__footer__sign-button' as requested in issue #6073 .  