### PR TITLE
Stop reloading dapps on network change allowing dapps to decide if it should refresh or not

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -91,6 +91,10 @@ inpageProvider.enable = function ({ force } = {}) {
   })
 }
 
+// give the dapps control of a refresh they can toggle this off on the window.ethereum
+// this will be default true so it does not break any old apps.
+inpageProvider.autoRefreshOnNetworkChange = true;
+
 // add metamask-specific convenience methods
 inpageProvider._metamask = new Proxy({
   /**

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -93,7 +93,7 @@ inpageProvider.enable = function ({ force } = {}) {
 
 // give the dapps control of a refresh they can toggle this off on the window.ethereum
 // this will be default true so it does not break any old apps.
-inpageProvider.autoRefreshOnNetworkChange = true;
+inpageProvider.autoRefreshOnNetworkChange = true
 
 // add metamask-specific convenience methods
 inpageProvider._metamask = new Proxy({

--- a/app/scripts/lib/auto-reload.js
+++ b/app/scripts/lib/auto-reload.js
@@ -20,6 +20,10 @@ function setupDappAutoReload (web3, observable) {
   })
 
   observable.subscribe(function (state) {
+    // if the auto refresh on network change is false do not
+    // do anything
+    if (!web3.ethereum.autoRefreshOnNetworkChange) return
+
     // if reload in progress, no need to check reload logic
     if (reloadInProgress) return
 

--- a/app/scripts/lib/auto-reload.js
+++ b/app/scripts/lib/auto-reload.js
@@ -22,7 +22,7 @@ function setupDappAutoReload (web3, observable) {
   observable.subscribe(function (state) {
     // if the auto refresh on network change is false do not
     // do anything
-    if (!web3.ethereum.autoRefreshOnNetworkChange) return
+    if (!window.ethereum.autoRefreshOnNetworkChange) return
 
     // if reload in progress, no need to check reload logic
     if (reloadInProgress) return


### PR DESCRIPTION
Hi I am a blockchain developer who works for FunFair. We really appreciate the epic work you're doing on your extension thanks a bunch and keep it up, now the juicy part! 😄  

https://medium.com/metamask/breaking-change-no-longer-reloading-pages-on-network-change-4a3e1fd2f5e7

We read this article around 9 months ago about no longer reloading the page on network change. When we first heard about it we all jumped for joy as this was a *HUGE* UX problem for us. Losing all the current state on refresh causes millions of issues. When you released and then straight away rolled back we were disappointed but knew why. So many dapps now depend on this behaviour so just bringing a breaking change like that just didn't make sense. 9 months later we are here now, still with the huge pain of it reloading. 

Thinking closely about this I think it was a mistake deciding on a breaking change, my view is dapps should have control of this feature, dapps should be able to decide if it should reload or not leading to a best of both worlds solution. This extends on to what i have changed in this PR. 

You introduced something called `ethereumProvider` which you create your web3 instance with. This holds methods like `enable()` which the dapps have to call to see if the user has given permission or not. If not then it will pop up the MetaMask screen for approval. So dapps are openly using the methods on `window.ethereumProvider` now. 

What I propose is a simple easy solution which solves this. Yes it may not be the perfect solution but it allows best of both worlds until you're ready to focus on completely killing the auto-refresh. 

If we added another method on the `ethereumProvider`  callled `autoRefreshOnNetworkChange` which is *default* set to true i.e. it will always reload like it does now meaning old dapps don't need to change a thing. Now if dapps want to disable this all they have to do is:

```js
window.ethereum.autoRefreshOnNetworkChange = false;
```

on startup of the app and then it will just return in the `auto-reload.js` file if that is not true. This even gives the flexibility for some parts of the dapps (say legacy) to reload and some old dapps which can't support this straight away can change it feature by feature and roll it out. 

I think we know now that this isn't your main focus, you have the mobile MetaMask and loads of awesome things you're doing. But this issue has a lot of attention and is the single biggest annoyance of the extension to date as you can see by the 23 comments on this issue:

https://github.com/MetaMask/metamask-extension/issues/3599

Dapps today are pushing the barriers of what they can do and to allow that to happen this needs to change ASAP. Something like this could solve all this until you're ready to kill it completely. 

I am looking forward to hearing your thoughts. 
Thanks for spending the time reading

Josh