### PR TITLE
Fix e2e tests and gas default

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -563,22 +563,23 @@ describe('MetaMask', function () {
       const dapp = windowHandles[1]
 
       await driver.switchTo().window(dapp)
-      await delay(regularDelayMs)
+      await delay(largeDelayMs)
 
       const send3eth = await findElement(driver, By.xpath(`//button[contains(text(), 'Send')]`), 10000)
       await send3eth.click()
-      await delay(largeDelayMs * 2)
+      await delay(largeDelayMs)
 
       const contractDeployment = await findElement(driver, By.xpath(`//button[contains(text(), 'Deploy Contract')]`), 10000)
       await contractDeployment.click()
-      await delay(largeDelayMs * 2)
+      await delay(largeDelayMs)
 
       await send3eth.click()
+      await delay(largeDelayMs)
       await contractDeployment.click()
-      await delay(largeDelayMs * 2)
+      await delay(largeDelayMs)
 
       await driver.switchTo().window(extension)
-      await delay(largeDelayMs * 2)
+      await delay(regularDelayMs)
 
       let transactions = await findElements(driver, By.css('.transaction-list-item'))
       await transactions[3].click()

--- a/ui/app/pages/send/send.constants.js
+++ b/ui/app/pages/send/send.constants.js
@@ -6,8 +6,6 @@ const MIN_GAS_PRICE_HEX = (parseInt(MIN_GAS_PRICE_DEC)).toString(16)
 const MIN_GAS_LIMIT_DEC = '21000'
 const MIN_GAS_LIMIT_HEX = (parseInt(MIN_GAS_LIMIT_DEC)).toString(16)
 
-const ARBITRARY_HIGH_BLOCK_GAS_LIMIT = (parseInt('8000000')).toString(16)
-
 const MIN_GAS_PRICE_GWEI = ethUtil.addHexPrefix(conversionUtil(MIN_GAS_PRICE_HEX, {
   fromDenomination: 'WEI',
   toDenomination: 'GWEI',
@@ -60,5 +58,4 @@ module.exports = {
   SIMPLE_GAS_COST,
   TOKEN_TRANSFER_FUNCTION_SIGNATURE,
   BASE_TOKEN_GAS_COST,
-  ARBITRARY_HIGH_BLOCK_GAS_LIMIT,
 }

--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -18,7 +18,6 @@ const {
   ONE_GWEI_IN_WEI_HEX,
   SIMPLE_GAS_COST,
   TOKEN_TRANSFER_FUNCTION_SIGNATURE,
-  ARBITRARY_HIGH_BLOCK_GAS_LIMIT,
 } = require('./send.constants')
 const abi = require('ethereumjs-abi')
 const ethUtil = require('ethereumjs-util')
@@ -245,7 +244,7 @@ async function estimateGas ({
 
   // if not, fall back to block gasLimit
   if (!blockGasLimit) {
-    blockGasLimit = ARBITRARY_HIGH_BLOCK_GAS_LIMIT
+    blockGasLimit = MIN_GAS_LIMIT_HEX
   }
 
   paramsForGasEstimate.gas = ethUtil.addHexPrefix(multiplyCurrencies(blockGasLimit, 0.95, {


### PR DESCRIPTION
This PR firstly fixes a bug in tests that was caused by an additional delay when creating transaction, introduced with #7252. Adding an additional delay in tests gets them to pass more consistently

Secondly, this replaces the default to the `ARBITRARY_HIGH_BLOCK_GAS_LIMIT` with a default to the originally intended `MIN_GAS_LIMIT_HEX`. This should have no effect on user experience, and may avoid errors on certain networks.

