### PR TITLE
Add scripts to automate GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,22 @@ workflows:
   version: 2
   test_and_release:
     jobs:
+      - create_release_pull_request:
+          filters:
+            branches:
+              only:
+                - /^Version-v(\d+)[.](\d+)[.](\d+)/
       - prep-deps-npm
       - prep-build:
           requires:
             - prep-deps-npm
+      - create_github_release:
+          requires:
+            - prep-build
+          filters:
+            branches:
+              only:
+                - develop
       # - prep-docs:
       #    requires:
       #      - prep-deps-npm
@@ -71,6 +83,18 @@ workflows:
             - all-tests-pass
 
 jobs:
+  create_release_pull_request:
+    docker:
+      - image: circleci/node:8.15.1-browsers
+    steps:
+      - checkout
+      - run:
+          name: Create GitHub Pull Request for version
+          command: |
+            .circleci/scripts/release-bump-changelog-version
+            .circleci/scripts/release-bump-manifest-version
+            .circleci/scripts/release-create-release-pr
+
   prep-deps-npm:
     docker:
       - image: circleci/node:10.16-browsers
@@ -298,3 +322,15 @@ jobs:
       - run:
           name: All Tests Passed
           command: echo 'weew - everything passed!'
+
+  create_github_release:
+    docker:
+      - image: circleci/node:8.15.1-browsers
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Create GitHub release
+          command: |
+            .circleci/scripts/release-create-gh-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 workflows:
   version: 2
-  full_test:
+  test_and_release:
     jobs:
       - prep-deps-npm
       - prep-build:

