### PR TITLE
Report errors in tests to `test-metamask` Sentry project

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -16,7 +16,7 @@ function setupSentry (opts) {
   // detect brave
   const isBrave = Boolean(window.chrome.ipcRenderer)
 
-  if (METAMASK_DEBUG) {
+  if (METAMASK_DEBUG || process.env.IN_TEST) {
     console.log('Setting up Sentry Remote Error Reporting: SENTRY_DSN_DEV')
     sentryTarget = SENTRY_DSN_DEV
   } else {


### PR DESCRIPTION
Previously, all errors encountered during testing or production were sent to the primary `metamask` Sentry project, whereas development errors were sent to `test-metamask` instead. This change ensures that errors encountered during tests are sent to `test-metamask` as well.