### PR TITLE
Remove trailing commas from JSON files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
       "templateStrings": true,
       "classes": true,
       "jsx": true
-    },
+    }
   },
 
   "extends": ["plugin:react/recommended"],

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -33,7 +33,7 @@
       "always",
       {
         "ignore": [
-          "after-comment",
+          "after-comment"
         ]
       }
     ],


### PR DESCRIPTION
This PR removes trailing commas from two JSON files in the project that had them. JSON doesn't allow trailing commas and JSON tools (e.g. Python's `python -m json.tool < .eslintrc`) will error when reading them.