### PR TITLE
Bump trezor-connect to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9762,7 +9762,7 @@
       }
     },
     "eth-contract-metadata": {
-      "version": "github:MetaMask/eth-contract-metadata#f6201b0c4aca8e98321b9b0b65744bc2fe8e35fa",
+      "version": "github:MetaMask/eth-contract-metadata#4d855fea9a5c899059134e03986be9d98e844270",
       "from": "github:MetaMask/eth-contract-metadata#master"
     },
     "eth-ens-namehash": {
@@ -9799,12 +9799,12 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.10.0",
@@ -9814,7 +9814,7 @@
           }
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.10.0",
@@ -9852,7 +9852,7 @@
       "dependencies": {
         "babelify": {
           "version": "7.3.0",
-          "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
             "babel-core": "^6.0.14",
@@ -9973,7 +9973,7 @@
       "dependencies": {
         "babelify": {
           "version": "7.3.0",
-          "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
             "babel-core": "^6.0.14",
@@ -10068,12 +10068,12 @@
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "dev": true,
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {
@@ -10084,7 +10084,7 @@
           }
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.10.0",
@@ -10264,7 +10264,7 @@
           "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.10.0",
@@ -10664,15 +10664,16 @@
       }
     },
     "eth-trezor-keyring": {
-      "version": "0.2.0",
-      "resolved": "github:MetaMask/eth-trezor-keyring#528840df6785101ac68ec9fc0cc4bc675eba9292",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eth-trezor-keyring/-/eth-trezor-keyring-0.3.0.tgz",
+      "integrity": "sha512-5mWY7A+52MAaUmMpciIET9lxdrYleFPFeVYCC7LWsA6Z/fT8+YPnKFRr6gmxF3yVk2Xk8YjSBN54/ujBv15Ogg==",
       "requires": {
         "eth-sig-util": "^1.4.2",
         "ethereumjs-tx": "^1.3.4",
         "ethereumjs-util": "^5.1.5",
         "events": "^2.0.0",
         "hdkey": "0.8.0",
-        "trezor-connect": "^6.0.2"
+        "trezor-connect": "^7.0.1"
       },
       "dependencies": {
         "eth-sig-util": {
@@ -10680,18 +10681,8 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
             "ethereumjs-util": "^5.1.1"
-          },
-          "dependencies": {
-            "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-              "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
-              }
-            }
           }
         },
         "ethereum-common": {
@@ -23151,7 +23142,7 @@
       "dependencies": {
         "babelify": {
           "version": "7.3.0",
-          "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
             "babel-core": "^6.0.14",
@@ -23190,7 +23181,7 @@
         },
         "babelify": {
           "version": "7.3.0",
-          "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
             "babel-core": "^6.0.14",
@@ -25769,7 +25760,7 @@
       "dependencies": {
         "babelify": {
           "version": "7.3.0",
-          "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
             "babel-core": "^6.0.14",
@@ -36964,19 +36955,37 @@
       "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
     },
     "trezor-connect": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-6.0.2.tgz",
-      "integrity": "sha512-oSYTPnQD9ZT3vO2hBRdgealHG7t8Wu3oTZXX/U4eRxJZ0WqdEcXG7Nvqe1BL6Rl3VTuj7ALT9DL1Uq3QFYAc3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-7.0.1.tgz",
+      "integrity": "sha512-cMPwSGMfBpp4z5AZvpRwbYNOJU/X+WaxPm+O1Bl1qsdtpl1P4mX81KDtImY6GBk0xC8aKyOd/ZIqYWXZF9tCRQ==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "events": "^1.1.1",
-        "whatwg-fetch": "^2.0.4"
+        "@babel/runtime": "^7.3.1",
+        "events": "^3.0.0",
+        "whatwg-fetch": "^3.0.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+          "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "events": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+          "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        },
         "whatwg-fetch": {
-          "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "eth-query": "^2.1.2",
     "eth-sig-util": "^2.0.2",
     "eth-token-tracker": "^1.1.5",
-    "eth-trezor-keyring": "^0.2.0",
+    "eth-trezor-keyring": "^0.3.0",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",


### PR DESCRIPTION
Trezor asked us to upgrade to the latest version of their library `trezor-connect` via https://github.com/MetaMask/eth-trezor-keyring/pull/13

I've published a new version of `eth-trezor-keyring` to npm and QA'ed myself in Chrome &  Firefox