### PR TITLE
Fix sourcemaps

### DIFF
--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -20,3 +20,6 @@ yarn --frozen-lockfile --ignore-scripts --har
 (cd node_modules/weak && yarn run install)
 (cd node_modules/chromedriver && yarn run install)
 (cd node_modules/geckodriver && yarn run postinstall)
+
+# for release
+(cd node_modules/@sentry/cli && yarn run install)


### PR DESCRIPTION
The `install` script of `@sentry/cli` is required for the Sentry CLI to work correctly. Without this step, the sourcemap upload fails silently.