### PR TITLE
Right-to-left CSS

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -210,7 +210,11 @@ class PreferencesController {
    *
    */
   setCurrentLocale (key) {
-    this.store.updateState({ currentLocale: key })
+    let textDirection = (['ar','dv','fa','he','ku'].indexOf(key) > -1) ? 'rtl' : 'auto';
+    this.store.updateState({
+      currentLocale: key,
+      textDirection: textDirection
+    })
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -210,10 +210,10 @@ class PreferencesController {
    *
    */
   setCurrentLocale (key) {
-    let textDirection = (['ar','dv','fa','he','ku'].indexOf(key) > -1) ? 'rtl' : 'auto';
+    const textDirection = (['ar', 'dv', 'fa', 'he', 'ku'].indexOf(key) > -1) ? 'rtl' : 'auto'
     this.store.updateState({
       currentLocale: key,
-      textDirection: textDirection
+      textDirection: textDirection,
     })
   }
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -210,7 +210,7 @@ class PreferencesController {
    *
    */
   setCurrentLocale (key) {
-    const textDirection = (['ar', 'dv', 'fa', 'he', 'ku'].indexOf(key) > -1) ? 'rtl' : 'auto'
+    const textDirection = (['ar', 'dv', 'fa', 'he', 'ku'].includes(key)) ? 'rtl' : 'auto'
     this.store.updateState({
       currentLocale: key,
       textDirection: textDirection,

--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -14,7 +14,7 @@
   }
 
   @media screen and (min-width: 576px) {
-    right: calc(((100vw - 100%) / 2) + 8px);
+    right: calc((100vw - 85vw) / 2);
 
     [dir='rtl'] & {
       left: calc(((100vw - 100%) / 2) + 8px);

--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -164,6 +164,10 @@
   .identicon {
     margin: 0 12px 0 0;
     flex: 0 0 auto;
+
+    [dir='rtl'] & {
+      margin: 0 0 0 12px;
+    }
   }
 
   &__name {

--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -6,23 +6,48 @@
 
   @media screen and (max-width: 575px) {
     right: calc(((100vw - 100%) / 2) + 8px);
+
+    [dir='rtl'] & {
+      left: calc(((100vw - 100%) / 2) + 8px);
+      right: auto;
+    }
   }
 
   @media screen and (min-width: 576px) {
-    right: calc((100vw - 85vw) / 2);
+    right: calc(((100vw - 100%) / 2) + 8px);
+
+    [dir='rtl'] & {
+      left: calc(((100vw - 100%) / 2) + 8px);
+      right: auto;
+    }
   }
 
   @media screen and (min-width: 769px) {
     right: calc((100vw - 80vw) / 2);
+
+    [dir='rtl'] & {
+      left: calc((100vw - 80vw) / 2);
+      right: auto;
+    }
   }
 
   @media screen and (min-width: 1281px) {
     right: calc((100vw - 65vw) / 2);
+
+    [dir='rtl'] & {
+      left: calc((100vw - 65vw) / 2);
+      right: auto;
+    }
   }
 
   &__icon {
     margin-left: 1rem;
     cursor: pointer;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 1rem;
+    }
 
     &--disabled {
       cursor: initial;
@@ -90,6 +115,11 @@
       width: 15px;
       margin-left: 10px;
       height: 15px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 10px;
+      }
     }
 
     &:hover {
@@ -114,6 +144,11 @@
     width: 14px;
     margin-right: 12px;
     flex: 0 0 auto;
+
+    [dir='rtl'] & {
+      margin-left: 12px;
+      margin-right: 0;
+    }
   }
 
   &__check-mark-icon {
@@ -169,6 +204,11 @@
     display: flex;
     justify-content: center;
     align-items: center;
+
+    [dir='rtl'] & {
+      left: 12px;
+      right: auto;
+    }
 
     &:hover {
       opacity: 1;

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
@@ -32,6 +32,11 @@
   &__identicon {
     flex: 0 0 auto;
     margin-right: 8px;
+
+    [dir='rtl'] & {
+      margin-left: 8px;
+      margin-right: 0;
+    }
   }
 
   &__title-text {

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/index.scss
@@ -9,6 +9,11 @@
   &__icon {
     flex: 0 0 auto;
     margin-right: 16px;
+
+    [dir='rtl'] & {
+      margin-left: 16px;
+      margin-right: 0;
+    }
   }
 
   &__warning {

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -43,6 +43,11 @@
     &-label {
       font-weight: 500;
       padding-right: 16px;
+
+      [dir='rtl'] & {
+        padding-left: 16px;
+        padding-right: 0;
+      }
     }
 
     &:not(:last-child) {
@@ -64,5 +69,10 @@
     text-transform: capitalize;
     color: $black;
     padding-left: 5px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 5px;
+    }
   }
 }

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/index.scss
@@ -15,6 +15,10 @@
     display: flex;
     justify-content: center;
     align-items: center;
+
+    [dir='rtl'] & img {
+      transform: rotate(180deg);
+    }
   }
 
   &__back-button {

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/index.scss
@@ -23,5 +23,10 @@
     cursor: pointer;
     font-weight: 400;
     padding-left: 5px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 5px;
+    }
   }
 }

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/index.scss
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/index.scss
@@ -20,11 +20,16 @@
       @media screen and (max-width: 576px) {
         font-size: 10px;
       }
-      
+
       .fa-info-circle {
         color: $silver;
         margin-left: 10px;
         cursor: pointer;
+
+        [dir='rtl'] & {
+          margin-left: 0;
+          margin-right: 10px;
+        }
       }
 
       .fa-info-circle:hover {
@@ -56,6 +61,11 @@
       padding-left: 8px;
       padding-top: 2px;
       margin-top: 7px;
+
+      [dir='rtl'] & {
+        padding-left: 0;
+        padding-right: 8px;
+      }
     }
 
     &__input--error {
@@ -80,6 +90,11 @@
       font-size: .8em;
       border-bottom-right-radius: 4px;
       cursor: pointer;
+
+      [dir='rtl'] & {
+        left: 0;
+        right: auto;
+      }
 
       &__i-wrap {
         width: 100%;
@@ -128,6 +143,11 @@
       top: 8px;
       right: 10px;
       color: $dusty-gray;
+
+      [dir='rtl'] & {
+        left: 10px;
+        right: auto;
+      }
     }
   }
 }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
@@ -66,6 +66,11 @@
       font-size: 12px;
       color: #313A5E;
       margin-left: 22px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 22px;
+      }
     }
 
     &__speed-buttons {
@@ -78,6 +83,11 @@
       width: 100%;
       font-size: 10px;
       color: #888EA3;
+
+      [dir='rtl'] & {
+        padding-left: 19px;
+        padding-right: 20px;
+      }
     }
 
     .loading-overlay {
@@ -98,6 +108,11 @@
     margin-left: 20px;
     margin-right: 10px;
     margin-top: 9px;
+
+    [dir='rtl'] & {
+      margin-left: 10px;
+      margin-right: 20px;
+    }
   }
 
   &__gas-edit-row {
@@ -115,6 +130,11 @@
         color: $silver;
         margin-left: 10px;
         cursor: pointer;
+
+        [dir='rtl'] & {
+          margin-left: 0;
+          margin-right: 10px;
+        }
       }
 
       .fa-info-circle:hover {
@@ -146,6 +166,11 @@
       padding-left: 8px;
       padding-top: 2px;
       margin-top: 7px;
+
+      [dir='rtl'] & {
+        padding-left: 0;
+        padding-right: 8px;
+      }
     }
 
     &__input--error {
@@ -170,6 +195,15 @@
       font-size: .8em;
       border-bottom-right-radius: 4px;
       cursor: pointer;
+
+      [dir='rtl'] & {
+        left: 0;
+        right: auto;
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
 
       &__i-wrap {
         width: 100%;
@@ -218,6 +252,11 @@
       top: 8px;
       right: 10px;
       color: $dusty-gray;
+
+      [dir='rtl'] & {
+        left: 10px;
+        right: auto;
+      }
     }
   }
 }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/time-remaining/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/time-remaining/index.scss
@@ -1,0 +1,22 @@
+.time-remaining {
+  color: #313A5E;
+  font-size: 16px;
+
+  .minutes-num, .seconds-num {
+    font-size: 16px;
+  }
+
+  .seconds-num {
+    margin-left: 7px;
+    font-size: 16px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 7px;
+    }
+  }
+
+  .minutes-label, .seconds-label {
+    font-size: 16px;
+  }
+}

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/time-remaining/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/time-remaining/index.scss
@@ -1,6 +1,7 @@
 .time-remaining {
   color: #313A5E;
   font-size: 16px;
+  direction: ltr;
 
   .minutes-num, .seconds-num {
     font-size: 16px;

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/index.scss
@@ -7,6 +7,11 @@
   background: #F5F7F8;
   border-bottom: 1px solid #d2d8dd;
 
+  [dir='rtl'] & {
+    padding-left: 0;
+    padding-right: 21px;
+  }
+
   &__title {
     margin-top: 19px;
     font-size: 16px;

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
@@ -38,6 +38,11 @@
       right: 16px;
       cursor: pointer;
       overflow: hidden;
+
+      [dir='rtl'] & {
+        left: 16px;
+        right: auto;
+      }
     }
 
     &__title {
@@ -49,6 +54,10 @@
       justify-content: center;
       align-items: flex-start;
       margin-right: 0;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+      }
     }
 
     &__subtitle {
@@ -65,6 +74,10 @@
 
       &:last-of-type {
         margin-right: 0;
+
+        [dir='rtl'] & {
+          margin-left: 0;
+        }
       }
 
       &--selected {

--- a/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
@@ -205,10 +205,20 @@
 
     &:first-child {
       margin-right: 6px;
+
+      [dir='rtl'] & {
+        margin-left: 6px;
+        margin-right: 0;
+      }
     }
 
     &:last-child {
       margin-left: 6px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 6px;
+      }
     }
   }
 
@@ -228,6 +238,11 @@
       flex-flow: row;
       justify-content: center;
       align-items: center;
+
+      [dir='rtl'] & {
+        left: -10px;
+        right: auto;
+      }
     }
 
     i {

--- a/ui/app/components/app/gas-customization/gas-slider/index.scss
+++ b/ui/app/components/app/gas-customization/gas-slider/index.scss
@@ -6,6 +6,11 @@
     width: 322px;
     margin-left: -2px;
     z-index: 2;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: -2px;
+    }
   }
 
   input[type=range] {
@@ -42,6 +47,11 @@
     width: 322px;
     z-index: 1;
     background-color: $blizzard-blue;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 102px;
+    }
   }
 
   &__labels {

--- a/ui/app/components/app/info-box/index.scss
+++ b/ui/app/components/app/info-box/index.scss
@@ -16,6 +16,11 @@
     right: 12px;
     top: 0;
     cursor: pointer;
+
+    [dir='rtl'] & {
+      left: 12px;
+      right: auto;
+    }
   }
 
   &__description {

--- a/ui/app/components/app/modal/index.scss
+++ b/ui/app/components/app/modal/index.scss
@@ -40,6 +40,11 @@
     top: -5px;
     right: 10px;
     cursor: pointer;
+
+    [dir='rtl'] & {
+      left: 10px;
+      right: auto;
+    }
   }
 
   &__footer {
@@ -54,8 +59,17 @@
       min-width: 0;
       margin-right: 16px;
 
+      [dir='rtl'] & {
+        margin-left: 16px;
+        margin-right: 0;
+      }
+
       &:last-of-type {
         margin-right: 0;
+
+        [dir='rtl'] & {
+          margin-left: 0;
+        }
       }
     }
   }

