### PR TITLE
Fix styles on 'import account' page, update help link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Develop Branch
 
+- [#6700](https://github.com/MetaMask/metamask-extension/pull/6700): Fix styles on 'import account' page, update help link
+
 ## 6.6.1 Thu Jun 06 2019
 
 - [#6691](https://github.com/MetaMask/metamask-extension/pull/6691): Revert "Improve ENS Address Input" to fix bugs on input field on non-main networks.

--- a/ui/app/css/itcss/components/new-account.scss
+++ b/ui/app/css/itcss/components/new-account.scss
@@ -143,6 +143,7 @@
     flex-flow: column;
     align-items: center;
     margin-top: 29px;
+    width: 100%;
   }
 
   &__buttons {

--- a/ui/app/pages/create-account/import-account/json.js
+++ b/ui/app/pages/create-account/import-account/json.js
@@ -8,8 +8,9 @@ const actions = require('../../../store/actions')
 const FileInput = require('react-simple-file-input').default
 const { DEFAULT_ROUTE } = require('../../../helpers/constants/routes')
 const { getMetaMaskAccounts } = require('../../../selectors/selectors')
-const HELP_LINK = 'https://support.metamask.io/kb/article/7-importing-accounts'
 import Button from '../../../components/ui/button'
+
+const HELP_LINK = 'https://metamask.zendesk.com/hc/en-us/articles/360015489351-Importing-Accounts'
 
 class JsonImportSubview extends Component {
   constructor (props) {
@@ -37,10 +38,11 @@ class JsonImportSubview extends Component {
           readAs: 'text',
           onLoad: this.onLoad.bind(this),
           style: {
-            margin: '20px 0px 12px 34%',
+            padding: '20px 0px 12px 15%',
             fontSize: '15px',
             display: 'flex',
             justifyContent: 'center',
+            width: '100%',
           },
         }),
 


### PR DESCRIPTION
1. The `File import not working? Click here!` link was broken. I changed it to https://metamask.zendesk.com/hc/en-us/articles/360015489351-Importing-Accounts (however it describes only Chrome workaround, can someone update it? Related issue: #3313).
2. Fixed styles for Firefox. Before:

![Screenshot from 2019-06-09 15-44-21](https://user-images.githubusercontent.com/1660460/59159324-b968e200-8ad0-11e9-86d3-1ff64091661b.png)

After:

![Screenshot from 2019-06-09 15-51-45](https://user-images.githubusercontent.com/1660460/59159328-bec62c80-8ad0-11e9-88e1-835b0b3b7393.png)

