### PR TITLE
Revert CircleCI Node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
 jobs:
   create_release_pull_request:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - run:
@@ -104,7 +104,7 @@ jobs:
 
   prep-deps:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - run:
@@ -123,7 +123,7 @@ jobs:
 
   prep-build:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -142,7 +142,7 @@ jobs:
 
   prep-build-test:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -160,7 +160,7 @@ jobs:
 
   prep-scss:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -179,7 +179,7 @@ jobs:
 
   test-lint:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -203,7 +203,7 @@ jobs:
 
   test-lint-lockfile:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -214,7 +214,7 @@ jobs:
 
   test-deps:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -225,7 +225,7 @@ jobs:
 
   test-e2e-chrome:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -243,7 +243,7 @@ jobs:
 
   test-e2e-firefox:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - run:
@@ -264,7 +264,7 @@ jobs:
 
   benchmark:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -285,7 +285,7 @@ jobs:
 
   job-publish-prerelease:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -315,7 +315,7 @@ jobs:
 
   job-publish-release:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -332,7 +332,7 @@ jobs:
           command: .circleci/scripts/release-create-master-pr
   # job-publish-storybook:
   #   docker:
-  #     - image: circleci/node:10.18-browsers
+  #     - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
   #   steps:
   #     - checkout
   #     - attach_workspace:
@@ -343,7 +343,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -358,7 +358,7 @@ jobs:
             - coverage
   test-unit-global:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -368,7 +368,7 @@ jobs:
           command: yarn test:unit:global
   test-mozilla-lint:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -379,7 +379,7 @@ jobs:
 
   test-integration-flat-firefox:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -395,7 +395,7 @@ jobs:
     environment:
       browsers: '["Chrome"]'
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:
@@ -406,7 +406,7 @@ jobs:
 
   all-tests-pass:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - run:
           name: All Tests Passed
@@ -414,7 +414,7 @@ jobs:
 
   coveralls-upload:
     docker:
-      - image: circleci/node:10.18-browsers
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
This PR "reverts" the image version of the CircleCI node image, to work around a chromedriver/Chrome/WebDriver error. We are currently seeing the following errors:<sup>[\[1\]][1][\[2\]][2]</sup>

  [1]:https://app.circleci.com/jobs/github/MetaMask/metamask-extension/135430
  [2]:https://app.circleci.com/jobs/github/MetaMask/metamask-extension/135431

```
WebDriverError: unknown error: Chrome failed to start: exited abnormally
(unknown error: DevToolsActivePort file doesn't exist)
(The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

I can surmise that the content changes in the Docker image, listed below, did result in this breakage:

1. `circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88`
2. `circleci/node@sha256:14d76b9e092ca03543328409223a2d2fba29e3ee5b8274c90b0c98b80005ecf2`

As the Chrome & chromedriver versions are both bumped:

**Before:**

```
$ docker run --rm -it circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88 bash
circleci@543bd0212ddc:/$ google-chrome --version
Google Chrome 79.0.3945.130 
$ docker run --rm -it circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88 bash
circleci@8999c20544d3:/$ chromedriver --version
ChromeDriver 79.0.3945.36 (3582db32b33893869b8c1339e8f4d9ed1816f143-refs/branch-heads/3945@{#614})
```

**After:**

```
$ docker run --rm -it circleci/node@sha256:14d76b9e092ca03543328409223a2d2fba29e3ee5b8274c90b0c98b80005ecf2 bash
circleci@51071006c3da:/$ google-chrome --version
Google Chrome 80.0.3987.87 
$ docker run --rm -it circleci/node@sha256:14d76b9e092ca03543328409223a2d2fba29e3ee5b8274c90b0c98b80005ecf2 bash
circleci@0c42878663e8:/$ chromedriver --version
ChromeDriver 80.0.3987.16 (320f6526c1632ad4f205ebce69b99a062ed78647-refs/branch-heads/3987@{#185})
```