### PR TITLE
Rename render function props from `Route`

### DIFF
--- a/ui/app/pages/first-time-flow/create-password/create-password.component.js
+++ b/ui/app/pages/first-time-flow/create-password/create-password.component.js
@@ -36,9 +36,9 @@ export default class CreatePassword extends PureComponent {
           <Route
             exact
             path={INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE}
-            render={props => (
+            render={routeProps => (
               <ImportWithSeedPhrase
-                { ...props }
+                { ...routeProps }
                 onSubmit={onCreateNewAccountFromSeed}
               />
             )}
@@ -46,9 +46,9 @@ export default class CreatePassword extends PureComponent {
           <Route
             exact
             path={INITIALIZE_CREATE_PASSWORD_ROUTE}
-            render={props => (
+            render={routeProps => (
               <NewAccount
-                { ...props }
+                { ...routeProps }
                 onSubmit={onCreateNewAccount}
               />
             )}

--- a/ui/app/pages/first-time-flow/first-time-flow.component.js
+++ b/ui/app/pages/first-time-flow/first-time-flow.component.js
@@ -107,9 +107,9 @@ export default class FirstTimeFlow extends PureComponent {
         <Switch>
           <Route
             path={INITIALIZE_SEED_PHRASE_ROUTE}
-            render={props => (
+            render={routeProps => (
               <SeedPhrase
-                { ...props }
+                { ...routeProps }
                 seedPhrase={seedPhrase}
                 verifySeedPhrase={verifySeedPhrase}
               />
@@ -117,9 +117,9 @@ export default class FirstTimeFlow extends PureComponent {
           />
           <Route
             path={INITIALIZE_BACKUP_SEED_PHRASE_ROUTE}
-            render={props => (
+            render={routeProps => (
               <SeedPhrase
-                { ...props }
+                { ...routeProps }
                 seedPhrase={seedPhrase}
                 verifySeedPhrase={verifySeedPhrase}
               />
@@ -127,9 +127,9 @@ export default class FirstTimeFlow extends PureComponent {
           />
           <Route
             path={INITIALIZE_CREATE_PASSWORD_ROUTE}
-            render={props => (
+            render={routeProps => (
               <CreatePassword
-                { ...props }
+                { ...routeProps }
                 isImportedKeyring={isImportedKeyring}
                 onCreateNewAccount={this.handleCreateNewAccount}
                 onCreateNewAccountFromSeed={this.handleImportWithSeedPhrase}
@@ -142,9 +142,9 @@ export default class FirstTimeFlow extends PureComponent {
           />
           <Route
             path={INITIALIZE_UNLOCK_ROUTE}
-            render={props => (
+            render={routeProps => (
               <Unlock
-                { ...props }
+                { ...routeProps }
                 onSubmit={this.handleUnlock}
               />
             )}

--- a/ui/app/pages/first-time-flow/seed-phrase/seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/seed-phrase.component.js
@@ -52,9 +52,9 @@ export default class SeedPhrase extends PureComponent {
             <Route
               exact
               path={INITIALIZE_CONFIRM_SEED_PHRASE_ROUTE}
-              render={props => (
+              render={routeProps => (
                 <ConfirmSeedPhrase
-                  { ...props }
+                  { ...routeProps }
                   seedPhrase={seedPhrase || verifiedSeedPhrase}
                 />
               )}
@@ -62,9 +62,9 @@ export default class SeedPhrase extends PureComponent {
             <Route
               exact
               path={INITIALIZE_SEED_PHRASE_ROUTE}
-              render={props => (
+              render={routeProps => (
                 <RevealSeedPhrase
-                  { ...props }
+                  { ...routeProps }
                   seedPhrase={seedPhrase || verifiedSeedPhrase}
                 />
               )}
@@ -72,9 +72,9 @@ export default class SeedPhrase extends PureComponent {
             <Route
               exact
               path={INITIALIZE_BACKUP_SEED_PHRASE_ROUTE}
-              render={props => (
+              render={routeProps => (
                 <RevealSeedPhrase
-                  { ...props }
+                  { ...routeProps }
                   seedPhrase={seedPhrase || verifiedSeedPhrase}
                 />
               )}


### PR DESCRIPTION
The props parameter from the `Route` render function has been renamed to `routeProps` to avoid confusion with the component props.

Technically these didn't shadow the outer props (`this.props` vs `props`), but it _seemed_ like it did at first. Probably best to avoid this sort of thing if possible, for the same reasons there are for avoiding shadowing.