### PR TITLE
Remove xtend from direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,8 +182,7 @@
     "textarea-caret": "^3.0.1",
     "valid-url": "^1.0.9",
     "web3": "^0.20.7",
-    "web3-stream-provider": "^4.0.0",
-    "xtend": "^4.0.1"
+    "web3-stream-provider": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",


### PR DESCRIPTION
Refs #7795, #7796

This PR removes xtend from our dependencies list.