--- a/ui/app/components/app/modals/confirm-remove-account/index.scss
+++ b/ui/app/components/app/modals/confirm-remove-account/index.scss
@@ -15,12 +15,22 @@
 
     &__identicon {
       margin-right: 10px;
+
+      [dir='rtl'] & {
+        margin-left: 10px;
+        margin-right: 0;
+      }
     }
 
     &__name,
     &__address {
       margin-right: 10px;
       font-size: 14px;
+
+      [dir='rtl'] & {
+        margin-left: 10px;
+        margin-right: 0;
+      }
     }
 
     &__name {

--- a/ui/app/components/app/modals/customize-gas/index.scss
+++ b/ui/app/components/app/modals/customize-gas/index.scss
@@ -27,6 +27,11 @@
 
   &__title {
     margin-left: 19.25px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 19.25px;
+    }
   }
 
   &__close::after {
@@ -36,6 +41,11 @@
     font-family: sans-serif;
     cursor: pointer;
     margin-right: 19.25px;
+
+    [dir='rtl'] & {
+      margin-left: 19.25px;
+      margin-right: 0;
+    }
   }
 
   &__content {
@@ -72,6 +82,11 @@
     display: flex;
     justify-content: space-between;
     margin-right: 21.25px;
+
+    [dir='rtl'] & {
+      margin-left: 21.25px;
+      margin-right: 0;
+    }
   }
 
   &__revert, &__cancel, &__save, &__save__error {
@@ -86,6 +101,11 @@
     color: $silver-chalice;
     font-size: 16px;
     margin-left: 21.25px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 21.25px;
+    }
   }
 
   &__cancel, &__save, &__save__error {
@@ -106,5 +126,10 @@
     font-size: 12px;
     line-height: 12px;
     color: $red;
+
+    [dir='rtl'] & {
+      left: 4px;
+      right: auto;
+    }
   }
 }

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/index.scss
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/index.scss
@@ -5,6 +5,11 @@
     margin-right: 0%;
     max-height: 75vh;
 
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 3%;
+    }
+
     @media screen and (max-width: 575px) {
       max-height: 100vh;
     }
@@ -17,6 +22,11 @@
 
   .metametrics-opt-in__content {
     padding-right: 6px;
+
+    [dir='rtl'] & {
+      padding-left: 6px;
+      padding-right: 0;
+    }
   }
 
   .metametrics-opt-in__footer {
@@ -25,6 +35,11 @@
       justify-content: center;
       margin-left: 2%;
       max-height: 520px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 2%;
+      }
     }
   }
 }

--- a/ui/app/components/app/modals/qr-scanner/index.scss
+++ b/ui/app/components/app/modals/qr-scanner/index.scss
@@ -59,6 +59,11 @@
 
     button {
       margin-right: 15px;
+
+      [dir='rtl'] & {
+        margin-left: 15px;
+        margin-right: 0;
+      }
     }
 
     button:last-of-type {
@@ -66,6 +71,10 @@
       background-color: #009eec;
       border: none;
       color: #fff;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+      }
     }
   }
 
@@ -78,6 +87,10 @@
     right: 20px;
     cursor: pointer;
     font-weight: 300;
+
+    [dir='rtl'] & {
+      left: 20px;
+      right: auto;
+    }
   }
 }
-

--- a/ui/app/components/app/network-display/index.scss
+++ b/ui/app/components/app/network-display/index.scss
@@ -35,6 +35,11 @@
   &__name {
     font-size: .75rem;
     padding-left: 5px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 5px;
+    }
   }
 
   &__icon {

--- a/ui/app/components/app/sidebars/index.scss
+++ b/ui/app/components/app/sidebars/index.scss
@@ -56,14 +56,28 @@
   width: 85%;
   height: 100%;
 
+  [dir='rtl'] & {
+    left: 0;
+    right: 15%;
+  }
+
   @media screen and (min-width: 769px) {
     width: 408px;
     left: calc(100% - 408px);
+
+    [dir='rtl'] & {
+      left: 0;
+      right: calc(100% - 408px);
+    }
   }
 
   @media screen and (max-width: $break-small) {
     width: 100%;
     left: 0%;
+
+    [dir='rtl'] & {
+      right: 0;
+    }
   }
 }
 

--- a/ui/app/components/app/transaction-activity-log/index.scss
+++ b/ui/app/components/app/transaction-activity-log/index.scss
@@ -24,6 +24,13 @@
       height: 100%;
       width: 7px;
       border-right: 1px solid #909090;
