### PR TITLE
Replace fast-deep-equal with isEqual from lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "ethjs-query": "^0.3.4",
     "extension-port-stream": "^1.0.0",
     "extensionizer": "^1.0.1",
-    "fast-deep-equal": "^2.0.1",
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
     "gaba": "^1.9.3",

--- a/ui/app/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.component.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import deepEqual from 'fast-deep-equal'
+import { isEqual } from 'lodash'
 import { PermissionPageContainerContent } from '.'
 import { PageContainerFooter } from '../../ui/page-container'
 
@@ -40,7 +40,7 @@ export default class PermissionPageContainer extends Component {
   componentDidUpdate () {
     const newMethodNames = this.getRequestedMethodNames(this.props)
 
-    if (!deepEqual(Object.keys(this.state.selectedPermissions), newMethodNames)) {
+    if (!isEqual(Object.keys(this.state.selectedPermissions), newMethodNames)) {
       // this should be a new request, so just overwrite
       this.setState({
         selectedPermissions: this.getRequestedMethodState(newMethodNames),


### PR DESCRIPTION
This PR replaces our single usage of [`fast-deep-equal`](https://www.npmjs.com/package/fast-deep-equal) with [`isEqual`](https://lodash.com/docs/4.17.15#isEqual) from lodash.