### PR TITLE
Skip null and undefined keys when translating via context

### DIFF
--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -15,6 +15,12 @@ class I18nProvider extends Component {
     const { localeMessages } = this.props
     const { current, en } = localeMessages
     return {
+      /**
+       * Returns a localized message for the given key
+       * @param {string} key The message key
+       * @param {string[]} args A list of message substitution replacements
+       * @return {string|undefined|null} The localized message if available
+       */
       t (key, ...args) {
         if (key === undefined || key === null) {
           return key

--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -16,6 +16,10 @@ class I18nProvider extends Component {
     const { current, en } = localeMessages
     return {
       t (key, ...args) {
+        if (key === undefined || key === null) {
+          return key
+        }
+
         return t(current, key, ...args) || t(en, key, ...args) || `[${key}]`
       },
       tOrDefault: this.tOrDefault,


### PR DESCRIPTION
Closes #6524

This is an alternative fix for `undefined` keys showing up as `[undefined]` when run through the translate fn (`t`). As we often follow a pattern of `this.context.t(someKey) || defaultString` this updates the `t` fn to return a falsy value when given one.