### PR TITLE
Update eth-contract-metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9762,7 +9762,7 @@
       }
     },
     "eth-contract-metadata": {
-      "version": "github:MetaMask/eth-contract-metadata#4d855fea9a5c899059134e03986be9d98e844270",
+      "version": "github:MetaMask/eth-contract-metadata#4427783ccd041d13dd3b13448f987b23214e25d7",
       "from": "github:MetaMask/eth-contract-metadata#master"
     },
     "eth-ens-namehash": {


### PR DESCRIPTION
Updated eth-contract-metadata to latest master commit [4427783ccd041d13dd3b13448f987b23214e25d7](https://github.com/MetaMask/eth-contract-metadata/commit/4427783ccd041d13dd3b13448f987b23214e25d7).