### PR TITLE
Add a/b test for full screen transaction confirmations

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -442,16 +442,14 @@ function triggerUi () {
  * Opens a new browser tab for user confirmation
  */
 function triggerUiInNewTab () {
-  extension.tabs.query({ active: true }, () => {
-    const tabIdsArray = Object.keys(openMetamaskTabsIDs)
-    if (tabIdsArray.length) {
-      extension.tabs.update(parseInt(tabIdsArray[0], 10), { 'active': true }, () => {
-        extension.tabs.reload(parseInt(tabIdsArray[0], 10))
-      })
-    } else {
-      platform.openExtensionInBrowser()
-    }
-  })
+  const tabIdsArray = Object.keys(openMetamaskTabsIDs)
+  if (tabIdsArray.length) {
+    extension.tabs.update(parseInt(tabIdsArray[0], 10), { 'active': true }, () => {
+      extension.tabs.reload(parseInt(tabIdsArray[0], 10))
+    })
+  } else {
+    platform.openExtensionInBrowser()
+  }
 }
 
 /**

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -443,8 +443,12 @@ function triggerUi () {
  */
 function triggerUiInNewTab () {
   extension.tabs.query({ active: true }, tabs => {
-    const currentlyActiveMetamaskTab = Boolean(tabs.find(tab => openMetamaskTabsIDs[tab.id]))
-    if (!currentlyActiveMetamaskTab) {
+    const tabIdsArray = Object.keys(openMetamaskTabsIDs)
+    if (tabIdsArray.length) {
+      extension.tabs.update(parseInt(tabIdsArray[0], 10), { 'active': true }, () => {
+        extension.tabs.reload(parseInt(tabIdsArray[0], 10))
+      })
+    } else {
       platform.openExtensionInBrowser()
     }
   })

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -233,11 +233,13 @@ function setupController (initState, initLangCode) {
   //
   // MetaMask Controller
   //
+  const { ABTestController = {} } = initState
+  const { abTests = {} } = ABTestController
 
   const controller = new MetamaskController({
     // User confirmation callbacks:
     showUnconfirmedMessage: triggerUi,
-    showUnapprovedTx: triggerUi,
+    showUnapprovedTx: abTests.fullScreenVsPopup === 'fullScreen' ? triggerUiInNewTab : triggerUi,
     openPopup: openPopup,
     closePopup: notificationManager.closePopup.bind(notificationManager),
     // initial state
@@ -432,6 +434,18 @@ function triggerUi () {
     if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
       notificationManager.showPopup()
       notificationIsOpen = true
+    }
+  })
+}
+
+/**
+ * Opens a new browser tab for user confirmation
+ */
+function triggerUiInNewTab () {
+  extension.tabs.query({ active: true }, tabs => {
+    const currentlyActiveMetamaskTab = Boolean(tabs.find(tab => openMetamaskTabsIDs[tab.id]))
+    if (!currentlyActiveMetamaskTab) {
+      platform.openExtensionInBrowser()
     }
   })
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -442,7 +442,7 @@ function triggerUi () {
  * Opens a new browser tab for user confirmation
  */
 function triggerUiInNewTab () {
-  extension.tabs.query({ active: true }, tabs => {
+  extension.tabs.query({ active: true }, () => {
     const tabIdsArray = Object.keys(openMetamaskTabsIDs)
     if (tabIdsArray.length) {
       extension.tabs.update(parseInt(tabIdsArray[0], 10), { 'active': true }, () => {

--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -24,7 +24,7 @@ class ABTestController {
     this.store = new ObservableStore(extend({
       abTests: {
         fullScreenVsPopup: this._getRandomizedTestGroupName('fullScreenVsPopup'),
-      }
+      },
     }, initState))
   }
 

--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -1,0 +1,55 @@
+const ObservableStore = require('obs-store')
+const extend = require('xtend')
+
+/**
+ * a/b test descriptions:
+ * - `fullScreenVsPopup`:
+ *   - description: tests whether showing tx confirmations in full screen in the browser will increase rates of successful
+ *   confirmations
+ *   - groups:
+ *     - popup: this is the control group, which follows the current UX of showing tx confirmations in the notification
+ *     window
+ *     - fullScreen: this is the only test group, which will cause users to be shown tx confirmations in a full screen
+ *     browser tab
+ */
+const abTestGroupNames = {
+  fullScreenVsPopup: ['control', 'fullScreen'],
+}
+
+class ABTestController {
+  /**
+   * @constructor
+   * @param opts
+   */
+  constructor (opts = {}) {
+    const { initState } = opts
+
+    this.store = new ObservableStore(extend({
+      fullScreenVsPopup: this._getRandomizedTestGroupName('fullScreenVsPopup'),
+    }, initState))
+  }
+
+  /**
+   * Returns the name of the test group to which the current user has been assigned
+   * @param {string} abTestKey the key of the a/b test
+   * @return {string} the name of the assigned test group
+   */
+  getAssignedABTestGroupName (abTestKey) {
+    return this.store.getState()[abTestKey]
+  }
+
+  /**
+   * Returns a randomly chosen name of a test group from a given a/b test
+   * @param {string} abTestKey the key of the a/b test
+   * @return {string} the name of the randomly selected test group
+   * @private
+   */
+  _getRandomizedTestGroupName (abTestKey) {
+    const nameArray = abTestGroupNames[abTestKey]
+    const randomIndex = Math.floor((Math.random() * nameArray.length))
+    return nameArray[randomIndex]
+  }
+}
+
+module.exports = ABTestController
+

--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -1,5 +1,6 @@
 const ObservableStore = require('obs-store')
 const extend = require('xtend')
+const { getRandomArrayItem } = require('../lib/util')
 
 /**
  * a/b test descriptions:
@@ -12,9 +13,6 @@ const extend = require('xtend')
  *     - fullScreen: this is the only test group, which will cause users to be shown tx confirmations in a full screen
  *     browser tab
  */
-const abTestGroupNames = {
-  fullScreenVsPopup: ['control', 'fullScreen'],
-}
 
 class ABTestController {
   /**
@@ -45,10 +43,13 @@ class ABTestController {
    * @private
    */
   _getRandomizedTestGroupName (abTestKey) {
-    const nameArray = abTestGroupNames[abTestKey]
-    const randomIndex = Math.floor((Math.random() * nameArray.length))
-    return nameArray[randomIndex]
+    const nameArray = ABTestController.abTestGroupNames[abTestKey]
+    return getRandomArrayItem(nameArray)
   }
+}
+
+ABTestController.abTestGroupNames = {
+  fullScreenVsPopup: ['control', 'fullScreen'],
 }
 
 module.exports = ABTestController

--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -21,9 +21,10 @@ class ABTestController {
    */
   constructor (opts = {}) {
     const { initState } = opts
-
     this.store = new ObservableStore(extend({
-      fullScreenVsPopup: this._getRandomizedTestGroupName('fullScreenVsPopup'),
+      abTests: {
+        fullScreenVsPopup: this._getRandomizedTestGroupName('fullScreenVsPopup'),
+      }
     }, initState))
   }
 
@@ -33,7 +34,7 @@ class ABTestController {
    * @return {string} the name of the assigned test group
    */
   getAssignedABTestGroupName (abTestKey) {
-    return this.store.getState()[abTestKey]
+    return this.store.getState().abTests[abTestKey]
   }
 
   /**

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -144,6 +144,10 @@ function removeListeners (listeners, emitter) {
   })
 }
 
+function getRandomArrayItem (array) {
+  return array[Math.floor((Math.random() * array.length))]
+}
+
 module.exports = {
   removeListeners,
   applyListeners,
@@ -154,4 +158,5 @@ module.exports = {
   hexToBn,
   bnToHex,
   BnMultiplyByFraction,
+  getRandomArrayItem,
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -39,6 +39,7 @@ const TransactionController = require('./controllers/transactions')
 const TokenRatesController = require('./controllers/token-rates')
 const DetectTokensController = require('./controllers/detect-tokens')
 const ProviderApprovalController = require('./controllers/provider-approval')
+const ABTestController = require('./controllers/ab-test')
 const nodeify = require('./lib/nodeify')
 const accountImporter = require('./account-import-strategies')
 const getBuyEthUrl = require('./lib/buy-eth-url')
@@ -270,6 +271,10 @@ module.exports = class MetamaskController extends EventEmitter {
       preferencesController: this.preferencesController,
     })
 
+    this.abTestController = new ABTestController({
+      initState: initState.ABTestController,
+    })
+
     this.store.updateStructure({
       AppStateController: this.appStateController.store,
       TransactionController: this.txController.store,
@@ -285,6 +290,7 @@ module.exports = class MetamaskController extends EventEmitter {
       ProviderApprovalController: this.providerApprovalController.store,
       IncomingTransactionsController: this.incomingTransactionsController.store,
       ThreeBoxController: this.threeBoxController.store,
+      ABTestController: this.abTestController.store,
     })
 
     this.memStore = new ComposableObservableStore(null, {
@@ -311,6 +317,7 @@ module.exports = class MetamaskController extends EventEmitter {
       IncomingTransactionsController: this.incomingTransactionsController.store,
       // ThreeBoxController
       ThreeBoxController: this.threeBoxController.store,
+      ABTestController: this.abTestController.store,
     })
     this.memStore.subscribe(this.sendUpdate.bind(this))
   }
@@ -426,6 +433,7 @@ module.exports = class MetamaskController extends EventEmitter {
     const providerApprovalController = this.providerApprovalController
     const onboardingController = this.onboardingController
     const threeBoxController = this.threeBoxController
+    const abTestController = this.abTestController
 
     return {
       // etc
@@ -539,6 +547,9 @@ module.exports = class MetamaskController extends EventEmitter {
       getThreeBoxLastUpdated: nodeify(threeBoxController.getLastUpdated, threeBoxController),
       turnThreeBoxSyncingOn: nodeify(threeBoxController.turnThreeBoxSyncingOn, threeBoxController),
       initializeThreeBox: nodeify(this.initializeThreeBox, this),
+
+      // a/b test controller
+      getAssignedABTestGroupName: nodeify(abTestController.getAssignedABTestGroupName, abTestController),
     }
   }
 

--- a/app/scripts/migrations/038.js
+++ b/app/scripts/migrations/038.js
@@ -19,16 +19,19 @@ module.exports = {
 
 function transformState (state) {
   const { ABTestController: ABTestControllerState = {} } = state
+  const { abTests = {} } = ABTestControllerState
 
-  if (!ABTestControllerState.fullScreenVsPopup) {
+  if (!abTests.fullScreenVsPopup) {
     state = {
       ...state,
       ABTestController: {
         ...ABTestControllerState,
-        fullScreenVsPopup: getRandomArrayItem(ABTestController.abTestGroupNames.fullScreenVsPopup),
+        abTests: {
+          ...abTests,
+          fullScreenVsPopup: getRandomArrayItem(ABTestController.abTestGroupNames.fullScreenVsPopup),
+        },
       },
     }
   }
-
   return state
 }

--- a/app/scripts/migrations/038.js
+++ b/app/scripts/migrations/038.js
@@ -1,0 +1,34 @@
+const version = 38
+const clone = require('clone')
+const ABTestController = require('../controllers/ab-test')
+const { getRandomArrayItem } = require('../lib/util')
+
+/**
+ * The purpose of this migration is to assign all users to a test group for the fullScreenVsPopup a/b test
+ */
+module.exports = {
+  version,
+  migrate: async function (originalVersionedData) {
+    const versionedData = clone(originalVersionedData)
+    versionedData.meta.version = version
+    const state = versionedData.data
+    versionedData.data = transformState(state)
+    return versionedData
+  },
+}
+
+function transformState (state) {
+  const { ABTestController: ABTestControllerState = {} } = state
+
+  if (!ABTestControllerState.fullScreenVsPopup) {
+    state = {
+      ...state,
+      ABTestController: {
+        ...ABTestControllerState,
+        fullScreenVsPopup: getRandomArrayItem(ABTestController.abTestGroupNames.fullScreenVsPopup),
+      },
+    }
+  }
+
+  return state
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -48,4 +48,5 @@ module.exports = [
   require('./035'),
   require('./036'),
   require('./037'),
+  require('./038'),
 ]

--- a/development/states/confirm-sig-requests.json
+++ b/development/states/confirm-sig-requests.json
@@ -23,6 +23,9 @@
         "name": "Send Account 4"
       }
     },
+    "abTests": {
+      "fullScreenVsPopup": "control"
+    },
     "cachedBalances": {},
     "conversionRate": 1200.88200327,
     "conversionDate": 1489013762,

--- a/development/states/currency-localization.json
+++ b/development/states/currency-localization.json
@@ -23,6 +23,9 @@
         "name": "Send Account 4"
       }
     },
+    "abTests": {
+      "fullScreenVsPopup": "control"
+    },
     "cachedBalances": {},
     "unapprovedTxs": {},
     "conversionRate": 19855,

--- a/development/states/tx-list-items.json
+++ b/development/states/tx-list-items.json
@@ -23,6 +23,9 @@
         "name": "Send Account 4"
       }
     },
+    "abTests": {
+      "fullScreenVsPopup": "control"
+    },
     "cachedBalances": {},
     "currentCurrency": "USD",
     "conversionRate": 1200.88200327,

--- a/test/unit/migrations/038-test.js
+++ b/test/unit/migrations/038-test.js
@@ -34,7 +34,9 @@ describe('migration #38', () => {
           })
         } catch (e) {
           assert.deepEqual(newStorage.data.ABTestController, {
-            'fullScreenVsPopup': 'fullScreen',
+            abTests: {
+              'fullScreenVsPopup': 'fullScreen',
+            },
           })
         }
         done()
@@ -47,7 +49,9 @@ describe('migration #38', () => {
       'meta': {},
       'data': {
         'ABTestController': {
-          'fullScreenVsPopup': 'fullScreen',
+          abTests: {
+            'fullScreenVsPopup': 'fullScreen',
+          },
         },
       },
     }
@@ -55,7 +59,9 @@ describe('migration #38', () => {
     migration38.migrate(oldStorage)
       .then((newStorage) => {
         assert.deepEqual(newStorage.data.ABTestController, {
-          'fullScreenVsPopup': 'fullScreen',
+          abTests: {
+            'fullScreenVsPopup': 'fullScreen',
+          },
         })
         done()
       })

--- a/test/unit/migrations/038-test.js
+++ b/test/unit/migrations/038-test.js
@@ -28,17 +28,7 @@ describe('migration #38', () => {
 
     migration38.migrate(oldStorage)
       .then((newStorage) => {
-        try {
-          assert.deepEqual(newStorage.data.ABTestController, {
-            'fullScreenVsPopup': 'control',
-          })
-        } catch (e) {
-          assert.deepEqual(newStorage.data.ABTestController, {
-            abTests: {
-              'fullScreenVsPopup': 'fullScreen',
-            },
-          })
-        }
+        assert(newStorage.data.ABTestController.abTests.fullScreenVsPopup.match(/control|fullScreen/))
         done()
       })
       .catch(done)

--- a/test/unit/migrations/038-test.js
+++ b/test/unit/migrations/038-test.js
@@ -1,0 +1,64 @@
+const assert = require('assert')
+const migration38 = require('../../../app/scripts/migrations/038')
+
+describe('migration #38', () => {
+  it('should update the version metadata', (done) => {
+    const oldStorage = {
+      'meta': {
+        'version': 37,
+      },
+      'data': {},
+    }
+
+    migration38.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.meta, {
+          'version': 38,
+        })
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should add a fullScreenVsPopup property set to either "control" or "fullScreen"', (done) => {
+    const oldStorage = {
+      'meta': {},
+      'data': {},
+    }
+
+    migration38.migrate(oldStorage)
+      .then((newStorage) => {
+        try {
+          assert.deepEqual(newStorage.data.ABTestController, {
+            'fullScreenVsPopup': 'control',
+          })
+        } catch (e) {
+          assert.deepEqual(newStorage.data.ABTestController, {
+            'fullScreenVsPopup': 'fullScreen',
+          })
+        }
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should leave the fullScreenVsPopup property unchanged if it exists', (done) => {
+    const oldStorage = {
+      'meta': {},
+      'data': {
+        'ABTestController': {
+          'fullScreenVsPopup': 'fullScreen',
+        },
+      },
+    }
+
+    migration38.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data.ABTestController, {
+          'fullScreenVsPopup': 'fullScreen',
+        })
+        done()
+      })
+      .catch(done)
+  })
+})

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -349,19 +349,19 @@ export default class ConfirmTransactionBase extends Component {
     const { metricsEvent } = this.context
     const { onCancel, txData, cancelTransaction, history, clearConfirmTransaction, actionKey, txData: { origin }, methodData = {} } = this.props
 
+    metricsEvent({
+      eventOpts: {
+        category: 'Transactions',
+        action: 'Confirm Screen',
+        name: 'Cancel',
+      },
+      customVariables: {
+        recipientKnown: null,
+        functionType: actionKey || getMethodName(methodData.name) || 'contractInteraction',
+        origin,
+      },
+    })
     if (onCancel) {
-      metricsEvent({
-        eventOpts: {
-          category: 'Transactions',
-          action: 'Confirm Screen',
-          name: 'Cancel',
-        },
-        customVariables: {
-          recipientKnown: null,
-          functionType: actionKey || getMethodName(methodData.name) || 'contractInteraction',
-          origin,
-        },
-      })
       onCancel(txData)
     } else {
       cancelTransaction(txData)

--- a/ui/app/pages/confirm-transaction/confirm-transaction.component.js
+++ b/ui/app/pages/confirm-transaction/confirm-transaction.component.js
@@ -23,6 +23,10 @@ import {
 } from '../../helpers/constants/routes'
 
 export default class ConfirmTransaction extends Component {
+  static contextTypes = {
+    metricsEvent: PropTypes.func,
+  }
+
   static propTypes = {
     history: PropTypes.object.isRequired,
     totalUnapprovedCount: PropTypes.number.isRequired,
@@ -39,6 +43,8 @@ export default class ConfirmTransaction extends Component {
     paramsTransactionId: PropTypes.string,
     getTokenParams: PropTypes.func,
     isTokenMethodAction: PropTypes.bool,
+    fullScreenVsPopupTestGroup: PropTypes.string,
+    trackABTest: PropTypes.bool,
   }
 
   componentDidMount () {
@@ -53,6 +59,8 @@ export default class ConfirmTransaction extends Component {
       paramsTransactionId,
       getTokenParams,
       isTokenMethodAction,
+      fullScreenVsPopupTestGroup,
+      trackABTest,
     } = this.props
 
     if (!totalUnapprovedCount && !send.to) {
@@ -67,6 +75,16 @@ export default class ConfirmTransaction extends Component {
     }
     const txId = transactionId || paramsTransactionId
     if (txId) this.props.setTransactionToConfirm(txId)
+
+    if (trackABTest) {
+      this.context.metricsEvent({
+        eventOpts: {
+          category: 'abtesting',
+          action: 'fullScreenVsPopup',
+          name: fullScreenVsPopupTestGroup === 'fullScreen' ? 'fullscreen' : 'original',
+        },
+      })
+    }
   }
 
   componentDidUpdate (prevProps) {

--- a/ui/app/pages/confirm-transaction/confirm-transaction.container.js
+++ b/ui/app/pages/confirm-transaction/confirm-transaction.container.js
@@ -20,7 +20,14 @@ import ConfirmTransaction from './confirm-transaction.component'
 import { unconfirmedTransactionsListSelector } from '../../selectors/confirm-transaction'
 
 const mapStateToProps = (state, ownProps) => {
-  const { metamask: { send, unapprovedTxs }, confirmTransaction } = state
+  const {
+    metamask: {
+      send,
+      unapprovedTxs,
+      abTests: { fullScreenVsPopup },
+    },
+    confirmTransaction,
+  } = state
   const { match: { params = {} } } = ownProps
   const { id } = params
 
@@ -29,7 +36,9 @@ const mapStateToProps = (state, ownProps) => {
   const transaction = totalUnconfirmed
     ? unapprovedTxs[id] || unconfirmedTransactions[totalUnconfirmed - 1]
     : {}
-  const { id: transactionId, transactionCategory } = transaction
+  const { id: transactionId, transactionCategory, origin } = transaction
+
+  const trackABTest = origin !== 'MetaMask'
 
   return {
     totalUnapprovedCount: totalUnconfirmed,
@@ -42,6 +51,8 @@ const mapStateToProps = (state, ownProps) => {
     unconfirmedTransactions,
     transaction,
     isTokenMethodAction: isTokenMethodAction(transactionCategory),
+    trackABTest,
+    fullScreenVsPopupTestGroup: fullScreenVsPopup,
   }
 }
 


### PR DESCRIPTION
Resolves #7022 

This PR adds an a/b test as per #7022. All users are placed in one of two groups. The control group sees confirmations of transactions from dapps via the current/normal notification window. The test group sees the confirmations in a full screen browser tab.

Here is a demo video of creating a transaction while in the test group: https://streamable.com/zwcjf

Meanwhile, create a tx while in the control group works as expected: https://streamable.com/xldp3

Here are the sorts of results we can see on matomo:

![Screenshot from 2019-09-12 14-38-36](https://user-images.githubusercontent.com/7499938/64805679-32faeb00-d56c-11e9-9079-8596cb3ff322.png)

cc @bdresser @omnat 

