### PR TITLE
Fixes popups not showing when screen size is odd

### DIFF
--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -26,8 +26,8 @@ class NotificationManager {
         extension.windows.update(popup.id, { focused: true })
       } else {
         const {screenX, screenY, outerWidth, outerHeight} = window
-        const notificationTop = screenY + (outerHeight / 2) - (NOTIFICATION_HEIGHT / 2)
-        const notificationLeft = screenX + (outerWidth / 2) - (NOTIFICATION_WIDTH / 2)
+        const notificationTop = Math.round(screenY + (outerHeight / 2) - (NOTIFICATION_HEIGHT / 2))
+        const notificationLeft = Math.round(screenX + (outerWidth / 2) - (NOTIFICATION_WIDTH / 2))
         const cb = (currentPopup) => { this._popupId = currentPopup.id }
         // create new notification popup
         const creation = extension.windows.create({


### PR DESCRIPTION
Fixes #6299 

When one of the screen dimensions is odd, the notificationTop/Left is a number (decimal) instead of an integer and windows.create throws an exception:

Error handling response: TypeError: Error in invocation of windows.create(optional object createData, optional function callback): Error at parameter 'createData': Error at property 'top': Invalid type: expected integer, found number.
at chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/background.js:1:131480
at chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/background.js:1:131824
at chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/background.js:1:131947