### PR TITLE
Add migration to remove `seedWords` state

### DIFF
--- a/app/scripts/migrations/035.js
+++ b/app/scripts/migrations/035.js
@@ -1,0 +1,28 @@
+// next version number
+const version = 35
+
+/*
+
+Removes the deprecated 'seedWords' state
+
+*/
+
+const clone = require('clone')
+
+module.exports = {
+  version,
+
+  migrate: async function (originalVersionedData) {
+    const versionedData = clone(originalVersionedData)
+    versionedData.meta.version = version
+    versionedData.data = transformState(versionedData.data)
+    return versionedData
+  },
+}
+
+function transformState (state) {
+  if (state.PreferencesController && state.PreferencesController.seedWords !== undefined) {
+    delete state.PreferencesController.seedWords
+  }
+  return state
+}

--- a/test/unit/migrations/035-test.js
+++ b/test/unit/migrations/035-test.js
@@ -1,0 +1,96 @@
+const assert = require('assert')
+const migration35 = require('../../../app/scripts/migrations/035')
+
+describe('migration #35', () => {
+  it('should update the version metadata', (done) => {
+    const oldStorage = {
+      meta: {
+        version: 34,
+      },
+      data: {},
+    }
+
+    migration35.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.meta, {
+          'version': 35,
+        })
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should delete seedWords', (done) => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          seedWords: 'seed words',
+        },
+      },
+    }
+
+    migration35.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data.PreferencesController, {})
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should delete falsy seedWords', (done) => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          seedWords: '',
+        },
+      },
+    }
+
+    migration35.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data.PreferencesController, {})
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should leave state without seedWords unchanged', (done) => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          frequentRpcListDetail: [],
+          currentAccountTab: 'history',
+          accountTokens: {},
+          assetImages: {},
+          tokens: [],
+          suggestedTokens: {},
+          useBlockie: false,
+          knownMethodData: {},
+          participateInMetaMetrics: null,
+          firstTimeFlowType: null,
+          currentLocale: 'en',
+          identities: {},
+          lostIdentities: {},
+          forgottenPassword: false,
+          preferences: {
+            useNativeCurrencyAsPrimaryCurrency: true,
+          },
+          completedOnboarding: false,
+          migratedPrivacyMode: false,
+          metaMetricsId: null,
+          metaMetricsSendCount: 0,
+        },
+      },
+    }
+
+    migration35.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data, oldStorage.data)
+        done()
+      })
+      .catch(done)
+  })
+})


### PR DESCRIPTION
The `seedWords` state was removed from the PreferencesController recently in #6920. That state hadn't been used in some time, and there was a long period during which `seedWords` was periodically scrubbed from the state, so it's highly unlikely that it still exists in state for most users. It's hard to guarantee that it _doesn't_ though, especially if a user hasn't opened MetaMask in a few months.