### PR TITLE
Move Browserify transforms to gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -501,6 +501,8 @@ function generateBundler (opts, performBundle) {
   }
 
   let bundler = browserify(browserifyOpts)
+    .transform('babelify')
+    .transform('brfs')
 
   if (opts.buildLib) {
     bundler = bundler.require(opts.dependenciesToBundle)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:flat:build:tests": "node test/integration/index.js",
     "test:flat:build:states": "node development/genStates.js",
     "test:flat:build:locales": "mkdirp dist/chrome && cp -R app/_locales dist/chrome/_locales",
-    "test:flat:build:ui": "npm run test:flat:build:states && browserify ./development/mock-dev.js -o ./development/bundle.js",
+    "test:flat:build:ui": "npm run test:flat:build:states && browserify --transform babelify --transform brfs ./development/mock-dev.js -o ./development/bundle.js",
     "ganache:start": "ganache-cli --noVMErrorsOnRPCResponse -i 5777 -m 'phrase upgrade clock rough situate wedding elder clever doctor stamp excess tent'",
     "sentry:publish": "node ./development/sentry-publish.js",
     "lint": "eslint .",
@@ -44,12 +44,6 @@
     "storybook": "start-storybook -p 6006 -c .storybook",
     "update-changelog": "./development/auto-changelog.sh",
     "rollback": "./development/rollback.sh"
-  },
-  "browserify": {
-    "transform": [
-      "babelify",
-      "brfs"
-    ]
   },
   "dependencies": {
     "@material-ui/core": "1.0.0",


### PR DESCRIPTION
The flat tests also rely upon these transformations, yet invoke
browserify from the command line rather than using the gulpfile. The
transformations have been specified on the command line for those
instead.

Of course it's not ideal to have the same transformations listed in two
different places, but the plan is to delete the flat tests soon anyway,
so this should suffice until then.

Closes #4538