### PR TITLE
ENS reverse resolution support

### DIFF
--- a/app/scripts/controllers/ens/ens.js
+++ b/app/scripts/controllers/ens/ens.js
@@ -1,0 +1,25 @@
+const EthJsEns = require('ethjs-ens')
+const ensNetworkMap = require('ethjs-ens/lib/network-map.json')
+
+class Ens {
+  constructor ({ network, provider } = {}) {
+    this._ethJsEns = new EthJsEns({
+      network,
+      provider,
+    })
+  }
+
+  lookup (ensName) {
+    return this._ethJsEns.lookup(ensName)
+  }
+
+  reverse (address) {
+    return this._ethJsEns.reverse(address)
+  }
+}
+
+Ens.getNetworkEnsSupport = function getNetworkEnsSupport (network) {
+  return Boolean(ensNetworkMap[network])
+}
+
+module.exports = Ens

--- a/app/scripts/controllers/ens/ens.js
+++ b/app/scripts/controllers/ens/ens.js
@@ -2,6 +2,10 @@ const EthJsEns = require('ethjs-ens')
 const ensNetworkMap = require('ethjs-ens/lib/network-map.json')
 
 class Ens {
+  static getNetworkEnsSupport (network) {
+    return Boolean(ensNetworkMap[network])
+  }
+
   constructor ({ network, provider } = {}) {
     this._ethJsEns = new EthJsEns({
       network,
@@ -16,10 +20,6 @@ class Ens {
   reverse (address) {
     return this._ethJsEns.reverse(address)
   }
-}
-
-Ens.getNetworkEnsSupport = function getNetworkEnsSupport (network) {
-  return Boolean(ensNetworkMap[network])
 }
 
 module.exports = Ens

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -8,6 +8,10 @@ const ZERO_X_ERROR_ADDRESS = '0x'
 
 class EnsController {
   constructor ({ ens, provider, networkStore } = {}) {
+    const initState = {
+      ensResolutionsByAddress: {},
+    }
+
     this._ens = ens
     if (!this._ens) {
       const network = networkStore.getState()
@@ -19,6 +23,7 @@ class EnsController {
       }
 
       networkStore.subscribe((network) => {
+        this.store.putState(initState)
         this._ens = new Ens({
           network,
           provider,
@@ -26,9 +31,7 @@ class EnsController {
       })
     }
 
-    this.store = new ObservableStore({
-      ensResolutionsByAddress: {},
-    })
+    this.store = new ObservableStore(initState)
   }
 
   reverseResolveAddress (address) {

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -21,17 +21,16 @@ class EnsController {
           provider,
         })
       }
-
-      networkStore.subscribe((network) => {
-        this.store.putState(initState)
-        this._ens = new Ens({
-          network,
-          provider,
-        })
-      })
     }
 
     this.store = new ObservableStore(initState)
+    networkStore.subscribe((network) => {
+      this.store.putState(initState)
+      this._ens = new Ens({
+        network,
+        provider,
+      })
+    })
   }
 
   reverseResolveAddress (address) {

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -43,6 +43,11 @@ class EnsController {
       return undefined
     }
 
+    const state = this.store.getState()
+    if (state.ensResolutionsByAddress[address]) {
+      return state.ensResolutionsByAddress[address]
+    }
+
     const domain = await this._ens.reverse(address)
     const registeredAddress = await this._ens.lookup(domain)
     if (registeredAddress === ZERO_ADDRESS) throw new Error('No address for name')

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -1,5 +1,6 @@
 const ethUtil = require('ethereumjs-util')
 const ObservableStore = require('obs-store')
+const punycode = require('punycode')
 const Ens = require('./ens')
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -45,8 +46,7 @@ class EnsController {
     if (registeredAddress === ZERO_X_ERROR_ADDRESS) throw new Error('ENS Registry error')
 
     if (ethUtil.toChecksumAddress(registeredAddress) === address) {
-      // TODO deal with homoglyphs
-      this._updateResolutionsByAddress(address, domain)
+      this._updateResolutionsByAddress(address, punycode.toASCII(domain))
       return domain
     } else {
       return undefined

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -49,15 +49,16 @@ class EnsController {
 
     const domain = await this._ens.reverse(address)
     const registeredAddress = await this._ens.lookup(domain)
-    if (registeredAddress === ZERO_ADDRESS) throw new Error('No address for name')
-    if (registeredAddress === ZERO_X_ERROR_ADDRESS) throw new Error('ENS Registry error')
-
-    if (ethUtil.toChecksumAddress(registeredAddress) === address) {
-      this._updateResolutionsByAddress(address, punycode.toASCII(domain))
-      return domain
-    } else {
+    if (registeredAddress === ZERO_ADDRESS || registeredAddress === ZERO_X_ERROR_ADDRESS) {
       return undefined
     }
+
+    if (ethUtil.toChecksumAddress(registeredAddress) !== address) {
+      return undefined
+    }
+
+    this._updateResolutionsByAddress(address, punycode.toASCII(domain))
+    return domain
   }
 
   _updateResolutionsByAddress (address, domain) {

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -1,0 +1,67 @@
+const ethUtil = require('ethereumjs-util')
+const ObservableStore = require('obs-store')
+const Ens = require('./ens')
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const ZERO_X_ERROR_ADDRESS = '0x'
+
+class EnsController {
+  constructor ({ ens, provider, networkStore } = {}) {
+    this._ens = ens
+    if (!this._ens) {
+      const network = networkStore.getState()
+      if (Ens.getNetworkEnsSupport(network)) {
+        this._ens = new Ens({
+          network,
+          provider,
+        })
+      }
+
+      networkStore.subscribe((network) => {
+        this._ens = new Ens({
+          network,
+          provider,
+        })
+      })
+    }
+
+    this.store = new ObservableStore({
+      ensResolutionsByAddress: {},
+    })
+  }
+
+  reverseResolveAddress (address) {
+    return this._reverseResolveAddress(ethUtil.toChecksumAddress(address))
+  }
+
+  async _reverseResolveAddress (address) {
+    if (!this._ens) {
+      return undefined
+    }
+
+    const domain = await this._ens.reverse(address)
+    const registeredAddress = await this._ens.lookup(domain)
+    if (registeredAddress === ZERO_ADDRESS) throw new Error('No address for name')
+    if (registeredAddress === ZERO_X_ERROR_ADDRESS) throw new Error('ENS Registry error')
+
+    if (ethUtil.toChecksumAddress(registeredAddress) === address) {
+      // TODO deal with homoglyphs
+      this._updateResolutionsByAddress(address, domain)
+      return domain
+    } else {
+      return undefined
+    }
+  }
+
+  _updateResolutionsByAddress (address, domain) {
+    const oldState = this.store.getState()
+    this.store.putState({
+      ensResolutionsByAddress: {
+        ...oldState.ensResolutionsByAddress,
+        [address]: domain,
+      },
+    })
+  }
+}
+
+module.exports = EnsController

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -23,6 +23,7 @@ const createLoggerMiddleware = require('./lib/createLoggerMiddleware')
 const providerAsMiddleware = require('eth-json-rpc-middleware/providerAsMiddleware')
 const {setupMultiplex} = require('./lib/stream-utils.js')
 const KeyringController = require('eth-keyring-controller')
+const EnsController = require('./controllers/ens')
 const NetworkController = require('./controllers/network')
 const PreferencesController = require('./controllers/preferences')
 const AppStateController = require('./controllers/app-state')
@@ -136,6 +137,11 @@ module.exports = class MetamaskController extends EventEmitter {
       blockTracker: this.blockTracker,
       provider: this.provider,
       networkController: this.networkController,
+    })
+
+    this.ensController = new EnsController({
+      provider: this.provider,
+      networkStore: this.networkController.networkStore,
     })
 
     this.incomingTransactionsController = new IncomingTransactionsController({
@@ -315,6 +321,8 @@ module.exports = class MetamaskController extends EventEmitter {
       // ThreeBoxController
       ThreeBoxController: this.threeBoxController.store,
       ABTestController: this.abTestController.store,
+      // ENS Controller
+      EnsController: this.ensController.store,
     })
     this.memStore.subscribe(this.sendUpdate.bind(this))
   }
@@ -500,6 +508,9 @@ module.exports = class MetamaskController extends EventEmitter {
 
       // AppStateController
       setLastActiveTime: nodeify(this.appStateController.setLastActiveTime, this.appStateController),
+
+      // EnsController
+      tryReverseResolveAddress: nodeify(this.ensController.reverseResolveAddress, this.ensController),
 
       // KeyringController
       setLocked: nodeify(this.setLocked, this),

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "prop-types": "^15.6.1",
     "pubnub": "4.24.4",
     "pump": "^3.0.0",
+    "punycode": "^2.1.1",
     "qrcode-generator": "1.4.1",
     "ramda": "^0.24.1",
     "react": "^15.6.2",

--- a/test/unit/app/controllers/ens-controller-test.js
+++ b/test/unit/app/controllers/ens-controller-test.js
@@ -1,0 +1,94 @@
+const assert = require('assert')
+const sinon = require('sinon')
+const ObservableStore = require('obs-store')
+const HttpProvider = require('ethjs-provider-http')
+const EnsController = require('../../../../app/scripts/controllers/ens')
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const ZERO_X_ERROR_ADDRESS = '0x'
+
+describe('EnsController', function () {
+  describe('#constructor', function () {
+    it('should construct the controller given a provider and a network', async () => {
+      const provider = new HttpProvider('https://ropsten.infura.io')
+      const currentNetworkId = '3'
+      const networkStore = new ObservableStore(currentNetworkId)
+      const ens = new EnsController({
+        provider,
+        networkStore,
+      })
+
+      assert.ok(ens._ens)
+    })
+
+    it('should construct the controller given an existing ENS instance', async () => {
+      const ens = new EnsController({
+        ens: {},
+      })
+
+      assert.ok(ens._ens)
+    })
+  })
+
+  describe('#reverseResolveName', function () {
+    it('should resolve to an ENS name', async () => {
+      const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const ens = new EnsController({
+        ens: {
+          reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
+          lookup: sinon.stub().withArgs('peaksignal.eth').returns(address),
+        },
+      })
+
+      const name = await ens.reverseResolveAddress(address)
+      assert.equal(name, 'peaksignal.eth')
+    })
+
+    it('should fail if the name is registered to a different address than the reverse-resolved', async () => {
+      const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const ens = new EnsController({
+        ens: {
+          reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
+          lookup: sinon.stub().withArgs('peaksignal.eth').returns('0xfoo'),
+        },
+      })
+
+      const name = await ens.reverseResolveAddress(address)
+      assert.strictEqual(name, undefined)
+    })
+
+    it('should throw an error when the lookup resolves to the zero address', async () => {
+      const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const ens = new EnsController({
+        ens: {
+          reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
+          lookup: sinon.stub().withArgs('peaksignal.eth').returns(ZERO_ADDRESS),
+        },
+      })
+
+      try {
+        await ens.reverseResolveAddress(address)
+        assert.fail('#reverseResolveAddress did not throw')
+      } catch (e) {
+        assert.ok(e)
+      }
+    })
+
+    it('should throw an error the lookup resolves to the zero x address', async () => {
+      const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const ens = new EnsController({
+        ens: {
+          reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
+          lookup: sinon.stub().withArgs('peaksignal.eth').returns(ZERO_X_ERROR_ADDRESS),
+        },
+      })
+
+      try {
+        await ens.reverseResolveAddress(address)
+        assert.fail('#reverseResolveAddress did not throw')
+      } catch (e) {
+        assert.ok(e)
+      }
+    })
+  })
+})

--- a/test/unit/app/controllers/ens-controller-test.js
+++ b/test/unit/app/controllers/ens-controller-test.js
@@ -44,6 +44,23 @@ describe('EnsController', function () {
       assert.equal(name, 'peaksignal.eth')
     })
 
+    it('should only resolve an ENS name once', async () => {
+      const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const reverse = sinon.stub().withArgs(address).returns('peaksignal.eth')
+      const lookup = sinon.stub().withArgs('peaksignal.eth').returns(address)
+      const ens = new EnsController({
+        ens: {
+          reverse,
+          lookup,
+        },
+      })
+
+      assert.equal(await ens.reverseResolveAddress(address), 'peaksignal.eth')
+      assert.equal(await ens.reverseResolveAddress(address), 'peaksignal.eth')
+      assert.ok(lookup.calledOnce)
+      assert.ok(reverse.calledOnce)
+    })
+
     it('should fail if the name is registered to a different address than the reverse-resolved', async () => {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
       const ens = new EnsController({

--- a/test/unit/app/controllers/ens-controller-test.js
+++ b/test/unit/app/controllers/ens-controller-test.js
@@ -22,8 +22,12 @@ describe('EnsController', function () {
     })
 
     it('should construct the controller given an existing ENS instance', async () => {
+      const networkStore = {
+        subscribe: sinon.spy(),
+      }
       const ens = new EnsController({
         ens: {},
+        networkStore,
       })
 
       assert.ok(ens._ens)
@@ -33,11 +37,15 @@ describe('EnsController', function () {
   describe('#reverseResolveName', function () {
     it('should resolve to an ENS name', async () => {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const networkStore = {
+        subscribe: sinon.spy(),
+      }
       const ens = new EnsController({
         ens: {
           reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
           lookup: sinon.stub().withArgs('peaksignal.eth').returns(address),
         },
+        networkStore,
       })
 
       const name = await ens.reverseResolveAddress(address)
@@ -48,11 +56,15 @@ describe('EnsController', function () {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
       const reverse = sinon.stub().withArgs(address).returns('peaksignal.eth')
       const lookup = sinon.stub().withArgs('peaksignal.eth').returns(address)
+      const networkStore = {
+        subscribe: sinon.spy(),
+      }
       const ens = new EnsController({
         ens: {
           reverse,
           lookup,
         },
+        networkStore,
       })
 
       assert.equal(await ens.reverseResolveAddress(address), 'peaksignal.eth')
@@ -63,11 +75,15 @@ describe('EnsController', function () {
 
     it('should fail if the name is registered to a different address than the reverse-resolved', async () => {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const networkStore = {
+        subscribe: sinon.spy(),
+      }
       const ens = new EnsController({
         ens: {
           reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
           lookup: sinon.stub().withArgs('peaksignal.eth').returns('0xfoo'),
         },
+        networkStore,
       })
 
       const name = await ens.reverseResolveAddress(address)
@@ -76,11 +92,15 @@ describe('EnsController', function () {
 
     it('should throw an error when the lookup resolves to the zero address', async () => {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const networkStore = {
+        subscribe: sinon.spy(),
+      }
       const ens = new EnsController({
         ens: {
           reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
           lookup: sinon.stub().withArgs('peaksignal.eth').returns(ZERO_ADDRESS),
         },
+        networkStore,
       })
 
       try {
@@ -93,11 +113,15 @@ describe('EnsController', function () {
 
     it('should throw an error the lookup resolves to the zero x address', async () => {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
+      const networkStore = {
+        subscribe: sinon.spy(),
+      }
       const ens = new EnsController({
         ens: {
           reverse: sinon.stub().withArgs(address).returns('peaksignal.eth'),
           lookup: sinon.stub().withArgs('peaksignal.eth').returns(ZERO_X_ERROR_ADDRESS),
         },
+        networkStore,
       })
 
       try {

--- a/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
@@ -24,6 +24,7 @@ export default class ConfirmPageContainer extends Component {
     fromName: PropTypes.string,
     toAddress: PropTypes.string,
     toName: PropTypes.string,
+    toEns: PropTypes.string,
     toNickname: PropTypes.string,
     // Content
     contentComponent: PropTypes.node,
@@ -69,6 +70,7 @@ export default class ConfirmPageContainer extends Component {
       fromName,
       fromAddress,
       toName,
+      toEns,
       toNickname,
       toAddress,
       disabled,
@@ -128,6 +130,7 @@ export default class ConfirmPageContainer extends Component {
             senderAddress={fromAddress}
             recipientName={toName}
             recipientAddress={toAddress}
+            recipientEns={toEns}
             recipientNickname={toNickname}
             assetImage={renderAssetImage ? assetImage : undefined}
           />

--- a/ui/app/components/app/transaction-list-item-details/index.js
+++ b/ui/app/components/app/transaction-list-item-details/index.js
@@ -1,1 +1,1 @@
-export { default } from './transaction-list-item-details.component'
+export { default } from './transaction-list-item-details.container'

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -17,6 +17,10 @@ export default class TransactionListItemDetails extends PureComponent {
     metricsEvent: PropTypes.func,
   }
 
+  static defaultProps = {
+    recipientEns: null,
+  }
+
   static propTypes = {
     onCancel: PropTypes.func,
     onRetry: PropTypes.func,
@@ -26,7 +30,11 @@ export default class TransactionListItemDetails extends PureComponent {
     isEarliestNonce: PropTypes.bool,
     cancelDisabled: PropTypes.bool,
     transactionGroup: PropTypes.object,
+    recipientEns: PropTypes.string,
+    recipientAddress: PropTypes.string.isRequired,
     rpcPrefs: PropTypes.object,
+    senderAddress: PropTypes.string.isRequired,
+    tryReverseResolveAddress: PropTypes.func.isRequired,
   }
 
   state = {
@@ -82,6 +90,12 @@ export default class TransactionListItemDetails extends PureComponent {
     })
   }
 
+  async componentDidMount () {
+    const { recipientAddress, tryReverseResolveAddress } = this.props
+
+    tryReverseResolveAddress(recipientAddress)
+  }
+
   renderCancel () {
     const { t } = this.context
     const {
@@ -128,11 +142,14 @@ export default class TransactionListItemDetails extends PureComponent {
       showRetry,
       onCancel,
       onRetry,
+      recipientEns,
+      recipientAddress,
       rpcPrefs: { blockExplorerUrl } = {},
+      senderAddress,
       isEarliestNonce,
     } = this.props
     const { primaryTransaction: transaction } = transactionGroup
-    const { hash, txParams: { to, from } = {} } = transaction
+    const { hash } = transaction
 
     return (
       <div className="transaction-list-item-details">
@@ -192,8 +209,9 @@ export default class TransactionListItemDetails extends PureComponent {
             <SenderToRecipient
               variant={FLAT_VARIANT}
               addressOnly
-              recipientAddress={to}
-              senderAddress={from}
+              recipientEns={recipientEns}
+              recipientAddress={recipientAddress}
+              senderAddress={senderAddress}
               onRecipientClick={() => {
                 this.context.metricsEvent({
                   eventOpts: {

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -1,0 +1,28 @@
+import { connect } from 'react-redux'
+import TransactionListItemDetails from './transaction-list-item-details.component'
+import { checksumAddress } from '../../../helpers/utils/util'
+import { tryReverseResolveAddress } from '../../../store/actions'
+
+const mapStateToProps = (state, ownProps) => {
+  const { metamask } = state
+  const {
+    ensResolutionsByAddress,
+  } = metamask
+  const { recipientAddress } = ownProps
+  const address = checksumAddress(recipientAddress)
+  const recipientEns = ensResolutionsByAddress[address] || ''
+
+  return {
+    recipientEns,
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    tryReverseResolveAddress: (address) => {
+      return dispatch(tryReverseResolveAddress(address))
+    },
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(TransactionListItemDetails)

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -185,6 +185,7 @@ export default class TransactionListItem extends PureComponent {
     } = this.props
     const { txParams = {} } = transaction
     const { showTransactionDetails } = this.state
+    const fromAddress = txParams.from
     const toAddress = tokenData
       ? tokenData.params && tokenData.params[0] && tokenData.params[0].value || txParams.to
       : txParams.to
@@ -240,6 +241,8 @@ export default class TransactionListItem extends PureComponent {
                   showCancel={showCancel}
                   cancelDisabled={!hasEnoughCancelGas}
                   rpcPrefs={rpcPrefs}
+                  senderAddress={fromAddress}
+                  recipientAddress={toAddress}
                 />
               </div>
             )

--- a/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -5,7 +5,7 @@ import Identicon from '../identicon'
 import Tooltip from '../tooltip-v2'
 import copyToClipboard from 'copy-to-clipboard'
 import { DEFAULT_VARIANT, CARDS_VARIANT, FLAT_VARIANT } from './sender-to-recipient.constants'
-import { checksumAddress } from '../../../helpers/utils/util'
+import { checksumAddress, addressSlicer } from '../../../helpers/utils/util'
 
 const variantHash = {
   [DEFAULT_VARIANT]: 'sender-to-recipient--default',
@@ -18,6 +18,7 @@ export default class SenderToRecipient extends PureComponent {
     senderName: PropTypes.string,
     senderAddress: PropTypes.string,
     recipientName: PropTypes.string,
+    recipientEns: PropTypes.string,
     recipientAddress: PropTypes.string,
     recipientNickname: PropTypes.string,
     t: PropTypes.func,
@@ -60,14 +61,28 @@ export default class SenderToRecipient extends PureComponent {
     return (
       <Tooltip
         position="bottom"
-        title={this.state.senderAddressCopied ? t('copiedExclamation') : t('copyAddress')}
+        html={
+          this.state.senderAddressCopied
+            ? <p>{t('copiedExclamation')}</p>
+            : addressOnly
+              ? <p>{t('copyAddress')}</p>
+              : (
+                <p>
+                  {addressSlicer(checksummedSenderAddress)}<br/>
+                  {t('copyAddress')}
+                </p>
+              )
+        }
         wrapperClassName="sender-to-recipient__tooltip-wrapper"
         containerClassName="sender-to-recipient__tooltip-container"
         onHidden={() => this.setState({ senderAddressCopied: false })}
       >
         <div className="sender-to-recipient__name">
-          <span>{ addressOnly ? `${t('from')}: ` : '' }</span>
-          { addressOnly ? checksummedSenderAddress : senderName }
+          {
+            addressOnly
+              ? <span>{`${t('from')}: ${checksummedSenderAddress}`}</span>
+              : senderName
+          }
         </div>
       </Tooltip>
     )
@@ -90,7 +105,7 @@ export default class SenderToRecipient extends PureComponent {
 
   renderRecipientWithAddress () {
     const { t } = this.context
-    const { recipientName, recipientAddress, recipientNickname, addressOnly, onRecipientClick } = this.props
+    const { recipientEns, recipientName, recipientAddress, recipientNickname, addressOnly, onRecipientClick } = this.props
     const checksummedRecipientAddress = checksumAddress(recipientAddress)
 
     return (
@@ -107,7 +122,18 @@ export default class SenderToRecipient extends PureComponent {
         { this.renderRecipientIdenticon() }
         <Tooltip
           position="bottom"
-          title={this.state.recipientAddressCopied ? t('copiedExclamation') : t('copyAddress')}
+          html={
+            this.state.senderAddressCopied
+              ? <p>{t('copiedExclamation')}</p>
+              : (addressOnly && !recipientNickname && !recipientEns)
+                ? <p>{t('copyAddress')}</p>
+                : (
+                  <p>
+                    {addressSlicer(checksummedRecipientAddress)}<br/>
+                    {t('copyAddress')}
+                  </p>
+                )
+          }
           wrapperClassName="sender-to-recipient__tooltip-wrapper"
           containerClassName="sender-to-recipient__tooltip-container"
           onHidden={() => this.setState({ recipientAddressCopied: false })}
@@ -117,7 +143,7 @@ export default class SenderToRecipient extends PureComponent {
             {
               addressOnly
                 ? (recipientNickname || checksummedRecipientAddress)
-                : (recipientNickname || recipientName || this.context.t('newContract'))
+                : (recipientNickname || recipientEns || recipientName || this.context.t('newContract'))
             }
           </div>
         </Tooltip>

--- a/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -116,7 +116,7 @@ export default class SenderToRecipient extends PureComponent {
             <span>{ addressOnly ? `${t('to')}: ` : '' }</span>
             {
               addressOnly
-                ? checksummedRecipientAddress
+                ? (recipientNickname || checksummedRecipientAddress)
                 : (recipientNickname || recipientName || this.context.t('newContract'))
             }
           </div>

--- a/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -142,7 +142,7 @@ export default class SenderToRecipient extends PureComponent {
             <span>{ addressOnly ? `${t('to')}: ` : '' }</span>
             {
               addressOnly
-                ? (recipientNickname || checksummedRecipientAddress)
+                ? (recipientNickname || recipientEns || checksummedRecipientAddress)
                 : (recipientNickname || recipientEns || recipientName || this.context.t('newContract'))
             }
           </div>

--- a/ui/app/components/ui/tooltip-v2.js
+++ b/ui/app/components/ui/tooltip-v2.js
@@ -8,6 +8,7 @@ export default class Tooltip extends PureComponent {
     children: null,
     containerClassName: '',
     hideOnClick: false,
+    html: null,
     onHidden: null,
     position: 'left',
     size: 'small',
@@ -21,6 +22,7 @@ export default class Tooltip extends PureComponent {
     children: PropTypes.node,
     containerClassName: PropTypes.string,
     disabled: PropTypes.bool,
+    html: PropTypes.node,
     onHidden: PropTypes.func,
     position: PropTypes.oneOf([
       'top',
@@ -38,9 +40,9 @@ export default class Tooltip extends PureComponent {
   }
 
   render () {
-    const {arrow, children, containerClassName, disabled, position, size, title, trigger, onHidden, wrapperClassName, style } = this.props
+    const {arrow, children, containerClassName, disabled, position, html, size, title, trigger, onHidden, wrapperClassName, style } = this.props
 
-    if (!title) {
+    if (!title && !html) {
       return (
         <div className={wrapperClassName}>
           {children}
@@ -51,6 +53,7 @@ export default class Tooltip extends PureComponent {
     return (
       <div className={wrapperClassName}>
         <ReactTippy
+          html={html}
           className={containerClassName}
           disabled={disabled}
           title={title}

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -64,6 +64,7 @@ export default class ConfirmTransactionBase extends Component {
     tokenData: PropTypes.object,
     tokenProps: PropTypes.object,
     toName: PropTypes.string,
+    toEns: PropTypes.string,
     toNickname: PropTypes.string,
     transactionStatus: PropTypes.string,
     txData: PropTypes.object,
@@ -615,6 +616,7 @@ export default class ConfirmTransactionBase extends Component {
       fromAddress,
       toName,
       toAddress,
+      toEns,
       toNickname,
       methodData,
       valid: propsValid = true,
@@ -645,6 +647,7 @@ export default class ConfirmTransactionBase extends Component {
         fromAddress={fromAddress}
         toName={toName}
         toAddress={toAddress}
+        toEns={toEns}
         toNickname={toNickname}
         showEdit={onEdit && !isTxReprice}
         // In the event that the key is falsy (and inherently invalid), use a fallback string

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -103,6 +103,7 @@ export default class ConfirmTransactionBase extends Component {
     transactionCategory: PropTypes.string,
     getNextNonce: PropTypes.func,
     nextNonce: PropTypes.number,
+    tryReverseResolveAddress: PropTypes.func.isRequired,
   }
 
   state = {
@@ -567,7 +568,7 @@ export default class ConfirmTransactionBase extends Component {
   }
 
   componentDidMount () {
-    const { txData: { origin, id } = {}, cancelTransaction, getNextNonce } = this.props
+    const { toAddress, txData: { origin, id } = {}, cancelTransaction, getNextNonce, tryReverseResolveAddress } = this.props
     const { metricsEvent } = this.context
     metricsEvent({
       eventOpts: {
@@ -598,6 +599,7 @@ export default class ConfirmTransactionBase extends Component {
     }
 
     getNextNonce()
+    tryReverseResolveAddress(toAddress)
   }
 
   componentWillUnmount () {

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -96,11 +96,9 @@ const mapStateToProps = (state, ownProps) => {
     )
 
   const checksummedAddress = checksumAddress(toAddress)
-  const ensName = ensResolutionsByAddress[checksummedAddress] || ''
   const addressBookObject = addressBook[checksummedAddress]
-  const toNickname = addressBookObject
-    ? addressBookObject.name
-    : ensName
+  const toEns = ensResolutionsByAddress[checksummedAddress] || ''
+  const toNickname = addressBookObject ? addressBookObject.name : ''
   const isTxReprice = Boolean(lastGasPrice)
   const transactionStatus = transaction ? transaction.status : ''
 
@@ -140,6 +138,7 @@ const mapStateToProps = (state, ownProps) => {
     fromAddress,
     fromName,
     toAddress,
+    toEns,
     toName,
     toNickname,
     ethTransactionAmount,

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -18,6 +18,7 @@ import {
   setMetaMetricsSendCount,
   updateTransaction,
   getNextNonce,
+  tryReverseResolveAddress,
 } from '../../store/actions'
 import {
   INSUFFICIENT_FUNDS_ERROR_KEY,
@@ -51,6 +52,7 @@ const mapStateToProps = (state, ownProps) => {
   const isMainnet = getIsMainnet(state)
   const { confirmTransaction, metamask } = state
   const {
+    ensResolutionsByAddress,
     conversionRate,
     identities,
     addressBook,
@@ -93,8 +95,12 @@ const mapStateToProps = (state, ownProps) => {
         : addressSlicer(checksumAddress(toAddress))
     )
 
-  const addressBookObject = addressBook[checksumAddress(toAddress)]
-  const toNickname = addressBookObject ? addressBookObject.name : ''
+  const checksummedAddress = checksumAddress(toAddress)
+  const ensName = ensResolutionsByAddress[checksummedAddress] || ''
+  const addressBookObject = addressBook[checksummedAddress]
+  const toNickname = addressBookObject
+    ? addressBookObject.name
+    : ensName
   const isTxReprice = Boolean(lastGasPrice)
   const transactionStatus = transaction ? transaction.status : ''
 
@@ -176,6 +182,9 @@ const mapStateToProps = (state, ownProps) => {
 
 export const mapDispatchToProps = dispatch => {
   return {
+    tryReverseResolveAddress: (address) => {
+      return dispatch(tryReverseResolveAddress(address))
+    },
     updateCustomNonce: value => {
       customNonceValue = value
       dispatch(updateCustomNonce(value))

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -392,6 +392,8 @@ var actions = {
   setShowRestorePromptToFalse,
   turnThreeBoxSyncingOn,
   turnThreeBoxSyncingOnAndInitialize,
+
+  tryReverseResolveAddress,
 }
 
 module.exports = actions
@@ -596,6 +598,19 @@ function requestRevealSeedWords (password) {
       dispatch(actions.displayWarning(error.message))
       throw new Error(error.message)
     }
+  }
+}
+
+function tryReverseResolveAddress (address) {
+  return () => {
+    return new Promise((resolve) => {
+      background.tryReverseResolveAddress(address, (err) => {
+        if (err) {
+          log.error(err)
+        }
+        resolve()
+      })
+    })
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21366,7 +21366,7 @@ punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==


### PR DESCRIPTION
Closes #5525

This PR adds ENS Reverse Resolution support to the UI, showing ENS names in a few places where addresses are currently used (the confirm screen & tx activity log). This represents a step towards "level two" of ENS integration, as outlined in the ENS docs:<sup>[\[1\]][1]</sup>

> The second level of ENS integration involves displaying ENS names wherever your app currently displays addresses.
>
> [...]
>
> If a user entered an address, or the address was obtained from elsewhere, you may still be able to show an ENS name, by doing [Reverse Resolution][2]. This permits you to find the canonical name for an address and display that when possible. If no canonical name is provided, your application can fall back to displaying the address as it did previously.
>
> By supporting reverse resolution, you make it easier for your users to identify accounts they interact with, associating them with a short human-readable name instead of a long opaque Ethereum address.

And, further, from _Resolving Names § Reverse Resolution_:<sup>[\[2\]][2]</sup>

> ENS does not enforce the accuracy of reverse records - for instance, anyone may claim that the name for their address is 'alice.eth'. To be certain that the claim is accurate, you must always perform a forward resolution for the returned name and check it matches the original address.

### IDN homograph attack<sup>[\[3\]][3]</sup>

As we're showing user-generated domain names in sensitive places in the UI, we need to prevent malicious users from tricking users by registering domains that use Unicode characters to look visually similar to other registered names (see also #1913).

This PR converts ENS domain names to [Punycode](https://en.wikipedia.org/wiki/Punycode) via [`punycode.toASCII`](https://github.com/bestiejs/punycode.js/tree/v2.1.1#punycodetoasciiinput).

### Tasks

- [x] Add tests for the ENS controller's reverse resolving functionality
- [x] Save punycode for ENS domains with Unicode characters (see also [RFC 3492](https://tools.ietf.org/html/rfc3492) and [RFC 5891](https://tools.ietf.org/html/rfc5891))
- [x] Update the confirm screen (screenshots below)
- [x] Update the transaction list details (screenshots below)

### Confirm Screen Screenshots (`SenderToRecipient`)

<details>
<summary><strong>Before, after, & tooltip</strong></summary>
<img width="1154" alt="" src="https://user-images.githubusercontent.com/1623628/67679944-3c4de480-f96d-11e9-8d7a-53b54623269b.png">
<img width="1154" alt="" src="https://user-images.githubusercontent.com/1623628/67679945-3ce67b00-f96d-11e9-840f-1f867b56c018.png">
<img width="1154" alt="" src="https://user-images.githubusercontent.com/1623628/67693195-43ccb800-f984-11e9-930c-8e1f10c42149.png">
</details>

### Transaction List Item Details (`TransactionListItemDetails`)

<details>
<summary><strong>Before, after, & tooltip</strong></summary>
<img width="1154" alt="" src="https://user-images.githubusercontent.com/1623628/67693041-010ae000-f984-11e9-9b95-6f73966ad369.png">
<img width="1154" alt="" src="https://user-images.githubusercontent.com/1623628/67693047-0405d080-f984-11e9-96c4-ca86df1b59f6.png">
<img width="1154" alt="" src="https://user-images.githubusercontent.com/1623628/67693236-5810b500-f984-11e9-8298-c5b656abce83.png">
</details>

### Test addresses

I've registered `peaksignal.eth` for test purposes and have correctly configured it to enable reverse resolution.<sup>[\[4\]][4]</sup>

```
> const ENS = require('ethjs-ens')
undefined
> const HttpProvider = require('ethjs-provider-http')
undefined
> const provider = new HttpProvider('https://ropsten.infura.io')
undefined
> const ens = new ENS({ provider, network: '3' })
undefined
> await ens.lookup('peaksignal.eth')
'0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
undefined
> await ens.reverse('0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5')
'peaksignal.eth'
```

  [1]:https://docs.ens.domains/dapp-developer-guide/ens-enabling-your-dapp#2-support-reverse-resolution
  [2]:https://docs.ens.domains/dapp-developer-guide/resolving-names#reverse-resolution
  [3]:https://en.wikipedia.org/wiki/IDN_homograph_attack
  [4]:https://consensys.slack.com/archives/GA3T07BFA/p1565893722064700
