### PR TITLE
Replace DetectRTC package with standard web APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "deep-extend": "^0.5.1",
     "deep-freeze-strict": "1.1.1",
     "detect-node": "^2.0.3",
-    "detectrtc": "^1.3.6",
     "dnode": "^1.2.2",
     "end-of-stream": "^1.1.0",
     "eth-block-tracker": "^4.4.2",

--- a/ui/lib/webcam-utils.js
+++ b/ui/lib/webcam-utils.js
@@ -1,34 +1,35 @@
 'use strict'
 
-import DetectRTC from 'detectrtc'
 import { ENVIRONMENT_TYPE_POPUP, PLATFORM_BRAVE, PLATFORM_FIREFOX } from '../../app/scripts/lib/enums'
 import { getEnvironmentType, getPlatform } from '../../app/scripts/lib/util'
 
 class WebcamUtils {
 
-  static checkStatus () {
-    return new Promise((resolve, reject) => {
-      const isPopup = getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP
-      const isFirefoxOrBrave = getPlatform() === (PLATFORM_FIREFOX || PLATFORM_BRAVE)
-      try {
-        DetectRTC.load(_ => {
-          if (DetectRTC.hasWebcam) {
-            let environmentReady = true
-            if ((isFirefoxOrBrave && isPopup) || (isPopup && !DetectRTC.isWebsiteHasWebcamPermissions)) {
-              environmentReady = false
-            }
-            resolve({
-              permissions: DetectRTC.isWebsiteHasWebcamPermissions,
-              environmentReady,
-            })
-          } else {
-            reject({ type: 'NO_WEBCAM_FOUND' })
-          }
-        })
-      } catch (e) {
-        reject({ type: 'UNKNOWN_ERROR' })
+  static async checkStatus () {
+    const isPopup = getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP
+    const isFirefoxOrBrave = getPlatform() === (PLATFORM_FIREFOX || PLATFORM_BRAVE)
+
+    const devices = await window.navigator.mediaDevices.enumerateDevices()
+    const webcams = devices.filter(device => device.kind === 'videoinput')
+    const hasWebcam = webcams.length > 0
+    // A non-empty-string label implies that the webcam has been granted permission, as
+    // otherwise the label is kept blank to prevent fingerprinting
+    const hasWebcamPermissions = webcams.some(webcam => webcam.label && webcam.label.length > 0)
+
+    if (hasWebcam) {
+      let environmentReady = true
+      if ((isFirefoxOrBrave && isPopup) || (isPopup && !hasWebcamPermissions)) {
+        environmentReady = false
       }
-    })
+      return {
+        permissions: hasWebcamPermissions,
+        environmentReady,
+      }
+    } else {
+      const error = new Error('No webcam found')
+      error.type = 'NO_WEBCAM_FOUND'
+      throw error
+    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8861,11 +8861,6 @@ detective@^5.0.2:
     defined "^1.0.0"
     minimist "^1.1.1"
 
-detectrtc@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/detectrtc/-/detectrtc-1.3.6.tgz#dabc0353981a3da7732de969071c08b6dddd5b59"
-  integrity sha1-2rwDU5gaPadzLelpBxwItt3dW1k=
-
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"


### PR DESCRIPTION
The only web API that our usage of DetectRTC relied upon was 'enumerateDevices', which is supported and stable among all of our supported browsers.

Note that the error handling here is a little... non-standard, and the logic around how Firefox and Brave are handled should be justified, but I've left the logic as-is for now to keep this PR small.