### PR TITLE
Reject connection request on window close

### DIFF
--- a/ui/app/components/app/provider-page-container/provider-page-container.component.js
+++ b/ui/app/components/app/provider-page-container/provider-page-container.component.js
@@ -34,7 +34,7 @@ export default class ProviderPageContainer extends PureComponent {
     })
   }
 
-  _beforeUnload () {
+  _beforeUnload = () => {
     const { origin, rejectProviderRequestByOrigin } = this.props
     this.context.metricsEvent({
       eventOpts: {


### PR DESCRIPTION
This was first implemented in #7335, but the final version didn't work because the `_beforeUnload` handler was not bound early, so `this` was not defined when it was triggered.