### PR TITLE
Inline networkStore to avoid having too many event listeners

### DIFF
--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -19,7 +19,6 @@ import { createTestProviderTools, getTestAccounts } from '../../../../stub/provi
 
 const noop = () => true
 const currentNetworkId = 42
-const netStore = new ObservableStore(currentNetworkId)
 
 describe('Transaction Controller', function () {
   let txController, provider, providerResultStub, fromAccount
@@ -41,7 +40,7 @@ describe('Transaction Controller', function () {
       getGasPrice: function () {
         return '0xee6b2800'
       },
-      networkStore: netStore,
+      networkStore: new ObservableStore(currentNetworkId),
       txHistoryLimit: 10,
       blockTracker: blockTrackerStub,
       signTransaction: (ethTx) => new Promise((resolve) => {


### PR DESCRIPTION
This PR inlines the networkStore obs store to avoid having too many listeners attached to it (that is, each test was constructing a new tx controller that was attaching to the same store).

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Transaction Controller
    #getState
      ✓ should return a state object with the right keys and datat types
    #getUnapprovedTxCount
      ✓ should return the number of unapproved txs
    #getPendingTxCount
      ✓ should return the number of pending txs
    #getConfirmedTransactions
      ✓ should return the number of confirmed txs
    #newUnapprovedTransaction
      ✓ should resolve when finished and status is submitted and resolve with the hash
      ✓ should reject when finished and status is rejected
    #addUnapprovedTransaction
      ✓ should add an unapproved transaction and return a valid txMeta (77ms)
      ✓ should emit newUnapprovedTx event and pass txMeta as the first argument
      ✓ should fail if recipient is public
      ✓ should fail if the from address isn't the selected address
{ MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 update listeners added. Use emitter.setMaxListeners() to increase limit
    at _addListener (/metamask-extension/node_modules/events/events.js:206:15)
    at ObservableStore.addListener (/metamask-extension/node_modules/events/events.js:222:10)
    at ObservableStore.on [as subscribe] (/metamask-extension/node_modules/obs-store/index.js:39:10)
    at new subscribe (/metamask-extension/app/scripts/controllers/transactions/index.js:118:23)
    at Context.<anonymous> (/metamask-extension/test/unit/app/controllers/transactions/tx-controller-test.js:39:20)
    at callFn (/metamask-extension/node_modules/mocha/lib/runnable.js:354:21)
    at Hook.Runnable.run (/metamask-extension/node_modules/mocha/lib/runnable.js:346:7)
    at next (/metamask-extension/node_modules/mocha/lib/runner.js:304:10)
    at Immediate._onImmediate (/metamask-extension/node_modules/mocha/lib/runner.js:334:5)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
  name: 'MaxListenersExceededWarning',
  emitter:
   ObservableStore {
     _events: [Object: null prototype] { update: [Array] },
     _eventsCount: 1,
     _maxListeners: undefined,
     _state: 42 },
  type: 'update',
  count: 11 }
      ✓ should not fail if recipient is public but not on mainnet
      ✓ should fail if netId is loading
    #addTxGasDefaults
      ✓ should add the tx defaults if their are none
    #addTx
      ✓ should emit updates
    #approveTransaction
      ✓ does not overwrite set values
    #sign replay-protected tx
      ✓ prepares a tx with the chainId set
    #updateAndApproveTransaction
      ✓ should update and approve transactions (67ms)
    #getChainId
      ✓ returns 0 when the chainId is NaN
    #cancelTransaction
      ✓ should emit a status change to rejected
    #createSpeedUpTransaction
      ✓ should call this.addTx and this.approveTransaction with the expected args (49ms)
      ✓ should call this.approveTransaction with the id of the returned tx
      ✓ should return the expected txMeta
    #publishTransaction
      ✓ should publish a tx, updates the rawTx when provided a one
      ✓ should ignore the error "Transaction Failed: known transaction" and be as usual
    #retryTransaction
      ✓ should create a new txMeta with the same txParams as the original one but with a higher gasPrice
    #_markNonceDuplicatesDropped
      ✓ should mark all nonce duplicates as dropped without marking the confirmed transaction as dropped
    #_determineTransactionCategory
      ✓ should return a simple send transactionCategory when to is truthy but data is falsey
      ✓ should return a token transfer transactionCategory when data is for the respective method call
      ✓ should return a token approve transactionCategory when data is for the respective method call
      ✓ should return a contract deployment transactionCategory when to is falsey and there is data
      ✓ should return a simple send transactionCategory with a 0x getCodeResponse when there is data and but the to address is not a contract address
      ✓ should return a simple send transactionCategory with a null getCodeResponse when to is truthy and there is data and but getCode returns an error
      ✓ should return a contract interaction transactionCategory with the correct getCodeResponse when to is truthy and there is data and it is not a token transaction
      ✓ should return a contract interaction transactionCategory with the correct getCodeResponse when to is a contract address and data is falsey
    #getPendingTransactions
      ✓ should show only submitted and approved transactions as pending transasction


  35 passing (1s)

✨  Done in 20.05s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Transaction Controller
    #getState
      ✓ should return a state object with the right keys and datat types
    #getUnapprovedTxCount
      ✓ should return the number of unapproved txs
    #getPendingTxCount
      ✓ should return the number of pending txs
    #getConfirmedTransactions
      ✓ should return the number of confirmed txs
    #newUnapprovedTransaction
      ✓ should resolve when finished and status is submitted and resolve with the hash
      ✓ should reject when finished and status is rejected
    #addUnapprovedTransaction
      ✓ should add an unapproved transaction and return a valid txMeta (70ms)
      ✓ should emit newUnapprovedTx event and pass txMeta as the first argument
      ✓ should fail if recipient is public
      ✓ should fail if the from address isn't the selected address
      ✓ should not fail if recipient is public but not on mainnet
      ✓ should fail if netId is loading
    #addTxGasDefaults
      ✓ should add the tx defaults if their are none
    #addTx
      ✓ should emit updates
    #approveTransaction
      ✓ does not overwrite set values
    #sign replay-protected tx
      ✓ prepares a tx with the chainId set
    #updateAndApproveTransaction
      ✓ should update and approve transactions (75ms)
    #getChainId
      ✓ returns 0 when the chainId is NaN
    #cancelTransaction
      ✓ should emit a status change to rejected
    #createSpeedUpTransaction
      ✓ should call this.addTx and this.approveTransaction with the expected args (49ms)
      ✓ should call this.approveTransaction with the id of the returned tx
      ✓ should return the expected txMeta
    #publishTransaction
      ✓ should publish a tx, updates the rawTx when provided a one
      ✓ should ignore the error "Transaction Failed: known transaction" and be as usual
    #retryTransaction
      ✓ should create a new txMeta with the same txParams as the original one but with a higher gasPrice
    #_markNonceDuplicatesDropped
      ✓ should mark all nonce duplicates as dropped without marking the confirmed transaction as dropped
    #_determineTransactionCategory
      ✓ should return a simple send transactionCategory when to is truthy but data is falsey
      ✓ should return a token transfer transactionCategory when data is for the respective method call
      ✓ should return a token approve transactionCategory when data is for the respective method call
      ✓ should return a contract deployment transactionCategory when to is falsey and there is data
      ✓ should return a simple send transactionCategory with a 0x getCodeResponse when there is data and but the to address is not a contract address
      ✓ should return a simple send transactionCategory with a null getCodeResponse when to is truthy and there is data and but getCode returns an error
      ✓ should return a contract interaction transactionCategory with the correct getCodeResponse when to is truthy and there is data and it is not a token transaction
      ✓ should return a contract interaction transactionCategory with the correct getCodeResponse when to is a contract address and data is falsey
    #getPendingTransactions
      ✓ should show only submitted and approved transactions as pending transasction


  35 passing (1s)

✨  Done in 17.19s.
```