### PR TITLE
Add description to Reset Account in settings

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1043,7 +1043,7 @@
     "message": "Reset Account"
   },
   "resetAccountDescription": {
-    "message": "Resetting your account will clear your transaction history."
+    "message": "Resetting your account clears local settings, activity, and logs. This will not change the balances in your accounts."
   },
   "deleteNetwork": {
     "message": "Delete Network?"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1043,7 +1043,7 @@
     "message": "Reset Account"
   },
   "resetAccountDescription": {
-    "message": "Resetting your account clears local settings, activity, and logs. This will not change the balances in your accounts."
+    "message": "Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your seed phrase."
   },
   "deleteNetwork": {
     "message": "Delete Network?"

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -108,6 +108,9 @@ export default class AdvancedTab extends PureComponent {
       <div className="settings-page__content-row">
         <div className="settings-page__content-item">
           <span>{ t('resetAccount') }</span>
+          <span className="settings-page__content-description">
+            { t('resetAccountDescription') }
+          </span>
         </div>
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">


### PR DESCRIPTION
Closes #5577
Closes #7493

This PR adds description text above the Reset Account in settings, pictured below.

> Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your seed phrase.

<img width="978" alt="" src="https://user-images.githubusercontent.com/1623628/70664921-f9f31500-1c45-11ea-9c20-4e487c0880e4.png">
