### PR TITLE
Fix usages of sinon deprecated APIs in MetaMaskController tests

### DIFF
--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -10,9 +10,9 @@ import createTxMeta from '../../../lib/createTxMeta'
 import EthQuery from 'eth-query'
 
 const threeBoxSpies = {
-  init: sinon.spy(),
+  init: sinon.stub(),
   getThreeBoxSyncingState: sinon.stub().returns(true),
-  turnThreeBoxSyncingOn: sinon.spy(),
+  turnThreeBoxSyncingOn: sinon.stub(),
   _registerUpdates: sinon.spy(),
 }
 import proxyquire from 'proxyquire'


### PR DESCRIPTION
This PR removes the deprecated usages of `#reset` on a sinon _spy_ (as opposed to a _stub_) in the `MetaMaskController` tests.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  MetaMaskController
    #getAccounts
      ✓ returns first address when dapp calls web3.eth.getAccounts
    #importAccountWithStrategy
      ✓ adds private key to keyrings in KeyringController
      ✓ adds private key to keyrings in KeyringController
    submitPassword
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ removes any identities that do not correspond to known accounts.
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
sinon.reset is deprecated and will be removed from the public API in a future version of sinon.
      ✓ gets the address from threebox and creates a new 3box instance
    #getGasPrice
      ✓ gives the 50th percentile lowest accepted gas price from recentBlocksController
    #createNewVaultAndKeychain
      ✓ can only create new vault on keyringController once
    #createNewVaultAndRestore
      ✓ should be able to call newVaultAndRestore despite a mistake.
      ✓ should clear previous identities after vault restoration
      ✓ should restore any consecutive accounts with balances
    #getBalance
      ✓ should return the balance known by accountTracker
      ✓ should ask the network for a balance when not known by accountTracker
    #getApi
      ✓ getState
    preferencesController
      ✓ defaults useBlockie to false
      ✓ setUseBlockie to true
    #selectFirstIdentity
      ✓ changes preferences controller select address
      ✓ changes metamask controller selected address
    connectHardware
      ✓ should throw if it receives an unknown device name
      ✓ should add the Trezor Hardware keyring
      ✓ should add the Ledger Hardware keyring
    checkHardwareStatus
      ✓ should throw if it receives an unknown device name
      ✓ should be locked by default
    forgetDevice
      ✓ should throw if it receives an unknown device name
      ✓ should wipe all the keyring info
    unlockHardwareWalletAccount
      ✓ should set unlockedAccount in the keyring
      ✓ should call keyringController.addNewAccount
      ✓ should call keyringController.getAccounts 
      ✓ should call preferencesController.setAddresses
      ✓ should call preferencesController.setSelectedAddress
      ✓ should call preferencesController.setAccountLabel
    #setCustomRpc
      ✓ returns custom RPC that when called
      ✓ changes the network controller rpc
    #setCurrentCurrency
      ✓ defaults to usd
      ✓ sets currency to JPY
    #addNewAccount
      ✓ errors when an primary keyring is does not exist
    #verifyseedPhrase
      ✓ errors when no keying is provided
      ✓ #addNewAccount
    #resetAccount
      ✓ wipes transactions from only the correct network id and with the selected address
    #removeAccount
      ✓ should call preferencesController.removeAddress
      ✓ should call accountTracker.removeAccount
      ✓ should call keyringController.removeAccount
      ✓ should return address
    #setCurrentLocale
      ✓ checks the default currentLocale
      ✓ sets current locale in preferences controller
    #newUnsignedMessage
      ✓ persists address from msg params
      ✓ persists data from msg params
      ✓ sets the status to unapproved
      ✓ sets the type to eth_sign
      ✓ rejects the message
      ✓ errors when signing a message
    #newUnsignedPersonalMessage
      ✓ errors with no from in msgParams
      ✓ persists address from msg params
      ✓ persists data from msg params
      ✓ sets the status to unapproved
      ✓ sets the type to personal_sign
      ✓ rejects the message
      ✓ errors when signing a message
    #setupUntrustedCommunication
      ✓ sets up phishing stream for untrusted communication 
    #setupTrustedCommunication
      ✓ sets up controller dnode api for trusted communication
    #markPasswordForgotten
      ✓ adds and sets forgottenPassword to config data to true
    #unMarkPasswordForgotten
      ✓ adds and sets forgottenPassword to config data to false
    #_onKeyringControllerUpdate
      ✓ should do nothing if there are no keyrings in state
      ✓ should update selected address if keyrings was locked
      ✓ should NOT update selected address if already unlocked


  64 passing (1s)

