### PR TITLE
Set minimum browser version in manifest

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -21,7 +21,8 @@
   },
   "applications": {
     "gecko": {
-      "id": "webextension@metamask.io"
+      "id": "webextension@metamask.io",
+      "strict_min_version": "53.0"
     }
   },
   "default_locale": "en",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,6 +153,7 @@ gulp.task('manifest:chrome', function () {
   return gulp.src('./dist/chrome/manifest.json')
   .pipe(jsoneditor(function (json) {
     delete json.applications
+    json.minimum_chrome_version = '58'
     return json
   }))
   .pipe(gulp.dest('./dist/chrome', { overwrite: true }))


### PR DESCRIPTION
Set the minimum browser version supported in the extension manifest. Currently we only ship the extension on Chrome and Firefox, so the minimum version has been set for those two browsers.

Relates to #6805