### PR TITLE
Update eth-contract-metadata dependency and sub-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1878,6 +1878,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "dev": true,
       "requires": {
         "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
@@ -3045,7 +3046,8 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
     },
     "array-from": {
       "version": "2.1.1",
@@ -4973,6 +4975,7 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
@@ -6448,30 +6451,6 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
-    "compressible": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
-      "dev": true,
-      "requires": {
-        "mime-db": ">= 1.30.0 < 2"
-      }
-    },
-    "compression": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
-      "dev": true,
-      "requires": {
-        "accepts": "~1.3.4",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.11",
-        "debug": "2.6.9",
-        "on-headers": "~1.0.1",
-        "safe-buffer": "5.1.1",
-        "vary": "~1.1.2"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6553,12 +6532,14 @@
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
     },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
     },
     "content-type-parser": {
       "version": "1.0.2",
@@ -6580,12 +6561,14 @@
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
     },
     "cookiejar": {
       "version": "2.1.2",
@@ -7822,7 +7805,8 @@
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -8711,7 +8695,8 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
     },
     "electron-releases": {
       "version": "2.1.0",
@@ -8756,7 +8741,8 @@
     "encodeurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -9143,7 +9129,8 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -9636,7 +9623,8 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
     },
     "eth-bin-to-ops": {
       "version": "1.0.1",
@@ -9816,8 +9804,8 @@
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             }
           }
@@ -9826,8 +9814,8 @@
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-util": {
@@ -9906,8 +9894,8 @@
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             }
           }
@@ -9916,8 +9904,8 @@
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-util": {
@@ -10086,8 +10074,8 @@
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             }
           }
@@ -10096,8 +10084,8 @@
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-util": {
@@ -10204,8 +10192,8 @@
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-util": {
@@ -10276,8 +10264,8 @@
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-tx": {
@@ -10499,8 +10487,8 @@
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-util": {
@@ -10698,8 +10686,8 @@
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             }
           }
@@ -10713,8 +10701,8 @@
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-tx": {
@@ -11717,6 +11705,7 @@
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
@@ -12176,6 +12165,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.1",
@@ -12756,7 +12746,8 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -12770,7 +12761,8 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "from": {
       "version": "0.1.7",
@@ -12980,13 +12972,13 @@
       "integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ="
     },
     "gaba": {
-      "version": "1.0.0-beta.62",
-      "resolved": "https://registry.npmjs.org/gaba/-/gaba-1.0.0-beta.62.tgz",
-      "integrity": "sha512-YTEe0ehL7z4EQDqzwGbkKXQkSu3Z+rC+zWx/9sj/favx5cRu6EDHcUvtHGTCz+6iCQo2NBjOIvwFguNGE3BrWQ==",
+      "version": "1.0.0-beta.65",
+      "resolved": "https://registry.npmjs.org/gaba/-/gaba-1.0.0-beta.65.tgz",
+      "integrity": "sha512-pX9hMd4RR5AXe7bwIamQEXLJe26fNvjOf7PjkHGKlRjKzBYmxZ03Y/Pa9nklNlG2Shc9sSgB6GXZpYlXNlJRIg==",
       "dev": true,
       "requires": {
         "await-semaphore": "^0.1.3",
-        "eth-contract-metadata": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
+        "eth-contract-metadata": "github:MetaMask/eth-contract-metadata#faa4f56fb17b3ae8579df68708be59d617732f31",
         "eth-json-rpc-infura": "^3.1.2",
         "eth-keyring-controller": "^4.0.0",
         "eth-phishing-detect": "^1.1.13",
@@ -13018,11 +13010,12 @@
         },
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
         },
         "eth-contract-metadata": {
-          "version": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
-          "from": "github:estebanmino/eth-contract-metadata#e307359ca9ea6be4ded6ac58ac7e16f192ae4e2a",
+          "version": "github:MetaMask/eth-contract-metadata#faa4f56fb17b3ae8579df68708be59d617732f31",
+          "from": "github:MetaMask/eth-contract-metadata#faa4f56fb17b3ae8579df68708be59d617732f31",
           "dev": true
         },
         "eth-hd-keyring": {
@@ -13041,9 +13034,9 @@
           }
         },
         "eth-keyring-controller": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eth-keyring-controller/-/eth-keyring-controller-4.0.0.tgz",
