### PR TITLE
Show lockfile diffs on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 CHANGELOG.md merge=union
+
+# Reviewing the lockfile contents is an important step in verifying that
+# we're using the dependencies we expect to be using
+package-lock.json linguist-generated=false
+yarn.lock linguist-generated=false


### PR DESCRIPTION
This PR updates our `.gitattributes` file to mark both npm and Yarn lockfiles as _not_ generated. While, yes, they are technically generated, it is important that we review changes to these files and GitHub doesn't show diffs for some generated files.<sup>[\[1\]][1]</sup> Showing the diffs by default is a first step to having these changes reviewed each time.

We may still see the diffs suppressed when the diff is large enough, but I don't believe there's anything we can do about that right now.

e.g. #6856:

![](https://user-images.githubusercontent.com/1623628/61240105-06b52080-a71b-11e9-8022-3b39453e9140.png)

  [1]:https://github.com/github/linguist#generated-code