### PR TITLE
Remove unneeded store connections

### DIFF
--- a/ui/app/components/ui/copyButton.js
+++ b/ui/app/components/ui/copyButton.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 
 const copyToClipboard = require('copy-to-clipboard')
 const Tooltip = require('./tooltip')
@@ -63,4 +62,4 @@ class CopyButton extends Component {
   }
 }
 
-module.exports = connect()(CopyButton)
+module.exports = CopyButton

--- a/ui/app/pages/create-account/import-account/index.js
+++ b/ui/app/pages/create-account/import-account/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 const inherits = require('util').inherits
 const PropTypes = require('prop-types')
-const connect = require('react-redux').connect
 import Select from 'react-select'
 
 // Subviews
@@ -13,7 +12,7 @@ AccountImportSubview.contextTypes = {
   t: PropTypes.func,
 }
 
-module.exports = connect()(AccountImportSubview)
+module.exports = AccountImportSubview
 
 
 inherits(AccountImportSubview, Component)


### PR DESCRIPTION
This PR removes (the last?) two unneeded store connections. These components don't need to be connected to the store as they use neither the state or dispatch. 🤷‍♂ 