### PR TITLE
Add required props for AdvancedTab component tests

### DIFF
--- a/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
+++ b/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
@@ -8,7 +8,15 @@ import TextField from '../../../../components/ui/text-field'
 describe('AdvancedTab Component', () => {
   it('should render correctly when threeBoxFeatureFlag', () => {
     const root = shallow(
-      <AdvancedTab />,
+      <AdvancedTab
+        ipfsGateway=""
+        setAutoLogoutTimeLimit={() => {}}
+        setIpfsGateway={() => {}}
+        setShowFiatConversionOnTestnetsPreference={() => {}}
+        setThreeBoxSyncingPermission={() => {}}
+        threeBoxDisabled
+        threeBoxSyncingAllowed={false}
+      />,
       {
         context: {
           t: s => `_${s}`,
@@ -23,7 +31,13 @@ describe('AdvancedTab Component', () => {
     const setAutoLogoutTimeLimitSpy = sinon.spy()
     const root = shallow(
       <AdvancedTab
+        ipfsGateway=""
         setAutoLogoutTimeLimit={setAutoLogoutTimeLimitSpy}
+        setIpfsGateway={() => {}}
+        setShowFiatConversionOnTestnetsPreference={() => {}}
+        setThreeBoxSyncingPermission={() => {}}
+        threeBoxDisabled
+        threeBoxSyncingAllowed={false}
       />,
       {
         context: {


### PR DESCRIPTION
This PR adds required props to the `AdvancedTab` component tests to reduce noise in the output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  AdvancedTab Component
Warning: Failed prop type: The prop `setAutoLogoutTimeLimit` is marked as required in `AdvancedTab`, but its value is `undefined`.
    in AdvancedTab
Warning: Failed prop type: The prop `setShowFiatConversionOnTestnetsPreference` is marked as required in `AdvancedTab`, but its value is `undefined`.
    in AdvancedTab
Warning: Failed prop type: The prop `threeBoxSyncingAllowed` is marked as required in `AdvancedTab`, but its value is `undefined`.
    in AdvancedTab
Warning: Failed prop type: The prop `setThreeBoxSyncingPermission` is marked as required in `AdvancedTab`, but its value is `undefined`.
    in AdvancedTab
Warning: Failed prop type: The prop `threeBoxDisabled` is marked as required in `AdvancedTab`, but its value is `undefined`.
    in AdvancedTab
Warning: Failed prop type: The prop `setIpfsGateway` is marked as required in `AdvancedTab`, but its value is `undefined`.
    in AdvancedTab
Warning: Failed prop type: The prop `ipfsGateway` is marked as required in `AdvancedTab`, but its value is `undefined`.
    in AdvancedTab
    ✓ should render correctly when threeBoxFeatureFlag
    ✓ should update autoLogoutTimeLimit


  2 passing (271ms)

✨  Done in 16.95s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  AdvancedTab Component
    ✓ should render correctly when threeBoxFeatureFlag
    ✓ should update autoLogoutTimeLimit


  2 passing (267ms)

✨  Done in 16.34s.
```