### PR TITLE
Remove redux-logger from mock-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "readable-stream": "^2.3.3",
     "recompose": "^0.25.0",
     "redux": "^3.0.5",
-    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1",
     "rpc-cap": "^1.0.3",

--- a/test/lib/mock-store.js
+++ b/test/lib/mock-store.js
@@ -1,17 +1,11 @@
 import { applyMiddleware, createStore } from 'redux'
 import thunkMiddleware from 'redux-thunk'
-import { createLogger } from 'redux-logger'
 
 const rootReducer = function () {}
 
 export default configureStore
 
-const loggerMiddleware = createLogger()
-
-const createStoreWithMiddleware = applyMiddleware(
-  thunkMiddleware,
-  loggerMiddleware
-)(createStore)
+const createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore)
 
 function configureStore (initialState) {
   return createStoreWithMiddleware(rootReducer, initialState)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8686,11 +8686,6 @@ decompress@^4.0.0, decompress@^4.2.0:
     pify "^2.3.0"
     strip-dirs "^2.0.0"
 
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
-  integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
-
 deep-eql@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
@@ -24307,13 +24302,6 @@ redux-devtools-instrument@^1.9.4:
   dependencies:
     lodash "^4.2.0"
     symbol-observable "^1.0.2"
-
-redux-logger@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
-  dependencies:
-    deep-diff "^0.3.5"
 
 redux-mock-store@^1.5.3:
   version "1.5.3"


### PR DESCRIPTION
This PR removes the redux-logger middleware from the mock redux store we use for testing. This certainly isn't needed for testing and hasn't been used outside of tests since #6793.