### PR TITLE
Replace bluebird with Node.js API for unhandled rejections

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "await-semaphore": "^0.1.1",
     "bignumber.js": "^4.1.0",
     "bip39": "^2.2.0",
-    "bluebird": "^3.5.0",
     "bn.js": "^4.11.7",
     "browserify-derequire": "^0.9.4",
     "c3": "^0.6.7",

--- a/test/helper.js
+++ b/test/helper.js
@@ -7,9 +7,28 @@ import log from 'loglevel'
 nock.disableNetConnect()
 nock.enableNetConnect('localhost')
 
+// catch rejections that are still unhandled when tests exit
+const unhandledRejections = new Map()
+process.on('unhandledRejection', (reason, promise) => {
+  console.log('Unhandled rejection:', reason)
+  unhandledRejections.set(promise, reason)
+})
+process.on('rejectionHandled', (promise) => {
+  console.log(`handled: ${unhandledRejections.get(promise)}`)
+  unhandledRejections.delete(promise)
+})
+
+process.on('exit', () => {
+  if (unhandledRejections.size > 0) {
+    console.error(`Found ${unhandledRejections.size} unhandled rejections:`)
+    for (const reason of unhandledRejections.values()) {
+      console.error('Unhandled rejection: ', reason)
+    }
+    process.exit(1)
+  }
+})
+
 Enzyme.configure({ adapter: new Adapter() })
-// disallow promises from swallowing errors
-enableFailureOnUnhandledPromiseRejection()
 
 // ganache server
 const server = Ganache.server()
@@ -38,37 +57,4 @@ if (!window.crypto) {
 }
 if (!window.crypto.getRandomValues) {
   window.crypto.getRandomValues = require('polyfill-crypto.getrandomvalues')
-}
-
-function enableFailureOnUnhandledPromiseRejection () {
-  // overwrite node's promise with the stricter Bluebird promise
-  global.Promise = require('bluebird')
-
-  // modified from https://github.com/mochajs/mocha/issues/1926#issuecomment-180842722
-
-  // rethrow unhandledRejections
-  if (typeof process !== 'undefined') {
-    process.on('unhandledRejection', function (reason) {
-      throw reason
-    })
-  } else if (typeof window !== 'undefined') {
-    // 2016-02-01: No browsers support this natively, however bluebird, when.js,
-    // and probably other libraries do.
-    if (typeof window.addEventListener === 'function') {
-      window.addEventListener('unhandledrejection', function (evt) {
-        throw evt.detail.reason
-      })
-    } else {
-      const oldOHR = window.onunhandledrejection
-      window.onunhandledrejection = function (evt) {
-        if (typeof oldOHR === 'function') {
-          oldOHR.apply(this, arguments)
-        }
-        throw evt.detail.reason
-      }
-    }
-  } else if (typeof console !== 'undefined' &&
-      typeof (console.error || console.log) === 'function') {
-    (console.error || console.log)('Unhandled rejections will be ignored!')
-  }
 }


### PR DESCRIPTION
Unhandled rejections are now caught using built-in Node.js APIs instead of with `bluebird`. `bluebird` was added as a production dependency but was only used for this purpose. The code responsible for catching unhandled rejection in the browser was removed, as this test helper is never run in the browser.

Additionally, unhandled rejections are tracked over the course of all tests, and result in a non-zero exit code if they remain at the end. This was done because it is possible for errors to trigger the `uncaughtRejection` event but then still be handled later on. This is uncommon, and doesn't seem to happen in our test suite. But if it does in the future, it'll be logged but won't result in a non-zero exit code.