### PR TITLE
Convert ReadOnlyInput to functional component

### DIFF
--- a/ui/app/components/ui/readonly-input.js
+++ b/ui/app/components/ui/readonly-input.js
@@ -1,21 +1,14 @@
-import React, { Component } from 'react'
-import { inherits } from 'util'
+import PropTypes from 'prop-types'
+import React from 'react'
 
-export default ReadOnlyInput
-
-inherits(ReadOnlyInput, Component)
-function ReadOnlyInput () {
-  Component.call(this)
-}
-
-ReadOnlyInput.prototype.render = function ReadOnlyInput () {
+export default function ReadOnlyInput (props) {
   const {
     wrapperClass = '',
     inputClass = '',
     value,
     textarea,
     onClick,
-  } = this.props
+  } = props
 
   const InputType = textarea ? 'textarea' : 'input'
 
@@ -32,3 +25,10 @@ ReadOnlyInput.prototype.render = function ReadOnlyInput () {
   )
 }
 
+ReadOnlyInput.propTypes = {
+  wrapperClass: PropTypes.string,
+  inputClass: PropTypes.string,
+  value: PropTypes.string,
+  textarea: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+}

--- a/ui/app/components/ui/readonly-input.js
+++ b/ui/app/components/ui/readonly-input.js
@@ -29,6 +29,6 @@ ReadOnlyInput.propTypes = {
   wrapperClass: PropTypes.string,
   inputClass: PropTypes.string,
   value: PropTypes.string,
-  textarea: PropTypes.bool.isRequired,
-  onClick: PropTypes.func.isRequired,
+  textarea: PropTypes.bool,
+  onClick: PropTypes.func,
 }


### PR DESCRIPTION
Refs #7766

This PR converts the `ReadOnlyInput` component to a functional component. This seems safe.