### PR TITLE
Fix seed phrase import back button

### DIFF
--- a/ui/app/pages/keychains/restore-vault.js
+++ b/ui/app/pages/keychains/restore-vault.js
@@ -123,6 +123,7 @@ class RestoreVaultPage extends Component {
               className="import-account__back-button"
               onClick={e => {
                 e.preventDefault()
+                this.props.leaveImportSeedScreenState()
                 this.props.history.goBack()
               }}
               href="#"


### PR DESCRIPTION
The back button on the import seed phrase page leaves the Redux store with `appState.forgottenPassword` set to true, which prevents the user from logging in. That flag is now unset when the user leaves the page.

Fixes #6740