### PR TITLE
Ensure home screen does not render if there are unapproved txs

### DIFF
--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -99,15 +99,18 @@ export default class ConfirmTransactionBase extends Component {
     submitError: null,
   }
 
-  componentDidUpdate () {
+  componentDidUpdate (prevProps) {
     const {
       transactionStatus,
       showTransactionConfirmedModal,
       history,
       clearConfirmTransaction,
     } = this.props
+    const { transactionStatus: prevTxStatus } = prevProps
+    const statusUpdated = transactionStatus !== prevTxStatus
+    const txDroppedOrConfirmed = transactionStatus === DROPPED_STATUS || transactionStatus === CONFIRMED_STATUS
 
-    if (transactionStatus === DROPPED_STATUS || transactionStatus === CONFIRMED_STATUS) {
+    if (statusUpdated && txDroppedOrConfirmed) {
       showTransactionConfirmedModal({
         onSubmit: () => {
           clearConfirmTransaction()

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -23,11 +23,21 @@ export default class Home extends PureComponent {
     providerRequests: PropTypes.array,
   }
 
+  componentWillMount () {
+    const {
+      history,
+      unconfirmedTransactionsCount = 0,
+    } = this.props
+
+    if (unconfirmedTransactionsCount > 0) {
+      history.push(CONFIRM_TRANSACTION_ROUTE)
+    }
+  }
+
   componentDidMount () {
     const {
       history,
       suggestedTokens = {},
-      unconfirmedTransactionsCount = 0,
     } = this.props
 
     // suggested new tokens
@@ -41,7 +51,7 @@ export default class Home extends PureComponent {
       forgottenPassword,
       seedWords,
       providerRequests,
-      unconfirmedTransactionsCount,
+      history,
     } = this.props
 
     // seed words
@@ -59,9 +69,6 @@ export default class Home extends PureComponent {
       )
     }
 
-    if (unconfirmedTransactionsCount > 0) {
-      return <Redirect to={{ pathname: CONFIRM_TRANSACTION_ROUTE }} />
-    }
     return (
       <div className="main-container">
         <div className="account-and-transaction-details">
@@ -69,7 +76,7 @@ export default class Home extends PureComponent {
             query="(min-width: 576px)"
             render={() => <WalletView />}
           />
-          <TransactionView />
+          { !history.location.pathname.match(/^\/confirm-transaction/) ? <TransactionView /> : null }
         </div>
       </div>
     )

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -34,10 +34,6 @@ export default class Home extends PureComponent {
     if (Object.keys(suggestedTokens).length > 0) {
         history.push(CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE)
     }
-
-    if (unconfirmedTransactionsCount > 0) {
-      history.push(CONFIRM_TRANSACTION_ROUTE)
-    }
   }
 
   render () {
@@ -45,6 +41,7 @@ export default class Home extends PureComponent {
       forgottenPassword,
       seedWords,
       providerRequests,
+      unconfirmedTransactionsCount,
     } = this.props
 
     // seed words
@@ -62,6 +59,9 @@ export default class Home extends PureComponent {
       )
     }
 
+    if (unconfirmedTransactionsCount > 0) {
+      return <Redirect to={{ pathname: CONFIRM_TRANSACTION_ROUTE }} />
+    }
     return (
       <div className="main-container">
         <div className="account-and-transaction-details">


### PR DESCRIPTION
This was causing significantly slow behaviour when transaction lists are large. I will add more details to this description later.

This was discovered while working on https://github.com/MetaMask/metamask-extension/issues/6380. Resolving that issue will lead to further performance improvements on the confirm screen, in some cases.

@bdresser This will fix performance problems that have the same symptoms as what some users describe in https://github.com/MetaMask/metamask-extension/issues/6017