### PR TITLE
Replace `undefined` selectedAddress with `null`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -367,7 +367,7 @@ module.exports = class MetamaskController extends EventEmitter {
       const result = {
         isUnlocked,
         isEnabled,
-        selectedAddress: isReady ? selectedAddress : undefined,
+        selectedAddress: isReady ? selectedAddress : null,
         networkVersion: network,
         onboardingcomplete: completedOnboarding,
         chainId: selectChainId({ network, provider }),

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "lodash.shuffle": "^4.2.0",
     "loglevel": "^1.4.1",
     "luxon": "^1.8.2",
-    "metamask-inpage-provider": "^2.1.0",
+    "metamask-inpage-provider": "^3.0.0",
     "metamask-logo": "^2.1.4",
     "mkdirp": "^0.5.1",
     "multihashes": "^0.4.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14651,10 +14651,10 @@ mersenne-twister@^1.0.1:
   resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
   integrity sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o=
 
-metamask-inpage-provider@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/metamask-inpage-provider/-/metamask-inpage-provider-2.1.0.tgz#69e23d63893a5e2bb7a09a6ec96c6f1500588673"
-  integrity sha512-1+m8Mp8/RM9JMTvDHAMt6a7aqwigRMLvU/VKKmHQFi7AZaagG8Fe4wBe8HdAMysRF3NHV/qOMw0UwP3w9m1Vaw==
+metamask-inpage-provider@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/metamask-inpage-provider/-/metamask-inpage-provider-3.0.0.tgz#3b9d4bae6f67962b6a7b1a9ee1efaf424f67b6f4"
+  integrity sha512-44bBCbQwcFF/XGaXSweCWHJaslKhJEFgvcHdxZf9Fm1QfK7VN4U3iAI0BVOLAIkRg0xV3w7xYGLpx2cM1BU7Qw==
   dependencies:
     json-rpc-engine "^5.1.3"
     json-rpc-middleware-stream "^2.1.1"


### PR DESCRIPTION
The `runtime.Port.postMessage` API will drop keys with a value of `undefined` on Chrome, but not on Firefox. This was a problem for the `publicConfig` stream, which passed the key `selectedAddress` with the value of `undefined` to communicate to dapps that the user had logged
out.

Instead a `null` is now passed for `selectedAddress` upon logout, which is correctly sent by the `runtime.Port.postMessage` API on both Chrome
and Firefox.

Relevant Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1003439

closes #7101
closes #7109