### PR TITLE
bugfix: show extension window if locked regardless of approval

### DIFF
--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -38,7 +38,8 @@ class ProviderApprovalController extends SafeEventEmitter {
       // only handle requestAccounts
       if (req.method !== 'eth_requestAccounts') return next()
       // if already approved or privacy mode disabled, return early
-      if (this.shouldExposeAccounts(origin)) {
+      const isUnlocked = this.keyringController.memStore.getState().isUnlocked
+      if (this.shouldExposeAccounts(origin) && isUnlocked) {
         res.result = [this.preferencesController.getSelectedAddress()]
         return
       }


### PR DESCRIPTION
The new 1102 implementation short-circuits an `enable` call if privacy mode is disabled or if a cached approval exists, but the old implementation also checked if the extension was unlocked. I think this is the source of reported issues: we should always act as if no approval exists if the extension is locked, which gives users a chance to unlock it. This matches the functionality of the old implementation.

Resolves https://github.com/MetaMask/metamask-extension/issues/6618

**To test:**
1. Open a webpage.
2. Call `ethereum.enable()` from the console.
3. Log in and / or approve.
4. Log out of MetaMask.
5. Call `ethereum.enable()` again from the console.
6. You should be presented with a login and approval prompt again. Before this PR, nothing would happen.

