### PR TITLE
Update permissions request parameter names and docs

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -133,7 +133,8 @@ class PermissionsController {
   /**
    * User approval callback. The request can fail if the request is invalid.
    *
-   * @param {object} approved the approved request object
+   * @param {object} approved - the approved request object
+   * @param {Array} accounts - The accounts to expose, if any
    */
   async approvePermissionsRequest (approved, accounts) {
 

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -186,8 +186,8 @@ export default class PermissionConnect extends Component {
             <div>
               <PermissionPageContainer
                 request={permissionsRequest || {}}
-                approvePermissionsRequest={ (requestId, accounts) => {
-                  approvePermissionsRequest(requestId, accounts)
+                approvePermissionsRequest={(request, accounts) => {
+                  approvePermissionsRequest(request, accounts)
                   this.redirectFlow(true)
                 }}
                 rejectPermissionsRequest={requestId => {

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -46,7 +46,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    approvePermissionsRequest: (requestId, accounts) => dispatch(approvePermissionsRequest(requestId, accounts)),
+    approvePermissionsRequest: (request, accounts) => dispatch(approvePermissionsRequest(request, accounts)),
     rejectPermissionsRequest: requestId => dispatch(rejectPermissionsRequest(requestId)),
     showNewAccountModal: ({ onCreateNewAccount, newAccountNumber }) => {
       return dispatch(showModal({

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2718,19 +2718,19 @@ function setPendingTokens (pendingTokens) {
 // Permissions
 
 /**
- * Approves the permission requests with the given IDs.
- * @param {string} requestId - The id of the permissions request.
+ * Approves the permissions request.
+ * @param {Object} request - The permissions request to approve
  * @param {string[]} accounts - The accounts to expose, if any.
  */
-function approvePermissionsRequest (requestId, accounts) {
+function approvePermissionsRequest (request, accounts) {
   return () => {
-    background.approvePermissionsRequest(requestId, accounts)
+    background.approvePermissionsRequest(request, accounts)
   }
 }
 
 /**
- * Rejects the permission requests with the given IDs.
- * @param {Array} requestId
+ * Rejects the permissions request with the given ID.
+ * @param {string} requestId - The id of the request to be rejected
  */
 function rejectPermissionsRequest (requestId) {
   return () => {


### PR DESCRIPTION
The parameter names and JSDoc comments for `approvePermissionsRequest` and `rejectPermissionsRequest` were incorrect in a few places.