### PR TITLE
Use tOrKey for actionKey in ConfirmTransactionBase

### DIFF
--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -19,7 +19,7 @@ class I18nProvider extends Component {
         return t(current, key, ...args) || t(en, key, ...args) || `[${key}]`
       },
       tOrDefault: this.tOrDefault,
-      tOrKey (key, ...args) {
+      tOrKey: (key, ...args) => {
         return this.tOrDefault(key, key, ...args)
       },
     }

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -18,6 +18,7 @@ import AdvancedGasInputs from '../../components/app/gas-customization/advanced-g
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
     t: PropTypes.func,
+    tOrKey: PropTypes.func.isRequired,
     metricsEvent: PropTypes.func,
   }
 
@@ -546,7 +547,8 @@ export default class ConfirmTransactionBase extends Component {
         toName={toName}
         toAddress={toAddress}
         showEdit={onEdit && !isTxReprice}
-        action={this.context.t(actionKey) || getMethodName(name) || this.context.t('contractInteraction')}
+        // In the event that the key is falsy (and inherently invalid), use a fallback string
+        action={this.context.tOrKey(actionKey) || getMethodName(name) || this.context.t('contractInteraction')}
         title={title}
         titleComponent={this.renderTitleComponent()}
         subtitle={subtitle}


### PR DESCRIPTION
Closes #6524
Closes #6544

This PR is an alternative to the two PRs listed above. In the event that `actionKey` is falsy we would like to render one of the fallback strings rather than the default `[${key}]` string.