### PR TITLE
Adding mechanism to randomize seed phrase filename

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -672,9 +672,6 @@
   "metamaskDescription": {
     "message": "ከ Ethereum እና ያልተማከለ መረብ ጋር እርስዎን ማገናኘት።"
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask የዘር ቃላት"
-  },
   "metamaskVersion": {
     "message": "የ MetaMask ስሪት"
   },

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -668,9 +668,6 @@
   "metamaskDescription": {
     "message": "إيصالك بالإيثيريوم وبالشبكة اللامركزية."
   },
-  "metamaskSeedWords": {
-    "message": "كلمات MetaMask البذرية"
-  },
   "metamaskVersion": {
     "message": "إصدار MetaMask "
   },

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -671,9 +671,6 @@
   "metamaskDescription": {
     "message": "Свързва ви с Ethereum и децентрализираната мрежа."
   },
-  "metamaskSeedWords": {
-    "message": "Думи зародиш на MetaMask"
-  },
   "metamaskVersion": {
     "message": "Версия на MetaMask"
   },

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -675,9 +675,6 @@
   "metamaskDescription": {
     "message": "আপনার Ethereum এবং ছড়িয়ে ছিটিয়ে থাকা ওয়েবের সাথে সংযোগ করছে। "
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask সীড শব্দসমূহ"
-  },
   "metamaskVersion": {
     "message": "MetaMask সংস্করণ"
   },

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -659,9 +659,6 @@
   "metamaskDescription": {
     "message": "Conectant-te a Ethereum i la web descentralitzada."
   },
