### PR TITLE
Remove usage of unlisted extend dependency

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -11,7 +11,6 @@ import createInfuraClient from './createInfuraClient'
 import createJsonRpcClient from './createJsonRpcClient'
 import createLocalhostClient from './createLocalhostClient'
 import { createSwappableProxy, createEventEmitterProxy } from 'swappable-obj-proxy'
-import extend from 'extend'
 
 const networks = { networkList: {} }
 
@@ -218,7 +217,7 @@ export default class NetworkController extends EventEmitter {
     let settings = {
       network: chainId,
     }
-    settings = extend(settings, networks.networkList['rpc'])
+    settings = Object.assign(settings, networks.networkList['rpc'])
     this.networkConfig.putState(settings)
     this._setNetworkClient(networkClient)
   }


### PR DESCRIPTION
This PR removes the single usage of the unlisted [`extend`](https://www.npmjs.com/package/extend) dependency. From the pkg description:

> * Since Node.js >= 4, [`Object.assign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) now offers the same functionality natively (but without the "deep copy" option).

Narrator: we don't use the "'deep copy' option".