### PR TITLE
Set a default value for code in _determineTransactionCategory

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -582,7 +582,7 @@ class TransactionController extends EventEmitter {
     ].find(tokenMethodName => tokenMethodName === name && name.toLowerCase())
 
     let result
-    let code
+    let code = 'default'
     if (!txParams.data) {
       result = SEND_ETHER_ACTION_KEY
     } else if (tokenMethodName) {
@@ -593,6 +593,7 @@ class TransactionController extends EventEmitter {
       try {
         code = await this.query.getCode(to)
       } catch (e) {
+        code = null
         log.warn(e)
       }
       // For an address with no code, geth will return '0x', and ganache-core v2.2.1 will return '0x0'

--- a/test/e2e/beta/contract-test/contract.js
+++ b/test/e2e/beta/contract-test/contract.js
@@ -37,6 +37,8 @@ web3.currentProvider.enable().then(() => {
   const createToken = document.getElementById('createToken')
   const transferTokens = document.getElementById('transferTokens')
   const approveTokens = document.getElementById('approveTokens')
+  const transferTokensWithoutGas = document.getElementById('transferTokensWithoutGas')
+  const approveTokensWithoutGas = document.getElementById('approveTokensWithoutGas')
 
   deployButton.addEventListener('click', async function () {
     document.getElementById('contractStatus').innerHTML = 'Deploying'
@@ -130,6 +132,29 @@ web3.currentProvider.enable().then(() => {
               to: contract.address,
               data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
               gas: 60000,
+              gasPrice: '20000000000',
+            }, function (result) {
+              console.log(result)
+            })
+          })
+
+          transferTokensWithoutGas.addEventListener('click', function (event) {
+            console.log(`event`, event)
+            contract.transfer('0x2f318C334780961FB129D2a6c30D0763d9a5C970', '7', {
+              from: web3.eth.accounts[0],
+              to: contract.address,
+              data: '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',
+              gasPrice: '20000000000',
+            }, function (result) {
+              console.log('result', result)
+            })
+          })
+
+          approveTokensWithoutGas.addEventListener('click', function () {
+            contract.approve('0x2f318C334780961FB129D2a6c30D0763d9a5C970', '7', {
+              from: web3.eth.accounts[0],
+              to: contract.address,
+              data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
               gasPrice: '20000000000',
             }, function (result) {
               console.log(result)

--- a/test/e2e/beta/contract-test/index.html
+++ b/test/e2e/beta/contract-test/index.html
@@ -27,6 +27,8 @@
       <button id="createToken">Create Token</button>
       <button id="transferTokens">Transfer Tokens</button>
       <button id="approveTokens">Approve Tokens</button>
+      <button id="transferTokensWithoutGas">Transfer Tokens Without Gas</button>
+      <button id="approveTokensWithoutGas">Approve Tokens Without Gas</button>
     </div>
   </div>
 

--- a/test/e2e/beta/metamask-beta-ui.spec.js
+++ b/test/e2e/beta/metamask-beta-ui.spec.js
@@ -812,10 +812,31 @@ describe('MetaMask', function () {
       await delay(regularDelayMs)
 
       const [gasPriceInput, gasLimitInput] = await findElements(driver, By.css('.advanced-tab__gas-edit-row__input'))
-      await gasPriceInput.clear()
+      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
+      await delay(50)
+
+      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
       await gasPriceInput.sendKeys('10')
-      await gasLimitInput.clear()
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
       await gasLimitInput.sendKeys('60001')
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'e'))
+      await delay(50)
 
       const save = await findElement(driver, By.xpath(`//button[contains(text(), 'Save')]`))
       await save.click()
@@ -1175,7 +1196,7 @@ describe('MetaMask', function () {
       const transferTokens = await findElement(driver, By.xpath(`//button[contains(text(), 'Approve Tokens')]`))
       await transferTokens.click()
 
-      await closeAllWindowHandlesExcept(driver, extension)
+      await closeAllWindowHandlesExcept(driver, [extension, dapp])
       await driver.switchTo().window(extension)
       await delay(regularDelayMs)
 
@@ -1228,21 +1249,31 @@ describe('MetaMask', function () {
       await delay(regularDelayMs)
 
       const [gasPriceInput, gasLimitInput] = await findElements(driver, By.css('.advanced-tab__gas-edit-row__input'))
-      await gasPriceInput.clear()
-      await delay(tinyDelayMs)
-      await gasPriceInput.sendKeys('10')
-      await delay(tinyDelayMs)
-      await gasLimitInput.clear()
-      await delay(tinyDelayMs)
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await gasLimitInput.sendKeys('60000')
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'e'))
+      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
+      await delay(50)
 
-      // Needed for different behaviour of input in different versions of firefox
-      const gasLimitInputValue = await gasLimitInput.getAttribute('value')
-      if (gasLimitInputValue === '600001') {
-        await gasLimitInput.sendKeys(Key.BACK_SPACE)
-      }
+      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasPriceInput.sendKeys('10')
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+      await delay(50)
+      await gasLimitInput.sendKeys('60001')
+      await delay(50)
+      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'e'))
+      await delay(50)
 
       const save = await findElement(driver, By.css('.page-container__footer-button'))
       await save.click()
@@ -1262,6 +1293,105 @@ describe('MetaMask', function () {
       await driver.wait(async () => {
         const confirmedTxes = await findElements(driver, By.css('.transaction-list__completed-transactions .transaction-list-item'))
         return confirmedTxes.length === 3
+      }, 10000)
+
+      const txValues = await findElements(driver, By.css('.transaction-list-item__amount--primary'))
+      await driver.wait(until.elementTextMatches(txValues[0], /-7\s*TST/))
+      const txStatuses = await findElements(driver, By.css('.transaction-list-item__action'))
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Approve/))
+    })
+  })
+
+  describe('Tranfers a custom token from dapp when no gas value is specified', () => {
+    it('transfers an already created token, without specifying gas', async () => {
+      const windowHandles = await driver.getAllWindowHandles()
+      const extension = windowHandles[0]
+      const dapp = await switchToWindowWithTitle(driver, 'E2E Test Dapp', windowHandles)
+      await closeAllWindowHandlesExcept(driver, [extension, dapp])
+      await delay(regularDelayMs)
+
+      await driver.switchTo().window(dapp)
+
+      const transferTokens = await findElement(driver, By.xpath(`//button[contains(text(), 'Transfer Tokens Without Gas')]`))
+      await transferTokens.click()
+
+      await closeAllWindowHandlesExcept(driver, [extension, dapp])
+      await driver.switchTo().window(extension)
+      await delay(regularDelayMs)
+
+      await driver.wait(async () => {
+        const pendingTxes = await findElements(driver, By.css('.transaction-list__pending-transactions .transaction-list-item'))
+        return pendingTxes.length === 1
+      }, 10000)
+
+      const [txListItem] = await findElements(driver, By.css('.transaction-list-item'))
+      const [txListValue] = await findElements(driver, By.css('.transaction-list-item__amount--primary'))
+      await driver.wait(until.elementTextMatches(txListValue, /-7\s*TST/))
+      await txListItem.click()
+      await delay(regularDelayMs)
+    })
+
+    it('submits the transaction', async function () {
+      await delay(regularDelayMs)
+      const confirmButton = await findElement(driver, By.xpath(`//button[contains(text(), 'Confirm')]`))
+      await confirmButton.click()
+      await delay(regularDelayMs)
+    })
+
+    it('finds the transaction in the transactions list', async function () {
+      await driver.wait(async () => {
+        const confirmedTxes = await findElements(driver, By.css('.transaction-list__completed-transactions .transaction-list-item'))
+        return confirmedTxes.length === 4
+      }, 10000)
+
+      const txValues = await findElements(driver, By.css('.transaction-list-item__amount--primary'))
+      await driver.wait(until.elementTextMatches(txValues[0], /-7\s*TST/))
+      const txStatuses = await findElements(driver, By.css('.transaction-list-item__action'))
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Sent Tokens/))
+    })
+  })
+
+  describe('Approves a custom token from dapp when no gas value is specified', () => {
+    it('approves an already created token', async () => {
+      const windowHandles = await driver.getAllWindowHandles()
+      const extension = windowHandles[0]
+      const dapp = await switchToWindowWithTitle(driver, 'E2E Test Dapp', windowHandles)
+      await closeAllWindowHandlesExcept(driver, [extension, dapp])
+      await delay(regularDelayMs)
+
+      await driver.switchTo().window(dapp)
+      await delay(tinyDelayMs)
+
+      const transferTokens = await findElement(driver, By.xpath(`//button[contains(text(), 'Approve Tokens Without Gas')]`))
+      await transferTokens.click()
+
+      await closeAllWindowHandlesExcept(driver, extension)
+      await driver.switchTo().window(extension)
+      await delay(regularDelayMs)
+
+      await driver.wait(async () => {
+        const pendingTxes = await findElements(driver, By.css('.transaction-list__pending-transactions .transaction-list-item'))
+        return pendingTxes.length === 1
+      }, 10000)
+
+      const [txListItem] = await findElements(driver, By.css('.transaction-list-item'))
+      const [txListValue] = await findElements(driver, By.css('.transaction-list-item__amount--primary'))
+      await driver.wait(until.elementTextMatches(txListValue, /-7\s*TST/))
+      await txListItem.click()
+      await delay(regularDelayMs)
+    })
+
+    it('submits the transaction', async function () {
+      await delay(regularDelayMs)
+      const confirmButton = await findElement(driver, By.xpath(`//button[contains(text(), 'Confirm')]`))
+      await confirmButton.click()
+      await delay(regularDelayMs)
+    })
+
+    it('finds the transaction in the transactions list', async function () {
+      await driver.wait(async () => {
+        const confirmedTxes = await findElements(driver, By.css('.transaction-list__completed-transactions .transaction-list-item'))
+        return confirmedTxes.length === 5
       }, 10000)
 
       const txValues = await findElements(driver, By.css('.transaction-list-item__amount--primary'))

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -550,7 +550,7 @@ describe('Transaction Controller', function () {
         to: '0xabc',
         data: '',
       })
-      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, code: 'default' })
+      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, getCodeResponse: undefined })
     })
 
     it('should return a token transfer transactionCategory when data is for the respective method call', async function () {
@@ -558,7 +558,7 @@ describe('Transaction Controller', function () {
         to: '0xabc',
         data: '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',
       })
-      assert.deepEqual(result, { transactionCategory: TOKEN_METHOD_TRANSFER, code: 'default' })
+      assert.deepEqual(result, { transactionCategory: TOKEN_METHOD_TRANSFER, getCodeResponse: undefined })
     })
 
     it('should return a token approve transactionCategory when data is for the respective method call', async function () {
@@ -566,7 +566,7 @@ describe('Transaction Controller', function () {
         to: '0xabc',
         data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
       })
-      assert.deepEqual(result, { transactionCategory: TOKEN_METHOD_APPROVE, code: 'default' })
+      assert.deepEqual(result, { transactionCategory: TOKEN_METHOD_APPROVE, getCodeResponse: undefined })
     })
 
     it('should return a contract deployment transactionCategory when to is falsey and there is data', async function () {
@@ -574,26 +574,26 @@ describe('Transaction Controller', function () {
         to: '',
         data: '0xabd',
       })
-      assert.deepEqual(result, { transactionCategory: DEPLOY_CONTRACT_ACTION_KEY, code: 'default' })
+      assert.deepEqual(result, { transactionCategory: DEPLOY_CONTRACT_ACTION_KEY, getCodeResponse: undefined })
     })
 
