### PR TITLE
Add migration on 3box imports and remove feature flag

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -42,7 +42,6 @@ class PreferencesController {
       // perform sensitive operations.
       featureFlags: {
         showIncomingTransactions: true,
-        threeBox: false,
       },
       knownMethodData: {},
       participateInMetaMetrics: null,

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -60,11 +60,7 @@ class ThreeBoxController {
     this.registeringUpdates = false
     this.lastMigration = migrations.sort((a, b) => a.version - b.version).slice(-1)[0]
 
-    const threeBoxFeatureFlagTurnedOn = this.preferencesController.getFeatureFlags().threeBox
-
-    if (threeBoxFeatureFlagTurnedOn) {
-      this.init()
-    }
+    this.init()
   }
 
   async init () {

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -49,7 +49,7 @@ class ThreeBoxController {
 
     const initState = {
       threeBoxSyncingAllowed: false,
-      restoredFromThreeBox: null,
+      showRestorePrompt: true,
       threeBoxLastUpdated: 0,
       ...opts.initState,
       threeBoxAddress: null,
@@ -85,7 +85,7 @@ class ThreeBoxController {
         }
 
         await this.space.private.set('metamaskBackup', JSON.stringify(newState))
-        await this.setRestoredFromThreeBoxToFalse()
+        await this.setShowRestorePromptToFalse()
       }
     } catch (error) {
       console.error(error)
@@ -153,6 +153,7 @@ class ThreeBoxController {
 
             clearTimeout(syncTimeout)
             this.store.updateState(stateUpdate)
+
             log.debug('3Box space sync done')
           },
         })
@@ -193,7 +194,7 @@ class ThreeBoxController {
     this.store.updateState({ threeBoxLastUpdated: backedUpState.lastUpdated })
     preferences && this.preferencesController.store.updateState(JSON.parse(preferences))
     addressBook && this.addressBookController.update(JSON.parse(addressBook), true)
-    this.setRestoredFromThreeBoxToTrue()
+    this.setShowRestorePromptToFalse()
   }
 
   turnThreeBoxSyncingOn () {
@@ -204,12 +205,8 @@ class ThreeBoxController {
     this.box.logout()
   }
 
-  setRestoredFromThreeBoxToTrue () {
-    this.store.updateState({ restoredFromThreeBox: true })
-  }
-
-  setRestoredFromThreeBoxToFalse () {
-    this.store.updateState({ restoredFromThreeBox: false })
+  setShowRestorePromptToFalse () {
+    this.store.updateState({ showRestorePrompt: false })
   }
 
   setThreeBoxSyncingPermission (newThreeboxSyncingState) {

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -2,7 +2,6 @@ const ObservableStore = require('obs-store')
 const Box = process.env.IN_TEST
   ? require('../../../development/mock-3box')
   : require('3box')
-// const Box = require(process.env.IN_TEST ? '../lib/mock-3box' : '3box/dist/3box.min')
 const log = require('loglevel')
 
 const JsonRpcEngine = require('json-rpc-engine')

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -71,7 +71,7 @@ class ThreeBoxController {
     }
   }
 
-  async _update3Box (newTypeState) {
+  async _update3Box () {
     try {
       const { threeBoxSyncingAllowed, threeBoxSynced } = this.store.getState()
       if (threeBoxSyncingAllowed && threeBoxSynced) {
@@ -151,7 +151,9 @@ class ThreeBoxController {
   }
 
   async getLastUpdated () {
-    return await this.space.private.get('metamaskBackup').lastUpdated
+    const res = await this.space.private.get('metamaskBackup')
+    const parsedRes = JSON.parse(res || '{}')
+    return parsedRes.lastUpdated
   }
 
   async migrateBackedUpState (backedUpState) {

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -71,7 +71,7 @@ class ThreeBoxController {
     }
   }
 
-  async _update3Box ({ type }, newTypeState) {
+  async _update3Box (newTypeState) {
     try {
       const { threeBoxSyncingAllowed, threeBoxSynced } = this.store.getState()
       if (threeBoxSyncingAllowed && threeBoxSynced) {
@@ -81,7 +81,6 @@ class ThreeBoxController {
           lastUpdated: Date.now(),
           lastMigration: this.lastMigration,
         }
-        newState[type] = newTypeState
 
         await this.space.private.set('metamaskBackup', JSON.stringify(newState))
       }
@@ -225,9 +224,9 @@ class ThreeBoxController {
 
   _registerUpdates () {
     if (!this.registeringUpdates) {
-      const updatePreferences = this._update3Box.bind(this, { type: 'preferences' })
+      const updatePreferences = this._update3Box.bind(this)
       this.preferencesController.store.subscribe(updatePreferences)
-      const updateAddressBook = this._update3Box.bind(this, { type: 'addressBook' })
+      const updateAddressBook = this._update3Box.bind(this)
       this.addressBookController.subscribe(updateAddressBook)
       this.registeringUpdates = true
     }

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -118,8 +118,11 @@ class ThreeBoxController {
       const threeBoxConfig = await Box.getConfig(this.address)
       backupExists = threeBoxConfig.spaces && threeBoxConfig.spaces.metamask
     } catch (e) {
-      log.error(e)
-      backupExists = false
+      if (e.message.match(/^Error: Invalid response (404)/)) {
+        backupExists = false
+      } else {
+        throw e
+      }
     }
     if (this.getThreeBoxSyncingState() || backupExists) {
       this.store.updateState({ threeBoxSynced: false })

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -110,10 +110,6 @@ class ThreeBoxController {
     })
   }
 
-  async _checkThreeBoxBackupExistance () {
-
-  }
-
   async new3Box () {
     const accounts = await this.keyringController.getAccounts()
     this.address = await this.keyringController.getAppKeyAddress(accounts[0], 'wallet://3box.metamask.io')

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -741,16 +741,12 @@ module.exports = class MetamaskController extends EventEmitter {
     await this.preferencesController.syncAddresses(accounts)
     await this.txController.pendingTxTracker.updatePendingTxs()
 
-    const threeBoxFeatureFlagTurnedOn = this.preferencesController.getFeatureFlags().threeBox
-
-    if (threeBoxFeatureFlagTurnedOn) {
-      const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
-      if (threeBoxSyncingAllowed && !this.threeBoxController.box) {
-        await this.threeBoxController.new3Box()
-        this.threeBoxController.turnThreeBoxSyncingOn()
-      } else if (threeBoxSyncingAllowed && this.threeBoxController.box) {
-        this.threeBoxController.turnThreeBoxSyncingOn()
-      }
+    const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
+    if (threeBoxSyncingAllowed && !this.threeBoxController.box) {
+      await this.threeBoxController.new3Box()
+      this.threeBoxController.turnThreeBoxSyncingOn()
+    } else if (threeBoxSyncingAllowed && this.threeBoxController.box) {
+      this.threeBoxController.turnThreeBoxSyncingOn()
     }
 
     return this.keyringController.fullUpdate()

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1699,7 +1699,7 @@ module.exports = class MetamaskController extends EventEmitter {
   }
 
   async initializeThreeBox () {
-    await this.threeBoxController.new3Box()
+    await this.threeBoxController.init()
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -535,7 +535,7 @@ module.exports = class MetamaskController extends EventEmitter {
       // 3Box
       setThreeBoxSyncingPermission: nodeify(threeBoxController.setThreeBoxSyncingPermission, threeBoxController),
       restoreFromThreeBox: nodeify(threeBoxController.restoreFromThreeBox, threeBoxController),
-      setRestoredFromThreeBoxToFalse: nodeify(threeBoxController.setRestoredFromThreeBoxToFalse, threeBoxController),
+      setShowRestorePromptToFalse: nodeify(threeBoxController.setShowRestorePromptToFalse, threeBoxController),
       getThreeBoxLastUpdated: nodeify(threeBoxController.getLastUpdated, threeBoxController),
       turnThreeBoxSyncingOn: nodeify(threeBoxController.turnThreeBoxSyncingOn, threeBoxController),
       initializeThreeBox: nodeify(this.initializeThreeBox, this),

--- a/development/mock-3box.js
+++ b/development/mock-3box.js
@@ -55,6 +55,13 @@ class Mock3Box {
       logout: () => {},
     })
   }
+
+  static async getConfig (address) {
+    const backup = await loadFromMock3Box(`${address}-metamask-metamaskBackup`)
+    return backup
+      ? { spaces: { metamask: {} } }
+      : {}
+  }
 }
 
 module.exports = Mock3Box

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -51,12 +51,6 @@ describe('MetaMask', function () {
   describe('set up data to be restored by 3box', () => {
 
     describe('First time flow starting from an existing seed phrase', () => {
-      it('turns on the threebox feature flag', async () => {
-        await delay(largeDelayMs)
-        await driver.executeScript('window.metamask.setFeatureFlag("threeBox", true)')
-        await delay(largeDelayMs)
-      })
-
       it('clicks the continue button on the welcome screen', async () => {
         await findElement(driver, By.css('.welcome-page__header'))
         const welcomeScreenBtn = await findElement(driver, By.css('.first-time-flow__button'))
@@ -163,12 +157,6 @@ describe('MetaMask', function () {
     })
 
     describe('First time flow starting from an existing seed phrase', () => {
-      it('turns on the threebox feature flag', async () => {
-        await delay(largeDelayMs)
-        await driver2.executeScript('window.metamask.setFeatureFlag("threeBox", true)')
-        await delay(largeDelayMs)
-      })
-
       it('clicks the continue button on the welcome screen', async () => {
         await findElement(driver2, By.css('.welcome-page__header'))
         const welcomeScreenBtn = await findElement(driver2, By.css('.first-time-flow__button'))

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -102,13 +102,30 @@ describe('MetaMask', function () {
       })
     })
 
-    describe('updates settings and address book', () => {
+    describe('turns on threebox syncing', () => {
       it('goes to the settings screen', async () => {
         await driver.findElement(By.css('.account-menu__icon')).click()
         await delay(regularDelayMs)
 
         const settingsButton = await findElement(driver, By.xpath(`//div[contains(text(), 'Settings')]`))
         settingsButton.click()
+      })
+
+      it('turns on threebox syncing', async () => {
+        const advancedButton = await findElement(driver, By.xpath(`//div[contains(text(), 'Advanced')]`))
+        await advancedButton.click()
+
+        const threeBoxToggle = await findElements(driver, By.css('.toggle-button'))
+        const threeBoxToggleButton = await threeBoxToggle[3].findElement(By.css('div'))
+        await threeBoxToggleButton.click()
+      })
+
+    })
+
+    describe('updates settings and address book', () => {
+      it('adds an address to the contact list', async () => {
+        const generalButton = await findElement(driver, By.xpath(`//div[contains(text(), 'General')]`))
+        await generalButton.click()
       })
 
       it('turns on use of blockies', async () => {

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -129,14 +129,7 @@ describe('MetaMaskController', function () {
       })
     })
 
-    it('gets does not instantiate 3box if the feature flag is false', async () => {
-      await metamaskController.submitPassword(password)
-      assert(threeBoxSpies.new3Box.notCalled)
-      assert(threeBoxSpies.turnThreeBoxSyncingOn.notCalled)
-    })
-
-    it('gets the address from threebox and creates a new 3box instance if the feature flag is true', async () => {
-      metamaskController.preferencesController.setFeatureFlag('threeBox', true)
+    it('gets the address from threebox and creates a new 3box instance', async () => {
       await metamaskController.submitPassword(password)
       assert(threeBoxSpies.new3Box.calledOnce)
       assert(threeBoxSpies.turnThreeBoxSyncingOn.calledOnce)

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -38,10 +38,10 @@ export default class Home extends PureComponent {
     threeBoxSynced: PropTypes.bool,
     setupThreeBox: PropTypes.func,
     turnThreeBoxSyncingOn: PropTypes.func,
-    restoredFromThreeBox: PropTypes.bool,
+    showRestorePrompt: PropTypes.bool,
     selectedAddress: PropTypes.string,
     restoreFromThreeBox: PropTypes.func,
-    setRestoredFromThreeBoxToFalse: PropTypes.func,
+    setShowRestorePromptToFalse: PropTypes.func,
     threeBoxLastUpdated: PropTypes.string,
   }
 
@@ -72,10 +72,10 @@ export default class Home extends PureComponent {
     const {
       threeBoxSynced,
       setupThreeBox,
-      restoredFromThreeBox,
+      showRestorePrompt,
       threeBoxLastUpdated,
     } = this.props
-    if (threeBoxSynced && restoredFromThreeBox === null && threeBoxLastUpdated === null) {
+    if (threeBoxSynced && showRestorePrompt && threeBoxLastUpdated === null) {
       setupThreeBox()
     }
   }
@@ -93,8 +93,8 @@ export default class Home extends PureComponent {
       selectedAddress,
       restoreFromThreeBox,
       turnThreeBoxSyncingOn,
-      setRestoredFromThreeBoxToFalse,
-      restoredFromThreeBox,
+      setShowRestorePromptToFalse,
+      showRestorePrompt,
       threeBoxLastUpdated,
     } = this.props
 
@@ -153,7 +153,7 @@ export default class Home extends PureComponent {
                       />,
                     },
                     {
-                      shouldBeRendered: threeBoxLastUpdated && restoredFromThreeBox === null,
+                      shouldBeRendered: threeBoxLastUpdated && showRestorePrompt,
                       component: <HomeNotification
                         descriptionText={t('restoreWalletPreferences', [ formatDate(parseInt(threeBoxLastUpdated), 'M/d/y') ])}
                         acceptText={t('restore')}
@@ -166,7 +166,7 @@ export default class Home extends PureComponent {
                             })
                         }}
                         onIgnore={() => {
-                          setRestoredFromThreeBoxToFalse()
+                          setShowRestorePromptToFalse()
                         }}
                         key="home-privacyModeDefault"
                       />,

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -43,7 +43,6 @@ export default class Home extends PureComponent {
     restoreFromThreeBox: PropTypes.func,
     setRestoredFromThreeBoxToFalse: PropTypes.func,
     threeBoxLastUpdated: PropTypes.string,
-    threeBoxFeatureFlagIsTrue: PropTypes.bool,
   }
 
   componentWillMount () {
@@ -97,7 +96,6 @@ export default class Home extends PureComponent {
       setRestoredFromThreeBoxToFalse,
       restoredFromThreeBox,
       threeBoxLastUpdated,
-      threeBoxFeatureFlagIsTrue,
     } = this.props
 
     if (forgottenPassword) {
@@ -155,7 +153,7 @@ export default class Home extends PureComponent {
                       />,
                     },
                     {
-                      shouldBeRendered: threeBoxFeatureFlagIsTrue && threeBoxLastUpdated && restoredFromThreeBox === null,
+                      shouldBeRendered: threeBoxLastUpdated && restoredFromThreeBox === null,
                       component: <HomeNotification
                         descriptionText={t('restoreWalletPreferences', [ formatDate(parseInt(threeBoxLastUpdated), 'M/d/y') ])}
                         acceptText={t('restore')}

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -26,7 +26,6 @@ const mapStateToProps = state => {
     threeBoxSynced,
     restoredFromThreeBox,
     selectedAddress,
-    featureFlags,
   } = metamask
   const accountBalance = getCurrentEthBalance(state)
   const { forgottenPassword, threeBoxLastUpdated } = appState
@@ -45,7 +44,6 @@ const mapStateToProps = state => {
     restoredFromThreeBox,
     selectedAddress,
     threeBoxLastUpdated,
-    threeBoxFeatureFlagIsTrue: featureFlags.threeBox,
   }
 }
 

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -9,7 +9,7 @@ import {
   restoreFromThreeBox,
   turnThreeBoxSyncingOn,
   getThreeBoxLastUpdated,
-  setRestoredFromThreeBoxToFalse,
+  setShowRestorePromptToFalse,
 } from '../../store/actions'
 import { setThreeBoxLastUpdated } from '../../ducks/app/app'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
@@ -24,7 +24,7 @@ const mapStateToProps = state => {
     seedPhraseBackedUp,
     tokens,
     threeBoxSynced,
-    restoredFromThreeBox,
+    showRestorePrompt,
     selectedAddress,
   } = metamask
   const accountBalance = getCurrentEthBalance(state)
@@ -41,7 +41,7 @@ const mapStateToProps = state => {
     shouldShowSeedPhraseReminder: !seedPhraseBackedUp && (parseInt(accountBalance, 16) > 0 || tokens.length > 0),
     isPopup,
     threeBoxSynced,
-    restoredFromThreeBox,
+    showRestorePrompt,
     selectedAddress,
     threeBoxLastUpdated,
   }
@@ -56,13 +56,13 @@ const mapDispatchToProps = (dispatch) => ({
         if (lastUpdated) {
           dispatch(setThreeBoxLastUpdated(lastUpdated))
         } else {
-          dispatch(setRestoredFromThreeBoxToFalse())
+          dispatch(setShowRestorePromptToFalse())
           dispatch(turnThreeBoxSyncingOn())
         }
       })
   },
   restoreFromThreeBox: (address) => dispatch(restoreFromThreeBox(address)),
-  setRestoredFromThreeBoxToFalse: () => dispatch(setRestoredFromThreeBoxToFalse()),
+  setShowRestorePromptToFalse: () => dispatch(setShowRestorePromptToFalse()),
 })
 
 export default compose(

--- a/ui/app/pages/keychains/restore-vault.js
+++ b/ui/app/pages/keychains/restore-vault.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 import {
   createNewVaultAndRestore,
   unMarkPasswordForgotten,
+  initializeThreeBox,
 } from '../../store/actions'
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes'
 import TextField from '../../components/ui/text-field'
@@ -21,6 +22,7 @@ class RestoreVaultPage extends Component {
     leaveImportSeedScreenState: PropTypes.func,
     history: PropTypes.object,
     isLoading: PropTypes.bool,
+    initializeThreeBox: PropTypes.func,
   };
 
   state = {
@@ -81,6 +83,7 @@ class RestoreVaultPage extends Component {
       createNewVaultAndRestore,
       leaveImportSeedScreenState,
       history,
+      initializeThreeBox,
     } = this.props
 
     leaveImportSeedScreenState()
@@ -93,6 +96,7 @@ class RestoreVaultPage extends Component {
             name: 'onboardingRestoredVault',
           },
         })
+        initializeThreeBox()
         history.push(DEFAULT_ROUTE)
       })
   }
@@ -194,5 +198,6 @@ export default connect(
       dispatch(unMarkPasswordForgotten())
     },
     createNewVaultAndRestore: (pw, seed) => dispatch(createNewVaultAndRestore(pw, seed)),
+    initializeThreeBox: () => dispatch(initializeThreeBox()),
   })
 )(RestoreVaultPage)

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -30,7 +30,6 @@ export default class AdvancedTab extends PureComponent {
     threeBoxSyncingAllowed: PropTypes.bool.isRequired,
     setThreeBoxSyncingPermission: PropTypes.func.isRequired,
     threeBoxDisabled: PropTypes.bool.isRequired,
-    threeBoxFeatureFlag: PropTypes.bool.isRequired,
   }
 
   state = { autoLogoutTimeLimit: this.props.autoLogoutTimeLimit }
@@ -301,7 +300,7 @@ export default class AdvancedTab extends PureComponent {
   }
 
   renderContent () {
-    const { warning, threeBoxFeatureFlag } = this.props
+    const { warning } = this.props
 
     return (
       <div className="settings-page__body">
@@ -313,7 +312,7 @@ export default class AdvancedTab extends PureComponent {
         { this.renderHexDataOptIn() }
         { this.renderShowConversionInTestnets() }
         { this.renderAutoLogoutTimeLimit() }
-        { threeBoxFeatureFlag ? this.renderThreeBoxControl() : null }
+        { this.renderThreeBoxControl() }
       </div>
     )
   }

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
@@ -10,6 +10,7 @@ import {
   setShowFiatConversionOnTestnetsPreference,
   setAutoLogoutTimeLimit,
   setThreeBoxSyncingPermission,
+  turnThreeBoxSyncingOnAndInitialize,
 } from '../../../store/actions'
 import {preferencesSelector} from '../../../selectors/selectors'
 
@@ -49,7 +50,13 @@ export const mapDispatchToProps = dispatch => {
     setAutoLogoutTimeLimit: value => {
       return dispatch(setAutoLogoutTimeLimit(value))
     },
-    setThreeBoxSyncingPermission: newThreeBoxSyncingState => dispatch(setThreeBoxSyncingPermission(newThreeBoxSyncingState)),
+    setThreeBoxSyncingPermission: newThreeBoxSyncingState => {
+      if (newThreeBoxSyncingState) {
+        dispatch(turnThreeBoxSyncingOnAndInitialize())
+      } else {
+        dispatch(setThreeBoxSyncingPermission(newThreeBoxSyncingState))
+      }
+    },
   }
 }
 

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
@@ -19,7 +19,6 @@ export const mapStateToProps = state => {
     featureFlags: {
       sendHexData,
       advancedInlineGas,
-      threeBox,
     } = {},
     threeBoxSyncingAllowed,
     threeBoxDisabled,
@@ -34,7 +33,6 @@ export const mapStateToProps = state => {
     autoLogoutTimeLimit,
     threeBoxSyncingAllowed,
     threeBoxDisabled,
-    threeBoxFeatureFlag: threeBox,
   }
 }
 

--- a/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
+++ b/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
@@ -6,22 +6,9 @@ import AdvancedTab from '../advanced-tab.component'
 import TextField from '../../../../components/ui/text-field'
 
 describe('AdvancedTab Component', () => {
-  it('should render correctly when threeBoxFeatureFlag is false', () => {
+  it('should render correctly when threeBoxFeatureFlag', () => {
     const root = shallow(
       <AdvancedTab />,
-      {
-        context: {
-          t: s => `_${s}`,
-        },
-      }
-    )
-
-    assert.equal(root.find('.settings-page__content-row').length, 7)
-  })
-
-  it('should render correctly threeBoxFeatureFlag is true', () => {
-    const root = shallow(
-      <AdvancedTab threeBoxFeatureFlag={true} />,
       {
         context: {
           t: s => `_${s}`,

--- a/ui/app/pages/settings/advanced-tab/tests/advanced-tab-container.test.js
+++ b/ui/app/pages/settings/advanced-tab/tests/advanced-tab-container.test.js
@@ -9,7 +9,6 @@ const defaultState = {
     featureFlags: {
       sendHexData: false,
       advancedInlineGas: false,
-      threeBox: false,
     },
     preferences: {
       autoLogoutTimeLimit: 0,
@@ -32,7 +31,6 @@ describe('AdvancedTab Container', () => {
       autoLogoutTimeLimit: 0,
       threeBoxSyncingAllowed: false,
       threeBoxDisabled: false,
-      threeBoxFeatureFlag: false,
     }
 
     assert.deepEqual(props, expected)

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -383,6 +383,7 @@ var actions = {
   setThreeBoxSyncingPermission,
   setRestoredFromThreeBoxToFalse,
   turnThreeBoxSyncingOn,
+  turnThreeBoxSyncingOnAndInitialize,
 }
 
 module.exports = actions
@@ -2877,5 +2878,13 @@ function setThreeBoxSyncingPermission (threeBoxSyncingAllowed) {
         resolve()
       })
     })
+  }
+}
+
+function turnThreeBoxSyncingOnAndInitialize () {
+  return async (dispatch) => {
+    await dispatch(setThreeBoxSyncingPermission(true))
+    await dispatch(turnThreeBoxSyncingOn())
+    await dispatch(initializeThreeBox(true))
   }
 }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -381,7 +381,7 @@ var actions = {
   restoreFromThreeBox,
   getThreeBoxLastUpdated,
   setThreeBoxSyncingPermission,
-  setRestoredFromThreeBoxToFalse,
+  setShowRestorePromptToFalse,
   turnThreeBoxSyncingOn,
   turnThreeBoxSyncingOnAndInitialize,
 }
@@ -2811,10 +2811,10 @@ function initializeThreeBox () {
   }
 }
 
-function setRestoredFromThreeBoxToFalse () {
+function setShowRestorePromptToFalse () {
   return (dispatch) => {
     return new Promise((resolve, reject) => {
-      background.setRestoredFromThreeBoxToFalse((err) => {
+      background.setShowRestorePromptToFalse((err) => {
         if (err) {
           dispatch(actions.displayWarning(err.message))
           return reject(err)

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -16,7 +16,6 @@ const { ENVIRONMENT_TYPE_NOTIFICATION } = require('../../../app/scripts/lib/enum
 const { hasUnconfirmedTransactions } = require('../helpers/utils/confirm-tx.util')
 const gasDuck = require('../ducks/gas/gas.duck')
 const WebcamUtils = require('../../lib/webcam-utils')
-const { getFeatureFlags } = require('../selectors/selectors')
 
 var actions = {
   _setBackgroundConnection: _setBackgroundConnection,
@@ -2798,116 +2797,85 @@ function hideSeedPhraseBackupAfterOnboarding () {
 }
 
 function initializeThreeBox () {
-  return (dispatch, getState) => {
-    const state = getState()
-
-    if (getFeatureFlags(state).threeBox) {
-      return new Promise((resolve, reject) => {
-        background.initializeThreeBox((err) => {
-          if (err) {
-            dispatch(actions.displayWarning(err.message))
-            return reject(err)
-          }
-          resolve()
-        })
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.initializeThreeBox((err) => {
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          return reject(err)
+        }
+        resolve()
       })
-    } else {
-      return Promise.resolve()
-    }
+    })
   }
 }
 
 function setRestoredFromThreeBoxToFalse () {
-  return (dispatch, getState) => {
-    const state = getState()
-    if (getFeatureFlags(state).threeBox) {
-      return new Promise((resolve, reject) => {
-        background.setRestoredFromThreeBoxToFalse((err) => {
-          if (err) {
-            dispatch(actions.displayWarning(err.message))
-            return reject(err)
-          }
-          resolve()
-        })
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.setRestoredFromThreeBoxToFalse((err) => {
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          return reject(err)
+        }
+        resolve()
       })
-    } else {
-      return Promise.resolve()
-    }
+    })
   }
 }
 
 function turnThreeBoxSyncingOn () {
-  return (dispatch, getState) => {
-    const state = getState()
-    if (getFeatureFlags(state).threeBox) {
-      return new Promise((resolve, reject) => {
-        background.turnThreeBoxSyncingOn((err) => {
-          if (err) {
-            dispatch(actions.displayWarning(err.message))
-            return reject(err)
-          }
-          resolve()
-        })
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.turnThreeBoxSyncingOn((err) => {
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          return reject(err)
+        }
+        resolve()
       })
-    } else {
-      return Promise.resolve()
-    }
+    })
   }
 }
 
 function restoreFromThreeBox (accountAddress) {
-  return (dispatch, getState) => {
-    const state = getState()
-    if (getFeatureFlags(state).threeBox) {
-      return new Promise((resolve, reject) => {
-        background.restoreFromThreeBox(accountAddress, (err) => {
-          if (err) {
-            dispatch(actions.displayWarning(err.message))
-            return reject(err)
-          }
-          resolve()
-        })
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.restoreFromThreeBox(accountAddress, (err) => {
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          return reject(err)
+        }
+        resolve()
       })
-    } else {
-      return Promise.resolve()
-    }
+    })
   }
 }
 
 function getThreeBoxLastUpdated () {
-  return (dispatch, getState) => {
-    const state = getState()
-    if (getFeatureFlags(state).threeBox) {
-      return new Promise((resolve, reject) => {
-        background.getThreeBoxLastUpdated((err, lastUpdated) => {
-          if (err) {
-            dispatch(actions.displayWarning(err.message))
-            return reject(err)
-          }
-          resolve(lastUpdated)
-        })
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.getThreeBoxLastUpdated((err, lastUpdated) => {
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          return reject(err)
+        }
+        resolve(lastUpdated)
       })
-    } else {
-      return Promise.resolve()
-    }
+    })
   }
 }
 
 function setThreeBoxSyncingPermission (threeBoxSyncingAllowed) {
-  return (dispatch, getState) => {
-    const state = getState()
-    if (getFeatureFlags(state).threeBox) {
-      return new Promise((resolve, reject) => {
-        background.setThreeBoxSyncingPermission(threeBoxSyncingAllowed, (err) => {
-          if (err) {
-            dispatch(actions.displayWarning(err.message))
-            return reject(err)
-          }
-          resolve()
-        })
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.setThreeBoxSyncingPermission(threeBoxSyncingAllowed, (err) => {
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          return reject(err)
+        }
+        resolve()
       })
-    } else {
-      return Promise.resolve()
-    }
+    })
   }
 }


### PR DESCRIPTION
This PR makes two notable changes:
- Updates the threebox controller so that data retrieved from threebox is run through new migrations before it is restored to metamask
- removes the 3box feature flag