### PR TITLE
Inline isomorphic-fetch test helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,6 @@
     "gulp-watch": "^5.0.1",
     "gulp-zip": "^4.0.0",
     "http-server": "^0.11.1",
-    "isomorphic-fetch": "^2.2.1",
     "jsdom": "^11.2.0",
     "jsdom-global": "^3.0.2",
     "karma": "^4.1.0",

--- a/test/helper.js
+++ b/test/helper.js
@@ -42,7 +42,12 @@ global.log = log
 //
 
 // fetch
-global.fetch = require('isomorphic-fetch')
+const fetch = require('node-fetch')
+
+global.fetch = fetch
+global.Response = fetch.Response
+global.Headers = fetch.Headers
+global.Request = fetch.Request
 require('abortcontroller-polyfill/dist/polyfill-patch-fetch')
 
 // dom


### PR DESCRIPTION
This PR drops our direct dependency on `isomorphic-fetch` and inlines the usage of `node-fetch` we need for running our test suite. We don't need to lean on a package for these 4 lines.