### PR TITLE
Enable mobile sync

### DIFF
--- a/docs/secret-preferences.md
+++ b/docs/secret-preferences.md
@@ -6,5 +6,5 @@ One example is our "sync with mobile" feature, which didn't make sense to roll o
 
 To enable features like this, first open the background console, and then you can use the global method `global.setPreference(key, value)`.
 
-For example, if the feature flag was a booelan was called `mobileSync`, you might type `setPreference('mobileSync', true)`.
+For example, if the feature flag was a booelan was called `useNativeCurrencyAsPrimaryCurrency`, you might type `setPreference('useNativeCurrencyAsPrimaryCurrency', true)`.
 

--- a/docs/secret-preferences.md
+++ b/docs/secret-preferences.md
@@ -6,5 +6,5 @@ One example is our "sync with mobile" feature, which didn't make sense to roll o
 
 To enable features like this, first open the background console, and then you can use the global method `global.setPreference(key, value)`.
 
-For example, if the feature flag was a booelan was called `useNativeCurrencyAsPrimaryCurrency`, you might type `setPreference('useNativeCurrencyAsPrimaryCurrency', true)`.
+For example, if the feature flag was a boolean was called `useNativeCurrencyAsPrimaryCurrency`, you might type `setPreference('useNativeCurrencyAsPrimaryCurrency', true)`.
 

--- a/ui/app/components/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/app/components/pages/settings/settings-tab/settings-tab.component.js
@@ -378,11 +378,7 @@ export default class SettingsTab extends PureComponent {
 
   renderMobileSync () {
     const { t } = this.context
-    const { history, mobileSync } = this.props
-
-    if (!mobileSync) {
-      return
-    }
+    const { history } = this.props
 
     return (
       <div className="settings-page__content-row">

--- a/ui/app/components/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/app/components/pages/settings/settings-tab/settings-tab.component.js
@@ -63,7 +63,6 @@ export default class SettingsTab extends PureComponent {
     setUseNativeCurrencyAsPrimaryCurrencyPreference: PropTypes.func,
     setAdvancedInlineGasFeatureFlag: PropTypes.func,
     advancedInlineGas: PropTypes.bool,
-    mobileSync: PropTypes.bool,
     showFiatInTestnets: PropTypes.bool,
     setShowFiatConversionOnTestnetsPreference: PropTypes.func.isRequired,
     participateInMetaMetrics: PropTypes.bool,

--- a/ui/app/components/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/app/components/pages/settings/settings-tab/settings-tab.container.js
@@ -28,7 +28,6 @@ const mapStateToProps = state => {
       sendHexData,
       privacyMode,
       advancedInlineGas,
-      mobileSync,
     } = {},
     provider = {},
     currentLocale,
@@ -48,7 +47,6 @@ const mapStateToProps = state => {
     privacyMode,
     provider,
     useNativeCurrencyAsPrimaryCurrency,
-    mobileSync,
     showFiatInTestnets,
     participateInMetaMetrics,
   }


### PR DESCRIPTION
Since this "experimental" feature won't cause any harm and it will make our beta testers life easier, we're turning it on by default and removing it from preferences.