### PR TITLE
Add codeowner for package*.json files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
+package*.json                        @whymarrh
 ui/                                  @danjm @whymarrh
 app/scripts/controllers/transactions @frankiebee
 


### PR DESCRIPTION
This PR adds myself as a codeowner for the `package.json` and `package-lock.json` file as the changes to the lockfile are best reviewed. I have and will continue to review the diffs of the lockfile for the correct hash and package version changes.