### PR TITLE
Purge xtend from the UI

### DIFF
--- a/ui/app/components/app/dropdowns/components/dropdown.js
+++ b/ui/app/components/app/dropdowns/components/dropdown.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import MenuDroppo from '../../menu-droppo'
-import extend from 'xtend'
 
 export class Dropdown extends Component {
   render () {
@@ -15,7 +14,7 @@ export class Dropdown extends Component {
       useCssTransition,
     } = this.props
 
-    const innerStyleDefaults = extend({
+    const innerStyleDefaults = Object.assign({
       borderRadius: '4px',
       padding: '8px 16px',
       background: 'rgba(0, 0, 0, 0.8)',

--- a/ui/app/ducks/app/app.js
+++ b/ui/app/ducks/app/app.js
@@ -1,4 +1,3 @@
-import extend from 'xtend'
 import txHelper from '../../../lib/tx-helper'
 import log from 'loglevel'
 import { actionConstants } from '../../store/actions'
@@ -30,7 +29,7 @@ export default function reduceApp (state, action) {
   }
 
   // default state
-  const appState = extend({
+  const appState = Object.assign({
     shouldClose: false,
     menuOpen: false,
     modal: {
@@ -85,57 +84,65 @@ export default function reduceApp (state, action) {
   switch (action.type) {
     // dropdown methods
     case actions.NETWORK_DROPDOWN_OPEN:
-      return extend(appState, {
+      return {
+        ...appState,
         networkDropdownOpen: true,
-      })
+      }
 
     case actions.NETWORK_DROPDOWN_CLOSE:
-      return extend(appState, {
+      return {
+        ...appState,
         networkDropdownOpen: false,
-      })
+      }
 
     // sidebar methods
     case actions.SIDEBAR_OPEN:
-      return extend(appState, {
+      return {
+        ...appState,
         sidebar: {
           ...action.value,
           isOpen: true,
         },
-      })
+      }
 
     case actions.SIDEBAR_CLOSE:
-      return extend(appState, {
+      return {
+        ...appState,
         sidebar: {
           ...appState.sidebar,
           isOpen: false,
         },
-      })
+      }
 
     // alert methods
     case actions.ALERT_OPEN:
-      return extend(appState, {
+      return {
+        ...appState,
         alertOpen: true,
         alertMessage: action.value,
-      })
+      }
 
     case actions.ALERT_CLOSE:
-      return extend(appState, {
+      return {
+        ...appState,
         alertOpen: false,
         alertMessage: null,
-      })
+      }
 
     // qr scanner methods
     case actions.QR_CODE_DETECTED:
-      return extend(appState, {
+      return {
+        ...appState,
         qrCodeData: action.value,
-      })
+      }
 
 
     // modal methods:
     case actions.MODAL_OPEN:
       const { name, ...modalProps } = action.payload
 
-      return extend(appState, {
+      return {
+        ...appState,
         modal: {
           open: true,
           modalState: {
@@ -144,28 +151,31 @@ export default function reduceApp (state, action) {
           },
           previousModalState: { ...appState.modal.modalState },
         },
-      })
+      }
 
     case actions.MODAL_CLOSE:
-      return extend(appState, {
+      return {
+        ...appState,
         modal: Object.assign(
           state.appState.modal,
           { open: false },
           { modalState: { name: null, props: {} } },
           { previousModalState: appState.modal.modalState },
         ),
-      })
+      }
 
     // transition methods
     case actions.TRANSITION_FORWARD:
-      return extend(appState, {
+      return {
+        ...appState,
         transForward: true,
-      })
+      }
 
     case actions.FORGOT_PASSWORD:
-      const newState = extend(appState, {
+      const newState = {
+        ...appState,
         forgottenPassword: action.value,
-      })
+      }
 
       if (action.value) {
         newState.currentView = {
@@ -176,85 +186,95 @@ export default function reduceApp (state, action) {
       return newState
 
     case actions.SHOW_CONFIG_PAGE:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'config',
           context: appState.currentView.context,
         },
         transForward: action.value,
-      })
+      }
 
     case actions.SHOW_ADD_TOKEN_PAGE:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'add-token',
           context: appState.currentView.context,
         },
         transForward: action.value,
-      })
+      }
 
     case actions.SET_NEW_ACCOUNT_FORM:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: appState.currentView.name,
           context: action.formToSelect,
         },
-      })
+      }
 
     case actions.SHOW_INFO_PAGE:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'info',
           context: appState.currentView.context,
         },
         transForward: true,
-      })
+      }
 
     case actions.SHOW_SEND_PAGE:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'sendTransaction',
           context: appState.currentView.context,
         },
         transForward: true,
         warning: null,
