### PR TITLE
Fixes #6321 & #6421 - Add Localhost 8545 for network dropdown names

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -308,6 +308,9 @@
   "connectingToRinkeby": {
     "message": "Connecting to Rinkeby Test Network"
   },
+  "connectingToLocalhost": {
+    "message": "Connecting to Localhost 8545"
+  },
   "connectingToUnknown": {
     "message": "Connecting to Unknown Network"
   },

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -140,10 +140,10 @@ module.exports = class NetworkController extends EventEmitter {
     this.providerConfig = providerConfig
   }
 
-  async setProviderType (type) {
+  async setProviderType (type, rpcTarget = '', ticker = 'ETH', nickname = '') {
     assert.notEqual(type, 'rpc', `NetworkController - cannot call "setProviderType" with type 'rpc'. use "setRpcTarget"`)
     assert(INFURA_PROVIDER_TYPES.includes(type) || type === LOCALHOST, `NetworkController - Unknown rpc type "${type}"`)
-    const providerConfig = { type }
+    const providerConfig = { type, rpcTarget, ticker, nickname }
     this.providerConfig = providerConfig
   }
 

--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -285,6 +285,8 @@ NetworkDropdown.prototype.getNetworkName = function () {
     name = this.context.t('kovan')
   } else if (providerName === 'rinkeby') {
     name = this.context.t('rinkeby')
+  } else if (providerName === 'localhost') {
+    name = this.context.t('localhost')
   } else {
     name = provider.nickname || this.context.t('unknownNetwork')
   }

--- a/ui/app/components/app/loading-network-screen/loading-network-screen.component.js
+++ b/ui/app/components/app/loading-network-screen/loading-network-screen.component.js
@@ -45,6 +45,8 @@ export default class LoadingNetworkScreen extends PureComponent {
       name = this.context.t('connectingToKovan')
     } else if (providerName === 'rinkeby') {
       name = this.context.t('connectingToRinkeby')
+    } else if (providerName === 'localhost') {
+      name = this.context.t('connectingToLocalhost')
     } else {
       name = this.context.t('connectingTo', [providerId])
     }

--- a/ui/app/components/app/network.js
+++ b/ui/app/components/app/network.js
@@ -139,7 +139,7 @@ Network.prototype.render = function () {
                 },
               }),
 
-              h('.network-name', providerNick || context.t('privateNetwork')),
+              h('.network-name', providerName === 'localhost' ? context.t('localhost') : providerNick || context.t('privateNetwork')),
               h('i.fa.fa-chevron-down.fa-lg.network-caret'),
             ])
         }

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -267,6 +267,8 @@ class Routes extends Component {
       name = this.context.t('connectingToKovan')
     } else if (providerName === 'rinkeby') {
       name = this.context.t('connectingToRinkeby')
+    } else if (providerName === 'localhost') {
+      name = this.context.t('connectingToLocalhost')
     } else {
       name = this.context.t('connectingTo', [providerId])
     }
@@ -288,6 +290,8 @@ class Routes extends Component {
       name = this.context.t('kovan')
     } else if (providerName === 'rinkeby') {
       name = this.context.t('rinkeby')
+    } else if (providerName === 'localhost') {
+      name = this.context.t('localhost')
     } else {
       name = this.context.t('unknownNetwork')
     }


### PR DESCRIPTION
This fixes the UI bug associate with https://github.com/MetaMask/metamask-extension/issues/6321. There still is an issue when setting Custom RPCs, which keeps the `rpcTarget/nickname` in the provider params even when switching off to one of the default networks. Evidently, this clears the `ticker` as well, which could be https://github.com/MetaMask/metamask-extension/issues/6421 issue as well.

Latest commit should fix #6421, and initial commit fixes #6321.