### PR TITLE
Only call onRecipient and onSender methods if defined in sender-to-recipient

### DIFF
--- a/ui/app/components/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/sender-to-recipient/sender-to-recipient.component.js
@@ -97,7 +97,9 @@ export default class SenderToRecipient extends PureComponent {
         onClick={() => {
           this.setState({ recipientAddressCopied: true })
           copyToClipboard(checksummedRecipientAddress)
-          onRecipientClick()
+          if (onRecipientClick) {
+            onRecipientClick()
+          }
         }}
       >
         { this.renderRecipientIdenticon() }
@@ -164,7 +166,9 @@ export default class SenderToRecipient extends PureComponent {
           onClick={() => {
             this.setState({ senderAddressCopied: true })
             copyToClipboard(checksummedSenderAddress)
-            onSenderClick()
+            if (onSenderClick) {
+              onSenderClick()
+            }
           }}
         >
           { this.renderSenderIdenticon() }


### PR DESCRIPTION
fixes https://sentry.io/organizations/metamask/issues/919690958/?project=273505&query=is%3Aunresolved+release%3A6.2.0&statsPeriod=14d&utc=false

There are some uses of SenderToRecipient that do not pass these methods.