### PR TITLE
Fix MultipleNotifications JSX

### DIFF
--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -117,9 +117,7 @@ export default class Home extends PureComponent {
           { !history.location.pathname.match(/^\/confirm-transaction/)
             ? (
               <TransactionView>
-                <MultipleNotifications
-                  className
-                >
+                <MultipleNotifications>
                   {
                     showPrivacyModeNotification
                       ? <HomeNotification


### PR DESCRIPTION
This PR cleans up the `MultipleNotifications` JSX, removing the `classNames` prop that didn't have a value passed in.