### PR TITLE
Remove unused `babel-polyfill` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.7.2",


### PR DESCRIPTION
The lockfile hasn't changed because this package is a dependency of `fetch-mock`.