### PR TITLE
Add additional rpcUrl verification

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -1344,7 +1344,7 @@
   "updatedWithDate": {
     "message": "የዘመነ $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URIs አግባብነት ያለው የ HTTP/HTTPS ቅድመ ቅጥያ ይፈልጋል።"
   },
   "usedByClients": {

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -1340,7 +1340,7 @@
   "updatedWithDate": {
     "message": "تم تحديث $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "تتطلب الروابط بادئة HTTP/HTTPS مناسبة."
   },
   "usedByClients": {

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -1343,7 +1343,7 @@
   "updatedWithDate": {
     "message": "Актуализирано $1 "
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI изискват съответния HTTP / HTTPS префикс."
   },
   "usedByClients": {

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -1347,7 +1347,7 @@
   "updatedWithDate": {
     "message": "আপডেট করা $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI গুলির যথাযথ HTTP/HTTPS প্রেফিক্সের প্রয়োজন।"
   },
   "usedByClients": {

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -1316,7 +1316,7 @@
   "updatedWithDate": {
     "message": "Actualitzat $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Els URIs requereixen el prefix HTTP/HTTPS  apropiat."
   },
   "usedByClients": {

--- a/app/_locales/cs/messages.json
+++ b/app/_locales/cs/messages.json
@@ -529,7 +529,7 @@
   "unknownNetwork": {
     "message": "Neznámá soukromá síť"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI vyžadují korektní HTTP/HTTPS prefix."
   },
   "usedByClients": {

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -1313,7 +1313,7 @@
   "updatedWithDate": {
     "message": "Opdaterede $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Links kræver det rette HTTP/HTTPS-præfix."
   },
   "usedByClients": {

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -1304,7 +1304,7 @@
   "updatedWithDate": {
     "message": "$1 aktualisiert"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URIs benötigen die korrekten HTTP/HTTPS Präfixe."
   },
   "usedByClients": {

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -1341,7 +1341,7 @@
   "updatedWithDate": {
     "message": "Ενημερώθηκε το $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Τα URI απαιτούν το κατάλληλο πρόθεμα HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1471,6 +1471,9 @@
   "uriErrorMsg": {
     "message": "URIs require the appropriate HTTP/HTTPS prefix."
   },
+  "uriExistsErrorMsg": {
+    "message": "URI is already present in the existing list of networks"
+  },
   "usedByClients": {
     "message": "Used by a variety of different clients"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1468,11 +1468,11 @@
   "updatedWithDate": {
     "message": "Updated $1"
   },
-  "uriErrorMsg": {
-    "message": "URIs require the appropriate HTTP/HTTPS prefix."
+  "urlErrorMsg": {
+    "message": "URLs require the appropriate HTTP/HTTPS prefix."
   },
-  "uriExistsErrorMsg": {
-    "message": "URI is already present in the existing list of networks"
+  "urlExistsErrorMsg": {
+    "message": "URL is already present in existing list of networks"
   },
   "usedByClients": {
     "message": "Used by a variety of different clients"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1091,7 +1091,7 @@
   "updatedWithDate": {
     "message": "Actualizado $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI necesita el prefijo HTTP/HTTPS apropiado"
   },
   "usedByClients": {

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1326,7 +1326,7 @@
   "updatedWithDate": {
     "message": "Actualización: $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Los URI deben tener el prefijo HTTP/HTTPS apropiado."
   },
   "usedByClients": {

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -1337,7 +1337,7 @@
   "updatedWithDate": {
     "message": "Värskendatud $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI-d nõuavad sobivat HTTP/HTTPS-i prefiksit."
   },
   "usedByClients": {

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -1347,7 +1347,7 @@
   "updatedWithDate": {
     "message": "بروزرسانی شد 1$1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URl ها نیازمند پیشوند مناسب HTTP/HTTPS اند."
   },
   "usedByClients": {

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -1344,7 +1344,7 @@
   "updatedWithDate": {
     "message": "$1 päivitetty"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI:t vaativat asianmukaisen HTTP/HTTPS-etuliitteen."
   },
   "usedByClients": {

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -1235,7 +1235,7 @@
   "updatedWithDate": {
     "message": "Na-update ang $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Kinakailangan ng mga URI ang naaangkop na HTTP/HTTPS prefix."
   },
   "usedByClients": {

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -1308,7 +1308,7 @@
   "updatedWithDate": {
     "message": "Mis à jour $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Les URLs requièrent un préfixe HTTP/HTTPS approprié."
   },
   "usedByClients": {

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -1341,7 +1341,7 @@
   "updatedWithDate": {
     "message": "עודכן $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "כתובות URI דורשות את קידומת HTTP/HTTPS המתאימה."
   },
   "usedByClients": {

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1341,7 +1341,7 @@
   "updatedWithDate": {
     "message": "$1 अपडेट किया गया"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI को उपयुक्त HTTP/HTTPS प्रीफ़िक्स की आवश्यकता होती है।"
   },
   "usedByClients": {

--- a/app/_locales/hn/messages.json
+++ b/app/_locales/hn/messages.json
@@ -491,7 +491,7 @@
   "unknownNetwork": {
     "message": "अज्ञात निजी नेटवर्क"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI-यूआरआई को उपयुक्त HTTP / HTTPS उपसर्ग की आवश्यकता होती है।"
   },
   "usedByClients": {

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -1337,7 +1337,7 @@
   "updatedWithDate": {
     "message": "Ažurirano $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI-jevima se zahtijeva prikladan prefiks HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -851,7 +851,7 @@
   "updatedWithDate": {
     "message": "Mete ajou $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URIs mande pou apwopriye prefiks HTTP / HTTPS a."
   },
   "usedByClients": {

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -1337,7 +1337,7 @@
   "updatedWithDate": {
     "message": "$1 frissítve"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Az URI-hez szükség van a megfelelő HTTP/HTTPS előtagra."
   },
   "usedByClients": {

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1316,7 +1316,7 @@
   "updatedWithDate": {
     "message": "Diperbarui $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI memerlukan awalan HTTP/HTTPS yang sesuai."
   },
   "usedByClients": {

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1307,7 +1307,7 @@
   "updatedWithDate": {
     "message": "Aggiornata $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Gli URI richiedono un prefisso HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -1347,7 +1347,7 @@
   "updatedWithDate": {
     "message": "$1 ನವೀಕರಿಸಲಾಗಿದೆ"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI ಗಳಿಗೆ ಸೂಕ್ತವಾದ HTTP/HTTPS ಪೂರ್ವಪ್ರತ್ಯಯದ ಅಗತ್ಯವಿದೆ."
   },
   "usedByClients": {

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1338,7 +1338,7 @@
   "updatedWithDate": {
     "message": "$1에 업데이트 됨"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI는 HTTP/HTTPS로 시작해야 합니다."
   },
   "usedByClients": {

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -1347,7 +1347,7 @@
   "updatedWithDate": {
     "message": "Atnaujinta $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI reikia atitinkamo HTTP/HTTPS priešdėlio."
   },
   "usedByClients": {

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -1343,7 +1343,7 @@
   "updatedWithDate": {
     "message": "Atjaunināts $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI jāsākas ar atbilstošo HTTP/HTTPS priedēkli."
   },
   "usedByClients": {

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -1315,7 +1315,7 @@
   "updatedWithDate": {
     "message": "Dikemaskini $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI memerlukan awalan HTTP/HTTPS yang sesuai."
   },
   "usedByClients": {

--- a/app/_locales/nl/messages.json
+++ b/app/_locales/nl/messages.json
@@ -478,7 +478,7 @@
   "unknownNetwork": {
     "message": "Onbekend privénetwerk"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Voor URI's is het juiste HTTP / HTTPS-voorvoegsel vereist."
   },
   "usedByClients": {

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -1319,7 +1319,7 @@
   "updatedWithDate": {
     "message": "Oppdatert $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI-er krever det aktuelle HTTP/HTTPS-prefikset."
   },
   "usedByClients": {

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -1332,7 +1332,7 @@
   "updatedWithDate": {
     "message": "Zaktualizowano $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI wymaga prawidłowego prefiksu HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -488,7 +488,7 @@
   "unknownNetwork": {
     "message": "Rede Privada Desconhecida"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Links requerem o prefixo HTTP/HTTPS apropriado."
   },
   "usedByClients": {

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -1326,7 +1326,7 @@
   "updatedWithDate": {
     "message": "$1 atualizado"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URIs exigem o devido prefixo HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -1328,7 +1328,7 @@
   "updatedWithDate": {
     "message": "Actualizat $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URL necesită prefixul potrivit HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -542,7 +542,7 @@
   "unknownNetwork": {
     "message": "Неизвестная частная сеть"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "Для URI требуется соответствующий префикс HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -1301,7 +1301,7 @@
   "updatedWithDate": {
     "message": "Aktualizované $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI vyžadují korektní HTTP/HTTPS prefix."
   },
   "usedByClients": {

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -1329,7 +1329,7 @@
   "updatedWithDate": {
     "message": "Posodobljeno $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI zahtevajo ustrezno HTTP/HTTPS predpono."
   },
   "usedByClients": {

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -1332,7 +1332,7 @@
   "updatedWithDate": {
     "message": "Ažuriran $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI-ovi zahtevaju odgovarajući prefiks HTTP / HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -1322,7 +1322,7 @@
   "updatedWithDate": {
     "message": "Uppdaterat $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI:er kräver lämpligt HTTP/HTTPS-prefix."
   },
   "usedByClients": {

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -1325,7 +1325,7 @@
   "updatedWithDate": {
     "message": "Imesasishwa $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI huhitaji kiambishi sahihi cha  HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/ta/messages.json
+++ b/app/_locales/ta/messages.json
@@ -554,7 +554,7 @@
   "unknownNetwork": {
     "message": "அறியப்படாத தனியார் நெட்வொர்க்"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI கள் சரியான HTTP / HTTPS முன்னொட்டு தேவை."
   },
   "usedByClients": {

--- a/app/_locales/th/messages.json
+++ b/app/_locales/th/messages.json
@@ -656,7 +656,7 @@
   "updatedWithDate": {
     "message": "อัปเดต $1 แล้ว"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URI ต้องมีคำนำหน้าเป็น HTTP หรือ HTTPS"
   },
   "usedByClients": {

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -547,7 +547,7 @@
   "unknownNetwork": {
     "message": "Bilinmeyen özel ağ"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URIler için HTTP/HTTPS öneki gerekmektedir."
   },
   "usedByClients": {

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -1347,7 +1347,7 @@
   "updatedWithDate": {
     "message": "Оновлено $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URIs вимагають відповідного префікса HTTP/HTTPS."
   },
   "usedByClients": {

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -1320,7 +1320,7 @@
   "updatedWithDate": {
     "message": "更新時間 $1"
   },
-  "uriErrorMsg": {
+  "urlErrorMsg": {
     "message": "URIs 需要加入適當的 HTTP/HTTPS 前綴字"
   },
   "usedByClients": {

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -222,11 +222,11 @@ export default class NetworkForm extends PureComponent {
       const appendedRpc = `http://${url}`
       const validWhenAppended = validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
 
-      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'uriErrorMsg' : invalidUrlErrorMsg))
+      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'urlErrorMsg' : invalidUrlErrorMsg))
     }
 
     if (rpcUrls.includes(url)) {
-      this.setErrorTo(stateKey, this.context.t('uriExistsErrorMsg'))
+      this.setErrorTo(stateKey, this.context.t('urlExistsErrorMsg'))
     }
   }
 

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -24,7 +24,7 @@ export default class NetworkForm extends PureComponent {
     isCurrentRpcTarget: PropTypes.bool,
     blockExplorerUrl: PropTypes.string,
     rpcPrefs: PropTypes.object,
-    networksToRender: PropTypes.array
+    networksToRender: PropTypes.array,
   }
 
   state = {

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -24,6 +24,7 @@ export default class NetworkForm extends PureComponent {
     isCurrentRpcTarget: PropTypes.bool,
     blockExplorerUrl: PropTypes.string,
     rpcPrefs: PropTypes.object,
+    networksToRender: PropTypes.array
   }
 
   state = {
@@ -211,8 +212,9 @@ export default class NetworkForm extends PureComponent {
     )
   }
 
-  validateUrl = (url, stateKey) => {
+  validateUrl = (networksToRender, url, stateKey) => {
     const invalidUrlErrorMsg = stateKey === 'rpcUrl' ? 'invalidRPC' : 'invalidBlockExplorerURL'
+    const rpcUrls = networksToRender.map(network => network.rpcUrl)
 
     if (validUrl.isWebUri(url) || (stateKey === 'blockExplorerUrl' && url === '')) {
       this.setErrorTo(stateKey, '')
@@ -222,6 +224,10 @@ export default class NetworkForm extends PureComponent {
 
       this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'uriErrorMsg' : invalidUrlErrorMsg))
     }
+
+    if (rpcUrls.includes(url)) {
+      this.setErrorTo(stateKey, this.context.t('uriExistsErrorMsg'))
+    }
   }
 
   render () {
@@ -230,6 +236,7 @@ export default class NetworkForm extends PureComponent {
       viewOnly,
       isCurrentRpcTarget,
       networksTabIsInAddMode,
+      networksToRender,
     } = this.props
     const {
       networkName,
@@ -254,7 +261,7 @@ export default class NetworkForm extends PureComponent {
         {this.renderFormTextField(
           'rpcUrl',
           'rpc-url',
-          this.setStateWithValue('rpcUrl', this.validateUrl),
+          this.setStateWithValue('rpcUrl', this.validateUrl.bind(null, networksToRender)),
           rpcUrl,
         )}
         {this.renderFormTextField(

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -212,12 +212,14 @@ export default class NetworkForm extends PureComponent {
     )
   }
 
+  isValidWhenAppended = url => {
+    const appendedRpc = `http://${url}`
+    return validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
+  }
+
   validateBlockExplorerURL = (url, stateKey) => {
     if (!validUrl.isWebUri(url) && url !== '') {
-      const appendedRpc = `http://${url}`
-      const validWhenAppended = validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
-
-      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'urlErrorMsg' : 'invalidBlockExplorerURL'))
+      this.setErrorTo(stateKey, this.context.t(this.isValidWhenAppended(url) ? 'urlErrorMsg' : 'invalidBlockExplorerURL'))
     } else {
       this.setErrorTo(stateKey, '')
     }
@@ -227,10 +229,7 @@ export default class NetworkForm extends PureComponent {
     const { rpcUrls } = this.props
 
     if (!validUrl.isWebUri(url) && url !== '') {
-      const appendedRpc = `http://${url}`
-      const validWhenAppended = validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
-
-      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'urlErrorMsg' : 'invalidRPC'))
+      this.setErrorTo(stateKey, this.context.t(this.isValidWhenAppended(url) ? 'urlErrorMsg' : 'invalidRPC'))
     } else if (rpcUrls.includes(url)) {
       this.setErrorTo(stateKey, this.context.t('urlExistsErrorMsg'))
     } else {

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -24,7 +24,7 @@ export default class NetworkForm extends PureComponent {
     isCurrentRpcTarget: PropTypes.bool,
     blockExplorerUrl: PropTypes.string,
     rpcPrefs: PropTypes.object,
-    networksToRender: PropTypes.array,
+    rpcUrls: PropTypes.array,
   }
 
   state = {
@@ -212,9 +212,9 @@ export default class NetworkForm extends PureComponent {
     )
   }
 
-  validateUrl = (networksToRender, url, stateKey) => {
+  validateUrl = (url, stateKey) => {
+    const { rpcUrls } = this.props
     const invalidUrlErrorMsg = stateKey === 'rpcUrl' ? 'invalidRPC' : 'invalidBlockExplorerURL'
-    const rpcUrls = networksToRender.map(network => network.rpcUrl)
 
     if (validUrl.isWebUri(url) || (stateKey === 'blockExplorerUrl' && url === '')) {
       this.setErrorTo(stateKey, '')
@@ -236,7 +236,6 @@ export default class NetworkForm extends PureComponent {
       viewOnly,
       isCurrentRpcTarget,
       networksTabIsInAddMode,
-      networksToRender,
     } = this.props
     const {
       networkName,
@@ -261,7 +260,7 @@ export default class NetworkForm extends PureComponent {
         {this.renderFormTextField(
           'rpcUrl',
           'rpc-url',
-          this.setStateWithValue('rpcUrl', this.validateUrl.bind(null, networksToRender)),
+          this.setStateWithValue('rpcUrl', this.validateUrl),
           rpcUrl,
         )}
         {this.renderFormTextField(

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -225,7 +225,7 @@ export default class NetworkForm extends PureComponent {
       this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'urlErrorMsg' : invalidUrlErrorMsg))
     }
 
-    if (rpcUrls.includes(url)) {
+    if (stateKey === 'rpcUrl' && rpcUrls.includes(url)) {
       this.setErrorTo(stateKey, this.context.t('urlExistsErrorMsg'))
     }
   }

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -213,8 +213,6 @@ export default class NetworkForm extends PureComponent {
   }
 
   validateBlockExplorerURL = (url, stateKey) => {
-    const { rpcUrls } = this.props
-
     if (!validUrl.isWebUri(url) && url !== '') {
       const appendedRpc = `http://${url}`
       const validWhenAppended = validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -212,21 +212,31 @@ export default class NetworkForm extends PureComponent {
     )
   }
 
-  validateUrl = (url, stateKey) => {
+  validateBlockExplorerURL = (url, stateKey) => {
     const { rpcUrls } = this.props
-    const invalidUrlErrorMsg = stateKey === 'rpcUrl' ? 'invalidRPC' : 'invalidBlockExplorerURL'
 
-    if (validUrl.isWebUri(url) || (stateKey === 'blockExplorerUrl' && url === '')) {
-      this.setErrorTo(stateKey, '')
-    } else {
+    if (!validUrl.isWebUri(url) && url !== '') {
       const appendedRpc = `http://${url}`
       const validWhenAppended = validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
 
-      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'urlErrorMsg' : invalidUrlErrorMsg))
+      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'urlErrorMsg' : 'invalidBlockExplorerURL'))
+    } else {
+      this.setErrorTo(stateKey, '')
     }
+  }
 
-    if (stateKey === 'rpcUrl' && rpcUrls.includes(url)) {
+  validateUrlRpcUrl = (url, stateKey) => {
+    const { rpcUrls } = this.props
+
+    if (!validUrl.isWebUri(url) && url !== '') {
+      const appendedRpc = `http://${url}`
+      const validWhenAppended = validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
+
+      this.setErrorTo(stateKey, this.context.t(validWhenAppended ? 'urlErrorMsg' : 'invalidRPC'))
+    } else if (rpcUrls.includes(url)) {
       this.setErrorTo(stateKey, this.context.t('urlExistsErrorMsg'))
+    } else {
+      this.setErrorTo(stateKey, '')
     }
   }
 
@@ -260,7 +270,7 @@ export default class NetworkForm extends PureComponent {
         {this.renderFormTextField(
           'rpcUrl',
           'rpc-url',
-          this.setStateWithValue('rpcUrl', this.validateUrl),
+          this.setStateWithValue('rpcUrl', this.validateUrlRpcUrl),
           rpcUrl,
         )}
         {this.renderFormTextField(
@@ -280,7 +290,7 @@ export default class NetworkForm extends PureComponent {
         {this.renderFormTextField(
           'blockExplorerUrl',
           'block-explorer-url',
-          this.setStateWithValue('blockExplorerUrl', this.validateUrl),
+          this.setStateWithValue('blockExplorerUrl', this.validateBlockExplorerURL),
           blockExplorerUrl,
           'optionalBlockExplorerUrl',
         )}

--- a/ui/app/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.component.js
@@ -177,6 +177,7 @@ export default class NetworksTab extends PureComponent {
       editRpc,
       networkDefaultedToProvider,
       providerUrl,
+      networksToRender
     } = this.props
 
     const envIsPopup = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
@@ -189,6 +190,7 @@ export default class NetworksTab extends PureComponent {
           shouldRenderNetworkForm
             ? (
               <NetworkForm
+                networksToRender={networksToRender}
                 setRpcTarget={setRpcTarget}
                 editRpc={editRpc}
                 networkName={label || labelKey && t(labelKey) || ''}

--- a/ui/app/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.component.js
@@ -177,7 +177,7 @@ export default class NetworksTab extends PureComponent {
       editRpc,
       networkDefaultedToProvider,
       providerUrl,
-      networksToRender
+      networksToRender,
     } = this.props
 
     const envIsPopup = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP

--- a/ui/app/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.component.js
@@ -20,7 +20,7 @@ export default class NetworksTab extends PureComponent {
     location: PropTypes.object.isRequired,
     networkIsSelected: PropTypes.bool,
     networksTabIsInAddMode: PropTypes.bool,
-    networksToRender: PropTypes.array.isRequired,
+    networksToRender: PropTypes.arrayOf(PropTypes.object).isRequired,
     selectedNetwork: PropTypes.object,
     setNetworksTabAddMode: PropTypes.func.isRequired,
     setRpcTarget: PropTypes.func.isRequired,
@@ -190,7 +190,7 @@ export default class NetworksTab extends PureComponent {
           shouldRenderNetworkForm
             ? (
               <NetworkForm
-                networksToRender={networksToRender}
+                rpcUrls={networksToRender.map(network => network.rpcUrl)}
                 setRpcTarget={setRpcTarget}
                 editRpc={editRpc}
                 networkName={label || labelKey && t(labelKey) || ''}


### PR DESCRIPTION
closes: #7388 

This adds additional verification so an existing `rpcUrl` cannot be added as part of a new network (thus ensuring our "key" is always unique).

![image](https://user-images.githubusercontent.com/675259/68917501-8d652300-0738-11ea-8eae-acfbc90c2212.png)

Wording might need to be changed