### PR TITLE
Add metricsEvent to contextTypes

### DIFF
--- a/ui/app/components/app/signature-request/signature-request.component.js
+++ b/ui/app/components/app/signature-request/signature-request.component.js
@@ -23,6 +23,7 @@ export default class SignatureRequest extends PureComponent {
 
   static contextTypes = {
     t: PropTypes.func,
+    metricsEvent: PropTypes.func,
   }
 
   componentDidMount () {


### PR DESCRIPTION
The metricsEvent context type was missing, resulting in an error when it was called.