### PR TITLE
Support gas limit customization on retries after transaction failure

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -526,6 +526,7 @@ module.exports = class MetamaskController extends EventEmitter {
       retryTransaction: nodeify(this.retryTransaction, this),
       createCancelTransaction: nodeify(this.createCancelTransaction, this),
       createSpeedUpTransaction: nodeify(this.createSpeedUpTransaction, this),
+      createRetryTransaction: nodeify(this.createRetryTransaction, this),
       getFilteredTxList: nodeify(txController.getFilteredTxList, txController),
       isNonceTaken: nodeify(txController.isNonceTaken, txController),
       estimateGas: nodeify(this.estimateGas, this),
@@ -1282,6 +1283,12 @@ module.exports = class MetamaskController extends EventEmitter {
 
   async createSpeedUpTransaction (originalTxId, customGasPrice) {
     await this.txController.createSpeedUpTransaction(originalTxId, customGasPrice)
+    const state = await this.getState()
+    return state
+  }
+
+  async createRetryTransaction (originalTxId, customGasPrice, customGasLimit) {
+    await this.txController.createRetryTransaction(originalTxId, customGasPrice, customGasLimit)
     const state = await this.getState()
     return state
   }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -190,8 +190,8 @@ const mapDispatchToProps = dispatch => {
     createSpeedUpTransaction: (txId, gasPrice) => {
       return dispatch(createSpeedUpTransaction(txId, gasPrice))
     },
-    createRetryTransaction: (txId, gasPrice) => {
-      return dispatch(createRetryTransaction(txId, gasPrice))
+    createRetryTransaction: (txId, gasPrice, gasLimit) => {
+      return dispatch(createRetryTransaction(txId, gasPrice, gasLimit))
     },
     hideGasButtonGroup: () => dispatch(hideGasButtonGroup()),
     setCustomTimeEstimate: (timeEstimateInSeconds) => dispatch(setCustomTimeEstimate(timeEstimateInSeconds)),
@@ -257,7 +257,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         dispatchHideSidebar()
         dispatchCancelAndClose()
       } else if (isRetry) {
-        dispatchCreateRetryTransaction(txId, gasPrice)
+        dispatchCreateRetryTransaction(txId, gasPrice, gasLimit)
         dispatchHideSidebar()
         dispatchCancelAndClose()
       } else {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1864,13 +1864,13 @@ function createSpeedUpTransaction (txId, customGasPrice) {
   }
 }
 
-function createRetryTransaction (txId, customGasPrice) {
+function createRetryTransaction (txId, customGasPrice, customGasLimit) {
   log.debug('background.createRetryTransaction')
   let newTx
 
   return dispatch => {
     return new Promise((resolve, reject) => {
-      background.createSpeedUpTransaction(txId, customGasPrice, (err, newState) => {
+      background.createRetryTransaction(txId, customGasPrice, customGasLimit, (err, newState) => {
         if (err) {
           dispatch(actions.displayWarning(err.message))
           return reject(err)


### PR DESCRIPTION
Fixes https://github.com/MetaMask/metamask-extension/issues/7382

This PR ensures that the user can change the gas limit when doing a retry of a failed transaction.

There is another aspect of #7382 that needs to be resolved. That is captured by https://github.com/MetaMask/metamask-extension/issues/7423