### PR TITLE
Clear persisted data on import

### DIFF
--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -61,33 +61,33 @@ class IncomingTransactionsController {
     }, opts.initState)
     this.store = new ObservableStore(initState)
 
-    this.preferencesController.store.subscribe(pairwise((prevState, currState) => {
-      const { featureFlags: { showIncomingTransactions: prevShowIncomingTransactions } = {} } = prevState
-      const { featureFlags: { showIncomingTransactions: currShowIncomingTransactions } = {} } = currState
-
-      if (currShowIncomingTransactions === prevShowIncomingTransactions) {
-        return
-      }
-
-      if (prevShowIncomingTransactions && !currShowIncomingTransactions) {
-        this.stop()
-        return
-      }
-
-      this.start()
-    }))
-
     this.preferencesController.store.subscribe(pairwise(async (prevState, currState) => {
-      const { selectedAddress: prevSelectedAddress } = prevState
-      const { selectedAddress: currSelectedAddress } = currState
+      const {
+        featureFlags: {
+          showIncomingTransactions: prevShowIncomingTransactions,
+        } = {},
+        selectedAddress: prevSelectedAddress,
+      } = prevState
+      const {
+        featureFlags: {
+          showIncomingTransactions: currShowIncomingTransactions,
+        } = {},
+        selectedAddress: currSelectedAddress,
+      } = currState
 
-      if (currSelectedAddress === prevSelectedAddress) {
-        return
+      if (currShowIncomingTransactions !== prevShowIncomingTransactions) {
+        if (prevShowIncomingTransactions && !currShowIncomingTransactions) {
+          this.stop()
+        } else {
+          this.start()
+        }
       }
 
-      await this._update({
-        address: currSelectedAddress,
-      })
+      if (currSelectedAddress !== prevSelectedAddress) {
+        return this._update({
+          address: currSelectedAddress,
+        })
+      }
     }))
 
     this.networkController.on('networkDidChange', async (newType) => {

--- a/app/scripts/controllers/onboarding.js
+++ b/app/scripts/controllers/onboarding.js
@@ -1,6 +1,10 @@
 const ObservableStore = require('obs-store')
 const extend = require('xtend')
+const clone = require('clone')
 
+const defaultState = {
+  seedPhraseBackedUp: true,
+}
 /**
  * @typedef {Object} InitState
  * @property {Boolean} seedPhraseBackedUp Indicates whether the user has completed the seed phrase backup challenge
@@ -22,9 +26,7 @@ class OnboardingController {
    * @param {OnboardingOptions} [opts] Controller configuration parameters
    */
   constructor (opts = {}) {
-    const initState = extend({
-      seedPhraseBackedUp: true,
-    }, opts.initState)
+    const initState = extend(clone(defaultState), opts.initState)
     this.store = new ObservableStore(initState)
   }
 
@@ -38,6 +40,13 @@ class OnboardingController {
     return this.store.getState().seedPhraseBackedUp
   }
 
+  /**
+   * Reset the controller with default state
+   * @returns {Promise<void>} Promise resolves with undefined
+   */
+  async reset () {
+    this.store.putState(clone(defaultState))
+  }
 }
 
 module.exports = OnboardingController

--- a/app/scripts/controllers/provider-approval.js
+++ b/app/scripts/controllers/provider-approval.js
@@ -2,6 +2,14 @@ const ObservableStore = require('obs-store')
 const SafeEventEmitter = require('safe-event-emitter')
 const createAsyncMiddleware = require('json-rpc-engine/src/createAsyncMiddleware')
 const { errors: rpcErrors } = require('eth-json-rpc-errors')
+const clone = require('clone')
+const defaultMemState = {
+  providerRequests: [],
+}
+
+const defaultState = {
+  approvedOrigins: {},
+}
 
 /**
  * A controller that services user-approved requests for a full Ethereum provider API
@@ -18,12 +26,8 @@ class ProviderApprovalController extends SafeEventEmitter {
     this.keyringController = keyringController
     this.openPopup = openPopup
     this.preferencesController = preferencesController
-    this.memStore = new ObservableStore({
-      providerRequests: [],
-    })
-
-    const defaultState = { approvedOrigins: {} }
-    this.store = new ObservableStore(Object.assign(defaultState, initState))
+    this.memStore = new ObservableStore(clone(defaultMemState))
+    this.store = new ObservableStore(Object.assign(clone(defaultState), initState))
   }
 
   /**
@@ -154,6 +158,15 @@ class ProviderApprovalController extends SafeEventEmitter {
    */
   _getMergedState () {
     return Object.assign({}, this.memStore.getState(), this.store.getState())
+  }
+
+  /**
+   * Reset the controller with default state
+   * @returns {Promise<void>} Promise resolves with undefined
+   */
+  async reset () {
+    this.memStore.putState(clone(defaultMemState))
+    this.store.putState(clone(defaultState))
   }
 }
 

--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -9,7 +9,7 @@ module.exports = class ExtensionStore {
    * @constructor
    */
   constructor () {
-    this.isSupported = !!(extension.storage.local)
+    this.isSupported = Boolean(extension.storage && extension.storage.local)
     if (!this.isSupported) {
       log.error('Storage local API not available.')
     }
@@ -41,6 +41,13 @@ module.exports = class ExtensionStore {
   }
 
   /**
+   * Clears local state
+   * @return {Promise<void>}
+   */
+  async clear () {
+    return this._clear()
+  }
+  /**
    * Returns all of the keys currently saved
    * @private
    * @return {object} the key-value map from local storage
@@ -70,6 +77,25 @@ module.exports = class ExtensionStore {
     return new Promise((resolve, reject) => {
       local.set(obj, () => {
         const err = checkForError()
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  /**
+   * Clears local state
+   * @return {Promise<void>}
+   * @private
+   */
+  _clear () {
+    const local = extension.storage.local
+    return new Promise((resolve, reject) => {
+      local.clear(() => {
+        const err = extension.runtime.lastError
         if (err) {
           reject(err)
         } else {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -58,6 +58,7 @@ const EthQuery = require('eth-query')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
 const contractMap = require('eth-contract-metadata')
+const LocalStore = require('./lib/local-store')
 const {
   AddressBookController,
   CurrencyRateController,
@@ -65,6 +66,8 @@ const {
   PhishingController,
 } = require('gaba')
 const backEndMetaMetricsEvent = require('./lib/backend-metametrics')
+
+const localStore = new LocalStore()
 
 module.exports = class MetamaskController extends EventEmitter {
 
@@ -631,6 +634,16 @@ module.exports = class MetamaskController extends EventEmitter {
       // set new identities
       this.preferencesController.setAddresses(accounts)
       this.selectFirstIdentity()
+
+      // clear local store
+      if (localStore.isSupported) {
+        try {
+          await localStore.clear()
+        } catch (error) {
+          log.error('Error clearing local store: ', error)
+        }
+      }
+
       releaseLock()
       return vault
     } catch (err) {

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -66,8 +66,8 @@ describe('MetaMask', function () {
     })
 
     it('clicks the "I agree" option on the metametrics opt-in screen', async () => {
-      const optOutButton = await findElement(driver, By.css('.btn-primary'))
-      optOutButton.click()
+      const optInButton = await findElement(driver, By.css('.btn-primary'))
+      optInButton.click()
       await delay(largeDelayMs)
     })
 
@@ -194,6 +194,12 @@ describe('MetaMask', function () {
       await passwordInputs[1].sendKeys('correct horse battery staple')
       await driver.findElement(By.css('.first-time-flow__button')).click()
       await delay(regularDelayMs)
+    })
+
+    it('clicks the "I agree" option on the metametrics opt-in screen', async () => {
+      const optInButton = await findElement(driver, By.css('.btn-primary'))
+      optInButton.click()
+      await delay(largeDelayMs)
     })
 
     it('switches to localhost', async () => {

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -253,6 +253,12 @@ describe('MetaMask', function () {
       await delay(regularDelayMs)
     })
 
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+      const optOutButton = await findElement(driver, By.css('.btn-default'))
+      optOutButton.click()
+      await delay(largeDelayMs)
+    })
+
     it('balance renders', async () => {
       const balance = await findElement(driver, By.css('.balance-display .token-amount'))
       await driver.wait(until.elementTextMatches(balance, /100\s*ETH/))

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -180,8 +180,11 @@ describe('MetaMaskController', function () {
   describe('#createNewVaultAndRestore', function () {
     it('should be able to call newVaultAndRestore despite a mistake.', async function () {
       const password = 'what-what-what'
-      sandbox.stub(metamaskController, 'getBalance')
-      metamaskController.getBalance.callsFake(() => { return Promise.resolve('0x0') })
+      sandbox
+        .stub(metamaskController, 'getBalance')
+        .callsFake(async () => '0x0')
+      sandbox.stub(metamaskController, 'resetControllerState')
+        .callsFake(async () => undefined)
 
       await metamaskController.createNewVaultAndRestore(password, TEST_SEED.slice(0, -1)).catch(() => null)
       await metamaskController.createNewVaultAndRestore(password, TEST_SEED)
@@ -190,8 +193,11 @@ describe('MetaMaskController', function () {
     })
 
     it('should clear previous identities after vault restoration', async () => {
-      sandbox.stub(metamaskController, 'getBalance')
-      metamaskController.getBalance.callsFake(() => { return Promise.resolve('0x0') })
+      sandbox
+        .stub(metamaskController, 'getBalance')
+        .callsFake(async () => '0x0')
+      sandbox.stub(metamaskController, 'resetControllerState')
+        .callsFake(async () => undefined)
 
       await metamaskController.createNewVaultAndRestore('foobar1337', TEST_SEED)
       assert.deepEqual(metamaskController.getState().identities, {
@@ -210,16 +216,18 @@ describe('MetaMaskController', function () {
     })
 
     it('should restore any consecutive accounts with balances', async () => {
+      sandbox.stub(metamaskController, 'resetControllerState')
+        .callsFake(async () => undefined)
       sandbox.stub(metamaskController, 'getBalance')
-      metamaskController.getBalance.withArgs(TEST_ADDRESS).callsFake(() => {
-        return Promise.resolve('0x14ced5122ce0a000')
-      })
-      metamaskController.getBalance.withArgs(TEST_ADDRESS_2).callsFake(() => {
-        return Promise.resolve('0x0')
-      })
-      metamaskController.getBalance.withArgs(TEST_ADDRESS_3).callsFake(() => {
-        return Promise.resolve('0x14ced5122ce0a000')
-      })
+      metamaskController.getBalance
+        .withArgs(TEST_ADDRESS)
+        .callsFake(async () => '0x14ced5122ce0a000')
+      metamaskController.getBalance
+        .withArgs(TEST_ADDRESS_2)
+        .callsFake(async () => '0x0')
+      metamaskController.getBalance
+        .withArgs(TEST_ADDRESS_3)
+        .callsFake(async () => '0x14ced5122ce0a000')
 
       await metamaskController.createNewVaultAndRestore('foobar1337', TEST_SEED)
       assert.deepEqual(metamaskController.getState().identities, {
@@ -629,8 +637,11 @@ describe('MetaMaskController', function () {
     const data = '0x43727970746f6b697474696573'
 
     beforeEach(async () => {
-      sandbox.stub(metamaskController, 'getBalance')
-      metamaskController.getBalance.callsFake(() => { return Promise.resolve('0x0') })
+      sandbox
+        .stub(metamaskController, 'getBalance')
+        .callsFake(async () => '0x0')
+      sandbox.stub(metamaskController, 'resetControllerState')
+        .callsFake(async () => undefined)
 
       await metamaskController.createNewVaultAndRestore('foobar1337', TEST_SEED_ALT)
 
@@ -687,8 +698,11 @@ describe('MetaMaskController', function () {
     const data = '0x43727970746f6b697474696573'
 
     beforeEach(async function () {
-      sandbox.stub(metamaskController, 'getBalance')
-      metamaskController.getBalance.callsFake(() => { return Promise.resolve('0x0') })
+      sandbox
+        .stub(metamaskController, 'getBalance')
+        .callsFake(async () => '0x0')
+      sandbox.stub(metamaskController, 'resetControllerState')
+        .callsFake(async () => undefined)
 
       await metamaskController.createNewVaultAndRestore('foobar1337', TEST_SEED_ALT)
 

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -36,8 +36,6 @@ describe('Actions', () => {
   const importPrivkey = '4cfd3e90fc78b0f86bf7524722150bb8da9c60cd532564d7ff43f5716514f553'
 
   beforeEach(async () => {
-
-
     metamaskController = new MetaMaskController({
       provider,
       keyringController: new KeyringController({}),
@@ -59,6 +57,7 @@ describe('Actions', () => {
       new3Box: sinon.spy(),
       getThreeBoxAddress: sinon.spy(),
       getThreeBoxSyncingState: sinon.spy(),
+      reset: sinon.spy(),
     }
 
     await metamaskController.createNewVaultAndRestore(password, TEST_SEED)

--- a/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.container.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.container.js
@@ -4,7 +4,8 @@ import { setCompletedOnboarding } from '../../../store/actions'
 
 const firstTimeFlowTypeNameMap = {
   create: 'New Wallet Created',
-  'import': 'New Wallet Imported',
+  import: 'New Wallet Imported',
+  restore: 'New Wallet Restored',
 }
 
 const mapStateToProps = ({ metamask }) => {

--- a/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.component.js
+++ b/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.component.js
@@ -14,7 +14,7 @@ export default class FirstTimeFlowSwitch extends PureComponent {
     completedOnboarding: PropTypes.bool,
     isInitialized: PropTypes.bool,
     isUnlocked: PropTypes.bool,
-    optInMetaMetrics: PropTypes.bool,
+    firstTimeFlowType: PropTypes.string,
   }
 
   render () {
@@ -22,14 +22,14 @@ export default class FirstTimeFlowSwitch extends PureComponent {
       completedOnboarding,
       isInitialized,
       isUnlocked,
-      optInMetaMetrics,
+      firstTimeFlowType,
     } = this.props
 
     if (completedOnboarding) {
       return <Redirect to={{ pathname: DEFAULT_ROUTE }} />
     }
 
-    if (isUnlocked) {
+    if (isUnlocked && firstTimeFlowType !== 'restore') {
       return <Redirect to={{ pathname: LOCK_ROUTE }} />
     }
 
@@ -41,7 +41,7 @@ export default class FirstTimeFlowSwitch extends PureComponent {
       return <Redirect to={{ pathname: INITIALIZE_UNLOCK_ROUTE }} />
     }
 
-    if (optInMetaMetrics === null) {
+    if (!firstTimeFlowType) {
       return <Redirect to={{ pathname: INITIALIZE_WELCOME_ROUTE }} />
     }
 

--- a/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.container.js
+++ b/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.container.js
@@ -6,14 +6,14 @@ const mapStateToProps = ({ metamask }) => {
     completedOnboarding,
     isInitialized,
     isUnlocked,
-    participateInMetaMetrics: optInMetaMetrics,
+    firstTimeFlowType,
   } = metamask
 
   return {
     completedOnboarding,
     isInitialized,
     isUnlocked,
-    optInMetaMetrics,
+    firstTimeFlowType,
   }
 }
 

--- a/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.container.js
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.container.js
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux'
 import MetaMetricsOptIn from './metametrics-opt-in.component'
-import { setParticipateInMetaMetrics } from '../../../store/actions'
+import { setParticipateInMetaMetrics, setCompletedOnboarding } from '../../../store/actions'
 import { getFirstTimeFlowTypeRoute } from '../first-time-flow.selectors'
 
 const firstTimeFlowTypeNameMap = {
   create: 'Selected Create New Wallet',
-  'import': 'Selected Import Wallet',
+  import: 'Selected Import Wallet',
+  restore: 'Restored Vault',
 }
 
 const mapStateToProps = (state) => {
@@ -15,11 +16,13 @@ const mapStateToProps = (state) => {
     nextRoute: getFirstTimeFlowTypeRoute(state),
     firstTimeSelectionMetaMetricsName: firstTimeFlowTypeNameMap[firstTimeFlowType],
     participateInMetaMetrics,
+    firstTimeFlowType,
   }
 }
 
 const mapDispatchToProps = dispatch => {
   return {
+    completeOnboarding: () => dispatch(setCompletedOnboarding()),
     setParticipateInMetaMetrics: (val) => dispatch(setParticipateInMetaMetrics(val)),
   }
 }


### PR DESCRIPTION
* Clear persisted state upon import
  After importing a new seed phrase, all existing state from the previous installation should be cleared. Otherwise settings from another account could be accidentally transferred to the current one.

* Clear in-memory state on import
  Only a few controllers have been cleared so far. Ideally we would clear the state of all controllers on import, but we've so far only cleared the ones that were known to have a user impact if they weren't cleared.