### PR TITLE
Fix Firefox e2e CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
           at: .
       - run:
           name: test:e2e:firefox
-          command: yarn build:test && yarn test:e2e:chrome
+          command: yarn build:test && yarn test:e2e:firefox
           no_output_timeout: 20m
       - store_artifacts:
           path: test-artifacts

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -1263,7 +1263,6 @@ describe('MetaMask', function () {
       const transferTokens = await findElement(driver, By.xpath(`//button[contains(text(), 'Approve Tokens')]`))
       await transferTokens.click()
 
-      await closeAllWindowHandlesExcept(driver, [extension, dapp])
       await driver.switchTo().window(extension)
       await delay(regularDelayMs)
 


### PR DESCRIPTION
The `test-e2e-firefox` CI job was accidentally changed to run the Chrome e2e test rather than the Firefox one.