### PR TITLE
Prevent redux state mutation

### DIFF
--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -322,7 +322,9 @@ function reduceMetamask (state, action) {
       let { selectedAddressTxList } = metamaskState
       selectedAddressTxList = selectedAddressTxList.map(tx => {
         if (tx.id === txId) {
-          tx.txParams = value
+          const newTx = Object.assign({}, tx)
+          newTx.txParams = value
+          return newTx
         }
         return tx
       })


### PR DESCRIPTION
The `txParams` property of a transaction in Redux state was being mutated. The mutation is now prevented with a shallow clone.