### PR TITLE
Add required props & fix propTypes for SendFooter tests

### DIFF
--- a/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
@@ -44,7 +44,7 @@ describe('SendFooter Component', function () {
         to="mockTo"
         toAccounts={['mockAccount']}
         tokenBalance="mockTokenBalance"
-        unapprovedTxs={['mockTx']}
+        unapprovedTxs={{}}
         update={propsMethodSpies.update}
         sendErrors={{}}
       />
@@ -87,36 +87,36 @@ describe('SendFooter Component', function () {
       },
       'should return true if gasTotal is falsy': {
         inError: false,
-        gasTotal: false,
+        gasTotal: '',
         expectedResult: true,
         gasIsLoading: false,
       },
       'should return true if to is truthy': {
         to: '0xsomevalidAddress',
         inError: false,
-        gasTotal: false,
+        gasTotal: '',
         expectedResult: true,
         gasIsLoading: false,
       },
       'should return true if selectedToken is truthy and tokenBalance is falsy': {
-        selectedToken: true,
-        tokenBalance: null,
+        selectedToken: { mockProp: 'mockSelectedTokenProp' },
+        tokenBalance: '',
         expectedResult: true,
         gasIsLoading: false,
       },
       'should return true if gasIsLoading is truthy but all other params are falsy': {
         inError: false,
-        gasTotal: null,
+        gasTotal: '',
         selectedToken: null,
-        tokenBalance: 0,
+        tokenBalance: '',
         expectedResult: true,
         gasIsLoading: true,
       },
       'should return false if inError is false and all other params are truthy': {
         inError: false,
         gasTotal: '0x123',
-        selectedToken: true,
-        tokenBalance: 123,
+        selectedToken: { mockProp: 'mockSelectedTokenProp' },
+        tokenBalance: '123',
         expectedResult: false,
         gasIsLoading: false,
       },
@@ -154,7 +154,7 @@ describe('SendFooter Component', function () {
           gasPrice: 'mockGasPrice',
           selectedToken: { mockProp: 'mockSelectedTokenProp' },
           to: 'mockTo',
-          unapprovedTxs: ['mockTx'],
+          unapprovedTxs: {},
         }
       )
     })
@@ -197,7 +197,7 @@ describe('SendFooter Component', function () {
 
   describe('render', () => {
     beforeEach(() => {
-      sinon.stub(SendFooter.prototype, 'formShouldBeDisabled').returns('formShouldBeDisabledReturn')
+      sinon.stub(SendFooter.prototype, 'formShouldBeDisabled').returns(true)
       wrapper = shallow((
         <SendFooter
           addToAddressBookIfNew={propsMethodSpies.addToAddressBookIfNew}
@@ -217,7 +217,7 @@ describe('SendFooter Component', function () {
           to="mockTo"
           toAccounts={['mockAccount']}
           tokenBalance="mockTokenBalance"
-          unapprovedTxs={['mockTx']}
+          unapprovedTxs={{}}
           update={propsMethodSpies.update}
         />
       ), { context: { t: str => str, metricsEvent: () => ({}) } })
@@ -237,7 +237,7 @@ describe('SendFooter Component', function () {
         onSubmit,
         disabled,
       } = wrapper.find(PageContainerFooter).props()
-      assert.equal(disabled, 'formShouldBeDisabledReturn')
+      assert.equal(disabled, true)
 
       assert.equal(SendFooter.prototype.onSubmit.callCount, 0)
       onSubmit(MOCK_EVENT)


### PR DESCRIPTION
This PR adds required props to the `SendFooter` component tests to reduce noise in the output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  SendFooter Component
    onCancel
Warning: Failed prop type: Invalid prop `unapprovedTxs` of type `array` supplied to `SendFooter`, expected `object`.
    in SendFooter
      ✓ should call clearSend
      ✓ should call history.push
    formShouldBeDisabled()
      ✓ should return true if inError is truthy
Warning: Failed prop type: Invalid prop `gasTotal` of type `boolean` supplied to `SendFooter`, expected `string`.
    in SendFooter
      ✓ should return true if gasTotal is falsy
      ✓ should return true if to is truthy
Warning: Failed prop type: Invalid prop `selectedToken` of type `boolean` supplied to `SendFooter`, expected `object`.
    in SendFooter
      ✓ should return true if selectedToken is truthy and tokenBalance is falsy
Warning: Failed prop type: Invalid prop `tokenBalance` of type `number` supplied to `SendFooter`, expected `string`.
    in SendFooter
      ✓ should return true if gasIsLoading is truthy but all other params are falsy
      ✓ should return false if inError is false and all other params are truthy
    onSubmit
      ✓ should call addToAddressBookIfNew with the correct params
      ✓ should call props.update if editingTransactionId is truthy
      ✓ should not call props.sign if editingTransactionId is truthy
      ✓ should call props.sign if editingTransactionId is falsy
      ✓ should not call props.update if editingTransactionId is falsy
      ✓ should call history.push
    render
Warning: Failed prop type: Invalid prop `disabled` of type `string` supplied to `PageContainerFooter`, expected `boolean`.
    in PageContainerFooter
      ✓ should render a PageContainerFooter component
      ✓ should pass the correct props to PageContainerFooter


  16 passing (340ms)

✨  Done in 17.69s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  SendFooter Component
    onCancel
      ✓ should call clearSend
      ✓ should call history.push
    formShouldBeDisabled()
      ✓ should return true if inError is truthy
      ✓ should return true if gasTotal is falsy
      ✓ should return true if to is truthy
      ✓ should return true if selectedToken is truthy and tokenBalance is falsy
      ✓ should return true if gasIsLoading is truthy but all other params are falsy
      ✓ should return false if inError is false and all other params are truthy
    onSubmit
      ✓ should call addToAddressBookIfNew with the correct params
      ✓ should call props.update if editingTransactionId is truthy
      ✓ should not call props.sign if editingTransactionId is truthy
      ✓ should call props.sign if editingTransactionId is falsy
      ✓ should not call props.update if editingTransactionId is falsy
      ✓ should call history.push
    render
      ✓ should render a PageContainerFooter component
      ✓ should pass the correct props to PageContainerFooter


  16 passing (330ms)

✨  Done in 16.85s.
```