### PR TITLE
circleci - disable npm dep cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,9 @@ jobs:
       - image: circleci/node:8.11.3-browsers
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
+      # - restore_cache:
+      #     keys:
+      #       - v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install npm 6 + deps via npm
           command: |
@@ -96,10 +96,10 @@ jobs:
           root: .
           paths:
           - node_modules
-      - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
+      # - save_cache:
+      #     key: v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
+      #     paths:
+      #       - node_modules
 
   prep-build:
     docker:


### PR DESCRIPTION
encountering this error when `npm install` happens on top of a cache

```
npm ERR! path /home/circleci/project/node_modules/ganache-core/node_modules/web3-providers-ws/node_modules/websocket
npm ERR! code EISGIT
npm ERR! git /home/circleci/project/node_modules/ganache-core/node_modules/web3-providers-ws/node_modules/websocket: Appears to be a git repo or submodule.
npm ERR! git     /home/circleci/project/node_modules/ganache-core/node_modules/web3-providers-ws/node_modules/websocket
npm ERR! git Refusing to remove it. Update manually,
npm ERR! git or move it out of the way first.
```

Updates #6286 