### PR TITLE
Add all icons to manifest

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -17,7 +17,12 @@
   },
   "icons": {
     "16": "images/icon-16.png",
-    "128": "images/icon-128.png"
+    "19": "images/icon-19.png",
+    "32": "images/icon-32.png",
+    "38": "images/icon-38.png",
+    "64": "images/icon-64.png",
+    "128": "images/icon-128.png",
+    "512": "images/icon-512.png"
   },
   "applications": {
     "gecko": {
@@ -36,8 +41,13 @@
   },
   "browser_action": {
     "default_icon": {
+      "16": "images/icon-16.png",
       "19": "images/icon-19.png",
-      "38": "images/icon-38.png"
+      "32": "images/icon-32.png",
+      "38": "images/icon-38.png",
+      "64": "images/icon-64.png",
+      "128": "images/icon-128.png",
+      "512": "images/icon-512.png"
     },
     "default_title": "MetaMask",
     "default_popup": "popup.html"


### PR DESCRIPTION
Of the 7 different icon sizes we have, only four were referenced in the manifest. All 7 are now listed, which leaves the browser more to choose from when deciding which to use.