### PR TITLE
Make Coveralls its own optional CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,9 @@ workflows:
             - prep-build
       #       - prep-docs
             - all-tests-pass
+      - coveralls-upload:
+          requires:
+            - test-unit
 
 jobs:
   create_release_pull_request:
@@ -302,6 +305,17 @@ jobs:
       - run:
           name: All Tests Passed
           command: echo 'weew - everything passed!'
+
+  coveralls-upload:
+    docker:
+      - image: circleci/node:10.16-browsers
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Coveralls upload
+          command: yarn test:coveralls-upload
 
   create_github_release:
     docker:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:web3:chrome": "SELENIUM_BROWSER=chrome test/e2e/run-web3.sh",
     "test:web3:firefox": "SELENIUM_BROWSER=firefox test/e2e/run-web3.sh",
     "test:e2e:firefox": "SELENIUM_BROWSER=firefox test/e2e/run-all.sh",
-    "test:coverage": "nyc --reporter=text --reporter=html npm run test:unit && yarn test:coveralls-upload",
+    "test:coverage": "nyc --reporter=text --reporter=html npm run test:unit",
     "test:coveralls-upload": "if [ $COVERALLS_REPO_TOKEN ]; then nyc report --reporter=text-lcov | coveralls; fi",
     "test:flat": "yarn test:flat:build && karma start test/flat.conf.js",
     "test:flat:build": "yarn test:flat:build:ui && yarn test:flat:build:tests && yarn test:flat:build:locales",


### PR DESCRIPTION
This PR moves Coveralls into its own optional CI job. Coveralls isn't run for PRs coming from forks (as the token doesn't exist) so it's already optional in that sense. 🤷‍♂ 