### PR TITLE
Add button to force edit token symbol when adding custom token

### DIFF
--- a/ui/app/components/pages/add-token/add-token.component.js
+++ b/ui/app/components/pages/add-token/add-token.component.js
@@ -43,6 +43,7 @@ class AddToken extends Component {
       customDecimalsError: null,
       autoFilled: false,
       displayedTab: SEARCH_TAB,
+      forceEditSymbol: false,
     }
   }
 
@@ -225,6 +226,7 @@ class AddToken extends Component {
       customSymbolError,
       customDecimalsError,
       autoFilled,
+      forceEditSymbol,
     } = this.state
 
     return (
@@ -241,14 +243,28 @@ class AddToken extends Component {
         />
         <TextField
           id="custom-symbol"
-          label={this.context.t('tokenSymbol')}
+          label={(
+            <div className="add-token__custom-symbol__label-wrapper">
+              <span className="add-token__custom-symbol__label">
+                {this.context.t('tokenSymbol')}
+              </span>
+              {(autoFilled && !forceEditSymbol) && (
+                <div
+                  className="add-token__custom-symbol__edit"
+                  onClick={() => this.setState({ forceEditSymbol: true })}
+                >
+                  {this.context.t('edit')}
+                </div>
+              )}
+            </div>
+          )}
           type="text"
           value={customSymbol}
           onChange={e => this.handleCustomSymbolChange(e.target.value)}
           error={customSymbolError}
           fullWidth
           margin="normal"
-          disabled={autoFilled}
+          disabled={autoFilled && !forceEditSymbol}
         />
         <TextField
           id="custom-decimals"

--- a/ui/app/components/pages/add-token/index.scss
+++ b/ui/app/components/pages/add-token/index.scss
@@ -22,4 +22,24 @@
   &__token-list {
     margin-top: 16px;
   }
+
+  &__custom-symbol {
+
+    &__label-wrapper {
+      display: flex;
+      flex-flow: row nowrap;
+    }
+
+    &__label {
+      flex: 0 0 auto;
+    }
+
+    &__edit {
+      flex: 1 1 auto;
+      text-align: right;
+      color: $curious-blue;
+      padding-right: 4px;
+      cursor: pointer;
+    }
+  }
 }


### PR DESCRIPTION
![forceedit](https://user-images.githubusercontent.com/8507735/52674592-eae1f000-2ed8-11e9-9346-eb21f05aba4a.gif)

@bdresser @cjeria 
Took some design liberty on this one to add a "Edit" button when custom token symbol is autofilled. I want to make it an explicit user action that they are editing the token symbol and are diverting from actual data from the token contract. Let me know what you think.