### PR TITLE
Check for unused function arguments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -133,7 +133,7 @@
     "no-unneeded-ternary": [2, { "defaultAssignment": false }],
     "no-unreachable": 2,
     "no-unsafe-finally": 2,
-    "no-unused-vars": [2, { "vars": "all", "args": "none" }],
+    "no-unused-vars": [2, { "vars": "all", "args": "all" }],
     "no-useless-call": 2,
     "no-useless-computed-key": 2,
     "no-useless-constructor": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -133,7 +133,7 @@
     "no-unneeded-ternary": [2, { "defaultAssignment": false }],
     "no-unreachable": 2,
     "no-unsafe-finally": 2,
-    "no-unused-vars": [2, { "vars": "all", "args": "all" }],
+    "no-unused-vars": [2, { "vars": "all", "args": "all", "argsIgnorePattern": "[_]+" }],
     "no-useless-call": 2,
     "no-useless-computed-key": 2,
     "no-useless-constructor": 2,

--- a/app/scripts/controllers/balance.js
+++ b/app/scripts/controllers/balance.js
@@ -68,7 +68,7 @@ class BalanceController {
   _registerUpdates () {
     const update = this.updateBalance.bind(this)
 
-    this.txController.on('tx:status-update', (txId, status) => {
+    this.txController.on('tx:status-update', (_, status) => {
       switch (status) {
         case 'submitted':
         case 'confirmed':

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -339,7 +339,7 @@ class PreferencesController {
   }
 
   removeSuggestedTokens () {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.store.updateState({ suggestedTokens: {} })
       resolve({})
     })
@@ -396,7 +396,7 @@ class PreferencesController {
     const newEntry = { address, symbol, decimals }
     const tokens = this.store.getState().tokens
     const assetImages = this.getAssetImages()
-    const previousEntry = tokens.find((token, index) => {
+    const previousEntry = tokens.find((token) => {
       return token.address === address
     })
     const previousIndex = tokens.indexOf(previousEntry)
@@ -461,7 +461,7 @@ class PreferencesController {
    *
    */
   setCurrentAccountTab (currentAccountTab) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.store.updateState({ currentAccountTab })
       resolve()
     })

--- a/app/scripts/controllers/shapeshift.js
+++ b/app/scripts/controllers/shapeshift.js
@@ -136,7 +136,7 @@ class ShapeshiftController {
    * @param {ShapeShiftTx} tx The tx to remove
    *
    */
-  removeShapeShiftTx (tx) {
+  removeShapeShiftTx () {
     const { shapeShiftTxList } = this.store.getState()
     const index = shapeShiftTxList.indexOf(index)
     if (index !== -1) {

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -126,10 +126,10 @@ class TransactionStateManager extends EventEmitter {
     @returns {object} the txMeta
   */
   addTx (txMeta) {
-    this.once(`${txMeta.id}:signed`, function (txId) {
+    this.once(`${txMeta.id}:signed`, function () {
       this.removeAllListeners(`${txMeta.id}:rejected`)
     })
-    this.once(`${txMeta.id}:rejected`, function (txId) {
+    this.once(`${txMeta.id}:rejected`, function () {
       this.removeAllListeners(`${txMeta.id}:signed`)
     })
     // initialize history

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -34,7 +34,7 @@ module.exports = class MessageManager extends EventEmitter {
    * @property {array} messages Holds all messages that have been created by this MessageManager
    *
    */
-  constructor (opts) {
+  constructor () {
     super()
     this.memStore = new ObservableStore({
       unapprovedMsgs: {},

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -36,7 +36,7 @@ module.exports = class PersonalMessageManager extends EventEmitter {
    * @property {array} messages Holds all messages that have been created by this PersonalMessageManager
    *
    */
-  constructor (opts) {
+  constructor () {
     super()
     this.memStore = new ObservableStore({
       unapprovedPersonalMsgs: {},

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1222,9 +1222,8 @@ module.exports = class MetamaskController extends EventEmitter {
    * with higher gas.
    *
    * @param {string} txId - The ID of the transaction to speed up.
-   * @param {Function} cb - The callback function called with a full state update.
    */
-  async retryTransaction (txId, gasPrice, cb) {
+  async retryTransaction (txId, gasPrice) {
     await this.txController.retryTransaction(txId, gasPrice)
     const state = await this.getState()
     return state
@@ -1237,7 +1236,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * @param {string=} customGasPrice - the hex value to use for the cancel transaction
    * @returns {object} MetaMask state
    */
-  async createCancelTransaction (originalTxId, customGasPrice, cb) {
+  async createCancelTransaction (originalTxId, customGasPrice) {
     try {
       await this.txController.createCancelTransaction(originalTxId, customGasPrice)
       const state = await this.getState()
@@ -1247,7 +1246,7 @@ module.exports = class MetamaskController extends EventEmitter {
     }
   }
 
-  async createSpeedUpTransaction (originalTxId, customGasPrice, cb) {
+  async createSpeedUpTransaction (originalTxId, customGasPrice) {
     await this.txController.createSpeedUpTransaction(originalTxId, customGasPrice)
     const state = await this.getState()
     return state
@@ -1463,7 +1462,7 @@ module.exports = class MetamaskController extends EventEmitter {
    *
    * @param {*} outStream - The stream to provide the api over.
    */
-  setupPublicApi (outStream, originDomain) {
+  setupPublicApi (outStream) {
     const dnode = Dnode()
     // connect dnode api to remote connection
     pump(

--- a/app/scripts/migrations/024.js
+++ b/app/scripts/migrations/024.js
@@ -27,7 +27,7 @@ function transformState (state) {
   const newState = state
   if (!newState.TransactionController) return newState
   const transactions = newState.TransactionController.transactions
-  newState.TransactionController.transactions = transactions.map((txMeta, _, txList) => {
+  newState.TransactionController.transactions = transactions.map((txMeta, _) => {
     if (
       txMeta.status === 'unapproved' &&
       txMeta.txParams &&

--- a/app/scripts/migrations/025.js
+++ b/app/scripts/migrations/025.js
@@ -43,7 +43,7 @@ function normalizeTxParams (txParams) {
   // functions that handle normalizing of that key in txParams
   const whiteList = {
     from: from => ethUtil.addHexPrefix(from).toLowerCase(),
-    to: to => ethUtil.addHexPrefix(txParams.to).toLowerCase(),
+    to: () => ethUtil.addHexPrefix(txParams.to).toLowerCase(),
     nonce: nonce => ethUtil.addHexPrefix(nonce),
     value: value => ethUtil.addHexPrefix(value),
     data: data => ethUtil.addHexPrefix(data),

--- a/development/backGroundConnectionModifiers.js
+++ b/development/backGroundConnectionModifiers.js
@@ -1,20 +1,20 @@
 module.exports = {
   'confirm sig requests': {
-    signMessage: (msgData, cb) => {
+    signMessage: (_, cb) => {
       const stateUpdate = {
         unapprovedMsgs: {},
         unapprovedMsgCount: 0,
       }
       return cb(null, stateUpdate)
     },
-    signPersonalMessage: (msgData, cb) => {
+    signPersonalMessage: (_, cb) => {
       const stateUpdate = {
         unapprovedPersonalMsgs: {},
         unapprovedPersonalMsgCount: 0,
       }
       return cb(null, stateUpdate)
     },
-    signTypedMessage: (msgData, cb) => {
+    signTypedMessage: (_, cb) => {
       const stateUpdate = {
         unapprovedTypedMessages: {},
         unapprovedTypedMessagesCount: 0,

--- a/gentests.js
+++ b/gentests.js
@@ -48,11 +48,11 @@ async function start (fileRegEx, testGenerator) {
 }
 */
 
-async function startContainer (fileRegEx, testGenerator) {
+async function startContainer (fileRegEx) {
   const fileNames = await getAllFileNames('./ui/app')
   const sFiles = fileNames.filter(name => name.match(fileRegEx))
 
-  async.each(sFiles, async (sFile, cb) => {
+  async.each(sFiles, async (sFile) => {
     console.log(`sFile`, sFile)
     const [, sRootPath, sPath] = sFile.match(/^(.+\/)([^/]+)$/)
 
@@ -91,7 +91,7 @@ async function startContainer (fileRegEx, testGenerator) {
           const proxyquireObject = ('{\n  ' + result
             .match(/import\s{[\s\S]+?}\sfrom\s.+/g)
             .map(s => s.replace(/\n/g, ''))
-            .map((s, i) => {
+            .map((s) => {
               const proxyKeys = s.match(/{.+}/)[0].match(/\w+/g)
               return '\'' + s.match(/'(.+)'/)[1] + '\': { ' + (proxyKeys.length > 1
                   ? '\n    ' + proxyKeys.join(': () => {},\n    ') + ': () => {},\n '

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -315,7 +315,7 @@ createTasksForBuildJsExtension({ buildJsFiles, taskPrefix: 'dev:test-extension:j
 createTasksForBuildJsExtension({ buildJsFiles, taskPrefix: 'build:extension:js' })
 createTasksForBuildJsExtension({ buildJsFiles, taskPrefix: 'build:test:extension:js', testing: 'true' })
 
-function createTasksForBuildJsUIDeps ({ dependenciesToBundle, filename }) {
+function createTasksForBuildJsUIDeps ({ filename }) {
   const destinations = browserPlatforms.map(platform => `./dist/${platform}`)
 
 

--- a/test/e2e/beta/contract-test/contract.js
+++ b/test/e2e/beta/contract-test/contract.js
@@ -38,7 +38,7 @@ web3.currentProvider.enable().then(() => {
   const transferTokens = document.getElementById('transferTokens')
   const approveTokens = document.getElementById('approveTokens')
 
-  deployButton.addEventListener('click', async function (event) {
+  deployButton.addEventListener('click', async function () {
     document.getElementById('contractStatus').innerHTML = 'Deploying'
 
     var piggybank = await piggybankContract.new(
@@ -55,7 +55,7 @@ web3.currentProvider.enable().then(() => {
 
           document.getElementById('contractStatus').innerHTML = 'Deployed'
 
-          depositButton.addEventListener('click', function (event) {
+          depositButton.addEventListener('click', function () {
             document.getElementById('contractStatus').innerHTML = 'Deposit initiated'
             contract.deposit({ from: web3.eth.accounts[0], value: '0x3782dace9d900000' }, function (result) {
               console.log(result)
@@ -63,7 +63,7 @@ web3.currentProvider.enable().then(() => {
             })
           })
 
-          withdrawButton.addEventListener('click', function (event) {
+          withdrawButton.addEventListener('click', function () {
             contract.withdraw('0xde0b6b3a7640000', { from: web3.eth.accounts[0] }, function (result) {
               console.log(result)
               document.getElementById('contractStatus').innerHTML = 'Withdrawn'
@@ -75,7 +75,7 @@ web3.currentProvider.enable().then(() => {
     console.log(piggybank)
   })
 
-  sendButton.addEventListener('click', function (event) {
+  sendButton.addEventListener('click', function () {
     web3.eth.sendTransaction({
       from: web3.eth.accounts[0],
       to: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
@@ -88,7 +88,7 @@ web3.currentProvider.enable().then(() => {
   })
 
 
-  createToken.addEventListener('click', async function (event) {
+  createToken.addEventListener('click', async function () {
     var _initialAmount = 100
     var _tokenName = 'TST'
     var _decimalUnits = 0
@@ -124,7 +124,7 @@ web3.currentProvider.enable().then(() => {
             })
           })
 
-          approveTokens.addEventListener('click', function (event) {
+          approveTokens.addEventListener('click', function () {
             contract.approve('0x2f318C334780961FB129D2a6c30D0763d9a5C970', '7', {
               from: web3.eth.accounts[0],
               to: contract.address,

--- a/test/integration/lib/confirm-sig-requests.js
+++ b/test/integration/lib/confirm-sig-requests.js
@@ -17,7 +17,7 @@ QUnit.test('successful confirmation of sig requests', (assert) => {
 
 global.ethQuery = global.ethQuery || {}
 
-async function runConfirmSigRequestsTest (assert, done) {
+async function runConfirmSigRequestsTest (assert) {
   const selectState = await queryAsync($, 'select')
   selectState.val('confirm sig requests')
   reactTriggerChange(selectState[0])

--- a/test/integration/lib/currency-localization.js
+++ b/test/integration/lib/currency-localization.js
@@ -16,7 +16,7 @@ QUnit.test('renders localized currency', (assert) => {
   })
 })
 
-async function runCurrencyLocalizationTest (assert, done) {
+async function runCurrencyLocalizationTest (assert) {
   console.log('*** start runCurrencyLocalizationTest')
   const selectState = await queryAsync($, 'select')
   selectState.val('currency localization')

--- a/test/integration/lib/send-new-ui.js
+++ b/test/integration/lib/send-new-ui.js
@@ -22,7 +22,7 @@ global.ethQuery = {
 
 global.ethereumProvider = {}
 
-async function runSendFlowTest (assert, done) {
+async function runSendFlowTest (assert) {
   const tempFetch = global.fetch
 
   const realFetch = window.fetch.bind(window)

--- a/test/integration/lib/tx-list-items.js
+++ b/test/integration/lib/tx-list-items.js
@@ -20,7 +20,7 @@ global.ethQuery.getTransactionCount = (_, cb) => {
   cb(null, '0x4')
 }
 
-async function runTxListItemsTest (assert, done) {
+async function runTxListItemsTest (assert) {
   console.log('*** start runTxListItemsTest')
   const selectState = await queryAsync($, 'select')
   selectState.val('tx list items')

--- a/test/lib/mock-encryptor.js
+++ b/test/lib/mock-encryptor.js
@@ -4,12 +4,12 @@ let cacheVal
 
 module.exports = {
 
-  encrypt (password, dataObj) {
+  encrypt (_, dataObj) {
     cacheVal = dataObj
     return Promise.resolve(mockHex)
   },
 
-  decrypt (password, text) {
+  decrypt () {
     return Promise.resolve(cacheVal || {})
   },
 
@@ -21,7 +21,7 @@ module.exports = {
     return this.decrypt(key, text)
   },
 
-  keyFromPassword (password) {
+  keyFromPassword () {
     return Promise.resolve(mockKey)
   },
 

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -6,7 +6,7 @@ module.exports = {
 }
 
 function timeout (time) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     setTimeout(resolve, time || 1500)
   })
 }

--- a/test/unit/actions/tx_test.js
+++ b/test/unit/actions/tx_test.js
@@ -33,8 +33,8 @@ describe('tx confirmation screen', function () {
   describe('cancelTx', function () {
     before(function (done) {
       actions._setBackgroundConnection({
-        approveTransaction (txId, cb) { cb('An error!') },
-        cancelTransaction (txId, cb) { cb() },
+        approveTransaction (_, cb) { cb('An error!') },
+        cancelTransaction (_, cb) { cb() },
         clearSeedWordCache (cb) { cb() },
         getState (cb) { cb() },
       })

--- a/test/unit/app/controllers/currency-controller-test.js
+++ b/test/unit/app/controllers/currency-controller-test.js
@@ -59,7 +59,7 @@ describe('currency-controller', function () {
 
 
         var promise = new Promise(
-          function (resolve, reject) {
+          function (resolve) {
             currencyController.setCurrentCurrency('jpy')
             currencyController.updateConversionRate().then(function () {
               resolve()

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -49,7 +49,7 @@ describe('MetaMaskController', function () {
       showUnapprovedTx: noop,
       showUnconfirmedMessage: noop,
       encryptor: {
-        encrypt: function (password, object) {
+        encrypt: function (_, object) {
           this.object = object
           return Promise.resolve('mock-encrypted')
         },
@@ -144,7 +144,7 @@ describe('MetaMaskController', function () {
       sandbox.stub(metamaskController, 'getBalance')
       metamaskController.getBalance.callsFake(() => { return Promise.resolve('0x0') })
 
-      await metamaskController.createNewVaultAndRestore(password, TEST_SEED.slice(0, -1)).catch((e) => null)
+      await metamaskController.createNewVaultAndRestore(password, TEST_SEED.slice(0, -1)).catch(() => null)
       await metamaskController.createNewVaultAndRestore(password, TEST_SEED)
 
       assert(metamaskController.keyringController.createNewVaultAndRestore.calledTwice)
@@ -207,7 +207,7 @@ describe('MetaMaskController', function () {
       const accounts = {}
       const balance = '0x14ced5122ce0a000'
       const ethQuery = new EthQuery()
-      sinon.stub(ethQuery, 'getBalance').callsFake((account, callback) => {
+      sinon.stub(ethQuery, 'getBalance').callsFake((_, callback) => {
         callback(undefined, balance)
       })
 
@@ -295,7 +295,7 @@ describe('MetaMaskController', function () {
 
     it('should add the Trezor Hardware keyring', async function () {
       sinon.spy(metamaskController.keyringController, 'addNewKeyring')
-      await metamaskController.connectHardware('trezor', 0).catch((e) => null)
+      await metamaskController.connectHardware('trezor', 0).catch(() => null)
       const keyrings = await metamaskController.keyringController.getKeyringsByType(
         'Trezor Hardware'
       )
@@ -305,7 +305,7 @@ describe('MetaMaskController', function () {
 
     it('should add the Ledger Hardware keyring', async function () {
       sinon.spy(metamaskController.keyringController, 'addNewKeyring')
-      await metamaskController.connectHardware('ledger', 0).catch((e) => null)
+      await metamaskController.connectHardware('ledger', 0).catch(() => null)
       const keyrings = await metamaskController.keyringController.getKeyringsByType(
         'Ledger Hardware'
       )
@@ -325,7 +325,7 @@ describe('MetaMaskController', function () {
     })
 
     it('should be locked by default', async function () {
-      await metamaskController.connectHardware('trezor', 0).catch((e) => null)
+      await metamaskController.connectHardware('trezor', 0).catch(() => null)
       const status = await metamaskController.checkHardwareStatus('trezor')
       assert.equal(status, false)
     })
@@ -341,7 +341,7 @@ describe('MetaMaskController', function () {
     })
 
     it('should wipe all the keyring info', async function () {
-      await metamaskController.connectHardware('trezor', 0).catch((e) => null)
+      await metamaskController.connectHardware('trezor', 0).catch(() => null)
       await metamaskController.forgetDevice('trezor')
       const keyrings = await metamaskController.keyringController.getKeyringsByType(
         'Trezor Hardware'
@@ -376,7 +376,7 @@ describe('MetaMaskController', function () {
       sinon.spy(metamaskController.preferencesController, 'setAddresses')
       sinon.spy(metamaskController.preferencesController, 'setSelectedAddress')
       sinon.spy(metamaskController.preferencesController, 'setAccountLabel')
-      await metamaskController.connectHardware('trezor', 0, `m/44/0'/0'`).catch((e) => null)
+      await metamaskController.connectHardware('trezor', 0, `m/44/0'/0'`).catch(() => null)
       await metamaskController.unlockHardwareWalletAccount(accountToUnlock, 'trezor', `m/44/0'/0'`)
     })
 
@@ -757,7 +757,7 @@ describe('MetaMaskController', function () {
 
       const { promise, resolve } = deferredPromise()
 
-      streamTest = createThoughStream((chunk, enc, cb) => {
+      streamTest = createThoughStream((chunk, _, cb) => {
         if (chunk.name !== 'phishing') return cb()
         assert.equal(chunk.data.hostname, phishingUrl)
         resolve()
@@ -777,7 +777,7 @@ describe('MetaMaskController', function () {
     })
 
     it('sets up controller dnode api for trusted communication', function (done) {
-      streamTest = createThoughStream((chunk, enc, cb) => {
+      streamTest = createThoughStream((chunk, _, cb) => {
         assert.equal(chunk.name, 'controller')
         cb()
         done()

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -100,7 +100,7 @@ describe('PendingTransactionTracker', function () {
 
   describe('#_checkPendingTx', function () {
     it('should emit \'tx:failed\' if the txMeta does not have a hash', function (done) {
-      pendingTxTracker.once('tx:failed', (txId, err) => {
+      pendingTxTracker.once('tx:failed', (txId) => {
         assert(txId, txMetaNoHash.id, 'should pass txId')
         done()
       })
@@ -128,7 +128,7 @@ describe('PendingTransactionTracker', function () {
       pendingTxTracker.getPendingTransactions = () => txList
       pendingTxTracker._checkPendingTx = (tx) => { tx.resolve(tx) }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
 
       pendingTxTracker.updatePendingTxs()
@@ -152,7 +152,7 @@ describe('PendingTransactionTracker', function () {
       pendingTxTracker.getPendingTransactions = () => txList
       pendingTxTracker._resubmitTx = async (tx) => { tx.resolve(tx) }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
       pendingTxTracker.resubmitPendingTxs(blockNumberStub)
     })
@@ -178,7 +178,7 @@ describe('PendingTransactionTracker', function () {
         throw new Error(knownErrors.pop())
       }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
 
       pendingTxTracker.resubmitPendingTxs(blockNumberStub)
@@ -194,9 +194,9 @@ describe('PendingTransactionTracker', function () {
       })
 
       pendingTxTracker.getPendingTransactions = () => txList
-      pendingTxTracker._resubmitTx = async (tx) => { throw new TypeError('im some real error') }
+      pendingTxTracker._resubmitTx = async () => { throw new TypeError('im some real error') }
       Promise.all(txList.map((tx) => tx.processed))
-      .then((txCompletedList) => done())
+      .then(() => done())
       .catch(done)
 
       pendingTxTracker.resubmitPendingTxs(blockNumberStub)

--- a/test/unit/app/controllers/transactions/tx-gas-util-test.js
+++ b/test/unit/app/controllers/transactions/tx-gas-util-test.js
@@ -11,7 +11,7 @@ describe('txUtils', function () {
 
   before(function () {
     txUtils = new TxUtils(new Proxy({}, {
-      get: (obj, name) => {
+      get: () => {
         return () => {}
       },
     }))

--- a/test/unit/app/controllers/transactions/tx-state-history-helper-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-history-helper-test.js
@@ -29,7 +29,7 @@ describe('Transaction state history helper', function () {
 
   describe('#migrateFromSnapshotsToDiffs', function () {
     it('migrates history to diffs and can recover original values', function () {
-      testVault.data.TransactionController.transactions.forEach((tx, index) => {
+      testVault.data.TransactionController.transactions.forEach((tx) => {
         const newHistory = txStateHistoryHelper.migrateFromSnapshotsToDiffs(tx.history)
         newHistory.forEach((newEntry, index) => {
           if (index === 0) {

--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -55,7 +55,7 @@ describe('TransactionStateManager', function () {
     it('should emit a rejected event to signal the exciton of callback', (done) => {
       const tx = { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }
       txStateManager.addTx(tx)
-      const noop = function (err, txId) {
+      const noop = function (err) {
           if (err) {
             console.log('Error: ', err)
           }

--- a/test/unit/app/edge-encryptor-test.js
+++ b/test/unit/app/edge-encryptor-test.js
@@ -83,7 +83,7 @@ describe('EdgeEncryptor', function () {
       edgeEncryptor.encrypt(password, data)
         .then(function (encryptedData) {
           edgeEncryptor.decrypt('wrong password', encryptedData)
-          .then(function (decryptedData) {
+          .then(function () {
             assert.fail('could decrypt with wrong password')
             done()
           })

--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -61,7 +61,7 @@ describe('Migrator', () => {
     const migrator = new Migrator({ migrations: [{ version: 1, migrate: async () => { throw new Error('test') } } ] })
     migrator.on('error', () => done())
     migrator.migrateData({ meta: {version: 0} })
-    .then((migratedData) => {
+    .then(() => {
     }).catch(done)
   })
 

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -44,7 +44,7 @@ describe('Actions', () => {
       showUnapprovedTx: noop,
       showUnconfirmedMessage: noop,
       encryptor: {
-        encrypt: function (password, object) {
+        encrypt: function (_, object) {
           this.object = object
           return Promise.resolve('mock-encrypted')
         },
@@ -103,7 +103,7 @@ describe('Actions', () => {
 
       submitPasswordSpy = sinon.stub(background, 'submitPassword')
 
-      submitPasswordSpy.callsFake((password, callback) => {
+      submitPasswordSpy.callsFake((_, callback) => {
         callback(new Error('error in submitPassword'))
       })
 
@@ -235,7 +235,7 @@ describe('Actions', () => {
 
       createNewVaultAndRestoreSpy = sinon.stub(background, 'createNewVaultAndRestore')
 
-      createNewVaultAndRestoreSpy.callsFake((password, seed, callback) => {
+      createNewVaultAndRestoreSpy.callsFake((_, __, callback) => {
         callback(new Error('error'))
       })
 
@@ -279,7 +279,7 @@ describe('Actions', () => {
       ]
 
       createNewVaultAndKeychainSpy = sinon.stub(background, 'createNewVaultAndKeychain')
-      createNewVaultAndKeychainSpy.callsFake((password, callback) => {
+      createNewVaultAndKeychainSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -342,7 +342,7 @@ describe('Actions', () => {
       ]
 
       submitPasswordSpy = sinon.stub(background, 'submitPassword')
-      submitPasswordSpy.callsFake((password, callback) => {
+      submitPasswordSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -414,7 +414,7 @@ describe('Actions', () => {
 
     it('displays warning error message when submitPassword in background errors', () => {
       submitPasswordSpy = sinon.stub(background, 'submitPassword')
-      submitPasswordSpy.callsFake((password, callback) => {
+      submitPasswordSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -483,7 +483,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
       removeAccountSpy = sinon.stub(background, 'removeAccount')
-      removeAccountSpy.callsFake((address, callback) => {
+      removeAccountSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -522,7 +522,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
 
-      addNewKeyringSpy.callsFake((type, opts, callback) => {
+      addNewKeyringSpy.callsFake((_, __, callback) => {
         callback(new Error('error'))
       })
 
@@ -611,7 +611,7 @@ describe('Actions', () => {
       ]
 
       importAccountWithStrategySpy = sinon.stub(background, 'importAccountWithStrategy')
-      importAccountWithStrategySpy.callsFake((strategy, args, callback) => {
+      importAccountWithStrategySpy.callsFake((_, __, callback) => {
         callback(new Error('error'))
       })
 
@@ -668,7 +668,7 @@ describe('Actions', () => {
         { type: 'HIDE_LOADING_INDICATION' },
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
-      setCurrentCurrencySpy.callsFake((currencyCode, callback) => {
+      setCurrentCurrencySpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -720,7 +720,7 @@ describe('Actions', () => {
       ]
 
       signMessageSpy = sinon.stub(background, 'signMessage')
-      signMessageSpy.callsFake((msgData, callback) => {
+      signMessageSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -775,7 +775,7 @@ describe('Actions', () => {
       ]
 
       signPersonalMessageSpy = sinon.stub(background, 'signPersonalMessage')
-      signPersonalMessageSpy.callsFake((msgData, callback) => {
+      signPersonalMessageSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -812,7 +812,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'error' },
         { type: 'SHOW_CONF_TX_PAGE', transForward: true, id: undefined },
       ]
-      sendTransactionSpy.callsFake((txData, callback) => {
+      sendTransactionSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -906,7 +906,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
 
-      setSelectedAddressSpy.callsFake((address, callback) => {
+      setSelectedAddressSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -941,7 +941,7 @@ describe('Actions', () => {
         { type: 'HIDE_LOADING_INDICATION' },
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
-      setSelectedAddressSpy.callsFake((address, callback) => {
+      setSelectedAddressSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -980,7 +980,7 @@ describe('Actions', () => {
         { type: 'UPDATE_TOKENS', newTokens: undefined },
       ]
 
-      addTokenSpy.callsFake((address, symbol, decimals, image, callback) => {
+      addTokenSpy.callsFake((_, __, ___, ____, callback) => {
         callback(new Error('error'))
       })
 
@@ -1020,7 +1020,7 @@ describe('Actions', () => {
         { type: 'UPDATE_TOKENS', newTokens: undefined },
       ]
 
-      removeTokenSpy.callsFake((address, callback) => {
+      removeTokenSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -1054,7 +1054,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'Had a problem changing networks!' },
       ]
 
-      setProviderTypeSpy.callsFake((type, callback) => {
+      setProviderTypeSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -1087,7 +1087,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'Had a problem changing networks!' },
       ]
 
-      setRpcTargetSpy.callsFake((newRpc, chainId, ticker, nickname, callback) => {
+      setRpcTargetSpy.callsFake((_, __, ___, ____, callback) => {
         callback(new Error('error'))
       })
 
@@ -1134,7 +1134,7 @@ describe('Actions', () => {
       exportAccountSpy = sinon.spy(background, 'exportAccount')
 
       return store.dispatch(actions.exportAccount(password, '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'))
-        .then((result) => {
+        .then(() => {
           assert(submitPasswordSpy.calledOnce)
           assert(exportAccountSpy.calledOnce)
           assert.deepEqual(store.getActions(), expectedActions)
@@ -1150,7 +1150,7 @@ describe('Actions', () => {
       ]
 
       submitPasswordSpy = sinon.stub(background, 'submitPassword')
-      submitPasswordSpy.callsFake((password, callback) => {
+      submitPasswordSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -1169,7 +1169,7 @@ describe('Actions', () => {
       ]
 
       exportAccountSpy = sinon.stub(background, 'exportAccount')
-      exportAccountSpy.callsFake((address, callback) => {
+      exportAccountSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -1246,7 +1246,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
 
-      setFeatureFlagSpy.callsFake((feature, activated, callback) => {
+      setFeatureFlagSpy.callsFake((_, __, callback) => {
         callback(new Error('error'))
       })
 
@@ -1300,7 +1300,7 @@ describe('Actions', () => {
       ]
 
       getTransactionCountSpy = sinon.stub(global.ethQuery, 'getTransactionCount')
-      getTransactionCountSpy.callsFake((address, callback) => {
+      getTransactionCountSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -1338,7 +1338,7 @@ describe('Actions', () => {
         { type: 'SET_USE_BLOCKIE', value: undefined },
       ]
 
-      setUseBlockieSpy.callsFake((val, callback) => {
+      setUseBlockieSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 
@@ -1385,7 +1385,7 @@ describe('Actions', () => {
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
       setCurrentLocaleSpy = sinon.stub(background, 'setCurrentLocale')
-      setCurrentLocaleSpy.callsFake((key, callback) => {
+      setCurrentLocaleSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 

--- a/test/web3/web3.js
+++ b/test/web3/web3.js
@@ -12,7 +12,7 @@ web3.currentProvider.enable().then(() => {
     Object.keys(methodGroup).forEach(methodKey => {
 
       const methodButton = document.getElementById(methodKey)
-      methodButton.addEventListener('click', function (event) {
+      methodButton.addEventListener('click', function () {
 
         window.ethereum.sendAsync({
           method: methodKey,

--- a/ui/app/components/app/account-panel.js
+++ b/ui/app/components/app/account-panel.js
@@ -69,18 +69,9 @@ AccountPanel.prototype.render = function () {
   )
 }
 
-function balanceOrFaucetingIndication (account, isFauceting) {
-  // Temporarily deactivating isFauceting indication
-  // because it shows fauceting for empty restored accounts.
-  if (/* isFauceting*/ false) {
-    return {
-      key: 'Account is auto-funding.',
-      value: 'Please wait.',
-    }
-  } else {
-    return {
-      key: 'BALANCE',
-      value: formatBalance(account.balance),
-    }
+function balanceOrFaucetingIndication (account) {
+  return {
+    key: 'BALANCE',
+    value: formatBalance(account.balance),
   }
 }

--- a/ui/app/components/app/bn-as-decimal-input.js
+++ b/ui/app/components/app/bn-as-decimal-input.js
@@ -116,7 +116,7 @@ BnAsDecimalInput.prototype.render = function () {
   )
 }
 
-BnAsDecimalInput.prototype.setValid = function (message) {
+BnAsDecimalInput.prototype.setValid = function () {
   this.setState({ invalid: null })
 }
 

--- a/ui/app/components/app/ens-input.js
+++ b/ui/app/components/app/ens-input.js
@@ -144,7 +144,7 @@ EnsInput.prototype.ensIcon = function (recipient) {
   }, this.ensIconContents(recipient))
 }
 
-EnsInput.prototype.ensIconContents = function (recipient) {
+EnsInput.prototype.ensIconContents = function () {
   const { loadingEns, ensFailure, ensResolution, toError } = this.state || { ensResolution: ZERO_ADDRESS }
 
   if (toError) return

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -58,7 +58,7 @@ export default class AdvancedTabContent extends Component {
     }
   }
 
-  gasInput ({ labelKey, value, onChange, insufficientBalance, showGWEI, customPriceIsSafe, isSpeedUp }) {
+  gasInput ({ labelKey, value, onChange, insufficientBalance, customPriceIsSafe, isSpeedUp }) {
     const {
       isInError,
       errorText,

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
@@ -17,8 +17,8 @@ function convertGasLimitForInputs (gasLimitInHexWEI) {
 
 const mapDispatchToProps = dispatch => {
   return {
-    showGasPriceInfoModal: modalName => dispatch(showModal({ name: 'GAS_PRICE_INFO_MODAL' })),
-    showGasLimitInfoModal: modalName => dispatch(showModal({ name: 'GAS_LIMIT_INFO_MODAL' })),
+    showGasPriceInfoModal: () => dispatch(showModal({ name: 'GAS_PRICE_INFO_MODAL' })),
+    showGasLimitInfoModal: () => dispatch(showModal({ name: 'GAS_LIMIT_INFO_MODAL' })),
   }
 }
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
@@ -67,7 +67,7 @@ export default class AdvancedTabContent extends Component {
     }
   }
 
-  gasInput ({ labelKey, value, onChange, insufficientBalance, showGWEI, customPriceIsSafe, isSpeedUp }) {
+  gasInput ({ labelKey, value, onChange, insufficientBalance, customPriceIsSafe, isSpeedUp }) {
     const {
       isInError,
       errorText,
@@ -148,7 +148,6 @@ export default class AdvancedTabContent extends Component {
     customGasPrice,
     updateCustomGasPrice,
     customGasLimit,
-    updateCustomGasLimit,
     insufficientBalance,
     customPriceIsSafe,
     isSpeedUp,

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -122,8 +122,6 @@ export default class GasModalPageContainer extends Component {
   }
 
   renderTabs ({
-    originalTotalFiat,
-    originalTotalEth,
     newTotalFiat,
     newTotalEth,
     sendAmount,

--- a/ui/app/components/app/gas-customization/gas-price-button-group/gas-price-button-group.component.js
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/gas-price-button-group.component.js
@@ -49,7 +49,7 @@ export default class GasPriceButtonGroup extends Component {
     priceInHexWei,
     ...renderableGasInfo
   }, {
-    buttonDataLoading,
+    buttonDataLoading: _,
     handleGasPriceSelection,
     ...buttonContentPropsAndFlags
   }, index) {

--- a/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.utils.js
+++ b/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.utils.js
@@ -68,7 +68,7 @@ export function handleChartUpdate ({ chart, gasPrices, newPrice, cssId }) {
 
 export function getAdjacentGasPrices ({ gasPrices, priceToPosition }) {
   const closestLowerValueIndex = gasPrices.findIndex((e, i, a) => e <= priceToPosition && a[i + 1] >= priceToPosition)
-  const closestHigherValueIndex = gasPrices.findIndex((e, i, a) => e > priceToPosition)
+  const closestHigherValueIndex = gasPrices.findIndex((e) => e > priceToPosition)
   return {
     closestLowerValueIndex,
     closestHigherValueIndex,
@@ -133,7 +133,7 @@ export function setTickPosition (axis, n, newPosition, secondNewPosition) {
   d3.select('#chart')
     .select(`.c3-axis-${axis}`)
     .selectAll('.tick')
-    .filter((d, i) => i === n)
+    .filter((_, i) => i === n)
     .select('text')
     .attr(positionToShift, 0)
     .select('tspan')
@@ -284,7 +284,7 @@ export function generateChart (gasPrices, estimatedTimes, gasPricesMax, estimate
         })
         return text + '</table>' + "<div class='tooltip-arrow'></div>"
       },
-      position: function (data) {
+      position: function () {
         if (d3.select('#overlayed-circle').empty()) {
           return { top: -100, left: -100 }
         }

--- a/ui/app/components/app/gas-customization/gas-price-chart/tests/gas-price-chart.component.test.js
+++ b/ui/app/components/app/gas-customization/gas-price-chart/tests/gas-price-chart.component.test.js
@@ -6,7 +6,7 @@ import shallow from '../../../../../../lib/shallow-with-context'
 import * as d3 from 'd3'
 
 function timeout (time) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     setTimeout(resolve, time)
   })
 }

--- a/ui/app/components/app/modals/deposit-ether-modal.js
+++ b/ui/app/components/app/modals/deposit-ether-modal.js
@@ -48,7 +48,7 @@ function mapDispatchToProps (dispatch) {
 }
 
 inherits(DepositEtherModal, Component)
-function DepositEtherModal (props, context) {
+function DepositEtherModal (_, context) {
   Component.call(this)
 
   // need to set after i18n locale has loaded

--- a/ui/app/components/app/modals/export-private-key-modal.js
+++ b/ui/app/components/app/modals/export-private-key-modal.js
@@ -98,7 +98,7 @@ ExportPrivateKeyModal.prototype.renderPasswordInput = function (privateKey) {
     })
 }
 
-ExportPrivateKeyModal.prototype.renderButtons = function (privateKey, password, address, hideModal) {
+ExportPrivateKeyModal.prototype.renderButtons = function (privateKey, address, hideModal) {
   return h('div.export-private-key-buttons', {}, [
     !privateKey && h(Button, {
       type: 'default',
@@ -171,7 +171,7 @@ ExportPrivateKeyModal.prototype.render = function () {
 
       h('div.private-key-password-warning', this.context.t('privateKeyWarning')),
 
-      this.renderButtons(privateKey, this.state.password, address, hideModal),
+      this.renderButtons(privateKey, address, hideModal),
 
   ])
 }

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.container.js
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.container.js
@@ -4,7 +4,7 @@ import MetaMetricsOptInModal from './metametrics-opt-in-modal.component'
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props'
 import { setParticipateInMetaMetrics } from '../../../../store/actions'
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (_, ownProps) => {
   const { unapprovedTxCount } = ownProps
 
   return {

--- a/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -71,7 +71,7 @@ export default class QrScanner extends Component {
   initCamera () {
     this.codeReader = new BrowserQRCodeReader()
     this.codeReader.getVideoInputDevices()
-      .then(videoInputDevices => {
+      .then(() => {
         clearTimeout(this.permissionChecker)
         this.checkPermisisions()
         this.codeReader.decodeFromInputVideoDevice(undefined, 'video')

--- a/ui/app/components/app/modals/reject-transactions/reject-transactions.container.js
+++ b/ui/app/components/app/modals/reject-transactions/reject-transactions.container.js
@@ -3,7 +3,7 @@ import { compose } from 'recompose'
 import RejectTransactionsModal from './reject-transactions.component'
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props'
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (_, ownProps) => {
   const { unapprovedTxCount } = ownProps
 
   return {

--- a/ui/app/components/app/token-cell.js
+++ b/ui/app/components/app/token-cell.js
@@ -155,7 +155,7 @@ TokenCell.prototype.send = function (address, event) {
   }
 }
 
-TokenCell.prototype.view = function (address, userAddress, network, event) {
+TokenCell.prototype.view = function (address, userAddress, network) {
   const url = etherscanLinkFor(address, userAddress, network)
   if (url) {
     navigateTo(url)

--- a/ui/app/components/app/user-preferenced-currency-display/tests/user-preferenced-currency-display.container.test.js
+++ b/ui/app/components/app/user-preferenced-currency-display/tests/user-preferenced-currency-display.container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps, mergeProps
 
 proxyquire('../user-preferenced-currency-display.container.js', {
   'react-redux': {
-    connect: (ms, md, mp) => {
+    connect: (ms, _, mp) => {
       mapStateToProps = ms
       mergeProps = mp
       return () => ({})

--- a/ui/app/components/app/user-preferenced-currency-display/user-preferenced-currency-display.container.js
+++ b/ui/app/components/app/user-preferenced-currency-display/user-preferenced-currency-display.container.js
@@ -3,7 +3,7 @@ import UserPreferencedCurrencyDisplay from './user-preferenced-currency-display.
 import { preferencesSelector, getIsMainnet } from '../../../selectors/selectors'
 import { ETH, PRIMARY, SECONDARY } from '../../../helpers/constants/common'
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const {
     useNativeCurrencyAsPrimaryCurrency,
     showFiatInTestnets,

--- a/ui/app/components/ui/alert/index.js
+++ b/ui/app/components/ui/alert/index.js
@@ -18,7 +18,7 @@ class Alert extends Component {
       if (!this.props.visible && nextProps.visible) {
         this.animateIn(nextProps)
       } else if (this.props.visible && !nextProps.visible) {
-        this.animateOut(nextProps)
+        this.animateOut()
       }
     }
 
@@ -30,7 +30,7 @@ class Alert extends Component {
       })
     }
 
-    animateOut (props) {
+    animateOut () {
       this.setState({
         msg: null,
         className: '.hidden',

--- a/ui/app/components/ui/currency-display/tests/currency-display.container.test.js
+++ b/ui/app/components/ui/currency-display/tests/currency-display.container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps, mergeProps
 
 proxyquire('../currency-display.container.js', {
   'react-redux': {
-    connect: (ms, md, mp) => {
+    connect: (ms, _, mp) => {
       mapStateToProps = ms
       mergeProps = mp
       return () => ({})

--- a/ui/app/components/ui/currency-input/tests/currency-input.container.test.js
+++ b/ui/app/components/ui/currency-input/tests/currency-input.container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps, mergeProps
 
 proxyquire('../currency-input.container.js', {
   'react-redux': {
-    connect: (ms, md, mp) => {
+    connect: (ms, _, mp) => {
       mapStateToProps = ms
       mergeProps = mp
       return () => ({})

--- a/ui/app/components/ui/token-input/tests/token-input.container.test.js
+++ b/ui/app/components/ui/token-input/tests/token-input.container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps, mergeProps
 
 proxyquire('../token-input.container.js', {
   'react-redux': {
-    connect: (ms, md, mp) => {
+    connect: (ms, _, mp) => {
       mapStateToProps = ms
       mergeProps = mp
       return () => ({})

--- a/ui/app/components/ui/unit-input/unit-input.component.js
+++ b/ui/app/components/ui/unit-input/unit-input.component.js
@@ -58,7 +58,7 @@ export default class UnitInput extends PureComponent {
     this.props.onChange(value)
   }
 
-  handleBlur = event => {
+  handleBlur = () => {
     const { onBlur } = this.props
     typeof onBlur === 'function' && onBlur(this.state.value)
   }

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -494,7 +494,7 @@ describe('Confirm Transaction Duck', () => {
     })
   })
 
-  describe('Thunk actions', done => {
+  describe('Thunk actions', () => {
     beforeEach(() => {
       global.eth = {
         getCode: sinon.stub().callsFake(

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -461,8 +461,8 @@ describe('Gas Duck', () => {
       assert.equal(thirdDispatchCallType, SET_PRICE_AND_TIME_ESTIMATES)
       assert(priceAndTimeEstimateResult.length < mockPredictTableResponse.length * 3 - 2)
       assert(!priceAndTimeEstimateResult.find(d => d.expectedTime > 100))
-      assert(!priceAndTimeEstimateResult.find((d, i, a) => a[a + 1] && d.expectedTime > a[a + 1].expectedTime))
-      assert(!priceAndTimeEstimateResult.find((d, i, a) => a[a + 1] && d.gasprice > a[a + 1].gasprice))
+      assert(!priceAndTimeEstimateResult.find((d, _, a) => a[a + 1] && d.expectedTime > a[a + 1].expectedTime))
+      assert(!priceAndTimeEstimateResult.find((d, _, a) => a[a + 1] && d.gasprice > a[a + 1].gasprice))
 
       assert.deepEqual(
         mockDistpatch.getCall(3).args,

--- a/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
+++ b/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
@@ -42,7 +42,7 @@ class MetaMetricsProvider extends Component {
       currentPath: window.location.href,
     }
 
-    props.history.listen(locationObj => {
+    props.history.listen(() => {
       this.setState({
         previousPath: this.state.currentPath,
         currentPath: window.location.href,

--- a/ui/app/helpers/higher-order-components/with-modal-props/tests/with-modal-props.test.js
+++ b/ui/app/helpers/higher-order-components/with-modal-props/tests/with-modal-props.test.js
@@ -21,7 +21,7 @@ const mockState = {
 
 describe('withModalProps', () => {
   it('should return a component wrapped with modal state props', () => {
-    const TestComponent = props => (
+    const TestComponent = () => (
       <div className="test">Testing</div>
     )
     const WrappedComponent = withModalProps(TestComponent)

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -42,7 +42,7 @@ const convert = R.invoker(1, 'times')
 const round = R.invoker(2, 'round')(R.__, BigNumber.ROUND_HALF_DOWN)
 const roundDown = R.invoker(2, 'round')(R.__, BigNumber.ROUND_DOWN)
 const invertConversionRate = conversionRate => () => new BigNumber(1.0).div(conversionRate)
-const decToBigNumberViaString = n => R.pipe(String, toBigNumber['dec'])
+const decToBigNumberViaString = () => R.pipe(String, toBigNumber['dec'])
 
 // Setter Maps
 const toBigNumber = {

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -84,7 +84,7 @@ function composeParamAddition (paramValue, paramName) {
     : `&${paramName}=${paramValue}`
 }
 
-function composeUrl (config, permissionPreferences = {}) {
+function composeUrl (config) {
   const {
     eventOpts = {},
     customVariables = '',

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -92,7 +92,7 @@ function miniAddressSummary (address) {
   return checked ? checked.slice(0, 4) + '...' + checked.slice(-4) : '...'
 }
 
-function isValidAddress (address, network) {
+function isValidAddress (address) {
   var prefixed = ethUtil.addHexPrefix(address)
   if (address === '0x0000000000000000000000000000000000000000') return false
   return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
@@ -268,7 +268,7 @@ function bnMultiplyByFraction (targetBN, numerator, denominator) {
   return targetBN.mul(numBN).div(denomBN)
 }
 
-function getTxFeeBn (gas, gasPrice = MIN_GAS_PRICE_BN.toString(16), blockGasLimit) {
+function getTxFeeBn (gas, gasPrice = MIN_GAS_PRICE_BN.toString(16)) {
   const gasBn = hexToBn(gas)
   const gasPriceBn = hexToBn(gasPrice)
   const txFeeBn = gasBn.mul(gasPriceBn)
@@ -297,7 +297,7 @@ function exportAsFile (filename, data, type = 'text/csv') {
 }
 
 function allNull (obj) {
-  return Object.entries(obj).every(([key, value]) => value === null)
+  return Object.entries(obj).every(([_, value]) => value === null)
 }
 
 function getTokenAddressFromTokenObject (token) {
@@ -308,11 +308,10 @@ function getTokenAddressFromTokenObject (token) {
  * Safely checksumms a potentially-null address
  *
  * @param {String} [address] - address to checksum
- * @param {String} [network] - network id
  * @returns {String} - checksummed address
  *
  */
-function checksumAddress (address, network) {
+function checksumAddress (address) {
   const checksummed = address ? ethUtil.toChecksumAddress(address) : ''
   return checksummed
 }

--- a/ui/app/pages/create-account/connect-hardware/account-list.js
+++ b/ui/app/pages/create-account/connect-hardware/account-list.js
@@ -6,10 +6,6 @@ const Select = require('react-select').default
 import Button from '../../../components/ui/button'
 
 class AccountList extends Component {
-    constructor (props, context) {
-        super(props)
-    }
-
     getHdPaths () {
       return [
         {

--- a/ui/app/pages/create-account/connect-hardware/connect-screen.js
+++ b/ui/app/pages/create-account/connect-hardware/connect-screen.js
@@ -4,7 +4,7 @@ const h = require('react-hyperscript')
 import Button from '../../../components/ui/button'
 
 class ConnectScreen extends Component {
-    constructor (props, context) {
+    constructor (props) {
         super(props)
         this.state = {
           selectedDevice: null,
@@ -103,7 +103,7 @@ class ConnectScreen extends Component {
     }
 
 
-    scrollToTutorial = (e) => {
+    scrollToTutorial = () => {
       if (this.referenceNode) this.referenceNode.scrollIntoView({behavior: 'smooth'})
     }
 

--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -12,7 +12,7 @@ const { getPlatform } = require('../../../../../app/scripts/lib/util')
 const { PLATFORM_FIREFOX } = require('../../../../../app/scripts/lib/enums')
 
 class ConnectHardwareForm extends Component {
-  constructor (props, context) {
+  constructor (props) {
     super(props)
     this.state = {
       error: null,
@@ -101,7 +101,7 @@ class ConnectHardwareForm extends Component {
           const newState = { unlocked: true, device, error: null }
           // Default to the first account
           if (this.state.selectedAccount === null) {
-            accounts.forEach((a, i) => {
+            accounts.forEach((a) => {
               if (a.address.toLowerCase() === this.props.address) {
                 newState.selectedAccount = a.index.toString()
               }

--- a/ui/app/pages/create-account/import-account/seed.js
+++ b/ui/app/pages/create-account/import-account/seed.js
@@ -11,7 +11,7 @@ SeedImportSubview.contextTypes = {
 module.exports = connect(mapStateToProps)(SeedImportSubview)
 
 
-function mapStateToProps (state) {
+function mapStateToProps () {
   return {}
 }
 

--- a/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
@@ -119,7 +119,7 @@ export default class MetaMetricsOptIn extends Component {
               hideCancel={false}
               onSubmit={() => {
                 setParticipateInMetaMetrics(true)
-                  .then(([participateStatus, metaMetricsId]) => {
+                  .then(([_, metaMetricsId]) => {
                     const promise = participateInMetaMetrics !== true
                       ? metricsEvent({
                         eventOpts: {

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -37,7 +37,7 @@ export default class ConfirmSeedPhrase extends PureComponent {
     isDragging: false,
   }
 
-  shouldComponentUpdate (nextProps, nextState, nextContext) {
+  shouldComponentUpdate (nextProps, nextState) {
     const { seedPhrase } = this.props
     const {
       selectedSeedIndices,
@@ -108,7 +108,7 @@ export default class ConfirmSeedPhrase extends PureComponent {
     }
   }
 
-  handleSelectSeedWord = (word, shuffledIndex) => {
+  handleSelectSeedWord = (shuffledIndex) => {
     this.setState({
       selectedSeedIndices: [...this.state.selectedSeedIndices, shuffledIndex],
       pendingSeedIndices: [...this.state.pendingSeedIndices, shuffledIndex],
@@ -183,7 +183,7 @@ export default class ConfirmSeedPhrase extends PureComponent {
                   selected={isSelected}
                   onClick={() => {
                     if (!isSelected) {
-                      this.handleSelectSeedWord(word, index)
+                      this.handleSelectSeedWord(index)
                     } else {
                       this.handleDeselectSeedWord(index)
                     }

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/draggable-seed.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/draggable-seed.component.js
@@ -28,7 +28,7 @@ class DraggableSeed extends Component {
     onClick () {},
   }
 
-  componentWillReceiveProps (nextProps, nextContext) {
+  componentWillReceiveProps (nextProps) {
     const { isOver, setHoveringIndex } = this.props
     if (isOver && !nextProps.isOver) {
       setHoveringIndex(-1)

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -438,7 +438,7 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch, ownProps) {
+function mapDispatchToProps (dispatch) {
   return {
     dispatch,
     hideSidebar: () => dispatch(actions.hideSidebar()),

--- a/ui/app/pages/send/account-list-item/tests/account-list-item-container.test.js
+++ b/ui/app/pages/send/account-list-item/tests/account-list-item-container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../account-list-item.container.js', {
   'react-redux': {
-    connect: (ms, md) => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-container.test.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../send-row-error-message.container.js', {
   'react-redux': {
-    connect: (ms, md) => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/pages/send/send-content/send-row-wrapper/send-row-warning-message/tests/send-row-warning-message-container.test.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/send-row-warning-message/tests/send-row-warning-message-container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../send-row-warning-message.container.js', {
   'react-redux': {
-    connect: (ms, md) => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/pages/send/send-content/send-to-row/send-to-row.utils.js
+++ b/ui/app/pages/send/send-content/send-to-row/send-to-row.utils.js
@@ -10,7 +10,7 @@ import { checkExistingAddresses } from '../../../add-token/util'
 const ethUtil = require('ethereumjs-util')
 const contractMap = require('eth-contract-metadata')
 
-function getToErrorObject (to, toError = null, hasHexData = false, tokens = [], selectedToken = null, network) {
+function getToErrorObject (to, toError = null, hasHexData = false, _, __, network) {
   if (!to) {
     if (!hasHexData) {
       toError = REQUIRED_ERROR

--- a/ui/app/pages/send/tests/send-container.test.js
+++ b/ui/app/pages/send/tests/send-container.test.js
@@ -24,7 +24,7 @@ proxyquire('../send.container.js', {
     },
   },
   'react-router-dom': { withRouter: () => {} },
-  'recompose': { compose: (arg1, arg2) => () => arg2() },
+  'recompose': { compose: (_, arg2) => () => arg2() },
   './send.selectors': {
     getAmountConversionRate: (s) => `mockAmountConversionRate:${s}`,
     getBlockGasLimit: (s) => `mockBlockGasLimit:${s}`,

--- a/ui/app/pages/send/tests/send-utils.test.js
+++ b/ui/app/pages/send/tests/send-utils.test.js
@@ -17,12 +17,12 @@ const {
 } = require('../send.constants')
 
 const stubs = {
-  addCurrencies: sinon.stub().callsFake((a, b, obj) => {
+  addCurrencies: sinon.stub().callsFake((a, b) => {
     if (String(a).match(/^0x.+/)) a = Number(String(a).slice(2))
     if (String(b).match(/^0x.+/)) b = Number(String(b).slice(2))
     return a + b
   }),
-  conversionUtil: sinon.stub().callsFake((val, obj) => parseInt(val, 16)),
+  conversionUtil: sinon.stub().callsFake((val) => parseInt(val, 16)),
   conversionGTE: sinon.stub().callsFake((obj1, obj2) => obj1.value >= obj2.value),
   multiplyCurrencies: sinon.stub().callsFake((a, b) => `${a}x${b}`),
   calcTokenAmount: sinon.stub().callsFake((a, d) => 'calc:' + a + d),

--- a/ui/app/pages/send/to-autocomplete/to-autocomplete.js
+++ b/ui/app/pages/send/to-autocomplete/to-autocomplete.js
@@ -84,7 +84,7 @@ ToAutoComplete.prototype.handleInputEvent = function (event = {}, cb) {
   cb && cb(event.target.value)
 }
 
-ToAutoComplete.prototype.componentDidUpdate = function (nextProps, nextState) {
+ToAutoComplete.prototype.componentDidUpdate = function (nextProps) {
   if (this.props.to !== nextProps.to) {
     this.handleInputEvent()
   }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -762,7 +762,7 @@ function addNewAccount () {
 
 function checkHardwareStatus (deviceName, hdPath) {
   log.debug(`background.checkHardwareStatus`, deviceName, hdPath)
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve, reject) => {
       background.checkHardwareStatus(deviceName, hdPath, (err, unlocked) => {
@@ -783,10 +783,10 @@ function checkHardwareStatus (deviceName, hdPath) {
 
 function forgetDevice (deviceName) {
   log.debug(`background.forgetDevice`, deviceName)
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve, reject) => {
-      background.forgetDevice(deviceName, (err, response) => {
+      background.forgetDevice(deviceName, (err) => {
         if (err) {
           log.error(err)
           dispatch(actions.displayWarning(err.message))
@@ -804,7 +804,7 @@ function forgetDevice (deviceName) {
 
 function connectHardware (deviceName, page, hdPath) {
   log.debug(`background.connectHardware`, deviceName, page, hdPath)
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve, reject) => {
       background.connectHardware(deviceName, page, hdPath, (err, accounts) => {
@@ -825,10 +825,10 @@ function connectHardware (deviceName, page, hdPath) {
 
 function unlockHardwareWalletAccount (index, deviceName, hdPath) {
   log.debug(`background.unlockHardwareWalletAccount`, index, deviceName, hdPath)
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve, reject) => {
-      background.unlockHardwareWalletAccount(index, deviceName, hdPath, (err, accounts) => {
+      background.unlockHardwareWalletAccount(index, deviceName, hdPath, (err) => {
         if (err) {
           log.error(err)
           dispatch(actions.displayWarning(err.message))
@@ -849,7 +849,7 @@ function showInfoPage () {
 }
 
 function showQrScanner (ROUTE) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     return WebcamUtils.checkStatus()
     .then(status => {
       if (!status.environmentReady) {
@@ -988,7 +988,7 @@ function signTypedMsg (msgData) {
 
 function signTx (txData) {
   return (dispatch) => {
-    global.ethQuery.sendTransaction(txData, (err, data) => {
+    global.ethQuery.sendTransaction(txData, (err) => {
       if (err) {
         return dispatch(actions.displayWarning(err.message))
       }
@@ -1021,7 +1021,6 @@ function setGasTotal (gasTotal) {
 function updateGasData ({
   gasPrice,
   blockGasLimit,
-  recentBlocks,
   selectedAddress,
   selectedToken,
   to,
@@ -1403,7 +1402,7 @@ function cancelTx (txData) {
  * @return {function(*): Promise<void>}
  */
 function cancelTxs (txDataList) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     window.onbeforeunload = null
     dispatch(actions.showLoadingIndication())
     const txIds = txDataList.map(({id}) => id)
@@ -1808,7 +1807,7 @@ function removeSuggestedTokens () {
   return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     window.onbeforeunload = null
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       background.removeSuggestedTokens((err, suggestedTokens) => {
         dispatch(actions.hideLoadingIndication())
         if (err) {
@@ -1827,7 +1826,7 @@ function removeSuggestedTokens () {
 }
 
 function addKnownMethodData (fourBytePrefix, methodData) {
-  return (dispatch) => {
+  return () => {
     background.addKnownMethodData(fourBytePrefix, methodData)
   }
 }
@@ -1932,7 +1931,7 @@ function setProviderType (type) {
   return (dispatch, getState) => {
     const { type: currentProviderType } = getState().metamask.provider
     log.debug(`background.setProviderType`, type)
-    background.setProviderType(type, (err, result) => {
+    background.setProviderType(type, (err) => {
       if (err) {
         log.error(err)
         return dispatch(actions.displayWarning('Had a problem changing networks!'))
@@ -1962,7 +1961,7 @@ function setPreviousProvider (type) {
 function updateAndSetCustomRpc (newRpc, chainId, ticker = 'ETH', nickname) {
   return (dispatch) => {
     log.debug(`background.updateAndSetCustomRpc: ${newRpc} ${chainId} ${ticker} ${nickname}`)
-    background.updateAndSetCustomRpc(newRpc, chainId, ticker, nickname || newRpc, (err, result) => {
+    background.updateAndSetCustomRpc(newRpc, chainId, ticker, nickname || newRpc, (err) => {
       if (err) {
         log.error(err)
         return dispatch(actions.displayWarning('Had a problem changing networks!'))
@@ -1978,7 +1977,7 @@ function updateAndSetCustomRpc (newRpc, chainId, ticker = 'ETH', nickname) {
 function setRpcTarget (newRpc, chainId, ticker = 'ETH', nickname) {
   return (dispatch) => {
     log.debug(`background.setRpcTarget: ${newRpc} ${chainId} ${ticker} ${nickname}`)
-    background.setCustomRpc(newRpc, chainId, ticker, nickname || newRpc, (err, result) => {
+    background.setCustomRpc(newRpc, chainId, ticker, nickname || newRpc, (err) => {
       if (err) {
         log.error(err)
         return dispatch(actions.displayWarning('Had a problem changing networks!'))
@@ -1991,7 +1990,7 @@ function setRpcTarget (newRpc, chainId, ticker = 'ETH', nickname) {
 function delRpcTarget (oldRpc) {
   return (dispatch) => {
     log.debug(`background.delRpcTarget: ${oldRpc}`)
-    background.delCustomRpc(oldRpc, (err, result) => {
+    background.delCustomRpc(oldRpc, (err) => {
       if (err) {
         log.error(err)
         return dispatch(self.displayWarning('Had a problem removing network!'))
@@ -2005,7 +2004,7 @@ function delRpcTarget (oldRpc) {
 function addToAddressBook (recipient, nickname = '') {
   log.debug(`background.addToAddressBook`)
   return (dispatch) => {
-    background.setAddressBook(recipient, nickname, (err, result) => {
+    background.setAddressBook(recipient, nickname, (err) => {
       if (err) {
         log.error(err)
         return dispatch(self.displayWarning('Address book failed to update'))
@@ -2274,7 +2273,7 @@ function pairUpdate (coin) {
   }
 }
 
-function shapeShiftSubview (network) {
+function shapeShiftSubview () {
   var pair = 'btc_eth'
   return (dispatch) => {
     dispatch(actions.showSubLoadingIndication())
@@ -2310,7 +2309,7 @@ function coinShiftRquest (data, marketData) {
 }
 
 function buyWithShapeShift (data) {
-  return dispatch => new Promise((resolve, reject) => {
+  return () => new Promise((resolve, reject) => {
     shapeShiftRequest('shift', { method: 'POST', data}, (response) => {
       if (response.error) {
         return reject(response.error)
@@ -2357,7 +2356,7 @@ function shapeShiftRequest (query, options, cb) {
   !options ? options = {} : null
   options.method ? method = options.method : method = 'GET'
 
-  var requestListner = function (request) {
+  var requestListner = function () {
     try {
       queryResponse = JSON.parse(this.responseText)
       cb ? cb(queryResponse) : null
@@ -2686,19 +2685,19 @@ function setPendingTokens (pendingTokens) {
 }
 
 function approveProviderRequestByOrigin (origin) {
-  return (dispatch) => {
+  return () => {
     background.approveProviderRequestByOrigin(origin)
   }
 }
 
 function rejectProviderRequestByOrigin (origin) {
-  return (dispatch) => {
+  return () => {
     background.rejectProviderRequestByOrigin(origin)
   }
 }
 
 function clearApprovedOrigins () {
-  return (dispatch) => {
+  return () => {
     background.clearApprovedOrigins()
   }
 }

--- a/ui/example.js
+++ b/ui/example.js
@@ -91,7 +91,7 @@ accountManager.setSelectedAccount = function (address, cb) {
   this._didUpdate()
 }
 
-accountManager.signTransaction = function (txParams, cb) {
+accountManager.signTransaction = function () {
   alert('signing tx....')
 }
 

--- a/ui/lib/test-timeout.js
+++ b/ui/lib/test-timeout.js
@@ -1,5 +1,5 @@
 export default function timeout (time) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     setTimeout(resolve, time || 1500)
   })
 }


### PR DESCRIPTION
This PR updates our ESLint rules to check for unused function arguments.

From the ESLint docs:<sup>[\[1\]][1]</sup>

> ### args
> The `args` option has three settings:
>
> - `after-used` - unused positional arguments that occur before the last used argument will not be checked, but all named arguments and all positional arguments after the last used argument will be checked.
> - `all` - all named arguments must be used.
> - `none` - do not check arguments.

Here we've switched from `none` (😱) to `all` (😎).

  [1]:https://eslint.org/docs/rules/no-unused-vars#args