+
+      [dir='rtl'] & {
+        left: auto;
+        right: 0;
+        border-left: 1px solid #909090;
+        border-right: 0;
+      }
     }
 
     &:first-child::after {
@@ -51,6 +58,11 @@
     justify-content: center;
     align-items: center;
     z-index: 1;
+
+    [dir='rtl'] & {
+      margin-left: 6px;
+      margin-right: 0;
+    }
   }
 
   &__activity-text {

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/index.scss
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/index.scss
@@ -11,6 +11,11 @@
 
   &__title {
     padding-right: 8px;
+
+    [dir='rtl'] & {
+      padding-left: 8px;
+      padding-right: 0;
+    }
   }
 
   &__value {

--- a/ui/app/components/app/transaction-list-item-details/index.scss
+++ b/ui/app/components/app/transaction-list-item-details/index.scss
@@ -21,6 +21,11 @@
 
     &:not(:last-child) {
       margin-right: 8px;
+
+      [dir='rtl'] & {
+        margin-left: 8px;
+        margin-right: 0;
+      }
     }
 
     &__copy-icon {
@@ -47,6 +52,11 @@
     margin-right: 8px;
     min-width: 0;
 
+    [dir='rtl'] & {
+      margin-left: 8px;
+      margin-right: 0;
+    }
+
     @media screen and (max-width: $break-small) {
       margin: 0 0 8px 0;
     }
@@ -58,6 +68,11 @@
 
     @media screen and (min-width: $break-large) {
       padding-left: 12px;
+
+      [dir='rtl'] & {
+        padding-left: 0;
+        padding-right: 12px;
+      }
     }
   }
 }

--- a/ui/app/components/app/transaction-list/index.scss
+++ b/ui/app/components/app/transaction-list/index.scss
@@ -18,8 +18,16 @@
     border-bottom: 1px solid $Grey-100;
     padding: 8px 0 8px 20px;
 
+    [dir='rtl'] & {
+      padding: 8px 20px 8px 0;
+    }
+
     @media screen and (max-width: $break-small) {
       padding: 8px 0 8px 16px;
+
+      [dir='rtl'] & {
+        padding: 8px 16px 8px 0;
+      }
     }
   }
 

--- a/ui/app/components/app/transaction-view-balance/index.scss
+++ b/ui/app/components/app/transaction-view-balance/index.scss
@@ -46,6 +46,11 @@
 
   &__cached-star {
     margin-left: 4px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 4px;
+    }
   }
 
   &__cached-balance, &__cached-star {
@@ -93,6 +98,11 @@
 
     &:not(:last-child) {
       margin-right: 12px;
+
+      [dir='rtl'] & {
+        margin-left: 12px;
+        margin-right: 0;
+      }
     }
   }
 }

--- a/ui/app/components/ui/currency-display/currency-display.component.js
+++ b/ui/app/components/ui/currency-display/currency-display.component.js
@@ -32,7 +32,7 @@ export default class CurrencyDisplay extends PureComponent {
         title={!hideTitle && title || null}
       >
         { prefixComponent }
-        <span className="currency-display-component__text">{ text }</span>
+        <span className="currency-display-component__text" dir="ltr">{ text }</span>
         {
           suffix && (
             <span className="currency-display-component__suffix">

--- a/ui/app/components/ui/currency-display/index.scss
+++ b/ui/app/components/ui/currency-display/index.scss
@@ -11,5 +11,10 @@
 
   &__suffix {
     padding-left: 4px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 4px;
+    }
   }
 }

--- a/ui/app/components/ui/editable-label.js
+++ b/ui/app/components/ui/editable-label.js
@@ -37,6 +37,7 @@ class EditableLabel extends Component {
       h('input.large-input.editable-label__input', {
         type: 'text',
         required: true,
+        dir: 'auto',
         value: this.state.value,
         onKeyPress: (event) => {
           if (event.key === 'Enter') {

--- a/ui/app/components/ui/identicon/index.scss
+++ b/ui/app/components/ui/identicon/index.scss
@@ -4,6 +4,7 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  direction: ltr;
 
   &__address-wrapper {
     height: 40px;

--- a/ui/app/components/ui/page-container/index.scss
+++ b/ui/app/components/ui/page-container/index.scss
@@ -34,6 +34,11 @@
       font-size: 40px;
       line-height: 20px;
     }
+
+    [dir='rtl'] & {
+      left: 16px;
+      right: auto;
+    }
   }
 
   &__header-row {

--- a/ui/app/components/ui/sender-to-recipient/index.scss
+++ b/ui/app/components/ui/sender-to-recipient/index.scss
@@ -50,6 +50,10 @@
         display: flex;
         align-items: center;
         justify-content: center;
+
+        [dir='rtl'] & {
+          transform: rotate(180deg);
+        }
       }
 
       &__arrow-circle {
@@ -108,6 +112,10 @@
         display: flex;
         justify-content: center;
         align-items: center;
+
+        [dir='rtl'] & {
+          transform: rotate(180deg);
+        }
       }
     }
   }
@@ -143,6 +151,10 @@
         display: flex;
         justify-content: center;
         align-items: center;
+
+        [dir='rtl'] & {
+          transform: rotate(180deg);
+        }
       }
     }
   }

--- a/ui/app/components/ui/sender-to-recipient/index.scss
+++ b/ui/app/components/ui/sender-to-recipient/index.scss
@@ -74,6 +74,16 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         font-size: .875rem;
+
+        [dir='rtl'] & {
+          direction: ltr;
+          text-align: right;
+
+          span {
+            display: block;
+            direction: rtl;
+          }
+        }
       }
     }
   }
@@ -106,6 +116,16 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         font-size: .5rem;
+
+        [dir='rtl'] & {
+          direction: ltr;
+          text-align: right;
+
+          span {
+            display: block;
+            direction: rtl;
+          }
+        }
       }
 
       &__arrow-container {
@@ -145,6 +165,16 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         font-size: .6875rem;
+
+        [dir='rtl'] & {
+          direction: ltr;
+          text-align: right;
+
+          span {
+            display: block;
+            direction: rtl;
+          }
+        }
       }
 
       &__arrow-container {

--- a/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -112,6 +112,7 @@ export default class SenderToRecipient extends PureComponent {
           onHidden={() => this.setState({ recipientAddressCopied: false })}
         >
           <div className="sender-to-recipient__name">
+            <span>{ addressOnly ? `${t('to')}: ` : '' }</span>
             {
               addressOnly
                 ? `${t('to')}: ${checksummedRecipientAddress}`

--- a/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -66,7 +66,8 @@ export default class SenderToRecipient extends PureComponent {
         onHidden={() => this.setState({ senderAddressCopied: false })}
       >
         <div className="sender-to-recipient__name">
-          { addressOnly ? `${t('from')}: ${checksummedSenderAddress}` : senderName }
+          <span>{ addressOnly ? `${t('from')}: ` : '' }</span>
+          { addressOnly ? checksummedSenderAddress : senderName }
         </div>
       </Tooltip>
     )
@@ -115,7 +116,7 @@ export default class SenderToRecipient extends PureComponent {
             <span>{ addressOnly ? `${t('to')}: ` : '' }</span>
             {
               addressOnly
-                ? `${t('to')}: ${checksummedRecipientAddress}`
+                ? checksummedRecipientAddress
                 : (recipientNickname || recipientName || this.context.t('newContract'))
             }
           </div>

--- a/ui/app/components/ui/unit-input/unit-input.component.js
+++ b/ui/app/components/ui/unit-input/unit-input.component.js
@@ -84,6 +84,7 @@ export default class UnitInput extends PureComponent {
           <div className="unit-input__input-container">
             <input
               type="number"
+              dir="ltr"
               className={classnames('unit-input__input', { 'unit-input__disabled': maxModeOn })}
               value={value}
               placeholder={placeholder}

--- a/ui/app/css/itcss/components/account-details-dropdown.scss
+++ b/ui/app/css/itcss/components/account-details-dropdown.scss
@@ -4,4 +4,9 @@
 	top: 120px;
 	right: 15px;
 	z-index: 2000;
+
+	[dir='rtl'] & {
+		left: 15px;
+		right: auto;
+	}
 }

--- a/ui/app/css/itcss/components/account-dropdown-mini.scss
+++ b/ui/app/css/itcss/components/account-dropdown-mini.scss
@@ -1,0 +1,53 @@
+.account-dropdown-mini {
+  height: 22px;
+  background-color: $white;
+  font-family: Roboto;
+  line-height: 16px;
+  font-size: 12px;
+  width: 124px;
+
+  &__close-area {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    width: 100%;
+    height: 100%;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 0;
+    }
+  }
+
+  &__list {
+    z-index: 1050;
+    position: absolute;
+    height: 180px;
+    width: 96pxpx;
+    border: 1px solid $geyser;
+    border-radius: 4px;
+    background-color: $white;
+    box-shadow: 0 3px 6px 0 rgba(0 ,0 ,0 ,.11);
+    overflow-y: scroll;
+  }
+
+  .account-list-item {
+    margin-top: 6px;
+  }
+
+  .account-list-item__account-name {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 80px;
+  }
+
+  .account-list-item__top-row {
+    margin: 0;
+  }
+
+  .account-list-item__icon {
+    position: initial;
+  }
+}

--- a/ui/app/css/itcss/components/account-dropdown.scss
+++ b/ui/app/css/itcss/components/account-dropdown.scss
@@ -22,10 +22,20 @@
     margin-top: 10px;
     margin-left: 8px;
     position: relative;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 8px;
+    }
   }
 
   &__tooltip-wrapper {
     left: -10px;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: -10px;
+    }
   }
 
   &__account-balances {
@@ -36,6 +46,11 @@
     margin-left: 34px;
     margin-top: 4px;
     position: relative;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 34px;
+    }
   }
 
   &__primary-cached-container {
@@ -44,6 +59,11 @@
 
   &__cached-star {
     margin-left: 4px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 4px;
+    }
   }
 
   &__cached-balances {
@@ -59,12 +79,22 @@
   &__account-name {
     font-size: 16px;
     margin-left: 8px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 8px;
+    }
   }
 
   &__icon {
     position: absolute;
     right: 12px;
     top: 1px;
+
+    [dir='rtl'] & {
+      left: 12px;
+      right: auto;
+    }
   }
 
   &__account-primary-balance,
