### PR TITLE
Hide accounts dropdown scrollbars on Firefox

### DIFF
--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -58,6 +58,7 @@
     max-height: 256px;
     position: relative;
     z-index: 200;
+    scrollbar-width: none;
 
     &::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
This hides the scrollbar on the account list on Firefox, making the behavior consistent with the Webkit based browsers.
The `scrollbar-width` selector is supported only by Firefox since version 64 on desktop.

The following are before-after pictures:

![Before](https://user-images.githubusercontent.com/28830727/68536072-1bae6300-034d-11ea-8091-589538ccc16a.jpg)
![After](https://user-images.githubusercontent.com/28830727/68536073-1bae6300-034d-11ea-9357-141bb8b0f331.jpg)
