### PR TITLE
Compat w/ Brave to support multi web3 providers

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1,3 +1,5 @@
+/*global chrome*/
+
 import pump from 'pump'
 import querystring from 'querystring'
 import LocalMessageDuplexStream from 'post-message-stream'
@@ -21,8 +23,19 @@ const inpageBundle = inpageContent + inpageSuffix
 // MetaMask will be much faster loading and performant on Firefox.
 
 if (shouldInjectProvider()) {
-  injectScript(inpageBundle)
-  start()
+  // If this is Brave, it requires coordination to know if we should be the
+  // web3 provider.
+  if (chrome.braveWallet && chrome.braveWallet.getWeb3Provider) {
+    chrome.braveWallet.getWeb3Provider((provider) => {
+      if (provider === extension.runtime.id) {
+        injectScript(inpageBundle)
+        start()
+      }
+    })
+  } else {
+    injectScript(inpageBundle)
+    start()
+  }
 }
 
 /**


### PR DESCRIPTION
This implements the spec changes needed for better compatibility with Brave:
https://github.com/brave/brave-browser/issues/7503

It makes it so both extensions can co-exist.

This might not be the cleanest way to accomplish it. Happy to receive review comments and I'll improve it. Thanks!