### PR TITLE
Ensure Etherscan result is valid before reading it

### DIFF
--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -208,7 +208,7 @@ class IncomingTransactionsController {
   }
 
   _processTxFetchResponse ({ status, result = [], address, currentNetworkID }) {
-    if (status !== '0' && result.length > 0) {
+    if (status === '1' && Array.isArray(result) && result.length > 0) {
       const remoteTxList = {}
       const remoteTxs = []
       result.forEach((tx) => {


### PR DESCRIPTION
This PR updates the conditions under which we attempt to read the results of an incoming tx list from Etherscan. We were previously reading the result when the status was non-zero but that saw type errors where the `result` property was `null` or a string.

We now handle the following responses:

```
{"status":"0","message":"No transactions found","result":[]}
```

```
{"status":"1","message":"OK","result":null}
```

```
{"status":"0","message":"NOTOK","result":"Error! Missing Or invalid Action name"}
```