### PR TITLE
Check for invalid gas estimates from local storage

### DIFF
--- a/development/states/confirm-new-ui.json
+++ b/development/states/confirm-new-ui.json
@@ -203,7 +203,6 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
-    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/development/states/confirm-sig-requests.json
+++ b/development/states/confirm-sig-requests.json
@@ -229,7 +229,6 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
-    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/development/states/currency-localization.json
+++ b/development/states/currency-localization.json
@@ -179,7 +179,6 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
-    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/development/states/send-edit.json
+++ b/development/states/send-edit.json
@@ -207,7 +207,6 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
-    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/development/states/send-new-ui.json
+++ b/development/states/send-new-ui.json
@@ -187,7 +187,6 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
-    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/development/states/tx-list-items.json
+++ b/development/states/tx-list-items.json
@@ -1110,7 +1110,6 @@
     },
     "basicEstimateIsLoading": false,
     "gasEstimatesLoading": false,
-    "basicPriceAndTimeEstimates": [],
     "priceAndTimeEstimates": [
       {
         "expectedTime": "1374.1168296452973076627",

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -118,7 +118,6 @@ describe('Gas Duck', () => {
     gasEstimatesLoading: true,
     priceAndTimeEstimates: [],
     priceAndTimeEstimatesLastRetrieved: 0,
-    basicPriceAndTimeEstimates: [],
     basicPriceAndTimeEstimatesLastRetrieved: 0,
     basicPriceEstimatesLastRetrieved: 0,
   }

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -50,7 +50,6 @@ const initState = {
   basicEstimateIsLoading: true,
   gasEstimatesLoading: true,
   priceAndTimeEstimates: [],
-  basicPriceAndTimeEstimates: [],
   priceAndTimeEstimatesLastRetrieved: 0,
   basicPriceAndTimeEstimatesLastRetrieved: 0,
   basicPriceEstimatesLastRetrieved: 0,
@@ -178,10 +177,7 @@ export function gasEstimatesLoadingFinished () {
 
 export function fetchBasicGasEstimates () {
   return (dispatch, getState) => {
-    const {
-      basicPriceEstimatesLastRetrieved,
-      basicPriceAndTimeEstimates,
-    } = getState().gas
+    const { basicPriceEstimatesLastRetrieved } = getState().gas
     const timeLastRetrieved = basicPriceEstimatesLastRetrieved || loadLocalStorageData('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED') || 0
 
     dispatch(basicGasEstimatesLoadingStarted())
@@ -220,10 +216,7 @@ export function fetchBasicGasEstimates () {
 
         return basicEstimates
       })
-    : Promise.resolve(basicPriceAndTimeEstimates.length
-        ? basicPriceAndTimeEstimates
-        : loadLocalStorageData('BASIC_PRICE_ESTIMATES')
-      )
+    : Promise.resolve(loadLocalStorageData('BASIC_PRICE_ESTIMATES'))
 
     return promiseToFetch.then(basicEstimates => {
       dispatch(setBasicGasEstimateData(basicEstimates))
@@ -235,10 +228,7 @@ export function fetchBasicGasEstimates () {
 
 export function fetchBasicGasAndTimeEstimates () {
   return (dispatch, getState) => {
-    const {
-      basicPriceAndTimeEstimatesLastRetrieved,
-      basicPriceAndTimeEstimates,
-    } = getState().gas
+    const { basicPriceAndTimeEstimatesLastRetrieved } = getState().gas
     const timeLastRetrieved = basicPriceAndTimeEstimatesLastRetrieved || loadLocalStorageData('BASIC_GAS_AND_TIME_API_ESTIMATES_LAST_RETRIEVED') || 0
 
     dispatch(basicGasEstimatesLoadingStarted())
@@ -294,10 +284,7 @@ export function fetchBasicGasAndTimeEstimates () {
 
           return basicEstimates
         })
-      : Promise.resolve(basicPriceAndTimeEstimates.length
-          ? basicPriceAndTimeEstimates
-          : loadLocalStorageData('BASIC_GAS_AND_TIME_API_ESTIMATES')
-        )
+      : Promise.resolve(loadLocalStorageData('BASIC_GAS_AND_TIME_API_ESTIMATES'))
 
       return promiseToFetch.then(basicEstimates => {
         dispatch(setBasicGasEstimateData(basicEstimates))


### PR DESCRIPTION
* Remove unused state `gas.basicPriceAndTimeEstimates`
* Check for invalid estimates from local storage

  Gas estimates were being cached in local storage then later retrieved, but the retrieved values were not being checked. If the data failed to save, failed to load, or was cleared since being saved, it would result in the gas estimates being set to undefined.

  The estimates retrieved from local storage are now checked before they are used. If they are falsy, the estimates are retrieved from the network instead.

  This should fix [this Sentry issue](https://sentry.io/share/issue/cfe470314a5741768b19050815322aa4/)

  A few additional changes were made to the gas-duck tests to accommodate the use of `sinon.restore`. `restore` is strongly recommended by the `sinon` team, as neglecting to use it can result in memory leaks. It has the additional benefit of ensuring you create fresh stubs/spies for each test, which means they no longer need to be reset between tests.