### PR TITLE
Version 6.6.2 RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Current Develop Branch
 
+## 6.6.2 Fri Jun 07 2019
+
+- [#6690](https://github.com/MetaMask/metamask-extension/pull/6690): Update dependencies, re-enable npm audit CI job
+
 ## 6.6.1 Thu Jun 06 2019
 
 - [#6691](https://github.com/MetaMask/metamask-extension/pull/6691): Revert "Improve ENS Address Input" to fix bugs on input field on non-main networks.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "__MSG_appDescription__",


### PR DESCRIPTION
Includes [many updated dependencies (as visible in this PR)](https://github.com/MetaMask/metamask-extension/pull/6690), so I'm drafting this RC very soon after our last release (6.6.1) for a potentially longer security review & QA period (Thinking we could publish this no sooner than Monday, June 17 2019)

I recommend the use of a dependency-diffing tool in particular for finding potential introduced vulnerabilities by this change, like [npmfs](https://npmfs.com/).