@@ -79,6 +109,11 @@
     top: 3px;
     left: -8px;
     color: $curious-blue;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: -8px;
+    }
   }
 
   &__account-primary-balance {
@@ -95,6 +130,11 @@
     width: 80%;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 35px;
+    }
   }
 
   &__dropdown {

--- a/ui/app/css/itcss/components/confirm.scss
+++ b/ui/app/css/itcss/components/confirm.scss
@@ -99,6 +99,11 @@
   @media screen and (max-width: $break-small) {
     margin-left: 22px;
     margin-right: 8px;
+
+    [dir='rtl'] & {
+      margin-left: 8px;
+      margin-right: 22px;
+    }
   }
 }
 
@@ -110,6 +115,11 @@
   top: 38px;
   right: 38px;
   background: none;
+
+  [dir='rtl'] & {
+    left: 38px;
+    right: auto;
+  }
 }
 
 .confirm-screen-account-wrapper {
@@ -205,6 +215,10 @@
   line-height: 40px;
   color: $scorpion;
   text-align: left;
+
+  [dir='rtl'] & {
+    text-align: right;
+  }
 }
 
 section .confirm-screen-account-name,
@@ -212,6 +226,10 @@ section .confirm-screen-account-number,
 .confirm-screen-row-info,
 .confirm-screen-row-detail {
   text-align: left;
+
+  [dir='rtl'] & {
+    text-align: right;
+  }
 }
 
 .confirm-screen-rows {
@@ -234,6 +252,11 @@ section .confirm-screen-account-number,
   padding-left: 35px;
   font-size: 16px;
   line-height: 22px;
+
+  [dir='rtl'] & {
+    padding-left: 12px;
+    padding-right: 25px;
+  }
 
   &:not(:last-of-type) {
     border-bottom: 1px solid $alto;
@@ -294,6 +317,12 @@ section .confirm-screen-account-number,
   right: 12px;
   width: 80px;
   text-align: right;
+
+  [dir='rtl'] & {
+    text-align: left;
+    left: 12px;
+    right: auto;
+  }
 }
 
 .confirm-screen-row.confirm-screen-total-box {
@@ -318,6 +347,11 @@ section .confirm-screen-account-number,
     width: 100%;
     margin-top: 7px;
     text-align: center;
+
+    [dir='rtl'] & {
+      left: 0;
+      right: auto;
+    }
   }
 }
 

--- a/ui/app/css/itcss/components/editable-label.scss
+++ b/ui/app/css/itcss/components/editable-label.scss
@@ -26,6 +26,13 @@
     position: absolute;
     margin-left: 10px;
     left: 100%;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 10px;
+      left: auto;
+      right: 100%;
+    }
   }
 
   &__icon {

--- a/ui/app/css/itcss/components/loading-overlay.scss
+++ b/ui/app/css/itcss/components/loading-overlay.scss
@@ -11,6 +11,11 @@
   height: 100%;
   background: rgba(255, 255, 255, .8);
 
+  [dir='rtl'] & {
+    left: auto;
+    right: 0;
+  }
+
   &__screen-content {
     display: flex;
     flex-direction: column;

--- a/ui/app/css/itcss/components/menu.scss
+++ b/ui/app/css/itcss/components/menu.scss
@@ -33,6 +33,11 @@
       height: 16px;
       width: 16px;
       margin-right: 14px;
+
+      [dir='rtl'] & {
+        margin-left: 14px;
+        margin-right: 0;
+      }
     }
 
     &__text {
@@ -59,5 +64,10 @@
     top: 0;
     left: 0;
     z-index: 100;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 0;
+    }
   }
 }

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -22,6 +22,7 @@
   border: none;
   font-family: Roboto;
   font-size: 14px;
+  direction: ltr;
 }
 
 @media screen and (max-width: 575px) {

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -160,6 +160,11 @@
   top: 12px;
   right: 20px;
   font-size: 25px;
+
+  [dir='rtl'] & {
+    left: 20px;
+    right: auto;
+  }
 }
 
 .edit-account-name-modal-title {
@@ -181,6 +186,10 @@
   margin: 10px;
   padding: 10px;
   font-size: 18px;
+
+  [dir='rtl'] & {
+    text-align: right;
+  }
 }
 
 // Account Modal Container
@@ -207,6 +216,11 @@
   left: 17px;
   cursor: pointer;
 
+  [dir='rtl'] & {
+    left: auto;
+    right: 17px;
+  }
+
   &__text {
     margin-top: 2px;
     font-family: Roboto;
@@ -223,6 +237,11 @@
   top: 10px;
   right: 12px;
   cursor: pointer;
+
+  [dir='rtl'] & {
+    left: 12px;
+    right: auto;
+  }
 }
 
 .account-modal-container .identicon {
@@ -313,6 +332,10 @@
   line-height: 21px;
   width: 291px;
   height: 44px;
+
+  [dir='rtl'] & {
+    padding: 10px 17px 13px 0;
+  }
 }
 
 .private-key-password::-webkit-input-placeholder {
@@ -347,6 +370,11 @@
 
 .export-private-key__button--cancel {
   margin-right: 15px;
+
+  [dir='rtl'] & {
+    margin-left: 15px;
+    margin-right: 0;
+  }
 }
 
 .private-key-password-display-wrapper {
@@ -403,6 +431,11 @@
   right: 17.5px;
   font-family: sans-serif;
   cursor: pointer;
+
+  [dir='rtl'] & {
+    left: 17.5px;
+    right: auto;
+  }
 }
 
 .new-account-modal-content {
@@ -635,6 +668,11 @@
       top: 20.8px;
       right: 28px;
       cursor: pointer;
+
+      [dir='rtl'] & {
+        left: 28px;
+        right: auto;
+      }
     }
   }
 
@@ -701,6 +739,11 @@
       position: absolute;
       top: 10px;
       left: 0px;
+
+      [dir='rtl'] & {
+        left: auto;
+        right: 0;
+      }
     }
 
     &__shapeshift-buy {

--- a/ui/app/css/itcss/components/network.scss
+++ b/ui/app/css/itcss/components/network.scss
@@ -62,6 +62,10 @@
     margin: 0 4px 0 6px;
     font-size: 1rem;
     flex: 0 0 auto;
+
+    [dir='rtl'] & {
+      margin: 0 6px 0 4px;
+    }
   }
 }
 
