### PR TITLE
Remove broken image walkthrough from metamaskbot comment

### DIFF
--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -27,20 +27,8 @@ async function start () {
   const FIREFOX = `${BUILD_LINK_BASE}/builds/metamask-firefox-${VERSION}.zip`
   const EDGE = `${BUILD_LINK_BASE}/builds/metamask-edge-${VERSION}.zip`
   const OPERA = `${BUILD_LINK_BASE}/builds/metamask-opera-${VERSION}.zip`
-  const WALKTHROUGH = `${BUILD_LINK_BASE}/test-artifacts/screens/walkthrough%20%28en%29.gif`
 
-  const commentBody = `
-  <details>
-    <summary>
-      Builds ready [${SHORT_SHA1}]:
-      <a href="${CHROME}">chrome</a>,
-      <a href="${FIREFOX}">firefox</a>,
-      <a href="${EDGE}">edge</a>,
-      <a href="${OPERA}">opera</a>
-    </summary>
-    <image src="${WALKTHROUGH}">
-  </details>
-  `
+  const commentBody = `Builds ready [${SHORT_SHA1}]: <a href="${CHROME}">chrome</a>, <a href="${FIREFOX}">firefox</a>, <a href="${EDGE}">edge</a>, <a href="${OPERA}">opera</a>`
 
   const JSON_PAYLOAD = JSON.stringify({ body: commentBody })
   const POST_COMMENT_URI = `https://api.github.com/repos/metamask/metamask-extension/issues/${CIRCLE_PR_NUMBER}/comments`


### PR DESCRIPTION
This PR remove the "walkthrough" from the metamaskbot comment on PRs here on GH.

For reference: on the more recent comments from metamaskbot is https://github.com/MetaMask/metamask-extension/pull/6358#issuecomment-477304147