### PR TITLE
Ensures the tx controller + state-manager orders transactions as received

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -193,12 +193,12 @@ class TransactionController extends EventEmitter {
     }
     txUtils.validateTxParams(normalizedTxParams)
     // construct txMeta
-    const { transactionCategory, getCodeResponse } = await this._determineTransactionCategory(txParams)
     let txMeta = this.txStateManager.generateTxMeta({
       txParams: normalizedTxParams,
       type: TRANSACTION_TYPE_STANDARD,
-      transactionCategory,
     })
+    const { transactionCategory, getCodeResponse } = await this._determineTransactionCategory(txParams)
+    txMeta.transactionCategory = transactionCategory
     this.addTx(txMeta)
     this.emit('newUnapprovedTx', txMeta)
 

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -192,7 +192,12 @@ class TransactionController extends EventEmitter {
       throw new Error(`Transaction from address isn't valid for this account`)
     }
     txUtils.validateTxParams(normalizedTxParams)
-    // construct txMeta
+    /**
+    `generateTxMeta` adds the default txMeta properties to the passed object.
+    These include the tx's `id`. As we use the id for determining order of
+    txes in the tx-state-manager, it is necessary to call the asynchronous
+    method `this._determineTransactionCategory` after `generateTxMeta`.
+    */
     let txMeta = this.txStateManager.generateTxMeta({
       txParams: normalizedTxParams,
       type: TRANSACTION_TYPE_STANDARD,

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -167,7 +167,12 @@ class TransactionStateManager extends EventEmitter {
         transactions.splice(index, 1)
       }
     }
-    transactions.push(txMeta)
+    const newTxIndex = transactions.findIndex((metaTx) => {
+      return metaTx.id === txMeta.id + 1
+    })
+    newTxIndex === -1
+      ? transactions.push(txMeta)
+      : transactions.splice(newTxIndex, 0, txMeta)
     this._saveTxList(transactions)
     return txMeta
   }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -168,7 +168,7 @@ class TransactionStateManager extends EventEmitter {
       }
     }
     const newTxIndex = transactions
-      .findIndex((currentTxMeta) => currentTxMeta.id > txMeta.id)
+      .findIndex((currentTxMeta) => currentTxMeta.time > txMeta.time)
 
     newTxIndex === -1
       ? transactions.push(txMeta)

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -167,9 +167,9 @@ class TransactionStateManager extends EventEmitter {
         transactions.splice(index, 1)
       }
     }
-    const newTxIndex = transactions.findIndex((metaTx) => {
-      return metaTx.id === txMeta.id + 1
-    })
+    const newTxIndex = transactions
+      .findIndex((currentTxMeta) => currentTxMeta.id > txMeta.id)
+
     newTxIndex === -1
       ? transactions.push(txMeta)
       : transactions.splice(newTxIndex, 0, txMeta)


### PR DESCRIPTION
These changes are needed to ensure consistency of transaction order. This was an issue for batch transactions and the same change is included in #7473 It was also needed to get my local e2e tests passing.

The strategy here is to ensure that the tx-state-manager orders transactions by id, and to ensure that ids are applied in the order they are received by the transaction controller (and not after an indeterminate async operation).

Although this commit is currently also part of #7473 and #7368, I believe it should be made directly to develop and then those can be rebased accordingly.