### PR TITLE
Don't wait for 3Box initialization during login

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -756,7 +756,8 @@ module.exports = class MetamaskController extends EventEmitter {
     try {
       const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
       if (threeBoxSyncingAllowed && !this.threeBoxController.box) {
-        await this.threeBoxController.new3Box()
+        // 'await' intentionally omitted to avoid waiting for initialization
+        this.threeBoxController.init()
         this.threeBoxController.turnThreeBoxSyncingOn()
       } else if (threeBoxSyncingAllowed && this.threeBoxController.box) {
         this.threeBoxController.turnThreeBoxSyncingOn()

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -9,7 +9,7 @@ const createTxMeta = require('../../../lib/createTxMeta')
 const EthQuery = require('eth-query')
 
 const threeBoxSpies = {
-  new3Box: sinon.spy(),
+  init: sinon.spy(),
   getThreeBoxAddress: sinon.spy(),
   getThreeBoxSyncingState: sinon.stub().returns(true),
   turnThreeBoxSyncingOn: sinon.spy(),
@@ -23,7 +23,7 @@ class ThreeBoxControllerMock {
       subscribe: () => {},
       getState: () => ({}),
     }
-    this.new3Box = threeBoxSpies.new3Box
+    this.init = threeBoxSpies.init
     this.getThreeBoxAddress = threeBoxSpies.getThreeBoxAddress
     this.getThreeBoxSyncingState = threeBoxSpies.getThreeBoxSyncingState
     this.turnThreeBoxSyncingOn = threeBoxSpies.turnThreeBoxSyncingOn
@@ -108,7 +108,7 @@ describe('MetaMaskController', function () {
 
     beforeEach(async function () {
       await metamaskController.createNewVaultAndKeychain(password)
-      threeBoxSpies.new3Box.reset()
+      threeBoxSpies.init.reset()
       threeBoxSpies.turnThreeBoxSyncingOn.reset()
     })
 
@@ -131,7 +131,7 @@ describe('MetaMaskController', function () {
 
     it('gets the address from threebox and creates a new 3box instance', async () => {
       await metamaskController.submitPassword(password)
-      assert(threeBoxSpies.new3Box.calledOnce)
+      assert(threeBoxSpies.init.calledOnce)
       assert(threeBoxSpies.turnThreeBoxSyncingOn.calledOnce)
     })
   })


### PR DESCRIPTION
The 3Box initialization is triggered by login, but it no longer blocks the login from finishing. The 3Box initialization is designed to run in the background, so there's no reason to block on it.