### PR TITLE
Remove top-level symlinks

### DIFF
--- a/fonts
+++ b/fonts
@@ -1,1 +1,0 @@
-app/fonts

--- a/images
+++ b/images
@@ -1,1 +1,0 @@
-app/images


### PR DESCRIPTION
This PR deletes the two top-level symlinks, `fonts` and `images`. The symlinks pointed to `app/fonts/` and `app/images/`, respectively, but the app works fine without them and I can't immediately see anywhere they're used.