### PR TITLE
Reduce time to show tx "speed up" buttons to 5 seconds.

### DIFF
--- a/ui/app/components/app/transaction-list/transaction-list.component.js
+++ b/ui/app/components/app/transaction-list/transaction-list.component.js
@@ -39,7 +39,7 @@ export default class TransactionList extends PureComponent {
     const { transactions = [], hasRetried } = transactionGroup
     const [earliestTransaction = {}] = transactions
     const { submittedTime } = earliestTransaction
-    return Date.now() - submittedTime > 30000 && isEarliestNonce && !hasRetried
+    return Date.now() - submittedTime > 5000 && isEarliestNonce && !hasRetried
   }
 
   shouldShowCancel (transactionGroup) {


### PR DESCRIPTION
...because sometimes 30 seconds is already longer than you wanted to wait.