### PR TITLE
Convert Copyable component to use JSX and ES6 class

### DIFF
--- a/ui/app/components/app/copyable.js
+++ b/ui/app/components/app/copyable.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 const PropTypes = require('prop-types')
 const Tooltip = require('../ui/tooltip')
 const copyToClipboard = require('copy-to-clipboard')
-const connect = require('react-redux').connect
 
 class Copyable extends Component {
   static contextTypes = {
@@ -53,4 +52,4 @@ class Copyable extends Component {
   }
 }
 
-module.exports = connect()(Copyable)
+module.exports = Copyable

--- a/ui/app/components/app/copyable.js
+++ b/ui/app/components/app/copyable.js
@@ -1,53 +1,56 @@
-const Component = require('react').Component
+import React, { Component } from 'react'
 const PropTypes = require('prop-types')
-const h = require('react-hyperscript')
-const inherits = require('util').inherits
-
 const Tooltip = require('../ui/tooltip')
 const copyToClipboard = require('copy-to-clipboard')
 const connect = require('react-redux').connect
 
-Copyable.contextTypes = {
-  t: PropTypes.func,
-}
+class Copyable extends Component {
+  static contextTypes = {
+    t: PropTypes.func,
+  }
 
-module.exports = connect()(Copyable)
-
-
-inherits(Copyable, Component)
-function Copyable () {
-  Component.call(this)
-  this.state = {
+  state = {
     copied: false,
+  }
+
+  debounceRestore = () => {
+    this.setState({ copied: true })
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      this.setState({ copied: false })
+    }, 850)
+  }
+
+  render () {
+    const props = this.props
+    const state = this.state
+    const { value, children } = props
+    const { copied } = state
+
+    return (
+      <Tooltip
+        title={
+          copied
+            ? this.context.t('copiedExclamation')
+            : this.context.t('copy')
+        }
+        position="bottom"
+      >
+        <span
+          style={{
+            cursor: 'pointer',
+          }}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            copyToClipboard(value)
+            this.debounceRestore()
+          }}>
+          {children}
+        </span>
+      </Tooltip>
+    )
   }
 }
 
-Copyable.prototype.render = function () {
-  const props = this.props
-  const state = this.state
-  const { value, children } = props
-  const { copied } = state
-
-  return h(Tooltip, {
-    title: copied ? this.context.t('copiedExclamation') : this.context.t('copy'),
-    position: 'bottom',
-  }, h('span', {
-    style: {
-      cursor: 'pointer',
-    },
-    onClick: (event) => {
-      event.preventDefault()
-      event.stopPropagation()
-      copyToClipboard(value)
-      this.debounceRestore()
-    },
-  }, children))
-}
-
-Copyable.prototype.debounceRestore = function () {
-  this.setState({ copied: true })
-  clearTimeout(this.timeout)
-  this.timeout = setTimeout(() => {
-    this.setState({ copied: false })
-  }, 850)
-}
+module.exports = connect()(Copyable)


### PR DESCRIPTION
Refs #6291

This PR replaces hyperscript in the `Copyable` component with JSX. I had to convert this one to easily add propTypes that ESLint would recognize.