### PR TITLE
Adds NPM scripts for running a dapp, and dapp + chain, locally.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "start:test": "gulp dev:test",
     "build:test": "gulp build:test",
     "test": "npm run test:unit && npm run test:integration && npm run lint",
+    "dapp": "static-server test/e2e/beta/contract-test --port 8080",
+    "dapp-chain": "shell-parallel -s 'npm run ganache:start -- -b 2' -x 'sleep 5 && static-server test/e2e/beta/contract-test --port 8080'",
     "watch:test:unit": "nodemon --exec \"npm run test:unit\" ./test ./app ./ui",
     "test:unit": "cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive \"test/unit/**/*.js\" \"ui/app/**/*.test.js\"",
     "test:single": "cross-env METAMASK_ENV=test mocha --require test/helper.js",


### PR DESCRIPTION
This PR adds two scripts that will make life a little easier while developing. The scripts are taken from `metamask-extension/test/e2e/beta/run-all.sh`