### PR TITLE
Send metrics event from backend for on chain transaction failures

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -117,6 +117,14 @@ class PreferencesController {
     return metaMetricsId
   }
 
+  getMetaMetricsId () {
+    return this.store.getState().metaMetricsId
+  }
+
+  getParticipateInMetaMetrics () {
+    return this.store.getState().participateInMetaMetrics
+  }
+
   setMetaMetricsSendCount (val) {
     this.store.updateState({ metaMetricsSendCount: val })
   }

--- a/app/scripts/lib/backend-metametrics.js
+++ b/app/scripts/lib/backend-metametrics.js
@@ -1,9 +1,5 @@
 const {
-  getCurrentNetworkId,
-  getSelectedAsset,
-  getAccountType,
-  getNumberOfAccounts,
-  getNumberOfTokens,
+  getMetaMetricState,
 } = require('../../../ui/app/selectors/selectors')
 const {
   sendMetaMetricsEvent,
@@ -15,19 +11,8 @@ const METAMETRICS_TRACKING_URL = inDevelopment
   ? 'http://www.metamask.io/metametrics'
   : 'http://www.metamask.io/metametrics-prod'
 
-async function backEndMetaMetricsEvent (getState, eventData) {
-  const metamask = await getState()
-  const state = { metamask }
-  console.log('!!!!!!!!!!!!!!!! state', state)
-  const stateEventData = {
-    network: getCurrentNetworkId(state),
-    activeCurrency: getSelectedAsset(state),
-    accountType: getAccountType(state),
-    metaMetricsId: state.metamask.metaMetricsId,
-    numberOfTokens: getNumberOfTokens(state),
-    numberOfAccounts: getNumberOfAccounts(state),
-    participateInMetaMetrics: state.metamask.participateInMetaMetrics,
-  }
+function backEndMetaMetricsEvent (metaMaskState, eventData) {
+  const stateEventData = getMetaMetricState({ metamask: metaMaskState })
 
   if (stateEventData.participateInMetaMetrics) {
       sendMetaMetricsEvent({

--- a/app/scripts/lib/backend-metametrics.js
+++ b/app/scripts/lib/backend-metametrics.js
@@ -1,0 +1,41 @@
+const {
+  getCurrentNetworkId,
+  getSelectedAsset,
+  getAccountType,
+  getNumberOfAccounts,
+  getNumberOfTokens,
+} = require('../../../ui/app/selectors/selectors')
+const {
+  sendMetaMetricsEvent,
+} = require('../../../ui/app/helpers/utils/metametrics.util')
+
+const inDevelopment = process.env.NODE_ENV === 'development'
+
+const METAMETRICS_TRACKING_URL = inDevelopment
+  ? 'http://www.metamask.io/metametrics'
+  : 'http://www.metamask.io/metametrics-prod'
+
+async function backEndMetaMetricsEvent (getState, eventData) {
+  const metamask = await getState()
+  const state = { metamask }
+  console.log('!!!!!!!!!!!!!!!! state', state)
+  const stateEventData = {
+    network: getCurrentNetworkId(state),
+    activeCurrency: getSelectedAsset(state),
+    accountType: getAccountType(state),
+    metaMetricsId: state.metamask.metaMetricsId,
+    numberOfTokens: getNumberOfTokens(state),
+    numberOfAccounts: getNumberOfAccounts(state),
+    participateInMetaMetrics: state.metamask.participateInMetaMetrics,
+  }
+
+  if (stateEventData.participateInMetaMetrics) {
+      sendMetaMetricsEvent({
+        ...stateEventData,
+        ...eventData,
+        url: METAMETRICS_TRACKING_URL + '/backend',
+      })
+  }
+}
+
+module.exports = backEndMetaMetricsEvent

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -191,7 +191,7 @@ module.exports = class MetamaskController extends EventEmitter {
     })
     this.txController.on('newUnapprovedTx', () => opts.showUnapprovedTx())
 
-    this.txController.on(`tx:status-update`, (txId, status) => {
+    this.txController.on(`tx:status-update`, async (txId, status) => {
       if (status === 'confirmed' || status === 'failed') {
         const txMeta = this.txController.txStateManager.getTx(txId)
         this.platform.showTransactionNotification(txMeta)
@@ -199,7 +199,8 @@ module.exports = class MetamaskController extends EventEmitter {
         const { txReceipt } = txMeta
         const participateInMetaMetrics = this.preferencesController.getParticipateInMetaMetrics()
         if (txReceipt && txReceipt.status === '0x0' && participateInMetaMetrics) {
-          backEndMetaMetricsEvent(this.getState.bind(this), {
+          const metamaskState = await this.getState()
+          backEndMetaMetricsEvent(metamaskState, {
             customVariables: {
               errorMessage: txMeta.simulationFails.reason,
             },

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -375,7 +375,7 @@ export function setTransactionToConfirm (transactionId) {
         dispatch(updateMethodData(methodData))
 
         try {
-          const toSmartContract = await isSmartContractAddress(to)
+          const toSmartContract = await isSmartContractAddress(to || '')
           dispatch(updateToSmartContract(toSmartContract))
         } catch (error) {
           log.error(error)

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -124,10 +124,10 @@ function composeUrl (config, permissionPreferences = {}) {
     numberOfTokens: customVariables && customVariables.numberOfTokens || numberOfTokens,
     numberOfAccounts: customVariables && customVariables.numberOfAccounts || numberOfAccounts,
   }) : ''
-  const url = configUrl || `&url=${encodeURIComponent(currentPath.replace(/chrome-extension:\/\/\w+/, METAMETRICS_TRACKING_URL))}`
+  const url = configUrl || currentPath ? `&url=${encodeURIComponent(currentPath.replace(/chrome-extension:\/\/\w+/, METAMETRICS_TRACKING_URL))}` : ''
   const _id = metaMetricsId && !excludeMetaMetricsId ? `&_id=${metaMetricsId.slice(2, 18)}` : ''
   const rand = `&rand=${String(Math.random()).slice(2)}`
-  const pv_id = `&pv_id=${ethUtil.bufferToHex(ethUtil.sha3(url || currentPath.match(/chrome-extension:\/\/\w+\/(.+)/)[0])).slice(2, 8)}`
+  const pv_id = (url || currentPath) && `&pv_id=${ethUtil.bufferToHex(ethUtil.sha3(url || currentPath.match(/chrome-extension:\/\/\w+\/(.+)/)[0])).slice(2, 8)}` || ''
   const uid = metaMetricsId && !excludeMetaMetricsId
     ? `&uid=${metaMetricsId.slice(2, 18)}`
     : excludeMetaMetricsId

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -165,7 +165,7 @@ function getSelectedToken (state) {
   const tokens = state.metamask.tokens || []
   const selectedTokenAddress = state.metamask.selectedTokenAddress
   const selectedToken = tokens.filter(({ address }) => address === selectedTokenAddress)[0]
-  const sendToken = state.metamask.send.token
+  const sendToken = state.metamask.send && state.metamask.send.token
 
   return selectedToken || sendToken || null
 }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -48,6 +48,7 @@ const selectors = {
   getNumberOfAccounts,
   getNumberOfTokens,
   isEthereumNetwork,
+  getMetaMetricState,
 }
 
 module.exports = selectors
@@ -313,4 +314,16 @@ function preferencesSelector ({ metamask }) {
 
 function getAdvancedInlineGasShown (state) {
   return Boolean(state.metamask.featureFlags.advancedInlineGas)
+}
+
+function getMetaMetricState (state) {
+  return {
+    network: getCurrentNetworkId(state),
+    activeCurrency: getSelectedAsset(state),
+    accountType: getAccountType(state),
+    metaMetricsId: state.metamask.metaMetricsId,
+    numberOfTokens: getNumberOfTokens(state),
+    numberOfAccounts: getNumberOfAccounts(state),
+    participateInMetaMetrics: state.metamask.participateInMetaMetrics,
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/MetaMask/metamask-extension/issues/6416

Uses front end selectors and metametrics utility to send from backend on a transaction status update that includes a txReciept