### PR TITLE
Address prop types errors

### DIFF
--- a/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.container.js
+++ b/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.container.js
@@ -18,7 +18,7 @@ const mapStateToProps = ({ metamask }) => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    addToken: ({address, symbol, decimals, image}) => dispatch(addToken(address, symbol, decimals, image)),
+    addToken: ({address, symbol, decimals, image}) => dispatch(addToken(address, symbol, Number(decimals), image)),
     removeSuggestedTokens: () => dispatch(removeSuggestedTokens()),
   }
 }

--- a/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -11,7 +11,7 @@ export default class SendAssetRow extends Component {
     tokens: PropTypes.arrayOf(
       PropTypes.shape({
         address: PropTypes.string,
-        decimals: PropTypes.number,
+        decimals: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         symbol: PropTypes.string,
       })
     ).isRequired,

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -91,7 +91,8 @@ function getAccountType (state) {
 }
 
 function getSelectedAsset (state) {
-  return getSelectedToken(state) || 'ETH'
+  const selectedToken = getSelectedToken(state)
+  return selectedToken && selectedToken.symbol || 'ETH'
 }
 
 function getCurrentNetworkId (state) {


### PR DESCRIPTION
Fixes first two items of https://github.com/MetaMask/metamask-extension/issues/6474

The first was caused by the existence of both number and string `decimals` in the `state.metamask.tokens` list. https://github.com/MetaMask/metamask-extension/pull/6475 doesn't fully fix the issue, because depending on how a token is added to the list, the decimals could be a string and not a number.

This PR fixes this by allowing decimals to be either string or number. In addition, this PR gets to the root of the issue by ensuring that all tokens in our list have `decimals` properties of type `Number`. These fixes are made in https://github.com/MetaMask/metamask-extension/commit/8a82e629bfa6545d09adf58e5b5d32cbdb1fba6f

The second item of #6474 is fixed in https://github.com/MetaMask/metamask-extension/commit/8c075b71586761aa7e813c7fb9ddddfa98f3a84a The provider was always receiving objects for its `activeCurrency` prop because of a bug in the `getSelectedAsset` selector. This is corrected so that the selector only returns token symbol strings, not whole objects.