### PR TITLE
Fix RPC URL message key casing

### DIFF
--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -51,7 +51,7 @@ export default class AdvancedTab extends PureComponent {
             <TextField
               type="text"
               id="new-rpc"
-              placeholder={t('rpcURL')}
+              placeholder={t('rpcUrl')}
               value={newRpc}
               onChange={e => this.setState({ newRpc: e.target.value })}
               onKeyPress={e => {


### PR DESCRIPTION
Refs 13be683701bc46d8f1bcbaa301e2b7f01a34e29c

This PR fixes the casing of the `rpcUrl` (previously `rpcURL`) message key shown in the advanced tab of the settings page.