### PR TITLE
Gracefully handle null/undefined in a couple methods that operate on hex values

### DIFF
--- a/ui/app/helpers/utils/confirm-tx.util.js
+++ b/ui/app/helpers/utils/confirm-tx.util.js
@@ -12,8 +12,8 @@ import {
 
 import { unconfirmedTransactionsCountSelector } from '../../selectors/confirm-transaction'
 
-export function increaseLastGasPrice (lastGasPrice) {
-  return ethUtil.addHexPrefix(multiplyCurrencies(lastGasPrice || '0x0', 1.1, {
+export function increaseLastGasPrice (lastGasPrice = '0x0') {
+  return ethUtil.addHexPrefix(multiplyCurrencies(lastGasPrice, 1.1, {
     multiplicandBase: 16,
     multiplierBase: 10,
     toNumericBase: 'hex',
@@ -27,8 +27,8 @@ export function hexGreaterThan (a, b) {
   )
 }
 
-export function getHexGasTotal ({ gasLimit, gasPrice }) {
-  return ethUtil.addHexPrefix(multiplyCurrencies(gasLimit || '0x0', gasPrice || '0x0', {
+export function getHexGasTotal ({ gasLimit = '0x0', gasPrice = '0x0' }) {
+  return ethUtil.addHexPrefix(multiplyCurrencies(gasLimit, gasPrice, {
     toNumericBase: 'hex',
     multiplicandBase: 16,
     multiplierBase: 16,

--- a/ui/app/helpers/utils/confirm-tx.util.js
+++ b/ui/app/helpers/utils/confirm-tx.util.js
@@ -13,7 +13,7 @@ import {
 import { unconfirmedTransactionsCountSelector } from '../../selectors/confirm-transaction'
 
 export function increaseLastGasPrice (lastGasPrice) {
-  return ethUtil.addHexPrefix(multiplyCurrencies(lastGasPrice, 1.1, {
+  return ethUtil.addHexPrefix(multiplyCurrencies(lastGasPrice || '0x0', 1.1, {
     multiplicandBase: 16,
     multiplierBase: 10,
     toNumericBase: 'hex',
@@ -28,7 +28,7 @@ export function hexGreaterThan (a, b) {
 }
 
 export function getHexGasTotal ({ gasLimit, gasPrice }) {
-  return ethUtil.addHexPrefix(multiplyCurrencies(gasLimit, gasPrice, {
+  return ethUtil.addHexPrefix(multiplyCurrencies(gasLimit || '0x0', gasPrice || '0x0', {
     toNumericBase: 'hex',
     multiplicandBase: 16,
     multiplierBase: 16,


### PR DESCRIPTION
This PR aims to correct https://sentry.io/organizations/metamask/issues/954408952/?project=273505&query=is%3Aunresolved+release%3A6.3.0&statsPeriod=14d&utc=true

It does so by ensuring that a couple methods that operate on hex values default to using 0 in case they are passed null, undefined or other falsy values.