### PR TITLE
Verify locales on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,11 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Test
+          name: Lint
           command: yarn lint
+      - run:
+          name: Verify locales
+          command: yarn verify-locales --quiet
 
   test-deps:
     docker:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lint:fix": "eslint . --ext js,json --fix",
     "lint:changed": "{ git ls-files --others --exclude-standard ; git diff-index --name-only --diff-filter=d HEAD ; } | grep --regexp='[.]js$' --regexp='[.]json$' | tr '\\n' '\\0' | xargs -0 eslint",
     "lint:changed:fix": "{ git ls-files --others --exclude-standard ; git diff-index --name-only --diff-filter=d HEAD ; } | grep --regexp='[.]js$' --regexp='[.]json$' | tr '\\n' '\\0' | xargs -0 eslint --fix",
+    "verify-locales": "node ./development/verify-locale-strings.js",
     "mozilla-lint": "addons-linter dist/firefox",
     "watch": "cross-env METAMASK_ENV=test mocha --watch --require test/setup.js --reporter min --recursive \"test/unit/**/*.js\" \"ui/app/**/*.test.js\"",
     "devtools:react": "react-devtools",


### PR DESCRIPTION
*   Add '--quiet' flag to verify locales script
  The `--quiet` flag reduces the console output to just the essential information for running in a CI environment. For each locale, it will print the number of unused messages (if any).
* Add `verify-locales` script to lint CI job
  The locales are now verified as part of the lint CI job. Any unused messages detected will result in the job failing.