### PR TITLE
Fix prop types for NetworkDropdown tests

### DIFF
--- a/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
+++ b/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
@@ -12,12 +12,13 @@ describe('Network Dropdown', () => {
   describe('NetworkDropdown in appState in false', () => {
     const mockState = {
       metamask: {
+        network: '1',
         provider: {
           type: 'test',
         },
       },
       appState: {
-        networkDropdown: false,
+        networkDropdownOpen: false,
       },
     }
 
@@ -42,6 +43,7 @@ describe('Network Dropdown', () => {
   describe('NetworkDropdown in appState is true', () => {
     const mockState = {
       metamask: {
+        network: '1',
         provider: {
           'type': 'test',
         },


### PR DESCRIPTION
This PR adds required props to the `NetworkDropdown` component tests to reduce noise in the output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Network Dropdown
    NetworkDropdown in appState in false
Warning: Failed prop type: The prop `network` is marked as required in `NetworkDropdown`, but its value is `undefined`.
    in NetworkDropdown (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(NetworkDropdown))
    in Router (created by BrowserRouter)
    in BrowserRouter (created by Wrapper)
    in Wrapper (created by WrapperComponent)
    in WrapperComponent
Warning: Failed prop type: The prop `networkDropdownOpen` is marked as required in `NetworkDropdown`, but its value is `undefined`.
    in NetworkDropdown (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(NetworkDropdown))
    in Router (created by BrowserRouter)
    in BrowserRouter (created by Wrapper)
    in Wrapper (created by WrapperComponent)
    in WrapperComponent
Warning: Failed prop type: The prop `isOpen` is marked as required in `Dropdown`, but its value is `undefined`.
    in Dropdown (created by NetworkDropdown)
    in NetworkDropdown (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(NetworkDropdown))
    in Router (created by BrowserRouter)
    in BrowserRouter (created by Wrapper)
    in Wrapper (created by WrapperComponent)
    in WrapperComponent
Warning: Failed prop type: The prop `isOpen` is marked as required in `MenuDroppoComponent`, but its value is `undefined`.
    in MenuDroppoComponent (created by Dropdown)
    in Dropdown (created by NetworkDropdown)
    in NetworkDropdown (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(NetworkDropdown))
    in Router (created by BrowserRouter)
    in BrowserRouter (created by Wrapper)
    in Wrapper (created by WrapperComponent)
    in WrapperComponent
      ✓ checks for network droppo class
      ✓ renders only one child when networkDropdown is false in state
    NetworkDropdown in appState is true
      ✓ renders 7 DropDownMenuItems 
      ✓ checks background color for first NetworkDropdownIcon
      ✓ checks background color for second NetworkDropdownIcon
      ✓ checks background color for third NetworkDropdownIcon
      ✓ checks background color for fourth NetworkDropdownIcon
      ✓ checks background color for fifth NetworkDropdownIcon
      ✓ checks background color for sixth NetworkDropdownIcon
      ✓ checks dropdown for frequestRPCList from  state 
      ✓ checks background color for seventh NetworkDropdownIcon


  11 passing (445ms)

✨  Done in 17.49s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Network Dropdown
    NetworkDropdown in appState in false
      ✓ checks for network droppo class
      ✓ renders only one child when networkDropdown is false in state
    NetworkDropdown in appState is true
      ✓ renders 7 DropDownMenuItems 
      ✓ checks background color for first NetworkDropdownIcon
      ✓ checks background color for second NetworkDropdownIcon
      ✓ checks background color for third NetworkDropdownIcon
      ✓ checks background color for fourth NetworkDropdownIcon
      ✓ checks background color for fifth NetworkDropdownIcon
      ✓ checks background color for sixth NetworkDropdownIcon
      ✓ checks dropdown for frequestRPCList from  state 
      ✓ checks background color for seventh NetworkDropdownIcon


  11 passing (441ms)

✨  Done in 18.14s.
```