### PR TITLE
Convert GasModalCard component to use JSX

### DIFF
--- a/ui/app/components/app/customize-gas-modal/gas-modal-card.js
+++ b/ui/app/components/app/customize-gas-modal/gas-modal-card.js
@@ -1,8 +1,6 @@
-const Component = require('react').Component
-const h = require('react-hyperscript')
+import React, {Component} from 'react'
 const inherits = require('util').inherits
 const InputNumber = require('../input-number.js')
-// const GasSlider = require('./gas-slider.js')
 
 module.exports = GasModalCard
 
@@ -11,44 +9,30 @@ function GasModalCard () {
   Component.call(this)
 }
 
-GasModalCard.prototype.render = function () {
+GasModalCard.prototype.render = function GasModalCard () {
   const {
-    // memo,
     onChange,
     unitLabel,
     value,
     min,
-    // max,
     step,
     title,
     copy,
   } = this.props
 
-  return h('div.send-v2__gas-modal-card', [
-
-    h('div.send-v2__gas-modal-card__title', {}, title),
-
-    h('div.send-v2__gas-modal-card__copy', {}, copy),
-
-    h(InputNumber, {
-      unitLabel,
-      step,
-      // max,
-      min,
-      placeholder: '0',
-      value,
-      onChange,
-    }),
-
-    // h(GasSlider, {
-    //   value,
-    //   step,
-    //   max,
-    //   min,
-    //   onChange,
-    // }),
-
-  ])
-
+  return (
+    <div className="send-v2__gas-modal-card">
+      <div className="send-v2__gas-modal-card__title">{title}</div>
+      <div className="send-v2__gas-modal-card__copy">{copy}</div>
+      <InputNumber
+        unitLabel={unitLabel}
+        step={step}
+        min={min}
+        placeholder="0"
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  )
 }
 


### PR DESCRIPTION
Refs #6291

This PR replaces hyperscript in the `GasModalCard` component with JSX.