### PR TITLE
Fetch Extension Metadata on eth_requestAccounts

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -72,7 +72,8 @@
     "activeTab",
     "webRequest",
     "*://*.eth/",
-    "notifications"
+    "notifications",
+    "management"
   ],
   "web_accessible_resources": [
     "inpage.js",

--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -30,7 +30,7 @@ class ProviderApprovalController extends SafeEventEmitter {
    *
    * @param {object} opts - opts for the middleware contains the origin for the middleware
    */
-  createMiddleware ({ origin, getSiteMetadata }) {
+  createMiddleware ({ origin, getSiteMetadata, getExtensionMetadata }) {
     return createAsyncMiddleware(async (req, res, next) => {
       // only handle requestAccounts
       if (req.method !== 'eth_requestAccounts') return next()
@@ -40,8 +40,11 @@ class ProviderApprovalController extends SafeEventEmitter {
         res.result = [this.preferencesController.getSelectedAddress()]
         return
       }
+
+      // get metadata from origin if extension or site
+      const metadata = await getExtensionMetadata(origin) || await getSiteMetadata(origin)
+
       // register the provider request
-      const metadata = await getSiteMetadata(origin)
       this._handleProviderRequest(origin, metadata.name, metadata.icon)
       // wait for resolution of request
       const approved = await new Promise(resolve => this.once(`resolvedRequest:${origin}`, ({ approved }) => resolve(approved)))


### PR DESCRIPTION
**tl;dr This PR allows the provider approval logic to fetch extension metadata in order to allow `eth_requestAccounts` calls to succeed when triggered from other extensions.**

This should resolve #5950 and https://github.com/MetaMask/metamask-extension-provider/issues/3

When an extension tries to call the `eth_requestAccounts` method via the web3 provider over the port stream to MetaMask, the provider approval logic was trying to fetch site metadata using an origin string that was not a FQDN, but rather an extension id.

This was silently throwing, resulting in no approval dialog/window.

I have added the `"management"` permission to this extension to allow it to determine if the origin string is an extension id, and to fetch the relevant extension name and its largest icon. This will only work in Chrome, or any other browser that supports `chrome.management.getAll`. However, it will simply behave as it did before if it cannot fetch the extension.

I have tested this locally and it seems to work so far. Not familiar with the linting rules around here, so this will likely fail some long-line rule. 