### PR TITLE
Update GABA version used

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "extensionizer": "^1.0.1",
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
-    "gaba": "^1.7.5",
+    "gaba": "^1.8.0",
     "human-standard-token-abi": "^2.0.0",
     "jazzicon": "^1.2.0",
     "json-rpc-engine": "^5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9694,19 +9694,6 @@ eth-ens-namehash@^1.0.2:
     idna-uts46 "^1.0.1"
     js-sha3 "^0.5.7"
 
-eth-hd-keyring@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eth-hd-keyring/-/eth-hd-keyring-2.0.0.tgz#487ca4f065088ee840739cbad9b853003e79bd06"
-  integrity sha512-lTeANNPNj/j08sWU7LUQZTsx9NUJaUsiOdVxeP0UI5kke7L+Sd7zJWBmCShudEVG8PkqKLE1KJo08o430sl6rw==
-  dependencies:
-    bip39 "^2.2.0"
-    eth-sig-util "^2.0.1"
-    ethereumjs-abi "^0.6.5"
-    ethereumjs-util "^5.1.1"
-    ethereumjs-wallet "^0.6.0"
-    events "^1.1.1"
-    xtend "^4.0.1"
-
 eth-hd-keyring@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/eth-hd-keyring/-/eth-hd-keyring-3.4.0.tgz#288e73041f2b3f047b4151fb4b5ab5ad5710b9a6"
@@ -9801,22 +9788,6 @@ eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5, eth-json-rpc-mid
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-keyring-controller@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.0.1.tgz#695ccde891bb050100c7ad39c4ddf8bfe2da6117"
-  integrity sha512-u87mdyQ1cOyLyaSME0XzV+qPvM+AO8MMMe+/rpvYxCYRK9KtvGTriyfF67zFcsYVaoRS5Ovc4QiQXCAZEyf3QQ==
-  dependencies:
-    bip39 "^2.4.0"
-    bluebird "^3.5.0"
-    browser-passworder "^2.0.3"
-    eth-hd-keyring "^2.0.0"
-    eth-sig-util "^1.4.0"
-    eth-simple-keyring "^2.0.0"
-    ethereumjs-util "^5.1.2"
-    loglevel "^1.5.0"
-    obs-store "^4.0.3"
-    promise-filter "^1.1.0"
-
 eth-keyring-controller@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.3.0.tgz#8d85a67b894360ab7d601222ca71df8ed5f456c6"
@@ -9901,7 +9872,7 @@ eth-query@^2.0.2, eth-query@^2.1.0, eth-query@^2.1.2:
     json-rpc-random-id "^1.0.0"
     xtend "^4.0.1"
 
-eth-sig-util@2.3.0, eth-sig-util@^2.0.1, eth-sig-util@^2.3.0:
+eth-sig-util@2.3.0, eth-sig-util@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.3.0.tgz#c54a6ac8e8796f7e25f59cf436982a930e645231"
   integrity sha512-ugD1AvaggvKaZDgnS19W5qOfepjGc7qHrt7TrAaL54gJw9SHvgIXJ3r2xOMW30RWJZNP+1GlTOy5oye7yXA4xA==
@@ -9932,18 +9903,6 @@ eth-sig-util@^2.4.4, eth-sig-util@^2.5.0:
     ethereumjs-util "^5.1.1"
     tweetnacl "^1.0.0"
     tweetnacl-util "^0.15.0"
-
-eth-simple-keyring@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eth-simple-keyring/-/eth-simple-keyring-2.0.0.tgz#ef1e97c4aebb7229dce9c0ec5cc84efcd3a76395"
-  integrity sha512-4dMbkIy2k1qotDTjWINvXG+7tBmofp0YUhlXgcG0+I3w684V46+MAHEkBtD2Y09iEeIB07RDXrezKP9WxOpynA==
-  dependencies:
-    eth-sig-util "^2.0.1"
-    ethereumjs-abi "^0.6.5"
-    ethereumjs-util "^5.1.1"
-    ethereumjs-wallet "^0.6.0"
-    events "^1.1.1"
-    xtend "^4.0.1"
 
 eth-simple-keyring@^3.4.0:
   version "3.4.0"
@@ -11824,16 +11783,16 @@ fuse.js@^3.4.4:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.5.tgz#8954fb43f9729bd5dbcb8c08f251db552595a7a6"
   integrity sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ==
 
-gaba@^1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.7.5.tgz#216cc3196178917a0ae56eda2e1d8981c125364c"
-  integrity sha512-1S70Sijw5VH4r+pyoZQEoYk+zzsHmwT+xjKPzCo1Ep8A/N1EfcgQxwsD9HNMvPol03Qaf92udIHhry1L7wMjgg==
+gaba@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.8.0.tgz#5370e5d662de6aa8e4e41de791da0996a7e12dbe"
+  integrity sha512-M20fZ6yKRefxgxb82l5Of0VutFxvc1Uxg8LSncaiq5kWQZO1UNe5pkxQc4EQT9rGAcBm6ASv7FG0B04syIELRA==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.9.1"
     eth-ens-namehash "^2.0.8"
     eth-json-rpc-infura "^4.0.1"
-    eth-keyring-controller "^5.0.1"
+    eth-keyring-controller "^5.3.0"
     eth-method-registry "1.1.0"
     eth-phishing-detect "^1.1.13"
     eth-query "^2.1.2"


### PR DESCRIPTION
Refs MetaMask/gaba#176

This PR updates our GABA version to the latest, 1.8.0.