### PR TITLE
Fixes invalid prop error, correctly types nextRoute

### DIFF
--- a/ui/app/pages/first-time-flow/first-time-flow.component.js
+++ b/ui/app/pages/first-time-flow/first-time-flow.component.js
@@ -29,7 +29,7 @@ export default class FirstTimeFlow extends PureComponent {
     isInitialized: PropTypes.bool,
     isUnlocked: PropTypes.bool,
     unlockAccount: PropTypes.func,
-    nextRoute: PropTypes.func,
+    nextRoute: PropTypes.string,
   }
 
   state = {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/6760

Changes `nextRoute` type from `PropTypes.func` -> `PropTypes.string`

cc: @danfinlay @whymarrh 