### PR TITLE
A/B full screen tx test, with tab return

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -236,11 +236,13 @@ function setupController (initState, initLangCode) {
   //
   // MetaMask Controller
   //
+  const { ABTestController = {} } = initState
+  const { abTests = {} } = ABTestController
 
   const controller = new MetamaskController({
     // User confirmation callbacks:
     showUnconfirmedMessage: triggerUi,
-    showUnapprovedTx: triggerUi,
+    showUnapprovedTx: abTests.fullScreenVsPopup === 'fullScreen' ? triggerUiInNewTab : triggerUi,
     openPopup: openPopup,
     closePopup: notificationManager.closePopup.bind(notificationManager),
     // initial state
@@ -462,6 +464,20 @@ function triggerUi () {
       notificationIsOpen = true
     }
   })
+}
+
+/**
+ * Opens a new browser tab for user confirmation
+ */
+function triggerUiInNewTab () {
+  const tabIdsArray = Object.keys(openMetamaskTabsIDs)
+  if (tabIdsArray.length) {
+    extension.tabs.update(parseInt(tabIdsArray[0], 10), { 'active': true }, () => {
+      extension.tabs.reload(parseInt(tabIdsArray[0], 10))
+    })
+  } else {
+    platform.openExtensionInBrowser()
+  }
 }
 
 /**

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -396,7 +396,7 @@ function setupController (initState, initLangCode) {
         const origin = url.hostname
 
         remotePort.onMessage.addListener((msg) => {
-          if (msg.data && msg.data.method === 'eth_requestAccounts') {
+          if (msg.data && ['eth_requestAccounts', 'eth_sendTransaction'].includes(msg.data.method)) {
             requestAccountTabIds[origin] = tabId
           }
         })

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -17,6 +17,7 @@ import {
   updateTransaction,
   getNextNonce,
   tryReverseResolveAddress,
+  getRequestAccountTabIds,
 } from '../../store/actions'
 import {
   INSUFFICIENT_FUNDS_ERROR_KEY,
@@ -66,7 +67,7 @@ const mapStateToProps = (state, ownProps) => {
     tokenProps,
     nonce,
   } = confirmTransaction
-  const { txParams = {}, lastGasPrice, id: transactionId, transactionCategory } = txData
+  const { txParams = {}, lastGasPrice, id: transactionId, transactionCategory, origin } = txData
   const transaction = Object.values(unapprovedTxs).find(
     ({ id }) => id === (transactionId || Number(paramsTransactionId))
   ) || {}
@@ -134,6 +135,8 @@ const mapStateToProps = (state, ownProps) => {
     }
   }
 
+  const { requestAccountTabs = {} } = state.appState
+
   return {
     balance,
     fromAddress,
@@ -170,6 +173,7 @@ const mapStateToProps = (state, ownProps) => {
     metaMetricsSendCount,
     transactionCategory,
     nextNonce,
+    returnTab: requestAccountTabs[origin],
   }
 }
 
@@ -200,6 +204,7 @@ export const mapDispatchToProps = (dispatch) => {
     sendTransaction: (txData) => dispatch(updateAndApproveTx(customNonceMerge(txData))),
     setMetaMetricsSendCount: (val) => dispatch(setMetaMetricsSendCount(val)),
     getNextNonce: () => dispatch(getNextNonce()),
+    getRequestAccountTabIds: () => dispatch(getRequestAccountTabIds()),
   }
 }
 

--- a/ui/app/pages/confirm-transaction/confirm-transaction.container.js
+++ b/ui/app/pages/confirm-transaction/confirm-transaction.container.js
@@ -35,9 +35,9 @@ const mapStateToProps = (state, ownProps) => {
   const transaction = totalUnconfirmed
     ? unapprovedTxs[id] || unconfirmedTransactions[0]
     : {}
-  const { id: transactionId, transactionCategory } = transaction
+  const { id: transactionId, transactionCategory, origin } = transaction
 
-  const trackABTest = false
+  const trackABTest = origin !== 'MetaMask'
 
   return {
     totalUnapprovedCount: totalUnconfirmed,


### PR DESCRIPTION
This PR fixes #7297 and turns back on the a/b test that was reverted with https://github.com/MetaMask/metamask-extension/pull/7298/files

The user will now be redirected back to a dapp after a full screen transaction

- [ ] still need to work through a couple edge cases