### PR TITLE
Remove duplicate keys in `ru` locale

### DIFF
--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -677,9 +677,6 @@
   "ropsten": {
     "message": "Тестовая сеть Ropsten"
   },
-  "rpc": {
-    "message": "Пользовательский RPC"
-  },
   "sampleAccountName": {
     "message": "Например, Мой новый счет",
     "description": "Help user understand concept of adding a human-readable name to their account"
@@ -1692,9 +1689,6 @@
   },
   "showHexDataDescription": {
     "message": "Выберите это, чтобы показать шестнадцатеричное поле данных на экране отправки"
-  },
-  "signatureRequest": {
-    "message": "Запрос подписи"
   },
   "somethingWentWrong": {
     "message": "Опс! Что-то пошло не так."


### PR DESCRIPTION
These were accidentally introduced recently as two separate updates to the `ru` locale were merged. They added these keys in different places, so they didn't conflict.

The duplicate messages were identical. Care was taken to ensure the one we kept was in the same position as in other locales (the message positions should all be consistent at the moment)