### PR TITLE
Merge transaction to txData for updated txParams

### DIFF
--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -91,10 +91,6 @@ const mapStateToProps = (state, ownProps) => {
   const transaction = R.find(({ id }) => id === (transactionId || Number(paramsTransactionId)))(selectedAddressTxList)
   const transactionStatus = transaction ? transaction.status : ''
 
-  if (transaction && transaction.simulationFails) {
-    txData.simulationFails = transaction.simulationFails
-  }
-
   const currentNetworkUnapprovedTxs = R.filter(
     ({ metamaskNetworkId }) => metamaskNetworkId === network,
     unapprovedTxs,
@@ -109,6 +105,11 @@ const mapStateToProps = (state, ownProps) => {
   })
 
   const methodData = getKnownMethodData(state, data) || {}
+
+  const fullTxData = {
+    ...txData,
+    ...transaction,
+  }
 
   return {
     balance,
@@ -125,7 +126,7 @@ const mapStateToProps = (state, ownProps) => {
     hexTransactionAmount,
     hexTransactionFee,
     hexTransactionTotal,
-    txData: Object.keys(txData).length ? txData : transaction || {},
+    txData: fullTxData,
     tokenData,
     methodData,
     tokenProps,


### PR DESCRIPTION
In the ConfirmTransactionBase `state.confirmTranasction.txParams` isn't updating properly when estimating gasLimits. I couldn't find where this is happening, but `state.unapprovedTxs.txParams` has the more appropriate gasLimit. This just merges both together.