### PR TITLE
Allow overriding GANACHE_ARGS for e2e tests

### DIFF
--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -6,8 +6,9 @@ set -u
 set -o pipefail
 
 export PATH="$PATH:./node_modules/.bin"
-export GANACHE_ARGS='--quiet --blockTime 2'
+export GANACHE_ARGS="${GANACHE_ARGS:---quiet}"
 
+export GANACHE_ARGS="--blockTime 2 $GANACHE_ARGS"
 concurrently --kill-others \
   --names 'ganache,dapp,e2e' \
   --prefix '[{time}][{name}]' \
@@ -16,6 +17,7 @@ concurrently --kill-others \
   'npm run dapp' \
   'sleep 5 && mocha test/e2e/metamask-ui.spec'
 
+export GANACHE_ARGS="--blockTime 2 $GANACHE_ARGS"
 concurrently --kill-others \
   --names 'ganache,dapp,e2e' \
   --prefix '[{time}][{name}]' \
@@ -24,7 +26,7 @@ concurrently --kill-others \
   'npm run dapp' \
   'sleep 5 && mocha test/e2e/metamask-responsive-ui.spec'
 
-export GANACHE_ARGS="$GANACHE_ARGS --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
+export GANACHE_ARGS="--deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000 $GANACHE_ARGS"
 concurrently --kill-others \
   --names 'ganache,e2e' \
   --prefix '[{time}][{name}]' \


### PR DESCRIPTION
This changeset allow the environment to set `GANACHE_ARGS` and have it override some of the flags used in the e2e tests.

You can now run without the quiet flag, e.g.:

```bash
GANACHE_ARGS='' npm run run test:e2e:chrome
```