### PR TITLE
Use eth-json-rpc-infura@4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-errors": "^2.0.0",
     "eth-json-rpc-filters": "^4.1.1",
-    "eth-json-rpc-infura": "^4.0.1",
+    "eth-json-rpc-infura": "^4.0.2",
     "eth-json-rpc-middleware": "^4.4.0",
     "eth-keyring-controller": "^5.3.0",
     "eth-ledger-bridge-keyring": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10555,16 +10555,15 @@ eth-json-rpc-infura@^3.1.0:
     json-rpc-error "^2.0.0"
     tape "^4.8.0"
 
-eth-json-rpc-infura@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.1.tgz#41159b7e90cb0a5a3d75e855339a05639ed4aa6d"
-  integrity sha512-7pZfz6bKy4KO5mYVZ1dqsqaTsbo0sQUNo4C11NuTJ0BPjzNRJpQhBTNgRpK0Hpys0jJe898KYqdSWxuaWuc18A==
+eth-json-rpc-infura@^4.0.1, eth-json-rpc-infura@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.2.tgz#8af1a1a2e9a0a82aaa302bbc96fb1a4c15d69b83"
+  integrity sha512-dvgOrci9lZqpjpp0hoC3Zfedhg3aIpLFVDH0TdlKxRlkhR75hTrKTwxghDrQwE0bn3eKrC8RsN1m/JdnIWltpw==
   dependencies:
     cross-fetch "^2.1.1"
     eth-json-rpc-errors "^1.0.1"
     eth-json-rpc-middleware "^4.1.4"
     json-rpc-engine "^5.1.3"
-    tape "^4.8.0"
 
 eth-json-rpc-middleware@^1.5.0:
   version "1.6.0"


### PR DESCRIPTION
This PR bumps our `eth-json-rpc-infura` dependency version, factored out of #7831.