-      })
+      }
 
     case actions.SHOW_SEND_TOKEN_PAGE:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'sendToken',
           context: appState.currentView.context,
         },
         transForward: true,
         warning: null,
-      })
+      }
 
       // unlock
 
     case actions.UNLOCK_METAMASK:
-      return extend(appState, {
+      return {
+        ...appState,
         forgottenPassword: appState.forgottenPassword ? !appState.forgottenPassword : null,
         detailView: {},
         transForward: true,
         isLoading: false,
         warning: null,
-      })
+      }
 
     case actions.LOCK_METAMASK:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: defaultView,
         transForward: false,
         warning: null,
-      })
+      }
 
       // accounts
 
     case actions.GO_HOME:
-      return extend(appState, {
-        currentView: extend(appState.currentView, {
+      return {
+        ...appState,
+        currentView: {
+          ...appState.currentView,
           name: 'accountDetail',
-        }),
+        },
         accountDetail: {
           subview: 'transactions',
           accountExport: 'none',
@@ -262,10 +282,11 @@ export default function reduceApp (state, action) {
         },
         transForward: false,
         warning: null,
-      })
+      }
 
     case actions.SHOW_ACCOUNT_DETAIL:
-      return extend(appState, {
+      return {
+        ...appState,
         forgottenPassword: appState.forgottenPassword ? !appState.forgottenPassword : null,
         currentView: {
           name: 'accountDetail',
@@ -277,10 +298,11 @@ export default function reduceApp (state, action) {
           privateKey: '',
         },
         transForward: false,
-      })
+      }
 
     case actions.SHOW_ACCOUNTS_PAGE:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'accounts',
         },
@@ -289,10 +311,11 @@ export default function reduceApp (state, action) {
         warning: null,
         scrollToBottom: false,
         forgottenPassword: false,
-      })
+      }
 
     case actions.SHOW_CONF_TX_PAGE:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'confTx',
           context: action.id ? indexForPending(state, action.id) : 0,
@@ -300,7 +323,7 @@ export default function reduceApp (state, action) {
         transForward: action.transForward,
         warning: null,
         isLoading: false,
-      })
+      }
 
     case actions.COMPLETED_TX:
       log.debug('reducing COMPLETED_TX for tx ' + action.value)
@@ -310,17 +333,19 @@ export default function reduceApp (state, action) {
 
       if (hasOtherUnconfActions) {
         log.debug('reducer detected txs - rendering confTx view')
-        return extend(appState, {
+        return {
+          ...appState,
           transForward: false,
           currentView: {
             name: 'confTx',
             context: 0,
           },
           warning: null,
-        })
+        }
       } else {
         log.debug('attempting to close popup')
-        return extend(appState, {
+        return {
+          ...appState,
           // indicate notification should close
           shouldClose: true,
           transForward: false,
@@ -332,79 +357,91 @@ export default function reduceApp (state, action) {
           accountDetail: {
             subview: 'transactions',
           },
-        })
+        }
       }
 
     case actions.TRANSACTION_ERROR:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'confTx',
           errorMessage: 'There was a problem submitting this transaction.',
         },
-      })
+      }
 
     case actions.UNLOCK_FAILED:
-      return extend(appState, {
+      return {
+        ...appState,
         warning: action.value || 'Incorrect password. Try again.',
-      })
+      }
 
     case actions.UNLOCK_SUCCEEDED:
-      return extend(appState, {
+      return {
+        ...appState,
         warning: '',
-      })
+      }
 
     case actions.SET_HARDWARE_WALLET_DEFAULT_HD_PATH:
       const { device, path } = action.value
       const newDefaults = { ...appState.defaultHdPaths }
       newDefaults[device] = path
 
