### PR TITLE
Use npm ci for fast(er) installs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,21 +85,14 @@ jobs:
       - image: circleci/node:8.11.3-browsers
     steps:
       - checkout
-      # - restore_cache:
-      #     keys:
-      #       - v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install npm 6 + deps via npm
           command: |
-           sudo npm install -g npm@6 && npm install --no-save --no-audit
+           sudo npm install -g npm@6 && npm ci
       - persist_to_workspace:
           root: .
           paths:
           - node_modules
-      # - save_cache:
-      #     key: v{{ .Environment.CACHE_VERSION }}-dependency-cache-{{ checksum "package-lock.json" }}
-      #     paths:
-      #       - node_modules
 
   prep-build:
     docker:


### PR DESCRIPTION
This PR updates our CI config to use the [`npm ci`](https://docs.npmjs.com/cli/ci.html) command to speed up our CI installs step.

> This command is similar to `npm-install`, except it’s meant to be used in automated environments such as test platforms, continuous integration, and deployment – or any situation where you want to make sure you’re doing a clean install of your dependencies. It can be significantly faster than a regular npm install by skipping certain user-oriented features. It is also more strict than a regular install, which can help catch errors or inconsistencies caused by the incrementally-installed local environments of most npm users.

> - If a `node_modules` is already present, it will be automatically removed before `npm ci` begins its install.

Which is fine now that we're not caching it anymore.