### PR TITLE
Update inpage provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "lodash.shuffle": "^4.2.0",
     "loglevel": "^1.4.1",
     "luxon": "^1.8.2",
-    "metamask-inpage-provider": "^4.0.2",
+    "metamask-inpage-provider": "^4.0.3",
     "metamask-logo": "^2.1.4",
     "mkdirp": "^0.5.1",
     "multihashes": "^0.4.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18639,10 +18639,10 @@ mersenne-twister@^1.0.1:
   resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
   integrity sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o=
 
-metamask-inpage-provider@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/metamask-inpage-provider/-/metamask-inpage-provider-4.0.2.tgz#50d9e46b5fdd6610ce185a165004e3c6b762dbb3"
-  integrity sha512-GXoMa7rP+fx9CriCA+RPHjvJJpfy9531eRdMvbDKv0q95/1pvtzYkj6BdzjxtbM91n4zYl6tmeKDILu+le9Qog==
+metamask-inpage-provider@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/metamask-inpage-provider/-/metamask-inpage-provider-4.0.3.tgz#856698255c2153b82203402c6b5337ca6363d9b0"
+  integrity sha512-JKbGkkR7qg+Z5Dayg6rpfXXzSVcXcp3BENbk2zgWwp/Aa70Sf9MHC7m364FeyIIio9A2r9OuJKV0Bcwmz0h+xg==
   dependencies:
     eth-json-rpc-errors "^2.0.0"
     fast-deep-equal "^2.0.1"


### PR DESCRIPTION
We just published a patch to `metamask-inpage-provider`. This PR updates this dependency.