### PR TITLE
Fix gas estimation when sending to contracts.

### DIFF
--- a/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/components/send/send-content/send-gas-row/send-gas-row.container.js
@@ -26,7 +26,7 @@ import {
 } from '../../../../ducks/gas.duck'
 import { getGasLoadingError, gasFeeIsInError, getGasButtonGroupShown } from './send-gas-row.selectors.js'
 import { showModal, setGasPrice, setGasLimit, setGasTotal } from '../../../../actions'
-import { getAdvancedInlineGasShown, getCurrentEthBalance } from '../../../../selectors'
+import { getAdvancedInlineGasShown, getCurrentEthBalance, getSelectedToken } from '../../../../selectors'
 import SendGasRow from './send-gas-row.component'
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(SendGasRow)
@@ -42,7 +42,7 @@ function mapStateToProps (state) {
   const balance = getCurrentEthBalance(state)
 
   const insufficientBalance = !isBalanceSufficient({
-    amount: getSendAmount(state),
+    amount: getSelectedToken(state) ? '0x0' : getSendAmount(state),
     gasTotal,
     balance,
     conversionRate,

--- a/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
+++ b/ui/app/components/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
@@ -35,6 +35,7 @@ proxyquire('../send-gas-row.container.js', {
   '../../../../selectors': {
     getCurrentEthBalance: (s) => `mockCurrentEthBalance:${s}`,
     getAdvancedInlineGasShown: (s) => `mockAdvancedInlineGasShown:${s}`,
+    getSelectedToken: () => false,
   },
   '../../send.selectors.js': {
     getConversionRate: (s) => `mockConversionRate:${s}`,

--- a/ui/app/components/send/send-footer/send-footer.container.js
+++ b/ui/app/components/send/send-footer/send-footer.container.js
@@ -66,7 +66,7 @@ function mapDispatchToProps (dispatch) {
       })
 
       selectedToken
-        ? dispatch(signTokenTx(selectedToken.address, to, amount, txParams))
+        ? dispatch(signTokenTx(selectedToken.address, to, txParams.amount, txParams))
         : dispatch(signTx(txParams))
     },
     update: ({

--- a/ui/app/components/send/send-footer/send-footer.container.js
+++ b/ui/app/components/send/send-footer/send-footer.container.js
@@ -66,7 +66,7 @@ function mapDispatchToProps (dispatch) {
       })
 
       selectedToken
-        ? dispatch(signTokenTx(selectedToken.address, to, txParams.amount, txParams))
+        ? dispatch(signTokenTx(selectedToken.address, to, amount, txParams))
         : dispatch(signTx(txParams))
     },
     update: ({

--- a/ui/app/components/send/send-footer/tests/send-footer-container.test.js
+++ b/ui/app/components/send/send-footer/tests/send-footer-container.test.js
@@ -14,7 +14,9 @@ const actionSpies = {
 }
 const utilsStubs = {
   addressIsNew: sinon.stub().returns(true),
-  constructTxParams: sinon.stub().returns('mockConstructedTxParams'),
+  constructTxParams: sinon.stub().returns({
+    amount: 'mockConstructedAmount',
+  }),
   constructUpdatedTx: sinon.stub().returns('mockConstructedUpdatedTxParams'),
 }
 
@@ -115,7 +117,7 @@ describe('send-footer container', () => {
         )
         assert.deepEqual(
           actionSpies.signTokenTx.getCall(0).args,
-          [ '0xabc', 'mockTo', 'mockAmount', 'mockConstructedTxParams' ]
+          [ '0xabc', 'mockTo', 'mockConstructedAmount', { amount: 'mockConstructedAmount' } ]
         )
       })
 
@@ -143,7 +145,7 @@ describe('send-footer container', () => {
         )
         assert.deepEqual(
           actionSpies.signTx.getCall(0).args,
-          [ 'mockConstructedTxParams' ]
+          [ { amount: 'mockConstructedAmount' } ]
         )
       })
     })

--- a/ui/app/components/send/send-footer/tests/send-footer-container.test.js
+++ b/ui/app/components/send/send-footer/tests/send-footer-container.test.js
@@ -15,7 +15,7 @@ const actionSpies = {
 const utilsStubs = {
   addressIsNew: sinon.stub().returns(true),
   constructTxParams: sinon.stub().returns({
-    amount: 'mockConstructedAmount',
+    value: 'mockAmount',
   }),
   constructUpdatedTx: sinon.stub().returns('mockConstructedUpdatedTxParams'),
 }
@@ -117,7 +117,7 @@ describe('send-footer container', () => {
         )
         assert.deepEqual(
           actionSpies.signTokenTx.getCall(0).args,
-          [ '0xabc', 'mockTo', 'mockConstructedAmount', { amount: 'mockConstructedAmount' } ]
+          [ '0xabc', 'mockTo', 'mockAmount', { value: 'mockAmount' } ]
         )
       })
 
@@ -145,7 +145,7 @@ describe('send-footer container', () => {
         )
         assert.deepEqual(
           actionSpies.signTx.getCall(0).args,
-          [ { amount: 'mockConstructedAmount' } ]
+          [ { value: 'mockAmount' } ]
         )
       })
     })

--- a/ui/app/components/send/send.utils.js
+++ b/ui/app/components/send/send.utils.js
@@ -234,10 +234,14 @@ async function estimateGas ({
     if (to) {
       paramsForGasEstimate.to = to
     }
+
+    if (!value || value === '0') {
+      paramsForGasEstimate.value = '0xff'
+    }
   }
 
   // if not, fall back to block gasLimit
-  paramsForGasEstimate.gas = ethUtil.addHexPrefix(multiplyCurrencies(blockGasLimit, 0.95, {
+  paramsForGasEstimate.gas = ethUtil.addHexPrefix(multiplyCurrencies(blockGasLimit || '0x5208', 0.95, {
     multiplicandBase: 16,
     multiplierBase: 10,
     roundDown: '0',

--- a/ui/app/components/send/tests/send-utils.test.js
+++ b/ui/app/components/send/tests/send-utils.test.js
@@ -316,6 +316,7 @@ describe('send utils', () => {
       from: 'mockAddress',
       gas: '0x64x0.95',
       to: '0xisContract',
+      value: '0xff',
     }
 
     beforeEach(() => {
@@ -373,7 +374,7 @@ describe('send utils', () => {
       assert.equal(baseMockParams.estimateGasMethod.callCount, 1)
       assert.deepEqual(
         baseMockParams.estimateGasMethod.getCall(0).args[0],
-        { gasPrice: undefined, value: undefined, data, from: baseExpectedCall.from, gas: baseExpectedCall.gas},
+        { gasPrice: undefined, value: '0xff', data, from: baseExpectedCall.from, gas: baseExpectedCall.gas},
       )
       assert.equal(result, '0xabc16')
     })

--- a/ui/app/reducers/metamask.js
+++ b/ui/app/reducers/metamask.js
@@ -36,7 +36,7 @@ function reduceMetamask (state, action) {
       tokenBalance: '0x0',
       from: '',
       to: '',
-      amount: '0x0',
+      amount: '0',
       memo: '',
       errors: {},
       maxModeOn: false,


### PR DESCRIPTION
fixes #5894

When estimating gas limit for a send to a contract and with a 0 value, the methods we rely on for estimation default to provided gas limits. To get an estimate that is based on the contract itself, the estimation method needs to be passed a non-zero value.