### PR TITLE
Login per site tab popup fixes

### DIFF
--- a/ui/app/components/app/permission-page-container/permission-page-container.container.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.container.js
@@ -8,14 +8,12 @@ import {
 } from '../../../selectors/selectors'
 
 const mapStateToProps = (state, ownProps) => {
-  const { request } = ownProps
+  const { request, cachedOrigin } = ownProps
   const { metadata: requestMetadata = {} } = request || {}
 
   const domainMetadata = getDomainMetadata(state)
-  const targetDomainMetadata = (
-    domainMetadata[requestMetadata.origin] ||
-    { name: requestMetadata.origin, icon: null }
-  )
+  const origin = requestMetadata.origin || cachedOrigin
+  const targetDomainMetadata = (domainMetadata[origin] || { name: origin, icon: null })
 
   return {
     permissionsDescriptions: getPermissionsDescriptions(state),

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -82,7 +82,8 @@ export default class PermissionConnect extends Component {
       } else {
         this.redirectFlow(false)
       }
-    } else if (permissionsRequestId && prevProps.permissionsRequestId && permissionsRequestId !== prevProps.permissionsRequestId) {
+    } else if (permissionsRequestId && prevProps.permissionsRequestId && 
+      permissionsRequestId !== prevProps.permissionsRequestId && page !== null) {
       this.setState({
         originName: this.props.originName,
         page: 1,

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -68,7 +68,7 @@ export default class PermissionConnect extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { permissionsRequest, domains, permissionsRequestId } = this.props
+    const { domains, permissionsRequestId } = this.props
     const { originName, page } = this.state
 
     if (!permissionsRequestId && prevProps.permissionsRequestId && page !== null) {
@@ -82,7 +82,7 @@ export default class PermissionConnect extends Component {
       } else {
         this.redirectFlow(false)
       }
-    } else if (permissionsRequestId && prevProps.permissionsRequestId && 
+    } else if (permissionsRequestId && prevProps.permissionsRequestId &&
       permissionsRequestId !== prevProps.permissionsRequestId && page !== null) {
       this.setState({
         originName: this.props.originName,
@@ -117,9 +117,9 @@ export default class PermissionConnect extends Component {
           global.platform.closeTab(currentTabId)
         }
       }, 2000)
-    } else if (etEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
+    } else if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
       history.push(DEFAULT_ROUTE)
-    } else if (etEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP) {
+    } else if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP) {
       history.push(CONNECTED_ROUTE)
     }
   }

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -1,10 +1,13 @@
 import { connect } from 'react-redux'
+import { compose } from 'recompose'
+import { withRouter } from 'react-router-dom'
 import PermissionApproval from './permissions-connect.component'
 import {
   getFirstPermissionRequest,
   getNativeCurrency,
   getAccountsWithLabels,
   getLastConnectedInfo,
+  getPermissionsDomains,
 } from '../../selectors/selectors'
 import { formatDate } from '../../helpers/utils/util'
 import { approvePermissionsRequest, rejectPermissionsRequest, showModal, getCurrentWindowTab, getRequestAccountTabIds } from '../../store/actions'
@@ -37,6 +40,7 @@ const mapStateToProps = state => {
     nativeCurrency,
     requestAccountTabs,
     addressLastConnectedMap,
+    domains: getPermissionsDomains(state),
   }
 }
 
@@ -56,4 +60,7 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PermissionApproval)
+export default compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps)
+)(PermissionApproval)

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -180,7 +180,11 @@ class Routes extends Component {
       return this.onConfirmPage() || hasPermissionsRequests
     }
 
-    if (hasPermissionsRequests) {
+    const isHandlingPermissionsRequest = Boolean(matchPath(location.pathname, {
+      path: CONNECT_ROUTE, exact: false,
+    }))
+
+    if (hasPermissionsRequests || isHandlingPermissionsRequest) {
       return true
     }
   }


### PR DESCRIPTION
This PR addresses the following issues:
- if metamask is open in popup view during the connect flow, the metamask that is already open in the tab will get into a weird state when the permission request is confirmed or rejected
- redirect doesn't work in the popup view