### PR TITLE
Use common test build during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ workflows:
       - prep-build:
           requires:
             - prep-deps
+      - prep-build-test:
+          requires:
+            - prep-deps
       # - prep-docs:
       #    requires:
       #      - prep-deps
@@ -25,10 +28,10 @@ workflows:
             - prep-deps
       - test-e2e-chrome:
           requires:
-            - prep-deps
+            - prep-build-test
       - test-e2e-firefox:
           requires:
-            - prep-deps
+            - prep-build-test
       - test-unit:
           requires:
             - prep-deps
@@ -122,6 +125,21 @@ jobs:
             - dist
             - builds
 
+  prep-build-test:
+    docker:
+      - image: circleci/node:10.16-browsers
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build extension for testing
+          command: yarn build:test
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
   prep-docs:
     docker:
       - image: circleci/node:10.16-browsers
@@ -187,7 +205,7 @@ jobs:
           at: .
       - run:
           name: test:e2e:chrome
-          command: yarn build:test && yarn test:e2e:chrome
+          command: yarn test:e2e:chrome
           no_output_timeout: 20m
       - store_artifacts:
           path: test-artifacts
@@ -205,7 +223,7 @@ jobs:
           at: .
       - run:
           name: test:e2e:firefox
-          command: yarn build:test && yarn test:e2e:firefox
+          command: yarn test:e2e:firefox
           no_output_timeout: 20m
       - store_artifacts:
           path: test-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,13 @@ jobs:
       - run:
           name: Build extension for testing
           command: yarn build:test
+      - run:
+          name: Move test build to 'dist-test' to avoid conflict with production build
+          command: mv ./dist ./dist-test
       - persist_to_workspace:
           root: .
           paths:
-            - dist
+            - dist-test
 
   prep-docs:
     docker:
@@ -204,6 +207,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Move test build to dist
+          command: mv ./dist-test ./dist
+      - run:
           name: test:e2e:chrome
           command: yarn test:e2e:chrome
           no_output_timeout: 20m
@@ -221,6 +227,9 @@ jobs:
           command: ./.circleci/scripts/firefox-install
       - attach_workspace:
           at: .
+      - run:
+          name: Move test build to dist
+          command: mv ./dist-test ./dist
       - run:
           name: test:e2e:firefox
           command: yarn test:e2e:firefox


### PR DESCRIPTION
Previously both e2e test jobs were running `test:build`. Now there is a separate job that runs `test:build` that runs before each e2e test job, so that `test:build` is only run once instead of twice.