### PR TITLE
Remove unnecessary `withRouter` and `compose` calls

### DIFF
--- a/ui/app/components/app/account-details/account-details.container.js
+++ b/ui/app/components/app/account-details/account-details.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux'
-import { compose } from 'recompose'
 import PropTypes from 'prop-types'
 import { hideSidebar, showModal } from '../../../store/actions'
 import AccountDetails from './account-details.component'
@@ -13,9 +12,7 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
-const AccountDetailsContainer = compose(
-  connect(null, mapDispatchToProps)
-)(AccountDetails)
+const AccountDetailsContainer = connect(null, mapDispatchToProps)(AccountDetails)
 
 AccountDetailsContainer.propTypes = {
   label: PropTypes.string.isRequired,

--- a/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux'
-import { compose } from 'recompose'
 
 import ConnectedSitesList from './connected-sites-list.component'
 import {
@@ -52,6 +51,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps)
-)(ConnectedSitesList)
+export default connect(mapStateToProps, mapDispatchToProps)(ConnectedSitesList)

--- a/ui/app/components/app/permission-page-container/permission-page-container.container.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.container.js
@@ -1,6 +1,4 @@
 import { connect } from 'react-redux'
-import { compose } from 'recompose'
-import { withRouter } from 'react-router-dom'
 import PermissionPageContainer from './permission-page-container.component'
 import {
   getPermissionsDescriptions,
@@ -22,7 +20,4 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default compose(
-  withRouter,
-  connect(mapStateToProps)
-)(PermissionPageContainer)
+export default connect(mapStateToProps)(PermissionPageContainer)

--- a/ui/app/components/app/signature-request/signature-request.container.js
+++ b/ui/app/components/app/signature-request/signature-request.container.js
@@ -1,6 +1,4 @@
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router-dom'
-import { compose } from 'recompose'
 import SignatureRequest from './signature-request.component'
 import { goHome } from '../../../store/actions'
 import { clearConfirmTransaction } from '../../../ducks/confirm-transaction/confirm-transaction.duck'
@@ -66,7 +64,4 @@ function mergeProps (stateProps, dispatchProps, ownProps) {
   }
 }
 
-export default compose(
-  withRouter,
-  connect(mapStateToProps, mapDispatchToProps, mergeProps)
-)(SignatureRequest)
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(SignatureRequest)

--- a/ui/app/components/app/transaction-list/transaction-list.container.js
+++ b/ui/app/components/app/transaction-list/transaction-list.container.js
@@ -1,6 +1,4 @@
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router-dom'
-import { compose } from 'recompose'
 import TransactionList from './transaction-list.component'
 import {
   nonceSortedCompletedTransactionsSelector,
@@ -45,7 +43,4 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   }
 }
 
-export default compose(
-  withRouter,
-  connect(mapStateToProps, mapDispatchToProps, mergeProps)
-)(TransactionList)
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(TransactionList)

--- a/ui/app/components/app/transaction-time-remaining/transaction-time-remaining.container.js
+++ b/ui/app/components/app/transaction-time-remaining/transaction-time-remaining.container.js
@@ -1,6 +1,4 @@
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router-dom'
-import { compose } from 'recompose'
 import TransactionTimeRemaining from './transaction-time-remaining.component'
 import {
   getTxParams,
@@ -31,10 +29,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default compose(
-  withRouter,
-  connect(mapStateToProps)
-)(TransactionTimeRemaining)
+export default connect(mapStateToProps)(TransactionTimeRemaining)
 
 function calcCustomGasPrice (customGasPriceInHex) {
   return Number(hexWEIToDecGWEI(customGasPriceInHex))

--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -1,8 +1,6 @@
 import { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { withRouter } from 'react-router-dom'
-import { compose } from 'recompose'
 import { getMessage } from '../utils/i18n-helper'
 
 class I18nProvider extends Component {
@@ -59,8 +57,4 @@ const mapStateToProps = state => {
   }
 }
 
-export default compose(
-  withRouter,
-  connect(mapStateToProps)
-)(I18nProvider)
-
+export default connect(mapStateToProps)(I18nProvider)

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux'
-import { compose } from 'recompose'
 import PropTypes from 'prop-types'
 import PermissionApproval from './permissions-connect.component'
 import {
@@ -63,9 +62,7 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-const PermissionApprovalContainer = compose(
-  connect(mapStateToProps, mapDispatchToProps)
-)(PermissionApproval)
+const PermissionApprovalContainer = connect(mapStateToProps, mapDispatchToProps)(PermissionApproval)
 
 PermissionApprovalContainer.propTypes = {
   history: PropTypes.object.isRequired,

--- a/ui/app/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/app/pages/settings/settings-tab/settings-tab.container.js
@@ -1,5 +1,4 @@
 import SettingsTab from './settings-tab.component'
-import { compose } from 'recompose'
 import { connect } from 'react-redux'
 import {
   setCurrentCurrency,
@@ -44,6 +43,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps)
-)(SettingsTab)
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsTab)

--- a/ui/app/pages/settings/settings.component.js
+++ b/ui/app/pages/settings/settings.component.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import { Switch, Route, matchPath, withRouter } from 'react-router-dom'
+import { Switch, Route, matchPath } from 'react-router-dom'
 import TabBar from '../../components/app/tab-bar'
 import c from 'classnames'
 import SettingsTab from './settings-tab'
@@ -244,4 +244,4 @@ class SettingsPage extends PureComponent {
   }
 }
 
-export default withRouter(SettingsPage)
+export default SettingsPage


### PR DESCRIPTION
`withRouter` has been removed from any components that were not using any of the three props injected by `withRouter`: `history`, `location`, and `match`.

`compose` is a no-op when called upon a single component, so it has been removed in all such cases.