### PR TITLE
Switch signature-request e2e tests to using ganache

### DIFF
--- a/test/e2e/contract-test/contract.js
+++ b/test/e2e/contract-test/contract.js
@@ -269,6 +269,9 @@ const initialize = () => {
     }
 
     signTypedData.addEventListener('click', () => {
+      const networkId = parseInt(networkDiv.innerHTML)
+      const chainId = parseInt(chainIdDiv.innerHTML) || networkId
+
       const typedData = {
         types: {
           EIP712Domain: [
@@ -291,7 +294,7 @@ const initialize = () => {
         domain: {
           name: 'Ether Mail',
           version: '1',
-          chainId: 3,
+          chainId,
           verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
         },
         message: {

--- a/test/e2e/fixtures/imported-account/state.json
+++ b/test/e2e/fixtures/imported-account/state.json
@@ -27,12 +27,12 @@
       "vault": "{\"data\":\"s6TpYjlUNsn7ifhEFTkuDGBUM1GyOlPrim7JSjtfIxgTt8/6MiXgiR/CtFfR4dWW2xhq85/NGIBYEeWrZThGdKGarBzeIqBfLFhw9n509jprzJ0zc2Rf+9HVFGLw+xxC4xPxgCS0IIWeAJQ+XtGcHmn0UZXriXm8Ja4kdlow6SWinB7sr/WM3R0+frYs4WgllkwggDf2/Tv6VHygvLnhtzp6hIJFyTjh+l/KnyJTyZW1TkZhDaNDzX3SCOHT\",\"iv\":\"FbeHDAW5afeWNORfNJBR0Q==\",\"salt\":\"TxZ+WbCW6891C9LK/hbMAoUsSEW1E8pyGLVBU6x5KR8=\"}"
     },
     "NetworkController": {
-      "network": "3",
+      "network": "5777",
       "provider": {
         "nickname": "",
         "rpcTarget": "",
         "ticker": "ETH",
-        "type": "ropsten"
+        "type": "localhost"
       },
       "settings": {
         "ticker": "ETH"


### PR DESCRIPTION
The signature request e2e tests were previously using ropsten. This expectation was even hard-coded into the test contract dapp.

Instead the contract-dapp has been updated to use the current `chainId` when calling `signTypedData` (falling back to the `networkId` if `chainId` is not set). The fixture used by `signature-request` has been updated to use ganache.