### PR TITLE
Prevent Logout Timer that's longer than a week.

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -741,6 +741,9 @@
   "logout": {
     "message": "Log out"
   },
+  "logoutTimeTooGreat": {
+    "message": "Logout time is too great"
+  },
   "mainnet": {
     "message": "Main Ethereum Network"
   },

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -293,7 +293,7 @@ export default class AdvancedTab extends PureComponent {
             />
             <Button
               type="primary"
-              className="button btn-primary settings-tab__rpc-save-button"
+              className="settings-tab__rpc-save-button"
               disabled={logoutTimeError !== ''}
               onClick={() => {
                 setAutoLogoutTimeLimit(this.state.autoLogoutTimeLimit)

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -34,7 +34,10 @@ export default class AdvancedTab extends PureComponent {
     threeBoxDisabled: PropTypes.bool.isRequired,
   }
 
-  state = { autoLogoutTimeLimit: this.props.autoLogoutTimeLimit }
+  state = {
+    autoLogoutTimeLimit: this.props.autoLogoutTimeLimit,
+    logoutTimeError: '',
+  }
 
   renderMobileSync () {
     const { t } = this.context
@@ -240,8 +243,27 @@ export default class AdvancedTab extends PureComponent {
     )
   }
 
+  handleLogoutChange (time) {
+    const { t } = this.context
+    const autoLogoutTimeLimit = Math.max(Number(time), 0)
+
+    this.setState(() => {
+      let logoutTimeError = ''
+
+      if (autoLogoutTimeLimit > 10080) {
+        logoutTimeError = t('logoutTimeTooGreat')
+      }
+
+      return {
+        autoLogoutTimeLimit,
+        logoutTimeError,
+      }
+    })
+  }
+
   renderAutoLogoutTimeLimit () {
     const { t } = this.context
+    const { logoutTimeError } = this.state
     const {
       autoLogoutTimeLimit,
       setAutoLogoutTimeLimit,
@@ -263,19 +285,22 @@ export default class AdvancedTab extends PureComponent {
               placeholder="5"
               value={this.state.autoLogoutTimeLimit}
               defaultValue={autoLogoutTimeLimit}
-              onChange={e => this.setState({ autoLogoutTimeLimit: Math.max(Number(e.target.value), 0) })}
+              onChange={e => this.handleLogoutChange(e.target.value)}
+              error={logoutTimeError}
               fullWidth
               margin="dense"
               min={0}
             />
-            <button
+            <Button
+              type="primary"
               className="button btn-primary settings-tab__rpc-save-button"
+              disabled={logoutTimeError !== ''}
               onClick={() => {
                 setAutoLogoutTimeLimit(this.state.autoLogoutTimeLimit)
               }}
             >
               { t('save') }
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
+++ b/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
@@ -38,7 +38,7 @@ describe('AdvancedTab Component', () => {
     textField.props().onChange({ target: { value: 1440 } })
     assert.equal(root.state().autoLogoutTimeLimit, 1440)
 
-    autoTimeout.find('button').simulate('click')
+    autoTimeout.find('.settings-tab__rpc-save-button').simulate('click')
     assert.equal(setAutoLogoutTimeLimitSpy.args[0][0], 1440)
   })
 })


### PR DESCRIPTION
Fixes #7231. Prevents the logout timer from being set longer than a week. This doesn't really fix the root cause of why the app logs out immediately and prevents login when setting an arbitrary large logout timer.