### PR TITLE
Remove link to missing Edge build from MMbot comment

### DIFF
--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -26,7 +26,7 @@ async function start () {
   // build the github comment content
 
   // links to extension builds
-  const platforms = ['chrome', 'firefox', 'opera', 'edge']
+  const platforms = ['chrome', 'firefox', 'opera']
   const buildLinks = platforms.map(platform => {
     const url = `${BUILD_LINK_BASE}/builds/metamask-${platform}-${VERSION}.zip`
     return `<a href="${url}">${platform}</a>`


### PR DESCRIPTION
This PR removes the link to the non-existent Edge build from the MetaMask bot comment. We don't build for Edge, currently.