### PR TITLE
Remove mocha-jsdom and mocha-sinon

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,8 +249,6 @@
     "koa": "^2.7.0",
     "lockfile-lint": "^3.0.5",
     "mocha": "^5.0.0",
-    "mocha-jsdom": "^1.1.0",
-    "mocha-sinon": "^2.0.0",
     "nock": "^9.0.14",
     "node-fetch": "^2.6.0",
     "node-sass": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19751,16 +19751,6 @@ mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0
   dependencies:
     minimist "0.0.8"
 
-mocha-jsdom@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mocha-jsdom/-/mocha-jsdom-1.1.0.tgz#e1576fbd0601cc89d358a213a0e5585d1b7c7a01"
-  integrity sha1-4VdvvQYBzInTWKIToOVYXRt8egE=
-
-mocha-sinon@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mocha-sinon/-/mocha-sinon-2.0.0.tgz#723a9310e7d737d7b77c7a66821237425b032d48"
-  integrity sha1-cjqTEOfXN9e3fHpmghI3QlsDLUg=
-
 mocha@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.0.tgz#cccac988b0bc5477119cba0e43de7af6d6ad8f4e"


### PR DESCRIPTION
This PR removes two unused deps from our `devDependencies`: [`mocha-jsdom`](https://www.npmjs.com/package/mocha-jsdom) and [`mocha-sinon`](https://www.npmjs.com/package/mocha-sinon)