### PR TITLE
Add required props for TransactionListItemDetails tests

### DIFF
--- a/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
+++ b/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
@@ -31,6 +31,9 @@ describe('TransactionListItemDetails Component', () => {
 
     const wrapper = shallow(
       <TransactionListItemDetails
+        recipientAddress="0x1"
+        senderAddress="0x2"
+        tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
       />,
       { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
@@ -69,6 +72,9 @@ describe('TransactionListItemDetails Component', () => {
 
     const wrapper = shallow(
       <TransactionListItemDetails
+        recipientAddress="0x1"
+        senderAddress="0x2"
+        tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
         showSpeedUp
       />,
@@ -102,6 +108,9 @@ describe('TransactionListItemDetails Component', () => {
 
     const wrapper = shallow(
       <TransactionListItemDetails
+        recipientAddress="0x1"
+        senderAddress="0x2"
+        tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
       />,
       { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
@@ -137,6 +146,9 @@ describe('TransactionListItemDetails Component', () => {
 
     const wrapper = shallow(
       <TransactionListItemDetails
+        recipientAddress="0x1"
+        senderAddress="0x2"
+        tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
       />,
       { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }


### PR DESCRIPTION
This PR adds required props to the `TransactionListItemDetails` component tests to reduce noise in the output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  TransactionListItemDetails Component
Warning: Failed prop type: The prop `recipientAddress` is marked as required in `TransactionListItemDetails`, but its value is `undefined`.
    in TransactionListItemDetails
Warning: Failed prop type: The prop `senderAddress` is marked as required in `TransactionListItemDetails`, but its value is `undefined`.
    in TransactionListItemDetails
Warning: Failed prop type: The prop `tryReverseResolveAddress` is marked as required in `TransactionListItemDetails`, but its value is `undefined`.
    in TransactionListItemDetails
    ✓ should render properly
    ✓ should render a retry button
    ✓ should disable the Copy Tx ID and View In Etherscan buttons when tx hash is missing
    ✓ should render functional Copy Tx ID and View In Etherscan buttons when tx hash exists


  4 passing (344ms)

✨  Done in 18.68s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  TransactionListItemDetails Component
    ✓ should render properly (46ms)
    ✓ should render a retry button
    ✓ should disable the Copy Tx ID and View In Etherscan buttons when tx hash is missing
    ✓ should render functional Copy Tx ID and View In Etherscan buttons when tx hash exists


  4 passing (298ms)

✨  Done in 18.98s.
```