### PR TITLE
Capitalized speed up label to match rest of UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Current Develop Branch
+- [#6828](https://github.com/MetaMask/metamask-extension/pull/6828): Capitalized speed up label to match rest of UI  
 
 ## 6.7.1 Fri Jun 28 2019
 - [#6764](https://github.com/MetaMask/metamask-extension/pull/6764): Fix display of token amount on confirm transaction screen

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1469,7 +1469,7 @@
     "message": "there can only be a space between words"
   },
   "speedUp": {
-    "message": "speed up"
+    "message": "Speed Up"
   },
   "speedUpTitle": {
     "message": "Speed Up Transaction"


### PR DESCRIPTION
Changed irksome uncapitalized "speed up" transaction table cell detail view label to match the rest of the UI.
![image](https://user-images.githubusercontent.com/1596183/60953458-ce4cb700-a2c2-11e9-9dc4-b40ffdf89bda.png)
"speed up" changed to "Speed Up"