### PR TITLE
circleCI - use cache version from circle environment var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1.0-dependency-cache-{{ checksum "package-lock.json" }}
+            - v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install npm 6 + deps via npm
           command: |
@@ -97,7 +97,7 @@ jobs:
           paths:
           - node_modules
       - save_cache:
-          key: v1.0-dependency-cache-{{ checksum "package-lock.json" }}
+          key: v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
 


### PR DESCRIPTION
circleci dep cache was bad so i added an environment var to CircleCI so we can manually change that to reset the cache without pushing commits

seems like a hack but its the official reccomendation https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-cache

extracted from #6285