### PR TITLE
Rename ConfirmPageContainerHeader class

### DIFF
--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
@@ -6,7 +6,7 @@ import {
 } from '../../../../../../app/scripts/lib/enums'
 import NetworkDisplay from '../../network-display'
 
-export default class ConfirmPageContainer extends Component {
+export default class ConfirmPageContainerHeader extends Component {
   static contextTypes = {
     t: PropTypes.func,
   }


### PR DESCRIPTION
The class has been renamed to reflect that it is a header, to avoid having the same name as the `ConfirmPageContainer` component. Multiple components with the same name can lead to confusing error messages.