### PR TITLE
Fix network-form ui 

### DIFF
--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -212,6 +212,17 @@ export default class NetworkForm extends PureComponent {
   }
 
   validateUrl = (url, stateKey) => {
+    if (validUrl.isWebUri(url)) {
+      this.setErrorTo(stateKey, '')
+    } else {
+      const appendedRpc = `http://${url}`
+      const validWhenAppended = validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
+
+      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'uriErrorMsg' : 'invalidRPC'))
+    }
+  }
+
+  validateBlockExplorerUrl = (url, stateKey) => {
     if (url === '' || validUrl.isWebUri(url)) {
       this.setErrorTo(stateKey, '')
     } else {
@@ -272,7 +283,7 @@ export default class NetworkForm extends PureComponent {
         {this.renderFormTextField(
           'blockExplorerUrl',
           'block-explorer-url',
-          this.setStateWithValue('blockExplorerUrl', this.validateUrl),
+          this.setStateWithValue('blockExplorerUrl', this.validateBlockExplorerUrl),
           blockExplorerUrl,
           'optionalBlockExplorerUrl',
         )}

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -212,7 +212,7 @@ export default class NetworkForm extends PureComponent {
   }
 
   validateUrl = (url, stateKey) => {
-    if (validUrl.isWebUri(url)) {
+    if (url === '' || validUrl.isWebUri(url)) {
       this.setErrorTo(stateKey, '')
     } else {
       const appendedRpc = `http://${url}`


### PR DESCRIPTION
<img width="356" alt="스크린샷 2019-09-10 오전 10 53 23" src="https://user-images.githubusercontent.com/31603479/64579136-b8d83400-d3bc-11e9-8d4a-0d6648a704a1.png">

When creating new network settings, Block Explorer URL is optional.
If I write a letter and then erase all letter on this form(Block Explorer URL), save button must be activated because there is no value.
But When I do this, the button is disabled, as shown in the picture.
So I solved this problem by adding checking the value of this form.