### PR TITLE
Fix eth_accounts language & selectability

### DIFF
--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -669,7 +669,7 @@
     "message": "Conectant-te a Ethereum i la web descentralitzada."
   },
   "metamaskSeedWords": {
-    "message": "Frase de recuperació de Metamask"
+    "message": "Frase de recuperació de MetaMask"
   },
   "metamaskVersion": {
     "message": "Versió MetaMask"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -507,7 +507,7 @@
   },
   "extensionId": {
     "message": "Extension ID: $1",
-    "description": "$1 is a string of random letters that are the id of another extension connecting to Metamask"
+    "description": "$1 is a string of random letters that are the id of another extension connecting to MetaMask"
   },
   "externalExtension": {
     "message": "External Extension"
@@ -764,7 +764,7 @@
     "message": "Would you like to add these tokens?"
   },
   "likeToConnect": {
-    "message": "$1 would like to connect to your Metamask account",
+    "message": "$1 would like to connect to your MetaMask account",
     "description": "$1 is the name/url of a site/dapp asking to connect to MetaMask"
   },
   "links": {
@@ -1368,7 +1368,7 @@
   },
   "thisWillAllowExternalExtension": {
     "message": "This will allow an external extension with id $1 to:",
-    "description":  "$1 is a string of random letters that are the id of another extension connecting to Metamask"
+    "description":  "$1 is a string of random letters that are the id of another extension connecting to MetaMask"
   },
   "thisWillCreate": {
     "message": "This will create a new wallet and seed phrase"

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -402,7 +402,7 @@
     "message": "Kui teil on küsimusi või näete midagi kahtlast, kirjutage meile support@metamask.io."
   },
   "endOfFlowMessage8": {
-    "message": "Metamask ei saa teie seemnefraasi taastada. Lisateave."
+    "message": "MetaMask ei saa teie seemnefraasi taastada. Lisateave."
   },
   "endOfFlowMessage9": {
     "message": "Lisateave."
@@ -1162,7 +1162,7 @@
     "message": "Saate sünkroonida oma kontod ja teabe oma mobiiliseadmega. Avage MetaMaski mobiilirakendus, avage \"Settings\" (Seaded) ja puudutage valikut \"Sync from Browser Extension\" (Sünkroonimine lehitseja laiendusest)"
   },
   "syncWithMobileDescNewUsers": {
-    "message": "Järgige Metamaski mobiilirakenduse esmakordsel avamisel telefonis esitatud samme."
+    "message": "Järgige MetaMaski mobiilirakenduse esmakordsel avamisel telefonis esitatud samme."
   },
   "syncWithMobileScanThisCode": {
     "message": "Skanneerige see kood MetaMaski mobiilirakendusega"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -72,7 +72,7 @@
     "message": "推奨トークンを追加"
   },
   "addAcquiredTokens": {
-    "message": "Metamaskで獲得したトークンを追加する"
+    "message": "MetaMaskで獲得したトークンを追加する"
   },
   "amount": {
     "message": "金額"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -75,7 +75,7 @@
     "message": "添加推荐代币"
   },
   "addAcquiredTokens": {
-    "message": "在Metamask上添加已用的代币"
+    "message": "在MetaMask上添加已用的代币"
   },
   "amount": {
     "message": "数量"

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -3,7 +3,7 @@ module.exports = function getRestrictedMethods (permissionsController) {
   return {
 
     'eth_accounts': {
-      description: 'View Ethereum accounts',
+      description: 'View selected Ethereum account(s)',
       method: (_, res, __, end) => {
         permissionsController.keyringController.getAccounts()
           .then((accounts) => {

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -3,7 +3,7 @@ module.exports = function getRestrictedMethods (permissionsController) {
   return {
 
     'eth_accounts': {
-      description: 'View selected Ethereum account',
+      description: 'View the address of the selected account',
       method: (_, res, __, end) => {
         permissionsController.keyringController.getAccounts()
           .then((accounts) => {

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -3,7 +3,7 @@ module.exports = function getRestrictedMethods (permissionsController) {
   return {
 
     'eth_accounts': {
-      description: 'View selected Ethereum account(s)',
+      description: 'View selected Ethereum account',
       method: (_, res, __, end) => {
         permissionsController.keyringController.getAccounts()
           .then((accounts) => {

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -158,7 +158,7 @@ describe('MetaMask', function () {
       await domains[0].click()
 
       const permissionDescription = await findElement(driver, By.css('.connected-sites-list__permission-description'))
-      assert.equal(await permissionDescription.getText(), 'View selected Ethereum account')
+      assert.equal(await permissionDescription.getText(), 'View the address of the selected account')
     })
 
     it('can get accounts within the dapp', async () => {

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -158,7 +158,7 @@ describe('MetaMask', function () {
       await domains[0].click()
 
       const permissionDescription = await findElement(driver, By.css('.connected-sites-list__permission-description'))
-      assert.equal(await permissionDescription.getText(), 'View Ethereum accounts')
+      assert.equal(await permissionDescription.getText(), 'View selected Ethereum account')
     })
 
     it('can get accounts within the dapp', async () => {

--- a/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -89,11 +89,17 @@ export default class PermissionPageContainerContent extends PureComponent {
         console.warn(`Unknown permission requested: ${methodName}`)
       }
       const description = permissionsDescriptions[methodName] || methodName
+      // don't allow deselecting eth_accounts
+      const isDisabled = methodName === 'eth_accounts'
 
       return (
         <div
           className="permission-approval-container__content__permission" key={methodName}
-          onClick={() => onPermissionToggle(methodName)}
+          onClick={() => {
+            if (!isDisabled) {
+              onPermissionToggle(methodName)
+            }
+          }}
         >
           { selectedPermissions[methodName]
             ? <i className="fa fa-check-circle fa-sm" />


### PR DESCRIPTION
- Change `eth_accounts` permission description to `View selected Ethereum account(s)`
- Prevent deselection of `eth_accounts` permission 
  - Unresolved: can we change the font-awesome `<i>` element in any way to indicate that it can't be deselected? Not critical at the moment, but we should do it if there's an easy fix.