### PR TITLE
Adds UX for connecting to dapps via the connected sites screen

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -251,6 +251,9 @@ function setupController (initState, initLangCode) {
     getRequestAccountTabIds: () => {
       return requestAccountTabIds
     },
+    getOpenMetamaskTabsIds: () => {
+      return openMetamaskTabsIDs
+    },
   })
 
   const provider = controller.provider

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -90,6 +90,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.platform = opts.platform
 
     this.getRequestAccountTabIds = opts.getRequestAccountTabIds
+    this.getOpenMetamaskTabsIds = opts.getOpenMetamaskTabsIds
 
     // observable state store
     this.store = new ComposableObservableStore(initState)
@@ -563,6 +564,7 @@ module.exports = class MetamaskController extends EventEmitter {
       legacyExposeAccounts: nodeify(permissionsController.legacyExposeAccounts, permissionsController),
 
       getRequestAccountTabIds: (cb) => cb(null, this.getRequestAccountTabIds()),
+      getOpenMetamaskTabsIds: (cb) => cb(null, this.getOpenMetamaskTabsIds()),
     }
   }
 

--- a/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
@@ -23,6 +23,7 @@ export default class ConnectedSitesList extends Component {
     tabToConnect: PropTypes.object,
     legacyExposeAccounts: PropTypes.func.isRequired,
     selectedAddress: PropTypes.string.isRequired,
+    getOpenMetamaskTabsIds: PropTypes.func.isRequired,
   }
 
   state = {
@@ -30,6 +31,11 @@ export default class ConnectedSitesList extends Component {
     iconError: '',
     domains: {},
     tabToConnect: null,
+  }
+
+  componentWillMount () {
+    const { getOpenMetamaskTabsIds } = this.props
+    getOpenMetamaskTabsIds()
   }
 
   handleDomainItemClick (domainKey) {

--- a/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
@@ -5,6 +5,7 @@ import ConnectedSitesList from './connected-sites-list.component'
 import {
   showModal,
   legacyExposeAccounts,
+  getOpenMetamaskTabsIds,
 } from '../../../store/actions'
 import {
   getRenderablePermissionsDomains,
@@ -16,10 +17,12 @@ import { getOriginFromUrl } from '../../../helpers/utils/util'
 
 const mapStateToProps = state => {
   const addressConnectedToCurrentTab = getAddressConnectedToCurrentTab(state)
-  const { title, url } = state.appState.currentActiveTab || {}
+  const { openMetaMaskTabs, currentActiveTab = {} } = state.appState
+  const { title, url, id } = currentActiveTab
+
   let tabToConnect
 
-  if (!addressConnectedToCurrentTab && url && !url.match(/^chrome-extension:\/\/.+\/home.html#connected$/)) {
+  if (!addressConnectedToCurrentTab && url && !openMetaMaskTabs[id]) {
     tabToConnect = {
       title,
       origin: getOriginFromUrl(url),
@@ -45,6 +48,7 @@ const mapDispatchToProps = dispatch => {
     legacyExposeAccounts: (origin, account) => {
       dispatch(legacyExposeAccounts(origin, [account]))
     },
+    getOpenMetamaskTabsIds: () => dispatch(getOpenMetamaskTabsIds()),
   }
 }
 

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -76,6 +76,7 @@ export default function reduceApp (state, action) {
     show3BoxModalAfterImport: false,
     threeBoxLastUpdated: null,
     requestAccountTabs: {},
+    openMetaMaskTabs: {},
     currentWindowTab: {},
     currentActiveTab: {},
   }, state.appState)
@@ -769,6 +770,11 @@ export default function reduceApp (state, action) {
     case actions.SET_REQUEST_ACCOUNT_TABS:
       return extend(appState, {
         requestAccountTabs: action.value,
+      })
+
+    case actions.SET_OPEN_METAMASK_TAB_IDS:
+      return extend(appState, {
+        openMetaMaskTabs: action.value,
       })
 
     case actions.SET_CURRENT_WINDOW_TAB:

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -405,6 +405,8 @@ var actions = {
   setActiveTab,
   SET_ACTIVE_TAB: 'SET_ACTIVE_TAB',
   getActiveTab,
+  getOpenMetamaskTabsIds,
+  SET_OPEN_METAMASK_TAB_IDS: 'SET_OPEN_METAMASK_TAB_IDS',
 }
 
 module.exports = actions
@@ -3041,6 +3043,20 @@ function getRequestAccountTabIds () {
   return async (dispatch) => {
     const requestAccountTabIds = await pify(background.getRequestAccountTabIds).call(background)
     dispatch(setRequestAccountTabIds(requestAccountTabIds))
+  }
+}
+
+function setOpenMetamaskTabsIDs (openMetaMaskTabIDs) {
+  return {
+    type: actions.SET_OPEN_METAMASK_TAB_IDS,
+    value: openMetaMaskTabIDs,
+  }
+}
+
+function getOpenMetamaskTabsIds () {
+  return async (dispatch) => {
+    const openMetaMaskTabIDs = await pify(background.getOpenMetamaskTabsIds).call(background)
+    dispatch(setOpenMetamaskTabsIDs(openMetaMaskTabIDs))
   }
 }
 


### PR DESCRIPTION
Demo video: https://streamable.com/ulah5

The PR adds the following feature: if a user has a non-metamask tab in focus, that has not granted `eth_accounts` permissions to MetaMask,  and goes to the "Connect Sites" screen, they will be able to click a button to connect to that focused/active tab.