### PR TITLE
Convert TokenMenuDropdown component to use JSX

### DIFF
--- a/ui/app/components/app/dropdowns/token-menu-dropdown.js
+++ b/ui/app/components/app/dropdowns/token-menu-dropdown.js
@@ -1,6 +1,5 @@
-const Component = require('react').Component
-const PropTypes = require('prop-types')
-const h = require('react-hyperscript')
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 const inherits = require('util').inherits
 const connect = require('react-redux').connect
 const actions = require('../../../store/actions')
@@ -40,29 +39,29 @@ TokenMenuDropdown.prototype.onClose = function (e) {
   this.props.onClose()
 }
 
-TokenMenuDropdown.prototype.render = function () {
+TokenMenuDropdown.prototype.render = function TokenMenuDropdown () {
   const { showHideTokenConfirmationModal } = this.props
 
-  return h(Menu, { className: 'token-menu-dropdown', isShowing: true }, [
-    h(CloseArea, {
-      onClick: this.onClose,
-    }),
-    h(Item, {
-      onClick: (e) => {
-        e.stopPropagation()
-        showHideTokenConfirmationModal(this.props.token)
-        this.props.onClose()
-      },
-      text: this.context.t('hideToken'),
-    }),
-    h(Item, {
-      onClick: (e) => {
-        e.stopPropagation()
-        const url = genAccountLink(this.props.token.address, this.props.network)
-        global.platform.openWindow({ url })
-        this.props.onClose()
-      },
-      text: this.context.t('viewOnEtherscan'),
-    }),
-  ])
+  return (
+    <Menu className="token-menu-dropdown" isShowing>
+      <CloseArea onClick={this.onClose} />
+      <Item
+        onClick={(e) => {
+          e.stopPropagation()
+          showHideTokenConfirmationModal(this.props.token)
+          this.props.onClose()
+        }}
+        text={this.context.t('hideToken')}
+      />
+      <Item
+        onClick={(e) => {
+          e.stopPropagation()
+          const url = genAccountLink(this.props.token.address, this.props.network)
+          global.platform.openWindow({ url })
+          this.props.onClose()
+        }}
+        text={this.context.t('viewOnEtherscan')}
+      />
+    </Menu>
+  )
 }


### PR DESCRIPTION
Refs #6291

This PR replaces hyperscript in the `TokenMenuDropdown` component with JSX.