### PR TITLE
Login per site no sitemetadata fix

### DIFF
--- a/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
@@ -89,7 +89,7 @@ export default class ConnectedSitesList extends Component {
                       }
                       {domainIsExpanded
                         ? <div className="connected-sites-list__domain-origin">
-                          { domain.extensionId ? t('extensionId', [domain.extensionId]) : domain.origin }
+                          { domain.extensionId ? t('extensionId', [domain.extensionId]) : domain.secondaryName }
                         </div>
                         : null
                       }

--- a/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
@@ -89,7 +89,7 @@ export default class ConnectedSitesList extends Component {
                       }
                       {domainIsExpanded
                         ? <div className="connected-sites-list__domain-origin">
-                          { domain.extensionId ? t('extensionId', [domain.extensionId]) : domain.key }
+                          { domain.extensionId ? t('extensionId', [domain.extensionId]) : domain.origin }
                         </div>
                         : null
                       }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -459,15 +459,16 @@ function getAddressConnectedDomainMap (state) {
   if (domains) {
     Object.keys(domains).forEach(domainKey => {
       const { permissions } = domains[domainKey]
-      const { icon, name } = domainMetadata[domainKey]
+      const { icon, name } = domainMetadata[domainKey] || {}
       permissions.forEach(perm => {
         const caveats = perm.caveats || []
         const exposedAccountCaveat = caveats.find(caveat => caveat.name === 'exposedAccounts')
         if (exposedAccountCaveat && exposedAccountCaveat.value && exposedAccountCaveat.value.length) {
           exposedAccountCaveat.value.forEach(address => {
+            const nameToRender = name ? name : domainKey
             addressConnectedIconMap[address] = addressConnectedIconMap[address]
-              ? { ...addressConnectedIconMap[address], [domainKey]: { icon, name } }
-              : { [domainKey]: { icon, name } }
+              ? { ...addressConnectedIconMap[address], [domainKey]: { icon, name: nameToRender } }
+              : { [domainKey]: { icon, name: nameToRender } }
           })
         }
       })
@@ -531,7 +532,7 @@ function getRenderablePermissionsDomains (state) {
         name,
         icon,
         extensionId,
-      } = domainMetadata[domainKey]
+      } = domainMetadata[domainKey] || {}
       const permissionsHistoryForDomain = permissionsHistory[domainKey] || {}
       const ethAccountsPermissionsForDomain = permissionsHistoryForDomain['eth_accounts'] || {}
       const accountsLastConnectedTime = ethAccountsPermissionsForDomain.accounts || {}
@@ -542,7 +543,8 @@ function getRenderablePermissionsDomains (state) {
         : ''
 
       return [ ...acc, {
-        name,
+        name: name ? name : domainKey,
+        origin: name ? domainKey : '',
         icon,
         key: domainKey,
         lastConnectedTime,

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -544,7 +544,7 @@ function getRenderablePermissionsDomains (state) {
 
       return [ ...acc, {
         name: name ? name : domainKey,
-        origin: name ? domainKey : '',
+        secondaryName: name ? domainKey : '',
         icon,
         key: domainKey,
         lastConnectedTime,

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -465,7 +465,7 @@ function getAddressConnectedDomainMap (state) {
         const exposedAccountCaveat = caveats.find(caveat => caveat.name === 'exposedAccounts')
         if (exposedAccountCaveat && exposedAccountCaveat.value && exposedAccountCaveat.value.length) {
           exposedAccountCaveat.value.forEach(address => {
-            const nameToRender = name ? name : domainKey
+            const nameToRender = name || domainKey
             addressConnectedIconMap[address] = addressConnectedIconMap[address]
               ? { ...addressConnectedIconMap[address], [domainKey]: { icon, name: nameToRender } }
               : { [domainKey]: { icon, name: nameToRender } }
@@ -543,7 +543,7 @@ function getRenderablePermissionsDomains (state) {
         : ''
 
       return [ ...acc, {
-        name: name ? name : domainKey,
+        name: name || domainKey,
         secondaryName: name ? domainKey : '',
         icon,
         key: domainKey,


### PR DESCRIPTION
This PR ensures our "Connected Sites" list can handle domains for which we have no domain metadata, which can occur for sites that were open in a tab before metamask was unlocked and then connected with using the legacy connection method via the `Connected Sites` list. 