### PR TITLE
reorder middleware to fix watchAsset

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1457,10 +1457,10 @@ module.exports = class MetamaskController extends EventEmitter {
     // filter and subscription polyfills
     engine.push(filterMiddleware)
     engine.push(subscriptionManager.middleware)
-    // permissions
-    engine.push(this.permissionsController.createMiddleware({ origin, extensionId }))
     // watch asset
     engine.push(this.preferencesController.requestWatchAsset.bind(this.preferencesController))
+    // permissions
+    engine.push(this.permissionsController.createMiddleware({ origin, extensionId }))
     // forward to metamask primary provider
     engine.push(providerAsMiddleware(provider))
     return engine


### PR DESCRIPTION
the watchAsset method was getting rejected by the permissions controller before dropping into the watchAsset middleware. `message: "The method does not exist / is not available."`
this pr changes the order of the middleware modules to unblock. 

for the transition to gaba preferences controller, we should refactor to have a similar pattern to the onboarding controller and onboarding middleware stack, but for now, this small change unblocks and doesn't depend on the larger work of splitting out the controllers and migrating to new state.