### PR TITLE
Consistent jsdoc syntax

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -224,7 +224,7 @@ async function loadStateFromPersistence () {
  * Creates platform listeners for new Dapps/Contexts, and sets up their data connections to the controller.
  *
  * @param {Object} initState - The initial state to start the controller with, matches the state that is emitted from the controller.
- * @param {String} initLangCode - The region code for the language preferred by the current user.
+ * @param {string} initLangCode - The region code for the language preferred by the current user.
  * @returns {Promise} After setup is complete.
  */
 function setupController (initState, initLangCode) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -150,7 +150,7 @@ const { submitMeshMetricsEntry } = setupMetamaskMeshMetrics()
 
 /**
  * Initializes the MetaMask controller, and sets up all platform configuration.
- * @returns {Promise} Setup complete.
+ * @returns {Promise} - Setup complete.
  */
 async function initialize () {
   const initState = await loadStateFromPersistence()
@@ -166,7 +166,7 @@ async function initialize () {
 /**
  * Loads any stored data, prioritizing the latest storage strategy.
  * Migrates that data schema in case it was last loaded on an older version.
- * @returns {Promise<MetaMaskState>} Last data emitted from previous instance of MetaMask.
+ * @returns {Promise<MetaMaskState>} - Last data emitted from previous instance of MetaMask.
  */
 async function loadStateFromPersistence () {
   // migrations
@@ -225,7 +225,7 @@ async function loadStateFromPersistence () {
  *
  * @param {Object} initState - The initial state to start the controller with, matches the state that is emitted from the controller.
  * @param {string} initLangCode - The region code for the language preferred by the current user.
- * @returns {Promise} After setup is complete.
+ * @returns {Promise} - After setup is complete.
  */
 function setupController (initState, initLangCode) {
   //
@@ -289,7 +289,7 @@ function setupController (initState, initLangCode) {
   /**
    * Assigns the given state to the versioned object (with metadata), and returns that.
    * @param {Object} state - The state object as emitted by the MetaMaskController.
-   * @returns {VersionedData} The state object wrapped in an object that includes a metadata key.
+   * @returns {VersionedData} - The state object wrapped in an object that includes a metadata key.
    */
   function versionifyData (state) {
     versionedData.data = state

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -109,8 +109,8 @@ function forwardTrafficBetweenMuxers (channelName, muxA, muxB) {
 /**
  * Error handler for page to extension stream disconnections
  *
- * @param {string} remoteLabel Remote stream name
- * @param {Error} err Stream connection error
+ * @param {string} remoteLabel - Remote stream name
+ * @param {Error} err - Stream connection error
  */
 function logStreamDisconnectWarning (remoteLabel, err) {
   let warningMsg = `MetamaskContentscript - lost connection to ${remoteLabel}`
@@ -123,7 +123,7 @@ function logStreamDisconnectWarning (remoteLabel, err) {
 /**
  * Determines if the provider should be injected
  *
- * @returns {boolean} {@code true} if the provider should be injected
+ * @returns {boolean} {@code true} - if the provider should be injected
  */
 function shouldInjectProvider () {
   return doctypeCheck() && suffixCheck() &&
@@ -133,7 +133,7 @@ function shouldInjectProvider () {
 /**
  * Checks the doctype of the current document if it exists
  *
- * @returns {boolean} {@code true} if the doctype is html or if none exists
+ * @returns {boolean} {@code true} - if the doctype is html or if none exists
  */
 function doctypeCheck () {
   const doctype = window.document.doctype
@@ -151,7 +151,7 @@ function doctypeCheck () {
  * that we should not inject the provider into. This check is indifferent of
  * query parameters in the location.
  *
- * @returns {boolean} whether or not the extension of the current document is prohibited
+ * @returns {boolean} - whether or not the extension of the current document is prohibited
  */
 function suffixCheck () {
   const prohibitedTypes = [
@@ -170,7 +170,7 @@ function suffixCheck () {
 /**
  * Checks the documentElement of the current document
  *
- * @returns {boolean} {@code true} if the documentElement is an html node or if none exists
+ * @returns {boolean} {@code true} - if the documentElement is an html node or if none exists
  */
 function documentElementCheck () {
   const documentElement = document.documentElement.nodeName
@@ -183,7 +183,7 @@ function documentElementCheck () {
 /**
  * Checks if the current domain is blacklisted
  *
- * @returns {boolean} {@code true} if the current domain is blacklisted
+ * @returns {boolean} {@code true} - if the current domain is blacklisted
  */
 function blacklistedDomainCheck () {
   const blacklistedDomains = [

--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -31,7 +31,7 @@ class ABTestController {
   /**
    * Returns the name of the test group to which the current user has been assigned
    * @param {string} abTestKey the key of the a/b test
-   * @return {string} the name of the assigned test group
+   * @returns {string} the name of the assigned test group
    */
   getAssignedABTestGroupName (abTestKey) {
     return this.store.getState().abTests[abTestKey]
@@ -40,7 +40,7 @@ class ABTestController {
   /**
    * Returns a randomly chosen name of a test group from a given a/b test
    * @param {string} abTestKey the key of the a/b test
-   * @return {string} the name of the randomly selected test group
+   * @returns {string} the name of the randomly selected test group
    * @private
    */
   _getRandomizedTestGroupName (abTestKey) {

--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -30,8 +30,8 @@ class ABTestController {
 
   /**
    * Returns the name of the test group to which the current user has been assigned
-   * @param {string} abTestKey the key of the a/b test
-   * @returns {string} the name of the assigned test group
+   * @param {string} abTestKey - the key of the a/b test
+   * @returns {string} - the name of the assigned test group
    */
   getAssignedABTestGroupName (abTestKey) {
     return this.store.getState().abTests[abTestKey]
@@ -39,8 +39,8 @@ class ABTestController {
 
   /**
    * Returns a randomly chosen name of a test group from a given a/b test
-   * @param {string} abTestKey the key of the a/b test
-   * @returns {string} the name of the randomly selected test group
+   * @param {string} abTestKey - the key of the a/b test
+   * @returns {string} - the name of the randomly selected test group
    * @private
    */
   _getRandomizedTestGroupName (abTestKey) {

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -32,7 +32,7 @@ class AppStateController {
 
   /**
    * Sets the last active time to the current time
-   * @return {void}
+   * @returns {void}
    */
   setLastActiveTime () {
     this._resetTimer()
@@ -41,7 +41,7 @@ class AppStateController {
   /**
    * Sets the inactive timeout for the app
    * @param {number} timeoutMinutes the inactive timeout in minutes
-   * @return {void}
+   * @returns {void}
    * @private
    */
   _setInactiveTimeout (timeoutMinutes) {
@@ -58,7 +58,7 @@ class AppStateController {
    * If the {@code timeoutMinutes} state is falsy (i.e., zero) then a new
    * timer will not be created.
    *
-   * @return {void}
+   * @returns {void}
    * @private
    */
   _resetTimer () {

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -40,7 +40,7 @@ class AppStateController {
 
   /**
    * Sets the inactive timeout for the app
-   * @param {number} timeoutMinutes the inactive timeout in minutes
+   * @param {number} timeoutMinutes - the inactive timeout in minutes
    * @returns {void}
    * @private
    */

--- a/app/scripts/controllers/balance.js
+++ b/app/scripts/controllers/balance.js
@@ -8,7 +8,7 @@ class BalanceController {
    * Controller responsible for storing and updating an account's balance.
    *
    * @typedef {Object} BalanceController
-   * @param {Object} opts Initialize various properties of the class.
+   * @param {Object} opts - Initialize various properties of the class.
    * @property {string} address A base 16 hex string. The account address which has the balance managed by this
    * BalanceController.
    * @property {AccountTracker} accountTracker Stores and updates the users accounts
@@ -47,7 +47,7 @@ class BalanceController {
   /**
    * Updates the ethBalance property to the current pending balance
    *
-   * @returns {Promise<void>} Promises undefined
+   * @returns {Promise<void>} - Promises undefined
    */
   async updateBalance () {
     const balance = await this.balanceCalc.getBalance()
@@ -87,7 +87,7 @@ class BalanceController {
    * Gets the balance, as a base 16 hex string, of the account at this BalanceController's current address.
    * If the current account has no balance, returns undefined.
    *
-   * @returns {Promise<BN|void>} Promises a BN with a value equal to the balance of the current account, or undefined
+   * @returns {Promise<BN|void>} - Promises a BN with a value equal to the balance of the current account, or undefined
    * if the current account has no balance
    *
    */
@@ -103,7 +103,7 @@ class BalanceController {
    * TransactionController passed to this BalanceController during construction.
    *
    * @private
-   * @returns {Promise<array>} Promises an array of transaction objects.
+   * @returns {Promise<array>} - Promises an array of transaction objects.
    *
    */
   async _getPendingTransactions () {
@@ -118,7 +118,7 @@ class BalanceController {
   /**
    * Validates that the passed options have all required properties.
    *
-   * @param {Object} opts The options object to validate
+   * @param {Object} opts - The options object to validate
    * @throws {string} Throw a custom error indicating that address, accountTracker, txController and blockTracker are
    * missing and at least one is required
    *

--- a/app/scripts/controllers/cached-balances.js
+++ b/app/scripts/controllers/cached-balances.js
@@ -36,7 +36,7 @@ class CachedBalancesController {
    * Updates the cachedBalances property for the current network. Cached balances will be updated to those in the passed accounts
    * if balances in the passed accounts are truthy.
    *
-   * @param {Object} obj The the recently updated accounts object for the current network
+   * @param {Object} obj - The the recently updated accounts object for the current network
    * @returns {Promise<void>}
    */
   async updateCachedBalances ({ accounts }) {

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -62,8 +62,8 @@ class DetectTokensController {
   /**
    * Find if selectedAddress has tokens with contract in contractAddress.
    *
-   * @param {string} contractAddress Hex address of the token contract to explore.
-   * @returns {boolean} If balance is detected, token is added.
+   * @param {string} contractAddress - Hex address of the token contract to explore.
+   * @returns {boolean} - If balance is detected, token is added.
    *
    */
   async detectTokenBalance (contractAddress) {

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -134,7 +134,7 @@ export class PermissionsController {
   /**
    * User approval callback. The request can fail if the request is invalid.
    *
-   * @param {object} approved - the approved request object
+   * @param {Object} approved - the approved request object
    * @param {Array} accounts - The accounts to expose, if any
    */
   async approvePermissionsRequest (approved, accounts) {
@@ -299,7 +299,7 @@ export class PermissionsController {
 
   /**
    * Removes the given permissions for the given domain.
-   * @param {object} domains { origin: [permissions] }
+   * @param {Object} domains { origin: [permissions] }
    */
   removePermissionsFor (domains) {
 

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -167,7 +167,7 @@ export class PermissionsController {
   /**
    * User rejection callback.
    *
-   * @param {string} id the id of the rejected request
+   * @param {string} id - the id of the rejected request
    */
   async rejectPermissionsRequest (id) {
     const approval = this.pendingApprovals[id]

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -10,7 +10,7 @@ class PreferencesController {
   /**
    *
    * @typedef {Object} PreferencesController
-   * @param {Object} opts Overrides the defaults for the initial state of this.store
+   * @param {Object} opts - Overrides the defaults for the initial state of this.store
    * @property {object} store The stored object containing a users preferences, stored in local storage
 	 * @property {array} store.frequentRpcList A list of custom rpcs to provide the user
    * @property {string} store.currentAccountTab Indicates the selected tab in the ui
@@ -79,7 +79,7 @@ class PreferencesController {
 
   /**
    * Sets the {@code forgottenPassword} state property
-   * @param {boolean} forgottenPassword whether or not the user has forgotten their password
+   * @param {boolean} forgottenPassword - whether or not the user has forgotten their password
    */
   setPasswordForgotten (forgottenPassword) {
     this.store.updateState({ forgottenPassword })
@@ -88,7 +88,7 @@ class PreferencesController {
   /**
    * Setter for the `useBlockie` property
    *
-   * @param {boolean} val Whether or not the user prefers blockie indicators
+   * @param {boolean} val - Whether or not the user prefers blockie indicators
    *
    */
   setUseBlockie (val) {
@@ -98,7 +98,7 @@ class PreferencesController {
   /**
    * Setter for the `useNonceField` property
    *
-   * @param {boolean} val Whether or not the user prefers to set nonce
+   * @param {boolean} val - Whether or not the user prefers to set nonce
    *
    */
   setUseNonceField (val) {
@@ -108,8 +108,8 @@ class PreferencesController {
   /**
    * Setter for the `participateInMetaMetrics` property
    *
-   * @param {boolean} bool Whether or not the user wants to participate in MetaMetrics
-   * @returns {string|null} the string of the new metametrics id, or null if not set
+   * @param {boolean} bool - Whether or not the user wants to participate in MetaMetrics
+   * @returns {string|null} - the string of the new metametrics id, or null if not set
    *
    */
   setParticipateInMetaMetrics (bool) {
@@ -135,7 +135,7 @@ class PreferencesController {
   /**
    * Setter for the `firstTimeFlowType` property
    *
-   * @param {string} type Indicates the type of first time flow - create or import - the user wishes to follow
+   * @param {string} type - Indicates the type of first time flow - create or import - the user wishes to follow
    *
    */
   setFirstTimeFlowType (type) {
@@ -164,8 +164,8 @@ class PreferencesController {
   /**
    * Add new methodData to state, to avoid requesting this information again through Infura
    *
-   * @param {string} fourBytePrefix Four-byte method signature
-   * @param {string} methodData Corresponding data method
+   * @param {string} fourBytePrefix - Four-byte method signature
+   * @param {string} methodData - Corresponding data method
    */
   addKnownMethodData (fourBytePrefix, methodData) {
     const knownMethodData = this.store.getState().knownMethodData
@@ -208,7 +208,7 @@ class PreferencesController {
   /**
    * Setter for the `currentLocale` property
    *
-   * @param {string} key he preferred language locale key
+   * @param {string} key - he preferred language locale key
    *
    */
   setCurrentLocale (key) {
@@ -224,7 +224,7 @@ class PreferencesController {
    * Updates identities to only include specified addresses. Removes identities
    * not included in addresses array
    *
-   * @param {string[]} addresses An array of hex addresses
+   * @param {string[]} addresses - An array of hex addresses
    *
    */
   setAddresses (addresses) {
@@ -247,8 +247,8 @@ class PreferencesController {
   /**
    * Removes an address from state
    *
-   * @param {string} address A hex address
-   * @returns {string} the address that was removed
+   * @param {string} address - A hex address
+   * @returns {string} - the address that was removed
    */
   removeAddress (address) {
     const identities = this.store.getState().identities
@@ -273,7 +273,7 @@ class PreferencesController {
   /**
    * Adds addresses to the identities object without removing identities
    *
-   * @param {string[]} addresses An array of hex addresses
+   * @param {string[]} addresses - An array of hex addresses
    *
    */
   addAddresses (addresses) {
@@ -297,8 +297,8 @@ class PreferencesController {
    * Synchronizes identity entries with known accounts.
    * Removes any unknown identities, and returns the resulting selected address.
    *
-   * @param {Array<string>} addresses known to the vault.
-   * @returns {Promise<string>} selectedAddress the selected address.
+   * @param {Array<string>} addresses - known to the vault.
+   * @returns {Promise<string>} - selectedAddress the selected address.
    */
   syncAddresses (addresses) {
     const { identities, lostIdentities } = this.store.getState()
@@ -349,8 +349,8 @@ class PreferencesController {
   /**
    * Setter for the `selectedAddress` property
    *
-   * @param {string} _address A new hex address for an account
-   * @returns {Promise<void>} Promise resolves with tokens
+   * @param {string} _address - A new hex address for an account
+   * @returns {Promise<void>} - Promise resolves with tokens
    *
    */
   setSelectedAddress (_address) {
@@ -364,7 +364,7 @@ class PreferencesController {
   /**
    * Getter for the `selectedAddress` property
    *
-   * @returns {string} The hex address for the currently selected account
+   * @returns {string} - The hex address for the currently selected account
    *
    */
   getSelectedAddress () {
@@ -386,10 +386,10 @@ class PreferencesController {
    * Modifies the existing tokens array from the store. All objects in the tokens array array AddedToken objects.
    * @see AddedToken {@link AddedToken}
    *
-   * @param {string} rawAddress Hex address of the token contract. May or may not be a checksum address.
-   * @param {string} symbol The symbol of the token
-   * @param {number} decimals  The number of decimals the token uses.
-   * @returns {Promise<array>} Promises the new array of AddedToken objects.
+   * @param {string} rawAddress - Hex address of the token contract. May or may not be a checksum address.
+   * @param {string} symbol - The symbol of the token
+   * @param {number} decimals  - The number of decimals the token uses.
+   * @returns {Promise<array>} - Promises the new array of AddedToken objects.
    *
    */
   async addToken (rawAddress, symbol, decimals, image) {
@@ -415,8 +415,8 @@ class PreferencesController {
   /**
    * Removes a specified token from the tokens array.
    *
-   * @param {string} rawAddress Hex address of the token contract to remove.
-   * @returns {Promise<array>} The new array of AddedToken objects
+   * @param {string} rawAddress - Hex address of the token contract to remove.
+   * @returns {Promise<array>} - The new array of AddedToken objects
    *
    */
   removeToken (rawAddress) {
@@ -431,7 +431,7 @@ class PreferencesController {
   /**
    * A getter for the `tokens` property
    *
-   * @returns {array} The current array of AddedToken objects
+   * @returns {array} - The current array of AddedToken objects
    *
    */
   getTokens () {
@@ -440,8 +440,8 @@ class PreferencesController {
 
   /**
    * Sets a custom label for an account
-   * @param {string} account the account to set a label for
-   * @param {string} label the custom label for the account
+   * @param {string} account - the account to set a label for
+   * @param {string} label - the custom label for the account
    * @returns {Promise<string>}
    */
   setAccountLabel (account, label) {
@@ -459,8 +459,8 @@ class PreferencesController {
   /**
    * Setter for the `currentAccountTab` property
    *
-   * @param {string} currentAccountTab Specifies the new tab to be marked as current
-   * @returns {Promise<void>} Promise resolves with undefined
+   * @param {string} currentAccountTab - Specifies the new tab to be marked as current
+   * @returns {Promise<void>} - Promise resolves with undefined
    *
    */
   setCurrentAccountTab (currentAccountTab) {
@@ -473,11 +473,11 @@ class PreferencesController {
   /**
    * updates custom RPC details
    *
-   * @param {string} url The RPC url to add to frequentRpcList.
-   * @param {number} chainId Optional chainId of the selected network.
-   * @param {string} ticker   Optional ticker symbol of the selected network.
-   * @param {string} nickname Optional nickname of the selected network.
-   * @returns {Promise<array>} Promise resolving to updated frequentRpcList.
+   * @param {string} url - The RPC url to add to frequentRpcList.
+   * @param {number} chainId - Optional chainId of the selected network.
+   * @param {string} ticker   - Optional ticker symbol of the selected network.
+   * @param {string} nickname - Optional nickname of the selected network.
+   * @returns {Promise<array>} - Promise resolving to updated frequentRpcList.
    *
    */
 
@@ -501,11 +501,11 @@ class PreferencesController {
   /**
    * Adds custom RPC url to state.
    *
-   * @param {string} url The RPC url to add to frequentRpcList.
-   * @param {number} chainId Optional chainId of the selected network.
-   * @param {string} ticker   Optional ticker symbol of the selected network.
-   * @param {string} nickname Optional nickname of the selected network.
-   * @returns {Promise<array>} Promise resolving to updated frequentRpcList.
+   * @param {string} url - The RPC url to add to frequentRpcList.
+   * @param {number} chainId - Optional chainId of the selected network.
+   * @param {string} ticker   - Optional ticker symbol of the selected network.
+   * @param {string} nickname - Optional nickname of the selected network.
+   * @returns {Promise<array>} - Promise resolving to updated frequentRpcList.
    *
    */
   addToFrequentRpcList (url, chainId, ticker = 'ETH', nickname = '', rpcPrefs = {}) {
@@ -530,8 +530,8 @@ class PreferencesController {
   /**
    * Removes custom RPC url from state.
    *
-   * @param {string} url The RPC url to remove from frequentRpcList.
-   * @returns {Promise<array>} Promise resolving to updated frequentRpcList.
+   * @param {string} url - The RPC url to remove from frequentRpcList.
+   * @returns {Promise<array>} - Promise resolving to updated frequentRpcList.
    *
    */
   removeFromFrequentRpcList (url) {
@@ -549,7 +549,7 @@ class PreferencesController {
   /**
    * Getter for the `frequentRpcListDetail` property.
    *
-   * @returns {array<array>} An array of rpc urls.
+   * @returns {array<array>} - An array of rpc urls.
    *
    */
   getFrequentRpcListDetail () {
@@ -559,9 +559,9 @@ class PreferencesController {
   /**
    * Updates the `featureFlags` property, which is an object. One property within that object will be set to a boolean.
    *
-   * @param {string} feature A key that corresponds to a UI feature.
-   * @param {boolean} activated Indicates whether or not the UI feature should be displayed
-   * @returns {Promise<object>} Promises a new object; the updated featureFlags object.
+   * @param {string} feature - A key that corresponds to a UI feature.
+   * @param {boolean} activated - Indicates whether or not the UI feature should be displayed
+   * @returns {Promise<object>} - Promises a new object; the updated featureFlags object.
    *
    */
   setFeatureFlag (feature, activated) {
@@ -579,9 +579,9 @@ class PreferencesController {
   /**
    * Updates the `preferences` property, which is an object. These are user-controlled features
    * found in the settings page.
-   * @param {string} preference The preference to enable or disable.
-   * @param {boolean} value Indicates whether or not the preference should be enabled or disabled.
-   * @returns {Promise<object>} Promises a new object; the updated preferences object.
+   * @param {string} preference - The preference to enable or disable.
+   * @param {boolean} value - Indicates whether or not the preference should be enabled or disabled.
+   * @returns {Promise<object>} - Promises a new object; the updated preferences object.
    */
   setPreference (preference, value) {
     const currentPreferences = this.getPreferences()
@@ -596,7 +596,7 @@ class PreferencesController {
 
   /**
    * A getter for the `preferences` property
-   * @returns {Object} A key-boolean map of user-selected preferences.
+   * @returns {Object} - A key-boolean map of user-selected preferences.
    */
   getPreferences () {
     return this.store.getState().preferences
@@ -613,7 +613,7 @@ class PreferencesController {
 
   /**
    * A getter for the `ipfsGateway` property
-   * @returns {string} The current IPFS gateway domain
+   * @returns {string} - The current IPFS gateway domain
    */
   getIpfsGateway () {
     return this.store.getState().ipfsGateway
@@ -621,8 +621,8 @@ class PreferencesController {
 
   /**
    * A setter for the `ipfsGateway` property
-   * @param {string} domain The new IPFS gateway domain
-   * @returns {Promise<string>} A promise of the update IPFS gateway domain
+   * @param {string} domain - The new IPFS gateway domain
+   * @returns {Promise<string>} - A promise of the update IPFS gateway domain
    */
   setIpfsGateway (domain) {
     this.store.updateState({ ipfsGateway: domain })
@@ -648,7 +648,7 @@ class PreferencesController {
   /**
    * Updates `accountTokens` and `tokens` of current account and network according to it.
    *
-   * @param {array} tokens Array of tokens to be updated.
+   * @param {array} tokens - Array of tokens to be updated.
    *
    */
   _updateAccountTokens (tokens, assetImages) {
@@ -660,7 +660,7 @@ class PreferencesController {
   /**
    * Updates `tokens` of current account and network.
    *
-   * @param {string} selectedAddress Account address to be updated with.
+   * @param {string} selectedAddress - Account address to be updated with.
    *
    */
   _updateTokens (selectedAddress) {
@@ -672,7 +672,7 @@ class PreferencesController {
    * A getter for `tokens` and `accountTokens` related states.
    *
    * @param {string} [selectedAddress] A new hex address for an account
-   * @returns {Object.<array, object, string, string>} States to interact with tokens in `accountTokens`
+   * @returns {Object.<array, object, string, string>} - States to interact with tokens in `accountTokens`
    *
    */
   _getTokenRelatedStates (selectedAddress) {
@@ -694,7 +694,7 @@ class PreferencesController {
   /**
    * Handle the suggestion of an ERC20 asset through `watchAsset`
    * *
-   * @param {Promise} promise Promise according to addition of ERC20 token
+   * @param {Promise} promise - Promise according to addition of ERC20 token
    *
    */
   async _handleWatchAssetERC20 (options) {
@@ -716,7 +716,7 @@ class PreferencesController {
   /**
    * Validates that the passed options for suggested token have all required properties.
    *
-   * @param {Object} opts The options object to validate
+   * @param {Object} opts - The options object to validate
    * @throws {string} Throw a custom error indicating that address, symbol and/or decimals
    * doesn't fulfill requirements
    *

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -442,7 +442,7 @@ class PreferencesController {
    * Sets a custom label for an account
    * @param {string} account the account to set a label for
    * @param {string} label the custom label for the account
-   * @return {Promise<string>}
+   * @returns {Promise<string>}
    */
   setAccountLabel (account, label) {
     if (!account) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -10,7 +10,7 @@ class PreferencesController {
   /**
    *
    * @typedef {Object} PreferencesController
-   * @param {object} opts Overrides the defaults for the initial state of this.store
+   * @param {Object} opts Overrides the defaults for the initial state of this.store
    * @property {object} store The stored object containing a users preferences, stored in local storage
 	 * @property {array} store.frequentRpcList A list of custom rpcs to provide the user
    * @property {string} store.currentAccountTab Indicates the selected tab in the ui
@@ -135,7 +135,7 @@ class PreferencesController {
   /**
    * Setter for the `firstTimeFlowType` property
    *
-   * @param {String} type Indicates the type of first time flow - create or import - the user wishes to follow
+   * @param {string} type Indicates the type of first time flow - create or import - the user wishes to follow
    *
    */
   setFirstTimeFlowType (type) {
@@ -596,7 +596,7 @@ class PreferencesController {
 
   /**
    * A getter for the `preferences` property
-   * @returns {object} A key-boolean map of user-selected preferences.
+   * @returns {Object} A key-boolean map of user-selected preferences.
    */
   getPreferences () {
     return this.store.getState().preferences

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -16,7 +16,7 @@ class RecentBlocksController {
    * (indicating that there is a new block to process).
    *
    * @typedef {Object} RecentBlocksController
-   * @param {object} opts Contains objects necessary for tracking blocks and querying the blockchain
+   * @param {Object} opts Contains objects necessary for tracking blocks and querying the blockchain
    * @param {BlockTracker} opts.blockTracker Contains objects necessary for tracking blocks and querying the blockchain
    * @param {BlockTracker} opts.provider The provider used to create a new EthQuery instance.
    * @property {BlockTracker} blockTracker Points to the passed BlockTracker. On RecentBlocksController construction,
@@ -69,7 +69,7 @@ class RecentBlocksController {
    * Receives a new block and modifies it with this.mapTransactionsToPrices. Then adds that block to the recentBlocks
    * array in storage. If the recentBlocks array contains the maximum number of blocks, the oldest block is removed.
    *
-   * @param {object} newBlock The new block to modify and add to the recentBlocks array
+   * @param {Object} newBlock The new block to modify and add to the recentBlocks array
    *
    */
   async processBlock (newBlockNumberHex) {
@@ -97,7 +97,7 @@ class RecentBlocksController {
    *
    * Unlike this.processBlock, backfillBlock adds the modified new block to the beginning of the recent block array.
    *
-   * @param {object} newBlock The new block to modify and add to the beginning of the recentBlocks array
+   * @param {Object} newBlock The new block to modify and add to the beginning of the recentBlocks array
    *
    */
   backfillBlock (newBlock) {
@@ -116,8 +116,8 @@ class RecentBlocksController {
    * Receives a block and gets the gasPrice of each of its transactions. These gas prices are added to the block at a
    * new property, and the block's transactions are removed.
    *
-   * @param {object} newBlock The block to modify. It's transaction array will be replaced by a gasPrices array.
-   * @returns {object} The modified block.
+   * @param {Object} newBlock The block to modify. It's transaction array will be replaced by a gasPrices array.
+   * @returns {Object} The modified block.
    *
    */
   mapTransactionsToPrices (newBlock) {

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -16,7 +16,7 @@ class RecentBlocksController {
    * (indicating that there is a new block to process).
    *
    * @typedef {Object} RecentBlocksController
-   * @param {Object} opts Contains objects necessary for tracking blocks and querying the blockchain
+   * @param {Object} opts - Contains objects necessary for tracking blocks and querying the blockchain
    * @param {BlockTracker} opts.blockTracker Contains objects necessary for tracking blocks and querying the blockchain
    * @param {BlockTracker} opts.provider The provider used to create a new EthQuery instance.
    * @property {BlockTracker} blockTracker Points to the passed BlockTracker. On RecentBlocksController construction,
@@ -69,7 +69,7 @@ class RecentBlocksController {
    * Receives a new block and modifies it with this.mapTransactionsToPrices. Then adds that block to the recentBlocks
    * array in storage. If the recentBlocks array contains the maximum number of blocks, the oldest block is removed.
    *
-   * @param {Object} newBlock The new block to modify and add to the recentBlocks array
+   * @param {Object} newBlock - The new block to modify and add to the recentBlocks array
    *
    */
   async processBlock (newBlockNumberHex) {
@@ -97,7 +97,7 @@ class RecentBlocksController {
    *
    * Unlike this.processBlock, backfillBlock adds the modified new block to the beginning of the recent block array.
    *
-   * @param {Object} newBlock The new block to modify and add to the beginning of the recentBlocks array
+   * @param {Object} newBlock - The new block to modify and add to the beginning of the recentBlocks array
    *
    */
   backfillBlock (newBlock) {
@@ -116,8 +116,8 @@ class RecentBlocksController {
    * Receives a block and gets the gasPrice of each of its transactions. These gas prices are added to the block at a
    * new property, and the block's transactions are removed.
    *
-   * @param {Object} newBlock The block to modify. It's transaction array will be replaced by a gasPrices array.
-   * @returns {Object} The modified block.
+   * @param {Object} newBlock - The block to modify. It's transaction array will be replaced by a gasPrices array.
+   * @returns {Object} - The modified block.
    *
    */
   mapTransactionsToPrices (newBlock) {
@@ -138,7 +138,7 @@ class RecentBlocksController {
    *
    * Each iteration over the block numbers is delayed by 100 milliseconds.
    *
-   * @returns {Promise<void>} Promises undefined
+   * @returns {Promise<void>} - Promises undefined
    */
   async backfill () {
     this.blockTracker.once('latest', async (blockNumberHex) => {
@@ -164,8 +164,8 @@ class RecentBlocksController {
   /**
    * Uses EthQuery to get a block that has a given block number.
    *
-   * @param {number} number The number of the block to get
-   * @returns {Promise<object>} Promises A block with the passed number
+   * @param {number} number - The number of the block to get
+   * @returns {Promise<object>} - Promises A block with the passed number
    *
    */
   async getBlockByNumber (number) {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -125,7 +125,7 @@ class TransactionController extends EventEmitter {
     this._updatePendingTxsAfterFirstBlock()
   }
 
-  /** @returns {number} the chainId*/
+  /** @returns {number} - the chainId*/
   getChainId () {
     const networkState = this.networkStore.getState()
     const getChainId = parseInt(networkState)
@@ -156,7 +156,7 @@ class TransactionController extends EventEmitter {
   /**
   * Add a new unapproved transaction to the pipeline
   *
-  * @returns {Promise<string>} the hash of the transaction after being submitted to the network
+  * @returns {Promise<string>} - the hash of the transaction after being submitted to the network
   * @param {Object} txParams - txParams for the transaction
   * @param {Object} opts - with the key origin to put the origin on the txMeta
   */
@@ -257,7 +257,7 @@ class TransactionController extends EventEmitter {
   /**
    * Adds the tx gas defaults: gas && gasPrice
    * @param {Object} txMeta - the txMeta object
-   * @returns {Promise<object>} resolves with txMeta
+   * @returns {Promise<object>} - resolves with txMeta
    */
   async addTxGasDefaults (txMeta, getCodeResponse) {
     const txParams = txMeta.txParams

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -278,7 +278,7 @@ class TransactionController extends EventEmitter {
     to allow the user to resign the transaction with a higher gas values
     @param {number} originalTxId - the id of the txMeta that
     you want to attempt to retry
-    @param {string=} gasPrice - Optional gas price to be increased to use as the retry
+    @param {string} [gasPrice] - Optional gas price to be increased to use as the retry
     transaction's gas price
     @return {txMeta}
   */
@@ -311,7 +311,7 @@ class TransactionController extends EventEmitter {
    * new transaction contains the same nonce as the previous, is a basic ETH transfer of 0x value to
    * the sender's address, and has a higher gasPrice than that of the previous transaction.
    * @param {number} originalTxId - the id of the txMeta that you want to attempt to cancel
-   * @param {string=} customGasPrice - the hex value to use for the cancel transaction
+   * @param {string} [customGasPrice] - the hex value to use for the cancel transaction
    * @returns {txMeta}
    */
   async createCancelTransaction (originalTxId, customGasPrice) {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -52,16 +52,16 @@ import { hexToBn, bnToHex, BnMultiplyByFraction } from '../../lib/util'
 
 
   @class
-  @param {object} - opts
-  @param {object}  opts.initState - initial transaction list default is an empty array
+  @param {Object} - opts
+  @param {Object}  opts.initState - initial transaction list default is an empty array
   @param {Object}  opts.networkStore - an observable store for network number
   @param {Object}  opts.blockTracker - An instance of eth-blocktracker
   @param {Object}  opts.provider - A network provider.
   @param {Function}  opts.signTransaction - function the signs an ethereumjs-tx
-  @param {object}  opts.getPermittedAccounts - get accounts that an origin has permissions for
+  @param {Object}  opts.getPermittedAccounts - get accounts that an origin has permissions for
   @param {Function}  [opts.getGasPrice] - optional gas price calculator
   @param {Function}  opts.signTransaction - ethTx signer that returns a rawTx
-  @param {Number}  [opts.txHistoryLimit] - number *optional* for limiting how many transactions are in state
+  @param {number}  [opts.txHistoryLimit] - number *optional* for limiting how many transactions are in state
   @param {Object}  opts.preferencesStore
 */
 
@@ -157,8 +157,8 @@ class TransactionController extends EventEmitter {
   * Add a new unapproved transaction to the pipeline
   *
   * @returns {Promise<string>} the hash of the transaction after being submitted to the network
-  * @param {object} txParams - txParams for the transaction
-  * @param {object} opts - with the key origin to put the origin on the txMeta
+  * @param {Object} txParams - txParams for the transaction
+  * @param {Object} opts - with the key origin to put the origin on the txMeta
   */
   async newUnapprovedTransaction (txParams, opts = {}) {
 
@@ -573,7 +573,7 @@ class TransactionController extends EventEmitter {
     this.getUnapprovedTxCount = () => Object.keys(this.txStateManager.getUnapprovedTxList()).length
     /**
       @returns {number} - number of transactions that have the status submitted
-      @param {String} account - hex prefixed account
+      @param {string} account - hex prefixed account
     */
     this.getPendingTxCount = (account) => this.txStateManager.getPendingTransactions(account).length
     /** see txStateManager */
@@ -687,7 +687,7 @@ class TransactionController extends EventEmitter {
     Sets other txMeta statuses to dropped if the txMeta that has been confirmed has other transactions
     in the list have the same nonce
 
-    @param {Number} txId - the txId of the transaction that has been confirmed in a block
+    @param {number} txId - the txId of the transaction that has been confirmed in a block
   */
   _markNonceDuplicatesDropped (txId) {
     // get the confirmed transactions nonce and from address

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -157,8 +157,8 @@ class TransactionController extends EventEmitter {
   * Add a new unapproved transaction to the pipeline
   *
   * @returns {Promise<string>} the hash of the transaction after being submitted to the network
-  * @param txParams {object} - txParams for the transaction
-  * @param opts {object} - with the key origin to put the origin on the txMeta
+  * @param {object} txParams - txParams for the transaction
+  * @param {object} opts - with the key origin to put the origin on the txMeta
   */
   async newUnapprovedTransaction (txParams, opts = {}) {
 
@@ -256,7 +256,7 @@ class TransactionController extends EventEmitter {
 
   /**
    * Adds the tx gas defaults: gas && gasPrice
-   * @param txMeta {Object} - the txMeta object
+   * @param {Object} txMeta - the txMeta object
    * @returns {Promise<object>} resolves with txMeta
    */
   async addTxGasDefaults (txMeta, getCodeResponse) {
@@ -276,9 +276,9 @@ class TransactionController extends EventEmitter {
   /**
     Creates a new txMeta with the same txParams as the original
     to allow the user to resign the transaction with a higher gas values
-    @param  originalTxId {number} - the id of the txMeta that
+    @param {number} originalTxId - the id of the txMeta that
     you want to attempt to retry
-    @param  gasPrice {string=} - Optional gas price to be increased to use as the retry
+    @param {string=} gasPrice - Optional gas price to be increased to use as the retry
     transaction's gas price
     @return {txMeta}
   */
@@ -365,7 +365,7 @@ class TransactionController extends EventEmitter {
 
   /**
   updates the txMeta in the txStateManager
-  @param txMeta {Object} - the updated txMeta
+  @param {Object} txMeta - the updated txMeta
   */
   async updateTransaction (txMeta) {
     this.txStateManager.updateTx(txMeta, 'confTx: user updated transaction')
@@ -373,7 +373,7 @@ class TransactionController extends EventEmitter {
 
   /**
   updates and approves the transaction
-  @param txMeta {Object}
+  @param {Object} txMeta
   */
   async updateAndApproveTransaction (txMeta) {
     this.txStateManager.updateTx(txMeta, 'confTx: user approved transaction')
@@ -386,7 +386,7 @@ class TransactionController extends EventEmitter {
   signs the transaction
   publishes the transaction
   if any of these steps fails the tx status will be set to failed
-    @param txId {number} - the tx's Id
+    @param {number} txId - the tx's Id
   */
   async approveTransaction (txId) {
     // TODO: Move this safety out of this function.
@@ -447,8 +447,8 @@ class TransactionController extends EventEmitter {
 
   /**
     adds the chain id and signs the transaction and set the status to signed
-    @param txId {number} - the tx's Id
-    @returns - rawTx {string}
+    @param {number} txId - the tx's Id
+    @returns {string} - rawTx
   */
   async signTransaction (txId) {
     const txMeta = this.txStateManager.getTx(txId)
@@ -476,8 +476,8 @@ class TransactionController extends EventEmitter {
 
   /**
     publishes the raw tx and sets the txMeta to submitted
-    @param txId {number} - the tx's Id
-    @param rawTx {string} - the hex string of the serialized signed transaction
+    @param {number} txId - the tx's Id
+    @param {string} rawTx - the hex string of the serialized signed transaction
     @returns {Promise<void>}
   */
   async publishTransaction (txId, rawTx) {
@@ -539,7 +539,7 @@ class TransactionController extends EventEmitter {
 
   /**
     Convenience method for the ui thats sets the transaction to rejected
-    @param txId {number} - the tx's Id
+    @param {number} txId - the tx's Id
     @returns {Promise<void>}
   */
   async cancelTransaction (txId) {
@@ -548,8 +548,8 @@ class TransactionController extends EventEmitter {
 
   /**
     Sets the txHas on the txMeta
-    @param txId {number} - the tx's Id
-    @param txHash {string} - the hash for the txMeta
+    @param {number} txId - the tx's Id
+    @param {string} txHash - the hash for the txMeta
   */
   setTxHash (txId, txHash) {
     // Add the tx hash to the persisted meta-tx object
@@ -563,17 +563,17 @@ class TransactionController extends EventEmitter {
   //
   /** maps methods for convenience*/
   _mapMethods () {
-    /** @returns the state in transaction controller */
+    /** @returns {Object} - the state in transaction controller */
     this.getState = () => this.memStore.getState()
-    /** @returns the network number stored in networkStore */
+    /** @returns {string|number} - the network number stored in networkStore */
     this.getNetwork = () => this.networkStore.getState()
-    /** @returns the user selected address */
+    /** @returns {string} - the user selected address */
     this.getSelectedAddress = () => this.preferencesStore.getState().selectedAddress
-    /** Returns an array of transactions whos status is unapproved */
+    /** @returns {array} - transactions whos status is unapproved */
     this.getUnapprovedTxCount = () => Object.keys(this.txStateManager.getUnapprovedTxList()).length
     /**
-      @returns a number that represents how many transactions have the status submitted
-      @param account {String} - hex prefixed account
+      @returns {number} - number of transactions that have the status submitted
+      @param {String} account - hex prefixed account
     */
     this.getPendingTxCount = (account) => this.txStateManager.getPendingTransactions(account).length
     /** see txStateManager */
@@ -687,7 +687,7 @@ class TransactionController extends EventEmitter {
     Sets other txMeta statuses to dropped if the txMeta that has been confirmed has other transactions
     in the list have the same nonce
 
-    @param txId {Number} - the txId of the transaction that has been confirmed in a block
+    @param {Number} txId - the txId of the transaction that has been confirmed in a block
   */
   _markNonceDuplicatesDropped (txId) {
     // get the confirmed transactions nonce and from address

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -280,7 +280,7 @@ class TransactionController extends EventEmitter {
     you want to attempt to retry
     @param {string} [gasPrice] - Optional gas price to be increased to use as the retry
     transaction's gas price
-    @return {txMeta}
+    @returns {txMeta}
   */
 
   async retryTransaction (originalTxId, gasPrice) {

--- a/app/scripts/controllers/transactions/lib/recipient-blacklist-checker.js
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist-checker.js
@@ -7,8 +7,8 @@ export default {
 
 /**
  * Checks if a specified account on a specified network is blacklisted.
-  @param networkId {number}
-  @param account {string}
+  @param {number} networkId
+  @param {string} account
 */
 function checkAccount (networkId, account) {
 

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -63,7 +63,7 @@ function replayHistory (_shortHistory) {
 
 /**
   @param {Object} txMeta
-  @returns {Object} a clone object of the txMeta with out history
+  @returns {Object} - a clone object of the txMeta with out history
 */
 function snapshotFromTxMeta (txMeta) {
   // create txMeta snapshot for history

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -34,8 +34,8 @@ function migrateFromSnapshotsToDiffs (longHistory) {
     path (the key and if a nested object then each key will be seperated with a `/`)
     value
   with the first entry having the note and a timestamp when the change took place
-  @param {object} previousState - the previous state of the object
-  @param {object} newState - the update object
+  @param {Object} previousState - the previous state of the object
+  @param {Object} newState - the update object
   @param {string} [note] - a optional note for the state change
   @returns {array}
 */
@@ -54,7 +54,7 @@ function generateHistoryEntry (previousState, newState, note) {
 
 /**
   Recovers previous txMeta state obj
-  @returns {object}
+  @returns {Object}
 */
 function replayHistory (_shortHistory) {
   const shortHistory = clone(_shortHistory)
@@ -63,7 +63,7 @@ function replayHistory (_shortHistory) {
 
 /**
   @param {Object} txMeta
-  @returns {object} a clone object of the txMeta with out history
+  @returns {Object} a clone object of the txMeta with out history
 */
 function snapshotFromTxMeta (txMeta) {
   // create txMeta snapshot for history

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -11,7 +11,7 @@ export default {
 
 /**
   converts non-initial history entries into diffs
-  @param longHistory {array}
+  @param {array} longHistory
   @returns {array}
 */
 function migrateFromSnapshotsToDiffs (longHistory) {
@@ -34,8 +34,8 @@ function migrateFromSnapshotsToDiffs (longHistory) {
     path (the key and if a nested object then each key will be seperated with a `/`)
     value
   with the first entry having the note and a timestamp when the change took place
-  @param previousState {object} - the previous state of the object
-  @param newState {object} - the update object
+  @param {object} previousState - the previous state of the object
+  @param {object} newState - the update object
   @param {string} [note] - a optional note for the state change
   @returns {array}
 */
@@ -62,7 +62,7 @@ function replayHistory (_shortHistory) {
 }
 
 /**
-  @param txMeta {Object}
+  @param {Object} txMeta
   @returns {object} a clone object of the txMeta with out history
 */
 function snapshotFromTxMeta (txMeta) {

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -15,7 +15,7 @@ const normalizers = {
 /**
   normalizes txParams
   @param {Object} txParams
-  @returns {Object} normalized txParams
+  @returns {Object} - normalized txParams
  */
 export function normalizeTxParams (txParams, LowerCase) {
   // apply only keys in the normalizers

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -14,8 +14,8 @@ const normalizers = {
 
 /**
   normalizes txParams
-  @param {object} txParams
-  @returns {object} normalized txParams
+  @param {Object} txParams
+  @returns {Object} normalized txParams
  */
 export function normalizeTxParams (txParams, LowerCase) {
   // apply only keys in the normalizers
@@ -30,7 +30,7 @@ export function normalizeTxParams (txParams, LowerCase) {
 
 /**
   validates txParams
-  @param {object} txParams
+  @param {Object} txParams
  */
 export function validateTxParams (txParams) {
   validateFrom(txParams)
@@ -49,7 +49,7 @@ export function validateTxParams (txParams) {
 
 /**
   validates the from field in  txParams
-  @param {object} txParams
+  @param {Object} txParams
  */
 export function validateFrom (txParams) {
   if (!(typeof txParams.from === 'string')) {
@@ -62,7 +62,7 @@ export function validateFrom (txParams) {
 
 /**
   validates the to field in  txParams
-  @param {object} txParams
+  @param {Object} txParams
  */
 export function validateRecipient (txParams) {
   if (txParams.to === '0x' || txParams.to === null) {

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -14,7 +14,7 @@ const normalizers = {
 
 /**
   normalizes txParams
-  @param txParams {object}
+  @param {object} txParams
   @returns {object} normalized txParams
  */
 export function normalizeTxParams (txParams, LowerCase) {
@@ -30,7 +30,7 @@ export function normalizeTxParams (txParams, LowerCase) {
 
 /**
   validates txParams
-  @param txParams {object}
+  @param {object} txParams
  */
 export function validateTxParams (txParams) {
   validateFrom(txParams)
@@ -49,7 +49,7 @@ export function validateTxParams (txParams) {
 
 /**
   validates the from field in  txParams
-  @param txParams {object}
+  @param {object} txParams
  */
 export function validateFrom (txParams) {
   if (!(typeof txParams.from === 'string')) {
@@ -62,7 +62,7 @@ export function validateFrom (txParams) {
 
 /**
   validates the to field in  txParams
-  @param txParams {object}
+  @param {object} txParams
  */
 export function validateRecipient (txParams) {
   if (txParams.to === '0x' || txParams.to === null) {
@@ -78,7 +78,7 @@ export function validateRecipient (txParams) {
 }
 
 /**
-    @returns an {array} of states that can be considered final
+    @returns {array} - states that can be considered final
   */
 export function getFinalStates () {
   return [

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -9,7 +9,7 @@ import EthQuery from 'ethjs-query'
 <br>
   As well as continues broadcast while in the pending state
 <br>
-@param config {object} - non optional configuration object consists of:
+@param {object} config - non optional configuration object consists of:
     @param {Object} config.provider - A network provider.
     @param {Object} config.nonceTracker see nonce tracker
     @param {function} config.getPendingTransactions a function for getting an array of transactions,
@@ -50,7 +50,7 @@ class PendingTransactionTracker extends EventEmitter {
 
   /**
     Will resubmit any transactions who have not been confirmed in a block
-    @param block {object} - a block object
+    @param {object} block - a block object
     @emits tx:warning
   */
   resubmitPendingTxs (blockNumber) {
@@ -95,10 +95,10 @@ class PendingTransactionTracker extends EventEmitter {
 
   /**
     resubmits the individual txMeta used in resubmitPendingTxs
-    @param txMeta {Object} - txMeta object
-    @param latestBlockNumber {string} - hex string for the latest block number
+    @param {Object} txMeta - txMeta object
+    @param {string} latestBlockNumber - hex string for the latest block number
     @emits tx:retry
-    @returns txHash {string}
+    @returns {string} txHash
   */
   async _resubmitTx (txMeta, latestBlockNumber) {
     if (!txMeta.firstRetryBlockNumber) {
@@ -130,7 +130,7 @@ class PendingTransactionTracker extends EventEmitter {
 
   /**
     Ask the network for the transaction to see if it has been include in a block
-    @param txMeta {Object} - the txMeta object
+    @param {Object} txMeta - the txMeta object
     @emits tx:failed
     @emits tx:dropped
     @emits tx:confirmed
@@ -209,8 +209,8 @@ class PendingTransactionTracker extends EventEmitter {
   }
   /**
     checks to see if if the tx's nonce has been used by another transaction
-    @param txMeta {Object} - txMeta object
-    @param transactionReceipt {Object} - transactionReceipt object
+    @param {Object} txMeta - txMeta object
+    @param {Object} transactionReceipt - transactionReceipt object
     @emits tx:dropped
     @returns {boolean}
   */
@@ -226,7 +226,7 @@ class PendingTransactionTracker extends EventEmitter {
 
   /**
     checks local txs to see if a confirmed txMeta has the same nonce
-    @param txMeta {Object} - txMeta object
+    @param {Object} txMeta - txMeta object
     @returns {boolean}
   */
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -9,7 +9,7 @@ import EthQuery from 'ethjs-query'
 <br>
   As well as continues broadcast while in the pending state
 <br>
-@param {object} config - non optional configuration object consists of:
+@param {Object} config - non optional configuration object consists of:
     @param {Object} config.provider - A network provider.
     @param {Object} config.nonceTracker see nonce tracker
     @param {function} config.getPendingTransactions a function for getting an array of transactions,
@@ -50,7 +50,7 @@ class PendingTransactionTracker extends EventEmitter {
 
   /**
     Will resubmit any transactions who have not been confirmed in a block
-    @param {object} block - a block object
+    @param {Object} block - a block object
     @emits tx:warning
   */
   resubmitPendingTxs (blockNumber) {

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -98,7 +98,7 @@ class PendingTransactionTracker extends EventEmitter {
     @param {Object} txMeta - txMeta object
     @param {string} latestBlockNumber - hex string for the latest block number
     @emits tx:retry
-    @returns {string} txHash
+    @returns {string} - txHash
   */
   async _resubmitTx (txMeta, latestBlockNumber) {
     if (!txMeta.firstRetryBlockNumber) {

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -22,7 +22,7 @@ class TxGasUtil {
   }
 
   /**
-    @param txMeta {Object} - the txMeta object
+    @param {Object} txMeta - the txMeta object
     @returns {object} the txMeta object with the gas written to the txParams
   */
   async analyzeGasUsage (txMeta, getCodeResponse) {
@@ -50,8 +50,8 @@ class TxGasUtil {
 
   /**
     Estimates the tx's gas usage
-    @param txMeta {Object} - the txMeta object
-    @param blockGasLimitHex {string} - hex string of the block's gas limit
+    @param {Object} txMeta - the txMeta object
+    @param {string} blockGasLimitHex - hex string of the block's gas limit
     @returns {string} the estimated gas limit as a hex string
   */
   async estimateTxGas (txMeta, blockGasLimitHex, getCodeResponse) {
@@ -104,9 +104,9 @@ class TxGasUtil {
 
   /**
     Writes the gas on the txParams in the txMeta
-    @param txMeta {Object} - the txMeta object to write to
-    @param blockGasLimitHex {string} - the block gas limit hex
-    @param estimatedGasHex {string} - the estimated gas hex
+    @param {Object} txMeta - the txMeta object to write to
+    @param {string} blockGasLimitHex - the block gas limit hex
+    @param {string} estimatedGasHex - the estimated gas hex
   */
   setTxGas (txMeta, blockGasLimitHex, estimatedGasHex) {
     txMeta.estimatedGas = addHexPrefix(estimatedGasHex)
@@ -128,8 +128,8 @@ class TxGasUtil {
   /**
     Adds a gas buffer with out exceeding the block gas limit
 
-    @param initialGasLimitHex {string} - the initial gas limit to add the buffer too
-    @param blockGasLimitHex {string} - the block gas limit
+    @param {string} initialGasLimitHex - the initial gas limit to add the buffer too
+    @param {string} blockGasLimitHex - the block gas limit
     @returns {string} the buffered gas limit as a hex string
   */
   addGasBuffer (initialGasLimitHex, blockGasLimitHex) {

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -23,7 +23,7 @@ class TxGasUtil {
 
   /**
     @param {Object} txMeta - the txMeta object
-    @returns {Object} the txMeta object with the gas written to the txParams
+    @returns {Object} - the txMeta object with the gas written to the txParams
   */
   async analyzeGasUsage (txMeta, getCodeResponse) {
     const block = await this.query.getBlockByNumber('latest', false)
@@ -52,7 +52,7 @@ class TxGasUtil {
     Estimates the tx's gas usage
     @param {Object} txMeta - the txMeta object
     @param {string} blockGasLimitHex - hex string of the block's gas limit
-    @returns {string} the estimated gas limit as a hex string
+    @returns {string} - the estimated gas limit as a hex string
   */
   async estimateTxGas (txMeta, blockGasLimitHex, getCodeResponse) {
     const txParams = txMeta.txParams
@@ -130,7 +130,7 @@ class TxGasUtil {
 
     @param {string} initialGasLimitHex - the initial gas limit to add the buffer too
     @param {string} blockGasLimitHex - the block gas limit
-    @returns {string} the buffered gas limit as a hex string
+    @returns {string} - the buffered gas limit as a hex string
   */
   addGasBuffer (initialGasLimitHex, blockGasLimitHex) {
     const initialGasLimitBn = hexToBn(initialGasLimitHex)

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -23,7 +23,7 @@ class TxGasUtil {
 
   /**
     @param {Object} txMeta - the txMeta object
-    @returns {object} the txMeta object with the gas written to the txParams
+    @returns {Object} the txMeta object with the gas written to the txParams
   */
   async analyzeGasUsage (txMeta, getCodeResponse) {
     const block = await this.query.getBlockByNumber('latest', false)

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -41,7 +41,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     @param {Object} opts - the object to use when overwriting defaults
-    @returns {txMeta} the default txMeta object
+    @returns {txMeta} - the default txMeta object
   */
   generateTxMeta (opts) {
     const netId = this.getNetwork()
@@ -58,7 +58,7 @@ class TransactionStateManager extends EventEmitter {
   }
 
   /**
-    @returns {array} of txMetas that have been filtered for only the current network
+    @returns {array} - of txMetas that have been filtered for only the current network
   */
   getTxList () {
     const network = this.getNetwork()
@@ -67,14 +67,14 @@ class TransactionStateManager extends EventEmitter {
   }
 
   /**
-    @returns {array} of all the txMetas in store
+    @returns {array} - of all the txMetas in store
   */
   getFullTxList () {
     return this.store.getState().transactions
   }
 
   /**
-    @returns {array} the tx list whos status is unapproved
+    @returns {array} - the tx list whos status is unapproved
   */
   getUnapprovedTxList () {
     const txList = this.getTxsByMetaData('status', 'unapproved')
@@ -86,7 +86,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
-    @returns {array} the tx list whos status is approved if no address is provide
+    @returns {array} - the tx list whos status is approved if no address is provide
     returns all txMetas who's status is approved for the current network
   */
   getApprovedTransactions (address) {
@@ -99,7 +99,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
-    @returns {array} the tx list whos status is submitted if no address is provide
+    @returns {array} - the tx list whos status is submitted if no address is provide
     returns all txMetas who's status is submitted for the current network
   */
   getPendingTransactions (address) {
@@ -112,7 +112,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
-    @returns {array} the tx list whos status is confirmed if no address is provide
+    @returns {array} - the tx list whos status is confirmed if no address is provide
     returns all txMetas who's status is confirmed for the current network
   */
   getConfirmedTransactions (address) {
@@ -130,7 +130,7 @@ class TransactionStateManager extends EventEmitter {
     it will allso add the key `history` to the txMeta with the snap shot of the original
     object
     @param {Object} txMeta
-    @returns {Object} the txMeta
+    @returns {Object} - the txMeta
   */
   addTx (txMeta) {
     // normalize and validate txParams if present
@@ -178,7 +178,7 @@ class TransactionStateManager extends EventEmitter {
   }
   /**
     @param {number} txId
-    @returns {Object} the txMeta who matches the given id if none found
+    @returns {Object} - the txMeta who matches the given id if none found
     for the network returns undefined
   */
   getTx (txId) {
@@ -303,7 +303,7 @@ class TransactionStateManager extends EventEmitter {
     @param value - the value your looking for can also be a function that returns a bool
     @param [txList=this.getTxList()] {array} - the list to search. default is the txList
     from txStateManager#getTxList
-    @returns {array} a list of txMetas who matches the search params
+    @returns {array} - a list of txMetas who matches the search params
   */
   getTxsByMetaData (key, value, txList = this.getTxList()) {
     const filter = typeof value === 'function' ? value : (v) => v === value
@@ -321,7 +321,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     @param {number} txId - the txMeta Id
-    @returns {string} the status of the tx.
+    @returns {string} - the status of the tx.
   */
   getTxStatus (txId) {
     const txMeta = this.getTx(txId)

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -321,7 +321,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     @param {number} txId - the txMeta Id
-    @return {string} the status of the tx.
+    @returns {string} the status of the tx.
   */
   getTxStatus (txId) {
     const txMeta = this.getTx(txId)

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -20,8 +20,8 @@ import { getFinalStates, normalizeTxParams } from './lib/util'
   <br>   - `'confirmed'` the tx has been included in a block.
   <br>   - `'failed'` the tx failed for some reason, included on tx data.
   <br>   - `'dropped'` the tx nonce was already used
-  @param {object} opts
-  @param {object} [opts.initState={ transactions: [] }] initial transactions list with the key transaction {array}
+  @param {Object} opts
+  @param {Object} [opts.initState={ transactions: [] }] initial transactions list with the key transaction {array}
   @param {number} [opts.txHistoryLimit] limit for how many finished
   transactions can hang around in state
   @param {function} opts.getNetwork return network number
@@ -40,7 +40,7 @@ class TransactionStateManager extends EventEmitter {
   }
 
   /**
-    @param {object} opts - the object to use when overwriting defaults
+    @param {Object} opts - the object to use when overwriting defaults
     @returns {txMeta} the default txMeta object
   */
   generateTxMeta (opts) {
@@ -130,7 +130,7 @@ class TransactionStateManager extends EventEmitter {
     it will allso add the key `history` to the txMeta with the snap shot of the original
     object
     @param {Object} txMeta
-    @returns {object} the txMeta
+    @returns {Object} the txMeta
   */
   addTx (txMeta) {
     // normalize and validate txParams if present
@@ -178,7 +178,7 @@ class TransactionStateManager extends EventEmitter {
   }
   /**
     @param {number} txId
-    @returns {object} the txMeta who matches the given id if none found
+    @returns {Object} the txMeta who matches the given id if none found
     for the network returns undefined
   */
   getTx (txId) {
@@ -218,7 +218,7 @@ class TransactionStateManager extends EventEmitter {
     merges txParams obj onto txMeta.txParams
     use extend to ensure that all fields are filled
     @param {number} txId - the id of the txMeta
-    @param {object} txParams - the updated txParams
+    @param {Object} txParams - the updated txParams
   */
   updateTxParams (txId, txParams) {
     const txMeta = this.getTx(txId)
@@ -228,7 +228,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
    * normalize and validate txParams members
-   * @param {object} txParams - txParams
+   * @param {Object} txParams - txParams
    */
   normalizeAndValidateTxParams (txParams) {
     if (typeof txParams.data === 'undefined') {
@@ -241,7 +241,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     validates txParams members by type
-    @param {object} txParams - txParams to validate
+    @param {Object} txParams - txParams to validate
   */
   validateTxParams (txParams) {
     Object.keys(txParams).forEach((key) => {
@@ -263,7 +263,7 @@ class TransactionStateManager extends EventEmitter {
   }
 
   /**
-  @param {object} opts -  an object of fields to search for eg:<br>
+  @param {Object} opts -  an object of fields to search for eg:<br>
   let <code>thingsToLookFor = {<br>
     to: '0x0..',<br>
     from: '0x0..',<br>

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -20,7 +20,7 @@ import { getFinalStates, normalizeTxParams } from './lib/util'
   <br>   - `'confirmed'` the tx has been included in a block.
   <br>   - `'failed'` the tx failed for some reason, included on tx data.
   <br>   - `'dropped'` the tx nonce was already used
-  @param opts {object}
+  @param {object} opts
   @param {object} [opts.initState={ transactions: [] }] initial transactions list with the key transaction {array}
   @param {number} [opts.txHistoryLimit] limit for how many finished
   transactions can hang around in state
@@ -40,7 +40,7 @@ class TransactionStateManager extends EventEmitter {
   }
 
   /**
-    @param opts {object} - the object to use when overwriting defaults
+    @param {object} opts - the object to use when overwriting defaults
     @returns {txMeta} the default txMeta object
   */
   generateTxMeta (opts) {
@@ -129,7 +129,7 @@ class TransactionStateManager extends EventEmitter {
     is in its final state
     it will allso add the key `history` to the txMeta with the snap shot of the original
     object
-    @param txMeta {Object}
+    @param {Object} txMeta
     @returns {object} the txMeta
   */
   addTx (txMeta) {
@@ -177,7 +177,7 @@ class TransactionStateManager extends EventEmitter {
     return txMeta
   }
   /**
-    @param txId {number}
+    @param {number} txId
     @returns {object} the txMeta who matches the given id if none found
     for the network returns undefined
   */
@@ -188,8 +188,8 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     updates the txMeta in the list and adds a history entry
-    @param txMeta {Object} - the txMeta to update
-    @param [note] {string} - a note about the update for history
+    @param {Object} txMeta - the txMeta to update
+    @param {string} [note] - a note about the update for history
   */
   updateTx (txMeta, note) {
     // normalize and validate txParams if present
@@ -217,8 +217,8 @@ class TransactionStateManager extends EventEmitter {
   /**
     merges txParams obj onto txMeta.txParams
     use extend to ensure that all fields are filled
-    @param txId {number} - the id of the txMeta
-    @param txParams {object} - the updated txParams
+    @param {number} txId - the id of the txMeta
+    @param {object} txParams - the updated txParams
   */
   updateTxParams (txId, txParams) {
     const txMeta = this.getTx(txId)
@@ -228,7 +228,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
    * normalize and validate txParams members
-   * @param txParams {object} - txParams
+   * @param {object} txParams - txParams
    */
   normalizeAndValidateTxParams (txParams) {
     if (typeof txParams.data === 'undefined') {
@@ -241,7 +241,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     validates txParams members by type
-    @param txParams {object} - txParams to validate
+    @param {object} txParams - txParams to validate
   */
   validateTxParams (txParams) {
     Object.keys(txParams).forEach((key) => {
@@ -263,7 +263,7 @@ class TransactionStateManager extends EventEmitter {
   }
 
   /**
-  @param opts {object} -  an object of fields to search for eg:<br>
+  @param {object} opts -  an object of fields to search for eg:<br>
   let <code>thingsToLookFor = {<br>
     to: '0x0..',<br>
     from: '0x0..',<br>
@@ -273,7 +273,7 @@ class TransactionStateManager extends EventEmitter {
   optionally the values of the keys can be functions for situations like where
   you want all but one status.
   @param [initialList=this.getTxList()]
-  @returns a {array} of txMeta with all
+  @returns {array} - array of txMeta with all
   options matching
   */
   /*
@@ -299,7 +299,7 @@ class TransactionStateManager extends EventEmitter {
   }
   /**
 
-    @param key {string} - the key to check
+    @param {string} key - the key to check
     @param value - the value your looking for can also be a function that returns a bool
     @param [txList=this.getTxList()] {array} - the list to search. default is the txList
     from txStateManager#getTxList
@@ -320,7 +320,7 @@ class TransactionStateManager extends EventEmitter {
   // get::set status
 
   /**
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
     @return {string} the status of the tx.
   */
   getTxStatus (txId) {
@@ -330,7 +330,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     should update the status of the tx to 'rejected'.
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
   */
   setTxStatusRejected (txId) {
     this._setTxStatus(txId, 'rejected')
@@ -339,14 +339,14 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     should update the status of the tx to 'unapproved'.
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
   */
   setTxStatusUnapproved (txId) {
     this._setTxStatus(txId, 'unapproved')
   }
   /**
     should update the status of the tx to 'approved'.
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
   */
   setTxStatusApproved (txId) {
     this._setTxStatus(txId, 'approved')
@@ -354,7 +354,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     should update the status of the tx to 'signed'.
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
   */
   setTxStatusSigned (txId) {
     this._setTxStatus(txId, 'signed')
@@ -363,7 +363,7 @@ class TransactionStateManager extends EventEmitter {
   /**
     should update the status of the tx to 'submitted'.
     and add a time stamp for when it was called
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
   */
   setTxStatusSubmitted (txId) {
     const txMeta = this.getTx(txId)
@@ -374,7 +374,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     should update the status of the tx to 'confirmed'.
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
   */
   setTxStatusConfirmed (txId) {
     this._setTxStatus(txId, 'confirmed')
@@ -382,7 +382,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     should update the status of the tx to 'dropped'.
-    @param txId {number} - the txMeta Id
+    @param {number} txId - the txMeta Id
   */
   setTxStatusDropped (txId) {
     this._setTxStatus(txId, 'dropped')
@@ -392,8 +392,8 @@ class TransactionStateManager extends EventEmitter {
   /**
     should update the status of the tx to 'failed'.
     and put the error on the txMeta
-    @param txId {number} - the txMeta Id
-    @param err {erroObject} - error object
+    @param {number} txId - the txMeta Id
+    @param {erroObject} err - error object
   */
   setTxStatusFailed (txId, err) {
     const error = !err ? new Error('Internal metamask failure') : err
@@ -411,7 +411,7 @@ class TransactionStateManager extends EventEmitter {
   /**
     Removes transaction from the given address for the current network
     from the txList
-    @param address {string} - hex string of the from address on the txParams to remove
+    @param {string} address - hex string of the from address on the txParams to remove
   */
   wipeTransactions (address) {
     // network only tx
@@ -440,8 +440,8 @@ class TransactionStateManager extends EventEmitter {
   //    - `'dropped'` the tx nonce was already used
 
   /**
-    @param txId {number} - the txMeta Id
-    @param status {string} - the status to set on the txMeta
+    @param {number} txId - the txMeta Id
+    @param {string} status - the status to set on the txMeta
     @emits tx:status-update - passes txId and status
     @emits ${txMeta.id}:finished - if it is a finished state. Passes the txMeta
     @emits update:badge
@@ -471,7 +471,7 @@ class TransactionStateManager extends EventEmitter {
 
   /**
     Saves the new/updated txList.
-    @param transactions {array} - the list of transactions to save
+    @param {array} transactions - the list of transactions to save
   */
   // Function is intended only for internal use
   _saveTxList (transactions) {

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -34,7 +34,7 @@ class AccountTracker {
    * It also tracks transaction hashes, and checks their inclusion status on each new block.
    *
    * @typedef {Object} AccountTracker
-   * @param {Object} opts Initialize various properties of the class.
+   * @param {Object} opts - Initialize various properties of the class.
    * @property {Object} store The stored object containing all accounts to track, as well as the current block's gas limit.
    * @property {Object} store.accounts The accounts currently stored in this AccountTracker
    * @property {string} store.currentBlockGasLimit A hex string indicating the gas limit of the current block
@@ -88,7 +88,7 @@ class AccountTracker {
    * Once this AccountTracker's accounts are up to date with those referenced by the passed addresses, each
    * of these accounts are given an updated balance via EthQuery.
    *
-   * @param {array} address The array of hex addresses for accounts with which this AccountTracker's accounts should be
+   * @param {array} address - The array of hex addresses for accounts with which this AccountTracker's accounts should be
    * in sync
    *
    */
@@ -118,7 +118,7 @@ class AccountTracker {
    * Adds new addresses to track the balances of
    * given a balance as long this._currentBlockNumber is defined.
    *
-   * @param {array} addresses An array of hex addresses of new accounts to track
+   * @param {array} addresses - An array of hex addresses of new accounts to track
    *
    */
   addAccounts (addresses) {
@@ -139,7 +139,7 @@ class AccountTracker {
   /**
    * Removes accounts from being tracked
    *
-   * @param {array} an array of hex addresses to stop tracking
+   * @param {array} an - array of hex addresses to stop tracking
    *
    */
   removeAccount (addresses) {
@@ -157,7 +157,7 @@ class AccountTracker {
    * via EthQuery
    *
    * @private
-   * @param {number} blockNumber the block number to update to.
+   * @param {number} blockNumber - the block number to update to.
    * @fires 'block' The updated state, if all account updates are successful
    *
    */
@@ -183,7 +183,7 @@ class AccountTracker {
    * balanceChecker is deployed on main eth (test)nets and requires a single call
    * for all other networks, calls this._updateAccount for each account in this.store
    *
-   * @returns {Promise} after all account balances updated
+   * @returns {Promise} - after all account balances updated
    *
    */
   async _updateAccounts () {
@@ -217,8 +217,8 @@ class AccountTracker {
    * Updates the current balance of an account.
    *
    * @private
-   * @param {string} address A hex address of a the account to be updated
-   * @returns {Promise} after the account balance is updated
+   * @param {string} address - A hex address of a the account to be updated
+   * @returns {Promise} - after the account balance is updated
    *
    */
   async _updateAccount (address) {

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -3,11 +3,11 @@ export default getBuyEthUrl
 /**
  * Gives the caller a url at which the user can acquire eth, depending on the network they are in
  *
- * @param {Object} opts Options required to determine the correct url
+ * @param {Object} opts - Options required to determine the correct url
  * @param {string} opts.network The network for which to return a url
  * @param {string} opts.amount The amount of ETH to buy on coinbase. Only relevant if network === '1'.
  * @param {string} opts.address The address the bought ETH should be sent to.  Only relevant if network === '1'.
- * @returns {string|undefined} The url at which the user can access ETH, while in the given network. If the passed
+ * @returns {string|undefined} - The url at which the user can access ETH, while in the given network. If the passed
  * network does not match any of the specified cases, or if no network is given, returns undefined.
  *
  */

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -3,7 +3,7 @@ export default getBuyEthUrl
 /**
  * Gives the caller a url at which the user can acquire eth, depending on the network they are in
  *
- * @param {object} opts Options required to determine the correct url
+ * @param {Object} opts Options required to determine the correct url
  * @param {string} opts.network The network for which to return a url
  * @param {string} opts.amount The amount of ETH to buy on coinbase. Only relevant if network === '1'.
  * @param {string} opts.address The address the bought ETH should be sent to.  Only relevant if network === '1'.

--- a/app/scripts/lib/cleanErrorStack.js
+++ b/app/scripts/lib/cleanErrorStack.js
@@ -1,7 +1,7 @@
 /**
  * Returns error without stack trace for better UI display
  * @param {Error} err - error
- * @returns {Error} Error with clean stack trace.
+ * @returns {Error} - Error with clean stack trace.
  */
 function cleanErrorStack (err) {
   let name = err.name

--- a/app/scripts/lib/extractEthjsErrorMessage.js
+++ b/app/scripts/lib/extractEthjsErrorMessage.js
@@ -8,8 +8,8 @@ export default extractEthjsErrorMessage
  * Extracts the important part of an ethjs-rpc error message. If the passed error is not an isEthjsRpcError, the error
  * is returned unchanged.
  *
- * @param {string} errorMessage The error message to parse
- * @returns {string} Returns an error message, either the same as was passed, or the ending message portion of an isEthjsRpcError
+ * @param {string} errorMessage - The error message to parse
+ * @returns {string} - Returns an error message, either the same as was passed, or the ending message portion of an isEthjsRpcError
  *
  * @example
  * // returns 'Transaction Failed: replacement transaction underpriced'

--- a/app/scripts/lib/freezeGlobals.js
+++ b/app/scripts/lib/freezeGlobals.js
@@ -20,7 +20,7 @@ if (
  * value is completely immutable. It is, however, better than nothing.
  *
  * @param {Object} target - The target object to freeze a property on.
- * @param {String} key - The key to freeze.
+ * @param {string} key - The key to freeze.
  * @param {any} [value] - The value to freeze, if different from the existing value on the target.
  * @param {boolean} [enumerable=true] - If given a value, whether the property is enumerable.
  */

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -19,7 +19,7 @@ allLocales.forEach(locale => {
  * Returns a preferred language code, based on settings within the user's browser. If we have no translations for the
  * users preferred locales, 'en' is returned.
  *
- * @returns {Promise<string>} Promises a locale code, either one from the user's preferred list that we have a translation for, or 'en'
+ * @returns {Promise<string>} - Promises a locale code, either one from the user's preferred list that we have a translation for, or 'en'
  *
  */
 async function getFirstPreferredLangCode () {

--- a/app/scripts/lib/getObjStructure.js
+++ b/app/scripts/lib/getObjStructure.js
@@ -18,8 +18,8 @@ export default getObjStructure
  * Creates an object that represents the structure of the given object. It replaces all values with the result of their
  * type.
  *
- * @param {object} obj The object for which a 'structure' will be returned. Usually a plain object and not a class.
- * @returns {object} The "mapped" version of a deep clone of the passed object, with each non-object property value
+ * @param {Object} obj The object for which a 'structure' will be returned. Usually a plain object and not a class.
+ * @returns {Object} The "mapped" version of a deep clone of the passed object, with each non-object property value
  * replaced with the javascript type of that value.
  *
  */
@@ -34,9 +34,9 @@ function getObjStructure (obj) {
  * Modifies all the properties and deeply nested of a passed object. Iterates recursively over all nested objects and
  * their properties, and covers the entire depth of the object. At each property value which is not an object is modified.
  *
- * @param {object} target The object to modify
+ * @param {Object} target The object to modify
  * @param {Function} visit The modifier to apply to each non-object property value
- * @returns {object} The modified object
+ * @returns {Object} The modified object
  */
 function deepMap (target = {}, visit) {
   Object.entries(target).forEach(([key, value]) => {

--- a/app/scripts/lib/getObjStructure.js
+++ b/app/scripts/lib/getObjStructure.js
@@ -18,8 +18,8 @@ export default getObjStructure
  * Creates an object that represents the structure of the given object. It replaces all values with the result of their
  * type.
  *
- * @param {Object} obj The object for which a 'structure' will be returned. Usually a plain object and not a class.
- * @returns {Object} The "mapped" version of a deep clone of the passed object, with each non-object property value
+ * @param {Object} obj - The object for which a 'structure' will be returned. Usually a plain object and not a class.
+ * @returns {Object} - The "mapped" version of a deep clone of the passed object, with each non-object property value
  * replaced with the javascript type of that value.
  *
  */
@@ -34,9 +34,9 @@ function getObjStructure (obj) {
  * Modifies all the properties and deeply nested of a passed object. Iterates recursively over all nested objects and
  * their properties, and covers the entire depth of the object. At each property value which is not an object is modified.
  *
- * @param {Object} target The object to modify
- * @param {Function} visit The modifier to apply to each non-object property value
- * @returns {Object} The modified object
+ * @param {Object} target - The object to modify
+ * @param {Function} visit - The modifier to apply to each non-object property value
+ * @returns {Object} - The modified object
  */
 function deepMap (target = {}, visit) {
   Object.entries(target).forEach(([key, value]) => {

--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -46,7 +46,7 @@ export default class ExtensionStore {
   /**
    * Returns all of the keys currently saved
    * @private
-   * @returns {Object} the key-value map from local storage
+   * @returns {Object} - the key-value map from local storage
    */
   _get () {
     const local = extension.storage.local

--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -18,7 +18,7 @@ export default class ExtensionStore {
 
   /**
    * Returns all of the keys currently saved
-   * @return {Promise<*>}
+   * @returns {Promise<*>}
    */
   async get () {
     if (!this.isSupported) {
@@ -37,7 +37,7 @@ export default class ExtensionStore {
   /**
    * Sets the key in local state
    * @param {object} state - The state to set
-   * @return {Promise<void>}
+   * @returns {Promise<void>}
    */
   async set (state) {
     return this._set(state)
@@ -46,7 +46,7 @@ export default class ExtensionStore {
   /**
    * Returns all of the keys currently saved
    * @private
-   * @return {object} the key-value map from local storage
+   * @returns {object} the key-value map from local storage
    */
   _get () {
     const local = extension.storage.local
@@ -65,7 +65,7 @@ export default class ExtensionStore {
   /**
    * Sets the key in local state
    * @param {object} obj - The key to set
-   * @return {Promise<void>}
+   * @returns {Promise<void>}
    * @private
    */
   _set (obj) {

--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -36,7 +36,7 @@ export default class ExtensionStore {
 
   /**
    * Sets the key in local state
-   * @param {object} state - The state to set
+   * @param {Object} state - The state to set
    * @returns {Promise<void>}
    */
   async set (state) {
@@ -46,7 +46,7 @@ export default class ExtensionStore {
   /**
    * Returns all of the keys currently saved
    * @private
-   * @returns {object} the key-value map from local storage
+   * @returns {Object} the key-value map from local storage
    */
   _get () {
     const local = extension.storage.local
@@ -64,7 +64,7 @@ export default class ExtensionStore {
 
   /**
    * Sets the key in local state
-   * @param {object} obj - The key to set
+   * @param {Object} obj - The key to set
    * @returns {Promise<void>}
    * @private
    */
@@ -85,7 +85,7 @@ export default class ExtensionStore {
 
 /**
  * Returns whether or not the given object contains no keys
- * @param {object} obj - The object to check
+ * @param {Object} obj - The object to check
  * @returns {boolean}
  */
 function isEmpty (obj) {

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -47,7 +47,7 @@ export default class MessageManager extends EventEmitter {
   /**
    * A getter for the number of 'unapproved' Messages in this.messages
    *
-   * @returns {number} The number of 'unapproved' Messages in this.messages
+   * @returns {number} - The number of 'unapproved' Messages in this.messages
    *
    */
   get unapprovedMsgCount () {
@@ -57,7 +57,7 @@ export default class MessageManager extends EventEmitter {
   /**
    * A getter for the 'unapproved' Messages in this.messages
    *
-   * @returns {Object} An index of Message ids to Messages, for all 'unapproved' Messages in this.messages
+   * @returns {Object} - An index of Message ids to Messages, for all 'unapproved' Messages in this.messages
    *
    */
   getUnapprovedMsgs () {
@@ -71,9 +71,9 @@ export default class MessageManager extends EventEmitter {
    * Creates a new Message with an 'unapproved' status using the passed msgParams. this.addMsg is called to add the
    * new Message to this.messages, and to save the unapproved Messages from that list to this.memStore.
    *
-   * @param {Object} msgParams The params for the eth_sign call to be made after the message is approved.
+   * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
    * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {promise} after signature has been
+   * @returns {promise} - after signature has been
    *
    */
   addUnapprovedMessageAsync (msgParams, req) {
@@ -97,9 +97,9 @@ export default class MessageManager extends EventEmitter {
    * Creates a new Message with an 'unapproved' status using the passed msgParams. this.addMsg is called to add the
    * new Message to this.messages, and to save the unapproved Messages from that list to this.memStore.
    *
-   * @param {Object} msgParams The params for the eth_sign call to be made after the message is approved.
+   * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
    * @param {Object} req (optional) The original request object where the origin may be specificied
-   * @returns {number} The id of the newly created message.
+   * @returns {number} - The id of the newly created message.
    *
    */
   addUnapprovedMessage (msgParams, req) {
@@ -129,7 +129,7 @@ export default class MessageManager extends EventEmitter {
    * Adds a passed Message to this.messages, and calls this._saveMsgList() to save the unapproved Messages from that
    * list to this.memStore.
    *
-   * @param {Message} msg The Message to add to this.messages
+   * @param {Message} msg - The Message to add to this.messages
    *
    */
   addMsg (msg) {
@@ -140,8 +140,8 @@ export default class MessageManager extends EventEmitter {
   /**
    * Returns a specified Message.
    *
-   * @param {number} msgId The id of the Message to get
-   * @returns {Message|undefined} The Message with the id that matches the passed msgId, or undefined if no Message has that id.
+   * @param {number} msgId - The id of the Message to get
+   * @returns {Message|undefined} - The Message with the id that matches the passed msgId, or undefined if no Message has that id.
    *
    */
   getMsg (msgId) {
@@ -152,9 +152,9 @@ export default class MessageManager extends EventEmitter {
    * Approves a Message. Sets the message status via a call to this.setMsgStatusApproved, and returns a promise with
    * any the message params modified for proper signing.
    *
-   * @param {Object} msgParams The msgParams to be used when eth_sign is called, plus data added by MetaMask.
+   * @param {Object} msgParams - The msgParams to be used when eth_sign is called, plus data added by MetaMask.
    * @param {Object} msgParams.metamaskId Added to msgParams for tracking and identification within MetaMask.
-   * @returns {Promise<object>} Promises the msgParams object with metamaskId removed.
+   * @returns {Promise<object>} - Promises the msgParams object with metamaskId removed.
    *
    */
   approveMessage (msgParams) {
@@ -165,7 +165,7 @@ export default class MessageManager extends EventEmitter {
   /**
    * Sets a Message status to 'approved' via a call to this._setMsgStatus.
    *
-   * @param {number} msgId The id of the Message to approve.
+   * @param {number} msgId - The id of the Message to approve.
    *
    */
   setMsgStatusApproved (msgId) {
@@ -176,8 +176,8 @@ export default class MessageManager extends EventEmitter {
    * Sets a Message status to 'signed' via a call to this._setMsgStatus and updates that Message in this.messages by
    * adding the raw signature data of the signature request to the Message
    *
-   * @param {number} msgId The id of the Message to sign.
-   * @param {buffer} rawSig The raw data of the signature request
+   * @param {number} msgId - The id of the Message to sign.
+   * @param {buffer} rawSig - The raw data of the signature request
    *
    */
   setMsgStatusSigned (msgId, rawSig) {
@@ -190,8 +190,8 @@ export default class MessageManager extends EventEmitter {
   /**
    * Removes the metamaskId property from passed msgParams and returns a promise which resolves the updated msgParams
    *
-   * @param {Object} msgParams The msgParams to modify
-   * @returns {Promise<object>} Promises the msgParams with the metamaskId property removed
+   * @param {Object} msgParams - The msgParams to modify
+   * @returns {Promise<object>} - Promises the msgParams with the metamaskId property removed
    *
    */
   prepMsgForSigning (msgParams) {
@@ -202,7 +202,7 @@ export default class MessageManager extends EventEmitter {
   /**
    * Sets a Message status to 'rejected' via a call to this._setMsgStatus.
    *
-   * @param {number} msgId The id of the Message to reject.
+   * @param {number} msgId - The id of the Message to reject.
    *
    */
   rejectMsg (msgId) {
@@ -213,8 +213,8 @@ export default class MessageManager extends EventEmitter {
    * Updates the status of a Message in this.messages via a call to this._updateMsg
    *
    * @private
-   * @param {number} msgId The id of the Message to update.
-   * @param {string} status The new status of the Message.
+   * @param {number} msgId - The id of the Message to update.
+   * @param {string} status - The new status of the Message.
    * @throws A 'MessageManager - Message not found for id: "${msgId}".' if there is no Message in this.messages with an
    * id equal to the passed msgId
    * @fires An event with a name equal to `${msgId}:${status}`. The Message is also fired.
@@ -239,7 +239,7 @@ export default class MessageManager extends EventEmitter {
    * storage via this._saveMsgList
    *
    * @private
-   * @param {msg} Message A Message that will replace an existing Message (with the same id) in this.messages
+   * @param {msg} Message - A Message that will replace an existing Message (with the same id) in this.messages
    *
    */
   _updateMsg (msg) {
@@ -269,8 +269,8 @@ export default class MessageManager extends EventEmitter {
 /**
  * A helper function that converts raw buffer data to a hex, or just returns the data if it is already formatted as a hex.
  *
- * @param {any} data The buffer data to convert to a hex
- * @returns {string} A hex string conversion of the buffer data
+ * @param {any} data - The buffer data to convert to a hex
+ * @returns {string} - A hex string conversion of the buffer data
  *
  */
 function normalizeMsgData (data) {

--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -77,7 +77,7 @@ class Migrator extends EventEmitter {
 
   /**
    * Returns the initial state for the migrator
-   * @param {object} [data] - The data for the initial state
+   * @param {Object} [data] - The data for the initial state
    * @returns {{meta: {version: number}, data: any}}
    */
   generateInitialState (data) {

--- a/app/scripts/lib/network-store.js
+++ b/app/scripts/lib/network-store.js
@@ -48,7 +48,7 @@ class ReadOnlyNetworkStore {
 
   /**
    * Set state
-   * @param {object} state - The state to set
+   * @param {Object} state - The state to set
    * @returns {Promise<void>}
    */
   async set (state) {

--- a/app/scripts/lib/network-store.js
+++ b/app/scripts/lib/network-store.js
@@ -37,7 +37,7 @@ class ReadOnlyNetworkStore {
 
   /**
    * Returns state
-   * @return {Promise<object>}
+   * @returns {Promise<object>}
    */
   async get () {
     if (!this._initialized) {
@@ -49,7 +49,7 @@ class ReadOnlyNetworkStore {
   /**
    * Set state
    * @param {object} state - The state to set
-   * @return {Promise<void>}
+   * @returns {Promise<void>}
    */
   async set (state) {
     if (!this._initialized) {

--- a/app/scripts/lib/nodeify.js
+++ b/app/scripts/lib/nodeify.js
@@ -10,8 +10,8 @@ const callbackNoop = function (err) {
  * A generator that returns a function which, when passed a promise, can treat that promise as a node style callback.
  * The prime advantage being that callbacks are better for error handling.
  *
- * @param {Function} fn The function to handle as a callback
- * @param {Object} context The context in which the fn is to be called, most often a this reference
+ * @param {Function} fn - The function to handle as a callback
+ * @param {Object} context - The context in which the fn is to be called, most often a this reference
  *
  */
 export default function nodeify (fn, context) {

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -70,7 +70,7 @@ class NotificationManager {
    * type 'popup')
    *
    * @private
-   * @param {Function} cb A node style callback that to whcih the found notification window will be passed.
+   * @param {Function} cb - A node style callback that to whcih the found notification window will be passed.
    *
    */
   _getPopup (cb) {
@@ -86,7 +86,7 @@ class NotificationManager {
    * Returns all open MetaMask windows.
    *
    * @private
-   * @param {Function} cb A node style callback that to which the windows will be passed.
+   * @param {Function} cb - A node style callback that to which the windows will be passed.
    *
    */
   _getWindows (cb) {
@@ -104,7 +104,7 @@ class NotificationManager {
    * Given an array of windows, returns the 'popup' that has been opened by MetaMask, or null if no such window exists.
    *
    * @private
-   * @param {array} windows An array of objects containing data about the open MetaMask extension windows.
+   * @param {array} windows - An array of objects containing data about the open MetaMask extension windows.
    *
    */
   _getPopupIn (windows) {

--- a/app/scripts/lib/pending-balance-calculator.js
+++ b/app/scripts/lib/pending-balance-calculator.js
@@ -46,7 +46,7 @@ class PendingBalanceCalculator {
   /**
    * Calculates the maximum possible cost of a single transaction, based on the value, gas price and gas limit.
    *
-   * @param {object} tx Contains all that data about a transaction.
+   * @param {Object} tx Contains all that data about a transaction.
    * @property {object} tx.txParams Contains data needed to calculate the maximum cost of the transaction: gas,
    * gasLimit and value.
    *

--- a/app/scripts/lib/pending-balance-calculator.js
+++ b/app/scripts/lib/pending-balance-calculator.js
@@ -8,8 +8,8 @@ class PendingBalanceCalculator {
    * pending transactions.
    *
    * @typedef {Object} PendingBalanceCalculator
-   * @param {Function} getBalance Returns a promise of a BN of the current balance in Wei
-   * @param {Function} getPendingTransactions Returns an array of TxMeta Objects, which have txParams properties,
+   * @param {Function} getBalance - Returns a promise of a BN of the current balance in Wei
+   * @param {Function} getPendingTransactions - Returns an array of TxMeta Objects, which have txParams properties,
    * which include value, gasPrice, and gas, all in a base=16 hex format.
    *
    */
@@ -22,7 +22,7 @@ class PendingBalanceCalculator {
    * Returns the users "pending balance": their current balance minus the total possible cost of all their
    * pending transactions.
    *
-   * @returns {Promise<string>} Promises a base 16 hex string that contains the user's "pending balance"
+   * @returns {Promise<string>} - Promises a base 16 hex string that contains the user's "pending balance"
    *
    */
   async getBalance () {
@@ -46,11 +46,11 @@ class PendingBalanceCalculator {
   /**
    * Calculates the maximum possible cost of a single transaction, based on the value, gas price and gas limit.
    *
-   * @param {Object} tx Contains all that data about a transaction.
+   * @param {Object} tx - Contains all that data about a transaction.
    * @property {object} tx.txParams Contains data needed to calculate the maximum cost of the transaction: gas,
    * gasLimit and value.
    *
-   * @returns {string} Returns a base 16 hex string that contains the maximum possible cost of the transaction.
+   * @returns {string} - Returns a base 16 hex string that contains the maximum possible cost of the transaction.
    */
   calculateMaxCost (tx) {
     const txValue = tx.txParams.value
@@ -68,8 +68,8 @@ class PendingBalanceCalculator {
   /**
    * Converts a hex string to a BN object
    *
-   * @param {string} hex A number represented as a hex string
-   * @returns {Object} A BN object
+   * @param {string} hex - A number represented as a hex string
+   * @returns {Object} - A BN object
    *
    */
   hexToBn (hex) {

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -50,7 +50,7 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * A getter for the number of 'unapproved' PersonalMessages in this.messages
    *
-   * @returns {number} The number of 'unapproved' PersonalMessages in this.messages
+   * @returns {number} - The number of 'unapproved' PersonalMessages in this.messages
    *
    */
   get unapprovedPersonalMsgCount () {
@@ -60,7 +60,7 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * A getter for the 'unapproved' PersonalMessages in this.messages
    *
-   * @returns {Object} An index of PersonalMessage ids to PersonalMessages, for all 'unapproved' PersonalMessages in
+   * @returns {Object} - An index of PersonalMessage ids to PersonalMessages, for all 'unapproved' PersonalMessages in
    * this.messages
    *
    */
@@ -76,9 +76,9 @@ export default class PersonalMessageManager extends EventEmitter {
    * the new PersonalMessage to this.messages, and to save the unapproved PersonalMessages from that list to
    * this.memStore.
    *
-   * @param {Object} msgParams The params for the eth_sign call to be made after the message is approved.
+   * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
    * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {promise} When the message has been signed or rejected
+   * @returns {promise} - When the message has been signed or rejected
    *
    */
   addUnapprovedMessageAsync (msgParams, req) {
@@ -105,9 +105,9 @@ export default class PersonalMessageManager extends EventEmitter {
    * the new PersonalMessage to this.messages, and to save the unapproved PersonalMessages from that list to
    * this.memStore.
    *
-   * @param {Object} msgParams The params for the eth_sign call to be made after the message is approved.
+   * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
    * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {number} The id of the newly created PersonalMessage.
+   * @returns {number} - The id of the newly created PersonalMessage.
    *
    */
   addUnapprovedMessage (msgParams, req) {
@@ -138,7 +138,7 @@ export default class PersonalMessageManager extends EventEmitter {
    * Adds a passed PersonalMessage to this.messages, and calls this._saveMsgList() to save the unapproved PersonalMessages from that
    * list to this.memStore.
    *
-   * @param {Message} msg The PersonalMessage to add to this.messages
+   * @param {Message} msg - The PersonalMessage to add to this.messages
    *
    */
   addMsg (msg) {
@@ -149,8 +149,8 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * Returns a specified PersonalMessage.
    *
-   * @param {number} msgId The id of the PersonalMessage to get
-   * @returns {PersonalMessage|undefined} The PersonalMessage with the id that matches the passed msgId, or undefined
+   * @param {number} msgId - The id of the PersonalMessage to get
+   * @returns {PersonalMessage|undefined} - The PersonalMessage with the id that matches the passed msgId, or undefined
    * if no PersonalMessage has that id.
    *
    */
@@ -162,9 +162,9 @@ export default class PersonalMessageManager extends EventEmitter {
    * Approves a PersonalMessage. Sets the message status via a call to this.setMsgStatusApproved, and returns a promise
    * with any the message params modified for proper signing.
    *
-   * @param {Object} msgParams The msgParams to be used when eth_sign is called, plus data added by MetaMask.
+   * @param {Object} msgParams - The msgParams to be used when eth_sign is called, plus data added by MetaMask.
    * @param {Object} msgParams.metamaskId Added to msgParams for tracking and identification within MetaMask.
-   * @returns {Promise<object>} Promises the msgParams object with metamaskId removed.
+   * @returns {Promise<object>} - Promises the msgParams object with metamaskId removed.
    *
    */
   approveMessage (msgParams) {
@@ -175,7 +175,7 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * Sets a PersonalMessage status to 'approved' via a call to this._setMsgStatus.
    *
-   * @param {number} msgId The id of the PersonalMessage to approve.
+   * @param {number} msgId - The id of the PersonalMessage to approve.
    *
    */
   setMsgStatusApproved (msgId) {
@@ -186,8 +186,8 @@ export default class PersonalMessageManager extends EventEmitter {
    * Sets a PersonalMessage status to 'signed' via a call to this._setMsgStatus and updates that PersonalMessage in
    * this.messages by adding the raw signature data of the signature request to the PersonalMessage
    *
-   * @param {number} msgId The id of the PersonalMessage to sign.
-   * @param {buffer} rawSig The raw data of the signature request
+   * @param {number} msgId - The id of the PersonalMessage to sign.
+   * @param {buffer} rawSig - The raw data of the signature request
    *
    */
   setMsgStatusSigned (msgId, rawSig) {
@@ -200,8 +200,8 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * Removes the metamaskId property from passed msgParams and returns a promise which resolves the updated msgParams
    *
-   * @param {Object} msgParams The msgParams to modify
-   * @returns {Promise<object>} Promises the msgParams with the metamaskId property removed
+   * @param {Object} msgParams - The msgParams to modify
+   * @returns {Promise<object>} - Promises the msgParams with the metamaskId property removed
    *
    */
   prepMsgForSigning (msgParams) {
@@ -212,7 +212,7 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * Sets a PersonalMessage status to 'rejected' via a call to this._setMsgStatus.
    *
-   * @param {number} msgId The id of the PersonalMessage to reject.
+   * @param {number} msgId - The id of the PersonalMessage to reject.
    *
    */
   rejectMsg (msgId) {
@@ -223,8 +223,8 @@ export default class PersonalMessageManager extends EventEmitter {
    * Updates the status of a PersonalMessage in this.messages via a call to this._updateMsg
    *
    * @private
-   * @param {number} msgId The id of the PersonalMessage to update.
-   * @param {string} status The new status of the PersonalMessage.
+   * @param {number} msgId - The id of the PersonalMessage to update.
+   * @param {string} status - The new status of the PersonalMessage.
    * @throws A 'PersonalMessageManager - PersonalMessage not found for id: "${msgId}".' if there is no PersonalMessage
    * in this.messages with an id equal to the passed msgId
    * @fires An event with a name equal to `${msgId}:${status}`. The PersonalMessage is also fired.
@@ -250,7 +250,7 @@ export default class PersonalMessageManager extends EventEmitter {
    * unapprovedPersonalMsgs index to storage via this._saveMsgList
    *
    * @private
-   * @param {msg} PersonalMessage A PersonalMessage that will replace an existing PersonalMessage (with the same
+   * @param {msg} PersonalMessage - A PersonalMessage that will replace an existing PersonalMessage (with the same
    * id) in this.messages
    *
    */
@@ -279,8 +279,8 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * A helper function that converts raw buffer data to a hex, or just returns the data if it is already formatted as a hex.
    *
-   * @param {any} data The buffer data to convert to a hex
-   * @returns {string} A hex string conversion of the buffer data
+   * @param {any} data - The buffer data to convert to a hex
+   * @returns {string} - A hex string conversion of the buffer data
    *
    */
   normalizeMsgData (data) {

--- a/app/scripts/lib/seed-phrase-verifier.js
+++ b/app/scripts/lib/seed-phrase-verifier.js
@@ -11,9 +11,9 @@ const seedPhraseVerifier = {
    * - The created accounts in the primary keyring are always the same.
    * - The keyring always creates the accounts in the same sequence.
    *
-   * @param {array} createdAccounts The accounts to restore
-   * @param {string} seedWords The seed words to verify
-   * @returns {Promise<void>} Promises undefined
+   * @param {array} createdAccounts - The accounts to restore
+   * @param {string} seedWords - The seed words to verify
+   * @returns {Promise<void>} - Promises undefined
    *
   */
   verifyAccounts (createdAccounts, seedWords) {

--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -4,7 +4,7 @@ import pump from 'pump'
 /**
  * Sets up stream multiplexing for the given stream
  * @param {any} connectionStream - the stream to mux
- * @return {stream.Stream} the multiplexed stream
+ * @returns {stream.Stream} the multiplexed stream
  */
 export function setupMultiplex (connectionStream) {
   const mux = new ObjectMultiplex()

--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -4,7 +4,7 @@ import pump from 'pump'
 /**
  * Sets up stream multiplexing for the given stream
  * @param {any} connectionStream - the stream to mux
- * @returns {stream.Stream} the multiplexed stream
+ * @returns {stream.Stream} - the multiplexed stream
  */
 export function setupMultiplex (connectionStream) {
   const mux = new ObjectMultiplex()

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -42,7 +42,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * A getter for the number of 'unapproved' TypedMessages in this.messages
    *
-   * @returns {number} The number of 'unapproved' TypedMessages in this.messages
+   * @returns {number} - The number of 'unapproved' TypedMessages in this.messages
    *
    */
   get unapprovedTypedMessagesCount () {
@@ -52,7 +52,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * A getter for the 'unapproved' TypedMessages in this.messages
    *
-   * @returns {Object} An index of TypedMessage ids to TypedMessages, for all 'unapproved' TypedMessages in
+   * @returns {Object} - An index of TypedMessage ids to TypedMessages, for all 'unapproved' TypedMessages in
    * this.messages
    *
    */
@@ -68,9 +68,9 @@ export default class TypedMessageManager extends EventEmitter {
    * the new TypedMessage to this.messages, and to save the unapproved TypedMessages from that list to
    * this.memStore. Before any of this is done, msgParams are validated
    *
-   * @param {Object} msgParams The params for the eth_sign call to be made after the message is approved.
+   * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
    * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {promise} When the message has been signed or rejected
+   * @returns {promise} - When the message has been signed or rejected
    *
    */
   addUnapprovedMessageAsync (msgParams, req, version) {
@@ -96,9 +96,9 @@ export default class TypedMessageManager extends EventEmitter {
    * the new TypedMessage to this.messages, and to save the unapproved TypedMessages from that list to
    * this.memStore. Before any of this is done, msgParams are validated
    *
-   * @param {Object} msgParams The params for the eth_sign call to be made after the message is approved.
+   * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
    * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {number} The id of the newly created TypedMessage.
+   * @returns {number} - The id of the newly created TypedMessage.
    *
    */
   addUnapprovedMessage (msgParams, req, version) {
@@ -130,7 +130,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * Helper method for this.addUnapprovedMessage. Validates that the passed params have the required properties.
    *
-   * @param {Object} params The params to validate
+   * @param {Object} params - The params to validate
    *
    */
   validateParams (params) {
@@ -172,7 +172,7 @@ export default class TypedMessageManager extends EventEmitter {
    * Adds a passed TypedMessage to this.messages, and calls this._saveMsgList() to save the unapproved TypedMessages from that
    * list to this.memStore.
    *
-   * @param {Message} msg The TypedMessage to add to this.messages
+   * @param {Message} msg - The TypedMessage to add to this.messages
    *
    */
   addMsg (msg) {
@@ -183,8 +183,8 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * Returns a specified TypedMessage.
    *
-   * @param {number} msgId The id of the TypedMessage to get
-   * @returns {TypedMessage|undefined} The TypedMessage with the id that matches the passed msgId, or undefined
+   * @param {number} msgId - The id of the TypedMessage to get
+   * @returns {TypedMessage|undefined} - The TypedMessage with the id that matches the passed msgId, or undefined
    * if no TypedMessage has that id.
    *
    */
@@ -196,9 +196,9 @@ export default class TypedMessageManager extends EventEmitter {
    * Approves a TypedMessage. Sets the message status via a call to this.setMsgStatusApproved, and returns a promise
    * with any the message params modified for proper signing.
    *
-   * @param {Object} msgParams The msgParams to be used when eth_sign is called, plus data added by MetaMask.
+   * @param {Object} msgParams - The msgParams to be used when eth_sign is called, plus data added by MetaMask.
    * @param {Object} msgParams.metamaskId Added to msgParams for tracking and identification within MetaMask.
-   * @returns {Promise<object>} Promises the msgParams object with metamaskId removed.
+   * @returns {Promise<object>} - Promises the msgParams object with metamaskId removed.
    *
    */
   approveMessage (msgParams) {
@@ -209,7 +209,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * Sets a TypedMessage status to 'approved' via a call to this._setMsgStatus.
    *
-   * @param {number} msgId The id of the TypedMessage to approve.
+   * @param {number} msgId - The id of the TypedMessage to approve.
    *
    */
   setMsgStatusApproved (msgId) {
@@ -220,8 +220,8 @@ export default class TypedMessageManager extends EventEmitter {
    * Sets a TypedMessage status to 'signed' via a call to this._setMsgStatus and updates that TypedMessage in
    * this.messages by adding the raw signature data of the signature request to the TypedMessage
    *
-   * @param {number} msgId The id of the TypedMessage to sign.
-   * @param {buffer} rawSig The raw data of the signature request
+   * @param {number} msgId - The id of the TypedMessage to sign.
+   * @param {buffer} rawSig - The raw data of the signature request
    *
    */
   setMsgStatusSigned (msgId, rawSig) {
@@ -234,8 +234,8 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * Removes the metamaskId property from passed msgParams and returns a promise which resolves the updated msgParams
    *
-   * @param {Object} msgParams The msgParams to modify
-   * @returns {Promise<object>} Promises the msgParams with the metamaskId property removed
+   * @param {Object} msgParams - The msgParams to modify
+   * @returns {Promise<object>} - Promises the msgParams with the metamaskId property removed
    *
    */
   prepMsgForSigning (msgParams) {
@@ -247,7 +247,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * Sets a TypedMessage status to 'rejected' via a call to this._setMsgStatus.
    *
-   * @param {number} msgId The id of the TypedMessage to reject.
+   * @param {number} msgId - The id of the TypedMessage to reject.
    *
    */
   rejectMsg (msgId) {
@@ -257,7 +257,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * Sets a TypedMessage status to 'errored' via a call to this._setMsgStatus.
    *
-   * @param {number} msgId The id of the TypedMessage to error
+   * @param {number} msgId - The id of the TypedMessage to error
    *
    */
   errorMessage (msgId, error) {
@@ -275,8 +275,8 @@ export default class TypedMessageManager extends EventEmitter {
    * Updates the status of a TypedMessage in this.messages via a call to this._updateMsg
    *
    * @private
-   * @param {number} msgId The id of the TypedMessage to update.
-   * @param {string} status The new status of the TypedMessage.
+   * @param {number} msgId - The id of the TypedMessage to update.
+   * @param {string} status - The new status of the TypedMessage.
    * @throws A 'TypedMessageManager - TypedMessage not found for id: "${msgId}".' if there is no TypedMessage
    * in this.messages with an id equal to the passed msgId
    * @fires An event with a name equal to `${msgId}:${status}`. The TypedMessage is also fired.
@@ -302,7 +302,7 @@ export default class TypedMessageManager extends EventEmitter {
    * unapprovedTypedMsgs index to storage via this._saveMsgList
    *
    * @private
-   * @param {msg} TypedMessage A TypedMessage that will replace an existing TypedMessage (with the same
+   * @param {msg} TypedMessage - A TypedMessage that will replace an existing TypedMessage (with the same
    * id) in this.messages
    *
    */

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -64,7 +64,7 @@ const getPlatform = _ => {
 /**
  * Checks whether a given balance of ETH, represented as a hex string, is sufficient to pay a value plus a gas fee
  *
- * @param {object} txParams Contains data about a transaction
+ * @param {Object} txParams Contains data about a transaction
  * @param {string} txParams.gas The gas for a transaction
  * @param {string} txParams.gasPrice The price per gas for the transaction
  * @param {string} txParams.value The value of ETH to send

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -22,7 +22,7 @@ import {
  *  - 'notification' refers to the popup that appears in its own window when taking action outside of metamask
  *  - 'background' refers to the background page
  *
- * @returns {string} A single word label that represents the type of window through which the app is being viewed
+ * @returns {string} - A single word label that represents the type of window through which the app is being viewed
  *
  */
 const getEnvironmentType = (url = window.location.href) => {
@@ -41,7 +41,7 @@ const getEnvironmentType = (url = window.location.href) => {
 /**
  * Returns the platform (browser) where the extension is running.
  *
- * @returns {string} the platform ENUM
+ * @returns {string} - the platform ENUM
  *
  */
 const getPlatform = _ => {
@@ -64,12 +64,12 @@ const getPlatform = _ => {
 /**
  * Checks whether a given balance of ETH, represented as a hex string, is sufficient to pay a value plus a gas fee
  *
- * @param {Object} txParams Contains data about a transaction
+ * @param {Object} txParams - Contains data about a transaction
  * @param {string} txParams.gas The gas for a transaction
  * @param {string} txParams.gasPrice The price per gas for the transaction
  * @param {string} txParams.value The value of ETH to send
- * @param {string} hexBalance A balance of ETH represented as a hex string
- * @returns {boolean} Whether the balance is greater than or equal to the value plus the value of gas times gasPrice
+ * @param {string} hexBalance - A balance of ETH represented as a hex string
+ * @returns {boolean} - Whether the balance is greater than or equal to the value plus the value of gas times gasPrice
  *
  */
 function sufficientBalance (txParams, hexBalance) {
@@ -89,8 +89,8 @@ function sufficientBalance (txParams, hexBalance) {
 /**
  * Converts a BN object to a hex string with a '0x' prefix
  *
- * @param {BN} inputBn The BN to convert to a hex string
- * @returns {string} A '0x' prefixed hex string
+ * @param {BN} inputBn - The BN to convert to a hex string
+ * @returns {string} - A '0x' prefixed hex string
  *
  */
 function bnToHex (inputBn) {
@@ -100,8 +100,8 @@ function bnToHex (inputBn) {
 /**
  * Converts a hex string to a BN object
  *
- * @param {string} inputHex A number represented as a hex string
- * @returns {Object} A BN object
+ * @param {string} inputHex - A number represented as a hex string
+ * @returns {Object} - A BN object
  *
  */
 function hexToBn (inputHex) {
@@ -111,10 +111,10 @@ function hexToBn (inputHex) {
 /**
  * Used to multiply a BN by a fraction
  *
- * @param {BN} targetBN The number to multiply by a fraction
- * @param {number|string} numerator The numerator of the fraction multiplier
- * @param {number|string} denominator The denominator of the fraction multiplier
- * @returns {BN} The product of the multiplication
+ * @param {BN} targetBN - The number to multiply by a fraction
+ * @param {number|string} numerator - The numerator of the fraction multiplier
+ * @param {number|string} denominator - The denominator of the fraction multiplier
+ * @returns {BN} - The product of the multiplication
  *
  */
 function BnMultiplyByFraction (targetBN, numerator, denominator) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -675,7 +675,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * Collects all the information that we want to share
    * with the mobile client for syncing purposes
-   * @returns Promise<Object> Parts of the state that we want to syncx
+   * @returns {Promise<Object>} - Parts of the state that we want to syncx
    */
   async fetchInfoToSync () {
     // Preferences
@@ -972,7 +972,7 @@ export default class MetamaskController extends EventEmitter {
    * Mostly used in development environments, when networks are restarted with
    * the same network ID.
    *
-   * @returns Promise<string> The current selected address.
+   * @returns {Promise<string>} - The current selected address.
    */
   async resetAccount () {
     const selectedAddress = this.preferencesController.getSelectedAddress()
@@ -1228,7 +1228,7 @@ export default class MetamaskController extends EventEmitter {
    * Allows a user to attempt to cancel a previously submitted transaction by creating a new
    * transaction.
    * @param {number} originalTxId - the id of the txMeta that you want to attempt to cancel
-   * @param {string=} customGasPrice - the hex value to use for the cancel transaction
+   * @param {string} [customGasPrice] - the hex value to use for the cancel transaction
    * @returns {object} MetaMask state
    */
   async createCancelTransaction (originalTxId, customGasPrice) {
@@ -1667,8 +1667,8 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Returns the nonce that will be associated with a transaction once approved
-   * @param address {string} - The hex string address for the transaction
-   * @returns Promise<number>
+   * @param {string} address - The hex string address for the transaction
+   * @returns {Promise<number>}
    */
   async getPendingNonce (address) {
     const { nonceDetails, releaseLock } = await this.txController.nonceTracker.getNonceLock(address)
@@ -1680,8 +1680,8 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Returns the next nonce according to the nonce-tracker
-   * @param address {string} - The hex string address for the transaction
-   * @returns Promise<number>
+   * @param {string} address - The hex string address for the transaction
+   * @returns {Promise<number>}
    */
   async getNextNonce (address) {
     let nonceLock

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1229,7 +1229,7 @@ export default class MetamaskController extends EventEmitter {
    * transaction.
    * @param {number} originalTxId - the id of the txMeta that you want to attempt to cancel
    * @param {string} [customGasPrice] - the hex value to use for the cancel transaction
-   * @returns {object} MetaMask state
+   * @returns {Object} MetaMask state
    */
   async createCancelTransaction (originalTxId, customGasPrice) {
     try {
@@ -1591,7 +1591,7 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Handle a KeyringController update
-   * @param {object} state the KC state
+   * @param {Object} state the KC state
    * @returns {Promise<void>}
    * @private
    */
@@ -1854,7 +1854,7 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Sets the type of first time flow the user wishes to follow: create or import
-   * @param {String} type - Indicates the type of first time flow the user wishes to follow
+   * @param {string} type - Indicates the type of first time flow the user wishes to follow
    * @param {Function} cb - A callback function called when complete.
    */
   setFirstTimeFlowType (type, cb) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -407,7 +407,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * The metamask-state of the various controllers, made available to the UI
    *
-   * @returns {Object} status
+   * @returns {Object} - status
    */
   getState () {
     const vault = this.keyringController.store.getState().vault
@@ -424,7 +424,7 @@ export default class MetamaskController extends EventEmitter {
    * These functions are the interface for the UI.
    * The API object can be transmitted over a stream with dnode.
    *
-   * @returns {Object} Object containing API functions.
+   * @returns {Object} - Object containing API functions.
    */
   getApi () {
     const keyringController = this.keyringController
@@ -581,7 +581,7 @@ export default class MetamaskController extends EventEmitter {
    *
    * @param  {string} password
    *
-   * @returns {Object} vault
+   * @returns {Object} - vault
    */
   async createNewVaultAndKeychain (password) {
     const releaseLock = await this.createVaultMutex.acquire()
@@ -941,7 +941,7 @@ export default class MetamaskController extends EventEmitter {
    *
    * Called when the first account is created and on unlocking the vault.
    *
-   * @returns {Promise<string>} Seed phrase to be confirmed by the user.
+   * @returns {Promise<string>} - Seed phrase to be confirmed by the user.
    */
   async verifySeedPhrase () {
 
@@ -985,7 +985,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * Removes an account from state / storage.
    *
-   * @param {string[]} address A hex address
+   * @param {string[]} address - A hex address
    *
    */
   async removeAccount (address) {
@@ -1056,8 +1056,8 @@ export default class MetamaskController extends EventEmitter {
   /**
    * Signifies user intent to complete an eth_sign method.
    *
-   * @param  {Object} msgParams The params passed to eth_call.
-   * @returns {Promise<Object>} Full state update.
+   * @param  {Object} msgParams - The params passed to eth_call.
+   * @returns {Promise<Object>} - Full state update.
    */
   signMessage (msgParams) {
     log.info('MetaMaskController - signMessage')
@@ -1169,7 +1169,7 @@ export default class MetamaskController extends EventEmitter {
    * Triggers the callback in newUnsignedTypedMessage.
    *
    * @param  {Object} msgParams - The params passed to eth_signTypedData.
-   * @returns {Object} Full state update.
+   * @returns {Object} - Full state update.
    */
   async signTypedMessage (msgParams) {
     log.info('MetaMaskController - eth_signTypedData')
@@ -1229,7 +1229,7 @@ export default class MetamaskController extends EventEmitter {
    * transaction.
    * @param {number} originalTxId - the id of the txMeta that you want to attempt to cancel
    * @param {string} [customGasPrice] - the hex value to use for the cancel transaction
-   * @returns {Object} MetaMask state
+   * @returns {Object} - MetaMask state
    */
   async createCancelTransaction (originalTxId, customGasPrice) {
     try {
@@ -1591,7 +1591,7 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Handle a KeyringController update
-   * @param {Object} state the KC state
+   * @param {Object} state - the KC state
    * @returns {Promise<void>}
    * @private
    */
@@ -1636,7 +1636,7 @@ export default class MetamaskController extends EventEmitter {
    * Returns the lowest price that would have been included in
    * 50% of recent blocks.
    *
-   * @returns {string} A hex representation of the suggested wei gas price.
+   * @returns {string} - A hex representation of the suggested wei gas price.
    */
   getGasPrice () {
     const { recentBlocksController } = this
@@ -1928,7 +1928,7 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Adds a domain to the PhishingController whitelist
-   * @param {string} hostname the domain to whitelist
+   * @param {string} hostname - the domain to whitelist
    */
   whitelistPhishingDomain (hostname) {
     return this.phishingController.bypass(hostname)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1592,7 +1592,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * Handle a KeyringController update
    * @param {object} state the KC state
-   * @return {Promise<void>}
+   * @returns {Promise<void>}
    * @private
    */
   async _onKeyringControllerUpdate (state) {

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -131,8 +131,8 @@ function initializeUi (activeTab, container, connectionStream, cb) {
 /**
  * Establishes a connection to the background and a Web3 provider
  *
- * @param {PortDuplexStream} connectionStream PortStream instance establishing a background connection
- * @param {Function} cb Called when controller connection is established
+ * @param {PortDuplexStream} connectionStream - PortStream instance establishing a background connection
+ * @param {Function} cb - Called when controller connection is established
  */
 function connectToAccountManager (connectionStream, cb) {
   const mx = setupMultiplex(connectionStream)
@@ -143,7 +143,7 @@ function connectToAccountManager (connectionStream, cb) {
 /**
  * Establishes a streamed connection to a Web3 provider
  *
- * @param {PortDuplexStream} connectionStream PortStream instance establishing a background connection
+ * @param {PortDuplexStream} connectionStream - PortStream instance establishing a background connection
  */
 function setupWeb3Connection (connectionStream) {
   const providerStream = new StreamProvider()
@@ -158,8 +158,8 @@ function setupWeb3Connection (connectionStream) {
 /**
  * Establishes a streamed connection to the background account manager
  *
- * @param {PortDuplexStream} connectionStream PortStream instance establishing a background connection
- * @param {Function} cb Called when the remote account manager connection is established
+ * @param {PortDuplexStream} connectionStream - PortStream instance establishing a background connection
+ * @param {Function} cb - Called when the remote account manager connection is established
  */
 function setupControllerConnection (connectionStream, cb) {
   const eventEmitter = new EventEmitter()

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -43,7 +43,7 @@ class ChromeDriver {
   /**
    * Returns the extension ID for the given extension name
    * @param {string} extensionName the extension name
-   * @return {Promise<string|undefined>} the extension ID
+   * @returns {Promise<string|undefined>} the extension ID
    */
   async getExtensionIdByName (extensionName) {
     await this._driver.get('chrome://extensions')

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -34,7 +34,7 @@ class ChromeDriver {
 
   /**
    * @constructor
-   * @param {!ThenableWebDriver} driver a {@code WebDriver} instance
+   * @param {!ThenableWebDriver} driver - a {@code WebDriver} instance
    */
   constructor (driver) {
     this._driver = driver
@@ -42,8 +42,8 @@ class ChromeDriver {
 
   /**
    * Returns the extension ID for the given extension name
-   * @param {string} extensionName the extension name
-   * @returns {Promise<string|undefined>} the extension ID
+   * @param {string} extensionName - the extension name
+   * @returns {Promise<string|undefined>} - the extension ID
    */
   async getExtensionIdByName (extensionName) {
     await this._driver.get('chrome://extensions')

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -108,8 +108,8 @@ class Driver {
 
   /**
    * Closes all windows except those in the given list of exceptions
-   * @param {Array<string>} exceptions the list of window handle exceptions
-   * @param {Array?} windowHandles the full list of window handles
+   * @param {Array<string>} exceptions - The list of window handle exceptions
+   * @param {Array} [windowHandles] - The full list of window handles
    * @returns {Promise<void>}
    */
   async closeAllWindowHandlesExcept (exceptions, windowHandles) {

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -23,7 +23,7 @@ class FirefoxDriver {
   /**
    * Builds a {@link FirefoxDriver} instance
    * @param {{extensionPath: string}} options the options for the build
-   * @return {Promise<{driver: !ThenableWebDriver, extensionUrl: string, extensionId: string}>}
+   * @returns {Promise<{driver: !ThenableWebDriver, extensionUrl: string, extensionId: string}>}
    */
   static async build ({ extensionPath, responsive, port }) {
     const templateProfile = fs.mkdtempSync(TEMP_PROFILE_PATH_PREFIX)
@@ -66,7 +66,7 @@ class FirefoxDriver {
 
   /**
    * Initializes the driver
-   * @return {Promise<void>}
+   * @returns {Promise<void>}
    */
   async init () {
     await this._driver.getExecutor()
@@ -80,7 +80,7 @@ class FirefoxDriver {
   /**
    * Installs the extension at the given path
    * @param {string} addonPath the path to the unpacked extension or XPI
-   * @return {Promise<string>} the extension ID
+   * @returns {Promise<string>} the extension ID
    */
   async installExtension (addonPath) {
     const cmd = new Command(GeckoDriverCommand.INSTALL_ADDON)
@@ -92,7 +92,7 @@ class FirefoxDriver {
 
   /**
    * Returns the Internal UUID for the given extension
-   * @return {Promise<string>} the Internal UUID for the given extension
+   * @returns {Promise<string>} the Internal UUID for the given extension
    */
   async getInternalId () {
     await this._driver.get('about:debugging#addons')

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -22,7 +22,7 @@ const GeckoDriverCommand = {
 class FirefoxDriver {
   /**
    * Builds a {@link FirefoxDriver} instance
-   * @param {{extensionPath: string}} options the options for the build
+   * @param {{extensionPath: string}} options - the options for the build
    * @returns {Promise<{driver: !ThenableWebDriver, extensionUrl: string, extensionId: string}>}
    */
   static async build ({ extensionPath, responsive, port }) {
@@ -58,7 +58,7 @@ class FirefoxDriver {
 
   /**
    * @constructor
-   * @param {!ThenableWebDriver} driver a {@code WebDriver} instance
+   * @param {!ThenableWebDriver} driver - a {@code WebDriver} instance
    */
   constructor (driver) {
     this._driver = driver
@@ -79,8 +79,8 @@ class FirefoxDriver {
 
   /**
    * Installs the extension at the given path
-   * @param {string} addonPath the path to the unpacked extension or XPI
-   * @returns {Promise<string>} the extension ID
+   * @param {string} addonPath - the path to the unpacked extension or XPI
+   * @returns {Promise<string>} - the extension ID
    */
   async installExtension (addonPath) {
     const cmd = new Command(GeckoDriverCommand.INSTALL_ADDON)
@@ -92,7 +92,7 @@ class FirefoxDriver {
 
   /**
    * Returns the Internal UUID for the given extension
-   * @returns {Promise<string>} the Internal UUID for the given extension
+   * @returns {Promise<string>} - the Internal UUID for the given extension
    */
   async getInternalId () {
     await this._driver.get('about:debugging#addons')

--- a/ui/app/components/app/dropdowns/components/menu.js
+++ b/ui/app/components/app/dropdowns/components/menu.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 
 /**
  * Menu component
- * @return {Component|null}
+ * @returns {Component|null}
  */
 export function Menu (props) {
   const { className, children, isShowing } = props

--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -22,7 +22,7 @@ class I18nProvider extends Component {
        * Returns a localized message for the given key
        * @param {string} key The message key
        * @param {string[]} args A list of message substitution replacements
-       * @return {string|undefined|null} The localized message if available
+       * @returns {string|undefined|null} The localized message if available
        */
       t (key, ...args) {
         return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args) || `[${key}]`

--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -20,9 +20,9 @@ class I18nProvider extends Component {
     return {
       /**
        * Returns a localized message for the given key
-       * @param {string} key The message key
-       * @param {string[]} args A list of message substitution replacements
-       * @returns {string|undefined|null} The localized message if available
+       * @param {string} key - The message key
+       * @param {string[]} args - A list of message substitution replacements
+       * @returns {string|undefined|null} - The localized message if available
        */
       t (key, ...args) {
         return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args) || `[${key}]`

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -4,7 +4,7 @@
 * numeric base, denomination and currency, and the desired numeric base, denomination and
 * currency. It should return a single value.
 *
-* @param {(number | string | BN)} value The value to convert.
+* @param {(number | string | BN)} value - The value to convert.
 * @param {Object} [options] Options to specify details of the conversion
 * @param {string} [options.fromCurrency = 'ETH' | 'USD'] The currency of the passed value
 * @param {string} [options.toCurrency = 'ETH' | 'USD'] The desired currency of the result

--- a/ui/app/helpers/utils/i18n-helper.js
+++ b/ui/app/helpers/utils/i18n-helper.js
@@ -12,7 +12,7 @@ const missingMessageErrors = {}
  * @param {object} localeMessages The map of messages for the current locale
  * @param {string} key The message key
  * @param {string[]} substitutions A list of message substitution replacements
- * @return {null|string} The localized message
+ * @returns {null|string} The localized message
  */
 export const getMessage = (localeCode, localeMessages, key, substitutions) => {
   if (!localeMessages) {

--- a/ui/app/helpers/utils/i18n-helper.js
+++ b/ui/app/helpers/utils/i18n-helper.js
@@ -9,7 +9,7 @@ const missingMessageErrors = {}
 /**
  * Returns a localized message for the given key
  * @param {string} localeCode The code for the current locale
- * @param {object} localeMessages The map of messages for the current locale
+ * @param {Object} localeMessages The map of messages for the current locale
  * @param {string} key The message key
  * @param {string[]} substitutions A list of message substitution replacements
  * @returns {null|string} The localized message

--- a/ui/app/helpers/utils/i18n-helper.js
+++ b/ui/app/helpers/utils/i18n-helper.js
@@ -8,11 +8,11 @@ const missingMessageErrors = {}
 
 /**
  * Returns a localized message for the given key
- * @param {string} localeCode The code for the current locale
- * @param {Object} localeMessages The map of messages for the current locale
- * @param {string} key The message key
- * @param {string[]} substitutions A list of message substitution replacements
- * @returns {null|string} The localized message
+ * @param {string} localeCode - The code for the current locale
+ * @param {Object} localeMessages - The map of messages for the current locale
+ * @param {string} key - The message key
+ * @param {string[]} substitutions - A list of message substitution replacements
+ * @returns {null|string} - The localized message
  */
 export const getMessage = (localeCode, localeMessages, key, substitutions) => {
   if (!localeMessages) {

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -116,7 +116,7 @@ function composeParamAddition (paramValue, paramName) {
   * @property {string} config.url The url to track an event at. Overrides `currentPath`
   * @property {boolean} config.excludeMetaMetricsId Whether or not the tracked event data should be associated with a metametrics id
   * @property {boolean} config.isNewVisit Whether or not the event should be tracked as a new visit/user sessions
-  * @returns {string} Returns a url to be passed to fetch to make the appropriate request to matomo.
+  * @returns {string} - Returns a url to be passed to fetch to make the appropriate request to matomo.
   *   Example: https://chromeextensionmm.innocraft.cloud/piwik.php?idsite=1&rec=1&apiv=1&e_c=Navigation&e_a=Home&e_n=Clicked%20Send:%20Eth&urlref=http%3A%2F%2Fwww.metamask.io%2Fmetametrics%2Fhome.html%23send&dimension5=3&dimension6=fullscreen&dimension7=ETH&dimension8=default&dimension9=0&dimension10=3&url=http%3A%2F%2Fwww.metamask.io%2Fmetametrics%2Fhome.html%23&_id=49c10aff19795e9a&rand=7906028754863992&pv_id=53acad&uid=49c1
   */
 function composeUrl (config) {

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -116,7 +116,7 @@ function composeParamAddition (paramValue, paramName) {
   * @property {string} config.url The url to track an event at. Overrides `currentPath`
   * @property {boolean} config.excludeMetaMetricsId Whether or not the tracked event data should be associated with a metametrics id
   * @property {boolean} config.isNewVisit Whether or not the event should be tracked as a new visit/user sessions
-  * @returns {String} Returns a url to be passed to fetch to make the appropriate request to matomo.
+  * @returns {string} Returns a url to be passed to fetch to make the appropriate request to matomo.
   *   Example: https://chromeextensionmm.innocraft.cloud/piwik.php?idsite=1&rec=1&apiv=1&e_c=Navigation&e_a=Home&e_n=Clicked%20Send:%20Eth&urlref=http%3A%2F%2Fwww.metamask.io%2Fmetametrics%2Fhome.html%23send&dimension5=3&dimension6=fullscreen&dimension7=ETH&dimension8=default&dimension9=0&dimension10=3&url=http%3A%2F%2Fwww.metamask.io%2Fmetametrics%2Fhome.html%23&_id=49c10aff19795e9a&rand=7906028754863992&pv_id=53acad&uid=49c1
   */
 function composeUrl (config) {

--- a/ui/app/helpers/utils/switch-direction.js
+++ b/ui/app/helpers/utils/switch-direction.js
@@ -1,6 +1,6 @@
 /**
  * Switch the CSS stylesheet used between 'rtl' and 'ltr'
- * @param {('ltr' | 'rtl')} direction Text direction, either left-to-right (ltr) or right-to-left (rtl)
+ * @param {('ltr' | 'rtl')} direction - Text direction, either left-to-right (ltr) or right-to-left (rtl)
  */
 const switchDirection = async (direction) => {
   if (direction === 'auto') {

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -236,8 +236,8 @@ export function getTokenAddressFromTokenObject (token) {
 /**
  * Safely checksumms a potentially-null address
  *
- * @param {String} [address] - address to checksum
- * @returns {String} - checksummed address
+ * @param {string} [address] - address to checksum
+ * @returns {string} - checksummed address
  *
  */
 export function checksumAddress (address) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1596,7 +1596,7 @@ export function addToAddressBook (recipient, nickname = '', memo = '') {
 
 /**
  * @description Calls the addressBookController to remove an existing address.
- * @param {String} addressToRemove - Address of the entry to remove from the address book
+ * @param {string} addressToRemove - Address of the entry to remove from the address book
  */
 export function removeFromAddressBook (chainId, addressToRemove) {
   log.debug(`background.removeFromAddressBook`)

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1064,7 +1064,7 @@ export function cancelTx (txData) {
 
 /**
  * Cancels all of the given transactions
- * @param {Array<object>} txDataList a list of tx data objects
+ * @param {Array<object>} txDataList - a list of tx data objects
  * @returns {function(*): Promise<void>}
  */
 export function cancelTxs (txDataList) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1065,7 +1065,7 @@ export function cancelTx (txData) {
 /**
  * Cancels all of the given transactions
  * @param {Array<object>} txDataList a list of tx data objects
- * @return {function(*): Promise<void>}
+ * @returns {function(*): Promise<void>}
  */
 export function cancelTxs (txDataList) {
   return async (dispatch) => {


### PR DESCRIPTION
Various changes to JSDoc comments have been made to ensure we're using a consistent format everywhere.

* Specify type before parameter name

  Various JSDoc `@param` entries were specified as `name {type}` rather
than `{type} name`.

  A couple of `@return` entries have been given types as well.

*  Use JSDoc optional syntax rather than Closure syntax

*   Use @returns rather than @return 

* Use consistent built-in type capitalization

  Primitive types are lower-case, and Object is upper-case.

* Separate param/return description with a dash