### PR TITLE
ci - build without scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: Install deps
           command: |
-           yarn --frozen-lockfile
+           yarn --frozen-lockfile --ignore-scripts
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
this is intended to reduce the security risks of scripts included in dependencies

this is just an experiment, I expect this to fail, I think we rely on scripts to install something correctly (like chrome builds for e2e tests)
