### PR TITLE
Update unlock route

### DIFF
--- a/ui/app/helpers/constants/routes.js
+++ b/ui/app/helpers/constants/routes.js
@@ -30,7 +30,7 @@ const CONNECTED_ROUTE = '/connected'
 
 const INITIALIZE_ROUTE = '/initialize'
 const INITIALIZE_WELCOME_ROUTE = '/initialize/welcome'
-const INITIALIZE_UNLOCK_ROUTE = '/initialize/unlock'
+const INITIALIZE_UNLOCK_ROUTE = '/unlock'
 const INITIALIZE_CREATE_PASSWORD_ROUTE = '/initialize/create-password'
 const INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE = '/initialize/create-password/import-with-seed-phrase'
 const INITIALIZE_SELECT_ACTION_ROUTE = '/initialize/select-action'


### PR DESCRIPTION
This is a result of some discovery...

I had a thought today about how seeing the network info on login seemed odd to me:

**Before:**

![image](https://user-images.githubusercontent.com/675259/74074480-46f02f00-49dc-11ea-92f0-5953507916bf.png)


and so I got to looking and it appears that <a href="https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/pages/routes/index.js#L163">this</a> is returning false when it should be truthy 

changing the value of `INITIALIZE_UNLOCK_ROUTE` fixes this:

**After:**

![image](https://user-images.githubusercontent.com/675259/74074788-bfa3bb00-49dd-11ea-9b70-c84a9ff41cfe.png)

I am unsure if there will be repercussions elsewhere in the app as a result of this change?

we could maybe also add an e2e test to verify this doesn't happen again