### PR TITLE
Edit contact details fix.

### DIFF
--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -59,6 +59,7 @@ export default class EditContact extends PureComponent {
             <TextField
               type="text"
               id="nickname"
+              placeholder={this.context.t('addAlias')}
               value={this.state.newName}
               onChange={e => this.setState({ newName: e.target.value })}
               fullWidth

--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -25,6 +25,12 @@ export default class EditContact extends PureComponent {
     setAccountLabel: PropTypes.func,
   }
 
+  static defaultProps = {
+    name: '',
+    address: '',
+    memo: '',
+  }
+
   state = {
     newName: this.props.name,
     newAddress: this.props.address,

--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -26,9 +26,9 @@ export default class EditContact extends PureComponent {
   }
 
   state = {
-    newName: '',
-    newAddress: '',
-    newMemo: '',
+    newName: this.props.name,
+    newAddress: this.props.address,
+    newMemo: this.props.memo,
     error: '',
   }
 
@@ -59,8 +59,7 @@ export default class EditContact extends PureComponent {
             <TextField
               type="text"
               id="nickname"
-              placeholder={this.context.t('addAlias')}
-              value={this.state.newName || name}
+              value={this.state.newName}
               onChange={e => this.setState({ newName: e.target.value })}
               fullWidth
               margin="dense"
@@ -74,8 +73,7 @@ export default class EditContact extends PureComponent {
             <TextField
               type="text"
               id="address"
-              placeholder={address}
-              value={this.state.newAddress || address}
+              value={this.state.newAddress}
               error={this.state.error}
               onChange={e => this.setState({ newAddress: e.target.value })}
               fullWidth
@@ -91,7 +89,7 @@ export default class EditContact extends PureComponent {
               type="text"
               id="memo"
               placeholder={memo}
-              value={this.state.newMemo || memo}
+              value={this.state.newMemo}
               onChange={e => this.setState({ newMemo: e.target.value })}
               fullWidth
               margin="dense"
@@ -110,12 +108,12 @@ export default class EditContact extends PureComponent {
             if (this.state.newAddress !== '' && this.state.newAddress !== address) {
               // if the user makes a valid change to the address field, remove the original address
               if (isValidAddress(this.state.newAddress)) {
-                removeFromAddressBook(address)
+                removeFromAddressBook(chainId, address)
                 addToAddressBook(this.state.newAddress, this.state.newName || name, this.state.newMemo || memo)
                 setAccountLabel(this.state.newAddress, this.state.newName || name)
                 history.push(listRoute)
               } else {
-                this.setState({ error: 'invalid address' })
+                this.setState({ error: this.context.t('invalidAddress') })
               }
             } else {
               // update name

--- a/ui/app/pages/settings/contact-list-tab/index.scss
+++ b/ui/app/pages/settings/contact-list-tab/index.scss
@@ -98,6 +98,8 @@
 
         &--copy-icon {
           padding-left: 4px;
+          width: 30px;
+          height: 20px;
         }
       }
 


### PR DESCRIPTION
Adds width and height to copy-to-clipboard svg element on edit contact screen.
Also, allows to clear the text fields of the edit contact screen to input new contact details.

Before:
![edit-contact-bug](https://user-images.githubusercontent.com/13376180/67817308-207c3880-fa6a-11e9-8396-72c4249ad6d4.gif)

After: 

![edit-contact-bug-fix](https://user-images.githubusercontent.com/13376180/67817100-80261400-fa69-11e9-8502-726eaa309b51.gif)
