### PR TITLE
Enable no-confusing-arrow rule for ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -72,6 +72,7 @@
     "no-caller": 2,
     "no-class-assign": 2,
     "no-cond-assign": 2,
+    "no-confusing-arrow": 2,
     "no-const-assign": 2,
     "no-control-regex": 2,
     "no-debugger": 2,

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -17,8 +17,8 @@ module.exports = {
 
 // functions that handle normalizing of that key in txParams
 const normalizers = {
-  from: (from, LowerCase = true) => LowerCase ? addHexPrefix(from).toLowerCase() : addHexPrefix(from),
-  to: (to, LowerCase = true) => LowerCase ? addHexPrefix(to).toLowerCase() : addHexPrefix(to),
+  from: (from, LowerCase = true) => (LowerCase ? addHexPrefix(from).toLowerCase() : addHexPrefix(from)),
+  to: (to, LowerCase = true) => (LowerCase ? addHexPrefix(to).toLowerCase() : addHexPrefix(to)),
   nonce: nonce => addHexPrefix(nonce),
   value: value => addHexPrefix(value),
   data: data => addHexPrefix(data),

--- a/test/unit/app/controllers/network/pending-middleware-test.js
+++ b/test/unit/app/controllers/network/pending-middleware-test.js
@@ -30,7 +30,7 @@ describe('#createPendingNonceMiddleware', function () {
 
 describe('#createPendingTxMiddleware', function () {
   let returnUndefined = true
-  const getPendingTransactionByHash = () => returnUndefined ? undefined : txMetaStub
+  const getPendingTransactionByHash = () => (returnUndefined ? undefined : txMetaStub)
   const address = '0xF231D46dD78806E1DD93442cf33C7671f8538748'
   const pendingTxMiddleware = createPendingTxMiddleware({ getPendingTransactionByHash })
   const spec = {

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -141,7 +141,7 @@ describe('GasModalPageContainer Component', function () {
           fetchBasicGasAndTimeEstimates={propsMethodSpies.fetchBasicGasAndTimeEstimates}
           fetchGasEstimates={propsMethodSpies.fetchGasEstimates}
         />
-      ), { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } })
+      ), { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } })
       const { tabsComponent } = renderTabsWrapperTester.find(PageContainer).props()
       assert.equal(tabsComponent, 'mockTabs')
       GasModalPageContainer.prototype.renderTabs.restore()

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
@@ -44,7 +44,7 @@ describe('TransactionActivityLog Component', () => {
         onRetry={() => {}}
         primaryTransactionStatus="confirmed"
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-activity-log'))
@@ -92,7 +92,7 @@ describe('TransactionActivityLog Component', () => {
         primaryTransactionStatus="pending"
         isEarliestNonce
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-activity-log'))
@@ -141,7 +141,7 @@ describe('TransactionActivityLog Component', () => {
         primaryTransactionStatus="pending"
         isEarliestNonce={false}
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-activity-log'))

--- a/ui/app/components/app/transaction-breakdown/tests/transaction-breakdown.component.test.js
+++ b/ui/app/components/app/transaction-breakdown/tests/transaction-breakdown.component.test.js
@@ -24,7 +24,7 @@ describe('TransactionBreakdown Component', () => {
         transaction={transaction}
         className="test-class"
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-breakdown'))

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/tests/transaction-breakdown-row.component.test.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/tests/transaction-breakdown-row.component.test.js
@@ -13,7 +13,7 @@ describe('TransactionBreakdownRow Component', () => {
       >
         Test
       </TransactionBreakdownRow>,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-breakdown-row'))
@@ -29,7 +29,7 @@ describe('TransactionBreakdownRow Component', () => {
       >
         <Button onClick={() => {}} >Button</Button>
       </TransactionBreakdownRow>,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-breakdown-row'))

--- a/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
+++ b/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
@@ -33,7 +33,7 @@ describe('TransactionListItemDetails Component', () => {
       <TransactionListItemDetails
         transactionGroup={transactionGroup}
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-list-item-details'))
@@ -72,7 +72,7 @@ describe('TransactionListItemDetails Component', () => {
         transactionGroup={transactionGroup}
         showSpeedUp
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-list-item-details'))
@@ -104,7 +104,7 @@ describe('TransactionListItemDetails Component', () => {
       <TransactionListItemDetails
         transactionGroup={transactionGroup}
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-list-item-details'))
@@ -139,7 +139,7 @@ describe('TransactionListItemDetails Component', () => {
       <TransactionListItemDetails
         transactionGroup={transactionGroup}
       />,
-      { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } }
+      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
 
     assert.ok(wrapper.hasClass('transaction-list-item-details'))

--- a/ui/app/components/app/transaction-view-balance/tests/token-view-balance.component.test.js
+++ b/ui/app/components/app/transaction-view-balance/tests/token-view-balance.component.test.js
@@ -15,7 +15,7 @@ const historySpies = {
   push: sinon.spy(),
 }
 
-const t = (str1, str2) => str2 ? str1 + str2 : str1
+const t = (str1, str2) => (str2 ? str1 + str2 : str1)
 const metricsEvent = () => ({})
 
 describe('TransactionViewBalance Component', () => {

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -353,7 +353,7 @@ function quartiles (data) {
 }
 
 function inliersByIQR (data, prop) {
-  const { lowerQuartile, upperQuartile } = quartiles(data.map(d => prop ? d[prop] : d))
+  const { lowerQuartile, upperQuartile } = quartiles(data.map(d => (prop ? d[prop] : d)))
   const IQR = upperQuartile - lowerQuartile
   const lowerBound = lowerQuartile - 1.5 * IQR
   const upperBound = upperQuartile + 1.5 * IQR

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -40,10 +40,10 @@ const casedContractMap = Object.keys(contractMap).reduce((acc, base) => {
 }, {})
 
 let customNonceValue = ''
-const customNonceMerge = txData => customNonceValue ? ({
+const customNonceMerge = txData => (customNonceValue ? ({
   ...txData,
   customNonceValue,
-}) : txData
+}) : txData)
 
 const mapStateToProps = (state, ownProps) => {
   const { toAddress: propsToAddress, customTxParamsData, match: { params = {} } } = ownProps

--- a/ui/app/pages/send/send-header/tests/send-header-component.test.js
+++ b/ui/app/pages/send/send-header/tests/send-header-component.test.js
@@ -26,7 +26,7 @@ describe('SendHeader Component', function () {
         history={historySpies}
         titleKey="mockTitleKey"
       />
-    ), { context: { t: (str1, str2) => str2 ? str1 + str2 : str1 } })
+    ), { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } })
   })
 
   afterEach(() => {

--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -331,7 +331,7 @@ function estimateGasPriceFromRecentBlocks (recentBlocks) {
       return parseInt(next, 16) < parseInt(currentLowest, 16) ? next : currentLowest
     })
   })
-    .sort((a, b) => parseInt(a, 16) > parseInt(b, 16) ? 1 : -1)
+    .sort((a, b) => (parseInt(a, 16) > parseInt(b, 16) ? 1 : -1))
 
   return lowestPrices[Math.floor(lowestPrices.length / 2)]
 }

--- a/ui/lib/shallow-with-context.js
+++ b/ui/lib/shallow-with-context.js
@@ -2,6 +2,6 @@ import { shallow } from 'enzyme'
 
 export default function (jsxComponent) {
   return shallow(jsxComponent, {
-    context: { t: (str1, str2) => str2 ? str1 + str2 : str1 },
+    context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) },
   })
 }


### PR DESCRIPTION
This PR enables [the `no-confusing-arrow` ESLint rule][1].

From the docs:<sup>[\[1\]][1]</sup>

> Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where it could be confused with a comparison operator.

The "solution" here is parentheses.

> The `--fix` option on the command line can automatically fix some of the problems reported by this rule.

  [1]:https://eslint.org/docs/rules/no-confusing-arrow