### PR TITLE
Report missing `en` locale messages to Sentry

### DIFF
--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -3,12 +3,15 @@ const connect = require('react-redux').connect
 const PropTypes = require('prop-types')
 const { withRouter } = require('react-router-dom')
 const { compose } = require('recompose')
-const t = require('../utils/i18n-helper').getMessage
+const { getMessage } = require('../utils/i18n-helper')
 
 class I18nProvider extends Component {
   tOrDefault = (key, defaultValue, ...args) => {
+    if (!key) {
+      return defaultValue
+    }
     const { localeMessages: { current, en } = {}, currentLocale } = this.props
-    return t(currentLocale, current, key, ...args) || t(currentLocale, en, key, ...args) || defaultValue
+    return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args) || defaultValue
   }
 
   getChildContext () {
@@ -22,11 +25,7 @@ class I18nProvider extends Component {
        * @return {string|undefined|null} The localized message if available
        */
       t (key, ...args) {
-        if (key === undefined || key === null) {
-          return key
-        }
-
-        return t(currentLocale, current, key, ...args) || t(currentLocale, en, key, ...args) || `[${key}]`
+        return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args) || `[${key}]`
       },
       tOrDefault: this.tOrDefault,
       tOrKey: (key, ...args) => {


### PR DESCRIPTION
Any missing messages in the `en` locale are now reported to Sentry as errors. They are printed to the console as an error upon the first encounter as well.

If a missing message is found during e2e testing, the error is thrown. This will likely break the e2e test even if it isn't looking for console errors, as the UI with the missing message will fail to render.

The `tOrDefault` method was updated to no longer attempt looking for messages with a key that is a falsey value (e.g. `undefined`). There are a few places where they key is determined dynamically, where it's expected during the normal flow for it to be `undefined` sometimes. In these cases we don't want the error to be thrown.