### PR TITLE
Fix wording in readdToken message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1176,7 +1176,7 @@
     "message": "Queue"
   },
   "readdToken": {
-    "message": "You can add this token back in the future by going go to “Add token” in your accounts options menu."
+    "message": "You can add this token back in the future by going to “Add token” in your accounts options menu."
   },
   "readMore": {
     "message": "Read more here."


### PR DESCRIPTION
- Removes extra "go" in
  app/_locales/en/messages.json's readdToken
  message