@@ -82,6 +86,11 @@
 .dropdown-menu-item .fa.delete {
     margin-right: 10px;
     display: none;
+
+    [dir='rtl'] & {
+      margin-left: 10px;
+      margin-right: 0;
+    }
 }
 
 .dropdown-menu-item:hover .fa.delete {
@@ -91,16 +100,36 @@
 .network-droppo {
   right: 2px;
 
+  [dir='rtl'] & {
+    left: 2px;
+    right: auto;
+  }
+
   @media screen and (min-width: 576px) {
     right: calc(((100% - 85vw) / 2) + 2px);
+
+    [dir='rtl'] & {
+      left: calc(((100% - 85vw) / 2) + 2px);
+      right: auto;
+    }
   }
 
   @media screen and (min-width: 769px) {
     right: calc(((100% - 80vw) / 2) + 2px);
+
+    [dir='rtl'] & {
+      left: calc(((100% - 80vw) / 2) + 2px);
+      right: auto;
+    }
   }
 
   @media screen and (min-width: 1281px) {
     right: calc(((100% - 65vw) / 2) + 2px);
+
+    [dir='rtl'] & {
+      left: calc(((100% - 65vw) / 2) + 2px);
+      right: auto;
+    }
   }
 }
 
@@ -116,6 +145,11 @@
 .network-check__transparent {
   color: $white;
   margin-left: 7px;
+
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 7px;
+  }
 }
 
 .network-check__transparent {
@@ -197,10 +231,20 @@
   width: 16px;
   margin-left: 5px;
 
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 5px;
+  }
+
   img {
     height: 26px;
     position: absolute;
     top: -5px;
     left: -6px;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: -6px;
+    }
   }
 }

--- a/ui/app/css/itcss/components/network.scss
+++ b/ui/app/css/itcss/components/network.scss
@@ -145,11 +145,6 @@
 .network-check__transparent {
   color: $white;
   margin-left: 7px;
-
-  [dir='rtl'] & {
-    margin-left: 0;
-    margin-right: 7px;
-  }
 }
 
 .network-check__transparent {

--- a/ui/app/css/itcss/components/new-account.scss
+++ b/ui/app/css/itcss/components/new-account.scss
@@ -23,12 +23,22 @@
     line-height: 43px;
     margin-top: 22px;
     margin-left: 29px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 29px;
+    }
   }
 
   &__tabs {
     margin-left: 22px;
     display: flex;
     margin-top: 10px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 22px;
+    }
 
     &__tab {
       height: 54px;
@@ -225,10 +235,20 @@
   &__btn:first-child {
     margin-right: 15px;
     margin-left: 20px;
+
+    [dir='rtl'] & {
+      margin-left: 15px;
+      margin-right: 20px;
+    }
   }
 
   &__btn:last-child {
     margin-right: 20px;
+
+    [dir='rtl'] & {
+      margin-left: 20px;
+      margin-right: 0;
+    }
   }
 
   &__hdPath {
@@ -242,6 +262,11 @@
       display: flex;
       margin-top: 10px;
       margin-right: 15px;
+
+      [dir='rtl'] & {
+        margin-left: 15px;
+        margin-right: 0;
+      }
     }
 
     &__select {
@@ -308,11 +333,21 @@
       width: 100%;
       display: block;
       margin-left: 20px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 20px;
+      }
     }
 
     &__link {
       color: #2f9ae0;
       margin-left: 5px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 5px;
+      }
     }
   }
 
@@ -416,6 +451,11 @@
     padding-left: 10px;
     padding-top: 10px;
     padding-bottom: 10px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 10px;
+    }
   }
 
   &__item__balance {
@@ -454,6 +494,11 @@
     padding: 0px;
     text-transform: uppercase;
     font-family: Roboto;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 16px;
+    }
   }
 }
 
@@ -484,6 +529,11 @@
 
   &__button:not(:last-child) {
     margin-right: 16px;
+
+    [dir='rtl'] & {
+      margin-left: 16px;
+      margin-right: 0;
+    }
   }
 }
 

--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -81,6 +81,11 @@ $wallet-view-bg: $alabaster;
   margin-left: 15px;
   font-size: 16px;
 
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 15px;
+  }
+
   // No title on mobile
   @media screen and (max-width: 575px) {
     display: none;

--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -57,6 +57,11 @@ $wallet-view-bg: $alabaster;
   z-index: 200;
   position: relative;
 
+  [dir='rtl'] & i.fa.fa-clipboard {
+    margin-left: 0 !important;
+    margin-right: 8px !important;
+  }
+
   @media screen and (min-width: 576px) {
     overflow-y: scroll;
     overflow-x: hidden;

--- a/ui/app/css/itcss/components/request-signature.scss
+++ b/ui/app/css/itcss/components/request-signature.scss
@@ -95,6 +95,11 @@
   &__account {
     color: $dusty-gray;
     margin-left: 17px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 17px;
+    }
   }
 
   &__account-text {
@@ -129,16 +134,29 @@
     color: $dusty-gray;
     margin-right: 17px;
     width: 124px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 17px;
+    }
   }
 
   &__balance-text {
     text-align: right;
     font-size: 14px;
+
+    [dir='rtl'] & {
+      text-align: left;
+    }
   }
 
   &__balance-value {
     text-align: right;
     margin-top: 2.5px;
+
+    [dir='rtl'] & {
+      text-align: left;
+    }
   }
 
   &__request-icon {
@@ -213,6 +231,11 @@
     margin-top: 12px;
     margin-left: 18px;
     width: 100%;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 18px;
+    }
   }
 
   &__row-value {
@@ -250,6 +273,11 @@
 
     &__cancel-button {
       margin-right: 1.2rem;
+
+      [dir='rtl'] & {
+        margin-left: 1.2rem;
+        margin-right: 0;
+      }
     }
   }
 }

--- a/ui/app/css/itcss/components/sections.scss
+++ b/ui/app/css/itcss/components/sections.scss
@@ -93,12 +93,21 @@ textarea.twelve-word-phrase {
 
 .section-title .fa-arrow-left {
   margin: -2px 8px 0px -8px;
+
+  [dir='rtl'] & {
+    margin: -2px -8px 0 8px;
+  }
 }
 
 .sizing-input {
   font-size: 14px;
   height: 30px;
   padding-left: 5px;
+
+  [dir='rtl'] & {
+    padding-left: 0;
+    padding-right: 5px;
+  }
 }
 
 .editable-label {
@@ -130,6 +139,10 @@ textarea.twelve-word-phrase {
 
 .unconftx-link .fa-arrow-right {
   margin: 0 -8px 0px 8px;
+
+  [dir='rtl'] & {
+    margin: 0 8px 0 -8px;
+  }
 }
 
 /* identity panel */
@@ -157,6 +170,11 @@ textarea.twelve-word-phrase {
   margin-top: 32px;
   margin-right: 6px;
   color: #b9b9b9;
+
+  [dir='rtl'] & {
+    margin-left: 6px;
+    margin-right: 0;
+  }
 }
 
 .identity-panel .arrow-right {
@@ -164,6 +182,11 @@ textarea.twelve-word-phrase {
   width: 42px;
   min-width: 18px;
   height: 100%;
+
+  [dir='rtl'] & {
+    padding-left: 0;
+    padding-right: 18px;
+  }
 }
 
 .identity-copy.flex-column {
@@ -233,6 +256,11 @@ textarea.twelve-word-phrase {
   font-size: 11px;
   text-rendering: geometricPrecision;
   color: #f7861c;
+
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 50px;
+  }
 }
 
 .name-label:hover .edit-text {
@@ -276,6 +304,11 @@ textarea.twelve-word-phrase {
   padding-bottom: 10px;
   display: inline-block;
   padding-left: 5px;
+
+  [dir='rtl'] & {
+    padding-left: 0;
+    padding-right: 5px;
+  }
 }
 
 /* buy eth warning screen */

--- a/ui/app/css/itcss/components/sections.scss
+++ b/ui/app/css/itcss/components/sections.scss
@@ -449,6 +449,7 @@ textarea.twelve-word-phrase {
 .qr-ellip-address, .ellip-address {
   overflow: hidden;
   text-overflow: ellipsis;
+  direction: ltr;
 }
 
 .qr-header {

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -570,11 +570,6 @@
       left: 0;
       right: 0;
       margin: 0 auto;
-
-      [dir='rtl'] & {
-        left: 0;
-        right: auto;
-      }
     }
   }
 
@@ -930,6 +925,11 @@
       + .send-v2__to-autocomplete__qr-code {
         top: 2px;
         right: 0;
+
+        [dir='rtl'] & {
+          left: 0;
+          right: auto;
+        }
       }
     }
   }

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -69,6 +69,11 @@
 
   .fa-bolt {
     padding-right: 4px;
+
+    [dir='rtl'] & {
+      padding-left: 4px;
+      padding-right: 0;
+    }
   }
 
   .large-input {
@@ -102,6 +107,11 @@
       line-height: 12px;
       left: 8px;
       color: $red;
+
+      [dir='rtl'] & {
+        left: auto;
+        right: 8px;
+      }
     }
   }
 
@@ -113,6 +123,11 @@
     line-height: 12px;
     left: 8px;
     color: $red;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 8px;
+    }
   }
 }
 
