### PR TITLE
obs-store/local-store should upgrade webextension error to real error

### DIFF
--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -97,5 +97,8 @@ function isEmpty (obj) {
 function checkForError () {
   const lastError = extension.runtime.lastError
   if (!lastError) return
+  // if it quacks like an Error, its an Error
+  if (lastError.stack && lastError.message) return lastError
+  // repair incomplete error object (eg chromium v77)
   return new Error(lastError.message)
 }

--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -49,7 +49,7 @@ module.exports = class ExtensionStore {
     const local = extension.storage.local
     return new Promise((resolve, reject) => {
       local.get(null, (/** @type {any} */ result) => {
-        const err = extension.runtime.lastError
+        const err = checkForError()
         if (err) {
           reject(err)
         } else {
@@ -69,7 +69,7 @@ module.exports = class ExtensionStore {
     const local = extension.storage.local
     return new Promise((resolve, reject) => {
       local.set(obj, () => {
-        const err = extension.runtime.lastError
+        const err = checkForError()
         if (err) {
           reject(err)
         } else {
@@ -87,4 +87,15 @@ module.exports = class ExtensionStore {
  */
 function isEmpty (obj) {
   return Object.keys(obj).length === 0
+}
+
+/**
+ * Returns an Error if extension.runtime.lastError is present
+ * this is a workaround for the non-standard error object thats used
+ * @returns {Error}
+ */
+function checkForError () {
+  const lastError = extension.runtime.lastError
+  if (!lastError) return
+  return new Error(lastError.message) 
 }

--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -97,5 +97,5 @@ function isEmpty (obj) {
 function checkForError () {
   const lastError = extension.runtime.lastError
   if (!lastError) return
-  return new Error(lastError.message) 
+  return new Error(lastError.message)
 }


### PR DESCRIPTION
the error (in chromium at least) is an object with a non-enumerable getter for message, so it serializes itself as an empty object. This ensures the error is a proper error object which may improve reporting to sentry