### PR TITLE
Remove dead link to team page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ To write tests that will be run in the browser using QUnit, add your test files 
 - [How to add custom build to Firefox](./docs/add-to-firefox.md)
 - [How to add a new translation to MetaMask](./docs/translating-guide.md)
 - [Publishing Guide](./docs/publishing.md)
-- [The MetaMask Team](./docs/team.md)
 - [How to live reload on local dependency changes](./docs/developing-on-deps.md)
 - [How to add new networks to the Provider Menu](./docs/adding-new-networks.md)
 - [How to port MetaMask to a new platform](./docs/porting_to_new_environment.md)


### PR DESCRIPTION
Refs #7928

This PR removes the now-dead link at the bottom of the README. 🤦‍♂ 