### PR TITLE
6933: Clears the history of the transactions in memory if too big

### DIFF
--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -68,7 +68,13 @@ class TransactionStateManager extends EventEmitter {
     @returns {array} of all the txMetas in store
   */
   getFullTxList () {
-    return this.store.getState().transactions
+    const txs = this.store.getState().transactions
+    // Clean transaction history if it is too big, in some cases that list is growing to 1000's of objects
+    // and slowing down Metamask to the point that it is unusable
+    for (var i = 0; i < txs.length; i++) {
+      if (txs[i].history) txs[i].history.length = Math.min(txs[i].history.length, 50)
+    }
+    return txs
   }
 
   /**


### PR DESCRIPTION
I could not find the root cause yet, but I got a case where a few transactions had 1000's of history objects inside it, which was causing Metamask to take several minutes to load each action, and sometimes crash, which rendered it unusable on my machine.

By removing these history objects when the array is too large, Metamask was back to instant UI responses.

I am aware this is not a very elegant solution, but besides needing to find what is causing the history to grow, we also need to make it work for machines that already got the data corrupted. (I see a few past issues where Metamask had a blank screen / too slow to use that were closed without a solution, this might be related to them)


