### PR TITLE
Prevent waiting for stale element

### DIFF
--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -207,11 +207,11 @@ describe('MetaMask', function () {
       const addToAddressBookButton = await findElement(driver, By.css('.dialog.send__dialog.dialog--message'))
       await addToAddressBookButton.click()
 
-      const addressBookAddModal = await driver.findElement(By.css('span .modal'))
       await findElement(driver, By.css('.add-to-address-book-modal'))
       const addressBookInput = await findElement(driver, By.css('.add-to-address-book-modal__input'))
       await addressBookInput.sendKeys('Test Name 1')
       await delay(tinyDelayMs)
+      const addressBookAddModal = await driver.findElement(By.css('span .modal'))
       const addressBookSaveButton = await findElement(driver, By.css('.add-to-address-book-modal__footer .btn-primary'))
       await addressBookSaveButton.click()
 

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -113,9 +113,9 @@ describe('Using MetaMask with an existing account', function () {
     it('shows a QR code for the account', async () => {
       await driver.findElement(By.css('.account-details__details-button')).click()
       await driver.findElement(By.css('.qr-wrapper')).isDisplayed()
-      const detailModal = await driver.findElement(By.css('span .modal'))
       await delay(regularDelayMs)
 
+      const detailModal = await driver.findElement(By.css('span .modal'))
       await driver.executeScript("document.querySelector('.account-modal-close').click()")
       await driver.wait(until.stalenessOf(detailModal))
       await delay(regularDelayMs)

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -785,7 +785,6 @@ describe('MetaMask', function () {
       await configureGas.click()
       await delay(regularDelayMs)
 
-      const gasModal = await findElement(driver, By.css('span .modal'))
       await delay(regularDelayMs)
       const modalTabs = await findElements(driver, By.css('.page-container__tab'))
       await modalTabs[1].click()
@@ -820,6 +819,7 @@ describe('MetaMask', function () {
       await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'e'))
       await delay(50)
 
+      const gasModal = await findElement(driver, By.css('span .modal'))
       const save = await findElement(driver, By.xpath(`//button[contains(text(), 'Save')]`))
       await save.click()
       await delay(regularDelayMs)
@@ -973,7 +973,6 @@ describe('MetaMask', function () {
   })
 
   describe('Send token from inside MetaMask', () => {
-    let gasModal
     it('starts to send a transaction', async function () {
       const sendButton = await findElement(driver, By.xpath(`//button[contains(text(), 'Send')]`))
       await sendButton.click()
@@ -988,22 +987,19 @@ describe('MetaMask', function () {
       // Set the gas limit
       const configureGas = await findElement(driver, By.css('.advanced-gas-options-btn'))
       await configureGas.click()
-      await delay(regularDelayMs)
-
-      gasModal = await driver.findElement(By.css('span .modal'))
-      await delay(regularDelayMs)
+      await driver.findElement(By.css('span .modal'))
     })
 
     it('opens customize gas modal', async () => {
       await driver.wait(until.elementLocated(By.css('.page-container__title')))
+      const gasModal = await driver.findElement(By.css('span .modal'))
       const save = await findElement(driver, By.xpath(`//button[contains(text(), 'Save')]`))
       await save.click()
+      await driver.wait(until.stalenessOf(gasModal))
       await delay(regularDelayMs)
     })
 
     it('transitions to the confirm screen', async () => {
-      await driver.wait(until.stalenessOf(gasModal))
-
       // Continue to next screen
       const nextScreen = await findElement(driver, By.xpath(`//button[contains(text(), 'Next')]`))
       await nextScreen.click()
@@ -1063,7 +1059,6 @@ describe('MetaMask', function () {
   })
 
   describe('Send a custom token from dapp', () => {
-    let gasModal
     it('sends an already created token', async () => {
       const windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
@@ -1092,9 +1087,7 @@ describe('MetaMask', function () {
       // Set the gas limit
       const configureGas = await driver.wait(until.elementLocated(By.css('.confirm-detail-row__header-text--edit')), 10000)
       await configureGas.click()
-      await delay(regularDelayMs)
-
-      gasModal = await driver.findElement(By.css('span .modal'))
+      await driver.findElement(By.css('span .modal'))
     })
 
     it('customizes gas', async () => {
@@ -1129,6 +1122,7 @@ describe('MetaMask', function () {
       await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'e'))
       await delay(50)
 
+      const gasModal = await driver.findElement(By.css('span .modal'))
       const save = await findElement(driver, By.css('.page-container__footer-button'))
       await save.click()
       await driver.wait(until.stalenessOf(gasModal))
@@ -1177,7 +1171,6 @@ describe('MetaMask', function () {
   })
 
   describe('Approves a custom token from dapp', () => {
-    let gasModal
     it('approves an already created token', async () => {
       const windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
@@ -1235,9 +1228,7 @@ describe('MetaMask', function () {
     it('opens the gas edit modal', async () => {
       const configureGas = await driver.wait(until.elementLocated(By.css('.confirm-detail-row__header-text--edit')))
       await configureGas.click()
-      await delay(regularDelayMs)
-
-      gasModal = await driver.findElement(By.css('span .modal'))
+      await driver.findElement(By.css('span .modal'))
     })
 
     it('customizes gas', async () => {
@@ -1272,6 +1263,7 @@ describe('MetaMask', function () {
       await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'e'))
       await delay(50)
 
+      const gasModal = await driver.findElement(By.css('span .modal'))
       const save = await findElement(driver, By.css('.page-container__footer-button'))
       await save.click()
       await driver.wait(until.stalenessOf(gasModal))

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -111,8 +111,6 @@ describe('Using MetaMask with an existing account', function () {
       await configureGas.click()
       await delay(regularDelayMs)
 
-      const gasModal = await driver.findElement(By.css('span .modal'))
-
       const [gasPriceInput, gasLimitInput] = await findElements(driver, By.css('.advanced-tab__gas-edit-row__input'))
       await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
       await delay(50)
@@ -131,6 +129,7 @@ describe('Using MetaMask with an existing account', function () {
 
       await gasLimitInput.sendKeys('25000')
 
+      const gasModal = await driver.findElement(By.css('span .modal'))
       const save = await findElement(driver, By.xpath(`//button[contains(text(), 'Save')]`))
       await save.click()
       await driver.wait(until.stalenessOf(gasModal))
@@ -168,8 +167,6 @@ describe('Using MetaMask with an existing account', function () {
       await configureGas.click()
       await delay(regularDelayMs)
 
-      const gasModal = await driver.findElement(By.css('span .modal'))
-
       const [gasPriceInput, gasLimitInput] = await findElements(driver, By.css('.advanced-tab__gas-edit-row__input'))
       await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
       await delay(50)
@@ -187,6 +184,7 @@ describe('Using MetaMask with an existing account', function () {
 
       await gasLimitInput.sendKeys('100000')
 
+      const gasModal = await driver.findElement(By.css('span .modal'))
       const save = await findElement(driver, By.xpath(`//button[contains(text(), 'Save')]`))
       await save.click()
       await driver.wait(until.stalenessOf(gasModal))


### PR DESCRIPTION
The `driver.wait(until.stalenessOf([elem])` is used throughout our tests to wait for an element to disappear. However we have been passing it elements that have already been destroyed and replaced by React, resulting in our tests essentially skipping that step.

Generally speaking I don't think it's safe to rely upon `until.stalenessOf` while using React, but for now we can reduce the chances that the element was already destroyed and re-rendered by obtaining the element reference as late as possible in the test.