### PR TITLE
Allow dismissing privacy mode from popup

### DIFF
--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -102,6 +102,10 @@ export default class Home extends PureComponent {
                           unsetMigratedPrivacyMode()
                           window.open('https://medium.com/metamask/42549d4870fa', '_blank', 'noopener')
                         }}
+                        ignoreText={t('dismiss')}
+                        onIgnore={() => {
+                          unsetMigratedPrivacyMode()
+                        }}
                         key="home-privacyModeDefault"
                       />,
                     },

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -99,8 +99,8 @@ export default class Home extends PureComponent {
                         descriptionText={t('privacyModeDefault')}
                         acceptText={t('learnMore')}
                         onAccept={() => {
-                          window.open('https://medium.com/metamask/42549d4870fa', '_blank', 'noopener')
                           unsetMigratedPrivacyMode()
+                          window.open('https://medium.com/metamask/42549d4870fa', '_blank', 'noopener')
                         }}
                         key="home-privacyModeDefault"
                       />,


### PR DESCRIPTION
The privacy mode notification was not able to be dismissed from the popup UI. It should have been dismissed after clicking "Learn more", but that button opens a new tab first before dismissing the flag. Opening the new tab kills the pop UI process before it has a chance to set that flag, so it never gets set.

Re-ordering the handler to set the flag first avoids this problem.

A separate dismiss button has also been added to the notification.

![dismissable](https://user-images.githubusercontent.com/2459287/64083322-82cbed80-ccf4-11e9-93ae-9afbe195d9a6.png)