✨  Done in 18.14s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  MetaMaskController
    #getAccounts
      ✓ returns first address when dapp calls web3.eth.getAccounts
    #importAccountWithStrategy
      ✓ adds private key to keyrings in KeyringController
      ✓ adds private key to keyrings in KeyringController
    submitPassword
      ✓ removes any identities that do not correspond to known accounts.
      ✓ gets the address from threebox and creates a new 3box instance
    #getGasPrice
      ✓ gives the 50th percentile lowest accepted gas price from recentBlocksController
    #createNewVaultAndKeychain
      ✓ can only create new vault on keyringController once
    #createNewVaultAndRestore
      ✓ should be able to call newVaultAndRestore despite a mistake.
      ✓ should clear previous identities after vault restoration
      ✓ should restore any consecutive accounts with balances
    #getBalance
      ✓ should return the balance known by accountTracker
      ✓ should ask the network for a balance when not known by accountTracker
    #getApi
      ✓ getState
    preferencesController
      ✓ defaults useBlockie to false
      ✓ setUseBlockie to true
    #selectFirstIdentity
      ✓ changes preferences controller select address
      ✓ changes metamask controller selected address
    connectHardware
      ✓ should throw if it receives an unknown device name
      ✓ should add the Trezor Hardware keyring
      ✓ should add the Ledger Hardware keyring
    checkHardwareStatus
      ✓ should throw if it receives an unknown device name
      ✓ should be locked by default
    forgetDevice
      ✓ should throw if it receives an unknown device name
      ✓ should wipe all the keyring info
    unlockHardwareWalletAccount
      ✓ should set unlockedAccount in the keyring
      ✓ should call keyringController.addNewAccount
      ✓ should call keyringController.getAccounts 
      ✓ should call preferencesController.setAddresses
      ✓ should call preferencesController.setSelectedAddress
      ✓ should call preferencesController.setAccountLabel
    #setCustomRpc
      ✓ returns custom RPC that when called
      ✓ changes the network controller rpc
    #setCurrentCurrency
      ✓ defaults to usd
      ✓ sets currency to JPY
    #addNewAccount
      ✓ errors when an primary keyring is does not exist
    #verifyseedPhrase
      ✓ errors when no keying is provided
      ✓ #addNewAccount
    #resetAccount
      ✓ wipes transactions from only the correct network id and with the selected address
    #removeAccount
      ✓ should call preferencesController.removeAddress
      ✓ should call accountTracker.removeAccount
      ✓ should call keyringController.removeAccount
      ✓ should return address
    #setCurrentLocale
      ✓ checks the default currentLocale
      ✓ sets current locale in preferences controller
    #newUnsignedMessage
      ✓ persists address from msg params
      ✓ persists data from msg params
      ✓ sets the status to unapproved
      ✓ sets the type to eth_sign
      ✓ rejects the message
      ✓ errors when signing a message
    #newUnsignedPersonalMessage
      ✓ errors with no from in msgParams
      ✓ persists address from msg params
      ✓ persists data from msg params
      ✓ sets the status to unapproved
      ✓ sets the type to personal_sign
      ✓ rejects the message
      ✓ errors when signing a message
    #setupUntrustedCommunication
      ✓ sets up phishing stream for untrusted communication 
    #setupTrustedCommunication
      ✓ sets up controller dnode api for trusted communication
    #markPasswordForgotten
      ✓ adds and sets forgottenPassword to config data to true
    #unMarkPasswordForgotten
      ✓ adds and sets forgottenPassword to config data to false
    #_onKeyringControllerUpdate
      ✓ should do nothing if there are no keyrings in state
      ✓ should update selected address if keyrings was locked
      ✓ should NOT update selected address if already unlocked


  64 passing (1s)

✨  Done in 17.52s.
```