### PR TITLE
Revert "Remove clipboardWrite permission"

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -65,6 +65,7 @@
   "permissions": [
     "storage",
     "unlimitedStorage",
+    "clipboardWrite",
     "http://localhost:8545/",
     "https://*.infura.io/",
     "activeTab",


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#6654

Since I’d like us to have a release cut soon, and there were some new concerns raised over whether this would prompt all users with a new permissions request (which resulted in a dramatic dropoff of users last time it happened), I’m opening this revert PR that I propose merging before cutting our next release.