### PR TITLE
Increase minimum version of Firefox supported

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
         "targets": {
           "browsers": [
             "chrome >= 58",
-            "firefox >= 53"
+            "firefox >= 60"
           ]
         }
       }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -22,7 +22,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "53.0"
+      "strict_min_version": "60.0"
     }
   },
   "default_locale": "en",


### PR DESCRIPTION
The minimum version supported is now Firefox 60. This is the current Extended Support Release. Various features we use were not supported by Firefox 53, such as `browser_action.default_popup`, `tabs.query`, and `permissions:unlimitedStorage`.