### PR TITLE
Remove unnecessary get environment type parameter

### DIFF
--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -18,7 +18,7 @@ import {
 /**
  * Used to determine the window type through which the app is being viewed.
  *  - 'popup' refers to the extension opened through the browser app icon (in top right corner in chrome and firefox)
- *  - 'responsive' refers to the main browser window
+ *  - 'fullscreen' refers to the main browser window
  *  - 'notification' refers to the popup that appears in its own window when taking action outside of metamask
  *  - 'background' refers to the background page
  *

--- a/app/scripts/phishing-detect.js
+++ b/app/scripts/phishing-detect.js
@@ -10,7 +10,7 @@ import ExtensionPlatform from './platforms/extension'
 document.addEventListener('DOMContentLoaded', start)
 
 function start () {
-  const windowType = getEnvironmentType(window.location.href)
+  const windowType = getEnvironmentType()
   const hash = window.location.hash.substring(1)
   const suspect = querystring.parse(hash)
 

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -52,7 +52,7 @@ async function start () {
   }
 
   // identify window type (popup, notification)
-  const windowType = getEnvironmentType(window.location.href)
+  const windowType = getEnvironmentType()
   global.METAMASK_UI_TYPE = windowType
   closePopupIfOpen(windowType)
 

--- a/ui/app/components/app/account-menu/account-menu.component.js
+++ b/ui/app/components/app/account-menu/account-menu.component.js
@@ -389,7 +389,7 @@ export default class AccountMenu extends Component {
                 name: 'Clicked Connect Hardware',
               },
             })
-            if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP) {
+            if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
               global.platform.openExtensionInBrowser(CONNECT_HARDWARE_ROUTE)
             } else {
               history.push(CONNECT_HARDWARE_ROUTE)

--- a/ui/app/components/app/modals/modal.js
+++ b/ui/app/components/app/modals/modal.js
@@ -236,7 +236,7 @@ const MODALS = {
     contents: <HideTokenConfirmationModal />,
     mobileModalStyle: {
       width: '95%',
-      top: getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP ? '52vh' : '36.5vh',
+      top: getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '52vh' : '36.5vh',
     },
     laptopModalStyle: {
       width: '449px',
@@ -265,7 +265,7 @@ const MODALS = {
     contents: <NotifcationModal header="gasPriceNoDenom" message="gasPriceInfoModalContent" />,
     mobileModalStyle: {
       width: '95%',
-      top: getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP ? '52vh' : '36.5vh',
+      top: getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '52vh' : '36.5vh',
     },
     laptopModalStyle: {
       width: '449px',
@@ -277,7 +277,7 @@ const MODALS = {
     contents: <NotifcationModal header="gasLimit" message="gasLimitInfoModalContent" />,
     mobileModalStyle: {
       width: '95%',
-      top: getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP ? '52vh' : '36.5vh',
+      top: getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '52vh' : '36.5vh',
     },
     laptopModalStyle: {
       width: '449px',

--- a/ui/app/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/app/components/app/signature-request-original/signature-request-original.component.js
@@ -35,7 +35,7 @@ export default class SignatureRequestOriginal extends Component {
   }
 
   componentDidMount = () => {
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       window.addEventListener('beforeunload', this._beforeUnload)
     }
   }
@@ -59,7 +59,7 @@ export default class SignatureRequestOriginal extends Component {
   }
 
   _removeBeforeUnload = () => {
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       window.removeEventListener('beforeunload', this._beforeUnload)
     }
   }

--- a/ui/app/components/app/signature-request/signature-request.component.js
+++ b/ui/app/components/app/signature-request/signature-request.component.js
@@ -29,7 +29,7 @@ export default class SignatureRequest extends PureComponent {
   componentDidMount () {
     const { clearConfirmTransaction, cancel } = this.props
     const { metricsEvent } = this.context
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       window.addEventListener('beforeunload', (event) => {
         metricsEvent({
           eventOpts: {

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -198,7 +198,7 @@ export default class TransactionListItem extends PureComponent {
       ? tokenData.params && tokenData.params[0] && tokenData.params[0].value || txParams.to
       : txParams.to
 
-    const isFullScreen = getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_FULLSCREEN
+    const isFullScreen = getEnvironmentType() === ENVIRONMENT_TYPE_FULLSCREEN
     const showEstimatedTime = transactionTimeFeatureActive &&
       (transaction.id === firstPendingTransactionId) &&
       isFullScreen

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -14,7 +14,7 @@ function reduceMetamask (state, action) {
     isInitialized: false,
     isUnlocked: false,
     isAccountMenuOpen: false,
-    isPopup: getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP,
+    isPopup: getEnvironmentType() === ENVIRONMENT_TYPE_POPUP,
     rpcTarget: 'https://rawtestrpc.metamask.io/',
     identities: {},
     unapprovedTxs: {},

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -584,7 +584,7 @@ export default class ConfirmTransactionBase extends Component {
   }
 
   _removeBeforeUnload = () => {
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       window.removeEventListener('beforeunload', this._beforeUnload)
     }
   }
@@ -603,7 +603,7 @@ export default class ConfirmTransactionBase extends Component {
       },
     })
 
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       window.addEventListener('beforeunload', this._beforeUnload)
     }
 

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -27,7 +27,7 @@ const mapStateToProps = state => {
   const accountBalance = getCurrentEthBalance(state)
   const { forgottenPassword, threeBoxLastUpdated } = appState
 
-  const isPopup = getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP
+  const isPopup = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
   const firstPermissionsRequest = getFirstPermissionRequest(state)
   const firstPermissionsRequestId = (firstPermissionsRequest && firstPermissionsRequest.metadata)
     ? firstPermissionsRequest.metadata.id

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -62,7 +62,7 @@ export default class PermissionConnect extends Component {
   }
 
   removeBeforeUnload = () => {
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_FULLSCREEN) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_FULLSCREEN) {
       window.removeEventListener('beforeunload', this.beforeUnload)
     }
   }
@@ -102,7 +102,7 @@ export default class PermissionConnect extends Component {
     })
     this.removeBeforeUnload()
 
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_FULLSCREEN) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_FULLSCREEN) {
       setTimeout(async () => {
         const currentTab = await global.platform.currentTab()
         try {
@@ -113,9 +113,9 @@ export default class PermissionConnect extends Component {
           global.platform.closeTab(currentTab.id)
         }
       }, 2000)
-    } else if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_NOTIFICATION) {
+    } else if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       history.push(DEFAULT_ROUTE)
-    } else if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP) {
+    } else if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
       history.push(CONNECTED_ROUTE)
     }
   }
@@ -134,7 +134,7 @@ export default class PermissionConnect extends Component {
       return history.push(DEFAULT_ROUTE)
     }
 
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_FULLSCREEN) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_FULLSCREEN) {
       window.addEventListener('beforeunload', this.beforeUnload)
     }
   }

--- a/ui/app/pages/settings/settings.container.js
+++ b/ui/app/pages/settings/settings.container.js
@@ -47,7 +47,7 @@ const mapStateToProps = (state, ownProps) => {
   const isEditContactPage = Boolean(pathname.match(CONTACT_EDIT_ROUTE))
   const isEditMyAccountsContactPage = Boolean(pathname.match(CONTACT_MY_ACCOUNTS_EDIT_ROUTE))
 
-  const isPopupView = getEnvironmentType(location.href) === ENVIRONMENT_TYPE_POPUP
+  const isPopupView = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
   const pathnameI18nKey = ROUTES_TO_I18N_KEYS[pathname]
 
   let backRoute

--- a/ui/app/pages/unlock-page/unlock-page.container.js
+++ b/ui/app/pages/unlock-page/unlock-page.container.js
@@ -38,7 +38,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     markPasswordForgotten()
     history.push(RESTORE_VAULT_ROUTE)
 
-    if (getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
       global.platform.openExtensionInBrowser(RESTORE_VAULT_ROUTE)
     }
   }

--- a/ui/lib/webcam-utils.js
+++ b/ui/lib/webcam-utils.js
@@ -6,7 +6,7 @@ import { getEnvironmentType, getPlatform } from '../../app/scripts/lib/util'
 class WebcamUtils {
 
   static async checkStatus () {
-    const isPopup = getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP
+    const isPopup = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
     const isFirefoxOrBrave = getPlatform() === (PLATFORM_FIREFOX || PLATFORM_BRAVE)
 
     const devices = await window.navigator.mediaDevices.enumerateDevices()


### PR DESCRIPTION
* Remove unnecessary `getEnvironmentType` parameter

  The default value of the first parameter is `window.location.href`, so there is no need to pass it in explicitly.

* Remove junk parameter from `getEnvironmentType` invocation

  `getEnvironmentType` doesn't need to be passed any parameter, as the default value is `window.location.href` which is generally what is wanted. In this case, the variable `location.href` was always `undefined` anyway. This particular `location` variable is from React Router, and does not have an `href` property.

* Fix comment for `getEnvironmentType`

  One of the possible return values was referred to by the wrong name.