### PR TITLE
DO NOT MERGE - Separate Confirmation screen to different app

### DIFF
--- a/app/notification.html
+++ b/app/notification.html
@@ -12,6 +12,6 @@
   <body class="notification" style="height:600px;">
     <div id="app-content"></div>
     <script src="./libs.js" type="text/javascript" charset="utf-8"></script>
-    <script src="./ui.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./notification.js" type="text/javascript" charset="utf-8"></script>
   </body>
 </html>

--- a/app/scripts/notification.js
+++ b/app/scripts/notification.js
@@ -1,0 +1,75 @@
+const injectCss = require('inject-css')
+const NewMetaMaskUiCss = require('../../ui/css')
+const startPopup = require('./popup-core')
+const PortStream = require('extension-port-stream')
+const { getEnvironmentType } = require('./lib/util')
+const { ENVIRONMENT_TYPE_NOTIFICATION, ENVIRONMENT_TYPE_FULLSCREEN } = require('./lib/enums')
+const extension = require('extensionizer')
+const ExtensionPlatform = require('./platforms/extension')
+const NotificationManager = require('./lib/notification-manager')
+const notificationManager = new NotificationManager()
+const setupSentry = require('./lib/setupSentry')
+const log = require('loglevel')
+
+start().catch(log.error)
+
+async function start () {
+
+  // create platform global
+  global.platform = new ExtensionPlatform()
+
+  // setup sentry error reporting
+  const release = global.platform.getVersion()
+  setupSentry({ release, getState })
+  // provide app state to append to error logs
+  function getState () {
+    // get app state
+    const state = window.getCleanAppState()
+    // remove unnecessary data
+    delete state.localeMessages
+    delete state.metamask.recentBlocks
+    // return state to be added to request
+    return state
+  }
+
+  // identify window type (popup, notification)
+  const windowType = getEnvironmentType(window.location.href)
+  global.METAMASK_UI_TYPE = windowType
+  closePopupIfOpen(windowType)
+
+  // setup stream to background
+  const extensionPort = extension.runtime.connect({ name: windowType })
+  const connectionStream = new PortStream(extensionPort)
+
+  // start ui
+  const container = document.getElementById('app-content')
+  startPopup({ container, connectionStream }, (err, store) => {
+    if (err) return displayCriticalError(err)
+
+    const state = store.getState()
+    const { metamask: { completedOnboarding } = {} } = state
+
+    if (!completedOnboarding && windowType !== ENVIRONMENT_TYPE_FULLSCREEN) {
+      global.platform.openExtensionInBrowser()
+      return
+    }
+
+    injectCss(NewMetaMaskUiCss())
+  })
+
+
+  function closePopupIfOpen (windowType) {
+    if (windowType !== ENVIRONMENT_TYPE_NOTIFICATION) {
+      // should close only chrome popup
+      notificationManager.closePopup()
+    }
+  }
+
+  function displayCriticalError (err) {
+    container.innerHTML = '<div class="critical-error">The MetaMask app failed to load: please open and close MetaMask again to restart.</div>'
+    container.style.height = '80px'
+    log.error(err.stack)
+    throw err
+  }
+
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -306,6 +306,7 @@ const buildJsFiles = [
   'background',
   'ui',
   'phishing-detect',
+  'notification',
 ]
 
 // bundle tasks

--- a/ui/app/pages/notification.js
+++ b/ui/app/pages/notification.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+const PropTypes = require('prop-types')
+const { Provider } = require('react-redux')
+const { HashRouter } = require('react-router-dom')
+const Notification = require('./routes/notification')
+const I18nProvider = require('../helpers/higher-order-components/i18n-provider')
+const MetaMetricsProvider = require('../helpers/higher-order-components/metametrics/metametrics.provider')
+
+class Index extends Component {
+  render () {
+    const { store } = this.props
+
+    return (
+      <Provider store={store}>
+        <HashRouter hashType="noslash">
+          <MetaMetricsProvider>
+            <I18nProvider>
+              <Notification />
+            </I18nProvider>
+          </MetaMetricsProvider>
+        </HashRouter>
+      </Provider>
+    )
+  }
+}
+
+Index.propTypes = {
+  store: PropTypes.object,
+}
+
+module.exports = Index

--- a/ui/app/pages/routes/notification.js
+++ b/ui/app/pages/routes/notification.js
@@ -1,0 +1,394 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { Route, Switch, withRouter, matchPath } from 'react-router-dom'
+import { compose } from 'recompose'
+import actions from '../../store/actions'
+import log from 'loglevel'
+import IdleTimer from 'react-idle-timer'
+import {getMetaMaskAccounts, getNetworkIdentifier, preferencesSelector} from '../../selectors/selectors'
+
+// accounts
+const SendTransactionScreen = require('../send/send.container')
+const ConfirmTransaction = require('../confirm-transaction')
+
+// slideout menu
+const { WALLET_VIEW_SIDEBAR } = require('../../components/app/sidebars/sidebar.constants')
+
+// other views
+import Home from '../home'
+import Authenticated from '../../helpers/higher-order-components/authenticated'
+import Initialized from '../../helpers/higher-order-components/initialized'
+import Lock from '../lock'
+
+const Loading = require('../../components/ui/loading-screen')
+const LoadingNetwork = require('../../components/app/loading-network-screen').default
+
+import UnlockPage from '../unlock-page'
+
+import {
+  submittedPendingTransactionsSelector,
+} from '../../selectors/transactions'
+
+// Routes
+import {
+  DEFAULT_ROUTE,
+  LOCK_ROUTE,
+  UNLOCK_ROUTE,
+  SEND_ROUTE,
+  CONFIRM_TRANSACTION_ROUTE,
+  INITIALIZE_ROUTE,
+  INITIALIZE_UNLOCK_ROUTE,
+} from '../../helpers/constants/routes'
+
+// enums
+import {
+  ENVIRONMENT_TYPE_NOTIFICATION,
+  ENVIRONMENT_TYPE_POPUP,
+} from '../../../../app/scripts/lib/enums'
+
+class Routes extends Component {
+  componentWillMount () {
+    const { currentCurrency, setCurrentCurrencyToUSD } = this.props
+
+    if (!currentCurrency) {
+      setCurrentCurrencyToUSD()
+    }
+
+    this.props.history.listen((locationObj, action) => {
+      if (action === 'PUSH') {
+        const url = `&url=${encodeURIComponent('http://www.metamask.io/metametrics' + locationObj.pathname)}`
+        this.context.metricsEvent({}, {
+          currentPath: '',
+          pathname: locationObj.pathname,
+          url,
+          pageOpts: {
+            hideDimensions: true,
+          },
+        })
+      }
+    })
+  }
+
+  renderRoutes () {
+    const { autoLogoutTimeLimit, setLastActiveTime } = this.props
+
+    const routes = (
+      <Switch>
+        <Route path={LOCK_ROUTE} component={Lock} exact />
+        <Initialized path={UNLOCK_ROUTE} component={UnlockPage} exact />
+        <Authenticated path={`${CONFIRM_TRANSACTION_ROUTE}/:id?`} component={ConfirmTransaction} />
+        <Authenticated path={SEND_ROUTE} component={SendTransactionScreen} exact />
+        <Authenticated path={DEFAULT_ROUTE} component={Home} exact />
+      </Switch>
+    )
+
+    if (autoLogoutTimeLimit > 0) {
+      return (
+        <IdleTimer onAction={setLastActiveTime} throttle={1000}>
+          {routes}
+        </IdleTimer>
+      )
+    }
+
+    return routes
+  }
+
+  onInitializationUnlockPage () {
+    const { location } = this.props
+    return Boolean(matchPath(location.pathname, { path: INITIALIZE_UNLOCK_ROUTE, exact: true }))
+  }
+
+  onConfirmPage () {
+    const { location } = this.props
+    return Boolean(matchPath(location.pathname, { path: CONFIRM_TRANSACTION_ROUTE, exact: false }))
+  }
+
+  hasProviderRequests () {
+    const { providerRequests } = this.props
+    return Array.isArray(providerRequests) && providerRequests.length > 0
+  }
+
+  hideAppHeader () {
+    const { location } = this.props
+
+    const isInitializing = Boolean(matchPath(location.pathname, {
+      path: INITIALIZE_ROUTE, exact: false,
+    }))
+
+    if (isInitializing && !this.onInitializationUnlockPage()) {
+      return true
+    }
+
+    if (window.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION) {
+      return true
+    }
+
+    if (window.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_POPUP) {
+      return this.onConfirmPage() || this.hasProviderRequests()
+    }
+  }
+
+  render () {
+    const {
+      isLoading,
+      alertMessage,
+      loadingMessage,
+      network,
+      provider,
+      frequentRpcListDetail,
+      currentView,
+      setMouseUserState,
+      sidebar,
+      submittedPendingTransactions,
+    } = this.props
+    const isLoadingNetwork = network === 'loading' && currentView.name !== 'config'
+    const loadMessage = loadingMessage || isLoadingNetwork ?
+      this.getConnectingLabel(loadingMessage) : null
+    log.debug('Main ui render function')
+
+    const sidebarOnOverlayClose = sidebarType === WALLET_VIEW_SIDEBAR
+      ? () => {
+        this.context.metricsEvent({
+          eventOpts: {
+            category: 'Navigation',
+            action: 'Wallet Sidebar',
+            name: 'Closed Sidebare Via Overlay',
+          },
+        })
+      }
+      : null
+
+    const {
+      isOpen: sidebarIsOpen,
+      transitionName: sidebarTransitionName,
+      type: sidebarType,
+      props,
+    } = sidebar
+    const { transaction: sidebarTransaction } = props || {}
+
+    return (
+      <div
+        className="app"
+        onClick={() => setMouseUserState(true)}
+        onKeyDown={e => {
+          if (e.keyCode === 9) {
+            setMouseUserState(false)
+          }
+        }}
+      >
+        <div className="main-container-wrapper">
+          { isLoading && <Loading loadingMessage={loadMessage} /> }
+          { !isLoading && isLoadingNetwork && <LoadingNetwork /> }
+          { this.renderRoutes() }
+        </div>
+      </div>
+    )
+  }
+
+  toggleMetamaskActive () {
+    if (!this.props.isUnlocked) {
+      // currently inactive: redirect to password box
+      var passwordBox = document.querySelector('input[type=password]')
+      if (!passwordBox) return
+      passwordBox.focus()
+    } else {
+      // currently active: deactivate
+      this.props.dispatch(actions.lockMetamask(false))
+    }
+  }
+
+  getConnectingLabel = function (loadingMessage) {
+    if (loadingMessage) {
+      return loadingMessage
+    }
+    const { provider, providerId } = this.props
+    const providerName = provider.type
+
+    let name
+
+    if (providerName === 'mainnet') {
+      name = this.context.t('connectingToMainnet')
+    } else if (providerName === 'ropsten') {
+      name = this.context.t('connectingToRopsten')
+    } else if (providerName === 'kovan') {
+      name = this.context.t('connectingToKovan')
+    } else if (providerName === 'rinkeby') {
+      name = this.context.t('connectingToRinkeby')
+    } else if (providerName === 'localhost') {
+      name = this.context.t('connectingToLocalhost')
+    } else if (providerName === 'goerli') {
+      name = this.context.t('connectingToGoerli')
+    } else {
+      name = this.context.t('connectingTo', [providerId])
+    }
+
+    return name
+  }
+
+  getNetworkName () {
+    const { provider } = this.props
+    const providerName = provider.type
+
+    let name
+
+    if (providerName === 'mainnet') {
+      name = this.context.t('mainnet')
+    } else if (providerName === 'ropsten') {
+      name = this.context.t('ropsten')
+    } else if (providerName === 'kovan') {
+      name = this.context.t('kovan')
+    } else if (providerName === 'rinkeby') {
+      name = this.context.t('rinkeby')
+    } else if (providerName === 'localhost') {
+      name = this.context.t('localhost')
+    } else if (providerName === 'goerli') {
+      name = this.context.t('goerli')
+    } else {
+      name = this.context.t('unknownNetwork')
+    }
+
+    return name
+  }
+}
+
+Routes.propTypes = {
+  currentCurrency: PropTypes.string,
+  setCurrentCurrencyToUSD: PropTypes.func,
+  isLoading: PropTypes.bool,
+  loadingMessage: PropTypes.string,
+  alertMessage: PropTypes.string,
+  network: PropTypes.string,
+  provider: PropTypes.object,
+  frequentRpcListDetail: PropTypes.array,
+  currentView: PropTypes.object,
+  sidebar: PropTypes.object,
+  alertOpen: PropTypes.bool,
+  hideSidebar: PropTypes.func,
+  isOnboarding: PropTypes.bool,
+  isUnlocked: PropTypes.bool,
+  networkDropdownOpen: PropTypes.bool,
+  showNetworkDropdown: PropTypes.func,
+  hideNetworkDropdown: PropTypes.func,
+  setLastActiveTime: PropTypes.func,
+  history: PropTypes.object,
+  location: PropTypes.object,
+  dispatch: PropTypes.func,
+  toggleAccountMenu: PropTypes.func,
+  selectedAddress: PropTypes.string,
+  lostAccounts: PropTypes.array,
+  isInitialized: PropTypes.bool,
+  forgottenPassword: PropTypes.bool,
+  activeAddress: PropTypes.string,
+  unapprovedTxs: PropTypes.object,
+  seedWords: PropTypes.string,
+  submittedPendingTransactions: PropTypes.array,
+  unapprovedMsgCount: PropTypes.number,
+  unapprovedPersonalMsgCount: PropTypes.number,
+  unapprovedTypedMessagesCount: PropTypes.number,
+  welcomeScreenSeen: PropTypes.bool,
+  isPopup: PropTypes.bool,
+  isMouseUser: PropTypes.bool,
+  setMouseUserState: PropTypes.func,
+  t: PropTypes.func,
+  providerId: PropTypes.string,
+  providerRequests: PropTypes.array,
+  autoLogoutTimeLimit: PropTypes.number,
+}
+
+function mapStateToProps (state) {
+  const { appState, metamask } = state
+  const {
+    networkDropdownOpen,
+    sidebar,
+    alertOpen,
+    alertMessage,
+    isLoading,
+    loadingMessage,
+  } = appState
+
+  const accounts = getMetaMaskAccounts(state)
+  const { autoLogoutTimeLimit = 0 } = preferencesSelector(state)
+
+  const {
+    identities,
+    address,
+    keyrings,
+    isInitialized,
+    seedWords,
+    unapprovedTxs,
+    lostAccounts,
+    unapprovedMsgCount,
+    unapprovedPersonalMsgCount,
+    unapprovedTypedMessagesCount,
+    providerRequests,
+  } = metamask
+  const selected = address || Object.keys(accounts)[0]
+
+  return {
+    // state from plugin
+    networkDropdownOpen,
+    sidebar,
+    alertOpen,
+    alertMessage,
+    isLoading,
+    loadingMessage,
+    isInitialized,
+    isUnlocked: state.metamask.isUnlocked,
+    selectedAddress: state.metamask.selectedAddress,
+    currentView: state.appState.currentView,
+    activeAddress: state.appState.activeAddress,
+    transForward: state.appState.transForward,
+    isOnboarding: Boolean(seedWords || !isInitialized),
+    isPopup: state.metamask.isPopup,
+    seedWords: state.metamask.seedWords,
+    submittedPendingTransactions: submittedPendingTransactionsSelector(state),
+    unapprovedTxs,
+    unapprovedMsgs: state.metamask.unapprovedMsgs,
+    unapprovedMsgCount,
+    unapprovedPersonalMsgCount,
+    unapprovedTypedMessagesCount,
+    menuOpen: state.appState.menuOpen,
+    network: state.metamask.network,
+    provider: state.metamask.provider,
+    forgottenPassword: state.appState.forgottenPassword,
+    lostAccounts,
+    frequentRpcListDetail: state.metamask.frequentRpcListDetail || [],
+    currentCurrency: state.metamask.currentCurrency,
+    isMouseUser: state.appState.isMouseUser,
+    isRevealingSeedWords: state.metamask.isRevealingSeedWords,
+    Qr: state.appState.Qr,
+    welcomeScreenSeen: state.metamask.welcomeScreenSeen,
+    providerId: getNetworkIdentifier(state),
+    autoLogoutTimeLimit,
+
+    // state needed to get account dropdown temporarily rendering from app bar
+    identities,
+    selected,
+    keyrings,
+    providerRequests,
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    dispatch,
+    hideSidebar: () => dispatch(actions.hideSidebar()),
+    showNetworkDropdown: () => dispatch(actions.showNetworkDropdown()),
+    hideNetworkDropdown: () => dispatch(actions.hideNetworkDropdown()),
+    setCurrentCurrencyToUSD: () => dispatch(actions.setCurrentCurrency('usd')),
+    toggleAccountMenu: () => dispatch(actions.toggleAccountMenu()),
+    setMouseUserState: (isMouseUser) => dispatch(actions.setMouseUserState(isMouseUser)),
+    setLastActiveTime: () => dispatch(actions.setLastActiveTime()),
+  }
+}
+
+Routes.contextTypes = {
+  t: PropTypes.func,
+  metricsEvent: PropTypes.func,
+}
+
+module.exports = compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps)
+)(Routes)

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,6 +1,6 @@
 const render = require('react-dom').render
 const h = require('react-hyperscript')
-const Root = require('./app/pages')
+const Root = require('./app/pages/notification')
 const actions = require('./app/store/actions')
 const configureStore = require('./app/store/store')
 const txHelper = require('./lib/tx-helper')


### PR DESCRIPTION
**Want to kick off a discussion here @danjm @whymarrh - basically this is my approach**
- create new entry point for notification. this requires a new `Root`, `ui/index.js`, and new build process
- Remove all unnecessary component from new entry point

**This does the following for bundle sizes:**
- increase overall app size (new bundle needs to be created for notification)
- the new `notification.js` bundle is 7.4MB, comparing to `ui.js` at 10.4MB

**This is fairly good result for such a simple fix. I want to touch base with you on the following:**
- What do you think about making this PR production ready as first issue toward a bigger epic for minimizing notification load time? Likely won't make it for Thursday, but it's <1 week of work. This won't get us the minimalistic `notification.js` that we want, but we can shave off 3MB relatively easy.

**For the bigger epic, I would propose**
1. UI first - create a new 'Notification` standalone component. Only pull in the necessary UI components. 
2. Integrate - we will want to review redux store logic and remove unnecessary polling and caching. We might even want to consider creating a new store for this.


Wdyt? Feel free to bring to DM
