### PR TITLE
Replace deprecated Chrome API

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -10,7 +10,7 @@ const extension = require('extensionizer')
 const PortStream = require('extension-port-stream')
 
 const inpageContent = fs.readFileSync(path.join(__dirname, '..', '..', 'dist', 'chrome', 'inpage.js')).toString()
-const inpageSuffix = '//# sourceURL=' + extension.extension.getURL('inpage.js') + '\n'
+const inpageSuffix = '//# sourceURL=' + extension.runtime.getURL('inpage.js') + '\n'
 const inpageBundle = inpageContent + inpageSuffix
 
 // Eventually this streaming injection could be replaced with:


### PR DESCRIPTION
The function `chrome.extension.getURL` [has been deprecated since Chrome 58](https://developer.chrome.com/extensions/extension#method-getURL). It is completely equivalent to `chrome.runtime.getURL`, which has been around since Chrome 31.