### PR TITLE
Contract test dapp improvements

### DIFF
--- a/test/e2e/contract-test/contract.js
+++ b/test/e2e/contract-test/contract.js
@@ -49,6 +49,8 @@ const initialize = () => {
   const approveTokensWithoutGas = document.getElementById('approveTokensWithoutGas')
   const signTypedData = document.getElementById('signTypedData')
   const signTypedDataResults = document.getElementById('signTypedDataResult')
+  const getAccountsButton = document.getElementById('getAccounts')
+  const getAccountsResults = document.getElementById('getAccountsResult')
 
   const contractStatus = document.getElementById('contractStatus')
   const tokenAddress = document.getElementById('tokenAddress')
@@ -315,6 +317,16 @@ const initialize = () => {
           signTypedDataResults.innerHTML = result
         }
       })
+    })
+
+    getAccountsButton.addEventListener('click', async () => {
+      try {
+        const accounts = await ethereum.send({ method: 'eth_accounts' })
+        getAccountsResults.innerHTML = accounts[0] || 'Not able to get accounts'
+      } catch (error) {
+        console.error(error)
+        getAccountsResults.innerHTML = `Error: ${error}`
+      }
     })
 
   }

--- a/test/e2e/contract-test/contract.js
+++ b/test/e2e/contract-test/contract.js
@@ -77,11 +77,8 @@ const initialize = () => {
     approveTokens,
     transferTokensWithoutGas,
     approveTokensWithoutGas,
+    signTypedData,
   ]
-
-  for (const button of accountButtons) {
-    button.disabled = true
-  }
 
   const isMetaMaskConnected = () => accounts && accounts.length > 0
 
@@ -105,6 +102,7 @@ const initialize = () => {
       deployButton.disabled = false
       sendButton.disabled = false
       createToken.disabled = false
+      signTypedData.disabled = false
     }
 
     if (!isMetaMaskInstalled()) {

--- a/test/e2e/contract-test/contract.js
+++ b/test/e2e/contract-test/contract.js
@@ -108,6 +108,7 @@ const initialize = () => {
     if (!isMetaMaskInstalled()) {
       onboardButton.innerText = 'Click here to install MetaMask!'
       onboardButton.onclick = onClickInstall
+      onboardButton.disabled = false
     } else if (isMetaMaskConnected()) {
       onboardButton.innerText = 'Connected'
       onboardButton.disabled = true
@@ -117,6 +118,7 @@ const initialize = () => {
     } else {
       onboardButton.innerText = 'Connect'
       onboardButton.onclick = onClickConnect
+      onboardButton.disabled = false
     }
   }
 

--- a/test/e2e/contract-test/contract.js
+++ b/test/e2e/contract-test/contract.js
@@ -314,7 +314,7 @@ const initialize = () => {
         if (err) {
           console.log(err)
         } else {
-          signTypedDataResults.innerHTML = result
+          signTypedDataResults.innerHTML = JSON.stringify(result)
         }
       })
     })

--- a/test/e2e/contract-test/index.html
+++ b/test/e2e/contract-test/index.html
@@ -43,6 +43,11 @@
       </div>
     </section>
     <section>
+      <h2>Get Accounts</h2>
+      <button id="getAccounts">eth_accounts</button>
+      <div id="getAccountsResult"></div>
+    </section>
+    <section>
       <h2>Status</h2>
       <div>
         Network: <span id="network"></span>

--- a/test/e2e/contract-test/index.html
+++ b/test/e2e/contract-test/index.html
@@ -2,7 +2,7 @@
 <head>
   <meta charset="UTF-8">
   <title>E2E Test Dapp</title>
-  <script src="node_modules/@metamask/onboarding/dist/metamask-onboarding.bundle.js"></script>
+  <script src="node_modules/@metamask/onboarding/dist/metamask-onboarding.bundle.js" defer></script>
   <script src="contract.js" defer></script>
 </head>
 <body>

--- a/test/e2e/contract-test/index.html
+++ b/test/e2e/contract-test/index.html
@@ -12,7 +12,7 @@
   <main>
     <section>
       <h2>Connect</h2>
-      <button id="connectButton">Connect</button>
+      <button id="connectButton" disabled></button>
     </section>
     <section>
       <h2>Contract</h2>

--- a/test/e2e/contract-test/index.html
+++ b/test/e2e/contract-test/index.html
@@ -17,9 +17,9 @@
     <section>
       <h2>Contract</h2>
       <div>
-        <button id="deployButton">Deploy Contract</button>
-        <button id="depositButton">Deposit</button>
-        <button id="withdrawButton">Withdraw</button>
+        <button id="deployButton" disabled>Deploy Contract</button>
+        <button id="depositButton" disabled>Deposit</button>
+        <button id="withdrawButton" disabled>Withdraw</button>
       </div>
       <div>
         Contract Status: <span id="contractStatus">Not clicked</span>
@@ -27,7 +27,7 @@
     </section>
     <section>
       <h2>Send Eth</h2>
-      <button id="sendButton">Send</button>
+      <button id="sendButton" disabled>Send</button>
     </section>
     <section>
       <h2>Send Tokens</h2>
@@ -35,11 +35,11 @@
         Token: <span id="tokenAddress"></span>
       </div>
       <div>
-        <button id="createToken">Create Token</button>
-        <button id="transferTokens">Transfer Tokens</button>
-        <button id="approveTokens">Approve Tokens</button>
-        <button id="transferTokensWithoutGas">Transfer Tokens Without Gas</button>
-        <button id="approveTokensWithoutGas">Approve Tokens Without Gas</button>
+        <button id="createToken" disabled>Create Token</button>
+        <button id="transferTokens" disabled>Transfer Tokens</button>
+        <button id="approveTokens" disabled>Approve Tokens</button>
+        <button id="transferTokensWithoutGas" disabled>Transfer Tokens Without Gas</button>
+        <button id="approveTokensWithoutGas" disabled>Approve Tokens Without Gas</button>
       </div>
     </section>
     <section>
@@ -61,7 +61,7 @@
     </section>
     <section>
       <h2>Sign Typed Data</h2>
-      <button id="signTypedData">Sign</button>
+      <button id="signTypedData" disabled>Sign</button>
       <div>Sign Typed Data Result: <span id="signTypedDataResult"></span></div>
     </section>
   </main>


### PR DESCRIPTION
* Add Get Accounts button
This button calls `eth_accounts`. This button is always enabled, even
when not connected.
* Disable account buttons by default
The buttons that require you to have first connected have been disabled
by default. Previously they would be enabled until the JavaScript
finished initializing the page, at which point they'd be disabled. This
resulted in a distracting flash as the page loaded and the buttons
changed.

   The `signTypedData` button was added to the accounts button set as
well, rather than being left enabled regardless of connected status.

*  Allow connect button to become re-enabled
The Connect button was broken previously in that after being disabled,
it would stay disabled even if the dapp lost access to MetaMask. The
button will now be enabled whenever not connected.
* Stringify signTypedData results 
* Defer metamask onboarding bundle to speed up page load