### PR TITLE
Add object to activeCurrency proptype validation

### DIFF
--- a/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
+++ b/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
@@ -23,7 +23,10 @@ class MetaMetricsProvider extends Component {
   static propTypes = {
     network: PropTypes.string.isRequired,
     environmentType: PropTypes.string.isRequired,
-    activeCurrency: PropTypes.string.isRequired,
+    activeCurrency: PropTypes.oneOfType([
+      PropTypes.string.isRequired,
+      PropTypes.object.isRequired,
+    ]),
     accountType: PropTypes.string.isRequired,
     metaMetricsSendCount: PropTypes.number.isRequired,
     children: PropTypes.object.isRequired,


### PR DESCRIPTION
Addresses part 2 of #6474, don't know if this propType validation is conventional, but it no longer shows the warning. The snippet below will almost always provide the token object.

https://github.com/MetaMask/metamask-extension/blob/1377bf3964983f9ff55424d7102174f14b2750d6/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js#L94

https://github.com/MetaMask/metamask-extension/blob/a844eb20da700b832003f63b83fc42ba74392d6c/ui/app/selectors/selectors.js#L93-L94

https://github.com/MetaMask/metamask-extension/blob/a844eb20da700b832003f63b83fc42ba74392d6c/ui/app/selectors/selectors.js#L163-L170