### PR TITLE
Increase CircleCI `addons-linter` memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
           at: .
       - run:
           name: test:mozilla-lint
-          command: npm run mozilla-lint
+          command: NODE_OPTIONS=--max_old_space_size=3072 npm run mozilla-lint
 
   test-integration-flat-firefox:
     docker:


### PR DESCRIPTION
`addons-linter` will occasionally run out of heap space. This provides 3 GB of heap for that script rather than the default ~1.5 GB. The CircleCI containers have  4GB of memory, so this should leave plenty of extra space for non-heap memory.