-      return extend(appState, {
+      return {
+        ...appState,
         defaultHdPaths: newDefaults,
-      })
+      }
 
     case actions.SHOW_LOADING:
-      return extend(appState, {
+      return {
+        ...appState,
         isLoading: true,
         loadingMessage: action.value,
-      })
+      }
 
     case actions.HIDE_LOADING:
-      return extend(appState, {
+      return {
+        ...appState,
         isLoading: false,
-      })
+      }
 
     case actions.SHOW_SUB_LOADING_INDICATION:
-      return extend(appState, {
+      return {
+        ...appState,
         isSubLoading: true,
-      })
+      }
 
     case actions.HIDE_SUB_LOADING_INDICATION:
-      return extend(appState, {
+      return {
+        ...appState,
         isSubLoading: false,
-      })
+      }
 
     case actions.DISPLAY_WARNING:
-      return extend(appState, {
+      return {
+        ...appState,
         warning: action.value,
         isLoading: false,
-      })
+      }
 
     case actions.HIDE_WARNING:
-      return extend(appState, {
+      return {
+        ...appState,
         warning: undefined,
-      })
+      }
 
     case actions.SHOW_PRIVATE_KEY:
-      return extend(appState, {
+      return {
+        ...appState,
         accountDetail: {
           subview: 'export',
           accountExport: 'completed',
           privateKey: action.value,
         },
-      })
+      }
 
     case actions.PAIR_UPDATE:
