### PR TITLE
Clean up MetaMetricsProvider constructor

### DIFF
--- a/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
+++ b/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
@@ -42,17 +42,17 @@ class MetaMetricsProvider extends Component {
   constructor (props) {
     super(props)
 
-    this.state = {
-      previousPath: '',
-      currentPath: window.location.href,
-    }
-
     props.history.listen(() => {
-      this.setState({
-        previousPath: this.state.currentPath,
+      this.setState((prevState) => ({
+        previousPath: prevState.currentPath,
         currentPath: window.location.href,
-      })
+      }))
     })
+  }
+
+  state = {
+    previousPath: '',
+    currentPath: window.location.href,
   }
 
   getChildContext () {


### PR DESCRIPTION
This PR is similar to #7718, but also includes switching the `setState` signature we're using to the function of `prevState`.