### PR TITLE
Explicitly set Sass compiler for gulp-sass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,8 @@ const { makeStringTransform } = require('browserify-transform-tools')
 
 const packageJSON = require('./package.json')
 
+sass.compiler = require('node-sass')
+
 const dependencies = Object.keys(packageJSON && packageJSON.dependencies || {})
 const materialUIDependencies = ['@material-ui/core']
 const reactDepenendencies = dependencies.filter(dep => dep.match(/react/))


### PR DESCRIPTION
As per the gulp-sass docs<sup>[\[1\]][1]</sup> we should be setting the `sass.compiler` property
for forwards-compatibility, emphasis mine:

> You can choose whether to use Dart Sass or Node Sass by setting the `sass.compiler` property. Node Sass will be used by default, but **it's strongly recommended that you set it explicitly for forwards-compatibility in case the default ever changes.**

  [1]:https://github.com/dlmanning/gulp-sass/tree/v4.0.2#basic-usage