### PR TITLE
Fix a few instances of signature mismatches

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -298,10 +298,10 @@ function setupController (initState, initLangCode) {
 
   async function persistData (state) {
     if (!state) {
-      throw new Error('MetaMask - updated state is missing', state)
+      throw new Error('MetaMask - updated state is missing')
     }
     if (!state.data) {
-      throw new Error('MetaMask - updated state does not have data', state)
+      throw new Error('MetaMask - updated state does not have data')
     }
     if (localStore.isSupported) {
       try {

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -34,7 +34,7 @@ function injectScript (content) {
   try {
     const container = document.head || document.documentElement
     const scriptTag = document.createElement('script')
-    scriptTag.setAttribute('async', false)
+    scriptTag.setAttribute('async', 'false')
     scriptTag.textContent = content
     container.insertBefore(scriptTag, container.children[0])
     container.removeChild(scriptTag)

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -671,7 +671,7 @@ class PreferencesController {
   /**
    * A getter for `tokens` and `accountTokens` related states.
    *
-   * @param {string=} selectedAddress A new hex address for an account
+   * @param {string} [selectedAddress] A new hex address for an account
    * @returns {Object.<array, object, string, string>} States to interact with tokens in `accountTokens`
    *
    */

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -671,7 +671,7 @@ class PreferencesController {
   /**
    * A getter for `tokens` and `accountTokens` related states.
    *
-   * @param {string} selectedAddress A new hex address for an account
+   * @param {string=} selectedAddress A new hex address for an account
    * @returns {Object.<array, object, string, string>} States to interact with tokens in `accountTokens`
    *
    */

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -79,7 +79,7 @@ class RecentBlocksController {
    */
   async processBlock (newBlockNumberHex) {
     const newBlockNumber = Number.parseInt(newBlockNumberHex, 16)
-    const newBlock = await this.getBlockByNumber(newBlockNumber, true)
+    const newBlock = await this.getBlockByNumber(newBlockNumber)
     if (!newBlock) {
       return
     }
@@ -153,7 +153,7 @@ class RecentBlocksController {
       const targetBlockNumbers = Array(blocksToFetch).fill().map((_, index) => prevBlockNumber - index)
       await Promise.all(targetBlockNumbers.map(async (targetBlockNumber) => {
         try {
-          const newBlock = await this.getBlockByNumber(targetBlockNumber, true)
+          const newBlock = await this.getBlockByNumber(targetBlockNumber)
           if (!newBlock) {
             return
           }

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -35,7 +35,7 @@ function migrateFromSnapshotsToDiffs (longHistory) {
   with the first entry having the note and a timestamp when the change took place
   @param previousState {object} - the previous state of the object
   @param newState {object} - the update object
-  @param note {string=} - a optional note for the state change
+  @param {string} [note] - a optional note for the state change
   @returns {array}
 */
 function generateHistoryEntry (previousState, newState, note) {

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -35,7 +35,7 @@ function migrateFromSnapshotsToDiffs (longHistory) {
   with the first entry having the note and a timestamp when the change took place
   @param previousState {object} - the previous state of the object
   @param newState {object} - the update object
-  @param note {string} - a optional note for the state change
+  @param note {string=} - a optional note for the state change
   @returns {array}
 */
 function generateHistoryEntry (previousState, newState, note) {


### PR DESCRIPTION
This PR fixes a few instances of signature mismatches, where the args passed into function calls were either the wrong type or not needed. I've also updated two instances of JSDoc parameter types for optional params.