### PR TITLE
Set minimum Firefox version to v56.2 to support Waterfox

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -22,7 +22,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "60.0"
+      "strict_min_version": "56.2"
     }
   },
   "default_locale": "en",

--- a/babel.config.js
+++ b/babel.config.js
@@ -8,7 +8,7 @@ module.exports = function (api) {
           targets: {
             browsers: [
               'chrome >= 58',
-              'firefox >= 60',
+              'firefox >= 56.2',
             ],
           },
         },


### PR DESCRIPTION
The minimum compatible version of Firefox has been lowered from `60.0` to `56.2`. It was originally set to `60.0` because that is Firefox ESR, which currently the minimum Firefox version with security updates. However Waterfox is based upon Firefox `56.0`, and has backported security fixes from the ESR release.

This change in minimum version requires no additional transpiling, and doesn't affect any browser APIs we use.

It does introduce one additional warning in the `addon-linter` about Firefox for Android `56` lacking support for browser action popups. However there is no version `56.2` of Firefox for Android, so the
minimum version remains `57` in practice (which does support browser action popups).