### PR TITLE
Fix RPC error messages

### DIFF
--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -1,6 +1,7 @@
 const ObservableStore = require('obs-store')
 const SafeEventEmitter = require('safe-event-emitter')
 const createAsyncMiddleware = require('json-rpc-engine/src/createAsyncMiddleware')
+const { errors: rpcErrors } = require('eth-json-rpc-errors')
 
 /**
  * A controller that services user-approved requests for a full Ethereum provider API
@@ -48,7 +49,7 @@ class ProviderApprovalController extends SafeEventEmitter {
       if (approved) {
         res.result = [this.preferencesController.getSelectedAddress()]
       } else {
-        throw new Error('User denied account authorization')
+        throw rpcErrors.eth.userRejectedRequest('User denied account authorization')
       }
     })
   }

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -3,6 +3,7 @@ const ObservableStore = require('obs-store')
 const ethUtil = require('ethereumjs-util')
 const Transaction = require('ethereumjs-tx')
 const EthQuery = require('ethjs-query')
+const { errors: rpcErrors } = require('eth-json-rpc-errors')
 const abi = require('human-standard-token-abi')
 const abiDecoder = require('abi-decoder')
 abiDecoder.addABI(abi)
@@ -166,11 +167,11 @@ class TransactionController extends EventEmitter {
           case 'submitted':
             return resolve(finishedTxMeta.hash)
           case 'rejected':
-            return reject(cleanErrorStack(new Error('MetaMask Tx Signature: User denied transaction signature.')))
+            return reject(cleanErrorStack(rpcErrors.eth.userRejectedRequest('MetaMask Tx Signature: User denied transaction signature.')))
           case 'failed':
-            return reject(cleanErrorStack(new Error(finishedTxMeta.err.message)))
+            return reject(cleanErrorStack(rpcErrors.internal(finishedTxMeta.err.message)))
           default:
-            return reject(cleanErrorStack(new Error(`MetaMask Tx Signature: Unknown problem: ${JSON.stringify(finishedTxMeta.txParams)}`)))
+            return reject(cleanErrorStack(rpcErrors.internal(`MetaMask Tx Signature: Unknown problem: ${JSON.stringify(finishedTxMeta.txParams)}`)))
         }
       })
     })

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events')
 const ObservableStore = require('obs-store')
 const ethUtil = require('ethereumjs-util')
+const { errors: rpcErrors } = require('eth-json-rpc-errors')
 const createId = require('./random-id')
 
 /**
@@ -82,7 +83,7 @@ module.exports = class MessageManager extends EventEmitter {
           case 'signed':
             return resolve(data.rawSig)
           case 'rejected':
-            return reject(new Error('MetaMask Message Signature: User denied message signature.'))
+            return reject(rpcErrors.eth.userRejectedRequest('MetaMask Message Signature: User denied message signature.'))
           default:
             return reject(new Error(`MetaMask Message Signature: Unknown problem: ${JSON.stringify(msgParams)}`))
         }

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events')
 const ObservableStore = require('obs-store')
 const ethUtil = require('ethereumjs-util')
+const { errors: rpcErrors } = require('eth-json-rpc-errors')
 const createId = require('./random-id')
 const hexRe = /^[0-9A-Fa-f]+$/g
 const log = require('loglevel')
@@ -88,7 +89,7 @@ module.exports = class PersonalMessageManager extends EventEmitter {
           case 'signed':
             return resolve(data.rawSig)
           case 'rejected':
-            return reject(new Error('MetaMask Message Signature: User denied message signature.'))
+            return reject(rpcErrors.eth.userRejectedRequest('MetaMask Message Signature: User denied message signature.'))
           default:
             return reject(new Error(`MetaMask Message Signature: Unknown problem: ${JSON.stringify(msgParams)}`))
         }

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events')
 const ObservableStore = require('obs-store')
 const createId = require('./random-id')
 const assert = require('assert')
+const { errors: rpcErrors } = require('eth-json-rpc-errors')
 const sigUtil = require('eth-sig-util')
 const log = require('loglevel')
 const jsonschema = require('jsonschema')
@@ -78,7 +79,7 @@ module.exports = class TypedMessageManager extends EventEmitter {
           case 'signed':
             return resolve(data.rawSig)
           case 'rejected':
-            return reject(new Error('MetaMask Message Signature: User denied message signature.'))
+            return reject(rpcErrors.eth.userRejectedRequest('MetaMask Message Signature: User denied message signature.'))
           case 'errored':
             return reject(new Error(`MetaMask Message Signature: ${data.error}`))
           default:

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "3box/ipfs/ipld-zcash/zcash-bitcore-lib/lodash": "^4.17.12"
   },
   "dependencies": {
+    "3box": "^1.10.2",
     "@babel/runtime": "^7.5.5",
     "@material-ui/core": "1.0.0",
     "@sentry/browser": "^4.1.1",
     "@zxing/library": "^0.8.0",
-    "3box": "^1.10.2",
     "abi-decoder": "^1.2.0",
     "abortcontroller-polyfill": "^1.3.0",
     "asmcrypto.js": "^2.3.2",
@@ -85,6 +85,7 @@
     "eth-block-tracker": "^4.4.2",
     "eth-contract-metadata": "^1.9.2",
     "eth-ens-namehash": "^2.0.8",
+    "eth-json-rpc-errors": "^1.0.1",
     "eth-json-rpc-filters": "^4.1.0",
     "eth-json-rpc-infura": "^4.0.1",
     "eth-json-rpc-middleware": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "gaba": "^1.6.0",
     "human-standard-token-abi": "^2.0.0",
     "jazzicon": "^1.2.0",
-    "json-rpc-engine": "^5.1.3",
+    "json-rpc-engine": "^5.1.4",
     "json-rpc-middleware-stream": "^2.1.1",
     "jsonschema": "^1.2.4",
     "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eth-block-tracker": "^4.4.2",
     "eth-contract-metadata": "^1.9.2",
     "eth-ens-namehash": "^2.0.8",
-    "eth-json-rpc-errors": "^1.0.1",
+    "eth-json-rpc-errors": "^1.1.0",
     "eth-json-rpc-filters": "^4.1.0",
     "eth-json-rpc-infura": "^4.0.1",
     "eth-json-rpc-middleware": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15000,6 +15000,16 @@ json-rpc-engine@^5.1.3:
     promise-to-callback "^1.0.0"
     safe-event-emitter "^1.0.1"
 
+json-rpc-engine@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-5.1.4.tgz#c18d1959eb175049fa7301d4866931ae2f879e47"
+  integrity sha512-nBFWYJ1mvlZL7gqq0M9230SxedL9CbSYO1WgrFi/C1Zo+ZrHUZWLRbr7fUdlLt9TC0G+sf/aEUeuJjR2lHsMvA==
+  dependencies:
+    async "^2.0.1"
+    eth-json-rpc-errors "^1.1.0"
+    promise-to-callback "^1.0.0"
+    safe-event-emitter "^1.0.1"
+
 json-rpc-error@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/json-rpc-error/-/json-rpc-error-2.0.0.tgz#a7af9c202838b5e905c7250e547f1aff77258a02"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9573,6 +9573,13 @@ eth-json-rpc-errors@^1.0.1:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
+eth-json-rpc-errors@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.0.tgz#2a4291fb20c0483c99b53286a814ed14ca4efb2e"
+  integrity sha512-AAA76BmwwSR5Mws+ivZUYxoDwMygDuMWxSTEmqDXhRPTExSWe5wuJLT/rSfvPSy9+owSudy67JmyRQ02RAOOYQ==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 eth-json-rpc-filters@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.0.tgz#e7357a38983cde29858818dc55d394b9cf47c0f0"


### PR DESCRIPTION
Fix error message issues described in: https://github.com/MetaMask/metamask-extension/pull/7138#issuecomment-531888238

*9/18/2019 update:* Ready to review.

~Pending~
- [x] ~https://github.com/MetaMask/json-rpc-engine/pull/19~

In a previous commit, `json-rpc-engine` started using [eth-json-rpc-errors](https://www.npmjs.com/package/eth-json-rpc-errors) for error serialization. This error serialization swallowed the original error message if the error had a missing or invalid code. The above PR to `json-rpc-engine` preserves the original error message if it exists and adds a valid code (JSON RPC Internal error, `-32603`) if the original code was missing/invalid.

With that change and the code changes introduced in this PR, all RPC errors returned from the extension to the inpage provider will follow JSON RPC 2.0 and EIP 1193, allowing dapp devs to identify and handle errors by code. Consistently using the `eth-json-rpc-errors` API internally will allow us to do the same. 