### PR TITLE
Mark onClick prop as not required for DraggableSeed

### DIFF
--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/draggable-seed.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/draggable-seed.component.js
@@ -13,7 +13,7 @@ class DraggableSeed extends Component {
     isOver: PropTypes.bool,
     canDrop: PropTypes.bool,
     // Own Props
-    onClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func,
     setHoveringIndex: PropTypes.func.isRequired,
     index: PropTypes.number,
     draggingSeedIndex: PropTypes.number,
@@ -25,6 +25,7 @@ class DraggableSeed extends Component {
 
   static defaultProps = {
     className: '',
+    onClick: undefined,
   }
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
Similar to #7578

This PR fixes the prop type listed for `onClick` in the `DraggableSeed` component.