### PR TITLE
Get and set average gas price button estimation as default

### DIFF
--- a/ui/app/pages/send/send.selectors.js
+++ b/ui/app/pages/send/send.selectors.js
@@ -13,7 +13,7 @@ const {
   calcGasTotal,
 } = require('./send.utils')
 import {
-  getFastPriceEstimateInHexWEI,
+  getAveragePriceEstimateInHexWEI,
 } from '../../selectors/custom-gas'
 
 const selectors = {
@@ -120,7 +120,7 @@ function getGasLimit (state) {
 }
 
 function getGasPrice (state) {
-  return state.metamask.send.gasPrice || getFastPriceEstimateInHexWEI(state)
+  return state.metamask.send.gasPrice || getAveragePriceEstimateInHexWEI(state)
 }
 
 function getGasPriceFromRecentBlocks (state) {


### PR DESCRIPTION
Should have been in #7059. Sets Average Button as default button for Tx Fee/Gas Price.