### PR TITLE
Restore `providerRequest` message translations

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "አይቀበሉ"
   },
+  "likeToConnect": {
+    "message": "$1ከመለያዎ ጋር ለመገናኘት ይፈልጋል"
+  },
   "about": {
     "message": "ስለ"
   },

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "رفض"
   },
+  "likeToConnect": {
+    "message": "يرغب $1 في الاتصال بحسابك"
+  },
   "about": {
     "message": "حول"
   },

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Отхвърляне"
   },
+  "likeToConnect": {
+    "message": "$1 би искал да се свърже с вашия акаунт"
+  },
   "about": {
     "message": "Информация"
   },

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "প্রত্যাখ্যান"
   },
+  "likeToConnect": {
+    "message": "$1 আপনার অ্যাকাউন্টের সাথে সংযোগ করতে চায়"
+  },
   "about": {
     "message": "সম্পর্কে"
   },

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Rebutja"
   },
+  "likeToConnect": {
+    "message": "a $1 li agradaria connectar-se al teu compte"
+  },
   "about": {
     "message": "Informació"
   },

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Afvis"
   },
+  "likeToConnect": {
+    "message": "$1 ønsker at forbinde til din konto"
+  },
   "about": {
     "message": "Om"
   },

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Ablehnen"
   },
+  "likeToConnect": {
+    "message": "$1 möchte sich mit deinem Account verbinden"
+  },
   "about": {
     "message": "Über"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Απόρριψη"
   },
+  "likeToConnect": {
+    "message": "Αίτημα σύνδεσης στον λογαριασμό σας από $1"
+  },
   "about": {
     "message": "Σχετικά με"
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Rechazar"
   },
+  "likeToConnect": {
+    "message": "$1 quisiera conectar con tu cuenta"
+  },
   "about": {
     "message": "Acerca"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Rechazar"
   },
+  "likeToConnect": {
+    "message": "$1 desea conectarse a tu cuenta"
+  },
   "about": {
     "message": "Acerca de"
   },

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Lükka tagasi"
   },
+  "likeToConnect": {
+    "message": "$1 soovib teie kontoga ühenduse luua"
+  },
   "about": {
     "message": "Teave"
   },

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "عدم پذیرش"
   },
+  "likeToConnect": {
+    "message": "1$1 میخواهید تا با حساب تان وصل شوید"
+  },
   "about": {
     "message": "درباره"
   },

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Hylkää"
   },
+  "likeToConnect": {
+    "message": "$1 haluaisi yhdistää tiliisi"
+  },
   "about": {
     "message": "Tietoja asetuksista"
   },

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Tanggihan"
   },
+  "likeToConnect": {
+    "message": "Gusto ng $1 na kumonekta sa iyong account"
+  },
   "about": {
     "message": "Tungkol sa"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Rejeter"
   },
+  "likeToConnect": {
+    "message": "$1 voudrait se connecter à votre compte"
+  },
   "about": {
     "message": "À propos"
   },

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "דחה"
   },
+  "likeToConnect": {
+    "message": "$1 מבקש להתחבר לחשבון שלך"
+  },
   "about": {
     "message": "מידע כללי"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "अस्‍वीकार करें"
   },
+  "likeToConnect": {
+    "message": "$1 आपके खाते से कनेक्ट होता चाहता हैं"
+  },
   "about": {
     "message": "इसके बारे में"
   },

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "Odbaci"
   },
+  "likeToConnect": {
+    "message": "Korisnik $1 želi se povezati na vaš račun"
+  },
   "about": {
     "message": "O opcijama"
   },

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "Elutasítás"
   },
+  "likeToConnect": {
+    "message": "$1 szeretne kapcsolódni az ön fiókjához"
+  },
   "about": {
     "message": "Névjegy"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "Tolak"
   },
+  "likeToConnect": {
+    "message": "$1 ingin menghubungkan ke akun Anda"
+  },
   "about": {
     "message": "Tentang"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Annulla"
   },
+  "likeToConnect": {
+    "message": "$1 vorrebbe connettersi al tuo account"
+  },
   "about": {
     "message": "Informazioni"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "拒否"
   },
+  "likeToConnect": {
+    "message": "$1 はあなたのアカウントにアクセスしようとしています。"
+  },
   "aboutSettingsDescription": {
     "message": "バージョンやサポート、問合せ先など"
   },

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "ತಿರಸ್ಕರಿಸಿ"
   },
