### PR TITLE
Handle tab update failure

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -57,14 +57,13 @@ export default class PermissionConnect extends Component {
       permissionAccepted: accepted,
     })
 
-    setTimeout(() => {
-      global.platform.currentTab()
-        .then(({ id: currentTabId }) => {
-          global.platform.switchToTab(requestAccountTabs[originName])
-            .then(() => {
-              global.platform.closeTab(currentTabId)
-            })
-        })
+    setTimeout(async () => {
+      const { id: currentTabId } = await global.platform.currentTab()
+      try {
+        await global.platform.switchToTab(requestAccountTabs[originName])
+      } finally {
+        global.platform.closeTab(currentTabId)
+      }
     }, 2000)
   }
 


### PR DESCRIPTION
`extension.tabs.update` can sometimes fail if the user interacts with the tabs directly around the same time. The redirect flow has been updated to ensure that the permissions tab is still closed in that case. The user is on their own to find the dapp tab again in that case.