### PR TITLE
Add isRequired flag to MobileSyncPage props

### DIFF
--- a/ui/app/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.component.js
@@ -20,11 +20,11 @@ export default class MobileSyncPage extends Component {
   }
 
   static propTypes = {
-    history: PropTypes.object,
-    selectedAddress: PropTypes.string,
-    displayWarning: PropTypes.func,
-    fetchInfoToSync: PropTypes.func,
-    requestRevealSeedWords: PropTypes.func,
+    history: PropTypes.object.isRequired,
+    selectedAddress: PropTypes.string.isRequired,
+    displayWarning: PropTypes.func.isRequired,
+    fetchInfoToSync: PropTypes.func.isRequired,
+    requestRevealSeedWords: PropTypes.func.isRequired,
   }
 
 


### PR DESCRIPTION
Refs #7534

This PR adds the `isRequired` flags to the props in the `MobileSyncPage` component.