### PR TITLE
Prevent attempting ENS resolution on unsupported networks

### DIFF
--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -26,10 +26,14 @@ class EnsController {
     this.store = new ObservableStore(initState)
     networkStore.subscribe((network) => {
       this.store.putState(initState)
-      this._ens = new Ens({
-        network,
-        provider,
-      })
+      if (Ens.getNetworkEnsSupport(network)) {
+        this._ens = new Ens({
+          network,
+          provider,
+        })
+      } else {
+        delete this._ens
+      }
     })
   }
 


### PR DESCRIPTION
The check for whether the network is supported was performed in the constructor, but it was accidentally omitted from the network change handler.