### PR TITLE
process url fragment

### DIFF
--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -28,7 +28,7 @@ function setupEnsIpfsResolver ({ provider }) {
     }
     // parse ens name
     const urlData = urlUtil.parse(url)
-    const { hostname: name, path, search } = urlData
+    const { hostname: name, path, search, hash: fragment } = urlData
     const domainParts = name.split('.')
     const topLevelDomain = domainParts[domainParts.length - 1]
     // if unsupported TLD, abort
@@ -36,16 +36,16 @@ function setupEnsIpfsResolver ({ provider }) {
       return
     }
     // otherwise attempt resolve
-    attemptResolve({ tabId, name, path, search })
+    attemptResolve({ tabId, name, path, search, fragment })
   }
 
-  async function attemptResolve ({ tabId, name, path, search }) {
+  async function attemptResolve ({ tabId, name, path, search, fragment }) {
     extension.tabs.update(tabId, { url: `loading.html` })
-    let url = `https://manager.ens.domains/name/${name}`
+    let url = `https://app.ens.domains/name/${name}`
     try {
       const {type, hash} = await resolveEnsToIpfsContentId({ provider, name })
       if (type === 'ipfs-ns') {
-        const resolvedUrl = `https://gateway.ipfs.io/ipfs/${hash}${path}${search || ''}`
+        const resolvedUrl = `https://gateway.ipfs.io/ipfs/${hash}${path}${search || ''}${fragment || ''}`
         try {
           // check if ipfs gateway has result
           const response = await fetch(resolvedUrl, { method: 'HEAD' })
@@ -56,11 +56,11 @@ function setupEnsIpfsResolver ({ provider }) {
           console.warn(err)
         }
       } else if (type === 'swarm-ns') {
-        url = `https://swarm-gateways.net/bzz:/${hash}${path}${search || ''}`
+        url = `https://swarm-gateways.net/bzz:/${hash}${path}${search || ''}${fragment || ''}`
       } else if (type === 'onion' || type === 'onion3') {
-        url = `http://${hash}.onion${path}${search || ''}`
+        url = `http://${hash}.onion${path}${search || ''}${fragment || ''}`
       } else if (type === 'zeronet') {
-        url = `http://127.0.0.1:43110/${hash}${path}${search || ''}`
+        url = `http://127.0.0.1:43110/${hash}${path}${search || ''}${fragment || ''}`
       }
     } catch (err) {
       console.warn(err)


### PR DESCRIPTION
1 - use app.ens.domains instead of manager.ens.domains
manager.ens.domains redirects to app.ens.domains however the pathname is stripped out breaking the feature to redirect to an unknown domain
this PR solves this issue
2 - process url fragment
ens url fragment are not processed and as such not resolved
this PR add the missing fragment.
I'm not familiar with swarm-ns, onion and zeronet however I added them the missing fragment.
This needs to be reviewed.
3 - The missing fragment happens also in Metamask Mobile on Android.
Thanks