### PR TITLE
Adds configurable shortcuts keys for navigation to routes

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1375,6 +1375,25 @@
   "shapeshiftBuy": {
     "message": "Buy with Shapeshift"
   },
+  "shortcuts": {
+    "message": "Shortcuts"
+  },
+  "shortCutDescription": {
+    "message": "Select a route for the $1 shortcut keys",
+    "description": "$1 to be replaced by a keyboard combo, e.g. Alt + Shift + M"
+  },
+  "shortcut1": {
+    "message": "Shortcut 1"
+  },
+  "shortcut2": {
+    "message": "Shortcut 2"
+  },
+  "shortcut3": {
+    "message": "Shortcut 3"
+  },
+  "shortcut4": {
+    "message": "Shortcut 4"
+  },
   "showAdvancedGasInline": {
     "message": "Advanced gas controls"
   },

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -84,5 +84,31 @@
     "ids": [
       "*"
     ]
+  },
+  "commands": {
+    "shortcut1": {
+      "suggested_key": {
+        "default": "Alt+Q"
+      },
+      "description": "Triggers `Shortcut 1` as set in MetaMask's settings page"
+    },
+    "shortcut2": {
+      "suggested_key": {
+        "default": "Alt+W"
+      },
+      "description": "Triggers `Shortcut 2` as set in MetaMask's settings page"
+    },
+    "shortcut3": {
+      "suggested_key": {
+        "default": "Alt+E"
+      },
+      "description": "Triggers `Shortcut 3` as set in MetaMask's settings page"
+    },
+    "shortcut4": {
+      "suggested_key": {
+        "default": "Alt+R"
+      },
+      "description": "Triggers `Shortcut 4` as set in MetaMask's settings page"
+    }
   }
 }

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -58,6 +58,7 @@ class PreferencesController {
       completedUiMigration: true,
       metaMetricsId: null,
       metaMetricsSendCount: 0,
+      shortCutRoutes: {},
     }, opts.initState)
 
     this.diagnostics = opts.diagnostics
@@ -152,6 +153,18 @@ class PreferencesController {
     const newEntry = { address, symbol, decimals, image }
     suggested[address] = newEntry
     this.store.updateState({ suggestedTokens: suggested })
+  }
+
+  /**
+   * Sets the route of a specified shortcut
+   * @param {string} shortCutKey The key of the shortcut to set
+   * @param {string} route The route to which the shortcut will take the user
+   */
+  setShortCutRoute (shortCutKey, route) {
+    console.log('!!!!!!!!!!! shortCutKey, route', shortCutKey, route)
+    const shortCutRoutes = this.store.getState().shortCutRoutes
+    shortCutRoutes[shortCutKey] = route
+    this.store.updateState({ shortCutRoutes })
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -423,6 +423,7 @@ module.exports = class MetamaskController extends EventEmitter {
       completeUiMigration: nodeify(preferencesController.completeUiMigration, preferencesController),
       completeOnboarding: nodeify(preferencesController.completeOnboarding, preferencesController),
       addKnownMethodData: nodeify(preferencesController.addKnownMethodData, preferencesController),
+      setShortCutRoute: nodeify(preferencesController.setShortCutRoute, preferencesController),
 
       // BlacklistController
       whitelistPhishingDomain: this.whitelistPhishingDomain.bind(this),

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -74,6 +74,14 @@ class ExtensionPlatform {
     })
   }
 
