### PR TITLE
Remove obsolete e2e test ignored error messages

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -84,14 +84,8 @@ async function setupFetchMocking (driver) {
 async function checkBrowserForConsoleErrors (driver) {
   const ignoredLogTypes = ['WARNING']
   const ignoredErrorMessages = [
-    // React throws error warnings on "dataset", but still sets the data-* properties correctly
-    'Warning: Unknown prop `dataset` on ',
     // Third-party Favicon 404s show up as errors
     'favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)',
-    // React Development build - known issue blocked by test build sys
-    'Warning: It looks like you\'re using a minified copy of the development build of React.',
-    // Redux Development build - known issue blocked by test build sys
-    'This means that you are running a slower development build of Redux.',
   ]
   const browserLogs = await driver.manage().logs().get('browser')
   const errorEntries = browserLogs.filter(entry => !ignoredLogTypes.includes(entry.level.toString()))


### PR DESCRIPTION
These error messages are no longer present during e2e tests, so they don't need to be ignored.

The first error is about a "dataset" property, which we no longer use anywhere.