### PR TITLE
Fixes bugs in 6.5.1

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -343,7 +343,7 @@ module.exports = class MetamaskController extends EventEmitter {
     updatePublicConfigStore(this.getState())
 
     publicConfigStore.destroy = () => {
-      this.removeEventListener('update', updatePublicConfigStore)
+      this.removeEventListener && this.removeEventListener('update', updatePublicConfigStore)
     }
 
     function updatePublicConfigStore (memState) {

--- a/ui/lib/account-link.js
+++ b/ui/lib/account-link.js
@@ -1,5 +1,5 @@
 module.exports = function (address, network, rpcPrefs) {
-  if (rpcPrefs.blockExplorerUrl) {
+  if (rpcPrefs && rpcPrefs.blockExplorerUrl) {
     return `${rpcPrefs.blockExplorerUrl}/address/${address}`
   }
 


### PR DESCRIPTION
- When adding a hardware wallet the BG throws an exception [here](https://github.com/MetaMask/metamask-extension/compare/hotfix-6.5.2?expand=1#diff-fd8e90928ae2cc670d306c0244a894d0R346) - Non critical

- [This UI issue](https://github.com/MetaMask/metamask-extension/pull/6613/files#diff-aad72da902091a708bb42ad630e5b4d5R2) breaks several parts of the extension:  Hardware wallets & remove accounts. Probably other places too.