-          "integrity": "sha512-D3Uj0b97vzEl/zXvrwYjFUYsz5gB4tnl/iMWqOm8jsvaREuHHbxRkm3iU/LG4fT8NGwS+fG8sLRPNBPu2/wRsA==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/eth-keyring-controller/-/eth-keyring-controller-4.0.1.tgz",
+          "integrity": "sha512-i+aff88wsDdgf99iPNE1/RwNos1EtMk0vmc1nsiaCBxrMJSMyNrqEB0njrv2TYWiJj5TnUaZ63vSUYoUYp2eHg==",
           "dev": true,
           "requires": {
             "bip39": "^2.4.0",
@@ -13066,25 +13059,42 @@
               "requires": {
                 "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
+              }
+            },
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               },
               "dependencies": {
-                "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
                   "dev": true,
                   "requires": {
-                    "bn.js": "^4.10.0",
-                    "ethereumjs-util": "^5.0.0"
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
                   }
                 }
               }
             },
-            "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+            "ethjs-util": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+              "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+              "dev": true,
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
               }
             }
           }
@@ -13099,9 +13109,9 @@
           }
         },
         "eth-sig-util": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.1.1.tgz",
-          "integrity": "sha512-B9VA2WCuf+dp0UbWlzsCXWcryZe1H9PixrNmG+tQDBpyTiIbDvf2w8jUb1BNPbxFXeWHUcr2I6pmg+MkdA4Ovg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.1.2.tgz",
+          "integrity": "sha512-bNgt7txkEmaNlLf+PrbwYIdp4KRkB3E7hW0/QwlBpgv920pVVyQnF0evoovfiRveNKM4OrtPYZTojjmsfuCUOw==",
           "dev": true,
           "requires": {
             "buffer": "^5.2.1",
@@ -13130,6 +13140,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -13203,13 +13214,6 @@
             "utf8": "^2.1.1",
             "xhr2-cookies": "^1.1.0",
             "xmlhttprequest": "*"
-          },
-          "dependencies": {
-            "bignumber.js": {
-              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-              "dev": true
-            }
           }
         }
       }
@@ -15359,8 +15363,8 @@
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             },
             "ethereumjs-block": {
@@ -19430,8 +19434,8 @@
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               }
             },
             "ethereumjs-block": {
@@ -22712,37 +22716,6 @@
         "postcss": "^6.0.1"
       }
     },
-    "idb-global": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/idb-global/-/idb-global-2.1.0.tgz",
-      "integrity": "sha512-tJPsvisI6A1xQ6y+orXavjgm/7O6v0YT4wKfw8rwv635pIhsc1Wi2ZhcS+6nYmpyyeaTBC/xG0MWcD9iwCD3xg==",
-      "requires": {
-        "obs-store": "^2.4.1"
-      },
-      "dependencies": {
-        "babelify": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-          "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-          "requires": {
-            "babel-core": "^6.0.14",
-            "object-assign": "^4.0.0"
-          }
-        },
-        "obs-store": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/obs-store/-/obs-store-2.4.1.tgz",
-          "integrity": "sha512-wpA8G4uSn8cnCKZ0pFTvqsamvy0Sm1hR2ot0Qonbfj5yBMwdAp/eD4vDI+U/ZCbV1hb2V5GapL8YKUdGCvahgg==",
-          "requires": {
-            "babel-preset-es2015": "^6.22.0",
-            "babelify": "^7.3.0",
-            "readable-stream": "^2.2.2",
-            "through2": "^2.0.3",
-            "xtend": "^4.0.1"
-          }
-        }
-      }
-    },
     "identicon.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/identicon.js/-/identicon.js-2.3.1.tgz",
