### PR TITLE
Construct AppStateController with the persisted initial state

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -111,6 +111,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.appStateController = new AppStateController({
       preferencesStore: this.preferencesController.store,
       onInactiveTimeout: () => this.setLocked(),
+      initState: initState.AppStateController,
     })
 
     // currency controller


### PR DESCRIPTION
This PR updates the `AppStateController` to include the `initState` from the persisted state.