### PR TITLE
Return promises from accountImporter tests

### DIFF
--- a/test/unit/app/account-import-strategies.spec.js
+++ b/test/unit/app/account-import-strategies.spec.js
@@ -13,25 +13,25 @@ describe('Account Import Strategies', function () {
     })
 
     it('throws an error for empty string private key', async () => {
-      assert.rejects(async function () {
+      return assert.rejects(async function () {
         await accountImporter.importAccount('Private Key', [ '' ])
       }, Error, 'no empty strings')
     })
 
     it('throws an error for undefined string private key', async () => {
-      assert.rejects(async function () {
+      return assert.rejects(async function () {
         await accountImporter.importAccount('Private Key', [ undefined ])
       })
     })
 
     it('throws an error for undefined string private key', async () => {
-      assert.rejects(async function () {
+      return assert.rejects(async function () {
         await accountImporter.importAccount('Private Key', [])
       })
     })
 
     it('throws an error for invalid private key', async () => {
-      assert.rejects(async function () {
+      return assert.rejects(async function () {
         await accountImporter.importAccount('Private Key', [ 'popcorn' ])
       })
     })


### PR DESCRIPTION
This PR returns the promises created in some of the accountImporter test cases. I believe this was an existing issue from before #7794.