### PR TITLE
Revert "Revert "Adds 4byte registry fallback to getMethodData()""

### DIFF
--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -30,6 +30,21 @@ export function getTokenData (data = '') {
   return abiDecoder.decodeMethod(data)
 }
 
+async function getMethodFrom4Byte (fourBytePrefix) {
+  const fourByteResponse = (await fetch(`https://www.4byte.directory/api/v1/signatures/?hex_signature=${fourBytePrefix}`, {
+    referrerPolicy: 'no-referrer-when-downgrade',
+    body: null,
+    method: 'GET',
+    mode: 'cors',
+  })).json()
+
+  if (fourByteResponse.count === 1) {
+    return fourByteResponse.results[0].text_signature
+  } else {
+    return null
+  }
+}
+
 const registry = new MethodRegistry({ provider: global.ethereumProvider })
 
 /**
@@ -43,7 +58,16 @@ const registry = new MethodRegistry({ provider: global.ethereumProvider })
     const fourBytePrefix = prefixedData.slice(0, 10)
 
     try {
-      const sig = await registry.lookup(fourBytePrefix)
+      const fourByteSig = getMethodFrom4Byte(fourBytePrefix).catch((e) => {
+          log.error(e)
+          return null
+      })
+
+      let sig = await registry.lookup(fourBytePrefix)
+
+      if (!sig) {
+        sig = await fourByteSig
+      }
 
       if (!sig) {
         return {}
@@ -57,8 +81,8 @@ const registry = new MethodRegistry({ provider: global.ethereumProvider })
       }
     } catch (error) {
       log.error(error)
-      const contractData = getTokenData(data)
-      const { name } = contractData || {}
+      const tokenData = getTokenData(data)
+      const { name } = tokenData || {}
       return { name }
     }
 


### PR DESCRIPTION
Refs #6435 and its reversal #6521

This PR re-introduces the 4Byte fallback (reverts #6521) for our method data.

We'll want to improve how this behaves before landing it on `develop` again, namely:

- Fix use of `knownMethodData`, elimate network requests for already known data #6530
- Add front end network request caching #6531
- Add timeout to fetch requests for tx method data #6535

**Note:** this PR targets a feature branch that will hold the 4byte fallback functionality until it is QA'd.