### PR TITLE
Fix positioning of tx status in tx-list

### DIFF
--- a/ui/app/components/app/transaction-list-item/index.scss
+++ b/ui/app/components/app/transaction-list-item/index.scss
@@ -17,6 +17,7 @@
     grid-template-areas:
       "identicon action status primary-amount"
       "identicon nonce status secondary-amount";
+    grid-template-rows: 24px;
 
     @media screen and (max-width: $break-small) {
       padding: .5rem 1rem;
@@ -25,6 +26,7 @@
         "nonce nonce nonce"
         "identicon action primary-amount"
         "identicon status secondary-amount";
+      grid-template-rows: auto 24px;
     }
 
     &:hover {


### PR DESCRIPTION
Fixes #7036 
Closes #7272 

This PR fixes the height placement of the status indicator within transaction list items. This issue was introduced with https://github.com/MetaMask/metamask-extension/pull/6744/commits/c05090ae6ea51cdcdfad624c6886e51e535af1d4

The additional div added on line 88 of the identicon component causes the grid row in the tx list to expand to the height of the identicon. Previously, the identicon was overflowing into the next row.

This PR explicitly sets the height of the relevant row, preventing problems from heights of grid cells.

Screenshots:
![Screenshot from 2019-10-28 17-43-49](https://user-images.githubusercontent.com/7499938/67714484-f0ba2b80-f9aa-11e9-9445-2b90e79782b7.png)
![Screenshot from 2019-10-28 17-43-35](https://user-images.githubusercontent.com/7499938/67714485-f0ba2b80-f9aa-11e9-90d8-b58ca256883a.png)
