### PR TITLE
prevent add duplicates when address is not new

### DIFF
--- a/ui/app/components/app/send/send-footer/send-footer.container.js
+++ b/ui/app/components/app/send/send-footer/send-footer.container.js
@@ -96,9 +96,10 @@ function mapDispatchToProps (dispatch) {
 
       return dispatch(updateTransaction(editingTx))
     },
+
     addToAddressBookIfNew: (newAddress, toAccounts, nickname = '') => {
       const hexPrefixedAddress = ethUtil.addHexPrefix(newAddress)
-      if (addressIsNew(toAccounts)) {
+      if (addressIsNew(toAccounts, hexPrefixedAddress)) {
         // TODO: nickname, i.e. addToAddressBook(recipient, nickname)
         dispatch(addToAddressBook(hexPrefixedAddress, nickname))
       }

--- a/ui/app/components/app/send/send-footer/send-footer.utils.js
+++ b/ui/app/components/app/send/send-footer/send-footer.utils.js
@@ -74,7 +74,9 @@ function constructUpdatedTx ({
 }
 
 function addressIsNew (toAccounts, newAddress) {
-  return !toAccounts.find(({ address }) => (newAddress === address || newAddress.toLowerCase() === address))
+  const newAddressNormalized = newAddress.toLowerCase()
+  const foundMatching = toAccounts.some(({ address }) => address === newAddressNormalized)
+  return !foundMatching
 }
 
 module.exports = {

--- a/ui/app/components/app/send/send-footer/send-footer.utils.js
+++ b/ui/app/components/app/send/send-footer/send-footer.utils.js
@@ -74,7 +74,7 @@ function constructUpdatedTx ({
 }
 
 function addressIsNew (toAccounts, newAddress) {
-  return !toAccounts.find(({ address }) => newAddress === address)
+  return !toAccounts.find(({ address }) => (newAddress === address || newAddress.toLowerCase() === address))
 }
 
 module.exports = {


### PR DESCRIPTION
we store the existing accounts all lowercase, which causes duplicated adds of existing accounts to the new address book