### PR TITLE
Remove unused props, prevent redundant gas update

### DIFF
--- a/ui/app/pages/send/send.container.js
+++ b/ui/app/pages/send/send.container.js
@@ -26,8 +26,6 @@ import {
   getSendToNickname,
   getTokenBalance,
   getQrCodeData,
-  getSendEnsResolution,
-  getSendEnsResolutionError,
 } from './send.selectors'
 import {
   getAddressBook,
@@ -69,8 +67,6 @@ function mapStateToProps (state) {
     blockGasLimit: getBlockGasLimit(state),
     conversionRate: getConversionRate(state),
     editingTransactionId: getSendEditingTransactionId(state),
-    ensResolution: getSendEnsResolution(state),
-    ensResolutionError: getSendEnsResolutionError(state),
     from: getSendFromObject(state),
     gasLimit: getGasLimit(state),
     gasPrice: getGasPrice(state),


### PR DESCRIPTION
These unused props weren't being caught by ESLint because this component extended another, which I guess made it difficult for the React plugin to determine what was unused.

The `componentWillUpdate` logic was moved into `componentDidUpdate` so that it would be picked up by ESLint. Also it seemed like a sensible place for it to go. Having three redundant gas updates as part of the same lifecycle function seemed too far, so I ensured it's only called once.