### PR TITLE
Fix undefined transaction id error in confirm-transaction component

### DIFF
--- a/ui/app/pages/confirm-transaction/confirm-transaction.component.js
+++ b/ui/app/pages/confirm-transaction/confirm-transaction.component.js
@@ -41,11 +41,6 @@ export default class ConfirmTransaction extends Component {
     isTokenMethodAction: PropTypes.bool,
   }
 
-  getParamsTransactionId () {
-    const { match: { params: { id } = {} } } = this.props
-    return id || null
-  }
-
   componentDidMount () {
     const {
       totalUnapprovedCount = 0,
@@ -70,7 +65,8 @@ export default class ConfirmTransaction extends Component {
     if (isTokenMethodAction) {
       getTokenParams(to)
     }
-    this.props.setTransactionToConfirm(transactionId || paramsTransactionId)
+    const txId = transactionId || paramsTransactionId
+    if (txId) this.props.setTransactionToConfirm(txId)
   }
 
   componentDidUpdate (prevProps) {


### PR DESCRIPTION
On occasion, the `confirm-transaction` component throws an error due to the transaction id being undefined. This does not cause builds, transactions, or the UI to fail, but it is an error nonetheless.

For example:
```
[2019-08-21 20:32:23.690][e2e] chrome-extension://aohcjlklkjjpdgebibknknkinbdpdmoe/ui.js 0:265094 "Transaction with id undefined not found"
```
Thrown in this e2e test: https://circleci.com/gh/MetaMask/metamask-extension/102563?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

To reproduce, simply send a transaction to one of your accounts with the console open expanded view.

My assessment is that the transaction id is still undefined when the component is mounted, causing the error. The fix is wrapping the call in an if statement.