-    it('should return a simple send transactionCategory with a 0x code when there is data and but the to address is not a contract address', async function () {
+    it('should return a simple send transactionCategory with a 0x getCodeResponse when there is data and but the to address is not a contract address', async function () {
       const result = await txController._determineTransactionCategory({
         to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
         data: '0xabd',
       })
-      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, code: '0x' })
+      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, getCodeResponse: '0x' })
     })
 
-    it('should return a simple send transactionCategory with a null code when to is truthy and there is data and but getCode returns an error', async function () {
+    it('should return a simple send transactionCategory with a null getCodeResponse when to is truthy and there is data and but getCode returns an error', async function () {
       const result = await txController._determineTransactionCategory({
         to: '0xabc',
         data: '0xabd',
       })
-      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, code: null })
+      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, getCodeResponse: null })
     })
 
-    it('should return a contract interaction transactionCategory with the correct code when to is truthy and there is data and it is not a token transaction', async function () {
+    it('should return a contract interaction transactionCategory with the correct getCodeResponse when to is truthy and there is data and it is not a token transaction', async function () {
       const _providerResultStub = {
         // 1 gwei
         eth_gasPrice: '0x0de0b6b3a7640000',
@@ -620,7 +620,7 @@ describe('Transaction Controller', function () {
         to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
         data: 'abd',
       })
-      assert.deepEqual(result, { transactionCategory: CONTRACT_INTERACTION_KEY, code: '0x0a' })
+      assert.deepEqual(result, { transactionCategory: CONTRACT_INTERACTION_KEY, getCodeResponse: '0x0a' })
     })
   })
 

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -8,6 +8,13 @@ const TransactionController = require('../../../../../app/scripts/controllers/tr
 const {
   TRANSACTION_TYPE_RETRY,
 } = require('../../../../../app/scripts/controllers/transactions/enums')
+const {
+  TOKEN_METHOD_APPROVE,
+  TOKEN_METHOD_TRANSFER,
+  SEND_ETHER_ACTION_KEY,
+  DEPLOY_CONTRACT_ACTION_KEY,
+  CONTRACT_INTERACTION_KEY,
+} = require('../../../../../ui/app/helpers/constants/transactions.js')
 const { createTestProviderTools, getTestAccounts } = require('../../../../stub/provider')
 
 const noop = () => true
@@ -534,6 +541,86 @@ describe('Transaction Controller', function () {
       assert.equal(confirmedTx.status, 'confirmed', 'the confirmedTx should remain confirmed')
       assert.equal(droppedTxs.length, 6, 'their should be 6 dropped txs')
 
+    })
+  })
+
+  describe('#_determineTransactionCategory', function () {
+    it('should return a simple send transactionCategory when to is truthy but data is falsey', async function () {
+      const result = await txController._determineTransactionCategory({
+        to: '0xabc',
+        data: '',
+      })
+      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, code: 'default' })
+    })
+
+    it('should return a token transfer transactionCategory when data is for the respective method call', async function () {
+      const result = await txController._determineTransactionCategory({
+        to: '0xabc',
+        data: '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',
+      })
+      assert.deepEqual(result, { transactionCategory: TOKEN_METHOD_TRANSFER, code: 'default' })
+    })
+
+    it('should return a token approve transactionCategory when data is for the respective method call', async function () {
+      const result = await txController._determineTransactionCategory({
+        to: '0xabc',
+        data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
+      })
+      assert.deepEqual(result, { transactionCategory: TOKEN_METHOD_APPROVE, code: 'default' })
+    })
+
+    it('should return a contract deployment transactionCategory when to is falsey and there is data', async function () {
+      const result = await txController._determineTransactionCategory({
+        to: '',
+        data: '0xabd',
+      })
+      assert.deepEqual(result, { transactionCategory: DEPLOY_CONTRACT_ACTION_KEY, code: 'default' })
+    })
+
+    it('should return a simple send transactionCategory with a 0x code when there is data and but the to address is not a contract address', async function () {
+      const result = await txController._determineTransactionCategory({
+        to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
+        data: '0xabd',
+      })
+      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, code: '0x' })
+    })
+
+    it('should return a simple send transactionCategory with a null code when to is truthy and there is data and but getCode returns an error', async function () {
+      const result = await txController._determineTransactionCategory({
+        to: '0xabc',
+        data: '0xabd',
+      })
+      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, code: null })
+    })
+
+    it('should return a contract interaction transactionCategory with the correct code when to is truthy and there is data and it is not a token transaction', async function () {
+      const _providerResultStub = {
+        // 1 gwei
+        eth_gasPrice: '0x0de0b6b3a7640000',
+        // by default, all accounts are external accounts (not contracts)
+        eth_getCode: '0xa',
+      }
+      const _provider = createTestProviderTools({ scaffold: _providerResultStub }).provider
+      const _fromAccount = getTestAccounts()[0]
+      const _blockTrackerStub = new EventEmitter()
+      _blockTrackerStub.getCurrentBlock = noop
+      _blockTrackerStub.getLatestBlock = noop
+      const _txController = new TransactionController({
+        provider: _provider,
+        getGasPrice: function () { return '0xee6b2800' },
+        networkStore: new ObservableStore(currentNetworkId),
+        txHistoryLimit: 10,
+        blockTracker: _blockTrackerStub,
+        signTransaction: (ethTx) => new Promise((resolve) => {
+          ethTx.sign(_fromAccount.key)
+          resolve()
+        }),
+      })
+      const result = await _txController._determineTransactionCategory({
+        to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
+        data: 'abd',
+      })
+      assert.deepEqual(result, { transactionCategory: CONTRACT_INTERACTION_KEY, code: '0x0a' })
     })
   })
 


### PR DESCRIPTION
Replaces https://github.com/MetaMask/metamask-extension/pull/6603

Fixes #6602.

In cases where token method calls were being created without specifying `gas` , our `estimateTxGas` method was throwing an error because it is expecting `code` to be truthy. This PR defaults `code` to truthy and only sets it otherwise when necessary.