### PR TITLE
Use gulp@4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "ganache-core": "2.8.0",
     "geckodriver": "^1.19.1",
     "get-port": "^5.1.0",
-    "gulp": "^4.0.0",
+    "gulp": "^4.0.2",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-babel": "^7.0.0",
     "gulp-debug": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13668,7 +13668,7 @@ gulp-zip@^4.0.0:
     vinyl "^2.1.0"
     yazl "^2.1.0"
 
-gulp@^4.0.0, gulp@^4.0.2:
+gulp@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
   integrity sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==


### PR DESCRIPTION
This PR bumps our _listed_ `gulp` dependency version, factored out of #7831.