### PR TITLE
Rename Contacts List settings tab to Contacts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -399,10 +399,10 @@
   "connectToTrezor": {
     "message": "Connect to Trezor"
   },
-  "contactList": {
-    "message": "Contact List"
+  "contacts": {
+    "message": "Contacts"
   },
-  "contactListDescription": {
+  "contactsSettingsDescription": {
     "message": "Add, edit, remove, and manage your contacts"
   },
   "continue": {

--- a/ui/app/pages/settings/settings.component.js
+++ b/ui/app/pages/settings/settings.component.js
@@ -149,7 +149,7 @@ class SettingsPage extends PureComponent {
         tabs={[
           { content: t('general'), description: t('generalSettingsDescription'), key: GENERAL_ROUTE },
           { content: t('advanced'), description: t('advancedSettingsDescription'), key: ADVANCED_ROUTE },
-          { content: t('contactList'), description: t('contactListDescription'), key: CONTACT_LIST_ROUTE },
+          { content: t('contacts'), description: t('contactsSettingsDescription'), key: CONTACT_LIST_ROUTE },
           { content: t('securityAndPrivacy'), description: t('securitySettingsDescription'), key: SECURITY_ROUTE },
           { content: t('networks'), description: t('networkSettingsDescription'), key: NETWORKS_ROUTE },
           { content: t('about'), description: t('aboutSettingsDescription'), key: ABOUT_US_ROUTE },

--- a/ui/app/pages/settings/settings.container.js
+++ b/ui/app/pages/settings/settings.container.js
@@ -27,7 +27,7 @@ const ROUTES_TO_I18N_KEYS = {
   [ADVANCED_ROUTE]: 'advanced',
   [SECURITY_ROUTE]: 'securityAndPrivacy',
   [ABOUT_US_ROUTE]: 'about',
-  [CONTACT_LIST_ROUTE]: 'contactList',
+  [CONTACT_LIST_ROUTE]: 'contacts',
   [CONTACT_ADD_ROUTE]: 'newContact',
   [CONTACT_EDIT_ROUTE]: 'editContact',
   [CONTACT_VIEW_ROUTE]: 'viewContact',


### PR DESCRIPTION
This PR renames the Contacts List settings tab to Contacts, as shown below:

<img width="1112" alt="" src="https://user-images.githubusercontent.com/1623628/63095314-8a924080-bf45-11e9-907e-091c84aab025.png">
<img width="1112" alt="" src="https://user-images.githubusercontent.com/1623628/63095315-8a924080-bf45-11e9-9b13-6af12eccac63.png">
<img width="1112" alt="" src="https://user-images.githubusercontent.com/1623628/63095316-8a924080-bf45-11e9-91da-a57fcc5fa99c.png">
