### PR TITLE
Add EOL normalization to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=auto
 CHANGELOG.md merge=union
 
 # Reviewing the lockfile contents is an important step in verifying that


### PR DESCRIPTION
This PR adds EOL conversion to the `.gitattributes` file. From the docs:<sup>[\[1\]][1]</sup>

> **`text`**
> This attribute enables and controls end-of-line normalization. When a text file is normalized, its line endings are converted to LF in the repository. To control what line ending style is used in the working directory, use the `eol` attribute for a single file and the `core.eol` configuration variable for all text files. Note that setting `core.autocrlf` to `true` or `input` overrides `core.eol` (see the definitions of those options in [git-config\[1\]][2]).

> **Set to string value "auto"**
> When `text` is set to "auto", the path is marked for automatic end-of-line conversion. If Git decides that the content is text, its line endings are converted to LF on checkin. When the file has been committed with CRLF, no conversion is done.

In practice this ensure that contributions from Windows machines still result in the correct newlines.

  [1]:https://git-scm.com/docs/gitattributes#_code_text_code
  [2]:https://git-scm.com/docs/git-config