### PR TITLE
Replace `deep-extend` with `merge` from `lodash`

### DIFF
--- a/app/scripts/migrations/009.js
+++ b/app/scripts/migrations/009.js
@@ -6,7 +6,7 @@ This migration breaks out the CurrencyController substate
 
 */
 
-import merge from 'deep-extend'
+import { merge } from 'lodash'
 
 import clone from 'clone'
 

--- a/app/scripts/migrations/010.js
+++ b/app/scripts/migrations/010.js
@@ -6,7 +6,7 @@ This migration breaks out the ShapeShiftController substate
 
 */
 
-import merge from 'deep-extend'
+import { merge } from 'lodash'
 
 import clone from 'clone'
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "d3": "^5.15.0",
     "debounce": "1.1.0",
     "debounce-stream": "^2.0.0",
-    "deep-extend": "^0.5.1",
     "deep-freeze-strict": "1.1.1",
     "detect-node": "^2.0.3",
     "dnode": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8734,7 +8734,7 @@ deep-equal@^1.0.0, deep-equal@^1.0.1, deep-equal@~1.0.1:
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
-deep-extend@^0.5.0, deep-extend@^0.5.1:
+deep-extend@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
   integrity sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==


### PR DESCRIPTION
The `merge` function from `deep-extend` is at least mostly equivalent to `merge` from `lodash` - certainly in how we're using it.