### PR TITLE
LoginPerSite UI fixes

### DIFF
--- a/ui/app/components/app/modals/disconnect-account/disconnect-account.container.js
+++ b/ui/app/components/app/modals/disconnect-account/disconnect-account.container.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-const mergeProps = (stateProps, dispatchProps) => {
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const {
     domainKey,
     domain,
@@ -29,6 +29,7 @@ const mergeProps = (stateProps, dispatchProps) => {
   } = dispatchProps
 
   return {
+    ...ownProps,
     ...stateProps,
     ...dispatchProps,
     disconnectAccount: () => dispatchDisconnectAccount(domainKey, domain),

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -537,7 +537,9 @@ function getRenderablePermissionsDomains (state) {
       const accountsLastConnectedTime = ethAccountsPermissionsForDomain.accounts || {}
       const selectedAddressLastConnectedTime = accountsLastConnectedTime[selectedAddress]
 
-      const lastConnectedTime = formatDate(selectedAddressLastConnectedTime, 'yyyy-M-d')
+      const lastConnectedTime = selectedAddressLastConnectedTime
+        ? formatDate(selectedAddressLastConnectedTime, 'yyyy-M-d')
+        : ''
 
       return [ ...acc, {
         name,


### PR DESCRIPTION
This PR fixes two issues:

- The "Disconnect Acount" modal wouldn't close. This is because the `hideModal` method was not defined on props. That method is actually available in `ownProps` because the container uses `withModalProps`
- The `getRenderablePermissionsDomains` would error if the `selectedAddress` had never been connected to one of  the domains before, because `formatDate` errors when passed `null` or `undefined`