### PR TITLE
Update minimum Firefox verison to 56.0

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -22,7 +22,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "56.2"
+      "strict_min_version": "56.0"
     }
   },
   "default_locale": "en",


### PR DESCRIPTION
The previous minimum version of 56.2 resulted in the build failing validation when it was uploaded to the Firefox web store, because that version doesn't exist. It was set to that version because a Firefox fork uses it.

Instead the minimum version has been reduced so that we pass validation. Unfortunately this will mean that a single incompatible version of Firefox Mobile will allow the extension to be installed
(in theory), but there was no other way to avoid cutting off support to WaterFox (the Firefox fork). The warning about this from the addons linter can be ignored for now.