### PR TITLE
Use Ganache programmatically in e2e tests

### DIFF
--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -12,7 +12,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -26,6 +29,14 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start({
+      accounts: [
+        {
+          secretKey: '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
+          balance: 25000000000000000000,
+        },
+      ],
+    })
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -46,6 +57,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/ethereum-on.spec.js
+++ b/test/e2e/ethereum-on.spec.js
@@ -14,7 +14,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -28,6 +31,14 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start({
+      accounts: [
+        {
+          secretKey: '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
+          balance: 25000000000000000000,
+        },
+      ],
+    })
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -48,6 +59,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -12,7 +12,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('Using MetaMask with an existing account', function () {
   let driver
@@ -29,6 +32,14 @@ describe('Using MetaMask with an existing account', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start({
+      accounts: [
+        {
+          secretKey: '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
+          balance: 25000000000000000000,
+        },
+      ],
+    })
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -49,6 +60,7 @@ describe('Using MetaMask with an existing account', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/ganache.js
+++ b/test/e2e/ganache.js
@@ -1,0 +1,37 @@
+const ganache = require('ganache-core')
+const { promisify } = require('util')
+
+const defaultOptions = {
+  blockTime: 2,
+  network_id: 5777,
+  mnemonic: 'phrase upgrade clock rough situate wedding elder clever doctor stamp excess tent',
+  port: 8545,
+  vmErrorsOnRPCResponse: false,
+}
+
+class Ganache {
+  async start (options) {
+    options = Object.assign({}, defaultOptions, options)
+
+    const port = options.port
+    this._server = ganache.server(options)
+
+    const listen = promisify(this._server.listen).bind(this._server)
+    const blockchain = await listen(port)
+
+    return {
+      ...blockchain,
+      port,
+    }
+  }
+
+  async quit () {
+    if (!this._server) {
+      throw new Error('Server not running yet')
+    }
+    const close = promisify(this._server.close).bind(this._server)
+    await close()
+  }
+}
+
+module.exports = Ganache

--- a/test/e2e/incremental-security.spec.js
+++ b/test/e2e/incremental-security.spec.js
@@ -14,7 +14,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -28,6 +31,18 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start({
+      accounts: [
+        {
+          secretKey: '0x250F458997A364988956409A164BA4E16F0F99F916ACDD73ADCD3A1DE30CF8D1',
+          balance: 0,
+        },
+        {
+          secretKey: '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
+          balance: 25000000000000000000,
+        },
+      ],
+    })
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -48,6 +63,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -12,7 +12,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -26,6 +29,7 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start()
     const result = await prepareExtensionForTesting({ responsive: true })
     driver = result.driver
     await setupFetchMocking(driver)
@@ -46,6 +50,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -17,7 +17,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -32,6 +35,7 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start()
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -52,6 +56,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -15,7 +15,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -29,6 +32,14 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start({
+      accounts: [
+        {
+          secretKey: '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
+          balance: 25000000000000000000,
+        },
+      ],
+    })
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -49,6 +60,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -5,93 +5,73 @@ set -e
 set -u
 set -o pipefail
 
-# Set the environment variable 'GANACHE_ARGS' to change any optional ganache flags
-# By default, the flag `--quiet` is used. Setting 'GANACHE_ARGS' will override the default.
-OPTIONAL_GANACHE_ARGS="${GANACHE_ARGS---quiet}"
-BASE_GANACHE_ARGS="${OPTIONAL_GANACHE_ARGS} --blockTime 2"
-
 export PATH="$PATH:./node_modules/.bin"
-export GANACHE_ARGS="${BASE_GANACHE_ARGS}"
 
 concurrently --kill-others \
-  --names 'ganache,dapp,e2e' \
+  --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'yarn ganache:start' \
   'yarn dapp' \
-  'sleep 5 && mocha test/e2e/metamask-ui.spec'
+  'mocha test/e2e/metamask-ui.spec'
 
 concurrently --kill-others \
-  --names 'ganache,dapp,e2e' \
+  --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'yarn ganache:start' \
   'yarn dapp' \
-  'sleep 5 && mocha test/e2e/metamask-responsive-ui.spec'
+  'mocha test/e2e/metamask-responsive-ui.spec'
 
 concurrently --kill-others \
-  --names 'ganache,dapp,e2e' \
+  --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'yarn ganache:start' \
   'yarn dapp' \
-  'sleep 5 && mocha test/e2e/signature-request.spec'
-
-export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
-concurrently --kill-others \
-  --names 'ganache,e2e' \
-  --prefix '[{time}][{name}]' \
-  --success first \
-  'yarn ganache:start' \
-  'sleep 5 && mocha test/e2e/from-import-ui.spec'
+  'mocha test/e2e/signature-request.spec'
 
 concurrently --kill-others \
-  --names 'ganache,e2e' \
+  --names 'e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'npm run ganache:start' \
-  'sleep 5 && mocha test/e2e/send-edit.spec'
+  'mocha test/e2e/from-import-ui.spec'
 
 concurrently --kill-others \
-  --names 'ganache,dapp,e2e' \
+  --names 'e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'yarn ganache:start' \
+  'mocha test/e2e/send-edit.spec'
+
+concurrently --kill-others \
+  --names 'dapp,e2e' \
+  --prefix '[{time}][{name}]' \
+  --success first \
   'yarn dapp' \
-  'sleep 5 && mocha test/e2e/ethereum-on.spec'
+  'mocha test/e2e/ethereum-on.spec'
 
 concurrently --kill-others \
-  --names 'ganache,dapp,e2e' \
+  --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'yarn ganache:start' \
   'yarn dapp' \
-  'sleep 5 && mocha test/e2e/permissions.spec'
+  'mocha test/e2e/permissions.spec'
 
-export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x250F458997A364988956409A164BA4E16F0F99F916ACDD73ADCD3A1DE30CF8D1,0  --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
 concurrently --kill-others \
-  --names 'ganache,sendwithprivatedapp,e2e' \
+  --names 'sendwithprivatedapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'npm run ganache:start' \
   'npm run sendwithprivatedapp' \
-  'sleep 5 && mocha test/e2e/incremental-security.spec'
+  'mocha test/e2e/incremental-security.spec'
 
-export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
 concurrently --kill-others \
-  --names 'ganache,dapp,e2e' \
+  --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
-  'yarn ganache:start' \
   'yarn dapp' \
-  'sleep 5 && mocha test/e2e/address-book.spec'
+  'mocha test/e2e/address-book.spec'
 
-export GANACHE_ARGS="${BASE_GANACHE_ARGS} --deterministic --account=0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9,25000000000000000000"
 concurrently --kill-others \
-  --names 'ganache,dapp,e2e' \
+  --names '3box,dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'node test/e2e/mock-3box/server.js' \
-  'yarn ganache:start' \
   'yarn dapp' \
-  'sleep 5 && mocha test/e2e/threebox.spec'
+  'mocha test/e2e/threebox.spec'

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -12,7 +12,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('Using MetaMask with an existing account', function () {
   let driver
@@ -26,6 +29,14 @@ describe('Using MetaMask with an existing account', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start({
+      accounts: [
+        {
+          secretKey: '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
+          balance: 25000000000000000000,
+        },
+      ],
+    })
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -46,6 +57,7 @@ describe('Using MetaMask with an existing account', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -15,7 +15,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -29,6 +32,7 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start()
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -49,6 +53,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -12,7 +12,10 @@ const {
   setupFetchMocking,
   prepareExtensionForTesting,
 } = require('./helpers')
+const Ganache = require('./ganache')
 const enLocaleMessages = require('../../app/_locales/en/messages.json')
+
+const ganacheServer = new Ganache()
 
 describe('MetaMask', function () {
   let driver
@@ -26,6 +29,14 @@ describe('MetaMask', function () {
   this.bail(true)
 
   before(async function () {
+    await ganacheServer.start({
+      accounts: [
+        {
+          secretKey: '0x53CB0AB5226EEBF4D872113D98332C1555DC304443BEE1CF759D15798D3C55A9',
+          balance: 25000000000000000000,
+        },
+      ],
+    })
     const result = await prepareExtensionForTesting()
     driver = result.driver
     await setupFetchMocking(driver)
@@ -46,6 +57,7 @@ describe('MetaMask', function () {
   })
 
   after(async function () {
+    await ganacheServer.quit()
     await driver.quit()
   })
 


### PR DESCRIPTION
The `ganache.js` helper module uses `ganache-core` to start `ganache` instead of `ganache-cli`, and allows all of the same customization. Using `ganache` programmatically from our e2e tests is much faster, as we don't have to wait that arbitrary 5 seconds before each test as we wait for `ganache-cli` to start up.