### PR TITLE
Fix integration tests: completedUiMigration state and fetch + ethquery mocking

### DIFF
--- a/development/states/confirm-new-ui.json
+++ b/development/states/confirm-new-ui.json
@@ -133,7 +133,8 @@
     "preferences": {
       "useNativeCurrencyAsPrimaryCurrency": true,
       "showFiatInTestnets": true
-    }
+    },
+    "completedUiMigration": true
   },
   "appState": {
     "menuOpen": false,

--- a/development/states/confirm-sig-requests.json
+++ b/development/states/confirm-sig-requests.json
@@ -156,7 +156,8 @@
     "currentLocale": "en",
     "preferences": {
       "useNativeCurrencyAsPrimaryCurrency": true
-    }
+    },
+    "completedUiMigration": true
   },
   "appState": {
     "menuOpen": false,

--- a/development/states/currency-localization.json
+++ b/development/states/currency-localization.json
@@ -115,7 +115,8 @@
     "preferences": {
       "useNativeCurrencyAsPrimaryCurrency": true,
       "showFiatInTestnets": true
-    }
+    },
+    "completedUiMigration": true
   },
   "appState": {
     "menuOpen": false,

--- a/development/states/send-edit.json
+++ b/development/states/send-edit.json
@@ -137,7 +137,8 @@
     "preferences": {
       "useNativeCurrencyAsPrimaryCurrency": true,
       "showFiatInTestnets": true
-    }
+    },
+    "completedUiMigration": true
   },
   "appState": {
     "menuOpen": false,

--- a/development/states/send-new-ui.json
+++ b/development/states/send-new-ui.json
@@ -116,7 +116,8 @@
     "preferences": {
       "useNativeCurrencyAsPrimaryCurrency": true,
       "showFiatInTestnets": true
-    }
+    },
+    "completedUiMigration": true
   },
   "appState": {
     "menuOpen": false,

--- a/development/states/tx-list-items.json
+++ b/development/states/tx-list-items.json
@@ -1058,7 +1058,8 @@
     "currentLocale": "en",
     "preferences": {
       "useNativeCurrencyAsPrimaryCurrency": true
-    }
+    },
+    "completedUiMigration": true
   },
   "appState": {
     "menuOpen": false,

--- a/test/integration/lib/confirm-sig-requests.js
+++ b/test/integration/lib/confirm-sig-requests.js
@@ -15,16 +15,25 @@ QUnit.test('successful confirmation of sig requests', (assert) => {
   })
 })
 
+global.ethQuery = global.ethQuery || {}
+
 async function runConfirmSigRequestsTest (assert, done) {
   const selectState = await queryAsync($, 'select')
   selectState.val('confirm sig requests')
   reactTriggerChange(selectState[0])
 
+  const realFetch = window.fetch.bind(window)
   global.fetch = (...args) => {
-    if (args[0].match(/chromeextensionmm/)) {
+    if (args[0] === 'https://ethgasstation.info/json/ethgasAPI.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
+    } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
+    } else if (args[0] === 'https://dev.blockscale.net/api/gasexpress.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.gasExpress)) })
+    } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })
     }
-    return window.fetch(...args)
+    return realFetch.fetch(...args)
   }
 
   const pendingRequestItem = $.find('.transaction-list-item .transaction-list-item__grid')

--- a/test/integration/lib/currency-localization.js
+++ b/test/integration/lib/currency-localization.js
@@ -21,11 +21,18 @@ async function runCurrencyLocalizationTest (assert, done) {
   const selectState = await queryAsync($, 'select')
   selectState.val('currency localization')
 
+  const realFetch = window.fetch.bind(window)
   global.fetch = (...args) => {
-    if (args[0].match(/chromeextensionmm/)) {
+    if (args[0] === 'https://ethgasstation.info/json/ethgasAPI.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
+    } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
+    } else if (args[0] === 'https://dev.blockscale.net/api/gasexpress.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.gasExpress)) })
+    } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })
     }
-    return window.fetch(...args)
+    return realFetch.fetch(...args)
   }
 
   await timeout(1000)

--- a/test/integration/lib/send-new-ui.js
+++ b/test/integration/lib/send-new-ui.js
@@ -25,6 +25,7 @@ global.ethereumProvider = {}
 async function runSendFlowTest (assert, done) {
   const tempFetch = global.fetch
 
+  const realFetch = window.fetch.bind(window)
   global.fetch = (...args) => {
     if (args[0] === 'https://ethgasstation.info/json/ethgasAPI.json') {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
@@ -35,7 +36,7 @@ async function runSendFlowTest (assert, done) {
     } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })
     }
-    return window.fetch(...args)
+    return realFetch.fetch(...args)
   }
 
   console.log('*** start runSendFlowTest')

--- a/test/integration/lib/tx-list-items.js
+++ b/test/integration/lib/tx-list-items.js
@@ -26,11 +26,18 @@ async function runTxListItemsTest (assert, done) {
   selectState.val('tx list items')
   reactTriggerChange(selectState[0])
 
+  const realFetch = window.fetch.bind(window)
   global.fetch = (...args) => {
-    if (args[0].match(/chromeextensionmm/)) {
+    if (args[0] === 'https://ethgasstation.info/json/ethgasAPI.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
+    } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
+    } else if (args[0] === 'https://dev.blockscale.net/api/gasexpress.json') {
+      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.gasExpress)) })
+    } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })
     }
-    return window.fetch(...args)
+    return realFetch.fetch(...args)
   }
 
   const metamaskLogo = await queryAsync($, '.app-header__logo-container')


### PR DESCRIPTION
This PR fixes a couple issues that are causing errors/warnings when running the integration tests, or are causing integration tests to not display the screens they are interacting with.

The first fix is to set `completedUiMigration` to true in the test fixtures so that the associated popup is not displayed.

The second fix is regarding the mocking of fetch that is done in the integration tests. It was causing a stack overflow error due to a function calling itself.