### PR TITLE
Metrics description

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1012,7 +1012,7 @@
   "participateInMetaMetrics": {
     "message": "Participate in MetaMetrics"
   },
-  "participateInMetaMetricsDesciption": {
+  "participateInMetaMetricsDescription": {
     "message": "Participate in MetaMetrics to help us make MetaMask better"
   },
   "password": {

--- a/ui/app/components/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/app/components/pages/settings/settings-tab/settings-tab.component.js
@@ -635,7 +635,7 @@ export default class SettingsTab extends PureComponent {
         <div className="settings-page__content-item">
           <span>{ t('participateInMetaMetrics') }</span>
           <div className="settings-page__content-description">
-            { t('participateInMetaMetricsDescription') }
+            <span>{ t('participateInMetaMetricsDescription') }</span>
           </div>
         </div>
         <div className="settings-page__content-item">


### PR DESCRIPTION
Fix `participateInMetaMetricsDescription` typo
Wrap in `span`
Fixes #6236 