### PR TITLE
Fix props for BasicTabContent component tests

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
@@ -5,6 +5,7 @@ import BasicTabContent from '../basic-tab-content.component'
 
 import GasPriceButtonGroup from '../../../gas-price-button-group'
 import Loading from '../../../../../ui/loading-screen'
+import { GAS_ESTIMATE_TYPES } from '../../../../../../helpers/constants/common'
 
 const mockGasPriceButtonGroupProps = {
   buttonDataLoading: false,
@@ -15,18 +16,21 @@ const mockGasPriceButtonGroupProps = {
       feeInSecondaryCurrency: '0.0048 ETH',
       timeEstimate: '~ 1 min 0 sec',
       priceInHexWei: '0xa1b2c3f',
+      gasEstimateType: GAS_ESTIMATE_TYPES.AVERAGE,
     },
     {
       feeInPrimaryCurrency: '$0.39',
       feeInSecondaryCurrency: '0.004 ETH',
       timeEstimate: '~ 1 min 30 sec',
       priceInHexWei: '0xa1b2c39',
+      gasEstimateType: GAS_ESTIMATE_TYPES.AVERAGE,
     },
     {
       feeInPrimaryCurrency: '$0.30',
       feeInSecondaryCurrency: '0.00354 ETH',
       timeEstimate: '~ 2 min 1 sec',
       priceInHexWei: '0xa1b2c30',
+      gasEstimateType: GAS_ESTIMATE_TYPES.AVERAGE,
     },
   ],
   handleGasPriceSelection: newPrice => console.log('NewPrice: ', newPrice),


### PR DESCRIPTION
This PR adds required props to the `BasicTabContent` component tests to reduce noise in the output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  BasicTabContent Component
    render
Warning: Failed prop type: The prop `gasButtonInfo[1].gasEstimateType` is marked as required in `GasPriceButtonGroup`, but its value is `undefined`.
    in GasPriceButtonGroup
      ✓ should have a title
      ✓ should render a GasPriceButtonGroup compenent
      ✓ should pass correct props to GasPriceButtonGroup
      ✓ should render a loading component instead of the GasPriceButtonGroup if gasPriceButtonGroupProps.loading is true


  4 passing (302ms)

✨  Done in 17.98s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  BasicTabContent Component
    render
      ✓ should have a title
      ✓ should render a GasPriceButtonGroup compenent
      ✓ should pass correct props to GasPriceButtonGroup
      ✓ should render a loading component instead of the GasPriceButtonGroup if gasPriceButtonGroupProps.loading is true


  4 passing (312ms)

✨  Done in 19.08s.
```