### PR TITLE
Convert Tooltip component to JSX

### DIFF
--- a/ui/app/components/ui/tooltip.js
+++ b/ui/app/components/ui/tooltip.js
@@ -1,22 +1,24 @@
-const Component = require('react').Component
-const h = require('react-hyperscript')
-const inherits = require('util').inherits
-const ReactTooltip = require('react-tooltip-component')
+import PropTypes from 'prop-types'
+import React from 'react'
+import ReactTooltip from 'react-tooltip-component'
+
+function Tooltip ({ position, title, children }) {
+  return (
+    <ReactTooltip position={position} title={title} fixed>
+      {children}
+    </ReactTooltip>
+  )
+}
+
+Tooltip.defaultProps = {
+  position: 'left',
+  children: null,
+}
+
+Tooltip.propTypes = {
+  position: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node,
+}
 
 module.exports = Tooltip
-
-inherits(Tooltip, Component)
-function Tooltip () {
-  Component.call(this)
-}
-
-Tooltip.prototype.render = function () {
-  const props = this.props
-  const { position, title, children } = props
-
-  return h(ReactTooltip, {
-    position: position || 'left',
-    title,
-    fixed: true,
-  }, children)
-}


### PR DESCRIPTION
Refs #6291

This PR replaces hyperscript in the `Tooltip` component with JSX. I converted this one to a function to facilitate `propTypes`.