### PR TITLE
Clean up "JSON File" import strategy test output

### DIFF
--- a/app/scripts/account-import-strategies/index.js
+++ b/app/scripts/account-import-strategies/index.js
@@ -1,3 +1,4 @@
+import log from 'loglevel'
 import Wallet from 'ethereumjs-wallet'
 import importers from 'ethereumjs-wallet/thirdparty'
 import ethUtil from 'ethereumjs-util'
@@ -35,10 +36,7 @@ const accountImporter = {
       try {
         wallet = importers.fromEtherWallet(input, password)
       } catch (e) {
-        console.log('Attempt to import as EtherWallet format failed, trying V3...')
-      }
-
-      if (!wallet) {
+        log.debug('Attempt to import as EtherWallet format failed, trying V3')
         wallet = Wallet.fromV3(input, password, true)
       }
 


### PR DESCRIPTION
This PR cleans up the "JSON File" import strategy test output.

**Before:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Account Import Strategies
    private key import
      ✓ imports a private key and strips 0x prefix
      ✓ throws an error for empty string private key
      ✓ throws an error for undefined string private key
      ✓ throws an error for undefined string private key
      ✓ throws an error for invalid private key
    JSON keystore import
Attempt to import as EtherWallet format failed, trying V3...
      ✓ fails when password is incorrect for keystore
Attempt to import as EtherWallet format failed, trying V3...
      ✓ imports json string and password to return a private key


  7 passing (317ms)

✨  Done in 18.60s.
```

**After:**

```
$ yarn test:unit
yarn run v1.19.2
$ cross-env METAMASK_ENV=test mocha --exit --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"


  Account Import Strategies
    private key import
      ✓ imports a private key and strips 0x prefix
      ✓ throws an error for empty string private key
      ✓ throws an error for undefined string private key
      ✓ throws an error for undefined string private key
      ✓ throws an error for invalid private key
    JSON keystore import
      ✓ fails when password is incorrect for keystore
      ✓ imports json string and password to return a private key


  7 passing (329ms)

✨  Done in 16.84s.
```