### PR TITLE
Remove redundant error logging

### DIFF
--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -171,12 +171,8 @@ class IncomingTransactionsController {
   }
 
   async _fetchAll (address, fromBlock, networkType) {
-    try {
-      const fetchedTxResponse = await this._fetchTxs(address, fromBlock, networkType)
-      return this._processTxFetchResponse(fetchedTxResponse)
-    } catch (err) {
-      log.error(err)
-    }
+    const fetchedTxResponse = await this._fetchTxs(address, fromBlock, networkType)
+    return this._processTxFetchResponse(fetchedTxResponse)
   }
 
   async _fetchTxs (address, fromBlock, networkType) {


### PR DESCRIPTION
The `_fetchAll` function is expected to return values, so catching errors and logging them only results in an additional error at the place where `_fetchAll` is called. It's better instead to let the error get thrown as normal.

In this particular case `_fetchAll` is only called in once place. The error is still correctly caught and logged (in the `_update` function)