### PR TITLE
Update badge colour

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -426,7 +426,7 @@ function setupController (initState, initLangCode) {
       label = String(count)
     }
     extension.browserAction.setBadgeText({ text: label })
-    extension.browserAction.setBadgeBackgroundColor({ color: '#506F8B' })
+    extension.browserAction.setBadgeBackgroundColor({ color: '#037DD6' })
   }
 
   return Promise.resolve()


### PR DESCRIPTION
The badge colour is now '#037DD6', which stands out a bit more on both light and dark modes.

Screenshot:
![badge_colour_update](https://user-images.githubusercontent.com/2459287/68901204-dc489380-070b-11ea-87a1-735b65b4115d.png)
