### PR TITLE
Address book fixes

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -464,7 +464,7 @@ module.exports = class MetamaskController extends EventEmitter {
       whitelistPhishingDomain: this.whitelistPhishingDomain.bind(this),
 
       // AddressController
-      setAddressBook: this.addressBookController.set.bind(this.addressBookController),
+      setAddressBook: nodeify(this.addressBookController.set, this.addressBookController),
       removeFromAddressBook: this.addressBookController.delete.bind(this.addressBookController),
 
       // AppStateController

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -30,10 +30,10 @@ export default class EnsInput extends Component {
     updateEnsResolution: PropTypes.func,
     scanQrCode: PropTypes.func,
     updateEnsResolutionError: PropTypes.func,
-    addressBook: PropTypes.array,
     onPaste: PropTypes.func,
     onReset: PropTypes.func,
     onValidAddressTyped: PropTypes.func,
+    contact: PropTypes.object,
   }
 
   state = {
@@ -181,8 +181,7 @@ export default class EnsInput extends Component {
 
   renderSelected () {
     const { t } = this.context
-    const { className, selectedAddress, selectedName, addressBook } = this.props
-    const contact = addressBook.filter(item => item.address.toLowerCase() === selectedAddress.toLowerCase())[0] || {}
+    const { className, selectedAddress, selectedName, contact = {} } = this.props
     const name = contact.name || selectedName
 
 

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -182,7 +182,7 @@ export default class EnsInput extends Component {
   renderSelected () {
     const { t } = this.context
     const { className, selectedAddress, selectedName, addressBook } = this.props
-    const contact = addressBook.filter(item => item.address === selectedAddress)[0] || {}
+    const contact = addressBook.filter(item => item.address.toLowerCase() === selectedAddress.toLowerCase())[0] || {}
     const name = contact.name || selectedName
 
 

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.container.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.container.js
@@ -5,16 +5,19 @@ import {
   getSendToNickname,
 } from '../../send.selectors'
 import {
-  getAddressBook,
+  getAddressBookEntry,
 } from '../../../../selectors/selectors'
 const connect = require('react-redux').connect
 
 
 export default connect(
-  state => ({
-    network: getCurrentNetwork(state),
-    selectedAddress: getSendTo(state),
-    selectedName: getSendToNickname(state),
-    addressBook: getAddressBook(state),
-  })
+  state => {
+    const selectedAddress = getSendTo(state)
+    return {
+      network: getCurrentNetwork(state),
+      selectedAddress,
+      selectedName: getSendToNickname(state),
+      contact: getAddressBookEntry(state, selectedAddress),
+    }
+  }
 )(EnsInput)

--- a/ui/app/pages/send/send-content/send-content.component.js
+++ b/ui/app/pages/send/send-content/send-content.component.js
@@ -18,9 +18,10 @@ export default class SendContent extends Component {
     scanQrCode: PropTypes.func,
     showAddToAddressBookModal: PropTypes.func,
     showHexData: PropTypes.bool,
-    to: PropTypes.string,
     ownedAccounts: PropTypes.array,
     addressBook: PropTypes.array,
+    contact: PropTypes.object,
+    isOwnedAccount: PropTypes.bool,
   }
 
   updateGas = (updateData) => this.props.updateGas(updateData)
@@ -47,9 +48,7 @@ export default class SendContent extends Component {
 
   maybeRenderAddContact () {
     const { t } = this.context
-    const { to, addressBook = [], ownedAccounts = [], showAddToAddressBookModal } = this.props
-    const isOwnedAccount = !!ownedAccounts.find(({ address }) => address.toLowerCase() === to.toLowerCase())
-    const contact = addressBook.find(({ address }) => address.toLowerCase() === to.toLowerCase()) || {}
+    const { isOwnedAccount, showAddToAddressBookModal, contact = {} } = this.props
 
     if (isOwnedAccount || contact.name) {
       return

--- a/ui/app/pages/send/send-content/send-content.component.js
+++ b/ui/app/pages/send/send-content/send-content.component.js
@@ -49,7 +49,7 @@ export default class SendContent extends Component {
     const { t } = this.context
     const { to, addressBook = [], ownedAccounts = [], showAddToAddressBookModal } = this.props
     const isOwnedAccount = !!ownedAccounts.find(({ address }) => address.toLowerCase() === to.toLowerCase())
-    const contact = addressBook.find(({ address }) => address === to) || {}
+    const contact = addressBook.find(({ address }) => address.toLowerCase() === to.toLowerCase()) || {}
 
     if (isOwnedAccount || contact.name) {
       return

--- a/ui/app/pages/send/send-content/send-content.container.js
+++ b/ui/app/pages/send/send-content/send-content.container.js
@@ -5,15 +5,17 @@ import {
   getSendTo,
 } from '../send.selectors'
 import {
-  getAddressBook,
+  getAddressBookEntry,
 } from '../../../selectors/selectors'
 import actions from '../../../store/actions'
 
 function mapStateToProps (state) {
+  const ownedAccounts = accountsWithSendEtherInfoSelector(state)
+  const to = getSendTo(state)
   return {
-    to: getSendTo(state),
-    addressBook: getAddressBook(state),
-    ownedAccounts: accountsWithSendEtherInfoSelector(state),
+    isOwnedAccount: !!ownedAccounts.find(({ address }) => address.toLowerCase() === to.toLowerCase()),
+    contact: getAddressBookEntry(state, to),
+    to,
   }
 }
 

--- a/ui/app/pages/send/send-content/tests/send-content-component.test.js
+++ b/ui/app/pages/send/send-content/tests/send-content-component.test.js
@@ -52,11 +52,10 @@ describe('SendContent Component', function () {
       assert.equal(PageContainerContentChild.childAt(4).exists(), false)
     })
 
-    it('should not render the Dialog if addressBook contains "to" address', () => {
+    it('should not render the Dialog if contact has a name', () => {
       wrapper.setProps({
         showHexData: false,
-        to: '0x80F061544cC398520615B5d3e7A3BedD70cd4510',
-        addressBook: [{ address: '0x80F061544cC398520615B5d3e7A3BedD70cd4510', name: 'dinodan' }],
+        contact: { name: 'testName' },
       })
       const PageContainerContentChild = wrapper.find(PageContainerContent).children()
       assert(PageContainerContentChild.childAt(0).is(SendAssetRow), 'row[1] should be SendAssetRow')
@@ -65,12 +64,10 @@ describe('SendContent Component', function () {
       assert.equal(PageContainerContentChild.childAt(3).exists(), false)
     })
 
-    it('should not render the Dialog if ownedAccounts contains "to" address', () => {
+    it('should not render the Dialog if it is an ownedAccount', () => {
       wrapper.setProps({
         showHexData: false,
-        to: '0x80F061544cC398520615B5d3e7A3BedD70cd4510',
-        addressBook: [],
-        ownedAccounts: [{ address: '0x80F061544cC398520615B5d3e7A3BedD70cd4510', name: 'dinodan' }],
+        isOwnedAccount: true,
       })
       const PageContainerContentChild = wrapper.find(PageContainerContent).children()
       assert(PageContainerContentChild.childAt(0).is(SendAssetRow), 'row[1] should be SendAssetRow')

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -11,6 +11,7 @@ const {
 } = require('../helpers/utils/conversion-util')
 import {
   addressSlicer,
+  checksumAddress,
 } from '../helpers/utils/util'
 
 const selectors = {
@@ -217,7 +218,7 @@ function getAddressBook (state) {
 
 function getAddressBookEntry (state, address) {
   const addressBook = getAddressBook(state)
-  const entry = addressBook.find(contact => contact.address.toLowerCase() === address.toLowerCase())
+  const entry = addressBook.find(contact => contact.address === checksumAddress(address))
   return entry
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1956,7 +1956,12 @@ function addToAddressBook (recipient, nickname = '', memo = '') {
 
   return (dispatch, getState) => {
     const chainId = getState().metamask.network
-    background.setAddressBook(checksumAddress(recipient), nickname, chainId, memo, (_, set) => {
+    background.setAddressBook(checksumAddress(recipient), nickname, chainId, memo, (err, set) => {
+      if (err) {
+        log.error(err)
+        dispatch(displayWarning('Address book failed to update'))
+        throw err
+      }
       if (!set) {
         return dispatch(displayWarning('Address book failed to update'))
       }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1956,10 +1956,12 @@ function addToAddressBook (recipient, nickname = '', memo = '') {
 
   return (dispatch, getState) => {
     const chainId = getState().metamask.network
-    const set = background.setAddressBook(checksumAddress(recipient), nickname, chainId, memo)
-    if (!set) {
-      return dispatch(displayWarning('Address book failed to update'))
-    }
+    background.setAddressBook(checksumAddress(recipient), nickname, chainId, memo, (_, set) => {
+      if (!set) {
+        return dispatch(displayWarning('Address book failed to update'))
+      }
+    })
+
   }
 }
 


### PR DESCRIPTION
This PR fixes two address book related issues:
- prior to this PR, if sending to an ENS address and assigning that address with a specific name, the to input would not update to the new name and the new address dialoag would not go away even when the name is added
- all addressbook additions would cause a "address book not set" warning to be shown in the settings screen