### PR TITLE
bugfix: reject enable promise on user rejection

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -33,8 +33,8 @@ inpageProvider.setMaxListeners(100)
 inpageProvider.enable = function ({ force } = {}) {
   return new Promise((resolve, reject) => {
     inpageProvider.sendAsync({ method: 'eth_requestAccounts', params: [force] }, (error, response) => {
-      if (error) {
-        reject(error)
+      if (error || response.error) {
+        reject(error || response.error)
       } else {
         resolve(response.result)
       }


### PR DESCRIPTION
This pull request checks for both types of possible RPC errors (the `error` argument and `result.error`) and rejects the `Promise` returned by `ethereum.enable` accordingly.

Fixes https://github.com/MetaMask/metamask-extension/issues/6631