### PR TITLE
Improve auto changelog script

### DIFF
--- a/development/auto-changelog.sh
+++ b/development/auto-changelog.sh
@@ -1,26 +1,50 @@
-#! /bin/bash
-# update tags
+#!/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+readonly URL='https://github.com/MetaMask/metamask-extension'
+
 git fetch --tags
-# get origin
-URL='https://github.com/MetaMask/metamask-extension'
-# get git logs from last tag until HEAD, pretty by 'subject::body' filtered by grep for PRs made with Github squash merge or Github regular merge
-LOG=$(git log $(git describe --tags $(git rev-list --tags --max-count=1))..HEAD --pretty="%s::%b" --reverse --grep="Merge pull request #" --grep="(#");
-while read -r line; do
-    # get git log subject
-    SUBJECT=$(echo $line | sed -E 's/(.*):{2}(.*)/\1/')
-    # get git log PR id, PR made with Github squash merge or Github regular merge
-    PR=$(echo $SUBJECT | sed 's/^.*(#\([^&]*\)).*/\1/' | sed 's/^.*#\([^&]*\) from.*/\1/')
-    # if PR made with Github squash merge, subject is the body
-    if [ -z "$(echo $line | sed -E 's/(.*):{2}(.*)/\2/')" ]; then
-        BODY=$(echo $SUBJECT | sed "s/(#$PR)//g"); else
-        BODY=$(echo $line | sed -E 's/(.*):{2}(.*)/\2/') 
+
+most_recent_tag="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
+
+readarray -t commits <<< "$(git rev-list "${most_recent_tag}"..HEAD)"
+
+for commit in "${commits[@]}"
+do
+    subject="$(git show -s --format="%s" "$commit")"
+
+    # Gets PR id embedded in commit subject, for PRs merged with Github squash merge or regular merge
+    if grep -E -q '\(#[[:digit:]]+\)|#[[:digit:]]+\sfrom' <<< "$subject"
+    then
+        # shellcheck disable=SC2001
+        pr="$(printf "%s" "$subject" | sed 's/^.*#\([[:digit:]]\+\).*$/\1/')"
+        prefix="[#$pr]($URL/pull/$pr): "
+    else
+        pr=''
+        prefix=''
     fi
+
+    body="$(git show -s --format="%b" "$commit" | head -n 1 | tr -d '\r')"
+    if [[ -z "$body" ]]
+    then
+        # shellcheck disable=SC2001
+        body="$(printf "%s" "$subject" | sed "s/\s*(#$pr)//g")"
+    fi
+
     # add entry to CHANGELOG
-    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    if [[ "$OSTYPE" == "linux-gnu" ]]
+    then
+        # shellcheck disable=SC1004
         sed -i'' '/## Current Develop Branch/a\
-- [#'"$PR"']('"$URL"'/pull/'"$PR"'): '"$BODY"''$'\n' CHANGELOG.md; else
+- '"$prefix$body"''$'\n' CHANGELOG.md
+    else
+        # shellcheck disable=SC1004
         sed -i '' '/## Current Develop Branch/a\
-- [#'"$PR"']('"$URL"'/pull/'"$PR"'): '"$BODY"''$'\n' CHANGELOG.md;
+- '"$prefix$body"''$'\n' CHANGELOG.md
     fi
-done <<< "$LOG"
+done
+
 echo 'CHANGELOG updated'

--- a/development/auto-changelog.sh
+++ b/development/auto-changelog.sh
@@ -19,7 +19,7 @@ do
     # Squash & Merge: the commit subject is parsed as `<description> (#<PR ID>)`
     if grep -E -q '\(#[[:digit:]]+\)' <<< "$subject"
     then
-        pr="$(awk '{print $NF}' <<< "$subject")"
+        pr="$(awk '{print $NF}' <<< "$subject" | tr -d '()')"
         prefix="[$pr]($URL/pull/${pr###}): "
         description="$(awk '{NF--; print $0}' <<< "$subject")"
 

--- a/development/auto-changelog.sh
+++ b/development/auto-changelog.sh
@@ -10,9 +10,7 @@ git fetch --tags
 
 most_recent_tag="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
 
-readarray -t commits <<< "$(git rev-list "${most_recent_tag}"..HEAD)"
-
-for commit in "${commits[@]}"
+git rev-list "${most_recent_tag}"..HEAD | while read commit
 do
     subject="$(git show -s --format="%s" "$commit")"
 


### PR DESCRIPTION
The auto changelog script was creating empty or invalid entries in a number of different cases, such as when the body of a commit spanned multiple lines. This has been fixed, and the following additional improvements have been made:

- Error handling (it will now crash upon encountering an error)
- Commits without a PR number in the subject are listed without the PR
prefix
- Invalid shellcheck warnings ignored
- Only the first line of the commit body is shown
- Carriage returns are stripped (some commits contain them)

This script should be more reliable for helping to manually update the changelog. It's still not sufficiently robust to use as part of an automated process - I don't think that's feasible without maintaining stricter control over commit messages conventions and/or merge strategies.