### PR TITLE
Improve disconnection modal messages

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -421,10 +421,10 @@
     "message": "Disconnect All"
   },
   "disconnectAllModalDescription": {
-    "message": "Are you sure? You will no longer be able to interact with any of these sites."
+    "message": "Are you sure? You will be disconnected from all sites on all accounts."
   },
   "disconnectAccountModalDescription": {
-    "message": "Are you sure? You will no longer be able to interact with this site."
+    "message": "Are you sure? You're account will be disconnected from this site."
   },
   "disconnectAccountQuestion": {
     "message": "Disconnect account?"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -424,7 +424,7 @@
     "message": "Are you sure? You will be disconnected from all sites on all accounts."
   },
   "disconnectAccountModalDescription": {
-    "message": "Are you sure? You're account will be disconnected from this site."
+    "message": "Are you sure? Your account will be disconnected from this site."
   },
   "disconnectAccountQuestion": {
     "message": "Disconnect account?"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -424,7 +424,7 @@
     "message": "Are you sure? You will be disconnected from all sites on all accounts."
   },
   "disconnectAccountModalDescription": {
-    "message": "Are you sure? Your account will be disconnected from this site."
+    "message": "Are you sure? Your account (\"$1\") will be disconnected from this site."
   },
   "disconnectAccountQuestion": {
     "message": "Disconnect account?"

--- a/ui/app/components/app/modals/disconnect-account/disconnect-account.component.js
+++ b/ui/app/components/app/modals/disconnect-account/disconnect-account.component.js
@@ -8,6 +8,7 @@ export default class DisconnectAccount extends PureComponent {
   static propTypes = {
     hideModal: PropTypes.func.isRequired,
     disconnectAccount: PropTypes.func.isRequired,
+    accountLabel: PropTypes.string.isRequired,
   }
 
   static contextTypes = {
@@ -16,7 +17,7 @@ export default class DisconnectAccount extends PureComponent {
 
   render () {
     const { t } = this.context
-    const { hideModal, disconnectAccount } = this.props
+    const { hideModal, disconnectAccount, accountLabel } = this.props
 
     return (
       <Modal
@@ -26,7 +27,7 @@ export default class DisconnectAccount extends PureComponent {
       >
         <div className="disconnect-account-modal">
           <div className="disconnect-account-modal__description">
-            { t('disconnectAccountModalDescription') }
+            { t('disconnectAccountModalDescription', [ accountLabel ]) }
           </div>
           <Button
             type="primary"

--- a/ui/app/components/app/modals/disconnect-account/disconnect-account.container.js
+++ b/ui/app/components/app/modals/disconnect-account/disconnect-account.container.js
@@ -2,11 +2,13 @@ import { connect } from 'react-redux'
 import { compose } from 'recompose'
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props'
 import DisconnectAccount from './disconnect-account.component'
+import { getCurrentAccountWithSendEtherInfo } from '../../../../selectors/selectors'
 import { removePermissionsFor } from '../../../../store/actions'
 
 const mapStateToProps = state => {
   return {
     ...state.appState.modal.modalState.props || {},
+    accountLabel: getCurrentAccountWithSendEtherInfo(state).name,
   }
 }
 


### PR DESCRIPTION
This PR makes two changes to the disconnection modal messages:

- removes the "no longer be able" phrasing as it sounds very final. A user might have read it a wrongly concluded that if they confirm the disconnect they would never be able to use that site/dapp again
- Makes it clear in the disconnectAllModalDescription that the user will be disconnected from all sites across all accounts.