### PR TITLE
Remove clipboardWrite permission

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -65,7 +65,6 @@
   "permissions": [
     "storage",
     "unlimitedStorage",
-    "clipboardWrite",
     "http://localhost:8545/",
     "https://*.infura.io/",
     "activeTab",


### PR DESCRIPTION
This PR removes the `clipboardWrite` permission from the manifest as the permission isn't required for extensions to be able to write to the clipboard. From the Google Chrome developer docs:<sup>[\[1\]](https://developer.chrome.com/apps/declare_permissions)</sup>

> Indicates the extension or app uses `document.execCommand('copy')` or `document.execCommand('cut')`. This permission is required for hosted apps; it's recommended for extensions and packaged apps.

This PR removes the following permissions from the app manifest.

## Before

<img width="1330" alt="Screen Shot 2019-05-23 at 10 25 36" src="https://user-images.githubusercontent.com/1623628/58257317-467b0f80-7d4b-11e9-93c0-2e1f7ae2e15b.png">

## After 

<img width="1330" alt="Screen Shot 2019-05-23 at 10 34 40" src="https://user-images.githubusercontent.com/1623628/58257334-4e3ab400-7d4b-11e9-8a94-dbce44fde1b9.png">
