### PR TITLE
Remove unused `gulp-uglify` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34769,45 +34769,6 @@
         }
       }
     },
-    "gulp-uglify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.0.tgz",
-      "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
-      "dev": true,
-      "requires": {
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash": "^4.13.1",
-        "make-error-cause": "^1.1.1",
-        "through2": "^2.0.0",
-        "uglify-js": "^3.0.5",
-        "vinyl-sourcemaps-apply": "^0.2.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "3.3.11",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.11.tgz",
-          "integrity": "sha512-AKLsYcdV+sS5eAE4NtVXF6f2u/DCQynQm0jTGxF261+Vltu1dYNuHzjqDmk11gInj+H/zJIM2EAwXG3MzPb3VA==",
-          "dev": true,
-          "requires": {
-            "commander": "~2.14.1",
-            "source-map": "~0.6.1"
-          }
-        }
-      }
-    },
     "gulp-uglify-es": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gulp-uglify-es/-/gulp-uglify-es-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,6 @@
     "gulp-sourcemaps": "^2.6.0",
     "gulp-stylefmt": "^1.1.0",
     "gulp-stylelint": "^7.0.0",
-    "gulp-uglify": "^3.0.0",
     "gulp-uglify-es": "^1.0.1",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^5.0.1",


### PR DESCRIPTION
The switch was made to `gulp-uglify-es` some time ago, but `gulp-uglify` was never removed.