### PR TITLE
Add `appName` message to each locale

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -144,6 +144,10 @@
     "message": "በማሰሺያዎ ውስጥ የ Ethereum ቋት",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "ፍቀድ"
   },

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -144,6 +144,10 @@
     "message": "محفظة إيثيريوم في متصفحك",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "موافق"
   },

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -144,6 +144,10 @@
     "message": "\nПортфейл за етереум в браузъра Ви",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Одобри"
   },

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -144,6 +144,10 @@
     "message": "আপনার ব্রাউজারে একটি Ethereum ওয়ালেট",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "অনুমোদন করুন"
   },

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -144,6 +144,10 @@
     "message": "Un Moneder Ethereum al teu Navegador",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Aprovar"
   },

--- a/app/_locales/cs/messages.json
+++ b/app/_locales/cs/messages.json
@@ -57,6 +57,10 @@
     "message": "Ethereum rozšíření prohlížeče",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Schválit"
   },

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -144,6 +144,10 @@
     "message": "En Ethereum-pung i din browser",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Godkend"
   },

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -141,6 +141,10 @@
     "message": "Ethereum Browsererweiterung",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Genehmigen"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -144,6 +144,10 @@
     "message": "Ένα Πορτοφόλι Ethereum στο Πρόγραμμα Περιήγησής σας",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Έγκριση"
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -141,6 +141,10 @@
     "message": "Extensión del navegador para Ethereum",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Aprobar"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -144,6 +144,10 @@
     "message": "Una billetera de Ethereum en tu navegador",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Aprobar"
   },

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -144,6 +144,10 @@
     "message": "Ethereumi rahakott teie lehitsejas",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Kinnita"
   },

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -144,6 +144,10 @@
     "message": "یک کیف ایتریوم در براوزر شما",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "تصدیق"
   },

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -144,6 +144,10 @@
     "message": "Ethereum-kukkaro selaimessasi",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Hyväksy"
   },

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -132,6 +132,10 @@
     "message": "Isang Ethereum Wallet sa iyong Browser",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Aprubahan"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -144,6 +144,10 @@
     "message": "Extension Ethereum pour navigateur",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Approuver"
   },

--- a/app/_locales/gu/messages.json
+++ b/app/_locales/gu/messages.json
@@ -1,4 +1,8 @@
 {
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "નકારો"
   },

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -144,6 +144,10 @@
     "message": "ארנק אתריום בדפדפן שלך",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "אישור"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -144,6 +144,10 @@
     "message": "आपके ब्राउज़र में एक Ethereum वॉलेट",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "स्वीकृत "
   },

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "Očisti podatke o privatnosti"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Odbaci"
   },

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -72,6 +72,10 @@
     "message": "Ekstansyon Navigatè Ethereum",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Apwouve"
   },

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "Adatvédelmi adatok törlése"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Elutasítás"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "Bersihkan Data Privasi"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Tolak"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -141,6 +141,10 @@
     "message": "Ethereum Browser Extension",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Approva"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -135,6 +135,10 @@
     "message": "Ethereumのブラウザ・エクステンション",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "承認する"
   },

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "ಗೌಪ್ಯತೆ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಿ"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "ತಿರಸ್ಕರಿಸಿ"
   },

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "Notīrīt konfidencialitātes datus"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Noraidīt"
   },

--- a/app/_locales/ml/messages.json
+++ b/app/_locales/ml/messages.json
@@ -1,4 +1,8 @@
 {
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "നിരസിക്കുക"
   },

--- a/app/_locales/mr/messages.json
+++ b/app/_locales/mr/messages.json
@@ -1,4 +1,8 @@
 {
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "नाकारा"
   },

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -144,6 +144,10 @@
     "message": "Dompat Ethereum di Pelayar anda",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Luluskan"
   },

--- a/app/_locales/nl/messages.json
+++ b/app/_locales/nl/messages.json
@@ -51,6 +51,10 @@
     "message": "Ethereum Browser-extensie",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Goedkeuren"
   },

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -144,6 +144,10 @@
     "message": "En Ethereum-lommebok i nettleseren din",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Godkjenn"
   },

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -17,6 +17,10 @@
   "clearApprovalData": {
     "message": "Tanggalin ang data ng pag-apruba"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Aprubahan"
   },

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -144,6 +144,10 @@
     "message": "Wtyczka przeglądarki do Ethereum",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Zatwierdź"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -57,6 +57,10 @@
     "message": "Extensão para o browser de Ethereum",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Aprovar"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "Limpar Dados de Privacidade"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Rejeitar"
   },

--- a/app/_locales/pt_PT/messages.json
+++ b/app/_locales/pt_PT/messages.json
@@ -1,4 +1,8 @@
 {
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Rejeitar"
   },

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -141,6 +141,10 @@
     "message": "Un portofel Ethereum în browserul dvs.",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Aprobați"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -57,6 +57,10 @@
     "message": "Расширение браузера для Ethereum",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Одобрить"
   },

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -144,6 +144,10 @@
     "message": "Ethereum rozšíření prohlížeče",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Schválit"
   },

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -144,6 +144,10 @@
     "message": "Denarnica za Ethereum v brskalniku",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Potrdi"
   },

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -144,6 +144,10 @@
     "message": "Ethereum novčanik u vašem pregledaču",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Odobrite"
   },

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "Rensa personlig data"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Avvisa"
   },

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -26,6 +26,10 @@
   "clearApprovalData": {
     "message": "Futa Data za Faragha"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "Kataa"
   },

--- a/app/_locales/te/messages.json
+++ b/app/_locales/te/messages.json
@@ -1,4 +1,8 @@
 {
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "reject": {
     "message": "తిరస్కరించు"
   },

--- a/app/_locales/th/messages.json
+++ b/app/_locales/th/messages.json
@@ -63,6 +63,10 @@
     "message": "ส่วนขยายเบราว์เซอร์สำหรับอีเธอเรียม",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "อนุมัติ"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -57,6 +57,10 @@
     "message": "Ethereum Tarayıcı Uzantısı",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Onaylamak"
   },

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -144,6 +144,10 @@
     "message": "Гаманець Ethereum у вашому браузері",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Затвердити"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -51,6 +51,10 @@
     "message": "Tính năng Ethereum cho trình duyệt",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "Phê duyệt"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -144,6 +144,10 @@
     "message": "以太坊浏览器插件",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "批准"
   },

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -144,6 +144,10 @@
     "message": "乙太坊瀏覽器擴充插件",
     "description": "The description of the application"
   },
+  "appName": {
+    "message": "MetaMask",
+    "description": "The name of the application"
+  },
   "approve": {
     "message": "批准"
   },


### PR DESCRIPTION
The Chrome Web store was rejecting the build because `appName` was missing from some locales.