### PR TITLE
Update `react-devtools` to `v4.4.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "qs": "^6.2.0",
     "qunitjs": "^2.4.1",
     "radgrad-jsdoc-template": "^1.1.3",
-    "react-devtools": "^4.2.1",
+    "react-devtools": "^4.4.0",
     "react-test-renderer": "^16.12.0",
     "read-installed": "^4.0.3",
     "redux-mock-store": "^1.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22498,25 +22498,25 @@ react-dev-utils@^9.0.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-devtools-core@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.2.1.tgz#0122ccb8a041b0b61811425a57e9dec05125e9d8"
-  integrity sha512-Puo0PwkpxWZY4E0cU7lpOR6Lh5UhGoOScSdhVtvK6HK6InC6+k9ypyVHI2ar2OoBasm3wP5mJlDHcUmbmqF78w==
+react-devtools-core@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.4.0.tgz#614cabe5f3d6fb69730dc76da10f8fa4eb033695"
+  integrity sha512-ayyz+clbjekj5rqTjieI/eE0xGZkgotklVnxfa4Pyk9se5+AHUAhUwMhLvK5N2+mR2PGOZkv159RDTmvgs+wZQ==
   dependencies:
     es6-symbol "^3"
     shell-quote "^1.6.1"
     ws "^7"
 
-react-devtools@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/react-devtools/-/react-devtools-4.2.1.tgz#54a6dbceff32185dcf70c8c86e0d6ea6f625cd46"
-  integrity sha512-ttp34xbtIv3o7veX4Tsl7onCSwFYEWsDUnpmCRTyZ/IG2avXpUUWU0gzODF/2SQwrCF6JurB6kTCY6GRNJlW/A==
+react-devtools@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-devtools/-/react-devtools-4.4.0.tgz#03df973d889583bc75afdf3352d3bb29141b3f36"
+  integrity sha512-Wfa7re+BJGy8fyYodbOfjB1YILKspmfgXLSZ0nPaVvaCpfy2lEqy3Unz5bOzOWoFsDldg7wVL2Xy0LOjd3rz1A==
   dependencies:
     cross-spawn "^5.0.1"
     electron "^5.0.0"
     ip "^1.1.4"
     minimist "^1.2.0"
-    react-devtools-core "4.2.1"
+    react-devtools-core "4.4.0"
     update-notifier "^2.1.0"
 
 react-dnd-html5-backend@^7.4.4:


### PR DESCRIPTION
This update was necessary to get React DevTools working in Chrome. The standalone UI was broken in Chrome in v4.2.1.