### PR TITLE
Wrap smaller custom block explorer url text

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1742,6 +1742,9 @@
   "viewAccount": {
     "message": "View Account"
   },
+  "viewinExplorer": {
+    "message": "View in Explorer"
+  },
   "viewOnCustomBlockExplorer": {
     "message": "View at $1"
   },

--- a/ui/app/components/app/dropdowns/account-details-dropdown.js
+++ b/ui/app/components/app/dropdowns/account-details-dropdown.js
@@ -119,8 +119,11 @@ AccountDetailsDropdown.prototype.render = function () {
         this.props.onClose()
       },
       text: (rpcPrefs.blockExplorerUrl
-        ? this.context.t('blockExplorerView', [rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/)[1]])
+        ? this.context.t('viewinExplorer')
         : this.context.t('viewOnEtherscan')),
+      subText: (rpcPrefs.blockExplorerUrl
+        ? rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/)[1]
+        : null),
       icon: h(`img`, { src: 'images/open-etherscan.svg', style: { height: '15px' } }),
     }),
     isRemovable ? h(Item, {

--- a/ui/app/components/app/dropdowns/components/menu.js
+++ b/ui/app/components/app/dropdowns/components/menu.js
@@ -20,16 +20,18 @@ Item.prototype.render = function () {
     icon,
     children,
     text,
+    subText,
     className = '',
     onClick,
   } = this.props
   const itemClassName = `menu__item ${className} ${onClick ? 'menu__item--clickable' : ''}`
   const iconComponent = icon ? h('div.menu__item__icon', [icon]) : null
   const textComponent = text ? h('div.menu__item__text', text) : null
+  const subTextComponent = subText ? h('div.menu__item__subtext', subText) : null
 
   return children
     ? h('div', { className: itemClassName, onClick }, children)
-    : h('div.menu__item', { className: itemClassName, onClick }, [ iconComponent, textComponent ]
+    : h('div.menu__item', { className: itemClassName, onClick }, [ iconComponent, textComponent, subTextComponent ]
       .filter(d => Boolean(d))
     )
 }

--- a/ui/app/css/itcss/components/menu.scss
+++ b/ui/app/css/itcss/components/menu.scss
@@ -8,7 +8,7 @@
   &__item {
     padding: 18px;
     display: flex;
-    flex-flow: row nowrap;
+    flex-flow: row wrap;
     align-items: center;
     position: relative;
     z-index: 201;
@@ -38,6 +38,11 @@
     &__text {
       font-size: 16px;
       line-height: 21px;
+    }
+
+    &__subtext {
+      font-size: 12px;
+      padding: 5px 0px 0px 30px;
     }
   }
 


### PR DESCRIPTION
Replaces PR #6594. with the updated design. 

- Add a different message for account-details-dropdown message
- Add Menu Item subtext for custom block explorer url
- Adjust CSS for Menu dropdown and subtext

![wrap-smaller-custom-explorer-text](https://user-images.githubusercontent.com/13376180/59540842-c8c2a380-8eb3-11e9-9e0a-a53c667a22fd.png)
