### PR TITLE
Convert TokenMenuDropdown to an ES6 class

### DIFF
--- a/ui/app/components/app/dropdowns/token-menu-dropdown.js
+++ b/ui/app/components/app/dropdowns/token-menu-dropdown.js
@@ -1,13 +1,53 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { inherits } from 'util'
 import { connect } from 'react-redux'
 import * as actions from '../../../store/actions'
 import { createAccountLink as genAccountLink } from 'etherscan-link'
 import { Menu, Item, CloseArea } from './components/menu'
 
-TokenMenuDropdown.contextTypes = {
-  t: PropTypes.func,
+class TokenMenuDropdown extends Component {
+  static contextTypes = {
+    t: PropTypes.func,
+  }
+
+  static propTypes = {
+    onClose: PropTypes.func.isRequired,
+    showHideTokenConfirmationModal: PropTypes.func.isRequired,
+    token: PropTypes.object.isRequired,
+    network: PropTypes.number.isRequired,
+  }
+
+  onClose = (e) => {
+    e.stopPropagation()
+    this.props.onClose()
+  }
+
+  render () {
+    const { showHideTokenConfirmationModal } = this.props
+
+    return (
+      <Menu className="token-menu-dropdown" isShowing>
+        <CloseArea onClick={this.onClose} />
+        <Item
+          onClick={(e) => {
+            e.stopPropagation()
+            showHideTokenConfirmationModal(this.props.token)
+            this.props.onClose()
+          }}
+          text={this.context.t('hideToken')}
+        />
+        <Item
+          onClick={(e) => {
+            e.stopPropagation()
+            const url = genAccountLink(this.props.token.address, this.props.network)
+            global.platform.openWindow({ url })
+            this.props.onClose()
+          }}
+          text={this.context.t('viewOnEtherscan')}
+        />
+      </Menu>
+    )
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(TokenMenuDropdown)
@@ -24,44 +64,4 @@ function mapDispatchToProps (dispatch) {
       dispatch(actions.showModal({ name: 'HIDE_TOKEN_CONFIRMATION', token }))
     },
   }
-}
-
-
-inherits(TokenMenuDropdown, Component)
-function TokenMenuDropdown () {
-  Component.call(this)
-
-  this.onClose = this.onClose.bind(this)
-}
-
-TokenMenuDropdown.prototype.onClose = function (e) {
-  e.stopPropagation()
-  this.props.onClose()
-}
-
-TokenMenuDropdown.prototype.render = function TokenMenuDropdown () {
-  const { showHideTokenConfirmationModal } = this.props
-
-  return (
-    <Menu className="token-menu-dropdown" isShowing>
-      <CloseArea onClick={this.onClose} />
-      <Item
-        onClick={(e) => {
-          e.stopPropagation()
-          showHideTokenConfirmationModal(this.props.token)
-          this.props.onClose()
-        }}
-        text={this.context.t('hideToken')}
-      />
-      <Item
-        onClick={(e) => {
-          e.stopPropagation()
-          const url = genAccountLink(this.props.token.address, this.props.network)
-          global.platform.openWindow({ url })
-          this.props.onClose()
-        }}
-        text={this.context.t('viewOnEtherscan')}
-      />
-    </Menu>
-  )
 }


### PR DESCRIPTION
Refs #7766

This PR converts the `TokenMenuDropdown` component to an ES6 class.