### PR TITLE
Suppress diffs for vendored e2e JS files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,5 @@ CHANGELOG.md merge=union
 package-lock.json linguist-generated=false
 yarn.lock linguist-generated=false
 
-test/e2e/send-eth-with-private-key-test/ethereumjs-tx.js linguist-vendored linguist-generated
+test/e2e/send-eth-with-private-key-test/ethereumjs-tx.js linguist-vendored linguist-generated -diff
+test/e2e/send-eth-with-private-key-test/web3js.js linguist-vendored linguist-generated -diff


### PR DESCRIPTION
This PR updates our `.gitattributes` file to suppress diffs (and `git grep` results) from showing these two vendored JS files.