@@ -22788,19 +22761,6 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
-    },
-    "iframe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iframe/-/iframe-1.0.0.tgz",
-      "integrity": "sha1-WOdIIrF4oFedCc0WlkD7lTdHDvU="
-    },
-    "iframe-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/iframe-stream/-/iframe-stream-3.0.0.tgz",
-      "integrity": "sha1-Aw2JE6mL7uuxD472feAJvCuSZtY=",
-      "requires": {
-        "post-message-stream": "^3.0.0"
-      }
     },
     "ignore": {
       "version": "3.3.7",
@@ -23120,7 +23080,8 @@
     "ipaddr.js": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+      "dev": true
     },
     "irregular-plurals": {
       "version": "1.4.0",
@@ -26417,7 +26378,8 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
     },
     "mem": {
       "version": "1.1.0",
@@ -26502,7 +26464,8 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "merge-source-map": {
       "version": "1.0.4",
@@ -26561,161 +26524,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
       "integrity": "sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o="
-    },
-    "metamascara": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/metamascara/-/metamascara-2.2.1.tgz",
-      "integrity": "sha512-3DmfdacKzZxeFpCNKCw1z3ITHLJHgFLGqh7fWgrVeRPq8Ni6qi1SYMBn0xspkEwzZAxiMohYDaZ/EEnNenuDqA==",
-      "requires": {
-        "iframe": "^1.0.0",
-        "iframe-stream": "^3.0.0",
-        "json-rpc-engine": "^3.1.0",
-        "json-rpc-middleware-stream": "^1.0.0",
-        "obj-multiplex": "^1.0.0",
-        "obs-store": "^2.4.1",
-        "pump": "^1.0.2"
-      },
-      "dependencies": {
-        "async-eventemitter": {
-          "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-          "from": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-          "requires": {
-            "async": "^2.4.0"
-          }
-        },
-        "babelify": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-          "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-          "requires": {
-            "babel-core": "^6.0.14",
-            "object-assign": "^4.0.0"
-          }
-        },
-        "eth-block-tracker": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
-          "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
-          "requires": {
-            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-            "eth-query": "^2.1.0",
-            "ethereumjs-tx": "^1.3.3",
-            "ethereumjs-util": "^5.1.3",
-            "ethjs-util": "^0.1.3",
-            "json-rpc-engine": "^3.6.0",
-            "pify": "^2.3.0",
-            "tape": "^4.6.3"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        },
-        "ethjs-format": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.2.2.tgz",
-          "integrity": "sha1-1zs6YFwuElcHn3B3/VRI6ZjOD80=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "ethjs-schema": "0.1.5",
-            "ethjs-util": "0.1.3",
-            "is-hex-prefixed": "1.0.0",
-            "number-to-bn": "1.7.0",
-            "strip-hex-prefix": "1.0.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.6",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-            },
-            "ethjs-util": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
-              "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
-              "requires": {
-                "is-hex-prefixed": "1.0.0",
-                "strip-hex-prefix": "1.0.0"
-              }
-            }
-          }
-        },
-        "ethjs-query": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/ethjs-query/-/ethjs-query-0.2.9.tgz",
-          "integrity": "sha1-om5rTzhpnpLzSyGE51x4lDKcQvE=",
-          "requires": {
-            "ethjs-format": "0.2.2",
-            "ethjs-rpc": "0.1.5"
-          }
-        },
-        "ethjs-schema": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.1.5.tgz",
-          "integrity": "sha1-WXQOOzl3vNu5sRvDBoIB6Kzquw0="
-        },
-        "json-rpc-engine": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.7.3.tgz",
-          "integrity": "sha512-+FO3UWu/wafh/+MZ6BXy0HZU+f5plwUn82FgxpC0scJkEh5snOjFrAAtqCITPDfvfLHRUFOG5pQDUx2pspfERQ==",
-          "requires": {
-            "async": "^2.0.1",
-            "babel-preset-env": "^1.3.2",
-            "babelify": "^7.3.0",
-            "clone": "^2.1.1",
-            "json-rpc-error": "^2.0.0",
-            "promise-to-callback": "^1.0.0"
-          }
-        },
-        "json-rpc-middleware-stream": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-1.0.1.tgz",
-          "integrity": "sha512-IR6cOO6B21NdLpiYblueB3O+g3UAYLIZd6ZgZfddVPl0z6vSECcpuiYnV5MmIMJY3D0fLYpJqOxYaEmLYQqTtA==",
-          "requires": {
-            "end-of-stream": "^1.4.0",
-            "eth-block-tracker": "^2.1.2",
-            "ethjs-query": "^0.2.9",
-            "json-rpc-engine": "^3.0.1",
-            "readable-stream": "^2.3.3"
-          }
-        },
-        "obs-store": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/obs-store/-/obs-store-2.4.1.tgz",
-          "integrity": "sha512-wpA8G4uSn8cnCKZ0pFTvqsamvy0Sm1hR2ot0Qonbfj5yBMwdAp/eD4vDI+U/ZCbV1hb2V5GapL8YKUdGCvahgg==",
-          "requires": {
-            "babel-preset-es2015": "^6.22.0",
-            "babelify": "^7.3.0",
-            "readable-stream": "^2.2.2",
-            "through2": "^2.0.3",
-            "xtend": "^4.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        },
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
     },
     "metamask-inpage-provider": {
       "version": "1.3.0",
@@ -27383,7 +27191,8 @@
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
     },
     "neo-async": {
       "version": "2.5.0",
@@ -29436,15 +29245,10 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
-    },
-    "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -29807,7 +29611,8 @@
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -29898,7 +29703,8 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
     },
     "path-type": {
       "version": "1.1.0",
@@ -32131,6 +31937,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
@@ -32570,7 +32377,8 @@
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
     },
     "raphael": {
       "version": "2.2.7",
@@ -34435,6 +34243,7 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.1",
@@ -34482,6 +34291,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "dev": true,
       "requires": {
         "encodeurl": "~1.0.1",
         "escape-html": "~1.0.3",
@@ -34519,7 +34329,8 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.9",
@@ -37158,61 +36969,6 @@
         }
       }
     },
