### PR TITLE
recent-blocks - dont listen for block when on infura providers

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -158,7 +158,7 @@ module.exports = class NetworkController extends EventEmitter {
   _switchNetwork (opts) {
     this.setNetworkState('loading')
     this._configureProvider(opts)
-    this.emit('networkDidChange')
+    this.emit('networkDidChange', opts.type)
   }
 
   _configureProvider (opts) {

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -3,6 +3,14 @@ const extend = require('xtend')
 const EthQuery = require('eth-query')
 const log = require('loglevel')
 const pify = require('pify')
+const {
+  ROPSTEN,
+  RINKEBY,
+  KOVAN,
+  MAINNET,
+} = require('./network/enums')
+const INFURA_PROVIDER_TYPES = [ROPSTEN, RINKEBY, KOVAN, MAINNET]
+
 
 class RecentBlocksController {
 
@@ -24,7 +32,7 @@ class RecentBlocksController {
    *
    */
   constructor (opts = {}) {
-    const { blockTracker, provider } = opts
+    const { blockTracker, provider, networkController } = opts
     this.blockTracker = blockTracker
     this.ethQuery = new EthQuery(provider)
     this.historyLength = opts.historyLength || 40
@@ -33,12 +41,29 @@ class RecentBlocksController {
       recentBlocks: [],
     }, opts.initState)
     this.store = new ObservableStore(initState)
-
-    this.blockTracker.on('latest', async (newBlockNumberHex) => {
+    const blockListner = async (newBlockNumberHex) => {
       try {
         await this.processBlock(newBlockNumberHex)
       } catch (err) {
         log.error(err)
+      }
+    }
+    let isListeng = false
+    const { type } = networkController.getProviderConfig()
+    if (!INFURA_PROVIDER_TYPES.includes(type) && type !== 'loading') {
+      this.blockTracker.on('latest', blockListner)
+      isListeng = true
+    }
+    networkController.on('networkDidChange', (newType) => {
+      if (INFURA_PROVIDER_TYPES.includes(newType) && isListeng) {
+        this.blockTracker.removeListener('latest', blockListner)
+      } else if (
+        !INFURA_PROVIDER_TYPES.includes(type) &&
+        type !== 'loading' &&
+        !isListeng
+      ) {
+        this.blockTracker.on('latest', blockListner)
+
       }
     })
     this.backfill()

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -48,19 +48,19 @@ class RecentBlocksController {
         log.error(err)
       }
     }
-    let isListeng = false
+    let isListening = false
     const { type } = networkController.getProviderConfig()
     if (!INFURA_PROVIDER_TYPES.includes(type) && type !== 'loading') {
       this.blockTracker.on('latest', blockListner)
-      isListeng = true
+      isListening = true
     }
     networkController.on('networkDidChange', (newType) => {
-      if (INFURA_PROVIDER_TYPES.includes(newType) && isListeng) {
+      if (INFURA_PROVIDER_TYPES.includes(newType) && isListening) {
         this.blockTracker.removeListener('latest', blockListner)
       } else if (
         !INFURA_PROVIDER_TYPES.includes(type) &&
         type !== 'loading' &&
-        !isListeng
+        !isListening
       ) {
         this.blockTracker.on('latest', blockListner)
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -126,6 +126,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.recentBlocksController = new RecentBlocksController({
       blockTracker: this.blockTracker,
       provider: this.provider,
+      networkController: this.networkController,
     })
 
     // account tracker watches balances, nonces, and any code at their address.


### PR DESCRIPTION
this will remove the listener off the block tracker when on infura providers sense it is not needed 

that will allow the block tracker to stop polling