### PR TITLE
Fix propTypes and test props for SignatureRequest component

### DIFF
--- a/ui/app/components/app/signature-request/signature-request-header/signature-request-header.component.js
+++ b/ui/app/components/app/signature-request/signature-request-header/signature-request-header.component.js
@@ -5,7 +5,7 @@ import NetworkDisplay from '../../network-display'
 
 export default class SignatureRequestHeader extends PureComponent {
   static propTypes = {
-    selectedAccount: PropTypes.object.isRequired,
+    selectedAccount: PropTypes.object,
   }
 
   render () {

--- a/ui/app/components/app/signature-request/signature-request.component.js
+++ b/ui/app/components/app/signature-request/signature-request.component.js
@@ -14,7 +14,7 @@ export default class SignatureRequest extends PureComponent {
       address: PropTypes.string,
       balance: PropTypes.string,
       name: PropTypes.string,
-    }).isRequired,
+    }),
 
     clearConfirmTransaction: PropTypes.func.isRequired,
     cancel: PropTypes.func.isRequired,

--- a/ui/app/components/app/signature-request/tests/signature-request.test.js
+++ b/ui/app/components/app/signature-request/tests/signature-request.test.js
@@ -10,6 +10,9 @@ describe('Signature Request Component', function () {
   beforeEach(() => {
     wrapper = shallow((
       <SignatureRequest
+        clearConfirmTransaction={() => {}}
+        cancel={() => {}}
+        sign={() => {}}
         txData={{
           msgParams: {
             data: '{"message": {"from": {"name": "hello"}}}',


### PR DESCRIPTION
This PR fixes the `propTypes` for the `SignatureRequest` component and adds the required props to the tests to reduce noise in the output. The `selectedAccount` prop isn't actually required because the `Header` component will test its existence.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Signature Request Component
    render
Warning: Failed prop type: The prop `selectedAccount` is marked as required in `SignatureRequest`, but its value is `undefined`.
    in SignatureRequest
Warning: Failed prop type: The prop `clearConfirmTransaction` is marked as required in `SignatureRequest`, but its value is `undefined`.
    in SignatureRequest
Warning: Failed prop type: The prop `cancel` is marked as required in `SignatureRequest`, but its value is `undefined`.
    in SignatureRequest
Warning: Failed prop type: The prop `sign` is marked as required in `SignatureRequest`, but its value is `undefined`.
    in SignatureRequest
Warning: Failed prop type: The prop `selectedAccount` is marked as required in `SignatureRequestHeader`, but its value is `undefined`.
    in SignatureRequestHeader
Warning: Failed prop type: The prop `cancelAction` is marked as required in `SignatureRequestFooter`, but its value is `undefined`.
    in SignatureRequestFooter
Warning: Failed prop type: The prop `signAction` is marked as required in `SignatureRequestFooter`, but its value is `undefined`.
    in SignatureRequestFooter
      ✓ should render a div with one child


  1 passing (254ms)

✨  Done in 17.87s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Signature Request Component
    render
      ✓ should render a div with one child


  1 passing (253ms)

✨  Done in 18.28s.
```