### PR TITLE
CI - create archive of dependency sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,13 +90,21 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install deps
+          name: Download deps
           command: |
            yarn --frozen-lockfile --ignore-scripts --har
       - run:
           name: Collect yarn install HAR logs
           command: |
             .circleci/scripts/collect-har-artifact.sh
+      - run:
+          name: Archive deps
+          command: |
+           echo "TODO - create uncorruptable report showing the unmodified dependency inputs at "$(yarn cache dir)""
+      - run:
+          name: Install deps
+          command: |
+           yarn --frozen-lockfile --offline
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run:
           name: Archive deps
           command: |
-           mkdir -p ./deps-archive/ && cp -R $(yarn cache dir)/* ./deps-archive/
+           mkdir -p ./deps-archive/ && tar -czvf ./deps-archive/yarn-cache.tar.gz $(yarn cache dir)/*
       - store_artifacts:
           path: deps-archive
           destination: deps-archive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - run:
           name: Install deps
           command: |
-           yarn --frozen-lockfile --har
+           yarn --frozen-lockfile --ignore-scripts --har
       - run:
           name: Collect yarn install HAR logs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run:
           name: Archive deps
           command: |
-           mkdir -p ./deps-archive/ && cp -R $(yarn cache dir) ./deps-archive/
+           mkdir -p ./deps-archive/ && cp -R $(yarn cache dir)/* ./deps-archive/
       - store_artifacts:
           path: deps-archive
           destination: deps-archive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,11 @@ jobs:
           command: |
            echo "TODO - create uncorruptable report showing the unmodified dependency inputs at "$(yarn cache dir)""
       - run:
-          name: Install deps
+          name: Clean for proper install
+          command: |
+           rm -rf node_modules
+      - run:
+          name: Install deps from cache
           command: |
            yarn --frozen-lockfile --offline
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,10 @@ jobs:
       - run:
           name: Archive deps
           command: |
-           echo "TODO - create uncorruptable report showing the unmodified dependency inputs at "$(yarn cache dir)""
+           mkdir -p ./deps-archive/ && cp -R $(yarn cache dir) ./deps-archive/
+      - store_artifacts:
+          path: deps-archive
+          destination: deps-archive
       - run:
           name: Clean for proper install
           command: |


### PR DESCRIPTION
status: experiment

the intention of this is to create an uncorruptible record of the dependencies used to create the build