### PR TITLE
Remove reload from Share Address button

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6,7 +6,7 @@
     "message": "Share your address to connect to $1?"
   },
   "shareAddressInfo": {
-    "message": "Sharing your address with $1 will allow you to interact with this dapp. This permission is to protect your privacy by default."
+    "message": "Sharing your address with $1 will allow you to interact with this dapp. This permission is to protect your privacy by default. You may need to reload the dapp for the change to take effect."
   },
   "privacyModeDefault": {
     "message": "Privacy Mode is now enabled by default"

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -114,7 +114,6 @@ function forwardTrafficBetweenMuxers (channelName, muxA, muxB) {
 
 async function setupPublicApi (outStream) {
   const api = {
-    forceReloadSite: (cb) => cb(null, forceReloadSite()),
     getSiteMetadata: (cb) => cb(null, getSiteMetadata()),
   }
   const dnode = Dnode(api)
@@ -306,11 +305,4 @@ async function domIsReady () {
   if (['interactive', 'complete'].includes(document.readyState)) return
   // wait for load
   await new Promise(resolve => window.addEventListener('DOMContentLoaded', resolve, { once: true }))
-}
-
-/**
- * Reloads the site
- */
-function forceReloadSite () {
-  window.location.reload()
 }

--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -156,8 +156,6 @@ class ProviderApprovalController extends SafeEventEmitter {
       dismissedOrigins: _dismissedOrigins,
       providerRequests: remainingProviderRequests,
     })
-
-    this.emit(`forceResolvedRequest:${origin}`, { approved: true, forced: true })
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1273,8 +1273,6 @@ module.exports = class MetamaskController extends EventEmitter {
     const publicApi = this.setupPublicApi(mux.createStream('publicApi'), originDomain)
     this.setupProviderConnection(mux.createStream('provider'), originDomain, publicApi)
     this.setupPublicConfig(mux.createStream('publicConfig'), originDomain)
-
-    this.providerApprovalController.on(`forceResolvedRequest:${originDomain}`, publicApi.forceReloadSite)
   }
 
   /**
@@ -1455,10 +1453,6 @@ module.exports = class MetamaskController extends EventEmitter {
 
     const publicApi = {
       // wrap with an await remote
-      forceReloadSite: async () => {
-        const remote = await getRemote()
-        return await pify(remote.forceReloadSite)()
-      },
       getSiteMetadata: async () => {
         const remote = await getRemote()
         return await pify(remote.getSiteMetadata)()


### PR DESCRIPTION
Fixes #6989, closes #6982

This PR updates the Share Address functionality shown in the popup to NOT reload tabs for that domain. I've included updated copy to help inform the user that a dapp might need to be reloaded for it to work.<sup>\[1\]</sup>

<sup>1. Sites that don't poll web3 access, for example</sup>