### PR TITLE
Declare variables before use

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -134,6 +134,7 @@
     "no-unreachable": 2,
     "no-unsafe-finally": 2,
     "no-unused-vars": [2, { "vars": "all", "args": "all", "argsIgnorePattern": "[_]+" }],
+    "no-use-before-define": [2, { "functions": false }],
     "no-useless-call": 2,
     "no-useless-computed-key": 2,
     "no-useless-constructor": 2,

--- a/app/scripts/lib/createStreamSink.js
+++ b/app/scripts/lib/createStreamSink.js
@@ -1,13 +1,6 @@
 const WritableStream = require('readable-stream').Writable
 const promiseToCallback = require('promise-to-callback')
 
-module.exports = createStreamSink
-
-
-function createStreamSink (asyncWriteFn, _opts) {
-  return new AsyncWritableStream(asyncWriteFn, _opts)
-}
-
 class AsyncWritableStream extends WritableStream {
 
   constructor (asyncWriteFn, _opts) {
@@ -22,3 +15,9 @@ class AsyncWritableStream extends WritableStream {
   }
 
 }
+
+function createStreamSink (asyncWriteFn, _opts) {
+  return new AsyncWritableStream(asyncWriteFn, _opts)
+}
+
+module.exports = createStreamSink

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -679,19 +679,6 @@ describe('MetaMaskController', function () {
   })
 
   describe('#newUnsignedPersonalMessage', function () {
-
-    it('errors with no from in msgParams', async () => {
-      const msgParams = {
-        'data': data,
-      }
-      try {
-        await metamaskController.newUnsignedPersonalMessage(msgParams)
-        assert.fail('should have thrown')
-      } catch (error) {
-        assert.equal(error.message, 'MetaMask Message Signature: from field is required.')
-      }
-    })
-
     let msgParams, metamaskPersonalMsgs, personalMessages, msgId
 
     const address = '0xc42edfcc21ed14dda456aa0756c153f7985d8813'
@@ -716,6 +703,18 @@ describe('MetaMaskController', function () {
       personalMessages = metamaskController.personalMessageManager.messages
       msgId = Object.keys(metamaskPersonalMsgs)[0]
       personalMessages[0].msgParams.metamaskId = parseInt(msgId)
+    })
+
+    it('errors with no from in msgParams', async () => {
+      const msgParams = {
+        'data': data,
+      }
+      try {
+        await metamaskController.newUnsignedPersonalMessage(msgParams)
+        assert.fail('should have thrown')
+      } catch (error) {
+        assert.equal(error.message, 'MetaMask Message Signature: from field is required.')
+      }
     })
 
     it('persists address from msg params', function () {

--- a/test/unit/ui/app/reducers/app.spec.js
+++ b/test/unit/ui/app/reducers/app.spec.js
@@ -700,7 +700,7 @@ describe('App State', () => {
   })
 
   it('hides sub loading indicator', () => {
-    const oldState = {...metamaskState, ...oldState}
+    const oldState = {...metamaskState, isSubLoading: true }
     const state = reduceApp(oldState, {
       type: actions.HIDE_SUB_LOADING_INDICATION,
     })

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -37,13 +37,6 @@ const BIG_NUMBER_WEI_MULTIPLIER = new BigNumber('1000000000000000000')
 const BIG_NUMBER_GWEI_MULTIPLIER = new BigNumber('1000000000')
 const BIG_NUMBER_ETH_MULTIPLIER = new BigNumber('1')
 
-// Individual Setters
-const convert = R.invoker(1, 'times')
-const round = R.invoker(2, 'round')(R.__, BigNumber.ROUND_HALF_DOWN)
-const roundDown = R.invoker(2, 'round')(R.__, BigNumber.ROUND_DOWN)
-const invertConversionRate = conversionRate => () => new BigNumber(1.0).div(conversionRate)
-const decToBigNumberViaString = () => R.pipe(String, toBigNumber['dec'])
-
 // Setter Maps
 const toBigNumber = {
   hex: n => new BigNumber(stripHexPrefix(n), 16),
@@ -65,6 +58,13 @@ const baseChange = {
   dec: n => (new BigNumber(n)).toString(10),
   BN: n => new BN(n.toString(16)),
 }
+
+// Individual Setters
+const convert = R.invoker(1, 'times')
+const round = R.invoker(2, 'round')(R.__, BigNumber.ROUND_HALF_DOWN)
+const roundDown = R.invoker(2, 'round')(R.__, BigNumber.ROUND_DOWN)
+const invertConversionRate = conversionRate => () => new BigNumber(1.0).div(conversionRate)
+const decToBigNumberViaString = () => R.pipe(String, toBigNumber['dec'])
 
 // Predicates
 const fromAndToCurrencyPropsNotEqual = R.compose(

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -183,18 +183,6 @@ class Routes extends Component {
       this.getConnectingLabel(loadingMessage) : null
     log.debug('Main ui render function')
 
-    const sidebarOnOverlayClose = sidebarType === WALLET_VIEW_SIDEBAR
-      ? () => {
-        this.context.metricsEvent({
-          eventOpts: {
-            category: 'Navigation',
-            action: 'Wallet Sidebar',
-            name: 'Closed Sidebare Via Overlay',
-          },
-        })
-      }
-      : null
-
     const {
       isOpen: sidebarIsOpen,
       transitionName: sidebarTransitionName,
@@ -202,6 +190,18 @@ class Routes extends Component {
       props,
     } = sidebar
     const { transaction: sidebarTransaction } = props || {}
+
+    const sidebarOnOverlayClose = sidebarType === WALLET_VIEW_SIDEBAR
+    ? () => {
+      this.context.metricsEvent({
+        eventOpts: {
+          category: 'Navigation',
+          action: 'Wallet Sidebar',
+          name: 'Closed Sidebare Via Overlay',
+        },
+      })
+    }
+    : null
 
     return (
       <div

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1210,6 +1210,20 @@ function signTokenTx (tokenAddress, toAddress, amount, txData) {
   }
 }
 
+const updateMetamaskStateFromBackground = () => {
+  log.debug(`background.getState`)
+
+  return new Promise((resolve, reject) => {
+    background.getState((error, newState) => {
+      if (error) {
+        return reject(error)
+      }
+
+      resolve(newState)
+    })
+  })
+}
+
 function updateTransaction (txData) {
   log.info('actions: updateTx: ' + JSON.stringify(txData))
   return dispatch => {
@@ -1614,20 +1628,6 @@ const backgroundSetLocked = () => {
         return reject(error)
       }
       resolve()
-    })
-  })
-}
-
-const updateMetamaskStateFromBackground = () => {
-  log.debug(`background.getState`)
-
-  return new Promise((resolve, reject) => {
-    background.getState((error, newState) => {
-      if (error) {
-        return reject(error)
-      }
-
-      resolve(newState)
     })
   })
 }


### PR DESCRIPTION
While working on #6805, I noticed that many variables were being used before they were declared. Technically this worked fine in practice because we were using the `transform-es2015-block-scoping` Babel plugin, which transforms `let` and `const` to `var`, which is hoisted. However, after removing that Babel transformation, many things broke.

All instances of variables or classes being used before declared have been fixed.

The `no-use-before-define` eslint rule has been added to catch these cases going forward. The rule is disabled for function declarations for the moment, because those are always hoisted. We could disable that too if we want to, but it's purely stylistic and would require a lot more changes.