### PR TITLE
Update mobile sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "promise-filter": "^1.1.0",
     "promise-to-callback": "^1.0.0",
     "prop-types": "^15.6.1",
-    "pubnub": "^4.21.5",
+    "pubnub": "4.24.4",
     "pump": "^3.0.0",
     "qrcode-generator": "1.4.1",
     "ramda": "^0.24.1",

--- a/ui/app/pages/mobile-sync/index.js
+++ b/ui/app/pages/mobile-sync/index.js
@@ -84,6 +84,9 @@ class MobileSyncPage extends Component {
   }
 
   initWebsockets () {
+    // Make sure there are no existing listeners
+    this.disconnectWebsockets()
+
     this.pubnub = new PubNub({
       subscribeKey: process.env.PUBNUB_SUB_KEY,
       publishKey: process.env.PUBNUB_PUB_KEY,
@@ -91,7 +94,7 @@ class MobileSyncPage extends Component {
       ssl: true,
     })
 
-    this.pubnubListener = this.pubnub.addListener({
+    this.pubnubListener = {
       message: (data) => {
         const {channel, message} = data
         // handle message
@@ -111,7 +114,9 @@ class MobileSyncPage extends Component {
           this.setState({syncing: false, completed: true})
         }
       },
-    })
+    }
+
+    this.pubnub.addListener(this.pubnubListener)
 
     this.pubnub.subscribe({
       channels: [this.channelName],
@@ -122,7 +127,7 @@ class MobileSyncPage extends Component {
 
   disconnectWebsockets () {
     if (this.pubnub && this.pubnubListener) {
-      this.pubnub.disconnect(this.pubnubListener)
+      this.pubnub.removeListener(this.pubnubListener)
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17150,10 +17150,10 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
 
-pubnub@^4.21.5:
-  version "4.21.7"
-  resolved "https://registry.yarnpkg.com/pubnub/-/pubnub-4.21.7.tgz#4daf999ead1aa9cf8e9af3d2fb2720c35085af6a"
-  integrity sha512-TZ96GuY+gZIu9rJaqcO2cZ6tl4JPLruoUcN01sljm1CcDgzIZbOfcDSZp4NcZas4ECSqAAwo/izMMiImRRS4Yg==
+pubnub@^4.24.4:
+  version "4.24.4"
+  resolved "https://registry.yarnpkg.com/pubnub/-/pubnub-4.24.4.tgz#6874b1836539765a1c1ec8c264f6b233ed28192a"
+  integrity sha512-otRny/9au/Xf0uAfPUrVwUPdFIE7nZv6+7TLcG8+wiZESgi7EgiGZ9VXAoe6istBj6hfZe0vj3+XCbkZHLHklw==
   dependencies:
     agentkeepalive "^3.5.2"
     lil-uuid "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17150,7 +17150,7 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
 
-pubnub@^4.24.4:
+pubnub@4.24.4:
   version "4.24.4"
   resolved "https://registry.yarnpkg.com/pubnub/-/pubnub-4.24.4.tgz#6874b1836539765a1c1ec8c264f6b233ed28192a"
   integrity sha512-otRny/9au/Xf0uAfPUrVwUPdFIE7nZv6+7TLcG8+wiZESgi7EgiGZ9VXAoe6istBj6hfZe0vj3+XCbkZHLHklw==


### PR DESCRIPTION
This PR is related to https://github.com/MetaMask/metamask-mobile/pull/989

- Updated the `pubnub` dep to match mobile
- Use exact match version for the pubnub dep so we're always in the same version on both sides.
- Updated the listener removal code to work with the latest pubnub SDK code.
