### PR TITLE
Updates to account search functionality

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -187,7 +187,7 @@ class PermissionsController {
     let error
     try {
       await new Promise((resolve, reject) => {
-        this.permissions.grantNewPermissions(origin, permissions, {}, err => err ? resolve() : reject(err))
+        this.permissions.grantNewPermissions(origin, permissions, {}, err => (err ? resolve() : reject(err)))
       })
     } catch (err) {
       error = err

--- a/ui/app/components/app/account-menu/account-menu.component.js
+++ b/ui/app/components/app/account-menu/account-menu.component.js
@@ -264,7 +264,7 @@ export default class AccountMenu extends Component {
 
     const shouldShowScrollButton = canScroll && !atAccountListBottom
 
-    this.setState({ shouldShowScrollButton})
+    this.setState({ shouldShowScrollButton })
   }
 
   onScroll = debounce(this.setShouldShowScrollButton, 25)

--- a/ui/app/components/app/account-menu/account-menu.container.js
+++ b/ui/app/components/app/account-menu/account-menu.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { compose, withProps } from 'recompose'
+import { compose } from 'recompose'
 import { withRouter } from 'react-router-dom'
 import {
   toggleAccountMenu,
@@ -27,6 +27,7 @@ const SHOW_SEARCH_ACCOUNTS_MIN_COUNT = 5
 
 function mapStateToProps (state) {
   const { metamask: { isAccountMenuOpen } } = state
+  const accounts = getMetaMaskAccountsOrdered(state)
 
   return {
     isAccountMenuOpen,
@@ -34,7 +35,8 @@ function mapStateToProps (state) {
     originOfCurrentTab: getOriginOfCurrentTab(state),
     selectedAddress: getSelectedAddress(state),
     keyrings: getMetaMaskKeyrings(state),
-    accounts: getMetaMaskAccountsOrdered(state),
+    accounts,
+    shouldShowAccountsSearch: accounts.length >= SHOW_SEARCH_ACCOUNTS_MIN_COUNT,
   }
 }
 
@@ -71,5 +73,4 @@ function mapDispatchToProps (dispatch) {
 export default compose(
   withRouter,
   connect(mapStateToProps, mapDispatchToProps),
-  withProps(({ accounts }) => ({ shouldShowAccountsSearch: accounts.length >= SHOW_SEARCH_ACCOUNTS_MIN_COUNT}))
 )(AccountMenu)

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -131,7 +131,7 @@ export const getMetaMaskAccountsOrdered = createSelector(
   (keyrings, identities, accounts) => keyrings
     .reduce((list, keyring) => list.concat(keyring.accounts), [])
     .filter(address => !!identities[address])
-    .map(address => ({ ...identities[address], ...accounts[address]}))
+    .map(address => ({ ...identities[address], ...accounts[address] }))
 )
 
 export function isBalanceCached (state) {


### PR DESCRIPTION
Refs #7261

This PR updates the account search functionality introduced in #7261, with the following:

1. Style fixes for consistency (pending #7573 and #7591)
2. Removed usage of `withProp` since that can be part of the existing `mapStateToProps` logic