### PR TITLE
Fix accessibility of first-time-flow terms checkboxes

### DIFF
--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -175,6 +175,12 @@ export default class ImportWithSeedPhrase extends PureComponent {
     return !passwordError && !confirmPasswordError && !seedPhraseError
   }
 
+  onTermsKeyPress = ({key}) => {
+    if (key === ' ' || key === 'Enter') {
+      this.toggleTermsCheck()
+    }
+  }
+
   toggleTermsCheck = () => {
     this.context.metricsEvent({
       eventOpts: {
@@ -183,7 +189,6 @@ export default class ImportWithSeedPhrase extends PureComponent {
         name: 'Check ToS',
       },
     })
-
     this.setState((prevState) => ({
       termsChecked: !prevState.termsChecked,
     }))
@@ -267,10 +272,17 @@ export default class ImportWithSeedPhrase extends PureComponent {
           largeLabel
         />
         <div className="first-time-flow__checkbox-container" onClick={this.toggleTermsCheck}>
-          <div className="first-time-flow__checkbox">
+          <div
+            className="first-time-flow__checkbox"
+            tabIndex="0"
+            role="checkbox"
+            onKeyPress={this.onTermsKeyPress}
+            aria-checked={termsChecked}
+            aria-labelledby="ftf-chk1-label"
+          >
             {termsChecked ? <i className="fa fa-check fa-2x" /> : null}
           </div>
-          <span className="first-time-flow__checkbox-label">
+          <span id="ftf-chk1-label" className="first-time-flow__checkbox-label">
             I have read and agree to the <a
               href="https://metamask.io/terms.html"
               target="_blank"

--- a/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Button from '../../../../components/ui/button'
 import {
   INITIALIZE_SEED_PHRASE_ROUTE,
-  INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE,
   INITIALIZE_SELECT_ACTION_ROUTE,
 } from '../../../../helpers/constants/routes'
 import TextField from '../../../../components/ui/text-field'
@@ -115,13 +114,6 @@ export default class NewAccount extends PureComponent {
     }
   }
 
-  handleImportWithSeedPhrase = event => {
-    const { history } = this.props
-
-    event.preventDefault()
-    history.push(INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE)
-  }
-
   toggleTermsCheck = () => {
     this.context.metricsEvent({
       eventOpts: {
@@ -134,6 +126,12 @@ export default class NewAccount extends PureComponent {
     this.setState((prevState) => ({
       termsChecked: !prevState.termsChecked,
     }))
+  }
+
+  onTermsKeyPress = ({key}) => {
+    if (key === ' ' || key === 'Enter') {
+      this.toggleTermsCheck()
+    }
   }
 
   render () {
@@ -195,10 +193,17 @@ export default class NewAccount extends PureComponent {
             largeLabel
           />
           <div className="first-time-flow__checkbox-container" onClick={this.toggleTermsCheck}>
-            <div className="first-time-flow__checkbox">
+            <div
+              className="first-time-flow__checkbox"
+              tabIndex="0"
+              role="checkbox"
+              onKeyPress={this.onTermsKeyPress}
+              aria-checked={termsChecked}
+              aria-labelledby="ftf-chk1-label"
+            >
               {termsChecked ? <i className="fa fa-check fa-2x" /> : null}
             </div>
-            <span className="first-time-flow__checkbox-label">
+            <span id="ftf-chk1-label" className="first-time-flow__checkbox-label">
               I have read and agree to the <a
                 href="https://metamask.io/terms.html"
                 target="_blank"


### PR DESCRIPTION
See [ARIA: checkbox role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role) for context.

This PR fixes one part of the accessibility of our checkboxes in the on-boarding flow. We were previously creating custom checkboxes without the correct assistive properties. In part, this now allows keyboard users to tab to and check the checkbox.