### PR TITLE
Allow cancel during first step of permissions request flow

### DIFF
--- a/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
+++ b/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
@@ -17,6 +17,8 @@ export default class ChooseAccount extends Component {
     selectNewAccountViaModal: PropTypes.func.isRequired,
     nativeCurrency: PropTypes.string.isRequired,
     addressLastConnectedMap: PropTypes.object,
+    cancelPermissionsRequest: PropTypes.func.isRequired,
+    permissionsRequestId: PropTypes.string.isRequired,
   }
 
   static defaultProps = {
@@ -71,7 +73,7 @@ export default class ChooseAccount extends Component {
   }
 
   render () {
-    const { originName, selectNewAccountViaModal } = this.props
+    const { originName, selectNewAccountViaModal, permissionsRequestId, cancelPermissionsRequest } = this.props
     const { t } = this.context
     return (
       <div className="permissions-connect-choose-account">
@@ -82,11 +84,19 @@ export default class ChooseAccount extends Component {
           { t('toConnectWith', [originName]) }
         </div>
         { this.renderAccountsList() }
-        <div
-          onClick={ () => selectNewAccountViaModal() }
-          className="permissions-connect-choose-account__new-account"
-        >
-          { t('newAccount') }
+        <div className="permissions-connect-choose-account__bottom-buttons">
+          <div
+            onClick={ () => cancelPermissionsRequest(permissionsRequestId) }
+            className="permissions-connect-choose-account__cancel"
+          >
+            { t('cancel') }
+          </div>
+          <div
+            onClick={ () => selectNewAccountViaModal() }
+            className="permissions-connect-choose-account__new-account"
+          >
+            { t('newAccount') }
+          </div>
         </div>
       </div>
     )

--- a/ui/app/pages/permissions-connect/choose-account/index.scss
+++ b/ui/app/pages/permissions-connect/choose-account/index.scss
@@ -76,12 +76,22 @@
     }
   }
 
-  &__new-account {
+  &__new-account, &__cancel {
     @extend %content-text;
     line-height: 20px;
     color: #037DD6;
     margin-top: 24px;
     cursor: pointer;
+  }
+
+  &__cancel {
+    color: $Red-400;
+  }
+
+  &__bottom-buttons {
+    display: flex;
+    justify-content: space-around;
+    width: 393px;
   }
 
 }

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -19,6 +19,7 @@ export default class PermissionConnect extends Component {
     permissionsRequest: PropTypes.object,
     addressLastConnectedMap: PropTypes.object,
     requestAccountTabs: PropTypes.object,
+    permissionsRequestId: PropTypes.string,
   }
 
   static defaultProps = {
@@ -27,6 +28,7 @@ export default class PermissionConnect extends Component {
     permissionsRequest: {},
     addressLastConnectedMap: {},
     requestAccountTabs: {},
+    permissionsRequestId: '',
   }
 
   static contextTypes = {
@@ -85,6 +87,7 @@ export default class PermissionConnect extends Component {
       nativeCurrency,
       permissionsRequest,
       addressLastConnectedMap,
+      permissionsRequestId,
     } = this.props
     const { page, selectedAccountAddress, permissionAccepted, originName } = this.state
 
@@ -107,6 +110,13 @@ export default class PermissionConnect extends Component {
               })
             }}
             addressLastConnectedMap={addressLastConnectedMap}
+            cancelPermissionsRequest={requestId => {
+              if (requestId) {
+                rejectPermissionsRequest(requestId)
+                this.redirectFlow(false)
+              }
+            }}
+            permissionsRequestId={permissionsRequestId}
           />
           : <div><PermissionPageContainer
             request={permissionsRequest || {}}

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -26,8 +26,11 @@ const mapStateToProps = state => {
     addressLastConnectedMap[key] = formatDate(addressLastConnectedMap[key], 'yyyy-M-d')
   })
 
+  const permissionsRequestId = (permissionsRequest && permissionsRequest.metadata) ? permissionsRequest.metadata.id : null
+
   return {
     permissionsRequest,
+    permissionsRequestId,
     accounts: accountsWithLabels,
     originName: origin,
     newAccountNumber: accountsWithLabels.length + 1,


### PR DESCRIPTION
This PR provides the user with a way to cancel/reject a permissions request on the first screen of the permissions flow. It adds a cancel "button" below the list of accounts.

![Screenshot from 2019-12-02 13-25-19](https://user-images.githubusercontent.com/7499938/69978662-6e6fda80-1507-11ea-8493-a98bc3d2449c.png)
----
![Screenshot from 2019-12-02 13-25-09](https://user-images.githubusercontent.com/7499938/69978663-6f087100-1507-11ea-8549-acadb0e50fbf.png)
