### PR TITLE
Disable semicolons for class props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
   },
 
   "plugins": [
+    "babel",
     "mocha",
     "chai",
     "react",
@@ -180,6 +181,7 @@
       "prop": "parens-new-line"
     }],
     "semi": [2, "never"],
+    "babel/semi": [2, "never"],
     "semi-spacing": [2, { "before": false, "after": true }],
     "space-before-blocks": [2, "always"],
     "space-before-function-paren": [2, "always"],

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
     "eslint": "^6.0.1",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-chai": "0.0.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-json": "^1.2.0",

--- a/ui/app/components/app/account-menu/account-menu.component.js
+++ b/ui/app/components/app/account-menu/account-menu.component.js
@@ -44,7 +44,7 @@ export default class AccountMenu extends Component {
     originOfCurrentTab: PropTypes.string,
   }
 
-  accountsRef;
+  accountsRef
 
   state = {
     shouldShowScrollButton: false,

--- a/ui/app/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.component.js
@@ -16,7 +16,7 @@ export default class PermissionPageContainer extends Component {
     permissionRejected: PropTypes.bool,
     requestMetadata: PropTypes.object,
     targetDomainMetadata: PropTypes.object.isRequired,
-  };
+  }
 
   static defaultProps = {
     redirect: null,
@@ -24,12 +24,12 @@ export default class PermissionPageContainer extends Component {
     request: {},
     requestMetadata: {},
     selectedIdentity: {},
-  };
+  }
 
   static contextTypes = {
     t: PropTypes.func,
     metricsEvent: PropTypes.func,
-  };
+  }
 
   state = {
     selectedPermissions: this.getRequestedMethodState(

--- a/ui/app/components/app/sidebars/sidebar.component.js
+++ b/ui/app/components/app/sidebars/sidebar.component.js
@@ -15,7 +15,7 @@ export default class Sidebar extends Component {
     type: PropTypes.string,
     sidebarProps: PropTypes.object,
     onOverlayClose: PropTypes.func,
-  };
+  }
 
   renderOverlay () {
     const { onOverlayClose } = this.props

--- a/ui/app/components/ui/page-container/page-container-content.component.js
+++ b/ui/app/components/ui/page-container/page-container-content.component.js
@@ -5,7 +5,7 @@ export default class PageContainerContent extends Component {
 
   static propTypes = {
     children: PropTypes.node.isRequired,
-  };
+  }
 
   render () {
     return (

--- a/ui/app/components/ui/tooltip.js
+++ b/ui/app/components/ui/tooltip.js
@@ -10,14 +10,14 @@ class ReactTooltip extends Component {
     position: PropTypes.oneOf(['left', 'top', 'right', 'bottom']),
     fixed: PropTypes.bool,
     space: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  };
+  }
 
   static defaultProps = {
     container: document.body,
     position: 'top',
     fixed: true,
     space: 5,
-  };
+  }
 
   componentDidMount = () => {
     this.container = this.props.container || document.body
@@ -40,26 +40,26 @@ class ReactTooltip extends Component {
 
     this.componentEl.addEventListener(this.props.fixed ? 'mouseenter' : 'mousemove', this.handleMouseMove)
     this.componentEl.addEventListener('mouseleave', this.handleMouseOut)
-  };
+  }
 
   componentDidUpdate = () => {
     this.tooltipEl.className = 'tooltip ' + this.props.position
     this.tooltipEl.childNodes[1].textContent = this.props.title
-  };
+  }
 
 
   componentWillUnmount = () => {
     this.componentEl.removeEventListener(this.props.fixed ? 'mouseenter' : 'mousemove', this.handleMouseMove)
     this.componentEl.removeEventListener('mouseleave', this.handleMouseOut)
     this.container.removeChild(this.tooltipEl)
-  };
+  }
 
   resetTooltip = () => {
     this.tooltipEl.style.transition = 'opacity 0.4s'
     this.tooltipEl.style.left = '-500px'
     this.tooltipEl.style.top = '-500px'
     this.tooltipEl.style.opacity = 0
-  };
+  }
 
   handleMouseMove = (e) => {
     if (this.props.title === '') {
@@ -72,11 +72,11 @@ class ReactTooltip extends Component {
     this.tooltipEl.style.left = tooltipPosition.x + tooltipOffset.x + 'px'
     this.tooltipEl.style.top = tooltipPosition.y + tooltipOffset.y + 'px'
     this.tooltipEl.style.opacity = 1
-  };
+  }
 
   handleMouseOut = () => {
     this.resetTooltip()
-  };
+  }
 
   getTooltipPosition = (e) => {
     let pointX
@@ -127,7 +127,7 @@ class ReactTooltip extends Component {
       x: pointX,
       y: pointY,
     }
-  };
+  }
 
   getTooltipOffset = () => {
     const tooltipW = this.tooltipEl.offsetWidth
@@ -160,7 +160,7 @@ class ReactTooltip extends Component {
       x: offsetX,
       y: offsetY,
     }
-  };
+  }
 
   render () {
     return this.props.children

--- a/ui/app/pages/keychains/restore-vault.js
+++ b/ui/app/pages/keychains/restore-vault.js
@@ -22,7 +22,7 @@ class RestoreVaultPage extends Component {
     history: PropTypes.object,
     isLoading: PropTypes.bool,
     initializeThreeBox: PropTypes.func,
-  };
+  }
 
   state = {
     seedPhrase: '',

--- a/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
+++ b/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
@@ -27,7 +27,7 @@ export default class ChooseAccount extends Component {
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   renderAccountsList = () => {
     const { accounts, selectAccount, nativeCurrency, addressLastConnectedMap } = this.props

--- a/ui/app/pages/send/account-list-item/account-list-item.component.js
+++ b/ui/app/pages/send/account-list-item/account-list-item.component.js
@@ -18,7 +18,7 @@ export default class AccountListItem extends Component {
     icon: PropTypes.node,
     balanceIsCached: PropTypes.bool,
     showFiat: PropTypes.bool,
-  };
+  }
 
   static defaultProps = {
     showFiat: true,
@@ -26,7 +26,7 @@ export default class AccountListItem extends Component {
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   render () {
     const {

--- a/ui/app/pages/send/send-content/send-dropdown-list/send-dropdown-list.component.js
+++ b/ui/app/pages/send/send-content/send-dropdown-list/send-dropdown-list.component.js
@@ -9,11 +9,11 @@ export default class SendDropdownList extends Component {
     closeDropdown: PropTypes.func,
     onSelect: PropTypes.func,
     activeAddress: PropTypes.string,
-  };
+  }
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   getListItemIcon (accountAddress, activeAddress) {
     return accountAddress === activeAddress

--- a/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
@@ -9,11 +9,11 @@ export default class GasFeeDisplay extends Component {
     gasLoadingError: PropTypes.bool,
     gasTotal: PropTypes.string,
     onReset: PropTypes.func,
-  };
+  }
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   render () {
     const { gasTotal, gasLoadingError, onReset } = this.props

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -31,7 +31,7 @@ export default class SendGasRow extends Component {
   static contextTypes = {
     t: PropTypes.func,
     metricsEvent: PropTypes.func,
-  };
+  }
 
   renderAdvancedOptionsButton () {
     const { metricsEvent } = this.context

--- a/ui/app/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
+++ b/ui/app/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
@@ -7,11 +7,11 @@ export default class SendHexDataRow extends Component {
     inError: PropTypes.bool,
     updateSendHexData: PropTypes.func.isRequired,
     updateGas: PropTypes.func.isRequired,
-  };
+  }
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   onInput = (event) => {
     const { updateSendHexData, updateGas } = this.props

--- a/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/send-row-error-message.component.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/send-row-error-message.component.js
@@ -7,11 +7,11 @@ export default class SendRowErrorMessage extends Component {
   static propTypes = {
     errors: PropTypes.object,
     errorType: PropTypes.string,
-  };
+  }
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   render () {
     const { errors, errorType } = this.props

--- a/ui/app/pages/send/send-content/send-row-wrapper/send-row-wrapper.component.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/send-row-wrapper.component.js
@@ -9,11 +9,11 @@ export default class SendRowWrapper extends Component {
     errorType: PropTypes.string,
     label: PropTypes.string,
     showError: PropTypes.bool,
-  };
+  }
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   renderAmountFormRow () {
     const {

--- a/ui/app/pages/send/send-footer/send-footer.component.js
+++ b/ui/app/pages/send/send-footer/send-footer.component.js
@@ -31,7 +31,7 @@ export default class SendFooter extends Component {
   static contextTypes = {
     t: PropTypes.func,
     metricsEvent: PropTypes.func,
-  };
+  }
 
   onCancel () {
     this.props.clearSend()

--- a/ui/app/pages/send/send-header/send-header.component.js
+++ b/ui/app/pages/send/send-header/send-header.component.js
@@ -9,11 +9,11 @@ export default class SendHeader extends Component {
     clearSend: PropTypes.func,
     history: PropTypes.object,
     titleKey: PropTypes.string,
-  };
+  }
 
   static contextTypes = {
     t: PropTypes.func,
-  };
+  }
 
   onClose () {
     this.props.clearSend()

--- a/yarn.lock
+++ b/yarn.lock
@@ -9929,6 +9929,13 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-babel@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz#2e7f251ccc249326da760c1a4c948a91c32d0023"
+  integrity sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-plugin-chai@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-chai/-/eslint-plugin-chai-0.0.1.tgz#9a1dea58b335c31242219d059b37ffb14309f6e1"
@@ -9981,6 +9988,11 @@ eslint-plugin-react@^7.4.0:
     has "^1.0.1"
     jsx-ast-utils "^2.0.0"
     prop-types "^15.6.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@3.7.1, eslint-scope@^3.7.1:
   version "3.7.1"


### PR DESCRIPTION
This PR updates our ESLint config to further check our `semi` style. The built-in `semi` rule doesn't cover some of the syntaxes Babel compiles for us, so enabling `babel/semi` fixes that.