### PR TITLE
adding a github donation page through a lock

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://donate.unlock-protocol.com/?r=MetaMask/metamask-extension

--- a/.unlock-protocol.config.json
+++ b/.unlock-protocol.config.json
@@ -1,0 +1,14 @@
+{
+   "icon": "https://assets.unlock-protocol.com/tmp/metamask.png",
+   "persistentCheckout": true,
+   "callToAction": {
+     "default": "Please support work on Metamask by purchasing a key to our Lock on Ethereum!",
+     "pending": "Thank you for your support. It means a lot to us!",
+     "confirmed": "Thank you for your support. It means a lot to us!"
+   },
+   "locks": {
+     "0x70841C98472553DF984AA033f8D3b8C261d17D82": {
+       "name": "Metamask Supporters"
+     }
+   }
+ }


### PR DESCRIPTION
Hello!

First of all, thanks for your (hard) work!

### Description

As an OpenSource project, I believe MetaMask should have a `FUNDING.yml` file which lets people make donations if they enjoy the software, like we do!

This pull requests adds donation thru an [Unlock](https://unlock-protocol.com/) lock. Locks are smart contract which let people become members by purchasing a key. The key itself is a non fungible token: 🗝 . (you can view the NFT on [OpenSea](https://opensea.io/assets/0x70841c98472553df984aa033f8d3b8c261d17d82/1) for example)

This specific lock is at [`0x70841c98472553df984aa033f8d3b8c261d17d82`](https://etherscan.io/address/0x70841c98472553df984aa033f8d3b8c261d17d82). The current key price is 1 DAI. I currently own the lock but I'll happily transfer its ownership to you if you can send me an address ;) Keys are valid for 1 month and there can be an infinite number of keys.

The pull-request adds 2 files: `FUNDING.yml` which is a github standard file to add a "donation button" with the right links when people click on it and a file which includes the configuration for the donation page.

Here is what it looks like :


<img width="808" alt="image" src="https://user-images.githubusercontent.com/17735/63724624-3aa95880-c826-11e9-84d9-52a61958fc98.png">

You can try this on another project which already uses the donation button such as [Unlock](https://github.com/unlock-protocol/unlock/), [MyCrypto](https://github.com/mycryptohq/mycrypto), or [WalletConnect](https://github.com/WalletConnect/walletconnect-monorepo/)...

When/if you merge this you also need to enable donations in the settings (see https://github.com/MetaMask/metamask-extension/settings): 

<img width="747" alt="image" src="https://user-images.githubusercontent.com/17735/63268593-88d8bd80-c262-11e9-92f7-2d458c07e74f.png">

