### PR TITLE
Update asmcrypto.js to latest version

### DIFF
--- a/app/scripts/edge-encryptor.js
+++ b/app/scripts/edge-encryptor.js
@@ -74,8 +74,10 @@ class EdgeEncryptor {
 
       var passBuffer = Unibabel.utf8ToBuffer(password)
       var saltBuffer = Unibabel.base64ToBuffer(salt)
+      const iterations = 10000
+      const length = 32 // SHA256 hash size
       return new Promise((resolve) => {
-          var key = asmcrypto.PBKDF2_HMAC_SHA256.bytes(passBuffer, saltBuffer, 10000)
+          var key = asmcrypto.Pbkdf2HmacSha256(passBuffer, saltBuffer, iterations, length)
           resolve(key)
       })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7885,9 +7885,9 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asmcrypto.js": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
-      "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
+      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
     },
     "asn1": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@sentry/browser": "^4.1.1",
     "@zxing/library": "^0.8.0",
     "abi-decoder": "^1.2.0",
-    "asmcrypto.js": "0.22.0",
+    "asmcrypto.js": "^2.3.2",
     "async": "^2.5.0",
     "await-semaphore": "^0.1.1",
     "babel-runtime": "^6.23.0",


### PR DESCRIPTION
This silences a warning message that was printed to the console whenever this module was loaded during tests.

The API changes between these two versions were reviewed carefully for differences. The only difference for us was to `PBKDF2_HMAC_SHA256.bytes`, which was replaced by `Pbkdf2HmacSha256`.

The length argument no longer has a default value, so it has been set to match what the default value was in the previous version we used, which is 32 (the SHA256 hash size).