### PR TITLE
Ensure SignatureRequestOriginal 'beforeunload' handler is bound

### DIFF
--- a/ui/app/components/app/signature-request-original.js
+++ b/ui/app/components/app/signature-request-original.js
@@ -101,9 +101,10 @@ function SignatureRequest (props) {
   this.state = {
     selectedAccount: props.selectedAccount,
   }
+  this._beforeUnload = this._beforeUnload.bind(this)
 }
 
-SignatureRequest.prototype._beforeUnload = (event) => {
+SignatureRequest.prototype._beforeUnload = function (event) {
   const { clearConfirmTransaction, cancel } = this.props
   const { metricsEvent } = this.context
   metricsEvent({
@@ -117,7 +118,7 @@ SignatureRequest.prototype._beforeUnload = (event) => {
   cancel(event)
 }
 
-SignatureRequest.prototype._removeBeforeUnload = () => {
+SignatureRequest.prototype._removeBeforeUnload = function () {
   if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
     window.removeEventListener('beforeunload', this._beforeUnload)
   }


### PR DESCRIPTION
The 'beforeunload' handler was being bound to the module scope instead of the instance scope, because the class was defined using prototypes rather than the ES6 class syntax. The arrow functions were removed, and the handler is now bound explicitly in the constructor.

