### PR TITLE
Bug fixes for incoming transactions

### DIFF
--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -2,7 +2,7 @@ const ObservableStore = require('obs-store')
 const log = require('loglevel')
 const BN = require('bn.js')
 const createId = require('../lib/random-id')
-const { bnToHex } = require('../lib/util')
+const { bnToHex, fetchWithTimeout } = require('../lib/util')
 const {
   MAINNET_CODE,
   ROPSTEN_CODE,
@@ -19,6 +19,9 @@ const networkTypeToIdMap = {
   [KOVAN]: String(KOVAN_CODE),
   [MAINNET]: String(MAINNET_CODE),
 }
+const fetch = fetchWithTimeout({
+  timeout: 30000,
+})
 
 class IncomingTransactionsController {
 

--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -14,10 +14,10 @@ const {
   MAINNET,
 } = require('./network/enums')
 const networkTypeToIdMap = {
-  [ROPSTEN]: ROPSTEN_CODE,
-  [RINKEBY]: RINKEYBY_CODE,
-  [KOVAN]: KOVAN_CODE,
-  [MAINNET]: MAINNET_CODE,
+  [ROPSTEN]: String(ROPSTEN_CODE),
+  [RINKEBY]: String(RINKEYBY_CODE),
+  [KOVAN]: String(KOVAN_CODE),
+  [MAINNET]: String(MAINNET_CODE),
 }
 
 class IncomingTransactionsController {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -144,6 +144,29 @@ function removeListeners (listeners, emitter) {
   })
 }
 
+function fetchWithTimeout ({ timeout = 120000 } = {}) {
+  return async function _fetch (url, opts) {
+    const abortController = new AbortController()
+    const abortSignal = abortController.signal
+    const f = fetch(url, {
+      ...opts,
+      signal: abortSignal,
+    })
+
+    const timer = setTimeout(() => abortController.abort(), timeout)
+
+    try {
+      const res = await f
+      clearTimeout(timer)
+      return res
+    } catch (e) {
+      clearTimeout(timer)
+      throw e
+    }
+  }
+}
+
+
 module.exports = {
   removeListeners,
   applyListeners,
@@ -154,4 +177,5 @@ module.exports = {
   hexToBn,
   bnToHex,
   BnMultiplyByFraction,
+  fetchWithTimeout,
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -156,8 +156,10 @@ module.exports = class MetamaskController extends EventEmitter {
     this.on('controllerConnectionChanged', (activeControllerConnections) => {
       if (activeControllerConnections > 0) {
         this.accountTracker.start()
+        this.incomingTransactionsController.start()
       } else {
         this.accountTracker.stop()
+        this.incomingTransactionsController.stop()
       }
     })
 

--- a/ui/app/components/app/transaction-list/index.scss
+++ b/ui/app/components/app/transaction-list/index.scss
@@ -11,34 +11,15 @@
   }
 
   &__header {
+    flex: 0 0 auto;
+    font-size: 14px;
+    line-height: 20px;
+    color: $Grey-400;
     border-bottom: 1px solid $Grey-100;
+    padding: 8px 0 8px 20px;
 
-    &__tabs {
-      display: flex; 
-    }
-
-    &__tab,
-    &__tab--selected {
-      flex: 0 0 auto;
-      font-size: 14px;
-      line-height: 20px;
-      color: $Grey-400;
-      padding: 8px 0 8px 20px;
-      cursor: pointer;
-
-      &:hover {
-        font-weight: bold;
-      }
-
-      @media screen and (max-width: $break-small) {
-        padding: 8px 0 8px 16px;
-      }
-    }
-
-    &__tab--selected {
-      font-weight: bold;
-      color: $Blue-400;
-      cursor: auto;
+    @media screen and (max-width: $break-small) {
+      padding: 8px 0 8px 16px;
     }
   }
 

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -16,9 +16,12 @@ import txHelper from '../../lib/tx-helper'
 export const shapeShiftTxListSelector = state => state.metamask.shapeShiftTxList
 
 export const incomingTxListSelector = state => {
+  const network = state.metamask.network
   const selectedAddress = state.metamask.selectedAddress
   return Object.values(state.metamask.incomingTransactions)
-    .filter(({ txParams }) => txParams.to === selectedAddress)
+    .filter(({ metamaskNetworkId, txParams }) => (
+      txParams.to === selectedAddress && metamaskNetworkId === network
+    ))
 }
 export const unapprovedMsgsSelector = state => state.metamask.unapprovedMsgs
 export const selectedAddressTxListSelector = state => state.metamask.selectedAddressTxList


### PR DESCRIPTION
Refs #6996

This PR contains commits* fixing the following issues found during QA:

> 1. CSS for `transaction-list__header`[...] removes CSS for History header
> 2. Tx History stays populated from Mainnet while on Test Networks.
> 3. [Take the incoming tx controller off] the block tracker and do a custom [timeout] for the etherscan call to avoid also pushing more traffic to infura…

\* Reviewing this commit-by-commit might be the easiest option, FYI