### PR TITLE
Revert the revert of "Use common test build during CI (#7196)" (#7404)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ workflows:
       - prep-build:
           requires:
             - prep-deps
+      - prep-build-test:
+          requires:
+            - prep-deps
       # - prep-docs:
       #    requires:
       #      - prep-deps
@@ -28,10 +31,10 @@ workflows:
             - prep-deps
       - test-e2e-chrome:
           requires:
-            - prep-deps
+            - prep-build-test
       - test-e2e-firefox:
           requires:
-            - prep-deps
+            - prep-build-test
       - test-unit:
           requires:
             - prep-deps
@@ -131,6 +134,24 @@ jobs:
             - dist
             - builds
 
+  prep-build-test:
+    docker:
+      - image: circleci/node:10.16-browsers
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build extension for testing
+          command: yarn build:test
+      - run:
+          name: Move test build to 'dist-test' to avoid conflict with production build
+          command: mv ./dist ./dist-test
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist-test
+
   prep-docs:
     docker:
       - image: circleci/node:10.17-browsers
@@ -219,8 +240,11 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Move test build to dist
+          command: mv ./dist-test ./dist
+      - run:
           name: test:e2e:chrome
-          command: yarn build:test && yarn test:e2e:chrome
+          command: yarn test:e2e:chrome
           no_output_timeout: 20m
       - store_artifacts:
           path: test-artifacts
@@ -237,8 +261,11 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Move test build to dist
+          command: mv ./dist-test ./dist
+      - run:
           name: test:e2e:firefox
-          command: yarn build:test && yarn test:e2e:firefox
+          command: yarn test:e2e:firefox
           no_output_timeout: 20m
       - store_artifacts:
           path: test-artifacts


### PR DESCRIPTION
This reverts commit 4b4c00e94fbb2f38746521864a568aab1400aac4. The original change was a possible optimization of CI, though it ended up not having a huge impact. It was thought that it may have broken source maps, because the test build overwrote the `dist` directory that the source maps were written to. However this turned out not to be the case, as the changes to `dist` are never persisted to the workspace.

This is being re-introduced because the test build is needed for an additional job (the page load benchmark), and sharing the same build for all three jobs would surely be faster than building it separately three times.