### PR TITLE
Fix `npm-audit` script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update npm
+          command: sudo npm install -g npm@6.10.2
+      - run:
           name: Install deps via npm
           command: |
            npm ci
@@ -175,6 +178,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Update npm
+          command: sudo npm install -g npm@6.10.2
       - run:
           name: npm audit
           command: .circleci/scripts/npm-audit

--- a/.circleci/scripts/npm-audit
+++ b/.circleci/scripts/npm-audit
@@ -4,9 +4,9 @@ set -e
 set -u
 set -o pipefail
 
-if ! npm audit
+if ! npm audit --production
 then
-    ! npm audit --json > audit.json
+    ! npm audit --production --json > audit.json
     printf '%s\n' ''
     node .circleci/scripts/npm-audit-check.js
 fi

--- a/.circleci/scripts/npm-audit-check.js
+++ b/.circleci/scripts/npm-audit-check.js
@@ -13,7 +13,7 @@ for (const advisory of advisories) {
     continue
   }
 
-  count += advisory.findings.some((finding) => (!finding.dev && !finding.optional))
+  count += advisory.findings.length
 }
 
 if (count > 0) {

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ npm-debug.log
 node_modules
 yarn.lock
 
+audit.json
+
 app/bower_components
 test/bower_components
 package


### PR DESCRIPTION
The npm audit script was auditing all dependencies, then filtering the results to just the advisories concerning production dependencies. This was done by checking the boolean `dev` and `optional` properties of each `findings` entry in each advisory.

The `dev` and `optional` properties are now missing, which is resulting in dev advisories being mistakenly identified as affecting production.

This check has been removed, and instead the `--production` flag is used when calling `npm audit`. This accomplishes the same goal without relying as much upon the audit output format.

The `--production` flag was added in `npm` `v6.10.0`, so `npm` has been updated to the current latest stable (`v6.10.2`) for the `test-deps` job. It was also updated on the `prep-deps-npm` job to ensure consistency in behaviour. The other jobs only use `npm run` which hasn't changed substantially in some time, so compatibility isn't really a concern for those.

`audit.json` has also been added to `.gitignore`. It was accidentally checked in once while working on this branch.