### PR TITLE
Sidebar refactor

### DIFF
--- a/ui/app/components/app/sidebars/index.js
+++ b/ui/app/components/app/sidebars/index.js
@@ -1,1 +1,1 @@
-export { default } from './sidebar.component'
+export { default } from './sidebar.container'

--- a/ui/app/components/app/sidebars/sidebar.component.js
+++ b/ui/app/components/app/sidebars/sidebar.component.js
@@ -10,7 +10,7 @@ export default class Sidebar extends Component {
   static propTypes = {
     sidebarOpen: PropTypes.bool,
     hideSidebar: PropTypes.func,
-    sidebarShouldClose: PropTypes.bool,
+    // sidebarShouldClose: PropTypes.bool,
     transitionName: PropTypes.string,
     type: PropTypes.string,
     sidebarProps: PropTypes.object,
@@ -43,14 +43,14 @@ export default class Sidebar extends Component {
 
   }
 
-  componentDidUpdate (prevProps) {
-    if (!prevProps.sidebarShouldClose && this.props.sidebarShouldClose) {
-      this.props.hideSidebar()
-    }
-  }
+  // componentDidUpdate (prevProps) {
+  //   if (!prevProps.sidebarShouldClose && this.props.sidebarShouldClose) {
+  //     this.props.hideSidebar()
+  //   }
+  // }
 
   render () {
-    const { transitionName, sidebarOpen, sidebarShouldClose } = this.props
+    const { transitionName, sidebarOpen } = this.props
 
     return (
       <div>
@@ -59,9 +59,9 @@ export default class Sidebar extends Component {
           transitionEnterTimeout={300}
           transitionLeaveTimeout={200}
         >
-          { sidebarOpen && !sidebarShouldClose ? this.renderSidebarContent() : null }
+          { sidebarOpen ? this.renderSidebarContent() : null }
         </ReactCSSTransitionGroup>
-        { sidebarOpen && !sidebarShouldClose ? this.renderOverlay() : null }
+        { sidebarOpen ? this.renderOverlay() : null }
       </div>
     )
   }

--- a/ui/app/components/app/sidebars/sidebar.container.js
+++ b/ui/app/components/app/sidebars/sidebar.container.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux'
+import SelectedAccount from './selected-account.component'
+
+const selectors = require('../../../selectors/selectors')
+
+const mapStateToProps = state => {
+  return {
+    selectedAddress: selectors.getSelectedAddress(state),
+    selectedIdentity: selectors.getSelectedIdentity(state),
+    network: state.metamask.network,
+  }
+}
+
+export default connect(mapStateToProps)(SelectedAccount)

--- a/ui/app/components/app/sidebars/sidebar.container.js
+++ b/ui/app/components/app/sidebars/sidebar.container.js
@@ -2,9 +2,9 @@ import { connect } from 'react-redux'
 import actions from '../../../store/actions'
 import SideBar from './sidebar.component'
 const { WALLET_VIEW_SIDEBAR } = require('../../../components/app/sidebars/sidebar.constants')
-import {
-  submittedPendingTransactionsSelector,
-} from '../../../selectors/transactions'
+// import {
+//   submittedPendingTransactionsSelector,
+// } from '../../../selectors/transactions'
 
 const mapStateToProps = state => {
   const {
@@ -13,8 +13,8 @@ const mapStateToProps = state => {
     type: sidebarType,
     props,
   } = state.appState.sidebar
-  const { transaction: sidebarTransaction } = props || {}
-  const submittedPendingTransactions = submittedPendingTransactionsSelector(state)
+  // const { transaction: sidebarTransaction } = props || {}
+  // const submittedPendingTransactions = submittedPendingTransactionsSelector(state)
 
   const sidebarOnOverlayClose = sidebarType === WALLET_VIEW_SIDEBAR
     ? () => {
@@ -28,13 +28,13 @@ const mapStateToProps = state => {
     }
     : null
 
-  const sidebarShouldClose = sidebarTransaction &&
-      !sidebarTransaction.status === 'failed' &&
-      !submittedPendingTransactions.find(({ id }) => id === sidebarTransaction.id)
+  // const sidebarShouldClose = sidebarTransaction &&
+  //     !sidebarTransaction.status === 'failed' &&
+  //     !submittedPendingTransactions.find(({ id }) => id === sidebarTransaction.id)
 
   return {
     sidebarOpen: sidebarIsOpen,
-    sidebarShouldClose,
+    // sidebarShouldClose,
     sidebarProps: props,
     transitionName: sidebarTransitionName,
     type: sidebarType,

--- a/ui/app/components/app/sidebars/sidebar.container.js
+++ b/ui/app/components/app/sidebars/sidebar.container.js
@@ -1,14 +1,52 @@
 import { connect } from 'react-redux'
-import SelectedAccount from './selected-account.component'
-
-const selectors = require('../../../selectors/selectors')
+import actions from '../../../store/actions'
+import SideBar from './sidebar.component'
+const { WALLET_VIEW_SIDEBAR } = require('../../../components/app/sidebars/sidebar.constants')
+import {
+  submittedPendingTransactionsSelector,
+} from '../../../selectors/transactions'
 
 const mapStateToProps = state => {
+  console.log(state)
+  const {
+    isOpen: sidebarIsOpen,
+    transitionName: sidebarTransitionName,
+    type: sidebarType,
+    props,
+  } = state.appState.sidebar
+  const { transaction: sidebarTransaction } = props || {}
+  const submittedPendingTransactions = submittedPendingTransactionsSelector(state)
+  console.log(submittedPendingTransactions)
+
+  const sidebarOnOverlayClose = sidebarType === WALLET_VIEW_SIDEBAR
+    ? () => {
+      console.log('Closed Sidebare Via Overlay')
+      this.context.metricsEvent({
+        eventOpts: {
+          category: 'Navigation',
+          action: 'Wallet Sidebar',
+          name: 'Closed Sidebare Via Overlay',
+        },
+      })
+    }
+    : null
+
+  const sidebarShouldClose = sidebarTransaction &&
+      !sidebarTransaction.status === 'failed' &&
+      !submittedPendingTransactions.find(({ id }) => id === sidebarTransaction.id)
+
   return {
-    selectedAddress: selectors.getSelectedAddress(state),
-    selectedIdentity: selectors.getSelectedIdentity(state),
-    network: state.metamask.network,
+    sidebarOpen: sidebarIsOpen,
+    sidebarShouldClose,
+    sidebarProps: props,
+    transitionName: sidebarTransitionName,
+    type: sidebarType,
+    onOverlayClose: sidebarOnOverlayClose,
   }
 }
 
-export default connect(mapStateToProps)(SelectedAccount)
+const mapDispatchToProps = dispatch => ({
+  hideSidebar: () => dispatch(actions.hideSidebar()),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(SideBar)

--- a/ui/app/components/app/sidebars/sidebar.container.js
+++ b/ui/app/components/app/sidebars/sidebar.container.js
@@ -7,7 +7,6 @@ import {
 } from '../../../selectors/transactions'
 
 const mapStateToProps = state => {
-  console.log(state)
   const {
     isOpen: sidebarIsOpen,
     transitionName: sidebarTransitionName,
@@ -16,11 +15,9 @@ const mapStateToProps = state => {
   } = state.appState.sidebar
   const { transaction: sidebarTransaction } = props || {}
   const submittedPendingTransactions = submittedPendingTransactionsSelector(state)
-  console.log(submittedPendingTransactions)
 
   const sidebarOnOverlayClose = sidebarType === WALLET_VIEW_SIDEBAR
     ? () => {
-      console.log('Closed Sidebare Via Overlay')
       this.context.metricsEvent({
         eventOpts: {
           category: 'Navigation',

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -2,6 +2,9 @@ const extend = require('xtend')
 const actions = require('../../store/actions')
 const txHelper = require('../../../lib/tx-helper')
 const log = require('loglevel')
+import {
+  submittedPendingTransactionsSelector,
+} from '../../selectors/transactions'
 
 // Actions
 const SET_THREEBOX_LAST_UPDATED = 'metamask/app/SET_THREEBOX_LAST_UPDATED'
@@ -91,15 +94,17 @@ export default function reduceApp (state, action) {
 
     // sidebar methods
     case actions.UPDATE_METAMASK_STATE:
-      const { metamask: was } = state
-      const { value: is } = action
+      const { value } = action
       const { sidebar, sidebar: { props: { transaction: { id: transactionId = null } = {} } } } = appState
+
+      const submittedPendingTransactions = submittedPendingTransactionsSelector(state)
+      const newSubmittedPendingTransactions = submittedPendingTransactionsSelector({ metamask: value })
 
       if (
         sidebar &&
         transactionId &&
-        was.selectedAddressTxList.find(({ id }) => id === transactionId).status === 'submitted' &&
-        is.selectedAddressTxList.find(({ id }) => id === transactionId).status !== 'submitted'
+        submittedPendingTransactions.find(({ id }) => id === transactionId) &&
+        !newSubmittedPendingTransactions.length
       ) {
         // close sidebar
         return extend(appState, {

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -104,7 +104,7 @@ export default function reduceApp (state, action) {
         sidebar &&
         transactionId &&
         submittedPendingTransactions.find(({ id }) => id === transactionId) &&
-        !newSubmittedPendingTransactions.length
+        !newSubmittedPendingTransactions.find(({ id }) => id === transactionId)
       ) {
         // close sidebar
         return extend(appState, {

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -90,6 +90,28 @@ export default function reduceApp (state, action) {
       })
 
     // sidebar methods
+    case actions.UPDATE_METAMASK_STATE:
+      const { metamask: was } = state
+      const { value: is } = action
+      const { sidebar, sidebar: { transactionId } } = appState
+
+      if (
+        sidebar &&
+        transactionId &&
+        was.transactions[transactionId].state === 'pending' &&
+        is.transactions[transactionId].state !== 'pending'
+      ) {
+        // close sidebar
+        return extend(appState, {
+          sidebar: {
+            ...appState.sidebar,
+            isOpen: false,
+          },
+        })
+      }
+
+      return appState
+
     case actions.SIDEBAR_OPEN:
       return extend(appState, {
         sidebar: {

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -93,13 +93,14 @@ export default function reduceApp (state, action) {
     case actions.UPDATE_METAMASK_STATE:
       const { metamask: was } = state
       const { value: is } = action
-      const { sidebar, sidebar: { transactionId } } = appState
+      const { sidebar, sidebar: { props: { transaction: { id: transactionId = null } = {} } } } = appState
 
       if (
         sidebar &&
         transactionId &&
-        was.transactions[transactionId].state === 'pending' &&
-        is.transactions[transactionId].state !== 'pending'
+        // consider reduce?
+        was.selectedAddressTxList.filter(({ id }) => id === transactionId).pop().status === 'submitted' &&
+        is.selectedAddressTxList.filter(({ id }) => id === transactionId).pop().status !== 'submitted'
       ) {
         // close sidebar
         return extend(appState, {

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -98,9 +98,8 @@ export default function reduceApp (state, action) {
       if (
         sidebar &&
         transactionId &&
-        // consider reduce?
-        was.selectedAddressTxList.filter(({ id }) => id === transactionId).pop().status === 'submitted' &&
-        is.selectedAddressTxList.filter(({ id }) => id === transactionId).pop().status !== 'submitted'
+        was.selectedAddressTxList.find(({ id }) => id === transactionId).status === 'submitted' &&
+        is.selectedAddressTxList.find(({ id }) => id === transactionId).status !== 'submitted'
       ) {
         // close sidebar
         return extend(appState, {

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -17,7 +17,6 @@ const ConfirmTransaction = require('../confirm-transaction')
 
 // slideout menu
 const Sidebar = require('../../components/app/sidebars').default
-const { WALLET_VIEW_SIDEBAR } = require('../../components/app/sidebars/sidebar.constants')
 
 // other views
 import Home from '../home'
@@ -45,10 +44,6 @@ const Alert = require('../../components/ui/alert')
 
 import AppHeader from '../../components/app/app-header'
 import UnlockPage from '../unlock-page'
-
-import {
-  submittedPendingTransactionsSelector,
-} from '../../selectors/transactions'
 
 // Routes
 import {
@@ -177,38 +172,12 @@ class Routes extends Component {
       frequentRpcListDetail,
       currentView,
       setMouseUserState,
-      sidebar,
-      submittedPendingTransactions,
       isMouseUser,
     } = this.props
     const isLoadingNetwork = network === 'loading' && currentView.name !== 'config'
     const loadMessage = loadingMessage || isLoadingNetwork ?
       this.getConnectingLabel(loadingMessage) : null
     log.debug('Main ui render function')
-
-    const {
-      isOpen: sidebarIsOpen,
-      transitionName: sidebarTransitionName,
-      type: sidebarType,
-      props,
-    } = sidebar
-    const { transaction: sidebarTransaction } = props || {}
-
-    const sidebarOnOverlayClose = sidebarType === WALLET_VIEW_SIDEBAR
-      ? () => {
-        this.context.metricsEvent({
-          eventOpts: {
-            category: 'Navigation',
-            action: 'Wallet Sidebar',
-            name: 'Closed Sidebare Via Overlay',
-          },
-        })
-      }
-      : null
-
-    const sidebarShouldClose = sidebarTransaction &&
-      !sidebarTransaction.status === 'failed' &&
-      !submittedPendingTransactions.find(({ id }) => id === sidebarTransaction.id)
 
     return (
       <div
@@ -234,15 +203,7 @@ class Routes extends Component {
             />
           )
         }
-        <Sidebar
-          sidebarOpen={sidebarIsOpen}
-          sidebarShouldClose={sidebarShouldClose}
-          hideSidebar={this.props.hideSidebar}
-          transitionName={sidebarTransitionName}
-          type={sidebarType}
-          sidebarProps={sidebar.props}
-          onOverlayClose={sidebarOnOverlayClose}
-        />
+        <Sidebar />
         <NetworkDropdown
           provider={provider}
           frequentRpcListDetail={frequentRpcListDetail}
@@ -336,7 +297,6 @@ Routes.propTypes = {
   provider: PropTypes.object,
   frequentRpcListDetail: PropTypes.array,
   currentView: PropTypes.object,
-  sidebar: PropTypes.object,
   alertOpen: PropTypes.bool,
   hideSidebar: PropTypes.func,
   isUnlocked: PropTypes.bool,
@@ -344,7 +304,6 @@ Routes.propTypes = {
   history: PropTypes.object,
   location: PropTypes.object,
   lockMetaMask: PropTypes.func,
-  submittedPendingTransactions: PropTypes.array,
   isMouseUser: PropTypes.bool,
   setMouseUserState: PropTypes.func,
   providerId: PropTypes.string,
@@ -355,7 +314,6 @@ Routes.propTypes = {
 function mapStateToProps (state) {
   const { appState, metamask } = state
   const {
-    sidebar,
     alertOpen,
     alertMessage,
     isLoading,
@@ -366,7 +324,6 @@ function mapStateToProps (state) {
 
   return {
     // state from plugin
-    sidebar,
     alertOpen,
     alertMessage,
     textDirection: state.metamask.textDirection,
@@ -374,7 +331,6 @@ function mapStateToProps (state) {
     loadingMessage,
     isUnlocked: state.metamask.isUnlocked,
     currentView: state.appState.currentView,
-    submittedPendingTransactions: submittedPendingTransactionsSelector(state),
     network: state.metamask.network,
     provider: state.metamask.provider,
     frequentRpcListDetail: state.metamask.frequentRpcListDetail || [],


### PR DESCRIPTION
This takes all the sidebar related _things_ out of `routes/index.js` and puts them into a `sidebar.container`...

This is a starting point for the fix requested here: https://github.com/MetaMask/metamask-extension/pull/7296#discussion_r339611326