### PR TITLE
Version 6.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Current Develop Branch
 
+## 6.3.1 Fri Mar 26 2019
+
+- [#6353](https://github.com/MetaMask/metamask-extension/pull/6353): Open restore vault in full screen when clicked from popup
+- [#6372](https://github.com/MetaMask/metamask-extension/pull/6372): Prevents duplicates of account addresses from showing in send screen "To" dropdown
+- [#6374](https://github.com/MetaMask/metamask-extension/pull/6374): Ensures users are placed on correct confirm screens even when registry service fails
+
 ## 6.3.0 Mon Mar 25 2019
 
 - [#6300](https://github.com/MetaMask/metamask-extension/pull/6300): Gas chart hidden on custom networks

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "__MSG_appDescription__",

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
@@ -25,6 +25,7 @@ export default class ConfirmTransactionSwitch extends Component {
     methodData: PropTypes.object,
     fetchingData: PropTypes.bool,
     isEtherTransaction: PropTypes.bool,
+    isTokenMethod: PropTypes.bool,
   }
 
   redirectToTransaction () {
@@ -33,6 +34,7 @@ export default class ConfirmTransactionSwitch extends Component {
       methodData: { name },
       fetchingData,
       isEtherTransaction,
+      isTokenMethod,
     } = this.props
     const { id, txParams: { data } = {} } = txData
 
@@ -45,7 +47,7 @@ export default class ConfirmTransactionSwitch extends Component {
       return <Redirect to={{ pathname }} />
     }
 
-    if (isEtherTransaction) {
+    if (isEtherTransaction && !isTokenMethod) {
       const pathname = `${CONFIRM_TRANSACTION_ROUTE}/${id}${CONFIRM_SEND_ETHER_PATH}`
       return <Redirect to={{ pathname }} />
     }

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
@@ -1,5 +1,10 @@
 import { connect } from 'react-redux'
 import ConfirmTransactionSwitch from './confirm-transaction-switch.component'
+import {
+  TOKEN_METHOD_TRANSFER,
+  TOKEN_METHOD_APPROVE,
+  TOKEN_METHOD_TRANSFER_FROM,
+} from '../../helpers/constants/transactions'
 
 const mapStateToProps = state => {
   const {
@@ -16,6 +21,7 @@ const mapStateToProps = state => {
     methodData,
     fetchingData,
     isEtherTransaction: !toSmartContract,
+    isTokenMethod: [TOKEN_METHOD_APPROVE, TOKEN_METHOD_TRANSFER, TOKEN_METHOD_TRANSFER_FROM].includes(methodData.name)
   }
 }
 

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
@@ -21,7 +21,7 @@ const mapStateToProps = state => {
     methodData,
     fetchingData,
     isEtherTransaction: !toSmartContract,
-    isTokenMethod: [TOKEN_METHOD_APPROVE, TOKEN_METHOD_TRANSFER, TOKEN_METHOD_TRANSFER_FROM].includes(methodData.name)
+    isTokenMethod: [TOKEN_METHOD_APPROVE, TOKEN_METHOD_TRANSFER, TOKEN_METHOD_TRANSFER_FROM].includes(methodData.name && methodData.name.toLowerCase()),
   }
 }
 


### PR DESCRIPTION
This PR provides the changes needed for the version release.

It includes two commits that fix bugs found during the first QA pass on the version release commit. These ensure that the user is shown the correct confirm screen even when our `eth.getCode` call fails due to network issues.