### PR TITLE
pin ethereumjs-tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "eth-token-tracker": "^1.1.5",
     "eth-trezor-keyring": "^0.4.0",
     "ethereumjs-abi": "^0.6.4",
-    "ethereumjs-tx": "^1.3.7",
+    "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",
     "etherscan-link": "^1.0.2",


### PR DESCRIPTION
Pin ethereumjs-tx v1.3.7, until we can change to the new behavior in v2.0.0. Changes are [here](https://github.com/ethereumjs/ethereumjs-tx/releases/tag/v2.0.0).