### PR TITLE
Add page navigation to e2e web driver

### DIFF
--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -28,7 +28,7 @@ class ChromeDriver {
 
     return {
       driver,
-      extensionUrl: `chrome-extension://${extensionId}/home.html`,
+      extensionUrl: `chrome-extension://${extensionId}`,
     }
   }
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -8,9 +8,10 @@ class Driver {
    * @param {string} browser - The type of browser this driver is controlling
    * @param {number} timeout
    */
-  constructor (driver, browser, timeout = 10000) {
+  constructor (driver, browser, extensionUrl, timeout = 10000) {
     this.driver = driver
     this.browser = browser
+    this.extensionUrl = extensionUrl
     this.timeout = timeout
   }
 
@@ -82,6 +83,12 @@ class Driver {
       assert(err instanceof webdriverError.NoSuchElementError || err instanceof webdriverError.TimeoutError)
     }
     assert.ok(!dataTab, 'Found element that should not be present')
+  }
+
+  // Navigation
+
+  async navigate (page = Driver.PAGES.HOME) {
+    return await this.driver.get(`${this.extensionUrl}/${page}.html`)
   }
 
   // Window management
@@ -171,6 +178,12 @@ class Driver {
     const errorObjects = errorEntries.map(entry => entry.toJSON())
     return errorObjects.filter(entry => !ignoredErrorMessages.some(message => entry.message.includes(message)))
   }
+}
+
+Driver.PAGES = {
+  HOME: 'home',
+  NOTIFICATION: 'notification',
+  POPUP: 'popup',
 }
 
 module.exports = Driver

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -52,7 +52,7 @@ class FirefoxDriver {
     return {
       driver,
       extensionId,
-      extensionUrl: `moz-extension://${internalExtensionId}/home.html`,
+      extensionUrl: `moz-extension://${internalExtensionId}`,
     }
   }
 

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -10,14 +10,12 @@ async function buildWebDriver ({ responsive, port } = {}) {
 
   const { driver: seleniumDriver, extensionId, extensionUrl } = await buildBrowserWebDriver(browser, { extensionPath, responsive, port })
   setupFetchMocking(seleniumDriver)
-  await seleniumDriver.get(extensionUrl)
-
-  const driver = new Driver(seleniumDriver, browser)
+  const driver = new Driver(seleniumDriver, browser, extensionUrl)
+  await driver.navigate()
 
   return {
     driver,
     extensionId,
-    extensionUrl,
   }
 }
 


### PR DESCRIPTION
The driver now has a page navigation function that can navigate to any of the three primary pages used in the extension. Additional pages and support of paths can be added later as needed.