### PR TITLE
Added visual documentation of the account menu component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current Develop Branch
 - [#6700](https://github.com/MetaMask/metamask-extension/pull/6700): Fix styles on 'import account' page, update help link
-- [#6775](https://github.com/MetaMask/metamask-extension/pull/6775): Started adding visual documentation of MetaMask plugin components with the menu bar component first
+- [#6775](https://github.com/MetaMask/metamask-extension/pull/6775): Started adding visual documentation of MetaMask plugin components with the account menu component first
 
 ## 6.6.2 Fri Jun 07 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Develop Branch
 - [#6700](https://github.com/MetaMask/metamask-extension/pull/6700): Fix styles on 'import account' page, update help link
+- [#6775](https://github.com/MetaMask/metamask-extension/pull/6775): Started adding visual documentation of MetaMask plugin components with the menu bar component first
 
 ## 6.6.2 Fri Jun 07 2019
 

--- a/docs/components/account-menu.md
+++ b/docs/components/account-menu.md
@@ -1,6 +1,6 @@
-# Menu Bar
+# Account Menu
 
-The menu bar is the popup menu which contains options such as:
+The account menu is the popup menu which contains options such as:
  - Logging out
  - Switching accounts
  - Creating a new account
@@ -11,7 +11,7 @@ The menu bar is the popup menu which contains options such as:
  
  It can be seen below where it has been outlined with a red box
  
- ![Screenshot of menu bar](https://i.imgur.com/xpkfIuR.png) 
+ ![Screenshot of account menu](https://i.imgur.com/xpkfIuR.png) 
  
  Above screenshot showing the menu bar in MetaMask 6.7.1
  

--- a/docs/components/menu-bar.md
+++ b/docs/components/menu-bar.md
@@ -1,0 +1,20 @@
+# Menu Bar
+
+The menu bar is the popup menu which contains options such as:
+ - Logging out
+ - Switching accounts
+ - Creating a new account
+ - Importing an account
+ - Connecting a HW wallet
+ - Looking up info & help
+ - Adjusting settings
+ 
+ It can be seen below where it has been outlined with a red box
+ 
+ ![Screenshot of menu bar](https://i.imgur.com/xpkfIuR.png) 
+ 
+ Above screenshot showing the menu bar in MetaMask 6.7.1
+ 
+   
+
+


### PR DESCRIPTION
Thought it would be a good idea to add documentation about the components of the project so that they're easier to find for newcomers of the project.

I've recently starting diving into the code and I'm currently trying to figure out where to find all the different components which are used to build the different popup pages or the background pages. 

Perhaps I'm finding it difficult because I've never worked with a React app before and the only other chrome extension projects I've seen from the Google tutorials didn't have an architecture like this project.

<img width="591" alt="Screenshot 2019-07-01 at 19 41 21" src="https://user-images.githubusercontent.com/6950843/60459166-49193080-9c38-11e9-838b-97c1b02eb6d6.png">


Having something visual like this would help illustrate exactly what the component is for.

I was debating whether or not it would be a good idea including the relative path to the component within the document however I realise that this could become problematic if there was a refactor and locations changed or directories were renamed.
