### PR TITLE
Add Sentry environment

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/browser'
 import { Dedupe, ExtraErrorData } from '@sentry/integrations'
 
-const METAMASK_DEBUG = process.env.METAMASK_DEBUG
 import extractEthjsErrorMessage from './extractEthjsErrorMessage'
 
+const METAMASK_DEBUG = process.env.METAMASK_DEBUG
+const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT
 const SENTRY_DSN_PROD = 'https://3567c198f8a8412082d32655da2961d0@sentry.io/273505'
 const SENTRY_DSN_DEV = 'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496'
 
@@ -17,16 +18,17 @@ function setupSentry (opts) {
   const isBrave = Boolean(window.chrome.ipcRenderer)
 
   if (METAMASK_DEBUG || process.env.IN_TEST) {
-    console.log('Setting up Sentry Remote Error Reporting: SENTRY_DSN_DEV')
+    console.log(`Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN_DEV`)
     sentryTarget = SENTRY_DSN_DEV
   } else {
-    console.log('Setting up Sentry Remote Error Reporting: SENTRY_DSN_PROD')
+    console.log(`Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN_PROD`)
     sentryTarget = SENTRY_DSN_PROD
   }
 
   Sentry.init({
     dsn: sentryTarget,
     debug: METAMASK_DEBUG,
+    environment: METAMASK_ENVIRONMENT,
     integrations: [
       new Dedupe(),
       new ExtraErrorData(),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -571,9 +571,27 @@ function generateBundler (opts, performBundle) {
     bundler = bundler.external(opts.externalDependencies)
   }
 
+  let environment
+  if (opts.devMode) {
+    environment = 'development'
+  } else if (opts.testing) {
+    environment = 'testing'
+  } else if (process.env.CIRCLE_BRANCH === 'master') {
+    environment = 'production'
+  } else if (/^Version-v(\d+)[.](\d+)[.](\d+)/.test(process.env.CIRCLE_BRANCH)) {
+    environment = 'release-candidate'
+  } else if (process.env.CIRCLE_BRANCH === 'develop') {
+    environment = 'staging'
+  } else if (process.env.CIRCLE_PULL_REQUEST) {
+    environment = 'pull-request'
+  } else {
+    environment = 'other'
+  }
+
   // Inject variables into bundle
   bundler.transform(envify({
     METAMASK_DEBUG: opts.devMode,
+    METAMASK_ENVIRONMENT: environment,
     NODE_ENV: opts.devMode ? 'development' : 'production',
     IN_TEST: opts.testing,
     PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY || '',


### PR DESCRIPTION
Any error sent to Sentry will now be marked with the environment they were sent from. The environment is set at build time, and is set dependant upon the build flags and CI-related environment variables.

Setting the environment will let us filter error reports in Sentry to focus specifically upon reports sent from production, release candidates, PR testing, or whatever else.