### PR TITLE
Import styles for showing multiple notifications

### DIFF
--- a/ui/app/components/app/index.scss
+++ b/ui/app/components/app/index.scss
@@ -84,4 +84,6 @@
 
 @import 'home-notification/index';
 
+@import 'multiple-notifications/index';
+
 @import 'signature-request/index';


### PR DESCRIPTION
The styles for the multi-notification component on the home screen were accidentally removed while resolving a merge conflict in #6891.

Fixes #7460