### PR TITLE
Disallow spaces around the equal sign in JSX

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -149,6 +149,7 @@
     "padded-blocks": "off",
     "quotes": [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
     "react/jsx-curly-brace-presence": [2, { "props": "never", "children": "never" }],
+    "react/jsx-equals-spacing": 2,
     "react/no-deprecated": 0,
     "react/default-props-match-prop-types": 2,
     "semi": [2, "never"],

--- a/ui/app/components/app/confirm-page-container/confirm-detail-row/tests/confirm-detail-row.component.test.js
+++ b/ui/app/components/app/confirm-page-container/confirm-detail-row/tests/confirm-detail-row.component.test.js
@@ -17,12 +17,12 @@ describe('Confirm Detail Row Component', function () {
         errorType="mockErrorType"
         label="mockLabel"
         showError={false}
-        primaryText = "mockFiatText"
-        secondaryText = "mockEthText"
-        primaryValueTextColor= "mockColor"
-        onHeaderClick= {propsMethodSpies.onHeaderClick}
-        headerText = "mockHeaderText"
-        headerTextClassName = "mockHeaderClass"
+        primaryText="mockFiatText"
+        secondaryText="mockEthText"
+        primaryValueTextColor="mockColor"
+        onHeaderClick={propsMethodSpies.onHeaderClick}
+        headerText="mockHeaderText"
+        headerTextClassName="mockHeaderClass"
       />
     )
   })

--- a/ui/app/components/app/dropdowns/tests/dropdown.test.js
+++ b/ui/app/components/app/dropdowns/tests/dropdown.test.js
@@ -12,9 +12,9 @@ describe('Dropdown', () => {
   beforeEach(() => {
     wrapper = shallow(
       <DropdownMenuItem
-        onClick = {onClickSpy}
-        style = {{test: 'style'}}
-        closeMenu = {closeMenuSpy}
+        onClick={onClickSpy}
+        style={{test: 'style'}}
+        closeMenu={closeMenuSpy}
       >
       </DropdownMenuItem>
     )

--- a/ui/app/components/app/dropdowns/tests/menu.test.js
+++ b/ui/app/components/app/dropdowns/tests/menu.test.js
@@ -11,7 +11,7 @@ describe('Dropdown Menu Components', () => {
 
     beforeEach(() => {
       wrapper = shallow(
-        <Menu className = "Test Class" isShowing = {true}/>
+        <Menu className="Test Class" isShowing={true}/>
       )
     })
 
@@ -29,10 +29,10 @@ describe('Dropdown Menu Components', () => {
     beforeEach(() => {
       wrapper = shallow(
         <Item
-          icon = "test icon"
-          text = "test text"
-          className = "test className"
-          onClick = {onClickSpy}
+          icon="test icon"
+          text="test text"
+          className="test className"
+          onClick={onClickSpy}
         />
       )
     })
@@ -74,7 +74,7 @@ describe('Dropdown Menu Components', () => {
 
     beforeEach(() => {
       wrapper = shallow(<CloseArea
-        onClick = {onClickSpy}
+        onClick={onClickSpy}
       />)
     })
 

--- a/ui/app/components/app/dropdowns/tests/network-dropdown-icon.test.js
+++ b/ui/app/components/app/dropdowns/tests/network-dropdown-icon.test.js
@@ -8,10 +8,10 @@ describe('Network Dropdown Icon', () => {
 
   beforeEach(() => {
     wrapper = shallow(<NetworkDropdownIcon
-      backgroundColor = "red"
-      isSelected = {false}
-      innerBorder = "none"
-      diameter = "12"
+      backgroundColor="red"
+      isSelected={false}
+      innerBorder="none"
+      diameter="12"
     />)
   })
 

--- a/ui/app/components/ui/page-container/page-container-footer/tests/page-container-footer.component.test.js
+++ b/ui/app/components/ui/page-container/page-container-footer/tests/page-container-footer.component.test.js
@@ -12,12 +12,12 @@ describe('Page Footer', () => {
 
   beforeEach(() => {
     wrapper = shallow(<PageFooter
-      onCancel = {onCancel}
-      onSubmit = {onSubmit}
-      cancelText = "Cancel"
-      submitText = "Submit"
-      disabled = {false}
-      submitButtonType = "Test Type"
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+      cancelText="Cancel"
+      submitText="Submit"
+      disabled={false}
+      submitButtonType="Test Type"
     />)
   })
 

--- a/ui/app/components/ui/page-container/page-container-header/tests/page-container-header.component.test.js
+++ b/ui/app/components/ui/page-container/page-container-header/tests/page-container-header.component.test.js
@@ -13,13 +13,13 @@ describe('Page Container Header', () => {
     onClose = sinon.spy()
 
     wrapper = shallow(<PageContainerHeader
-      showBackButton = {true}
-      onBackButtonClick = {onBackButtonClick}
-      backButtonStyles = {style}
-      title = "Test Title"
-      subtitle = "Test Subtitle"
-      tabs = "Test Tab"
-      onClose = {onClose}
+      showBackButton={true}
+      onBackButtonClick={onBackButtonClick}
+      backButtonStyles={style}
+      title="Test Title"
+      subtitle="Test Subtitle"
+      tabs="Test Tab"
+      onClose={onClose}
     />)
   })
 


### PR DESCRIPTION
This PR enforces stricter spacing rules around the equals sign in the JSX