### PR TITLE
ENS Address preservation when calling URLs

### DIFF
--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -43,10 +43,11 @@ function setupEnsIpfsResolver ({ provider, getIpfsGateway }) {
     const ipfsGateway = getIpfsGateway()
     extension.tabs.update(tabId, { url: `loading.html` })
     let url = `https://app.ens.domains/name/${name}`
+    const completeSearch = (search || '') + (!search || search.indexOf('?') === -1 ? '?' : '&') + 'ensd=' + name
     try {
       const { type, hash } = await resolveEnsToIpfsContentId({ provider, name })
       if (type === 'ipfs-ns') {
-        const resolvedUrl = `https://${hash}.${ipfsGateway}${path}${search || ''}${fragment || ''}`
+        const resolvedUrl = `https://${hash}.${ipfsGateway}${path}${completeSearch || ''}${fragment || ''}`
         try {
           // check if ipfs gateway has result
           const response = await fetch(resolvedUrl, { method: 'HEAD' })
@@ -57,11 +58,11 @@ function setupEnsIpfsResolver ({ provider, getIpfsGateway }) {
           console.warn(err)
         }
       } else if (type === 'swarm-ns') {
-        url = `https://swarm-gateways.net/bzz:/${hash}${path}${search || ''}${fragment || ''}`
+        url = `https://swarm-gateways.net/bzz:/${hash}${path}${completeSearch || ''}${fragment || ''}`
       } else if (type === 'onion' || type === 'onion3') {
-        url = `http://${hash}.onion${path}${search || ''}${fragment || ''}`
+        url = `http://${hash}.onion${path}${completeSearch || ''}${fragment || ''}`
       } else if (type === 'zeronet') {
-        url = `http://127.0.0.1:43110/${hash}${path}${search || ''}${fragment || ''}`
+        url = `http://127.0.0.1:43110/${hash}${path}${completeSearch || ''}${fragment || ''}`
       }
     } catch (err) {
       console.warn(err)


### PR DESCRIPTION
It could be extremely useful to have more ENS domains to point to the same IPFS/Swarm/every-other-distributed-file-system destination. 
But how to find the original source call? 
Inserting the original ens domain name as query param is the best method I found,
I hope you will appreciate the idea because me and my team really need it.

Thank you very much