### PR TITLE
Remove unneeded array cloning in getSendToAccounts selector

### DIFF
--- a/ui/app/components/app/send/send.selectors.js
+++ b/ui/app/components/app/send/send.selectors.js
@@ -240,9 +240,7 @@ function getSendTo (state) {
 function getSendToAccounts (state) {
   const fromAccounts = accountsWithSendEtherInfoSelector(state)
   const addressBookAccounts = getAddressBook(state)
-  const allAccounts = [...fromAccounts, ...addressBookAccounts]
-  // TODO: figure out exactly what the below returns and put a descriptive variable name on it
-  return Object.entries(allAccounts).map(([key, account]) => account)
+  return [...fromAccounts, ...addressBookAccounts]
 }
 
 function getSendWarnings (state) {


### PR DESCRIPTION
The use of [`Object.entries`][1] here to map the accounts into a new array effectively produces a shallow clone of the array without guaranteeing the order of the original array (as object iteration order is implementation-specific and variable). From MDN:<sup>[\[1\]][1]</sup>

> The **`Object.entries()`** method returns an array of a given object's own enumerable string-keyed property `[key, value]` pairs, in the same order as that provided by a `for...in` loop

And also:

> The ordering of the properties is the same as that given by looping over the property values of the object manually.

Both of which suggest that the iteration order is the same as `for...in`, which is to say that it's not specified.<sup>[\[2\]][2] [\[3\]][3]</sup>

This PR removes the cloning, keeping the shallow clone created the line before which preserves the order of the items in the array.

  [1]:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
  [2]:https://stackoverflow.com/a/5525820/1267663
  [3]:https://stackoverflow.com/a/30919039/1267663