### PR TITLE
Generate complete source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "browserify": {
     "transform": [
       "babelify",
-      "reactify",
       "brfs"
     ]
   },


### PR DESCRIPTION
The source maps generated previously were mapping the bundled files to the post-Babel files - they weren't mapping to the source files as written.

It looks like this was a result of `reactify` being used in addition to babel - that transformation must have dropped the source maps.

`reactify` still needs to be listed as a dependency because it is an unlisted requirement of the `boron` package, which we use. We don't need to use it to create our bundles though, as Babel already performs the transformations we need.

Before changes:
![with_reactify](https://user-images.githubusercontent.com/2459287/60204592-8b500580-9825-11e9-93b9-d29f9b73bfd9.png)

After changes:
![without_reactify](https://user-images.githubusercontent.com/2459287/60204599-9014b980-9825-11e9-8375-26ead56f0015.png)


