### PR TITLE
Set default advanced tab gas limit

### DIFF
--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -11,8 +11,8 @@ export default class AdvancedGasInputs extends Component {
   static propTypes = {
     updateCustomGasPrice: PropTypes.func,
     updateCustomGasLimit: PropTypes.func,
-    customGasPrice: PropTypes.number,
-    customGasLimit: PropTypes.number,
+    customGasPrice: PropTypes.number.isRequired,
+    customGasLimit: PropTypes.number.isRequired,
     insufficientBalance: PropTypes.bool,
     customPriceIsSafe: PropTypes.bool,
     isSpeedUp: PropTypes.bool,

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
@@ -12,7 +12,7 @@ function convertGasPriceForInputs (gasPriceInHexWEI) {
 }
 
 function convertGasLimitForInputs (gasLimitInHexWEI) {
-  return parseInt(gasLimitInHexWEI, 16)
+  return parseInt(gasLimitInHexWEI, 16) || 0
 }
 
 const mapDispatchToProps = dispatch => {

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -84,7 +84,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const { gasPrice: currentGasPrice, gas: currentGasLimit, value } = getTxParams(state, selectedTransaction)
   const customModalGasPriceInHex = getCustomGasPrice(state) || currentGasPrice
-  const customModalGasLimitInHex = getCustomGasLimit(state) || currentGasLimit
+  const customModalGasLimitInHex = getCustomGasLimit(state) || currentGasLimit || '0x5208'
   const customGasTotal = calcGasTotal(customModalGasLimitInHex, customModalGasPriceInHex)
 
   const gasButtonInfo = getRenderableBasicEstimateData(state, customModalGasLimitInHex)


### PR DESCRIPTION
* Set default advanced tab gas limit

   The advanced tab of the transaction confirmation screen would enter into an infinite loop and crash if the given gas price was falsy and some interaction was made with the gas limit field.

   To prevent this infinite loop, a default value of 0 has been set. The user will still need to update the gas limit in order to confirm the transaction, as zero is too low a gas limit (the lowest is 21000). 21000 cannot be the default gas limit at this layer, because the limit used is from a layer above this, which wouldn't have that same 21000 set.

*  Set default gas limit to minimum allowed

   A transaction initiated from a dapp might not set a gas limit, which would result in a default of zero being used in the advanced tab. The default gas limit in that case has been changed to 21,000, the minimum allowed gas limit, so that users aren't forced to manually update it.