### PR TITLE
Display coverage of `develop` instead of `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MetaMask Browser Extension
-[![Build Status](https://circleci.com/gh/MetaMask/metamask-extension.svg?style=shield&circle-token=a1ddcf3cd38e29267f254c9c59d556d513e3a1fd)](https://circleci.com/gh/MetaMask/metamask-extension) [![Coverage Status](https://coveralls.io/repos/github/MetaMask/metamask-extension/badge.svg?branch=master)](https://coveralls.io/github/MetaMask/metamask-extension?branch=master)
+[![Build Status](https://circleci.com/gh/MetaMask/metamask-extension.svg?style=shield&circle-token=a1ddcf3cd38e29267f254c9c59d556d513e3a1fd)](https://circleci.com/gh/MetaMask/metamask-extension) [![Coverage Status](https://coveralls.io/repos/github/MetaMask/metamask-extension/badge.svg?branch=develop)](https://coveralls.io/github/MetaMask/metamask-extension?branch=develop)
 
 You can find the latest version of MetaMask on [our official website](https://metamask.io/). For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/hc/en-us).
 


### PR DESCRIPTION
I think it's generally expected that README badges reflect the state of the development branch. This should make it easier for us to notice coverage changes over time. It will now match the CircleCI badge, which also refers to `develop`.