### PR TITLE
Fix propTypes for TransactionBreakdown component

### DIFF
--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -14,7 +14,7 @@ export default class TransactionBreakdown extends PureComponent {
 
   static propTypes = {
     className: PropTypes.string,
-    nativeCurrency: PropTypes.string.isRequired,
+    nativeCurrency: PropTypes.string,
     showFiat: PropTypes.bool,
     gas: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
This PR fixes the propTypes for the `TransactionBreakdown` component to reduce noise in the test output. The `nativeCurrency` prop isn't actually required because the `CurrencyDisplayContainer` will handle it not being set.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  TransactionBreakdown Component
Warning: Failed prop type: The prop `nativeCurrency` is marked as required in `TransactionBreakdown`, but its value is `undefined`.
    in TransactionBreakdown
    ✓ should render properly


  1 passing (263ms)

✨  Done in 22.10s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  TransactionBreakdown Component
    ✓ should render properly


  1 passing (232ms)

✨  Done in 18.56s.
```