### PR TITLE
getSiteMetadata if possibly FQDN and not extension id, for eth_requestAccounts

### DIFF
--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -41,7 +41,7 @@ class ProviderApprovalController extends SafeEventEmitter {
         return
       }
       // register the provider request
-      const metadata = await getSiteMetadata(origin)
+      const metadata = /localhost|[.:/]/.test(origin) ? await getSiteMetadata(origin) : { name: 'An extenstion' }
       this._handleProviderRequest(origin, metadata.name, metadata.icon)
       // wait for resolution of request
       const approved = await new Promise(resolve => this.once(`resolvedRequest:${origin}`, ({ approved }) => resolve(approved)))


### PR DESCRIPTION
tl:dr This PR allows the provider approval logic to display "an extension is trying to connect..." when an extension calls eth_requestAccounts (via the web3 provider over the port stream to MetaMask).

This should resolve #5950 and MetaMask/metamask-extension-provider#3

When an extension tries to call the eth_requestAccounts method via the web3 provider over the port stream to MetaMask, the provider approval logic was trying to fetch site metadata using an origin string that was not a FQDN, but rather an extension id.

This was silently throwing, resulting in no approval dialog/window.

I have tested this fix locally and it seems to work so far.

This is also a follow up to PR #7039. I think this is the safest and simplest fix for now, since there is no way for MetaMask to know for sure which extension is requesting to connect (without management permissions). As per comments in PR #7039, a second PR can come later which improves UX by allowing extensions to register their metadata.