### PR TITLE
Mark 3Box sync as experimental

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1255,10 +1255,10 @@
     "message": "Symbol must be between 0 and 12 characters."
   },
   "syncWithThreeBox": {
-    "message": "Sync data with 3Box"
+    "message": "Sync data with 3Box (experimental)"
   },
   "syncWithThreeBoxDescription": {
-    "message": "Turn on to have your settings backed up with 3Box"
+    "message": "Turn on to have your settings backed up with 3Box. This feature is currenty experimental; use at your own risk."
   },
   "syncWithThreeBoxDisabled": {
     "message": "3Box has been disabled due to an error during the initial sync"


### PR DESCRIPTION
The initial release of the 3Box sync will be marked as experimental. This is to allow us time to test the 3Box sync and reduce the load on 3Box's infrastructure.

![experimental](https://user-images.githubusercontent.com/2459287/66078202-f2bdd580-e537-11e9-8d01-73ce8d4b23f9.png)