### PR TITLE
Improve e2e helper functions

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -164,12 +164,11 @@ async function switchToWindowWithTitle (driver, title, windowHandles) {
 /**
  * Closes all windows except those in the given list of exceptions
  * @param {object} driver the WebDriver instance
- * @param {string|Array<string>} exceptions the list of window handle exceptions
+ * @param {Array<string>} exceptions the list of window handle exceptions
  * @param {Array?} windowHandles the full list of window handles
  * @returns {Promise<void>}
  */
 async function closeAllWindowHandlesExcept (driver, exceptions, windowHandles) {
-  exceptions = typeof exceptions === 'string' ? [ exceptions ] : exceptions
   windowHandles = windowHandles || await driver.getAllWindowHandles()
 
   for (const handle of windowHandles) {

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -127,15 +127,9 @@ async function findElements (driver, by, timeout = 10000) {
 }
 
 async function openNewPage (driver, url) {
-  await driver.executeScript('window.open()')
-  await delay(1000)
-
-  const handles = await driver.getAllWindowHandles()
-  const lastHandle = handles[handles.length - 1]
-  await driver.switchTo().window(lastHandle)
-
+  const newHandle = await driver.switchTo().newWindow()
   await driver.get(url)
-  await delay(1000)
+  return newHandle
 }
 
 async function waitUntilXWindowHandles (driver, x, delayStep = 1000, timeout = 5000) {


### PR DESCRIPTION
* Improve `openNewPage` helper function

  The two delays were removed, and the window handle for the new page is now returned. This was made possible with the new `newWindow` function added in `v4.0.0-alpha.3` of `selenium-webdriver`.

* Replace recursion with loops

  This should result in far more pleasant stack traces for any exceptions in these functions. It might also be faster. These functions seem easier to understand as loops as well.

* Remove unused string parameter

  The `closeAllWindowHandlesExcept` function has been simplified by removing a branch that handles the case where the `exceptions` parameter given is a string. That parameter is never a string.