### PR TITLE
Feature: sync with mobile v2

### DIFF
--- a/ui/app/pages/mobile-sync/index.js
+++ b/ui/app/pages/mobile-sync/index.js
@@ -65,6 +65,11 @@ class MobileSyncPage extends Component {
     this.channelName = `mm-${PubNub.generateUUID()}`
   }
 
+  initWithCipherKeyAndChannelName (cipherKey, channelName) {
+    this.cipherKey = cipherKey
+    this.channelName = channelName
+  }
+
   initWebsockets () {
     this.pubnub = new PubNub({
       subscribeKey: process.env.PUBNUB_SUB_KEY,
@@ -83,6 +88,10 @@ class MobileSyncPage extends Component {
 
         if (message.event === 'start-sync') {
             this.startSyncing()
+        } else if (message.event === 'connection-info') {
+            this.initWithCipherKeyAndChannelName(message.cipher, message.channel)
+            this.disconnectWebsockets()
+            this.initWebsockets()
         } else if (message.event === 'end-sync') {
             this.disconnectWebsockets()
             this.setState({syncing: false, completed: true})

--- a/ui/app/pages/mobile-sync/index.js
+++ b/ui/app/pages/mobile-sync/index.js
@@ -68,7 +68,7 @@ class MobileSyncPage extends Component {
     this.generateCipherKeyAndChannelName()
     this.initWebsockets()
     this.handle = setTimeout(() => {
-      this.startKeysGenerator()
+      this.startKeysGeneration()
     }, KEYS_GENERATION_TIME)
   }
 

--- a/ui/app/pages/mobile-sync/index.js
+++ b/ui/app/pages/mobile-sync/index.js
@@ -73,20 +73,21 @@ class MobileSyncPage extends Component {
   }
 
   generateCipherKeyAndChannelName () {
-    const cipherKey = `${this.props.selectedAddress.substr(-4)}-${PubNub.generateUUID()}`
-    const channelName = `mm-${PubNub.generateUUID()}`
-    this.setState({cipherKey, channelName})
+    this.cipherKey = `${this.props.selectedAddress.substr(-4)}-${PubNub.generateUUID()}`
+    this.channelName = `mm-${PubNub.generateUUID()}`
+    this.setState({cipherKey: this.cipherKey, channelName: this.channelName})
   }
 
   initWithCipherKeyAndChannelName (cipherKey, channelName) {
-    this.setState({cipherKey, channelName})
+    this.cipherKey = cipherKey
+    this.channelName = channelName
   }
 
   initWebsockets () {
     this.pubnub = new PubNub({
       subscribeKey: process.env.PUBNUB_SUB_KEY,
       publishKey: process.env.PUBNUB_PUB_KEY,
-      cipherKey: this.state.cipherKey,
+      cipherKey: this.cipherKey,
       ssl: true,
     })
 
@@ -94,7 +95,7 @@ class MobileSyncPage extends Component {
       message: (data) => {
         const {channel, message} = data
         // handle message
-        if (channel !== this.state.channelName || !message) {
+        if (channel !== this.channelName || !message) {
           return false
         }
 
@@ -102,8 +103,8 @@ class MobileSyncPage extends Component {
             this.startSyncing()
         } else if (message.event === 'connection-info') {
             this.handle && clearTimeout(this.handle)
-            this.initWithCipherKeyAndChannelName(message.cipher, message.channel)
             this.disconnectWebsockets()
+            this.initWithCipherKeyAndChannelName(message.cipher, message.channel)
             this.initWebsockets()
         } else if (message.event === 'end-sync') {
             this.disconnectWebsockets()
@@ -113,7 +114,7 @@ class MobileSyncPage extends Component {
     })
 
     this.pubnub.subscribe({
-      channels: [this.state.channelName],
+      channels: [this.channelName],
       withPresence: false,
     })
 
@@ -149,7 +150,7 @@ class MobileSyncPage extends Component {
             event: 'error-sync',
             data: errorMsg,
           },
-          channel: this.state.channelName,
+          channel: this.channelName,
           sendByPost: false, // true to send via post
           storeInHistory: false,
       },
@@ -205,7 +206,7 @@ class MobileSyncPage extends Component {
               totalPkg: count,
               currentPkg: pkg,
             },
-            channel: this.state.channelName,
+            channel: this.channelName,
             sendByPost: false, // true to send via post
             storeInHistory: false,
         },


### PR DESCRIPTION
This PR updates how sync with mobile works.

A new code will be generated each 30 seconds of QR view opened, if there is no communication with mobile app

Communication goes as follows:
- Extension defines `cipherKey` and `channelName` to first communication with mobile
- Mobile app connects and gives the extension new `cipherKey` and `channelName`, for the extension to connect.
- Extension connects and sync happens
