### PR TITLE
Fix confirm token transaction amount display

### DIFF
--- a/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
+++ b/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
@@ -28,6 +28,10 @@ export default class ConfirmTokenTransactionBase extends Component {
     currentCurrency: PropTypes.string,
   }
 
+  static defaultProps = {
+    tokenAmount: 0,
+  }
+
   getFiatTransactionAmount () {
     const { tokenAmount, currentCurrency, conversionRate, contractExchangeRate } = this.props
 

--- a/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.container.js
+++ b/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.container.js
@@ -39,7 +39,7 @@ const mapStateToProps = (state, ownProps) => {
   const tokenData = getTokenData(data)
   const tokenValue = tokenData && getTokenValue(tokenData.params)
   const toAddress = tokenData && getTokenToAddress(tokenData.params)
-  const tokenAmount = tokenData && calcTokenAmount(tokenValue, decimals).toString()
+  const tokenAmount = tokenData && calcTokenAmount(tokenValue, decimals).toNumber()
   const contractExchangeRate = contractExchangeRateSelector(state)
 
   return {


### PR DESCRIPTION
The token amount displayed when confirming a token transaction was wrongly being converted to a string in the container. As a result, the conversion into the user's preferred currency would fail.

A default value of '0' was added for the token amount as well, to prevent `undefined` from being rendered as the value. Really the value should never be undefined, but it was rather difficult to handle that case without a deeper investigation into how it might occur. The 0 default is consistent with existing rendering logic.