### PR TITLE
dev - move gource instructions from docs to development script

### DIFF
--- a/development/gource-viz.sh
+++ b/development/gource-viz.sh
@@ -1,25 +1,16 @@
-### Generate Development Visualization
+#!/usr/bin/env bash
+set -x
 
-This will generate a video of the repo commit history.
-
-Install preqs:
-```
-brew install gource
-brew install ffmpeg
-```
-
-From the repo dir, pipe `gource` into `ffmpeg`:
-```
 gource \
-  --seconds-per-day .1 \
+  --seconds-per-day .025 \
   --user-scale 1.5 \
   --default-user-image "./images/icon-512.png" \
   --viewport 1280x720 \
-  --auto-skip-seconds .1 \
+  --auto-skip-seconds .05 \
   --multi-sampling \
-  --stop-at-end \
   --highlight-users \
-  --hide mouse,progress \
+  --hide mouse,progress,filenames \
+  --dir-name-depth 2 \
   --file-idle-time 0 \
   --max-files 0  \
   --background-colour 000000 \
@@ -31,5 +22,3 @@ gource \
   --output-ppm-stream - \
   --output-framerate 30 \
   | ffmpeg -y -r 30 -f image2pipe -vcodec ppm -i - -b 65536K metamask-dev-history.mp4
-```
-


### PR DESCRIPTION
previously it was a markdown file under docs. now its a bash script with some updated parameters. weew