-      return extend(appState, {
+      return {
+        ...appState,
         buyView: {
           subview: 'ShapeShift',
           formView: {
@@ -417,10 +454,11 @@ export default function reduceApp (state, action) {
           amount: appState.buyView.amount,
           warning: null,
         },
-      })
+      }
 
     case actions.SHOW_QR:
-      return extend(appState, {
+      return {
+        ...appState,
         qrRequested: true,
         transForward: true,
 
@@ -428,10 +466,11 @@ export default function reduceApp (state, action) {
           message: action.value.message,
           data: action.value.data,
         },
-      })
+      }
 
     case actions.SHOW_QR_VIEW:
-      return extend(appState, {
+      return {
+        ...appState,
         currentView: {
           name: 'qr',
           context: appState.currentView.context,
@@ -441,75 +480,88 @@ export default function reduceApp (state, action) {
           message: action.value.message,
           data: action.value.data,
         },
-      })
+      }
 
     case actions.SET_MOUSE_USER_STATE:
-      return extend(appState, {
+      return {
+        ...appState,
         isMouseUser: action.value,
-      })
+      }
 
     case actions.GAS_LOADING_STARTED:
-      return extend(appState, {
+      return {
+        ...appState,
         gasIsLoading: true,
-      })
+      }
 
     case actions.GAS_LOADING_FINISHED:
-      return extend(appState, {
+      return {
+        ...appState,
         gasIsLoading: false,
-      })
+      }
 
     case actions.SET_NETWORK_NONCE:
-      return extend(appState, {
+      return {
+        ...appState,
         networkNonce: action.value,
-      })
+      }
 
     case actions.SET_PREVIOUS_PROVIDER:
       if (action.value === 'loading') {
         return appState
       }
-      return extend(appState, {
+      return {
+        ...appState,
         lastSelectedProvider: action.value,
-      })
+      }
 
     case actions.SET_SELECTED_SETTINGS_RPC_URL:
-      return extend(appState, {
+      return {
+        ...appState,
         networksTabSelectedRpcUrl: action.value,
-      })
+      }
 
     case actions.SET_NETWORKS_TAB_ADD_MODE:
-      return extend(appState, {
+      return {
+        ...appState,
         networksTabIsInAddMode: action.value,
-      })
+      }
 
     case actions.LOADING_METHOD_DATA_STARTED:
-      return extend(appState, {
+      return {
+        ...appState,
         loadingMethodData: true,
-      })
+      }
 
     case actions.LOADING_METHOD_DATA_FINISHED:
-      return extend(appState, {
+      return {
+        ...appState,
         loadingMethodData: false,
-      })
+      }
 
     case SET_THREEBOX_LAST_UPDATED:
-      return extend(appState, {
+      return {
+        ...appState,
         threeBoxLastUpdated: action.value,
-      })
+      }
 
     case actions.SET_REQUEST_ACCOUNT_TABS:
-      return extend(appState, {
+      return {
+        ...appState,
         requestAccountTabs: action.value,
-      })
+      }
 
     case actions.SET_OPEN_METAMASK_TAB_IDS:
-      return extend(appState, {
+      return {
+        ...appState,
         openMetaMaskTabs: action.value,
-      })
+      }
 
     case actions.SET_CURRENT_WINDOW_TAB:
-      return extend(appState, {
+      return {
+        ...appState,
         currentWindowTab: action.value,
-      })
+      }
 
     default:
       return appState

--- a/ui/app/ducks/index.js
+++ b/ui/app/ducks/index.js
@@ -1,5 +1,4 @@
 import clone from 'clone'
-import extend from 'xtend'
 import copyToClipboard from 'copy-to-clipboard'
 
 //
@@ -19,7 +18,7 @@ export default rootReducer
 
 function rootReducer (state, action) {
   // clone
-  state = extend(state)
+  state = { ...state }
 
   if (action.type === 'GLOBAL_FORCE_UPDATE') {
     return action.value

--- a/ui/app/ducks/locale/locale.js
+++ b/ui/app/ducks/locale/locale.js
@@ -1,16 +1,16 @@
-import extend from 'xtend'
 import { actionConstants } from '../../store/actions'
 
 export default reduceMetamask
 
 function reduceMetamask (state, action) {
-  const localeMessagesState = extend({}, state.localeMessages)
+  const localeMessagesState = { ...state.localeMessages }
 
   switch (action.type) {
     case actionConstants.SET_CURRENT_LOCALE:
-      return extend(localeMessagesState, {
+      return {
+        ...localeMessagesState,
         current: action.value.messages,
-      })
+      }
     default:
       return localeMessagesState
   }

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -1,4 +1,3 @@
-import extend from 'xtend'
 import { actionConstants } from '../../store/actions'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
@@ -11,7 +10,7 @@ function reduceMetamask (state, action) {
   let newState
 
   // clone + defaults
-  const metamaskState = extend({
+  const metamaskState = Object.assign({
     isInitialized: false,
     isUnlocked: false,
     isAccountMenuOpen: false,
@@ -65,41 +64,46 @@ function reduceMetamask (state, action) {
   switch (action.type) {
 
     case actions.UPDATE_METAMASK_STATE:
-      return extend(metamaskState, action.value)
+      return { ...metamaskState, ...action.value }
 
     case actions.UNLOCK_METAMASK:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         isUnlocked: true,
         isInitialized: true,
         selectedAddress: action.value,
-      })
+      }
 
     case actions.LOCK_METAMASK:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         isUnlocked: false,
-      })
+      }
 
     case actions.SET_RPC_TARGET:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         provider: {
           type: 'rpc',
           rpcTarget: action.value,
         },
-      })
+      }
 
     case actions.SET_PROVIDER_TYPE:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         provider: {
           type: action.value,
         },
-      })
+      }
 
     case actions.COMPLETED_TX:
       const stringId = String(action.id)
-      newState = extend(metamaskState, {
+      newState = {
+        ...metamaskState,
         unapprovedTxs: {},
         unapprovedMsgs: {},
-      })
+      }
       for (const id in metamaskState.unapprovedTxs) {
         if (id !== stringId) {
           newState.unapprovedTxs[id] = metamaskState.unapprovedTxs[id]
@@ -113,28 +117,31 @@ function reduceMetamask (state, action) {
       return newState
 
     case actions.SHOW_ACCOUNT_DETAIL:
-      newState = extend(metamaskState, {
+      return {
+        ...metamaskState,
         isUnlocked: true,
         isInitialized: true,
         selectedAddress: action.value,
-      })
-      return newState
+      }
 
     case actions.SET_SELECTED_TOKEN:
-      newState = extend(metamaskState, {
+      newState = {
+        ...metamaskState,
         selectedTokenAddress: action.value,
-      })
-      const newSend = extend(metamaskState.send)
+      }
+      const newSend = { ...metamaskState.send }
 
       if (metamaskState.send.editingTransactionId && !action.value) {
         delete newSend.token
         const unapprovedTx = newState.unapprovedTxs[newSend.editingTransactionId] || {}
         const txParams = unapprovedTx.txParams || {}
-        newState.unapprovedTxs = extend(newState.unapprovedTxs, {
-          [newSend.editingTransactionId]: extend(unapprovedTx, {
-            txParams: extend(txParams, { data: '' }),
-          }),
-        })
+        newState.unapprovedTxs = {
+          ...newState.unapprovedTxs,
+          [newSend.editingTransactionId]: {
+            ...unapprovedTx,
+            txParams: { ...txParams, data: '' },
+          },
+        }
         newSend.tokenBalance = null
         newSend.balance = '0'
       }
@@ -146,98 +153,109 @@ function reduceMetamask (state, action) {
       const account = action.value.account
       const name = action.value.label
       const id = {}
-      id[account] = extend(metamaskState.identities[account], { name })
-      const identities = extend(metamaskState.identities, id)
-      return extend(metamaskState, { identities })
+      id[account] = Object.assign({}, metamaskState.identities[account], { name })
+      const identities = Object.assign({}, metamaskState.identities, id)
+      return Object.assign(metamaskState, { identities })
 
     case actions.SET_CURRENT_FIAT:
-      return extend(metamaskState, {
+      return Object.assign(metamaskState, {
         currentCurrency: action.value.currentCurrency,
         conversionRate: action.value.conversionRate,
         conversionDate: action.value.conversionDate,
       })
 
     case actions.UPDATE_TOKENS:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         tokens: action.newTokens,
-      })
+      }
 
     // metamask.send
     case actions.UPDATE_GAS_LIMIT:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           gasLimit: action.value,
         },
-      })
+      }
     case actions.UPDATE_CUSTOM_NONCE:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         customNonceValue: action.value,
