### PR TITLE
Assign a tab id to all request objects passing through middleware

### DIFF
--- a/app/scripts/lib/createOnboardingMiddleware.js
+++ b/app/scripts/lib/createOnboardingMiddleware.js
@@ -3,18 +3,18 @@ import extension from 'extensionizer'
 
 /**
  * Returns a middleware that intercepts `wallet_registerOnboarding` messages
- * @param {{ location: string, tabId: number, registerOnboarding: Function }} opts - The middleware options
+ * @param {{ location: string, registerOnboarding: Function }} opts - The middleware options
  * @returns {(req: any, res: any, next: Function, end: Function) => void}
  */
-function createOnboardingMiddleware ({ location, tabId, registerOnboarding }) {
+function createOnboardingMiddleware ({ location, registerOnboarding }) {
   return async function originMiddleware (req, res, next, end) {
     try {
       if (req.method !== 'wallet_registerOnboarding') {
         next()
         return
       }
-      if (tabId && tabId !== extension.tabs.TAB_ID_NONE) {
-        await registerOnboarding(location, tabId)
+      if (req.tabId && req.tabId !== extension.tabs.TAB_ID_NONE) {
+        await registerOnboarding(location, req.tabId)
       } else {
         log.debug(`'wallet_registerOnboarding' message from ${location} ignored due to missing tabId`)
       }

--- a/app/scripts/lib/createTabIdMiddleware.js
+++ b/app/scripts/lib/createTabIdMiddleware.js
@@ -1,0 +1,14 @@
+
+module.exports = createTabIdMiddleware
+
+/**
+ * Returns a middleware that appends the DApp TabId to the request
+ * @param {{ tabId: number }} opts - The middleware options
+ * @returns {Function}
+ */
+function createTabIdMiddleware (opts) {
+  return function tabIdMiddleware (/** @type {any} */ req, /** @type {any} */ _, /** @type {Function} */ next) {
+    req.tabId = opts.tabId
+    next()
+  }
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -20,6 +20,7 @@ import createFilterMiddleware from 'eth-json-rpc-filters'
 import createSubscriptionManager from 'eth-json-rpc-filters/subscriptionManager'
 import createLoggerMiddleware from './lib/createLoggerMiddleware'
 import createOriginMiddleware from './lib/createOriginMiddleware'
+import createTabIdMiddleware from './lib/createTabIdMiddleware'
 import createOnboardingMiddleware from './lib/createOnboardingMiddleware'
 import providerAsMiddleware from 'eth-json-rpc-middleware/providerAsMiddleware'
 import { setupMultiplex } from './lib/stream-utils.js'
@@ -1627,11 +1628,14 @@ export default class MetamaskController extends EventEmitter {
 
     // append origin to each request
     engine.push(createOriginMiddleware({ origin }))
+    // append tabId to each request if it exists
+    if (tabId) {
+      engine.push(createTabIdMiddleware({ tabId }))
+    }
     // logging
     engine.push(createLoggerMiddleware({ origin }))
     engine.push(createOnboardingMiddleware({
       location,
-      tabId,
       registerOnboarding: this.onboardingController.registerOnboarding,
     }))
     // filter and subscription polyfills


### PR DESCRIPTION
This PR uses the additions made to the `setupUntrustedCommunication`, `setupTrustedCommunication`, `setupProviderConnection`, and  `setupProviderEngine` methods in https://github.com/MetaMask/metamask-extension/pull/7602

Using the `tabId` made available in via those changes, it adds the tabId to all requests passing through the middleware. It does so in the same way that the existing `createOriginMiddleware` does.

This additional data is only used in a unit test at this time. Future PR will use it for the closing of tabs after user action on certain types of requests. For example, we will need it to close tabs where full screen transaction confirmations take place.