### PR TITLE
Get  prop for signed typed data from domain instead of message

### DIFF
--- a/ui/app/components/app/signature-request/signature-request.component.js
+++ b/ui/app/components/app/signature-request/signature-request.component.js
@@ -54,7 +54,7 @@ export default class SignatureRequest extends PureComponent {
       cancel,
       sign,
     } = this.props
-    const { message } = JSON.parse(data)
+    const { message, domain = {} } = JSON.parse(data)
 
     return (
       <div className="signature-request page-container">
@@ -62,14 +62,14 @@ export default class SignatureRequest extends PureComponent {
         <div className="signature-request-content">
           <div className="signature-request-content__title">{this.context.t('sigRequest')}</div>
           <div className="signature-request-content__identicon-container">
-            <div className="signature-request-content__identicon-initial" >{ message.from.name && message.from.name[0] }</div>
+            <div className="signature-request-content__identicon-initial" >{ domain.name && domain.name[0] }</div>
             <div className="signature-request-content__identicon-border" />
             <Identicon
-              address={message.from.wallet}
+              address={senderWallet}
               diameter={70}
             />
           </div>
-          <div className="signature-request-content__info--bolded">{message.from.name}</div>
+          <div className="signature-request-content__info--bolded">{domain.name}</div>
           <div className="signature-request-content__info">{origin}</div>
           <div className="signature-request-content__info">{this.formatWallet(senderWallet)}</div>
         </div>


### PR DESCRIPTION
Fixes #7395 

We were mistakenly looking for the user readable name of the message sender within the wrong property of the message data. The name is optionally available within the `domain` property, as detailed here: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator

This updates the UI code to reflect that.

Ideally we should test this with a few use cases.