### PR TITLE
build - dont create bundler until task is actually run

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -543,13 +543,19 @@ function generateBundler (opts, performBundle) {
 }
 
 function bundleTask (opts) {
-  const bundler = generateBundler(opts, performBundle)
-  // output build logs to terminal
-  bundler.on('log', gutil.log)
+  let bundler
 
   return performBundle
 
   function performBundle () {
+    // initialize bundler if not available yet
+    // dont create bundler until task is actually run
+    if (!bundler) {
+      bundler = generateBundler(opts, performBundle)
+      // output build logs to terminal
+      bundler.on('log', gutil.log)
+    }
+
     let buildStream = bundler.bundle()
 
     // handle errors


### PR DESCRIPTION
we were creating the bundler (browserify instance) at task definition time, so it was being instantiated even if it was never used.