### PR TITLE
Update eth-json-rpc-filters

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1419,7 +1419,7 @@ module.exports = class MetamaskController extends EventEmitter {
       providerStream,
       outStream,
       (err) => {
-        // cleanup filter polyfill middleware
+        // handle any middleware cleanup
         engine._middleware.forEach((mid) => {
           if (mid.destroy && typeof mid.destroy === 'function') {
             mid.destroy()

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "extensionizer": "^1.0.1",
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
-    "gaba": "^1.7.4",
+    "gaba": "^1.7.5",
     "human-standard-token-abi": "^2.0.0",
     "jazzicon": "^1.2.0",
     "json-rpc-engine": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "extensionizer": "^1.0.1",
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
-    "gaba": "^1.7.0",
+    "gaba": "^1.7.4",
     "human-standard-token-abi": "^2.0.0",
     "jazzicon": "^1.2.0",
     "json-rpc-engine": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eth-contract-metadata": "^1.9.2",
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-errors": "^1.1.0",
-    "eth-json-rpc-filters": "^4.1.0",
+    "eth-json-rpc-filters": "^4.1.1",
     "eth-json-rpc-infura": "^4.0.1",
     "eth-json-rpc-middleware": "^4.2.0",
     "eth-keyring-controller": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11860,10 +11860,10 @@ fuse.js@^3.4.4:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.5.tgz#8954fb43f9729bd5dbcb8c08f251db552595a7a6"
   integrity sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ==
 
-gaba@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.7.4.tgz#0ac712068824d094ec58adcbc3e6a32b74ca7d68"
-  integrity sha512-/A9eGH19V4jNKMelrcRnCoqEgYNHZWKBara7TZZwuULv3A7KWy/qxnTDB3yZ4QUlkYnmWu6uTpcuCT4PowPtHQ==
+gaba@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.7.5.tgz#216cc3196178917a0ae56eda2e1d8981c125364c"
+  integrity sha512-1S70Sijw5VH4r+pyoZQEoYk+zzsHmwT+xjKPzCo1Ep8A/N1EfcgQxwsD9HNMvPol03Qaf92udIHhry1L7wMjgg==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9777,6 +9777,18 @@ eth-json-rpc-filters@^4.1.0:
     lodash.flatmap "^4.5.0"
     safe-event-emitter "^1.0.1"
 
+eth-json-rpc-filters@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz#15277c66790236d85f798f4d7dc6bab99a798cd2"
+  integrity sha512-GkXb2h6STznD+AmMzblwXgm1JMvjdK9PTIXG7BvIkTlXQ9g0QOxuU1iQRYHoslF9S30BYBSoLSisAYPdLggW+A==
+  dependencies:
+    await-semaphore "^0.1.3"
+    eth-json-rpc-middleware "^4.1.4"
+    eth-query "^2.1.2"
+    json-rpc-engine "^5.1.3"
+    lodash.flatmap "^4.5.0"
+    safe-event-emitter "^1.0.1"
+
 eth-json-rpc-infura@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.0.tgz#62c3f516b51351038c32a548704467cec113ca8f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9765,18 +9765,6 @@ eth-json-rpc-errors@^1.0.1, eth-json-rpc-errors@^1.1.0:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-json-rpc-filters@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.0.tgz#e7357a38983cde29858818dc55d394b9cf47c0f0"
-  integrity sha512-r/Zk0Tvx3BNYOCPCSEXxe2BeZJpKlA+E+76kYo8g95cHGXRP4uXKDnoTkFaRc/mamabmRhfyCoOjhDDx8iA3eA==
-  dependencies:
-    await-semaphore "^0.1.3"
-    eth-json-rpc-middleware "^4.1.4"
-    eth-query "^2.1.2"
-    json-rpc-engine "^5.1.3"
-    lodash.flatmap "^4.5.0"
-    safe-event-emitter "^1.0.1"
-
 eth-json-rpc-filters@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz#15277c66790236d85f798f4d7dc6bab99a798cd2"
@@ -9969,18 +9957,6 @@ eth-sig-util@^1.4.0, eth-sig-util@^1.4.2:
   dependencies:
     ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
     ethereumjs-util "^5.1.1"
-
-eth-sig-util@^2.1.0:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.4.4.tgz#8804ead83de8648bcf81eadbfac1e3ccdd360aea"
-  integrity sha512-iWGqEJwsUMgtk8AqQQqIDTjMz+pW8s2Sq8gN640dh9U9HoEFQJO3m6ro96DgV6hMB2LYu8F5812LQyynOgCbEw==
-  dependencies:
-    buffer "^5.2.1"
-    elliptic "^6.4.0"
-    ethereumjs-abi "0.6.5"
-    ethereumjs-util "^5.1.1"
-    tweetnacl "^1.0.0"
-    tweetnacl-util "^0.15.0"
 
 eth-sig-util@^2.4.4, eth-sig-util@^2.5.0:
   version "2.5.0"
@@ -11884,10 +11860,10 @@ fuse.js@^3.4.4:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.5.tgz#8954fb43f9729bd5dbcb8c08f251db552595a7a6"
   integrity sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ==
 
-gaba@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.7.0.tgz#10e3dc25401a46f7e7ee3261159ca908667ce08a"
-  integrity sha512-LFXrP3fexIvg+YQuRIg7DT+2duMohWETGvVuPNaaAzqCxDl7EsVe7uJSSc3yb1X/qk9pJVh4Zuu1C7safjkDIg==
+gaba@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.7.4.tgz#0ac712068824d094ec58adcbc3e6a32b74ca7d68"
+  integrity sha512-/A9eGH19V4jNKMelrcRnCoqEgYNHZWKBara7TZZwuULv3A7KWy/qxnTDB3yZ4QUlkYnmWu6uTpcuCT4PowPtHQ==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.9.1"
@@ -11897,7 +11873,7 @@ gaba@^1.7.0:
     eth-method-registry "1.1.0"
     eth-phishing-detect "^1.1.13"
     eth-query "^2.1.2"
-    eth-sig-util "^2.1.0"
+    eth-sig-util "^2.3.0"
     ethereumjs-util "^6.1.0"
     ethereumjs-wallet "0.6.0"
     ethjs-query "^0.3.8"
@@ -11909,7 +11885,7 @@ gaba@^1.7.0:
     single-call-balance-checker-abi "^1.0.0"
     uuid "^3.3.2"
     web3 "^0.20.7"
-    web3-provider-engine "^15.0.3"
+    web3-provider-engine "^15.0.4"
 
 ganache-cli@^6.4.4:
   version "6.4.4"
@@ -27371,10 +27347,10 @@ web3-provider-engine@14.2.1:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-web3-provider-engine@^15.0.3:
-  version "15.0.3"
-  resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-15.0.3.tgz#462d2439dafa6fdc3550696be8cdb80c44593c96"
-  integrity sha512-E2/j0iEA1JJVijV84bPpiFKZPA6jFkcCKJtzDCl/CUn8CeqtkGykpjP55pnQtzxszzmpGgSZlThMEFUzBU7X2g==
+web3-provider-engine@^15.0.4:
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/web3-provider-engine/-/web3-provider-engine-15.0.4.tgz#5c336bcad2274dff5218bc8db003fa4e9e464c24"
+  integrity sha512-Ob9oK0TUZfVC7NXkB7CQSWAiCdCD/Xnlh2zTnV8NdJR8LCrMAy2i6JedU70JHaxw59y7mM4GnsYOTTGkquFnNQ==
   dependencies:
     async "^2.5.0"
     backoff "^2.5.0"
@@ -27382,7 +27358,7 @@ web3-provider-engine@^15.0.3:
     cross-fetch "^2.1.0"
     eth-block-tracker "^4.4.2"
     eth-json-rpc-errors "^1.0.1"
-    eth-json-rpc-filters "^4.1.0"
+    eth-json-rpc-filters "^4.1.1"
     eth-json-rpc-infura "^4.0.1"
     eth-json-rpc-middleware "^4.1.5"
     eth-sig-util "^1.4.2"


### PR DESCRIPTION
This fixes an `eth-json-rpc-filters`-related memory leak. Specifically, the subscription manager middleware would not be torn down when a connection was closed, and some listeners would never be removed. That middleware now exposes a `destroy` function, which will be called by the extension on connection teardown, here: https://github.com/MetaMask/metamask-extension/blob/8dfb0e8154d258d5c20ee4d7fd0c5b9e478478d6/app/scripts/metamask-controller.js#L1422-L1436

#### Changes
- add `eth-json-rpc-filters@4.1.1`
  - https://github.com/MetaMask/eth-json-rpc-filters/pull/10
- add `gaba@1.7.4` (depends on `eth-json-rpc-filters`)
  - https://github.com/MetaMask/gaba/pull/166
    - https://github.com/MetaMask/web3-provider-engine/pull/321
      - https://github.com/MetaMask/eth-json-rpc-filters/pull/10

#### Result
```bash
yarn why eth-json-rpc-filters
=> Found "eth-json-rpc-filters@4.1.1"
info Has been hoisted to "eth-json-rpc-filters"
info Reasons this module exists
   - Specified in "dependencies"
   - Hoisted from "gaba#web3-provider-engine#eth-json-rpc-filters"
```