### PR TITLE
Update gas when asset is changed on send screen.

### DIFF
--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -165,6 +165,7 @@ export default class SendTransactionScreen extends PersistentForm {
 
     if (selectedTokenAddress && prevTokenAddress !== selectedTokenAddress) {
       this.updateSendToken()
+      this.updateGas()
     }
   }
 

--- a/ui/app/pages/send/tests/send-component.test.js
+++ b/ui/app/pages/send/tests/send-component.test.js
@@ -57,10 +57,10 @@ describe('Send Component', function () {
       primaryCurrency="mockPrimaryCurrency"
       recentBlocks={['mockBlock']}
       selectedAddress="mockSelectedAddress"
-      selectedToken="mockSelectedToken"
+      selectedToken={{ address: 'mockTokenAddress', decimals: 18, symbol: 'TST' }}
       showHexData
       tokenBalance="mockTokenBalance"
-      tokenContract="mockTokenContract"
+      tokenContract={{ method: 'mockTokenMethod' }}
       updateAndSetGasLimit={propsMethodSpies.updateAndSetGasLimit}
       updateSendErrors={propsMethodSpies.updateSendErrors}
       updateSendTokenBalance={propsMethodSpies.updateSendTokenBalance}
@@ -79,6 +79,7 @@ describe('Send Component', function () {
     propsMethodSpies.updateAndSetGasLimit.resetHistory()
     propsMethodSpies.updateSendErrors.resetHistory()
     propsMethodSpies.updateSendTokenBalance.resetHistory()
+    propsMethodSpies.updateToNicknameIfNecessary.resetHistory()
   })
 
   it('should call componentDidMount', () => {
@@ -129,7 +130,7 @@ describe('Send Component', function () {
           prevBalance: '',
           prevGasTotal: undefined,
           prevTokenBalance: undefined,
-          selectedToken: 'mockSelectedToken',
+          selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' },
           tokenBalance: 'mockTokenBalance',
         }
       )
@@ -162,7 +163,7 @@ describe('Send Component', function () {
           conversionRate: 10,
           gasTotal: 'mockGasTotal',
           primaryCurrency: 'mockPrimaryCurrency',
-          selectedToken: 'mockSelectedToken',
+          selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' },
           tokenBalance: 'mockTokenBalance',
         }
       )
@@ -184,7 +185,7 @@ describe('Send Component', function () {
           conversionRate: 10,
           gasTotal: 'mockGasTotal',
           primaryCurrency: 'mockPrimaryCurrency',
-          selectedToken: 'mockSelectedToken',
+          selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' },
         }
       )
     })
@@ -225,7 +226,7 @@ describe('Send Component', function () {
 
     it('should call updateSendErrors with the expected params if selectedToken is truthy', () => {
       propsMethodSpies.updateSendErrors.resetHistory()
-      wrapper.setProps({ selectedToken: 'someToken' })
+      wrapper.setProps({ selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' }})
       wrapper.instance().componentDidUpdate({
         from: {
           balance: 'balanceChanged',
@@ -246,6 +247,7 @@ describe('Send Component', function () {
           balance: 'balanceChanged',
         },
         network: '3',
+        selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' }, // Make sure not to hit updateGas when changing asset
       })
       assert.equal(propsMethodSpies.updateSendTokenBalance.callCount, 0)
       assert.equal(SendTransactionScreen.prototype.updateGas.callCount, 0)
@@ -260,6 +262,7 @@ describe('Send Component', function () {
           balance: 'balanceChanged',
         },
         network: '3',
+        selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' }, // Make sure not to hit updateGas when changing asset
       })
       assert.equal(propsMethodSpies.updateSendTokenBalance.callCount, 0)
       assert.equal(SendTransactionScreen.prototype.updateGas.callCount, 0)
@@ -273,13 +276,14 @@ describe('Send Component', function () {
           balance: 'balanceChanged',
         },
         network: '2',
+        selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' }, // Make sure not to hit updateGas when changing asset
       })
       assert.equal(propsMethodSpies.updateSendTokenBalance.callCount, 1)
       assert.deepEqual(
         propsMethodSpies.updateSendTokenBalance.getCall(0).args[0],
         {
-          selectedToken: 'mockSelectedToken',
-          tokenContract: 'mockTokenContract',
+          selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' }, // Make sure not to hit updateGas when changing asset
+          tokenContract: { method: 'mockTokenMethod' },
           address: 'mockAddress',
         }
       )
@@ -288,6 +292,20 @@ describe('Send Component', function () {
         SendTransactionScreen.prototype.updateGas.getCall(0).args,
         []
       )
+    })
+
+    it('should call updateGas when ', () => {
+      SendTransactionScreen.prototype.updateGas.resetHistory()
+      propsMethodSpies.updateAndSetGasLimit.resetHistory()
+      wrapper.instance().componentDidUpdate({
+        from: {
+          balance: 'balancedChanged',
+        },
+        network: '3', // Make sure not to hit updateGas when changing network
+        selectedToken: { address: 'newSelectedToken' },
+      })
+      assert.equal(propsMethodSpies.updateToNicknameIfNecessary.callCount, 0) // Network did not change
+      assert.equal(propsMethodSpies.updateAndSetGasLimit.callCount, 1)
     })
   })
 
@@ -305,7 +323,7 @@ describe('Send Component', function () {
           gasPrice: 'mockGasPrice',
           recentBlocks: ['mockBlock'],
           selectedAddress: 'mockSelectedAddress',
-          selectedToken: 'mockSelectedToken',
+          selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' },
           to: '',
           value: 'mockAmount',
           data: undefined,
@@ -431,9 +449,7 @@ describe('Send Component', function () {
     })
 
     it('should warn when send to a known token contract address', () => {
-      wrapper.setProps({
-        selectedToken: '0x888',
-      })
+      wrapper.setProps({ address: '0x888', decimals: 18, symbol: '888' })
       const instance = wrapper.instance()
       instance.onRecipientInputChange('0x13cb85823f78Cff38f0B0E90D3e975b8CB3AAd64')
 

--- a/ui/app/pages/send/tests/send-component.test.js
+++ b/ui/app/pages/send/tests/send-component.test.js
@@ -294,7 +294,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should call updateGas when ', () => {
+    it('should call updateGas when selectedToken.address is changed', () => {
       SendTransactionScreen.prototype.updateGas.resetHistory()
       propsMethodSpies.updateAndSetGasLimit.resetHistory()
       wrapper.instance().componentDidUpdate({


### PR DESCRIPTION
Fixes #7382

Edge case not accounted for is going from token address -> ETH, but tx in this instance usually don't fail.