### PR TITLE
Convert HideTokenConfirmationModal to an ES6 class

### DIFF
--- a/ui/app/components/app/modals/hide-token-confirmation-modal.js
+++ b/ui/app/components/app/modals/hide-token-confirmation-modal.js
@@ -30,7 +30,6 @@ class HideTokenConfirmationModal extends Component {
   }
 
   static propTypes = {
-    network: PropTypes.number,
     hideToken: PropTypes.func.isRequired,
     hideModal: PropTypes.func.isRequired,
     assetImages: PropTypes.object.isRequired,
@@ -43,7 +42,7 @@ class HideTokenConfirmationModal extends Component {
   state = {}
 
   render () {
-    const { token, network, hideToken, hideModal, assetImages } = this.props
+    const { token, hideToken, hideModal, assetImages } = this.props
     const { symbol, address } = token
     const image = assetImages[address]
 
@@ -57,7 +56,6 @@ class HideTokenConfirmationModal extends Component {
             className="hide-token-confirmation__identicon"
             diameter={45}
             address={address}
-            network={network}
             image={image}
           />
           <div className="hide-token-confirmation__symbol">{symbol}</div>

--- a/ui/app/components/app/modals/hide-token-confirmation-modal.js
+++ b/ui/app/components/app/modals/hide-token-confirmation-modal.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { inherits } from 'util'
 import { connect } from 'react-redux'
 import * as actions from '../../../store/actions'
 import Identicon from '../../ui/identicon'
@@ -25,57 +24,64 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
-inherits(HideTokenConfirmationModal, Component)
-function HideTokenConfirmationModal () {
-  Component.call(this)
+class HideTokenConfirmationModal extends Component {
+  static contextTypes = {
+    t: PropTypes.func,
+  }
 
-  this.state = {}
-}
+  static propTypes = {
+    network: PropTypes.number,
+    hideToken: PropTypes.func.isRequired,
+    hideModal: PropTypes.func.isRequired,
+    assetImages: PropTypes.object.isRequired,
+    token: PropTypes.shape({
+      symbol: PropTypes.string,
+      address: PropTypes.string,
+    }),
+  }
 
-HideTokenConfirmationModal.contextTypes = {
-  t: PropTypes.func,
+  state = {}
+
+  render () {
+    const { token, network, hideToken, hideModal, assetImages } = this.props
+    const { symbol, address } = token
+    const image = assetImages[address]
+
+    return (
+      <div className="hide-token-confirmation">
+        <div className="hide-token-confirmation__container">
+          <div className="hide-token-confirmation__title">
+            {this.context.t('hideTokenPrompt')}
+          </div>
+          <Identicon
+            className="hide-token-confirmation__identicon"
+            diameter={45}
+            address={address}
+            network={network}
+            image={image}
+          />
+          <div className="hide-token-confirmation__symbol">{symbol}</div>
+          <div className="hide-token-confirmation__copy">
+            {this.context.t('readdToken')}
+          </div>
+          <div className="hide-token-confirmation__buttons">
+            <button
+              className="btn-default hide-token-confirmation__button btn--large"
+              onClick={() => hideModal()}
+            >
+              {this.context.t('cancel')}
+            </button>
+            <button
+              className="btn-secondary hide-token-confirmation__button btn--large"
+              onClick={() => hideToken(address)}
+            >
+              {this.context.t('hide')}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(HideTokenConfirmationModal)
-
-
-HideTokenConfirmationModal.prototype.render = function HideTokenConfirmationModal () {
-  const { token, network, hideToken, hideModal, assetImages } = this.props
-  const { symbol, address } = token
-  const image = assetImages[address]
-
-  return (
-    <div className="hide-token-confirmation">
-      <div className="hide-token-confirmation__container">
-        <div className="hide-token-confirmation__title">
-          {this.context.t('hideTokenPrompt')}
-        </div>
-        <Identicon
-          className="hide-token-confirmation__identicon"
-          diameter={45}
-          address={address}
-          network={network}
-          image={image}
-        />
-        <div className="hide-token-confirmation__symbol">{symbol}</div>
-        <div className="hide-token-confirmation__copy">
-          {this.context.t('readdToken')}
-        </div>
-        <div className="hide-token-confirmation__buttons">
-          <button
-            className="btn-default hide-token-confirmation__button btn--large"
-            onClick={() => hideModal()}
-          >
-            {this.context.t('cancel')}
-          </button>
-          <button
-            className="btn-secondary hide-token-confirmation__button btn--large"
-            onClick={() => hideToken(address)}
-          >
-            {this.context.t('hide')}
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}


### PR DESCRIPTION
Refs #7766

This PR converts the `HideTokenConfirmationModal` component to an ES6 class.