### PR TITLE
Add end of flow translation wrapper

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -562,6 +562,12 @@
   "endOfFlowMessage8": {
     "message": "MetaMask cannot recover your seedphrase. Learn more."
   },
+  "endOfFlowMessage9": {
+    "message": "Learn more."
+  },
+  "endOfFlowMessage10": {
+    "message": "All Done"
+  },
   "ensNameNotFound": {
     "message": "ENS name not found"
   },
@@ -1814,6 +1820,6 @@
     "message": "MetaMask will never ask for your seed phrase!"
   },
   "zeroGasPriceOnSpeedUpError": {
-    "message":"Zero gas price on speed up"
+    "message": "Zero gas price on speed up"
   }
 }

--- a/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
@@ -55,7 +55,7 @@ export default class EndOfFlowScreen extends PureComponent {
             rel="noopener noreferrer"
           >
             <span className="first-time-flow__link-text">
-              Learn More
+              {t('endOfFlowMessage9')}
             </span>
           </a>.
         </div>
@@ -74,7 +74,7 @@ export default class EndOfFlowScreen extends PureComponent {
             history.push(DEFAULT_ROUTE)
           }}
         >
-          { 'All Done' }
+          { t('endOfFlowMessage10') }
         </Button>
       </div>
     )


### PR DESCRIPTION
This work covers adding translations to two previously hard coded messages on the end of flow screen when signing up. I've only added english translations.

https://github.com/MetaMask/metamask-extension/issues/6834