### PR TITLE
Replace wild random number key with index

### DIFF
--- a/ui/app/components/app/account-panel.js
+++ b/ui/app/components/app/account-panel.js
@@ -42,8 +42,8 @@ AccountPanel.prototype.render = function () {
         <span className="font-small">{panelState.identiconLabel.substring(0, 7) + '...'}</span>
       </div>
       <div className="identity-data flex-column flex-justify-center flex-grow select-none">
-        {panelState.attributes.map((attr) => (
-          <div className="flex-row flex-space-between" key={'' + Math.round(Math.random() * 1000000)}>
+        {panelState.attributes.map((attr, index) => (
+          <div className="flex-row flex-space-between" key={index}>
             <label className="font-small no-select">{attr.key}</label>
             <span className="font-small">{attr.value}</span>
           </div>


### PR DESCRIPTION
This PR updates the key we're using to prevent re-renders, replacing a random number with a fixed key. I don't know why this used to be this way.