### PR TITLE
Prevent install popup during e2e tests

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -43,8 +43,6 @@ const {
 // METAMASK_TEST_CONFIG is used in e2e tests to set the default network to localhost
 const firstTimeState = Object.assign({}, rawFirstTimeState, global.METAMASK_TEST_CONFIG)
 
-const METAMASK_DEBUG = process.env.METAMASK_DEBUG
-
 log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
 const platform = new ExtensionPlatform()
@@ -478,7 +476,7 @@ function openPopup () {
 
 // On first install, open a new tab with MetaMask
 extension.runtime.onInstalled.addListener(({ reason }) => {
-  if ((reason === 'install') && (!METAMASK_DEBUG)) {
+  if (reason === 'install' && !(process.env.METAMASK_DEBUG || process.env.IN_TEST)) {
     platform.openExtensionInBrowser()
   }
 })

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -34,16 +34,6 @@ async function prepareExtensionForTesting ({ responsive, port } = {}) {
   const extensionPath = `dist/${browser}`
   const { driver, extensionId, extensionUrl } = await buildWebDriver({ browser, extensionPath, responsive, port })
 
-  // Depending on the state of the application built into the above directory (extPath) and the value of
-  // METAMASK_DEBUG we will see different post-install behaviour and possibly some extra windows. Here we
-  // are closing any extraneous windows to reset us to a single window before continuing.
-
-  // wait an extra long time so any slow popups can trigger
-  await delay(4 * largeDelayMs)
-
-  const [tab1] = await driver.getAllWindowHandles()
-  await closeAllWindowHandlesExcept(driver, [tab1])
-  await driver.switchTo().window(tab1)
   await driver.get(extensionUrl)
 
   return { driver, extensionId, extensionUrl }


### PR DESCRIPTION
Typically the fullscreen UI will open upon installation, though this behaviour was suppressed in development. This was dealt with in the e2e tests by waiting for it to open, then closing it.

Instead this behaviour is now suppressed for test builds as well.