@@ -134,6 +149,11 @@
   padding-right: 12px;
   font-size: 16px;
   color: $scorpion;
+
+  [dir='rtl'] & {
+    padding-left: 12px;
+    padding-right: 10px;
+  }
 }
 
 .send-screen-amount-labels {
@@ -173,6 +193,11 @@
   z-index: 1000;
   width: 100%;
   height: 100%;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: 0;
+  }
 }
 
 .customize-gas-tooltip-container {
@@ -201,6 +226,11 @@
   left: 107px;
   top: 294px;
   box-shadow: 2px 2px 2px $alto;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: 107px;
+  }
 }
 
 .customize-gas-tooltip-container input[type="number"]::-webkit-inner-spin-button {
@@ -238,6 +268,11 @@
 .gas-tooltip-input-label i {
   color: $silver-chalice;
   margin-left: 6px;
+
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 6px;
+  }
 }
 
 .customize-gas-input {
@@ -247,6 +282,11 @@
   font-size: 16px;
   color: $nile-blue;
   padding-left: 8px;
+
+  [dir='rtl'] & {
+    padding-left: 0;
+    padding-right: 8px;
+  }
 }
 
 .customize-gas-input-wrapper {
@@ -259,6 +299,11 @@
   right: 26px;
   font-size: 12px;
   color: $silver-chalice;
+
+  [dir='rtl'] & {
+    left: 26px;
+    right: auto;
+  }
 }
 
 .gas-tooltip-input-arrows {
@@ -275,12 +320,24 @@
   font-size: .8em;
   padding: 1px 4px;
   cursor: pointer;
+
+  [dir='rtl'] & {
+    border-left: 1px solid #dadada;
+    border-right: 0;
+    left: 4px;
+    right: auto;
+  }
 }
 
 .token-gas {
   &__amount {
     display: inline-block;
     margin-right: 4px;
+
+    [dir='rtl'] & {
+      margin-left: 4px;
+      margin-right: 0;
+    }
   }
 
   &__symbol {
@@ -374,6 +431,11 @@
 
     .token-balance__amount {
       padding-right: 12px;
+
+      [dir='rtl'] & {
+        padding-left: 12px;
+        padding-right: 0;
+      }
     }
   }
 
@@ -447,6 +509,11 @@
     top: -2px;
     left: 0;
     font-size: 1.12em;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 0;
+    }
   }
 
   &__arrow-background {
@@ -458,6 +525,11 @@
     left: 199px;
     border-radius: 50%;
     z-index: 100;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 199px;
+    }
 
     @media screen and (max-width: $break-small) {
       top: 36px;
@@ -488,11 +560,21 @@
     left: 178px;
     top: 75px;
 
+    [dir='rtl'] & {
+      left: auto;
+      right: 178px;
+    }
+
     @media screen and (max-width: $break-small) {
       top: 46px;
       left: 0;
       right: 0;
       margin: 0 auto;
+
+      [dir='rtl'] & {
+        left: 0;
+        right: auto;
+      }
     }
   }
 
@@ -518,6 +600,11 @@
     line-height: 12px;
     left: 8px;
     color: $red;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 8px;
+    }
   }
 
   &__error-amount {
@@ -529,6 +616,11 @@
     line-height: 12px;
     left: 8px;
     color: $orange;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 8px;
+    }
   }
 
   &__error-border {
@@ -618,6 +710,11 @@
       z-index: 1000;
       width: 100%;
       height: 100%;
+
+      [dir='rtl'] & {
+        left: auto;
+        right: 0;
+      }
     }
 
     &__list {
@@ -632,6 +729,11 @@
       margin-top: 11px;
       margin-left: -1px;
       overflow-y: scroll;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: -1px;
+      }
     }
   }
 
@@ -676,6 +778,11 @@
       display: flex;
       flex-flow: column nowrap;
       margin-left: 8px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 8px;
+      }
     }
 
     &__symbol {
@@ -690,6 +797,11 @@
 
       &__label {
         margin-right: .25rem;
+
+        [dir='rtl'] & {
+          margin-left: .25rem;
+          margin-right: 0;
+        }
       }
     }
 
@@ -712,6 +824,11 @@
       overflow-y: scroll;
       margin-top: 0;
       padding: 4px 0;
+
+      [dir='rtl'] & {
+        left: auto;
+        right: 0;
+      }
 
       .send-v2__asset-dropdown__asset {
         padding: 8px;
@@ -762,6 +879,11 @@
       cursor: pointer;
       padding: 8px 5px 5px;
       border-radius: 4px;
+
+      [dir='rtl'] & {
+        left: 33px;
+        right: auto;
+      }
     }
 
     &__qr-code:hover {
@@ -899,6 +1021,11 @@
     top: 14px;
     cursor: pointer;
     font-size: 1em;
+
+    [dir='rtl'] & {
+      left: 15px;
+      right: auto;
+    }
   }
 
   &__sliders-icon {
@@ -958,6 +1085,11 @@
 
     &__title {
       margin-left: 19.25px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 19.25px;
+      }
     }
 
     &__close::after {
@@ -967,6 +1099,11 @@
       font-family: sans-serif;
       cursor: pointer;
       margin-right: 19.25px;
+
+      [dir='rtl'] & {
+        margin-left: 19.25px;
+        margin-right: 0;
+      }
     }
 
     &__content {
@@ -1003,6 +1140,11 @@
       display: flex;
       justify-content: space-between;
       margin-right: 21.25px;
+
+      [dir='rtl'] & {
+        margin-left: 21.25px;
+        margin-right: 0;
+      }
     }
 
     &__revert, &__cancel, &__save, &__save__error {
@@ -1017,6 +1159,11 @@
       color: $silver-chalice;
       font-size: 16px;
       margin-left: 21.25px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 21.25px;
+      }
     }
 
     &__cancel, &__save, &__save__error {
@@ -1039,10 +1186,20 @@
       color: $red;
       width: 100%;
       text-align: center;
+
+      [dir='rtl'] & {
+        left: 0;
+        right: auto;
+      }
     }
 
     &__cancel {
       margin-right: 10px;
+
+      [dir='rtl'] & {
+        margin-left: 10px;
+        margin-right: 0;
+      }
     }
   }
 
@@ -1052,6 +1209,11 @@
     flex-flow: column;
     align-items: flex-start;
     padding-left: 20px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 20px;
+    }
 
     &__title {
       height: 26px;
@@ -1082,6 +1244,11 @@
       border: 1px solid $geyser;
       background-color: $white;
       padding-left: 15px;
+
+      [dir='rtl'] & {
+        padding-left: 0;
+        padding-right: 15px;
+      }
     }
 
     .gas-tooltip-input-arrows {
@@ -1095,6 +1262,13 @@
       display: flex;
       justify-content: space-around;
       align-items: center;
+
+      [dir='rtl'] & {
+        border-left: 0;
+        border-right: 1px solid #dadada;
+        left: 0;
+        right: auto;
+      }
     }
 
     .gas-tooltip-input-arrow-wrapper {
@@ -1142,6 +1316,11 @@
   top: 14px;
   cursor: pointer;
   font-size: 1em;
+
+  [dir='rtl'] & {
+    left: 15px;
+    right: auto;
+  }
 }
 
 .gas-fee-reset {
@@ -1159,6 +1338,11 @@
   font-size: 14px;
   color: #2f9ae0;
   font-family: Roboto;
+
+  [dir='rtl'] & {
+    left: 12px;
+    right: auto;
+  }
 }
 
 .sliders-icon {

--- a/ui/app/css/itcss/components/simple-dropdown.scss
+++ b/ui/app/css/itcss/components/simple-dropdown.scss
@@ -36,6 +36,11 @@
   overflow-y: scroll;
   left: 0;
   top: 100%;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: 0;
+  }
 }
 
 .simple-dropdown__option {
@@ -62,4 +67,9 @@
   z-index: 1000;
   width: 100%;
   height: 100%;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: 0;
+  }
 }

--- a/ui/app/css/itcss/components/tab-bar.scss
+++ b/ui/app/css/itcss/components/tab-bar.scss
@@ -62,6 +62,10 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: center;
+
+      [dir='rtl'] & {
+        transform: rotate(180deg);
+      }
     }
   }
 

