### PR TITLE
Using contact names in place of tx address when applicable

### DIFF
--- a/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
+++ b/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
@@ -35,6 +35,8 @@ describe('TransactionListItemDetails Component', () => {
         senderAddress="0x2"
         tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
+        senderNickname="sender-nickname"
+        recipientNickname="recipient-nickname"
       />,
       { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
@@ -77,6 +79,8 @@ describe('TransactionListItemDetails Component', () => {
         tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
         showSpeedUp
+        senderNickname="sender-nickname"
+        recipientNickname="recipient-nickname"
       />,
       { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
@@ -112,6 +116,8 @@ describe('TransactionListItemDetails Component', () => {
         senderAddress="0x2"
         tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
+        senderNickname="sender-nickname"
+        recipientNickname="recipient-nickname"
       />,
       { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )
@@ -150,6 +156,8 @@ describe('TransactionListItemDetails Component', () => {
         senderAddress="0x2"
         tryReverseResolveAddress={() => {}}
         transactionGroup={transactionGroup}
+        senderNickname="sender-nickname"
+        recipientNickname="recipient-nickname"
       />,
       { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } }
     )

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -35,6 +35,8 @@ export default class TransactionListItemDetails extends PureComponent {
     rpcPrefs: PropTypes.object,
     senderAddress: PropTypes.string.isRequired,
     tryReverseResolveAddress: PropTypes.func.isRequired,
+    senderNickname: PropTypes.string.isRequired,
+    recipientNickname: PropTypes.string.isRequired,
   }
 
   state = {
@@ -146,6 +148,8 @@ export default class TransactionListItemDetails extends PureComponent {
       rpcPrefs: { blockExplorerUrl } = {},
       senderAddress,
       isEarliestNonce,
+      senderNickname,
+      recipientNickname,
     } = this.props
     const { primaryTransaction: transaction } = transactionGroup
     const { hash } = transaction
@@ -212,6 +216,8 @@ export default class TransactionListItemDetails extends PureComponent {
               addressOnly
               recipientEns={recipientEns}
               recipientAddress={recipientAddress}
+              recipientNickname={recipientNickname}
+              senderName={senderNickname}
               senderAddress={senderAddress}
               onRecipientClick={() => {
                 this.context.metricsEvent({

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -2,18 +2,29 @@ import { connect } from 'react-redux'
 import TransactionListItemDetails from './transaction-list-item-details.component'
 import { checksumAddress } from '../../../helpers/utils/util'
 import { tryReverseResolveAddress } from '../../../store/actions'
+import { getAddressBook } from '../../../selectors/selectors'
 
 const mapStateToProps = (state, ownProps) => {
   const { metamask } = state
   const {
     ensResolutionsByAddress,
   } = metamask
-  const { recipientAddress } = ownProps
+  const { recipientAddress, senderAddress } = ownProps
   const address = checksumAddress(recipientAddress)
   const recipientEns = ensResolutionsByAddress[address] || ''
+  const addressBook = getAddressBook(state)
+
+  const getNickName = (address) => {
+    const entry = addressBook.find((contact) => {
+      return address.toLowerCase() === contact.address.toLowerCase()
+    })
+    return entry && entry.name || ''
+  }
 
   return {
     recipientEns,
+    senderNickname: getNickName(senderAddress),
+    recipientNickname: getNickName(recipientAddress),
   }
 }
 

--- a/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -78,7 +78,7 @@ export default class SenderToRecipient extends PureComponent {
         <div className="sender-to-recipient__name">
           {
             addressOnly
-              ? <span>{`${t('from')}: ${checksummedSenderAddress}`}</span>
+              ? <span>{`${t('from')}: ${senderName || checksummedSenderAddress}`}</span>
               : senderName
           }
         </div>


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/7967

I used another address of mine as a contact and `vitalik.eth` for the other

<img width="400" alt="Screen Shot 2020-02-01 at 3 40 53 PM" src="https://user-images.githubusercontent.com/8732757/73600280-325af500-450b-11ea-813e-6ec968977ebc.png">
<img width="616" alt="Screen Shot 2020-02-01 at 3 41 51 PM" src="https://user-images.githubusercontent.com/8732757/73600281-3424b880-450b-11ea-8778-c3ade3ba0d1f.png">
<img width="627" alt="Screen Shot 2020-02-01 at 3 41 58 PM" src="https://user-images.githubusercontent.com/8732757/73600283-36871280-450b-11ea-94d1-f49bd849ee19.png">
<img width="627" alt="Screen Shot 2020-02-01 at 3 42 35 PM" src="https://user-images.githubusercontent.com/8732757/73600284-3850d600-450b-11ea-9f90-6d8280505a7d.png">
