### PR TITLE
Ensure showing of add contact dialog on send accounts for checksum inputs

### DIFF
--- a/ui/app/pages/send/send-content/send-content.component.js
+++ b/ui/app/pages/send/send-content/send-content.component.js
@@ -48,7 +48,7 @@ export default class SendContent extends Component {
   maybeRenderAddContact () {
     const { t } = this.context
     const { to, addressBook = [], ownedAccounts = [], showAddToAddressBookModal } = this.props
-    const isOwnedAccount = !!ownedAccounts.find(({ address }) => address === to)
+    const isOwnedAccount = !!ownedAccounts.find(({ address }) => address.toLowerCase() === to.toLowerCase())
     const contact = addressBook.find(({ address }) => address === to) || {}
 
     if (isOwnedAccount || contact.name) {


### PR DESCRIPTION
This PR fixes some behaviour on the send screen. Previous to this PR, entering checksummed addresses in the 'Add Recipient' input could incorrectly result in seeing a dialog to add a new contact. This could happen when entering one's own address. This PR fixes such cases.

cc @tmashuang 