### PR TITLE
Update `react-transition-group` to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "react-tippy": "^1.2.2",
     "react-toggle-button": "^2.2.0",
     "react-tooltip-component": "^0.3.0",
-    "react-transition-group": "^1.2.1",
+    "react-transition-group": "^4.3.0",
     "react-trigger-change": "^1.0.2",
     "readable-stream": "^2.3.3",
     "recompose": "^0.25.0",

--- a/ui/app/components/app/menu-droppo.js
+++ b/ui/app/components/app/menu-droppo.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { findDOMNode } from 'react-dom'
-import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
+import { TransitionGroup, CSSTransition } from 'react-transition-group'
 
 export default class MenuDroppoComponent extends Component {
   static propTypes = {
@@ -71,7 +71,8 @@ export default class MenuDroppoComponent extends Component {
 
   render () {
     const { containerClassName = '', style } = this.props
-    const speed = this.props.speed || '300ms'
+    const speedStyle = this.props.speed || '300ms'
+    const speed = parseInt(speedStyle)
     const useCssTransition = this.props.useCssTransition
     const zIndex = ('zIndex' in this.props) ? this.props.zIndex : 0
 
@@ -87,22 +88,22 @@ export default class MenuDroppoComponent extends Component {
       <div style={baseStyle} className={`menu-droppo-container ${containerClassName}`}>
         <style>{`
           .menu-droppo-enter {
-            transition: transform ${speed} ease-in-out;
+            transition: transform ${speedStyle} ease-in-out;
             transform: translateY(-200%);
           }
 
           .menu-droppo-enter.menu-droppo-enter-active {
-            transition: transform ${speed} ease-in-out;
+            transition: transform ${speedStyle} ease-in-out;
             transform: translateY(0%);
           }
 
-          .menu-droppo-leave {
-            transition: transform ${speed} ease-in-out;
+          .menu-droppo-exit {
+            transition: transform ${speedStyle} ease-in-out;
             transform: translateY(0%);
           }
 
-          .menu-droppo-leave.menu-droppo-leave-active {
-            transition: transform ${speed} ease-in-out;
+          .menu-droppo-exit.menu-droppo-exit-active {
+            transition: transform ${speedStyle} ease-in-out;
             transform: translateY(-200%);
           }
         `}
@@ -110,14 +111,14 @@ export default class MenuDroppoComponent extends Component {
         {
           useCssTransition
             ? (
-              <ReactCSSTransitionGroup
-                className="css-transition-group"
-                transitionName="menu-droppo"
-                transitionEnterTimeout={parseInt(speed)}
-                transitionLeaveTimeout={parseInt(speed)}
-              >
-                {this.renderPrimary()}
-              </ReactCSSTransitionGroup>
+              <TransitionGroup>
+                <CSSTransition
+                  classNames="menu-droppo"
+                  timeout={speed}
+                >
+                  {this.renderPrimary()}
+                </CSSTransition>
+              </TransitionGroup>
             )
             : this.renderPrimary()
         }

--- a/ui/app/components/app/sidebars/index.scss
+++ b/ui/app/components/app/sidebars/index.scss
@@ -10,12 +10,12 @@
   transform: translateX(0%);
 }
 
-.sidebar-right-leave {
+.sidebar-right-exit {
   transition: transform 200ms ease-out;
   transform: translateX(0%);
 }
 
-.sidebar-right-leave.sidebar-right-leave-active {
+.sidebar-right-exit.sidebar-right-exit-active {
   transition: transform 200ms ease-out;
   transform: translateX(-100%);
 }
@@ -30,12 +30,12 @@
   transform: translateX(0%);
 }
 
-.sidebar-left-leave {
+.sidebar-left-exit {
   transition: transform 200ms ease-out;
   transform: translateX(0%);
 }
 
-.sidebar-left-leave.sidebar-left-leave-active {
+.sidebar-left-exit.sidebar-left-exit-active {
   transition: transform 200ms ease-out;
   transform: translateX(100%);
 }

--- a/ui/app/components/app/sidebars/sidebar.component.js
+++ b/ui/app/components/app/sidebars/sidebar.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
+import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import WalletView from '../wallet-view'
 import { WALLET_VIEW_SIDEBAR } from './sidebar.constants'
 import CustomizeGas from '../gas-customization/gas-modal-page-container'
@@ -56,13 +56,14 @@ export default class Sidebar extends Component {
 
     return (
       <div>
-        <ReactCSSTransitionGroup
-          transitionName={transitionName}
-          transitionEnterTimeout={300}
-          transitionLeaveTimeout={200}
-        >
-          { sidebarOpen && !sidebarShouldClose ? this.renderSidebarContent() : null }
-        </ReactCSSTransitionGroup>
+        <TransitionGroup>
+          <CSSTransition
+            classNames={transitionName}
+            timeout={{ enter: 300, leave: 200 }}
+          >
+            { sidebarOpen && !sidebarShouldClose ? this.renderSidebarContent() : null }
+          </CSSTransition>
+        </TransitionGroup>
         { sidebarOpen && !sidebarShouldClose ? this.renderOverlay() : null }
       </div>
     )

--- a/ui/app/components/app/sidebars/sidebar.component.js
+++ b/ui/app/components/app/sidebars/sidebar.component.js
@@ -12,7 +12,7 @@ export default class Sidebar extends Component {
     hideSidebar: PropTypes.func,
     sidebarShouldClose: PropTypes.bool,
     transitionName: PropTypes.string,
-    type: PropTypes.string,
+    type: PropTypes.oneOf(WALLET_VIEW_SIDEBAR, 'customize-gas'),
     sidebarProps: PropTypes.object,
     onOverlayClose: PropTypes.func,
   }
@@ -52,18 +52,24 @@ export default class Sidebar extends Component {
   }
 
   render () {
-    const { transitionName, sidebarOpen, sidebarShouldClose } = this.props
+    const { transitionName, sidebarOpen, sidebarShouldClose, type } = this.props
 
     return (
       <div>
-        <TransitionGroup>
-          <CSSTransition
-            classNames={transitionName}
-            timeout={{ enter: 300, leave: 200 }}
-          >
-            { sidebarOpen && !sidebarShouldClose ? this.renderSidebarContent() : null }
-          </CSSTransition>
-        </TransitionGroup>
+        {
+          type && sidebarOpen && !sidebarShouldClose
+            ? (
+              <TransitionGroup>
+                <CSSTransition
+                  classNames={transitionName}
+                  timeout={{ enter: 300, leave: 200 }}
+                >
+                  { this.renderSidebarContent() }
+                </CSSTransition>
+              </TransitionGroup>
+            )
+            : null
+        }
         { sidebarOpen && !sidebarShouldClose ? this.renderOverlay() : null }
       </div>
     )

--- a/ui/app/components/app/sidebars/tests/sidebars-component.test.js
+++ b/ui/app/components/app/sidebars/tests/sidebars-component.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import assert from 'assert'
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
-import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
+import { CSSTransition } from 'react-transition-group'
 import Sidebar from '../sidebar.component.js'
 
 import WalletView from '../../wallet-view'
@@ -83,17 +83,15 @@ describe('Sidebar Component', function () {
       assert.equal(wrapper.children().length, 1)
     })
 
-    it('should render the ReactCSSTransitionGroup without any children', () => {
-      assert(wrapper.children().at(0).is(ReactCSSTransitionGroup))
-      assert.equal(wrapper.children().at(0).children().length, 0)
+    it('should render the CSSTransition without any children', () => {
+      const transition = wrapper.find(CSSTransition)
+      assert.equal(transition.children().length, 0)
     })
 
     it('should render sidebar content and the overlay if sidebarOpen is true', () => {
       wrapper.setProps({ sidebarOpen: true })
-      assert.equal(wrapper.children().length, 2)
-      assert(wrapper.children().at(1).hasClass('sidebar-overlay'))
-      assert.equal(wrapper.children().at(0).children().length, 1)
-      assert(wrapper.children().at(0).children().at(0).is(WalletView))
+      assert(wrapper.find('.sidebar-overlay').length, 1)
+      assert(wrapper.find(WalletView).length, 1)
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,6 +1330,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
@@ -6632,11 +6639,6 @@ chai@^4.1.0:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chain-function@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
-  integrity sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg==
-
 chalk@2.3.2, chalk@^2.3.0, chalk@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
@@ -7948,6 +7950,11 @@ csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
   integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
 
+csstype@^2.6.7:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
+  integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
+
 currency-formatter@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/currency-formatter/-/currency-formatter-1.4.2.tgz#9da20b3706f7a42daf73b356b09a2a2b76ff3870"
@@ -9055,17 +9062,25 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.2.0, dom-helpers@^3.4.0:
+dom-helpers@^3.2.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
+  integrity sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==
+
+dom-helpers@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-helpers@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
-  integrity sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==
+dom-helpers@^5.0.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.3.tgz#7233248eb3a2d1f74aafca31e52c5299cc8ce821"
+  integrity sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    csstype "^2.6.7"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -21810,7 +21825,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.5.6, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -22921,17 +22936,6 @@ react-tooltip-component@^0.3.0:
   resolved "https://registry.yarnpkg.com/react-tooltip-component/-/react-tooltip-component-0.3.0.tgz#fb3ec78c3270fe919692bc31f1404108bcf4785e"
   integrity sha1-+z7HjDJw/pGWkrwx8UBBCLz0eF4=
 
-react-transition-group@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
-  integrity sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==
-  dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
-
 react-transition-group@^2.2.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
@@ -22941,6 +22945,16 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
+  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-trigger-change@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
v1 of this package is no longer maintained, and was not updated for React v16 compatibility. As a result, warnings about this package were being thrown in the console.

The update to v4 was done following this v1 to v2 migration guide:
https://github.com/reactjs/react-transition-group/blob/master/Migration.md

The differences between v2 and v4 are minimal, and didn't affect us.