### PR TITLE
Purge xtend from the background scripts

### DIFF
--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -1,5 +1,4 @@
 import ObservableStore from 'obs-store'
-import extend from 'xtend'
 import { getRandomArrayItem } from '../lib/util'
 
 /**
@@ -21,7 +20,7 @@ class ABTestController {
    */
   constructor (opts = {}) {
     const { initState } = opts
-    this.store = new ObservableStore(extend({
+    this.store = new ObservableStore(Object.assign({
       abTests: {
         fullScreenVsPopup: this._getRandomizedTestGroupName('fullScreenVsPopup'),
       },

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -1,5 +1,4 @@
 import ObservableStore from 'obs-store'
-import extend from 'xtend'
 
 class AppStateController {
   /**
@@ -11,7 +10,7 @@ class AppStateController {
     const { preferences } = preferencesStore.getState()
 
     this.onInactiveTimeout = onInactiveTimeout || (() => {})
-    this.store = new ObservableStore(extend({
+    this.store = new ObservableStore(Object.assign({
       timeoutMinutes: 0,
       mkrMigrationReminderTimestamp: null,
     }, initState))

--- a/app/scripts/controllers/cached-balances.js
+++ b/app/scripts/controllers/cached-balances.js
@@ -1,5 +1,4 @@
 import ObservableStore from 'obs-store'
-import extend from 'xtend'
 
 /**
  * @typedef {Object} CachedBalancesOptions
@@ -24,7 +23,7 @@ class CachedBalancesController {
     this.accountTracker = accountTracker
     this.getNetwork = getNetwork
 
-    const initState = extend({
+    const initState = Object.assign({
       cachedBalances: {},
     }, opts.initState)
     this.store = new ObservableStore(initState)

--- a/app/scripts/controllers/infura.js
+++ b/app/scripts/controllers/infura.js
@@ -1,5 +1,4 @@
 import ObservableStore from 'obs-store'
-import extend from 'xtend'
 import log from 'loglevel'
 
 // every ten minutes
@@ -8,7 +7,7 @@ const POLLING_INTERVAL = 10 * 60 * 1000
 class InfuraController {
 
   constructor (opts = {}) {
-    const initState = extend({
+    const initState = Object.assign({
       infuraNetworkStatus: {},
     }, opts.initState)
     this.store = new ObservableStore(initState)

--- a/app/scripts/controllers/onboarding.js
+++ b/app/scripts/controllers/onboarding.js
@@ -1,5 +1,4 @@
 import ObservableStore from 'obs-store'
-import extend from 'xtend'
 import log from 'loglevel'
 
 /**
@@ -27,7 +26,7 @@ class OnboardingController {
     const initialTransientState = {
       onboardingTabs: {},
     }
-    const initState = extend(
+    const initState = Object.assign(
       {
         seedPhraseBackedUp: true,
       },

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -2,8 +2,6 @@ import ObservableStore from 'obs-store'
 import { addInternalMethodPrefix } from './permissions'
 import { normalize as normalizeAddress } from 'eth-sig-util'
 import { isValidAddress, sha3, bufferToHex } from 'ethereumjs-util'
-import extend from 'xtend'
-
 
 class PreferencesController {
 
@@ -29,7 +27,7 @@ class PreferencesController {
    *
    */
   constructor (opts = {}) {
-    const initState = extend({
+    const initState = Object.assign({
       frequentRpcListDetail: [],
       currentAccountTab: 'history',
       accountTokens: {},
@@ -489,7 +487,7 @@ class PreferencesController {
     })
     if (index > -1) {
       const rpcDetail = rpcList[index]
-      const updatedRpc = extend(rpcDetail, newRpcDetails)
+      const updatedRpc = { ...rpcDetail, ...newRpcDetails }
       rpcList[index] = updatedRpc
       this.store.updateState({ frequentRpcListDetail: rpcList })
     } else {

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -1,5 +1,4 @@
 import ObservableStore from 'obs-store'
-import extend from 'xtend'
 import EthQuery from 'eth-query'
 import log from 'loglevel'
 import pify from 'pify'
@@ -33,7 +32,7 @@ class RecentBlocksController {
     this.ethQuery = new EthQuery(provider)
     this.historyLength = opts.historyLength || 40
 
-    const initState = extend({
+    const initState = Object.assign({
       recentBlocks: [],
     }, opts.initState)
     this.store = new ObservableStore(initState)
@@ -121,11 +120,12 @@ class RecentBlocksController {
    *
    */
   mapTransactionsToPrices (newBlock) {
-    const block = extend(newBlock, {
+    const block = {
+      ...newBlock,
       gasPrices: newBlock.transactions.map((tx) => {
         return tx.gasPrice
       }),
-    })
+    }
     delete block.transactions
     return block
   }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -1,4 +1,3 @@
-import extend from 'xtend'
 import EventEmitter from 'safe-event-emitter'
 import ObservableStore from 'obs-store'
 import log from 'loglevel'
@@ -32,7 +31,7 @@ class TransactionStateManager extends EventEmitter {
     super()
 
     this.store = new ObservableStore(
-      extend({
+      Object.assign({
         transactions: [],
       }, initState))
     this.txHistoryLimit = txHistoryLimit
@@ -48,7 +47,7 @@ class TransactionStateManager extends EventEmitter {
     if (netId === 'loading') {
       throw new Error('MetaMask is having trouble connecting to the network')
     }
-    return extend({
+    return Object.assign({
       id: createId(),
       time: (new Date()).getTime(),
       status: 'unapproved',
@@ -222,7 +221,7 @@ class TransactionStateManager extends EventEmitter {
   */
   updateTxParams (txId, txParams) {
     const txMeta = this.getTx(txId)
-    txMeta.txParams = extend(txMeta.txParams, txParams)
+    txMeta.txParams = { ...txMeta.txParams, ...txParams }
     this.updateTx(txMeta, `txStateManager#updateTxParams`)
   }
 

--- a/app/scripts/migrations/005.js
+++ b/app/scripts/migrations/005.js
@@ -6,8 +6,6 @@ This migration moves state from the flat state trie into KeyringController subst
 
 */
 
-import extend from 'xtend'
-
 import clone from 'clone'
 
 
@@ -30,13 +28,14 @@ export default {
 
 function selectSubstateForKeyringController (state) {
   const config = state.config
-  const newState = extend(state, {
+  const newState = {
+    ...state,
     KeyringController: {
       vault: state.vault,
       selectedAccount: config.selectedAccount,
       walletNicknames: state.walletNicknames,
     },
-  })
+  }
   delete newState.vault
   delete newState.walletNicknames
   delete newState.config.selectedAccount

--- a/app/scripts/migrations/006.js
+++ b/app/scripts/migrations/006.js
@@ -6,8 +6,6 @@ This migration moves KeyringController.selectedAddress to PreferencesController.
 
 */
 
-import extend from 'xtend'
-
 import clone from 'clone'
 
 export default {
@@ -31,11 +29,12 @@ function migrateState (state) {
   const keyringSubstate = state.KeyringController
 
   // add new state
-  const newState = extend(state, {
+  const newState = {
+    ...state,
     PreferencesController: {
       selectedAddress: keyringSubstate.selectedAccount,
     },
-  })
+  }
 
   // rm old state
   delete newState.KeyringController.selectedAccount

--- a/app/scripts/migrations/007.js
+++ b/app/scripts/migrations/007.js
@@ -6,8 +6,6 @@ This migration breaks out the TransactionManager substate
 
 */
 
-import extend from 'xtend'
-
 import clone from 'clone'
 
 export default {
@@ -28,12 +26,13 @@ export default {
 }
 
 function transformState (state) {
-  const newState = extend(state, {
+  const newState = {
+    ...state,
     TransactionManager: {
       transactions: state.transactions || [],
       gasMultiplier: state.gasMultiplier || 1,
     },
-  })
+  }
   delete newState.transactions
   delete newState.gasMultiplier
 

--- a/app/scripts/migrations/008.js
+++ b/app/scripts/migrations/008.js
@@ -6,8 +6,6 @@ This migration breaks out the NoticeController substate
 
 */
 
-import extend from 'xtend'
-
 import clone from 'clone'
 
 export default {
@@ -28,11 +26,12 @@ export default {
 }
 
 function transformState (state) {
-  const newState = extend(state, {
+  const newState = {
+    ...state,
     NoticeController: {
       noticesList: state.noticesList || [],
     },
-  })
+  }
   delete newState.noticesList
 
   return newState

--- a/test/lib/mock-tx-gen.js
+++ b/test/lib/mock-tx-gen.js
@@ -1,4 +1,3 @@
-import extend from 'xtend'
 import { BN } from 'ethereumjs-util'
 
 const template = {
@@ -23,7 +22,7 @@ class TxGenerator {
     let nonce = fromNonce || this.txs.length
     const txs = []
     for (let i = 0; i < count; i++) {
-      txs.push(extend(template, {
+      txs.push(Object.assign({}, template, {
         txParams: {
           nonce: hexify(nonce++),
         },


### PR DESCRIPTION
Similar to #7795

This PR removes xtend usages, replacing them with a shallow copy via the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) (or [`Object.assign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) where that's a cleaner diff). This functionality doesn't require an external library anymore.