### PR TITLE
Trim whitespace from seed phrase during import

### DIFF
--- a/ui/app/components/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/components/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -30,6 +30,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
 
   parseSeedPhrase = (seedPhrase) => {
     return seedPhrase
+      .trim()
       .match(/\w+/g)
       .join(' ')
   }
@@ -38,9 +39,10 @@ export default class ImportWithSeedPhrase extends PureComponent {
     let seedPhraseError = ''
 
     if (seedPhrase) {
-      if (this.parseSeedPhrase(seedPhrase).split(' ').length !== 12) {
+      const parsedSeedPhrase = this.parseSeedPhrase(seedPhrase)
+      if (parsedSeedPhrase.split(' ').length !== 12) {
         seedPhraseError = this.context.t('seedPhraseReq')
-      } else if (!validateMnemonic(seedPhrase)) {
+      } else if (!validateMnemonic(parsedSeedPhrase)) {
         seedPhraseError = this.context.t('invalidSeedPhrase')
       }
     }


### PR DESCRIPTION
Refs #5827

This PR updates the import seed phrase screen (during on-boarding) to strip extraneous leading and trailing whitespace from the seed phrase. This is useful when the seed phrased pasted has a trailing newline or similar.