+  getAllShortcuts () {
+    return new Promise(resolve => {
+      extension.commands.getAll((...shortcuts) => {
+        resolve(shortcuts)
+      })
+    })
+  }
+
   _showConfirmedTransaction (txMeta) {
 
     this._subscribeToNotificationClicked()

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -43,11 +43,19 @@ async function start () {
 
   // start ui
   const container = document.getElementById('app-content')
-  startPopup({ container, connectionStream }, (err, store) => {
+  startPopup({ container, connectionStream }, (err, { store, history }) => {
     if (err) return displayCriticalError(err)
 
-    const state = store.getState()
+    let state = store.getState()
     const { metamask: { completedOnboarding } = {} } = state
+
+    extension.commands.onCommand.addListener(function (command) {
+      state = store.getState()
+      const { metamask: { shortCutRoutes } = {} } = state
+      if (shortCutRoutes[command]) {
+        history.push(shortCutRoutes[command])
+      }
+    })
 
     if (!completedOnboarding && windowType !== ENVIRONMENT_TYPE_FULLSCREEN) {
       global.platform.openExtensionInBrowser()

--- a/ui/app/components/app/dropdowns/simple-dropdown.js
+++ b/ui/app/components/app/dropdowns/simple-dropdown.js
@@ -22,11 +22,21 @@ class SimpleDropdown extends Component {
   }
 
   handleClose () {
+    const { onClose } = this.props
+    if (onClose) {
+      onClose()
+    }
     this.setState({ isOpen: false })
   }
 
   toggleOpen () {
     const { isOpen } = this.state
+    const { onOpen } = this.props
+
+    if (!isOpen && onOpen) {
+      onOpen()
+    }
+
     this.setState({ isOpen: !isOpen })
   }
 
@@ -86,6 +96,8 @@ SimpleDropdown.propTypes = {
   options: PropTypes.array.isRequired,
   placeholder: PropTypes.string,
   onSelect: PropTypes.func,
+  onOpen: PropTypes.func,
+  onClose: PropTypes.func,
   selectedOption: PropTypes.string,
 }
 

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -77,6 +77,7 @@ function reduceApp (state, action) {
       ledger: `m/44'/60'/0'/0/0`,
     },
     lastSelectedProvider: null,
+    extensionShortcuts: [],
   }, state.appState)
 
   switch (action.type) {
@@ -749,6 +750,12 @@ function reduceApp (state, action) {
       }
       return extend(appState, {
         lastSelectedProvider: action.value,
+      })
+
+    case actions.SET_EXTENSION_SHORTCUTS:
+      console.log('action', action)
+      return extend(appState, {
+        extensionShortcuts: action.value,
       })
 
     default:

--- a/ui/app/helpers/constants/routes.js
+++ b/ui/app/helpers/constants/routes.js
@@ -8,6 +8,7 @@ const ADVANCED_ROUTE = '/settings/advanced'
 const SECURITY_ROUTE = '/settings/security'
 const COMPANY_ROUTE = '/settings/company'
 const ABOUT_US_ROUTE = '/settings/about-us'
+const SHORTCUTS_ROUTE = '/settings/shortcuts'
 const REVEAL_SEED_ROUTE = '/seed'
 const MOBILE_SYNC_ROUTE = '/mobile-sync'
 const CONFIRM_SEED_ROUTE = '/confirm-seed'
@@ -86,4 +87,5 @@ module.exports = {
   COMPANY_ROUTE,
   GENERAL_ROUTE,
   ABOUT_US_ROUTE,
+  SHORTCUTS_ROUTE,
 }

--- a/ui/app/pages/index.js
+++ b/ui/app/pages/index.js
@@ -1,24 +1,24 @@
 import React, { Component } from 'react'
 const PropTypes = require('prop-types')
 const { Provider } = require('react-redux')
-const { HashRouter } = require('react-router-dom')
+const { Router } = require('react-router-dom')
 const Routes = require('./routes')
 const I18nProvider = require('../helpers/higher-order-components/i18n-provider')
 const MetaMetricsProvider = require('../helpers/higher-order-components/metametrics/metametrics.provider')
 
 class Index extends Component {
   render () {
-    const { store } = this.props
+    const { store, history } = this.props
 
     return (
       <Provider store={store}>
-        <HashRouter hashType="noslash">
+        <Router history={history}>
           <MetaMetricsProvider>
             <I18nProvider>
               <Routes />
             </I18nProvider>
           </MetaMetricsProvider>
-        </HashRouter>
+        </Router>
       </Provider>
     )
   }
@@ -26,6 +26,7 @@ class Index extends Component {
 
 Index.propTypes = {
   store: PropTypes.object,
+  history: PropTypes.object,
 }
 
 module.exports = Index

--- a/ui/app/pages/settings/index.scss
+++ b/ui/app/pages/settings/index.scss
@@ -2,6 +2,8 @@
 
 @import 'settings-tab/index';
 
+@import 'shortcuts-tab/index';
+
 .settings-page {
   position: relative;
   background: $white;
@@ -84,7 +86,8 @@
     padding: 10px 0 20px;
   }
 
-  &__content-item {
+  &__content-item,
+  &__content-item--tight {
     flex: 1;
     min-width: 0;
     display: flex;
@@ -100,6 +103,10 @@
     &--without-height {
       height: initial;
     }
+  }
+
+  &__content-item--tight {
+    min-height: 0px;
   }
 
   &__content-label {

--- a/ui/app/pages/settings/settings.component.js
+++ b/ui/app/pages/settings/settings.component.js
@@ -6,6 +6,7 @@ import { getEnvironmentType } from '../../../../app/scripts/lib/util'
 import TabBar from '../../components/app/tab-bar'
 import c from 'classnames'
 import SettingsTab from './settings-tab'
+import ShortCutsTab from './shortcuts-tab'
 import AdvancedTab from './advanced-tab'
 import InfoTab from './info-tab'
 import SecurityTab from './security-tab'
@@ -16,6 +17,7 @@ import {
   GENERAL_ROUTE,
   ABOUT_US_ROUTE,
   SETTINGS_ROUTE,
+  SHORTCUTS_ROUTE,
 } from '../../helpers/constants/routes'
 
 const ROUTES_TO_I18N_KEYS = {
@@ -92,6 +94,7 @@ export default class SettingsPage extends PureComponent {
           { content: t('general'), description: t('generalSettingsDescription'), key: GENERAL_ROUTE },
           { content: t('advanced'), description: t('advancedSettingsDescription'), key: ADVANCED_ROUTE },
           { content: t('securityAndPrivacy'), description: t('securitySettingsDescription'), key: SECURITY_ROUTE },
+          { content: t('shortcuts'), description: t('shortcutsSettingsDescription'), key: SHORTCUTS_ROUTE },
           { content: t('about'), description: t('aboutSettingsDescription'), key: ABOUT_US_ROUTE },
         ]}
         isActive={key => {
@@ -127,6 +130,11 @@ export default class SettingsPage extends PureComponent {
           exact
           path={SECURITY_ROUTE}
           component={SecurityTab}
+        />
+        <Route
+          exact
+          path={SHORTCUTS_ROUTE}
+          component={ShortCutsTab}
         />
         <Route
           component={SettingsTab}

--- a/ui/app/pages/settings/shortcuts-tab/index.js
+++ b/ui/app/pages/settings/shortcuts-tab/index.js
@@ -1,0 +1,1 @@
+export { default } from './shortcuts-tab.container'

--- a/ui/app/pages/settings/shortcuts-tab/index.scss
+++ b/ui/app/pages/settings/shortcuts-tab/index.scss
@@ -1,0 +1,9 @@
+.shortcuts-tab {
+  &__body {
+    min-height: 510px;
+
+    .simple-dropdown__options {
+      height: 320px;
+    }
+  }
+}

--- a/ui/app/pages/settings/shortcuts-tab/shortcuts-tab.component.js
+++ b/ui/app/pages/settings/shortcuts-tab/shortcuts-tab.component.js
@@ -1,0 +1,74 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import SimpleDropdown from '../../../components/app/dropdowns/simple-dropdown'
+import routes from '../../../helpers/constants/routes'
+
+const routesOptions = Object.values(routes).sort().map(route => {
+  return {
+    displayValue: route,
+    key: route,
+    value: route,
+  }
+})
+
+export default class ShortCutsTab extends PureComponent {
+  static contextTypes = {
+    t: PropTypes.func,
+    metricsEvent: PropTypes.func,
+  }
+
+  static propTypes = {
+    shortCutRoutes: PropTypes.object,
+    setShortCutRoute: PropTypes.func,
+    setExtensionShortcuts: PropTypes.func,
+    extensionShortcuts: PropTypes.array,
+  }
+
+  state = {
+    openDropdown: '',
+  }
+
+  componentDidMount () {
+    const { setExtensionShortcuts } = this.props
+    setExtensionShortcuts()
+  }
+
+  renderShortCutSelect ({ name, shortcut }) {
+    const { t } = this.context
+    const { openDropdown } = this.state
+    const { shortCutRoutes, setShortCutRoute } = this.props
+
+    return name === openDropdown || openDropdown === ''
+      ? (<div className="settings-page__content-row" key={`${name}-select`}>
+        <div className="settings-page__content-item--tight">
+          <span>{ `${t(name)}: ${shortcut}` }</span>
+        </div>
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-item-col">
+            <SimpleDropdown
+              placeholder={'Select Route'}
+              options={routesOptions}
+              selectedOption={shortCutRoutes[name]}
+              onOpen={() => {
+                console.log('this.state', this.state)
+                this.setState({ openDropdown: name })
+              }}
+              onClose={() => this.setState({ openDropdown: '' })}
+              onSelect={(newRoute) => setShortCutRoute(name, newRoute)}
+            />
+          </div>
+        </div>
+      </div>)
+      : null
+  }
+
+  render () {
+    const { extensionShortcuts } = this.props
+
+    return (
+      <div className="settings-page__body shortcuts-tab__body">
+        { extensionShortcuts && extensionShortcuts.map(extensionShortcut => this.renderShortCutSelect(extensionShortcut)) }
+      </div>
+    )
+  }
+}

--- a/ui/app/pages/settings/shortcuts-tab/shortcuts-tab.container.js
+++ b/ui/app/pages/settings/shortcuts-tab/shortcuts-tab.container.js
@@ -1,0 +1,32 @@
+import ShortCutsTab from './shortcuts-tab.component'
+import { compose } from 'recompose'
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
+import {
+  setShortCutRoute,
+  setExtensionShortcuts,
+} from '../../../store/actions'
+
+const mapStateToProps = state => {
+  const {
+    metamask: { shortCutRoutes = {} },
+    appState: { extensionShortcuts = [] },
+  } = state
+
+  return {
+    shortCutRoutes,
+    extensionShortcuts,
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    setShortCutRoute: (shortCutKey, route) => dispatch(setShortCutRoute(shortCutKey, route)),
+    setExtensionShortcuts: () => dispatch(setExtensionShortcuts()),
+  }
+}
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps)
+)(ShortCutsTab)

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -235,6 +235,7 @@ var actions = {
   updateTokens,
   removeSuggestedTokens,
   addKnownMethodData,
+  setShortCutRoute,
   UPDATE_TOKENS: 'UPDATE_TOKENS',
   updateAndSetCustomRpc: updateAndSetCustomRpc,
   setRpcTarget: setRpcTarget,
@@ -349,6 +350,9 @@ var actions = {
 
   setFirstTimeFlowType,
   SET_FIRST_TIME_FLOW_TYPE: 'SET_FIRST_TIME_FLOW_TYPE',
+
+  setExtensionShortcuts,
+  SET_EXTENSION_SHORTCUTS: 'SET_EXTENSION_SHORTCUTS',
 }
 
 module.exports = actions
@@ -1831,6 +1835,10 @@ function addKnownMethodData (fourBytePrefix, methodData) {
   }
 }
 
+function setShortCutRoute (shortCutKey, route) {
+  return callBackgroundThenUpdate(background.setShortCutRoute, shortCutKey, route)
+}
+
 function updateTokens (newTokens) {
   return {
     type: actions.UPDATE_TOKENS,
@@ -2710,5 +2718,19 @@ function setFirstTimeFlowType (type) {
       type: actions.SET_FIRST_TIME_FLOW_TYPE,
       value: type,
     })
+  }
+}
+
+function setExtensionShortcuts () {
+  return (dispatch) => {
+    log.debug(`getAllShortcuts`)
+    return global.platform.getAllShortcuts()
+      .then(extensionShortcuts => {
+        console.log('!!!! setExtensionShortcuts extensionShortcuts', extensionShortcuts)
+        dispatch({
+          type: actions.SET_EXTENSION_SHORTCUTS,
+          value: extensionShortcuts[0].slice(1),
+        })
+      })
   }
 }

--- a/ui/history.js
+++ b/ui/history.js
@@ -1,0 +1,5 @@
+import { createHashHistory } from 'history'
+
+export default createHashHistory({
+  hashType: 'noslash',
+})

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,6 +1,7 @@
 const render = require('react-dom').render
 const h = require('react-hyperscript')
 const Root = require('./app/pages')
+import history from './history'
 const actions = require('./app/store/actions')
 const configureStore = require('./app/store/store')
 const txHelper = require('./lib/tx-helper')
@@ -18,8 +19,8 @@ function launchMetamaskUi (opts, cb) {
   accountManager.getState(function (err, metamaskState) {
     if (err) return cb(err)
     startApp(metamaskState, accountManager, opts)
-      .then((store) => {
-        cb(null, store)
+      .then(({ store, history }) => {
+        cb(null, { store, history })
       })
   })
 }
@@ -78,8 +79,9 @@ async function startApp (metamaskState, accountManager, opts) {
     h(Root, {
       // inject initial state
       store: store,
+      history: history,
     }
   ), opts.container)
 
-  return store
+  return { store, history }
 }


### PR DESCRIPTION
This PR adds a shortcut key feature. Users can set up to four shortcut key combinations to visit specified routes to speed up in-app navigation. The short-cut key combos can be set by the user in: chrome://extensions/shortcuts

The destinations of short-cut keys can be set in Settings.

Creating this as a draft as it has not yet had any discussion as to whether it is desired, let alone design treatment.

Demo:
![Peek 2019-04-29 03-24](https://user-images.githubusercontent.com/7499938/56878674-d4572980-6a2f-11e9-9140-616b75e2c82f.gif)

![Screenshot from 2019-04-29 03-40-03](https://user-images.githubusercontent.com/7499938/56878824-8b53a500-6a30-11e9-9d99-a0e38ffce982.png)

