### PR TITLE
Allow overriding GANACHE_ARGS for e2e tests

### DIFF
--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -5,8 +5,13 @@ set -e
 set -u
 set -o pipefail
 
+# Set the environment variable 'GANACHE_ARGS' to change any optional ganache flags
+# By default, the flag `--quiet` is used. Setting 'GANACHE_ARGS' will override the default.
+OPTIONAL_GANACHE_ARGS="${GANACHE_ARGS---quiet}"
+BASE_GANACHE_ARGS="${OPTIONAL_GANACHE_ARGS} --blockTime 2"
+
 export PATH="$PATH:./node_modules/.bin"
-export GANACHE_ARGS='--blockTime 2 --quiet'
+export GANACHE_ARGS="${BASE_GANACHE_ARGS}"
 
 concurrently --kill-others \
   --names 'ganache,dapp,e2e' \
@@ -24,7 +29,7 @@ concurrently --kill-others \
   'yarn dapp' \
   'sleep 5 && mocha test/e2e/metamask-responsive-ui.spec'
 
-export GANACHE_ARGS="$GANACHE_ARGS --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
+export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
 concurrently --kill-others \
   --names 'ganache,e2e' \
   --prefix '[{time}][{name}]' \
@@ -32,7 +37,7 @@ concurrently --kill-others \
   'yarn ganache:start' \
   'sleep 5 && mocha test/e2e/from-import-ui.spec'
 
-export GANACHE_ARGS="$GANACHE_ARGS --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
+export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
 concurrently --kill-others \
   --names 'ganache,e2e' \
   --prefix '[{time}][{name}]' \
@@ -41,7 +46,7 @@ concurrently --kill-others \
   'sleep 5 && mocha test/e2e/send-edit.spec'
 
 
-export GANACHE_ARGS="$GANACHE_ARGS --deterministic --account=0x250F458997A364988956409A164BA4E16F0F99F916ACDD73ADCD3A1DE30CF8D1,0  --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
+export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x250F458997A364988956409A164BA4E16F0F99F916ACDD73ADCD3A1DE30CF8D1,0  --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
 concurrently --kill-others \
   --names 'ganache,sendwithprivatedapp,e2e' \
   --prefix '[{time}][{name}]' \
@@ -50,7 +55,7 @@ concurrently --kill-others \
   'npm run sendwithprivatedapp' \
   'sleep 5 && mocha test/e2e/incremental-security.spec'
 
-export GANACHE_ARGS="$GANACHE_ARGS --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
+export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
 concurrently --kill-others \
   --names 'ganache,dapp,e2e' \
   --prefix '[{time}][{name}]' \


### PR DESCRIPTION
This allows the environment variable `GANACHE_ARGS` to override the default set of optional flags used. By default, the flag `--quiet` is set. Setting `GANACHE_ARGS` will override the default.

For example, you can now run the e2e tests without the `--quiet` flag by running this:

```bash
GANACHE_ARGS='' yarn test:e2e:chrome
```

This change also prevents the arguments from being needlessly repeated. Previously this script accidentally build up `GANACHE_ARGS`, adding to the set of flags used with each change in arguments.

This PR is based upon #6870