### PR TITLE
Add metrics events for clicking and saving tx speed ups

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -8,6 +8,7 @@ import BasicTabContent from './basic-tab-content'
 export default class GasModalPageContainer extends Component {
   static contextTypes = {
     t: PropTypes.func,
+    metricsEvent: PropTypes.func,
   }
 
   static propTypes = {
@@ -162,6 +163,7 @@ export default class GasModalPageContainer extends Component {
       customModalGasPriceInHex,
       customModalGasLimitInHex,
       disableSave,
+      isSpeedUp,
       ...tabProps
     } = this.props
 
@@ -175,6 +177,15 @@ export default class GasModalPageContainer extends Component {
           onCancel={() => cancelAndClose()}
           onClose={() => cancelAndClose()}
           onSubmit={() => {
+            if (isSpeedUp) {
+              this.context.metricsEvent({
+                eventOpts: {
+                  category: 'Navigation',
+                  action: 'Activity Log',
+                  name: 'Saved "Speed Up"',
+                },
+              })
+            }
             onSubmit(customModalGasLimitInHex, customModalGasPriceInHex)
           }}
           submitText={this.context.t('save')}

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -113,6 +113,14 @@ export default class TransactionListItem extends PureComponent {
 
     const retryId = id || initialTransactionId
 
+    this.context.metricsEvent({
+      eventOpts: {
+        category: 'Navigation',
+        action: 'Activity Log',
+        name: 'Clicked "Speed Up"',
+      },
+    })
+
     return fetchBasicGasAndTimeEstimates()
       .then(basicEstimates => fetchGasEstimates(basicEstimates.blockTime))
       .then(retryTransaction(retryId, gasPrice))


### PR DESCRIPTION
Fixes #6660 

Adds metrics events for user click of the "speed up" button on a transaction, and user click of the submit button when done editing data.