### PR TITLE
ci - install deps with "--har" flag to capture network activity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: Collect yarn install HAR logs
           command: |
-            ./circleci/scripts/collect-har-artifact.sh
+            .circleci/scripts/collect-har-artifact.sh
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - run:
           name: Install deps
           command: |
-           yarn --frozen-lockfile
+           yarn --frozen-lockfile --har
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,15 @@ jobs:
           name: Install deps
           command: |
            yarn --frozen-lockfile --har
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            ./circleci/scripts/collect-har-artifact.sh
       - persist_to_workspace:
           root: .
           paths:
           - node_modules
+          - build-artifacts
 
   prep-build:
     docker:

--- a/.circleci/scripts/collect-har-artifact.sh
+++ b/.circleci/scripts/collect-har-artifact.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -x
+
+mkdir -p build-artifacts/yarn-install-har
+mv *.har build-artifacts/yarn-install-har/

--- a/.circleci/scripts/collect-har-artifact.sh
+++ b/.circleci/scripts/collect-har-artifact.sh
@@ -2,4 +2,4 @@
 set -x
 
 mkdir -p build-artifacts/yarn-install-har
-mv *.har build-artifacts/yarn-install-har/
+mv ./*.har build-artifacts/yarn-install-har/


### PR DESCRIPTION
Add yarn install HTTP Archive (HAR) file to `build-artifacts`.
The intention of this is to have some documentation on provenance of dependency sources for use in incident response.

If something weird ends up in our bundle, we should be able to clearly identify how it got there. This is intended to be one piece of that puzzle.

https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-har
https://en.wikipedia.org/wiki/HAR_(file_format)
https://w3c.github.io/web-performance/specs/HAR/Overview.html