### PR TITLE
Use envify@4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "css-loader": "^2.1.1",
     "del": "^3.0.0",
     "deps-dump": "^1.1.0",
-    "envify": "^4.0.0",
+    "envify": "^4.1.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
     "eslint": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9767,7 +9767,7 @@ env-paths@^1.0.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
   integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
 
-envify@^4.0.0:
+envify@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
   integrity sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==


### PR DESCRIPTION
This PR bumps our _listed_ `envify` dependency version, factored out of #7831.