### PR TITLE
Enable default-case rule for ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,6 +44,7 @@
   },
 
   "rules": {
+    "default-case": 2,
     "import/no-unresolved": ["error", { "commonjs": true }],
     "no-restricted-globals": ["error", "event"],
     "accessor-pairs": 2,

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -32,8 +32,9 @@ function getBuyEthUrl ({ network, amount, address, service }) {
       return 'https://github.com/kovan-testnet/faucet'
     case 'goerli-faucet':
       return 'https://goerli-faucet.slock.it/'
+    default:
+      throw new Error(`Unknown cryptocurrency exchange or faucet: "${service}"`)
   }
-  throw new Error(`Unknown cryptocurrency exchange or faucet: "${service}"`)
 }
 
 function getDefaultServiceForNetwork (network) {
@@ -48,6 +49,7 @@ function getDefaultServiceForNetwork (network) {
       return 'kovan-faucet'
     case '5':
       return 'goerli-faucet'
+    default:
+      throw new Error(`No default cryptocurrency exchange or faucet for networkId: "${network}"`)
   }
-  throw new Error(`No default cryptocurrency exchange or faucet for networkId: "${network}"`)
 }

--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -66,5 +66,7 @@ function getRegistryForChainId (chainId) {
     // goerli
     case 5:
       return '0x112234455c3a32fd11230c42e7bccd4a84e02010'
+    default:
+      return null
   }
 }

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -163,6 +163,8 @@ module.exports = class TypedMessageManager extends EventEmitter {
         const activeChainId = parseInt(this.networkController.getNetworkState())
         chainId && assert.equal(chainId, activeChainId, `Provided chainId (${chainId}) must match the active chainId (${activeChainId})`)
         break
+      default:
+        assert.fail(`Unknown params.version ${params.version}`)
     }
   }
 

--- a/app/scripts/migrations/004.js
+++ b/app/scripts/migrations/004.js
@@ -23,6 +23,7 @@ module.exports = {
             type: 'mainnet',
           }
           break
+        // No default
       }
     } catch (_) {}
     return Promise.resolve(safeVersionedData)

--- a/development/version-bump.js
+++ b/development/version-bump.js
@@ -40,6 +40,8 @@ function newVersionFrom (manifest, bumpType) {
     case 'patch':
       segments[2] += 1
       break
+    default:
+      throw new Error(`invalid bumpType ${bumpType}`)
   }
 
   return segments.map(String).join('.')

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -123,6 +123,8 @@ async function loadExtension (driver, extensionId) {
       await driver.get(`moz-extension://${extensionId}/home.html`)
       break
     }
+    default:
+      throw new Error('Unrecognized SELENIUM_BROWSER value')
   }
 }
 

--- a/test/unit/app/typed-message-manager.spec.js
+++ b/test/unit/app/typed-message-manager.spec.js
@@ -30,12 +30,12 @@ describe('Typed Message Manager', () => {
           'EIP712Domain': [
             {'name': 'name', 'type': 'string' },
             {'name': 'version', 'type': 'string' },
-            {'name': 'chainId', ' type': 'uint256' },
-            {'name': 'verifyingContract', ' type': 'address' },
+            {'name': 'chainId', 'type': 'uint256' },
+            {'name': 'verifyingContract', 'type': 'address' },
           ],
           'Person': [
             {'name': 'name', 'type': 'string' },
-            {'name': 'wallet', ' type': 'address' },
+            {'name': 'wallet', 'type': 'address' },
           ],
           'Mail': [
             {'name': 'from', 'type': 'Person' },
@@ -64,7 +64,7 @@ describe('Typed Message Manager', () => {
       }),
     }
 
-    typedMessageManager.addUnapprovedMessage(msgParamsV3, 'V3')
+    typedMessageManager.addUnapprovedMessage(msgParamsV3, null, 'V3')
     typedMsgs = typedMessageManager.getUnapprovedMsgs()
     messages = typedMessageManager.messages
     msgId = Object.keys(typedMsgs)[0]
@@ -73,7 +73,7 @@ describe('Typed Message Manager', () => {
   })
 
   it('supports version 1 of signedTypedData', () => {
-    typedMessageManager.addUnapprovedMessage(msgParamsV1, 'V1')
+    typedMessageManager.addUnapprovedMessage(msgParamsV1, null, 'V1')
     assert.equal(messages[messages.length - 1].msgParams.data, msgParamsV1.data)
   })
 
@@ -87,7 +87,7 @@ describe('Typed Message Manager', () => {
 
   it('validates params', function () {
     assert.doesNotThrow(() => {
-      typedMessageManager.validateParams(messages[0])
+      typedMessageManager.validateParams(messages[0].msgParams)
     }, 'Does not throw with valid parameters')
   })
 

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -755,7 +755,6 @@ describe('Actions', () => {
         'domain': {
           'name': 'Ether Mainl',
           'version': '1',
-          'chainId': 1,
           'verifyingContract': '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
         },
         'message': {
@@ -773,11 +772,12 @@ describe('Actions', () => {
     }
 
     beforeEach(() => {
-      metamaskController.newUnsignedTypedMessage(msgParamsV3, 'V3')
+      metamaskController.newUnsignedTypedMessage(msgParamsV3, null, 'V3')
       messages = metamaskController.typedMessageManager.getUnapprovedMsgs()
       typedMessages = metamaskController.typedMessageManager.messages
       msgId = Object.keys(messages)[0]
       typedMessages[0].msgParams.metamaskId = parseInt(msgId)
+      signTypedMsgSpy = sinon.stub(background, 'signTypedMessage')
     })
 
     afterEach(() => {
@@ -786,7 +786,6 @@ describe('Actions', () => {
 
     it('calls signTypedMsg in background with no error', () => {
       const store = mockStore()
-      signTypedMsgSpy = sinon.stub(background, 'signTypedMessage')
 
       store.dispatch(actions.signTypedMsg(msgParamsV3))
       assert(signTypedMsgSpy.calledOnce)
@@ -800,8 +799,6 @@ describe('Actions', () => {
         { type: 'HIDE_LOADING_INDICATION' },
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
-
-      signTypedMsgSpy = sinon.stub(background, 'signTypedMessage')
 
       signTypedMsgSpy.callsFake((_, callback) => {
         callback(new Error('error'))

--- a/ui/app/components/app/account-menu/account-menu.component.js
+++ b/ui/app/components/app/account-menu/account-menu.component.js
@@ -156,9 +156,11 @@ export default class AccountMenu extends PureComponent {
       case 'Simple Key Pair':
         label = t('imported')
         break
+      default:
+        return null
     }
 
-    return label && (
+    return (
       <div className="keyring-label allcaps">
         { label }
       </div>


### PR DESCRIPTION
This PR enables [the `default-case` ESLint rule][1].

From the docs:<sup>[\[1\]][1]</sup>

> The thinking is that it’s better to always explicitly state what the default behavior should be so that it’s clear whether or not the developer forgot to include the default behavior by mistake.

> This rule aims to require `default` case in `switch` statements. You may optionally include a `// no default` after the last `case` if there is no `default` case. The comment may be in any desired case, such as `// No Default`.

  [1]:https://eslint.org/docs/rules/default-case