### PR TITLE
ENS Address preservation when calling IPFS

### DIFF
--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -43,6 +43,7 @@ function setupEnsIpfsResolver ({ provider, getIpfsGateway }) {
     const ipfsGateway = getIpfsGateway()
     extension.tabs.update(tabId, { url: `loading.html` })
     let url = `https://app.ens.domains/name/${name}`
+    (search = search || '') += ((search.indexOf('?') === -1 ? '?' : '&') + 'ensd=' + name);
     try {
       const { type, hash } = await resolveEnsToIpfsContentId({ provider, name })
       if (type === 'ipfs-ns') {


### PR DESCRIPTION
It could be extremely useful to have more ENS domains to point to the same IPFS/Swarm/every-other-distributed-file-system destination. But how to find the original source call? Inserting the original ens domain name as query param is the best idea I made,
I hope you will appreciate the idea because my team needs it very much.