### PR TITLE
Add suffix to CurrencyDisplay title text only when it exists

### DIFF
--- a/ui/app/components/ui/currency-display/currency-display.component.js
+++ b/ui/app/components/ui/currency-display/currency-display.component.js
@@ -23,7 +23,7 @@ export default class CurrencyDisplay extends PureComponent {
   render () {
     const { className, displayValue, prefix, prefixComponent, style, suffix, hideTitle } = this.props
     const text = `${prefix || ''}${displayValue}`
-    const title = `${text} ${suffix}`
+    const title = suffix ? `${text} ${suffix}` : text
 
     return (
       <div


### PR DESCRIPTION
This PR updates the title text used in the `CurrencyDisplay` component to only append the suffix if it exists. A lot of usages of this component don't pass a `suffix` prop (`propsSuffix` in the container's merge fn) or pass a `hideLabel` prop (which results in `suffix === undefined`).

**Before & after**

![Screenshot of title text before and after this PR](https://user-images.githubusercontent.com/1623628/57004471-c1686480-6ba9-11e9-8361-7aa38a6f81d9.jpg)

