### PR TITLE
Remove unused `unlockAccountMessage` callback

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -253,7 +253,6 @@ function setupController (initState, initLangCode) {
   const controller = new MetamaskController({
     // User confirmation callbacks:
     showUnconfirmedMessage: triggerUi,
-    unlockAccountMessage: triggerUi,
     showUnapprovedTx: triggerUi,
     openPopup: openPopup,
     closePopup: notificationManager.closePopup.bind(notificationManager),

--- a/development/mock-dev.js
+++ b/development/mock-dev.js
@@ -63,7 +63,6 @@ function updateQueryParams (newView) {
 const controller = new MetamaskController({
   // User confirmation callbacks:
   showUnconfirmedMessage: noop,
-  unlockAccountMessage: noop,
   showUnapprovedTx: noop,
   platform: {},
   // initial state

--- a/docs/porting_to_new_environment.md
+++ b/docs/porting_to_new_environment.md
@@ -99,7 +99,6 @@ In that file, there's a lot going on, so it's maybe worth focusing on our MetaMa
 const controller = new MetamaskController({
     // User confirmation callbacks:
     showUnconfirmedMessage: triggerUi,
-    unlockAccountMessage: triggerUi,
     showUnapprovedTx: triggerUi,
     // initial state
     initState,


### PR DESCRIPTION
This callback has been unused for a long time. It was removed in #1076