### PR TITLE
Remove unnecessary `shouldComponentUpdate`

### DIFF
--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -38,27 +38,6 @@ export default class ConfirmSeedPhrase extends PureComponent {
     pendingSeedIndices: [],
     draggingSeedIndex: -1,
     hoveringIndex: -1,
-    isDragging: false,
-  }
-
-  shouldComponentUpdate (nextProps, nextState) {
-    const { seedPhrase } = this.props
-    const {
-      selectedSeedIndices,
-      shuffledSeedWords,
-      pendingSeedIndices,
-      draggingSeedIndex,
-      hoveringIndex,
-      isDragging,
-    } = this.state
-
-    return seedPhrase !== nextProps.seedPhrase ||
-      draggingSeedIndex !== nextState.draggingSeedIndex ||
-      isDragging !== nextState.isDragging ||
-      hoveringIndex !== nextState.hoveringIndex ||
-      selectedSeedIndices.join(' ') !== nextState.selectedSeedIndices.join(' ') ||
-      shuffledSeedWords.join(' ') !== nextState.shuffledSeedWords.join(' ') ||
-      pendingSeedIndices.join(' ') !== nextState.pendingSeedIndices.join(' ')
   }
 
   componentDidMount () {


### PR DESCRIPTION
The `confirm-seed-phrase` component extends PureComponent, so it doesn't need a `shouldComponentUpdate` function. The state is effectively immutable, as all state is either a primitive type or is updated with new instances rather than mutation.

Removing this function will silence a warning message printed to the console during e2e tests (React doesn't want you to set this function on `PureComponent`s).

Removing this function also exposed an unused piece of state, which has also been removed.