### PR TITLE
Add 1 second pause at the beginning of each e2e test run

### DIFF
--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -13,6 +13,8 @@ async function buildWebDriver ({ responsive, port } = {}) {
   const driver = new Driver(seleniumDriver, browser, extensionUrl)
   await driver.navigate()
 
+  await driver.delay(1000)
+
   return {
     driver,
     extensionId,


### PR DESCRIPTION
There have been intermittent test failures at the beginning of various e2e test runs. Most tests start with waiting for the 'Welcome' button to be visible and enabled, which means waiting for the loading screen to go away.

It looks like the reason the test intermittently fails is that sometimes the loading screen doesn't appear until a few moments _after_ the page loads (or that it vanishes and comes back).

It was rather difficult to track down each possible cause for the loading screens, so in the meantime a pause has been added at the start of each run. This should hopefully suffice to ensure the momentary gap in loading has been passed by the time the first test starts up.