### PR TITLE
Ignore permission approval/rejection if request is missing

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -1,6 +1,7 @@
 const JsonRpcEngine = require('json-rpc-engine')
 const asMiddleware = require('json-rpc-engine/src/asMiddleware')
 const ObservableStore = require('obs-store')
+const log = require('loglevel')
 const RpcCap = require('rpc-cap').CapabilitiesController
 const { ethErrors } = require('eth-json-rpc-errors')
 
@@ -140,6 +141,11 @@ class PermissionsController {
     const { id } = approved.metadata
     const approval = this.pendingApprovals[id]
 
+    if (!approval) {
+      log.warn(`Permissions request with id '${id}' not found`)
+      return
+    }
+
     try {
 
       // attempt to finalize the request and resolve it
@@ -164,6 +170,12 @@ class PermissionsController {
    */
   async rejectPermissionsRequest (id) {
     const approval = this.pendingApprovals[id]
+
+    if (!approval) {
+      log.warn(`Permissions request with id '${id}' not found`)
+      return
+    }
+
     approval.reject(ethErrors.provider.userRejectedRequest())
     delete this.pendingApprovals[id]
   }


### PR DESCRIPTION
Attempts to approve or reject a permissions request that is no longer pending will now emit a warning instead of throwing an exception.

I _think_ this can happen by clicking 'Submit' on the Permission Connect screen twice, though I've been unable to reproduce that. I know that it can be done if using multiple windows though. While it is
possible we have a UI bug somewhere (e.g. maybe we're not preventing 'Submit' from being clicked twice), I don't think it's possible to eliminate the chance of this happening altogether, so we'd best prepare for it.