### PR TITLE
Display seed phrase reminder if user has tokens

### DIFF
--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -23,6 +23,7 @@ const mapStateToProps = state => {
       privacyMode,
     } = {},
     seedPhraseBackedUp,
+    tokens,
   } = metamask
   const accountBalance = getCurrentEthBalance(state)
   const { forgottenPassword } = appState
@@ -39,7 +40,7 @@ const mapStateToProps = state => {
     showPrivacyModeNotification: migratedPrivacyMode,
     activeTab,
     viewingUnconnectedDapp: isUnconnected && isPopup,
-    shouldShowSeedPhraseReminder: parseInt(accountBalance, 16) > 0 && !seedPhraseBackedUp,
+    shouldShowSeedPhraseReminder: !seedPhraseBackedUp && (parseInt(accountBalance, 16) > 0 || tokens.length > 0),
   }
 }
 


### PR DESCRIPTION
The seed phrase reminder will now be triggered if the user has eth *OR* if the user has added a token. This is to ensure that a user can't have a positive token balance without being reminded to backup the account.

Checking for the token in preferences was easier than checking the actual token balance, because the token balance is not yet in Redux. That would require a more substantial refactor.