### PR TITLE
Override `ownProps` with state props in `SignatureRequest`

### DIFF
--- a/ui/app/components/app/signature-request.js
+++ b/ui/app/components/app/signature-request.js
@@ -76,9 +76,9 @@ function mergeProps (stateProps, dispatchProps, ownProps) {
   }
 
   return {
+    ...ownProps,
     ...stateProps,
     ...dispatchProps,
-    ...ownProps,
     txData,
     cancel,
     sign,

--- a/ui/app/pages/confirm-transaction/conf-tx.js
+++ b/ui/app/pages/confirm-transaction/conf-tx.js
@@ -12,7 +12,6 @@ const R = require('ramda')
 const SignatureRequest = require('../../components/app/signature-request')
 const Loading = require('../../components/ui/loading-screen')
 const { DEFAULT_ROUTE } = require('../../helpers/constants/routes')
-const { getMetaMaskAccounts } = require('../../selectors/selectors')
 
 module.exports = compose(
   withRouter,
@@ -29,8 +28,6 @@ function mapStateToProps (state) {
 
   return {
     identities: state.metamask.identities,
-    accounts: getMetaMaskAccounts(state),
-    selectedAddress: state.metamask.selectedAddress,
     unapprovedTxs: state.metamask.unapprovedTxs,
     unapprovedMsgs: state.metamask.unapprovedMsgs,
     unapprovedPersonalMsgs: state.metamask.unapprovedPersonalMsgs,
@@ -39,7 +36,6 @@ function mapStateToProps (state) {
     warning: state.appState.warning,
     network: state.metamask.network,
     provider: state.metamask.provider,
-    conversionRate: state.metamask.conversionRate,
     currentCurrency: state.metamask.currentCurrency,
     blockGasLimit: state.metamask.currentBlockGasLimit,
     computedBalances: state.metamask.computedBalances,
@@ -146,7 +142,6 @@ ConfirmTxScreen.prototype.render = function () {
   const props = this.props
   const {
     currentCurrency,
-    conversionRate,
     blockGasLimit,
   } = props
 
@@ -159,10 +154,7 @@ ConfirmTxScreen.prototype.render = function () {
       // Properties
       txData: txData,
       key: txData.id,
-      selectedAddress: props.selectedAddress,
-      accounts: props.accounts,
       identities: props.identities,
-      conversionRate,
       currentCurrency,
       blockGasLimit,
       // Actions


### PR DESCRIPTION
The `accounts` prop of `SignatureRequest` was throwing a PropType warning because `accounts` was an object instead of an array. It looks like when the `mergeProps` function was added in #6340, the ownProps were accidentally set to override the state props.

The now ignored props have been removed from the parent `ConfirmTxScreen` component as well. `conversionRate` was identical to the one retrieved in `SignatureRequest`, and `selectedAddress` differed only in the fallback behaviour when `state.metamask.selectedAddress` does not exist; it will now default to the first account instead (as it did prior to #6340).