-  "metamaskSeedWords": {
-    "message": "Frase de recuperació de MetaMask"
-  },
   "metamaskVersion": {
     "message": "Versió MetaMask"
   },

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -659,9 +659,6 @@
   "metamaskDescription": {
     "message": "Som forbinder dig til Ethereum og de decentraliserede internet."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask Seedord"
-  },
   "missingYourTokens": {
     "message": "Kan du ikke se dine tokens?"
   },

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -651,9 +651,6 @@
   "metamaskDescription": {
     "message": "MetaMask ist ein sicherer Identitätssafe für Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask-Seed-Wörter"
-  },
   "metamaskVersion": {
     "message": "MetaMask-Version"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -672,9 +672,6 @@
   "metamaskDescription": {
     "message": "Σύνδεση με το Ethereum και τον Αποκεντρωμένο Ιστό."
   },
-  "metamaskSeedWords": {
-    "message": "Λέξεις Φύτρου MetaMask"
-  },
   "metamaskVersion": {
     "message": "Έκδοση MetaMask "
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -815,9 +815,6 @@
   "metamaskDescription": {
     "message": "Connecting you to Ethereum and the Decentralized Web."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask Seed Words"
-  },
   "metamaskVersion": {
     "message": "MetaMask Version"
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -551,9 +551,6 @@
   "metamaskDescription": {
     "message": "MetaMask es una identidad segura en Ethereum"
   },
-  "metamaskSeedWords": {
-    "message": "Palabras semilla de MetaMask"
-  },
   "metamaskVersion": {
     "message": "Versión de MetaMask"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -660,9 +660,6 @@
   "metamaskDescription": {
     "message": "Te estamos conectando a Ethereum y a la web descentralizada."
   },
-  "metamaskSeedWords": {
-    "message": "Palabras de inicialización de MetaMask"
-  },
   "metamaskVersion": {
     "message": "Versión de MetaMask"
   },

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -665,9 +665,6 @@
   "metamaskDescription": {
     "message": "Teid ühendatakse Ethereumi ja detsentraliseeritud võrguga."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMaski seemnesõnad"
-  },
   "metamaskVersion": {
     "message": "MetaMaski versioon"
   },

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -675,9 +675,6 @@
   "metamaskDescription": {
     "message": "در حال اتصال شما با ایترم و وب غیر متمرکز شده."
   },
-  "metamaskSeedWords": {
-    "message": "کلمات بازیاب MetaMask"
-  },
   "metamaskVersion": {
     "message": "نسخه MetaMask"
   },

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -672,9 +672,6 @@
   "metamaskDescription": {
     "message": "Sinua yhdistetään Ethereumiin ja hajautettuun verkkoon."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMaskin siemensanat"
-  },
   "metamaskVersion": {
     "message": "MetaMask-versio"
   },

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -610,9 +610,6 @@
   "metamaskDescription": {
     "message": "Kinokonekta ka sa Ethereum at sa Decentralized Web."
   },
-  "metamaskSeedWords": {
-    "message": "Seed Words ng MetaMask"
-  },
   "metamaskVersion": {
     "message": "Bersyon ng MetaMask"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -654,9 +654,6 @@
   "metamaskDescription": {
     "message": "MetaMask est un coffre sécurisé pour votre identité sur Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "Mots Seed pour MetaMask"
-  },
   "metamaskVersion": {
     "message": "Version de MetaMask"
   },

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -672,9 +672,6 @@
   "metamaskDescription": {
     "message": "מחבר אותך לאתריום ולרשת המבוזרת."
   },
-  "metamaskSeedWords": {
-    "message": "מילות גרעין (Seed) של MetaMask "
-  },
   "metamaskVersion": {
     "message": "גרסת MetaMask"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -672,9 +672,6 @@
   "metamaskDescription": {
     "message": "आपको Ethereum और विकेंद्रीकृत वेब से कनेक्ट कर रहे हैं।"
   },
-  "metamaskSeedWords": {
-    "message": "मेटामास्क बीज शब्द"
-  },
   "metamaskVersion": {
     "message": "MetaMask का संस्करण"
   },

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -668,9 +668,6 @@
   "metamaskDescription": {
     "message": "Povezujete se na Ethereum i decentralizirani internet."
   },
-  "metamaskSeedWords": {
-    "message": "Početne riječi za MetaMask"
-  },
   "metamaskVersion": {
     "message": "Inačica usluge MetaMask"
   },

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -404,9 +404,6 @@
   "metamaskDescription": {
     "message": "MetaMask sekirize idantite pou Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask Seed Mo"
-  },
   "metamaskVersion": {
     "message": "MetaMask Vèsyon"
   },

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -668,9 +668,6 @@
   "metamaskDescription": {
     "message": "Csatlakozás az Ethereumhoz és a decentralizált hálózathoz."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask seed szavak"
-  },
   "metamaskVersion": {
     "message": "MetaMask verzió"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -653,9 +653,6 @@
   "metamaskDescription": {
     "message": "Menghubungkan Anda ke Ethereum dan Web Terdesentralisasi."
   },
-  "metamaskSeedWords": {
-    "message": "Kata Benih MetaMask"
-  },
   "metamaskVersion": {
     "message": "Versi MetaMask"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -645,9 +645,6 @@
   "metamaskDescription": {
     "message": "MetaMask è una cassaforte sicura per identità su Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "Parole Seed di MetaMask"
-  },
   "metamaskVersion": {
     "message": "versione di MetaMask"
   },

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -675,9 +675,6 @@
   "metamaskDescription": {
     "message": "ನಿಮ್ಮನ್ನು ಎಥೆರಿಯಮ್ ಮತ್ತು ವಿಕೇಂದ್ರೀಕೃತ ವೆಬ್‌ಗೆ ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask ಸೀಡ್ ಪದಗಳು"
-  },
   "metamaskVersion": {
     "message": "MetaMask ಆವೃತ್ತಿ"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -669,9 +669,6 @@
   "metamaskDescription": {
     "message": "메타마스크는 이더리움을 위한 안전한 저장소입니다."
   },
-  "metamaskSeedWords": {
-    "message": "메타마스크 시드 단어"
-  },
   "metamaskVersion": {
     "message": "메타마스크 버전"
   },

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -675,9 +675,6 @@
   "metamaskDescription": {
     "message": "Prijungiame jus prie „Ethereum“ ir decentralizuotojo žiniatinklio."
   },
-  "metamaskSeedWords": {
-    "message": "„MetaMask“ atkūrimo žodžiai"
-  },
   "metamaskVersion": {
     "message": "„MetaMask“ versija"
   },

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -671,9 +671,6 @@
   "metamaskDescription": {
     "message": "Veido savienojumu ar Ethereum un decentralizēto tīmekli."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask atkopšanas vārdi"
-  },
   "metamaskVersion": {
     "message": "MetaMask versija"
   },

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -646,9 +646,6 @@
   "metamaskDescription": {
     "message": "Menyambungkan anda kepada Ethereum dan Web Ternyahpusat."
   },
-  "metamaskSeedWords": {
-    "message": "Perkataan Benih MetaMask"
-  },
   "metamaskVersion": {
     "message": "Versi MetaMask"
   },

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -665,9 +665,6 @@
   "metamaskDescription": {
     "message": "Kobler deg til Ethereum og det desentraliserte nettet."
   },
-  "metamaskSeedWords": {
-    "message": "Mnemoniske gjenopprettingsfraser for MetaMask "
-  },
   "metamaskVersion": {
     "message": "MetaMask-versjon "
   },

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -666,9 +666,6 @@
   "metamaskDescription": {
     "message": "MetaMask to bezpieczny portfel dla Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "Słowa Seed MetaMask"
-  },
   "metamaskVersion": {
     "message": "Wersja MetaMask"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -660,9 +660,6 @@
   "metamaskDescription": {
     "message": "Conectando você ao Ethereum e à Web Descentralizada."
   },
-  "metamaskSeedWords": {
-    "message": "Palavras-semente do MetaMask"
-  },
   "metamaskVersion": {
     "message": "Versão do MetaMask"
   },

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -662,9 +662,6 @@
   "metamaskDescription": {
     "message": "Vă conectăm la Ethereum și la Internetul descentralizat."
   },
-  "metamaskSeedWords": {
-    "message": "Cuvinte Seed MetaMask"
-  },
   "metamaskVersion": {
     "message": "Versiune MetaMask"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -899,9 +899,6 @@
   "menu": {
     "message": "Меню"
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask ключевая фраза (сид)"
-  },
   "metamaskVersion": {
     "message": "Версия MetaMask"
   },

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -641,9 +641,6 @@
   "metamaskDescription": {
     "message": "MetaMask je bezpečný osobní trezor pro Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "Seed slová MetaMask"
-  },
   "metamaskVersion": {
     "message": "Verzia MetaMask"
   },

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -660,9 +660,6 @@
   "metamaskDescription": {
     "message": "MetaMask je varen identitetni sklad za Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "Seed Words"
-  },
   "metamaskVersion": {
     "message": "Različica"
   },

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -666,9 +666,6 @@
   "metamaskDescription": {
     "message": "Povezivanje na Ethereum i decentralizovani veb."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask reči početne vrednosti"
-  },
   "metamaskVersion": {
     "message": "MetaMask verzija"
   },

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -659,9 +659,6 @@
   "metamaskDescription": {
     "message": "Ansluter dig mot Ethereum och den decentraliserade webben."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask"
-  },
   "metamaskVersion": {
     "message": "MetaMask-version"
   },

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -653,9 +653,6 @@
   "metamaskDescription": {
     "message": "Kukuunganisha kwenye Ethereum na Wavutiu Uliotawanywa."
   },
-  "metamaskSeedWords": {
-    "message": "Maeno ya Kianzio ya MetaMask"
-  },
   "metamaskVersion": {
     "message": "Toleo la MetaMask"
   },

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -675,9 +675,6 @@
   "metamaskDescription": {
     "message": "Під'єднуємо вас до Ethereum та децентралізованої мережі."
   },
-  "metamaskSeedWords": {
-    "message": "Початкові слова MetaMask"
-  },
   "metamaskVersion": {
     "message": "Версія MetaMask"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -663,9 +663,6 @@
   "metamaskDescription": {
     "message": "MetaMask is a secure identity vault for Ethereum."
   },
-  "metamaskSeedWords": {
-    "message": "MetaMask 助记词"
-  },
   "metamaskVersion": {
     "message": "MetaMask 版本"
   },

--- a/ui/app/components/ui/export-text-container/export-text-container.component.js
+++ b/ui/app/components/ui/export-text-container/export-text-container.component.js
@@ -5,7 +5,7 @@ import { exportAsFile } from '../../../helpers/utils/util'
 
 class ExportTextContainer extends Component {
   render () {
-    const { text = '', filename = '' } = this.props
+    const { text = '' } = this.props
     const { t } = this.context
 
     return (
@@ -27,7 +27,7 @@ class ExportTextContainer extends Component {
           </div>
           <div
             className="export-text-container__button"
-            onClick={() => exportAsFile(filename, text)}
+            onClick={() => exportAsFile('', text)}
           >
             <img src="images/download.svg" alt="" />
             <div className="export-text-container__button-text">
@@ -42,7 +42,6 @@ class ExportTextContainer extends Component {
 
 ExportTextContainer.propTypes = {
   text: PropTypes.string,
-  filename: PropTypes.string,
 }
 
 ExportTextContainer.contextTypes = {

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -213,7 +213,22 @@ export function getContractAtAddress (tokenAddress) {
   return global.eth.contract(abi).at(tokenAddress)
 }
 
+export function getRandomFileName () {
+  let fileName = ''
+  const charBank = [
+    ...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+  ]
+  const fileNameLength = Math.floor((Math.random() * 7) + 6)
+
+  for (let i = 0; i < fileNameLength; i++) {
+    fileName += charBank[Math.floor(Math.random() * charBank.length)]
+  }
+
+  return fileName
+}
+
 export function exportAsFile (filename, data, type = 'text/csv') {
+  filename = filename || getRandomFileName()
   // source: https://stackoverflow.com/a/33542499 by Ludovic Feltz
   const blob = new Blob([data], { type })
   if (window.navigator.msSaveOrOpenBlob) {

--- a/ui/app/helpers/utils/util.test.js
+++ b/ui/app/helpers/utils/util.test.js
@@ -254,5 +254,20 @@ describe('util', function () {
         assert(result)
       })
     })
+
+    describe('#getRandomFileName', function () {
+      it('should only return a string containing alphanumeric characters', function () {
+        const result = util.getRandomFileName()
+        assert(result.match(/^[a-zA-Z0-9]*$/g))
+      })
+
+      // 50 samples
+      it('should return a string that is between 6 and 12 characters in length', function () {
+        for (let i = 0; i < 50; i++) {
+          const result = util.getRandomFileName()
+          assert(result.length >= 6 && result.length <= 12)
+        }
+      })
+    })
   })
 })

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -88,7 +88,7 @@ export default class ConfirmSeedPhrase extends PureComponent {
   }
 
   handleExport = () => {
-    exportAsFile('MetaMask Secret Backup Phrase', this.props.seedPhrase, 'text/plain')
+    exportAsFile('', this.props.seedPhrase, 'text/plain')
   }
 
   handleSubmit = async () => {

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
@@ -30,7 +30,7 @@ export default class RevealSeedPhrase extends PureComponent {
   }
 
   handleExport = () => {
-    exportAsFile('MetaMask Secret Backup Phrase', this.props.seedPhrase, 'text/plain')
+    exportAsFile('', this.props.seedPhrase, 'text/plain')
   }
 
   handleNext = () => {

--- a/ui/app/pages/keychains/reveal-seed.js
+++ b/ui/app/pages/keychains/reveal-seed.js
@@ -88,7 +88,7 @@ class RevealSeedPage extends Component {
     return (
       <div>
         <label className="reveal-seed__label">{t('yourPrivateSeedPhrase')}</label>
-        <ExportTextContainer text={this.state.seedWords} filename={t('metamaskSeedWords')} />
+        <ExportTextContainer text={this.state.seedWords} />
       </div>
     )
   }


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/7687

(Follow up after talking with @danfinlay)

The filename is seeded by a simple use of `Math.random()` pulling from an alphanumeric character bank, as opposed to a more cryptographically random solution. This provides a simple layer of difficulty for bad actors to seek out the recovery phrase file. 