### PR TITLE
Close sidebar when opening connected sites

### DIFF
--- a/ui/app/components/app/account-details/account-details.component.js
+++ b/ui/app/components/app/account-details/account-details.component.js
@@ -4,7 +4,6 @@ import classnames from 'classnames'
 import Identicon from '../../ui/identicon'
 import Tooltip from '../../ui/tooltip-v2'
 import copyToClipboard from 'copy-to-clipboard'
-import { CONNECTED_ROUTE } from '../../../helpers/constants/routes'
 
 export default class AccountDetails extends Component {
   static contextTypes = {
@@ -20,6 +19,7 @@ export default class AccountDetails extends Component {
   static propTypes = {
     hideSidebar: PropTypes.func,
     showAccountDetailModal: PropTypes.func,
+    showConnectedSites: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
     checksummedAddress: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
@@ -44,17 +44,13 @@ export default class AccountDetails extends Component {
     setTimeout(() => this.setState({ hasCopied: false }), 3000)
   }
 
-  showConnectedSites = () => {
-    const { history } = this.props
-    history.push(CONNECTED_ROUTE)
-  }
-
   render () {
     const { t } = this.context
 
     const {
       hideSidebar,
       showAccountDetailModal,
+      showConnectedSites,
       label,
       checksummedAddress,
       name,
@@ -81,7 +77,7 @@ export default class AccountDetails extends Component {
               <button className="btn-secondary account-details__details-button" onClick={showAccountDetailModal} >
                 {t('details')}
               </button>
-              <button className="btn-secondary account-details__details-button" onClick={this.showConnectedSites}>
+              <button className="btn-secondary account-details__details-button" onClick={showConnectedSites}>
                 {t('connectedSites')}
               </button>
             </div>

--- a/ui/app/components/app/account-details/account-details.container.js
+++ b/ui/app/components/app/account-details/account-details.container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { compose } from 'recompose'
 import { withRouter } from 'react-router-dom'
+import PropTypes from 'prop-types'
 import { hideSidebar, showModal } from '../../../store/actions'
 import AccountDetails from './account-details.component'
 
@@ -13,4 +14,16 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
-export default compose(withRouter, connect(null, mapDispatchToProps))(AccountDetails)
+const AccountDetailsContainer = compose(
+  withRouter,
+  connect(null, mapDispatchToProps)
+)(AccountDetails)
+
+AccountDetailsContainer.propTypes = {
+  label: PropTypes.string.isRequired,
+  checksummedAddress: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  showConnectedSites: PropTypes.func.isRequired,
+}
+
+export default AccountDetailsContainer

--- a/ui/app/components/app/wallet-view/wallet-view.component.js
+++ b/ui/app/components/app/wallet-view/wallet-view.component.js
@@ -7,7 +7,7 @@ import AccountDetails from '../account-details'
 
 const { checksumAddress } = require('../../../helpers/utils/util')
 const TokenList = require('../token-list')
-const { ADD_TOKEN_ROUTE } = require('../../../helpers/constants/routes')
+const { ADD_TOKEN_ROUTE, CONNECTED_ROUTE } = require('../../../helpers/constants/routes')
 
 export default class WalletView extends Component {
   static contextTypes = {
@@ -89,6 +89,18 @@ export default class WalletView extends Component {
     )
   }
 
+  showConnectedSites = () => {
+    const {
+      sidebarOpen,
+      hideSidebar,
+      history,
+    } = this.props
+    history.push(CONNECTED_ROUTE)
+    if (sidebarOpen) {
+      hideSidebar()
+    }
+  }
+
   render () {
     const {
       responsiveDisplayClassname,
@@ -122,6 +134,7 @@ export default class WalletView extends Component {
           label={label}
           checksummedAddress={checksummedAddress}
           name={identities[selectedAddress].name}
+          showConnectedSites={this.showConnectedSites}
         />
         {this.renderWalletBalance()}
         <TokenList />


### PR DESCRIPTION
The 'Connected Sites' button in the accounts details now closes the sidebar, if it is open. This was accomplished by pulling the click handler for that button up to the wallet view component, where another button already followed a similar pattern of closing the sidebar.

It seemed confusing to me that one handler was in the `AccountsDetails` container component, and one was handed down from above, so I added PropTypes to the container component.

I'm not sure that the WalletView component is the best place for this logic, but I've put it there for now to be consistent with the add token button.