### PR TITLE
Remove stray period from Learn More link

### DIFF
--- a/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
@@ -57,7 +57,7 @@ export default class EndOfFlowScreen extends PureComponent {
             <span className="first-time-flow__link-text">
               {t('endOfFlowMessage9')}
             </span>
-          </a>.
+          </a>
         </div>
         <Button
           type="primary"


### PR DESCRIPTION
Refs #6847

This PR removes the extra period at the end of the first time flow. Currently:

> *MetaMask cannot recover your seedphrase. Learn more..

Note the two periods at the end there. This change removes the one from the component, leaving the period in the translated string.