### PR TITLE
Publish GitHub release from master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - master
       # - prep-docs:
       #    requires:
       #      - prep-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,9 @@ jobs:
           name: Create GitHub release
           command: |
             .circleci/scripts/release-create-gh-release
+      - run:
+          name: Create GitHub Pull Request to sync master with develop
+          command: .circleci/scripts/release-create-master-pr
       # - run:
       #    name: github gh-pages docs publish
       #    command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,6 @@ workflows:
       - prep-build:
           requires:
             - prep-deps
-      - create_github_release:
-          requires:
-            - prep-build
-          filters:
-            branches:
-              only:
-                - master
       # - prep-docs:
       #    requires:
       #      - prep-deps
@@ -243,6 +236,10 @@ jobs:
       - run:
           name: sentry sourcemaps upload
           command: yarn sentry:publish
+      - run:
+          name: Create GitHub release
+          command: |
+            .circleci/scripts/release-create-gh-release
       # - run:
       #    name: github gh-pages docs publish
       #    command: >
@@ -321,15 +318,3 @@ jobs:
       - run:
           name: Coveralls upload
           command: yarn test:coveralls-upload
-
-  create_github_release:
-    docker:
-      - image: circleci/node:8.15.1-browsers
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Create GitHub release
-          command: |
-            .circleci/scripts/release-create-gh-release

--- a/.circleci/scripts/release-create-gh-release
+++ b/.circleci/scripts/release-create-gh-release
@@ -28,24 +28,24 @@ function install_github_cli ()
 
 current_commit_msg=$(git show -s --format='%s' HEAD)
 
-if grep --quiet '^Version v' <<< "$current_commit_msg"
+if [[ $current_commit_msg =~ Version[-[:space:]]v([[:digit:]]+.[[:digit:]]+.[[:digit:]]+) ]]
 then
+    tag="${BASH_REMATCH[1]}"
+
     install_github_cli
 
     printf '%s\n' 'Creating GitHub Release'
-    read -ra commit_words <<< "$current_commit_msg"
-    tag="${commit_words[1]}"
     release_body="$(awk -v version="${tag##v}" -f .circleci/scripts/show-changelog.awk CHANGELOG.md)"
     pushd builds
         hub release create \
             --attach metamask-chrome-*.zip \
             --attach metamask-firefox-*.zip \
-            --message "${commit_words[0]} ${commit_words[1]#v}" \
+            --message "Version ${tag##v}" \
             --message "$release_body" \
             --commitish "$CIRCLE_SHA1" \
             "$tag"
     popd
 else
-    printf '%s\n' 'Skipping GitHub Release'
+    printf '%s\n' 'Version not found in commit message; skipping GitHub Release'
     exit 0
 fi

--- a/.circleci/scripts/release-create-gh-release
+++ b/.circleci/scripts/release-create-gh-release
@@ -28,7 +28,7 @@ function install_github_cli ()
 
 current_commit_msg=$(git show -s --format='%s' HEAD)
 
-if [[ $current_commit_msg =~ Version[-[:space:]]v([[:digit:]]+.[[:digit:]]+.[[:digit:]]+) ]]
+if [[ $current_commit_msg =~ Version[-[:space:]](v[[:digit:]]+.[[:digit:]]+.[[:digit:]]+) ]]
 then
     tag="${BASH_REMATCH[1]}"
 

--- a/.circleci/scripts/release-create-master-pr
+++ b/.circleci/scripts/release-create-master-pr
@@ -31,8 +31,7 @@ function install_github_cli ()
     popd
 }
 
-version="${CIRCLE_BRANCH/Version-v/}"
-base_branch='master'
+base_branch='develop'
 
 if [[ -n "${CI_PULL_REQUEST:-}" ]]
 then
@@ -42,11 +41,11 @@ fi
 
 install_github_cli
 
-printf '%s\n' "Creating a Pull Request for $version on GitHub"
+printf '%s\n' "Creating a Pull Request to sync 'master' with 'develop'"
 
 if ! hub pull-request \
     --reviewer '@MetaMask/extension-release-team' \
-    --message "${CIRCLE_BRANCH/-/ } RC" --message ':package: :rocket:' \
+    --message "Master => develop" --message 'Merge latest release back into develop' \
     --base "$CIRCLE_PROJECT_USERNAME:$base_branch" \
     --head "$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH";
 then


### PR DESCRIPTION
This ensures that changes made on `develop` since branching for the release are not included. It also ensures that the final release sourcemaps line-up correctly (they were always build on master)`.