### PR TITLE
Clean up Migrator test cases

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -167,6 +167,7 @@ async function initialize () {
 async function loadStateFromPersistence () {
   // migrations
   const migrator = new Migrator({ migrations })
+  migrator.on('error', console.warn)
 
   // read from disk
   // first from preferred, async API:

--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -52,7 +52,6 @@ class Migrator extends EventEmitter {
         // rewrite error message to add context without clobbering stack
         const originalErrorMessage = err.message
         err.message = `MetaMask Migration Error #${migration.version}: ${originalErrorMessage}`
-        console.warn(err.stack)
         // emit error instead of throw so as to not break the run (gracefully fail)
         this.emit('error', err)
         // stop migrating and use state as is

--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -60,33 +60,27 @@ describe('liveMigrations require list', () => {
 
 describe('Migrator', () => {
   const migrator = new Migrator({ migrations: stubMigrations })
-  it('migratedData version should be version 3', (done) => {
-    migrator.migrateData(versionedData)
-      .then((migratedData) => {
-        assert.equal(migratedData.meta.version, stubMigrations[2].version)
-        done()
-      }).catch(done)
+  it('migratedData version should be version 3', async () => {
+    const migratedData = await migrator.migrateData(versionedData)
+    assert.equal(migratedData.meta.version, stubMigrations[2].version)
   })
 
-  it('should match the last version in live migrations', (done) => {
+  it('should match the last version in live migrations', async () => {
     const migrator = new Migrator({ migrations: liveMigrations })
-    migrator.migrateData(firstTimeState)
-      .then((migratedData) => {
-        const last = liveMigrations.length - 1
-        assert.equal(migratedData.meta.version, liveMigrations[last].version)
-        done()
-      }).catch(done)
+    const migratedData = await migrator.migrateData(firstTimeState)
+    const last = liveMigrations.length - 1
+    assert.equal(migratedData.meta.version, liveMigrations[last].version)
   })
 
-  it('should emit an error', function (done) {
-    this.timeout(15000)
-    const migrator = new Migrator({ migrations: [{ version: 1, migrate: async () => {
-      throw new Error('test')
-    } } ] })
-    migrator.on('error', () => done())
-    migrator.migrateData({ meta: { version: 0 } })
-      .then(() => {
-      }).catch(done)
+  it('should emit an error', async () => {
+    const migrator = new Migrator({
+      migrations: [{
+        version: 1,
+        async migrate () {
+          throw new Error('test')
+        },
+      }],
+    })
+    await assert.rejects(migrator.migrateData({ meta: { version: 0 } }))
   })
-
 })


### PR DESCRIPTION
This PR tidies up the `Migrator` tests to reduce noise in the output. I've moved the `console.warn` from the migrator itself to the background script where the app uses it.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  liveMigrations require list
    ✓ should include all the migrations

  Migrator
    ✓ migratedData version should be version 3
    ✓ should match the last version in live migrations
Error: MetaMask Migration Error #1: test
    at Object.migrate (/metamask-extension/test/unit/migrations/migrator-test.js:84:13)
    at Migrator.migrate [as migrateData] (/metamask-extension/app/scripts/lib/migrator/index.js:42:46)
    at Context.migrateData (/metamask-extension/test/unit/migrations/migrator-test.js:87:14)
    at callFnAsync (/metamask-extension/node_modules/mocha/lib/runnable.js:377:21)
    at Test.Runnable.run (/metamask-extension/node_modules/mocha/lib/runnable.js:324:7)
    at Runner.runTest (/metamask-extension/node_modules/mocha/lib/runner.js:442:10)
    at /metamask-extension/node_modules/mocha/lib/runner.js:560:12
    at next (/metamask-extension/node_modules/mocha/lib/runner.js:356:14)
    at /metamask-extension/node_modules/mocha/lib/runner.js:366:7
    at next (/metamask-extension/node_modules/mocha/lib/runner.js:290:14)
    at Immediate.<anonymous> (/metamask-extension/node_modules/mocha/lib/runner.js:334:5)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
    ✓ should emit an error


  4 passing (328ms)

✨  Done in 23.19s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  liveMigrations require list
    ✓ should include all the migrations

  Migrator
    ✓ migratedData version should be version 3
    ✓ should match the last version in live migrations
    ✓ should emit an error


  4 passing (307ms)

✨  Done in 19.16s.
```