### PR TITLE
Remove unused browser-passworder dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "bip39": "^2.2.0",
     "bluebird": "^3.5.0",
     "bn.js": "^4.11.7",
-    "browser-passworder": "^2.0.3",
     "browserify-derequire": "^0.9.4",
     "c3": "^0.6.7",
     "classnames": "^2.2.5",


### PR DESCRIPTION
This package is not used _directly_ in the extension