### PR TITLE
Convert HideTokenConfirmationModal component to use JSX

### DIFF
--- a/ui/app/components/app/modals/hide-token-confirmation-modal.js
+++ b/ui/app/components/app/modals/hide-token-confirmation-modal.js
@@ -1,6 +1,5 @@
-const Component = require('react').Component
-const PropTypes = require('prop-types')
-const h = require('react-hyperscript')
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 const inherits = require('util').inherits
 const connect = require('react-redux').connect
 const actions = require('../../../store/actions')
@@ -40,44 +39,43 @@ HideTokenConfirmationModal.contextTypes = {
 module.exports = connect(mapStateToProps, mapDispatchToProps)(HideTokenConfirmationModal)
 
 
-HideTokenConfirmationModal.prototype.render = function () {
+HideTokenConfirmationModal.prototype.render = function HideTokenConfirmationModal () {
   const { token, network, hideToken, hideModal, assetImages } = this.props
   const { symbol, address } = token
   const image = assetImages[address]
 
-  return h('div.hide-token-confirmation', {}, [
-    h('div.hide-token-confirmation__container', {
-    }, [
-      h('div.hide-token-confirmation__title', {}, [
-        this.context.t('hideTokenPrompt'),
-      ]),
-
-      h(Identicon, {
-        className: 'hide-token-confirmation__identicon',
-        diameter: 45,
-        address,
-        network,
-        image,
-      }),
-
-      h('div.hide-token-confirmation__symbol', {}, symbol),
-
-      h('div.hide-token-confirmation__copy', {}, [
-        this.context.t('readdToken'),
-      ]),
-
-      h('div.hide-token-confirmation__buttons', {}, [
-        h('button.btn-default.hide-token-confirmation__button.btn--large', {
-          onClick: () => hideModal(),
-        }, [
-          this.context.t('cancel'),
-        ]),
-        h('button.btn-secondary.hide-token-confirmation__button.btn--large', {
-          onClick: () => hideToken(address),
-        }, [
-          this.context.t('hide'),
-        ]),
-      ]),
-    ]),
-  ])
+  return (
+    <div className="hide-token-confirmation">
+      <div className="hide-token-confirmation__container">
+        <div className="hide-token-confirmation__title">
+          {this.context.t('hideTokenPrompt')}
+        </div>
+        <Identicon
+          className="hide-token-confirmation__identicon"
+          diameter={45}
+          address={address}
+          network={network}
+          image={image}
+        />
+        <div className="hide-token-confirmation__symbol">{symbol}</div>
+        <div className="hide-token-confirmation__copy">
+          {this.context.t('readdToken')}
+        </div>
+        <div className="hide-token-confirmation__buttons">
+          <button
+            className="btn-default hide-token-confirmation__button btn--large"
+            onClick={() => hideModal()}
+          >
+            {this.context.t('cancel')}
+          </button>
+          <button
+            className="btn-secondary hide-token-confirmation__button btn--large"
+            onClick={() => hideToken(address)}
+          >
+            {this.context.t('hide')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
Refs #6291

This PR replaces hyperscript in the `HideTokenConfirmationModal` component with JSX.