### PR TITLE
Ensure we pass history to UnlockPage component

### DIFF
--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -14,7 +14,7 @@ export default class UnlockPage extends Component {
   }
 
   static propTypes = {
-    history: PropTypes.object,
+    history: PropTypes.object.isRequired,
     isUnlocked: PropTypes.bool,
     onImport: PropTypes.func,
     onRestore: PropTypes.func,

--- a/ui/app/pages/unlock-page/unlock-page.container.js
+++ b/ui/app/pages/unlock-page/unlock-page.container.js
@@ -55,6 +55,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     onImport,
     onRestore: onImport,
     onSubmit: ownPropsSubmit || onSubmit,
+    history,
   }
 }
 


### PR DESCRIPTION
when i login and navigate using the browser back button the application throws:

**Before:**

![image](https://user-images.githubusercontent.com/675259/74075315-d4814e00-49df-11ea-8fbd-db8aa682e0d8.png)

<strike>now it just goes back to the login screen instead:</strike>

now it more appropriately does nothing if you're on the first page after login



