### PR TITLE
Restrict unconnected notice to specific protocols

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -92,9 +92,9 @@ async function queryCurrentActiveTab (windowType) {
     extension.tabs.query({active: true, currentWindow: true}, (tabs) => {
       const [activeTab] = tabs
       const {title, url} = activeTab
-      const origin = url ? urlUtil.parse(url).hostname : null
+      const { hostname: origin, protocol } = url ? urlUtil.parse(url) : {}
       resolve({
-        title, origin, url,
+        title, origin, protocol, url,
       })
     })
   })

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -11,6 +11,8 @@ import {
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
 
+const activeTabDappProtocols = ['http:', 'https:', 'dweb:', 'ipfs:', 'ipns:', 'ssb:']
+
 const mapStateToProps = state => {
   const { activeTab, metamask, appState } = state
   const {
@@ -27,7 +29,12 @@ const mapStateToProps = state => {
   const accountBalance = getCurrentEthBalance(state)
   const { forgottenPassword } = appState
 
-  const isUnconnected = Boolean(activeTab && privacyMode && !approvedOrigins[activeTab.origin])
+  const isUnconnected = Boolean(
+    activeTab &&
+    activeTabDappProtocols.includes(activeTab.protocol) &&
+    privacyMode &&
+    !approvedOrigins[activeTab.origin]
+  )
   const isPopup = getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP
 
   return {


### PR DESCRIPTION
The notice asking whether you wanted to connect to a site was showing
up in places it shouldn't, like on the Firefox/Chrome settings pages
and on our fullscreen extension. It has now been restricted to only
be displayed for active tabs with specific protocols:

* http
* https
* dat
* dweb
* ipfs
* ipns
* ssb

This prevents the notice from being shown on settings pages, browser
extensions, and files such as PDFs.