-      })
+      }
     case actions.UPDATE_GAS_PRICE:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           gasPrice: action.value,
         },
-      })
+      }
 
     case actions.TOGGLE_ACCOUNT_MENU:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         isAccountMenuOpen: !metamaskState.isAccountMenuOpen,
-      })
+      }
 
     case actions.UPDATE_GAS_TOTAL:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           gasTotal: action.value,
         },
-      })
+      }
 
     case actions.UPDATE_SEND_TOKEN_BALANCE:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           tokenBalance: action.value,
         },
-      })
+      }
 
     case actions.UPDATE_SEND_HEX_DATA:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           data: action.value,
         },
-      })
+      }
 
     case actions.UPDATE_SEND_TO:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           to: action.value.to,
           toNickname: action.value.nickname,
         },
-      })
+      }
 
     case actions.UPDATE_SEND_AMOUNT:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           amount: action.value,
         },
-      })
+      }
 
     case actions.UPDATE_MAX_MODE:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           maxModeOn: action.value,
         },
-      })
+      }
 
     case actions.UPDATE_SEND:
-      return extend(metamaskState, {
+      return Object.assign(metamaskState, {
         send: {
           ...metamaskState.send,
           ...action.value,
@@ -245,25 +263,28 @@ function reduceMetamask (state, action) {
       })
 
     case actions.UPDATE_SEND_ENS_RESOLUTION:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           ensResolution: action.payload,
           ensResolutionError: '',
         },
-      })
+      }
 
     case actions.UPDATE_SEND_ENS_RESOLUTION_ERROR:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           ...metamaskState.send,
           ensResolution: null,
           ensResolutionError: action.payload,
         },
-      })
+      }
 
     case actions.CLEAR_SEND:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         send: {
           gasLimit: null,
           gasPrice: null,
@@ -279,7 +300,7 @@ function reduceMetamask (state, action) {
           forceGasMin: null,
           toNickname: '',
         },
-      })
+      }
 
     case actions.UPDATE_TRANSACTION_PARAMS:
       const { id: txId, value } = action
@@ -293,85 +314,99 @@ function reduceMetamask (state, action) {
         return tx
       })
 
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         selectedAddressTxList,
-      })
+      }
 
     case actions.PAIR_UPDATE:
       const { value: { marketinfo: pairMarketInfo } } = action
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         tokenExchangeRates: {
           ...metamaskState.tokenExchangeRates,
           [pairMarketInfo.pair]: pairMarketInfo,
         },
