### PR TITLE
Adjust QrCodeView propTypes for its Qr.messages prop

### DIFF
--- a/ui/app/components/ui/qr-code.js
+++ b/ui/app/components/ui/qr-code.js
@@ -69,7 +69,10 @@ function QrCodeView (props) {
 QrCodeView.propTypes = {
   warning: PropTypes.node,
   Qr: PropTypes.shape({
-    message: PropTypes.array,
+    message: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node,
+    ]),
     data: PropTypes.string.isRequired,
   }).isRequired,
 }


### PR DESCRIPTION
Refs #7504

This PR adjusts the propTypes introduced in #7504 to reflect the case when `message` isn't an array.