### PR TITLE
disable import button on Import Account screen for empty string/file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Current Develop Branch
+- [#7912](https://github.com/MetaMask/metamask-extension/pull/7912): Disable import button for empty string/file
 
 ## 7.7.0 Thu Nov 28 2019
 - [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Connect distinct accounts per site

--- a/ui/app/pages/create-account/import-account/json.js
+++ b/ui/app/pages/create-account/import-account/json.js
@@ -14,10 +14,12 @@ const HELP_LINK = 'https://metamask.zendesk.com/hc/en-us/articles/360015489351-I
 class JsonImportSubview extends Component {
   state = {
     fileContents: '',
+    isEmpty: true,
   }
 
   render () {
     const { error } = this.props
+    const enabled = !this.state.isEmpty && this.state.fileContents !== ''
 
     return (
       <div className="new-account-import-form__json">
@@ -40,6 +42,7 @@ class JsonImportSubview extends Component {
           placeholder={this.context.t('enterPassword')}
           id="json-password-box"
           onKeyPress={this.createKeyringOnEnter.bind(this)}
+          onChange={() => this.checkInputEmpty()}
         />
         <div className="new-account-create-form__buttons">
           <Button
@@ -55,6 +58,7 @@ class JsonImportSubview extends Component {
             large
             className="new-account-create-form__button"
             onClick={() => this.createNewKeychain()}
+            disabled={!enabled}
           >
             {this.context.t('import')}
           </Button>
@@ -118,6 +122,16 @@ class JsonImportSubview extends Component {
         }
       })
       .catch(err => err && displayWarning(err.message || err))
+  }
+
+  checkInputEmpty () {
+    const input = document.getElementById('json-password-box')
+    const password = input.value
+    let isEmpty = true
+    if (password !== '') {
+      isEmpty = false
+    }
+    this.setState({ isEmpty })
   }
 }
 

--- a/ui/app/pages/create-account/import-account/json.js
+++ b/ui/app/pages/create-account/import-account/json.js
@@ -17,6 +17,8 @@ class JsonImportSubview extends Component {
     isEmpty: true,
   }
 
+  inputRef = React.createRef()
+
   render () {
     const { error } = this.props
     const enabled = !this.state.isEmpty && this.state.fileContents !== ''
@@ -43,6 +45,7 @@ class JsonImportSubview extends Component {
           id="json-password-box"
           onKeyPress={this.createKeyringOnEnter.bind(this)}
           onChange={() => this.checkInputEmpty()}
+          ref={this.inputRef}
         />
         <div className="new-account-create-form__buttons">
           <Button
@@ -94,8 +97,7 @@ class JsonImportSubview extends Component {
       return displayWarning(message)
     }
 
-    const passwordInput = document.getElementById('json-password-box')
-    const password = passwordInput.value
+    const password = this.inputRef.current.value
 
     importNewJsonAccount([ fileContents, password ])
       .then(({ selectedAddress }) => {
@@ -125,8 +127,7 @@ class JsonImportSubview extends Component {
   }
 
   checkInputEmpty () {
-    const input = document.getElementById('json-password-box')
-    const password = input.value
+    const password = this.inputRef.current.value
     let isEmpty = true
     if (password !== '') {
       isEmpty = false

--- a/ui/app/pages/create-account/import-account/private-key.js
+++ b/ui/app/pages/create-account/import-account/private-key.js
@@ -23,6 +23,7 @@ class PrivateKeyImportView extends Component {
     error: PropTypes.node,
   }
 
+  state = { isEmpty: true }
 
   createNewKeychain () {
     const input = document.getElementById('private-key-box')
@@ -63,6 +64,16 @@ class PrivateKeyImportView extends Component {
     }
   }
 
+  checkInputEmpty () {
+    const input = document.getElementById('private-key-box')
+    const privateKey = input.value
+    let isEmpty = true
+    if (privateKey !== '') {
+      isEmpty = false
+    }
+    this.setState({ isEmpty })
+  }
+
   render () {
     const { error, displayWarning } = this.props
 
@@ -77,6 +88,7 @@ class PrivateKeyImportView extends Component {
             type="password"
             id="private-key-box"
             onKeyPress={e => this.createKeyringOnEnter(e)}
+            onChange={() => this.checkInputEmpty()}
           />
         </div>
         <div className="new-account-import-form__buttons">
@@ -96,6 +108,7 @@ class PrivateKeyImportView extends Component {
             large
             className="new-account-create-form__button"
             onClick={() => this.createNewKeychain()}
+            disabled={this.state.isEmpty}
           >
             {this.context.t('import')}
           </Button>

--- a/ui/app/pages/create-account/import-account/private-key.js
+++ b/ui/app/pages/create-account/import-account/private-key.js
@@ -23,11 +23,12 @@ class PrivateKeyImportView extends Component {
     error: PropTypes.node,
   }
 
+  inputRef = React.createRef()
+
   state = { isEmpty: true }
 
   createNewKeychain () {
-    const input = document.getElementById('private-key-box')
-    const privateKey = input.value
+    const privateKey = this.inputRef.current.value
     const { importNewAccount, history, displayWarning, setSelectedAddress, firstAddress } = this.props
 
     importNewAccount('Private Key', [ privateKey ])
@@ -65,8 +66,7 @@ class PrivateKeyImportView extends Component {
   }
 
   checkInputEmpty () {
-    const input = document.getElementById('private-key-box')
-    const privateKey = input.value
+    const privateKey = this.inputRef.current.value
     let isEmpty = true
     if (privateKey !== '') {
       isEmpty = false
@@ -89,6 +89,7 @@ class PrivateKeyImportView extends Component {
             id="private-key-box"
             onKeyPress={e => this.createKeyringOnEnter(e)}
             onChange={() => this.checkInputEmpty()}
+            ref={this.inputRef}
           />
         </div>
         <div className="new-account-import-form__buttons">


### PR DESCRIPTION
Disabled the import button on the "Import Account" screen when the private key input field is empty, or if importing from a JSON file, when either of the file or password fields are empty. 

Edited files private-key.js and json.js to check if inputs are not empty before enabling button.

Fixes #7424