### PR TITLE
Adds fetchWithCache to guard against unnecessary API calls

### DIFF
--- a/ui/app/helpers/utils/fetch-with-cache.js
+++ b/ui/app/helpers/utils/fetch-with-cache.js
@@ -1,0 +1,22 @@
+import {
+  loadLocalStorageData,
+  saveLocalStorageData,
+} from '../../../lib/local-storage-helpers'
+
+export default function fetchWithCache (url, opts, cacheRefreshTime = 360000) {
+  const currentTime = Date.now()
+  const cachedFetch = loadLocalStorageData('cachedFetch') || {}
+  const { cachedUrl, cachedTime } = cachedFetch[url] || {}
+  if (cachedUrl && currentTime - cachedTime < 360000) {
+    return cachedFetch[url]
+  } else {
+    cachedFetch[url] = { cachedUrl: url, cachedTime: currentTime }
+    saveLocalStorageData(cachedFetch, 'cachedFetch')
+    return fetch(url, {
+      referrerPolicy: 'no-referrer-when-downgrade',
+      body: null,
+      method: 'GET',
+      mode: 'cors',
+    })
+  }
+}

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -6,6 +6,7 @@ import {
   TRANSACTION_TYPE_CANCEL,
   TRANSACTION_STATUS_CONFIRMED,
 } from '../../../../app/scripts/controllers/transactions/enums'
+import fetchWithCache from './fetch-with-cache'
 
 import {
   TOKEN_METHOD_TRANSFER,
@@ -31,7 +32,7 @@ export function getTokenData (data = '') {
 }
 
 async function getMethodFrom4Byte (fourBytePrefix) {
-  const fourByteResponse = (await fetch(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${fourBytePrefix}`, {
+  const fourByteResponse = (await fetchWithCache(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${fourBytePrefix}`, {
     referrerPolicy: 'no-referrer-when-downgrade',
     body: null,
     method: 'GET',


### PR DESCRIPTION
fixes https://github.com/MetaMask/metamask-extension/issues/6531

Add a simple wrapper around `fetch` to create a method that utilizes a local storage based cached to ensure that duplicate network requests are sent much more rarely for the same machine.