### PR TITLE
Version-6.2.2 patch/fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Current Develop Branch
 
+## 6.2.2 Wed Mar 06 2019
+
+- [#6250](https://github.com/MetaMask/metamask-extension/pull/6250): Add privacy policy link to modal metrics opt-in
+- [#6248](Prevent advanced gas input arrows from setting value to < 0)
+
 ## 6.2.0 Tue Mar 05 2019
 - [#6192](https://github.com/MetaMask/metamask-extension/pull/6192): Improves design and UX of onboarding flow
 - [#6195](https://github.com/MetaMask/metamask-extension/pull/6195): Fixes gas estimation when sending to contracts

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "6.2.0",
+  "version": "6.2.2",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "__MSG_appDescription__",


### PR DESCRIPTION
Both this and https://github.com/MetaMask/metamask-extension/pull/6251 are the version bumps. Which ever is the correct one to release, grab the build for their respective PRs.