### PR TITLE
Fix prop types for SendGasRow component tests

### DIFF
--- a/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
@@ -21,7 +21,7 @@ describe('SendGasRow Component', function () {
       <SendGasRow
         conversionRate={20}
         convertedCurrency="mockConvertedCurrency"
-        gasFeeError="mockGasFeeError"
+        gasFeeError
         gasLoadingError={false}
         gasTotal="mockGasTotal"
         gasButtonGroupShown={false}
@@ -52,7 +52,7 @@ describe('SendGasRow Component', function () {
       } = wrapper.find(SendRowWrapper).props()
 
       assert.equal(label, 'transactionFee_t:')
-      assert.equal(showError, 'mockGasFeeError')
+      assert.equal(showError, true)
       assert.equal(errorType, 'gasFee')
     })
 


### PR DESCRIPTION
This PR adds required props to the `SendGasRow` component tests to reduce noise in the output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  SendGasRow Component
    render
Warning: Failed prop type: Invalid prop `gasFeeError` of type `string` supplied to `SendGasRow`, expected `boolean`.
    in SendGasRow
Warning: Failed prop type: Invalid prop `showError` of type `string` supplied to `SendRowWrapper`, expected `boolean`.
    in SendRowWrapper
      ✓ should render a SendRowWrapper component
      ✓ should pass the correct props to SendRowWrapper
      ✓ should render a GasFeeDisplay as a child of the SendRowWrapper
      ✓ should render the GasFeeDisplay
      ✓ should render the GasPriceButtonGroup if gasButtonGroupShown is true
      ✓ should render an advanced options button if gasButtonGroupShown is true


  6 passing (344ms)

✨  Done in 20.66s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  SendGasRow Component
    render
      ✓ should render a SendRowWrapper component
      ✓ should pass the correct props to SendRowWrapper
      ✓ should render a GasFeeDisplay as a child of the SendRowWrapper
      ✓ should render the GasFeeDisplay
      ✓ should render the GasPriceButtonGroup if gasButtonGroupShown is true
      ✓ should render an advanced options button if gasButtonGroupShown is true


  6 passing (342ms)

✨  Done in 19.00s.
```