### PR TITLE
Adds 4byte registry fallback to getMethodData()

### DIFF
--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -78,8 +78,8 @@ const registry = new MethodRegistry({ provider: global.ethereumProvider })
       }
     } catch (error) {
       log.error(error)
-      const contractData = getTokenData(data)
-      const { name } = contractData || {}
+      const tokenData = getTokenData(data)
+      const { name } = tokenData || {}
       return { name }
     }
 

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -30,6 +30,23 @@ export function getTokenData (data = '') {
   return abiDecoder.decodeMethod(data)
 }
 
+function getMethodFrom4Byte (fourBytePrefix) {
+  return fetch(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${fourBytePrefix}`, {
+    referrerPolicy: 'no-referrer-when-downgrade',
+    body: null,
+    method: 'GET',
+    mode: 'cors',
+  })
+  .then(r => r.json())
+  .then(res => {
+    if (res.count === 1) {
+      return res.results[0].text_signature
+    } else {
+      return null
+    }
+  })
+}
+
 const registry = new MethodRegistry({ provider: global.ethereumProvider })
 
 /**
@@ -43,7 +60,11 @@ const registry = new MethodRegistry({ provider: global.ethereumProvider })
     const fourBytePrefix = prefixedData.slice(0, 10)
 
     try {
-      const sig = await registry.lookup(fourBytePrefix)
+      let sig = await registry.lookup(fourBytePrefix)
+
+      if (!sig) {
+        sig = await getMethodFrom4Byte(fourBytePrefix)
+      }
 
       if (!sig) {
         return {}

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -58,10 +58,15 @@ const registry = new MethodRegistry({ provider: global.ethereumProvider })
     const fourBytePrefix = prefixedData.slice(0, 10)
 
     try {
+      const fourByteSig = getMethodFrom4Byte(fourBytePrefix).catch((e) => {
+          log.error(e)
+          return null
+      })
+
       let sig = await registry.lookup(fourBytePrefix)
 
       if (!sig) {
-        sig = await getMethodFrom4Byte(fourBytePrefix)
+        sig = await fourByteSig
       }
 
       if (!sig) {

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -30,21 +30,19 @@ export function getTokenData (data = '') {
   return abiDecoder.decodeMethod(data)
 }
 
-function getMethodFrom4Byte (fourBytePrefix) {
-  return fetch(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${fourBytePrefix}`, {
+async function getMethodFrom4Byte (fourBytePrefix) {
+  const fourByteResponse = (await fetch(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${fourBytePrefix}`, {
     referrerPolicy: 'no-referrer-when-downgrade',
     body: null,
     method: 'GET',
     mode: 'cors',
-  })
-  .then(r => r.json())
-  .then(res => {
-    if (res.count === 1) {
-      return res.results[0].text_signature
-    } else {
-      return null
-    }
-  })
+  })).json()
+
+  if (fourByteResponse.count === 1) {
+    return fourByteResponse.results[0].text_signature
+  } else {
+    return null
+  }
 }
 
 const registry = new MethodRegistry({ provider: global.ethereumProvider })

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -543,7 +543,7 @@ export default class ConfirmTransactionBase extends Component {
         toName={toName}
         toAddress={toAddress}
         showEdit={onEdit && !isTxReprice}
-        action={this.context.t(actionKey) || getMethodName(name) || this.context.t('contractInteraction')}
+        action={actionKey && this.context.t(actionKey) || getMethodName(name) || this.context.t('contractInteraction')}
         title={title}
         titleComponent={this.renderTitleComponent()}
         subtitle={subtitle}


### PR DESCRIPTION
fixes #5057 

This PR adds a call to the 4byte registry as a fallback if our `eth-method-registry` call comes up empty. The work is done in getMethodData. A couple other minor issues that I came across while completing this PR are addressed. They are explained by the commit history.

- [x] This PR increases the time it takes to load the confirm screen. It is possible to avoid that by only blocking the name of the method and associated arg data, and not the whole screen, on the 4byte registry request. We could even go as far as rendering a screen with minimal details even before the eth-method-registry request is resolved. This would help with the already too long loading screen. I may move this into another PR.