+  "likeToConnect": {
+    "message": "$1 ನಿಮ್ಮ ಖಾತೆಗೆ ಸಂಪರ್ಕಿಸಲು ಬಯಸುತ್ತಿದೆ"
+  },
   "about": {
     "message": "ಕುರಿತು"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "거부"
   },
+  "likeToConnect": {
+    "message": "$1이 당신의 계정에 연결하길 원합니다."
+  },
   "about": {
     "message": "정보"
   },

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Atmesti"
   },
+  "likeToConnect": {
+    "message": "$1 norėtų prisijungti prie jūsų paskyros"
+  },
   "about": {
     "message": "Apie"
   },

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "Noraidīt"
   },
+  "likeToConnect": {
+    "message": "$1 vēlas izveidot savienojumu ar jūsu kontu"
+  },
   "about": {
     "message": "Par"
   },

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Tolak"
   },
+  "likeToConnect": {
+    "message": "$1 ingin menyambung kepada akaun anda"
+  },
   "about": {
     "message": "Mengenai"
   },

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Avslå"
   },
+  "likeToConnect": {
+    "message": "$1 ønsker å forbindes med kontoen din "
+  },
   "about": {
     "message": "Info"
   },

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Odrzuć"
   },
+  "likeToConnect": {
+    "message": "$1 chce połączyć się z Twoim kontem"
+  },
   "about": {
     "message": "Informacje"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "Rejeitar"
   },
+  "likeToConnect": {
+    "message": "$1 gostaria de se conectar à sua conta"
+  },
   "about": {
     "message": "Sobre"
   },

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Respingeți"
   },
+  "likeToConnect": {
+    "message": "$1 ar dori să se conecteze la contul dvs."
+  },
   "about": {
     "message": "Despre"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -545,6 +545,9 @@
   "contractInteraction": {
     "message": "Взаимодействие с контрактом"
   },
+  "likeToConnect": {
+    "message": "$1 запрашивает доступ к вашему аккаунту"
+  },
   "about": {
     "message": "О нас"
   },

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Odmítnout"
   },
+  "likeToConnect": {
+    "message": "$1 sa chce pripojiť k vášmu účtu"
+  },
   "about": {
     "message": "Informácie"
   },

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Zavrni"
   },
+  "likeToConnect": {
+    "message": "$1 se želi povezati z vašim računom."
+  },
   "about": {
     "message": "O možnostih"
   },

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Одбиј"
   },
+  "likeToConnect": {
+    "message": "$1 bi hteo da se poveže sa vašim nalogom"
+  },
   "about": {
     "message": "Основни подаци"
   },

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "Avvisa"
   },
+  "likeToConnect": {
+    "message": "$1 vill ansluta till ditt konto"
+  },
   "about": {
     "message": "Om"
   },

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -12,6 +12,9 @@
   "reject": {
     "message": "Kataa"
   },
+  "likeToConnect": {
+    "message": "$1 ingependa kuunganishwa kwenye akaunti yako"
+  },
   "about": {
     "message": "Kuhusu"
   },

--- a/app/_locales/th/messages.json
+++ b/app/_locales/th/messages.json
@@ -2,6 +2,9 @@
   "reject": {
     "message": "ปฏิเสธ"
   },
+  "likeToConnect": {
+    "message": "$1 ต้องการเชื่อมต่อกับบัญชีของคุณ"
+  },
   "about": {
     "message": "เกี่ยวกับ"
   },

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "Відхилити"
   },
+  "likeToConnect": {
+    "message": "$1 бажає підключитися до вашого облікового запису"
+  },
   "about": {
     "message": "Про Google Chrome"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "拒绝"
   },
+  "likeToConnect": {
+    "message": "$1 希望关联您的账户"
+  },
   "about": {
     "message": "关于"
   },

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -8,6 +8,9 @@
   "reject": {
     "message": "拒絕"
   },
+  "likeToConnect": {
+    "message": "$1 請求訪問帳戶權限"
+  },
   "about": {
     "message": "關於"
   },


### PR DESCRIPTION
This message was removed, but it was replaced with a very similar message called `likeToConnect`. The only difference is that the new message has "MetaMask" in it. Preserving these messages without "MetaMask" is probably better than deleting them, so these messages have all been restored and renamed to `likeToConnect`.