### PR TITLE
Allow seed phrases with a trailing newline

### DIFF
--- a/ui/app/components/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/components/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -104,7 +104,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
     const { history, onSubmit } = this.props
 
     try {
-      await onSubmit(password, seedPhrase)
+      await onSubmit(password, this.parseSeedPhrase(seedPhrase))
       this.context.metricsEvent({
         eventOpts: {
           category: 'Onboarding',


### PR DESCRIPTION
Refs #6134 and #5827

Take 3 🎬 

This PR updates the import seed phrase screen (during on-boarding) to strip extraneous leading and trailing whitespace from the seed phrase. This adds the crucial step of using the trimmed seed phrase in the `onSubmit` handler.