### PR TITLE
Ipfs cid v1 base32

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -739,10 +739,13 @@
     "message": "IPFS Gateway"
   },
   "ipfsGatewayDescription": {
-    "message": "Enter the URL of the ipfs gateway to use for ENS content resolution"
+    "message": "Enter the URL of the IPFS CID gateway to use for ENS content resolution."
   },
   "invalidIpfsGateway": {
-    "message": "Invalid IPFS Gateway : the value must be a valid URL"
+    "message": "Invalid IPFS Gateway: The value must be a valid URL"
+  },
+  "forbiddenIpfsGateway": {
+    "message": "Forbidden IPFS Gateway: Please specify a CID gateway"
   },
   "jsonFile": {
     "message": "JSON File",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -735,6 +735,15 @@
   "invalidSeedPhrase": {
     "message": "Invalid seed phrase"
   },
+  "ipfsGateway": {
+    "message": "IPFS Gateway"
+  },
+  "ipfsGatewayDescription": {
+    "message": "Enter the URL of the ipfs gateway to use for ENS content resolution"
+  },
+  "invalidIpfsGateway": {
+    "message": "Invalid IPFS Gateway : the value must be a valid URL"
+  },
   "jsonFile": {
     "message": "JSON File",
     "description": "format for importing an account"
@@ -1336,7 +1345,7 @@
     "message": "Sync data with 3Box (experimental)"
   },
   "syncWithThreeBoxDescription": {
-    "message": "Turn on to have your settings backed up with 3Box. This feature is currenty experimental; use at your own risk."
+    "message": "Turn on to have your settings backed up with 3Box. This feature is currently experimental; use at your own risk."
   },
   "syncWithThreeBoxDisabled": {
     "message": "3Box has been disabled due to an error during the initial sync"
@@ -1360,7 +1369,7 @@
     "message": "Make sure nobody else is looking at your screen when you scan this code"
   },
   "syncWithMobileComplete": {
-    "message": "Your data has been synced succesfully. Enjoy the MetaMask mobile app!"
+    "message": "Your data has been synced successfully. Enjoy the MetaMask mobile app!"
   },
   "terms": {
     "message": "Terms of Use"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -603,10 +603,13 @@
     "message": "IPFS Gateway"
   },
   "ipfsGatewayDescription": {
-    "message": "Entrez l'URL de la gateway IPFS à utiliser pour résoudre les contenus ENS"
+    "message": "Entrez l'URL de la gateway CID IPFS à utiliser pour résoudre les contenus ENS."
   },
   "invalidIpfsGateway": {
-    "message": "IPFS Gateway Invalide : la valeur doit être une URL valide"
+    "message": "IPFS Gateway Invalide: la valeur doit être une URL valide"
+  },
+  "forbiddenIpfsGateway": {
+    "message": "IPFS Gateway Interdite: veuillez spécifier une gateway CID"
   },
   "jsonFile": {
     "message": "Fichier JSON",

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -599,6 +599,15 @@
   "invalidSeedPhrase": {
     "message": "Phrase Seed invalide"
   },
+  "ipfsGateway": {
+    "message": "IPFS Gateway"
+  },
+  "ipfsGatewayDescription": {
+    "message": "Entrez l'URL de la gateway IPFS à utiliser pour résoudre les contenus ENS"
+  },
+  "invalidIpfsGateway": {
+    "message": "IPFS Gateway Invalide : la valeur doit être une URL valide"
+  },
   "jsonFile": {
     "message": "Fichier JSON",
     "description": "format for importing an account"

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -253,7 +253,10 @@ function setupController (initState, initLangCode) {
   })
 
   const provider = controller.provider
-  setupEnsIpfsResolver({ provider, preferences: controller.preferencesController })
+  setupEnsIpfsResolver({
+    getIpfsGateway: controller.preferencesController.getIpfsGateway,
+    provider,
+  })
 
   // submit rpc requests to mesh-metrics
   controller.networkController.on('rpc-req', (data) => {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -252,10 +252,9 @@ function setupController (initState, initLangCode) {
     },
   })
 
-  const provider = controller.provider
   setupEnsIpfsResolver({
-    getIpfsGateway: controller.preferencesController.getIpfsGateway,
-    provider,
+    getIpfsGateway: controller.preferencesController.getIpfsGateway.bind(controller.preferencesController),
+    provider: controller.provider,
   })
 
   // submit rpc requests to mesh-metrics

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -253,7 +253,7 @@ function setupController (initState, initLangCode) {
   })
 
   const provider = controller.provider
-  setupEnsIpfsResolver({ provider })
+  setupEnsIpfsResolver({ provider, preferences: controller.preferencesController })
 
   // submit rpc requests to mesh-metrics
   controller.networkController.on('rpc-req', (data) => {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -60,6 +60,9 @@ class PreferencesController {
       completedOnboarding: false,
       metaMetricsId: null,
       metaMetricsSendCount: 0,
+
+      // ENS decentralized website resolution
+      ipfsGateway: 'ipfs.dweb.link',
     }, opts.initState)
 
     this.diagnostics = opts.diagnostics
@@ -645,6 +648,24 @@ class PreferencesController {
   completeOnboarding () {
     this.store.updateState({ completedOnboarding: true })
     return Promise.resolve(true)
+  }
+
+  /**
+   * A getter for the `ipfsGateway` property
+   * @returns {string} The current IPFS gateway domain
+   */
+  getIpfsGateway () {
+    return this.store.getState().ipfsGateway
+  }
+
+  /**
+   * A setter for the `ipfsGateway` property
+   * @param {string} domain The new IPFS gateway domain
+   * @returns {Promise<string>} A promise of the update IPFS gateway domain
+   */
+  setIpfsGateway (domain) {
+    this.store.updateState({ ipfsGateway: domain })
+    return Promise.resolve(domain)
   }
 
   //

--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -39,7 +39,7 @@ async function resolveEnsToIpfsContentId ({ provider, name }) {
       decodedContentHash = contentHash.helpers.cidV0ToV1Base32(decodedContentHash)
     }
 
-    return {type: type, hash: decodedContentHash}
+    return { type: type, hash: decodedContentHash }
   }
   if (isLegacyResolver[0]) {
     // lookup content id

--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -32,9 +32,14 @@ async function resolveEnsToIpfsContentId ({ provider, name }) {
   if (isEIP1577Compliant[0]) {
     const contentLookupResult = await Resolver.contenthash(hash)
     const rawContentHash = contentLookupResult[0]
-    const decodedContentHash = contentHash.decode(rawContentHash)
+    let decodedContentHash = contentHash.decode(rawContentHash)
     const type = contentHash.getCodec(rawContentHash)
-    return { type: type, hash: decodedContentHash }
+
+    if (type === 'ipfs-ns') {
+      decodedContentHash = contentHash.helpers.cidV0ToV1Base32(decodedContentHash)
+    }
+
+    return {type: type, hash: decodedContentHash}
   }
   if (isLegacyResolver[0]) {
     // lookup content id

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -6,7 +6,7 @@ const supportedTopLevelDomains = ['eth']
 
 module.exports = setupEnsIpfsResolver
 
-function setupEnsIpfsResolver ({ provider }) {
+function setupEnsIpfsResolver ({ provider, preferences }) {
 
   // install listener
   const urlPatterns = supportedTopLevelDomains.map(tld => `*://*.${tld}/*`)
@@ -40,12 +40,13 @@ function setupEnsIpfsResolver ({ provider }) {
   }
 
   async function attemptResolve ({ tabId, name, path, search, fragment }) {
+    const ipfsGateway = preferences.getIpfsGateway()
     extension.tabs.update(tabId, { url: `loading.html` })
     let url = `https://app.ens.domains/name/${name}`
     try {
       const { type, hash } = await resolveEnsToIpfsContentId({ provider, name })
       if (type === 'ipfs-ns') {
-        const resolvedUrl = `https://gateway.ipfs.io/ipfs/${hash}${path}${search || ''}${fragment || ''}`
+        const resolvedUrl = `https://${hash}.${ipfsGateway}${path}${search || ''}${fragment || ''}`
         try {
           // check if ipfs gateway has result
           const response = await fetch(resolvedUrl, { method: 'HEAD' })

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -6,7 +6,7 @@ const supportedTopLevelDomains = ['eth']
 
 module.exports = setupEnsIpfsResolver
 
-function setupEnsIpfsResolver ({ provider, preferences }) {
+function setupEnsIpfsResolver ({ provider, getIpfsGateway }) {
 
   // install listener
   const urlPatterns = supportedTopLevelDomains.map(tld => `*://*.${tld}/*`)
@@ -40,7 +40,7 @@ function setupEnsIpfsResolver ({ provider, preferences }) {
   }
 
   async function attemptResolve ({ tabId, name, path, search, fragment }) {
-    const ipfsGateway = preferences.getIpfsGateway()
+    const ipfsGateway = getIpfsGateway()
     extension.tabs.update(tabId, { url: `loading.html` })
     let url = `https://app.ens.domains/name/${name}`
     try {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -439,6 +439,7 @@ module.exports = class MetamaskController extends EventEmitter {
       setCurrentCurrency: this.setCurrentCurrency.bind(this),
       setUseBlockie: this.setUseBlockie.bind(this),
       setUseNonceField: this.setUseNonceField.bind(this),
+      setIpfsGateway: this.setIpfsGateway.bind(this),
       setParticipateInMetaMetrics: this.setParticipateInMetaMetrics.bind(this),
       setMetaMetricsSendCount: this.setMetaMetricsSendCount.bind(this),
       setFirstTimeFlowType: this.setFirstTimeFlowType.bind(this),
@@ -1835,6 +1836,20 @@ module.exports = class MetamaskController extends EventEmitter {
   setUseNonceField (val, cb) {
     try {
       this.preferencesController.setUseNonceField(val)
+      cb(null)
+    } catch (err) {
+      cb(err)
+    }
+  }
+
+  /**
+   * Sets the IPFS gateway to use for ENS content resolution.
+   * @param {string} val - the host of the gateway to set
+   * @param {Function} cb - A callback function called when complete.
+   */
+  setIpfsGateway (val, cb) {
+    try {
+      this.preferencesController.setIpfsGateway(val)
       cb(null)
     } catch (err) {
       cb(err)

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "c3": "^0.6.7",
     "classnames": "^2.2.5",
     "clone": "^2.1.2",
-    "content-hash": "^2.4.4",
+    "content-hash": "^2.5.0",
     "copy-to-clipboard": "^3.0.8",
     "currency-formatter": "^1.4.2",
     "d3": "^5.7.0",

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -363,7 +363,9 @@ export default class AdvancedTab extends PureComponent {
 
       try {
         const urlObj = new URL(url) // check if is valid url
-        if (!urlObj.host) throw new Error('invalid url : no host')
+        if (!urlObj.host) {
+          throw new Error('invalid url : no host')
+        }
       } catch (error) {
         ipfsGatewayError = t('invalidIpfsGateway')
       }

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -31,11 +31,15 @@ export default class AdvancedTab extends PureComponent {
     threeBoxSyncingAllowed: PropTypes.bool.isRequired,
     setThreeBoxSyncingPermission: PropTypes.func.isRequired,
     threeBoxDisabled: PropTypes.bool.isRequired,
+    setIpfsGateway: PropTypes.func.isRequired,
+    ipfsGateway: PropTypes.string.isRequired,
   }
 
   state = {
     autoLogoutTimeLimit: this.props.autoLogoutTimeLimit,
     logoutTimeError: '',
+    ipfsGateway: `https://${this.props.ipfsGateway}`,
+    ipfsGatewayError: '',
   }
 
   renderMobileSync () {
@@ -351,6 +355,72 @@ export default class AdvancedTab extends PureComponent {
     )
   }
 
+  handleIpfsGatewayChange (url) {
+    const { t } = this.context
+
+    this.setState(() => {
+      let ipfsGatewayError = ''
+
+      try {
+        const urlObj = new URL(url) // check if is valid url
+        if (!urlObj.host) throw new Error('invalid url : no host')
+      } catch (error) {
+        ipfsGatewayError = t('invalidIpfsGateway')
+      }
+
+      return {
+        ipfsGateway: url,
+        ipfsGatewayError,
+      }
+    })
+  }
+
+  handleIpfsGatewaySave () {
+    const url = new URL(this.state.ipfsGateway)
+    const host = url.host
+    this.props.setIpfsGateway(host)
+  }
+
+  renderIpfsGatewayControl () {
+    const { t } = this.context
+    const { ipfsGatewayError } = this.state
+    const { ipfsGateway } = this.props
+
+    return (
+      <div className="settings-page__content-row">
+        <div className="settings-page__content-item">
+          <span>{ t('ipfsGateway') }</span>
+          <div className="settings-page__content-description">
+            { t('ipfsGatewayDescription') }
+          </div>
+        </div>
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-item-col">
+            <TextField
+              type="text"
+              value={this.state.ipfsGateway}
+              defaultValue={ipfsGateway}
+              onChange={e => this.handleIpfsGatewayChange(e.target.value)}
+              error={ipfsGatewayError}
+              fullWidth
+              margin="dense"
+            />
+            <Button
+              type="primary"
+              className="settings-tab__rpc-save-button"
+              disabled={ ipfsGatewayError !== '' }
+              onClick={() => {
+                this.handleIpfsGatewaySave()
+              }}
+            >
+              { t('save') }
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   renderContent () {
     const { warning } = this.props
 
@@ -366,6 +436,7 @@ export default class AdvancedTab extends PureComponent {
         { this.renderUseNonceOptIn() }
         { this.renderAutoLogoutTimeLimit() }
         { this.renderThreeBoxControl() }
+        { this.renderIpfsGatewayControl() }
       </div>
     )
   }

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
@@ -11,6 +11,7 @@ import {
   setThreeBoxSyncingPermission,
   turnThreeBoxSyncingOnAndInitialize,
   setUseNonceField,
+  setIpfsGateway,
 } from '../../../store/actions'
 import { preferencesSelector } from '../../../selectors/selectors'
 
@@ -24,6 +25,7 @@ export const mapStateToProps = state => {
     threeBoxSyncingAllowed,
     threeBoxDisabled,
     useNonceField,
+    ipfsGateway,
   } = metamask
   const { showFiatInTestnets, autoLogoutTimeLimit } = preferencesSelector(state)
 
@@ -36,6 +38,7 @@ export const mapStateToProps = state => {
     threeBoxSyncingAllowed,
     threeBoxDisabled,
     useNonceField,
+    ipfsGateway,
   }
 }
 
@@ -58,6 +61,9 @@ export const mapDispatchToProps = dispatch => {
       } else {
         dispatch(setThreeBoxSyncingPermission(newThreeBoxSyncingState))
       }
+    },
+    setIpfsGateway: value => {
+      return dispatch(setIpfsGateway(value))
     },
   }
 }

--- a/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
+++ b/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
@@ -16,7 +16,7 @@ describe('AdvancedTab Component', () => {
       }
     )
 
-    assert.equal(root.find('.settings-page__content-row').length, 9)
+    assert.equal(root.find('.settings-page__content-row').length, 10)
   })
 
   it('should update autoLogoutTimeLimit', () => {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -543,3 +543,7 @@ export function getLastConnectedInfo (state) {
   }, {})
   return lastConnectedInfoData
 }
+
+export function getIpfsGateway (state) {
+  return state.metamask.ipfsGateway
+}

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -304,6 +304,8 @@ const actions = {
   setUseNonceField,
   UPDATE_CUSTOM_NONCE: 'UPDATE_CUSTOM_NONCE',
   updateCustomNonce,
+  SET_IPFS_GATEWAY: 'SET_IPFS_GATEWAY',
+  setIpfsGateway,
 
   SET_PARTICIPATE_IN_METAMETRICS: 'SET_PARTICIPATE_IN_METAMETRICS',
   SET_METAMETRICS_SEND_COUNT: 'SET_METAMETRICS_SEND_COUNT',
@@ -2655,6 +2657,23 @@ function setUseNonceField (val) {
     })
     dispatch({
       type: actions.SET_USE_NONCEFIELD,
+      value: val,
+    })
+  }
+}
+
+function setIpfsGateway (val) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    log.debug(`background.setIpfsGateway`)
+    background.setIpfsGateway(val, (err) => {
+      dispatch(actions.hideLoadingIndication())
+      if (err) {
+        return dispatch(actions.displayWarning(err.message))
+      }
+    })
+    dispatch({
+      type: actions.SET_IPFS_GATEWAY,
       value: val,
     })
   }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2670,11 +2670,12 @@ function setIpfsGateway (val) {
       dispatch(actions.hideLoadingIndication())
       if (err) {
         return dispatch(actions.displayWarning(err.message))
+      } else {
+        dispatch({
+          type: actions.SET_IPFS_GATEWAY,
+          value: val,
+        })
       }
-    })
-    dispatch({
-      type: actions.SET_IPFS_GATEWAY,
-      value: val,
     })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6826,16 +6826,6 @@ cids@^0.5.3, cids@~0.5.4, cids@~0.5.6:
     multicodec "~0.5.0"
     multihashes "~0.4.14"
 
-cids@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cids/-/cids-0.6.0.tgz#0de7056a5246a7c7ebf3134eb4d83b3b8b841a06"
-  integrity sha512-34wuIeiBZOuvBwUuYR4XooVuXUQI2PYU9VmgM2eB3xkSmQYRlv2kh/dIbmGiLY2GuONlGR3lLtYdVkx1G9yXUg==
-  dependencies:
-    class-is "^1.1.0"
-    multibase "~0.6.0"
-    multicodec "~0.5.0"
-    multihashes "~0.4.14"
-
 cids@^0.7.1, cids@~0.7.0, cids@~0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.1.tgz#d8bba49a35a0e82110879b5001abf1039c62347f"
@@ -7413,12 +7403,12 @@ content-disposition@0.5.3, content-disposition@^0.5.2, content-disposition@~0.5.
   dependencies:
     safe-buffer "5.1.2"
 
-content-hash@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/content-hash/-/content-hash-2.4.4.tgz#4bec87caecfcff8cf1a37645301cbef4728a083f"
-  integrity sha512-3FaUsqt7VR725pVxe0vIScGI5efmpryIXdVSeXafQ63fb5gRGparAQlAGxTSOiv0yRg7YeliseXuB20ByD1duQ==
+content-hash@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/content-hash/-/content-hash-2.5.0.tgz#6f8a98feec0360f09213e951c69e57c727093e3a"
+  integrity sha512-Opn9YSjQQc3Wst/VPwGTdKcNONuQr4yc0dtvEbV82UGDIsc7dE2bdTz3FpLRxfnuOkHx8y9/94sZ3aytmUQ1HA==
   dependencies:
-    cids "^0.6.0"
+    cids "^0.7.1"
     multicodec "^0.5.5"
     multihashes "^0.4.15"
 


### PR DESCRIPTION
Fixes #5724 

> Recent IPFS update let user query gateways with the following url construction `<ipfs-hash>.gateway.com`. This url construct break same origin policy. Thus making ipfs resolved web site more secured as they will not share cookies & locaStorage anymore.

> The problem is that usual ipfs hash are base58 encoded and contains capital letters, and so it cannot be used in the host part of urls. Before being resolved ipfs hash must be converted to a base32 encoding. To do that I have added a [simple helper function](https://github.com/pldespaigne/content-hash/blob/27dfe53ffc85a44467d466b2d70f5d9f5645efd4/src/helpers.js#L26) to my content-hash library ([already used](https://github.com/MetaMask/metamask-extension/pull/6402) to resolve ENS content).

#### This PR add the following features to MetaMask :
- [x] use new content-hash helper function to convert base58 ipfs hash into base32 (url compatible)
- [x] use new orgin secure ipfs gateway by default
- [x] let the user choose the ipfs gateway in "settings > advanced" menu

#### To test it you can :
1) load this PR's MetaMask version in your browser
2) use the Goerli network
3) go to https://wikipedia.secure-origin.eth
4) open browser developer console and set a random value into the localStorage
5) go to https://other.secure-origin.eth
6) re open localStorage, you should not see the previous value
7) *(optional) repeat without this PR updated code and you should be able to see the same localStorage on every .eth website*