### PR TITLE
Use eth-contract-metadata@1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "dnode": "^1.2.2",
     "end-of-stream": "^1.1.0",
     "eth-block-tracker": "^4.4.2",
-    "eth-contract-metadata": "^1.12.0",
+    "eth-contract-metadata": "^1.12.1",
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-errors": "^2.0.0",
     "eth-json-rpc-filters": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10339,10 +10339,10 @@ eth-block-tracker@^4.4.2:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-contract-metadata@^1.11.0, eth-contract-metadata@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/eth-contract-metadata/-/eth-contract-metadata-1.12.0.tgz#312258682733471f04747e24defade0af43f57da"
-  integrity sha512-ho796inrIW15aWoi9G3e2IeMPnffLr9zLtsD6GCNbgyiqrzyLgEcO4Sj2U1WZ/y8y9a7FYTEtSi5NHXUweNWNg==
+eth-contract-metadata@^1.11.0, eth-contract-metadata@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/eth-contract-metadata/-/eth-contract-metadata-1.12.1.tgz#41014c8c0123453cee15acbcc14299c4d470c759"
+  integrity sha512-9u2jUcdxaKIv4RvA9RtjyD4+M2yWt4yCulR5bpdQTiG3HUFnN9lHtNL5NIRDpvQVJKerFhexrgEM2WdGP3a6VA==
 
 eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
This PR bumps our direct dependency to `eth-contract-metadata@1.12.1`