### PR TITLE
Add external extension id to metadata

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -43,8 +43,15 @@ class PermissionsController {
     this._initializePermissions(restoredPermissions)
   }
 
-  createMiddleware (options) {
-    const { origin } = options
+  createMiddleware ({ origin, extensionId }) {
+    if (extensionId) {
+      this.store.updateState({
+        [METADATA_STORE_KEY]: {
+          ...this.store.getState()[METADATA_STORE_KEY],
+          [origin]: { extensionId },
+        },
+      })
+    }
     const engine = new JsonRpcEngine()
     engine.push(createRequestMiddleware({
       store: this.store,

--- a/app/scripts/controllers/permissions/requestMiddleware.js
+++ b/app/scripts/controllers/permissions/requestMiddleware.js
@@ -24,14 +24,21 @@ module.exports = function createRequestMiddleware ({
 
       // custom method for getting metadata from the requesting domain
       case 'wallet_sendDomainMetadata':
+        const storeState = store.getState()[storeKey]
+        const extensionId = storeState[req.origin]
+          ? storeState[req.origin].extensionId
+          : undefined
         if (
           req.domainMetadata &&
           typeof req.domainMetadata.name === 'string'
         ) {
           store.updateState({
             [storeKey]: {
-              ...store.getState()[storeKey],
-              [req.origin]: req.domainMetadata,
+              ...storeState,
+              [req.origin]: {
+                extensionId,
+                ...req.domainMetadata,
+              },
             },
           })
         }


### PR DESCRIPTION
External extensions can connect to MetaMask by using `postMessage` directly. When this is done, the extension id of the sender is accessible. This extension id has been added to the metadata for the extension, so that we're able to recognize it as an extension rather than a dapp.

This was originally added in #7218. The controller with this logic was replaced in LoginPerSite, so it needed to be re-added.