### PR TITLE
Fix phishing detect script

### DIFF
--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -38,7 +38,7 @@ const getEnvironmentType = (url = window.location.href) => {
   const parsedUrl = new URL(url)
   if (parsedUrl.pathname === '/popup.html') {
     return ENVIRONMENT_TYPE_POPUP
-  } else if (parsedUrl.pathname === '/home.html') {
+  } else if (['/home.html', '/phishing.html'].includes(parsedUrl.pathname)) {
     return ENVIRONMENT_TYPE_FULLSCREEN
   } else if (parsedUrl.pathname === '/notification.html') {
     return ENVIRONMENT_TYPE_NOTIFICATION

--- a/test/unit/app/util-test.js
+++ b/test/unit/app/util-test.js
@@ -18,8 +18,13 @@ describe('getEnvironmentType', function () {
     assert.equal(environmentType, ENVIRONMENT_TYPE_NOTIFICATION)
   })
 
-  it('should return fullscreen type', function () {
+  it('should return fullscreen type for home.html', function () {
     const environmentType = getEnvironmentType('http://extension-id/home.html')
+    assert.equal(environmentType, ENVIRONMENT_TYPE_FULLSCREEN)
+  })
+
+  it('should return fullscreen type for phishing.html', function () {
+    const environmentType = getEnvironmentType('http://extension-id/phishing.html')
     assert.equal(environmentType, ENVIRONMENT_TYPE_FULLSCREEN)
   })
 


### PR DESCRIPTION
Fixes #7100

This PR fixes the "continuing at your own risk" link on the phishing page, which has been broken since v7.0.1 where we introduced 12e055a37c54c6fe12c1c02676041b8d29c753bd via #6966.

The result of `getEnvironmentType` (the value of `windowType`) used in the phishing detect script changed in the above commit and resulted in a connection to the incorrect context.