### PR TITLE
Ensure correct confirm screen in case of smartcontract check fail

### DIFF
--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
@@ -25,6 +25,7 @@ export default class ConfirmTransactionSwitch extends Component {
     methodData: PropTypes.object,
     fetchingData: PropTypes.bool,
     isEtherTransaction: PropTypes.bool,
+    isTokenMethod: PropTypes.bool,
   }
 
   redirectToTransaction () {
@@ -33,6 +34,7 @@ export default class ConfirmTransactionSwitch extends Component {
       methodData: { name },
       fetchingData,
       isEtherTransaction,
+      isTokenMethod,
     } = this.props
     const { id, txParams: { data } = {} } = txData
 
@@ -45,7 +47,7 @@ export default class ConfirmTransactionSwitch extends Component {
       return <Redirect to={{ pathname }} />
     }
 
-    if (isEtherTransaction) {
+    if (isEtherTransaction && !isTokenMethod) {
       const pathname = `${CONFIRM_TRANSACTION_ROUTE}/${id}${CONFIRM_SEND_ETHER_PATH}`
       return <Redirect to={{ pathname }} />
     }

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
@@ -1,5 +1,10 @@
 import { connect } from 'react-redux'
 import ConfirmTransactionSwitch from './confirm-transaction-switch.component'
+import {
+  TOKEN_METHOD_TRANSFER,
+  TOKEN_METHOD_APPROVE,
+  TOKEN_METHOD_TRANSFER_FROM,
+} from '../../helpers/constants/transactions'
 
 const mapStateToProps = state => {
   const {
@@ -16,6 +21,7 @@ const mapStateToProps = state => {
     methodData,
     fetchingData,
     isEtherTransaction: !toSmartContract,
+    isTokenMethod: [TOKEN_METHOD_APPROVE, TOKEN_METHOD_TRANSFER, TOKEN_METHOD_TRANSFER_FROM].includes(methodData.name)
   }
 }
 

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
@@ -21,7 +21,7 @@ const mapStateToProps = state => {
     methodData,
     fetchingData,
     isEtherTransaction: !toSmartContract,
-    isTokenMethod: [TOKEN_METHOD_APPROVE, TOKEN_METHOD_TRANSFER, TOKEN_METHOD_TRANSFER_FROM].includes(methodData.name)
+    isTokenMethod: [TOKEN_METHOD_APPROVE, TOKEN_METHOD_TRANSFER, TOKEN_METHOD_TRANSFER_FROM].includes(methodData.name && methodData.name.toLowerCase()),
   }
 }
 


### PR DESCRIPTION
This PR ensures that failed calls of `global.eth.getCode` when determining if an address is a smart contract address do not inadvertently route the user to the simple send screen. The router checks whether the method name (which also has a fallback not dependent on a network request) matches the three supported token method names.