### PR TITLE
Fix nock usages in unit tests

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1196,7 +1196,6 @@ describe('Actions', () => {
 
   describe('#pairUpdate', () => {
     beforeEach(() => {
-
       nock('https://shapeshift.io')
         .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
         .get('/marketinfo/btc_eth')
@@ -1206,10 +1205,6 @@ describe('Actions', () => {
         .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
         .get('/coins')
         .reply(200)
-      })
-
-    afterEach(() => {
-      nock.restore()
     })
 
     it('', () => {

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.js
@@ -15,6 +15,7 @@ export default class AmountMaxButton extends Component {
 
   static contextTypes = {
     t: PropTypes.func,
+    metricsEvent: PropTypes.func,
   }
 
   setMaxAmount () {
@@ -35,11 +36,15 @@ export default class AmountMaxButton extends Component {
   }
 
   onMaxClick = (event) => {
-    const { setMaxModeTo, selectedToken } = this.props
+    const { setMaxModeTo } = this.props
+    const { metricsEvent } = this.context
 
-    fetch('https://chromeextensionmm.innocraft.cloud/piwik.php?idsite=1&rec=1&e_c=send&e_a=amountMax&e_n=' + (selectedToken ? 'token' : 'eth'), {
-      'headers': {},
-      'method': 'GET',
+    metricsEvent({
+      eventOpts: {
+        category: 'Transactions',
+        action: 'Edit Screen',
+        name: 'Clicked "Amount Max"',
+      },
     })
 
     event.preventDefault()

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
@@ -26,7 +26,12 @@ describe('AmountMaxButton Component', function () {
       setAmountToMax={propsMethodSpies.setAmountToMax}
       setMaxModeTo={propsMethodSpies.setMaxModeTo}
       tokenBalance={'mockTokenBalance'}
-    />, { context: { t: str => str + '_t' } })
+    />, {
+      context: {
+        t: str => str + '_t',
+        metricsEvent: () => {},
+      },
+    })
     instance = wrapper.instance()
   })
 


### PR DESCRIPTION
This PR fixes our usages of [nock](https://github.com/nock/nock) in the unit tests by removing a stray call to [`nock#restore`][1]. We had a single call to `nock#restore` in the `actions.spec.js` file that was disabling the http interceptor and allowing tests after that file to hit the network.

From the nock docs:<sup>[\[1\]][1]</sup>

> ## Restoring
>
> You can restore the HTTP interceptor to the normal unmocked behaviour by calling:
>
>     nock.restore()
>
> **note 1**: restore does not clear the interceptor list. Use nock.cleanAll() if you expect the interceptor list to be empty.
>
> **note 2**: restore will also remove the http interceptor itself. You need to run nock.activate() to re-activate the http interceptor. Without re-activation, nock will not intercept any calls.

The 2nd note there is important, as it confirms that this call will require re-activating HTTP mocking.

I've also updated our test for the `AmountMaxButton` component that was previously making a metrics request in its test.

  [1]:https://github.com/nock/nock/tree/560a5d863095c6a860914c46b2c5eab8e42fdade#restoring