### PR TITLE
feature: switch token pricing to CoinGecko API

### DIFF
--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -28,16 +28,16 @@ class TokenRatesController {
   async updateExchangeRates () {
     if (!this.isActive) { return }
     const contractExchangeRates = {}
-    const nativeCurrency = this.currency ? this.currency.getState().nativeCurrency.toUpperCase() : 'ETH'
-    const pairs = this._tokens.map(token => `pairs[]=${token.address}/${nativeCurrency}`)
-    const query = pairs.join('&')
+    const nativeCurrency = this.currency ? this.currency.getState().nativeCurrency.toLowerCase() : 'eth'
+    const pairs = this._tokens.map(token => token.address).join(',')
+    const query = `contract_addresses=${pairs}&vs_currencies=${nativeCurrency}`
     if (this._tokens.length > 0) {
       try {
-        const response = await fetch(`https://exchanges.balanc3.net/pie?${query}&autoConversion=false`)
-        const { prices = [] } = await response.json()
-        prices.forEach(({ pair, price }) => {
-          const address = pair.split('/')[0]
-          contractExchangeRates[normalizeAddress(address)] = typeof price === 'number' ? price : 0
+        const response = await fetch(`https://api.coingecko.com/api/v3/simple/token_price/ethereum?${query}`)
+        const prices = await response.json()
+        this._tokens.forEach(token => {
+          const price = prices[token.address.toLowerCase()]
+          contractExchangeRates[normalizeAddress(token.address)] = price ? price[nativeCurrency] : 0
         })
       } catch (error) {
         log.warn(`MetaMask - TokenRatesController exchange rate fetch failed.`, error)


### PR DESCRIPTION
This pull request updates the `TokenRatesController` to use the CoinGecko API instead of the Balanc3 API that will be shut down in the near future. The API seemed to hold up under the local stress tests I did (50+ tokens per request at 100 requests per minute - the rate limit max - for several minutes).

We may want to release this slowly to a small percentage of clients since it's a new API for a feature that's very visible to users.

Resolves #6383 