### PR TITLE
Remove useless component constructors

### DIFF
--- a/ui/app/components/app/info-box/info-box.component.js
+++ b/ui/app/components/app/info-box/info-box.component.js
@@ -12,12 +12,8 @@ export default class InfoBox extends Component {
     description: PropTypes.string,
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      isShowing: true,
-    }
+  state = {
+    isShowing: true,
   }
 
   handleClose () {

--- a/ui/app/components/ui/tabs/tabs.component.js
+++ b/ui/app/components/ui/tabs/tabs.component.js
@@ -2,17 +2,17 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 export default class Tabs extends Component {
+  static defaultProps = {
+    defaultActiveTabIndex: 0,
+  }
+
   static propTypes = {
     defaultActiveTabIndex: PropTypes.number,
     children: PropTypes.node,
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      activeTabIndex: props.defaultActiveTabIndex || 0,
-    }
+  state = {
+    activeTabIndex: this.props.defaultActiveTabIndex,
   }
 
   handleTabClick (tabIndex) {

--- a/ui/app/components/ui/unit-input/unit-input.component.js
+++ b/ui/app/components/ui/unit-input/unit-input.component.js
@@ -22,15 +22,12 @@ export default class UnitInput extends PureComponent {
   }
 
   static defaultProps = {
+    value: '',
     placeholder: '0',
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      value: props.value || '',
-    }
+  state = {
+    value: this.props.value,
   }
 
   componentDidUpdate (prevProps) {

--- a/ui/app/helpers/higher-order-components/with-token-tracker/with-token-tracker.component.js
+++ b/ui/app/helpers/higher-order-components/with-token-tracker/with-token-tracker.component.js
@@ -9,18 +9,14 @@ export default function withTokenTracker (WrappedComponent) {
       token: PropTypes.object.isRequired,
     }
 
-    constructor (props) {
-      super(props)
-
-      this.state = {
-        string: '',
-        symbol: '',
-        balance: '',
-        error: null,
-      }
-
-      this.tracker = null
+    state = {
+      string: '',
+      symbol: '',
+      balance: '',
+      error: null,
     }
+
+    tracker = null
 
     componentDidMount () {
       this.createFreshTokenTracker()

--- a/ui/app/pages/add-token/add-token.component.js
+++ b/ui/app/pages/add-token/add-token.component.js
@@ -26,22 +26,18 @@ class AddToken extends Component {
     identities: PropTypes.object,
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      customAddress: '',
-      customSymbol: '',
-      customDecimals: 0,
-      searchResults: [],
-      selectedTokens: {},
-      tokenSelectorError: null,
-      customAddressError: null,
-      customSymbolError: null,
-      customDecimalsError: null,
-      autoFilled: false,
-      forceEditSymbol: false,
-    }
+  state = {
+    customAddress: '',
+    customSymbol: '',
+    customDecimals: 0,
+    searchResults: [],
+    selectedTokens: {},
+    tokenSelectorError: null,
+    customAddressError: null,
+    customSymbolError: null,
+    customDecimalsError: null,
+    autoFilled: false,
+    forceEditSymbol: false,
   }
 
   componentDidMount () {

--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -9,16 +9,13 @@ const { DEFAULT_ROUTE } = require('../../../helpers/constants/routes')
 const { formatBalance } = require('../../../helpers/utils/util')
 
 class ConnectHardwareForm extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      error: null,
-      selectedAccount: null,
-      accounts: [],
-      browserSupported: true,
-      unlocked: false,
-      device: null,
-    }
+  state = {
+    error: null,
+    selectedAccount: null,
+    accounts: [],
+    browserSupported: true,
+    unlocked: false,
+    device: null,
   }
 
   UNSAFE_componentWillReceiveProps (nextProps) {

--- a/ui/app/pages/create-account/new-account.component.js
+++ b/ui/app/pages/create-account/new-account.component.js
@@ -4,14 +4,15 @@ import { DEFAULT_ROUTE } from '../../helpers/constants/routes'
 import Button from '../../components/ui/button'
 
 export default class NewAccountCreateForm extends Component {
-  constructor (props, context) {
-    super(props)
-    const { newAccountNumber = 0 } = props
+  static defaultProps = {
+    newAccountNumber: 0,
+  }
 
-    this.state = {
-      newAccountName: '',
-      defaultAccountName: context.t('newAccountNumberName', [newAccountNumber]),
-    }
+  state = {
+    newAccountName: '',
+    defaultAccountName: this.context.t('newAccountNumberName', [
+      this.props.newAccountNumber,
+    ]),
   }
 
   render () {

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -23,17 +23,14 @@ export default class UnlockPage extends Component {
     showOptInModal: PropTypes.func,
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      password: '',
-      error: null,
-    }
-
-    this.submitting = false
-    this.animationEventEmitter = new EventEmitter()
+  state = {
+    password: '',
+    error: null,
   }
+
+  submitting = false
+
+  animationEventEmitter = new EventEmitter()
 
   UNSAFE_componentWillMount () {
     const { isUnlocked, history } = this.props


### PR DESCRIPTION
This PR moves state initialization from React component constructors onto the class as properties, and removes any empty constructors that result from that.