### PR TITLE
bugfix: block ERC721 on mobile sync

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -55,6 +55,7 @@ const HW_WALLETS_KEYRINGS = [TrezorKeyring.type, LedgerBridgeKeyring.type]
 const EthQuery = require('eth-query')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
+const contractMap = require('eth-contract-metadata')
 const {
   AddressBookController,
   CurrencyRateController,
@@ -62,7 +63,6 @@ const {
   PhishingController,
 } = require('gaba')
 const backEndMetaMetricsEvent = require('./lib/backend-metametrics')
-
 
 module.exports = class MetamaskController extends EventEmitter {
 
@@ -648,8 +648,24 @@ module.exports = class MetamaskController extends EventEmitter {
       tokens,
     } = this.preferencesController.store.getState()
 
+    // Filter ERC20 tokens
+    const filteredAccountTokens = {}
+    Object.keys(accountTokens).forEach(address => {
+      const checksummedAddress = ethUtil.toChecksumAddress(address)
+      filteredAccountTokens[checksummedAddress] = {}
+      Object.keys(accountTokens[address]).forEach(
+        networkType => (filteredAccountTokens[checksummedAddress][networkType] = networkType !== 'mainnet' ?
+          accountTokens[address][networkType] :
+          accountTokens[address][networkType].filter(({ address }) => {
+            const tokenAddress = ethUtil.toChecksumAddress(address)
+            return contractMap[tokenAddress] ? contractMap[tokenAddress].erc20 : true
+          })
+        )
+      )
+    })
+
     const preferences = {
-      accountTokens,
+      accountTokens: filteredAccountTokens,
       currentLocale,
       frequentRpcList,
       identities,


### PR DESCRIPTION
This PR blocks ERC721 assets to be sync with mobile. There are some ERC721 assets handled as ERC20 so I added a filter to block mainnet assets that we know are ERC721, in order to not send non useful data.