--- a/ui/app/css/itcss/components/token-list.scss
+++ b/ui/app/css/itcss/components/token-list.scss
@@ -20,6 +20,11 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
     text-overflow: ellipsis;
     min-width: 0;
     max-width: 100%;
+
+    [dir='rtl'] & {
+      margin-left: 4px;
+      margin-right: 0;
+    }
   }
 
   &__token-balance, &__token-symbol {
@@ -56,8 +61,18 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
     border: '1px solid #dedede';
     min-width: 50px;
 
+    [dir='rtl'] & {
+      margin-left: 15px;
+      margin-right: 0;
+    }
+
     @media #{$wallet-balance-breakpoint-range} {
       margin-right: 4%;
+
+      [dir='rtl'] & {
+        margin-left: 4%;
+        margin-right: 0;
+      }
     }
   }
 
@@ -71,6 +86,11 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
   &__ellipsis {
     line-height: 45px;
     margin-left: 5px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 5px;
+    }
   }
 
   &__balance-wrapper {
@@ -88,8 +108,18 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
   right: 25px;
   z-index: 2000;
 
+  [dir='rtl'] & {
+    left: 25px;
+    right: auto;
+  }
+
   @media #{$wallet-balance-breakpoint-range} {
     right: 18px;
+
+    [dir='rtl'] & {
+      left: 18px;
+      right: auto;
+    }
   }
 
   &__close-area {
@@ -100,6 +130,11 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
     width: 100%;
     height: 100%;
     cursor: default;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 0;
+    }
   }
 
   &__container {

--- a/ui/app/css/itcss/components/transaction-list.scss
+++ b/ui/app/css/itcss/components/transaction-list.scss
@@ -138,6 +138,11 @@
   padding: 4px;
   cursor: pointer;
 
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 44px;
+  }
+
   @media screen and (min-width: 576px) and (max-width: 679px) {
     flex-flow: column;
     align-items: center;
@@ -158,17 +163,34 @@
   margin-left: 6px;
   cursor: pointer;
 
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 6px;
+  }
+
   @media screen and (min-width: 576px) and (max-width: 679px) {
     margin-left: 0px;
+
+    [dir='rtl'] & {
+      margin-right: 0;
+    }
   }
 
   @media screen and (min-width: 380px) and (max-width: 575px) {
     margin-left: 6px;
+
+    [dir='rtl'] & {
+      margin-right: 6px;
+    }
   }
 
   @media screen and (max-width: 379px) {
     margin-left: 0px;
     text-align: center;
+
+    [dir='rtl'] & {
+      margin-right: 0;
+    }
   }
 }
 
@@ -183,6 +205,11 @@
   flex: 0 0 auto;
   margin-right: 16px;
   display: flex;
+
+  [dir='rtl'] & {
+    margin-left: 16px;
+    margin-right: 0;
+  }
 }
 
 .tx-list-account-and-status-wrapper {
@@ -269,6 +296,10 @@
     .tx-list-value {
       font-size: 16px;
       text-align: right;
+
+      [dir='rtl'] & {
+        text-align: left;
+      }
     }
 
     .tx-list-value--confirmed {
@@ -278,6 +309,10 @@
     .tx-list-fiat-value {
       font-size: 12px;
       text-align: right;
+
+      [dir='rtl'] & {
+        text-align: left;
+      }
     }
   }
 
@@ -299,6 +334,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+
+  [dir='rtl'] & {
+    text-align: left;
+  }
 }
 
 .tx-list-fiat-value {
@@ -308,6 +347,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+
+  [dir='rtl'] & {
+    text-align: left;
+  }
 }
 
 .tx-list-value--confirmed {

--- a/ui/app/css/itcss/components/wallet-balance.scss
+++ b/ui/app/css/itcss/components/wallet-balance.scss
@@ -40,6 +40,11 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
     margin-left: 15px;
     min-width: 0;
 
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 15px;
+    }
+
     .token-amount {
       font-size: 1.5rem;
     }
@@ -51,6 +56,11 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
 
     @media #{$wallet-balance-breakpoint-range} {
       margin-left: 4%;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 4%;
+      }
 
       .token-amount {
         font-size: 105%;

--- a/ui/app/pages/add-token/index.scss
+++ b/ui/app/pages/add-token/index.scss
@@ -17,6 +17,11 @@
 
   &__search-token {
     padding: 16px;
+
+    [dir='rtl'] & img {
+      margin-left: 12px !important;
+      margin-right: 0 !important;
+    }
   }
 
   &__token-list {

--- a/ui/app/pages/add-token/index.scss
+++ b/ui/app/pages/add-token/index.scss
@@ -40,6 +40,12 @@
       color: $curious-blue;
       padding-right: 4px;
       cursor: pointer;
+
+      [dir='rtl'] & {
+        text-align: left;
+        padding-left: 4px;
+        padding-right: 0;
+      }
     }
   }
 }

--- a/ui/app/pages/add-token/token-list/index.scss
+++ b/ui/app/pages/add-token/token-list/index.scss
@@ -66,5 +66,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    direction: ltr;
   }
 }

--- a/ui/app/pages/add-token/token-list/index.scss
+++ b/ui/app/pages/add-token/token-list/index.scss
@@ -48,6 +48,11 @@
     box-shadow: 0 2px 4px 0 rgba($black, .24);
     margin-right: 12px;
     flex: 0 0 auto;
+
+    [dir='rtl'] & {
+      margin-left: 12px;
+      margin-right: 0;
+    }
   }
 
   &__token-data {

--- a/ui/app/pages/confirm-add-token/index.scss
+++ b/ui/app/pages/confirm-add-token/index.scss
@@ -30,6 +30,11 @@
         font-size: 43px;
         line-height: 43px;
         margin-right: 8px;
+
+        [dir='rtl'] & {
+          margin-left: 8px;
+          margin-right: 0;
+        }
       }
 
       &__symbol {
@@ -65,5 +70,10 @@
   &__token-icon {
     margin-right: 12px;
     flex: 0 0 auto;
+
+    [dir='rtl'] & {
+      margin-left: 12px;
+      margin-right: 0;
+    }
   }
 }

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -81,6 +81,7 @@
     background-color: #FFFFFF;
     padding: 16px;
     margin-top: 8px;
+    direction: ltr;
   }
 
   &__breadcrumbs {

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -155,6 +155,11 @@
     font-size: 18px;
     color: #939090;
     margin-left: 18px;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 18px;
+    }
   }
 
   &__link-text {

--- a/ui/app/pages/first-time-flow/metametrics-opt-in/index.scss
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/index.scss
@@ -13,10 +13,20 @@
     margin-right: 28%;
     color: black;
 
+    [dir='rtl'] & {
+      margin-left: 28%;
+      margin-right: 26.26%;
+    }
+
     @media screen and (max-width: 575px) {
       justify-content: center;
       margin-left: 2%;
       margin-right: 0%;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 2%;
+      }
     }
 
     .app-header__logo-container {
@@ -69,11 +79,21 @@
     .fa-check {
       margin-right: 12px;
       color: #1ACC56;
+
+      [dir='rtl'] & {
+        margin-left: 12px;
+        margin-right: 0;
+      }
     }
 
     .fa-times {
       margin-right: 12px;
       color: #D0021B;
+
+      [dir='rtl'] & {
+        margin-left: 12px;
+        margin-right: 0;
+      }
     }
   }
 
@@ -115,6 +135,11 @@
       justify-content: center;
       margin-left: 2%;
       max-height: 520px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 2%;
