### PR TITLE
Enable no-var rule for ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,6 +143,7 @@
     "no-useless-computed-key": 2,
     "no-useless-constructor": 2,
     "no-useless-escape": 2,
+    "no-var": 2,
     "no-whitespace-before-property": 2,
     "no-with": 2,
     "one-var": [2, { "initialized": "never" }],

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -198,7 +198,7 @@ module.exports = class NetworkController extends EventEmitter {
     })
     this._setNetworkClient(networkClient)
     // setup networkConfig
-    var settings = {
+    const settings = {
       ticker: 'ETH',
     }
     this.networkConfig.putState(settings)
@@ -221,7 +221,7 @@ module.exports = class NetworkController extends EventEmitter {
       nickname,
     }
     // setup networkConfig
-    var settings = {
+    let settings = {
       network: chainId,
     }
     settings = extend(settings, networks.networkList['rpc'])

--- a/app/scripts/edge-encryptor.js
+++ b/app/scripts/edge-encryptor.js
@@ -14,17 +14,17 @@ class EdgeEncryptor {
    * @returns {Promise<string>} Promise resolving to an object with ciphertext
    */
   encrypt (password, dataObject) {
-    var salt = this._generateSalt()
+    const salt = this._generateSalt()
     return this._keyFromPassword(password, salt)
       .then(function (key) {
-        var data = JSON.stringify(dataObject)
-        var dataBuffer = Unibabel.utf8ToBuffer(data)
-        var vector = global.crypto.getRandomValues(new Uint8Array(16))
-        var resultbuffer = asmcrypto.AES_GCM.encrypt(dataBuffer, key, vector)
+        const data = JSON.stringify(dataObject)
+        const dataBuffer = Unibabel.utf8ToBuffer(data)
+        const vector = global.crypto.getRandomValues(new Uint8Array(16))
+        const resultbuffer = asmcrypto.AES_GCM.encrypt(dataBuffer, key, vector)
 
-        var buffer = new Uint8Array(resultbuffer)
-        var vectorStr = Unibabel.bufferToBase64(vector)
-        var vaultStr = Unibabel.bufferToBase64(buffer)
+        const buffer = new Uint8Array(resultbuffer)
+        const vectorStr = Unibabel.bufferToBase64(vector)
+        const vaultStr = Unibabel.bufferToBase64(buffer)
         return JSON.stringify({
           data: vaultStr,
           iv: vectorStr,
@@ -48,7 +48,7 @@ class EdgeEncryptor {
         const encryptedData = Unibabel.base64ToBuffer(payload.data)
         const vector = Unibabel.base64ToBuffer(payload.iv)
         return new Promise((resolve, reject) => {
-          var result
+          let result
           try {
             result = asmcrypto.AES_GCM.decrypt(encryptedData, key, vector)
           } catch (err) {
@@ -72,12 +72,12 @@ class EdgeEncryptor {
    */
   _keyFromPassword (password, salt) {
 
-    var passBuffer = Unibabel.utf8ToBuffer(password)
-    var saltBuffer = Unibabel.base64ToBuffer(salt)
+    const passBuffer = Unibabel.utf8ToBuffer(password)
+    const saltBuffer = Unibabel.base64ToBuffer(salt)
     const iterations = 10000
     const length = 32 // SHA256 hash size
     return new Promise((resolve) => {
-      var key = asmcrypto.Pbkdf2HmacSha256(passBuffer, saltBuffer, iterations, length)
+      const key = asmcrypto.Pbkdf2HmacSha256(passBuffer, saltBuffer, iterations, length)
       resolve(key)
     })
   }
@@ -89,9 +89,9 @@ class EdgeEncryptor {
    * @returns {string} Randomized base64 encoded data
    */
   _generateSalt (byteCount = 32) {
-    var view = new Uint8Array(byteCount)
+    const view = new Uint8Array(byteCount)
     global.crypto.getRandomValues(view)
-    var b64encoded = btoa(String.fromCharCode.apply(null, view))
+    const b64encoded = btoa(String.fromCharCode.apply(null, view))
     return b64encoded
   }
 }

--- a/app/scripts/lib/cleanErrorStack.js
+++ b/app/scripts/lib/cleanErrorStack.js
@@ -4,10 +4,10 @@
  * @returns {Error} Error with clean stack trace.
  */
 function cleanErrorStack (err) {
-  var name = err.name
+  let name = err.name
   name = (name === undefined) ? 'Error' : String(name)
 
-  var msg = err.message
+  let msg = err.message
   msg = (msg === undefined) ? '' : String(msg)
 
   if (name === '') {

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -109,9 +109,9 @@ module.exports = class MessageManager extends EventEmitter {
     }
     msgParams.data = normalizeMsgData(msgParams.data)
     // create txData obj with parameters and meta data
-    var time = (new Date()).getTime()
-    var msgId = createId()
-    var msgData = {
+    const time = (new Date()).getTime()
+    const msgId = createId()
+    const msgData = {
       id: msgId,
       msgParams: msgParams,
       time: time,

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -117,9 +117,9 @@ module.exports = class PersonalMessageManager extends EventEmitter {
     }
     msgParams.data = this.normalizeMsgData(msgParams.data)
     // create txData obj with parameters and meta data
-    var time = (new Date()).getTime()
-    var msgId = createId()
-    var msgData = {
+    const time = (new Date()).getTime()
+    const msgId = createId()
+    const msgData = {
       id: msgId,
       msgParams: msgParams,
       time: time,

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -111,9 +111,9 @@ module.exports = class TypedMessageManager extends EventEmitter {
 
     log.debug(`TypedMessageManager addUnapprovedMessage: ${JSON.stringify(msgParams)}`)
     // create txData obj with parameters and meta data
-    var time = (new Date()).getTime()
-    var msgId = createId()
-    var msgData = {
+    const time = (new Date()).getTime()
+    const msgId = createId()
+    const msgData = {
       id: msgId,
       msgParams: msgParams,
       time: time,

--- a/development/announcer.js
+++ b/development/announcer.js
@@ -1,11 +1,11 @@
-var manifest = require('../app/manifest.json')
-var version = manifest.version
+const manifest = require('../app/manifest.json')
+const version = manifest.version
 
-var fs = require('fs')
-var path = require('path')
-var changelog = fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md')).toString()
+const fs = require('fs')
+const path = require('path')
+const changelog = fs.readFileSync(path.join(__dirname, '..', 'CHANGELOG.md')).toString()
 
-var log = changelog.split(version)[1].split('##')[0].trim()
+const log = changelog.split(version)[1].split('##')[0].trim()
 
 const msg = `*MetaMask ${version}* now published! It should auto-update soon!\n${log}`
 

--- a/development/mock-dev.js
+++ b/development/mock-dev.js
@@ -94,7 +94,7 @@ function modifyBackgroundConnection (backgroundConnectionModifier) {
 }
 
 // parse opts
-var store = configureStore(firstState)
+const store = configureStore(firstState)
 
 // start app
 startApp()

--- a/development/sourcemap-validator.js
+++ b/development/sourcemap-validator.js
@@ -96,8 +96,8 @@ async function validateSourcemapForFile ({ buildName }) {
 }
 
 function indicesOf (substring, string) {
-  var a = []
-  var i = -1
+  const a = []
+  let i = -1
   while ((i = string.indexOf(substring, i + 1)) >= 0) {
     a.push(i)
   }

--- a/test/e2e/web3.spec.js
+++ b/test/e2e/web3.spec.js
@@ -30,7 +30,7 @@ describe('Using MetaMask with an existing account', function () {
     await delay(largeDelayMs)
     const [results] = await findElements(driver, By.css('#results'))
     const resulttext = await results.getText()
-    var parsedData = JSON.parse(resulttext)
+    const parsedData = JSON.parse(resulttext)
 
     return (parsedData)
 
@@ -153,14 +153,14 @@ describe('Using MetaMask with an existing account', function () {
     it('testing hexa methods', async () => {
 
 
-      var List = await driver.findElements(By.className('hexaNumberMethods'))
+      const List = await driver.findElements(By.className('hexaNumberMethods'))
 
       for (let i = 0; i < List.length; i++) {
         try {
 
-          var parsedData = await button(List[i])
+          const parsedData = await button(List[i])
           console.log(parsedData)
-          var result = parseInt(parsedData.result, 16)
+          const result = parseInt(parsedData.result, 16)
 
           assert.equal((typeof result === 'number'), true)
           await delay(regularDelayMs)
@@ -174,14 +174,14 @@ describe('Using MetaMask with an existing account', function () {
 
     it('testing booleanMethods', async () => {
 
-      var List = await driver.findElements(By.className('booleanMethods'))
+      const List = await driver.findElements(By.className('booleanMethods'))
 
       for (let i = 0; i < List.length; i++) {
         try {
 
-          var parsedData = await button(List[i])
+          const parsedData = await button(List[i])
           console.log(parsedData)
-          var result = parsedData.result
+          const result = parsedData.result
 
           assert.equal(result, false)
           await delay(regularDelayMs)
@@ -197,16 +197,16 @@ describe('Using MetaMask with an existing account', function () {
 
     it('testing  transactionMethods', async () => {
 
-      var List = await driver.findElements(By.className('transactionMethods'))
+      const List = await driver.findElements(By.className('transactionMethods'))
 
       for (let i = 0; i < List.length; i++) {
         try {
 
-          var parsedData = await button(List[i])
+          const parsedData = await button(List[i])
 
           console.log(parsedData.result.blockHash)
 
-          var result = []
+          const result = []
           result.push(parseInt(parsedData.result.blockHash, 16))
           result.push(parseInt(parsedData.result.blockNumber, 16))
           result.push(parseInt(parsedData.result.gas, 16))
@@ -239,17 +239,17 @@ describe('Using MetaMask with an existing account', function () {
 
     it('testing blockMethods', async () => {
 
-      var List = await driver.findElements(By.className('blockMethods'))
+      const List = await driver.findElements(By.className('blockMethods'))
 
       for (let i = 0; i < List.length; i++) {
         try {
 
-          var parsedData = await button(List[i])
+          const parsedData = await button(List[i])
           console.log(JSON.stringify(parsedData) + i)
 
           console.log(parsedData.result.parentHash)
 
-          var result = parseInt(parsedData.result.parentHash, 16)
+          const result = parseInt(parsedData.result.parentHash, 16)
 
           assert.equal((typeof result === 'number'), true)
           await delay(regularDelayMs)
@@ -265,9 +265,9 @@ describe('Using MetaMask with an existing account', function () {
 
     it('testing methods', async () => {
 
-      var List = await driver.findElements(By.className('methods'))
-      var parsedData
-      var result
+      const List = await driver.findElements(By.className('methods'))
+      let parsedData
+      let result
 
       for (let i = 0; i < List.length; i++) {
         try {

--- a/test/helper.js
+++ b/test/helper.js
@@ -17,7 +17,7 @@ server.listen(8545, () => {
 })
 
 // logging util
-var log = require('loglevel')
+const log = require('loglevel')
 log.setDefaultLevel(5)
 global.log = log
 
@@ -62,7 +62,7 @@ function enableFailureOnUnhandledPromiseRejection () {
         throw evt.detail.reason
       })
     } else {
-      var oldOHR = window.onunhandledrejection
+      const oldOHR = window.onunhandledrejection
       window.onunhandledrejection = function (evt) {
         if (typeof oldOHR === 'function') {
           oldOHR.apply(this, arguments)

--- a/test/lib/mock-encryptor.js
+++ b/test/lib/mock-encryptor.js
@@ -1,5 +1,5 @@
-var mockHex = '0xabcdef0123456789'
-var mockKey = Buffer.alloc(32)
+const mockHex = '0xabcdef0123456789'
+const mockKey = Buffer.alloc(32)
 let cacheVal
 
 module.exports = {

--- a/test/lib/mock-simple-keychain.js
+++ b/test/lib/mock-simple-keychain.js
@@ -1,4 +1,4 @@
-var fakeWallet = {
+const fakeWallet = {
   privKey: '0x123456788890abcdef',
   address: '0xfedcba0987654321',
 }
@@ -28,7 +28,7 @@ module.exports = class MockSimpleKeychain {
   }
 
   addAccounts (n = 1) {
-    for (var i = 0; i < n; i++) {
+    for (let i = 0; i < n; i++) {
       this.wallets.push(fakeWallet)
     }
   }

--- a/test/lib/react-trigger-change.js
+++ b/test/lib/react-trigger-change.js
@@ -18,7 +18,7 @@
 // Constants and functions are declared inside the closure.
 // In this way, reactTriggerChange can be passed directly to executeScript in Selenium.
 module.exports = function reactTriggerChange (node) {
-  var supportedInputTypes = {
+  const supportedInputTypes = {
     color: true,
     date: true,
     datetime: true,
@@ -35,27 +35,27 @@ module.exports = function reactTriggerChange (node) {
     url: true,
     week: true,
   }
-  var nodeName = node.nodeName.toLowerCase()
-  var type = node.type
-  var event
-  var descriptor
-  var initialValue
-  var initialChecked
-  var initialCheckedRadio
+  const nodeName = node.nodeName.toLowerCase()
+  const type = node.type
+  let event
+  let descriptor
+  let initialValue
+  let initialChecked
+  let initialCheckedRadio
 
   // Do not try to delete non-configurable properties.
   // Value and checked properties on DOM elements are non-configurable in PhantomJS.
   function deletePropertySafe (elem, prop) {
-    var desc = Object.getOwnPropertyDescriptor(elem, prop)
+    const desc = Object.getOwnPropertyDescriptor(elem, prop)
     if (desc && desc.configurable) {
       delete elem[prop]
     }
   }
 
   function getCheckedRadio (radio) {
-    var name = radio.name
-    var radios
-    var i
+    const name = radio.name
+    let radios
+    let i
     if (name) {
       radios = document.querySelectorAll('input[type="radio"][name="' + name + '"]')
       for (i = 0; i < radios.length; i += 1) {

--- a/test/unit/actions/config_test.js
+++ b/test/unit/actions/config_test.js
@@ -1,13 +1,13 @@
 // var jsdom = require('mocha-jsdom')
-var assert = require('assert')
-var freeze = require('deep-freeze-strict')
-var path = require('path')
+const assert = require('assert')
+const freeze = require('deep-freeze-strict')
+const path = require('path')
 
-var actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
-var reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
+const actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
+const reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
 
 describe('config view actions', function () {
-  var initialState = {
+  const initialState = {
     metamask: {
       rpcTarget: 'foo',
       frequentRpcList: [],
@@ -22,7 +22,7 @@ describe('config view actions', function () {
 
   describe('SHOW_CONFIG_PAGE', function () {
     it('should set appState.currentView.name to config', function () {
-      var result = reducers(initialState, actions.showConfigPage())
+      const result = reducers(initialState, actions.showConfigPage())
       assert.equal(result.appState.currentView.name, 'config')
     })
   })
@@ -34,7 +34,7 @@ describe('config view actions', function () {
         value: 'foo',
       }
 
-      var result = reducers(initialState, action)
+      const result = reducers(initialState, action)
       assert.equal(result.metamask.provider.type, 'rpc')
       assert.equal(result.metamask.provider.rpcTarget, 'foo')
     })

--- a/test/unit/actions/set_selected_account_test.js
+++ b/test/unit/actions/set_selected_account_test.js
@@ -1,14 +1,14 @@
 // var jsdom = require('mocha-jsdom')
-var assert = require('assert')
-var freeze = require('deep-freeze-strict')
-var path = require('path')
+const assert = require('assert')
+const freeze = require('deep-freeze-strict')
+const path = require('path')
 
-var actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
-var reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
+const actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
+const reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
 
 describe('SET_SELECTED_ACCOUNT', function () {
   it('sets the state.appState.activeAddress property of the state to the action.value', function () {
-    var initialState = {
+    const initialState = {
       appState: {
         activeAddress: 'foo',
       },
@@ -21,14 +21,14 @@ describe('SET_SELECTED_ACCOUNT', function () {
     }
     freeze(action)
 
-    var resultingState = reducers(initialState, action)
+    const resultingState = reducers(initialState, action)
     assert.equal(resultingState.appState.activeAddress, action.value)
   })
 })
 
 describe('SHOW_ACCOUNT_DETAIL', function () {
   it('updates metamask state', function () {
-    var initialState = {
+    const initialState = {
       metamask: {
         selectedAddress: 'foo',
       },
@@ -41,7 +41,7 @@ describe('SHOW_ACCOUNT_DETAIL', function () {
     }
     freeze(action)
 
-    var resultingState = reducers(initialState, action)
+    const resultingState = reducers(initialState, action)
     assert.equal(resultingState.metamask.selectedAddress, action.value)
   })
 })

--- a/test/unit/actions/tx_test.js
+++ b/test/unit/actions/tx_test.js
@@ -1,5 +1,5 @@
-var assert = require('assert')
-var path = require('path')
+const assert = require('assert')
+const path = require('path')
 
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'

--- a/test/unit/actions/view_info_test.js
+++ b/test/unit/actions/view_info_test.js
@@ -1,14 +1,14 @@
 // var jsdom = require('mocha-jsdom')
-var assert = require('assert')
-var freeze = require('deep-freeze-strict')
-var path = require('path')
+const assert = require('assert')
+const freeze = require('deep-freeze-strict')
+const path = require('path')
 
-var actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
-var reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
+const actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
+const reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
 
 describe('SHOW_INFO_PAGE', function () {
   it('sets the state.appState.currentView.name property to info', function () {
-    var initialState = {
+    const initialState = {
       appState: {
         activeAddress: 'foo',
       },
@@ -16,7 +16,7 @@ describe('SHOW_INFO_PAGE', function () {
     freeze(initialState)
 
     const action = actions.showInfoPage()
-    var resultingState = reducers(initialState, action)
+    const resultingState = reducers(initialState, action)
     assert.equal(resultingState.appState.currentView.name, 'info')
   })
 })

--- a/test/unit/actions/warning_test.js
+++ b/test/unit/actions/warning_test.js
@@ -1,14 +1,14 @@
 // var jsdom = require('mocha-jsdom')
-var assert = require('assert')
-var freeze = require('deep-freeze-strict')
-var path = require('path')
+const assert = require('assert')
+const freeze = require('deep-freeze-strict')
+const path = require('path')
 
-var actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
-var reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
+const actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
+const reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
 
 describe('action DISPLAY_WARNING', function () {
   it('sets appState.warning to provided value', function () {
-    var initialState = {
+    const initialState = {
       appState: {},
     }
     freeze(initialState)

--- a/test/unit/app/controllers/detect-tokens-test.js
+++ b/test/unit/app/controllers/detect-tokens-test.js
@@ -54,7 +54,7 @@ describe('DetectTokensController', () => {
     controller.isOpen = true
     controller.isUnlocked = true
 
-    var stub = sandbox.stub(controller, 'detectNewTokens')
+    const stub = sandbox.stub(controller, 'detectNewTokens')
 
     clock.tick(1)
     sandbox.assert.notCalled(stub)
@@ -70,7 +70,7 @@ describe('DetectTokensController', () => {
     controller.isOpen = true
     controller.isUnlocked = true
 
-    var stub = sandbox.stub(controller, 'detectTokenBalance')
+    const stub = sandbox.stub(controller, 'detectTokenBalance')
       .withArgs('0x0D262e5dC4A06a0F1c90cE79C7a60C09DfC884E4').returns(true)
       .withArgs('0xBC86727E770de68B1060C91f6BB6945c73e10388').returns(true)
 
@@ -114,7 +114,7 @@ describe('DetectTokensController', () => {
   it('should trigger detect new tokens when change address', async () => {
     controller.isOpen = true
     controller.isUnlocked = true
-    var stub = sandbox.stub(controller, 'detectNewTokens')
+    const stub = sandbox.stub(controller, 'detectNewTokens')
     await preferences.setSelectedAddress('0xbc86727e770de68b1060c91f6bb6945c73e10388')
     sandbox.assert.called(stub)
   })
@@ -122,7 +122,7 @@ describe('DetectTokensController', () => {
   it('should trigger detect new tokens when submit password', async () => {
     controller.isOpen = true
     controller.selectedAddress = '0x0'
-    var stub = sandbox.stub(controller, 'detectNewTokens')
+    const stub = sandbox.stub(controller, 'detectNewTokens')
     await controller._keyringMemStore.updateState({ isUnlocked: true })
     sandbox.assert.called(stub)
   })
@@ -130,7 +130,7 @@ describe('DetectTokensController', () => {
   it('should not trigger detect new tokens when not open or not unlocked', async () => {
     controller.isOpen = true
     controller.isUnlocked = false
-    var stub = sandbox.stub(controller, 'detectTokenBalance')
+    const stub = sandbox.stub(controller, 'detectTokenBalance')
     clock.tick(180000)
     sandbox.assert.notCalled(stub)
     controller.isOpen = false

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -342,7 +342,7 @@ describe('preferences controller', function () {
   })
 
   describe('on watchAsset', function () {
-    var stubNext, stubEnd, stubHandleWatchAssetERC20, asy, req, res
+    let stubNext, stubEnd, stubHandleWatchAssetERC20, asy, req, res
     const sandbox = sinon.createSandbox()
 
     beforeEach(() => {
@@ -359,8 +359,8 @@ describe('preferences controller', function () {
 
     it('shouldn not do anything if method not corresponds', async function () {
       const asy = {next: () => {}, end: () => {}}
-      var stubNext = sandbox.stub(asy, 'next')
-      var stubEnd = sandbox.stub(asy, 'end').returns(0)
+      const stubNext = sandbox.stub(asy, 'next')
+      const stubEnd = sandbox.stub(asy, 'end').returns(0)
       req.method = 'metamask'
       await preferencesController.requestWatchAsset(req, res, asy.next, asy.end)
       sandbox.assert.notCalled(stubEnd)
@@ -368,8 +368,8 @@ describe('preferences controller', function () {
     })
     it('should do something if method is supported', async function () {
       const asy = {next: () => {}, end: () => {}}
-      var stubNext = sandbox.stub(asy, 'next')
-      var stubEnd = sandbox.stub(asy, 'end').returns(0)
+      const stubNext = sandbox.stub(asy, 'next')
+      const stubEnd = sandbox.stub(asy, 'end').returns(0)
       req.method = 'metamask_watchAsset'
       req.params.type = 'someasset'
       await preferencesController.requestWatchAsset(req, res, asy.next, asy.end)
@@ -400,7 +400,7 @@ describe('preferences controller', function () {
   })
 
   describe('on watchAsset of type ERC20', function () {
-    var req
+    let req
 
     const sandbox = sinon.createSandbox()
     beforeEach(() => {

--- a/test/unit/app/controllers/transactions/tx-utils-test.js
+++ b/test/unit/app/controllers/transactions/tx-utils-test.js
@@ -5,7 +5,7 @@ const txUtils = require('../../../../../app/scripts/controllers/transactions/lib
 describe('txUtils', function () {
   describe('#validateTxParams', function () {
     it('does not throw for positive values', function () {
-      var sample = {
+      const sample = {
         from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
         value: '0x01',
       }
@@ -13,7 +13,7 @@ describe('txUtils', function () {
     })
 
     it('returns error for negative values', function () {
-      var sample = {
+      const sample = {
         from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
         value: '-0x01',
       }

--- a/test/unit/app/edge-encryptor-test.js
+++ b/test/unit/app/edge-encryptor-test.js
@@ -2,8 +2,8 @@ const assert = require('assert')
 
 const EdgeEncryptor = require('../../../app/scripts/edge-encryptor')
 
-var password = 'passw0rd1'
-var data = 'some random data'
+const password = 'passw0rd1'
+const data = 'some random data'
 
 global.crypto = global.crypto || {
   getRandomValues: function (array) {

--- a/test/unit/app/message-manager-test.js
+++ b/test/unit/app/message-manager-test.js
@@ -10,7 +10,7 @@ describe('Message Manager', function () {
 
   describe('#getMsgList', function () {
     it('when new should return empty array', function () {
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 0)
     })
@@ -21,9 +21,9 @@ describe('Message Manager', function () {
 
   describe('#addMsg', function () {
     it('adds a Msg returned in getMsgList', function () {
-      var Msg = { id: 1, status: 'approved', metamaskNetworkId: 'unit test' }
+      const Msg = { id: 1, status: 'approved', metamaskNetworkId: 'unit test' }
       messageManager.addMsg(Msg)
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 1)
       assert.equal(result[0].id, 1)
@@ -32,10 +32,10 @@ describe('Message Manager', function () {
 
   describe('#setMsgStatusApproved', function () {
     it('sets the Msg status to approved', function () {
-      var Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
+      const Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
       messageManager.addMsg(Msg)
       messageManager.setMsgStatusApproved(1)
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 1)
       assert.equal(result[0].status, 'approved')
@@ -44,10 +44,10 @@ describe('Message Manager', function () {
 
   describe('#rejectMsg', function () {
     it('sets the Msg status to rejected', function () {
-      var Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
+      const Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
       messageManager.addMsg(Msg)
       messageManager.rejectMsg(1)
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 1)
       assert.equal(result[0].status, 'rejected')
@@ -59,7 +59,7 @@ describe('Message Manager', function () {
       messageManager.addMsg({ id: '1', status: 'unapproved', metamaskNetworkId: 'unit test' })
       messageManager.addMsg({ id: '2', status: 'approved', metamaskNetworkId: 'unit test' })
       messageManager._updateMsg({ id: '1', status: 'blah', hash: 'foo', metamaskNetworkId: 'unit test' })
-      var result = messageManager.getMsg('1')
+      const result = messageManager.getMsg('1')
       assert.equal(result.hash, 'foo')
     })
   })

--- a/test/unit/app/personal-message-manager-test.js
+++ b/test/unit/app/personal-message-manager-test.js
@@ -11,7 +11,7 @@ describe('Personal Message Manager', function () {
 
   describe('#getMsgList', function () {
     it('when new should return empty array', function () {
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 0)
     })
@@ -22,9 +22,9 @@ describe('Personal Message Manager', function () {
 
   describe('#addMsg', function () {
     it('adds a Msg returned in getMsgList', function () {
-      var Msg = { id: 1, status: 'approved', metamaskNetworkId: 'unit test' }
+      const Msg = { id: 1, status: 'approved', metamaskNetworkId: 'unit test' }
       messageManager.addMsg(Msg)
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 1)
       assert.equal(result[0].id, 1)
@@ -33,10 +33,10 @@ describe('Personal Message Manager', function () {
 
   describe('#setMsgStatusApproved', function () {
     it('sets the Msg status to approved', function () {
-      var Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
+      const Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
       messageManager.addMsg(Msg)
       messageManager.setMsgStatusApproved(1)
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 1)
       assert.equal(result[0].status, 'approved')
@@ -45,10 +45,10 @@ describe('Personal Message Manager', function () {
 
   describe('#rejectMsg', function () {
     it('sets the Msg status to rejected', function () {
-      var Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
+      const Msg = { id: 1, status: 'unapproved', metamaskNetworkId: 'unit test' }
       messageManager.addMsg(Msg)
       messageManager.rejectMsg(1)
-      var result = messageManager.messages
+      const result = messageManager.messages
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 1)
       assert.equal(result[0].status, 'rejected')
@@ -60,7 +60,7 @@ describe('Personal Message Manager', function () {
       messageManager.addMsg({ id: '1', status: 'unapproved', metamaskNetworkId: 'unit test' })
       messageManager.addMsg({ id: '2', status: 'approved', metamaskNetworkId: 'unit test' })
       messageManager._updateMsg({ id: '1', status: 'blah', hash: 'foo', metamaskNetworkId: 'unit test' })
-      var result = messageManager.getMsg('1')
+      const result = messageManager.getMsg('1')
       assert.equal(result.hash, 'foo')
     })
   })
@@ -87,20 +87,20 @@ describe('Personal Message Manager', function () {
 
   describe('#normalizeMsgData', function () {
     it('converts text to a utf8 hex string', function () {
-      var input = 'hello'
-      var output = messageManager.normalizeMsgData(input)
+      const input = 'hello'
+      const output = messageManager.normalizeMsgData(input)
       assert.equal(output, '0x68656c6c6f', 'predictably hex encoded')
     })
 
     it('tolerates a hex prefix', function () {
-      var input = '0x12'
-      var output = messageManager.normalizeMsgData(input)
+      const input = '0x12'
+      const output = messageManager.normalizeMsgData(input)
       assert.equal(output, '0x12', 'un modified')
     })
 
     it('tolerates normal hex', function () {
-      var input = '12'
-      var output = messageManager.normalizeMsgData(input)
+      const input = '12'
+      const output = messageManager.normalizeMsgData(input)
       assert.equal(output, '0x12', 'adds prefix')
     })
   })

--- a/test/unit/reducers/unlock_vault_test.js
+++ b/test/unit/reducers/unlock_vault_test.js
@@ -1,11 +1,11 @@
 // var jsdom = require('mocha-jsdom')
-var assert = require('assert')
+const assert = require('assert')
 // var freeze = require('deep-freeze-strict')
-var path = require('path')
-var sinon = require('sinon')
+const path = require('path')
+const sinon = require('sinon')
 
-var actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
-var reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
+const actions = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'store', 'actions.js'))
+const reducers = require(path.join(__dirname, '..', '..', '..', 'ui', 'app', 'ducks', 'index.js'))
 
 describe('#unlockMetamask(selectedAccount)', function () {
   beforeEach(function () {

--- a/test/unit/util_test.js
+++ b/test/unit/util_test.js
@@ -1,13 +1,13 @@
-var assert = require('assert')
-var sinon = require('sinon')
+const assert = require('assert')
+const sinon = require('sinon')
 const ethUtil = require('ethereumjs-util')
 
-var path = require('path')
-var util = require(path.join(__dirname, '..', '..', 'ui', 'app', 'helpers', 'utils', 'util.js'))
+const path = require('path')
+const util = require(path.join(__dirname, '..', '..', 'ui', 'app', 'helpers', 'utils', 'util.js'))
 
 describe('util', function () {
-  var ethInWei = '1'
-  for (var i = 0; i < 18; i++) {
+  let ethInWei = '1'
+  for (let i = 0; i < 18; i++) {
     ethInWei += '0'
   }
 
@@ -47,52 +47,52 @@ describe('util', function () {
 
   describe('#addressSummary', function () {
     it('should add case-sensitive checksum', function () {
-      var address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
-      var result = util.addressSummary(address)
+      const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
+      const result = util.addressSummary(address)
       assert.equal(result, '0xFDEa65C8...b825')
     })
 
     it('should accept arguments for firstseg, lastseg, and keepPrefix', function () {
-      var address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
-      var result = util.addressSummary(address, 4, 4, false)
+      const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
+      const result = util.addressSummary(address, 4, 4, false)
       assert.equal(result, 'FDEa...b825')
     })
   })
 
   describe('#isValidAddress', function () {
     it('should allow 40-char non-prefixed hex', function () {
-      var address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b825'
-      var result = util.isValidAddress(address)
+      const address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b825'
+      const result = util.isValidAddress(address)
       assert.ok(result)
     })
 
     it('should allow 42-char non-prefixed hex', function () {
-      var address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
-      var result = util.isValidAddress(address)
+      const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
+      const result = util.isValidAddress(address)
       assert.ok(result)
     })
 
     it('should not allow less non hex-prefixed', function () {
-      var address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b85'
-      var result = util.isValidAddress(address)
+      const address = 'fdea65c8e26263f6d9a1b5de9555d2931a33b85'
+      const result = util.isValidAddress(address)
       assert.ok(!result)
     })
 
     it('should not allow less hex-prefixed', function () {
-      var address = '0xfdea65ce26263f6d9a1b5de9555d2931a33b85'
-      var result = util.isValidAddress(address)
+      const address = '0xfdea65ce26263f6d9a1b5de9555d2931a33b85'
+      const result = util.isValidAddress(address)
       assert.ok(!result)
     })
 
     it('should recognize correct capitalized checksum', function () {
-      var address = '0xFDEa65C8e26263F6d9A1B5de9555D2931A33b825'
-      var result = util.isValidAddress(address)
+      const address = '0xFDEa65C8e26263F6d9A1B5de9555D2931A33b825'
+      const result = util.isValidAddress(address)
       assert.ok(result)
     })
 
     it('should recognize incorrect capitalized checksum', function () {
-      var address = '0xFDea65C8e26263F6d9A1B5de9555D2931A33b825'
-      var result = util.isValidAddress(address)
+      const address = '0xFDea65C8e26263F6d9A1B5de9555D2931A33b825'
+      const result = util.isValidAddress(address)
       assert.ok(!result)
     })
 
@@ -107,58 +107,58 @@ describe('util', function () {
 
   describe('#numericBalance', function () {
     it('should return a BN 0 if given nothing', function () {
-      var result = util.numericBalance()
+      const result = util.numericBalance()
       assert.equal(result.toString(10), 0)
     })
 
     it('should work with hex prefix', function () {
-      var result = util.numericBalance('0x012')
+      const result = util.numericBalance('0x012')
       assert.equal(result.toString(10), '18')
     })
 
     it('should work with no hex prefix', function () {
-      var result = util.numericBalance('012')
+      const result = util.numericBalance('012')
       assert.equal(result.toString(10), '18')
     })
   })
 
   describe('#formatBalance', function () {
     it('when given nothing', function () {
-      var result = util.formatBalance()
+      const result = util.formatBalance()
       assert.equal(result, 'None', 'should return "None"')
     })
 
     it('should return eth as string followed by ETH', function () {
-      var input = new ethUtil.BN(ethInWei, 10).toJSON()
-      var result = util.formatBalance(input, 4)
+      const input = new ethUtil.BN(ethInWei, 10).toJSON()
+      const result = util.formatBalance(input, 4)
       assert.equal(result, '1.0000 ETH')
     })
 
     it('should return eth as string followed by ETH', function () {
-      var input = new ethUtil.BN(ethInWei, 10).div(new ethUtil.BN('2', 10)).toJSON()
-      var result = util.formatBalance(input, 3)
+      const input = new ethUtil.BN(ethInWei, 10).div(new ethUtil.BN('2', 10)).toJSON()
+      const result = util.formatBalance(input, 3)
       assert.equal(result, '0.500 ETH')
     })
 
     it('should display specified decimal points', function () {
-      var input = '0x128dfa6a90b28000'
-      var result = util.formatBalance(input, 2)
+      const input = '0x128dfa6a90b28000'
+      const result = util.formatBalance(input, 2)
       assert.equal(result, '1.33 ETH')
     })
     it('should default to 3 decimal points', function () {
-      var input = '0x128dfa6a90b28000'
-      var result = util.formatBalance(input)
+      const input = '0x128dfa6a90b28000'
+      const result = util.formatBalance(input)
       assert.equal(result, '1.337 ETH')
     })
     it('should show 2 significant digits for tiny balances', function () {
-      var input = '0x1230fa6a90b28'
-      var result = util.formatBalance(input)
+      const input = '0x1230fa6a90b28'
+      const result = util.formatBalance(input)
       assert.equal(result, '0.00032 ETH')
     })
     it('should not parse the balance and return value with 2 decimal points with ETH at the end', function () {
-      var value = '1.2456789'
-      var needsParse = false
-      var result = util.formatBalance(value, 2, needsParse)
+      const value = '1.2456789'
+      const needsParse = false
+      const result = util.formatBalance(value, 2, needsParse)
       assert.equal(result, '1.24 ETH')
     })
   })
@@ -166,7 +166,7 @@ describe('util', function () {
   describe('normalizing values', function () {
     describe('#normalizeToWei', function () {
       it('should convert an eth to the appropriate equivalent values', function () {
-        var valueTable = {
+        const valueTable = {
           wei: '1000000000000000000',
           kwei: '1000000000000000',
           mwei: '1000000000000',
@@ -181,11 +181,11 @@ describe('util', function () {
           // gether:'0.000000001',
           // tether:'0.000000000001',
         }
-        var oneEthBn = new ethUtil.BN(ethInWei, 10)
+        const oneEthBn = new ethUtil.BN(ethInWei, 10)
 
-        for (var currency in valueTable) {
-          var value = new ethUtil.BN(valueTable[currency], 10)
-          var output = util.normalizeToWei(value, currency)
+        for (const currency in valueTable) {
+          const value = new ethUtil.BN(valueTable[currency], 10)
+          const output = util.normalizeToWei(value, currency)
           assert.equal(output.toString(10), valueTable.wei, `value of ${output.toString(10)} ${currency} should convert to ${oneEthBn}`)
         }
       })
@@ -193,66 +193,66 @@ describe('util', function () {
 
     describe('#normalizeEthStringToWei', function () {
       it('should convert decimal eth to pure wei BN', function () {
-        var input = '1.23456789'
-        var output = util.normalizeEthStringToWei(input)
+        const input = '1.23456789'
+        const output = util.normalizeEthStringToWei(input)
         assert.equal(output.toString(10), '1234567890000000000')
       })
 
       it('should convert 1 to expected wei', function () {
-        var input = '1'
-        var output = util.normalizeEthStringToWei(input)
+        const input = '1'
+        const output = util.normalizeEthStringToWei(input)
         assert.equal(output.toString(10), ethInWei)
       })
 
       it('should account for overflow numbers gracefully by dropping extra precision.', function () {
-        var input = '1.11111111111111111111'
-        var output = util.normalizeEthStringToWei(input)
+        const input = '1.11111111111111111111'
+        const output = util.normalizeEthStringToWei(input)
         assert.equal(output.toString(10), '1111111111111111111')
       })
 
       it('should not truncate very exact wei values that do not have extra precision.', function () {
-        var input = '1.100000000000000001'
-        var output = util.normalizeEthStringToWei(input)
+        const input = '1.100000000000000001'
+        const output = util.normalizeEthStringToWei(input)
         assert.equal(output.toString(10), '1100000000000000001')
       })
     })
 
     describe('#normalizeNumberToWei', function () {
       it('should handle a simple use case', function () {
-        var input = 0.0002
-        var output = util.normalizeNumberToWei(input, 'ether')
-        var str = output.toString(10)
+        const input = 0.0002
+        const output = util.normalizeNumberToWei(input, 'ether')
+        const str = output.toString(10)
         assert.equal(str, '200000000000000')
       })
 
       it('should convert a kwei number to the appropriate equivalent wei', function () {
-        var result = util.normalizeNumberToWei(1.111, 'kwei')
+        const result = util.normalizeNumberToWei(1.111, 'kwei')
         assert.equal(result.toString(10), '1111', 'accepts decimals')
       })
 
       it('should convert a ether number to the appropriate equivalent wei', function () {
-        var result = util.normalizeNumberToWei(1.111, 'ether')
+        const result = util.normalizeNumberToWei(1.111, 'ether')
         assert.equal(result.toString(10), '1111000000000000000', 'accepts decimals')
       })
     })
     describe('#isHex', function () {
       it('should return true when given a hex string', function () {
-        var result = util.isHex('c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
+        const result = util.isHex('c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
         assert(result)
       })
 
       it('should return false when given a non-hex string', function () {
-        var result = util.isHex('c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714imnotreal')
+        const result = util.isHex('c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714imnotreal')
         assert(!result)
       })
 
       it('should return false when given a string containing a non letter/number character', function () {
-        var result = util.isHex('c3ab8ff13720!8ad9047dd39466b3c%8974e592c2fa383d4a396071imnotreal')
+        const result = util.isHex('c3ab8ff13720!8ad9047dd39466b3c%8974e592c2fa383d4a396071imnotreal')
         assert(!result)
       })
 
       it('should return true when given a hex string with hex-prefix', function () {
-        var result = util.isHex('0xc3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
+        const result = util.isHex('0xc3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
         assert(result)
       })
     })

--- a/test/web3/schema.js
+++ b/test/web3/schema.js
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars: 0 */
 
-var params = {
+const params = {
   // diffrent params used in the methods
   param: [],
   blockHashParams: '0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35',
@@ -93,7 +93,7 @@ var params = {
   },
 }
 
-var methods = {
+const methods = {
   hexaNumberMethods: {
     // these are the methods which have output in the form of hexa decimal numbers
     eth_blockNumber: ['eth_blockNumber', params.param, 'Q'],

--- a/test/web3/web3.js
+++ b/test/web3/web3.js
@@ -1,6 +1,6 @@
 /* eslint no-undef: 0 */
 
-var json = methods
+const json = methods
 
 web3.currentProvider.enable().then(() => {
 

--- a/ui/app/components/app/account-panel.js
+++ b/ui/app/components/app/account-panel.js
@@ -13,12 +13,12 @@ function AccountPanel () {
 }
 
 AccountPanel.prototype.render = function () {
-  var state = this.props
-  var identity = state.identity || {}
-  var account = state.account || {}
-  var isFauceting = state.isFauceting
+  const state = this.props
+  const identity = state.identity || {}
+  const account = state.account || {}
+  const isFauceting = state.isFauceting
 
-  var panelState = {
+  const panelState = {
     key: `accountPanel${identity.address}`,
     identiconKey: identity.address,
     identiconLabel: identity.name || '',

--- a/ui/app/components/app/menu-droppo.js
+++ b/ui/app/components/app/menu-droppo.js
@@ -98,7 +98,7 @@ MenuDroppoComponent.prototype.componentDidMount = function () {
     this.globalClickHandler = this.globalClickOccurred.bind(this)
     document.body.addEventListener('click', this.globalClickHandler)
     // eslint-disable-next-line react/no-find-dom-node
-    var container = findDOMNode(this)
+    const container = findDOMNode(this)
     this.container = container
   }
 }
@@ -122,7 +122,7 @@ MenuDroppoComponent.prototype.globalClickOccurred = function (event) {
 }
 
 function isDescendant (parent, child) {
-  var node = child.parentNode
+  let node = child.parentNode
   while (node !== null) {
     if (node === parent) {
       return true

--- a/ui/app/components/ui/fiat-value.js
+++ b/ui/app/components/ui/fiat-value.js
@@ -19,8 +19,8 @@ FiatValue.prototype.render = function () {
   if (value === 'None') {
     return value
   }
-  var fiatDisplayNumber, fiatTooltipNumber
-  var splitBalance = value.split(' ')
+  let fiatDisplayNumber, fiatTooltipNumber
+  const splitBalance = value.split(' ')
 
   if (conversionRate !== 0) {
     fiatTooltipNumber = Number(splitBalance[0]) * conversionRate

--- a/ui/app/components/ui/mascot.js
+++ b/ui/app/components/ui/mascot.js
@@ -33,8 +33,8 @@ Mascot.prototype.render = function Mascot () {
 }
 
 Mascot.prototype.componentDidMount = function () {
-  var targetDivId = 'metamask-mascot-container'
-  var container = document.getElementById(targetDivId)
+  const targetDivId = 'metamask-mascot-container'
+  const container = document.getElementById(targetDivId)
   container.appendChild(this.logo.container)
 }
 

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -21,14 +21,14 @@ export default function reduceApp (state, action) {
     name = 'confTx'
   }
 
-  var defaultView = {
+  const defaultView = {
     name,
     detailView: null,
     context: selectedAddress,
   }
 
   // default state
-  var appState = extend({
+  const appState = extend({
     shouldClose: false,
     menuOpen: false,
     modal: {

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -10,7 +10,7 @@ function reduceMetamask (state, action) {
   let newState
 
   // clone + defaults
-  var metamaskState = extend({
+  const metamaskState = extend({
     isInitialized: false,
     isUnlocked: false,
     isAccountMenuOpen: false,
@@ -99,7 +99,7 @@ function reduceMetamask (state, action) {
       })
 
     case actions.COMPLETED_TX:
-      var stringId = String(action.id)
+      const stringId = String(action.id)
       newState = extend(metamaskState, {
         unapprovedTxs: {},
         unapprovedMsgs: {},

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -12,7 +12,7 @@ function formatDate (date, format = 'M/d/y \'at\' T') {
   return DateTime.fromMillis(date).toFormat(format)
 }
 
-var valueTable = {
+const valueTable = {
   wei: '1000000000000000000',
   kwei: '1000000000000000',
   mwei: '1000000000000',
@@ -25,8 +25,8 @@ var valueTable = {
   gether: '0.000000001',
   tether: '0.000000000001',
 }
-var bnTable = {}
-for (var currency in valueTable) {
+const bnTable = {}
+for (const currency in valueTable) {
   bnTable[currency] = new ethUtil.BN(valueTable[currency], 10)
 }
 
@@ -97,12 +97,12 @@ function miniAddressSummary (address) {
   if (!address) {
     return ''
   }
-  var checked = checksumAddress(address)
+  const checked = checksumAddress(address)
   return checked ? checked.slice(0, 4) + '...' + checked.slice(-4) : '...'
 }
 
 function isValidAddress (address) {
-  var prefixed = ethUtil.addHexPrefix(address)
+  const prefixed = ethUtil.addHexPrefix(address)
   if (address === '0x0000000000000000000000000000000000000000') {
     return false
   }
@@ -114,7 +114,7 @@ function isValidENSAddress (address) {
 }
 
 function isInvalidChecksumAddress (address) {
-  var prefixed = ethUtil.addHexPrefix(address)
+  const prefixed = ethUtil.addHexPrefix(address)
   if (address === '0x0000000000000000000000000000000000000000') {
     return false
   }
@@ -125,8 +125,8 @@ function isAllOneCase (address) {
   if (!address) {
     return true
   }
-  var lower = address.toLowerCase()
-  var upper = address.toUpperCase()
+  const lower = address.toLowerCase()
+  const upper = address.toUpperCase()
   return address === lower || address === upper
 }
 
@@ -135,18 +135,18 @@ function numericBalance (balance) {
   if (!balance) {
     return new ethUtil.BN(0, 16)
   }
-  var stripped = ethUtil.stripHexPrefix(balance)
+  const stripped = ethUtil.stripHexPrefix(balance)
   return new ethUtil.BN(stripped, 16)
 }
 
 // Takes  hex, returns [beforeDecimal, afterDecimal]
 function parseBalance (balance) {
-  var beforeDecimal, afterDecimal
+  let afterDecimal
   const wei = numericBalance(balance)
-  var weiString = wei.toString()
+  const weiString = wei.toString()
   const trailingZeros = /0+$/
 
-  beforeDecimal = weiString.length > 18 ? weiString.slice(0, weiString.length - 18) : '0'
+  const beforeDecimal = weiString.length > 18 ? weiString.slice(0, weiString.length - 18) : '0'
   afterDecimal = ('000000000000000000' + wei).slice(-18).replace(trailingZeros, '')
   if (afterDecimal === '') {
     afterDecimal = '0'
@@ -157,14 +157,14 @@ function parseBalance (balance) {
 // Takes wei hex, returns an object with three properties.
 // Its "formatted" property is what we generally use to render values.
 function formatBalance (balance, decimalsToKeep, needsParse = true, ticker = 'ETH') {
-  var parsed = needsParse ? parseBalance(balance) : balance.split('.')
-  var beforeDecimal = parsed[0]
-  var afterDecimal = parsed[1]
-  var formatted = 'None'
+  const parsed = needsParse ? parseBalance(balance) : balance.split('.')
+  const beforeDecimal = parsed[0]
+  let afterDecimal = parsed[1]
+  let formatted = 'None'
   if (decimalsToKeep === undefined) {
     if (beforeDecimal === '0') {
       if (afterDecimal !== '0') {
-        var sigFigs = afterDecimal.match(/^0*(.{2})/) // default: grabs 2 most significant digits
+        const sigFigs = afterDecimal.match(/^0*(.{2})/) // default: grabs 2 most significant digits
         if (sigFigs) {
           afterDecimal = sigFigs[0]
         }
@@ -182,11 +182,11 @@ function formatBalance (balance, decimalsToKeep, needsParse = true, ticker = 'ET
 
 
 function generateBalanceObject (formattedBalance, decimalsToKeep = 1) {
-  var balance = formattedBalance.split(' ')[0]
-  var label = formattedBalance.split(' ')[1]
-  var beforeDecimal = balance.split('.')[0]
-  var afterDecimal = balance.split('.')[1]
-  var shortBalance = shortenBalance(balance, decimalsToKeep)
+  let balance = formattedBalance.split(' ')[0]
+  const label = formattedBalance.split(' ')[1]
+  const beforeDecimal = balance.split('.')[0]
+  const afterDecimal = balance.split('.')[1]
+  const shortBalance = shortenBalance(balance, decimalsToKeep)
 
   if (beforeDecimal === '0' && afterDecimal.substr(0, 5) === '00000') {
     // eslint-disable-next-line eqeqeq
@@ -203,8 +203,8 @@ function generateBalanceObject (formattedBalance, decimalsToKeep = 1) {
 }
 
 function shortenBalance (balance, decimalsToKeep = 1) {
-  var truncatedValue
-  var convertedBalance = parseFloat(balance)
+  let truncatedValue
+  const convertedBalance = parseFloat(balance)
   if (convertedBalance > 1000000) {
     truncatedValue = (balance / 1000000).toFixed(decimalsToKeep)
     return `${truncatedValue}m`
@@ -216,7 +216,7 @@ function shortenBalance (balance, decimalsToKeep = 1) {
   } else if (convertedBalance < 0.001) {
     return '<0.001'
   } else if (convertedBalance < 1) {
-    var stringBalance = convertedBalance.toString()
+    const stringBalance = convertedBalance.toString()
     if (stringBalance.split('.')[1].length > 3) {
       return convertedBalance.toFixed(3)
     } else {
@@ -228,7 +228,7 @@ function shortenBalance (balance, decimalsToKeep = 1) {
 }
 
 function dataSize (data) {
-  var size = data ? ethUtil.stripHexPrefix(data).length : 0
+  const size = data ? ethUtil.stripHexPrefix(data).length : 0
   return size + ' bytes'
 }
 
@@ -245,7 +245,7 @@ function normalizeEthStringToWei (str) {
   const parts = str.split('.')
   let eth = new ethUtil.BN(parts[0], 10).mul(bnTable.wei)
   if (parts[1]) {
-    var decimal = parts[1]
+    let decimal = parts[1]
     while (decimal.length < 18) {
       decimal += '0'
     }
@@ -258,24 +258,24 @@ function normalizeEthStringToWei (str) {
   return eth
 }
 
-var multiple = new ethUtil.BN('10000', 10)
+const multiple = new ethUtil.BN('10000', 10)
 function normalizeNumberToWei (n, currency) {
-  var enlarged = n * 10000
-  var amount = new ethUtil.BN(String(enlarged), 10)
+  const enlarged = n * 10000
+  const amount = new ethUtil.BN(String(enlarged), 10)
   return normalizeToWei(amount, currency).div(multiple)
 }
 
 function readableDate (ms) {
-  var date = new Date(ms)
-  var month = date.getMonth()
-  var day = date.getDate()
-  var year = date.getFullYear()
-  var hours = date.getHours()
-  var minutes = '0' + date.getMinutes()
-  var seconds = '0' + date.getSeconds()
+  const date = new Date(ms)
+  const month = date.getMonth()
+  const day = date.getDate()
+  const year = date.getFullYear()
+  const hours = date.getHours()
+  const minutes = '0' + date.getMinutes()
+  const seconds = '0' + date.getSeconds()
 
-  var dateStr = `${month}/${day}/${year}`
-  var time = `${hours}:${minutes.substr(-2)}:${seconds.substr(-2)}`
+  const dateStr = `${month}/${day}/${year}`
+  const time = `${hours}:${minutes.substr(-2)}:${seconds.substr(-2)}`
   return `${dateStr} ${time}`
 }
 

--- a/ui/app/pages/confirm-transaction/conf-tx.js
+++ b/ui/app/pages/confirm-transaction/conf-tx.js
@@ -153,7 +153,7 @@ ConfirmTxScreen.prototype.render = function () {
     conversionRate,
   } = this.props
 
-  var txData = this.getTxData() || {}
+  const txData = this.getTxData() || {}
   const { msgParams, type, msgParams: { version } } = txData
   log.debug('msgParams detected, rendering pending msg')
 
@@ -186,7 +186,7 @@ ConfirmTxScreen.prototype.render = function () {
 
 ConfirmTxScreen.prototype.signMessage = function (msgData, event) {
   log.info('conf-tx.js: signing message')
-  var params = msgData.msgParams
+  const params = msgData.msgParams
   params.metamaskId = msgData.id
   this.stopPropagation(event)
   return this.props.dispatch(actions.signMsg(params))
@@ -200,7 +200,7 @@ ConfirmTxScreen.prototype.stopPropagation = function (event) {
 
 ConfirmTxScreen.prototype.signPersonalMessage = function (msgData, event) {
   log.info('conf-tx.js: signing personal message')
-  var params = msgData.msgParams
+  const params = msgData.msgParams
   params.metamaskId = msgData.id
   this.stopPropagation(event)
   return this.props.dispatch(actions.signPersonalMsg(params))
@@ -208,7 +208,7 @@ ConfirmTxScreen.prototype.signPersonalMessage = function (msgData, event) {
 
 ConfirmTxScreen.prototype.signTypedMessage = function (msgData, event) {
   log.info('conf-tx.js: signing typed message')
-  var params = msgData.msgParams
+  const params = msgData.msgParams
   params.metamaskId = msgData.id
   this.stopPropagation(event)
   return this.props.dispatch(actions.signTypedMsg(params))

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -260,7 +260,7 @@ class Routes extends Component {
   toggleMetamaskActive () {
     if (!this.props.isUnlocked) {
       // currently inactive: redirect to password box
-      var passwordBox = document.querySelector('input[type=password]')
+      const passwordBox = document.querySelector('input[type=password]')
       if (!passwordBox) {
         return
       }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -17,7 +17,7 @@ const { hasUnconfirmedTransactions } = require('../helpers/utils/confirm-tx.util
 const gasDuck = require('../ducks/gas/gas.duck')
 const WebcamUtils = require('../../lib/webcam-utils')
 
-var actions = {
+const actions = {
   _setBackgroundConnection: _setBackgroundConnection,
 
   GO_HOME: 'GO_HOME',
@@ -399,7 +399,7 @@ var actions = {
 
 module.exports = actions
 
-var background = null
+let background = null
 function _setBackgroundConnection (backgroundConnection) {
   background = backgroundConnection
 }
@@ -2171,7 +2171,7 @@ function requestExportAccount () {
 }
 
 function exportAccount (password, address) {
-  var self = this
+  const self = this
 
   return function (dispatch) {
     dispatch(self.showLoadingIndication())
@@ -2305,7 +2305,7 @@ function pairUpdate (coin) {
 }
 
 function shapeShiftSubview () {
-  var pair = 'btc_eth'
+  const pair = 'btc_eth'
   return (dispatch) => {
     dispatch(actions.showSubLoadingIndication())
     shapeShiftRequest('marketinfo', {pair}, (mktResponse) => {
@@ -2334,7 +2334,7 @@ function coinShiftRquest (data, marketData) {
       if (response.error) {
         return dispatch(actions.displayWarning(response.error))
       }
-      var message = `
+      const message = `
         Deposit your ${response.depositType} to the address below:`
       log.debug(`background.createShapeShiftTx`)
       background.createShapeShiftTx(response.deposit, response.depositType)
@@ -2372,7 +2372,7 @@ function reshowQrCode (data, coin) {
         return dispatch(actions.displayWarning(mktResponse.error))
       }
 
-      var message = [
+      const message = [
         `Deposit your ${coin} to the address below:`,
         `Deposit Limit: ${mktResponse.limit}`,
         `Deposit Minimum:${mktResponse.minimum}`,
@@ -2385,10 +2385,10 @@ function reshowQrCode (data, coin) {
 }
 
 function shapeShiftRequest (query, options = {}, cb) {
-  var queryResponse, method
+  let queryResponse, method
   options.method ? method = options.method : method = 'GET'
 
-  var requestListner = function () {
+  const requestListner = function () {
     try {
       queryResponse = JSON.parse(this.responseText)
       if (cb) {
@@ -2403,12 +2403,12 @@ function shapeShiftRequest (query, options = {}, cb) {
     }
   }
 
-  var shapShiftReq = new XMLHttpRequest()
+  const shapShiftReq = new XMLHttpRequest()
   shapShiftReq.addEventListener('load', requestListner)
   shapShiftReq.open(method, `https://shapeshift.io/${query}/${options.pair ? options.pair : ''}`, true)
 
   if (options.method === 'POST') {
-    var jsonObj = JSON.stringify(options.data)
+    const jsonObj = JSON.stringify(options.data)
     shapShiftReq.setRequestHeader('Content-Type', 'application/json')
     return shapShiftReq.send(jsonObj)
   } else {

--- a/ui/index.js
+++ b/ui/index.js
@@ -13,7 +13,7 @@ module.exports = launchMetamaskUi
 log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn')
 
 function launchMetamaskUi (opts, cb) {
-  var {backgroundConnection} = opts
+  const {backgroundConnection} = opts
   actions._setBackgroundConnection(backgroundConnection)
   // check if we are unlocked first
   backgroundConnection.getState(function (err, metamaskState) {

--- a/ui/lib/icon-factory.js
+++ b/ui/lib/icon-factory.js
@@ -1,4 +1,4 @@
-var iconFactory
+let iconFactory
 const isValidAddress = require('ethereumjs-util').isValidAddress
 const { checksumAddress } = require('../app/helpers/utils/util')
 const contractMap = require('eth-contract-metadata')
@@ -26,18 +26,18 @@ IconFactory.prototype.iconForAddress = function (address, diameter) {
 
 // returns svg dom element
 IconFactory.prototype.generateIdenticonSvg = function (address, diameter) {
-  var cacheId = `${address}:${diameter}`
+  const cacheId = `${address}:${diameter}`
   // check cache, lazily generate and populate cache
-  var identicon = this.cache[cacheId] || (this.cache[cacheId] = this.generateNewIdenticon(address, diameter))
+  const identicon = this.cache[cacheId] || (this.cache[cacheId] = this.generateNewIdenticon(address, diameter))
   // create a clean copy so you can modify it
-  var cleanCopy = identicon.cloneNode(true)
+  const cleanCopy = identicon.cloneNode(true)
   return cleanCopy
 }
 
 // creates a new identicon
 IconFactory.prototype.generateNewIdenticon = function (address, diameter) {
-  var numericRepresentation = jsNumberForAddress(address)
-  var identicon = this.jazzicon(diameter, numericRepresentation)
+  const numericRepresentation = jsNumberForAddress(address)
+  const identicon = this.jazzicon(diameter, numericRepresentation)
   return identicon
 }
 
@@ -58,8 +58,8 @@ function imageElFor (address) {
 }
 
 function jsNumberForAddress (address) {
-  var addr = address.slice(2, 10)
-  var seed = parseInt(addr, 16)
+  const addr = address.slice(2, 10)
+  const seed = parseInt(addr, 16)
   return seed
 }
 

--- a/ui/lib/persistent-form.js
+++ b/ui/lib/persistent-form.js
@@ -15,7 +15,7 @@ PersistentForm.prototype.componentDidMount = function () {
   const fields = document.querySelectorAll('[data-persistent-formid]')
   const store = this.getPersistentStore()
 
-  for (var i = 0; i < fields.length; i++) {
+  for (let i = 0; i < fields.length; i++) {
     const field = fields[i]
     const key = field.getAttribute('data-persistent-formid')
     const cached = store[key]
@@ -52,7 +52,7 @@ PersistentForm.prototype.persistentFieldDidUpdate = function (event) {
 
 PersistentForm.prototype.componentWillUnmount = function () {
   const fields = document.querySelectorAll('[data-persistent-formid]')
-  for (var i = 0; i < fields.length; i++) {
+  for (let i = 0; i < fields.length; i++) {
     const field = fields[i]
     field.removeEventListener(eventName, this.persistentFieldDidUpdate.bind(this))
   }


### PR DESCRIPTION
This PR enables [the `no-var` ESLint rule][1]. `const` or `let` should be used instead.

> The `--fix` option on the command line can automatically fix some of the problems reported by this rule.

  [1]:https://eslint.org/docs/rules/no-var