### PR TITLE
Add ESLint rule forbidding extraneous defaultProps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -149,6 +149,7 @@
     "padded-blocks": "off",
     "quotes": [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
     "react/no-deprecated": 0,
+    "react/default-props-match-prop-types": 2,
     "semi": [2, "never"],
     "semi-spacing": [2, { "before": false, "after": true }],
     "space-before-blocks": [2, "always"],

--- a/ui/app/components/app/dropdowns/components/dropdown.js
+++ b/ui/app/components/app/dropdowns/components/dropdown.js
@@ -4,8 +4,6 @@ const h = require('react-hyperscript')
 const MenuDroppo = require('../../menu-droppo')
 const extend = require('xtend')
 
-const noop = () => {}
-
 class Dropdown extends Component {
   render () {
     const {
@@ -55,8 +53,6 @@ class Dropdown extends Component {
 }
 
 Dropdown.defaultProps = {
-  isOpen: false,
-  onClick: noop,
   useCssTransition: false,
 }
 

--- a/ui/app/components/ui/tooltip-v2.js
+++ b/ui/app/components/ui/tooltip-v2.js
@@ -7,7 +7,6 @@ export default class Tooltip extends PureComponent {
     arrow: true,
     children: null,
     containerClassName: '',
-    hideOnClick: false,
     html: null,
     onHidden: null,
     position: 'left',

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/draggable-seed.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/draggable-seed.component.js
@@ -25,7 +25,6 @@ class DraggableSeed extends Component {
 
   static defaultProps = {
     className: '',
-    onClick () {},
   }
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
This PR enables an ESLint rule forbidding extraneous `defaultProps`.<sup>[\[1\]][1]</sup> Any `defaultProps` entries for props marked as `isRequired` are either redundant (or the prop is incorrectly marked as `isRequired`).

  [1]:https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md