### PR TITLE
Don't include tx value in calculation of balance sufficiency for cancel button disabling

### DIFF
--- a/ui/app/components/app/transaction-list-item/transaction-list-item.container.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.container.js
@@ -22,11 +22,11 @@ const mapStateToProps = (state, ownProps) => {
   const { showFiatInTestnets } = preferencesSelector(state)
   const isMainnet = getIsMainnet(state)
   const { transactionGroup: { primaryTransaction } = {} } = ownProps
-  const { txParams: { gas: gasLimit, gasPrice, value } = {} } = primaryTransaction
+  const { txParams: { gas: gasLimit, gasPrice } = {} } = primaryTransaction
   const selectedAccountBalance = accounts[getSelectedAddress(state)].balance
 
   const hasEnoughCancelGas = primaryTransaction.txParams && isBalanceSufficient({
-    amount: value,
+    amount: '0x0',
     gasTotal: getHexGasTotal({
       gasPrice: increaseLastGasPrice(gasPrice),
       gasLimit,


### PR DESCRIPTION
When we are determining whether a user has sufficient balance to cancel a tx, we don't need to worry about the value of the tx, because they will retain that value if the cancel is successful.