### PR TITLE
Delete unused .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-builds
-development


### PR DESCRIPTION
This PR removes the unused `.dockerignore` file, originally introduced in #1311 (https://github.com/MetaMask/metamask-extension/commit/4b8324620e4f850b1674692cf8c45a4ca70101b4)