### PR TITLE
Updates the version of the eth-method-registry dependency to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10398,9 +10398,9 @@
       }
     },
     "eth-method-registry": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eth-method-registry/-/eth-method-registry-1.0.0.tgz",
-      "integrity": "sha1-8Ij3Wdad6f3BK3EEm83GiKMoOLY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eth-method-registry/-/eth-method-registry-1.2.0.tgz",
+      "integrity": "sha512-m+nphH4kOxz5KTvQ+BeIKVggxAul1sp4Ev09lfxRXIEHM1t/6NQEtaErL5ddTDFXXFVtTiW8uC9edTVUTnBZNg==",
       "requires": {
         "ethjs": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eth-json-rpc-infura": "^3.0.0",
     "eth-keyring-controller": "^3.3.1",
     "eth-ledger-bridge-keyring": "^0.2.0",
-    "eth-method-registry": "^1.0.0",
+    "eth-method-registry": "^1.2.0",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
     "eth-sig-util": "^2.0.2",


### PR DESCRIPTION
To be merged after [Update parse() to handle args that are tuples](https://github.com/danfinlay/eth-method-registry/pull/6) from https://github.com/danfinlay/eth-method-registry