### PR TITLE
Avoid race condtion that could prevent contextual account switching

### DIFF
--- a/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
@@ -17,8 +17,8 @@ import { getOriginFromUrl } from '../../../helpers/utils/util'
 
 const mapStateToProps = state => {
   const addressConnectedToCurrentTab = getAddressConnectedToCurrentTab(state)
-  const { openMetaMaskTabs, currentActiveTab = {} } = state.appState
-  const { title, url, id } = currentActiveTab
+  const { openMetaMaskTabs } = state.appState
+  const { title, url, id } = state.activeTab
 
   let tabToConnect
 

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -78,7 +78,6 @@ export default function reduceApp (state, action) {
     requestAccountTabs: {},
     openMetaMaskTabs: {},
     currentWindowTab: {},
-    currentActiveTab: {},
   }, state.appState)
 
   switch (action.type) {
@@ -780,11 +779,6 @@ export default function reduceApp (state, action) {
     case actions.SET_CURRENT_WINDOW_TAB:
       return extend(appState, {
         currentWindowTab: action.value,
-      })
-
-    case actions.SET_ACTIVE_TAB:
-      return extend(appState, {
-        currentActiveTab: action.value,
       })
 
     default:

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -86,7 +86,7 @@ import {
 
 class Routes extends Component {
   componentWillMount () {
-    const { currentCurrency, setCurrentCurrencyToUSD, getActiveTab } = this.props
+    const { currentCurrency, setCurrentCurrencyToUSD } = this.props
 
     if (!currentCurrency) {
       setCurrentCurrencyToUSD()
@@ -105,8 +105,13 @@ class Routes extends Component {
         })
       }
     })
+  }
 
-    getActiveTab()
+  componentDidMount () {
+    const { addressConnectedToCurrentTab, showAccountDetail, selectedAddress } = this.props
+    if (addressConnectedToCurrentTab && addressConnectedToCurrentTab !== selectedAddress) {
+      showAccountDetail(addressConnectedToCurrentTab)
+    }
   }
 
   componentDidUpdate (prevProps) {
@@ -357,6 +362,7 @@ Routes.propTypes = {
   textDirection: PropTypes.string,
   network: PropTypes.string,
   provider: PropTypes.object,
+  selectedAddress: PropTypes.string,
   frequentRpcListDetail: PropTypes.array,
   currentView: PropTypes.object,
   sidebar: PropTypes.object,
@@ -373,9 +379,12 @@ Routes.propTypes = {
   providerId: PropTypes.string,
   hasPermissionsRequests: PropTypes.bool,
   autoLogoutTimeLimit: PropTypes.number,
-  getActiveTab: PropTypes.func,
   addressConnectedToCurrentTab: PropTypes.string,
   showAccountDetail: PropTypes.func,
+}
+
+Routes.defaultProps = {
+  selectedAddress: undefined,
 }
 
 function mapStateToProps (state) {
@@ -403,6 +412,7 @@ function mapStateToProps (state) {
     submittedPendingTransactions: submittedPendingTransactionsSelector(state),
     network: state.metamask.network,
     provider: state.metamask.provider,
+    selectedAddress: state.metamask.selectedAddress,
     frequentRpcListDetail: state.metamask.frequentRpcListDetail || [],
     currentCurrency: state.metamask.currentCurrency,
     isMouseUser: state.appState.isMouseUser,
@@ -420,7 +430,6 @@ function mapDispatchToProps (dispatch) {
     setCurrentCurrencyToUSD: () => dispatch(actions.setCurrentCurrency('usd')),
     setMouseUserState: (isMouseUser) => dispatch(actions.setMouseUserState(isMouseUser)),
     setLastActiveTime: () => dispatch(actions.setLastActiveTime()),
-    getActiveTab: () => dispatch(actions.getActiveTab()),
     showAccountDetail: address => dispatch(actions.showAccountDetail(address)),
   }
 }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -561,7 +561,7 @@ function getRenderablePermissionsDomains (state) {
 
 function getOriginOfCurrentTab (state) {
   const { activeTab } = state
-  return activeTab.url && getOriginFromUrl(activeTab.url)
+  return activeTab && activeTab.url && getOriginFromUrl(activeTab.url)
 }
 
 function getLastConnectedInfo (state) {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -560,8 +560,8 @@ function getRenderablePermissionsDomains (state) {
 }
 
 function getOriginOfCurrentTab (state) {
-  const { appState: { currentActiveTab = {} } } = state
-  return currentActiveTab.url && getOriginFromUrl(currentActiveTab.url)
+  const { activeTab } = state
+  return activeTab.url && getOriginFromUrl(activeTab.url)
 }
 
 function getLastConnectedInfo (state) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -402,9 +402,6 @@ var actions = {
   getCurrentWindowTab,
   SET_REQUEST_ACCOUNT_TABS: 'SET_REQUEST_ACCOUNT_TABS',
   SET_CURRENT_WINDOW_TAB: 'SET_CURRENT_WINDOW_TAB',
-  setActiveTab,
-  SET_ACTIVE_TAB: 'SET_ACTIVE_TAB',
-  getActiveTab,
   getOpenMetamaskTabsIds,
   SET_OPEN_METAMASK_TAB_IDS: 'SET_OPEN_METAMASK_TAB_IDS',
 }
@@ -3072,23 +3069,5 @@ function getCurrentWindowTab () {
   return async (dispatch) => {
     const currentWindowTab = await global.platform.currentTab()
     dispatch(setCurrentWindowTab(currentWindowTab))
-  }
-}
-
-function setActiveTab (activeTab) {
-  return {
-    type: actions.SET_ACTIVE_TAB,
-    value: activeTab,
-  }
-}
-
-function getActiveTab () {
-  return (dispatch) => {
-    return global.platform.queryTabs()
-      .then(tabs => {
-        const activeTab = tabs.find(tab => tab.active)
-        dispatch(setActiveTab(activeTab))
-        return activeTab
-      })
   }
 }


### PR DESCRIPTION
There was a race condition in the logic responsible for switching the selected account based upon the active tab. It was asynchronously querying the active tab, then assuming it had been retrieved later.

The active tab info itself was already in the redux store in another spot, one that is guaranteed to be set before the UI renders. The race condition was avoided by deleting the duplicate state, and using the other active tab state.