### PR TITLE
Update shellcheck version used in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,10 +193,10 @@ jobs:
 
   test-lint-shellcheck:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: koalaman/shellcheck-alpine:stable
     steps:
       - checkout
-      - run: sudo apt-get install shellcheck
+      - run: apk add --no-cache bash jq yarn
       - run:
           name: Shellcheck Lint
           command: yarn lint:shellcheck


### PR DESCRIPTION
This PR updates the version of shellcheck we're running in CI by switching the Docker image used to run `lint:shellcheck` to the official shellcheck Docker image ([`koalaman/shellcheck-alpine`](https://hub.docker.com/r/koalaman/shellcheck-alpine/))—instead of using the base node image and installing an outdated version we're now installing a few deps onto the latest shellcheck image.

**Before:**

```
+ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.4.4
license: GNU General Public License, version 3
website: http://www.shellcheck.net
```

**After:**

```
+ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.7.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
```