### PR TITLE
Custom nonce fixes

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -198,9 +198,6 @@
   "nonceField": {
     "message": "Customize transaction nonce"
   },
-  "nonceFieldPlaceholder": {
-    "message": "Automatically calculate"
-  },
   "nonceFieldHeading": {
     "message": "Custom Nonce"
   },

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1626,9 +1626,15 @@ module.exports = class MetamaskController extends EventEmitter {
    * @returns Promise<number>
    */
   async getNextNonce (address) {
-    const { nextNonce, releaseLock } = await this.txController.nonceTracker.getNonceLock(address)
-    releaseLock()
-    return nextNonce
+    let nonceLock
+    try {
+      nonceLock = await this.txController.nonceTracker.getNonceLock(address)
+    } catch (e) {
+      throw new Error('Error getting nonce lock: ', e.message)
+    } finally {
+      nonceLock.releaseLock()
+    }
+    return nonceLock.nextNonce
   }
 
   //=============================================================================

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1613,7 +1613,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * @returns Promise<number>
    */
   async getPendingNonce (address) {
-    const { nonceDetails, releaseLock} = await this.txController.nonceTracker.getNonceLock(address)
+    const { nonceDetails, releaseLock } = await this.txController.nonceTracker.getNonceLock(address)
     const pendingNonce = nonceDetails.params.highestSuggested
 
     releaseLock()

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1626,9 +1626,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * @returns Promise<number>
    */
   async getNextNonce (address) {
-    const { nonceDetails, releaseLock} = await this.txController.nonceTracker.getNonceLock(address)
-    const nextNonce = nonceDetails.nextNonce
-
+    const { nextNonce, releaseLock } = await this.txController.nonceTracker.getNonceLock(address)
     releaseLock()
     return nextNonce
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1629,8 +1629,6 @@ module.exports = class MetamaskController extends EventEmitter {
     let nonceLock
     try {
       nonceLock = await this.txController.nonceTracker.getNonceLock(address)
-    } catch (e) {
-      throw new Error('Error getting nonce lock: ', e.message)
     } finally {
       nonceLock.releaseLock()
     }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -520,6 +520,7 @@ module.exports = class MetamaskController extends EventEmitter {
       isNonceTaken: nodeify(txController.isNonceTaken, txController),
       estimateGas: nodeify(this.estimateGas, this),
       getPendingNonce: nodeify(this.getPendingNonce, this),
+      getNextNonce: nodeify(this.getNextNonce, this),
 
       // messageManager
       signMessage: nodeify(this.signMessage, this),
@@ -1617,6 +1618,19 @@ module.exports = class MetamaskController extends EventEmitter {
 
     releaseLock()
     return pendingNonce
+  }
+
+  /**
+   * Returns the next nonce according to the nonce-tracker
+   * @param address {string} - The hex string address for the transaction
+   * @returns Promise<number>
+   */
+  async getNextNonce (address) {
+    const { nonceDetails, releaseLock} = await this.txController.nonceTracker.getNonceLock(address)
+    const nextNonce = nonceDetails.nextNonce
+
+    releaseLock()
+    return nextNonce
   }
 
   //=============================================================================

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -131,6 +131,7 @@ export default class ConfirmTransactionBase extends Component {
       } else {
         this.setState({ submitWarning: '' })
       }
+
     }
 
     if (useNonceField && prevProps.nextNonce === null && nextNonce !== null && customNonceValue === '') {
@@ -500,6 +501,7 @@ export default class ConfirmTransactionBase extends Component {
                   submitting: false,
                   submitError: error.message,
                 })
+                updateCustomNonce('')
               })
           }
         })

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -282,7 +282,7 @@ export default class ConfirmTransactionBase extends Component {
                 <TextField
                   type="number"
                   min="0"
-                  placeholder={ this.context.t('nonceFieldPlaceholder') }
+                  placeholder={ customNonceValue || nextNonce }
                   onChange={({ target: { value } }) => {
                     if (!value.length || Number(value) < 0) {
                       updateCustomNonce('')

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -118,8 +118,6 @@ export default class ConfirmTransactionBase extends Component {
       clearConfirmTransaction,
       nextNonce,
       customNonceValue,
-      updateCustomNonce,
-      useNonceField,
     } = this.props
     const { transactionStatus: prevTxStatus } = prevProps
     const statusUpdated = transactionStatus !== prevTxStatus
@@ -131,11 +129,6 @@ export default class ConfirmTransactionBase extends Component {
       } else {
         this.setState({ submitWarning: '' })
       }
-
-    }
-
-    if (useNonceField && prevProps.nextNonce === null && nextNonce !== null && customNonceValue === '') {
-      updateCustomNonce(String(nextNonce))
     }
 
     if (statusUpdated && txDroppedOrConfirmed) {

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -118,6 +118,8 @@ export default class ConfirmTransactionBase extends Component {
       clearConfirmTransaction,
       nextNonce,
       customNonceValue,
+      updateCustomNonce,
+      useNonceField,
     } = this.props
     const { transactionStatus: prevTxStatus } = prevProps
     const statusUpdated = transactionStatus !== prevTxStatus
@@ -129,6 +131,10 @@ export default class ConfirmTransactionBase extends Component {
       } else {
         this.setState({ submitWarning: '' })
       }
+    }
+
+    if (useNonceField && prevProps.nextNonce === null && nextNonce !== null && customNonceValue === '') {
+      updateCustomNonce(String(nextNonce))
     }
 
     if (statusUpdated && txDroppedOrConfirmed) {

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -282,7 +282,7 @@ export default class ConfirmTransactionBase extends Component {
                 <TextField
                   type="number"
                   min="0"
-                  placeholder={ customNonceValue || nextNonce }
+                  placeholder={ nextNonce }
                   onChange={({ target: { value } }) => {
                     if (!value.length || Number(value) < 0) {
                       updateCustomNonce('')
@@ -293,7 +293,7 @@ export default class ConfirmTransactionBase extends Component {
                   }}
                   fullWidth
                   margin="dense"
-                  value={customNonceValue || nextNonce || ''}
+                  value={ customNonceValue || '' }
                 />
               </div>
             </div>

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2932,13 +2932,13 @@ function getNextNonce () {
   return (dispatch, getState) => {
     const address = getState().metamask.selectedAddress
     return new Promise((resolve, reject) => {
-      background.getPendingNonce(address, (err, pendingNonce) => {
+      background.getNextNonce(address, (err, nextNonce) => {
         if (err) {
           dispatch(actions.displayWarning(err.message))
           return reject(err)
         }
-        dispatch(setNextNonce(pendingNonce))
-        resolve(pendingNonce)
+        dispatch(setNextNonce(nextNonce))
+        resolve(nextNonce)
       })
     })
   }


### PR DESCRIPTION
This PR fixes two issues with the custom nonce feature:
(1) If there is a local failure when submitting a tx, the custom nonce will now be reset, given that the user will be taken away from the confirmation screen
~(2) If there is a pending transaction with a nonce that is higher than the `highestSuggested` tx from the `nonce-tracker` and the user wishes to submit a tx with that nonce (which would be the default one in the nonce field on the confirm screen), attempts to do so would create another tx with the `highestSuggested` nonce.~
(2) The suggested nonce now accounts for locally pending nonces