### PR TITLE
Update publishing doc to reflect automation

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -20,9 +20,9 @@ We try to ensure certain criteria are met before deploying:
 
 ## Incrementing Version & Changelog
 
-Version can be automatically incremented [using our bump script](./bumping-version.md).
+Version can be automatically incremented by creating a branch with the name `Version-vX.Y.Z`, where `X`, `Y`, and `Z` are numbers. Branches should be created off of the main branch. [Branches can be created on GitHub.](https://help.github.com/en/articles/creating-and-deleting-branches-within-your-repository)
 
-npm run version:bump `$BUMP_TYPE` where `$BUMP_TYPE` is one of `major`, `minor`, or `patch`.
+Once a version branch has been created, a build on CircleCI will create a Pull Request for the release with the app manifest and changelog versions bumped.
 
 ## Preparing for Sensitive Changes
 

--- a/docs/sensitive-release.md
+++ b/docs/sensitive-release.md
@@ -18,10 +18,9 @@ Simply follow the steps in [the publishing guide](./publishing.md).
 
 ### Prepare Rollback Release
 
-1. Be on the new risky version branch.
-2. Run `npm run rollback $ROLLBACK_TARGET_VERSION`.
+Follow the steps in [the publishing guide](./publishing.md) with a different context:
 
-The rollback version will now be a branch and tag on the origin.
+Instead of creating a version branch off of the main branch, create a version branch off of the latest release. It is customary that this release increments the patch version number.
 
 ### Roll the normal release out
 


### PR DESCRIPTION
As promised,<sup>[\[1\]][1]</sup> this PR updates the publishing guide to reflect the changes to the workflow now that some automation is in place (#6653). I've left out the automatic creation of the release here on GH since that's not a process that involves a human.

  [1]:https://github.com/MetaMask/metamask-extension/pull/6653#issuecomment-511511911