### PR TITLE
Adds the chainId to remove contact from state

### DIFF
--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -18,6 +18,7 @@ export default class EditContact extends PureComponent {
     history: PropTypes.object,
     name: PropTypes.string,
     address: PropTypes.string,
+    chainId: PropTypes.string,
     memo: PropTypes.string,
     viewRoute: PropTypes.string,
     listRoute: PropTypes.string,
@@ -33,7 +34,7 @@ export default class EditContact extends PureComponent {
 
   render () {
     const { t } = this.context
-    const { history, name, addToAddressBook, removeFromAddressBook, address, memo, viewRoute, listRoute, setAccountLabel } = this.props
+    const { history, name, addToAddressBook, removeFromAddressBook, address, chainId, memo, viewRoute, listRoute, setAccountLabel } = this.props
 
     return (
       <div className="settings-page__content-row address-book__edit-contact">
@@ -43,7 +44,7 @@ export default class EditContact extends PureComponent {
             type="link"
             className="settings-page__address-book-button"
             onClick={() => {
-              removeFromAddressBook(address)
+              removeFromAddressBook(chainId, address)
               history.push(listRoute)
             }}
           >

--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
@@ -21,10 +21,13 @@ const mapStateToProps = (state, ownProps) => {
 
   const { memo, name } = getAddressBookEntry(state, address) || state.metamask.identities[address]
 
+  const chainId = state.metamask.network
+
   const showingMyAccounts = Boolean(pathname.match(CONTACT_MY_ACCOUNTS_EDIT_ROUTE))
 
   return {
     address,
+    chainId,
     name,
     memo,
     viewRoute: showingMyAccounts ? CONTACT_MY_ACCOUNTS_VIEW_ROUTE : CONTACT_VIEW_ROUTE,
@@ -36,7 +39,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch => {
   return {
     addToAddressBook: (recipient, nickname, memo) => dispatch(addToAddressBook(recipient, nickname, memo)),
-    removeFromAddressBook: (addressToRemove) => dispatch(removeFromAddressBook(addressToRemove)),
+    removeFromAddressBook: (chainId, addressToRemove) => dispatch(removeFromAddressBook(chainId, addressToRemove)),
     setAccountLabel: (address, label) => dispatch(setAccountLabel(address, label)),
   }
 }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2011,11 +2011,11 @@ function addToAddressBook (recipient, nickname = '', memo = '') {
  * @description Calls the addressBookController to remove an existing address.
  * @param {String} addressToRemove - Address of the entry to remove from the address book
  */
-function removeFromAddressBook (addressToRemove) {
+function removeFromAddressBook (chainId, addressToRemove) {
   log.debug(`background.removeFromAddressBook`)
 
   return () => {
-    background.removeFromAddressBook(checksumAddress(addressToRemove))
+    background.removeFromAddressBook(chainId, checksumAddress(addressToRemove))
   }
 }
 


### PR DESCRIPTION
Fixes #7318

Gaba/AddressBookController requires a chainId to delete contact from state.
https://github.com/MetaMask/gaba/blob/develop/src/user/AddressBookController.ts#L83