### PR TITLE
Fix SimpleDropdown close event

### DIFF
--- a/ui/app/components/app/dropdowns/simple-dropdown.js
+++ b/ui/app/components/app/dropdowns/simple-dropdown.js
@@ -53,7 +53,8 @@ class SimpleDropdown extends Component {
                 'simple-dropdown__option--selected': option.value === selectedOption,
               })}
               key={option.value}
-              onClick={() => {
+              onClick={(event) => {
+                event.stopPropagation()
                 if (option.value !== selectedOption) {
                   onSelect(option.value)
                 }


### PR DESCRIPTION
Refs #7540

This PR fixes a bug that has surfaced post-#7540, where the dropdown wouldn't close after a selection.

The call to `this.handleClose()` in the onClick handler would set the state to false which would result in `toggleOpen`, called in the `onClick` handler on the parent `div`, reading `false` from `prevState`. This wasn't an issue before as the reference to state was stale/read before the setState call.

The fix here stops the propagation of the click event to the parent.