### PR TITLE
Fix a typo made comparing previous prop

### DIFF
--- a/ui/app/components/app/account-menu/account-menu.component.js
+++ b/ui/app/components/app/account-menu/account-menu.component.js
@@ -29,7 +29,6 @@ export default class AccountMenu extends PureComponent {
     history: PropTypes.object,
     identities: PropTypes.object,
     isAccountMenuOpen: PropTypes.bool,
-    prevIsAccountMenuOpen: PropTypes.bool,
     keyrings: PropTypes.array,
     lockMetamask: PropTypes.func,
     selectedAddress: PropTypes.string,
@@ -45,7 +44,7 @@ export default class AccountMenu extends PureComponent {
   }
 
   componentDidUpdate (prevProps) {
-    const { prevIsAccountMenuOpen } = prevProps
+    const { isAccountMenuOpen: prevIsAccountMenuOpen } = prevProps
     const { isAccountMenuOpen } = this.props
 
     if (!prevIsAccountMenuOpen && isAccountMenuOpen) {


### PR DESCRIPTION
The prop `prevIsAccountMenuOpen` was referenced in `prevProps`, despite it not existing. It seems clear from the context that the intention was to check the `isAccountMenuOpen` prop from `prevProps`, and name the local variable `prevIsAccountMenuOpen`.

Thanks to @desfero for catching this!