### PR TITLE
getMethodData() default to abi decoded method if registry lookup errors

### DIFF
--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -1,3 +1,4 @@
+import log from 'loglevel'
 import {
   conversionRateSelector,
   currentCurrencySelector,
@@ -369,23 +370,17 @@ export function setTransactionToConfirm (transactionId) {
         const { tokens: existingTokens } = state
         const { data, to: tokenAddress } = txParams
 
-        try {
-          dispatch(setFetchingData(true))
-          const methodData = await getMethodData(data)
-
-          dispatch(updateMethodData(methodData))
-        } catch (error) {
-          dispatch(updateMethodData({}))
-          dispatch(setFetchingData(false))
-        }
+        dispatch(setFetchingData(true))
+        const methodData = await getMethodData(data)
+        dispatch(updateMethodData(methodData))
 
         try {
           const toSmartContract = await isSmartContractAddress(to)
           dispatch(updateToSmartContract(toSmartContract))
-          dispatch(setFetchingData(false))
         } catch (error) {
-          dispatch(setFetchingData(false))
+          log.error(error)
         }
+        dispatch(setFetchingData(false))
 
         const tokenData = getTokenData(data)
         dispatch(updateTokenData(tokenData))


### PR DESCRIPTION
This fixes a bug that was causing the confirm screen to navigate to the simple send confirm screen when it should have been navigating to the token transfer confirm screen. This could happen in when the http request made by "registry.lookup" failed.

Our router depends on the contract method name when the registry lookup failed, the name passed to the router was undefined.

This PR adds a fallback in our `getMethodData()` function - the use of abiDecoder.decodeMethod -which prevents the above described issue. W