### PR TITLE
Fix casing of Etherscan title

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -68,7 +68,7 @@ class ExtensionPlatform {
     const nonce = parseInt(txMeta.txParams.nonce, 16)
 
     const title = 'Confirmed transaction'
-    const message = `Transaction ${nonce} confirmed! View on EtherScan`
+    const message = `Transaction ${nonce} confirmed! View on Etherscan`
     this._showNotification(title, message, url)
   }
 
@@ -92,12 +92,12 @@ class ExtensionPlatform {
   }
 
   _subscribeToNotificationClicked () {
-    if (!extension.notifications.onClicked.hasListener(this._viewOnEtherScan)) {
-      extension.notifications.onClicked.addListener(this._viewOnEtherScan)
+    if (!extension.notifications.onClicked.hasListener(this._viewOnEtherscan)) {
+      extension.notifications.onClicked.addListener(this._viewOnEtherscan)
     }
   }
 
-  _viewOnEtherScan (txId) {
+  _viewOnEtherscan (txId) {
     if (txId.startsWith('http://')) {
       extension.tabs.create({ url: txId })
     }


### PR DESCRIPTION
See also: [Etherscan | About Us](https://etherscan.io/aboutus)

This PR fixes the casing of _Etherscan_ used in the tx notifications.