### PR TITLE
Only redirect back to dapp if current tab is active

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -110,11 +110,13 @@ export default class PermissionConnect extends Component {
 
     if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_FULLSCREEN) {
       setTimeout(async () => {
-        const { id: currentTabId } = await global.platform.currentTab()
+        const currentTab = await global.platform.currentTab()
         try {
-          await global.platform.switchToTab(requestAccountTabs[originName])
+          if (currentTab.active) {
+            await global.platform.switchToTab(requestAccountTabs[originName])
+          }
         } finally {
-          global.platform.closeTab(currentTabId)
+          global.platform.closeTab(currentTab.id)
         }
       }, 2000)
     } else if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {


### PR DESCRIPTION
The "redirect back to dapp" behaviour can be disruptive when the permissions connect tab is not active. The purpose of the redirect was to maintain context between the dapp and the permissions request, but if the user has already moved to another tab, that no longer applies.