### PR TITLE
Parse custom block explorer url for domain and capitalize

### DIFF
--- a/ui/app/components/app/dropdowns/account-details-dropdown.js
+++ b/ui/app/components/app/dropdowns/account-details-dropdown.js
@@ -119,7 +119,9 @@ AccountDetailsDropdown.prototype.render = function () {
         this.props.onClose()
       },
       text: (rpcPrefs.blockExplorerUrl
-        ? this.context.t('blockExplorerView', [rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/)[1]])
+        ? this.context.t('blockExplorerView', [
+          rpcPrefs.blockExplorerUrl.match(/[^https?://]\w+/)[0].charAt(0).toUpperCase() + rpcPrefs.blockExplorerUrl.match(/[^https?://]\w+/)[0].slice(1),
+        ])
         : this.context.t('viewOnEtherscan')),
       icon: h(`img`, { src: 'images/open-etherscan.svg', style: { height: '15px' } }),
     }),

--- a/ui/app/components/app/modals/account-details-modal.js
+++ b/ui/app/components/app/modals/account-details-modal.js
@@ -92,7 +92,9 @@ AccountDetailsModal.prototype.render = function () {
           global.platform.openWindow({ url: genAccountLink(address, network, rpcPrefs) })
         },
       }, (rpcPrefs.blockExplorerUrl
-        ? this.context.t('blockExplorerView', [rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/)[1]])
+        ? this.context.t('blockExplorerView', [
+          rpcPrefs.blockExplorerUrl.match(/[^https?://]\w+/)[0].charAt(0).toUpperCase() + rpcPrefs.blockExplorerUrl.match(/[^https?://]\w+/)[0].slice(1),
+        ])
         : this.context.t('viewOnEtherscan'))),
 
       // Holding on redesign for Export Private Key functionality

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -159,7 +159,9 @@ export default class TransactionListItemDetails extends PureComponent {
                 />
               </Button>
             </Tooltip>
-            <Tooltip title={blockExplorerUrl ? t('viewOnCustomBlockExplorer', [blockExplorerUrl]) : t('viewOnEtherscan')}>
+            <Tooltip title={blockExplorerUrl ? t('viewOnCustomBlockExplorer', [
+              blockExplorerUrl.match(/[^https?://]\w+/)[0].charAt(0).toUpperCase() + blockExplorerUrl.match(/[^https?://]\w+/)[0].slice(1),
+            ]) : t('viewOnEtherscan')}>
               <Button
                 type="raised"
                 onClick={this.handleEtherscanClick}


### PR DESCRIPTION
Parse custom block explorer url for domain and capitalize it.

Currently, we show the whole url just without the `https://`

Before:
![blockexplorerurl](https://user-images.githubusercontent.com/13376180/57494936-85f02900-7280-11e9-97d9-27aaf88b1c99.png)

After: 
![blockexplorernourl](https://user-images.githubusercontent.com/13376180/57494944-8ee0fa80-7280-11e9-95de-8f33c4c8a1fa.png)


