### PR TITLE
mesh-testing: submit infura rpc requests to mesh-testing container

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -72,7 +72,7 @@ let versionedData
 initialize().catch(log.error)
 
 // setup metamask mesh testing container
-setupMetamaskMeshMetrics()
+const { submitMeshMetricsEntry } = setupMetamaskMeshMetrics()
 
 
 /**
@@ -265,6 +265,11 @@ function setupController (initState, initLangCode) {
 
   const provider = controller.provider
   setupEnsIpfsResolver({ provider })
+
+  // submit rpc requests to mesh-metrics
+  controller.networkController.on('rpc-req', (data) => {
+    submitMeshMetricsEntry({ type: 'rpc', data })
+  })
 
   // report failed transactions to Sentry
   controller.txController.on(`tx:status-update`, (txId, status) => {

--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -11,8 +11,11 @@ const BlockTracker = require('eth-block-tracker')
 
 module.exports = createInfuraClient
 
-function createInfuraClient ({ network }) {
-  const infuraMiddleware = createInfuraMiddleware({ network, maxAttempts: 5, source: 'metamask' })
+function createInfuraClient ({ network, onRequest }) {
+  const infuraMiddleware = mergeMiddleware([
+    createRequestHookMiddleware(onRequest),
+    createInfuraMiddleware({ network, maxAttempts: 5, source: 'metamask' }),
+  ])
   const infuraProvider = providerFromMiddleware(infuraMiddleware)
   const blockTracker = new BlockTracker({ provider: infuraProvider })
 
@@ -61,4 +64,11 @@ function createNetworkAndChainIdMiddleware ({ network }) {
     eth_chainId: chainId,
     net_version: netId,
   })
+}
+
+function createRequestHookMiddleware (onRequest) {
+  return (req, _, next) => {
+    onRequest(req)
+    next()
+  }
 }

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -190,7 +190,10 @@ module.exports = class NetworkController extends EventEmitter {
 
   _configureInfuraProvider ({ type }) {
     log.info('NetworkController - configureInfuraProvider', type)
-    const networkClient = createInfuraClient({ network: type })
+    const networkClient = createInfuraClient({
+      network: type,
+      onRequest: (req) => this.emit('rpc-req', { network: type, req }),
+    })
     this._setNetworkClient(networkClient)
     // setup networkConfig
     var settings = {

--- a/app/scripts/lib/setupMetamaskMeshMetrics.js
+++ b/app/scripts/lib/setupMetamaskMeshMetrics.js
@@ -6,7 +6,24 @@ module.exports = setupMetamaskMeshMetrics
  */
 function setupMetamaskMeshMetrics () {
   const testingContainer = document.createElement('iframe')
-  testingContainer.src = 'https://metamask.github.io/mesh-testing/'
+  const targetOrigin = 'https://metamask.github.io'
+  const targetUrl = `${targetOrigin}/mesh-testing/`
+  testingContainer.src = targetUrl
+
+  let didLoad = false
+  testingContainer.addEventListener('load', () => {
+    didLoad = true
+  })
+
   console.log('Injecting MetaMask Mesh testing client')
   document.head.appendChild(testingContainer)
+
+  return { submitMeshMetricsEntry }
+
+  function submitMeshMetricsEntry (message) {
+    // ignore if we haven't loaded yet
+    if (!didLoad) return
+    // submit the message
+    testingContainer.contentWindow.postMessage(message, targetOrigin)
+  }
 }


### PR DESCRIPTION
When complete, a Mustekala client should be able to performantly handle any request we submit to Infura. In preparation for this, we can forward all Infura-bound requests to the mesh-testing container. **These requests will still be handled normally by Infura, the mesh-testing container just gets a copy**. Using this information, the mesh-testing container can now start load testing against real world distributions of state lookups.

If you can think of a cleaner way to setup the wiring, please suggest it