### PR TITLE
Update ENS registry addresses

### DIFF
--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -57,20 +57,22 @@ function hexValueIsEmpty (value) {
   return [undefined, null, '0x', '0x0', '0x0000000000000000000000000000000000000000000000000000000000000000'].includes(value)
 }
 
+/**
+ * Returns the registry address for the given chain ID
+ * @param {number} chainId the chain ID
+ * @returns {string|null} the registry address if known, null otherwise
+ */
 function getRegistryForChainId (chainId) {
   switch (chainId) {
-    // mainnet
     case 1:
-      return '0x314159265dd8dbb310642f98f50c066173c1259b'
-    // ropsten
+      // falls through
     case 3:
-      return '0x112234455c3a32fd11230c42e7bccd4a84e02010'
-    // rinkeby
+      // falls through
     case 4:
-      return '0xe7410170f87102df0055eb195163a03b7f2bff4a'
-    // goerli
+      // falls through
     case 5:
-      return '0x112234455c3a32fd11230c42e7bccd4a84e02010'
+      // Mainnet, Ropsten, Rinkeby, and Goerli, respectively, use the same address
+      return '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
     default:
       return null
   }


### PR DESCRIPTION
This PR updates the ENS registry address we directly use to fix CVE-2020-5232.

See also: https://github.com/ensdomains/ens/security/advisories/GHSA-8f9f-pc5v-9r5h

From _[Guide for DApp Developers](https://docs.ens.domains/ens-migration/guide-for-dapp-developers)_:

> You should update the ENS registry address in your code to the new address of `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e` as soon as possible. This new address is functional now, and will return the same results as the old one. Switching now ensures your users will not experience any disruption or interruption of service.