### PR TITLE
Nonmultiple notifications for batch txs

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -448,7 +448,7 @@ function setupController (initState, initLangCode) {
 function triggerUi () {
   extension.tabs.query({ active: true }, tabs => {
     const currentlyActiveMetamaskTab = Boolean(tabs.find(tab => openMetamaskTabsIDs[tab.id]))
-    if (!popupIsOpen && !currentlyActiveMetamaskTab) {
+    if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
       notificationManager.showPopup()
       notificationIsOpen = true
     }


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/6264
Fixes https://github.com/MetaMask/metamask-extension/issues/6273

Will no longer bring the notification to the foreground, but will no longer create multiple notifications for batch txs.