### PR TITLE
Right align "Total" line items in tx detail view

### DIFF
--- a/ui/app/components/app/transaction-breakdown/index.scss
+++ b/ui/app/components/app/transaction-breakdown/index.scss
@@ -12,6 +12,9 @@
   }
 
   &__value {
+    display: flex;
+    justify-content: flex-end;
+
     text-align: end;
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
Fixes #7044

<details>
<summary>
<strong>Before & after</strong>
</summary>
<img width="1112" alt="" src="https://user-images.githubusercontent.com/1623628/63460981-351cce80-c432-11e9-98f7-afd4e6501f77.png">
<img width="1112" alt="" src="https://user-images.githubusercontent.com/1623628/63460982-351cce80-c432-11e9-8e7d-931d03eb310c.png">
</details>