### PR TITLE
Delete limited_site_access.md

### DIFF
--- a/docs/limited_site_access.md
+++ b/docs/limited_site_access.md
@@ -1,5 +1,0 @@
-# Google Chrome/Brave Limited Site Access for Extensions
-
-Problem: MetaMask doesn't work with limited site access enabled under Chrome's extensions. 
-
-Solution: In addition to the site you wish to whitelist, you must add 'api.infura.io' as another domain, so the MetaMask extension is authorized to make RPC calls to Infura.


### PR DESCRIPTION
This PR removes a unnecessary doc detailing a possible solution to running MetaMask under "limited site access" where users futz with our permissions in the settings page (pictured below). This isn't a supported action and the existence of this doc suggests we care about this.

<img width="722" alt="" src="https://user-images.githubusercontent.com/1623628/73976285-8f3b1e80-4902-11ea-9c18-f1121dc3a8c6.png">

Please don't do this, and if you _do_, you'll need understand how debug the result. We'd need more than just the ability to contact Infura whitelisted/custom networks might not even use Infura.