### PR TITLE
Ensure seed phrase backup only shows up for new users

### DIFF
--- a/app/scripts/controllers/onboarding.js
+++ b/app/scripts/controllers/onboarding.js
@@ -23,7 +23,7 @@ class OnboardingController {
    */
   constructor (opts = {}) {
     const initState = extend({
-      seedPhraseBackedUp: null,
+      seedPhraseBackedUp: true,
     }, opts.initState)
     this.store = new ObservableStore(initState)
   }


### PR DESCRIPTION
This PR makes the seed phrase backup reminder only show up for new users.