### PR TITLE
Remove extraneous console output from TransactionStateManager tests

### DIFF
--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -56,10 +56,7 @@ describe('TransactionStateManager', function () {
     it('should emit a rejected event to signal the exciton of callback', (done) => {
       const tx = { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }
       txStateManager.addTx(tx)
-      const noop = function (err) {
-        if (err) {
-          console.log('Error: ', err)
-        }
+      const noop = () => {
         assert(true, 'event listener has been triggered and noop executed')
         done()
       }


### PR DESCRIPTION
This PR removes the single use of `console.log` from the `TransactionStateManager` tests to reduce noise in the output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  TransactionStateManager
    #setTxStatusSigned
      ✓ sets the tx status to signed
      ✓ should emit a signed event to signal the exciton of callback
    #setTxStatusRejected
      ✓ sets the tx status to rejected and removes it from history
Error:  1
      ✓ should emit a rejected event to signal the exciton of callback
    #getFullTxList
      ✓ when new should return empty array
    #getTxList
      ✓ when new should return empty array
    #addTx
      ✓ adds a tx returned in getTxList
      ✓ throws error and does not add tx if txParams are invalid
      ✓ does not override txs from other networks
      ✓ cuts off early txs beyond a limit
      ✓ cuts off early txs beyond a limit whether or not it is confirmed or rejected
      ✓ cuts off early txs beyond a limit but does not cut unapproved txs
    #updateTx
      ✓ replaces the tx with the same id
      ✓ throws error and does not update tx if txParams are invalid
      ✓ updates gas price and adds history items
    #getUnapprovedTxList
      ✓ returns unapproved txs in a hash
    #getTx
      ✓ returns a tx with the requested id
    #getFilteredTxList
      ✓ returns a tx with the requested data
    #wipeTransactions
      ✓ should remove only the transactions from a specific address
      ✓ should not remove the transactions from other networks
    #_removeTx
      ✓ should remove the transaction from the storage
      ✓ should only remove the transaction with ID 1 from the storage


  22 passing (306ms)

✨  Done in 16.27s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  TransactionStateManager
    #setTxStatusSigned
      ✓ sets the tx status to signed
      ✓ should emit a signed event to signal the exciton of callback
    #setTxStatusRejected
      ✓ sets the tx status to rejected and removes it from history
      ✓ should emit a rejected event to signal the exciton of callback
    #getFullTxList
      ✓ when new should return empty array
    #getTxList
      ✓ when new should return empty array
    #addTx
      ✓ adds a tx returned in getTxList
      ✓ throws error and does not add tx if txParams are invalid
      ✓ does not override txs from other networks
      ✓ cuts off early txs beyond a limit
      ✓ cuts off early txs beyond a limit whether or not it is confirmed or rejected
      ✓ cuts off early txs beyond a limit but does not cut unapproved txs
    #updateTx
      ✓ replaces the tx with the same id
      ✓ throws error and does not update tx if txParams are invalid
      ✓ updates gas price and adds history items
    #getUnapprovedTxList
      ✓ returns unapproved txs in a hash
    #getTx
      ✓ returns a tx with the requested id
    #getFilteredTxList
      ✓ returns a tx with the requested data
    #wipeTransactions
      ✓ should remove only the transactions from a specific address
      ✓ should not remove the transactions from other networks
    #_removeTx
      ✓ should remove the transaction from the storage
      ✓ should only remove the transaction with ID 1 from the storage


  22 passing (326ms)

✨  Done in 17.53s.
```