### PR TITLE
Fix oversized loading overlay on gas customization modal.

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
@@ -63,6 +63,10 @@
       font-size: 10px;
       color: #888EA3;
     }
+
+    .loading-overlay {
+      height: auto;
+    }
   }
 
   &__slider-container {


### PR DESCRIPTION
fixes #6322 

Before:

![Peek 2019-03-20 13-54](https://user-images.githubusercontent.com/7499938/54701772-9570b280-4b18-11e9-8988-c7db1ff50239.gif)

After:

![Peek 2019-03-20 13-58](https://user-images.githubusercontent.com/7499938/54701791-9a356680-4b18-11e9-84d6-6ffad91cb9c4.gif)
