### PR TITLE
Fix error handling when checking for 3Box backup

### DIFF
--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -118,7 +118,7 @@ class ThreeBoxController {
       const threeBoxConfig = await Box.getConfig(this.address)
       backupExists = threeBoxConfig.spaces && threeBoxConfig.spaces.metamask
     } catch (e) {
-      if (e.message.match(/^Error: Invalid response (404)/)) {
+      if (e.message.match(/^Error: Invalid response \(404\)/)) {
         backupExists = false
       } else {
         throw e

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -754,12 +754,16 @@ module.exports = class MetamaskController extends EventEmitter {
     await this.preferencesController.syncAddresses(accounts)
     await this.txController.pendingTxTracker.updatePendingTxs()
 
-    const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
-    if (threeBoxSyncingAllowed && !this.threeBoxController.box) {
-      await this.threeBoxController.new3Box()
-      this.threeBoxController.turnThreeBoxSyncingOn()
-    } else if (threeBoxSyncingAllowed && this.threeBoxController.box) {
-      this.threeBoxController.turnThreeBoxSyncingOn()
+    try {
+      const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
+      if (threeBoxSyncingAllowed && !this.threeBoxController.box) {
+        await this.threeBoxController.new3Box()
+        this.threeBoxController.turnThreeBoxSyncingOn()
+      } else if (threeBoxSyncingAllowed && this.threeBoxController.box) {
+        this.threeBoxController.turnThreeBoxSyncingOn()
+      }
+    } catch (error) {
+      log.error(error)
     }
 
     return this.keyringController.fullUpdate()


### PR DESCRIPTION
The 3Box SDK throws an HTTP 404 error when attempting to get the config for an account that doesn't yet exist in 3Box. The regex we were using to differentiate this error from others was broken. This ended up preventing the user from logging in if they had 3Box enabled but hadn't
yet synced.

The regex has been corrected to catch this case, while allowing other errors to propagate upward. Other 3Box errors will now be caught and reported rather than interrupting login completely.

At some point in the future, we should expose these errors to the user in some way, and allow them to retry in case 3Box was just temporarily offline.