### PR TITLE
Fix 'watch' npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "mozilla-lint": "addons-linter dist/firefox",
-    "watch": "mocha watch --recursive \"test/unit/**/*.js\"",
+    "watch": "cross-env METAMASK_ENV=test mocha --watch --require test/setup.js --reporter min --recursive \"test/unit/**/*.js\" \"ui/app/**/*.test.js\"",
     "disc": "gulp disc --debug",
     "announce": "node development/announcer.js",
     "version:bump": "node development/run-version-bump.js",


### PR DESCRIPTION
The `watch` npm script did not work - it must have gone unused for some
time. The following changes were required for it to work:
* Use the `--watch` flag, rather than the `watch` command (which appears
to not exist)
* Set the `METAMASK_ENV` environment variable to "test"
* Include the tests in the `ui` directory
* require the `test/setup.js` file before running the tests

The reporter was also changed to `min`, which is generally recommended
for use with the `--watch` flag.