### PR TITLE
Fix gas fee in the submitted step of the transaction details activity log

### DIFF
--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.util.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.util.js
@@ -51,7 +51,14 @@ const statusHash = {
  * @returns {Array}
  */
 export function getActivities (transaction, isFirstTransaction = false) {
-  const { id, hash, history = [], txReceipt: { status } = {}, type } = transaction
+  const {
+    id,
+    hash,
+    history = [],
+    txParams: { gas: paramsGasLimit, gasPrice: paramsGasPrice},
+    xReceipt: { status } = {},
+    type,
+  } = transaction
 
   let cachedGasLimit = '0x0'
   let cachedGasPrice = '0x0'
@@ -88,7 +95,9 @@ export function getActivities (transaction, isFirstTransaction = false) {
         if (path in eventPathsHash && op === REPLACE_OP) {
           switch (path) {
             case STATUS_PATH: {
-              const gasFee = getHexGasTotal({ gasLimit: cachedGasLimit, gasPrice: cachedGasPrice })
+              const gasFee = cachedGasLimit === '0x0' && cachedGasPrice === '0x0'
+                ? getHexGasTotal({ gasLimit: paramsGasLimit, gasPrice: paramsGasPrice })
+                : getHexGasTotal({ gasLimit: cachedGasLimit, gasPrice: cachedGasPrice })
 
               if (value in statusHash) {
                 let eventKey = statusHash[value]


### PR DESCRIPTION
fixes #6208

Prior to this PR, transactions created outside of metamask could represent the submitted gas fee (incorrectly) as '0 wei' in the activity log.

This PR corrects that.

Before

![Screenshot from 2019-03-14 00-57-19](https://user-images.githubusercontent.com/7499938/54329314-2533cf80-45f4-11e9-9f42-e9158fd2badc.png)

After

![Screenshot from 2019-03-14 00-54-37](https://user-images.githubusercontent.com/7499938/54329323-29f88380-45f4-11e9-8e16-537474864120.png)
