### PR TITLE
Update `classnames` to `v2.2.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "bn.js": "^4.11.7",
     "browserify-derequire": "^0.9.4",
     "c3": "^0.6.7",
-    "classnames": "^2.2.5",
+    "classnames": "^2.2.6",
     "clone": "^2.1.2",
     "content-hash": "^2.5.0",
     "copy-to-clipboard": "^3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6918,10 +6918,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.4, classnames@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-  integrity sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=
+classnames@^2.2.4, classnames@^2.2.5, classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@4.2.x:
   version "4.2.1"


### PR DESCRIPTION
This patch update includes a bug fix for ES6 imports. The bug doesn't affect our use of this module, but it ensures that we can safely use the `dedupe` and `bind` APIs as ES6 imports if we decide to.