### PR TITLE
Fix propTypes and test props for Dropdown components

### DIFF
--- a/test/unit/responsive/components/dropdown-test.js
+++ b/test/unit/responsive/components/dropdown-test.js
@@ -12,7 +12,6 @@ const mockState = {
 
 describe('Dropdown components', function () {
   let onClickOutside
-  let closeMenu
   let onClick
 
   const dropdownComponentProps = {
@@ -32,7 +31,6 @@ describe('Dropdown components', function () {
   let component
   beforeEach(function () {
     onClickOutside = sinon.spy()
-    closeMenu = sinon.spy()
     onClick = sinon.spy()
 
     store = createMockStore(mockState)
@@ -46,8 +44,8 @@ describe('Dropdown components', function () {
             `
           }
         </style>
-        <li closeMenu={closeMenu} onClick={onClick}>Item 1</li>
-        <li closeMenu={closeMenu} onClick={onClick}>Item 2</li>
+        <li onClick={onClick}>Item 1</li>
+        <li onClick={onClick}>Item 2</li>
       </Dropdown>
     ), store)
     dropdownComponent = component
@@ -58,17 +56,10 @@ describe('Dropdown components', function () {
     assert.equal(items.length, 2)
   })
 
-  it('closes when item clicked', function () {
-    const items = dropdownComponent.find('li')
-    const node = items.at(0)
-    node.simulate('click')
-    assert.equal(node.props().closeMenu, closeMenu)
-  })
-
   it('invokes click handler when item clicked', function () {
     const items = dropdownComponent.find('li')
     const node = items.at(0)
     node.simulate('click')
-    assert.equal(onClick.calledOnce, true)
+    assert.ok(onClick.calledOnce)
   })
 })

--- a/ui/app/components/app/menu-droppo.js
+++ b/ui/app/components/app/menu-droppo.js
@@ -8,7 +8,7 @@ export default class MenuDroppoComponent extends Component {
     isOpen: PropTypes.bool.isRequired,
     innerStyle: PropTypes.object,
     children: PropTypes.node.isRequired,
-    onClickOutside: PropTypes.func.isRequired,
+    onClickOutside: PropTypes.func,
     containerClassName: PropTypes.string,
     zIndex: PropTypes.number,
     style: PropTypes.object.isRequired,


### PR DESCRIPTION
This PR cleans up the `propTypes` and tests for the `Dropdown` components, reducing noise in the test output. The `onClickOutside` props isn't actually required because the component it's passed to (`MenuDroppoComponent`) will test its existence (via `outsideClickHandler`). I've deleted the "closes when item clicked" test case here because it wasn't testing the correct functionality—`closeMenu` isn't called and shouldn't be a prop on the node.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Dropdown components
Warning: Failed prop type: The prop `onClickOutside` is marked as required in `MenuDroppoComponent`, but its value is `undefined`.
    in MenuDroppoComponent (created by Dropdown)
    in Dropdown (created by WrapperComponent)
    in WrapperComponent
Warning: React does not recognize the `closeMenu` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `closemenu` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in li
    in div (created by MenuDroppoComponent)
    in div (created by MenuDroppoComponent)
    in MenuDroppoComponent (created by Dropdown)
    in Dropdown (created by WrapperComponent)
    in WrapperComponent
    ✓ can render two items
    ✓ closes when item clicked
    ✓ invokes click handler when item clicked


  3 passing (278ms)

✨  Done in 16.07s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Dropdown components
    ✓ can render two items
    ✓ invokes click handler when item clicked


  2 passing (276ms)

✨  Done in 17.31s.
```