### PR TITLE
Check balance before testing it with isZero

### DIFF
--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -47,7 +47,7 @@ class DetectTokensController {
       }
       tokensToDetect.forEach((tokenAddress, index) => {
         const balance = result[index]
-        if (!balance.isZero()) {
+        if (balance && !balance.isZero()) {
           this._preferences.addToken(tokenAddress, contracts[tokenAddress].symbol, contracts[tokenAddress].decimals)
         }
       })


### PR DESCRIPTION
Fixes #6897

This PR fixes a case in the `DetectTokensController` where we were sometimes calling `isZero` on an undefined property. I've not added a test here because I'm not quite sure how/if the tests for this controller test this method fully.