### PR TITLE
Re enable the setMouseUserState styles

### DIFF
--- a/ui/app/components/ui/button/buttons.scss
+++ b/ui/app/components/ui/button/buttons.scss
@@ -22,7 +22,6 @@ $hover-orange: #FFD3B5;
   box-sizing: border-box;
   border-radius: 6px;
   width: 100%;
-  outline: none;
   transition: border-color .3s ease, background-color .3s ease;
 
   &--disabled,

--- a/ui/app/css/itcss/generic/index.scss
+++ b/ui/app/css/itcss/generic/index.scss
@@ -43,6 +43,12 @@ textarea:focus {
   outline: none;
 }
 
+.mouse-user-styles {
+  button:focus {
+    outline: none;
+  }
+}
+
 /* stylelint-disable */
 #app-content {
   overflow-x: hidden;

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -7,6 +7,7 @@ import actions from '../../store/actions'
 import log from 'loglevel'
 import IdleTimer from 'react-idle-timer'
 import {getMetaMaskAccounts, getNetworkIdentifier, preferencesSelector} from '../../selectors/selectors'
+import classnames from 'classnames'
 
 // init
 import FirstTimeFlow from '../first-time-flow'
@@ -177,6 +178,7 @@ class Routes extends Component {
       setMouseUserState,
       sidebar,
       submittedPendingTransactions,
+      isMouseUser,
     } = this.props
     const isLoadingNetwork = network === 'loading' && currentView.name !== 'config'
     const loadMessage = loadingMessage || isLoadingNetwork ?
@@ -205,7 +207,7 @@ class Routes extends Component {
 
     return (
       <div
-        className="app"
+        className={classnames('app', { 'mouse-user-styles': isMouseUser})}
         onClick={() => setMouseUserState(true)}
         onKeyDown={e => {
           if (e.keyCode === 9) {


### PR DESCRIPTION
This PR addresses: https://github.com/MetaMask/metamask-extension/issues/5593

I've re enabled tabbing through metamask with focus but not on click, the [original PR](https://github.com/MetaMask/metamask-extension/issues/3058) used a redux action to detect if the user is using touch/click controls, this work was still present I just needed to add back the css class. This work *only* covers the button component.

There's other area's of the codebase that have set `outline: none;` I'd recommend going through and replacing that to fall under `.mouse-user-styles` to further improve accessibility. It seemed out of scope to I didn't include it.