### PR TITLE
Update checks for ENS network support

### DIFF
--- a/app/scripts/controllers/ens/ens.js
+++ b/app/scripts/controllers/ens/ens.js
@@ -1,5 +1,5 @@
 import EthJsEns from 'ethjs-ens'
-import ensNetworkMap from 'ethjs-ens/lib/network-map.json'
+import ensNetworkMap from 'ethereum-ens-network-map'
 
 class Ens {
   static getNetworkEnsSupport (network) {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "eth-sig-util": "^2.3.0",
     "eth-token-tracker": "^1.1.10",
     "eth-trezor-keyring": "^0.4.0",
+    "ethereum-ens-network-map": "^1.0.2",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "5.1.0",

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -7,7 +7,7 @@ import { ellipsify } from '../../send.utils'
 import { debounce } from 'lodash'
 import copyToClipboard from 'copy-to-clipboard/index'
 import ENS from 'ethjs-ens'
-import networkMap from 'ethjs-ens/lib/network-map.json'
+import networkMap from 'ethereum-ens-network-map'
 import log from 'loglevel'
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10814,7 +10814,7 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=
 
-ethereum-ens-network-map@^1.0.0:
+ethereum-ens-network-map@^1.0.0, ethereum-ens-network-map@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ethereum-ens-network-map/-/ethereum-ens-network-map-1.0.2.tgz#4e27bad18dae7bd95d84edbcac2c9e739fc959b9"
   integrity sha512-5qwJ5n3YhjSpE6O/WEBXCAb2nagUgyagJ6C0lGUBWC4LjKp/rRzD+pwtDJ6KCiITFEAoX4eIrWOjRy0Sylq5Hg==


### PR DESCRIPTION
Related to #7959

This PR updates our usages of `ethjs-ens/lib/network-map.json` which has the incorrect addresses to use `ethereum-ens-network-map` directly. These usages aren't impacted by CVE-2020-5232 as we're simply checking whether or not an address exists.