### PR TITLE
Update version of Firefox used on CI

### DIFF
--- a/.circleci/scripts/firefox-install
+++ b/.circleci/scripts/firefox-install
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-FIREFOX_VERSION='62.0'
+FIREFOX_VERSION='68.0'
 FIREFOX_BINARY="firefox-${FIREFOX_VERSION}.tar.bz2"
 FIREFOX_BINARY_URL="https://ftp.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/${FIREFOX_BINARY}"
 FIREFOX_PATH='/opt/firefox'


### PR DESCRIPTION
Firefox v68.0 is now used on CI, which is the latest stable version.