### PR TITLE
Remove unused `gasExpress` fetch mocks

### DIFF
--- a/test/e2e/fetch-mocks.json
+++ b/test/e2e/fetch-mocks.json
@@ -5916,14 +5916,6 @@
       "hpa_coef": -0.0243
     }
   ],
-  "gasExpress": {
-    "safeLow": 2,
-    "standard": 3,
-    "fast": 10,
-    "fastest": 52,
-    "block_time": 15,
-    "blockNum": 6693030
-  },
   "metametrics": {
     "mockMetaMetricsResponse": true
   }

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -91,8 +91,6 @@ async function setupFetchMocking (driver) {
         return { json: async () => clone(fetchMockResponses.ethGasPredictTable) }
       } else if (url.match(/chromeextensionmm/)) {
         return { json: async () => clone(fetchMockResponses.metametrics) }
-      } else if (url === 'https://dev.blockscale.net/api/gasexpress.json') {
-        return { json: async () => clone(fetchMockResponses.gasExpress) }
       }
       return window.origFetch(...args)
     }

--- a/test/integration/lib/confirm-sig-requests.js
+++ b/test/integration/lib/confirm-sig-requests.js
@@ -28,8 +28,6 @@ async function runConfirmSigRequestsTest (assert) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
     } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
-    } else if (args[0] === 'https://dev.blockscale.net/api/gasexpress.json') {
-      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.gasExpress)) })
     } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })
     }

--- a/test/integration/lib/currency-localization.js
+++ b/test/integration/lib/currency-localization.js
@@ -27,8 +27,6 @@ async function runCurrencyLocalizationTest (assert) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
     } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
-    } else if (args[0] === 'https://dev.blockscale.net/api/gasexpress.json') {
-      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.gasExpress)) })
     } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })
     }

--- a/test/integration/lib/tx-list-items.js
+++ b/test/integration/lib/tx-list-items.js
@@ -32,8 +32,6 @@ async function runTxListItemsTest (assert) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
     } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
-    } else if (args[0] === 'https://dev.blockscale.net/api/gasexpress.json') {
-      return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.gasExpress)) })
     } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })
     }

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -67,7 +67,7 @@ describe('Gas Duck', () => {
     { expectedTime: 1, expectedWait: 0.5, gasprice: 20, somethingElse: 'foobar' },
   ]
   const fakeFetch = (url) => new Promise(resolve => {
-    const dataToResolve = url.match(/ethgasAPI|gasexpress/)
+    const dataToResolve = url.match(/ethgasAPI/)
       ? mockEthGasApiResponse
       : mockPredictTableResponse
     resolve({


### PR DESCRIPTION
These fetch mocks have been unnecessary since #7059