### PR TITLE
Use tOrDefault for ConfirmTransactionBase action string

### DIFF
--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -18,6 +18,7 @@ import AdvancedGasInputs from '../../components/app/gas-customization/advanced-g
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
     t: PropTypes.func,
+    tOrDefault: PropTypes.func.isRequired,
     metricsEvent: PropTypes.func,
   }
 
@@ -546,7 +547,7 @@ export default class ConfirmTransactionBase extends Component {
         toName={toName}
         toAddress={toAddress}
         showEdit={onEdit && !isTxReprice}
-        action={this.context.t(actionKey) || getMethodName(name) || this.context.t('contractInteraction')}
+        action={this.context.tOrDefault(actionKey, getMethodName(name) || this.context.t('contractInteraction'))}
         title={title}
         titleComponent={this.renderTitleComponent()}
         subtitle={subtitle}


### PR DESCRIPTION
Closes #6524

This is an(other) alternative to #6524 that uses `tOrDefault` to provide a default for the action string passed to `ConfirmPageContainer` in the `ConfirmTransactionBase` component. While this should work fine, I prefer #6543 as this change would see the default string expression evaluated even when the `actionKey` resolves to a message.

That is, `getMethodName(name) || this.context.t('contractInteraction')` would be evaluated on every render regardless of the `actionKey` passed.