### PR TITLE
Add defaultProps to MultipleNotifications

### DIFF
--- a/ui/app/components/app/multiple-notifications/multiple-notifications.component.js
+++ b/ui/app/components/app/multiple-notifications/multiple-notifications.component.js
@@ -3,6 +3,11 @@ import classnames from 'classnames'
 import PropTypes from 'prop-types'
 
 export default class MultipleNotifications extends PureComponent {
+  static defaultProps = {
+    children: [],
+    classNames: [],
+  }
+
   static propTypes = {
     children: PropTypes.array,
     classNames: PropTypes.array,
@@ -14,7 +19,7 @@ export default class MultipleNotifications extends PureComponent {
 
   render () {
     const { showAll } = this.state
-    const { children, classNames = [] } = this.props
+    const { children, classNames } = this.props
 
     const childrenToRender = children.filter(child => child)
     if (childrenToRender.length === 0) {


### PR DESCRIPTION
This PR updates the `MultipleNotifications` to add `defaultProps` values. This allows us to set the default values for each of the props in one location.