### PR TITLE
Update metamask-inpage-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "lodash.shuffle": "^4.2.0",
     "loglevel": "^1.4.1",
     "luxon": "^1.8.2",
-    "metamask-inpage-provider": "^3.0.0",
+    "metamask-inpage-provider": "MetaMask/metamask-inpage-provider#update-rpc-engine",
     "metamask-logo": "^2.1.4",
     "mkdirp": "^0.5.1",
     "multihashes": "^0.4.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17828,12 +17828,11 @@ mersenne-twister@^1.0.1:
   resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
   integrity sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o=
 
-metamask-inpage-provider@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/metamask-inpage-provider/-/metamask-inpage-provider-3.0.0.tgz#3b9d4bae6f67962b6a7b1a9ee1efaf424f67b6f4"
-  integrity sha512-44bBCbQwcFF/XGaXSweCWHJaslKhJEFgvcHdxZf9Fm1QfK7VN4U3iAI0BVOLAIkRg0xV3w7xYGLpx2cM1BU7Qw==
+metamask-inpage-provider@MetaMask/metamask-inpage-provider#update-rpc-engine:
+  version "3.0.1"
+  resolved "https://codeload.github.com/MetaMask/metamask-inpage-provider/tar.gz/f26f801cd143c232561bb2cfd2b0391172dfd994"
   dependencies:
-    json-rpc-engine "^5.1.3"
+    json-rpc-engine "^5.1.5"
     json-rpc-middleware-stream "^2.1.1"
     loglevel "^1.6.1"
     obj-multiplex "^1.0.0"


### PR DESCRIPTION
We updated `json-rpc-engine` to support ordered batch requests. Unfortunately, the inpage provider still uses the older version of that module. This PR addresses this problem.

Fixes #5852 

Depends on: https://github.com/MetaMask/metamask-inpage-provider/pull/10