### PR TITLE
Add missing hex prefixes for advanced gas inputs

### DIFF
--- a/ui/app/components/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
+++ b/ui/app/components/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import { addHexPrefix } from 'ethereumjs-util'
 import { showModal } from '../../../actions'
 import {
   decGWEIToHexWEI,
@@ -30,8 +31,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...ownProps,
     customGasPrice: convertGasPriceForInputs(customGasPrice),
     customGasLimit: convertGasLimitForInputs(customGasLimit),
-    updateCustomGasPrice: (price) => updateCustomGasPrice(decGWEIToHexWEI(price)),
-    updateCustomGasLimit: (limit) => updateCustomGasLimit(decimalToHex(limit)),
+    updateCustomGasPrice: (price) => updateCustomGasPrice(addHexPrefix(decGWEIToHexWEI(price))),
+    updateCustomGasLimit: (limit) => updateCustomGasLimit(addHexPrefix(decimalToHex(limit))),
   }
 }
 


### PR DESCRIPTION
This PR adds hex prefixes to the data coming out of the `AdvancedGasInputs` component.