### PR TITLE
Allow eip712 signatures to use 712Domain as primaryType

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eth-method-registry": "^1.2.0",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
-    "eth-sig-util": "^2.0.2",
+    "eth-sig-util": "2.2.0",
     "eth-token-tracker": "^1.1.5",
     "eth-trezor-keyring": "^0.4.0",
     "ethereumjs-abi": "^0.6.4",


### PR DESCRIPTION
As discussed here:
https://ethereum-magicians.org/t/eip-712-standards-clarification-primarytype-as-domaintype/3286

And merged in sig-util here:
https://github.com/MetaMask/eth-sig-util/pull/51

Allows the creation of cheaper-to-verify signatures. Cheers to @SilentSicero