### PR TITLE
Remove unused number-to-bn package

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "multihashes": "^0.4.12",
     "nanoid": "^2.1.6",
     "nonce-tracker": "^1.0.0",
-    "number-to-bn": "^1.7.0",
     "obj-multiplex": "^1.0.0",
     "obs-store": "^4.0.3",
     "percentile": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20758,7 +20758,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-number-to-bn@1.7.0, number-to-bn@^1.7.0:
+number-to-bn@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/number-to-bn/-/number-to-bn-1.7.0.tgz#bb3623592f7e5f9e0030b1977bd41a0c53fe1ea0"
   integrity sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=


### PR DESCRIPTION
This PR removes `number-to-bn` from our dependencies list as it is unused.