-      })
+      }
 
     case actions.SET_PARTICIPATE_IN_METAMETRICS:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         participateInMetaMetrics: action.value,
-      })
+      }
 
     case actions.SET_METAMETRICS_SEND_COUNT:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         metaMetricsSendCount: action.value,
-      })
+      }
 
     case actions.SET_USE_BLOCKIE:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         useBlockie: action.value,
-      })
+      }
 
     case actions.UPDATE_FEATURE_FLAGS:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         featureFlags: action.value,
-      })
+      }
 
     case actions.CLOSE_WELCOME_SCREEN:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         welcomeScreenSeen: true,
-      })
+      }
 
     case actions.SET_CURRENT_LOCALE:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         currentLocale: action.value.locale,
-      })
+      }
 
     case actions.SET_PENDING_TOKENS:
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         pendingTokens: { ...action.payload },
-      })
+      }
 
     case actions.CLEAR_PENDING_TOKENS: {
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         pendingTokens: {},
-      })
+      }
     }
 
     case actions.UPDATE_PREFERENCES: {
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         preferences: {
           ...metamaskState.preferences,
           ...action.payload,
         },
-      })
+      }
     }
 
     case actions.COMPLETE_ONBOARDING: {
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         completedOnboarding: true,
-      })
+      }
     }
 
     case actions.SET_FIRST_TIME_FLOW_TYPE: {
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         firstTimeFlowType: action.value,
-      })
+      }
     }
 
     case actions.SET_NEXT_NONCE: {
-      return extend(metamaskState, {
+      return {
+        ...metamaskState,
         nextNonce: action.value,
-      })
+      }
     }
 
     default:

--- a/ui/app/ducks/send/send.duck.js
+++ b/ui/app/ducks/send/send.duck.js
@@ -1,5 +1,3 @@
-import extend from 'xtend'
-
 // Actions
 const OPEN_TO_DROPDOWN = 'metamask/send/OPEN_TO_DROPDOWN'
 const CLOSE_TO_DROPDOWN = 'metamask/send/CLOSE_TO_DROPDOWN'
@@ -17,34 +15,39 @@ const initState = {
 
 // Reducer
 export default function reducer ({ send: sendState = initState }, action = {}) {
-  const newState = extend({}, sendState)
+  const newState = { ...sendState }
 
   switch (action.type) {
     case OPEN_TO_DROPDOWN:
-      return extend(newState, {
+      return {
+        ...newState,
         toDropdownOpen: true,
-      })
+      }
     case CLOSE_TO_DROPDOWN:
-      return extend(newState, {
+      return {
+        ...newState,
         toDropdownOpen: false,
-      })
+      }
     case UPDATE_SEND_ERRORS:
-      return extend(newState, {
+      return {
+        ...newState,
         errors: {
           ...newState.errors,
           ...action.value,
         },
-      })
+      }
     case SHOW_GAS_BUTTON_GROUP:
-      return extend(newState, {
+      return {
+        ...newState,
         gasButtonGroupShown: true,
-      })
+      }
     case HIDE_GAS_BUTTON_GROUP:
-      return extend(newState, {
+      return {
+        ...newState,
         gasButtonGroupShown: false,
-      })
+      }
     case RESET_SEND_STATE:
-      return extend({}, initState)
+      return { ...initState }
     default:
       return newState
   }

--- a/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.container.js
+++ b/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.container.js
@@ -2,13 +2,11 @@ import { connect } from 'react-redux'
 import { compose } from 'recompose'
 import ConfirmAddSuggestedToken from './confirm-add-suggested-token.component'
 import { withRouter } from 'react-router-dom'
-
-import extend from 'xtend'
 import { addToken, removeSuggestedTokens } from '../../store/actions'
 
 const mapStateToProps = ({ metamask }) => {
   const { pendingTokens, suggestedTokens } = metamask
-  const params = extend(pendingTokens, suggestedTokens)
+  const params = { ...pendingTokens, ...suggestedTokens }
 
   return {
     pendingTokens: params,


### PR DESCRIPTION
This PR removes `xtend` from the UI code, replacing it with a shallow copy via the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) (or [`Object.assign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) where that's a cleaner diff).