### PR TITLE
Disable release script from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ workflows:
       - prep-build:
           requires:
             - prep-deps-npm
-      - prep-docs:
-          requires:
-            - prep-deps-npm
+      # - prep-docs:
+      #    requires:
+      #      - prep-deps-npm
       - prep-scss:
           requires:
             - prep-deps-npm
@@ -66,16 +66,16 @@ workflows:
             - prep-build
             - job-screens
             - all-tests-pass
-      - job-publish-release:
-          filters:
-            branches:
-              only: master
-          requires:
-            - prep-deps-npm
-            - prep-build
-            - prep-docs
-            - job-screens
-            - all-tests-pass
+      # - job-publish-release:
+      #    filters:
+      #      branches:
+      #        only: master
+      #    requires:
+      #      - prep-deps-npm
+      #      - prep-build
+      #       - prep-docs
+      #      - job-screens
+      #      - all-tests-pass
 
 jobs:
   prep-deps-npm:


### PR DESCRIPTION
The MetaMask bot is currently failing to publish docs updates, and it is
[blocking our ability to release new versions](https://github.com/MetaMask/metamask-extension/pull/6765).

While we should pursue a proper fix, I think it's worth disabling in the
meanwhile so this glitch doesn't interfere with our regular release
cadence further.