### PR TITLE
Add custom fetch wrapper with abort on timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1884,6 +1884,12 @@
         }
       }
     },
+    "abortcontroller-polyfill": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz",
+      "integrity": "sha512-lbWQgf+eRvku3va8poBlDBO12FigTQr9Zb7NIjXrePrhxWVKdCP2wbDl1tLDaYa18PWTom3UEWwdH13S46I+yA==",
+      "dev": true
+    },
     "abstract-leveldown": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "@storybook/addon-info": "^3.4.2",
     "@storybook/addon-knobs": "^3.4.2",
     "@storybook/react": "^3.4.2",
+    "abortcontroller-polyfill": "^1.3.0",
     "addons-linter": "^1.3.4",
     "babel-core": "^6.24.1",
     "babel-eslint": "^8.0.0",

--- a/test/helper.js
+++ b/test/helper.js
@@ -27,6 +27,7 @@ global.log = log
 
 // fetch
 global.fetch = require('isomorphic-fetch')
+require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
 
 // dom
 require('jsdom-global')()

--- a/ui/app/helpers/utils/fetch-with-cache.js
+++ b/ui/app/helpers/utils/fetch-with-cache.js
@@ -7,7 +7,7 @@ export default function fetchWithCache (url, opts, cacheRefreshTime = 360000) {
   const currentTime = Date.now()
   const cachedFetch = loadLocalStorageData('cachedFetch') || {}
   const { cachedUrl, cachedTime } = cachedFetch[url] || {}
-  if (cachedUrl && currentTime - cachedTime < 360000) {
+  if (cachedUrl && currentTime - cachedTime < cacheRefreshTime) {
     return cachedFetch[url]
   } else {
     cachedFetch[url] = { cachedUrl: url, cachedTime: currentTime }
@@ -17,6 +17,7 @@ export default function fetchWithCache (url, opts, cacheRefreshTime = 360000) {
       body: null,
       method: 'GET',
       mode: 'cors',
+      ...opts,
     })
   }
 }

--- a/ui/app/helpers/utils/fetch-with-cache.js
+++ b/ui/app/helpers/utils/fetch-with-cache.js
@@ -2,6 +2,11 @@ import {
   loadLocalStorageData,
   saveLocalStorageData,
 } from '../../../lib/local-storage-helpers'
+import http from './fetch'
+
+const fetch = http({
+  timeout: 30000,
+})
 
 export default function fetchWithCache (url, opts, cacheRefreshTime = 360000) {
   const currentTime = Date.now()

--- a/ui/app/helpers/utils/fetch.js
+++ b/ui/app/helpers/utils/fetch.js
@@ -1,0 +1,25 @@
+/* global AbortController */
+
+export default function ({ timeout = 120000 } = {}) {
+  return function _fetch (url, opts) {
+    return new Promise(async (resolve, reject) => {
+      const abortController = new AbortController()
+      const abortSignal = abortController.signal
+      const f = fetch(url, {
+        ...opts,
+        signal: abortSignal,
+      })
+
+      const timer = setTimeout(() => abortController.abort(), timeout)
+
+      try {
+        const res = await f
+        clearTimeout(timer)
+        return resolve(res)
+      } catch (e) {
+        clearTimeout(timer)
+        return reject(e)
+      }
+    })
+  }
+}

--- a/ui/app/helpers/utils/fetch.test.js
+++ b/ui/app/helpers/utils/fetch.test.js
@@ -1,0 +1,54 @@
+import assert from 'assert'
+import nock from 'nock'
+
+import http from './fetch'
+
+describe('custom fetch fn', () => {
+  it('fetches a url', async () => {
+    nock('https://api.infura.io')
+      .get('/money')
+      .reply(200, '{"hodl": false}')
+
+    const fetch = http()
+    const response = await (await fetch('https://api.infura.io/money')).json()
+    assert.deepEqual(response, {
+      hodl: false,
+    })
+  })
+
+  it('throws when the request hits a custom timeout', async () => {
+    nock('https://api.infura.io')
+      .get('/moon')
+      .delay(2000)
+      .reply(200, '{"moon": "2012-12-21T11:11:11Z"}')
+
+    const fetch = http({
+      timeout: 123,
+    })
+
+    try {
+      await fetch('https://api.infura.io/moon').then(r => r.json())
+      assert.fail('Request should throw')
+    } catch (e) {
+      assert.ok(e)
+    }
+  })
+
+  it('should abort the request when the custom timeout is hit', async () => {
+    nock('https://api.infura.io')
+      .get('/moon')
+      .delay(2000)
+      .reply(200, '{"moon": "2012-12-21T11:11:11Z"}')
+
+    const fetch = http({
+      timeout: 123,
+    })
+
+    try {
+      await fetch('https://api.infura.io/moon').then(r => r.json())
+      assert.fail('Request should be aborted')
+    } catch (e) {
+      assert.deepEqual(e.message, 'Aborted')
+    }
+  })
+})


### PR DESCRIPTION
Refs #6535

This PR adds a wrapper around fetch that aborts the request on timeout (using the [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) API).

Can we use `AbortController`? Yes, I believe so:<sup>[\[1\]][1]</sup>

![Screen Shot 2019-05-07 at 15 17 50](https://user-images.githubusercontent.com/1623628/57321370-c1052780-70db-11e9-9df9-1c29117a29f8.png)

  [1]:https://caniuse.com/#feat=abortcontroller