### PR TITLE
Adjust colour of Reset Account btn to reflect danger

### DIFF
--- a/ui/app/components/app/modals/confirm-reset-account/confirm-reset-account.component.js
+++ b/ui/app/components/app/modals/confirm-reset-account/confirm-reset-account.component.js
@@ -26,7 +26,7 @@ export default class ConfirmResetAccount extends PureComponent {
         onCancel={() => this.props.hideModal()}
         submitText={t('reset')}
         cancelText={t('nevermind')}
-        submitType="secondary"
+        submitType="danger"
       >
         <ModalContent
           title={`${t('resetAccount')}?`}

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -117,7 +117,7 @@ export default class AdvancedTab extends PureComponent {
             <Button
               type="warning"
               large
-              className="settings-tab__button--orange"
+              className="settings-tab__button--red"
               onClick={event => {
                 event.preventDefault()
                 this.context.metricsEvent({


### PR DESCRIPTION
This PR updates the colour of the Reset Account button in settings, and its confirmation modal confirm button. As suggested by @cjeria in #7686.

<details>
<summary><strong>Before (expand)</strong></summary>
<img width="978" alt="Screen Shot 2019-12-12 at 13 18 18" src="https://user-images.githubusercontent.com/1623628/70734985-dda7b480-1ce7-11ea-8e06-5c6c5abf31af.png">
<img width="978" alt="Screen Shot 2019-12-12 at 13 58 11" src="https://user-images.githubusercontent.com/1623628/70734986-dda7b480-1ce7-11ea-8048-12f2911abf8b.png">
</details>

<strong>After:</strong>
<img width="978" alt="Screen Shot 2019-12-12 at 13 58 24" src="https://user-images.githubusercontent.com/1623628/70735110-1ba4d880-1ce8-11ea-9f10-64bc92092c55.png">
<img width="978" alt="Screen Shot 2019-12-12 at 13 58 27" src="https://user-images.githubusercontent.com/1623628/70735111-1ba4d880-1ce8-11ea-8450-e9f4d4ce8dbe.png">