### PR TITLE
Add locale fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:changed:fix": "{ git ls-files --others --exclude-standard ; git diff-index --name-only --diff-filter=d HEAD ; } | grep --regexp='[.]js$' --regexp='[.]json$' | tr '\\n' '\\0' | xargs -0 eslint --fix",
     "lint:shellcheck": "shellcheck --version && find . -type f -name '*.sh' ! -path './node_modules/*' -print0 | xargs -0 shellcheck",
     "verify-locales": "node ./development/verify-locale-strings.js",
+    "verify-locales:fix": "node ./development/verify-locale-strings.js --fix",
     "mozilla-lint": "addons-linter dist/firefox",
     "watch": "cross-env METAMASK_ENV=test mocha --watch --require test/setup.js --reporter min --recursive \"test/unit/**/*.js\" \"ui/app/**/*.test.js\"",
     "devtools:react": "react-devtools",


### PR DESCRIPTION
Now we can do `yarn verify-locales:fix` to run `node ./development/verify-locale-strings.js --fix`