### PR TITLE
Add Chrome flags to maybe fix build issues

### DIFF
--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -13,6 +13,11 @@ class ChromeDriver {
       args.push('--auto-open-devtools-for-tabs')
     }
     const options = new chrome.Options()
+      .addArguments(
+        '--disable-dev-shm-usage',
+        '--headless',
+        '--no-sandbox',
+      )
       .addArguments(args)
     const builder = new Builder()
       .forBrowser('chrome')


### PR DESCRIPTION
Refs https://stackoverflow.com/a/50642913/1267663

This PR attempts to fix our sudden build failure with some random flags.

```
unknown error: DevToolsActivePort file doesn't exist
```
```
WebDriverError: unknown error: Chrome failed to start: exited abnormally
```