### PR TITLE
Fixing broken JSON import help link

### DIFF
--- a/ui/app/pages/create-account/import-account/json.js
+++ b/ui/app/pages/create-account/import-account/json.js
@@ -9,7 +9,7 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes'
 import { getMetaMaskAccounts } from '../../../selectors/selectors'
 import Button from '../../../components/ui/button'
 
-const HELP_LINK = 'https://metamask.zendesk.com/hc/en-us/articles/360015489351-Importing-Accounts'
+const HELP_LINK = 'https://metamask.zendesk.com/hc/en-us/articles/360015489331-Importing-an-Account'
 
 class JsonImportSubview extends Component {
   state = {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/7909

The correct article regarding JSON account import appears to be: `https://metamask.zendesk.com/hc/en-us/articles/360015489331-Importing-an-Account`