### PR TITLE
Expand home notification height

### DIFF
--- a/ui/app/components/app/home-notification/index.scss
+++ b/ui/app/components/app/home-notification/index.scss
@@ -8,7 +8,7 @@
   background: rgba(36, 41, 46, 0.9);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
   border-radius: 8px;
-  height: 116px;
+  min-height: 116px;
   padding: 16px;
 
   @media screen and (min-width: 576px) {
@@ -95,6 +95,7 @@
   &__buttons {
     display: flex;
     width: 100%;
+    margin-top: 10px;
     justify-content: flex-start;
     flex-direction: row-reverse;
   }


### PR DESCRIPTION
The home notification static height of 116px is too cramped for longer messages, such as the one used for the Sai migration. The old height is now used for the minimum height instead, with a margin to ensure the text doesn't get too close to the buttons.

Before:
![before_height](https://user-images.githubusercontent.com/2459287/69087730-38b5f680-0a1d-11ea-8550-d480b3a1d00b.png)

After:
![after_height](https://user-images.githubusercontent.com/2459287/69087745-3a7fba00-0a1d-11ea-9299-dcb40e7033b3.png)