### PR TITLE
Handle whitespace-only strings during seed phrase import

### DIFF
--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -30,10 +30,12 @@ export default class ImportWithSeedPhrase extends PureComponent {
   }
 
   parseSeedPhrase = (seedPhrase) => {
-    return seedPhrase
-      .trim()
-      .match(/\w+/g)
-      .join(' ')
+    const trimmed = seedPhrase.trim()
+    if (!trimmed) {
+      return ''
+    }
+
+    return trimmed.match(/\w+/g).join(' ')
   }
 
   componentWillMount () {

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -30,12 +30,21 @@ export default class ImportWithSeedPhrase extends PureComponent {
   }
 
   parseSeedPhrase = (seedPhrase) => {
+    if (!seedPhrase) {
+      return ''
+    }
+
     const trimmed = seedPhrase.trim()
     if (!trimmed) {
       return ''
     }
 
-    return trimmed.match(/\w+/g).join(' ')
+    const words = trimmed.match(/\w+/g)
+    if (!words) {
+      return ''
+    }
+
+    return words.join(' ')
   }
 
   componentWillMount () {

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
@@ -53,5 +53,26 @@ describe('ImportWithSeedPhrase Component', () => {
 
       assert.deepEqual(parseSeedPhrase('   '), '')
     })
+
+    it('should return an empty string when given a string with only symbols', () => {
+      const root = shallowRender({
+        onSubmit: sinon.spy(),
+      })
+
+      const {parseSeedPhrase} = root.instance()
+
+      assert.deepEqual(parseSeedPhrase('$'), '')
+    })
+
+    it('should return an empty string for both null and undefined', () => {
+      const root = shallowRender({
+        onSubmit: sinon.spy(),
+      })
+
+      const {parseSeedPhrase} = root.instance()
+
+      assert.deepEqual(parseSeedPhrase(undefined), '')
+      assert.deepEqual(parseSeedPhrase(null), '')
+    })
   })
 })

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import assert from 'assert'
+import { shallow } from 'enzyme'
+import sinon from 'sinon'
+import ImportWithSeedPhrase from '../import-with-seed-phrase.component'
+
+function shallowRender (props = {}, context = {}) {
+  return shallow(<ImportWithSeedPhrase {...props} />, {
+    context: {
+      t: str => str + '_t',
+      metricsEvent: sinon.spy(),
+      ...context,
+    },
+  })
+}
+
+describe('ImportWithSeedPhrase Component', () => {
+  it('should render without error', () => {
+    const root = shallowRender({
+      onSubmit: sinon.spy(),
+    })
+    const textareaCount = root.find('.first-time-flow__textarea').length
+    assert.equal(textareaCount, 1, 'should render 12 seed phrases')
+  })
+
+  describe('parseSeedPhrase', () => {
+    it('should handle a regular seed phrase', () => {
+      const root = shallowRender({
+        onSubmit: sinon.spy(),
+      })
+
+      const {parseSeedPhrase} = root.instance()
+
+      assert.deepEqual(parseSeedPhrase('foo bar baz'), 'foo bar baz')
+    })
+
+    it('should trim extraneous whitespace from the given seed phrase', () => {
+      const root = shallowRender({
+        onSubmit: sinon.spy(),
+      })
+
+      const {parseSeedPhrase} = root.instance()
+
+      assert.deepEqual(parseSeedPhrase('  foo   bar   baz  '), 'foo bar baz')
+    })
+  })
+})

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
@@ -43,5 +43,15 @@ describe('ImportWithSeedPhrase Component', () => {
 
       assert.deepEqual(parseSeedPhrase('  foo   bar   baz  '), 'foo bar baz')
     })
+
+    it('should return an empty string when given a whitespace-only string', () => {
+      const root = shallowRender({
+        onSubmit: sinon.spy(),
+      })
+
+      const {parseSeedPhrase} = root.instance()
+
+      assert.deepEqual(parseSeedPhrase('   '), '')
+    })
   })
 })


### PR DESCRIPTION
Fixes #6694

This PR fixes our parsing of seed phrases during import to handle the case where a user tries to import a seed phrase that consists solely of whitespace. We no longer produce an error and instead treat it as an incorrect seed phrase.