### PR TITLE
Replace `clone` dependency with `cloneDeep` from lodash

### DIFF
--- a/app/scripts/controllers/permissions/permissionsLog.js
+++ b/app/scripts/controllers/permissions/permissionsLog.js
@@ -1,5 +1,5 @@
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import { isValidAddress } from 'ethereumjs-util'
 import {
   CAVEAT_NAMES,
@@ -374,7 +374,7 @@ function cloneObj (obj) {
 
   for (let i = 3; i > 1; i--) {
     try {
-      return clone(obj, false, i)
+      return cloneDeep(obj, false, i)
     } catch (_) {}
   }
   return { ...obj }

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -1,5 +1,5 @@
 import jsonDiffer from 'fast-json-patch'
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 /** @module*/
 export default {
@@ -57,7 +57,7 @@ function generateHistoryEntry (previousState, newState, note) {
   @returns {Object}
 */
 function replayHistory (_shortHistory) {
-  const shortHistory = clone(_shortHistory)
+  const shortHistory = cloneDeep(_shortHistory)
   return shortHistory.reduce((val, entry) => jsonDiffer.applyPatch(val, entry).newDocument)
 }
 
@@ -67,7 +67,7 @@ function replayHistory (_shortHistory) {
 */
 function snapshotFromTxMeta (txMeta) {
   // create txMeta snapshot for history
-  const snapshot = clone(txMeta)
+  const snapshot = cloneDeep(txMeta)
   // dont include previous history in this snapshot
   delete snapshot.history
   return snapshot

--- a/app/scripts/lib/getObjStructure.js
+++ b/app/scripts/lib/getObjStructure.js
@@ -1,4 +1,4 @@
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default getObjStructure
 
@@ -24,7 +24,7 @@ export default getObjStructure
  *
  */
 function getObjStructure (obj) {
-  const structure = clone(obj)
+  const structure = cloneDeep(obj)
   return deepMap(structure, (value) => {
     return value === null ? 'null' : typeof value
   })

--- a/app/scripts/migrations/002.js
+++ b/app/scripts/migrations/002.js
@@ -1,13 +1,13 @@
 const version = 2
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       if (versionedData.data.config.provider.type === 'etherscan') {

--- a/app/scripts/migrations/003.js
+++ b/app/scripts/migrations/003.js
@@ -2,13 +2,13 @@ const version = 3
 const oldTestRpc = 'https://rawtestrpc.metamask.io/'
 const newTestRpc = 'https://testrpc.metamask.io/'
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       if (versionedData.data.config.provider.rpcTarget === oldTestRpc) {

--- a/app/scripts/migrations/004.js
+++ b/app/scripts/migrations/004.js
@@ -1,12 +1,12 @@
 const version = 4
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (versionedData) {
-    const safeVersionedData = clone(versionedData)
+    const safeVersionedData = cloneDeep(versionedData)
     safeVersionedData.meta.version = version
     try {
       if (safeVersionedData.data.config.provider.type !== 'rpc') {

--- a/app/scripts/migrations/005.js
+++ b/app/scripts/migrations/005.js
@@ -6,14 +6,14 @@ This migration moves state from the flat state trie into KeyringController subst
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/006.js
+++ b/app/scripts/migrations/006.js
@@ -6,13 +6,13 @@ This migration moves KeyringController.selectedAddress to PreferencesController.
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/007.js
+++ b/app/scripts/migrations/007.js
@@ -6,13 +6,13 @@ This migration breaks out the TransactionManager substate
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/008.js
+++ b/app/scripts/migrations/008.js
@@ -6,13 +6,13 @@ This migration breaks out the NoticeController substate
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/009.js
+++ b/app/scripts/migrations/009.js
@@ -6,15 +6,13 @@ This migration breaks out the CurrencyController substate
 
 */
 
-import { merge } from 'lodash'
-
-import clone from 'clone'
+import { cloneDeep, merge } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/010.js
+++ b/app/scripts/migrations/010.js
@@ -6,15 +6,13 @@ This migration breaks out the ShapeShiftController substate
 
 */
 
-import { merge } from 'lodash'
-
-import clone from 'clone'
+import { cloneDeep, merge } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/011.js
+++ b/app/scripts/migrations/011.js
@@ -6,13 +6,13 @@ This migration removes the discaimer state from our app, which was integrated in
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/012.js
+++ b/app/scripts/migrations/012.js
@@ -6,13 +6,13 @@ This migration modifies our notices to delete their body after being read.
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/013.js
+++ b/app/scripts/migrations/013.js
@@ -6,13 +6,13 @@ This migration modifies the network config from ambiguous 'testnet' to explicit 
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/014.js
+++ b/app/scripts/migrations/014.js
@@ -6,13 +6,13 @@ This migration removes provider from config and moves it too NetworkController.
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/015.js
+++ b/app/scripts/migrations/015.js
@@ -7,13 +7,13 @@ to a 'failed' stated
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/016.js
+++ b/app/scripts/migrations/016.js
@@ -7,13 +7,13 @@ to a 'failed' stated
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/017.js
+++ b/app/scripts/migrations/017.js
@@ -6,13 +6,13 @@ This migration sets transactions who were retried and marked as failed to submit
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/018.js
+++ b/app/scripts/migrations/018.js
@@ -6,7 +6,7 @@ This migration updates "transaction state history" to diffs style
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 import txStateHistoryHelper from '../controllers/transactions/lib/tx-state-history-helper'
 
@@ -15,7 +15,7 @@ export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/019.js
+++ b/app/scripts/migrations/019.js
@@ -8,13 +8,13 @@ whos nonce is too high
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/020.js
+++ b/app/scripts/migrations/020.js
@@ -8,13 +8,13 @@ so that we can version notices in the future.
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/021.js
+++ b/app/scripts/migrations/021.js
@@ -6,13 +6,13 @@ This migration removes the BlackListController from disk state
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/022.js
+++ b/app/scripts/migrations/022.js
@@ -7,13 +7,13 @@ This migration adds submittedTime to the txMeta if it is not their
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/023.js
+++ b/app/scripts/migrations/023.js
@@ -7,13 +7,13 @@ This migration removes transactions that are no longer usefull down to 40 total
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/024.js
+++ b/app/scripts/migrations/024.js
@@ -8,13 +8,13 @@ all unapproved transactions
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/app/scripts/migrations/025.js
+++ b/app/scripts/migrations/025.js
@@ -8,13 +8,13 @@ normalizes txParams on unconfirmed txs
 */
 import ethUtil from 'ethereumjs-util'
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/app/scripts/migrations/026.js
+++ b/app/scripts/migrations/026.js
@@ -7,12 +7,12 @@ This migration moves the identities stored in the KeyringController
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
   migrate (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/027.js
+++ b/app/scripts/migrations/027.js
@@ -6,13 +6,13 @@ const version = 27
 normalizes txParams on unconfirmed txs
 
 */
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/app/scripts/migrations/028.js
+++ b/app/scripts/migrations/028.js
@@ -6,13 +6,13 @@ const version = 28
 normalizes txParams on unconfirmed txs
 
 */
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/app/scripts/migrations/030.js
+++ b/app/scripts/migrations/030.js
@@ -7,13 +7,13 @@ removes invalid chaids from preferences and networkController for custom rpcs
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/app/scripts/migrations/031.js
+++ b/app/scripts/migrations/031.js
@@ -1,6 +1,6 @@
 // next version number
 const version = 31
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 /*
   * The purpose of this migration is to properly set the completedOnboarding flag based on the state
@@ -10,7 +10,7 @@ export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/app/scripts/migrations/032.js
+++ b/app/scripts/migrations/032.js
@@ -1,5 +1,5 @@
 const version = 32
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 /**
  * The purpose of this migration is to set the {@code completedUiMigration} flag based on the user's UI preferences
@@ -7,7 +7,7 @@ import clone from 'clone'
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/033.js
+++ b/app/scripts/migrations/033.js
@@ -7,13 +7,13 @@ Cleans up notices and assocated notice controller code
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/app/scripts/migrations/034.js
+++ b/app/scripts/migrations/034.js
@@ -1,5 +1,5 @@
 const version = 34
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 /**
  * The purpose of this migration is to enable the {@code privacyMode} feature flag and set the user as being migrated
@@ -8,7 +8,7 @@ import clone from 'clone'
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/035.js
+++ b/app/scripts/migrations/035.js
@@ -7,13 +7,13 @@ Removes the deprecated 'seedWords' state
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     versionedData.data = transformState(versionedData.data)
     return versionedData

--- a/app/scripts/migrations/036.js
+++ b/app/scripts/migrations/036.js
@@ -1,5 +1,5 @@
 const version = 36
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 /**
  * The purpose of this migration is to remove the {@code privacyMode} feature flag.
@@ -7,7 +7,7 @@ import clone from 'clone'
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/037.js
+++ b/app/scripts/migrations/037.js
@@ -1,5 +1,5 @@
 const version = 37
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import { util } from 'gaba'
 
 /**
@@ -10,7 +10,7 @@ import { util } from 'gaba'
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/038.js
+++ b/app/scripts/migrations/038.js
@@ -1,5 +1,5 @@
 const version = 38
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import ABTestController from '../controllers/ab-test'
 import { getRandomArrayItem } from '../lib/util'
 
@@ -9,7 +9,7 @@ import { getRandomArrayItem } from '../lib/util'
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/039.js
+++ b/app/scripts/migrations/039.js
@@ -1,5 +1,5 @@
 const version = 39
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import ethUtil from 'ethereumjs-util'
 
 const DAI_V1_CONTRACT_ADDRESS = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
@@ -22,7 +22,7 @@ function isOldDai (token = {}) {
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/040.js
+++ b/app/scripts/migrations/040.js
@@ -1,5 +1,5 @@
 const version = 40
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 /**
  * Site connections are now managed by the PermissionsController, and the
@@ -9,7 +9,7 @@ import clone from 'clone'
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/041.js
+++ b/app/scripts/migrations/041.js
@@ -1,5 +1,5 @@
 const version = 41
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 /**
  * PreferencesController.autoLogoutTimeLimit -> autoLockTimeLimit
@@ -7,7 +7,7 @@ import clone from 'clone'
 export default {
   version,
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     versionedData.data = transformState(state)

--- a/app/scripts/migrations/fail-tx.js
+++ b/app/scripts/migrations/fail-tx.js
@@ -1,8 +1,8 @@
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default function failTxsThat (version, reason, condition) {
   return function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     try {
       const state = versionedData.data

--- a/app/scripts/migrations/template.js
+++ b/app/scripts/migrations/template.js
@@ -7,13 +7,13 @@ description of migration and what it does
 
 */
 
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 
 export default {
   version,
 
   migrate: async function (originalVersionedData) {
-    const versionedData = clone(originalVersionedData)
+    const versionedData = cloneDeep(originalVersionedData)
     versionedData.meta.version = version
     const state = versionedData.data
     const newState = transformState(state)

--- a/development/version-bump.js
+++ b/development/version-bump.js
@@ -1,7 +1,7 @@
-const clone = require('clone')
+const { cloneDeep } = require('lodash')
 
 async function versionBump (bumpType, changelog, oldManifest) {
-  const manifest = clone(oldManifest)
+  const manifest = cloneDeep(oldManifest)
   const newVersion = newVersionFrom(manifest, bumpType)
 
   manifest.version = newVersion

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "browserify-derequire": "^0.9.4",
     "c3": "^0.7.10",
     "classnames": "^2.2.6",
-    "clone": "^2.1.2",
     "content-hash": "^2.5.0",
     "copy-to-clipboard": "^3.0.8",
     "currency-formatter": "^1.4.2",

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import sinon from 'sinon'
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import nock from 'nock'
 import ethUtil from 'ethereumjs-util'
 import { obj as createThoughStream } from 'through2'
@@ -94,7 +94,7 @@ describe('MetaMaskController', function () {
           return Promise.resolve(this.object)
         },
       },
-      initState: clone(firstTimeState),
+      initState: cloneDeep(firstTimeState),
       platform: { showTransactionNotification: () => {} },
     })
     // disable diagnostics

--- a/test/unit/app/seed-phrase-verifier-test.js
+++ b/test/unit/app/seed-phrase-verifier-test.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import KeyringController from 'eth-keyring-controller'
 import firstTimeState from '../../../app/scripts/first-time-state'
 import seedPhraseVerifier from '../../../app/scripts/lib/seed-phrase-verifier'
@@ -17,7 +17,7 @@ describe('SeedPhraseVerifier', function () {
 
     beforeEach(async function () {
       keyringController = new KeyringController({
-        initState: clone(firstTimeState),
+        initState: cloneDeep(firstTimeState),
         encryptor: mockEncryptor,
       })
 

--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import assert from 'assert'
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import pify from 'pify'
 import Migrator from '../../../app/scripts/lib/migrator'
 import liveMigrations from '../../../app/scripts/migrations'
@@ -10,7 +10,7 @@ const stubMigrations = [
     version: 1,
     migrate: (data) => {
       // clone the data just like we do in migrations
-      const clonedData = clone(data)
+      const clonedData = cloneDeep(data)
       clonedData.meta.version = 1
       return Promise.resolve(clonedData)
     },
@@ -18,7 +18,7 @@ const stubMigrations = [
   {
     version: 2,
     migrate: (data) => {
-      const clonedData = clone(data)
+      const clonedData = cloneDeep(data)
       clonedData.meta.version = 2
       return Promise.resolve(clonedData)
     },
@@ -26,7 +26,7 @@ const stubMigrations = [
   {
     version: 3,
     migrate: (data) => {
-      const clonedData = clone(data)
+      const clonedData = cloneDeep(data)
       clonedData.meta.version = 3
       return Promise.resolve(clonedData)
     },

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -5,7 +5,7 @@
 import assert from 'assert'
 
 import sinon from 'sinon'
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import nock from 'nock'
 import fetchMock from 'fetch-mock'
 import configureStore from 'redux-mock-store'
@@ -53,7 +53,7 @@ describe('Actions', () => {
           return Promise.resolve(this.object)
         },
       },
-      initState: clone(firstTimeState),
+      initState: cloneDeep(firstTimeState),
     })
 
     metamaskController.threeBoxController = {

--- a/ui/app/ducks/index.js
+++ b/ui/app/ducks/index.js
@@ -1,4 +1,4 @@
-import clone from 'clone'
+import { cloneDeep } from 'lodash'
 import copyToClipboard from 'copy-to-clipboard'
 
 //
@@ -57,7 +57,7 @@ function rootReducer (state, action) {
 }
 
 window.getCleanAppState = function () {
-  const state = clone(window.METAMASK_CACHED_LOG_STATE)
+  const state = cloneDeep(window.METAMASK_CACHED_LOG_STATE)
   // append additional information
   state.version = global.platform.getVersion()
   state.browser = window.navigator.userAgent


### PR DESCRIPTION
This was done to reduce the number of direct dependencies we have. It should be functionally equivalent. The bundle size should not change, as we use `clone` as a transitive dependency in a number of places.