### PR TITLE
Fix failed prop type warning

### DIFF
--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.js
@@ -65,7 +65,7 @@ export default class AmountMaxButton extends Component {
 
     return (
       <div className="send-v2__amount-max" onClick={buttonDataLoading || inError ? null : this.onMaxClick}>
-        <input type="checkbox" checked={maxModeOn} />
+        <input type="checkbox" checked={maxModeOn} readOnly />
         <div className={classnames('send-v2__amount-max__button', { 'send-v2__amount-max__button__disabled': buttonDataLoading || inError })}>
           {this.context.t('max')}
         </div>


### PR DESCRIPTION
Noticed this recently when setting up a transaction... the warning provided a couple possible solutions but this seemed to make the most sense.

![image](https://user-images.githubusercontent.com/675259/73885368-a4964700-4835-11ea-931b-94ced411e23f.png)
