### PR TITLE
Fix Coveralls CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,11 @@ jobs:
       - run:
           name: test:coverage
           command: yarn test:coverage
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .nyc_output
+            - coverage
   test-mozilla-lint:
     docker:
       - image: circleci/node:10.16-browsers


### PR DESCRIPTION
This PR updates the `test-unit` job to persist the coverage data paths it generates for the downstream `coveralls-upload` job.

**Context**

The `coveralls-upload` job was failing with the following error:<sup>[\[1\]][1]</sup>

```
yarn run v1.17.3
$ if [ $COVERALLS_REPO_TOKEN ]; then nyc report --reporter=text-lcov | coveralls; fi
/home/circleci/project/node_modules/nyc/node_modules/yargs/yargs.js:1133
      else throw err
           ^

Error: ENOENT: no such file or directory, scandir '/home/circleci/project/.nyc_output'
    at Object.readdirSync (fs.js:790:3)
    at NYC.eachReport (/home/circleci/project/node_modules/nyc/index.js:529:31)
    at NYC.getCoverageMapFromAllCoverageFiles (/home/circleci/project/node_modules/nyc/index.js:428:8)
    at NYC.report (/home/circleci/project/node_modules/nyc/index.js:446:18)
    at Object.exports.handler (/home/circleci/project/node_modules/nyc/lib/commands/report.js:44:7)
    at Object.runCommand (/home/circleci/project/node_modules/nyc/node_modules/yargs/lib/command.js:235:44)
    at Object.parseArgs [as _parseArgs] (/home/circleci/project/node_modules/nyc/node_modules/yargs/yargs.js:1046:30)
    at Object.parse (/home/circleci/project/node_modules/nyc/node_modules/yargs/yargs.js:551:25)
    at Object.<anonymous> (/home/circleci/project/node_modules/nyc/bin/nyc.js:24:35)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
[error] "2019-08-14T12:42:44.482Z"  'error from lcovParse: ' 'Failed to parse string'
[error] "2019-08-14T12:42:44.483Z"  'input: ' ''
[error] "2019-08-14T12:42:44.483Z"  'error from convertLcovToCoveralls'

/home/circleci/project/node_modules/coveralls/bin/coveralls.js:18
        throw err;
        ^
Failed to parse string
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

  [1]:https://circleci.com/gh/MetaMask/metamask-extension/101554?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link