### PR TITLE
Adds MetaMask specific in-page ethereum provider.

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -143,6 +143,10 @@ const proxiedInpageProvider = new Proxy(inpageProvider, {
 
 window.ethereum = createStandardProvider(proxiedInpageProvider)
 
+// Set window.MetaMaskEthereum to allow applications to specifically choose to use the MetaMask provider over other 3rd party
+// window.ethereum implementations.
+window.MetaMaskEthereum = createStandardProvider(proxiedInpageProvider)
+
 //
 // setup web3
 //

--- a/app/scripts/lib/auto-reload.js
+++ b/app/scripts/lib/auto-reload.js
@@ -22,7 +22,7 @@ function setupDappAutoReload (web3, observable) {
   observable.subscribe(function (state) {
     // if the auto refresh on network change is false do not
     // do anything
-    if (!window.ethereum.autoRefreshOnNetworkChange) return
+    if (!window.ethereum.autoRefreshOnNetworkChange || !window.MetaMaskEthereum.autoRefreshOnNetworkChange) return
 
     // if reload in progress, no need to check reload logic
     if (reloadInProgress) return


### PR DESCRIPTION
## 👋 Overview & Background

An issue with current ethereum wallet extensions is an unfortunate race condition each wallet faces in setting their provider to the `window.ethereum` variable. This inhibits an applications ability to support multiple ethereum wallets, since only one wallet can have their provider set to that variable at a time.

While efforts exist to [standardize ethereum provider implementations](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md) (EIP 1193), their efforts aren't (and shouldn't be) directed towards standardizing the injection of providers into the `window` variable.

Powerful distributed applications desire an ability to allow users to specify which wallet provider they wish to use with their application. However, many ethereum wallet extensions exist, presenting users who enjoy having multiple wallets enabled in their browser the problem of having the enable and disable their wallets depending on which one they wish to use. This is a negative and annoying user experience for informed power users, and a source of confusion for people new to ethereum and distributed applications.

While wallets compliant with EIP 1102 [must support injecting their providers on `window.ethereum`](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md) , there exists the possibility to increase usability of wallets and the dapp ecosystem as a whole if ethereum wallets _additionally_ inject their providers to unique window variables.

## 💡Proposed Changes

The PR injects a new in-page variable,

`window.MetaMaskEthereum` 

which will exist alongside `window.ethereum`. With this change, dapps can choose to support MetaMask specifically by creating their `Web3` instances using the `window.MetaMaskEthereum` provider. However, they do not necessarily need to as `window.ethereum` will exist as it does currently.

This small change allows for massive new possibilities for dapps. Developers can now enjoy allowing users to toggle between ethereum wallets by creating `Web3` instances dependant on which provider is available. Should a developer choose to prioritize MetaMask over other ethereum wallet extensions, they can check to see if `window.MetaMaskEthereum` is available to create their `Web3` instance before checking `window.ethereum` as per the standard.

## 👨‍💻 👩‍💻 Considerations

- This PR passes all tests.
- This PR has been tested against a wildly popular ethereum based distributed application, and works perfectly.

I would appreciate a developer with experience on this project to carefully review these non-breaking additions to verify they're acceptable.

Thank you for your time. 