-    "sw-controller": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sw-controller/-/sw-controller-1.0.3.tgz",
-      "integrity": "sha512-q+rS4v7kj1MPDxFRyl8GAICw/BbQzewd5HhVDNIPLnyvKtcpxi26fVXReUeUMRl4CRL/fX56PvKKqxtKhAaMpg==",
-      "requires": {
-        "babel-preset-es2015": "^6.22.0",
-        "babel-runtime": "^6.23.0",
-        "babelify": "^7.3.0"
-      },
-      "dependencies": {
-        "babelify": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-          "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-          "requires": {
-            "babel-core": "^6.0.14",
-            "object-assign": "^4.0.0"
-          }
-        }
-      }
-    },
-    "sw-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sw-stream/-/sw-stream-2.0.2.tgz",
-      "integrity": "sha512-V/aer72LYQ0Cn1y4O0xOGz794l7ccqlqpwgqO04Dm9yYb8pwR484FV+TS6G+cXhUZ6vnZ+CnX6g2uoDzpHZgFQ==",
-      "requires": {
-        "babel-preset-es2015": "^6.22.0",
-        "babel-runtime": "^6.23.0",
-        "babelify": "^7.3.0",
-        "end-of-stream": "^1.1.0",
-        "pump": "^1.0.2",
-        "readable-stream": "^2.2.2",
-        "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "babelify": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-          "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-          "requires": {
-            "babel-core": "^6.0.14",
-            "object-assign": "^4.0.0"
-          }
-        },
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
     "swappable-obj-proxy": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/swappable-obj-proxy/-/swappable-obj-proxy-1.1.0.tgz",
@@ -38088,6 +37844,7 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.15"
@@ -38742,7 +38499,8 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
     },
     "uuid": {
       "version": "2.0.3",
@@ -38791,7 +38549,8 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "velocity-animate": {
       "version": "1.5.1",
@@ -39172,25 +38931,42 @@
           "requires": {
             "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
             "ethereumjs-util": "^5.1.1"
-          },
-          "dependencies": {
-            "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-              "dev": true,
-              "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^5.0.0"
-              }
-            }
           }
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#572d4bafe08a8a231137e1f9daeb0f8a23f197d2",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "dev": true,
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+              "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "ethjs-util": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+              "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+              "dev": true,
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            }
           }
         },
         "ethereumjs-common": {
@@ -39203,6 +38979,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "file-loader": "^1.1.11",
     "fs-extra": "^6.0.1",
     "fs-promise": "^2.0.3",
-    "gaba": "1.0.0-beta.62",
+    "gaba": "1.0.0-beta.65",
     "ganache-cli": "^6.1.0",
     "ganache-core": "^2.5.3",
     "geckodriver": "^1.14.1",


### PR DESCRIPTION
This PR updates our links to `eth-contract-metadata` in the dependency tree