### PR TITLE
Updating deprecated Etherscam link 

### DIFF
--- a/app/phishing.html
+++ b/app/phishing.html
@@ -47,7 +47,7 @@
           <a href="https://github.com/metamask/eth-phishing-detect">Ethereum Phishing Detector</a>.
           Domains on these warning lists may include outright malicious websites and legitimate websites that have been compromised by a malicious actor.
         </p>
-        <p>To read more about this site <a id="csdbLink">please review the domain on CryptoScamDB</a>.</p>
+        <p>To read more about this site <a id="csdbLink">please search for the domain on CryptoScamDB</a>.</p>
         <p>
           Note that this warning list is compiled on a voluntary basis. This list may be inaccurate or incomplete.
           Just because a domain does not appear on this list is not an implicit guarantee of that domain's safety.

--- a/app/phishing.html
+++ b/app/phishing.html
@@ -47,7 +47,7 @@
           <a href="https://github.com/metamask/eth-phishing-detect">Ethereum Phishing Detector</a>.
           Domains on these warning lists may include outright malicious websites and legitimate websites that have been compromised by a malicious actor.
         </p>
-        <p>To read more about this site <a id="esdbLink">please review the domain on Etherscam</a>.</p>
+        <p>To read more about this site <a id="csdbLink">please review the domain on CryptoScamDB</a>.</p>
         <p>
           Note that this warning list is compiled on a voluntary basis. This list may be inaccurate or incomplete.
           Just because a domain does not appear on this list is not an implicit guarantee of that domain's safety.

--- a/app/scripts/phishing-detect.js
+++ b/app/scripts/phishing-detect.js
@@ -14,7 +14,7 @@ function start () {
   const hash = window.location.hash.substring(1)
   const suspect = querystring.parse(hash)
 
-  document.getElementById('esdbLink').href = `https://etherscamdb.info/domain/${suspect.hostname}`
+  document.getElementById('csdbLink').href = `https://cryptoscamdb.org/search`
 
   global.platform = new ExtensionPlatform()
   global.METAMASK_UI_TYPE = windowType


### PR DESCRIPTION
## Description

When visiting a potential phishing scam, Metamask gives a warning page to users. This warning page includes a link to `https://etherscamdb.info/domain/${suspect.hostname}`.

However when you visit this site, e.g. https://etherscamdb.info/domain/sai2dai.com, the site states that it is deprecated, and that you should instead visit https://cryptoscamdb.org/.

<img width="792" alt="Screenshot 2019-11-18 at 3 40 47 PM" src="https://user-images.githubusercontent.com/34962750/69092236-f3dc9080-0a19-11ea-9c02-07c6996e296d.png">

This PR updates the URL to be the new site.

