### PR TITLE
Add ESLint rule `no-async-promise-executor`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,7 @@
     "new-cap": [2, { "newIsCap": true, "capIsNew": false }],
     "new-parens": 2,
     "no-array-constructor": 2,
+    "no-async-promise-executor": "error",
     "no-caller": 2,
     "no-class-assign": 2,
     "no-cond-assign": 2,

--- a/development/mock-3box.js
+++ b/development/mock-3box.js
@@ -2,26 +2,22 @@ function delay (time) {
   return new Promise(resolve => setTimeout(resolve, time))
 }
 
-function loadFromMock3Box (key) {
-  return new Promise(async (resolve) => {
-    const res = await fetch('http://localhost:8889?key=' + key)
-    const text = await res.text()
-    resolve(text.length ? JSON.parse(text) : null)
-  })
+async function loadFromMock3Box (key) {
+  const res = await fetch('http://localhost:8889?key=' + key)
+  const text = await res.text()
+  return text.length ? JSON.parse(text) : null
 }
 
-function saveToMock3Box (key, newDataAtKey) {
-  return new Promise(async (resolve) => {
-    const res = await fetch('http://localhost:8889', {
-      method: 'POST',
-      body: JSON.stringify({
-        key,
-        data: newDataAtKey,
-      }),
-    })
-
-    resolve(res.text())
+async function saveToMock3Box (key, newDataAtKey) {
+  const res = await fetch('http://localhost:8889', {
+    method: 'POST',
+    body: JSON.stringify({
+      key,
+      data: newDataAtKey,
+    }),
   })
+
+  return res.text()
 }
 
 class Mock3Box {


### PR DESCRIPTION
The [`no-async-promise-executor` ESLint rule](https://eslint.org/docs/rules/no-async-promise-executor) as been enabled. This rule prevents using an async function as a Promise executor (e.g. as the argument to a `Promise` constructor).

This pattern is usually a mistake because it implies that the Promise constructor was not necessary in the first place. It also makes error handling difficult, as any errors thrown would be uncaught unless you wrap the body in a try/catch block.