### PR TITLE
Remove unused onClick prop from Dropdown component

### DIFF
--- a/ui/app/components/app/dropdowns/components/dropdown.js
+++ b/ui/app/components/app/dropdowns/components/dropdown.js
@@ -58,7 +58,6 @@ Dropdown.defaultProps = {
 
 Dropdown.propTypes = {
   isOpen: PropTypes.bool.isRequired,
-  onClick: PropTypes.func.isRequired,
   children: PropTypes.node,
   style: PropTypes.object.isRequired,
   onClickOutside: PropTypes.func,


### PR DESCRIPTION
This PR fixes a warning that shows up during render:

```
Warning: Failed prop type: The prop `onClick` is marked as required in `Dropdown`, but its value is `undefined`.
    in Dropdown (created by NetworkDropdown)
    in NetworkDropdown (created by Connect(NetworkDropdown))
    in Connect(NetworkDropdown) (created by Route)
    in Route (created by withRouter(Connect(NetworkDropdown)))
    in withRouter(Connect(NetworkDropdown)) (created by Routes)
    in div (created by Routes)
    in Routes (created by Connect(Routes))
    in Connect(Routes) (created by Route)
    in Route (created by withRouter(Connect(Routes)))
    in withRouter(Connect(Routes)) (created by Index)
    in I18nProvider (created by Connect(I18nProvider))
    in Connect(I18nProvider) (created by Route)
    in Route (created by withRouter(Connect(I18nProvider)))
    in withRouter(Connect(I18nProvider)) (created by Index)
    in MetaMetricsProvider (created by Connect(MetaMetricsProvider))
    in Connect(MetaMetricsProvider) (created by Route)
    in Route (created by withRouter(Connect(MetaMetricsProvider)))
    in withRouter(Connect(MetaMetricsProvider)) (created by Index)
    in Router (created by HashRouter)
    in HashRouter (created by Index)
    in Provider (created by Index)
    in Index
```