### PR TITLE
ConfirmTransactionScreen - Display actual actionKey instead of searching from translator for Contract Interactions.

### DIFF
--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -543,7 +543,7 @@ export default class ConfirmTransactionBase extends Component {
         toName={toName}
         toAddress={toAddress}
         showEdit={onEdit && !isTxReprice}
-        action={this.context.t(actionKey) || getMethodName(name) || this.context.t('contractInteraction')}
+        action={actionKey || getMethodName(name) || this.context.t('contractInteraction')}
         title={title}
         titleComponent={this.renderTitleComponent()}
         subtitle={subtitle}


### PR DESCRIPTION
When actionKey is returning undefined, it will display the actual `[undefined]`.

Don't what the use cases are for looking up the translator for it, but this will fallback to `contractInteraction` when actionKey is undefined.

<img width="384" alt="Screen Shot 2019-04-26 at 10 21 41 AM" src="https://user-images.githubusercontent.com/13376180/56827184-f1fb7780-6812-11e9-88d2-4e69d32dafc8.png">
