### PR TITLE
Run `test-deps` in parallel with `prep-deps-npm`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
               only:
                 - /^Version-v(\d+)[.](\d+)[.](\d+)/
       - prep-deps-npm
+      - test-deps
       - prep-build:
           requires:
             - prep-deps-npm
@@ -27,9 +28,6 @@ workflows:
           requires:
             - prep-deps-npm
       - test-lint:
-          requires:
-            - prep-deps-npm
-      - test-deps:
           requires:
             - prep-deps-npm
       - test-e2e-chrome:


### PR DESCRIPTION
`test-deps` runs `npm audit`, which doesn't require the dependencies to be installed. `npm audit` just uses the lockfile.