+      }
     }
 
     .page-container__footer {
@@ -126,6 +151,11 @@
         height: 44px;
         min-height: 44px;
         margin-right: 16px;
+
+        [dir='rtl'] & {
+          margin-left: 16px;
+          margin-right: 0;
+        }
       }
 
       header {

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/index.scss
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/index.scss
@@ -73,6 +73,7 @@
     background-color: $white;
     margin: 24px 0 36px;
     padding: 12px;
+    direction: ltr;
 
     &__pending-seed {
       display: none;

--- a/ui/app/pages/first-time-flow/seed-phrase/index.scss
+++ b/ui/app/pages/first-time-flow/seed-phrase/index.scss
@@ -27,6 +27,11 @@
 
     @media screen and (min-width: $break-large) {
       margin-left: 81px;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: 81px;
+      }
     }
 
     @media screen and (max-width: $break-small) {

--- a/ui/app/pages/first-time-flow/select-action/index.scss
+++ b/ui/app/pages/first-time-flow/select-action/index.scss
@@ -40,6 +40,11 @@
     border-radius: 10px;
     margin-left: 22px;
 
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 22px;
+    }
+
     .first-time-flow__button {
       max-width: 221px;
       height: 44px;

--- a/ui/app/pages/keychains/index.scss
+++ b/ui/app/pages/keychains/index.scss
@@ -194,4 +194,9 @@
   font-size: 18px;
   line-height: 23px;
   margin-left: 22px;
+
+  [dir='rtl'] & {
+    margin-left: 0;
+    margin-right: 22px;
+  }
 }

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -170,6 +170,7 @@ class Routes extends Component {
     const {
       isLoading,
       alertMessage,
+      languageDirection,
       loadingMessage,
       network,
       provider,
@@ -208,6 +209,7 @@ class Routes extends Component {
     return (
       <div
         className={classnames('app', { 'mouse-user-styles': isMouseUser})}
+        dir={languageDirection}
         onClick={() => setMouseUserState(true)}
         onKeyDown={e => {
           if (e.keyCode === 9) {
@@ -323,6 +325,7 @@ Routes.propTypes = {
   isLoading: PropTypes.bool,
   loadingMessage: PropTypes.string,
   alertMessage: PropTypes.string,
+  languageDirection: PropTypes.string,
   network: PropTypes.string,
   provider: PropTypes.object,
   frequentRpcListDetail: PropTypes.array,
@@ -349,6 +352,7 @@ function mapStateToProps (state) {
     sidebar,
     alertOpen,
     alertMessage,
+    languageDirection,
     isLoading,
     loadingMessage,
   } = appState
@@ -360,6 +364,7 @@ function mapStateToProps (state) {
     sidebar,
     alertOpen,
     alertMessage,
+    languageDirection,
     isLoading,
     loadingMessage,
     isUnlocked: state.metamask.isUnlocked,

--- a/ui/app/pages/settings/index.scss
+++ b/ui/app/pages/settings/index.scss
@@ -37,6 +37,11 @@
     display: flex;
     flex-flow: row nowrap;
 
+    [dir='rtl'] & {
+      margin-left: 24px;
+      margin-right: 0;
+    }
+
     @media screen and (max-width: 575px) {
       display: none;
     }
@@ -92,6 +97,11 @@
       background-position: center;
       margin-right: 16px;
       cursor: pointer;
+
+      [dir='rtl'] & {
+        margin-left: 16px;
+        margin-right: 0;
+      }
     }
   }
 

--- a/ui/app/pages/settings/index.scss
+++ b/ui/app/pages/settings/index.scss
@@ -101,6 +101,7 @@
       [dir='rtl'] & {
         margin-left: 16px;
         margin-right: 0;
+        transform: rotate(180deg);
       }
     }
   }

--- a/ui/app/pages/settings/networks-tab/index.scss
+++ b/ui/app/pages/settings/networks-tab/index.scss
@@ -17,6 +17,11 @@
     display: flex;
     flex-direction: column;
 
+    [dir='rtl'] & {
+      padding-left: 24px;
+      padding-right: 0;
+    }
+
     @media screen and (max-width: 575px) {
       padding: 0;
     }
@@ -38,6 +43,11 @@
       cursor: pointer;
       position: absolute;
       margin-left: 10px;
+
+      [dir='rtl'] & {
+        margin-left: 16px;
+        margin-right: 10px;
+      }
     }
   }
 
@@ -169,6 +179,11 @@
     line-height: 23px;
     color: #6A737D;
 
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 11px;
+    }
+
     &:hover {
       cursor: pointer;
     }
@@ -190,6 +205,11 @@
       position: absolute;
       width: 24px;
       height: 24px;
+
+      [dir='rtl'] & {
+        left: 10px;
+        right: auto;
+      }
     }
   }
 
@@ -207,14 +227,29 @@
 
     .btn-default {
       margin-right: .375rem;
+
+      [dir='rtl'] & {
+        margin-left: .375rem;
+        margin-right: 0;
+      }
     }
 
     .btn-secondary {
       margin-left: .375rem;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: .375rem;
+      }
     }
 
     .btn-danger {
       margin-right: 3.75rem;
+
+      [dir='rtl'] & {
+        margin-left: 3.75rem;
+        margin-right: 0;
+      }
     }
   }
 }

--- a/ui/app/pages/settings/settings-tab/index.scss
+++ b/ui/app/pages/settings/settings-tab/index.scss
@@ -8,6 +8,11 @@
   &__advanced-link {
     @extend %small-link;
     padding-left: 5px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 5px;
+    }
   }
 
   &__rpc-save-button {
@@ -42,10 +47,20 @@
 
     &:not(:last-child) {
       margin-right: 16px;
+
+      [dir='rtl'] & {
+        margin-left: 16px;
+        margin-right: 0;
+      }
     }
   }
 
   &__radio-label {
     padding-left: 4px;
+
+    [dir='rtl'] & {
+      padding-left: 0;
+      padding-right: 4px;
+    }
   }
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -40,7 +40,9 @@ async function startApp (metamaskState, backgroundConnection, opts) {
     metamask: metamaskState,
 
     // appState represents the current tab's popup state
-    appState: {},
+    appState: {
+      languageDirection: (metamaskState.currentLocale && ['ar','dv','fa','he','ku'].indexOf(metamaskState.currentLocale) > -1) ? 'rtl' : 'auto'
+    },
 
     localeMessages: {
       current: currentLocaleMessages,

--- a/ui/index.js
+++ b/ui/index.js
@@ -41,7 +41,7 @@ async function startApp (metamaskState, backgroundConnection, opts) {
 
     // appState represents the current tab's popup state
     appState: {
-      languageDirection: (metamaskState.currentLocale && ['ar','dv','fa','he','ku'].indexOf(metamaskState.currentLocale) > -1) ? 'rtl' : 'auto'
+      languageDirection: (metamaskState.currentLocale && ['ar', 'dv', 'fa', 'he', 'ku'].indexOf(metamaskState.currentLocale) > -1) ? 'rtl' : 'auto',
     },
 
     localeMessages: {

--- a/ui/index.js
+++ b/ui/index.js
@@ -41,7 +41,7 @@ async function startApp (metamaskState, backgroundConnection, opts) {
 
     // appState represents the current tab's popup state
     appState: {
-      languageDirection: (metamaskState.currentLocale && ['ar', 'dv', 'fa', 'he', 'ku'].indexOf(metamaskState.currentLocale) > -1) ? 'rtl' : 'auto',
+      languageDirection: (metamaskState.currentLocale && ['ar', 'dv', 'fa', 'he', 'ku'].includes(metamaskState.currentLocale)) ? 'rtl' : 'auto',
     },
 
     localeMessages: {


### PR DESCRIPTION
Long time in the works, and finally here - right-to-left CSS (and a little JS) for MetaMask #5436

I recently met a blockchain teacher at Re-Coded's coworking space in Erbil, and he is interested in translating MetaMask into Persian (and maybe Kurdish later). On my side I offered to add RTL stylesheets. Here's what it looks like with the translation (which will be in a separate PR)

![Screen Shot 2019-07-08 at 10 58 51 PM](https://user-images.githubusercontent.com/643918/60820517-2d7fce00-a1d4-11e9-8483-f497d9e6409e.png)
![Screen Shot 2019-07-08 at 10 58 29 PM](https://user-images.githubusercontent.com/643918/60820519-2e186480-a1d4-11e9-9a8f-b96d979f09f1.png)
![Screen Shot 2019-07-08 at 10 58 14 PM](https://user-images.githubusercontent.com/643918/60820520-2e186480-a1d4-11e9-8384-eceddf61642d.png)

CSS notes:
- Most changes are wrapped in ```[dir='rtl'] & { }``` blocks , this means their internal changes (swapping left and right) happen only if an upper element has set ```dir="rtl"```
- In some cases I have added ```direction: ltr;``` to CSS; this will not change any current views but maintains consistency displaying token names, seed phrases, negative numbers, and other LTR content

JS notes:
- When the app launches and when you change languages, RTL settings should be updated by adding ```dir="rtl"``` or ```dir="auto"``` to the top-level div
- I think there are one or two places where I added ```dir="auto"``` to a text field such as account name; this will accommodate typing LTR or RTL languages into that text field
- An array of locales anticipates Arabic, Dhivehi, Hebrew, Persian, Hebrew, and Kurdish as RTL languages. If someone adds another RTL language we would need to update the list there