### PR TITLE
Update Wyre ETH purchase url

### DIFF
--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -19,7 +19,7 @@ function getBuyEthUrl ({ network, amount, address, service }) {
 
   switch (service) {
     case 'wyre':
-      return `https://dash.sendwyre.com/sign-up`
+      return `https://pay.sendwyre.com/?dest=ethereum:${address}&destCurrency=ETH&accountId=AC-7AG3W4XH4N2`
     case 'coinswitch':
       return `https://metamask.coinswitch.co/?address=${address}&to=eth`
     case 'coinbase':

--- a/test/unit/app/buy-eth-url.spec.js
+++ b/test/unit/app/buy-eth-url.spec.js
@@ -17,10 +17,10 @@ describe('buy-eth-url', function () {
     network: '42',
   }
 
-  it('returns coinbase url with amount and address for network 1', function () {
+  it('returns wyre url with address for network 1', function () {
     const wyreUrl = getBuyEthUrl(mainnet)
 
-    assert.equal(wyreUrl, 'https://dash.sendwyre.com/sign-up')
+    assert.equal(wyreUrl, 'https://pay.sendwyre.com/?dest=ethereum:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc&destCurrency=ETH&accountId=AC-7AG3W4XH4N2')
 
   })
 


### PR DESCRIPTION
updates the metamask buy ETH link for Wyre to use the new hosted widget for faster, simpler purchases