### PR TITLE
Update README comment about browser tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,6 @@ yarn start
 yarn dist
 ```
 
-#### Writing Browser Tests
-
-To write tests that will be run in the browser using QUnit, add your test files to `test/integration/lib`.
-
 ## Other Docs
 
 - [How to add custom build to Chrome](./docs/add-to-chrome.md)


### PR DESCRIPTION
This PR removes the line in the README about writing integration tests with QUnit.