### PR TITLE
Don't overwrite state when setting inactive timeout

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -45,7 +45,7 @@ class AppStateController {
    * @private
    */
   _setInactiveTimeout (timeoutMinutes) {
-    this.store.putState({
+    this.store.updateState({
       timeoutMinutes,
     })
 


### PR DESCRIPTION
Closes #7577

Using `#putState` here was clearing the other fields in the store and causing the Dai migration notification to reappear.