### PR TITLE
Targets base inputs and only prevents outline if user uses a mouse

### DIFF
--- a/ui/app/components/ui/unit-input/index.scss
+++ b/ui/app/components/ui/unit-input/index.scss
@@ -38,7 +38,6 @@
     font-size: 1rem;
     font-family: Roboto;
     border: none;
-    outline: 0 !important;
     max-width: 22ch;
     height: 16px;
     line-height: 18px;

--- a/ui/app/css/itcss/components/account-dropdown.scss
+++ b/ui/app/css/itcss/components/account-dropdown.scss
@@ -84,7 +84,6 @@
   &__account-primary-balance {
     color: $scorpion;
     border: none;
-    outline: 0 !important;
   }
 
   &__account-secondary-balance {

--- a/ui/app/css/itcss/components/currency-display.scss
+++ b/ui/app/css/itcss/components/currency-display.scss
@@ -19,7 +19,6 @@
     font-size: 16px;
     line-height: 22px;
     border: none;
-    outline: 0 !important;
     max-width: 22ch;
   }
 

--- a/ui/app/css/itcss/generic/index.scss
+++ b/ui/app/css/itcss/generic/index.scss
@@ -38,13 +38,15 @@ html {
   display: flex;
 }
 
-input:focus,
-textarea:focus {
-  outline: none;
-}
-
 .mouse-user-styles {
-  button:focus {
+  button:focus,
+  input:focus,
+  textarea:focus,
+  .unit-input__input,
+  .account-list-item__account-primary-balance,
+  .account-list-item__input,
+  .currency-display__input
+   {
     outline: none;
   }
 }


### PR DESCRIPTION
I moved the outline overrides to the `.mouse-user-styles` class. I had started down the path of making more of the extension accessible via tabs but that quickly was becoming a manual process that should really just be put into base components. It seemed out of scope for the PR so I cut it off.

This PR refers to https://github.com/MetaMask/metamask-extension/issues/6861