### PR TITLE
Remove public property from package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "metamask-crx",
   "version": "0.0.0",
-  "public": false,
   "private": true,
   "scripts": {
     "start": "gulp dev:extension",


### PR DESCRIPTION
As per the `package.json` documentation [\[1\]][1] setting `"private": true` in the `package.json` file is enough for npm to refuse to publish it. The docs don't specify that a `public` key is respected.

  [1]:https://docs.npmjs.com/files/package.json#private