--- a/.circleci/scripts/release-bump-changelog-version
+++ b/.circleci/scripts/release-bump-changelog-version
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+if [[ "${CI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CI environment variable must be set to true'
+    exit 1
+fi
+
+if [[ "${CIRCLECI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CIRCLECI environment variable must be set to true'
+    exit 1
+fi
+
+version="${CIRCLE_BRANCH/Version-v/}"
+
+if ! grep --quiet --fixed-strings "$version" CHANGELOG.md
+then
+    printf '%s\n' 'Adding this release to CHANGELOG.md'
+    date_str="$(date '+%a %b %d %Y')"
+    cp CHANGELOG.md{,.bak}
+
+update_headers=$(cat <<END
+/## Current Develop Branch/ {
+    print "## Current Develop Branch\n";
+    print "## ${version} ${date_str}";
+    next;
+}
+{
+    print;
+}
+END
+)
+
+    awk "$update_headers" CHANGELOG.md.bak > CHANGELOG.md
+    rm CHANGELOG.md.bak
+else
+    printf '%s\n' "CHANGELOG.md already includes a header for ${version}"
+    exit 0
+fi

--- a/.circleci/scripts/release-bump-manifest-version
+++ b/.circleci/scripts/release-bump-manifest-version
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+if [[ "${CI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CI environment variable must be set to true'
+    exit 1
+fi
+
+if [[ "${CIRCLECI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CIRCLECI environment variable must be set to true'
+    exit 1
+fi
+
+printf '%s\n' 'Updating the manifest version if needed'
+
+version="${CIRCLE_BRANCH/Version-v/}"
+updated_manifest="$(jq ".version = \"$version\"" app/manifest.json)"
+printf '%s\n' "$updated_manifest" > app/manifest.json
+
+if [[ -z $(git status --porcelain) ]]
+then
+    printf '%s\n' 'App manifest version already set'
+    exit 0
+fi
+
+git \
+    -c user.name='MetaMask Bot' \
+    -c user.email='metamaskbot@users.noreply.github.com' \
+    commit --message "${CIRCLE_BRANCH/-/ }" \
+        CHANGELOG.md app/manifest.json
+
+repo_slug="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+git push "https://$GITHUB_TOKEN_USER:$GITHUB_TOKEN@github.com/$repo_slug" "$CIRCLE_BRANCH"

--- a/.circleci/scripts/release-create-gh-release
+++ b/.circleci/scripts/release-create-gh-release
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -u
+set -o pipefail
+
+if [[ "${CI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CI environment variable must be set to true'
+    exit 1
+fi
+
+if [[ "${CIRCLECI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CIRCLECI environment variable must be set to true'
+    exit 1
+fi
+
+function install_github_cli ()
+{
+    printf '%s\n' 'Installing hub CLI'
+    pushd "$(mktemp -d)"
+        curl -sSL 'https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz' | tar xz
+        PATH="$PATH:$PWD/hub-linux-amd64-2.11.2/bin"
+    popd
+}
+
+current_commit_msg=$(git show -s --format='%s' HEAD)
+
+if grep --quiet '^Version v' <<< "$current_commit_msg"
+then
+    install_github_cli
+
+    printf '%s\n' 'Creating GitHub Release'
+    read -ra commit_words <<< "$current_commit_msg"
+    tag="${commit_words[1]}"
+    release_body="$(awk -v version="${tag##v}" -f .circleci/scripts/show-changelog.awk CHANGELOG.md)"
+    pushd builds
+        hub release create \
+            --attach metamask-chrome-*.zip \
+            --attach metamask-firefox-*.zip \
+            --message "${commit_words[0]} ${commit_words[1]#v}" \
+            --message "$release_body" \
+            --commitish "$CIRCLE_SHA1" \
+            "$tag"
+    popd
+else
+    printf '%s\n' 'Skipping GitHub Release'
+    exit 0
+fi

--- a/.circleci/scripts/release-create-release-pr
+++ b/.circleci/scripts/release-create-release-pr
@@ -45,6 +45,7 @@ install_github_cli
 printf '%s\n' "Creating a Pull Request for $version on GitHub"
 
 if ! hub pull-request \
+    --reviewer '@MetaMask/extension-release-team' \
     --message "${CIRCLE_BRANCH/-/ } RC" --message ':package: :rocket:' \
     --base "$CIRCLE_PROJECT_USERNAME:$base_branch" \
     --head "$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH";

--- a/.circleci/scripts/release-create-release-pr
+++ b/.circleci/scripts/release-create-release-pr
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+if [[ "${CI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CI environment variable must be set to true'
+    exit 1
+fi
+
+if [[ "${CIRCLECI:-}" != 'true' ]]
+then
+    printf '%s\n' 'CIRCLECI environment variable must be set to true'
+    exit 1
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]
+then
+    printf '%s\n' 'GITHUB_TOKEN environment variable must be set'
+    exit 1
+fi
+
+function install_github_cli ()
+{
+    printf '%s\n' 'Installing hub CLI'
+    pushd "$(mktemp -d)"
+        curl -sSL 'https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz' | tar xz
+        PATH="$PATH:$PWD/hub-linux-amd64-2.11.2/bin"
+    popd
+}
+
+version="${CIRCLE_BRANCH/Version-v/}"
+base_branch='develop'
+
+if [[ -n "${CI_PULL_REQUEST:-}" ]]
+then
+    printf '%s\n' 'CI_PULL_REQUEST is set, pull request already exists for this build'
+    exit 0
+fi
+
+install_github_cli
+
+printf '%s\n' "Creating a Pull Request for $version on GitHub"
+
+if ! hub pull-request \
+    --message "${CIRCLE_BRANCH/-/ } RC" --message ':package: :rocket:' \
+    --base "$CIRCLE_PROJECT_USERNAME:$base_branch" \
+    --head "$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH";
+then
+    printf '%s\n' 'Pull Request already exists'
+fi

--- a/.circleci/scripts/show-changelog.awk
+++ b/.circleci/scripts/show-changelog.awk
@@ -1,0 +1,52 @@
+# DESCRIPTION
+#
+# This script will print out all of the CHANGELOG.md lines for a given version
+# with the assumption that the CHANGELOG.md files looks something along the
+# lines of:
+#
+# ```
+# ## 6.6.2 Fri Jun 07 2019
+#
+# - [#6690](https://github.com/MetaMask/metamask-extension/pull/6690): Some words
+# - [#6700](https://github.com/MetaMask/metamask-extension/pull/6700): some more words
+#
+# ## 6.6.1 Thu Jun 06 2019
+#
+# - [#6691](https://github.com/MetaMask/metamask-extension/pull/6691): Revert other words
+#
+# ## 6.6.0 Mon Jun 03 2019
+#
+# - [#6659](https://github.com/MetaMask/metamask-extension/pull/6659): foo
+# - [#6671](https://github.com/MetaMask/metamask-extension/pull/6671): bar
+# - [#6625](https://github.com/MetaMask/metamask-extension/pull/6625): baz
+# - [#6633](https://github.com/MetaMask/metamask-extension/pull/6633): Many many words
+#
+#
+# ```
+#
+# EXAMPLE
+#
+# Run this script like so, passing in the version:
+#
+# ```
+# awk -v version='6.6.0' -f .circleci/scripts/show-changelog.awk CHANGELOG.md
+# ```
+#
+
+BEGIN {
+    inside_section = 0;
+}
+
+$1 == "##" && $2 == version {
+    inside_section = 1;
+    next;
+}
+
+$1 == "##" && $2 != version {
+    inside_section = 0;
+    next;
+}
+
+inside_section && !/^$/ {
+    print $0;
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ package
 .vscode
 .sublime-project
 
+*.bak
+
 # VIM
 *.swp
 *.swo


### PR DESCRIPTION
This PR updates our CircleCI configuration, adding new 1 new job and 1 new workflow to automate parts of our release process. The work here ultimately results in a GitHub Release with the artifacts from `npm run dist` attached.

### The Workflow

The high-level workflow is:

- A version branch is created off of `develop`
    1. CI sets the manifest version and commits that
    2. CI creates a Pull Request for the version
- When the Pull Request gets merged, CI creates a tag and GitHub Release for the commit

I've been playing around with the configuration on my fork, if you want to look at the [CI builds](https://circleci.com/gh/whymarrh/workflows/metamask-extension) for that repository:

- An example set of version branch builds: https://circleci.com/workflow-run/375c708c-9ae9-4264-9815-0ead4e3055b6
- An example `develop` build: https://circleci.com/workflow-run/83240798-7fea-4d4c-811f-e45cb2202618

#### Step 1: Creating a RC Pull Request

**End result:** a pull request for the version is created

**Process:** when a branch is created matching `^Version-v\d+[.]\d+[.]\d+`, a CI job will use the version number from the branch name to update the version field in the manifest, and create a PR for that change. That PR can then be reviewed and updated as appropriate. When we go to merge the PR, we can squash+merge the changes into a single commit with the message `Version vX.Y.Z`.

#### Step 2: Creating a GitHub Release

**End result:** a release is created with the Chrome and Firefox builds attached

**Process:** when a commit to `develop` is made with a message matching `^Version v\d+[.]\d+[.]\d+`. the CI build for that commit will include tagging it as `vX.Y.Z` and creating a release with the Chrome and Firefox builds as assets.

### ~Unanswered~ Questions

- [x] ~How do we want to deal with `CHANGELOG.md`?~ Scripts added to update the changelog
- [x] ~Who should we set as reviewers on the RC PR?~ `@MetaMask/extension-release-team`

## Tasks

- [x] Set `GITHUB_TOKEN` and `GITHUB_TOKEN_USER` environment variables in CircleCI
- [x] Double-check copy

### Refs

- Closes https://github.com/MetaMask/metamask-extension/issues/3403
- [Using Workflows to Schedule Jobs](https://circleci.com/docs/2.0/workflows/)
- [Configuring CircleCI](https://circleci.com/docs/2.0/configuration-reference/)
