### PR TITLE
Add warning about reload on network change

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -61,8 +61,19 @@ const inpageProvider = new MetamaskInpageProvider(metamaskStream)
 // set a high max listener count to avoid unnecesary warnings
 inpageProvider.setMaxListeners(100)
 
+let warnedOfAutoRefreshDeprecation = false
 // augment the provider with its enable method
 inpageProvider.enable = function ({ force } = {}) {
+  if (
+    !warnedOfAutoRefreshDeprecation &&
+    inpageProvider.autoRefreshOnNetworkChange
+  ) {
+    console.warn(`MetaMask: MetaMask will soon stop reloading pages on network change.
+If you rely upon this behavior, add a 'networkChanged' event handler to trigger the reload manually: https://metamask.github.io/metamask-docs/API_Reference/Ethereum_Provider#ethereum.on(eventname%2C-callback)
+Set 'ethereum.autoRefreshOnNetworkChange' to 'false' to silence this warning: https://metamask.github.io/metamask-docs/API_Reference/Ethereum_Provider#ethereum.autorefreshonnetworkchange'
+`)
+    warnedOfAutoRefreshDeprecation = true
+  }
   return new Promise((resolve, reject) => {
     inpageProvider.sendAsync({ method: 'eth_requestAccounts', params: [force] }, (error, response) => {
       if (error || response.error) {


### PR DESCRIPTION
We are soon removing the automatic refresh on network change behavior. A warning has been added to ensure sites know about this upcoming change.

Any site that calls `.enable` is advised to either add a `networkChanged` event handler to reload manually, or set the flag `autoRefreshOnNetworkChange` to `false` to opt-out of the reload behavior early.

This warning might be irritating for certain sites, as they might be indifferent to whether or not the site reloads, and not eager to set a flag to opt-in early just to silence the warning. However there was no other obvious way to warning the right people about this change, as any warning prior to an actual reload would only be seen by the few people that set their browser console to preserve logs.

Relates to #3599 