### PR TITLE
Update ESLint rules for test suite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,17 +21,16 @@ module.exports = {
   extends: [
     '@metamask/eslint-config',
     '@metamask/eslint-config/config/nodejs',
+    '@metamask/eslint-config/config/mocha',
     'plugin:react/recommended',
   ],
 
   env: {
     'browser': true,
-    'mocha': true,
   },
 
   plugins: [
     'babel',
-    'mocha',
     'chai',
     'react',
     'json',
@@ -91,6 +90,6 @@ module.exports = {
       'prop': 'parens-new-line',
     }],
     'babel/semi': ['error', 'never'],
-    'mocha/no-exclusive-tests': 'error',
+    'mocha/no-setup-in-describe': 'off',
   },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   parser: 'babel-eslint',
   parserOptions: {
     'sourceType': 'module',

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.5.5",
-    "@metamask/eslint-config": "^1.0.0",
+    "@metamask/eslint-config": "^1.1.0",
     "@metamask/forwarder": "^1.1.0",
     "@metamask/onboarding": "^0.2.0",
     "@sentry/cli": "^1.49.0",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "eslint-plugin-chai": "0.0.1",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-mocha": "^6.2.2",
     "eslint-plugin-react": "^7.4.0",
     "fancy-log": "^1.3.3",
     "fetch-mock": "^6.5.2",

--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'mocha/no-hooks-for-single-case': 'off',
+  },
+}

--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -52,24 +52,24 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('Going through the first time flow', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('Going through the first time flow', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Create New Wallet" option', async () => {
+    it('clicks the "Create New Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create a Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('accepts a secure password', async () => {
+    it('accepts a secure password', async function () {
       const passwordBox = await driver.findElement(By.css('.first-time-flow__form #create-password'))
       const passwordBoxConfirm = await driver.findElement(By.css('.first-time-flow__form #confirm-password'))
 
@@ -83,7 +83,7 @@ describe('MetaMask', function () {
 
     let seedPhrase
 
-    it('reveals the seed phrase', async () => {
+    it('reveals the seed phrase', async function () {
       const byRevealButton = By.css('.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button')
       await driver.clickElement(byRevealButton)
       await driver.delay(regularDelayMs)
@@ -102,7 +102,7 @@ describe('MetaMask', function () {
       await driver.delay(tinyDelayMs)
     }
 
-    it('can retype the seed phrase', async () => {
+    it('can retype the seed phrase', async function () {
       const words = seedPhrase.split(' ')
 
       for (const word of words) {
@@ -113,15 +113,15 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('clicks through the success screen', async () => {
+    it('clicks through the success screen', async function () {
       await driver.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Import seed phrase', () => {
-    it('logs out of the vault', async () => {
+  describe('Import seed phrase', function () {
+    it('logs out of the vault', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -131,7 +131,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('imports seed phrase', async () => {
+    it('imports seed phrase', async function () {
       const restoreSeedLink = await driver.findClickableElement(By.css('.unlock-page__link--import'))
       assert.equal(await restoreSeedLink.getText(), 'Import using account seed phrase')
       await restoreSeedLink.click()
@@ -150,14 +150,14 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('balance renders', async () => {
+    it('balance renders', async function () {
       const balance = await driver.findElement(By.css('.balance-display .token-amount'))
       await driver.wait(until.elementTextMatches(balance, /25\s*ETH/))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Adds an entry to the address book and sends eth to that address', () => {
+  describe('Adds an entry to the address book and sends eth to that address', function () {
     it('starts a send transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
@@ -205,7 +205,7 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Sends to an address book entry', () => {
+  describe('Sends to an address book entry', function () {
     it('starts a send transaction by clicking address book entry', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)

--- a/test/e2e/ethereum-on.spec.js
+++ b/test/e2e/ethereum-on.spec.js
@@ -51,24 +51,24 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('Going through the first time flow, but skipping the seed phrase challenge', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('Going through the first time flow, but skipping the seed phrase challenge', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Create New Wallet" option', async () => {
+    it('clicks the "Create New Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create a Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('accepts a secure password', async () => {
+    it('accepts a secure password', async function () {
       const passwordBox = await driver.findElement(By.css('.first-time-flow__form #create-password'))
       const passwordBoxConfirm = await driver.findElement(By.css('.first-time-flow__form #confirm-password'))
 
@@ -80,7 +80,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('skips the seed phrase challenge', async () => {
+    it('skips the seed phrase challenge', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.remindMeLater.message}')]`))
       await driver.delay(regularDelayMs)
 
@@ -88,7 +88,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('gets the current accounts address', async () => {
+    it('gets the current accounts address', async function () {
       const addressInput = await driver.findElement(By.css('.qr-ellip-address'))
       publicAddress = await addressInput.getAttribute('value')
       const accountModal = await driver.findElement(By.css('span .modal'))
@@ -101,12 +101,12 @@ describe('MetaMask', function () {
 
   })
 
-  describe('provider listening for events', () => {
+  describe('provider listening for events', function () {
     let extension
     let popup
     let dapp
 
-    it('connects to the dapp', async () => {
+    it('connects to the dapp', async function () {
       await driver.openNewPage('http://127.0.0.1:8080/')
       await driver.delay(regularDelayMs)
 
@@ -134,13 +134,13 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('has the ganache network id within the dapp', async () => {
+    it('has the ganache network id within the dapp', async function () {
       const networkDiv = await driver.findElement(By.css('#network'))
       await driver.delay(regularDelayMs)
       assert.equal(await networkDiv.getText(), '5777')
     })
 
-    it('changes the network', async () => {
+    it('changes the network', async function () {
       await driver.switchToWindow(extension)
 
       await driver.clickElement(By.css('.network-name'))
@@ -150,19 +150,19 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('sets the network div within the dapp', async () => {
+    it('sets the network div within the dapp', async function () {
       await driver.switchToWindow(dapp)
       const networkDiv = await driver.findElement(By.css('#network'))
       assert.equal(await networkDiv.getText(), '3')
     })
 
-    it('sets the chainId div within the dapp', async () => {
+    it('sets the chainId div within the dapp', async function () {
       await driver.switchToWindow(dapp)
       const chainIdDiv = await driver.findElement(By.css('#chainId'))
       assert.equal(await chainIdDiv.getText(), '0x3')
     })
 
-    it('sets the account div within the dapp', async () => {
+    it('sets the account div within the dapp', async function () {
       await driver.switchToWindow(dapp)
       const accountsDiv = await driver.findElement(By.css('#accounts'))
       assert.equal(await accountsDiv.getText(), publicAddress.toLowerCase())

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -56,24 +56,24 @@ describe('Using MetaMask with an existing account', function () {
     await driver.quit()
   })
 
-  describe('First time flow starting from an existing seed phrase', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('First time flow starting from an existing seed phrase', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Import Wallet" option', async () => {
+    it('clicks the "Import Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('imports a seed phrase', async () => {
+    it('imports a seed phrase', async function () {
       const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
       await seedTextArea.sendKeys(testSeedPhrase)
       await driver.delay(regularDelayMs)
@@ -89,15 +89,15 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('clicks through the success screen', async () => {
+    it('clicks through the success screen', async function () {
       await driver.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Show account information', () => {
-    it('shows the correct account address', async () => {
+  describe('Show account information', function () {
+    it('shows the correct account address', async function () {
       await driver.clickElement(By.css('.account-details__details-button'))
       await driver.findVisibleElement(By.css('.qr-wrapper'))
       await driver.delay(regularDelayMs)
@@ -109,7 +109,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('shows a QR code for the account', async () => {
+    it('shows a QR code for the account', async function () {
       await driver.clickElement(By.css('.account-details__details-button'))
       await driver.findVisibleElement(By.css('.qr-wrapper'))
       const detailModal = await driver.findElement(By.css('span .modal'))
@@ -121,8 +121,8 @@ describe('Using MetaMask with an existing account', function () {
     })
   })
 
-  describe('Lock and unlock', () => {
-    it('logs out of the account', async () => {
+  describe('Lock and unlock', function () {
+    it('logs out of the account', async function () {
       await driver.clickElement(By.css('.account-menu__icon .identicon'))
       await driver.delay(regularDelayMs)
 
@@ -132,7 +132,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('accepts the account password after lock', async () => {
+    it('accepts the account password after lock', async function () {
       const passwordField = await driver.findElement(By.id('password'))
       await passwordField.sendKeys('correct horse battery staple')
       await passwordField.sendKeys(Key.ENTER)
@@ -140,8 +140,8 @@ describe('Using MetaMask with an existing account', function () {
     })
   })
 
-  describe('Add an account', () => {
-    it('switches to localhost', async () => {
+  describe('Add an account', function () {
+    it('switches to localhost', async function () {
       await driver.clickElement(By.css('.network-name'))
       await driver.delay(regularDelayMs)
 
@@ -149,7 +149,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('choose Create Account from the account menu', async () => {
+    it('choose Create Account from the account menu', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -157,7 +157,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('set account name', async () => {
+    it('set account name', async function () {
       const [accountName] = await driver.findElements(By.css('.new-account-create-form input'))
       await accountName.sendKeys('2nd account')
       await driver.delay(regularDelayMs)
@@ -166,15 +166,15 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('should show the correct account name', async () => {
+    it('should show the correct account name', async function () {
       const [accountName] = await driver.findElements(By.css('.account-details__account-name'))
       assert.equal(await accountName.getText(), '2nd account')
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Switch back to original account', () => {
-    it('chooses the original account from the account menu', async () => {
+  describe('Switch back to original account', function () {
+    it('chooses the original account from the account menu', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -183,7 +183,7 @@ describe('Using MetaMask with an existing account', function () {
     })
   })
 
-  describe('Send ETH from inside MetaMask', () => {
+  describe('Send ETH from inside MetaMask', function () {
     it('starts a send transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
@@ -225,8 +225,8 @@ describe('Using MetaMask with an existing account', function () {
     })
   })
 
-  describe('Imports an account with private key', () => {
-    it('choose Create Account from the account menu', async () => {
+  describe('Imports an account with private key', function () {
+    it('choose Create Account from the account menu', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -234,7 +234,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('enter private key', async () => {
+    it('enter private key', async function () {
       const privateKeyInput = await driver.findElement(By.css('#private-key-box'))
       await privateKeyInput.sendKeys(testPrivateKey2)
       await driver.delay(regularDelayMs)
@@ -242,21 +242,21 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('should show the correct account name', async () => {
+    it('should show the correct account name', async function () {
       const [accountName] = await driver.findElements(By.css('.account-details__account-name'))
       assert.equal(await accountName.getText(), 'Account 4')
       await driver.delay(regularDelayMs)
     })
 
-    it('should show the imported label', async () => {
+    it('should show the imported label', async function () {
       const [importedLabel] = await driver.findElements(By.css('.account-details__keyring-label'))
       assert.equal(await importedLabel.getText(), 'IMPORTED')
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Imports and removes an account', () => {
-    it('choose Create Account from the account menu', async () => {
+  describe('Imports and removes an account', function () {
+    it('choose Create Account from the account menu', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -264,7 +264,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('enter private key', async () => {
+    it('enter private key', async function () {
       const privateKeyInput = await driver.findElement(By.css('#private-key-box'))
       await privateKeyInput.sendKeys(testPrivateKey3)
       await driver.delay(regularDelayMs)
@@ -272,7 +272,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('should open the remove account modal', async () => {
+    it('should open the remove account modal', async function () {
       const [accountName] = await driver.findElements(By.css('.account-details__account-name'))
       assert.equal(await accountName.getText(), 'Account 5')
       await driver.delay(regularDelayMs)
@@ -289,7 +289,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.findElement(By.css('.confirm-remove-account__account'))
     })
 
-    it('should remove the account', async () => {
+    it('should remove the account', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Remove')]`))
 
       await driver.delay(regularDelayMs)
@@ -303,13 +303,13 @@ describe('Using MetaMask with an existing account', function () {
     })
   })
 
-  describe('Connects to a Hardware wallet', () => {
-    it('choose Connect Hardware Wallet from the account menu', async () => {
+  describe('Connects to a Hardware wallet', function () {
+    it('choose Connect Hardware Wallet from the account menu', async function () {
       await driver.clickElement(By.xpath(`//div[contains(text(), 'Connect Hardware Wallet')]`))
       await driver.delay(regularDelayMs)
     })
 
-    it('should open the TREZOR Connect popup', async () => {
+    it('should open the TREZOR Connect popup', async function () {
       await driver.clickElement(By.css('.hw-connect__btn:nth-of-type(2)'))
       await driver.delay(regularDelayMs)
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Connect')]`))

--- a/test/e2e/incremental-security.spec.js
+++ b/test/e2e/incremental-security.spec.js
@@ -56,24 +56,24 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('Going through the first time flow, but skipping the seed phrase challenge', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('Going through the first time flow, but skipping the seed phrase challenge', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Create New Wallet" option', async () => {
+    it('clicks the "Create New Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create a Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('accepts a secure password', async () => {
+    it('accepts a secure password', async function () {
       const passwordBox = await driver.findElement(By.css('.first-time-flow__form #create-password'))
       const passwordBoxConfirm = await driver.findElement(By.css('.first-time-flow__form #confirm-password'))
 
@@ -86,7 +86,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('skips the seed phrase challenge', async () => {
+    it('skips the seed phrase challenge', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.remindMeLater.message}')]`))
       await driver.delay(regularDelayMs)
 
@@ -94,7 +94,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('gets the current accounts address', async () => {
+    it('gets the current accounts address', async function () {
       const addressInput = await driver.findElement(By.css('.qr-ellip-address'))
       publicAddress = await addressInput.getAttribute('value')
 
@@ -108,10 +108,10 @@ describe('MetaMask', function () {
 
   })
 
-  describe('send to current account from dapp with different provider', () => {
+  describe('send to current account from dapp with different provider', function () {
     let extension
 
-    it('switches to dapp screen', async () => {
+    it('switches to dapp screen', async function () {
       const windowHandles = await driver.getAllWindowHandles()
       extension = windowHandles[0]
 
@@ -119,7 +119,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('sends eth to the current account', async () => {
+    it('sends eth to the current account', async function () {
       const addressInput = await driver.findElement(By.css('#address'))
       await addressInput.sendKeys(publicAddress)
       await driver.delay(regularDelayMs)
@@ -130,11 +130,11 @@ describe('MetaMask', function () {
       await driver.wait(until.elementTextMatches(txStatus, /Success/), 15000)
     })
 
-    it('switches back to MetaMask', async () => {
+    it('switches back to MetaMask', async function () {
       await driver.switchToWindow(extension)
     })
 
-    it('should have the correct amount of eth', async () => {
+    it('should have the correct amount of eth', async function () {
       const balances = await driver.findElements(By.css('.currency-display-component__text'))
       await driver.wait(until.elementTextMatches(balances[0], /1/), 15000)
       const balance = await balances[0].getText()
@@ -143,20 +143,20 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('backs up the seed phrase', () => {
-    it('should show a backup reminder', async () => {
+  describe('backs up the seed phrase', function () {
+    it('should show a backup reminder', async function () {
       const backupReminder = await driver.findElements(By.xpath("//div[contains(@class, 'home-notification__text') and contains(text(), 'Backup your Secret Recovery code to keep your wallet and funds secure')]"))
       assert.equal(backupReminder.length, 1)
     })
 
-    it('should take the user to the seedphrase backup screen', async () => {
+    it('should take the user to the seedphrase backup screen', async function () {
       await driver.clickElement(By.css('.home-notification__accept-button'))
       await driver.delay(regularDelayMs)
     })
 
     let seedPhrase
 
-    it('reveals the seed phrase', async () => {
+    it('reveals the seed phrase', async function () {
       const byRevealButton = By.css('.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button')
       await driver.clickElement(byRevealButton)
       await driver.delay(regularDelayMs)
@@ -175,7 +175,7 @@ describe('MetaMask', function () {
       await driver.delay(tinyDelayMs)
     }
 
-    it('can retype the seed phrase', async () => {
+    it('can retype the seed phrase', async function () {
       const words = seedPhrase.split(' ')
 
       for (const word of words) {
@@ -186,12 +186,12 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('can click through the success screen', async () => {
+    it('can click through the success screen', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'All Done')]`))
       await driver.delay(regularDelayMs)
     })
 
-    it('should have the correct amount of eth', async () => {
+    it('should have the correct amount of eth', async function () {
       const balances = await driver.findElements(By.css('.currency-display-component__text'))
       await driver.wait(until.elementTextMatches(balances[0], /1/), 15000)
       const balance = await balances[0].getText()
@@ -199,7 +199,7 @@ describe('MetaMask', function () {
       assert.equal(balance, '1')
     })
 
-    it('should not show a backup reminder', async () => {
+    it('should not show a backup reminder', async function () {
       await driver.assertElementNotPresent(By.css('.backup-notification'))
     })
   })

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -46,24 +46,24 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('Going through the first time flow', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('Going through the first time flow', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Create New Wallet" option', async () => {
+    it('clicks the "Create New Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create a Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "I agree" option on the metametrics opt-in screen', async () => {
+    it('clicks the "I agree" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-primary'))
       await driver.delay(largeDelayMs)
     })
 
-    it('accepts a secure password', async () => {
+    it('accepts a secure password', async function () {
       const passwordBox = await driver.findElement(By.css('.first-time-flow__form #create-password'))
       const passwordBoxConfirm = await driver.findElement(By.css('.first-time-flow__form #confirm-password'))
 
@@ -78,7 +78,7 @@ describe('MetaMask', function () {
 
     let seedPhrase
 
-    it('reveals the seed phrase', async () => {
+    it('reveals the seed phrase', async function () {
       const byRevealButton = By.css('.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button')
       await driver.clickElement(byRevealButton)
       await driver.delay(regularDelayMs)
@@ -97,7 +97,7 @@ describe('MetaMask', function () {
       await driver.delay(tinyDelayMs)
     }
 
-    it('can retype the seed phrase', async () => {
+    it('can retype the seed phrase', async function () {
       const words = seedPhrase.split(' ')
 
       for (const word of words) {
@@ -108,15 +108,15 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('clicks through the success screen', async () => {
+    it('clicks through the success screen', async function () {
       await driver.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Show account information', () => {
-    it('show account details dropdown menu', async () => {
+  describe('Show account information', function () {
+    it('show account details dropdown menu', async function () {
       await driver.clickElement(By.css('div.menu-bar__open-in-browser'))
       const options = await driver.findElements(By.css('div.menu.account-details-dropdown div.menu__item'))
       assert.equal(options.length, 4) // HD Wallet type does not have to show the Remove Account option
@@ -124,8 +124,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Import seed phrase', () => {
-    it('logs out of the vault', async () => {
+  describe('Import seed phrase', function () {
+    it('logs out of the vault', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -135,7 +135,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('imports seed phrase', async () => {
+    it('imports seed phrase', async function () {
       const restoreSeedLink = await driver.findClickableElement(By.css('.unlock-page__link--import'))
       assert.equal(await restoreSeedLink.getText(), 'Import using account seed phrase')
       await restoreSeedLink.click()
@@ -154,7 +154,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('switches to localhost', async () => {
+    it('switches to localhost', async function () {
       await driver.clickElement(By.css('.network-name'))
       await driver.delay(regularDelayMs)
 
@@ -162,14 +162,14 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs * 2)
     })
 
-    it('balance renders', async () => {
+    it('balance renders', async function () {
       const balance = await driver.findElement(By.css('.transaction-view-balance__primary-balance'))
       await driver.wait(until.elementTextMatches(balance, /100\s*ETH/))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Send ETH from inside MetaMask', () => {
+  describe('Send ETH from inside MetaMask', function () {
     it('starts to send a transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -47,24 +47,24 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('Going through the first time flow', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('Going through the first time flow', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Create New Wallet" option', async () => {
+    it('clicks the "Create New Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create a Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('accepts a secure password', async () => {
+    it('accepts a secure password', async function () {
       const passwordBox = await driver.findElement(By.css('.first-time-flow__form #create-password'))
       const passwordBoxConfirm = await driver.findElement(By.css('.first-time-flow__form #confirm-password'))
 
@@ -79,7 +79,7 @@ describe('MetaMask', function () {
 
     let seedPhrase
 
-    it('reveals the seed phrase', async () => {
+    it('reveals the seed phrase', async function () {
       const byRevealButton = By.css('.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button')
       await driver.findElement(byRevealButton)
       await driver.clickElement(byRevealButton)
@@ -99,7 +99,7 @@ describe('MetaMask', function () {
       await driver.delay(tinyDelayMs)
     }
 
-    it('can retype the seed phrase', async () => {
+    it('can retype the seed phrase', async function () {
       const words = seedPhrase.split(' ')
 
       for (const word of words) {
@@ -110,15 +110,15 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('clicks through the success screen', async () => {
+    it('clicks through the success screen', async function () {
       await driver.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Show account information', () => {
-    it('shows the QR code for the account', async () => {
+  describe('Show account information', function () {
+    it('shows the QR code for the account', async function () {
       await driver.clickElement(By.css('.account-details__details-button'))
       await driver.findVisibleElement(By.css('.qr-wrapper'))
       await driver.delay(regularDelayMs)
@@ -131,8 +131,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Lock an unlock', () => {
-    it('logs out of the account', async () => {
+  describe('Lock an unlock', function () {
+    it('logs out of the account', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -142,7 +142,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('accepts the account password after lock', async () => {
+    it('accepts the account password after lock', async function () {
       const passwordField = await driver.findElement(By.id('password'))
       await passwordField.sendKeys('correct horse battery staple')
       await passwordField.sendKeys(Key.ENTER)
@@ -150,8 +150,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Add account', () => {
-    it('choose Create Account from the account menu', async () => {
+  describe('Add account', function () {
+    it('choose Create Account from the account menu', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -159,7 +159,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('set account name', async () => {
+    it('set account name', async function () {
       const accountName = await driver.findElement(By.css('.new-account-create-form input'))
       await accountName.sendKeys('2nd account')
       await driver.delay(regularDelayMs)
@@ -168,15 +168,15 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('should display correct account name', async () => {
+    it('should display correct account name', async function () {
       const accountName = await driver.findElement(By.css('.account-details__account-name'))
       assert.equal(await accountName.getText(), '2nd account')
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Import seed phrase', () => {
-    it('logs out of the vault', async () => {
+  describe('Import seed phrase', function () {
+    it('logs out of the vault', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -186,7 +186,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('imports seed phrase', async () => {
+    it('imports seed phrase', async function () {
       const restoreSeedLink = await driver.findClickableElement(By.css('.unlock-page__link--import'))
       assert.equal(await restoreSeedLink.getText(), 'Import using account seed phrase')
       await restoreSeedLink.click()
@@ -205,14 +205,14 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('balance renders', async () => {
+    it('balance renders', async function () {
       const balance = await driver.findElement(By.css('.balance-display .token-amount'))
       await driver.wait(until.elementTextMatches(balance, /100\s*ETH/))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Send ETH from inside MetaMask using default gas', () => {
+  describe('Send ETH from inside MetaMask using default gas', function () {
     it('starts a send transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
@@ -275,7 +275,7 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Send ETH from inside MetaMask using fast gas option', () => {
+  describe('Send ETH from inside MetaMask using fast gas option', function () {
     it('starts a send transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
@@ -314,7 +314,7 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Send ETH from inside MetaMask using advanced gas modal', () => {
+  describe('Send ETH from inside MetaMask using advanced gas modal', function () {
     it('starts a send transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)
@@ -362,13 +362,13 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Send ETH from dapp using advanced gas controls', () => {
+  describe('Send ETH from dapp using advanced gas controls', function () {
     let windowHandles
     let extension
     let popup
     let dapp
 
-    it('goes to the settings screen', async () => {
+    it('goes to the settings screen', async function () {
       await driver.clickElement(By.css('.account-menu__icon'))
       await driver.delay(regularDelayMs)
 
@@ -394,7 +394,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('connects the dapp', async () => {
+    it('connects the dapp', async function () {
       await driver.openNewPage('http://127.0.0.1:8080/')
       await driver.delay(regularDelayMs)
 
@@ -422,7 +422,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('initiates a send from the dapp', async () => {
+    it('initiates a send from the dapp', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`), 10000)
       await driver.delay(2000)
 
@@ -478,8 +478,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Navigate transactions', () => {
-    it('adds multiple transactions', async () => {
+  describe('Navigate transactions', function () {
+    it('adds multiple transactions', async function () {
       await driver.delay(regularDelayMs)
 
       await driver.waitUntilXWindowHandles(2)
@@ -510,7 +510,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('navigates the transactions', async () => {
+    it('navigates the transactions', async function () {
       await driver.clickElement(By.css('[data-testid="next-page"]'))
       let navigationElement = await driver.findElement(By.css('.confirm-page-container-navigation'))
       let navigationText = await navigationElement.getText()
@@ -547,7 +547,7 @@ describe('MetaMask', function () {
       assert.equal(navigationText.includes('2'), true, 'changed transaction left')
     })
 
-    it('adds a transaction while confirm screen is in focus', async () => {
+    it('adds a transaction while confirm screen is in focus', async function () {
       let navigationElement = await driver.findElement(By.css('.confirm-page-container-navigation'))
       let navigationText = await navigationElement.getText()
       assert.equal(navigationText.includes('2'), true, 'second transaction in focus')
@@ -570,7 +570,7 @@ describe('MetaMask', function () {
       assert.equal(navigationText.includes('2'), true, 'correct (same) transaction in focus')
     })
 
-    it('rejects a transaction', async () => {
+    it('rejects a transaction', async function () {
       await driver.delay(tinyDelayMs)
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Reject')]`))
       await driver.delay(largeDelayMs * 2)
@@ -581,7 +581,7 @@ describe('MetaMask', function () {
       assert.equal(navigationText.includes('4'), true, 'transaction rejected')
     })
 
-    it('confirms a transaction', async () => {
+    it('confirms a transaction', async function () {
       await driver.delay(tinyDelayMs / 2)
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Confirm')]`))
       await driver.delay(regularDelayMs)
@@ -593,7 +593,7 @@ describe('MetaMask', function () {
       assert.equal(navigationText.includes('3'), true, 'transaction confirmed')
     })
 
-    it('rejects the rest of the transactions', async () => {
+    it('rejects the rest of the transactions', async function () {
       await driver.clickElement(By.xpath(`//a[contains(text(), 'Reject 3')]`))
       await driver.delay(regularDelayMs)
 
@@ -605,10 +605,10 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Deploy contract and call contract methods', () => {
+  describe('Deploy contract and call contract methods', function () {
     let extension
     let dapp
-    it('creates a deploy contract transaction', async () => {
+    it('creates a deploy contract transaction', async function () {
       const windowHandles = await driver.getAllWindowHandles()
       extension = windowHandles[0]
       dapp = windowHandles[1]
@@ -627,7 +627,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('displays the contract creation data', async () => {
+    it('displays the contract creation data', async function () {
       await driver.clickElement(By.xpath(`//li[contains(text(), 'Data')]`))
       await driver.delay(regularDelayMs)
 
@@ -641,7 +641,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('confirms a deploy contract transaction', async () => {
+    it('confirms a deploy contract transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Confirm')]`))
       await driver.delay(largeDelayMs)
 
@@ -655,7 +655,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('calls and confirms a contract method where ETH is sent', async () => {
+    it('calls and confirms a contract method where ETH is sent', async function () {
       await driver.switchToWindow(dapp)
       await driver.delay(regularDelayMs)
 
@@ -721,7 +721,7 @@ describe('MetaMask', function () {
       await driver.wait(until.elementTextMatches(txValues[0], /-4\s*ETH/), 10000)
     })
 
-    it('calls and confirms a contract method where ETH is received', async () => {
+    it('calls and confirms a contract method where ETH is received', async function () {
       await driver.switchToWindow(dapp)
       await driver.delay(regularDelayMs)
 
@@ -749,7 +749,7 @@ describe('MetaMask', function () {
       await driver.switchToWindow(extension)
     })
 
-    it('renders the correct ETH balance', async () => {
+    it('renders the correct ETH balance', async function () {
       const balance = await driver.findElement(By.css('.transaction-view-balance__primary-balance'))
       await driver.delay(regularDelayMs)
       await driver.wait(until.elementTextMatches(balance, /^87.*\s*ETH.*$/), 10000)
@@ -759,8 +759,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Add a custom token from a dapp', () => {
-    it('creates a new token', async () => {
+  describe('Add a custom token from a dapp', function () {
+    it('creates a new token', async function () {
       let windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
       const dapp = windowHandles[1]
@@ -807,12 +807,12 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks on the Add Token button', async () => {
+    it('clicks on the Add Token button', async function () {
       await driver.clickElement(By.xpath(`//div[contains(text(), 'Add Token')]`))
       await driver.delay(regularDelayMs)
     })
 
-    it('picks the newly created Test token', async () => {
+    it('picks the newly created Test token', async function () {
       await driver.clickElement(By.xpath("//li[contains(text(), 'Custom Token')]"))
       await driver.delay(regularDelayMs)
 
@@ -827,7 +827,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('renders the balance for the new token', async () => {
+    it('renders the balance for the new token', async function () {
       const balance = await driver.findElement(By.css('.transaction-view-balance .transaction-view-balance__primary-balance'))
       await driver.wait(until.elementTextMatches(balance, /^10.000\s*TST\s*$/))
       const tokenAmount = await balance.getText()
@@ -836,7 +836,7 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Send token from inside MetaMask', () => {
+  describe('Send token from inside MetaMask', function () {
     let gasModal
     it('starts to send a transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
@@ -856,13 +856,13 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('opens customize gas modal', async () => {
+    it('opens customize gas modal', async function () {
       await driver.findElement(By.css('.page-container__title'))
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Save')]`))
       await driver.delay(regularDelayMs)
     })
 
-    it('transitions to the confirm screen', async () => {
+    it('transitions to the confirm screen', async function () {
       await driver.wait(until.stalenessOf(gasModal))
 
       // Continue to next screen
@@ -870,7 +870,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('displays the token transfer data', async () => {
+    it('displays the token transfer data', async function () {
       await driver.clickElement(By.xpath(`//li[contains(text(), 'Data')]`))
       await driver.delay(regularDelayMs)
 
@@ -912,9 +912,9 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Send a custom token from dapp', () => {
+  describe('Send a custom token from dapp', function () {
     let gasModal
-    it('sends an already created token', async () => {
+    it('sends an already created token', async function () {
       const windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
       const dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
@@ -945,7 +945,7 @@ describe('MetaMask', function () {
       gasModal = await driver.findElement(By.css('span .modal'))
     })
 
-    it('customizes gas', async () => {
+    it('customizes gas', async function () {
       await driver.clickElement(By.css('.page-container__tab:nth-of-type(2)'))
       await driver.delay(regularDelayMs)
 
@@ -1003,9 +1003,9 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Approves a custom token from dapp', () => {
+  describe('Approves a custom token from dapp', function () {
     let gasModal
-    it('approves an already created token', async () => {
+    it('approves an already created token', async function () {
       const windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
       const dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
@@ -1031,7 +1031,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('displays the token approval data', async () => {
+    it('displays the token approval data', async function () {
       await driver.clickElement(By.css('.confirm-approve-content__view-full-tx-button'))
       await driver.delay(regularDelayMs)
 
@@ -1044,14 +1044,14 @@ describe('MetaMask', function () {
       assert(confirmDataText.match(/0x095ea7b30000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef4/))
     })
 
-    it('opens the gas edit modal', async () => {
+    it('opens the gas edit modal', async function () {
       await driver.clickElement(By.css('.confirm-approve-content__small-blue-text.cursor-pointer'))
       await driver.delay(regularDelayMs)
 
       gasModal = await driver.findElement(By.css('span .modal'))
     })
 
-    it('customizes gas', async () => {
+    it('customizes gas', async function () {
       await driver.clickElement(By.css('.page-container__tab:nth-of-type(2)'))
       await driver.delay(regularDelayMs)
 
@@ -1078,7 +1078,7 @@ describe('MetaMask', function () {
       assert.equal(await gasFeeInEth.getText(), '0.0006 ETH')
     })
 
-    it('edits the permission', async () => {
+    it('edits the permission', async function () {
       const editButtons = await driver.findClickableElements(By.css('.confirm-approve-content__small-blue-text.cursor-pointer'))
       await editButtons[1].click()
       await driver.delay(regularDelayMs)
@@ -1121,8 +1121,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Tranfers a custom token from dapp when no gas value is specified', () => {
-    it('transfers an already created token, without specifying gas', async () => {
+  describe('Tranfers a custom token from dapp when no gas value is specified', function () {
+    it('transfers an already created token, without specifying gas', async function () {
       const windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
       const dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
@@ -1166,8 +1166,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Approves a custom token from dapp when no gas value is specified', () => {
-    it('approves an already created token', async () => {
+  describe('Approves a custom token from dapp when no gas value is specified', function () {
+    it('approves an already created token', async function () {
       const windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
       const dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
@@ -1221,8 +1221,8 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Hide token', () => {
-    it('hides the token when clicked', async () => {
+  describe('Hide token', function () {
+    it('hides the token when clicked', async function () {
       await driver.clickElement(By.css('.token-list-item__ellipsis'))
 
       const byTokenMenuDropdownOption = By.css('.menu__item--clickable')
@@ -1237,13 +1237,13 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('Add existing token using search', () => {
-    it('clicks on the Add Token button', async () => {
+  describe('Add existing token using search', function () {
+    it('clicks on the Add Token button', async function () {
       await driver.clickElement(By.xpath(`//div[contains(text(), 'Add Token')]`))
       await driver.delay(regularDelayMs)
     })
 
-    it('can pick a token from the existing options', async () => {
+    it('can pick a token from the existing options', async function () {
       const tokenSearch = await driver.findElement(By.css('#search-tokens'))
       await tokenSearch.sendKeys('BAT')
       await driver.delay(regularDelayMs)
@@ -1258,14 +1258,14 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('renders the balance for the chosen token', async () => {
+    it('renders the balance for the chosen token', async function () {
       const balance = await driver.findElement(By.css('.transaction-view-balance__primary-balance'))
       await driver.wait(until.elementTextMatches(balance, /0\s*BAT/))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Stores custom RPC history', () => {
+  describe('Stores custom RPC history', function () {
     const customRpcUrls = [
       'http://127.0.0.1:8545/1',
       'http://127.0.0.1:8545/2',
@@ -1274,7 +1274,7 @@ describe('MetaMask', function () {
     ]
 
     customRpcUrls.forEach(customRpcUrl => {
-      it(`creates custom RPC: ${customRpcUrl}`, async () => {
+      it(`creates custom RPC: ${customRpcUrl}`, async function () {
         await driver.clickElement(By.css('.network-name'))
         await driver.delay(regularDelayMs)
 
@@ -1293,7 +1293,7 @@ describe('MetaMask', function () {
       })
     })
 
-    it('selects another provider', async () => {
+    it('selects another provider', async function () {
       await driver.clickElement(By.css('.network-name'))
       await driver.delay(regularDelayMs)
 
@@ -1301,7 +1301,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs * 2)
     })
 
-    it('finds all recent RPCs in history', async () => {
+    it('finds all recent RPCs in history', async function () {
       await driver.clickElement(By.css('.network-name'))
       await driver.delay(regularDelayMs)
 
@@ -1311,7 +1311,7 @@ describe('MetaMask', function () {
       assert.equal(customRpcs.length, customRpcUrls.length)
     })
 
-    it('deletes a custom RPC', async () => {
+    it('deletes a custom RPC', async function () {
       const networkListItems = await driver.findClickableElements(By.css('.networks-tab__networks-list-name'))
       const lastNetworkListItem = networkListItems[networkListItems.length - 1]
       await lastNetworkListItem.click()

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -51,24 +51,24 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('Going through the first time flow, but skipping the seed phrase challenge', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('Going through the first time flow, but skipping the seed phrase challenge', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Create New Wallet" option', async () => {
+    it('clicks the "Create New Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create a Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('accepts a secure password', async () => {
+    it('accepts a secure password', async function () {
       const passwordBox = await driver.findElement(By.css('.first-time-flow__form #create-password'))
       const passwordBoxConfirm = await driver.findElement(By.css('.first-time-flow__form #confirm-password'))
 
@@ -81,7 +81,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('skips the seed phrase challenge', async () => {
+    it('skips the seed phrase challenge', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.remindMeLater.message}')]`))
       await driver.delay(regularDelayMs)
 
@@ -89,7 +89,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('gets the current accounts address', async () => {
+    it('gets the current accounts address', async function () {
       const addressInput = await driver.findElement(By.css('.qr-ellip-address'))
       publicAddress = await addressInput.getAttribute('value')
       const accountModal = await driver.findElement(By.css('span .modal'))
@@ -101,12 +101,12 @@ describe('MetaMask', function () {
     })
   })
 
-  describe('sets permissions', () => {
+  describe('sets permissions', function () {
     let extension
     let popup
     let dapp
 
-    it('connects to the dapp', async () => {
+    it('connects to the dapp', async function () {
       await driver.openNewPage('http://127.0.0.1:8080/')
       await driver.delay(regularDelayMs)
 
@@ -132,7 +132,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('shows connected sites', async () => {
+    it('shows connected sites', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Connected Sites')]`))
 
       await driver.findElement(By.css('.connected-sites__title'))
@@ -149,7 +149,7 @@ describe('MetaMask', function () {
       assert.equal(await permissionDescription.getText(), 'View the address of the selected account')
     })
 
-    it('can get accounts within the dapp', async () => {
+    it('can get accounts within the dapp', async function () {
       await driver.switchToWindow(dapp)
       await driver.delay(regularDelayMs)
 
@@ -159,7 +159,7 @@ describe('MetaMask', function () {
       assert.equal((await getAccountsResult.getText()).toLowerCase(), publicAddress.toLowerCase())
     })
 
-    it('can disconnect all accounts', async () => {
+    it('can disconnect all accounts', async function () {
       await driver.switchToWindow(extension)
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Disconnect All')]`))
@@ -172,7 +172,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('can no longer get accounts within the dapp', async () => {
+    it('can no longer get accounts within the dapp', async function () {
       await driver.switchToWindow(dapp)
       await driver.delay(regularDelayMs)
 

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -53,24 +53,24 @@ describe('Using MetaMask with an existing account', function () {
     await driver.quit()
   })
 
-  describe('First time flow starting from an existing seed phrase', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('First time flow starting from an existing seed phrase', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Import Wallet" option', async () => {
+    it('clicks the "Import Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('imports a seed phrase', async () => {
+    it('imports a seed phrase', async function () {
       const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
       await seedTextArea.sendKeys(testSeedPhrase)
       await driver.delay(regularDelayMs)
@@ -86,14 +86,14 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('clicks through the success screen', async () => {
+    it('clicks through the success screen', async function () {
       await driver.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
   })
 
-  describe('Send ETH from inside MetaMask', () => {
+  describe('Send ETH from inside MetaMask', function () {
     it('starts a send transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Send')]`))
       await driver.delay(regularDelayMs)

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -51,13 +51,13 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('successfuly signs typed data', () => {
+  describe('successfuly signs typed data', function () {
     let extension
     let popup
     let dapp
     let windowHandles
 
-    it('accepts the account password after lock', async () => {
+    it('accepts the account password after lock', async function () {
       await driver.delay(1000)
       const passwordField = await driver.findElement(By.id('password'))
       await passwordField.sendKeys('correct horse battery staple')
@@ -65,7 +65,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs * 4)
     })
 
-    it('connects to the dapp', async () => {
+    it('connects to the dapp', async function () {
       await driver.openNewPage('http://127.0.0.1:8080/')
       await driver.delay(regularDelayMs)
 
@@ -92,7 +92,7 @@ describe('MetaMask', function () {
       await driver.switchToWindow(dapp)
     })
 
-    it('creates a sign typed data signature request', async () => {
+    it('creates a sign typed data signature request', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Sign')]`), 10000)
       await driver.delay(largeDelayMs)
 
@@ -112,7 +112,7 @@ describe('MetaMask', function () {
       assert.equal(await address.getText(), publicAddress.slice(0, 8) + '...' + publicAddress.slice(publicAddress.length - 8))
     })
 
-    it('signs the transaction', async () => {
+    it('signs the transaction', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Sign')]`), 10000)
       await driver.delay(regularDelayMs)
 
@@ -120,7 +120,7 @@ describe('MetaMask', function () {
       await driver.switchToWindow(extension)
     })
 
-    it('gets the current accounts address', async () => {
+    it('gets the current accounts address', async function () {
       await driver.clickElement(By.css('.account-details__details-button'))
       await driver.delay(regularDelayMs)
 

--- a/test/e2e/tests/simple-send.spec.js
+++ b/test/e2e/tests/simple-send.spec.js
@@ -2,7 +2,7 @@ const { By, Key } = require('selenium-webdriver')
 const { withFixtures } = require('../helpers')
 
 describe('MetaMask Browser Extension', function () {
-  it('can send a simple transaction from one account to another', async () => {
+  it('can send a simple transaction from one account to another', async function () {
     const ganacheOptions = {
       accounts: [
         {

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -54,26 +54,26 @@ describe('MetaMask', function () {
     await driver.quit()
   })
 
-  describe('set up data to be restored by 3box', () => {
+  describe('set up data to be restored by 3box', function () {
 
-    describe('First time flow starting from an existing seed phrase', () => {
-      it('clicks the continue button on the welcome screen', async () => {
+    describe('First time flow starting from an existing seed phrase', function () {
+      it('clicks the continue button on the welcome screen', async function () {
         await driver.findElement(By.css('.welcome-page__header'))
         await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
         await driver.delay(largeDelayMs)
       })
 
-      it('clicks the "Import Wallet" option', async () => {
+      it('clicks the "Import Wallet" option', async function () {
         await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
         await driver.delay(largeDelayMs)
       })
 
-      it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+      it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
         await driver.clickElement(By.css('.btn-default'))
         await driver.delay(largeDelayMs)
       })
 
-      it('imports a seed phrase', async () => {
+      it('imports a seed phrase', async function () {
         const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
         await seedTextArea.sendKeys(testSeedPhrase)
         await driver.delay(regularDelayMs)
@@ -89,44 +89,44 @@ describe('MetaMask', function () {
         await driver.delay(regularDelayMs)
       })
 
-      it('clicks through the success screen', async () => {
+      it('clicks through the success screen', async function () {
         await driver.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
         await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
         await driver.delay(regularDelayMs)
       })
 
-      it('balance renders', async () => {
+      it('balance renders', async function () {
         const balance = await driver.findElement(By.css('.balance-display .token-amount'))
         await driver.wait(until.elementTextMatches(balance, /25\s*ETH/))
         await driver.delay(regularDelayMs)
       })
     })
 
-    describe('turns on threebox syncing', () => {
-      it('goes to the settings screen', async () => {
+    describe('turns on threebox syncing', function () {
+      it('goes to the settings screen', async function () {
         await driver.clickElement(By.css('.account-menu__icon'))
         await driver.delay(regularDelayMs)
 
         await driver.clickElement(By.xpath(`//div[contains(text(), 'Settings')]`))
       })
 
-      it('turns on threebox syncing', async () => {
+      it('turns on threebox syncing', async function () {
         await driver.clickElement(By.xpath(`//div[contains(text(), 'Advanced')]`))
         await driver.clickElement(By.css('[data-testid="advanced-setting-3box"] .toggle-button div'))
       })
 
     })
 
-    describe('updates settings and address book', () => {
-      it('adds an address to the contact list', async () => {
+    describe('updates settings and address book', function () {
+      it('navigates to General settings', async function () {
         await driver.clickElement(By.xpath(`//div[contains(text(), 'General')]`))
       })
 
-      it('turns on use of blockies', async () => {
+      it('turns on use of blockies', async function () {
         await driver.clickElement(By.css('.toggle-button > div'))
       })
 
-      it('adds an address to the contact list', async () => {
+      it('adds an address to the contact list', async function () {
         await driver.clickElement(By.xpath(`//div[contains(text(), 'Contacts')]`))
 
         await driver.clickElement(By.css('.address-book-add-button__button'))
@@ -150,7 +150,7 @@ describe('MetaMask', function () {
 
   })
 
-  describe('restoration from 3box', () => {
+  describe('restoration from 3box', function () {
     let driver2
 
     before(async function () {
@@ -162,24 +162,24 @@ describe('MetaMask', function () {
       await driver2.quit()
     })
 
-    describe('First time flow starting from an existing seed phrase', () => {
-      it('clicks the continue button on the welcome screen', async () => {
+    describe('First time flow starting from an existing seed phrase', function () {
+      it('clicks the continue button on the welcome screen', async function () {
         await driver2.findElement(By.css('.welcome-page__header'))
         await driver2.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
         await driver2.delay(largeDelayMs)
       })
 
-      it('clicks the "Import Wallet" option', async () => {
+      it('clicks the "Import Wallet" option', async function () {
         await driver2.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
         await driver2.delay(largeDelayMs)
       })
 
-      it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+      it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
         await driver2.clickElement(By.css('.btn-default'))
         await driver2.delay(largeDelayMs)
       })
 
-      it('imports a seed phrase', async () => {
+      it('imports a seed phrase', async function () {
         const [seedTextArea] = await driver2.findElements(By.css('textarea.first-time-flow__textarea'))
         await seedTextArea.sendKeys(testSeedPhrase)
         await driver2.delay(regularDelayMs)
@@ -195,40 +195,40 @@ describe('MetaMask', function () {
         await driver2.delay(regularDelayMs)
       })
 
-      it('clicks through the success screen', async () => {
+      it('clicks through the success screen', async function () {
         await driver2.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
         await driver2.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
         await driver2.delay(regularDelayMs)
       })
 
-      it('balance renders', async () => {
+      it('balance renders', async function () {
         const balance = await driver2.findElement(By.css('.balance-display .token-amount'))
         await driver2.wait(until.elementTextMatches(balance, /25\s*ETH/))
         await driver2.delay(regularDelayMs)
       })
     })
 
-    describe('restores 3box data', () => {
-      it('confirms the 3box restore notification', async () => {
+    describe('restores 3box data', function () {
+      it('confirms the 3box restore notification', async function () {
         await driver2.clickElement(By.css('.home-notification__accept-button'))
       })
 
       // TODO: Fix tests from here forward; they're using the wrong driver
-      it('goes to the settings screen', async () => {
+      it('goes to the settings screen', async function () {
         await driver.clickElement(By.css('.account-menu__icon'))
         await driver.delay(regularDelayMs)
 
         await driver.clickElement(By.xpath(`//div[contains(text(), 'Settings')]`))
       })
 
-      it('finds the blockies toggle turned on', async () => {
+      it('finds the blockies toggle turned on', async function () {
         await driver.delay(regularDelayMs)
         const toggleLabel = await driver.findElement(By.css('.toggle-button__status-label'))
         const toggleLabelText = await toggleLabel.getText()
         assert.equal(toggleLabelText, 'ON')
       })
 
-      it('finds the restored address in the contact list', async () => {
+      it('finds the restored address in the contact list', async function () {
         await driver.clickElement(By.xpath(`//div[contains(text(), 'Contacts')]`))
         await driver.delay(regularDelayMs)
 

--- a/test/e2e/web3.spec.js
+++ b/test/e2e/web3.spec.js
@@ -52,24 +52,24 @@ describe('Using MetaMask with an existing account', function () {
     await driver.quit()
   })
 
-  describe('First time flow starting from an existing seed phrase', () => {
-    it('clicks the continue button on the welcome screen', async () => {
+  describe('First time flow starting from an existing seed phrase', function () {
+    it('clicks the continue button on the welcome screen', async function () {
       await driver.findElement(By.css('.welcome-page__header'))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.getStarted.message}')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "Import Wallet" option', async () => {
+    it('clicks the "Import Wallet" option', async function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "No thanks" option on the metametrics opt-in screen', async () => {
+    it('clicks the "No thanks" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-default'))
       await driver.delay(largeDelayMs)
     })
 
-    it('imports a seed phrase', async () => {
+    it('imports a seed phrase', async function () {
       const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
       await seedTextArea.sendKeys(testSeedPhrase)
       await driver.delay(regularDelayMs)
@@ -85,7 +85,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
     })
 
-    it('clicks through the success screen', async () => {
+    it('clicks through the success screen', async function () {
       await driver.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
@@ -93,9 +93,9 @@ describe('Using MetaMask with an existing account', function () {
   })
 
 
-  describe('opens dapp', () => {
+  describe('opens dapp', function () {
 
-    it('switches to mainnet', async () => {
+    it('switches to mainnet', async function () {
       await driver.clickElement(By.css('.network-name'))
       await driver.delay(regularDelayMs)
 
@@ -103,7 +103,7 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(largeDelayMs * 2)
     })
 
-    it('connects to dapp', async () => {
+    it('connects to dapp', async function () {
       await driver.openNewPage('http://127.0.0.1:8080/')
       await driver.delay(regularDelayMs)
 
@@ -126,10 +126,10 @@ describe('Using MetaMask with an existing account', function () {
     })
   })
 
-  describe('testing web3 methods', async () => {
+  describe('testing web3 methods', function () {
 
 
-    it('testing hexa methods', async () => {
+    it('testing hexa methods', async function () {
 
 
       const List = await driver.findClickableElements(By.className('hexaNumberMethods'))
@@ -151,7 +151,7 @@ describe('Using MetaMask with an existing account', function () {
       }
     })
 
-    it('testing booleanMethods', async () => {
+    it('testing booleanMethods', async function () {
 
       const List = await driver.findClickableElement(By.className('booleanMethods'))
 
@@ -174,7 +174,7 @@ describe('Using MetaMask with an existing account', function () {
 
     })
 
-    it('testing  transactionMethods', async () => {
+    it('testing  transactionMethods', async function () {
 
       const List = await driver.findClickableElement(By.className('transactionMethods'))
 
@@ -216,7 +216,7 @@ describe('Using MetaMask with an existing account', function () {
 
     })
 
-    it('testing blockMethods', async () => {
+    it('testing blockMethods', async function () {
 
       const List = await driver.findClickableElement(By.className('blockMethods'))
 
@@ -242,7 +242,7 @@ describe('Using MetaMask with an existing account', function () {
       }
     })
 
-    it('testing methods', async () => {
+    it('testing methods', async function () {
 
       const List = await driver.findClickableElement(By.className('methods'))
       let parsedData

--- a/test/unit-global/frozenPromise.js
+++ b/test/unit-global/frozenPromise.js
@@ -6,9 +6,9 @@ import '../../app/scripts/lib/freezeGlobals'
 
 import assert from 'assert'
 
-describe('Promise global is immutable', () => {
+describe('Promise global is immutable', function () {
 
-  it('throws when reassinging promise (syntax 1)', () => {
+  it('throws when reassinging promise (syntax 1)', function () {
     try {
       Promise = {}
       assert.fail('did not throw error')
@@ -17,7 +17,7 @@ describe('Promise global is immutable', () => {
     }
   })
 
-  it('throws when reassinging promise (syntax 2)', () => {
+  it('throws when reassinging promise (syntax 2)', function () {
     try {
       global.Promise = {}
       assert.fail('did not throw error')
@@ -26,7 +26,7 @@ describe('Promise global is immutable', () => {
     }
   })
 
-  it('throws when mutating existing Promise property', () => {
+  it('throws when mutating existing Promise property', function () {
     try {
       Promise.all = () => {}
       assert.fail('did not throw error')
@@ -35,7 +35,7 @@ describe('Promise global is immutable', () => {
     }
   })
 
-  it('throws when adding new Promise property', () => {
+  it('throws when adding new Promise property', function () {
     try {
       Promise.foo = 'bar'
       assert.fail('did not throw error')
@@ -44,7 +44,7 @@ describe('Promise global is immutable', () => {
     }
   })
 
-  it('throws when deleting Promise from global', () => {
+  it('throws when deleting Promise from global', function () {
     try {
       delete global.Promise
       assert.fail('did not throw error')

--- a/test/unit/actions/tx_test.js
+++ b/test/unit/actions/tx_test.js
@@ -25,7 +25,7 @@ describe('tx confirmation screen', function () {
   const store = mockStore(initialState)
 
   describe('cancelTx', function () {
-    before(function (done) {
+    it('creates COMPLETED_TX with the cancelled transaction ID', async function () {
       actions._setBackgroundConnection({
         approveTransaction (_, cb) {
           cb('An error!')
@@ -37,10 +37,7 @@ describe('tx confirmation screen', function () {
           cb()
         },
       })
-      done()
-    })
 
-    it('creates COMPLETED_TX with the cancelled transaction ID', async function () {
       await store.dispatch(actions.cancelTx({ id: txId }))
       const storeActions = store.getActions()
       const completedTxAction = storeActions.find(({ type }) => type === actions.actionConstants.COMPLETED_TX)

--- a/test/unit/app/ComposableObservableStore.js
+++ b/test/unit/app/ComposableObservableStore.js
@@ -2,20 +2,20 @@ import assert from 'assert'
 import ComposableObservableStore from '../../../app/scripts/lib/ComposableObservableStore'
 import ObservableStore from 'obs-store'
 
-describe('ComposableObservableStore', () => {
-  it('should register initial state', () => {
+describe('ComposableObservableStore', function () {
+  it('should register initial state', function () {
     const store = new ComposableObservableStore('state')
     assert.strictEqual(store.getState(), 'state')
   })
 
-  it('should register initial structure', () => {
+  it('should register initial structure', function () {
     const testStore = new ObservableStore()
     const store = new ComposableObservableStore(null, { TestStore: testStore })
     testStore.putState('state')
     assert.deepEqual(store.getState(), { TestStore: 'state' })
   })
 
-  it('should update structure', () => {
+  it('should update structure', function () {
     const testStore = new ObservableStore()
     const store = new ComposableObservableStore()
     store.updateStructure({ TestStore: testStore })
@@ -23,7 +23,7 @@ describe('ComposableObservableStore', () => {
     assert.deepEqual(store.getState(), { TestStore: 'state' })
   })
 
-  it('should return flattened state', () => {
+  it('should return flattened state', function () {
     const fooStore = new ObservableStore({ foo: 'foo' })
     const barStore = new ObservableStore({ bar: 'bar' })
     const store = new ComposableObservableStore(null, {

--- a/test/unit/app/account-import-strategies.spec.js
+++ b/test/unit/app/account-import-strategies.spec.js
@@ -12,26 +12,24 @@ describe('Account Import Strategies', function () {
       assert.equal(importPrivKey, ethUtil.stripHexPrefix(privkey))
     })
 
-    it('throws an error for empty string private key', async () => {
-      return assert.rejects(async function () {
+    it('throws an error for empty string private key', async function () {
+      await assert.rejects(async () => {
         await accountImporter.importAccount('Private Key', [ '' ])
       }, Error, 'no empty strings')
     })
 
-    it('throws an error for undefined string private key', async () => {
-      return assert.rejects(async function () {
+    it('throws an error for undefined string private key', async function () {
+      await assert.rejects(async () => {
         await accountImporter.importAccount('Private Key', [ undefined ])
       })
-    })
 
-    it('throws an error for undefined string private key', async () => {
-      return assert.rejects(async function () {
+      await assert.rejects(async () => {
         await accountImporter.importAccount('Private Key', [])
       })
     })
 
-    it('throws an error for invalid private key', async () => {
-      return assert.rejects(async function () {
+    it('throws an error for invalid private key', async function () {
+      await assert.rejects(async () => {
         await accountImporter.importAccount('Private Key', [ 'popcorn' ])
       })
     })

--- a/test/unit/app/cleanErrorStack.spec.js
+++ b/test/unit/app/cleanErrorStack.spec.js
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import cleanErrorStack from '../../../app/scripts/lib/cleanErrorStack'
 
-describe('Clean Error Stack', () => {
+describe('Clean Error Stack', function () {
 
   const testMessage = 'Test Message'
   const testError = new Error(testMessage)
@@ -9,24 +9,24 @@ describe('Clean Error Stack', () => {
   const blankErrorName = new Error(testMessage)
   const blankMsgError = new Error()
 
-  beforeEach(() => {
+  beforeEach(function () {
     undefinedErrorName.name = undefined
     blankErrorName.name = ''
   })
 
-  it('tests error with message', () => {
+  it('tests error with message', function () {
     assert.equal(cleanErrorStack(testError), 'Error: Test Message')
   })
 
-  it('tests error with undefined name', () => {
+  it('tests error with undefined name', function () {
     assert.equal(cleanErrorStack(undefinedErrorName).toString(), 'Error: Test Message')
   })
 
-  it('tests error with blank name', () => {
+  it('tests error with blank name', function () {
     assert.equal(cleanErrorStack(blankErrorName).toString(), 'Test Message')
   })
 
-  it('tests error with blank message', () => {
+  it('tests error with blank message', function () {
     assert.equal(cleanErrorStack(blankMsgError), 'Error')
   })
 

--- a/test/unit/app/controllers/balance-controller.spec.js
+++ b/test/unit/app/controllers/balance-controller.spec.js
@@ -17,7 +17,7 @@ const accounts = {
   },
 }
 
-describe('Balance Controller', () => {
+describe('Balance Controller', function () {
 
   let balanceController
 
@@ -29,7 +29,7 @@ describe('Balance Controller', () => {
     }
   })
 
-  beforeEach(() => {
+  beforeEach(function () {
     balanceController = new BalanceController({
       address: TEST_ADDRESS,
       accountTracker: new AccountTracker({

--- a/test/unit/app/controllers/cached-balances-test.js
+++ b/test/unit/app/controllers/cached-balances-test.js
@@ -2,9 +2,9 @@ import assert from 'assert'
 import sinon from 'sinon'
 import CachedBalancesController from '../../../../app/scripts/controllers/cached-balances'
 
-describe('CachedBalancesController', () => {
-  describe('updateCachedBalances', () => {
-    it('should update the cached balances', async () => {
+describe('CachedBalancesController', function () {
+  describe('updateCachedBalances', function () {
+    it('should update the cached balances', async function () {
       const controller = new CachedBalancesController({
         getNetwork: () => Promise.resolve(17),
         accountTracker: {
@@ -27,8 +27,8 @@ describe('CachedBalancesController', () => {
     })
   })
 
-  describe('_generateBalancesToCache', () => {
-    it('should generate updated account balances where the current network was updated', () => {
+  describe('_generateBalancesToCache', function () {
+    it('should generate updated account balances where the current network was updated', function () {
       const controller = new CachedBalancesController({
         accountTracker: {
           store: {
@@ -71,7 +71,7 @@ describe('CachedBalancesController', () => {
       })
     })
 
-    it('should generate updated account balances where the a new network was selected', () => {
+    it('should generate updated account balances where the a new network was selected', function () {
       const controller = new CachedBalancesController({
         accountTracker: {
           store: {
@@ -109,8 +109,8 @@ describe('CachedBalancesController', () => {
     })
   })
 
-  describe('_registerUpdates', () => {
-    it('should subscribe to the account tracker with the updateCachedBalances method', async () => {
+  describe('_registerUpdates', function () {
+    it('should subscribe to the account tracker with the updateCachedBalances method', async function () {
       const subscribeSpy = sinon.spy()
       const controller = new CachedBalancesController({
         getNetwork: () => Promise.resolve(17),

--- a/test/unit/app/controllers/detect-tokens-test.js
+++ b/test/unit/app/controllers/detect-tokens-test.js
@@ -6,7 +6,7 @@ import DetectTokensController from '../../../../app/scripts/controllers/detect-t
 import NetworkController from '../../../../app/scripts/controllers/network/network'
 import PreferencesController from '../../../../app/scripts/controllers/preferences'
 
-describe('DetectTokensController', () => {
+describe('DetectTokensController', function () {
   const sandbox = sinon.createSandbox()
   let clock, keyringMemStore, network, preferences, controller
 
@@ -16,7 +16,7 @@ describe('DetectTokensController', () => {
     getAccounts: noop,
   }
 
-  beforeEach(async () => {
+  beforeEach(async function () {
 
 
     nock('https://api.infura.io')
@@ -32,19 +32,19 @@ describe('DetectTokensController', () => {
 
   })
 
-  after(() => {
+  after(function () {
     sandbox.restore()
     nock.cleanAll()
   })
 
-  it('should poll on correct interval', async () => {
+  it('should poll on correct interval', async function () {
     const stub = sinon.stub(global, 'setInterval')
     new DetectTokensController({ interval: 1337 }) // eslint-disable-line no-new
     assert.strictEqual(stub.getCall(0).args[1], 1337)
     stub.restore()
   })
 
-  it('should be called on every polling period', async () => {
+  it('should be called on every polling period', async function () {
     clock = sandbox.useFakeTimers()
     const network = new NetworkController()
     network.initializeProvider(networkControllerProviderConfig)
@@ -66,7 +66,7 @@ describe('DetectTokensController', () => {
     sandbox.assert.calledThrice(stub)
   })
 
-  it('should not check tokens while in test network', async () => {
+  it('should not check tokens while in test network', async function () {
     controller.isOpen = true
     controller.isUnlocked = true
 
@@ -78,7 +78,7 @@ describe('DetectTokensController', () => {
     sandbox.assert.notCalled(stub)
   })
 
-  it('should only check and add tokens while in main network', async () => {
+  it('should only check and add tokens while in main network', async function () {
     const controller = new DetectTokensController({ preferences: preferences, network: network, keyringMemStore: keyringMemStore })
     controller.isOpen = true
     controller.isUnlocked = true
@@ -94,7 +94,7 @@ describe('DetectTokensController', () => {
       { address: '0xbc86727e770de68b1060c91f6bb6945c73e10388', decimals: 18, symbol: 'XNK' }])
   })
 
-  it('should not detect same token while in main network', async () => {
+  it('should not detect same token while in main network', async function () {
     preferences.addToken('0x0d262e5dc4a06a0f1c90ce79c7a60c09dfc884e4', 'J8T', 8)
     const controller = new DetectTokensController({ preferences: preferences, network: network, keyringMemStore: keyringMemStore })
     controller.isOpen = true
@@ -111,7 +111,7 @@ describe('DetectTokensController', () => {
       { address: '0xbc86727e770de68b1060c91f6bb6945c73e10388', decimals: 18, symbol: 'XNK' }])
   })
 
-  it('should trigger detect new tokens when change address', async () => {
+  it('should trigger detect new tokens when change address', async function () {
     controller.isOpen = true
     controller.isUnlocked = true
     const stub = sandbox.stub(controller, 'detectNewTokens')
@@ -119,7 +119,7 @@ describe('DetectTokensController', () => {
     sandbox.assert.called(stub)
   })
 
-  it('should trigger detect new tokens when submit password', async () => {
+  it('should trigger detect new tokens when submit password', async function () {
     controller.isOpen = true
     controller.selectedAddress = '0x0'
     const stub = sandbox.stub(controller, 'detectNewTokens')
@@ -127,7 +127,7 @@ describe('DetectTokensController', () => {
     sandbox.assert.called(stub)
   })
 
-  it('should not trigger detect new tokens when not open or not unlocked', async () => {
+  it('should not trigger detect new tokens when not open or not unlocked', async function () {
     controller.isOpen = true
     controller.isUnlocked = false
     const stub = sandbox.stub(controller, 'detectTokenBalance')

--- a/test/unit/app/controllers/ens-controller-test.js
+++ b/test/unit/app/controllers/ens-controller-test.js
@@ -9,7 +9,7 @@ const ZERO_X_ERROR_ADDRESS = '0x'
 
 describe('EnsController', function () {
   describe('#constructor', function () {
-    it('should construct the controller given a provider and a network', async () => {
+    it('should construct the controller given a provider and a network', async function () {
       const provider = new HttpProvider('https://ropsten.infura.io')
       const currentNetworkId = '3'
       const networkStore = new ObservableStore(currentNetworkId)
@@ -21,7 +21,7 @@ describe('EnsController', function () {
       assert.ok(ens._ens)
     })
 
-    it('should construct the controller given an existing ENS instance', async () => {
+    it('should construct the controller given an existing ENS instance', async function () {
       const networkStore = {
         subscribe: sinon.spy(),
       }
@@ -35,7 +35,7 @@ describe('EnsController', function () {
   })
 
   describe('#reverseResolveName', function () {
-    it('should resolve to an ENS name', async () => {
+    it('should resolve to an ENS name', async function () {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
       const networkStore = {
         subscribe: sinon.spy(),
@@ -52,7 +52,7 @@ describe('EnsController', function () {
       assert.equal(name, 'peaksignal.eth')
     })
 
-    it('should only resolve an ENS name once', async () => {
+    it('should only resolve an ENS name once', async function () {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
       const reverse = sinon.stub().withArgs(address).returns('peaksignal.eth')
       const lookup = sinon.stub().withArgs('peaksignal.eth').returns(address)
@@ -73,7 +73,7 @@ describe('EnsController', function () {
       assert.ok(reverse.calledOnce)
     })
 
-    it('should fail if the name is registered to a different address than the reverse-resolved', async () => {
+    it('should fail if the name is registered to a different address than the reverse-resolved', async function () {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
       const networkStore = {
         subscribe: sinon.spy(),
@@ -90,7 +90,7 @@ describe('EnsController', function () {
       assert.strictEqual(name, undefined)
     })
 
-    it('should throw an error when the lookup resolves to the zero address', async () => {
+    it('should throw an error when the lookup resolves to the zero address', async function () {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
       const networkStore = {
         subscribe: sinon.spy(),
@@ -111,7 +111,7 @@ describe('EnsController', function () {
       }
     })
 
-    it('should throw an error the lookup resolves to the zero x address', async () => {
+    it('should throw an error the lookup resolves to the zero x address', async function () {
       const address = '0x8e5d75d60224ea0c33d0041e75de68b1c3cb6dd5'
       const networkStore = {
         subscribe: sinon.spy(),

--- a/test/unit/app/controllers/incoming-transactions-test.js
+++ b/test/unit/app/controllers/incoming-transactions-test.js
@@ -8,7 +8,7 @@ const IncomingTransactionsController = proxyquire('../../../../app/scripts/contr
 
 import { ROPSTEN, RINKEBY, KOVAN, GOERLI, MAINNET } from '../../../../app/scripts/controllers/network/enums'
 
-describe('IncomingTransactionsController', () => {
+describe('IncomingTransactionsController', function () {
   const EMPTY_INIT_STATE = {
     incomingTransactions: {},
     incomingTxLastFetchedBlocksByNetwork: {
@@ -71,8 +71,8 @@ describe('IncomingTransactionsController', () => {
     },
   }
 
-  describe('constructor', () => {
-    it('should set up correct store, listeners and properties in the constructor', () => {
+  describe('constructor', function () {
+    it('should set up correct store, listeners and properties in the constructor', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -102,7 +102,7 @@ describe('IncomingTransactionsController', () => {
       incomingTransactionsController._update.resetHistory()
     })
 
-    it('should set the store to a provided initial state', () => {
+    it('should set the store to a provided initial state', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -114,8 +114,8 @@ describe('IncomingTransactionsController', () => {
     })
   })
 
-  describe('#start', () => {
-    it('should set up a listener for the latest block', () => {
+  describe('#start', function () {
+    it('should set up a listener for the latest block', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -139,8 +139,8 @@ describe('IncomingTransactionsController', () => {
     })
   })
 
-  describe('_getDataForUpdate', () => {
-    it('should call fetchAll with the correct params when passed a new block number and the current network has no stored block', async () => {
+  describe('_getDataForUpdate', function () {
+    it('should call fetchAll with the correct params when passed a new block number and the current network has no stored block', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -158,7 +158,7 @@ describe('IncomingTransactionsController', () => {
       ])
     })
 
-    it('should call fetchAll with the correct params when passed a new block number but the current network has a stored block', async () => {
+    it('should call fetchAll with the correct params when passed a new block number but the current network has a stored block', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -176,7 +176,7 @@ describe('IncomingTransactionsController', () => {
       ])
     })
 
-    it('should call fetchAll with the correct params when passed a new network type but no block info exists', async () => {
+    it('should call fetchAll with the correct params when passed a new network type but no block info exists', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -197,25 +197,7 @@ describe('IncomingTransactionsController', () => {
       ])
     })
 
-    it('should call fetchAll with the correct params when passed a new block number but the current network has a stored block', async () => {
-      const incomingTransactionsController = new IncomingTransactionsController({
-        blockTracker: MOCK_BLOCKTRACKER,
-        networkController: MOCK_NETWORK_CONTROLLER,
-        preferencesController: MOCK_PREFERENCES_CONTROLLER,
-        initState: NON_EMPTY_INIT_STATE_WITH_FAKE_NETWORK_STATE,
-      })
-      incomingTransactionsController._fetchAll = sinon.stub().returns({})
-
-      await incomingTransactionsController._getDataForUpdate({ address: 'fakeAddress', newBlockNumberDec: 999 })
-
-      assert(incomingTransactionsController._fetchAll.calledOnce)
-
-      assert.deepEqual(incomingTransactionsController._fetchAll.getCall(0).args, [
-        'fakeAddress', 1111, 'FAKE_NETWORK',
-      ])
-    })
-
-    it('should return the expected data', async () => {
+    it('should return the expected data', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -252,7 +234,7 @@ describe('IncomingTransactionsController', () => {
     })
   })
 
-  describe('_updateStateWithNewTxData', () => {
+  describe('_updateStateWithNewTxData', function () {
     const MOCK_INPUT_WITHOUT_LASTEST = {
       newTxs: [{ id: 555, hash: '0xfff' }],
       currentIncomingTxs: {
@@ -275,7 +257,7 @@ describe('IncomingTransactionsController', () => {
       latestIncomingTxBlockNumber: 444,
     }
 
-    it('should update state with correct blockhash and transactions when passed a truthy latestIncomingTxBlockNumber', async () => {
+    it('should update state with correct blockhash and transactions when passed a truthy latestIncomingTxBlockNumber', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -300,7 +282,7 @@ describe('IncomingTransactionsController', () => {
       })
     })
 
-    it('should update state with correct blockhash and transactions when passed a falsy latestIncomingTxBlockNumber', async () => {
+    it('should update state with correct blockhash and transactions when passed a falsy latestIncomingTxBlockNumber', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -326,22 +308,22 @@ describe('IncomingTransactionsController', () => {
     })
   })
 
-  describe('_fetchTxs', () => {
+  describe('_fetchTxs', function () {
     const mockFetch = sinon.stub().returns(Promise.resolve({
       json: () => Promise.resolve({ someKey: 'someValue' }),
     }))
     let tempFetch
-    beforeEach(() => {
+    beforeEach(function () {
       tempFetch = global.fetch
       global.fetch = mockFetch
     })
 
-    afterEach(() => {
+    afterEach(function () {
       global.fetch = tempFetch
       mockFetch.resetHistory()
     })
 
-    it('should call fetch with the expected url when passed an address, block number and supported network', async () => {
+    it('should call fetch with the expected url when passed an address, block number and supported network', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -355,7 +337,7 @@ describe('IncomingTransactionsController', () => {
       assert.equal(mockFetch.getCall(0).args[0], `https://api-${ROPSTEN}.etherscan.io/api?module=account&action=txlist&address=0xfakeaddress&tag=latest&page=1&startBlock=789`)
     })
 
-    it('should call fetch with the expected url when passed an address, block number and MAINNET', async () => {
+    it('should call fetch with the expected url when passed an address, block number and MAINNET', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -369,7 +351,7 @@ describe('IncomingTransactionsController', () => {
       assert.equal(mockFetch.getCall(0).args[0], `https://api.etherscan.io/api?module=account&action=txlist&address=0xfakeaddress&tag=latest&page=1&startBlock=789`)
     })
 
-    it('should call fetch with the expected url when passed an address and supported network, but a falsy block number', async () => {
+    it('should call fetch with the expected url when passed an address and supported network, but a falsy block number', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -383,7 +365,7 @@ describe('IncomingTransactionsController', () => {
       assert.equal(mockFetch.getCall(0).args[0], `https://api-${ROPSTEN}.etherscan.io/api?module=account&action=txlist&address=0xfakeaddress&tag=latest&page=1`)
     })
 
-    it('should not fetch and return an empty object when passed an unsported network', async () => {
+    it('should not fetch and return an empty object when passed an unsported network', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -397,7 +379,7 @@ describe('IncomingTransactionsController', () => {
       assert.deepEqual(result, {})
     })
 
-    it('should return the results from the fetch call, plus the address and currentNetworkID, when passed an address, block number and supported network', async () => {
+    it('should return the results from the fetch call, plus the address and currentNetworkID, when passed an address, block number and supported network', async function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -416,8 +398,8 @@ describe('IncomingTransactionsController', () => {
     })
   })
 
-  describe('_processTxFetchResponse', () => {
-    it('should return a null block number and empty tx array if status is 0', () => {
+  describe('_processTxFetchResponse', function () {
+    it('should return a null block number and empty tx array if status is 0', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -437,7 +419,7 @@ describe('IncomingTransactionsController', () => {
       })
     })
 
-    it('should return a null block number and empty tx array if the passed result array is empty', () => {
+    it('should return a null block number and empty tx array if the passed result array is empty', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -457,7 +439,7 @@ describe('IncomingTransactionsController', () => {
       })
     })
 
-    it('should return the expected block number and tx list when passed data from a successful fetch', () => {
+    it('should return the expected block number and tx list when passed data from a successful fetch', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -575,8 +557,8 @@ describe('IncomingTransactionsController', () => {
     })
   })
 
-  describe('_normalizeTxFromEtherscan', () => {
-    it('should return the expected data when the tx is in error', () => {
+  describe('_normalizeTxFromEtherscan', function () {
+    it('should return the expected data when the tx is in error', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,
@@ -616,7 +598,7 @@ describe('IncomingTransactionsController', () => {
       })
     })
 
-    it('should return the expected data when the tx is not in error', () => {
+    it('should return the expected data when the tx is not in error', function () {
       const incomingTransactionsController = new IncomingTransactionsController({
         blockTracker: MOCK_BLOCKTRACKER,
         networkController: MOCK_NETWORK_CONTROLLER,

--- a/test/unit/app/controllers/infura-controller-test.js
+++ b/test/unit/app/controllers/infura-controller-test.js
@@ -6,18 +6,17 @@ describe('infura-controller', function () {
   let infuraController, sandbox, networkStatus
   const response = { 'mainnet': 'degraded', 'ropsten': 'ok', 'kovan': 'ok', 'rinkeby': 'down', 'goerli': 'ok' }
 
-  before(async function () {
-    infuraController = new InfuraController()
-    sandbox = sinon.createSandbox()
-    sinon.stub(infuraController, 'checkInfuraNetworkStatus').resolves(response)
-    networkStatus = await infuraController.checkInfuraNetworkStatus()
-  })
-
-  after(function () {
-    sandbox.restore()
-  })
-
   describe('Network status queries', function () {
+    before(async function () {
+      infuraController = new InfuraController()
+      sandbox = sinon.createSandbox()
+      sinon.stub(infuraController, 'checkInfuraNetworkStatus').resolves(response)
+      networkStatus = await infuraController.checkInfuraNetworkStatus()
+    })
+
+    after(function () {
+      sandbox.restore()
+    })
 
     describe('Mainnet', function () {
       it('should have Mainnet', function () {

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -110,14 +110,10 @@ describe('MetaMaskController', function () {
   })
 
   describe('#getAccounts', function () {
-
-    beforeEach(async function () {
+    it('returns first address when dapp calls web3.eth.getAccounts', async function () {
       const password = 'a-fake-password'
-
       await metamaskController.createNewVaultAndRestore(password, TEST_SEED)
-    })
 
-    it('returns first address when dapp calls web3.eth.getAccounts', function () {
       metamaskController.networkController._baseProviderParams.getAccounts((err, res) => {
         assert.ifError(err)
         assert.equal(res.length, 1)
@@ -127,12 +123,10 @@ describe('MetaMaskController', function () {
   })
 
   describe('#importAccountWithStrategy', function () {
-
     const importPrivkey = '4cfd3e90fc78b0f86bf7524722150bb8da9c60cd532564d7ff43f5716514f553'
 
     beforeEach(async function () {
       const password = 'a-fake-password'
-
       await metamaskController.createNewVaultAndRestore(password, TEST_SEED)
       await metamaskController.importAccountWithStrategy('Private Key', [ importPrivkey ])
     })
@@ -148,7 +142,7 @@ describe('MetaMaskController', function () {
       assert.equal(pubKey, '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc')
     })
 
-    it('adds private key to keyrings in KeyringController', async function () {
+    it('adds 1 account', async function () {
       const keyringAccounts = await metamaskController.keyringController.getAccounts()
       assert.equal(keyringAccounts[keyringAccounts.length - 1], '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc')
     })
@@ -180,7 +174,7 @@ describe('MetaMaskController', function () {
       })
     })
 
-    it('gets the address from threebox and creates a new 3box instance', async () => {
+    it('gets the address from threebox and creates a new 3box instance', async function () {
       await metamaskController.submitPassword(password)
       assert(threeBoxSpies.init.calledOnce)
       assert(threeBoxSpies.turnThreeBoxSyncingOn.calledOnce)
@@ -242,7 +236,7 @@ describe('MetaMaskController', function () {
       assert(metamaskController.keyringController.createNewVaultAndRestore.calledTwice)
     })
 
-    it('should clear previous identities after vault restoration', async () => {
+    it('should clear previous identities after vault restoration', async function () {
       sandbox.stub(metamaskController, 'getBalance')
       metamaskController.getBalance.callsFake(() => {
         return Promise.resolve('0x0')
@@ -264,7 +258,7 @@ describe('MetaMaskController', function () {
       })
     })
 
-    it('should restore any consecutive accounts with balances', async () => {
+    it('should restore any consecutive accounts with balances', async function () {
       sandbox.stub(metamaskController, 'getBalance')
       metamaskController.getBalance.withArgs(TEST_ADDRESS).callsFake(() => {
         return Promise.resolve('0x14ced5122ce0a000')
@@ -284,8 +278,8 @@ describe('MetaMaskController', function () {
     })
   })
 
-  describe('#getBalance', () => {
-    it('should return the balance known by accountTracker', async () => {
+  describe('#getBalance', function () {
+    it('should return the balance known by accountTracker', async function () {
       const accounts = {}
       const balance = '0x14ced5122ce0a000'
       accounts[TEST_ADDRESS] = { balance: balance }
@@ -297,7 +291,7 @@ describe('MetaMaskController', function () {
       assert.equal(balance, gotten)
     })
 
-    it('should ask the network for a balance when not known by accountTracker', async () => {
+    it('should ask the network for a balance when not known by accountTracker', async function () {
       const accounts = {}
       const balance = '0x14ced5122ce0a000'
       const ethQuery = new EthQuery()
@@ -314,13 +308,9 @@ describe('MetaMaskController', function () {
   })
 
   describe('#getApi', function () {
-    let getApi, state
-
-    beforeEach(function () {
-      getApi = metamaskController.getApi()
-    })
-
     it('getState', function (done) {
+      let state
+      const getApi = metamaskController.getApi()
       getApi.getState((err, res) => {
         if (err) {
           done(err)
@@ -331,7 +321,6 @@ describe('MetaMaskController', function () {
       assert.deepEqual(state, metamaskController.getState())
       done()
     })
-
   })
 
   describe('preferencesController', function () {
@@ -549,16 +538,12 @@ describe('MetaMaskController', function () {
   })
 
   describe('#addNewAccount', function () {
-    let addNewAccount
-
-    beforeEach(function () {
-      addNewAccount = metamaskController.addNewAccount()
-    })
-
     it('errors when an primary keyring is does not exist', async function () {
+      const addNewAccount = metamaskController.addNewAccount()
+
       try {
         await addNewAccount
-        assert.equal(1 === 0)
+        assert.fail('should throw')
       } catch (e) {
         assert.equal(e.message, 'MetamaskController - No HD Key Tree found')
       }
@@ -586,8 +571,7 @@ describe('MetaMaskController', function () {
   })
 
   describe('#resetAccount', function () {
-
-    beforeEach(function () {
+    it('wipes transactions from only the correct network id and with the selected address', async function () {
       const selectedAddressStub = sinon.stub(metamaskController.preferencesController, 'getSelectedAddress')
       const getNetworkstub = sinon.stub(metamaskController.txController.txStateManager, 'getNetwork')
 
@@ -600,9 +584,7 @@ describe('MetaMaskController', function () {
         createTxMeta({ id: 2, status: 'rejected', metamaskNetworkId: 32 }),
         createTxMeta({ id: 3, status: 'submitted', metamaskNetworkId: currentNetworkId, txParams: { from: '0xB09d8505E1F4EF1CeA089D47094f5DD3464083d4' } }),
       ])
-    })
 
-    it('wipes transactions from only the correct network id and with the selected address', async function () {
       await metamaskController.resetAccount()
       assert.equal(metamaskController.txController.txStateManager.getTx(1), undefined)
     })
@@ -656,14 +638,14 @@ describe('MetaMaskController', function () {
 
   })
 
-  describe('#newUnsignedMessage', () => {
+  describe('#newUnsignedMessage', function () {
 
     let msgParams, metamaskMsgs, messages, msgId
 
     const address = '0xc42edfcc21ed14dda456aa0756c153f7985d8813'
     const data = '0x43727970746f6b697474696573'
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       sandbox.stub(metamaskController, 'getBalance')
       metamaskController.getBalance.callsFake(() => {
         return Promise.resolve('0x0')
@@ -746,7 +728,7 @@ describe('MetaMaskController', function () {
       personalMessages[0].msgParams.metamaskId = parseInt(msgId)
     })
 
-    it('errors with no from in msgParams', async () => {
+    it('errors with no from in msgParams', async function () {
       const msgParams = {
         'data': data,
       }
@@ -788,23 +770,15 @@ describe('MetaMaskController', function () {
   })
 
   describe('#setupUntrustedCommunication', function () {
-    let streamTest
-
-    const phishingMessageSender = {
-      url: 'http://myethereumwalletntw.com',
-      tab: {},
-    }
-
-    afterEach(function () {
-      streamTest.end()
-    })
-
-    it('sets up phishing stream for untrusted communication ', async () => {
+    it('sets up phishing stream for untrusted communication ', async function () {
+      const phishingMessageSender = {
+        url: 'http://myethereumwalletntw.com',
+        tab: {},
+      }
       await metamaskController.phishingController.updatePhishingLists()
 
       const { promise, resolve } = deferredPromise()
-
-      streamTest = createThoughStream((chunk, _, cb) => {
+      const streamTest = createThoughStream((chunk, _, cb) => {
         if (chunk.name !== 'phishing') {
           return cb()
         }
@@ -812,31 +786,29 @@ describe('MetaMaskController', function () {
         resolve()
         cb()
       })
-      metamaskController.setupUntrustedCommunication(streamTest, phishingMessageSender)
 
+      metamaskController.setupUntrustedCommunication(streamTest, phishingMessageSender)
       await promise
+      streamTest.end()
     })
   })
 
   describe('#setupTrustedCommunication', function () {
-    let streamTest
-
-    afterEach(function () {
-      streamTest.end()
-    })
-
-    it('sets up controller dnode api for trusted communication', function (done) {
+    it('sets up controller dnode api for trusted communication', async function () {
       const messageSender = {
         url: 'http://mycrypto.com',
         tab: {},
       }
-      streamTest = createThoughStream((chunk, _, cb) => {
+      const { promise, resolve } = deferredPromise()
+      const streamTest = createThoughStream((chunk, _, cb) => {
         assert.equal(chunk.name, 'controller')
+        resolve()
         cb()
-        done()
       })
 
       metamaskController.setupTrustedCommunication(streamTest, messageSender)
+      await promise
+      streamTest.end()
     })
   })
 

--- a/test/unit/app/controllers/network/network-controller-test.js
+++ b/test/unit/app/controllers/network/network-controller-test.js
@@ -3,30 +3,28 @@ import nock from 'nock'
 import NetworkController from '../../../../../app/scripts/controllers/network'
 import { getNetworkDisplayName } from '../../../../../app/scripts/controllers/network/util'
 
-describe('# Network Controller', function () {
-  let networkController
-  const noop = () => {}
-  const networkControllerProviderConfig = {
-    getAccounts: noop,
-  }
+describe('NetworkController', function () {
+  describe('controller', function () {
+    let networkController
+    const noop = () => {}
+    const networkControllerProviderConfig = {
+      getAccounts: noop,
+    }
 
-  beforeEach(function () {
+    beforeEach(function () {
+      nock('https://rinkeby.infura.io')
+        .persist()
+        .post('/metamask')
+        .reply(200)
 
-    nock('https://rinkeby.infura.io')
-      .persist()
-      .post('/metamask')
-      .reply(200)
+      networkController = new NetworkController()
+      networkController.initializeProvider(networkControllerProviderConfig)
+    })
 
-    networkController = new NetworkController()
+    afterEach(function () {
+      nock.cleanAll()
+    })
 
-    networkController.initializeProvider(networkControllerProviderConfig)
-  })
-
-  afterEach(function () {
-    nock.cleanAll()
-  })
-
-  describe('network', function () {
     describe('#provider', function () {
       it('provider should be updatable without reassignment', function () {
         networkController.initializeProvider(networkControllerProviderConfig)
@@ -64,38 +62,38 @@ describe('# Network Controller', function () {
       })
     })
   })
-})
 
-describe('Network utils', () => {
-  it('getNetworkDisplayName should return the correct network name', () => {
-    const tests = [
-      {
-        input: 3,
-        expected: 'Ropsten',
-      }, {
-        input: 4,
-        expected: 'Rinkeby',
-      }, {
-        input: 42,
-        expected: 'Kovan',
-      }, {
-        input: 'ropsten',
-        expected: 'Ropsten',
-      }, {
-        input: 'rinkeby',
-        expected: 'Rinkeby',
-      }, {
-        input: 'kovan',
-        expected: 'Kovan',
-      }, {
-        input: 'mainnet',
-        expected: 'Main Ethereum Network',
-      }, {
-        input: 'goerli',
-        expected: 'Goerli',
-      },
-    ]
+  describe('utils', function () {
+    it('getNetworkDisplayName should return the correct network name', function () {
+      const tests = [
+        {
+          input: 3,
+          expected: 'Ropsten',
+        }, {
+          input: 4,
+          expected: 'Rinkeby',
+        }, {
+          input: 42,
+          expected: 'Kovan',
+        }, {
+          input: 'ropsten',
+          expected: 'Ropsten',
+        }, {
+          input: 'rinkeby',
+          expected: 'Rinkeby',
+        }, {
+          input: 'kovan',
+          expected: 'Kovan',
+        }, {
+          input: 'mainnet',
+          expected: 'Main Ethereum Network',
+        }, {
+          input: 'goerli',
+          expected: 'Goerli',
+        },
+      ]
 
-    tests.forEach(({ input, expected }) => assert.equal(getNetworkDisplayName(input), expected))
+      tests.forEach(({ input, expected }) => assert.equal(getNetworkDisplayName(input), expected))
+    })
   })
 })

--- a/test/unit/app/controllers/network/pending-middleware-test.js
+++ b/test/unit/app/controllers/network/pending-middleware-test.js
@@ -2,85 +2,77 @@ import assert from 'assert'
 import { createPendingNonceMiddleware, createPendingTxMiddleware } from '../../../../../app/scripts/controllers/network/middleware/pending'
 import { txMetaStub } from './stubs'
 
-describe('#createPendingNonceMiddleware', function () {
-  const getPendingNonce = async () => '0x2'
-  const address = '0xF231D46dD78806E1DD93442cf33C7671f8538748'
-  const pendingNonceMiddleware = createPendingNonceMiddleware({ getPendingNonce })
+describe('PendingNonceMiddleware', function () {
+  describe('#createPendingNonceMiddleware', function () {
+    const getPendingNonce = async () => '0x2'
+    const address = '0xF231D46dD78806E1DD93442cf33C7671f8538748'
+    const pendingNonceMiddleware = createPendingNonceMiddleware({ getPendingNonce })
 
-  it('should call next if not a eth_getTransactionCount request', (done) => {
-    const req = { method: 'eth_getBlockByNumber' }
-    const res = {}
-    pendingNonceMiddleware(req, res, () => done())
-  })
-  it('should call next if not a "pending" block request', (done) => {
-    const req = { method: 'eth_getTransactionCount', params: [address] }
-    const res = {}
-    pendingNonceMiddleware(req, res, () => done())
-  })
-  it('should fill the result with a the "pending" nonce', (done) => {
-    const req = { method: 'eth_getTransactionCount', params: [address, 'pending'] }
-    const res = {}
-    pendingNonceMiddleware(req, res, () => {
-      done(new Error('should not have called next'))
-    }, () => {
-      assert(res.result === '0x2')
-      done()
+    it('should call next if not a eth_getTransactionCount request', function (done) {
+      const req = { method: 'eth_getBlockByNumber' }
+      const res = {}
+      pendingNonceMiddleware(req, res, () => done())
     })
-  })
-})
-
-describe('#createPendingTxMiddleware', function () {
-  let returnUndefined = true
-  const getPendingTransactionByHash = () => (returnUndefined ? undefined : txMetaStub)
-  const address = '0xF231D46dD78806E1DD93442cf33C7671f8538748'
-  const pendingTxMiddleware = createPendingTxMiddleware({ getPendingTransactionByHash })
-  const spec = {
-    'blockHash': null,
-    'blockNumber': null,
-    'from': '0xf231d46dd78806e1dd93442cf33c7671f8538748',
-    'gas': '0x5208',
-    'gasPrice': '0x1e8480',
-    'hash': '0x2cc5a25744486f7383edebbf32003e5a66e18135799593d6b5cdd2bb43674f09',
-    'input': '0x',
-    'nonce': '0x4',
-    'to': '0xf231d46dd78806e1dd93442cf33c7671f8538748',
-    'transactionIndex': null,
-    'value': '0x0',
-    'v': '0x2c',
-    'r': '0x5f973e540f2d3c2f06d3725a626b75247593cb36477187ae07ecfe0a4db3cf57',
-    's': '0x0259b52ee8c58baaa385fb05c3f96116e58de89bcc165cb3bfdfc708672fed8a',
-  }
-  it('should call next if not a eth_getTransactionByHash request', (done) => {
-    const req = { method: 'eth_getBlockByNumber' }
-    const res = {}
-    pendingTxMiddleware(req, res, () => done())
-  })
-
-  it('should call next if no pending txMeta is in history', (done) => {
-    const req = { method: 'eth_getTransactionByHash', params: [address] }
-    const res = {}
-    pendingTxMiddleware(req, res, () => done())
-  })
-
-  it('should fill the result with a the "pending" tx the result should match the rpc spec', (done) => {
-    returnUndefined = false
-    const req = { method: 'eth_getTransactionByHash', params: [address, 'pending'] }
-    const res = {}
-    pendingTxMiddleware(req, res, () => {
-      done(new Error('should not have called next'))
-    }, () => {
-      /*
-      // uncomment this section for debugging help with non matching keys
-      const coppy = {...res.result}
-      Object.keys(spec).forEach((key) => {
-        console.log(coppy[key], '===', spec[key], coppy[key] === spec[key], key)
-        delete coppy[key]
+    it('should call next if not a "pending" block request', function (done) {
+      const req = { method: 'eth_getTransactionCount', params: [address] }
+      const res = {}
+      pendingNonceMiddleware(req, res, () => done())
+    })
+    it('should fill the result with a the "pending" nonce', function (done) {
+      const req = { method: 'eth_getTransactionCount', params: [address, 'pending'] }
+      const res = {}
+      pendingNonceMiddleware(req, res, () => {
+        done(new Error('should not have called next'))
+      }, () => {
+        assert(res.result === '0x2')
+        done()
       })
-      console.log(coppy)
-      */
-      assert.deepStrictEqual(res.result, spec, new Error('result does not match the spec object'))
-      done()
     })
   })
 
+  describe('#createPendingTxMiddleware', function () {
+    let returnUndefined = true
+    const getPendingTransactionByHash = () => (returnUndefined ? undefined : txMetaStub)
+    const address = '0xF231D46dD78806E1DD93442cf33C7671f8538748'
+    const pendingTxMiddleware = createPendingTxMiddleware({ getPendingTransactionByHash })
+    const spec = {
+      'blockHash': null,
+      'blockNumber': null,
+      'from': '0xf231d46dd78806e1dd93442cf33c7671f8538748',
+      'gas': '0x5208',
+      'gasPrice': '0x1e8480',
+      'hash': '0x2cc5a25744486f7383edebbf32003e5a66e18135799593d6b5cdd2bb43674f09',
+      'input': '0x',
+      'nonce': '0x4',
+      'to': '0xf231d46dd78806e1dd93442cf33c7671f8538748',
+      'transactionIndex': null,
+      'value': '0x0',
+      'v': '0x2c',
+      'r': '0x5f973e540f2d3c2f06d3725a626b75247593cb36477187ae07ecfe0a4db3cf57',
+      's': '0x0259b52ee8c58baaa385fb05c3f96116e58de89bcc165cb3bfdfc708672fed8a',
+    }
+    it('should call next if not a eth_getTransactionByHash request', function (done) {
+      const req = { method: 'eth_getBlockByNumber' }
+      const res = {}
+      pendingTxMiddleware(req, res, () => done())
+    })
+
+    it('should call next if no pending txMeta is in history', function (done) {
+      const req = { method: 'eth_getTransactionByHash', params: [address] }
+      const res = {}
+      pendingTxMiddleware(req, res, () => done())
+    })
+
+    it('should fill the result with a the "pending" tx the result should match the rpc spec', function (done) {
+      returnUndefined = false
+      const req = { method: 'eth_getTransactionByHash', params: [address, 'pending'] }
+      const res = {}
+      pendingTxMiddleware(req, res, () => {
+        done(new Error('should not have called next'))
+      }, () => {
+        assert.deepStrictEqual(res.result, spec, new Error('result does not match the spec object'))
+        done()
+      })
+    })
+  })
 })

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -8,7 +8,7 @@ describe('preferences controller', function () {
   let preferencesController
   let network
 
-  beforeEach(() => {
+  beforeEach(function () {
     network = { providerStore: new ObservableStore({ type: 'mainnet' }) }
     preferencesController = new PreferencesController({ network })
   })
@@ -346,7 +346,7 @@ describe('preferences controller', function () {
     let stubNext, stubEnd, stubHandleWatchAssetERC20, asy, req, res
     const sandbox = sinon.createSandbox()
 
-    beforeEach(() => {
+    beforeEach(function () {
       req = { params: {} }
       res = {}
       asy = { next: () => {}, end: () => {} }
@@ -354,7 +354,7 @@ describe('preferences controller', function () {
       stubEnd = sandbox.stub(asy, 'end').returns(0)
       stubHandleWatchAssetERC20 = sandbox.stub(preferencesController, '_handleWatchAssetERC20')
     })
-    after(() => {
+    after(function () {
       sandbox.restore()
     })
 
@@ -404,10 +404,10 @@ describe('preferences controller', function () {
     let req
 
     const sandbox = sinon.createSandbox()
-    beforeEach(() => {
+    beforeEach(function () {
       req = { params: { type: 'ERC20' } }
     })
-    after(() => {
+    after(function () {
       sandbox.restore()
     })
 
@@ -514,7 +514,7 @@ describe('preferences controller', function () {
   })
 
   describe('#updateRpc', function () {
-    it('should update the rpcDetails properly', () => {
+    it('should update the rpcDetails properly', function () {
       preferencesController.store.updateState({ frequentRpcListDetail: [{}, { rpcUrl: 'test' }, {}] })
       preferencesController.updateRpc({ rpcUrl: 'test', chainId: 1 })
       preferencesController.updateRpc({ rpcUrl: 'test/1', chainId: 1 })

--- a/test/unit/app/controllers/token-rates-controller.js
+++ b/test/unit/app/controllers/token-rates-controller.js
@@ -3,15 +3,15 @@ import sinon from 'sinon'
 import TokenRatesController from '../../../../app/scripts/controllers/token-rates'
 import ObservableStore from 'obs-store'
 
-describe('TokenRatesController', () => {
-  it('should listen for preferences store updates', () => {
+describe('TokenRatesController', function () {
+  it('should listen for preferences store updates', function () {
     const preferences = new ObservableStore({ tokens: [] })
     const controller = new TokenRatesController({ preferences })
     preferences.putState({ tokens: ['foo'] })
     assert.deepEqual(controller._tokens, ['foo'])
   })
 
-  it('should poll on correct interval', async () => {
+  it('should poll on correct interval', async function () {
     const stub = sinon.stub(global, 'setInterval')
     new TokenRatesController({ interval: 1337 }) // eslint-disable-line no-new
     assert.strictEqual(stub.getCall(0).args[1], 1337)

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -56,17 +56,7 @@ describe('PendingTransactionTracker', function () {
   })
 
   describe('_checkPendingTx state management', function () {
-    let stub
-
-    afterEach(function () {
-      if (stub) {
-        stub.restore()
-      }
-    })
-
     it('should emit dropped if another tx with the same nonce succeeds', async function () {
-
-      // SETUP
       const txGen = new MockTxGen()
 
       txGen.generate({
@@ -83,21 +73,19 @@ describe('PendingTransactionTracker', function () {
         status: 'submitted',
       }, { count: 1, fromNonce: '0x01' })[0]
 
-      stub = sinon.stub(pendingTxTracker, 'getCompletedTransactions')
+      const stub = sinon.stub(pendingTxTracker, 'getCompletedTransactions')
         .returns(txGen.txs)
 
-      // THE EXPECTATION
       const spy = sinon.spy()
       pendingTxTracker.on('tx:dropped', (txId) => {
         assert.equal(txId, pending.id, 'should fail the pending tx')
         spy(txId)
       })
 
-      // THE METHOD
       await pendingTxTracker._checkPendingTx(pending)
 
-      // THE ASSERTION
       assert.ok(spy.calledWith(pending.id), 'tx dropped should be emitted')
+      stub.restore()
     })
   })
 
@@ -161,7 +149,7 @@ describe('PendingTransactionTracker', function () {
   })
 
   describe('#_checkPendingTxs', function () {
-    beforeEach(function () {
+    it('should warp all txMeta\'s in #updatePendingTxs', function (done) {
       const txMeta2 = txMeta3 = txMeta
       txMeta2.id = 2
       txMeta3.id = 3
@@ -171,9 +159,6 @@ describe('PendingTransactionTracker', function () {
         })
         return tx
       })
-    })
-
-    it('should warp all txMeta\'s in #updatePendingTxs', function (done) {
       pendingTxTracker.getPendingTransactions = () => txList
       pendingTxTracker._checkPendingTx = (tx) => {
         tx.resolve(tx)
@@ -263,7 +248,7 @@ describe('PendingTransactionTracker', function () {
     const mockFirstRetryBlockNumber = '0x1'
     let txMetaToTestExponentialBackoff, enoughBalance
 
-    beforeEach(() => {
+    beforeEach(function () {
       pendingTxTracker.getBalance = (address) => {
         assert.equal(address, txMeta.txParams.from, 'Should pass the address')
         return enoughBalance
@@ -280,7 +265,7 @@ describe('PendingTransactionTracker', function () {
       })
     })
 
-    afterEach(() => {
+    afterEach(function () {
       pendingTxTracker.publishTransaction.restore()
     })
 
@@ -327,7 +312,7 @@ describe('PendingTransactionTracker', function () {
       assert.equal(pendingTxTracker.publishTransaction.callCount, 1, 'Should call publish transaction')
     })
 
-    it('should call opts.approveTransaction with the id if the tx is not signed', async () => {
+    it('should call opts.approveTransaction with the id if the tx is not signed', async function () {
       const stubTx = {
         id: 40,
       }
@@ -340,7 +325,7 @@ describe('PendingTransactionTracker', function () {
     })
   })
 
-  describe('#_checkIftxWasDropped', () => {
+  describe('#_checkIftxWasDropped', function () {
     const txMeta = {
       id: 1,
       hash: '0x0593ee121b92e10d63150ad08b4b8f9c7857d1bd160195ee648fb9a0f8d00eeb',
@@ -352,7 +337,7 @@ describe('PendingTransactionTracker', function () {
       },
       rawTx: '0xf86c808504a817c800827b0d940c62bb85faa3311a998d3aba8098c1235c564966880de0b6b3a7640000802aa08ff665feb887a25d4099e40e11f0fef93ee9608f404bd3f853dd9e84ed3317a6a02ec9d3d1d6e176d4d2593dd760e74ccac753e6a0ea0d00cc9789d0d7ff1f471d',
     }
-    it('should return false when the nonce is the suggested network nonce', (done) => {
+    it('should return false when the nonce is the suggested network nonce', function (done) {
       providerResultStub['eth_getTransactionCount'] = '0x01'
       providerResultStub['eth_getTransactionReceipt'] = {}
       pendingTxTracker._checkIftxWasDropped(txMeta, {}).then((dropped) => {

--- a/test/unit/app/controllers/transactions/recipient-blacklist-checker-test.js
+++ b/test/unit/app/controllers/transactions/recipient-blacklist-checker-test.js
@@ -4,22 +4,21 @@ import { ROPSTEN_CODE, RINKEBY_CODE, KOVAN_CODE, GOERLI_CODE } from '../../../..
 import KeyringController from 'eth-keyring-controller'
 
 describe('Recipient Blacklist Checker', function () {
-
-  let publicAccounts
-
-  before(async function () {
-    const damnedMnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
-    const keyringController = new KeyringController({})
-    const Keyring = keyringController.getKeyringClassForType('HD Key Tree')
-    const opts = {
-      mnemonic: damnedMnemonic,
-      numberOfAccounts: 10,
-    }
-    const keyring = new Keyring(opts)
-    publicAccounts = await keyring.getAccounts()
-  })
-
   describe('#checkAccount', function () {
+    let publicAccounts
+
+    before(async function () {
+      const damnedMnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
+      const keyringController = new KeyringController({})
+      const Keyring = keyringController.getKeyringClassForType('HD Key Tree')
+      const opts = {
+        mnemonic: damnedMnemonic,
+        numberOfAccounts: 10,
+      }
+      const keyring = new Keyring(opts)
+      publicAccounts = await keyring.getAccounts()
+    })
+
     it('does not fail on test networks', function () {
       let callCount = 0
       const networks = [ROPSTEN_CODE, RINKEBY_CODE, KOVAN_CODE, GOERLI_CODE]

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -87,9 +87,8 @@ describe('Transaction Controller', function () {
   })
 
   describe('#getConfirmedTransactions', function () {
-    let address
-    beforeEach(function () {
-      address = '0xc684832530fcbddae4b4230a47e991ddcec2831d'
+    it('should return the number of confirmed txs', function () {
+      const address = '0xc684832530fcbddae4b4230a47e991ddcec2831d'
       const txParams = {
         'from': address,
         'to': '0xc684832530fcbddae4b4230a47e991ddcec2831d',
@@ -105,9 +104,6 @@ describe('Transaction Controller', function () {
         { id: 7, status: 'submitted', metamaskNetworkId: currentNetworkId, txParams, history: [{}] },
         { id: 8, status: 'failed', metamaskNetworkId: currentNetworkId, txParams, history: [{}] },
       ])
-    })
-
-    it('should return the number of confirmed txs', function () {
       assert.equal(txController.nonceTracker.getConfirmedTransactions(address).length, 3)
     })
   })
@@ -132,11 +128,11 @@ describe('Transaction Controller', function () {
         txController.emit('newUnapprovedTx', txMeta)
         return Promise.resolve(txController.txStateManager.addTx(txMeta))
       })
+    })
 
-      afterEach(function () {
-        txController.txStateManager._saveTxList([])
-        stub.restore()
-      })
+    afterEach(function () {
+      txController.txStateManager._saveTxList([])
+      stub.restore()
     })
 
     it('should resolve when finished and status is submitted and resolve with the hash', function (done) {
@@ -226,11 +222,11 @@ describe('Transaction Controller', function () {
 
     it('should fail if the from address isn\'t the selected address', function (done) {
       txController.addUnapprovedTransaction({ from: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' })
-        .then(function () {
+        .then(() => {
           assert.fail('transaction should not have been added')
           done()
         })
-        .catch(function () {
+        .catch(() => {
           assert.ok('pass')
           done()
         })
@@ -259,7 +255,7 @@ describe('Transaction Controller', function () {
   })
 
   describe('#addTxGasDefaults', function () {
-    it('should add the tx defaults if their are none', async () => {
+    it('should add the tx defaults if their are none', async function () {
       const txMeta = {
         txParams: {
           from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
@@ -307,11 +303,9 @@ describe('Transaction Controller', function () {
   })
 
   describe('#approveTransaction', function () {
-    let txMeta, originalValue
-
-    beforeEach(function () {
-      originalValue = '0x01'
-      txMeta = {
+    it('does not overwrite set values', function (done) {
+      const originalValue = '0x01'
+      const txMeta = {
         id: '1',
         status: 'unapproved',
         metamaskNetworkId: currentNetworkId,
@@ -321,10 +315,6 @@ describe('Transaction Controller', function () {
           gasPrice: originalValue,
         },
       }
-    })
-
-
-    it('does not overwrite set values', function (done) {
       this.timeout(15000)
       const wrongValue = '0x05'
 
@@ -366,9 +356,8 @@ describe('Transaction Controller', function () {
   })
 
   describe('#updateAndApproveTransaction', function () {
-    let txMeta
-    beforeEach(() => {
-      txMeta = {
+    it('should update and approve transactions', async function () {
+      const txMeta = {
         id: 1,
         status: 'unapproved',
         txParams: {
@@ -380,8 +369,6 @@ describe('Transaction Controller', function () {
         },
         metamaskNetworkId: currentNetworkId,
       }
-    })
-    it('should update and approve transactions', async () => {
       txController.txStateManager.addTx(txMeta)
       const approvalPromise = txController.updateAndApproveTransaction(txMeta)
       const tx = txController.txStateManager.getTx(1)
@@ -398,7 +385,7 @@ describe('Transaction Controller', function () {
   })
 
   describe('#cancelTransaction', function () {
-    beforeEach(function () {
+    it('should emit a status change to rejected', function (done) {
       txController.txStateManager._saveTxList([
         { id: 0, status: 'unapproved', txParams: {}, metamaskNetworkId: currentNetworkId, history: [{}] },
         { id: 1, status: 'rejected', txParams: {}, metamaskNetworkId: currentNetworkId, history: [{}] },
@@ -408,9 +395,7 @@ describe('Transaction Controller', function () {
         { id: 5, status: 'confirmed', txParams: {}, metamaskNetworkId: currentNetworkId, history: [{}] },
         { id: 6, status: 'failed', txParams: {}, metamaskNetworkId: currentNetworkId, history: [{}] },
       ])
-    })
 
-    it('should emit a status change to rejected', function (done) {
       txController.once('tx:status-update', (txId, status) => {
         try {
           assert.equal(status, 'rejected', 'status should e rejected')
@@ -426,13 +411,13 @@ describe('Transaction Controller', function () {
 
   })
 
-  describe('#createSpeedUpTransaction', () => {
+  describe('#createSpeedUpTransaction', function () {
     let addTxSpy
     let approveTransactionSpy
     let txParams
     let expectedTxParams
 
-    beforeEach(() => {
+    beforeEach(function () {
       addTxSpy = sinon.spy(txController, 'addTx')
       approveTransactionSpy = sinon.spy(txController, 'approveTransaction')
 
@@ -450,12 +435,12 @@ describe('Transaction Controller', function () {
       expectedTxParams = Object.assign({}, txParams, { gasPrice: '0xb' })
     })
 
-    afterEach(() => {
+    afterEach(function () {
       addTxSpy.restore()
       approveTransactionSpy.restore()
     })
 
-    it('should call this.addTx and this.approveTransaction with the expected args', async () => {
+    it('should call this.addTx and this.approveTransaction with the expected args', async function () {
       await txController.createSpeedUpTransaction(1)
       assert.equal(addTxSpy.callCount, 1)
 
@@ -469,7 +454,7 @@ describe('Transaction Controller', function () {
       })
     })
 
-    it('should call this.approveTransaction with the id of the returned tx', async () => {
+    it('should call this.approveTransaction with the id of the returned tx', async function () {
       const result = await txController.createSpeedUpTransaction(1)
       assert.equal(approveTransactionSpy.callCount, 1)
 
@@ -477,7 +462,7 @@ describe('Transaction Controller', function () {
       assert.equal(result.id, approveTransactionArg)
     })
 
-    it('should return the expected txMeta', async () => {
+    it('should return the expected txMeta', async function () {
       const result = await txController.createSpeedUpTransaction(1)
 
       assert.deepEqual(result.txParams, expectedTxParams)
@@ -686,7 +671,7 @@ describe('Transaction Controller', function () {
   })
 
   describe('#getPendingTransactions', function () {
-    beforeEach(function () {
+    it('should show only submitted and approved transactions as pending transasction', function () {
       txController.txStateManager._saveTxList([
         { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} },
         { id: 2, status: 'rejected', metamaskNetworkId: currentNetworkId, txParams: {}, history: [{}] },
@@ -696,8 +681,7 @@ describe('Transaction Controller', function () {
         { id: 6, status: 'confirmed', metamaskNetworkId: currentNetworkId, txParams: {}, history: [{}] },
         { id: 7, status: 'failed', metamaskNetworkId: currentNetworkId, txParams: {}, history: [{}] },
       ])
-    })
-    it('should show only submitted and approved transactions as pending transasction', function () {
+
       assert(txController.pendingTxTracker.getPendingTransactions().length, 2)
       const states = txController.pendingTxTracker.getPendingTransactions().map(tx => tx.status)
       assert(states.includes('approved'), 'includes approved')

--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -30,7 +30,7 @@ describe('TransactionStateManager', function () {
       assert.equal(result[0].status, 'signed')
     })
 
-    it('should emit a signed event to signal the exciton of callback', (done) => {
+    it('should emit a signed event to signal the exciton of callback', function (done) {
       const tx = { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }
       const noop = function () {
         assert(true, 'event listener has been triggered and noop executed')
@@ -53,7 +53,7 @@ describe('TransactionStateManager', function () {
       assert.equal(result.length, 0)
     })
 
-    it('should emit a rejected event to signal the exciton of callback', (done) => {
+    it('should emit a rejected event to signal the exciton of callback', function (done) {
       const tx = { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }
       txStateManager.addTx(tx)
       const noop = () => {
@@ -303,7 +303,6 @@ describe('TransactionStateManager', function () {
       assert.equal(txStateManager.getFilteredTxList(filterParams).length, 5, `getFilteredTxList - ${JSON.stringify(filterParams)}`)
       filterParams = { status: (status) => status !== 'confirmed' }
       assert.equal(txStateManager.getFilteredTxList(filterParams).length, 5, `getFilteredTxList - ${JSON.stringify(filterParams)}`)
-
     })
   })
 
@@ -346,18 +345,17 @@ describe('TransactionStateManager', function () {
 
       assert.equal(txsFromCurrentNetworkAndAddress.length, 0)
       assert.equal(txFromOtherNetworks.length, 2)
-
     })
   })
 
   describe('#_removeTx', function () {
-    it('should remove the transaction from the storage', () => {
+    it('should remove the transaction from the storage', function () {
       txStateManager._saveTxList([ { id: 1 } ])
       txStateManager._removeTx(1)
       assert(!txStateManager.getFullTxList().length, 'txList should be empty')
     })
 
-    it('should only remove the transaction with ID 1 from the storage', () => {
+    it('should only remove the transaction with ID 1 from the storage', function () {
       txStateManager._saveTxList([ { id: 1 }, { id: 2 } ])
       txStateManager._removeTx(1)
       assert.equal(txStateManager.getFullTxList()[0].id, 2, 'txList should have a id of 2')

--- a/test/unit/app/controllers/transactions/tx-utils-test.js
+++ b/test/unit/app/controllers/transactions/tx-utils-test.js
@@ -25,8 +25,8 @@ describe('txUtils', function () {
     })
   })
 
-  describe('#normalizeTxParams', () => {
-    it('should normalize txParams', () => {
+  describe('#normalizeTxParams', function () {
+    it('should normalize txParams', function () {
       const txParams = {
         chainId: '0x1',
         from: 'a7df1beDBF813f57096dF77FCd515f0B3900e402',
@@ -50,7 +50,7 @@ describe('txUtils', function () {
     })
   })
 
-  describe('#validateRecipient', () => {
+  describe('#validateRecipient', function () {
     it('removes recipient for txParams with 0x when contract data is provided', function () {
       const zeroRecipientandDataTxParams = {
         from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
@@ -73,7 +73,7 @@ describe('txUtils', function () {
   })
 
 
-  describe('#validateFrom', () => {
+  describe('#validateFrom', function () {
     it('should error when from is not a hex string', function () {
 
       // where from is undefined

--- a/test/unit/app/fetch-with-timeout.test.js
+++ b/test/unit/app/fetch-with-timeout.test.js
@@ -3,8 +3,8 @@ import nock from 'nock'
 
 import fetchWithTimeout from '../../../app/scripts/lib/fetch-with-timeout'
 
-describe('fetchWithTimeout', () => {
-  it('fetches a url', async () => {
+describe('fetchWithTimeout', function () {
+  it('fetches a url', async function () {
     nock('https://api.infura.io')
       .get('/money')
       .reply(200, '{"hodl": false}')
@@ -16,7 +16,7 @@ describe('fetchWithTimeout', () => {
     })
   })
 
-  it('throws when the request hits a custom timeout', async () => {
+  it('throws when the request hits a custom timeout', async function () {
     nock('https://api.infura.io')
       .get('/moon')
       .delay(2000)
@@ -34,7 +34,7 @@ describe('fetchWithTimeout', () => {
     }
   })
 
-  it('should abort the request when the custom timeout is hit', async () => {
+  it('should abort the request when the custom timeout is hit', async function () {
     nock('https://api.infura.io')
       .get('/moon')
       .delay(2000)

--- a/test/unit/app/nodeify-test.js
+++ b/test/unit/app/nodeify-test.js
@@ -12,7 +12,7 @@ describe('nodeify', function () {
 
   it('should retain original context', function (done) {
     const nodified = nodeify(obj.promiseFunc, obj)
-    nodified('baz', function (err, res) {
+    nodified('baz', (err, res) => {
       if (!err) {
         assert.equal(res, 'barbaz')
         done()
@@ -36,7 +36,7 @@ describe('nodeify', function () {
     const nodified = nodeify(async () => {
       throw new Error('boom!')
     }, obj)
-    process.prependOnceListener('uncaughtException', function (err) {
+    process.prependOnceListener('uncaughtException', (err) => {
       assert.ok(err, 'got expected error')
       assert.ok(err.message.includes('boom!'), 'got expected error message')
       done()

--- a/test/unit/app/pending-balance-test.js
+++ b/test/unit/app/pending-balance-test.js
@@ -45,19 +45,15 @@ describe('PendingBalanceCalculator', function () {
   })
 
   describe('if you have no pending txs and one ether', function () {
-
-    beforeEach(function () {
-      balanceCalculator = generateBalanceCalcWith([], etherBn)
-    })
-
     it('returns the network balance', async function () {
+      balanceCalculator = generateBalanceCalcWith([], etherBn)
       const result = await balanceCalculator.getBalance()
       assert.equal(result, ether, `gave ${result} needed ${ether}`)
     })
   })
 
   describe('if you have a one ether pending tx and one ether', function () {
-    beforeEach(function () {
+    it('returns the subtracted result', async function () {
       const txGen = new MockTxGen()
       pendingTxs = txGen.generate({
         status: 'submitted',
@@ -69,14 +65,11 @@ describe('PendingBalanceCalculator', function () {
       }, { count: 1 })
 
       balanceCalculator = generateBalanceCalcWith(pendingTxs, etherBn)
-    })
 
-    it('returns the subtracted result', async function () {
       const result = await balanceCalculator.getBalance()
       assert.equal(result, '0x0', `gave ${result} needed '0x0'`)
       return true
     })
-
   })
 })
 

--- a/test/unit/app/typed-message-manager.spec.js
+++ b/test/unit/app/typed-message-manager.spec.js
@@ -3,14 +3,14 @@ import sinon from 'sinon'
 import NetworkController from '../../../app/scripts/controllers/network/index'
 import TypedMessageManager from '../../../app/scripts/lib/typed-message-manager'
 
-describe('Typed Message Manager', () => {
+describe('Typed Message Manager', function () {
   let typedMessageManager, msgParamsV1, msgParamsV3, typedMsgs, messages, msgId, numberMsgId
 
   const address = '0xc42edfcc21ed14dda456aa0756c153f7985d8813'
   const networkController = new NetworkController()
   sinon.stub(networkController, 'getNetworkState').returns('1')
 
-  beforeEach(() => {
+  beforeEach(function () {
     typedMessageManager = new TypedMessageManager({
       networkController,
     })
@@ -72,7 +72,7 @@ describe('Typed Message Manager', () => {
     numberMsgId = parseInt(msgId)
   })
 
-  it('supports version 1 of signedTypedData', () => {
+  it('supports version 1 of signedTypedData', function () {
     typedMessageManager.addUnapprovedMessage(msgParamsV1, null, 'V1')
     assert.equal(messages[messages.length - 1].msgParams.data, msgParamsV1.data)
   })

--- a/test/unit/app/util-test.js
+++ b/test/unit/app/util-test.js
@@ -8,82 +8,84 @@ import {
   ENVIRONMENT_TYPE_BACKGROUND,
 } from '../../../app/scripts/lib/enums'
 
-describe('getEnvironmentType', function () {
-  it('should return popup type', function () {
-    const environmentType = getEnvironmentType('http://extension-id/popup.html')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
+describe('app utils', function () {
+  describe('getEnvironmentType', function () {
+    it('should return popup type', function () {
+      const environmentType = getEnvironmentType('http://extension-id/popup.html')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
+    })
+
+    it('should return notification type', function () {
+      const environmentType = getEnvironmentType('http://extension-id/notification.html')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_NOTIFICATION)
+    })
+
+    it('should return fullscreen type for home.html', function () {
+      const environmentType = getEnvironmentType('http://extension-id/home.html')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_FULLSCREEN)
+    })
+
+    it('should return fullscreen type for phishing.html', function () {
+      const environmentType = getEnvironmentType('http://extension-id/phishing.html')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_FULLSCREEN)
+    })
+
+    it('should return background type', function () {
+      const environmentType = getEnvironmentType('http://extension-id/_generated_background_page.html')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_BACKGROUND)
+    })
+
+    it('should return the correct type for a URL with a hash fragment', function () {
+      const environmentType = getEnvironmentType('http://extension-id/popup.html#hash')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
+    })
+
+    it('should return the correct type for a URL with query parameters', function () {
+      const environmentType = getEnvironmentType('http://extension-id/popup.html?param=foo')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
+    })
+
+    it('should return the correct type for a URL with query parameters and a hash fragment', function () {
+      const environmentType = getEnvironmentType('http://extension-id/popup.html?param=foo#hash')
+      assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
+    })
   })
 
-  it('should return notification type', function () {
-    const environmentType = getEnvironmentType('http://extension-id/notification.html')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_NOTIFICATION)
-  })
+  describe('SufficientBalance', function () {
+    it('returns true if max tx cost is equal to balance.', function () {
+      const tx = {
+        'value': '0x1',
+        'gas': '0x2',
+        'gasPrice': '0x3',
+      }
+      const balance = '0x8'
 
-  it('should return fullscreen type for home.html', function () {
-    const environmentType = getEnvironmentType('http://extension-id/home.html')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_FULLSCREEN)
-  })
+      const result = sufficientBalance(tx, balance)
+      assert.ok(result, 'sufficient balance found.')
+    })
 
-  it('should return fullscreen type for phishing.html', function () {
-    const environmentType = getEnvironmentType('http://extension-id/phishing.html')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_FULLSCREEN)
-  })
+    it('returns true if max tx cost is less than balance.', function () {
+      const tx = {
+        'value': '0x1',
+        'gas': '0x2',
+        'gasPrice': '0x3',
+      }
+      const balance = '0x9'
 
-  it('should return background type', function () {
-    const environmentType = getEnvironmentType('http://extension-id/_generated_background_page.html')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_BACKGROUND)
-  })
+      const result = sufficientBalance(tx, balance)
+      assert.ok(result, 'sufficient balance found.')
+    })
 
-  it('should return the correct type for a URL with a hash fragment', function () {
-    const environmentType = getEnvironmentType('http://extension-id/popup.html#hash')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
-  })
+    it('returns false if max tx cost is more than balance.', function () {
+      const tx = {
+        'value': '0x1',
+        'gas': '0x2',
+        'gasPrice': '0x3',
+      }
+      const balance = '0x6'
 
-  it('should return the correct type for a URL with query parameters', function () {
-    const environmentType = getEnvironmentType('http://extension-id/popup.html?param=foo')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
-  })
-
-  it('should return the correct type for a URL with query parameters and a hash fragment', function () {
-    const environmentType = getEnvironmentType('http://extension-id/popup.html?param=foo#hash')
-    assert.equal(environmentType, ENVIRONMENT_TYPE_POPUP)
-  })
-})
-
-describe('SufficientBalance', function () {
-  it('returns true if max tx cost is equal to balance.', function () {
-    const tx = {
-      'value': '0x1',
-      'gas': '0x2',
-      'gasPrice': '0x3',
-    }
-    const balance = '0x8'
-
-    const result = sufficientBalance(tx, balance)
-    assert.ok(result, 'sufficient balance found.')
-  })
-
-  it('returns true if max tx cost is less than balance.', function () {
-    const tx = {
-      'value': '0x1',
-      'gas': '0x2',
-      'gasPrice': '0x3',
-    }
-    const balance = '0x9'
-
-    const result = sufficientBalance(tx, balance)
-    assert.ok(result, 'sufficient balance found.')
-  })
-
-  it('returns false if max tx cost is more than balance.', function () {
-    const tx = {
-      'value': '0x1',
-      'gas': '0x2',
-      'gasPrice': '0x3',
-    }
-    const balance = '0x6'
-
-    const result = sufficientBalance(tx, balance)
-    assert.ok(!result, 'insufficient balance found.')
+      const result = sufficientBalance(tx, balance)
+      assert.ok(!result, 'insufficient balance found.')
+    })
   })
 })

--- a/test/unit/migrations/021-test.js
+++ b/test/unit/migrations/021-test.js
@@ -2,8 +2,8 @@ import assert from 'assert'
 import wallet2 from '../../lib/migrations/002.json'
 import migration21 from '../../../app/scripts/migrations/021'
 
-describe('wallet2 is migrated successfully with out the BlacklistController', () => {
-  it('should delete BlacklistController key', (done) => {
+describe('wallet2 is migrated successfully with out the BlacklistController', function () {
+  it('should delete BlacklistController key', function (done) {
     migration21.migrate(wallet2)
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, 21)

--- a/test/unit/migrations/022-test.js
+++ b/test/unit/migrations/022-test.js
@@ -15,8 +15,8 @@ const storage = {
   },
 }
 
-describe('storage is migrated successfully where transactions that are submitted have submittedTimes', () => {
-  it('should add submittedTime key on the txMeta if appropriate', (done) => {
+describe('storage is migrated successfully where transactions that are submitted have submittedTimes', function () {
+  it('should add submittedTime key on the txMeta if appropriate', function (done) {
     migration22.migrate(storage)
       .then((migratedData) => {
         const [txMeta1, txMeta2, txMeta3] = migratedData.data.TransactionController.transactions

--- a/test/unit/migrations/023-test.js
+++ b/test/unit/migrations/023-test.js
@@ -57,8 +57,8 @@ while (transactions20.length < 20) {
 
 storage.data.TransactionController.transactions = transactions
 
-describe('storage is migrated successfully and the proper transactions are remove from state', () => {
-  it('should remove transactions that are unneeded', (done) => {
+describe('storage is migrated successfully and the proper transactions are remove from state', function () {
+  it('should remove transactions that are unneeded', function (done) {
     migration23.migrate(storage)
       .then((migratedData) => {
         let leftoverNonDeletableTxCount = 0
@@ -74,7 +74,7 @@ describe('storage is migrated successfully and the proper transactions are remov
       }).catch(done)
   })
 
-  it('should not remove any transactions because 40 is the expectable limit', (done) => {
+  it('should not remove any transactions because 40 is the expectable limit', function (done) {
     storage.meta.version = 22
     storage.data.TransactionController.transactions = transactions40
     migration23.migrate(storage)
@@ -86,7 +86,7 @@ describe('storage is migrated successfully and the proper transactions are remov
       }).catch(done)
   })
 
-  it('should not remove any transactions because 20 txs is under the expectable limit', (done) => {
+  it('should not remove any transactions because 20 txs is under the expectable limit', function (done) {
     storage.meta.version = 22
     storage.data.TransactionController.transactions = transactions20
     migration23.migrate(storage)

--- a/test/unit/migrations/024-test.js
+++ b/test/unit/migrations/024-test.js
@@ -27,8 +27,8 @@ while (transactions.length <= 10) {
 
 storage.data.TransactionController.transactions = transactions
 
-describe('storage is migrated successfully and the txParams.from are lowercase', () => {
-  it('should lowercase the from for unapproved txs', (done) => {
+describe('storage is migrated successfully and the txParams.from are lowercase', function () {
+  it('should lowercase the from for unapproved txs', function (done) {
     migration24.migrate(storage)
       .then((migratedData) => {
         const migratedTransactions = migratedData.data.TransactionController.transactions
@@ -43,7 +43,7 @@ describe('storage is migrated successfully and the txParams.from are lowercase',
       }).catch(done)
   })
 
-  it('should migrate first time state', (done) => {
+  it('should migrate first time state', function (done) {
     migration24.migrate(firstTimeState)
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, 24)

--- a/test/unit/migrations/025-test.js
+++ b/test/unit/migrations/025-test.js
@@ -28,8 +28,8 @@ while (transactions.length <= 10) {
 
 storage.data.TransactionController.transactions = transactions
 
-describe('storage is migrated successfully and the txParams.from are lowercase', () => {
-  it('should lowercase the from for unapproved txs', (done) => {
+describe('storage is migrated successfully and the txParams.from are lowercase', function () {
+  it('should lowercase the from for unapproved txs', function (done) {
     migration25.migrate(storage)
       .then((migratedData) => {
         const migratedTransactions = migratedData.data.TransactionController.transactions
@@ -45,7 +45,7 @@ describe('storage is migrated successfully and the txParams.from are lowercase',
       }).catch(done)
   })
 
-  it('should migrate first time state', (done) => {
+  it('should migrate first time state', function (done) {
     migration25.migrate(firstTimeState)
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, 25)

--- a/test/unit/migrations/026-test.js
+++ b/test/unit/migrations/026-test.js
@@ -14,8 +14,8 @@ const oldStorage = {
   },
 }
 
-describe('migration #26', () => {
-  it('should move the identities from KeyringController', (done) => {
+describe('migration #26', function () {
+  it('should move the identities from KeyringController', function (done) {
     migration26.migrate(oldStorage)
       .then((newStorage) => {
         const identities = newStorage.data.PreferencesController.identities
@@ -29,7 +29,7 @@ describe('migration #26', () => {
       .catch(done)
   })
 
-  it('should successfully migrate first time state', (done) => {
+  it('should successfully migrate first time state', function (done) {
     migration26.migrate({
       meta: {},
       data: require('../../../app/scripts/first-time-state'),

--- a/test/unit/migrations/027-test.js
+++ b/test/unit/migrations/027-test.js
@@ -23,8 +23,8 @@ while (transactions.length < 9) {
 
 oldStorage.data.TransactionController.transactions = transactions
 
-describe('migration #27', () => {
-  it('should remove rejected transactions', (done) => {
+describe('migration #27', function () {
+  it('should remove rejected transactions', function (done) {
     migration27.migrate(oldStorage)
       .then((newStorage) => {
         const newTransactions = newStorage.data.TransactionController.transactions
@@ -39,7 +39,7 @@ describe('migration #27', () => {
       .catch(done)
   })
 
-  it('should successfully migrate first time state', (done) => {
+  it('should successfully migrate first time state', function (done) {
     migration27.migrate({
       meta: {},
       data: require('../../../app/scripts/first-time-state'),

--- a/test/unit/migrations/028-test.js
+++ b/test/unit/migrations/028-test.js
@@ -14,8 +14,8 @@ const oldStorage = {
   },
 }
 
-describe('migration #28', () => {
-  it('should add corresponding tokens to accountTokens', (done) => {
+describe('migration #28', function () {
+  it('should add corresponding tokens to accountTokens', function (done) {
     migration28.migrate(oldStorage)
       .then((newStorage) => {
         const newTokens = newStorage.data.PreferencesController.tokens
@@ -33,7 +33,7 @@ describe('migration #28', () => {
       .catch(done)
   })
 
-  it('should successfully migrate first time state', (done) => {
+  it('should successfully migrate first time state', function (done) {
     migration28.migrate({
       meta: {},
       data: require('../../../app/scripts/first-time-state'),

--- a/test/unit/migrations/029-test.js
+++ b/test/unit/migrations/029-test.js
@@ -17,8 +17,8 @@ const storage = {
   },
 }
 
-describe('storage is migrated successfully where transactions that are submitted have submittedTimes', () => {
-  it('should auto fail transactions more than 12 hours old', (done) => {
+describe('storage is migrated successfully where transactions that are submitted have submittedTimes', function () {
+  it('should auto fail transactions more than 12 hours old', function (done) {
     migration29.migrate(storage)
       .then((migratedData) => {
         const txs = migratedData.data.TransactionController.transactions

--- a/test/unit/migrations/030-test.js
+++ b/test/unit/migrations/030-test.js
@@ -23,8 +23,8 @@ const storage = {
   },
 }
 
-describe('storage is migrated successfully', () => {
-  it('should work', (done) => {
+describe('storage is migrated successfully', function () {
+  it('should work', function (done) {
     migrationTemplate.migrate(storage)
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, 30)

--- a/test/unit/migrations/031-test.js
+++ b/test/unit/migrations/031-test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import migration31 from '../../../app/scripts/migrations/031'
 
-describe('migration #31', () => {
-  it('should set completedOnboarding to true if vault exists', done => {
+describe('migration #31', function () {
+  it('should set completedOnboarding to true if vault exists', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -31,7 +31,7 @@ describe('migration #31', () => {
       .catch(done)
   })
 
-  it('should set completedOnboarding to false if vault does not exist', done => {
+  it('should set completedOnboarding to false if vault does not exist', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {

--- a/test/unit/migrations/033-test.js
+++ b/test/unit/migrations/033-test.js
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import migration33 from '../../../app/scripts/migrations/033'
 
-describe('Migration to delete notice controller', () => {
+describe('Migration to delete notice controller', function () {
   const oldStorage = {
     'meta': {},
     'data': {
@@ -31,7 +31,7 @@ describe('Migration to delete notice controller', () => {
     },
   }
 
-  it('removes notice controller from state', () => {
+  it('removes notice controller from state', function () {
     migration33.migrate(oldStorage)
       .then(newStorage => {
         assert.equal(newStorage.data.NoticeController, undefined)

--- a/test/unit/migrations/034-test.js
+++ b/test/unit/migrations/034-test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import migration34 from '../../../app/scripts/migrations/034'
 
-describe('migration #34', () => {
-  it('should update the version metadata', (done) => {
+describe('migration #34', function () {
+  it('should update the version metadata', function (done) {
     const oldStorage = {
       'meta': {
         'version': 33,
@@ -20,7 +20,7 @@ describe('migration #34', () => {
       .catch(done)
   })
 
-  it('should set migratedPrivacyMode & privacyMode if featureFlags.privacyMode was false', (done) => {
+  it('should set migratedPrivacyMode & privacyMode if featureFlags.privacyMode was false', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -45,7 +45,7 @@ describe('migration #34', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if migratedPrivacyMode is already set to true', (done) => {
+  it('should NOT change any state if migratedPrivacyMode is already set to true', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -66,7 +66,7 @@ describe('migration #34', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if migratedPrivacyMode is already set to false', (done) => {
+  it('should NOT change any state if migratedPrivacyMode is already set to false', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -87,7 +87,7 @@ describe('migration #34', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if PreferencesController is missing', (done) => {
+  it('should NOT change any state if PreferencesController is missing', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {},
@@ -101,7 +101,7 @@ describe('migration #34', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if featureFlags.privacyMode is already true', (done) => {
+  it('should NOT change any state if featureFlags.privacyMode is already true', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {

--- a/test/unit/migrations/035-test.js
+++ b/test/unit/migrations/035-test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import migration35 from '../../../app/scripts/migrations/035'
 
-describe('migration #35', () => {
-  it('should update the version metadata', (done) => {
+describe('migration #35', function () {
+  it('should update the version metadata', function (done) {
     const oldStorage = {
       meta: {
         version: 34,
@@ -20,7 +20,7 @@ describe('migration #35', () => {
       .catch(done)
   })
 
-  it('should delete seedWords', (done) => {
+  it('should delete seedWords', function (done) {
     const oldStorage = {
       meta: {},
       data: {
@@ -38,7 +38,7 @@ describe('migration #35', () => {
       .catch(done)
   })
 
-  it('should delete falsy seedWords', (done) => {
+  it('should delete falsy seedWords', function (done) {
     const oldStorage = {
       meta: {},
       data: {
@@ -56,7 +56,7 @@ describe('migration #35', () => {
       .catch(done)
   })
 
-  it('should leave state without seedWords unchanged', (done) => {
+  it('should leave state without seedWords unchanged', function (done) {
     const oldStorage = {
       meta: {},
       data: {

--- a/test/unit/migrations/036-test.js
+++ b/test/unit/migrations/036-test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import migration36 from '../../../app/scripts/migrations/036'
 
-describe('migration #36', () => {
-  it('should update the version metadata', (done) => {
+describe('migration #36', function () {
+  it('should update the version metadata', function (done) {
     const oldStorage = {
       'meta': {
         'version': 35,
@@ -20,7 +20,7 @@ describe('migration #36', () => {
       .catch(done)
   })
 
-  it('should remove privacyMode if featureFlags.privacyMode was false', (done) => {
+  it('should remove privacyMode if featureFlags.privacyMode was false', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -43,7 +43,7 @@ describe('migration #36', () => {
       .catch(done)
   })
 
-  it('should remove privacyMode if featureFlags.privacyMode was true', (done) => {
+  it('should remove privacyMode if featureFlags.privacyMode was true', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -66,7 +66,7 @@ describe('migration #36', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if privacyMode does not exist', (done) => {
+  it('should NOT change any state if privacyMode does not exist', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -86,7 +86,7 @@ describe('migration #36', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if PreferencesController is missing', (done) => {
+  it('should NOT change any state if PreferencesController is missing', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {},
@@ -100,7 +100,7 @@ describe('migration #36', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if featureFlags is missing', (done) => {
+  it('should NOT change any state if featureFlags is missing', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {

--- a/test/unit/migrations/037-test.js
+++ b/test/unit/migrations/037-test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import migration37 from '../../../app/scripts/migrations/037'
 
-describe('migration #37', () => {
-  it('should update the version metadata', (done) => {
+describe('migration #37', function () {
+  it('should update the version metadata', function (done) {
     const oldStorage = {
       'meta': {
         'version': 36,
@@ -20,7 +20,7 @@ describe('migration #37', () => {
       .catch(done)
   })
 
-  it('should transform old state to new format', (done) => {
+  it('should transform old state to new format', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -84,7 +84,7 @@ describe('migration #37', () => {
       .catch(done)
   })
 
-  it('ens validation test', (done) => {
+  it('ens validation test', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {

--- a/test/unit/migrations/038-test.js
+++ b/test/unit/migrations/038-test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import migration38 from '../../../app/scripts/migrations/038'
 
-describe('migration #38', () => {
-  it('should update the version metadata', (done) => {
+describe('migration #38', function () {
+  it('should update the version metadata', function (done) {
     const oldStorage = {
       'meta': {
         'version': 37,
@@ -20,7 +20,7 @@ describe('migration #38', () => {
       .catch(done)
   })
 
-  it('should add a fullScreenVsPopup property set to either "control" or "fullScreen"', (done) => {
+  it('should add a fullScreenVsPopup property set to either "control" or "fullScreen"', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {},
@@ -34,7 +34,7 @@ describe('migration #38', () => {
       .catch(done)
   })
 
-  it('should leave the fullScreenVsPopup property unchanged if it exists', (done) => {
+  it('should leave the fullScreenVsPopup property unchanged if it exists', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {

--- a/test/unit/migrations/039-test.js
+++ b/test/unit/migrations/039-test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import migration39 from '../../../app/scripts/migrations/039'
 
-describe('migration #39', () => {
-  it('should update the version metadata', (done) => {
+describe('migration #39', function () {
+  it('should update the version metadata', function (done) {
     const oldStorage = {
       'meta': {
         'version': 38,
@@ -20,7 +20,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should update old DAI token symbol to SAI in tokens', (done) => {
+  it('should update old DAI token symbol to SAI in tokens', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -64,7 +64,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should update old DAI token symbol to SAI in accountTokens', (done) => {
+  it('should update old DAI token symbol to SAI in accountTokens', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -152,7 +152,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if accountTokens is not an object', (done) => {
+  it('should NOT change any state if accountTokens is not an object', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -170,7 +170,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if accountTokens is an object with invalid values', (done) => {
+  it('should NOT change any state if accountTokens is an object with invalid values', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -206,7 +206,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if accountTokens includes the new DAI token', (done) => {
+  it('should NOT change any state if accountTokens includes the new DAI token', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -258,7 +258,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if tokens includes the new DAI token', (done) => {
+  it('should NOT change any state if tokens includes the new DAI token', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -284,7 +284,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if tokens does not include DAI', (done) => {
+  it('should NOT change any state if tokens does not include DAI', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -310,7 +310,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if a tokens property has invalid entries', (done) => {
+  it('should NOT change any state if a tokens property has invalid entries', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -333,7 +333,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if a tokens property is not an array', (done) => {
+  it('should NOT change any state if a tokens property is not an array', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -351,7 +351,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if a tokens property is null', (done) => {
+  it('should NOT change any state if a tokens property is null', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -369,7 +369,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if a tokens property is missing', (done) => {
+  it('should NOT change any state if a tokens property is missing', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -386,7 +386,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if a accountTokens property is missing', (done) => {
+  it('should NOT change any state if a accountTokens property is missing', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {
@@ -403,7 +403,7 @@ describe('migration #39', () => {
       .catch(done)
   })
 
-  it('should NOT change any state if PreferencesController is missing', (done) => {
+  it('should NOT change any state if PreferencesController is missing', function (done) {
     const oldStorage = {
       'meta': {},
       'data': {},

--- a/test/unit/migrations/migrations-test.js
+++ b/test/unit/migrations/migrations-test.js
@@ -19,8 +19,8 @@ let vault5, vault6, vault7, vault8, vault9 // vault10, vault11
 const oldTestRpc = 'https://rawtestrpc.metamask.io/'
 const newTestRpc = 'https://testrpc.metamask.io/'
 
-describe('wallet1 is migrated successfully', () => {
-  it('should convert providers', () => {
+describe('wallet1 is migrated successfully', function () {
+  it('should convert providers', function () {
     wallet1.data.config.provider = { type: 'etherscan', rpcTarget: null }
 
     return migration2.migrate(wallet1)

--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -40,47 +40,50 @@ const firstTimeState = {
   meta: { version: 0 },
   data,
 }
-describe('liveMigrations require list', () => {
-  it('should include all the migrations', async () => {
-    const fileNames = await pify(cb => fs.readdir('./app/scripts/migrations/', cb))()
-    const migrationNumbers = fileNames.reduce((agg, filename) => {
-      const name = filename.split('.')[0]
-      if (/^\d+$/.test(name)) {
-        agg.push(name)
-      }
-      return agg
-    }, []).map((num) => parseInt(num))
 
-    migrationNumbers.forEach((num) => {
-      const migration = liveMigrations.find((m) => m.version === num)
-      assert(migration, `migration should be include in the index missing migration ${num}`)
+describe('migrations', function () {
+  describe('liveMigrations require list', function () {
+    it('should include all the migrations', async function () {
+      const fileNames = await pify(cb => fs.readdir('./app/scripts/migrations/', cb))()
+      const migrationNumbers = fileNames.reduce((agg, filename) => {
+        const name = filename.split('.')[0]
+        if (/^\d+$/.test(name)) {
+          agg.push(name)
+        }
+        return agg
+      }, []).map((num) => parseInt(num))
+
+      migrationNumbers.forEach((num) => {
+        const migration = liveMigrations.find((m) => m.version === num)
+        assert(migration, `migration should be include in the index missing migration ${num}`)
+      })
     })
   })
-})
 
-describe('Migrator', () => {
-  const migrator = new Migrator({ migrations: stubMigrations })
-  it('migratedData version should be version 3', async () => {
-    const migratedData = await migrator.migrateData(versionedData)
-    assert.equal(migratedData.meta.version, stubMigrations[2].version)
-  })
-
-  it('should match the last version in live migrations', async () => {
-    const migrator = new Migrator({ migrations: liveMigrations })
-    const migratedData = await migrator.migrateData(firstTimeState)
-    const last = liveMigrations.length - 1
-    assert.equal(migratedData.meta.version, liveMigrations[last].version)
-  })
-
-  it('should emit an error', async () => {
-    const migrator = new Migrator({
-      migrations: [{
-        version: 1,
-        async migrate () {
-          throw new Error('test')
-        },
-      }],
+  describe('Migrator', function () {
+    const migrator = new Migrator({ migrations: stubMigrations })
+    it('migratedData version should be version 3', async function () {
+      const migratedData = await migrator.migrateData(versionedData)
+      assert.equal(migratedData.meta.version, stubMigrations[2].version)
     })
-    await assert.rejects(migrator.migrateData({ meta: { version: 0 } }))
+
+    it('should match the last version in live migrations', async function () {
+      const migrator = new Migrator({ migrations: liveMigrations })
+      const migratedData = await migrator.migrateData(firstTimeState)
+      const last = liveMigrations.length - 1
+      assert.equal(migratedData.meta.version, liveMigrations[last].version)
+    })
+
+    it('should emit an error', async function () {
+      const migrator = new Migrator({
+        migrations: [{
+          version: 1,
+          async migrate () {
+            throw new Error('test')
+          },
+        }],
+      })
+      await assert.rejects(migrator.migrateData({ meta: { version: 0 } }))
+    })
   })
 })

--- a/test/unit/migrations/template-test.js
+++ b/test/unit/migrations/template-test.js
@@ -6,8 +6,8 @@ const storage = {
   data: {},
 }
 
-describe('storage is migrated successfully', () => {
-  it('should work', (done) => {
+describe('storage is migrated successfully', function () {
+  it('should work', function (done) {
     migrationTemplate.migrate(storage)
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, 0)

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -19,7 +19,7 @@ const provider = createTestProviderTools({ scaffold: {} }).provider
 const middleware = [thunk]
 const mockStore = configureStore(middleware)
 
-describe('Actions', () => {
+describe('Actions', function () {
 
   const noop = () => {}
 
@@ -31,7 +31,7 @@ describe('Actions', () => {
   const password = 'a-fake-password'
   const importPrivkey = '4cfd3e90fc78b0f86bf7524722150bb8da9c60cd532564d7ff43f5716514f553'
 
-  beforeEach(async () => {
+  beforeEach(async function () {
 
     metamaskController = new MetaMaskController({
       provider,
@@ -66,16 +66,16 @@ describe('Actions', () => {
     global.ethQuery = new EthQuery(provider)
   })
 
-  describe('#tryUnlockMetamask', () => {
+  describe('#tryUnlockMetamask', function () {
 
     let submitPasswordSpy, verifySeedPhraseSpy
 
-    afterEach(() => {
+    afterEach(function () {
       submitPasswordSpy.restore()
       verifySeedPhraseSpy.restore()
     })
 
-    it('calls submitPassword and verifySeedPhrase', async () => {
+    it('calls submitPassword and verifySeedPhrase', async function () {
 
       const store = mockStore({})
 
@@ -87,7 +87,7 @@ describe('Actions', () => {
       assert(verifySeedPhraseSpy.calledOnce)
     })
 
-    it('errors on submitPassword will fail', async () => {
+    it('errors on submitPassword will fail', async function () {
 
       const store = mockStore({})
 
@@ -113,7 +113,7 @@ describe('Actions', () => {
       }
     })
 
-    it('displays warning error and unlock failed when verifySeed fails', async () => {
+    it('displays warning error and unlock failed when verifySeed fails', async function () {
       const store = mockStore({})
       const displayWarningError = [ { type: 'DISPLAY_WARNING', value: 'error' } ]
       const unlockFailedError = [ { type: 'UNLOCK_FAILED', value: 'error' } ]
@@ -136,15 +136,15 @@ describe('Actions', () => {
     })
   })
 
-  describe('#createNewVaultAndRestore', () => {
+  describe('#createNewVaultAndRestore', function () {
 
     let createNewVaultAndRestoreSpy
 
-    afterEach(() => {
+    afterEach(function () {
       createNewVaultAndRestoreSpy.restore()
     })
 
-    it('restores new vault', async () => {
+    it('restores new vault', async function () {
 
       const store = mockStore({})
 
@@ -158,7 +158,7 @@ describe('Actions', () => {
       }
     })
 
-    it('errors when callback in createNewVaultAndRestore throws', async () => {
+    it('errors when callback in createNewVaultAndRestore throws', async function () {
       const store = mockStore({})
 
       const expectedActions = [
@@ -182,14 +182,14 @@ describe('Actions', () => {
     })
   })
 
-  describe('#requestRevealSeedWords', () => {
+  describe('#requestRevealSeedWords', function () {
     let submitPasswordSpy
 
-    afterEach(() => {
+    afterEach(function () {
       submitPasswordSpy.restore()
     })
 
-    it('calls submitPassword in background', async () => {
+    it('calls submitPassword in background', async function () {
       const store = mockStore()
 
       submitPasswordSpy = sinon.spy(background, 'verifySeedPhrase')
@@ -198,7 +198,7 @@ describe('Actions', () => {
       assert(submitPasswordSpy.calledOnce)
     })
 
-    it('displays warning error message then callback in background errors', async () => {
+    it('displays warning error message then callback in background errors', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -222,14 +222,14 @@ describe('Actions', () => {
     })
   })
 
-  describe('#removeAccount', () => {
+  describe('#removeAccount', function () {
     let removeAccountSpy
 
-    afterEach(() => {
+    afterEach(function () {
       removeAccountSpy.restore()
     })
 
-    it('calls removeAccount in background and expect actions to show account', async () => {
+    it('calls removeAccount in background and expect actions to show account', async function () {
       const store = mockStore(devState)
 
       const expectedActions = [
@@ -249,7 +249,7 @@ describe('Actions', () => {
       assert.deepEqual(actionTypes, expectedActions)
     })
 
-    it('displays warning error message when removeAccount callback errors', async () => {
+    it('displays warning error message when removeAccount callback errors', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -276,18 +276,18 @@ describe('Actions', () => {
     })
   })
 
-  describe('#addNewKeyring', () => {
+  describe('#addNewKeyring', function () {
     let addNewKeyringSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       addNewKeyringSpy = sinon.stub(background, 'addNewKeyring')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       addNewKeyringSpy.restore()
     })
 
-    it('calls addNewKeyring', () => {
+    it('calls addNewKeyring', function () {
       const privateKey = 'c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
 
       const store = mockStore()
@@ -295,7 +295,7 @@ describe('Actions', () => {
       assert(addNewKeyringSpy.calledOnce)
     })
 
-    it('errors then addNewKeyring in background throws', () => {
+    it('errors then addNewKeyring in background throws', function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -313,15 +313,15 @@ describe('Actions', () => {
 
   })
 
-  describe('#resetAccount', () => {
+  describe('#resetAccount', function () {
 
     let resetAccountSpy
 
-    afterEach(() => {
+    afterEach(function () {
       resetAccountSpy.restore()
     })
 
-    it('resets account', async () => {
+    it('resets account', async function () {
 
       const store = mockStore()
 
@@ -338,7 +338,7 @@ describe('Actions', () => {
       assert.deepEqual(store.getActions(), expectedActions)
     })
 
-    it('throws if resetAccount throws', async () => {
+    it('throws if resetAccount throws', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -361,15 +361,15 @@ describe('Actions', () => {
     })
   })
 
-  describe('#importNewAccount', () => {
+  describe('#importNewAccount', function () {
 
     let importAccountWithStrategySpy
 
-    afterEach(() => {
+    afterEach(function () {
       importAccountWithStrategySpy.restore()
     })
 
-    it('calls importAccountWithStrategies in background', () => {
+    it('calls importAccountWithStrategies in background', function () {
       const store = mockStore()
 
       importAccountWithStrategySpy = sinon.spy(background, 'importAccountWithStrategy')
@@ -380,7 +380,7 @@ describe('Actions', () => {
       assert(importAccountWithStrategySpy.calledOnce)
     })
 
-    it('displays warning error message when importAccount in background callback errors', async () => {
+    it('displays warning error message when importAccount in background callback errors', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -403,9 +403,9 @@ describe('Actions', () => {
     })
   })
 
-  describe('#addNewAccount', () => {
+  describe('#addNewAccount', function () {
 
-    it('Adds a new account', () => {
+    it('Adds a new account', function () {
       const store = mockStore({ metamask: devState })
 
       const addNewAccountSpy = sinon.spy(background, 'addNewAccount')
@@ -416,19 +416,19 @@ describe('Actions', () => {
 
   })
 
-  describe('#checkHardwareStatus', () => {
+  describe('#checkHardwareStatus', function () {
 
     let checkHardwareStatusSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       checkHardwareStatusSpy = sinon.stub(background, 'checkHardwareStatus')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       checkHardwareStatusSpy.restore()
     })
 
-    it('calls checkHardwareStatus in background', async () => {
+    it('calls checkHardwareStatus in background', async function () {
 
       const store = mockStore()
 
@@ -436,7 +436,7 @@ describe('Actions', () => {
       assert.equal(checkHardwareStatusSpy.calledOnce, true)
     })
 
-    it('shows loading indicator and displays error', async () => {
+    it('shows loading indicator and displays error', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -457,19 +457,19 @@ describe('Actions', () => {
     })
   })
 
-  describe('#forgetDevice', () => {
+  describe('#forgetDevice', function () {
 
     let forgetDeviceSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       forgetDeviceSpy = sinon.stub(background, 'forgetDevice')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       forgetDeviceSpy.restore()
     })
 
-    it('calls forgetDevice in background', () => {
+    it('calls forgetDevice in background', function () {
 
       const store = mockStore()
 
@@ -478,7 +478,7 @@ describe('Actions', () => {
 
     })
 
-    it('shows loading indicator and displays error', async () => {
+    it('shows loading indicator and displays error', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -499,19 +499,19 @@ describe('Actions', () => {
     })
   })
 
-  describe('#connectHardware', () => {
+  describe('#connectHardware', function () {
 
     let connectHardwareSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       connectHardwareSpy = sinon.stub(background, 'connectHardware')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       connectHardwareSpy.restore()
     })
 
-    it('calls connectHardware in background', () => {
+    it('calls connectHardware in background', function () {
 
       const store = mockStore()
 
@@ -520,7 +520,7 @@ describe('Actions', () => {
 
     })
 
-    it('shows loading indicator and displays error', async () => {
+    it('shows loading indicator and displays error', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -541,19 +541,19 @@ describe('Actions', () => {
     })
   })
 
-  describe('#unlockHardwareWalletAccount', () => {
+  describe('#unlockHardwareWalletAccount', function () {
 
     let unlockHardwareWalletAccountSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       unlockHardwareWalletAccountSpy = sinon.stub(background, 'unlockHardwareWalletAccount')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       unlockHardwareWalletAccountSpy.restore()
     })
 
-    it('calls unlockHardwareWalletAccount in background', () => {
+    it('calls unlockHardwareWalletAccount in background', function () {
 
       const store = mockStore()
 
@@ -562,7 +562,7 @@ describe('Actions', () => {
 
     })
 
-    it('shows loading indicator and displays error', async () => {
+    it('shows loading indicator and displays error', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -583,26 +583,26 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setCurrentCurrency', () => {
+  describe('#setCurrentCurrency', function () {
 
     let setCurrentCurrencySpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       setCurrentCurrencySpy = sinon.stub(background, 'setCurrentCurrency')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setCurrentCurrencySpy.restore()
     })
 
-    it('calls setCurrentCurrency', () => {
+    it('calls setCurrentCurrency', function () {
       const store = mockStore()
 
       store.dispatch(actions.setCurrentCurrency('jpy'))
       assert(setCurrentCurrencySpy.calledOnce)
     })
 
-    it('throws if setCurrentCurrency throws', () => {
+    it('throws if setCurrentCurrency throws', function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -618,7 +618,7 @@ describe('Actions', () => {
     })
   })
 
-  describe('#signMsg', () => {
+  describe('#signMsg', function () {
 
     let signMessageSpy, metamaskMsgs, msgId, messages
 
@@ -627,7 +627,7 @@ describe('Actions', () => {
       data: '0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0',
     }
 
-    beforeEach(() => {
+    beforeEach(function () {
       metamaskController.newUnsignedMessage(msgParams, noop)
       metamaskMsgs = metamaskController.messageManager.getUnapprovedMsgs()
       messages = metamaskController.messageManager.messages
@@ -635,11 +635,11 @@ describe('Actions', () => {
       messages[0].msgParams.metamaskId = parseInt(msgId)
     })
 
-    afterEach(() => {
+    afterEach(function () {
       signMessageSpy.restore()
     })
 
-    it('calls signMsg in background', () => {
+    it('calls signMsg in background', function () {
       const store = mockStore({
         metamask: {},
       })
@@ -650,7 +650,7 @@ describe('Actions', () => {
 
     })
 
-    it('errors when signMessage in background throws', async () => {
+    it('errors when signMessage in background throws', async function () {
       const store = mockStore({
         metamask: {},
       })
@@ -676,7 +676,7 @@ describe('Actions', () => {
 
   })
 
-  describe('#signPersonalMsg', () => {
+  describe('#signPersonalMsg', function () {
 
     let signPersonalMessageSpy, metamaskMsgs, msgId, personalMessages
 
@@ -685,7 +685,7 @@ describe('Actions', () => {
       data: '0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0',
     }
 
-    beforeEach(() => {
+    beforeEach(function () {
       metamaskController.newUnsignedPersonalMessage(msgParams, noop)
       metamaskMsgs = metamaskController.personalMessageManager.getUnapprovedMsgs()
       personalMessages = metamaskController.personalMessageManager.messages
@@ -693,11 +693,11 @@ describe('Actions', () => {
       personalMessages[0].msgParams.metamaskId = parseInt(msgId)
     })
 
-    afterEach(() => {
+    afterEach(function () {
       signPersonalMessageSpy.restore()
     })
 
-    it('calls signPersonalMessage', () => {
+    it('calls signPersonalMessage', function () {
       const store = mockStore({
         metamask: {},
       })
@@ -709,7 +709,7 @@ describe('Actions', () => {
 
     })
 
-    it('throws if signPersonalMessage throws', async () => {
+    it('throws if signPersonalMessage throws', async function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -733,7 +733,7 @@ describe('Actions', () => {
 
   })
 
-  describe('#signTypedMsg', () => {
+  describe('#signTypedMsg', function () {
     let signTypedMsgSpy, messages, typedMessages, msgId
 
     const msgParamsV3 = {
@@ -776,7 +776,7 @@ describe('Actions', () => {
       }),
     }
 
-    beforeEach(() => {
+    beforeEach(function () {
       metamaskController.newUnsignedTypedMessage(msgParamsV3, null, 'V3')
       messages = metamaskController.typedMessageManager.getUnapprovedMsgs()
       typedMessages = metamaskController.typedMessageManager.messages
@@ -785,18 +785,18 @@ describe('Actions', () => {
       signTypedMsgSpy = sinon.stub(background, 'signTypedMessage')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       signTypedMsgSpy.restore()
     })
 
-    it('calls signTypedMsg in background with no error', () => {
+    it('calls signTypedMsg in background with no error', function () {
       const store = mockStore()
 
       store.dispatch(actions.signTypedMsg(msgParamsV3))
       assert(signTypedMsgSpy.calledOnce)
     })
 
-    it('returns expected actions with error', async () => {
+    it('returns expected actions with error', async function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -819,26 +819,26 @@ describe('Actions', () => {
 
   })
 
-  describe('#signTx', () => {
+  describe('#signTx', function () {
 
     let sendTransactionSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       sendTransactionSpy = sinon.stub(global.ethQuery, 'sendTransaction')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       sendTransactionSpy.restore()
     })
 
-    it('calls sendTransaction in global ethQuery', () => {
+    it('calls sendTransaction in global ethQuery', function () {
       const store = mockStore()
 
       store.dispatch(actions.signTx())
       assert(sendTransactionSpy.calledOnce)
     })
 
-    it('errors in when sendTransaction throws', () => {
+    it('errors in when sendTransaction throws', function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'DISPLAY_WARNING', value: 'error' },
@@ -853,8 +853,8 @@ describe('Actions', () => {
     })
   })
 
-  describe('#updatedGasData', () => {
-    it('errors when get code does not return', async () => {
+  describe('#updatedGasData', function () {
+    it('errors when get code does not return', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -878,31 +878,19 @@ describe('Actions', () => {
         assert.deepEqual(store.getActions(), expectedActions)
       }
     })
-  })
 
-  describe('#updatedGasData', () => {
-
-    const stub = sinon.stub().returns('0x')
-
-    const mockData = {
-      gasPrice: '0x3b9aca00', //
-      blockGasLimit: '0x6ad79a', // 7002010
-      selectedAddress: '0x0DCD5D886577d5081B0c52e242Ef29E70Be3E7bc',
-      to: '0xEC1Adf982415D2Ef5ec55899b9Bfb8BC0f29251B',
-      value: '0xde0b6b3a7640000', // 1000000000000000000
-    }
-
-    beforeEach(() => {
-      global.eth = {
-        getCode: stub,
+    it('returns default gas limit for basic eth transaction', async function () {
+      const mockData = {
+        gasPrice: '0x3b9aca00',
+        blockGasLimit: '0x6ad79a', // 7002010
+        selectedAddress: '0x0DCD5D886577d5081B0c52e242Ef29E70Be3E7bc',
+        to: '0xEC1Adf982415D2Ef5ec55899b9Bfb8BC0f29251B',
+        value: '0xde0b6b3a7640000', // 1000000000000000000
       }
-    })
 
-    afterEach(() => {
-      stub.reset()
-    })
-
-    it('returns default gas limit for basic eth transaction', async () => {
+      global.eth = {
+        getCode: sinon.stub().returns('0x'),
+      }
       const store = mockStore()
 
       const expectedActions = [
@@ -915,30 +903,22 @@ describe('Actions', () => {
 
       await store.dispatch(actions.updateGasData(mockData))
       assert.deepEqual(store.getActions(), expectedActions)
+      global.eth.getCode.reset()
     })
   })
 
-  describe('#signTokenTx', () => {
-
-    let tokenSpy
-
-    beforeEach(() => {
+  describe('#signTokenTx', function () {
+    it('calls eth.contract', function () {
       global.eth = new Eth(provider)
-      tokenSpy = sinon.spy(global.eth, 'contract')
-    })
-
-    afterEach(() => {
-      tokenSpy.restore()
-    })
-
-    it('calls eth.contract', () => {
+      const tokenSpy = sinon.spy(global.eth, 'contract')
       const store = mockStore()
       store.dispatch(actions.signTokenTx())
       assert(tokenSpy.calledOnce)
+      tokenSpy.restore()
     })
   })
 
-  describe('#updateTransaction', () => {
+  describe('#updateTransaction', function () {
 
     let updateTransactionSpy
 
@@ -952,15 +932,15 @@ describe('Actions', () => {
 
     const txData = { id: '1', status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: txParams }
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       await metamaskController.txController.txStateManager.addTx(txData)
     })
 
-    afterEach(() => {
+    afterEach(function () {
       updateTransactionSpy.restore()
     })
 
-    it('updates transaction', async () => {
+    it('updates transaction', async function () {
       const store = mockStore()
 
       updateTransactionSpy = sinon.spy(background, 'updateTransaction')
@@ -972,7 +952,7 @@ describe('Actions', () => {
       assert.deepEqual(resultantActions[1], { type: 'UPDATE_TRANSACTION_PARAMS', id: txData.id, value: txParams })
     })
 
-    it('rejects with error message', async () => {
+    it('rejects with error message', async function () {
       const store = mockStore()
 
       updateTransactionSpy = sinon.stub(background, 'updateTransaction')
@@ -989,14 +969,14 @@ describe('Actions', () => {
     })
   })
 
-  describe('#lockMetamask', () => {
+  describe('#lockMetamask', function () {
     let backgroundSetLockedSpy
 
-    afterEach(() => {
+    afterEach(function () {
       backgroundSetLockedSpy.restore()
     })
 
-    it('calls setLocked', async () => {
+    it('calls setLocked', async function () {
       const store = mockStore()
 
       backgroundSetLockedSpy = sinon.spy(background, 'setLocked')
@@ -1005,7 +985,7 @@ describe('Actions', () => {
       assert(backgroundSetLockedSpy.calledOnce)
     })
 
-    it('returns display warning error with value when setLocked in background callback errors', async () => {
+    it('returns display warning error with value when setLocked in background callback errors', async function () {
       const store = mockStore()
 
       const expectedActions = [
@@ -1029,25 +1009,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setSelectedAddress', () => {
+  describe('#setSelectedAddress', function () {
     let setSelectedAddressSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setSelectedAddressSpy.restore()
     })
 
-    it('calls setSelectedAddress in background', () => {
+    it('calls setSelectedAddress in background', function () {
       const store = mockStore({ metamask: devState })
 
       store.dispatch(actions.setSelectedAddress('0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'))
       assert(setSelectedAddressSpy.calledOnce)
     })
 
-    it('errors when setSelectedAddress throws', () => {
+    it('errors when setSelectedAddress throws', function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1065,25 +1045,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#showAccountDetail', () => {
+  describe('#showAccountDetail', function () {
     let setSelectedAddressSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setSelectedAddressSpy.restore()
     })
 
-    it('#showAccountDetail', () => {
+    it('#showAccountDetail', function () {
       const store = mockStore()
 
       store.dispatch(actions.showAccountDetail())
       assert(setSelectedAddressSpy.calledOnce)
     })
 
-    it('displays warning if setSelectedAddress throws', () => {
+    it('displays warning if setSelectedAddress throws', function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1099,25 +1079,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#addToken', () => {
+  describe('#addToken', function () {
     let addTokenSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       addTokenSpy = sinon.stub(background, 'addToken')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       addTokenSpy.restore()
     })
 
-    it('calls addToken in background', async () => {
+    it('calls addToken in background', async function () {
       const store = mockStore()
 
       store.dispatch(actions.addToken())
       assert(addTokenSpy.calledOnce)
     })
 
-    it('errors when addToken in background throws', async () => {
+    it('errors when addToken in background throws', async function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1138,25 +1118,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#removeToken', () => {
+  describe('#removeToken', function () {
 
     let removeTokenSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       removeTokenSpy = sinon.stub(background, 'removeToken')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       removeTokenSpy.restore()
     })
 
-    it('calls removeToken in background', async () => {
+    it('calls removeToken in background', async function () {
       const store = mockStore()
       store.dispatch(await actions.removeToken())
       assert(removeTokenSpy.calledOnce)
     })
 
-    it('errors when removeToken in background fails', async () => {
+    it('errors when removeToken in background fails', async function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1177,25 +1157,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setProviderType', () => {
+  describe('#setProviderType', function () {
     let setProviderTypeSpy
     let store
 
-    beforeEach(() => {
+    beforeEach(function () {
       store = mockStore({ metamask: { provider: {} } })
       setProviderTypeSpy = sinon.stub(background, 'setProviderType')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setProviderTypeSpy.restore()
     })
 
-    it('calls setProviderType', () => {
+    it('calls setProviderType', function () {
       store.dispatch(actions.setProviderType())
       assert(setProviderTypeSpy.calledOnce)
     })
 
-    it('displays warning when setProviderType throws', () => {
+    it('displays warning when setProviderType throws', function () {
       const expectedActions = [
         { type: 'DISPLAY_WARNING', value: 'Had a problem changing networks!' },
       ]
@@ -1210,24 +1190,24 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setRpcTarget', () => {
+  describe('#setRpcTarget', function () {
     let setRpcTargetSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       setRpcTargetSpy = sinon.stub(background, 'setCustomRpc')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setRpcTargetSpy.restore()
     })
 
-    it('calls setRpcTarget', () => {
+    it('calls setRpcTarget', function () {
       const store = mockStore()
       store.dispatch(actions.setRpcTarget('http://localhost:8545'))
       assert(setRpcTargetSpy.calledOnce)
     })
 
-    it('displays warning when setRpcTarget throws', () => {
+    it('displays warning when setRpcTarget throws', function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'DISPLAY_WARNING', value: 'Had a problem changing networks!' },
@@ -1242,33 +1222,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#addToAddressBook', () => {
-    let addToAddressBookSpy
-
-    beforeEach(() => {
-      addToAddressBookSpy = sinon.stub(background, 'setAddressBook')
-    })
-
-    afterEach(() => {
-      addToAddressBookSpy.restore()
-    })
-
-    it('calls setAddressBook', () => {
+  describe('#addToAddressBook', function () {
+    it('calls setAddressBook', function () {
+      const addToAddressBookSpy = sinon.stub(background, 'setAddressBook')
       const store = mockStore({ metamask: devState })
       store.dispatch(actions.addToAddressBook('test'))
       assert(addToAddressBookSpy.calledOnce)
+      addToAddressBookSpy.restore()
     })
   })
 
-  describe('#exportAccount', () => {
+  describe('#exportAccount', function () {
     let submitPasswordSpy, exportAccountSpy
 
-    afterEach(() => {
+    afterEach(function () {
       submitPasswordSpy.restore()
       exportAccountSpy.restore()
     })
 
-    it('returns expected actions for successful action', async () => {
+    it('returns expected actions for successful action', async function () {
       const store = mockStore(devState)
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1285,7 +1257,7 @@ describe('Actions', () => {
       assert.deepEqual(store.getActions(), expectedActions)
     })
 
-    it('returns action errors when first func callback errors', async () => {
+    it('returns action errors when first func callback errors', async function () {
       const store = mockStore(devState)
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1306,7 +1278,7 @@ describe('Actions', () => {
       }
     })
 
-    it('returns action errors when second func callback errors', async () => {
+    it('returns action errors when second func callback errors', async function () {
       const store = mockStore(devState)
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1328,22 +1300,17 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setAccountLabel', () => {
-    let setAccountLabelSpy
-
-    beforeEach(() => {
-      setAccountLabelSpy = sinon.stub(background, 'setAccountLabel')
-    })
-
-    it('calls setAccountLabel', () => {
+  describe('#setAccountLabel', function () {
+    it('calls setAccountLabel', function () {
+      const setAccountLabelSpy = sinon.stub(background, 'setAccountLabel')
       const store = mockStore()
       store.dispatch(actions.setAccountLabel('0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc', 'test'))
       assert(setAccountLabelSpy.calledOnce)
     })
   })
 
-  describe('#pairUpdate', () => {
-    beforeEach(() => {
+  describe('#pairUpdate', function () {
+    it('calls expected actions', function () {
       nock('https://shapeshift.io')
         .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
         .get('/marketinfo/btc_eth')
@@ -1353,9 +1320,7 @@ describe('Actions', () => {
         .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
         .get('/coins')
         .reply(200)
-    })
 
-    it('calls expected actions', () => {
       const store = mockStore()
       // issue with dispatch action in callback not showing
       const expectedActions = [
@@ -1368,25 +1333,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setFeatureFlag', () => {
+  describe('#setFeatureFlag', function () {
     let setFeatureFlagSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       setFeatureFlagSpy = sinon.stub(background, 'setFeatureFlag')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setFeatureFlagSpy.restore()
     })
 
-    it('calls setFeatureFlag in the background', () => {
+    it('calls setFeatureFlag in the background', function () {
       const store = mockStore()
 
       store.dispatch(actions.setFeatureFlag())
       assert(setFeatureFlagSpy.calledOnce)
     })
 
-    it('errors when setFeatureFlag in background throws', async () => {
+    it('errors when setFeatureFlag in background throws', async function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1407,33 +1372,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setCompletedOnboarding', () => {
-    let completeOnboardingSpy
-
-    beforeEach(() => {
-      completeOnboardingSpy = sinon.stub(background, 'completeOnboarding')
+  describe('#setCompletedOnboarding', function () {
+    it('completes onboarding', async function () {
+      const completeOnboardingSpy = sinon.stub(background, 'completeOnboarding')
       completeOnboardingSpy.callsFake(cb => cb())
-    })
-
-    after(() => {
-      completeOnboardingSpy.restore()
-    })
-
-    it('completes onboarding', async () => {
       const store = mockStore()
       await store.dispatch(actions.setCompletedOnboarding())
       assert.equal(completeOnboardingSpy.callCount, 1)
+      completeOnboardingSpy.restore()
     })
   })
 
-  describe('#updateNetworkNonce', () => {
+  describe('#updateNetworkNonce', function () {
     let getTransactionCountSpy
 
-    afterEach(() => {
+    afterEach(function () {
       getTransactionCountSpy.restore()
     })
 
-    it('calls getTransactionCount', () => {
+    it('calls getTransactionCount', function () {
       const store = mockStore()
       getTransactionCountSpy = sinon.spy(global.ethQuery, 'getTransactionCount')
 
@@ -1441,7 +1398,7 @@ describe('Actions', () => {
       assert(getTransactionCountSpy.calledOnce)
     })
 
-    it('errors when getTransactionCount throws', async () => {
+    it('errors when getTransactionCount throws', async function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'DISPLAY_WARNING', value: 'error' },
@@ -1461,25 +1418,25 @@ describe('Actions', () => {
     })
   })
 
-  describe('#setUseBlockie', () => {
+  describe('#setUseBlockie', function () {
     let setUseBlockieSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       setUseBlockieSpy = sinon.stub(background, 'setUseBlockie')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setUseBlockieSpy.restore()
     })
 
-    it('calls setUseBlockie in background', () => {
+    it('calls setUseBlockie in background', function () {
       const store = mockStore()
 
       store.dispatch(actions.setUseBlockie())
       assert(setUseBlockieSpy.calledOnce)
     })
 
-    it('errors when setUseBlockie in background throws', () => {
+    it('errors when setUseBlockie in background throws', function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1497,19 +1454,19 @@ describe('Actions', () => {
     })
   })
 
-  describe('#updateCurrentLocale', () => {
+  describe('#updateCurrentLocale', function () {
     let setCurrentLocaleSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       fetchMock.get('*', enLocale)
     })
 
-    afterEach(() => {
+    afterEach(function () {
       setCurrentLocaleSpy.restore()
       fetchMock.restore()
     })
 
-    it('calls expected actions', async () => {
+    it('calls expected actions', async function () {
       const store = mockStore()
       setCurrentLocaleSpy = sinon.spy(background, 'setCurrentLocale')
 
@@ -1524,7 +1481,7 @@ describe('Actions', () => {
       assert.deepEqual(store.getActions(), expectedActions)
     })
 
-    it('errors when setCurrentLocale throws', async () => {
+    it('errors when setCurrentLocale throws', async function () {
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -1546,8 +1503,8 @@ describe('Actions', () => {
     })
   })
 
-  describe('#markPasswordForgotten', () => {
-    it('calls markPasswordForgotten', () => {
+  describe('#markPasswordForgotten', function () {
+    it('calls markPasswordForgotten', function () {
       const store = mockStore()
       const markPasswordForgottenSpy = sinon.stub(background, 'markPasswordForgotten').callsArg(0)
 
@@ -1560,8 +1517,8 @@ describe('Actions', () => {
     })
   })
 
-  describe('#unMarkPasswordForgotten', () => {
-    it('calls unMarkPasswordForgotten', async () => {
+  describe('#unMarkPasswordForgotten', function () {
+    it('calls unMarkPasswordForgotten', async function () {
       const store = mockStore()
       const unMarkPasswordForgottenSpy = sinon.stub(background, 'unMarkPasswordForgotten').callsArg(0)
 

--- a/test/unit/ui/app/components/token-cell.spec.js
+++ b/test/unit/ui/app/components/token-cell.spec.js
@@ -8,7 +8,7 @@ import { mount } from 'enzyme'
 import TokenCell from '../../../../../ui/app/components/app/token-cell'
 import Identicon from '../../../../../ui/app/components/ui/identicon'
 
-describe('Token Cell', () => {
+describe('Token Cell', function () {
   let wrapper
 
   const state = {
@@ -33,7 +33,7 @@ describe('Token Cell', () => {
   const mockStore = configureMockStore(middlewares)
   const store = mockStore(state)
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <Provider store={store}>
         <TokenCell
@@ -48,21 +48,21 @@ describe('Token Cell', () => {
     )
   })
 
-  it('renders Identicon with props from token cell', () => {
+  it('renders Identicon with props from token cell', function () {
     assert.equal(wrapper.find(Identicon).prop('address'), '0xAnotherToken')
     assert.equal(wrapper.find(Identicon).prop('network'), 'test')
     assert.equal(wrapper.find(Identicon).prop('image'), './test-image')
   })
 
-  it('renders token balance', () => {
+  it('renders token balance', function () {
     assert.equal(wrapper.find('.token-list-item__token-balance').text(), '5.000')
   })
 
-  it('renders token symbol', () => {
+  it('renders token symbol', function () {
     assert.equal(wrapper.find('.token-list-item__token-symbol').text(), 'TEST')
   })
 
-  it('renders converted fiat amount', () => {
+  it('renders converted fiat amount', function () {
     assert.equal(wrapper.find('.token-list-item__fiat-amount').text(), '0.52 USD')
   })
 

--- a/test/unit/ui/app/reducers/app.spec.js
+++ b/test/unit/ui/app/reducers/app.spec.js
@@ -4,7 +4,7 @@ import { actionConstants } from '../../../../../ui/app/store/actions'
 
 const actions = actionConstants
 
-describe('App State', () => {
+describe('App State', function () {
 
   const metamaskState = {
     selectedAddress: '0xAddress',
@@ -16,13 +16,13 @@ describe('App State', () => {
     },
   }
 
-  it('App init state', () => {
+  it('App init state', function () {
     const initState = reduceApp(metamaskState, {})
 
     assert(initState)
   })
 
-  it('sets networkDropdownOpen dropdown to true', () => {
+  it('sets networkDropdownOpen dropdown to true', function () {
     const state = reduceApp(metamaskState, {
       type: actions.NETWORK_DROPDOWN_OPEN,
     })
@@ -30,7 +30,7 @@ describe('App State', () => {
     assert.equal(state.networkDropdownOpen, true)
   })
 
-  it('sets networkDropdownOpen dropdown to false', () => {
+  it('sets networkDropdownOpen dropdown to false', function () {
     const dropdown = { networkDropdowopen: true }
     const state = { ...metamaskState, ...dropdown }
     const newState = reduceApp(state, {
@@ -40,7 +40,7 @@ describe('App State', () => {
     assert.equal(newState.networkDropdownOpen, false)
   })
 
-  it('opens sidebar', () => {
+  it('opens sidebar', function () {
     const value = {
       'transitionName': 'sidebar-right',
       'type': 'wallet-view',
@@ -54,7 +54,7 @@ describe('App State', () => {
     assert.deepEqual(state.sidebar, value)
   })
 
-  it('closes sidebar', () => {
+  it('closes sidebar', function () {
     const openSidebar = { sidebar: { isOpen: true } }
     const state = { ...metamaskState, ...openSidebar }
 
@@ -65,7 +65,7 @@ describe('App State', () => {
     assert.equal(newState.sidebar.isOpen, false)
   })
 
-  it('opens alert', () => {
+  it('opens alert', function () {
     const state = reduceApp(metamaskState, {
       type: actions.ALERT_OPEN,
       value: 'test message',
@@ -75,7 +75,7 @@ describe('App State', () => {
     assert.equal(state.alertMessage, 'test message')
   })
 
-  it('closes alert', () => {
+  it('closes alert', function () {
     const alert = { alertOpen: true, alertMessage: 'test message' }
     const state = { ...metamaskState, ...alert }
     const newState = reduceApp(state, {
@@ -86,7 +86,7 @@ describe('App State', () => {
     assert.equal(newState.alertMessage, null)
   })
 
-  it('detects qr code data', () => {
+  it('detects qr code data', function () {
     const state = reduceApp(metamaskState, {
       type: actions.QR_CODE_DETECTED,
       value: 'qr data',
@@ -95,7 +95,7 @@ describe('App State', () => {
     assert.equal(state.qrCodeData, 'qr data')
   })
 
-  it('opens modal', () => {
+  it('opens modal', function () {
     const state = reduceApp(metamaskState, {
       type: actions.MODAL_OPEN,
       payload: {
@@ -107,7 +107,7 @@ describe('App State', () => {
     assert.equal(state.modal.modalState.name, 'test')
   })
 
-  it('closes modal, but moves open modal state to previous modal state', () => {
+  it('closes modal, but moves open modal state to previous modal state', function () {
     const opensModal = {
       modal: {
         open: true,
@@ -127,7 +127,7 @@ describe('App State', () => {
     assert.equal(newState.modal.modalState.name, null)
   })
 
-  it('transitions forwards', () => {
+  it('transitions forwards', function () {
     const state = reduceApp(metamaskState, {
       type: actions.TRANSITION_FORWARD,
     })
@@ -135,7 +135,7 @@ describe('App State', () => {
     assert.equal(state.transForward, true)
   })
 
-  it('shows send token page', () => {
+  it('shows send token page', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SHOW_SEND_TOKEN_PAGE,
     })
@@ -144,7 +144,7 @@ describe('App State', () => {
     assert.equal(state.warning, null)
   })
 
-  it('unlocks Metamask', () => {
+  it('unlocks Metamask', function () {
     const state = reduceApp(metamaskState, {
       type: actions.UNLOCK_METAMASK,
     })
@@ -155,7 +155,7 @@ describe('App State', () => {
     assert.equal(state.warning, null)
   })
 
-  it('locks Metamask', () => {
+  it('locks Metamask', function () {
     const state = reduceApp(metamaskState, {
       type: actions.LOCK_METAMASK,
     })
@@ -164,7 +164,7 @@ describe('App State', () => {
     assert.equal(state.warning, null)
   })
 
-  it('goes home', () => {
+  it('goes home', function () {
     const state = reduceApp(metamaskState, {
       type: actions.GO_HOME,
     })
@@ -177,7 +177,7 @@ describe('App State', () => {
 
   })
 
-  it('shows account detail', () => {
+  it('shows account detail', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SHOW_ACCOUNT_DETAIL,
       value: 'context address',
@@ -190,7 +190,7 @@ describe('App State', () => {
 
   })
 
-  it('shoes account page', () => {
+  it('shoes account page', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SHOW_ACCOUNTS_PAGE,
     })
@@ -202,7 +202,7 @@ describe('App State', () => {
     assert.equal(state.forgottenPassword, false)
   })
 
-  it('shows confirm tx page', () => {
+  it('shows confirm tx page', function () {
     const txs = {
       unapprovedTxs: {
         1: {
@@ -227,7 +227,7 @@ describe('App State', () => {
 
   })
 
-  it('completes tx continues to show pending txs current view context', () => {
+  it('completes tx continues to show pending txs current view context', function () {
     const txs = {
       unapprovedTxs: {
         1: {
@@ -253,7 +253,7 @@ describe('App State', () => {
     assert.equal(state.warning, null)
   })
 
-  it('returns to account detail page when no unconf actions completed tx', () => {
+  it('returns to account detail page when no unconf actions completed tx', function () {
     const state = reduceApp(metamaskState, {
       type: actions.COMPLETED_TX,
       value: {
@@ -264,10 +264,9 @@ describe('App State', () => {
     assert.equal(state.transForward, false)
     assert.equal(state.warning, null)
     assert.equal(state.accountDetail.subview, 'transactions')
-
   })
 
-  it('sets default warning when unlock fails', () => {
+  it('sets default warning when unlock fails', function () {
     const state = reduceApp(metamaskState, {
       type: actions.UNLOCK_FAILED,
     })
@@ -275,7 +274,7 @@ describe('App State', () => {
     assert.equal(state.warning, 'Incorrect password. Try again.')
   })
 
-  it('sets default warning when unlock fails', () => {
+  it('sets errors when unlock fails', function () {
     const state = reduceApp(metamaskState, {
       type: actions.UNLOCK_FAILED,
       value: 'errors',
@@ -284,7 +283,7 @@ describe('App State', () => {
     assert.equal(state.warning, 'errors')
   })
 
-  it('sets warning to empty string when unlock succeeds', () => {
+  it('sets warning to empty string when unlock succeeds', function () {
     const errorState = { warning: 'errors' }
     const oldState = { ...metamaskState, ...errorState }
     const state = reduceApp(oldState, {
@@ -294,7 +293,7 @@ describe('App State', () => {
     assert.equal(state.warning, '')
   })
 
-  it('sets hardware wallet default hd path', () => {
+  it('sets hardware wallet default hd path', function () {
     const hdPaths = {
       trezor: "m/44'/60'/0'/0",
       ledger: "m/44'/60'/0'",
@@ -310,7 +309,7 @@ describe('App State', () => {
     assert.deepEqual(state.defaultHdPaths, hdPaths)
   })
 
-  it('shows loading message', () => {
+  it('shows loading message', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SHOW_LOADING,
       value: 'loading',
@@ -320,7 +319,7 @@ describe('App State', () => {
     assert.equal(state.loadingMessage, 'loading')
   })
 
-  it('hides loading message', () => {
+  it('hides loading message', function () {
     const loadingState = { isLoading: true }
     const oldState = { ...metamaskState, ...loadingState }
 
@@ -331,7 +330,7 @@ describe('App State', () => {
     assert.equal(state.isLoading, false)
   })
 
-  it('shows sub loading indicator', () => {
+  it('shows sub loading indicator', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SHOW_SUB_LOADING_INDICATION,
     })
@@ -339,7 +338,7 @@ describe('App State', () => {
     assert.equal(state.isSubLoading, true)
   })
 
-  it('hides sub loading indicator', () => {
+  it('hides sub loading indicator', function () {
     const oldState = { ...metamaskState, isSubLoading: true }
     const state = reduceApp(oldState, {
       type: actions.HIDE_SUB_LOADING_INDICATION,
@@ -348,7 +347,7 @@ describe('App State', () => {
     assert.equal(state.isSubLoading, false)
   })
 
-  it('displays warning', () => {
+  it('displays warning', function () {
     const state = reduceApp(metamaskState, {
       type: actions.DISPLAY_WARNING,
       value: 'warning',
@@ -358,7 +357,7 @@ describe('App State', () => {
     assert.equal(state.warning, 'warning')
   })
 
-  it('hides warning', () => {
+  it('hides warning', function () {
     const displayWarningState = { warning: 'warning' }
     const oldState = { ...metamaskState, ...displayWarningState }
     const state = reduceApp(oldState, {
@@ -368,7 +367,7 @@ describe('App State', () => {
     assert.equal(state.warning, undefined)
   })
 
-  it('shows private key', () => {
+  it('shows private key', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SHOW_PRIVATE_KEY,
       value: 'private key',
@@ -379,7 +378,7 @@ describe('App State', () => {
     assert.equal(state.accountDetail.privateKey, 'private key')
   })
 
-  it('updates pair', () => {
+  it('updates pair', function () {
     const coinOptions = {
       BTC: {
         symbol: 'BTC',
@@ -427,7 +426,7 @@ describe('App State', () => {
     assert.equal(state.buyView.amount, '12.00')
   })
 
-  it('shows QR', () => {
+  it('shows QR', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SHOW_QR,
       value: {
@@ -442,7 +441,7 @@ describe('App State', () => {
     assert.equal(state.Qr.data, 'data')
   })
 
-  it('shows qr view', () => {
+  it('shows qr view', function () {
     const appState = {
       currentView: {
         context: 'accounts',
@@ -463,7 +462,7 @@ describe('App State', () => {
     assert.equal(state.Qr.data, 'data')
   })
 
-  it('set mouse user state', () => {
+  it('set mouse user state', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SET_MOUSE_USER_STATE,
       value: true,
@@ -472,7 +471,7 @@ describe('App State', () => {
     assert.equal(state.isMouseUser, true)
   })
 
-  it('sets gas loading', () => {
+  it('sets gas loading', function () {
     const state = reduceApp(metamaskState, {
       type: actions.GAS_LOADING_STARTED,
     })
@@ -480,7 +479,7 @@ describe('App State', () => {
     assert.equal(state.gasIsLoading, true)
   })
 
-  it('unsets gas loading', () => {
+  it('unsets gas loading', function () {
     const gasLoadingState = { gasIsLoading: true }
     const oldState = { ...metamaskState, ...gasLoadingState }
     const state = reduceApp(oldState, {
@@ -490,7 +489,7 @@ describe('App State', () => {
     assert.equal(state.gasIsLoading, false)
   })
 
-  it('sets network nonce', () => {
+  it('sets network nonce', function () {
     const state = reduceApp(metamaskState, {
       type: actions.SET_NETWORK_NONCE,
       value: '33',

--- a/test/unit/ui/app/reducers/metamask.spec.js
+++ b/test/unit/ui/app/reducers/metamask.spec.js
@@ -2,14 +2,14 @@ import assert from 'assert'
 import reduceMetamask from '../../../../../ui/app/ducks/metamask/metamask'
 import { actionConstants as actions } from '../../../../../ui/app/store/actions'
 
-describe('MetaMask Reducers', () => {
+describe('MetaMask Reducers', function () {
 
-  it('init state', () => {
+  it('init state', function () {
     const initState = reduceMetamask(undefined, {})
     assert(initState)
   })
 
-  it('unlocks MetaMask', () => {
+  it('unlocks MetaMask', function () {
     const state = reduceMetamask({}, {
       type: actions.UNLOCK_METAMASK,
       value: 'test address',
@@ -20,7 +20,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.selectedAddress, 'test address')
   })
 
-  it('locks MetaMask', () => {
+  it('locks MetaMask', function () {
     const unlockMetaMaskState = {
       isUnlocked: true,
       isInitialzed: false,
@@ -33,7 +33,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(lockMetaMask.isUnlocked, false)
   })
 
-  it('sets rpc target', () => {
+  it('sets rpc target', function () {
     const state = reduceMetamask({}, {
       type: actions.SET_RPC_TARGET,
       value: 'https://custom.rpc',
@@ -42,7 +42,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.provider.rpcTarget, 'https://custom.rpc')
   })
 
-  it('sets provider type', () => {
+  it('sets provider type', function () {
     const state = reduceMetamask({}, {
       type: actions.SET_PROVIDER_TYPE,
       value: 'provider type',
@@ -51,7 +51,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.provider.type, 'provider type')
   })
 
-  it('shows account detail', () => {
+  it('shows account detail', function () {
 
     const state = reduceMetamask({}, {
       type: actions.SHOW_ACCOUNT_DETAIL,
@@ -63,7 +63,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.selectedAddress, 'test address')
   })
 
-  it('sets select ', () => {
+  it('sets select ', function () {
     const state = reduceMetamask({}, {
       type: actions.SET_SELECTED_TOKEN,
       value: 'test token',
@@ -72,7 +72,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.selectedTokenAddress, 'test token')
   })
 
-  it('sets account label', () => {
+  it('sets account label', function () {
     const state = reduceMetamask({}, {
       type: actions.SET_ACCOUNT_LABEL,
       value: {
@@ -84,7 +84,7 @@ describe('MetaMask Reducers', () => {
     assert.deepEqual(state.identities, { 'test account': { name: 'test label' } })
   })
 
-  it('sets current fiat', () => {
+  it('sets current fiat', function () {
     const value = {
       currentCurrency: 'yen',
       conversionRate: 3.14,
@@ -101,7 +101,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.conversionDate, value.conversionDate)
   })
 
-  it('updates tokens', () => {
+  it('updates tokens', function () {
     const newTokens = {
       'address': '0x617b3f8050a0bd94b6b1da02b4384ee5b4df13f4',
       'decimals': 18,
@@ -116,7 +116,7 @@ describe('MetaMask Reducers', () => {
     assert.deepEqual(state.tokens, newTokens)
   })
 
-  it('updates send gas limit', () => {
+  it('updates send gas limit', function () {
 
     const state = reduceMetamask({}, {
       type: actions.UPDATE_GAS_LIMIT,
@@ -126,7 +126,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.gasLimit, '0xGasLimit')
   })
 
-  it('updates send gas price', () => {
+  it('updates send gas price', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_GAS_PRICE,
       value: '0xGasPrice',
@@ -135,7 +135,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.gasPrice, '0xGasPrice')
   })
 
-  it('toggles account menu ', () => {
+  it('toggles account menu ', function () {
     const state = reduceMetamask({}, {
       type: actions.TOGGLE_ACCOUNT_MENU,
     })
@@ -143,7 +143,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.isAccountMenuOpen, true)
   })
 
-  it('updates gas total', () => {
+  it('updates gas total', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_GAS_TOTAL,
       value: '0xGasTotal',
@@ -152,7 +152,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.gasTotal, '0xGasTotal')
   })
 
-  it('updates send token balance', () => {
+  it('updates send token balance', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_SEND_TOKEN_BALANCE,
       value: '0xTokenBalance',
@@ -161,7 +161,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.tokenBalance, '0xTokenBalance')
   })
 
-  it('updates data', () => {
+  it('updates data', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_SEND_HEX_DATA,
       value: '0xData',
@@ -170,7 +170,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.data, '0xData')
   })
 
-  it('updates send to', () => {
+  it('updates send to', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_SEND_TO,
       value: {
@@ -183,7 +183,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.toNickname, 'nickname')
   })
 
-  it('update send amount', () => {
+  it('update send amount', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_SEND_AMOUNT,
       value: '0xAmount',
@@ -192,7 +192,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.amount, '0xAmount')
   })
 
-  it('updates max mode', () => {
+  it('updates max mode', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_MAX_MODE,
       value: true,
@@ -201,7 +201,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.send.maxModeOn, true)
   })
 
-  it('update send', () => {
+  it('update send', function () {
     const value = {
       gasLimit: '0xGasLimit',
       gasPrice: '0xGasPrice',
@@ -228,7 +228,7 @@ describe('MetaMask Reducers', () => {
     assert.deepEqual(sendState.send, value)
   })
 
-  it('clears send', () => {
+  it('clears send', function () {
     const initStateSend = {
       send:
       { gasLimit: null,
@@ -272,7 +272,7 @@ describe('MetaMask Reducers', () => {
     assert.deepEqual(state.send, initStateSend.send)
   })
 
-  it('updates value of tx by id', () => {
+  it('updates value of tx by id', function () {
     const oldState = {
       selectedAddressTxList: [
         {
@@ -291,7 +291,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.selectedAddressTxList[0].txParams, 'bar')
   })
 
-  it('updates pair for shapeshift', () => {
+  it('updates pair for shapeshift', function () {
     const state = reduceMetamask({}, {
       type: actions.PAIR_UPDATE,
       value: {
@@ -304,7 +304,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.tokenExchangeRates['test pair'].pair, 'test pair')
   })
 
-  it('sets blockies', () => {
+  it('sets blockies', function () {
     const state = reduceMetamask({}, {
       type: actions.SET_USE_BLOCKIE,
       value: true,
@@ -313,7 +313,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.useBlockie, true)
   })
 
-  it('updates an arbitrary feature flag', () => {
+  it('updates an arbitrary feature flag', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_FEATURE_FLAGS,
       value: {
@@ -324,7 +324,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.featureFlags.foo, true)
   })
 
-  it('close welcome screen', () => {
+  it('close welcome screen', function () {
     const state = reduceMetamask({}, {
       type: actions.CLOSE_WELCOME_SCREEN,
     })
@@ -332,7 +332,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.welcomeScreenSeen, true)
   })
 
-  it('sets current locale', () => {
+  it('sets current locale', function () {
     const state = reduceMetamask({}, {
       type: actions.SET_CURRENT_LOCALE,
       value: { locale: 'ge' },
@@ -341,7 +341,7 @@ describe('MetaMask Reducers', () => {
     assert.equal(state.currentLocale, 'ge')
   })
 
-  it('sets pending tokens ', () => {
+  it('sets pending tokens ', function () {
     const payload = {
       'address': '0x617b3f8050a0bd94b6b1da02b4384ee5b4df13f4',
       'decimals': 18,
@@ -356,7 +356,7 @@ describe('MetaMask Reducers', () => {
     assert.deepEqual(pendingTokensState.pendingTokens, payload)
   })
 
-  it('clears pending tokens', () => {
+  it('clears pending tokens', function () {
     const payload = {
       'address': '0x617b3f8050a0bd94b6b1da02b4384ee5b4df13f4',
       'decimals': 18,
@@ -374,7 +374,7 @@ describe('MetaMask Reducers', () => {
     assert.deepEqual(state.pendingTokens, {})
   })
 
-  it('update ensResolution', () => {
+  it('update ensResolution', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_SEND_ENS_RESOLUTION,
       payload: '0x1337',
@@ -384,7 +384,7 @@ describe('MetaMask Reducers', () => {
     assert.deepEqual(state.send.ensResolutionError, '')
   })
 
-  it('update ensResolutionError', () => {
+  it('update ensResolutionError', function () {
     const state = reduceMetamask({}, {
       type: actions.UPDATE_SEND_ENS_RESOLUTION_ERROR,
       payload: 'ens name not found',

--- a/test/unit/ui/app/selectors.spec.js
+++ b/test/unit/ui/app/selectors.spec.js
@@ -109,50 +109,50 @@ describe('Selectors', function () {
     assert.equal(currentAccountwithSendEther.name, 'Test Account')
   })
 
-  it('#getGasIsLoading', () => {
+  it('#getGasIsLoading', function () {
     const gasIsLoading = selectors.getGasIsLoading(mockState)
     assert.equal(gasIsLoading, false)
   })
 
-  describe('Send From', () => {
-    it('#getSendFrom', () => {
+  describe('Send From', function () {
+    it('#getSendFrom', function () {
       const sendFrom = selectors.getSendFrom(mockState)
       assert.equal(sendFrom, '0xc42edfcc21ed14dda456aa0756c153f7985d8813')
     })
 
-    it('#getForceGasMin', () => {
+    it('#getForceGasMin', function () {
       const forceGasMin = selectors.getForceGasMin(mockState)
       assert.equal(forceGasMin, null)
     })
 
-    it('#getSendAmount', () => {
+    it('#getSendAmount', function () {
       const sendAmount = selectors.getSendAmount(mockState)
       assert.equal(sendAmount, '1bc16d674ec80000')
     })
 
-    it('#getSendMaxModeState', () => {
+    it('#getSendMaxModeState', function () {
       const sendMaxModeState = selectors.getSendMaxModeState(mockState)
       assert.equal(sendMaxModeState, false)
     })
   })
 
-  it('#getCurrentCurrency', () => {
+  it('#getCurrentCurrency', function () {
     const currentCurrency = selectors.getCurrentCurrency(mockState)
     assert.equal(currentCurrency, 'usd')
   })
 
-  it('#getSelectedTokenToFiatRate', () => {
+  it('#getSelectedTokenToFiatRate', function () {
     const selectedTokenToFiatRate = selectors.getSelectedTokenToFiatRate(mockState)
     assert.equal(selectedTokenToFiatRate, '0.21880988420033492152')
   })
 
-  it('#getSelectedTokenContract', () => {
+  it('#getSelectedTokenContract', function () {
     global.eth = new Eth(provider)
     const selectedTokenContract = selectors.getSelectedTokenContract(mockState)
     assert(selectedTokenContract.abi)
   })
 
-  it('#getTotalUnapprovedCount', () => {
+  it('#getTotalUnapprovedCount', function () {
     const totalUnapprovedCount = selectors.getTotalUnapprovedCount(mockState)
     assert.equal(totalUnapprovedCount, 1)
   })

--- a/test/unit/ui/etherscan-prefix-for-network.spec.js
+++ b/test/unit/ui/etherscan-prefix-for-network.spec.js
@@ -1,29 +1,29 @@
 import assert from 'assert'
 import etherscanNetworkPrefix from '../../../ui/lib/etherscan-prefix-for-network'
 
-describe('Etherscan Network Prefix', () => {
+describe('Etherscan Network Prefix', function () {
 
-  it('returns empy string as default value', () => {
+  it('returns empy string as default value', function () {
     assert.equal(etherscanNetworkPrefix(), '')
   })
 
-  it('returns empty string as a prefix for networkId of 1', () => {
+  it('returns empty string as a prefix for networkId of 1', function () {
     assert.equal(etherscanNetworkPrefix(1), '')
   })
 
-  it('returns ropsten as prefix for networkId of 3', () => {
+  it('returns ropsten as prefix for networkId of 3', function () {
     assert.equal(etherscanNetworkPrefix(3), 'ropsten.')
   })
 
-  it('returns rinkeby as prefix for networkId of 4', () => {
+  it('returns rinkeby as prefix for networkId of 4', function () {
     assert.equal(etherscanNetworkPrefix(4), 'rinkeby.')
   })
 
-  it('returs kovan as prefix for networkId of 42', () => {
+  it('returs kovan as prefix for networkId of 42', function () {
     assert.equal(etherscanNetworkPrefix(42), 'kovan.')
   })
 
-  it('returs goerli as prefix for networkId of 5', () => {
+  it('returs goerli as prefix for networkId of 5', function () {
     assert.equal(etherscanNetworkPrefix(5), 'goerli.')
   })
 

--- a/test/web3/web3.js
+++ b/test/web3/web3.js
@@ -12,12 +12,12 @@ web3.currentProvider.enable().then(() => {
     Object.keys(methodGroup).forEach(methodKey => {
 
       const methodButton = document.getElementById(methodKey)
-      methodButton.addEventListener('click', function () {
+      methodButton.addEventListener('click', () => {
 
         window.ethereum.sendAsync({
           method: methodKey,
           params: methodGroup[methodKey][1],
-        }, function (err, result) {
+        }, (err, result) => {
           if (err) {
             console.log(err)
             console.log(methodKey)

--- a/ui/app/components/app/account-menu/tests/account-menu.test.js
+++ b/ui/app/components/app/account-menu/tests/account-menu.test.js
@@ -6,7 +6,7 @@ import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import AccountMenu from '../index'
 import { Provider } from 'react-redux'
 
-describe('Account Menu', async () => {
+describe('Account Menu', function () {
 
   let wrapper
 
@@ -63,7 +63,7 @@ describe('Account Menu', async () => {
 
   }
 
-  before(() => {
+  before(function () {
     wrapper = mountWithRouter(
       <Provider store={store}>
         <AccountMenu.WrappedComponent {...props} />
@@ -71,23 +71,23 @@ describe('Account Menu', async () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.toggleAccountMenu.resetHistory()
     props.history.push.resetHistory()
   })
 
-  describe('Render Content', () => {
-    it('returns account name from identities', () => {
+  describe('Render Content', function () {
+    it('returns account name from identities', function () {
       const accountName = wrapper.find('.account-menu__name')
       assert.equal(accountName.length, 2)
     })
 
-    it('renders user preference currency display balance from account balance', () => {
+    it('renders user preference currency display balance from account balance', function () {
       const accountBalance = wrapper.find('.currency-display-component.account-menu__balance')
       assert.equal(accountBalance.length, 2)
     })
 
-    it('simulate click', () => {
+    it('simulate click', function () {
       const click = wrapper.find('.account-menu__account.menu__item--clickable')
       click.first().simulate('click')
 
@@ -95,12 +95,12 @@ describe('Account Menu', async () => {
       assert.equal(props.showAccountDetail.getCall(0).args[0], '0xAddress')
     })
 
-    it('render imported account label', () => {
+    it('render imported account label', function () {
       const importedAccount = wrapper.find('.keyring-label.allcaps')
       assert.equal(importedAccount.text(), 'imported')
     })
 
-    it('remove account', () => {
+    it('remove account', function () {
       const removeAccount = wrapper.find('.remove-account-icon')
       removeAccount.simulate('click', {
         preventDefault: () => {},
@@ -114,93 +114,93 @@ describe('Account Menu', async () => {
     })
   })
 
-  describe('Log Out', () => {
+  describe('Log Out', function () {
     let logout
 
-    it('logout', () => {
+    it('logout', function () {
       logout = wrapper.find('.account-menu__lock-button')
       assert.equal(logout.length, 1)
     })
 
-    it('simulate click', () => {
+    it('simulate click', function () {
       logout.simulate('click')
       assert(props.lockMetamask.calledOnce)
       assert.equal(props.history.push.getCall(0).args[0], '/')
     })
   })
 
-  describe('Create Account', () => {
+  describe('Create Account', function () {
     let createAccount
 
-    it('renders create account item', () => {
+    it('renders create account item', function () {
       createAccount = wrapper.find({ text: 'createAccount' })
       assert.equal(createAccount.length, 1)
     })
 
-    it('calls toggle menu and push new-account route to history', () => {
+    it('calls toggle menu and push new-account route to history', function () {
       createAccount.simulate('click')
       assert(props.toggleAccountMenu.calledOnce)
       assert.equal(props.history.push.getCall(0).args[0], '/new-account')
     })
   })
 
-  describe('Import Account', () => {
+  describe('Import Account', function () {
     let importAccount
 
-    it('renders import account item', () => {
+    it('renders import account item', function () {
       importAccount = wrapper.find({ text: 'importAccount' })
       assert.equal(importAccount.length, 1)
     })
 
-    it('calls toggle menu and push /new-account/import route to history', () => {
+    it('calls toggle menu and push /new-account/import route to history', function () {
       importAccount.simulate('click')
       assert(props.toggleAccountMenu.calledOnce)
       assert(props.history.push.getCall(0).args[0], '/new-account/import')
     })
   })
 
-  describe('Connect Hardware Wallet', () => {
+  describe('Connect Hardware Wallet', function () {
 
     let connectHardwareWallet
 
-    it('renders import account item', () => {
+    it('renders import account item', function () {
       connectHardwareWallet = wrapper.find({ text: 'connectHardwareWallet' })
       assert.equal(connectHardwareWallet.length, 1)
     })
 
-    it('calls toggle menu and push /new-account/connect route to history', () => {
+    it('calls toggle menu and push /new-account/connect route to history', function () {
       connectHardwareWallet.simulate('click')
       assert(props.toggleAccountMenu.calledOnce)
       assert.equal(props.history.push.getCall(0).args[0], '/new-account/connect')
     })
   })
 
-  describe('Info & Help', () => {
+  describe('Info & Help', function () {
 
     let infoHelp
 
-    it('renders import account item', () => {
+    it('renders import account item', function () {
       infoHelp = wrapper.find({ text: 'infoHelp' })
       assert.equal(infoHelp.length, 1)
     })
 
-    it('calls toggle menu and push /new-account/connect route to history', () => {
+    it('calls toggle menu and push /new-account/connect route to history', function () {
       infoHelp.simulate('click')
       assert(props.toggleAccountMenu.calledOnce)
       assert.equal(props.history.push.getCall(0).args[0], '/settings/about-us')
     })
   })
 
-  describe('Settings', () => {
+  describe('Settings', function () {
 
     let settings
 
-    it('renders import account item', () => {
+    it('renders import account item', function () {
       settings = wrapper.find({ text: 'settings' })
       assert.equal(settings.length, 1)
     })
 
-    it('calls toggle menu and push /new-account/connect route to history', () => {
+    it('calls toggle menu and push /new-account/connect route to history', function () {
       settings.simulate('click')
       assert(props.toggleAccountMenu.calledOnce)
       assert.equal(props.history.push.getCall(0).args[0], '/settings')

--- a/ui/app/components/app/app-header/tests/app-header.test.js
+++ b/ui/app/components/app/app-header/tests/app-header.test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme'
 import MetaFoxLogo from '../../../ui/metafox-logo'
 import AppHeader from '../index'
 
-describe('App Header', () => {
+describe('App Header', function () {
   let wrapper
 
   const props = {
@@ -25,7 +25,7 @@ describe('App Header', () => {
     isUnlocked: true,
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow(
       <AppHeader.WrappedComponent {...props} />, {
         context: {
@@ -36,12 +36,12 @@ describe('App Header', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.toggleAccountMenu.resetHistory()
   })
 
-  describe('App Header Logo', () => {
-    it('routes to default route when logo is clicked', () => {
+  describe('App Header Logo', function () {
+    it('routes to default route when logo is clicked', function () {
       const appLogo = wrapper.find(MetaFoxLogo)
       appLogo.simulate('click')
       assert(props.history.push.calledOnce)
@@ -49,8 +49,8 @@ describe('App Header', () => {
     })
   })
 
-  describe('Network', () => {
-    it('shows network dropdown when networkDropdownOpen is false', () => {
+  describe('Network', function () {
+    it('shows network dropdown when networkDropdownOpen is false', function () {
       const network = wrapper.find({ network: 'test' })
 
       network.simulate('click', {
@@ -61,7 +61,7 @@ describe('App Header', () => {
       assert(props.showNetworkDropdown.calledOnce)
     })
 
-    it('hides network dropdown when networkDropdownOpen is true', () => {
+    it('hides network dropdown when networkDropdownOpen is true', function () {
       wrapper.setProps({ networkDropdownOpen: true })
       const network = wrapper.find({ network: 'test' })
 
@@ -73,22 +73,22 @@ describe('App Header', () => {
       assert(props.hideNetworkDropdown.calledOnce)
     })
 
-    it('hides network indicator', () => {
+    it('hides network indicator', function () {
       wrapper.setProps({ hideNetworkIndicator: true })
       const network = wrapper.find({ network: 'test' })
       assert.equal(network.length, 0)
     })
   })
 
-  describe('Account Menu', () => {
+  describe('Account Menu', function () {
 
-    it('toggles account menu', () => {
+    it('toggles account menu', function () {
       const accountMenu = wrapper.find('.account-menu__icon')
       accountMenu.simulate('click')
       assert(props.toggleAccountMenu.calledOnce)
     })
 
-    it('does not toggle account menu when disabled', () => {
+    it('does not toggle account menu when disabled', function () {
       wrapper.setProps({ disabled: true })
       const accountMenu = wrapper.find('.account-menu__icon')
       accountMenu.simulate('click')

--- a/ui/app/components/app/confirm-page-container/confirm-detail-row/tests/confirm-detail-row.component.test.js
+++ b/ui/app/components/app/confirm-page-container/confirm-detail-row/tests/confirm-detail-row.component.test.js
@@ -9,56 +9,56 @@ const propsMethodSpies = {
 }
 
 describe('Confirm Detail Row Component', function () {
-  let wrapper
+  describe('render', function () {
+    let wrapper
 
-  beforeEach(() => {
-    wrapper = shallow(
-      <ConfirmDetailRow
-        errorType="mockErrorType"
-        label="mockLabel"
-        showError={false}
-        primaryText="mockFiatText"
-        secondaryText="mockEthText"
-        primaryValueTextColor="mockColor"
-        onHeaderClick={propsMethodSpies.onHeaderClick}
-        headerText="mockHeaderText"
-        headerTextClassName="mockHeaderClass"
-      />
-    )
-  })
+    beforeEach(function () {
+      wrapper = shallow(
+        <ConfirmDetailRow
+          errorType="mockErrorType"
+          label="mockLabel"
+          showError={false}
+          primaryText="mockFiatText"
+          secondaryText="mockEthText"
+          primaryValueTextColor="mockColor"
+          onHeaderClick={propsMethodSpies.onHeaderClick}
+          headerText="mockHeaderText"
+          headerTextClassName="mockHeaderClass"
+        />
+      )
+    })
 
-  describe('render', () => {
-    it('should render a div with a confirm-detail-row class', () => {
+    it('should render a div with a confirm-detail-row class', function () {
       assert.equal(wrapper.find('div.confirm-detail-row').length, 1)
     })
 
-    it('should render the label as a child of the confirm-detail-row__label', () => {
+    it('should render the label as a child of the confirm-detail-row__label', function () {
       assert.equal(wrapper.find('.confirm-detail-row > .confirm-detail-row__label').childAt(0).text(), 'mockLabel')
     })
 
-    it('should render the headerText as a child of the confirm-detail-row__header-text', () => {
+    it('should render the headerText as a child of the confirm-detail-row__header-text', function () {
       assert.equal(wrapper.find('.confirm-detail-row__details > .confirm-detail-row__header-text').childAt(0).text(), 'mockHeaderText')
     })
 
-    it('should render the primaryText as a child of the confirm-detail-row__primary', () => {
+    it('should render the primaryText as a child of the confirm-detail-row__primary', function () {
       assert.equal(wrapper.find('.confirm-detail-row__details > .confirm-detail-row__primary').childAt(0).text(), 'mockFiatText')
     })
 
-    it('should render the ethText as a child of the confirm-detail-row__secondary', () => {
+    it('should render the ethText as a child of the confirm-detail-row__secondary', function () {
       assert.equal(wrapper.find('.confirm-detail-row__details > .confirm-detail-row__secondary').childAt(0).text(), 'mockEthText')
     })
 
-    it('should set the fiatTextColor on confirm-detail-row__primary', () => {
+    it('should set the fiatTextColor on confirm-detail-row__primary', function () {
       assert.equal(wrapper.find('.confirm-detail-row__primary').props().style.color, 'mockColor')
     })
 
-    it('should assure the confirm-detail-row__header-text classname is correct', () => {
+    it('should assure the confirm-detail-row__header-text classname is correct', function () {
       assert.equal(wrapper.find('.confirm-detail-row__header-text').props().className, 'confirm-detail-row__header-text mockHeaderClass')
     })
 
-    it('should call onHeaderClick when headerText div gets clicked', () => {
+    it('should call onHeaderClick when headerText div gets clicked', function () {
       wrapper.find('.confirm-detail-row__header-text').props().onClick()
-      assert.equal(assert.equal(propsMethodSpies.onHeaderClick.callCount, 1))
+      assert.ok(propsMethodSpies.onHeaderClick.calledOnce)
     })
   })
 })

--- a/ui/app/components/app/dropdowns/tests/dropdown.test.js
+++ b/ui/app/components/app/dropdowns/tests/dropdown.test.js
@@ -4,12 +4,12 @@ import sinon from 'sinon'
 import { shallow } from 'enzyme'
 import { DropdownMenuItem } from '../components/dropdown.js'
 
-describe('Dropdown', () => {
+describe('Dropdown', function () {
   let wrapper
   const onClickSpy = sinon.spy()
   const closeMenuSpy = sinon.spy()
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow(
       <DropdownMenuItem
         onClick={onClickSpy}
@@ -20,15 +20,15 @@ describe('Dropdown', () => {
     )
   })
 
-  it('renders li with dropdown-menu-item class', () => {
+  it('renders li with dropdown-menu-item class', function () {
     assert.equal(wrapper.find('li.dropdown-menu-item').length, 1)
   })
 
-  it('adds style based on props passed', () => {
+  it('adds style based on props passed', function () {
     assert.equal(wrapper.prop('style').test, 'style')
   })
 
-  it('simulates click event and calls onClick and closeMenu', () => {
+  it('simulates click event and calls onClick and closeMenu', function () {
     wrapper.prop('onClick')()
     assert.equal(onClickSpy.callCount, 1)
     assert.equal(closeMenuSpy.callCount, 1)

--- a/ui/app/components/app/dropdowns/tests/menu.test.js
+++ b/ui/app/components/app/dropdowns/tests/menu.test.js
@@ -4,29 +4,21 @@ import sinon from 'sinon'
 import { shallow } from 'enzyme'
 import { Menu, Item, Divider, CloseArea } from '../components/menu'
 
-describe('Dropdown Menu Components', () => {
-
-  describe('Menu', () => {
-    let wrapper
-
-    beforeEach(() => {
-      wrapper = shallow(
+describe('Dropdown Menu Components', function () {
+  describe('Menu', function () {
+    it('adds prop className to menu', function () {
+      const wrapper = shallow(
         <Menu className="Test Class" isShowing />
       )
-    })
-
-    it('adds prop className to menu', () => {
       assert.equal(wrapper.find('.menu').prop('className'), 'menu Test Class')
     })
-
   })
 
-  describe('Item', () => {
+  describe('Item', function () {
     let wrapper
-
     const onClickSpy = sinon.spy()
 
-    beforeEach(() => {
+    beforeEach(function () {
       wrapper = shallow(
         <Item
           icon="test icon"
@@ -37,53 +29,41 @@ describe('Dropdown Menu Components', () => {
       )
     })
 
-    it('add className based on props', () => {
+    it('add className based on props', function () {
       assert.equal(wrapper.find('.menu__item').prop('className'), 'menu__item test foo1 menu__item--clickable')
     })
 
-    it('simulates onClick called', () => {
+    it('simulates onClick called', function () {
       wrapper.find('.menu__item').prop('onClick')()
       assert.equal(onClickSpy.callCount, 1)
     })
 
-    it('adds icon based on icon props', () => {
+    it('adds icon based on icon props', function () {
       assert.equal(wrapper.find('.menu__item__icon').text(), 'test icon')
     })
 
-    it('adds html text based on text props', () => {
+    it('adds html text based on text props', function () {
       assert.equal(wrapper.find('.menu__item__text').text(), 'test text')
     })
   })
 
-  describe('Divider', () => {
-    let wrapper
-
-    before(() => {
-      wrapper = shallow(<Divider />)
-    })
-
-    it('renders menu divider', () => {
+  describe('Divider', function () {
+    it('renders menu divider', function () {
+      const wrapper = shallow(<Divider />)
       assert.equal(wrapper.find('.menu__divider').length, 1)
     })
   })
 
-  describe('CloseArea', () => {
-    let wrapper
-
-    const onClickSpy = sinon.spy()
-
-    beforeEach(() => {
-      wrapper = shallow((
+  describe('CloseArea', function () {
+    it('simulates click', function () {
+      const onClickSpy = sinon.spy()
+      const wrapper = shallow((
         <CloseArea
           onClick={onClickSpy}
         />
       ))
-    })
-
-    it('simulates click', () => {
       wrapper.prop('onClick')()
-      assert.equal(onClickSpy.callCount, 1)
+      assert.ok(onClickSpy.calledOnce)
     })
   })
-
 })

--- a/ui/app/components/app/dropdowns/tests/network-dropdown-icon.test.js
+++ b/ui/app/components/app/dropdowns/tests/network-dropdown-icon.test.js
@@ -3,11 +3,9 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import NetworkDropdownIcon from '../components/network-dropdown-icon'
 
-describe('Network Dropdown Icon', () => {
-  let wrapper
-
-  beforeEach(() => {
-    wrapper = shallow((
+describe('Network Dropdown Icon', function () {
+  it('adds style props based on props', function () {
+    const wrapper = shallow((
       <NetworkDropdownIcon
         backgroundColor="red"
         isSelected={false}
@@ -15,9 +13,6 @@ describe('Network Dropdown Icon', () => {
         diameter="12"
       />
     ))
-  })
-
-  it('adds style props based on props', () => {
     const styleProp = wrapper.find('.menu-icon-circle').children().prop('style')
     assert.equal(styleProp.background, 'red')
     assert.equal(styleProp.border, 'none')

--- a/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
+++ b/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
@@ -6,10 +6,10 @@ import NetworkDropdown from '../network-dropdown'
 import { DropdownMenuItem } from '../components/dropdown'
 import NetworkDropdownIcon from '../components/network-dropdown-icon'
 
-describe('Network Dropdown', () => {
+describe('Network Dropdown', function () {
   let wrapper
 
-  describe('NetworkDropdown in appState in false', () => {
+  describe('NetworkDropdown in appState in false', function () {
     const mockState = {
       metamask: {
         network: '1',
@@ -24,23 +24,23 @@ describe('Network Dropdown', () => {
 
     const store = createMockStore(mockState)
 
-    beforeEach(() => {
+    beforeEach(function () {
       wrapper = mountWithRouter(
         <NetworkDropdown store={store} />
       )
     })
 
-    it('checks for network droppo class', () => {
+    it('checks for network droppo class', function () {
       assert.equal(wrapper.find('.network-droppo').length, 1)
     })
 
-    it('renders only one child when networkDropdown is false in state', () => {
+    it('renders only one child when networkDropdown is false in state', function () {
       assert.equal(wrapper.children().length, 1)
     })
 
   })
 
-  describe('NetworkDropdown in appState is true', () => {
+  describe('NetworkDropdown in appState is true', function () {
     const mockState = {
       metamask: {
         network: '1',
@@ -57,45 +57,45 @@ describe('Network Dropdown', () => {
     }
     const store = createMockStore(mockState)
 
-    beforeEach(() => {
+    beforeEach(function () {
       wrapper = mountWithRouter(
         <NetworkDropdown store={store} />,
       )
     })
 
-    it('renders 7 DropDownMenuItems ', () => {
+    it('renders 7 DropDownMenuItems ', function () {
       assert.equal(wrapper.find(DropdownMenuItem).length, 8)
     })
 
-    it('checks background color for first NetworkDropdownIcon', () => {
+    it('checks background color for first NetworkDropdownIcon', function () {
       assert.equal(wrapper.find(NetworkDropdownIcon).at(0).prop('backgroundColor'), '#29B6AF') // Main Ethereum Network Teal
     })
 
-    it('checks background color for second NetworkDropdownIcon', () => {
+    it('checks background color for second NetworkDropdownIcon', function () {
       assert.equal(wrapper.find(NetworkDropdownIcon).at(1).prop('backgroundColor'), '#ff4a8d') // Ropsten Red
     })
 
-    it('checks background color for third NetworkDropdownIcon', () => {
+    it('checks background color for third NetworkDropdownIcon', function () {
       assert.equal(wrapper.find(NetworkDropdownIcon).at(2).prop('backgroundColor'), '#7057ff') // Kovan Purple
     })
 
-    it('checks background color for fourth NetworkDropdownIcon', () => {
+    it('checks background color for fourth NetworkDropdownIcon', function () {
       assert.equal(wrapper.find(NetworkDropdownIcon).at(3).prop('backgroundColor'), '#f6c343') // Rinkeby Yellow
     })
 
-    it('checks background color for fifth NetworkDropdownIcon', () => {
+    it('checks background color for fifth NetworkDropdownIcon', function () {
       assert.equal(wrapper.find(NetworkDropdownIcon).at(4).prop('backgroundColor'), '#3099f2') // Goerli Blue
     })
 
-    it('checks background color for sixth NetworkDropdownIcon', () => {
+    it('checks background color for sixth NetworkDropdownIcon', function () {
       assert.equal(wrapper.find(NetworkDropdownIcon).at(5).prop('innerBorder'), '1px solid #9b9b9b')
     })
 
-    it('checks dropdown for frequestRPCList from  state ', () => {
+    it('checks dropdown for frequestRPCList from  state ', function () {
       assert.equal(wrapper.find(DropdownMenuItem).at(6).text(), '✓http://localhost:7545')
     })
 
-    it('checks background color for seventh NetworkDropdownIcon', () => {
+    it('checks background color for seventh NetworkDropdownIcon', function () {
       assert.equal(wrapper.find(NetworkDropdownIcon).at(6).prop('innerBorder'), '1px solid #9b9b9b')
     })
 

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/tests/advanced-gas-input-component.test.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/tests/advanced-gas-input-component.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import AdvancedTabContent from '../index'
 
-describe('Advanced Gas Inputs', () => {
+describe('Advanced Gas Inputs', function () {
   let wrapper, clock
 
   const props = {
@@ -19,7 +19,7 @@ describe('Advanced Gas Inputs', () => {
     isSpeedUp: false,
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     clock = sinon.useFakeTimers()
 
     wrapper = mount(
@@ -32,11 +32,11 @@ describe('Advanced Gas Inputs', () => {
       })
   })
 
-  afterEach(() => {
+  afterEach(function () {
     clock.restore()
   })
 
-  it('wont update gasPrice in props before debounce', () => {
+  it('wont update gasPrice in props before debounce', function () {
     const event = { target: { value: 1 } }
 
     wrapper.find('input').at(0).simulate('change', event)
@@ -45,7 +45,7 @@ describe('Advanced Gas Inputs', () => {
     assert.equal(props.updateCustomGasPrice.callCount, 0)
   })
 
-  it('simulates onChange on gas price after debounce', () => {
+  it('simulates onChange on gas price after debounce', function () {
     const event = { target: { value: 1 } }
 
     wrapper.find('input').at(0).simulate('change', event)
@@ -55,7 +55,7 @@ describe('Advanced Gas Inputs', () => {
     assert.equal(props.updateCustomGasPrice.calledWith(1), true)
   })
 
-  it('wont update gasLimit in props before debounce', () => {
+  it('wont update gasLimit in props before debounce', function () {
     const event = { target: { value: 21000 } }
 
     wrapper.find('input').at(1).simulate('change', event)
@@ -64,7 +64,7 @@ describe('Advanced Gas Inputs', () => {
     assert.equal(props.updateCustomGasLimit.callCount, 0)
   })
 
-  it('simulates onChange on gas limit after debounce', () => {
+  it('simulates onChange on gas limit after debounce', function () {
     const event = { target: { value: 21000 } }
 
     wrapper.find('input').at(1).simulate('change', event)
@@ -74,7 +74,7 @@ describe('Advanced Gas Inputs', () => {
     assert.equal(props.updateCustomGasLimit.calledWith(21000), true)
   })
 
-  it('errors when insuffientBalance under gas price and gas limit', () => {
+  it('errors when insuffientBalance under gas price and gas limit', function () {
     wrapper.setProps({ insufficientBalance: true })
     const renderError = wrapper.find('.advanced-gas-inputs__gas-edit-row__error-text')
     assert.equal(renderError.length, 2)
@@ -83,7 +83,7 @@ describe('Advanced Gas Inputs', () => {
     assert.equal(renderError.at(1).text(), 'insufficientBalance')
   })
 
-  it('errors zero gas price / speed up', () => {
+  it('errors zero gas price / speed up', function () {
     wrapper.setProps({ isSpeedUp: true })
 
     const renderError = wrapper.find('.advanced-gas-inputs__gas-edit-row__error-text')
@@ -93,7 +93,7 @@ describe('Advanced Gas Inputs', () => {
     assert.equal(renderError.at(1).text(), 'gasLimitTooLow')
   })
 
-  it('warns when custom gas price is too low', () => {
+  it('warns when custom gas price is too low', function () {
     wrapper.setProps({ customPriceIsSafe: false })
 
     const renderWarning = wrapper.find('.advanced-gas-inputs__gas-edit-row__warning-text')

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
@@ -17,7 +17,7 @@ sinon.spy(AdvancedTabContent.prototype, 'renderDataSummary')
 describe('AdvancedTabContent Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <AdvancedTabContent
         updateCustomGasPrice={propsMethodSpies.updateCustomGasPrice}
@@ -34,18 +34,18 @@ describe('AdvancedTabContent Component', function () {
     ))
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.updateCustomGasPrice.resetHistory()
     propsMethodSpies.updateCustomGasLimit.resetHistory()
     AdvancedTabContent.prototype.renderDataSummary.resetHistory()
   })
 
-  describe('render()', () => {
-    it('should render the advanced-tab root node', () => {
+  describe('render()', function () {
+    it('should render the advanced-tab root node', function () {
       assert(wrapper.hasClass('advanced-tab'))
     })
 
-    it('should render the expected four children of the advanced-tab div', () => {
+    it('should render the expected four children of the advanced-tab div', function () {
       const advancedTabChildren = wrapper.children()
       assert.equal(advancedTabChildren.length, 2)
 
@@ -59,7 +59,7 @@ describe('AdvancedTabContent Component', function () {
       assert(feeChartDiv.childAt(1).childAt(2).hasClass('advanced-tab__fee-chart__speed-buttons'))
     })
 
-    it('should render a loading component instead of the chart if gasEstimatesLoading is true', () => {
+    it('should render a loading component instead of the chart if gasEstimatesLoading is true', function () {
       wrapper.setProps({ gasEstimatesLoading: true })
       const advancedTabChildren = wrapper.children()
       assert.equal(advancedTabChildren.length, 2)
@@ -74,31 +74,31 @@ describe('AdvancedTabContent Component', function () {
       assert(feeChartDiv.childAt(1).childAt(2).hasClass('advanced-tab__fee-chart__speed-buttons'))
     })
 
-    it('should call renderDataSummary with the expected params', () => {
+    it('should call renderDataSummary with the expected params', function () {
       const renderDataSummaryArgs = AdvancedTabContent.prototype.renderDataSummary.getCall(0).args
       assert.deepEqual(renderDataSummaryArgs, ['$0.25', 21500])
     })
   })
 
-  describe('renderDataSummary()', () => {
+  describe('renderDataSummary()', function () {
     let dataSummary
 
-    beforeEach(() => {
+    beforeEach(function () {
       dataSummary = shallow(wrapper.instance().renderDataSummary('mockTotalFee', 'mockMsRemaining'))
     })
 
-    it('should render the transaction-data-summary root node', () => {
+    it('should render the transaction-data-summary root node', function () {
       assert(dataSummary.hasClass('advanced-tab__transaction-data-summary'))
     })
 
-    it('should render titles of the data', () => {
+    it('should render titles of the data', function () {
       const titlesNode = dataSummary.children().at(0)
       assert(titlesNode.hasClass('advanced-tab__transaction-data-summary__titles'))
       assert.equal(titlesNode.children().at(0).text(), 'newTransactionFee')
       assert.equal(titlesNode.children().at(1).text(), '~transactionTime')
     })
 
-    it('should render the data', () => {
+    it('should render the data', function () {
       const dataNode = dataSummary.children().at(1)
       assert(dataNode.hasClass('advanced-tab__transaction-data-summary__container'))
       assert.equal(dataNode.children().at(0).text(), 'mockTotalFee')

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 import assert from 'assert'
 import shallow from '../../../../../../../lib/shallow-with-context'
 import BasicTabContent from '../basic-tab-content.component'
-
 import GasPriceButtonGroup from '../../../gas-price-button-group'
 import Loading from '../../../../../ui/loading-screen'
 import { GAS_ESTIMATE_TYPES } from '../../../../../../helpers/constants/common'
@@ -39,26 +38,26 @@ const mockGasPriceButtonGroupProps = {
 }
 
 describe('BasicTabContent Component', function () {
-  let wrapper
+  describe('render', function () {
+    let wrapper
 
-  beforeEach(() => {
-    wrapper = shallow((
-      <BasicTabContent
-        gasPriceButtonGroupProps={mockGasPriceButtonGroupProps}
-      />
-    ))
-  })
+    beforeEach(function () {
+      wrapper = shallow((
+        <BasicTabContent
+          gasPriceButtonGroupProps={mockGasPriceButtonGroupProps}
+        />
+      ))
+    })
 
-  describe('render', () => {
-    it('should have a title', () => {
+    it('should have a title', function () {
       assert(wrapper.find('.basic-tab-content').childAt(0).hasClass('basic-tab-content__title'))
     })
 
-    it('should render a GasPriceButtonGroup compenent', () => {
+    it('should render a GasPriceButtonGroup compenent', function () {
       assert.equal(wrapper.find(GasPriceButtonGroup).length, 1)
     })
 
-    it('should pass correct props to GasPriceButtonGroup', () => {
+    it('should pass correct props to GasPriceButtonGroup', function () {
       const {
         buttonDataLoading,
         className,
@@ -76,7 +75,7 @@ describe('BasicTabContent Component', function () {
       assert.equal(JSON.stringify(handleGasPriceSelection), JSON.stringify(mockGasPriceButtonGroupProps.handleGasPriceSelection))
     })
 
-    it('should render a loading component instead of the GasPriceButtonGroup if gasPriceButtonGroupProps.loading is true', () => {
+    it('should render a loading component instead of the GasPriceButtonGroup if gasPriceButtonGroupProps.loading is true', function () {
       wrapper.setProps({
         gasPriceButtonGroupProps: { ...mockGasPriceButtonGroupProps, loading: true },
       })

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -62,7 +62,7 @@ const GP = GasModalPageContainer.prototype
 describe('GasModalPageContainer Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <GasModalPageContainer
         cancelAndClose={propsMethodSpies.cancelAndClose}
@@ -84,19 +84,19 @@ describe('GasModalPageContainer Component', function () {
     ))
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.cancelAndClose.resetHistory()
   })
 
-  describe('componentDidMount', () => {
-    it('should call props.fetchBasicGasAndTimeEstimates', () => {
+  describe('componentDidMount', function () {
+    it('should call props.fetchBasicGasAndTimeEstimates', function () {
       propsMethodSpies.fetchBasicGasAndTimeEstimates.resetHistory()
       assert.equal(propsMethodSpies.fetchBasicGasAndTimeEstimates.callCount, 0)
       wrapper.instance().componentDidMount()
       assert.equal(propsMethodSpies.fetchBasicGasAndTimeEstimates.callCount, 1)
     })
 
-    it('should call props.fetchGasEstimates with the block time returned by fetchBasicGasAndTimeEstimates', async () => {
+    it('should call props.fetchGasEstimates with the block time returned by fetchBasicGasAndTimeEstimates', async function () {
       propsMethodSpies.fetchGasEstimates.resetHistory()
       assert.equal(propsMethodSpies.fetchGasEstimates.callCount, 0)
       wrapper.instance().componentDidMount()
@@ -106,12 +106,12 @@ describe('GasModalPageContainer Component', function () {
     })
   })
 
-  describe('render', () => {
-    it('should render a PageContainer compenent', () => {
+  describe('render', function () {
+    it('should render a PageContainer compenent', function () {
       assert.equal(wrapper.find(PageContainer).length, 1)
     })
 
-    it('should pass correct props to PageContainer', () => {
+    it('should pass correct props to PageContainer', function () {
       const {
         title,
         subtitle,
@@ -122,7 +122,7 @@ describe('GasModalPageContainer Component', function () {
       assert.equal(disabled, false)
     })
 
-    it('should pass the correct onCancel and onClose methods to PageContainer', () => {
+    it('should pass the correct onCancel and onClose methods to PageContainer', function () {
       const {
         onCancel,
         onClose,
@@ -134,7 +134,7 @@ describe('GasModalPageContainer Component', function () {
       assert.equal(propsMethodSpies.cancelAndClose.callCount, 2)
     })
 
-    it('should pass the correct renderTabs property to PageContainer', () => {
+    it('should pass the correct renderTabs property to PageContainer', function () {
       sinon.stub(GP, 'renderTabs').returns('mockTabs')
       const renderTabsWrapperTester = shallow((
         <GasModalPageContainer
@@ -148,20 +148,20 @@ describe('GasModalPageContainer Component', function () {
     })
   })
 
-  describe('renderTabs', () => {
-    beforeEach(() => {
+  describe('renderTabs', function () {
+    beforeEach(function () {
       sinon.spy(GP, 'renderBasicTabContent')
       sinon.spy(GP, 'renderAdvancedTabContent')
       sinon.spy(GP, 'renderInfoRows')
     })
 
-    afterEach(() => {
+    afterEach(function () {
       GP.renderBasicTabContent.restore()
       GP.renderAdvancedTabContent.restore()
       GP.renderInfoRows.restore()
     })
 
-    it('should render a Tabs component with "Basic" and "Advanced" tabs', () => {
+    it('should render a Tabs component with "Basic" and "Advanced" tabs', function () {
       const renderTabsResult = wrapper.instance().renderTabs()
       const renderedTabs = shallow(renderTabsResult)
       assert.equal(renderedTabs.props().className, 'tabs')
@@ -176,7 +176,7 @@ describe('GasModalPageContainer Component', function () {
       assert.equal(tabs.at(1).childAt(0).props().className, 'gas-modal-content')
     })
 
-    it('should call renderInfoRows with the expected props', () => {
+    it('should call renderInfoRows with the expected props', function () {
       assert.equal(GP.renderInfoRows.callCount, 0)
 
       wrapper.instance().renderTabs()
@@ -187,7 +187,7 @@ describe('GasModalPageContainer Component', function () {
       assert.deepEqual(GP.renderInfoRows.getCall(1).args, ['mockNewTotalFiat', 'mockNewTotalEth', 'mockSendAmount', 'mockTransactionFee'])
     })
 
-    it('should not render the basic tab if hideBasic is true', () => {
+    it('should not render the basic tab if hideBasic is true', function () {
       wrapper = shallow((
         <GasModalPageContainer
           cancelAndClose={propsMethodSpies.cancelAndClose}
@@ -217,8 +217,8 @@ describe('GasModalPageContainer Component', function () {
     })
   })
 
-  describe('renderBasicTabContent', () => {
-    it('should render', () => {
+  describe('renderBasicTabContent', function () {
+    it('should render', function () {
       const renderBasicTabContentResult = wrapper.instance().renderBasicTabContent(mockGasPriceButtonGroupProps)
 
       assert.deepEqual(
@@ -228,8 +228,8 @@ describe('GasModalPageContainer Component', function () {
     })
   })
 
-  describe('renderInfoRows', () => {
-    it('should render the info rows with the passed data', () => {
+  describe('renderInfoRows', function () {
+    it('should render the info rows with the passed data', function () {
       const baseClassName = 'gas-modal-content__info-row'
       const renderedInfoRowsContainer = shallow(wrapper.instance().renderInfoRows(
         'mockNewTotalFiat',

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -53,10 +53,10 @@ proxyquire('../gas-modal-page-container.container.js', {
   },
 })
 
-describe('gas-modal-page-container container', () => {
+describe('gas-modal-page-container container', function () {
 
-  describe('mapStateToProps()', () => {
-    it('should map the correct properties to props', () => {
+  describe('mapStateToProps()', function () {
+    it('should map the correct properties to props', function () {
       const baseMockState = {
         appState: {
           modal: {
@@ -257,31 +257,31 @@ describe('gas-modal-page-container container', () => {
 
   })
 
-  describe('mapDispatchToProps()', () => {
+  describe('mapDispatchToProps()', function () {
     let dispatchSpy
     let mapDispatchToPropsObject
 
-    beforeEach(() => {
+    beforeEach(function () {
       dispatchSpy = sinon.spy()
       mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
     })
 
-    afterEach(() => {
+    afterEach(function () {
       actionSpies.hideModal.resetHistory()
       gasActionSpies.setCustomGasPrice.resetHistory()
       gasActionSpies.setCustomGasLimit.resetHistory()
     })
 
-    describe('hideGasButtonGroup()', () => {
-      it('should dispatch a hideGasButtonGroup action', () => {
+    describe('hideGasButtonGroup()', function () {
+      it('should dispatch a hideGasButtonGroup action', function () {
         mapDispatchToPropsObject.hideGasButtonGroup()
         assert(dispatchSpy.calledOnce)
         assert(sendActionSpies.hideGasButtonGroup.calledOnce)
       })
     })
 
-    describe('cancelAndClose()', () => {
-      it('should dispatch a hideModal action', () => {
+    describe('cancelAndClose()', function () {
+      it('should dispatch a hideModal action', function () {
         mapDispatchToPropsObject.cancelAndClose()
         assert(dispatchSpy.calledTwice)
         assert(actionSpies.hideModal.calledOnce)
@@ -289,17 +289,15 @@ describe('gas-modal-page-container container', () => {
       })
     })
 
-    describe('updateCustomGasPrice()', () => {
-      it('should dispatch a setCustomGasPrice action with the arg passed to updateCustomGasPrice hex prefixed', () => {
+    describe('updateCustomGasPrice()', function () {
+      it('should dispatch a setCustomGasPrice action with the arg passed to updateCustomGasPrice hex prefixed', function () {
         mapDispatchToPropsObject.updateCustomGasPrice('ffff')
         assert(dispatchSpy.calledOnce)
         assert(gasActionSpies.setCustomGasPrice.calledOnce)
         assert.equal(gasActionSpies.setCustomGasPrice.getCall(0).args[0], '0xffff')
       })
-    })
 
-    describe('updateCustomGasPrice()', () => {
-      it('should dispatch a setCustomGasPrice action', () => {
+      it('should dispatch a setCustomGasPrice action', function () {
         mapDispatchToPropsObject.updateCustomGasPrice('0xffff')
         assert(dispatchSpy.calledOnce)
         assert(gasActionSpies.setCustomGasPrice.calledOnce)
@@ -307,9 +305,8 @@ describe('gas-modal-page-container container', () => {
       })
     })
 
-
-    describe('updateCustomGasLimit()', () => {
-      it('should dispatch a setCustomGasLimit action', () => {
+    describe('updateCustomGasLimit()', function () {
+      it('should dispatch a setCustomGasLimit action', function () {
         mapDispatchToPropsObject.updateCustomGasLimit('0x10')
         assert(dispatchSpy.calledOnce)
         assert(gasActionSpies.setCustomGasLimit.calledOnce)
@@ -317,8 +314,8 @@ describe('gas-modal-page-container container', () => {
       })
     })
 
-    describe('setGasData()', () => {
-      it('should dispatch a setGasPrice and setGasLimit action with the correct props', () => {
+    describe('setGasData()', function () {
+      it('should dispatch a setGasPrice and setGasLimit action with the correct props', function () {
         mapDispatchToPropsObject.setGasData('ffff', 'aaaa')
         assert(dispatchSpy.calledTwice)
         assert(actionSpies.setGasPrice.calledOnce)
@@ -328,8 +325,8 @@ describe('gas-modal-page-container container', () => {
       })
     })
 
-    describe('updateConfirmTxGasAndCalculate()', () => {
-      it('should dispatch a updateGasAndCalculate action with the correct props', () => {
+    describe('updateConfirmTxGasAndCalculate()', function () {
+      it('should dispatch a updateGasAndCalculate action with the correct props', function () {
         mapDispatchToPropsObject.updateConfirmTxGasAndCalculate('ffff', 'aaaa')
         assert.equal(dispatchSpy.callCount, 3)
         assert(actionSpies.setGasPrice.calledOnce)
@@ -341,12 +338,12 @@ describe('gas-modal-page-container container', () => {
 
   })
 
-  describe('mergeProps', () => {
+  describe('mergeProps', function () {
     let stateProps
     let dispatchProps
     let ownProps
 
-    beforeEach(() => {
+    beforeEach(function () {
       stateProps = {
         gasPriceButtonGroupProps: {
           someGasPriceButtonGroupProp: 'foo',
@@ -370,7 +367,7 @@ describe('gas-modal-page-container container', () => {
       ownProps = { someOwnProp: 123 }
     })
 
-    afterEach(() => {
+    afterEach(function () {
       dispatchProps.updateCustomGasPrice.resetHistory()
       dispatchProps.hideGasButtonGroup.resetHistory()
       dispatchProps.setGasData.resetHistory()
@@ -380,7 +377,7 @@ describe('gas-modal-page-container container', () => {
       dispatchProps.hideSidebar.resetHistory()
       dispatchProps.hideModal.resetHistory()
     })
-    it('should return the expected props when isConfirm is true', () => {
+    it('should return the expected props when isConfirm is true', function () {
       const result = mergeProps(stateProps, dispatchProps, ownProps)
 
       assert.equal(result.isConfirm, true)
@@ -410,7 +407,7 @@ describe('gas-modal-page-container container', () => {
       assert.equal(dispatchProps.someOtherDispatchProp.callCount, 1)
     })
 
-    it('should return the expected props when isConfirm is false', () => {
+    it('should return the expected props when isConfirm is false', function () {
       const result = mergeProps(Object.assign({}, stateProps, { isConfirm: false }), dispatchProps, ownProps)
 
       assert.equal(result.isConfirm, false)
@@ -441,7 +438,7 @@ describe('gas-modal-page-container container', () => {
       assert.equal(dispatchProps.someOtherDispatchProp.callCount, 1)
     })
 
-    it('should dispatch the expected actions from obSubmit when isConfirm is false and isSpeedUp is true', () => {
+    it('should dispatch the expected actions from obSubmit when isConfirm is false and isSpeedUp is true', function () {
       const result = mergeProps(Object.assign({}, stateProps, { isSpeedUp: true, isConfirm: false }), dispatchProps, ownProps)
 
       result.onSubmit()

--- a/ui/app/components/app/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
@@ -47,7 +47,7 @@ sinon.spy(GasPriceButtonGroup.prototype, 'renderButtonContent')
 describe('GasPriceButtonGroup Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <GasPriceButtonGroup
         {...mockGasPriceButtonGroupProps}
@@ -55,18 +55,18 @@ describe('GasPriceButtonGroup Component', function () {
     ))
   })
 
-  afterEach(() => {
+  afterEach(function () {
     GasPriceButtonGroup.prototype.renderButton.resetHistory()
     GasPriceButtonGroup.prototype.renderButtonContent.resetHistory()
     mockGasPriceButtonGroupProps.handleGasPriceSelection.resetHistory()
   })
 
-  describe('render', () => {
-    it('should render a ButtonGroup', () => {
+  describe('render', function () {
+    it('should render a ButtonGroup', function () {
       assert(wrapper.is(ButtonGroup))
     })
 
-    it('should render the correct props on the ButtonGroup', () => {
+    it('should render the correct props on the ButtonGroup', function () {
       const {
         className,
         defaultActiveButtonIndex,
@@ -88,14 +88,14 @@ describe('GasPriceButtonGroup Component', function () {
       )
     }
 
-    it('should call this.renderButton 3 times, with the correct args', () => {
+    it('should call this.renderButton 3 times, with the correct args', function () {
       assert.equal(GasPriceButtonGroup.prototype.renderButton.callCount, 3)
       renderButtonArgsTest(0, mockButtonPropsAndFlags)
       renderButtonArgsTest(1, mockButtonPropsAndFlags)
       renderButtonArgsTest(2, mockButtonPropsAndFlags)
     })
 
-    it('should show loading if buttonDataLoading', () => {
+    it('should show loading if buttonDataLoading', function () {
       wrapper.setProps({ buttonDataLoading: true })
       assert(wrapper.is('div'))
       assert(wrapper.hasClass('gas-price-button-group__loading-container'))
@@ -103,10 +103,10 @@ describe('GasPriceButtonGroup Component', function () {
     })
   })
 
-  describe('renderButton', () => {
+  describe('renderButton', function () {
     let wrappedRenderButtonResult
 
-    beforeEach(() => {
+    beforeEach(function () {
       GasPriceButtonGroup.prototype.renderButtonContent.resetHistory()
       const renderButtonResult = GasPriceButtonGroup.prototype.renderButton(
         Object.assign({}, mockGasPriceButtonGroupProps.gasButtonInfo[0]),
@@ -115,11 +115,11 @@ describe('GasPriceButtonGroup Component', function () {
       wrappedRenderButtonResult = shallow(renderButtonResult)
     })
 
-    it('should render a button', () => {
+    it('should render a button', function () {
       assert.equal(wrappedRenderButtonResult.type(), 'button')
     })
 
-    it('should call the correct method when clicked', () => {
+    it('should call the correct method when clicked', function () {
       assert.equal(mockGasPriceButtonGroupProps.handleGasPriceSelection.callCount, 0)
       wrappedRenderButtonResult.props().onClick()
       assert.equal(mockGasPriceButtonGroupProps.handleGasPriceSelection.callCount, 1)
@@ -129,7 +129,7 @@ describe('GasPriceButtonGroup Component', function () {
       )
     })
 
-    it('should call this.renderButtonContent with the correct args', () => {
+    it('should call this.renderButtonContent with the correct args', function () {
       assert.equal(GasPriceButtonGroup.prototype.renderButtonContent.callCount, 1)
       const {
         feeInPrimaryCurrency,
@@ -157,8 +157,8 @@ describe('GasPriceButtonGroup Component', function () {
     })
   })
 
-  describe('renderButtonContent', () => {
-    it('should render a label if passed a gasEstimateType', () => {
+  describe('renderButtonContent', function () {
+    it('should render a label if passed a gasEstimateType', function () {
       const renderButtonContentResult = wrapper.instance().renderButtonContent({
         gasEstimateType: 'SLOW',
       }, {
@@ -169,7 +169,7 @@ describe('GasPriceButtonGroup Component', function () {
       assert.equal(wrappedRenderButtonContentResult.find('.someClass__label').text(), 'slow')
     })
 
-    it('should render a feeInPrimaryCurrency if passed a feeInPrimaryCurrency', () => {
+    it('should render a feeInPrimaryCurrency if passed a feeInPrimaryCurrency', function () {
       const renderButtonContentResult = GasPriceButtonGroup.prototype.renderButtonContent({
         feeInPrimaryCurrency: 'mockFeeInPrimaryCurrency',
       }, {
@@ -180,7 +180,7 @@ describe('GasPriceButtonGroup Component', function () {
       assert.equal(wrappedRenderButtonContentResult.find('.someClass__primary-currency').text(), 'mockFeeInPrimaryCurrency')
     })
 
-    it('should render a feeInSecondaryCurrency if passed a feeInSecondaryCurrency', () => {
+    it('should render a feeInSecondaryCurrency if passed a feeInSecondaryCurrency', function () {
       const renderButtonContentResult = GasPriceButtonGroup.prototype.renderButtonContent({
         feeInSecondaryCurrency: 'mockFeeInSecondaryCurrency',
       }, {
@@ -191,7 +191,7 @@ describe('GasPriceButtonGroup Component', function () {
       assert.equal(wrappedRenderButtonContentResult.find('.someClass__secondary-currency').text(), 'mockFeeInSecondaryCurrency')
     })
 
-    it('should render a timeEstimate if passed a timeEstimate', () => {
+    it('should render a timeEstimate if passed a timeEstimate', function () {
       const renderButtonContentResult = GasPriceButtonGroup.prototype.renderButtonContent({
         timeEstimate: 'mockTimeEstimate',
       }, {
@@ -202,7 +202,7 @@ describe('GasPriceButtonGroup Component', function () {
       assert.equal(wrappedRenderButtonContentResult.find('.someClass__time-estimate').text(), 'mockTimeEstimate')
     })
 
-    it('should render a check if showCheck is true', () => {
+    it('should render a check if showCheck is true', function () {
       const renderButtonContentResult = GasPriceButtonGroup.prototype.renderButtonContent({}, {
         className: 'someClass',
         showCheck: true,
@@ -211,7 +211,7 @@ describe('GasPriceButtonGroup Component', function () {
       assert.equal(wrappedRenderButtonContentResult.find('.fa-check').length, 1)
     })
 
-    it('should render all elements if all args passed', () => {
+    it('should render all elements if all args passed', function () {
       const renderButtonContentResult = wrapper.instance().renderButtonContent({
         gasEstimateType: 'SLOW',
         feeInPrimaryCurrency: 'mockFeeInPrimaryCurrency',
@@ -226,7 +226,7 @@ describe('GasPriceButtonGroup Component', function () {
     })
 
 
-    it('should render no elements if all args passed', () => {
+    it('should render no elements if all args passed', function () {
       const renderButtonContentResult = GasPriceButtonGroup.prototype.renderButtonContent({}, {})
       const wrappedRenderButtonContentResult = shallow(renderButtonContentResult)
       assert.equal(wrappedRenderButtonContentResult.children().length, 0)

--- a/ui/app/components/app/gas-customization/gas-price-chart/tests/gas-price-chart.component.test.js
+++ b/ui/app/components/app/gas-customization/gas-price-chart/tests/gas-price-chart.component.test.js
@@ -77,37 +77,37 @@ sinon.spy(GasPriceChart.prototype, 'renderChart')
 describe('GasPriceChart Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow(<GasPriceChart {...testProps} />)
   })
 
-  describe('render()', () => {
-    it('should render', () => {
+  describe('render()', function () {
+    it('should render', function () {
       assert(wrapper.hasClass('gas-price-chart'))
     })
 
-    it('should render the chart div', () => {
+    it('should render the chart div', function () {
       assert(wrapper.childAt(0).hasClass('gas-price-chart__root'))
       assert.equal(wrapper.childAt(0).props().id, 'chart')
     })
   })
 
-  describe('componentDidMount', () => {
-    it('should call this.renderChart', () => {
+  describe('componentDidMount', function () {
+    it('should call this.renderChart', function () {
       assert(GasPriceChart.prototype.renderChart.callCount, 1)
       wrapper.instance().componentDidMount()
       assert(GasPriceChart.prototype.renderChart.callCount, 2)
     })
   })
 
-  describe('componentDidUpdate', () => {
-    it('should call handleChartUpdate if props.currentPrice has changed', () => {
+  describe('componentDidUpdate', function () {
+    it('should call handleChartUpdate if props.currentPrice has changed', function () {
       gasPriceChartUtilsSpies.handleChartUpdate.resetHistory()
       wrapper.instance().componentDidUpdate({ currentPrice: 7 })
       assert.equal(gasPriceChartUtilsSpies.handleChartUpdate.callCount, 1)
     })
 
-    it('should call handleChartUpdate with the correct props', () => {
+    it('should call handleChartUpdate with the correct props', function () {
       gasPriceChartUtilsSpies.handleChartUpdate.resetHistory()
       wrapper.instance().componentDidUpdate({ currentPrice: 7 })
       assert.deepEqual(gasPriceChartUtilsSpies.handleChartUpdate.getCall(0).args, [{
@@ -118,15 +118,15 @@ describe('GasPriceChart Component', function () {
       }])
     })
 
-    it('should not call handleChartUpdate if props.currentPrice has not changed', () => {
+    it('should not call handleChartUpdate if props.currentPrice has not changed', function () {
       gasPriceChartUtilsSpies.handleChartUpdate.resetHistory()
       wrapper.instance().componentDidUpdate({ currentPrice: 6 })
       assert.equal(gasPriceChartUtilsSpies.handleChartUpdate.callCount, 0)
     })
   })
 
-  describe('renderChart', () => {
-    it('should call setTickPosition 4 times, with the expected props', async () => {
+  describe('renderChart', function () {
+    it('should call setTickPosition 4 times, with the expected props', async function () {
       await timeout(0)
       gasPriceChartUtilsSpies.setTickPosition.resetHistory()
       assert.equal(gasPriceChartUtilsSpies.setTickPosition.callCount, 0)
@@ -139,7 +139,7 @@ describe('GasPriceChart Component', function () {
       assert.deepEqual(gasPriceChartUtilsSpies.setTickPosition.getCall(3).args, ['x', 1, 3, -8])
     })
 
-    it('should call handleChartUpdate with the correct props', async () => {
+    it('should call handleChartUpdate with the correct props', async function () {
       await timeout(0)
       gasPriceChartUtilsSpies.handleChartUpdate.resetHistory()
       wrapper.instance().renderChart(testProps)
@@ -152,7 +152,7 @@ describe('GasPriceChart Component', function () {
       }])
     })
 
-    it('should add three events to the chart', async () => {
+    it('should add three events to the chart', async function () {
       await timeout(0)
       selectReturnSpies.on.resetHistory()
       assert.equal(selectReturnSpies.on.callCount, 0)
@@ -168,7 +168,7 @@ describe('GasPriceChart Component', function () {
       assert.equal(thirdOnEventArgs[0], 'mousemove')
     })
 
-    it('should hide the data UI on mouseout', async () => {
+    it('should hide the data UI on mouseout', async function () {
       await timeout(0)
       selectReturnSpies.on.resetHistory()
       wrapper.instance().renderChart(testProps)
@@ -181,7 +181,7 @@ describe('GasPriceChart Component', function () {
       assert.deepEqual(gasPriceChartUtilsSpies.hideDataUI.getCall(0).args, [{ mockChart: true }, '#overlayed-circle'])
     })
 
-    it('should updateCustomGasPrice on click', async () => {
+    it('should updateCustomGasPrice on click', async function () {
       await timeout(0)
       selectReturnSpies.on.resetHistory()
       wrapper.instance().renderChart(testProps)
@@ -194,7 +194,7 @@ describe('GasPriceChart Component', function () {
       assert.equal(propsMethodSpies.updateCustomGasPrice.getCall(0).args[0], 'mockX')
     })
 
-    it('should handle mousemove', async () => {
+    it('should handle mousemove', async function () {
       await timeout(0)
       selectReturnSpies.on.resetHistory()
       wrapper.instance().renderChart(testProps)

--- a/ui/app/components/app/info-box/tests/info-box.test.js
+++ b/ui/app/components/app/info-box/tests/info-box.test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme'
 
 import InfoBox from '../index'
 
-describe('InfoBox', () => {
+describe('InfoBox', function () {
 
   let wrapper
 
@@ -15,21 +15,21 @@ describe('InfoBox', () => {
     onClose: sinon.spy(),
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow(<InfoBox {...props} />)
   })
 
-  it('renders title from props', () => {
+  it('renders title from props', function () {
     const title = wrapper.find('.info-box__title')
     assert.equal(title.text(), props.title)
   })
 
-  it('renders description from props', () => {
+  it('renders description from props', function () {
     const description = wrapper.find('.info-box__description')
     assert.equal(description.text(), props.description)
   })
 
-  it('closes info box', () => {
+  it('closes info box', function () {
     const close = wrapper.find('.info-box__close')
     close.simulate('click')
     assert(props.onClose.calledOnce)

--- a/ui/app/components/app/menu-bar/tests/menu-bar.test.js
+++ b/ui/app/components/app/menu-bar/tests/menu-bar.test.js
@@ -6,7 +6,7 @@ import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import MenuBar from '../index'
 import { Provider } from 'react-redux'
 
-describe('MenuBar', () => {
+describe('MenuBar', function () {
   let wrapper
 
   const mockStore = {
@@ -38,11 +38,11 @@ describe('MenuBar', () => {
 
   const store = configureStore()(mockStore)
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore()
   })
 
-  it('shows side bar when sidbarOpen is set to false', () => {
+  it('shows side bar when sidbarOpen is set to false', function () {
     const props = {
       showSidebar: sinon.spy(),
     }
@@ -58,7 +58,7 @@ describe('MenuBar', () => {
     assert(props.showSidebar.calledOnce)
   })
 
-  it('hides side when sidebarOpen is set to true', () => {
+  it('hides side when sidebarOpen is set to true', function () {
     const props = {
       showSidebar: sinon.spy(),
       hideSidebar: sinon.spy(),
@@ -76,13 +76,13 @@ describe('MenuBar', () => {
     assert(props.hideSidebar.calledOnce)
   })
 
-  it('opens account detail menu when account options is clicked', () => {
+  it('opens account detail menu when account options is clicked', function () {
     const accountOptions = wrapper.find('.menu-bar__open-in-browser')
     accountOptions.simulate('click')
     assert.equal(wrapper.find('MenuBar').instance().state.accountDetailsMenuOpen, true)
   })
 
-  it('sets accountDetailsMenuOpen to false when closed', () => {
+  it('sets accountDetailsMenuOpen to false when closed', function () {
     wrapper.find('MenuBar').instance().setState({ accountDetailsMenuOpen: true })
     wrapper.update()
 

--- a/ui/app/components/app/modal/modal-content/tests/modal-content.component.test.js
+++ b/ui/app/components/app/modal/modal-content/tests/modal-content.component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import ModalContent from '../modal-content.component'
 
-describe('ModalContent Component', () => {
-  it('should render a title', () => {
+describe('ModalContent Component', function () {
+  it('should render a title', function () {
     const wrapper = shallow(
       <ModalContent
         title="Modal Title"
@@ -16,7 +16,7 @@ describe('ModalContent Component', () => {
     assert.equal(wrapper.find('.modal-content__description').length, 0)
   })
 
-  it('should render a description', () => {
+  it('should render a description', function () {
     const wrapper = shallow(
       <ModalContent
         description="Modal Description"
@@ -28,7 +28,7 @@ describe('ModalContent Component', () => {
     assert.equal(wrapper.find('.modal-content__description').text(), 'Modal Description')
   })
 
-  it('should render both a title and a description', () => {
+  it('should render both a title and a description', function () {
     const wrapper = shallow(
       <ModalContent
         title="Modal Title"

--- a/ui/app/components/app/modal/tests/modal.component.test.js
+++ b/ui/app/components/app/modal/tests/modal.component.test.js
@@ -5,8 +5,8 @@ import sinon from 'sinon'
 import Modal from '../modal.component'
 import Button from '../../../ui/button'
 
-describe('Modal Component', () => {
-  it('should render a modal with a submit button', () => {
+describe('Modal Component', function () {
+  it('should render a modal with a submit button', function () {
     const wrapper = shallow(<Modal />)
 
     assert.equal(wrapper.find('.modal-container').length, 1)
@@ -15,7 +15,7 @@ describe('Modal Component', () => {
     assert.equal(buttons.at(0).props().type, 'secondary')
   })
 
-  it('should render a modal with a cancel and a submit button', () => {
+  it('should render a modal with a cancel and a submit button', function () {
     const handleCancel = sinon.spy()
     const handleSubmit = sinon.spy()
     const wrapper = shallow(
@@ -45,7 +45,7 @@ describe('Modal Component', () => {
     assert.equal(handleSubmit.callCount, 1)
   })
 
-  it('should render a modal with different button types', () => {
+  it('should render a modal with different button types', function () {
     const wrapper = shallow(
       <Modal
         onCancel={() => {}}
@@ -63,7 +63,7 @@ describe('Modal Component', () => {
     assert.equal(buttons.at(1).props().type, 'confirm')
   })
 
-  it('should render a modal with children', () => {
+  it('should render a modal with children', function () {
     const wrapper = shallow(
       <Modal
         onCancel={() => {}}
@@ -78,7 +78,7 @@ describe('Modal Component', () => {
     assert.ok(wrapper.find('.test-class'))
   })
 
-  it('should render a modal with a header', () => {
+  it('should render a modal with a header', function () {
     const handleCancel = sinon.spy()
     const handleSubmit = sinon.spy()
     const wrapper = shallow(
@@ -101,7 +101,7 @@ describe('Modal Component', () => {
     assert.equal(handleSubmit.callCount, 0)
   })
 
-  it('should disable the submit button if submitDisabled is true', () => {
+  it('should disable the submit button if submitDisabled is true', function () {
     const handleCancel = sinon.spy()
     const handleSubmit = sinon.spy()
     const wrapper = mount(

--- a/ui/app/components/app/modals/cancel-transaction/cancel-transaction-gas-fee/tests/cancel-transaction-gas-fee.component.test.js
+++ b/ui/app/components/app/modals/cancel-transaction/cancel-transaction-gas-fee/tests/cancel-transaction-gas-fee.component.test.js
@@ -4,8 +4,8 @@ import { shallow } from 'enzyme'
 import CancelTransactionGasFee from '../cancel-transaction-gas-fee.component'
 import UserPreferencedCurrencyDisplay from '../../../../user-preferenced-currency-display'
 
-describe('CancelTransactionGasFee Component', () => {
-  it('should render', () => {
+describe('CancelTransactionGasFee Component', function () {
+  it('should render', function () {
     const wrapper = shallow(
       <CancelTransactionGasFee
         value="0x3b9aca00"

--- a/ui/app/components/app/modals/cancel-transaction/tests/cancel-transaction.component.test.js
+++ b/ui/app/components/app/modals/cancel-transaction/tests/cancel-transaction.component.test.js
@@ -6,10 +6,10 @@ import CancelTransaction from '../cancel-transaction.component'
 import CancelTransactionGasFee from '../cancel-transaction-gas-fee'
 import Modal from '../../../modal'
 
-describe('CancelTransaction Component', () => {
+describe('CancelTransaction Component', function () {
   const t = key => key
 
-  it('should render a CancelTransaction modal', () => {
+  it('should render a CancelTransaction modal', function () {
     const wrapper = shallow(
       <CancelTransaction
         newGasFee="0x1319718a5000"
@@ -25,7 +25,7 @@ describe('CancelTransaction Component', () => {
     assert.equal(wrapper.find('.cancel-transaction__description').text(), 'attemptToCancelDescription')
   })
 
-  it('should pass the correct props to the Modal component', async () => {
+  it('should pass the correct props to the Modal component', async function () {
     const createCancelTransactionSpy = sinon.stub().callsFake(() => Promise.resolve())
     const hideModalSpy = sinon.spy()
 

--- a/ui/app/components/app/modals/confirm-delete-network/tests/confirm-delete-network.test.js
+++ b/ui/app/components/app/modals/confirm-delete-network/tests/confirm-delete-network.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import ConfirmDeleteNetwork from '../index'
 
-describe('Confirm Delete Network', () => {
+describe('Confirm Delete Network', function () {
   let wrapper
 
   const props = {
@@ -14,7 +14,7 @@ describe('Confirm Delete Network', () => {
     target: '',
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <ConfirmDeleteNetwork.WrappedComponent {...props} />, {
         context: {
@@ -24,18 +24,18 @@ describe('Confirm Delete Network', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.hideModal.resetHistory()
     props.delRpcTarget.resetHistory()
     props.onConfirm.resetHistory()
   })
 
-  it('renders delete network modal title', () => {
+  it('renders delete network modal title', function () {
     const modalTitle = wrapper.find('.modal-content__title')
     assert.equal(modalTitle.text(), 'deleteNetwork')
   })
 
-  it('clicks cancel to hide modal', () => {
+  it('clicks cancel to hide modal', function () {
     const cancelButton = wrapper.find('.button.btn-default.modal-container__footer-button')
     cancelButton.simulate('click')
 
@@ -43,7 +43,7 @@ describe('Confirm Delete Network', () => {
 
   })
 
-  it('clicks delete to delete the target and hides modal', () => {
+  it('clicks delete to delete the target and hides modal', function () {
     const deleteButton = wrapper.find('.button.btn-danger.modal-container__footer-button')
 
     deleteButton.simulate('click')

--- a/ui/app/components/app/modals/confirm-remove-account/tests/confirm-remove-account.test.js
+++ b/ui/app/components/app/modals/confirm-remove-account/tests/confirm-remove-account.test.js
@@ -7,7 +7,7 @@ import configureStore from 'redux-mock-store'
 import { mount } from 'enzyme'
 import ConfirmRemoveAccount from '../index'
 
-describe('Confirm Remove Account', () => {
+describe('Confirm Remove Account', function () {
   let wrapper
 
   const state = {
@@ -30,7 +30,7 @@ describe('Confirm Remove Account', () => {
   const mockStore = configureStore()
   const store = mockStore(state)
 
-  beforeEach(() => {
+  beforeEach(function () {
 
     wrapper = mount(
       <Provider store={store} >
@@ -48,18 +48,18 @@ describe('Confirm Remove Account', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.hideModal.resetHistory()
   })
 
-  it('nevermind', () => {
+  it('nevermind', function () {
     const nevermind = wrapper.find({ type: 'default' })
     nevermind.simulate('click')
 
     assert(props.hideModal.calledOnce)
   })
 
-  it('remove', (done) => {
+  it('remove', function (done) {
     const remove = wrapper.find({ type: 'secondary' })
     remove.simulate('click')
 
@@ -73,7 +73,7 @@ describe('Confirm Remove Account', () => {
 
   })
 
-  it('closes', () => {
+  it('closes', function () {
     const close = wrapper.find('.modal-container__header-close')
     close.simulate('click')
 

--- a/ui/app/components/app/modals/confirm-reset-account/tests/confirm-reset-account.test.js
+++ b/ui/app/components/app/modals/confirm-reset-account/tests/confirm-reset-account.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import ConfirmResetAccount from '../index'
 
-describe('Confirm Reset Account', () => {
+describe('Confirm Reset Account', function () {
   let wrapper
 
   const props = {
@@ -12,7 +12,7 @@ describe('Confirm Reset Account', () => {
     resetAccount: sinon.stub().resolves(),
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <ConfirmResetAccount.WrappedComponent {...props} />, {
         context: {
@@ -22,18 +22,18 @@ describe('Confirm Reset Account', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.hideModal.resetHistory()
   })
 
-  it('hides modal when nevermind button is clicked', () => {
+  it('hides modal when nevermind button is clicked', function () {
     const nevermind = wrapper.find('.btn-default.modal-container__footer-button')
     nevermind.simulate('click')
 
     assert(props.hideModal.calledOnce)
   })
 
-  it('resets account and hidels modal when reset button is clicked', (done) => {
+  it('resets account and hidels modal when reset button is clicked', function (done) {
     const reset = wrapper.find('.btn-danger.modal-container__footer-button')
     reset.simulate('click')
 

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/tests/metametrics-opt-in-modal.test.js
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/tests/metametrics-opt-in-modal.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import MetaMetricsOptIn from '../index'
 
-describe('MetaMetrics Opt In', () => {
+describe('MetaMetrics Opt In', function () {
   let wrapper
 
   const props = {
@@ -13,7 +13,7 @@ describe('MetaMetrics Opt In', () => {
     participateInMetaMetrics: null,
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <MetaMetricsOptIn.WrappedComponent {...props} />, {
         context: {
@@ -23,12 +23,12 @@ describe('MetaMetrics Opt In', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.setParticipateInMetaMetrics.resetHistory()
     props.hideModal.resetHistory()
   })
 
-  it('passes false to setParticipateInMetaMetrics and hides modal', (done) => {
+  it('passes false to setParticipateInMetaMetrics and hides modal', function (done) {
     const noThanks = wrapper.find('.btn-default.page-container__footer-button')
     noThanks.simulate('click')
 
@@ -40,7 +40,7 @@ describe('MetaMetrics Opt In', () => {
     })
   })
 
-  it('passes true to setParticipateInMetaMetrics and hides modal', (done) => {
+  it('passes true to setParticipateInMetaMetrics and hides modal', function (done) {
     const iAgree = wrapper.find('.btn-primary.page-container__footer-button')
     iAgree.simulate('click')
 

--- a/ui/app/components/app/modals/reject-transactions/tests/reject-transactions.test.js
+++ b/ui/app/components/app/modals/reject-transactions/tests/reject-transactions.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import RejectTransactionsModal from '../index'
 
-describe('Reject Transactions Model', () => {
+describe('Reject Transactions Model', function () {
   let wrapper
 
   const props = {
@@ -13,7 +13,7 @@ describe('Reject Transactions Model', () => {
     unapprovedTxCount: 2,
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <RejectTransactionsModal.WrappedComponent {...props} />, {
         context: {
@@ -23,18 +23,18 @@ describe('Reject Transactions Model', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.hideModal.resetHistory()
   })
 
-  it('hides modal when cancel button is clicked', () => {
+  it('hides modal when cancel button is clicked', function () {
     const cancelButton = wrapper.find('.btn-default.modal-container__footer-button')
     cancelButton.simulate('click')
 
     assert(props.hideModal.calledOnce)
   })
 
-  it('onSubmit is called and hides modal when reject all clicked', (done) => {
+  it('onSubmit is called and hides modal when reject all clicked', function (done) {
     const rejectAllButton = wrapper.find('.btn-secondary.modal-container__footer-button')
     rejectAllButton.simulate('click')
 

--- a/ui/app/components/app/modals/tests/account-details-modal.test.js
+++ b/ui/app/components/app/modals/tests/account-details-modal.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { shallow } from 'enzyme'
 import AccountDetailsModal from '../account-details-modal'
 
-describe('Account Details Modal', () => {
+describe('Account Details Modal', function () {
   let wrapper
 
   global.platform = { openWindow: sinon.spy() }
@@ -36,7 +36,7 @@ describe('Account Details Modal', () => {
     },
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow(
       <AccountDetailsModal.WrappedComponent {...props} />, {
         context: {
@@ -46,7 +46,7 @@ describe('Account Details Modal', () => {
     )
   })
 
-  it('sets account label when changing default account label', () => {
+  it('sets account label when changing default account label', function () {
     const accountLabel = wrapper.find('.account-modal__name').first()
     accountLabel.simulate('submit', 'New Label')
 
@@ -54,7 +54,7 @@ describe('Account Details Modal', () => {
     assert.equal(props.setAccountLabel.getCall(0).args[1], 'New Label')
   })
 
-  it('opens new window when view block explorer is clicked', () => {
+  it('opens new window when view block explorer is clicked', function () {
     const modalButton = wrapper.find('.account-modal__button')
     const etherscanLink = modalButton.first()
 
@@ -62,7 +62,7 @@ describe('Account Details Modal', () => {
     assert(global.platform.openWindow.calledOnce)
   })
 
-  it('shows export private key modal when clicked', () => {
+  it('shows export private key modal when clicked', function () {
     const modalButton = wrapper.find('.account-modal__button')
     const etherscanLink = modalButton.last()
 
@@ -70,7 +70,7 @@ describe('Account Details Modal', () => {
     assert(props.showExportPrivateKeyModal.calledOnce)
   })
 
-  it('sets blockexplorerview text when block explorer url in rpcPrefs exists', () => {
+  it('sets blockexplorerview text when block explorer url in rpcPrefs exists', function () {
     const blockExplorerUrl = 'https://block.explorer'
     wrapper.setProps({ rpcPrefs: { blockExplorerUrl } })
 

--- a/ui/app/components/app/modals/transaction-confirmed/tests/transaction-confirmed.test.js
+++ b/ui/app/components/app/modals/transaction-confirmed/tests/transaction-confirmed.test.js
@@ -4,25 +4,19 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import TransactionConfirmed from '../index'
 
-describe('Transaction Confirmed', () => {
-  let wrapper
-
-  const props = {
-    onSubmit: sinon.spy(),
-    hideModal: sinon.spy(),
-  }
-
-  beforeEach(() => {
-    wrapper = mount(
+describe('Transaction Confirmed', function () {
+  it('clicks ok to submit and hide modal', function () {
+    const props = {
+      onSubmit: sinon.spy(),
+      hideModal: sinon.spy(),
+    }
+    const wrapper = mount(
       <TransactionConfirmed.WrappedComponent {...props} />, {
         context: {
           t: str => str,
         },
       }
     )
-  })
-
-  it('clicks ok to submit and hide modal', () => {
     const submit = wrapper.find('.btn-secondary.modal-container__footer-button')
     submit.simulate('click')
 

--- a/ui/app/components/app/selected-account/tests/selected-account-component.test.js
+++ b/ui/app/components/app/selected-account/tests/selected-account-component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { render } from 'enzyme'
 import SelectedAccount from '../selected-account.component'
 
-describe('SelectedAccount Component', () => {
-  it('should render checksummed address', () => {
+describe('SelectedAccount Component', function () {
+  it('should render checksummed address', function () {
     const wrapper = render((
       <SelectedAccount
         selectedAddress="0x1b82543566f41a7db9a9a75fc933c340ffb55c9d"

--- a/ui/app/components/app/sidebars/tests/sidebars-component.test.js
+++ b/ui/app/components/app/sidebars/tests/sidebars-component.test.js
@@ -15,7 +15,7 @@ const propsMethodSpies = {
 describe('Sidebar Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <Sidebar
         sidebarOpen={false}
@@ -26,43 +26,43 @@ describe('Sidebar Component', function () {
     ))
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.hideSidebar.resetHistory()
   })
 
-  describe('renderOverlay', () => {
+  describe('renderOverlay', function () {
     let renderOverlay
 
-    beforeEach(() => {
+    beforeEach(function () {
       renderOverlay = shallow(wrapper.instance().renderOverlay())
     })
 
-    it('should render a overlay element', () => {
+    it('should render a overlay element', function () {
       assert(renderOverlay.hasClass('sidebar-overlay'))
     })
 
-    it('should pass the correct onClick function to the element', () => {
+    it('should pass the correct onClick function to the element', function () {
       assert.equal(propsMethodSpies.hideSidebar.callCount, 0)
       renderOverlay.props().onClick()
       assert.equal(propsMethodSpies.hideSidebar.callCount, 1)
     })
   })
 
-  describe('renderSidebarContent', () => {
+  describe('renderSidebarContent', function () {
     let renderSidebarContent
 
-    beforeEach(() => {
+    beforeEach(function () {
       wrapper.setProps({ type: 'wallet-view' })
       renderSidebarContent = wrapper.instance().renderSidebarContent()
     })
 
-    it('should render sidebar content with the correct props', () => {
+    it('should render sidebar content with the type wallet-view', function () {
       wrapper.setProps({ type: 'wallet-view' })
       renderSidebarContent = wrapper.instance().renderSidebarContent()
       assert.equal(renderSidebarContent.props.responsiveDisplayClassname, 'sidebar-right')
     })
 
-    it('should render sidebar content with the correct props', () => {
+    it('should render sidebar content with the type customize-gas', function () {
       wrapper.setProps({ type: 'customize-gas' })
       renderSidebarContent = wrapper.instance().renderSidebarContent()
       const renderedSidebarContent = shallow(renderSidebarContent)
@@ -70,25 +70,25 @@ describe('Sidebar Component', function () {
       assert(renderedSidebarContent.childAt(0).is(CustomizeGas))
     })
 
-    it('should not render with an unrecognized type', () => {
+    it('should not render with an unrecognized type', function () {
       wrapper.setProps({ type: 'foobar' })
       renderSidebarContent = wrapper.instance().renderSidebarContent()
       assert.equal(renderSidebarContent, undefined)
     })
   })
 
-  describe('render', () => {
-    it('should render a div with one child', () => {
+  describe('render', function () {
+    it('should render a div with one child', function () {
       assert(wrapper.is('div'))
       assert.equal(wrapper.children().length, 1)
     })
 
-    it('should render the ReactCSSTransitionGroup without any children', () => {
+    it('should render the ReactCSSTransitionGroup without any children', function () {
       assert(wrapper.children().at(0).is(ReactCSSTransitionGroup))
       assert.equal(wrapper.children().at(0).children().length, 0)
     })
 
-    it('should render sidebar content and the overlay if sidebarOpen is true', () => {
+    it('should render sidebar content and the overlay if sidebarOpen is true', function () {
       wrapper.setProps({ sidebarOpen: true })
       assert.equal(wrapper.children().length, 2)
       assert(wrapper.children().at(1).hasClass('sidebar-overlay'))

--- a/ui/app/components/app/signature-request/tests/signature-request.test.js
+++ b/ui/app/components/app/signature-request/tests/signature-request.test.js
@@ -5,26 +5,22 @@ import SignatureRequest from '../signature-request.component'
 
 
 describe('Signature Request Component', function () {
-  let wrapper
+  describe('render', function () {
+    it('should render a div with one child', function () {
+      const wrapper = shallow((
+        <SignatureRequest
+          clearConfirmTransaction={() => {}}
+          cancel={() => {}}
+          sign={() => {}}
+          txData={{
+            msgParams: {
+              data: '{"message": {"from": {"name": "hello"}}}',
+              from: '0x123456789abcdef',
+            },
+          }}
+        />
+      ))
 
-  beforeEach(() => {
-    wrapper = shallow((
-      <SignatureRequest
-        clearConfirmTransaction={() => {}}
-        cancel={() => {}}
-        sign={() => {}}
-        txData={{
-          msgParams: {
-            data: '{"message": {"from": {"name": "hello"}}}',
-            from: '0x123456789abcdef',
-          },
-        }}
-      />
-    ))
-  })
-
-  describe('render', () => {
-    it('should render a div with one child', () => {
       assert(wrapper.is('div'))
       assert.equal(wrapper.length, 1)
       assert(wrapper.hasClass('signature-request'))

--- a/ui/app/components/app/tests/signature-request.test.js
+++ b/ui/app/components/app/tests/signature-request.test.js
@@ -6,7 +6,7 @@ import configureMockStore from 'redux-mock-store'
 import { mountWithRouter } from '../../../../../test/lib/render-helpers'
 import SignatureRequest from '../signature-request'
 
-describe('Signature Request', () => {
+describe('Signature Request', function () {
   let wrapper
 
   const mockStore = {
@@ -40,7 +40,7 @@ describe('Signature Request', () => {
     },
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mountWithRouter(
       <Provider store={store}>
         <SignatureRequest.WrappedComponent {...props} />
@@ -48,18 +48,18 @@ describe('Signature Request', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.clearConfirmTransaction.resetHistory()
   })
 
-  it('cancel', () => {
+  it('cancel', function () {
     const cancelButton = wrapper.find('button.btn-default')
     cancelButton.simulate('click')
 
     assert(props.cancel.calledOnce)
   })
 
-  it('sign', () => {
+  it('sign', function () {
     const signButton = wrapper.find('button.btn-primary')
     signButton.simulate('click')
 

--- a/ui/app/components/app/tests/token-cell.spec.js
+++ b/ui/app/components/app/tests/token-cell.spec.js
@@ -8,7 +8,7 @@ import { mount } from 'enzyme'
 import TokenCell from '../token-cell'
 import Identicon from '../../ui/identicon'
 
-describe('Token Cell', () => {
+describe('Token Cell', function () {
   let wrapper
 
   const state = {
@@ -33,7 +33,7 @@ describe('Token Cell', () => {
   const mockStore = configureMockStore(middlewares)
   const store = mockStore(state)
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <Provider store={store}>
         <TokenCell
@@ -48,21 +48,21 @@ describe('Token Cell', () => {
     )
   })
 
-  it('renders Identicon with props from token cell', () => {
+  it('renders Identicon with props from token cell', function () {
     assert.equal(wrapper.find(Identicon).prop('address'), '0xAnotherToken')
     assert.equal(wrapper.find(Identicon).prop('network'), 'test')
     assert.equal(wrapper.find(Identicon).prop('image'), './test-image')
   })
 
-  it('renders token balance', () => {
+  it('renders token balance', function () {
     assert.equal(wrapper.find('.token-list-item__token-balance').text(), '5.000')
   })
 
-  it('renders token symbol', () => {
+  it('renders token symbol', function () {
     assert.equal(wrapper.find('.token-list-item__token-symbol').text(), 'TEST')
   })
 
-  it('renders converted fiat amount', () => {
+  it('renders converted fiat amount', function () {
     assert.equal(wrapper.find('.token-list-item__fiat-amount').text(), '0.52 USD')
   })
 

--- a/ui/app/components/app/transaction-action/tests/transaction-action.component.test.js
+++ b/ui/app/components/app/transaction-action/tests/transaction-action.component.test.js
@@ -4,12 +4,12 @@ import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import TransactionAction from '../transaction-action.component'
 
-describe('TransactionAction Component', () => {
+describe('TransactionAction Component', function () {
   const t = key => key
 
 
-  describe('Outgoing transaction', () => {
-    beforeEach(() => {
+  describe('Outgoing transaction', function () {
+    beforeEach(function () {
       global.eth = {
         getCode: sinon.stub().callsFake(address => {
           const code = address === 'approveAddress' ? 'contract' : '0x'
@@ -18,7 +18,7 @@ describe('TransactionAction Component', () => {
       }
     })
 
-    it('should render Sent Ether', () => {
+    it('should render Sent Ether', function () {
       const methodData = { data: {}, done: true, error: null }
       const transaction = {
         id: 1,
@@ -48,7 +48,7 @@ describe('TransactionAction Component', () => {
       assert.equal(wrapper.text(), 'sentEther')
     })
 
-    it('should render Approved', async () => {
+    it('should render Approved', async function () {
       const methodData = {
         name: 'Approve',
       }
@@ -83,7 +83,7 @@ describe('TransactionAction Component', () => {
       assert.equal(wrapper.find('.transaction-action').text().trim(), 'Approve')
     })
 
-    it('should render contractInteraction', async () => {
+    it('should render contractInteraction', async function () {
       const methodData = {}
       const transaction = {
         id: 1,

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import TransactionActivityLog from '../transaction-activity-log.component'
 
-describe('TransactionActivityLog Component', () => {
-  it('should render properly', () => {
+describe('TransactionActivityLog Component', function () {
+  it('should render properly', function () {
     const activities = [
       {
         eventKey: 'transactionCreated',
@@ -51,7 +51,7 @@ describe('TransactionActivityLog Component', () => {
     assert.ok(wrapper.hasClass('test-class'))
   })
 
-  it('should render inline retry and cancel buttons for earliest pending transaction', () => {
+  it('should render inline retry and cancel buttons for earliest pending transaction', function () {
     const activities = [
       {
         eventKey: 'transactionCreated',
@@ -100,7 +100,7 @@ describe('TransactionActivityLog Component', () => {
     assert.equal(wrapper.find('.transaction-activity-log__action-link').length, 2)
   })
 
-  it('should not render inline retry and cancel buttons for newer pending transactions', () => {
+  it('should not render inline retry and cancel buttons for newer pending transactions', function () {
     const activities = [
       {
         eventKey: 'transactionCreated',

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.container.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.container.test.js
@@ -12,9 +12,9 @@ proxyquire('../transaction-activity-log.container.js', {
   },
 })
 
-describe('TransactionActivityLog container', () => {
-  describe('mapStateToProps()', () => {
-    it('should return the correct props', () => {
+describe('TransactionActivityLog container', function () {
+  describe('mapStateToProps()', function () {
+    it('should return the correct props', function () {
       const mockState = {
         metamask: {
           conversionRate: 280.45,

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
@@ -1,335 +1,337 @@
 import assert from 'assert'
 import { combineTransactionHistories, getActivities } from '../transaction-activity-log.util'
 
-describe('combineTransactionHistories', () => {
-  it('should return no activites for an empty list of transactions', () => {
-    assert.deepEqual(combineTransactionHistories([]), [])
-  })
+describe('TransactionActivityLog utils', function () {
+  describe('combineTransactionHistories', function () {
+    it('should return no activites for an empty list of transactions', function () {
+      assert.deepEqual(combineTransactionHistories([]), [])
+    })
 
-  it('should return activities for an array of transactions', () => {
-    const transactions = [
-      {
-        estimatedGas: '0x5208',
-        hash: '0xa14f13d36b3901e352ce3a7acb9b47b001e5a3370f06232a0953c6fc6fad91b3',
-        history: [
-          {
-            'id': 6400627574331058,
-            'time': 1543958845581,
-            'status': 'unapproved',
-            'metamaskNetworkId': '3',
-            'loadingDefaults': true,
-            'txParams': {
-              'from': '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
-              'to': '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
-              'value': '0x2386f26fc10000',
-              'gas': '0x5208',
-              'gasPrice': '0x3b9aca00',
-            },
-            'type': 'standard',
-          },
-          [{ 'op': 'replace', 'path': '/status', 'value': 'approved', 'note': 'txStateManager: setting status to approved', 'timestamp': 1543958847813 }],
-          [{ 'op': 'replace', 'path': '/status', 'value': 'submitted', 'note': 'txStateManager: setting status to submitted', 'timestamp': 1543958848147 }],
-          [{ 'op': 'replace', 'path': '/status', 'value': 'dropped', 'note': 'txStateManager: setting status to dropped', 'timestamp': 1543958897181 }, { 'op': 'add', 'path': '/replacedBy', 'value': '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33' }],
-        ],
-        id: 6400627574331058,
-        loadingDefaults: false,
-        metamaskNetworkId: '3',
-        status: 'dropped',
-        submittedTime: 1543958848135,
-        time: 1543958845581,
-        txParams: {
-          from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
-          gas: '0x5208',
-          gasPrice: '0x3b9aca00',
-          nonce: '0x32',
-          to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
-          value: '0x2386f26fc10000',
-        },
-        type: 'standard',
-      }, {
-        hash: '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33',
-        history: [
-          {
-            'id': 6400627574331060,
-            'time': 1543958857697,
-            'status': 'unapproved',
-            'metamaskNetworkId': '3',
-            'loadingDefaults': false,
-            'txParams': {
-              'from': '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
-              'to': '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
-              'value': '0x2386f26fc10000',
-              'gas': '0x5208',
-              'gasPrice': '0x3b9aca00',
-              'nonce': '0x32',
-            },
-            'lastGasPrice': '0x4190ab00',
-            'type': 'retry',
-          },
-          [{ 'op': 'replace', 'path': '/txParams/gasPrice', 'value': '0x481f2280', 'note': 'confTx: user approved transaction', 'timestamp': 1543958859470 }],
-          [{ 'op': 'replace', 'path': '/status', 'value': 'approved', 'note': 'txStateManager: setting status to approved', 'timestamp': 1543958859485 }],
-          [{ 'op': 'replace', 'path': '/status', 'value': 'signed', 'note': 'transactions#publishTransaction', 'timestamp': 1543958859889 }],
-          [{ 'op': 'replace', 'path': '/status', 'value': 'submitted', 'note': 'txStateManager: setting status to submitted', 'timestamp': 1543958860061 }], [{ 'op': 'add', 'path': '/firstRetryBlockNumber', 'value': '0x45a0fd', 'note': 'transactions/pending-tx-tracker#event: tx:block-update', 'timestamp': 1543958896466 }],
-          [{ 'op': 'replace', 'path': '/status', 'value': 'confirmed', 'timestamp': 1543958897165 }],
-        ],
-        id: 6400627574331060,
-        lastGasPrice: '0x4190ab00',
-        loadingDefaults: false,
-        metamaskNetworkId: '3',
-        status: 'confirmed',
-        submittedTime: 1543958860054,
-        time: 1543958857697,
-        txParams: {
-          from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
-          gas: '0x5208',
-          gasPrice: '0x481f2280',
-          nonce: '0x32',
-          to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
-          value: '0x2386f26fc10000',
-        },
-        txReceipt: {
-          status: '0x1',
-        },
-        type: 'retry',
-      },
-    ]
-
-    const expected = [
-      {
-        id: 6400627574331058,
-        hash: '0xa14f13d36b3901e352ce3a7acb9b47b001e5a3370f06232a0953c6fc6fad91b3',
-        eventKey: 'transactionCreated',
-        timestamp: 1543958845581,
-        value: '0x2386f26fc10000',
-      }, {
-        id: 6400627574331058,
-        hash: '0xa14f13d36b3901e352ce3a7acb9b47b001e5a3370f06232a0953c6fc6fad91b3',
-        eventKey: 'transactionSubmitted',
-        timestamp: 1543958848147,
-        value: '0x1319718a5000',
-      }, {
-        id: 6400627574331060,
-        hash: '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33',
-        eventKey: 'transactionResubmitted',
-        timestamp: 1543958860061,
-        value: '0x171c3a061400',
-      }, {
-        id: 6400627574331060,
-        hash: '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33',
-        eventKey: 'transactionConfirmed',
-        timestamp: 1543958897165,
-        value: '0x171c3a061400',
-      },
-    ]
-
-    assert.deepEqual(combineTransactionHistories(transactions), expected)
-  })
-})
-
-describe('getActivities', () => {
-  it('should return no activities for an empty history', () => {
-    const transaction = {
-      history: [],
-      id: 1,
-      status: 'confirmed',
-      txParams: {
-        from: '0x1',
-        gas: '0x5208',
-        gasPrice: '0x3b9aca00',
-        nonce: '0xa4',
-        to: '0x2',
-        value: '0x2386f26fc10000',
-      },
-    }
-
-    assert.deepEqual(getActivities(transaction), [])
-  })
-
-  it('should return activities for a transaction\'s history', () => {
-    const transaction = {
-      history: [
+    it('should return activities for an array of transactions', function () {
+      const transactions = [
         {
-          id: 5559712943815343,
-          loadingDefaults: true,
+          estimatedGas: '0x5208',
+          hash: '0xa14f13d36b3901e352ce3a7acb9b47b001e5a3370f06232a0953c6fc6fad91b3',
+          history: [
+            {
+              'id': 6400627574331058,
+              'time': 1543958845581,
+              'status': 'unapproved',
+              'metamaskNetworkId': '3',
+              'loadingDefaults': true,
+              'txParams': {
+                'from': '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
+                'to': '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
+                'value': '0x2386f26fc10000',
+                'gas': '0x5208',
+                'gasPrice': '0x3b9aca00',
+              },
+              'type': 'standard',
+            },
+            [{ 'op': 'replace', 'path': '/status', 'value': 'approved', 'note': 'txStateManager: setting status to approved', 'timestamp': 1543958847813 }],
+            [{ 'op': 'replace', 'path': '/status', 'value': 'submitted', 'note': 'txStateManager: setting status to submitted', 'timestamp': 1543958848147 }],
+            [{ 'op': 'replace', 'path': '/status', 'value': 'dropped', 'note': 'txStateManager: setting status to dropped', 'timestamp': 1543958897181 }, { 'op': 'add', 'path': '/replacedBy', 'value': '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33' }],
+          ],
+          id: 6400627574331058,
+          loadingDefaults: false,
           metamaskNetworkId: '3',
-          status: 'unapproved',
-          time: 1535507561452,
+          status: 'dropped',
+          submittedTime: 1543958848135,
+          time: 1543958845581,
           txParams: {
-            from: '0x1',
+            from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
             gas: '0x5208',
             gasPrice: '0x3b9aca00',
-            nonce: '0xa4',
-            to: '0x2',
+            nonce: '0x32',
+            to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
             value: '0x2386f26fc10000',
           },
+          type: 'standard',
+        }, {
+          hash: '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33',
+          history: [
+            {
+              'id': 6400627574331060,
+              'time': 1543958857697,
+              'status': 'unapproved',
+              'metamaskNetworkId': '3',
+              'loadingDefaults': false,
+              'txParams': {
+                'from': '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
+                'to': '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
+                'value': '0x2386f26fc10000',
+                'gas': '0x5208',
+                'gasPrice': '0x3b9aca00',
+                'nonce': '0x32',
+              },
+              'lastGasPrice': '0x4190ab00',
+              'type': 'retry',
+            },
+            [{ 'op': 'replace', 'path': '/txParams/gasPrice', 'value': '0x481f2280', 'note': 'confTx: user approved transaction', 'timestamp': 1543958859470 }],
+            [{ 'op': 'replace', 'path': '/status', 'value': 'approved', 'note': 'txStateManager: setting status to approved', 'timestamp': 1543958859485 }],
+            [{ 'op': 'replace', 'path': '/status', 'value': 'signed', 'note': 'transactions#publishTransaction', 'timestamp': 1543958859889 }],
+            [{ 'op': 'replace', 'path': '/status', 'value': 'submitted', 'note': 'txStateManager: setting status to submitted', 'timestamp': 1543958860061 }], [{ 'op': 'add', 'path': '/firstRetryBlockNumber', 'value': '0x45a0fd', 'note': 'transactions/pending-tx-tracker#event: tx:block-update', 'timestamp': 1543958896466 }],
+            [{ 'op': 'replace', 'path': '/status', 'value': 'confirmed', 'timestamp': 1543958897165 }],
+          ],
+          id: 6400627574331060,
+          lastGasPrice: '0x4190ab00',
+          loadingDefaults: false,
+          metamaskNetworkId: '3',
+          status: 'confirmed',
+          submittedTime: 1543958860054,
+          time: 1543958857697,
+          txParams: {
+            from: '0x50a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706',
+            gas: '0x5208',
+            gasPrice: '0x481f2280',
+            nonce: '0x32',
+            to: '0xc5ae6383e126f901dcb06131d97a88745bfa88d6',
+            value: '0x2386f26fc10000',
+          },
+          txReceipt: {
+            status: '0x1',
+          },
+          type: 'retry',
         },
-        [
+      ]
+
+      const expected = [
+        {
+          id: 6400627574331058,
+          hash: '0xa14f13d36b3901e352ce3a7acb9b47b001e5a3370f06232a0953c6fc6fad91b3',
+          eventKey: 'transactionCreated',
+          timestamp: 1543958845581,
+          value: '0x2386f26fc10000',
+        }, {
+          id: 6400627574331058,
+          hash: '0xa14f13d36b3901e352ce3a7acb9b47b001e5a3370f06232a0953c6fc6fad91b3',
+          eventKey: 'transactionSubmitted',
+          timestamp: 1543958848147,
+          value: '0x1319718a5000',
+        }, {
+          id: 6400627574331060,
+          hash: '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33',
+          eventKey: 'transactionResubmitted',
+          timestamp: 1543958860061,
+          value: '0x171c3a061400',
+        }, {
+          id: 6400627574331060,
+          hash: '0xecbe181ee67c4291d04a7cb9ffbf1d5d831e4fbaa89994fd06bab5dd4cc79b33',
+          eventKey: 'transactionConfirmed',
+          timestamp: 1543958897165,
+          value: '0x171c3a061400',
+        },
+      ]
+
+      assert.deepEqual(combineTransactionHistories(transactions), expected)
+    })
+  })
+
+  describe('getActivities', function () {
+    it('should return no activities for an empty history', function () {
+      const transaction = {
+        history: [],
+        id: 1,
+        status: 'confirmed',
+        txParams: {
+          from: '0x1',
+          gas: '0x5208',
+          gasPrice: '0x3b9aca00',
+          nonce: '0xa4',
+          to: '0x2',
+          value: '0x2386f26fc10000',
+        },
+      }
+
+      assert.deepEqual(getActivities(transaction), [])
+    })
+
+    it('should return activities for a transaction\'s history', function () {
+      const transaction = {
+        history: [
           {
-            op: 'replace',
-            path: '/loadingDefaults',
-            timestamp: 1535507561515,
-            value: false,
-          },
-          {
-            op: 'add',
-            path: '/gasPriceSpecified',
-            value: true,
-          },
-          {
-            op: 'add',
-            path: '/gasLimitSpecified',
-            value: true,
-          },
-          {
-            op: 'add',
-            path: '/estimatedGas',
-            value: '0x5208',
-          },
-        ],
-        [
-          {
-            note: '#newUnapprovedTransaction - adding the origin',
-            op: 'add',
-            path: '/origin',
-            timestamp: 1535507561516,
-            value: 'MetaMask',
-          },
-          [],
-        ],
-        [
-          {
-            note: 'confTx: user approved transaction',
-            op: 'replace',
-            path: '/txParams/gasPrice',
-            timestamp: 1535664571504,
-            value: '0x77359400',
-          },
-        ],
-        [
-          {
-            note: 'txStateManager: setting status to approved',
-            op: 'replace',
-            path: '/status',
-            timestamp: 1535507564302,
-            value: 'approved',
-          },
-        ],
-        [
-          {
-            note: 'transactions#approveTransaction',
-            op: 'add',
-            path: '/txParams/nonce',
-            timestamp: 1535507564439,
-            value: '0xa4',
-          },
-          {
-            op: 'add',
-            path: '/nonceDetails',
-            value: {
-              local: {},
-              network: {},
-              params: {},
+            id: 5559712943815343,
+            loadingDefaults: true,
+            metamaskNetworkId: '3',
+            status: 'unapproved',
+            time: 1535507561452,
+            txParams: {
+              from: '0x1',
+              gas: '0x5208',
+              gasPrice: '0x3b9aca00',
+              nonce: '0xa4',
+              to: '0x2',
+              value: '0x2386f26fc10000',
             },
           },
+          [
+            {
+              op: 'replace',
+              path: '/loadingDefaults',
+              timestamp: 1535507561515,
+              value: false,
+            },
+            {
+              op: 'add',
+              path: '/gasPriceSpecified',
+              value: true,
+            },
+            {
+              op: 'add',
+              path: '/gasLimitSpecified',
+              value: true,
+            },
+            {
+              op: 'add',
+              path: '/estimatedGas',
+              value: '0x5208',
+            },
+          ],
+          [
+            {
+              note: '#newUnapprovedTransaction - adding the origin',
+              op: 'add',
+              path: '/origin',
+              timestamp: 1535507561516,
+              value: 'MetaMask',
+            },
+            [],
+          ],
+          [
+            {
+              note: 'confTx: user approved transaction',
+              op: 'replace',
+              path: '/txParams/gasPrice',
+              timestamp: 1535664571504,
+              value: '0x77359400',
+            },
+          ],
+          [
+            {
+              note: 'txStateManager: setting status to approved',
+              op: 'replace',
+              path: '/status',
+              timestamp: 1535507564302,
+              value: 'approved',
+            },
+          ],
+          [
+            {
+              note: 'transactions#approveTransaction',
+              op: 'add',
+              path: '/txParams/nonce',
+              timestamp: 1535507564439,
+              value: '0xa4',
+            },
+            {
+              op: 'add',
+              path: '/nonceDetails',
+              value: {
+                local: {},
+                network: {},
+                params: {},
+              },
+            },
+          ],
+          [
+            {
+              note: 'transactions#publishTransaction',
+              op: 'replace',
+              path: '/status',
+              timestamp: 1535507564518,
+              value: 'signed',
+            },
+            {
+              op: 'add',
+              path: '/rawTx',
+              value: '0xf86b81a4843b9aca008252089450a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706872386f26fc10000802aa007b30119fc4fc5954fad727895b7e3ba80a78d197e95703cc603bcf017879151a01c50beda40ffaee541da9c05b9616247074f25f392800e0ad6c7a835d5366edf',
+            },
+          ],
+          [],
+          [
+            {
+              note: 'transactions#setTxHash',
+              op: 'add',
+              path: '/hash',
+              timestamp: 1535507564658,
+              value: '0x7acc4987b5c0dfa8d423798a8c561138259de1f98a62e3d52e7e83c0e0dd9fb7',
+            },
+          ],
+          [
+            {
+              note: 'txStateManager - add submitted time stamp',
+              op: 'add',
+              path: '/submittedTime',
+              timestamp: 1535507564660,
+              value: 1535507564660,
+            },
+          ],
+          [
+            {
+              note: 'txStateManager: setting status to submitted',
+              op: 'replace',
+              path: '/status',
+              timestamp: 1535507564665,
+              value: 'submitted',
+            },
+          ],
+          [
+            {
+              note: 'transactions/pending-tx-tracker#event: tx:block-update',
+              op: 'add',
+              path: '/firstRetryBlockNumber',
+              timestamp: 1535507575476,
+              value: '0x3bf624',
+            },
+          ],
+          [
+            {
+              note: 'txStateManager: setting status to confirmed',
+              op: 'replace',
+              path: '/status',
+              timestamp: 1535507615993,
+              value: 'confirmed',
+            },
+          ],
         ],
-        [
-          {
-            note: 'transactions#publishTransaction',
-            op: 'replace',
-            path: '/status',
-            timestamp: 1535507564518,
-            value: 'signed',
-          },
-          {
-            op: 'add',
-            path: '/rawTx',
-            value: '0xf86b81a4843b9aca008252089450a9d56c2b8ba9a5c7f2c08c3d26e0499f23a706872386f26fc10000802aa007b30119fc4fc5954fad727895b7e3ba80a78d197e95703cc603bcf017879151a01c50beda40ffaee541da9c05b9616247074f25f392800e0ad6c7a835d5366edf',
-          },
-        ],
-        [],
-        [
-          {
-            note: 'transactions#setTxHash',
-            op: 'add',
-            path: '/hash',
-            timestamp: 1535507564658,
-            value: '0x7acc4987b5c0dfa8d423798a8c561138259de1f98a62e3d52e7e83c0e0dd9fb7',
-          },
-        ],
-        [
-          {
-            note: 'txStateManager - add submitted time stamp',
-            op: 'add',
-            path: '/submittedTime',
-            timestamp: 1535507564660,
-            value: 1535507564660,
-          },
-        ],
-        [
-          {
-            note: 'txStateManager: setting status to submitted',
-            op: 'replace',
-            path: '/status',
-            timestamp: 1535507564665,
-            value: 'submitted',
-          },
-        ],
-        [
-          {
-            note: 'transactions/pending-tx-tracker#event: tx:block-update',
-            op: 'add',
-            path: '/firstRetryBlockNumber',
-            timestamp: 1535507575476,
-            value: '0x3bf624',
-          },
-        ],
-        [
-          {
-            note: 'txStateManager: setting status to confirmed',
-            op: 'replace',
-            path: '/status',
-            timestamp: 1535507615993,
-            value: 'confirmed',
-          },
-        ],
-      ],
-      id: 1,
-      status: 'confirmed',
-      txParams: {
-        from: '0x1',
-        gas: '0x5208',
-        gasPrice: '0x3b9aca00',
-        nonce: '0xa4',
-        to: '0x2',
-        value: '0x2386f26fc10000',
-      },
-      hash: '0xabc',
-    }
+        id: 1,
+        status: 'confirmed',
+        txParams: {
+          from: '0x1',
+          gas: '0x5208',
+          gasPrice: '0x3b9aca00',
+          nonce: '0xa4',
+          to: '0x2',
+          value: '0x2386f26fc10000',
+        },
+        hash: '0xabc',
+      }
 
-    const expectedResult = [
-      {
-        'eventKey': 'transactionCreated',
-        'timestamp': 1535507561452,
-        'value': '0x2386f26fc10000',
-        'id': 1,
-        'hash': '0xabc',
-      },
-      {
-        'eventKey': 'transactionSubmitted',
-        'timestamp': 1535507564665,
-        'value': '0x2632e314a000',
-        'id': 1,
-        'hash': '0xabc',
-      },
-      {
-        'eventKey': 'transactionConfirmed',
-        'timestamp': 1535507615993,
-        'value': '0x2632e314a000',
-        'id': 1,
-        'hash': '0xabc',
-      },
-    ]
+      const expectedResult = [
+        {
+          'eventKey': 'transactionCreated',
+          'timestamp': 1535507561452,
+          'value': '0x2386f26fc10000',
+          'id': 1,
+          'hash': '0xabc',
+        },
+        {
+          'eventKey': 'transactionSubmitted',
+          'timestamp': 1535507564665,
+          'value': '0x2632e314a000',
+          'id': 1,
+          'hash': '0xabc',
+        },
+        {
+          'eventKey': 'transactionConfirmed',
+          'timestamp': 1535507615993,
+          'value': '0x2632e314a000',
+          'id': 1,
+          'hash': '0xabc',
+        },
+      ]
 
-    assert.deepEqual(getActivities(transaction, true), expectedResult)
+      assert.deepEqual(getActivities(transaction, true), expectedResult)
+    })
   })
 })

--- a/ui/app/components/app/transaction-breakdown/tests/transaction-breakdown.component.test.js
+++ b/ui/app/components/app/transaction-breakdown/tests/transaction-breakdown.component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import TransactionBreakdown from '../transaction-breakdown.component'
 
-describe('TransactionBreakdown Component', () => {
-  it('should render properly', () => {
+describe('TransactionBreakdown Component', function () {
+  it('should render properly', function () {
     const transaction = {
       history: [],
       id: 1,

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/tests/transaction-breakdown-row.component.test.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/tests/transaction-breakdown-row.component.test.js
@@ -4,8 +4,8 @@ import { shallow } from 'enzyme'
 import TransactionBreakdownRow from '../transaction-breakdown-row.component'
 import Button from '../../../../ui/button'
 
-describe('TransactionBreakdownRow Component', () => {
-  it('should render text properly', () => {
+describe('TransactionBreakdownRow Component', function () {
+  it('should render text properly', function () {
     const wrapper = shallow(
       <TransactionBreakdownRow
         title="test"
@@ -21,7 +21,7 @@ describe('TransactionBreakdownRow Component', () => {
     assert.equal(wrapper.find('.transaction-breakdown-row__value').text(), 'Test')
   })
 
-  it('should render components properly', () => {
+  it('should render components properly', function () {
     const wrapper = shallow(
       <TransactionBreakdownRow
         title="test"

--- a/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
+++ b/ui/app/components/app/transaction-list-item-details/tests/transaction-list-item-details.component.test.js
@@ -7,8 +7,8 @@ import SenderToRecipient from '../../../ui/sender-to-recipient'
 import TransactionBreakdown from '../../transaction-breakdown'
 import TransactionActivityLog from '../../transaction-activity-log'
 
-describe('TransactionListItemDetails Component', () => {
-  it('should render properly', () => {
+describe('TransactionListItemDetails Component', function () {
+  it('should render properly', function () {
     const transaction = {
       history: [],
       id: 1,
@@ -46,7 +46,7 @@ describe('TransactionListItemDetails Component', () => {
     assert.equal(wrapper.find(TransactionActivityLog).length, 1)
   })
 
-  it('should render a retry button', () => {
+  it('should render a retry button', function () {
     const transaction = {
       history: [],
       id: 1,
@@ -85,7 +85,7 @@ describe('TransactionListItemDetails Component', () => {
     assert.equal(wrapper.find(Button).length, 3)
   })
 
-  it('should disable the Copy Tx ID and View In Etherscan buttons when tx hash is missing', () => {
+  it('should disable the Copy Tx ID and View In Etherscan buttons when tx hash is missing', function () {
     const transaction = {
       history: [],
       id: 1,
@@ -122,7 +122,7 @@ describe('TransactionListItemDetails Component', () => {
     assert.strictEqual(buttons.at(1).prop('disabled'), true)
   })
 
-  it('should render functional Copy Tx ID and View In Etherscan buttons when tx hash exists', () => {
+  it('should render functional Copy Tx ID and View In Etherscan buttons when tx hash exists', function () {
     const transaction = {
       history: [],
       id: 1,

--- a/ui/app/components/app/transaction-status/tests/transaction-status.component.test.js
+++ b/ui/app/components/app/transaction-status/tests/transaction-status.component.test.js
@@ -4,8 +4,8 @@ import { mount } from 'enzyme'
 import TransactionStatus from '../transaction-status.component'
 import Tooltip from '../../../ui/tooltip-v2'
 
-describe('TransactionStatus Component', () => {
-  it('should render APPROVED properly', () => {
+describe('TransactionStatus Component', function () {
+  it('should render APPROVED properly', function () {
     const wrapper = mount(
       <TransactionStatus
         statusKey="approved"
@@ -19,7 +19,7 @@ describe('TransactionStatus Component', () => {
     assert.equal(wrapper.find(Tooltip).props().title, 'test-title')
   })
 
-  it('should render SUBMITTED properly', () => {
+  it('should render SUBMITTED properly', function () {
     const wrapper = mount(
       <TransactionStatus
         statusKey="submitted"

--- a/ui/app/components/app/transaction-view-balance/tests/token-view-balance.component.test.js
+++ b/ui/app/components/app/transaction-view-balance/tests/token-view-balance.component.test.js
@@ -18,13 +18,13 @@ const historySpies = {
 const t = (str1, str2) => (str2 ? str1 + str2 : str1)
 const metricsEvent = () => ({})
 
-describe('TransactionViewBalance Component', () => {
-  afterEach(() => {
+describe('TransactionViewBalance Component', function () {
+  afterEach(function () {
     propsMethodSpies.showDepositModal.resetHistory()
     historySpies.push.resetHistory()
   })
 
-  it('should render ETH balance properly', () => {
+  it('should render ETH balance properly', function () {
     const wrapper = shallow((
       <TransactionViewBalance
         showDepositModal={propsMethodSpies.showDepositModal}
@@ -50,7 +50,7 @@ describe('TransactionViewBalance Component', () => {
     assert.equal(historySpies.push.getCall(0).args[0], SEND_ROUTE)
   })
 
-  it('should render token balance properly', () => {
+  it('should render token balance properly', function () {
     const token = {
       address: '0x35865238f0bec9d5ce6abff0fdaebe7b853dfcc5',
       decimals: '2',

--- a/ui/app/components/app/user-preferenced-currency-display/tests/user-preferenced-currency-display.component.test.js
+++ b/ui/app/components/app/user-preferenced-currency-display/tests/user-preferenced-currency-display.component.test.js
@@ -4,9 +4,9 @@ import { shallow } from 'enzyme'
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display.component'
 import CurrencyDisplay from '../../../ui/currency-display'
 
-describe('UserPreferencedCurrencyDisplay Component', () => {
-  describe('rendering', () => {
-    it('should render properly', () => {
+describe('UserPreferencedCurrencyDisplay Component', function () {
+  describe('rendering', function () {
+    it('should render properly', function () {
       const wrapper = shallow(
         <UserPreferencedCurrencyDisplay />
       )
@@ -15,7 +15,7 @@ describe('UserPreferencedCurrencyDisplay Component', () => {
       assert.equal(wrapper.find(CurrencyDisplay).length, 1)
     })
 
-    it('should pass all props to the CurrencyDisplay child component', () => {
+    it('should pass all props to the CurrencyDisplay child component', function () {
       const wrapper = shallow(
         <UserPreferencedCurrencyDisplay
           prop1

--- a/ui/app/components/app/user-preferenced-currency-display/tests/user-preferenced-currency-display.container.test.js
+++ b/ui/app/components/app/user-preferenced-currency-display/tests/user-preferenced-currency-display.container.test.js
@@ -13,9 +13,9 @@ proxyquire('../user-preferenced-currency-display.container.js', {
   },
 })
 
-describe('UserPreferencedCurrencyDisplay container', () => {
-  describe('mapStateToProps()', () => {
-    it('should return the correct props', () => {
+describe('UserPreferencedCurrencyDisplay container', function () {
+  describe('mapStateToProps()', function () {
+    it('should return the correct props', function () {
       const mockState = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -37,7 +37,7 @@ describe('UserPreferencedCurrencyDisplay container', () => {
       })
     })
 
-    it('should return the correct props when not in mainnet and showFiatInTestnets is true', () => {
+    it('should return the correct props when not in mainnet and showFiatInTestnets is true', function () {
       const mockState = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -60,8 +60,8 @@ describe('UserPreferencedCurrencyDisplay container', () => {
     })
   })
 
-  describe('mergeProps()', () => {
-    it('should return the correct props', () => {
+  describe('mergeProps()', function () {
+    it('should return the correct props', function () {
       const mockDispatchProps = {}
 
       const tests = [

--- a/ui/app/components/app/user-preferenced-currency-input/tests/user-preferenced-currency-input.component.test.js
+++ b/ui/app/components/app/user-preferenced-currency-input/tests/user-preferenced-currency-input.component.test.js
@@ -4,9 +4,9 @@ import { shallow } from 'enzyme'
 import UserPreferencedCurrencyInput from '../user-preferenced-currency-input.component'
 import CurrencyInput from '../../../ui/currency-input'
 
-describe('UserPreferencedCurrencyInput Component', () => {
-  describe('rendering', () => {
-    it('should render properly', () => {
+describe('UserPreferencedCurrencyInput Component', function () {
+  describe('rendering', function () {
+    it('should render properly', function () {
       const wrapper = shallow(
         <UserPreferencedCurrencyInput />
       )
@@ -15,7 +15,7 @@ describe('UserPreferencedCurrencyInput Component', () => {
       assert.equal(wrapper.find(CurrencyInput).length, 1)
     })
 
-    it('should render useFiat for CurrencyInput based on preferences.useNativeCurrencyAsPrimaryCurrency', () => {
+    it('should render useFiat for CurrencyInput based on preferences.useNativeCurrencyAsPrimaryCurrency', function () {
       const wrapper = shallow(
         <UserPreferencedCurrencyInput
           useNativeCurrencyAsPrimaryCurrency

--- a/ui/app/components/app/user-preferenced-currency-input/tests/user-preferenced-currency-input.container.test.js
+++ b/ui/app/components/app/user-preferenced-currency-input/tests/user-preferenced-currency-input.container.test.js
@@ -12,9 +12,9 @@ proxyquire('../user-preferenced-currency-input.container.js', {
   },
 })
 
-describe('UserPreferencedCurrencyInput container', () => {
-  describe('mapStateToProps()', () => {
-    it('should return the correct props', () => {
+describe('UserPreferencedCurrencyInput container', function () {
+  describe('mapStateToProps()', function () {
+    it('should return the correct props', function () {
       const mockState = {
         metamask: {
           preferences: {

--- a/ui/app/components/app/user-preferenced-token-input/tests/user-preferenced-token-input.component.test.js
+++ b/ui/app/components/app/user-preferenced-token-input/tests/user-preferenced-token-input.component.test.js
@@ -4,9 +4,9 @@ import { shallow } from 'enzyme'
 import UserPreferencedTokenInput from '../user-preferenced-token-input.component'
 import TokenInput from '../../../ui/token-input'
 
-describe('UserPreferencedCurrencyInput Component', () => {
-  describe('rendering', () => {
-    it('should render properly', () => {
+describe('UserPreferencedCurrencyInput Component', function () {
+  describe('rendering', function () {
+    it('should render properly', function () {
       const wrapper = shallow(
         <UserPreferencedTokenInput />
       )
@@ -15,7 +15,7 @@ describe('UserPreferencedCurrencyInput Component', () => {
       assert.equal(wrapper.find(TokenInput).length, 1)
     })
 
-    it('should render showFiat for TokenInput based on preferences.useNativeCurrencyAsPrimaryCurrency', () => {
+    it('should render showFiat for TokenInput based on preferences.useNativeCurrencyAsPrimaryCurrency', function () {
       const wrapper = shallow(
         <UserPreferencedTokenInput
           useNativeCurrencyAsPrimaryCurrency

--- a/ui/app/components/app/user-preferenced-token-input/tests/user-preferenced-token-input.container.test.js
+++ b/ui/app/components/app/user-preferenced-token-input/tests/user-preferenced-token-input.container.test.js
@@ -12,9 +12,9 @@ proxyquire('../user-preferenced-token-input.container.js', {
   },
 })
 
-describe('UserPreferencedTokenInput container', () => {
-  describe('mapStateToProps()', () => {
-    it('should return the correct props', () => {
+describe('UserPreferencedTokenInput container', function () {
+  describe('mapStateToProps()', function () {
+    it('should return the correct props', function () {
       const mockState = {
         metamask: {
           preferences: {

--- a/ui/app/components/ui/alert/tests/alert.test.js
+++ b/ui/app/components/ui/alert/tests/alert.test.js
@@ -4,21 +4,21 @@ import sinon from 'sinon'
 import { shallow } from 'enzyme'
 import Alert from '../index'
 
-describe('Alert', () => {
+describe('Alert', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow(
       <Alert />
     )
   })
 
-  it('renders nothing with no visible boolean in state', () => {
+  it('renders nothing with no visible boolean in state', function () {
     const alert = wrapper.find('.global-alert')
     assert.equal(alert.length, 0)
   })
 
-  it('renders when visible in state is true, and message', () => {
+  it('renders when visible in state is true, and message', function () {
     const errorMessage = 'Error Message'
 
     wrapper.setState({ visible: true, msg: errorMessage })
@@ -30,7 +30,7 @@ describe('Alert', () => {
     assert.equal(errorText.text(), errorMessage)
   })
 
-  it('calls component method when componentWillReceiveProps is called', () => {
+  it('calls component method when componentWillReceiveProps is called', function () {
     const animateInSpy = sinon.stub(wrapper.instance(), 'animateIn')
     const animateOutSpy = sinon.stub(wrapper.instance(), 'animateOut')
 

--- a/ui/app/components/ui/breadcrumbs/tests/breadcrumbs.component.test.js
+++ b/ui/app/components/ui/breadcrumbs/tests/breadcrumbs.component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import Breadcrumbs from '../breadcrumbs.component'
 
-describe('Breadcrumbs Component', () => {
-  it('should render with the correct colors', () => {
+describe('Breadcrumbs Component', function () {
+  it('should render with the correct colors', function () {
     const wrapper = shallow(
       <Breadcrumbs
         currentIndex={1}

--- a/ui/app/components/ui/button-group/tests/button-group-component.test.js
+++ b/ui/app/components/ui/button-group/tests/button-group-component.test.js
@@ -20,7 +20,7 @@ const mockButtons = [
 describe('ButtonGroup Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <ButtonGroup
         defaultActiveButtonIndex={1}
@@ -33,47 +33,47 @@ describe('ButtonGroup Component', function () {
     ))
   })
 
-  afterEach(() => {
+  afterEach(function () {
     childButtonSpies.onClick.resetHistory()
     ButtonGroup.prototype.handleButtonClick.resetHistory()
     ButtonGroup.prototype.renderButtons.resetHistory()
   })
 
-  describe('componentDidUpdate', () => {
-    it('should set the activeButtonIndex to the updated newActiveButtonIndex', () => {
+  describe('componentDidUpdate', function () {
+    it('should set the activeButtonIndex to the updated newActiveButtonIndex', function () {
       assert.equal(wrapper.state('activeButtonIndex'), 1)
       wrapper.setProps({ newActiveButtonIndex: 2 })
       assert.equal(wrapper.state('activeButtonIndex'), 2)
     })
 
-    it('should not set the activeButtonIndex to an updated newActiveButtonIndex that is not a number', () => {
+    it('should not set the activeButtonIndex to an updated newActiveButtonIndex that is not a number', function () {
       assert.equal(wrapper.state('activeButtonIndex'), 1)
       wrapper.setProps({ newActiveButtonIndex: null })
       assert.equal(wrapper.state('activeButtonIndex'), 1)
     })
   })
 
-  describe('handleButtonClick', () => {
-    it('should set the activeButtonIndex', () => {
+  describe('handleButtonClick', function () {
+    it('should set the activeButtonIndex', function () {
       assert.equal(wrapper.state('activeButtonIndex'), 1)
       wrapper.instance().handleButtonClick(2)
       assert.equal(wrapper.state('activeButtonIndex'), 2)
     })
   })
 
-  describe('renderButtons', () => {
-    it('should render a button for each child', () => {
+  describe('renderButtons', function () {
+    it('should render a button for each child', function () {
       const childButtons = wrapper.find('.button-group__button')
       assert.equal(childButtons.length, 3)
     })
 
-    it('should render the correct button with an active state', () => {
+    it('should render the correct button with an active state', function () {
       const childButtons = wrapper.find('.button-group__button')
       const activeChildButton = wrapper.find('.button-group__button--active')
       assert.deepEqual(childButtons.get(1), activeChildButton.get(0))
     })
 
-    it('should call handleButtonClick and the respective button\'s onClick method when a button is clicked', () => {
+    it('should call handleButtonClick and the respective button\'s onClick method when a button is clicked', function () {
       assert.equal(ButtonGroup.prototype.handleButtonClick.callCount, 0)
       assert.equal(childButtonSpies.onClick.callCount, 0)
       const childButtons = wrapper.find('.button-group__button')
@@ -84,7 +84,7 @@ describe('ButtonGroup Component', function () {
       assert.equal(childButtonSpies.onClick.callCount, 3)
     })
 
-    it('should render all child buttons as disabled if props.disabled is true', () => {
+    it('should render all child buttons as disabled if props.disabled is true', function () {
       const childButtons = wrapper.find('.button-group__button')
       childButtons.forEach(button => {
         assert.equal(button.props().disabled, undefined)
@@ -94,19 +94,19 @@ describe('ButtonGroup Component', function () {
       assert.equal(disabledChildButtons.length, 3)
     })
 
-    it('should render the children of the button', () => {
+    it('should render the children of the button', function () {
       const mockClass = wrapper.find('.mockClass')
       assert.equal(mockClass.length, 1)
     })
   })
 
-  describe('render', () => {
-    it('should render a div with the expected class and style', () => {
+  describe('render', function () {
+    it('should render a div with the expected class and style', function () {
       assert.equal(wrapper.find('div').at(0).props().className, 'someClassName')
       assert.deepEqual(wrapper.find('div').at(0).props().style, { color: 'red' })
     })
 
-    it('should call renderButtons when rendering', () => {
+    it('should call renderButtons when rendering', function () {
       assert.equal(ButtonGroup.prototype.renderButtons.callCount, 1)
       wrapper.instance().render()
       assert.equal(ButtonGroup.prototype.renderButtons.callCount, 2)

--- a/ui/app/components/ui/card/tests/card.component.test.js
+++ b/ui/app/components/ui/card/tests/card.component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import Card from '../card.component'
 
-describe('Card Component', () => {
-  it('should render a card with a title and child element', () => {
+describe('Card Component', function () {
+  it('should render a card with a title and child element', function () {
     const wrapper = shallow(
       <Card
         title="Test"

--- a/ui/app/components/ui/currency-display/tests/currency-display.component.test.js
+++ b/ui/app/components/ui/currency-display/tests/currency-display.component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import CurrencyDisplay from '../currency-display.component'
 
-describe('CurrencyDisplay Component', () => {
-  it('should render text with a className', () => {
+describe('CurrencyDisplay Component', function () {
+  it('should render text with a className', function () {
     const wrapper = shallow((
       <CurrencyDisplay
         displayValue="$123.45"
@@ -16,7 +16,7 @@ describe('CurrencyDisplay Component', () => {
     assert.equal(wrapper.text(), '$123.45')
   })
 
-  it('should render text with a prefix', () => {
+  it('should render text with a prefix', function () {
     const wrapper = shallow((
       <CurrencyDisplay
         displayValue="$123.45"

--- a/ui/app/components/ui/currency-display/tests/currency-display.container.test.js
+++ b/ui/app/components/ui/currency-display/tests/currency-display.container.test.js
@@ -13,9 +13,9 @@ proxyquire('../currency-display.container.js', {
   },
 })
 
-describe('CurrencyDisplay container', () => {
-  describe('mapStateToProps()', () => {
-    it('should return the correct props', () => {
+describe('CurrencyDisplay container', function () {
+  describe('mapStateToProps()', function () {
+    it('should return the correct props', function () {
       const mockState = {
         metamask: {
           conversionRate: 280.45,
@@ -32,8 +32,8 @@ describe('CurrencyDisplay container', () => {
     })
   })
 
-  describe('mergeProps()', () => {
-    it('should return the correct props', () => {
+  describe('mergeProps()', function () {
+    it('should return the correct props', function () {
       const mockStateProps = {
         conversionRate: 280.45,
         currentCurrency: 'usd',

--- a/ui/app/components/ui/currency-input/tests/currency-input.component.test.js
+++ b/ui/app/components/ui/currency-input/tests/currency-input.component.test.js
@@ -9,9 +9,9 @@ import CurrencyInput from '../currency-input.component'
 import UnitInput from '../../unit-input'
 import CurrencyDisplay from '../../currency-display'
 
-describe('CurrencyInput Component', () => {
-  describe('rendering', () => {
-    it('should render properly without a suffix', () => {
+describe('CurrencyInput Component', function () {
+  describe('rendering', function () {
+    it('should render properly without a suffix', function () {
       const wrapper = shallow(
         <CurrencyInput />
       )
@@ -20,7 +20,7 @@ describe('CurrencyInput Component', () => {
       assert.equal(wrapper.find(UnitInput).length, 1)
     })
 
-    it('should render properly with a suffix', () => {
+    it('should render properly with a suffix', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -46,7 +46,7 @@ describe('CurrencyInput Component', () => {
       assert.equal(wrapper.find(CurrencyDisplay).length, 1)
     })
 
-    it('should render properly with an ETH value', () => {
+    it('should render properly with an ETH value', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -79,7 +79,7 @@ describe('CurrencyInput Component', () => {
       assert.equal(wrapper.find('.currency-display-component').text(), '$231.06USD')
     })
 
-    it('should render properly with a fiat value', () => {
+    it('should render properly with a fiat value', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -113,7 +113,7 @@ describe('CurrencyInput Component', () => {
       assert.equal(wrapper.find('.currency-display-component').text(), '0.004328ETH')
     })
 
-    it('should render properly with a native value when hideFiat is true', () => {
+    it('should render properly with a native value when hideFiat is true', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -153,16 +153,16 @@ describe('CurrencyInput Component', () => {
     })
   })
 
-  describe('handling actions', () => {
+  describe('handling actions', function () {
     const handleChangeSpy = sinon.spy()
     const handleBlurSpy = sinon.spy()
 
-    afterEach(() => {
+    afterEach(function () {
       handleChangeSpy.resetHistory()
       handleBlurSpy.resetHistory()
     })
 
-    it('should call onChange on input changes with the hex value for ETH', () => {
+    it('should call onChange on input changes with the hex value for ETH', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -202,7 +202,7 @@ describe('CurrencyInput Component', () => {
       assert.equal(currencyInputInstance.state.hexValue, 'de0b6b3a7640000')
     })
 
-    it('should call onChange on input changes with the hex value for fiat', () => {
+    it('should call onChange on input changes with the hex value for fiat', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -243,7 +243,7 @@ describe('CurrencyInput Component', () => {
       assert.equal(currencyInputInstance.state.hexValue, 'f602f2234d0ea')
     })
 
-    it('should change the state and pass in a new decimalValue when props.value changes', () => {
+    it('should change the state and pass in a new decimalValue when props.value changes', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -278,7 +278,7 @@ describe('CurrencyInput Component', () => {
       assert.equal(currencyInputInstance.find(UnitInput).props().value, 2)
     })
 
-    it('should swap selected currency when swap icon is clicked', () => {
+    it('should swap selected currency when swap icon is clicked', function () {
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',

--- a/ui/app/components/ui/currency-input/tests/currency-input.container.test.js
+++ b/ui/app/components/ui/currency-input/tests/currency-input.container.test.js
@@ -13,8 +13,8 @@ proxyquire('../currency-input.container.js', {
   },
 })
 
-describe('CurrencyInput container', () => {
-  describe('mapStateToProps()', () => {
+describe('CurrencyInput container', function () {
+  describe('mapStateToProps()', function () {
     const tests = [
       // Test # 1
       {
@@ -127,11 +127,13 @@ describe('CurrencyInput container', () => {
     ]
 
     tests.forEach(({ mockState, expected, comment }) => {
-      it(comment, () => assert.deepEqual(mapStateToProps(mockState), expected))
+      it(comment, function () {
+        return assert.deepEqual(mapStateToProps(mockState), expected)
+      })
     })
   })
 
-  describe('mergeProps()', () => {
+  describe('mergeProps()', function () {
     const tests = [
       // Test # 1
       {
@@ -178,7 +180,7 @@ describe('CurrencyInput container', () => {
     ]
 
     tests.forEach(({ mock: { stateProps, dispatchProps, ownProps }, expected, comment }) => {
-      it(comment, () => {
+      it(comment, function () {
         assert.deepEqual(mergeProps(stateProps, dispatchProps, ownProps), expected)
       })
     })

--- a/ui/app/components/ui/error-message/tests/error-message.component.test.js
+++ b/ui/app/components/ui/error-message/tests/error-message.component.test.js
@@ -3,10 +3,10 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import ErrorMessage from '../error-message.component'
 
-describe('ErrorMessage Component', () => {
+describe('ErrorMessage Component', function () {
   const t = key => `translate ${key}`
 
-  it('should render a message from props.errorMessage', () => {
+  it('should render a message from props.errorMessage', function () {
     const wrapper = shallow(
       <ErrorMessage
         errorMessage="This is an error."
@@ -20,7 +20,7 @@ describe('ErrorMessage Component', () => {
     assert.equal(wrapper.find('.error-message__text').text(), 'ALERT: This is an error.')
   })
 
-  it('should render a message translated from props.errorKey', () => {
+  it('should render a message translated from props.errorKey', function () {
     const wrapper = shallow(
       <ErrorMessage
         errorKey="testKey"

--- a/ui/app/components/ui/hex-to-decimal/tests/hex-to-decimal.component.test.js
+++ b/ui/app/components/ui/hex-to-decimal/tests/hex-to-decimal.component.test.js
@@ -3,8 +3,8 @@ import assert from 'assert'
 import { shallow } from 'enzyme'
 import HexToDecimal from '../hex-to-decimal.component'
 
-describe('HexToDecimal Component', () => {
-  it('should render a prefixed hex as a decimal with a className', () => {
+describe('HexToDecimal Component', function () {
+  it('should render a prefixed hex as a decimal with a className', function () {
     const wrapper = shallow((
       <HexToDecimal
         value="0x3039"
@@ -16,7 +16,7 @@ describe('HexToDecimal Component', () => {
     assert.equal(wrapper.text(), '12345')
   })
 
-  it('should render an unprefixed hex as a decimal with a className', () => {
+  it('should render an unprefixed hex as a decimal with a className', function () {
     const wrapper = shallow((
       <HexToDecimal
         value="1A85"

--- a/ui/app/components/ui/identicon/tests/identicon.component.test.js
+++ b/ui/app/components/ui/identicon/tests/identicon.component.test.js
@@ -5,7 +5,7 @@ import configureMockStore from 'redux-mock-store'
 import { mount } from 'enzyme'
 import Identicon from '../identicon.component'
 
-describe('Identicon', () => {
+describe('Identicon', function () {
   const state = {
     metamask: {
       useBlockie: false,
@@ -16,7 +16,7 @@ describe('Identicon', () => {
   const mockStore = configureMockStore(middlewares)
   const store = mockStore(state)
 
-  it('renders default eth_logo identicon with no props', () => {
+  it('renders default eth_logo identicon with no props', function () {
     const wrapper = mount(
       <Identicon store={store} />
     )
@@ -24,7 +24,7 @@ describe('Identicon', () => {
     assert.equal(wrapper.find('img.balance-icon').prop('src'), './images/eth_logo.svg')
   })
 
-  it('renders custom image and add className props', () => {
+  it('renders custom image and add className props', function () {
     const wrapper = mount(
       <Identicon
         store={store}
@@ -37,7 +37,7 @@ describe('Identicon', () => {
     assert.equal(wrapper.find('img.test-image').prop('src'), 'test-image')
   })
 
-  it('renders div with address prop', () => {
+  it('renders div with address prop', function () {
     const wrapper = mount(
       <Identicon
         store={store}

--- a/ui/app/components/ui/metafox-logo/tests/metafox-logo.component.test.js
+++ b/ui/app/components/ui/metafox-logo/tests/metafox-logo.component.test.js
@@ -3,9 +3,9 @@ import assert from 'assert'
 import { mount } from 'enzyme'
 import MetaFoxLogo from '..'
 
-describe('MetaFoxLogo', () => {
+describe('MetaFoxLogo', function () {
 
-  it('sets icon height and width to 42 by default', () => {
+  it('sets icon height and width to 42 by default', function () {
     const wrapper = mount(
       <MetaFoxLogo />
     )
@@ -14,7 +14,7 @@ describe('MetaFoxLogo', () => {
     assert.equal(wrapper.find('img.app-header__metafox-logo--icon').prop('height'), 42)
   })
 
-  it('does not set icon height and width when unsetIconHeight is true', () => {
+  it('does not set icon height and width when unsetIconHeight is true', function () {
     const wrapper = mount(
       <MetaFoxLogo unsetIconHeight />
     )

--- a/ui/app/components/ui/page-container/page-container-footer/tests/page-container-footer.component.test.js
+++ b/ui/app/components/ui/page-container/page-container-footer/tests/page-container-footer.component.test.js
@@ -5,12 +5,12 @@ import sinon from 'sinon'
 import Button from '../../../button'
 import PageFooter from '../page-container-footer.component'
 
-describe('Page Footer', () => {
+describe('Page Footer', function () {
   let wrapper
   const onCancel = sinon.spy()
   const onSubmit = sinon.spy()
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <PageFooter
         onCancel={onCancel}
@@ -23,11 +23,11 @@ describe('Page Footer', () => {
     ))
   })
 
-  it('renders page container footer', () => {
+  it('renders page container footer', function () {
     assert.equal(wrapper.find('.page-container__footer').length, 1)
   })
 
-  it('should render a footer inside page-container__footer when given children', () => {
+  it('should render a footer inside page-container__footer when given children', function () {
     const wrapper = shallow(
       <PageFooter>
         <div>Works</div>
@@ -38,42 +38,42 @@ describe('Page Footer', () => {
     assert.equal(wrapper.find('.page-container__footer footer').length, 1)
   })
 
-  it('renders two button components', () => {
+  it('renders two button components', function () {
     assert.equal(wrapper.find(Button).length, 2)
   })
 
-  describe('Cancel Button', () => {
+  describe('Cancel Button', function () {
 
-    it('has button type of default', () => {
+    it('has button type of default', function () {
       assert.equal(wrapper.find('.page-container__footer-button').first().prop('type'), 'default')
     })
 
-    it('has children text of Cancel', () => {
+    it('has children text of Cancel', function () {
       assert.equal(wrapper.find('.page-container__footer-button').first().prop('children'), 'Cancel')
     })
 
-    it('should call cancel when click is simulated', () => {
+    it('should call cancel when click is simulated', function () {
       wrapper.find('.page-container__footer-button').first().prop('onClick')()
       assert.equal(onCancel.callCount, 1)
     })
 
   })
 
-  describe('Submit Button', () => {
+  describe('Submit Button', function () {
 
-    it('assigns button type based on props', () => {
+    it('assigns button type based on props', function () {
       assert.equal(wrapper.find('.page-container__footer-button').last().prop('type'), 'Test Type')
     })
 
-    it('has disabled prop', () => {
+    it('has disabled prop', function () {
       assert.equal(wrapper.find('.page-container__footer-button').last().prop('disabled'), false)
     })
 
-    it('has children text when submitText prop exists', () => {
+    it('has children text when submitText prop exists', function () {
       assert.equal(wrapper.find('.page-container__footer-button').last().prop('children'), 'Submit')
     })
 
-    it('should call submit when click is simulated', () => {
+    it('should call submit when click is simulated', function () {
       wrapper.find('.page-container__footer-button').last().prop('onClick')()
       assert.equal(onSubmit.callCount, 1)
     })

--- a/ui/app/components/ui/page-container/page-container-header/tests/page-container-header.component.test.js
+++ b/ui/app/components/ui/page-container/page-container-header/tests/page-container-header.component.test.js
@@ -4,10 +4,10 @@ import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import PageContainerHeader from '../page-container-header.component'
 
-describe('Page Container Header', () => {
+describe('Page Container Header', function () {
   let wrapper, style, onBackButtonClick, onClose
 
-  beforeEach(() => {
+  beforeEach(function () {
     style = { test: 'style' }
     onBackButtonClick = sinon.spy()
     onClose = sinon.spy()
@@ -25,27 +25,27 @@ describe('Page Container Header', () => {
     ))
   })
 
-  describe('Render Header Row', () => {
+  describe('Render Header Row', function () {
 
-    it('renders back button', () => {
+    it('renders back button', function () {
       assert.equal(wrapper.find('.page-container__back-button').length, 1)
       assert.equal(wrapper.find('.page-container__back-button').text(), 'Back')
     })
 
-    it('ensures style prop', () => {
+    it('ensures style prop', function () {
       assert.equal(wrapper.find('.page-container__back-button').props().style, style)
     })
 
-    it('should call back button when click is simulated', () => {
+    it('should call back button when click is simulated', function () {
       wrapper.find('.page-container__back-button').prop('onClick')()
       assert.equal(onBackButtonClick.callCount, 1)
     })
   })
 
-  describe('Render', () => {
+  describe('Render', function () {
     let header, headerRow, pageTitle, pageSubtitle, pageClose, pageTab
 
-    beforeEach(() => {
+    beforeEach(function () {
       header = wrapper.find('.page-container__header--no-padding-bottom')
       headerRow = wrapper.find('.page-container__header-row')
       pageTitle = wrapper.find('.page-container__title')
@@ -54,7 +54,7 @@ describe('Page Container Header', () => {
       pageTab = wrapper.find('.page-container__tabs')
     })
 
-    it('renders page container', () => {
+    it('renders page container', function () {
       assert.equal(header.length, 1)
       assert.equal(headerRow.length, 1)
       assert.equal(pageTitle.length, 1)
@@ -63,19 +63,19 @@ describe('Page Container Header', () => {
       assert.equal(pageTab.length, 1)
     })
 
-    it('renders title', () => {
+    it('renders title', function () {
       assert.equal(pageTitle.text(), 'Test Title')
     })
 
-    it('renders subtitle', () => {
+    it('renders subtitle', function () {
       assert.equal(pageSubtitle.text(), 'Test Subtitle')
     })
 
-    it('renders tabs', () => {
+    it('renders tabs', function () {
       assert.equal(pageTab.text(), 'Test Tab')
     })
 
-    it('should call close when click is simulated', () => {
+    it('should call close when click is simulated', function () {
       pageClose.prop('onClick')()
       assert.equal(onClose.callCount, 1)
     })

--- a/ui/app/components/ui/token-input/tests/token-input.component.test.js
+++ b/ui/app/components/ui/token-input/tests/token-input.component.test.js
@@ -9,11 +9,11 @@ import TokenInput from '../token-input.component'
 import UnitInput from '../../unit-input'
 import CurrencyDisplay from '../../currency-display'
 
-describe('TokenInput Component', () => {
+describe('TokenInput Component', function () {
   const t = key => `translate ${key}`
 
-  describe('rendering', () => {
-    it('should render properly without a token', () => {
+  describe('rendering', function () {
+    it('should render properly without a token', function () {
       const wrapper = shallow(
         <TokenInput />,
         { context: { t } }
@@ -23,7 +23,7 @@ describe('TokenInput Component', () => {
       assert.equal(wrapper.find(UnitInput).length, 1)
     })
 
-    it('should render properly with a token', () => {
+    it('should render properly with a token', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',
@@ -57,7 +57,7 @@ describe('TokenInput Component', () => {
       assert.equal(wrapper.find('.currency-input__conversion-component').text(), 'translate noConversionRateAvailable')
     })
 
-    it('should render properly with a token and selectedTokenExchangeRate', () => {
+    it('should render properly with a token and selectedTokenExchangeRate', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',
@@ -91,7 +91,7 @@ describe('TokenInput Component', () => {
       assert.equal(wrapper.find(CurrencyDisplay).length, 1)
     })
 
-    it('should render properly with a token value for ETH', () => {
+    it('should render properly with a token value for ETH', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',
@@ -125,7 +125,7 @@ describe('TokenInput Component', () => {
       assert.equal(wrapper.find('.currency-display-component').text(), '2ETH')
     })
 
-    it('should render properly with a token value for fiat', () => {
+    it('should render properly with a token value for fiat', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',
@@ -160,7 +160,7 @@ describe('TokenInput Component', () => {
       assert.equal(wrapper.find('.currency-display-component').text(), '$462.12USD')
     })
 
-    it('should render properly with a token value for fiat, but hideConversion is true', () => {
+    it('should render properly with a token value for fiat, but hideConversion is true', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',
@@ -203,16 +203,16 @@ describe('TokenInput Component', () => {
     })
   })
 
-  describe('handling actions', () => {
+  describe('handling actions', function () {
     const handleChangeSpy = sinon.spy()
     const handleBlurSpy = sinon.spy()
 
-    afterEach(() => {
+    afterEach(function () {
       handleChangeSpy.resetHistory()
       handleBlurSpy.resetHistory()
     })
 
-    it('should call onChange on input changes with the hex value for ETH', () => {
+    it('should call onChange on input changes with the hex value for ETH', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',
@@ -254,7 +254,7 @@ describe('TokenInput Component', () => {
       assert.equal(tokenInputInstance.state.hexValue, '2710')
     })
 
-    it('should call onChange on input changes with the hex value for fiat', () => {
+    it('should call onChange on input changes with the hex value for fiat', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',
@@ -297,7 +297,7 @@ describe('TokenInput Component', () => {
       assert.equal(tokenInputInstance.state.hexValue, '2710')
     })
 
-    it('should change the state and pass in a new decimalValue when props.value changes', () => {
+    it('should change the state and pass in a new decimalValue when props.value changes', function () {
       const mockStore = {
         metamask: {
           currentCurrency: 'usd',

--- a/ui/app/components/ui/token-input/tests/token-input.container.test.js
+++ b/ui/app/components/ui/token-input/tests/token-input.container.test.js
@@ -13,9 +13,9 @@ proxyquire('../token-input.container.js', {
   },
 })
 
-describe('TokenInput container', () => {
-  describe('mapStateToProps()', () => {
-    it('should return the correct props when send is empty', () => {
+describe('TokenInput container', function () {
+  describe('mapStateToProps()', function () {
+    it('should return the correct props when send is empty', function () {
       const mockState = {
         metamask: {
           currentCurrency: 'usd',
@@ -50,7 +50,7 @@ describe('TokenInput container', () => {
       })
     })
 
-    it('should return the correct props when selectedTokenAddress is not found and send is populated', () => {
+    it('should return the correct props when selectedTokenAddress is not found and send is populated', function () {
       const mockState = {
         metamask: {
           currentCurrency: 'usd',
@@ -85,7 +85,7 @@ describe('TokenInput container', () => {
       })
     })
 
-    it('should return the correct props when contractExchangeRates is populated', () => {
+    it('should return the correct props when contractExchangeRates is populated', function () {
       const mockState = {
         metamask: {
           currentCurrency: 'usd',
@@ -122,7 +122,7 @@ describe('TokenInput container', () => {
       })
     })
 
-    it('should return the correct props when not in mainnet and showFiatInTestnets is false', () => {
+    it('should return the correct props when not in mainnet and showFiatInTestnets is false', function () {
       const mockState = {
         metamask: {
           currentCurrency: 'usd',
@@ -157,7 +157,7 @@ describe('TokenInput container', () => {
       })
     })
 
-    it('should return the correct props when not in mainnet and showFiatInTestnets is true', () => {
+    it('should return the correct props when not in mainnet and showFiatInTestnets is true', function () {
       const mockState = {
         metamask: {
           currentCurrency: 'usd',
@@ -192,7 +192,7 @@ describe('TokenInput container', () => {
       })
     })
 
-    it('should return the correct props when in mainnet and showFiatInTestnets is true', () => {
+    it('should return the correct props when in mainnet and showFiatInTestnets is true', function () {
       const mockState = {
         metamask: {
           currentCurrency: 'usd',
@@ -228,8 +228,8 @@ describe('TokenInput container', () => {
     })
   })
 
-  describe('mergeProps()', () => {
-    it('should return the correct props', () => {
+  describe('mergeProps()', function () {
+    it('should return the correct props', function () {
       const mockStateProps = {
         currentCurrency: 'usd',
         selectedToken: {

--- a/ui/app/components/ui/unit-input/tests/unit-input.component.test.js
+++ b/ui/app/components/ui/unit-input/tests/unit-input.component.test.js
@@ -4,9 +4,9 @@ import { shallow, mount } from 'enzyme'
 import sinon from 'sinon'
 import UnitInput from '../unit-input.component'
 
-describe('UnitInput Component', () => {
-  describe('rendering', () => {
-    it('should render properly without a suffix', () => {
+describe('UnitInput Component', function () {
+  describe('rendering', function () {
+    it('should render properly without a suffix', function () {
       const wrapper = shallow(
         <UnitInput />
       )
@@ -15,7 +15,7 @@ describe('UnitInput Component', () => {
       assert.equal(wrapper.find('.unit-input__suffix').length, 0)
     })
 
-    it('should render properly with a suffix', () => {
+    it('should render properly with a suffix', function () {
       const wrapper = shallow(
         <UnitInput
           suffix="ETH"
@@ -27,7 +27,7 @@ describe('UnitInput Component', () => {
       assert.equal(wrapper.find('.unit-input__suffix').text(), 'ETH')
     })
 
-    it('should render properly with a child omponent', () => {
+    it('should render properly with a child omponent', function () {
       const wrapper = shallow(
         <UnitInput>
           <div className="testing">
@@ -41,7 +41,7 @@ describe('UnitInput Component', () => {
       assert.equal(wrapper.find('.testing').text(), 'TESTCOMPONENT')
     })
 
-    it('should render with an error class when props.error === true', () => {
+    it('should render with an error class when props.error === true', function () {
       const wrapper = shallow(
         <UnitInput
           error
@@ -53,16 +53,16 @@ describe('UnitInput Component', () => {
     })
   })
 
-  describe('handling actions', () => {
+  describe('handling actions', function () {
     const handleChangeSpy = sinon.spy()
     const handleBlurSpy = sinon.spy()
 
-    afterEach(() => {
+    afterEach(function () {
       handleChangeSpy.resetHistory()
       handleBlurSpy.resetHistory()
     })
 
-    it('should focus the input on component click', () => {
+    it('should focus the input on component click', function () {
       const wrapper = mount(
         <UnitInput />
       )
@@ -76,7 +76,7 @@ describe('UnitInput Component', () => {
       assert.equal(handleFocusSpy.callCount, 1)
     })
 
-    it('should call onChange on input changes with the value', () => {
+    it('should call onChange on input changes with the value', function () {
       const wrapper = mount(
         <UnitInput
           onChange={handleChangeSpy}
@@ -92,7 +92,7 @@ describe('UnitInput Component', () => {
       assert.equal(wrapper.state('value'), 123)
     })
 
-    it('should set the component state value with props.value', () => {
+    it('should set the component state value with props.value', function () {
       const wrapper = mount(
         <UnitInput
           value={123}
@@ -103,7 +103,7 @@ describe('UnitInput Component', () => {
       assert.equal(wrapper.state('value'), 123)
     })
 
-    it('should update the component state value with props.value', () => {
+    it('should update the component state value with props.value', function () {
       const wrapper = mount(
         <UnitInput
           onChange={handleChangeSpy}

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -43,8 +43,8 @@ const FETCH_DATA_START = 'metamask/confirm-transaction/FETCH_DATA_START'
 const FETCH_DATA_END = 'metamask/confirm-transaction/FETCH_DATA_END'
 const CLEAR_CONFIRM_TRANSACTION = 'metamask/confirm-transaction/CLEAR_CONFIRM_TRANSACTION'
 
-describe('Confirm Transaction Duck', () => {
-  describe('State changes', () => {
+describe('Confirm Transaction Duck', function () {
+  describe('State changes', function () {
     const mockState = {
       txData: {
         id: 1,
@@ -73,11 +73,11 @@ describe('Confirm Transaction Duck', () => {
       fetchingData: false,
     }
 
-    it('should initialize state', () => {
+    it('should initialize state', function () {
       assert.deepEqual(ConfirmTransactionReducer(undefined, {}), initialState)
     })
 
-    it('should return state unchanged if it does not match a dispatched actions type', () => {
+    it('should return state unchanged if it does not match a dispatched actions type', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: 'someOtherAction',
@@ -87,7 +87,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should set txData when receiving a UPDATE_TX_DATA action', () => {
+    it('should set txData when receiving a UPDATE_TX_DATA action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_TX_DATA,
@@ -105,7 +105,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should clear txData when receiving a CLEAR_TX_DATA action', () => {
+    it('should clear txData when receiving a CLEAR_TX_DATA action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: CLEAR_TX_DATA,
@@ -117,7 +117,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should set tokenData when receiving a UPDATE_TOKEN_DATA action', () => {
+    it('should set tokenData when receiving a UPDATE_TOKEN_DATA action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_TOKEN_DATA,
@@ -135,7 +135,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should clear tokenData when receiving a CLEAR_TOKEN_DATA action', () => {
+    it('should clear tokenData when receiving a CLEAR_TOKEN_DATA action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: CLEAR_TOKEN_DATA,
@@ -147,7 +147,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should set methodData when receiving a UPDATE_METHOD_DATA action', () => {
+    it('should set methodData when receiving a UPDATE_METHOD_DATA action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_METHOD_DATA,
@@ -165,7 +165,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should clear methodData when receiving a CLEAR_METHOD_DATA action', () => {
+    it('should clear methodData when receiving a CLEAR_METHOD_DATA action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: CLEAR_METHOD_DATA,
@@ -177,7 +177,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should update transaction amounts when receiving an UPDATE_TRANSACTION_AMOUNTS action', () => {
+    it('should update transaction amounts when receiving an UPDATE_TRANSACTION_AMOUNTS action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_TRANSACTION_AMOUNTS,
@@ -196,7 +196,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should update transaction fees when receiving an UPDATE_TRANSACTION_FEES action', () => {
+    it('should update transaction fees when receiving an UPDATE_TRANSACTION_FEES action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_TRANSACTION_FEES,
@@ -215,7 +215,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should update transaction totals when receiving an UPDATE_TRANSACTION_TOTALS action', () => {
+    it('should update transaction totals when receiving an UPDATE_TRANSACTION_TOTALS action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_TRANSACTION_TOTALS,
@@ -234,7 +234,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should update tokenProps when receiving an UPDATE_TOKEN_PROPS action', () => {
+    it('should update tokenProps when receiving an UPDATE_TOKEN_PROPS action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_TOKEN_PROPS,
@@ -253,7 +253,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should update nonce when receiving an UPDATE_NONCE action', () => {
+    it('should update nonce when receiving an UPDATE_NONCE action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_NONCE,
@@ -266,7 +266,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should update nonce when receiving an UPDATE_TO_SMART_CONTRACT action', () => {
+    it('should update nonce when receiving an UPDATE_TO_SMART_CONTRACT action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: UPDATE_TO_SMART_CONTRACT,
@@ -279,7 +279,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should set fetchingData to true when receiving a FETCH_DATA_START action', () => {
+    it('should set fetchingData to true when receiving a FETCH_DATA_START action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer(mockState, {
           type: FETCH_DATA_START,
@@ -291,20 +291,20 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should set fetchingData to false when receiving a FETCH_DATA_END action', () => {
+    it('should set fetchingData to false when receiving a FETCH_DATA_END action', function () {
       assert.deepEqual(
         ConfirmTransactionReducer({ fetchingData: true }, { type: FETCH_DATA_END }),
         { fetchingData: false },
       )
     })
 
-    it('should clear confirmTransaction when receiving a FETCH_DATA_END action', () => {
+    it('should clear confirmTransaction when receiving a FETCH_DATA_END action', function () {
       assert.deepEqual(ConfirmTransactionReducer(mockState, { type: CLEAR_CONFIRM_TRANSACTION }), initialState)
     })
   })
 
-  describe('Single actions', () => {
-    it('should create an action to update txData', () => {
+  describe('Single actions', function () {
+    it('should create an action to update txData', function () {
       const txData = { test: 123 }
       const expectedAction = {
         type: UPDATE_TX_DATA,
@@ -317,7 +317,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to clear txData', () => {
+    it('should create an action to clear txData', function () {
       const expectedAction = {
         type: CLEAR_TX_DATA,
       }
@@ -328,7 +328,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to update tokenData', () => {
+    it('should create an action to update tokenData', function () {
       const tokenData = { test: 123 }
       const expectedAction = {
         type: UPDATE_TOKEN_DATA,
@@ -341,7 +341,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to clear tokenData', () => {
+    it('should create an action to clear tokenData', function () {
       const expectedAction = {
         type: CLEAR_TOKEN_DATA,
       }
@@ -352,7 +352,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to update methodData', () => {
+    it('should create an action to update methodData', function () {
       const methodData = { test: 123 }
       const expectedAction = {
         type: UPDATE_METHOD_DATA,
@@ -365,7 +365,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to clear methodData', () => {
+    it('should create an action to clear methodData', function () {
       const expectedAction = {
         type: CLEAR_METHOD_DATA,
       }
@@ -376,7 +376,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to update transaction amounts', () => {
+    it('should create an action to update transaction amounts', function () {
       const transactionAmounts = { test: 123 }
       const expectedAction = {
         type: UPDATE_TRANSACTION_AMOUNTS,
@@ -389,7 +389,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to update transaction fees', () => {
+    it('should create an action to update transaction fees', function () {
       const transactionFees = { test: 123 }
       const expectedAction = {
         type: UPDATE_TRANSACTION_FEES,
@@ -402,7 +402,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to update transaction totals', () => {
+    it('should create an action to update transaction totals', function () {
       const transactionTotals = { test: 123 }
       const expectedAction = {
         type: UPDATE_TRANSACTION_TOTALS,
@@ -415,7 +415,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to update tokenProps', () => {
+    it('should create an action to update tokenProps', function () {
       const tokenProps = {
         tokenDecimals: '1',
         tokenSymbol: 'abc',
@@ -431,7 +431,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to update nonce', () => {
+    it('should create an action to update nonce', function () {
       const nonce = '0x1'
       const expectedAction = {
         type: UPDATE_NONCE,
@@ -444,7 +444,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to set fetchingData to true', () => {
+    it('should create an action to set fetchingData to true', function () {
       const expectedAction = {
         type: FETCH_DATA_START,
       }
@@ -455,7 +455,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to set fetchingData to false', () => {
+    it('should create an action to set fetchingData to false', function () {
       const expectedAction = {
         type: FETCH_DATA_END,
       }
@@ -466,7 +466,7 @@ describe('Confirm Transaction Duck', () => {
       )
     })
 
-    it('should create an action to clear confirmTransaction', () => {
+    it('should create an action to clear confirmTransaction', function () {
       const expectedAction = {
         type: CLEAR_CONFIRM_TRANSACTION,
       }
@@ -478,8 +478,8 @@ describe('Confirm Transaction Duck', () => {
     })
   })
 
-  describe('Thunk actions', () => {
-    beforeEach(() => {
+  describe('Thunk actions', function () {
+    beforeEach(function () {
       global.eth = {
         getCode: sinon.stub().callsFake(
           address => Promise.resolve(address && address.match(/isContract/) ? 'not-0x' : '0x')
@@ -487,11 +487,11 @@ describe('Confirm Transaction Duck', () => {
       }
     })
 
-    afterEach(() => {
+    afterEach(function () {
       global.eth.getCode.resetHistory()
     })
 
-    it('updates txData and gas on an existing transaction in confirmTransaction', () => {
+    it('updates txData and gas on an existing transaction in confirmTransaction', function () {
       const mockState = {
         metamask: {
           conversionRate: 468.58,
@@ -546,7 +546,7 @@ describe('Confirm Transaction Duck', () => {
       storeActions.forEach((action, index) => assert.equal(action.type, expectedActions[index]))
     })
 
-    it('updates txData and updates gas values in confirmTransaction', () => {
+    it('updates txData and updates gas values in confirmTransaction', function () {
       const txData = {
         estimatedGas: '0x5208',
         gasLimitSpecified: false,
@@ -614,7 +614,7 @@ describe('Confirm Transaction Duck', () => {
       storeActions.forEach((action, index) => assert.equal(action.type, expectedActions[index]))
     })
 
-    it('updates confirmTransaction transaction', () => {
+    it('updates confirmTransaction transaction', function () {
       const mockState = {
         metamask: {
           conversionRate: 468.58,

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -27,7 +27,7 @@ const {
 } = GasDuck
 const GasReducer = GasDuck.default
 
-describe('Gas Duck', () => {
+describe('Gas Duck', function () {
   let tempFetch
   let tempDateNow
   const mockEthGasApiResponse = {
@@ -75,7 +75,7 @@ describe('Gas Duck', () => {
     })
   })
 
-  beforeEach(() => {
+  beforeEach(function () {
     tempFetch = global.fetch
     tempDateNow = global.Date.now
 
@@ -85,7 +85,7 @@ describe('Gas Duck', () => {
     global.Date.now = () => 2000000
   })
 
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore()
 
     global.fetch = tempFetch
@@ -136,12 +136,12 @@ describe('Gas Duck', () => {
   const SET_BASIC_API_ESTIMATES_LAST_RETRIEVED = 'metamask/gas/SET_BASIC_API_ESTIMATES_LAST_RETRIEVED'
   const SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED = 'metamask/gas/SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED'
 
-  describe('GasReducer()', () => {
-    it('should initialize state', () => {
+  describe('GasReducer()', function () {
+    it('should initialize state', function () {
       assert.deepEqual(GasReducer(undefined, {}), initState)
     })
 
-    it('should return state unchanged if it does not match a dispatched actions type', () => {
+    it('should return state unchanged if it does not match a dispatched actions type', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: 'someOtherAction',
@@ -151,35 +151,35 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set basicEstimateIsLoading to true when receiving a BASIC_GAS_ESTIMATE_LOADING_STARTED action', () => {
+    it('should set basicEstimateIsLoading to true when receiving a BASIC_GAS_ESTIMATE_LOADING_STARTED action', function () {
       assert.deepEqual(
         GasReducer(mockState, { type: BASIC_GAS_ESTIMATE_LOADING_STARTED }),
         { basicEstimateIsLoading: true, ...mockState },
       )
     })
 
-    it('should set basicEstimateIsLoading to false when receiving a BASIC_GAS_ESTIMATE_LOADING_FINISHED action', () => {
+    it('should set basicEstimateIsLoading to false when receiving a BASIC_GAS_ESTIMATE_LOADING_FINISHED action', function () {
       assert.deepEqual(
         GasReducer(mockState, { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED }),
         { basicEstimateIsLoading: false, ...mockState },
       )
     })
 
-    it('should set gasEstimatesLoading to true when receiving a GAS_ESTIMATE_LOADING_STARTED action', () => {
+    it('should set gasEstimatesLoading to true when receiving a GAS_ESTIMATE_LOADING_STARTED action', function () {
       assert.deepEqual(
         GasReducer(mockState, { type: GAS_ESTIMATE_LOADING_STARTED }),
         { gasEstimatesLoading: true, ...mockState }
       )
     })
 
-    it('should set gasEstimatesLoading to false when receiving a GAS_ESTIMATE_LOADING_FINISHED action', () => {
+    it('should set gasEstimatesLoading to false when receiving a GAS_ESTIMATE_LOADING_FINISHED action', function () {
       assert.deepEqual(
         GasReducer(mockState, { type: GAS_ESTIMATE_LOADING_FINISHED }),
         { gasEstimatesLoading: false, ...mockState },
       )
     })
 
-    it('should set basicEstimates when receiving a SET_BASIC_GAS_ESTIMATE_DATA action', () => {
+    it('should set basicEstimates when receiving a SET_BASIC_GAS_ESTIMATE_DATA action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_BASIC_GAS_ESTIMATE_DATA,
@@ -189,7 +189,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set priceAndTimeEstimates when receiving a SET_PRICE_AND_TIME_ESTIMATES action', () => {
+    it('should set priceAndTimeEstimates when receiving a SET_PRICE_AND_TIME_ESTIMATES action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_PRICE_AND_TIME_ESTIMATES,
@@ -199,7 +199,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set customData.price when receiving a SET_CUSTOM_GAS_PRICE action', () => {
+    it('should set customData.price when receiving a SET_CUSTOM_GAS_PRICE action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_CUSTOM_GAS_PRICE,
@@ -209,7 +209,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set customData.limit when receiving a SET_CUSTOM_GAS_LIMIT action', () => {
+    it('should set customData.limit when receiving a SET_CUSTOM_GAS_LIMIT action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_CUSTOM_GAS_LIMIT,
@@ -219,7 +219,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set customData.total when receiving a SET_CUSTOM_GAS_TOTAL action', () => {
+    it('should set customData.total when receiving a SET_CUSTOM_GAS_TOTAL action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_CUSTOM_GAS_TOTAL,
@@ -229,7 +229,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set priceAndTimeEstimatesLastRetrieved when receiving a SET_API_ESTIMATES_LAST_RETRIEVED action', () => {
+    it('should set priceAndTimeEstimatesLastRetrieved when receiving a SET_API_ESTIMATES_LAST_RETRIEVED action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_API_ESTIMATES_LAST_RETRIEVED,
@@ -239,7 +239,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set priceAndTimeEstimatesLastRetrieved when receiving a SET_BASIC_API_ESTIMATES_LAST_RETRIEVED action', () => {
+    it('should set priceAndTimeEstimatesLastRetrieved when receiving a SET_BASIC_API_ESTIMATES_LAST_RETRIEVED action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_BASIC_API_ESTIMATES_LAST_RETRIEVED,
@@ -249,7 +249,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should set errors when receiving a SET_CUSTOM_GAS_ERRORS action', () => {
+    it('should set errors when receiving a SET_CUSTOM_GAS_ERRORS action', function () {
       assert.deepEqual(
         GasReducer(mockState, {
           type: SET_CUSTOM_GAS_ERRORS,
@@ -259,7 +259,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should return the initial state in response to a RESET_CUSTOM_GAS_STATE action', () => {
+    it('should return the initial state in response to a RESET_CUSTOM_GAS_STATE action', function () {
       assert.deepEqual(
         GasReducer(mockState, { type: RESET_CUSTOM_GAS_STATE }),
         initState,
@@ -267,20 +267,20 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('basicGasEstimatesLoadingStarted', () => {
-    it('should create the correct action', () => {
+  describe('basicGasEstimatesLoadingStarted', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(basicGasEstimatesLoadingStarted(), { type: BASIC_GAS_ESTIMATE_LOADING_STARTED })
     })
   })
 
-  describe('basicGasEstimatesLoadingFinished', () => {
-    it('should create the correct action', () => {
+  describe('basicGasEstimatesLoadingFinished', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(basicGasEstimatesLoadingFinished(), { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED })
     })
   })
 
-  describe('fetchBasicGasEstimates', () => {
-    it('should call fetch with the expected params', async () => {
+  describe('fetchBasicGasEstimates', function () {
+    it('should call fetch with the expected params', async function () {
       const mockDistpatch = sinon.spy()
 
       await fetchBasicGasEstimates()(mockDistpatch, () => ({
@@ -328,7 +328,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should fetch recently retrieved estimates from local storage', async () => {
+    it('should fetch recently retrieved estimates from local storage', async function () {
       const mockDistpatch = sinon.spy()
       fakeLocalStorage.loadLocalStorageData
         .withArgs('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED')
@@ -374,7 +374,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should fallback to network if retrieving estimates from local storage fails', async () => {
+    it('should fallback to network if retrieving estimates from local storage fails', async function () {
       const mockDistpatch = sinon.spy()
       fakeLocalStorage.loadLocalStorageData
         .withArgs('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED')
@@ -428,8 +428,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('fetchBasicGasAndTimeEstimates', () => {
-    it('should call fetch with the expected params', async () => {
+  describe('fetchBasicGasAndTimeEstimates', function () {
+    it('should call fetch with the expected params', async function () {
       const mockDistpatch = sinon.spy()
 
       await fetchBasicGasAndTimeEstimates()(mockDistpatch, () => ({ gas: Object.assign(
@@ -488,7 +488,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should fetch recently retrieved estimates from local storage', async () => {
+    it('should fetch recently retrieved estimates from local storage', async function () {
       const mockDistpatch = sinon.spy()
       fakeLocalStorage.loadLocalStorageData
         .withArgs('BASIC_GAS_AND_TIME_API_ESTIMATES_LAST_RETRIEVED')
@@ -547,7 +547,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should fallback to network if retrieving estimates from local storage fails', async () => {
+    it('should fallback to network if retrieving estimates from local storage fails', async function () {
       const mockDistpatch = sinon.spy()
       fakeLocalStorage.loadLocalStorageData
         .withArgs('BASIC_GAS_AND_TIME_API_ESTIMATES_LAST_RETRIEVED')
@@ -610,8 +610,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('fetchGasEstimates', () => {
-    it('should call fetch with the expected params', async () => {
+  describe('fetchGasEstimates', function () {
+    it('should call fetch with the expected params', async function () {
       const mockDistpatch = sinon.spy()
 
       await fetchGasEstimates(5)(mockDistpatch, () => ({ gas: Object.assign(
@@ -658,7 +658,7 @@ describe('Gas Duck', () => {
       )
     })
 
-    it('should not call fetch if the estimates were retrieved < 75000 ms ago', async () => {
+    it('should not call fetch if the estimates were retrieved < 75000 ms ago', async function () {
       const mockDistpatch = sinon.spy()
 
       await fetchGasEstimates(5)(mockDistpatch, () => ({ gas: Object.assign(
@@ -702,8 +702,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('gasEstimatesLoadingStarted', () => {
-    it('should create the correct action', () => {
+  describe('gasEstimatesLoadingStarted', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         gasEstimatesLoadingStarted(),
         { type: GAS_ESTIMATE_LOADING_STARTED }
@@ -711,8 +711,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('gasEstimatesLoadingFinished', () => {
-    it('should create the correct action', () => {
+  describe('gasEstimatesLoadingFinished', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         gasEstimatesLoadingFinished(),
         { type: GAS_ESTIMATE_LOADING_FINISHED }
@@ -720,8 +720,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('setPricesAndTimeEstimates', () => {
-    it('should create the correct action', () => {
+  describe('setPricesAndTimeEstimates', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         setPricesAndTimeEstimates('mockPricesAndTimeEstimates'),
         { type: SET_PRICE_AND_TIME_ESTIMATES, value: 'mockPricesAndTimeEstimates' }
@@ -729,8 +729,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('setBasicGasEstimateData', () => {
-    it('should create the correct action', () => {
+  describe('setBasicGasEstimateData', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         setBasicGasEstimateData('mockBasicEstimatData'),
         { type: SET_BASIC_GAS_ESTIMATE_DATA, value: 'mockBasicEstimatData' }
@@ -738,8 +738,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('setCustomGasPrice', () => {
-    it('should create the correct action', () => {
+  describe('setCustomGasPrice', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         setCustomGasPrice('mockCustomGasPrice'),
         { type: SET_CUSTOM_GAS_PRICE, value: 'mockCustomGasPrice' }
@@ -747,8 +747,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('setCustomGasLimit', () => {
-    it('should create the correct action', () => {
+  describe('setCustomGasLimit', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         setCustomGasLimit('mockCustomGasLimit'),
         { type: SET_CUSTOM_GAS_LIMIT, value: 'mockCustomGasLimit' }
@@ -756,8 +756,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('setCustomGasTotal', () => {
-    it('should create the correct action', () => {
+  describe('setCustomGasTotal', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         setCustomGasTotal('mockCustomGasTotal'),
         { type: SET_CUSTOM_GAS_TOTAL, value: 'mockCustomGasTotal' }
@@ -765,8 +765,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('setCustomGasErrors', () => {
-    it('should create the correct action', () => {
+  describe('setCustomGasErrors', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         setCustomGasErrors('mockErrorObject'),
         { type: SET_CUSTOM_GAS_ERRORS, value: 'mockErrorObject' }
@@ -774,8 +774,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('setApiEstimatesLastRetrieved', () => {
-    it('should create the correct action', () => {
+  describe('setApiEstimatesLastRetrieved', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         setApiEstimatesLastRetrieved(1234),
         { type: SET_API_ESTIMATES_LAST_RETRIEVED, value: 1234 }
@@ -783,8 +783,8 @@ describe('Gas Duck', () => {
     })
   })
 
-  describe('resetCustomGasState', () => {
-    it('should create the correct action', () => {
+  describe('resetCustomGasState', function () {
+    it('should create the correct action', function () {
       assert.deepEqual(
         resetCustomGasState(),
         { type: RESET_CUSTOM_GAS_STATE }

--- a/ui/app/ducks/send/send-duck.test.js
+++ b/ui/app/ducks/send/send-duck.test.js
@@ -8,7 +8,7 @@ import SendReducer, {
   hideGasButtonGroup,
 } from './send.duck.js'
 
-describe('Send Duck', () => {
+describe('Send Duck', function () {
   const mockState = {
     mockProp: 123,
   }
@@ -24,12 +24,12 @@ describe('Send Duck', () => {
   const SHOW_GAS_BUTTON_GROUP = 'metamask/send/SHOW_GAS_BUTTON_GROUP'
   const HIDE_GAS_BUTTON_GROUP = 'metamask/send/HIDE_GAS_BUTTON_GROUP'
 
-  describe('SendReducer()', () => {
-    it('should initialize state', () => {
+  describe('SendReducer()', function () {
+    it('should initialize state', function () {
       assert.deepEqual(SendReducer(undefined, {}), initState)
     })
 
-    it('should return state unchanged if it does not match a dispatched actions type', () => {
+    it('should return state unchanged if it does not match a dispatched actions type', function () {
       assert.deepEqual(
         SendReducer(mockState, {
           type: 'someOtherAction',
@@ -39,7 +39,7 @@ describe('Send Duck', () => {
       )
     })
 
-    it('should set toDropdownOpen to true when receiving a OPEN_TO_DROPDOWN action', () => {
+    it('should set toDropdownOpen to true when receiving a OPEN_TO_DROPDOWN action', function () {
       assert.deepEqual(
         SendReducer(mockState, {
           type: OPEN_TO_DROPDOWN,
@@ -48,7 +48,7 @@ describe('Send Duck', () => {
       )
     })
 
-    it('should set toDropdownOpen to false when receiving a CLOSE_TO_DROPDOWN action', () => {
+    it('should set toDropdownOpen to false when receiving a CLOSE_TO_DROPDOWN action', function () {
       assert.deepEqual(
         SendReducer(mockState, {
           type: CLOSE_TO_DROPDOWN,
@@ -57,21 +57,21 @@ describe('Send Duck', () => {
       )
     })
 
-    it('should set gasButtonGroupShown to true when receiving a SHOW_GAS_BUTTON_GROUP action', () => {
+    it('should set gasButtonGroupShown to true when receiving a SHOW_GAS_BUTTON_GROUP action', function () {
       assert.deepEqual(
         SendReducer({ ...mockState, gasButtonGroupShown: false }, { type: SHOW_GAS_BUTTON_GROUP }),
         { gasButtonGroupShown: true, ...mockState },
       )
     })
 
-    it('should set gasButtonGroupShown to false when receiving a HIDE_GAS_BUTTON_GROUP action', () => {
+    it('should set gasButtonGroupShown to false when receiving a HIDE_GAS_BUTTON_GROUP action', function () {
       assert.deepEqual(
         SendReducer(mockState, { type: HIDE_GAS_BUTTON_GROUP }),
         { gasButtonGroupShown: false, ...mockState },
       )
     })
 
-    it('should extend send.errors with the value of a UPDATE_SEND_ERRORS action', () => {
+    it('should extend send.errors with the value of a UPDATE_SEND_ERRORS action', function () {
       const modifiedMockState = {
         ...mockState,
         errors: {
@@ -93,7 +93,7 @@ describe('Send Duck', () => {
       )
     })
 
-    it('should return the initial state in response to a RESET_SEND_STATE action', () => {
+    it('should return the initial state in response to a RESET_SEND_STATE action', function () {
       assert.deepEqual(
         SendReducer(mockState, {
           type: RESET_SEND_STATE,
@@ -103,23 +103,23 @@ describe('Send Duck', () => {
     })
   })
 
-  describe('openToDropdown', () => {
+  describe('openToDropdown', function () {
     assert.deepEqual(openToDropdown(), { type: OPEN_TO_DROPDOWN })
   })
 
-  describe('closeToDropdown', () => {
+  describe('closeToDropdown', function () {
     assert.deepEqual(closeToDropdown(), { type: CLOSE_TO_DROPDOWN })
   })
 
-  describe('showGasButtonGroup', () => {
+  describe('showGasButtonGroup', function () {
     assert.deepEqual(showGasButtonGroup(), { type: SHOW_GAS_BUTTON_GROUP })
   })
 
-  describe('hideGasButtonGroup', () => {
+  describe('hideGasButtonGroup', function () {
     assert.deepEqual(hideGasButtonGroup(), { type: HIDE_GAS_BUTTON_GROUP })
   })
 
-  describe('updateSendErrors', () => {
+  describe('updateSendErrors', function () {
     assert.deepEqual(updateSendErrors('mockErrorObject'), { type: UPDATE_SEND_ERRORS, value: 'mockErrorObject' })
   })
 })

--- a/ui/app/helpers/higher-order-components/with-modal-props/tests/with-modal-props.test.js
+++ b/ui/app/helpers/higher-order-components/with-modal-props/tests/with-modal-props.test.js
@@ -19,8 +19,8 @@ const mockState = {
   },
 }
 
-describe('withModalProps', () => {
-  it('should return a component wrapped with modal state props', () => {
+describe('withModalProps', function () {
+  it('should return a component wrapped with modal state props', function () {
     const TestComponent = () => (
       <div className="test">Testing</div>
     )

--- a/ui/app/helpers/higher-order-components/with-token-tracker/tests/with-token-tracker.component.test.js
+++ b/ui/app/helpers/higher-order-components/with-token-tracker/tests/with-token-tracker.component.test.js
@@ -10,10 +10,10 @@ const { createTestProviderTools } = require('../../../../../../test/stub/provide
 
 const provider = createTestProviderTools({ scaffold: {} }).provider
 
-describe('WithTokenTracker HOC', () => {
+describe('WithTokenTracker HOC', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     const TokenTracker = withTokenTracker(TokenBalance)
     wrapper = shallow(
       <TokenTracker
@@ -27,12 +27,12 @@ describe('WithTokenTracker HOC', () => {
     )
   })
 
-  it('#setError', () => {
+  it('#setError', function () {
     wrapper.instance().setError('test')
     assert.equal(wrapper.props().error, 'test')
   })
 
-  it('#updateBalance', () => {
+  it('#updateBalance', function () {
     wrapper.instance().tracker = new TokenTracker({
       provider,
     })

--- a/ui/app/helpers/utils/common.util.test.js
+++ b/ui/app/helpers/utils/common.util.test.js
@@ -1,9 +1,9 @@
 import * as utils from './common.util'
 import assert from 'assert'
 
-describe('Common utils', () => {
-  describe('camelCaseToCapitalize', () => {
-    it('should return a capitalized string from a camel-cased string', () => {
+describe('Common utils', function () {
+  describe('camelCaseToCapitalize', function () {
+    it('should return a capitalized string from a camel-cased string', function () {
       const tests = [
         {
           test: undefined,

--- a/ui/app/helpers/utils/confirm-tx.util.test.js
+++ b/ui/app/helpers/utils/confirm-tx.util.test.js
@@ -1,42 +1,42 @@
 import * as utils from './confirm-tx.util'
 import assert from 'assert'
 
-describe('Confirm Transaction utils', () => {
-  describe('increaseLastGasPrice', () => {
-    it('should increase the gasPrice by 10%', () => {
+describe('Confirm Transaction utils', function () {
+  describe('increaseLastGasPrice', function () {
+    it('should increase the gasPrice by 10%', function () {
       const increasedGasPrice = utils.increaseLastGasPrice('0xa')
       assert.equal(increasedGasPrice, '0xb')
     })
 
-    it('should prefix the result with 0x', () => {
+    it('should prefix the result with 0x', function () {
       const increasedGasPrice = utils.increaseLastGasPrice('a')
       assert.equal(increasedGasPrice, '0xb')
     })
   })
 
-  describe('hexGreaterThan', () => {
-    it('should return true if the first value is greater than the second value', () => {
+  describe('hexGreaterThan', function () {
+    it('should return true if the first value is greater than the second value', function () {
       assert.equal(
         utils.hexGreaterThan('0xb', '0xa'),
         true
       )
     })
 
-    it('should return false if the first value is less than the second value', () => {
+    it('should return false if the first value is less than the second value', function () {
       assert.equal(
         utils.hexGreaterThan('0xa', '0xb'),
         false
       )
     })
 
-    it('should return false if the first value is equal to the second value', () => {
+    it('should return false if the first value is equal to the second value', function () {
       assert.equal(
         utils.hexGreaterThan('0xa', '0xa'),
         false
       )
     })
 
-    it('should correctly compare prefixed and non-prefixed hex values', () => {
+    it('should correctly compare prefixed and non-prefixed hex values', function () {
       assert.equal(
         utils.hexGreaterThan('0xb', 'a'),
         true
@@ -44,15 +44,15 @@ describe('Confirm Transaction utils', () => {
     })
   })
 
-  describe('getHexGasTotal', () => {
-    it('should multiply the hex gasLimit and hex gasPrice values together', () => {
+  describe('getHexGasTotal', function () {
+    it('should multiply the hex gasLimit and hex gasPrice values together', function () {
       assert.equal(
         utils.getHexGasTotal({ gasLimit: '0x5208', gasPrice: '0x3b9aca00' }),
         '0x1319718a5000'
       )
     })
 
-    it('should prefix the result with 0x', () => {
+    it('should prefix the result with 0x', function () {
       assert.equal(
         utils.getHexGasTotal({ gasLimit: '5208', gasPrice: '3b9aca00' }),
         '0x1319718a5000'
@@ -60,15 +60,15 @@ describe('Confirm Transaction utils', () => {
     })
   })
 
-  describe('addEth', () => {
-    it('should add two values together rounding to 6 decimal places', () => {
+  describe('addEth', function () {
+    it('should add two values together rounding to 6 decimal places', function () {
       assert.equal(
         utils.addEth('0.12345678', '0'),
         '0.123457'
       )
     })
 
-    it('should add any number of values together rounding to 6 decimal places', () => {
+    it('should add any number of values together rounding to 6 decimal places', function () {
       assert.equal(
         utils.addEth('0.1', '0.02', '0.003', '0.0004', '0.00005', '0.000006', '0.0000007'),
         '0.123457'
@@ -76,15 +76,15 @@ describe('Confirm Transaction utils', () => {
     })
   })
 
-  describe('addFiat', () => {
-    it('should add two values together rounding to 2 decimal places', () => {
+  describe('addFiat', function () {
+    it('should add two values together rounding to 2 decimal places', function () {
       assert.equal(
         utils.addFiat('0.12345678', '0'),
         '0.12'
       )
     })
 
-    it('should add any number of values together rounding to 2 decimal places', () => {
+    it('should add any number of values together rounding to 2 decimal places', function () {
       assert.equal(
         utils.addFiat('0.1', '0.02', '0.003', '0.0004', '0.00005', '0.000006', '0.0000007'),
         '0.12'
@@ -92,8 +92,8 @@ describe('Confirm Transaction utils', () => {
     })
   })
 
-  describe('getValueFromWeiHex', () => {
-    it('should get the transaction amount in ETH', () => {
+  describe('getValueFromWeiHex', function () {
+    it('should get the transaction amount in ETH', function () {
       const ethTransactionAmount = utils.getValueFromWeiHex({
         value: '0xde0b6b3a7640000', toCurrency: 'ETH', conversionRate: 468.58, numberOfDecimals: 6,
       })
@@ -101,7 +101,7 @@ describe('Confirm Transaction utils', () => {
       assert.equal(ethTransactionAmount, '1')
     })
 
-    it('should get the transaction amount in fiat', () => {
+    it('should get the transaction amount in fiat', function () {
       const fiatTransactionAmount = utils.getValueFromWeiHex({
         value: '0xde0b6b3a7640000', toCurrency: 'usd', conversionRate: 468.58, numberOfDecimals: 2,
       })
@@ -110,8 +110,8 @@ describe('Confirm Transaction utils', () => {
     })
   })
 
-  describe('getTransactionFee', () => {
-    it('should get the transaction fee in ETH', () => {
+  describe('getTransactionFee', function () {
+    it('should get the transaction fee in ETH', function () {
       const ethTransactionFee = utils.getTransactionFee({
         value: '0x1319718a5000', toCurrency: 'ETH', conversionRate: 468.58, numberOfDecimals: 6,
       })
@@ -119,7 +119,7 @@ describe('Confirm Transaction utils', () => {
       assert.equal(ethTransactionFee, '0.000021')
     })
 
-    it('should get the transaction fee in fiat', () => {
+    it('should get the transaction fee in fiat', function () {
       const fiatTransactionFee = utils.getTransactionFee({
         value: '0x1319718a5000', toCurrency: 'usd', conversionRate: 468.58, numberOfDecimals: 2,
       })
@@ -128,8 +128,8 @@ describe('Confirm Transaction utils', () => {
     })
   })
 
-  describe('formatCurrency', () => {
-    it('should format USD values', () => {
+  describe('formatCurrency', function () {
+    it('should format USD values', function () {
       const value = utils.formatCurrency('123.45', 'usd')
       assert.equal(value, '$123.45')
     })

--- a/ui/app/helpers/utils/conversion-util.test.js
+++ b/ui/app/helpers/utils/conversion-util.test.js
@@ -2,19 +2,19 @@ import assert from 'assert'
 import { addCurrencies } from './conversion-util'
 
 
-describe('conversion utils', () => {
-  describe('addCurrencies()', () => {
-    it('add whole numbers', () => {
+describe('conversion utils', function () {
+  describe('addCurrencies()', function () {
+    it('add whole numbers', function () {
       const result = addCurrencies(3, 9)
       assert.equal(result.toNumber(), 12)
     })
 
-    it('add decimals', () => {
+    it('add decimals', function () {
       const result = addCurrencies(1.3, 1.9)
       assert.equal(result.toNumber(), 3.2)
     })
 
-    it('add repeating decimals', () => {
+    it('add repeating decimals', function () {
       const result = addCurrencies(1 / 3, 1 / 9)
       assert.equal(result.toNumber(), 0.4444444444444444)
     })

--- a/ui/app/helpers/utils/fetch-with-cache.test.js
+++ b/ui/app/helpers/utils/fetch-with-cache.test.js
@@ -8,17 +8,17 @@ const fetchWithCache = proxyquire('./fetch-with-cache', {
   '../../../lib/local-storage-helpers': fakeLocalStorageHelpers,
 }).default
 
-describe('Fetch with cache', () => {
-  beforeEach(() => {
+describe('Fetch with cache', function () {
+  beforeEach(function () {
     fakeLocalStorageHelpers.loadLocalStorageData = sinon.stub()
     fakeLocalStorageHelpers.saveLocalStorageData = sinon.stub()
   })
-  afterEach(() => {
+  afterEach(function () {
     sinon.restore()
     nock.cleanAll()
   })
 
-  it('fetches a url', async () => {
+  it('fetches a url', async function () {
     nock('https://fetchwithcache.metamask.io')
       .get('/price')
       .reply(200, '{"average": 1}')
@@ -29,7 +29,7 @@ describe('Fetch with cache', () => {
     })
   })
 
-  it('returns cached response', async () => {
+  it('returns cached response', async function () {
     nock('https://fetchwithcache.metamask.io')
       .get('/price')
       .reply(200, '{"average": 2}')
@@ -47,7 +47,7 @@ describe('Fetch with cache', () => {
     })
   })
 
-  it('fetches URL again after cache refresh time has passed', async () => {
+  it('fetches URL again after cache refresh time has passed', async function () {
     nock('https://fetchwithcache.metamask.io')
       .get('/price')
       .reply(200, '{"average": 3}')
@@ -65,7 +65,7 @@ describe('Fetch with cache', () => {
     })
   })
 
-  it('should abort the request when the custom timeout is hit', async () => {
+  it('should abort the request when the custom timeout is hit', async function () {
     nock('https://fetchwithcache.metamask.io')
       .get('/price')
       .delay(100)
@@ -79,7 +79,7 @@ describe('Fetch with cache', () => {
     }
   })
 
-  it('throws when the response is unsuccessful', async () => {
+  it('throws when the response is unsuccessful', async function () {
     nock('https://fetchwithcache.metamask.io')
       .get('/price')
       .reply(500, '{"average": 6}')
@@ -92,7 +92,7 @@ describe('Fetch with cache', () => {
     }
   })
 
-  it('throws when a POST request is attempted', async () => {
+  it('throws when a POST request is attempted', async function () {
     nock('https://fetchwithcache.metamask.io')
       .post('/price')
       .reply(200, '{"average": 7}')
@@ -105,7 +105,7 @@ describe('Fetch with cache', () => {
     }
   })
 
-  it('throws when the request has a truthy body', async () => {
+  it('throws when the request has a truthy body', async function () {
     nock('https://fetchwithcache.metamask.io')
       .get('/price')
       .reply(200, '{"average": 8}')
@@ -118,7 +118,7 @@ describe('Fetch with cache', () => {
     }
   })
 
-  it('throws when the request has an invalid Content-Type header', async () => {
+  it('throws when the request has an invalid Content-Type header', async function () {
     nock('https://fetchwithcache.metamask.io')
       .get('/price')
       .reply(200, '{"average": 9}')

--- a/ui/app/helpers/utils/transactions.util.test.js
+++ b/ui/app/helpers/utils/transactions.util.test.js
@@ -1,9 +1,9 @@
 import * as utils from './transactions.util'
 import assert from 'assert'
 
-describe('Transactions utils', () => {
-  describe('getTokenData', () => {
-    it('should return token data', () => {
+describe('Transactions utils', function () {
+  describe('getTokenData', function () {
+    it('should return token data', function () {
       const tokenData = utils.getTokenData('0xa9059cbb00000000000000000000000050a9d56c2b8ba9a5c7f2c08c3d26e0499f23a7060000000000000000000000000000000000000000000000000000000000004e20')
       assert.ok(tokenData)
       const { name, params } = tokenData
@@ -15,13 +15,13 @@ describe('Transactions utils', () => {
       assert.equal(value.type, 'uint256')
     })
 
-    it('should not throw errors when called without arguments', () => {
+    it('should not throw errors when called without arguments', function () {
       assert.doesNotThrow(() => utils.getTokenData())
     })
   })
 
-  describe('getStatusKey', () => {
-    it('should return the correct status', () => {
+  describe('getStatusKey', function () {
+    it('should return the correct status', function () {
       const tests = [
         {
           transaction: {

--- a/ui/app/helpers/utils/util.test.js
+++ b/ui/app/helpers/utils/util.test.js
@@ -121,18 +121,18 @@ describe('util', function () {
   })
 
   describe('#formatBalance', function () {
-    it('when given nothing', function () {
+    it('should return None when given nothing', function () {
       const result = util.formatBalance()
       assert.equal(result, 'None', 'should return "None"')
     })
 
-    it('should return eth as string followed by ETH', function () {
+    it('should return 1.0000 ETH', function () {
       const input = new ethUtil.BN(ethInWei, 10).toJSON()
       const result = util.formatBalance(input, 4)
       assert.equal(result, '1.0000 ETH')
     })
 
-    it('should return eth as string followed by ETH', function () {
+    it('should return 0.500 ETH', function () {
       const input = new ethUtil.BN(ethInWei, 10).div(new ethUtil.BN('2', 10)).toJSON()
       const result = util.formatBalance(input, 3)
       assert.equal(result, '0.500 ETH')

--- a/ui/app/pages/add-token/tests/add-token.test.js
+++ b/ui/app/pages/add-token/tests/add-token.test.js
@@ -6,7 +6,7 @@ import configureMockStore from 'redux-mock-store'
 import { mountWithRouter } from '../../../../../test/lib/render-helpers'
 import AddToken from '../index'
 
-describe('Add Token', () => {
+describe('Add Token', function () {
   let wrapper
 
   const state = {
@@ -15,8 +15,7 @@ describe('Add Token', () => {
     },
   }
 
-  const mockStore = configureMockStore()
-  const store = mockStore(state)
+  const store = configureMockStore()(state)
 
   const props = {
     history: {
@@ -28,29 +27,28 @@ describe('Add Token', () => {
     identities: {},
   }
 
-  before(() => {
-    wrapper = mountWithRouter(
-      <Provider store={store}>
-        <AddToken.WrappedComponent {...props} />
-      </Provider>, store
-    )
+  describe('Add Token', function () {
+    before(function () {
+      wrapper = mountWithRouter(
+        <Provider store={store}>
+          <AddToken.WrappedComponent {...props} />
+        </Provider>, store
+      )
 
-    wrapper.find({ name: 'customToken' }).simulate('click')
-  })
+      wrapper.find({ name: 'customToken' }).simulate('click')
+    })
 
-  afterEach(() => {
-    props.history.push.reset()
-  })
+    afterEach(function () {
+      props.history.push.reset()
+    })
 
-  describe('Add Token', () => {
-
-    it('next button is disabled when no fields are populated', () => {
+    it('next button is disabled when no fields are populated', function () {
       const nextButton = wrapper.find('.button.btn-secondary.page-container__footer-button')
 
       assert.equal(nextButton.props().disabled, true)
     })
 
-    it('edits token address', () => {
+    it('edits token address', function () {
       const tokenAddress = '0x617b3f8050a0BD94b6b1da02B4384eE5B4DF13F4'
       const event = { target: { value: tokenAddress } }
       const customAddress = wrapper.find('input#custom-address')
@@ -60,7 +58,7 @@ describe('Add Token', () => {
     })
 
 
-    it('edits token symbol', () => {
+    it('edits token symbol', function () {
       const tokenSymbol = 'META'
       const event = { target: { value: tokenSymbol } }
       const customAddress = wrapper.find('#custom-symbol')
@@ -69,17 +67,16 @@ describe('Add Token', () => {
       assert.equal(wrapper.find('AddToken').instance().state.customSymbol, tokenSymbol)
     })
 
-    it('edits token decimal precision', () => {
+    it('edits token decimal precision', function () {
       const tokenPrecision = '2'
       const event = { target: { value: tokenPrecision } }
       const customAddress = wrapper.find('#custom-decimals')
       customAddress.last().simulate('change', event)
 
       assert.equal(wrapper.find('AddToken').instance().state.customDecimals, tokenPrecision)
-
     })
 
-    it('next', () => {
+    it('next', function () {
       const nextButton = wrapper.find('.button.btn-secondary.page-container__footer-button')
       nextButton.simulate('click')
 
@@ -88,7 +85,7 @@ describe('Add Token', () => {
       assert.equal(props.history.push.getCall(0).args[0], '/confirm-add-token')
     })
 
-    it('cancels', () => {
+    it('cancels', function () {
       const cancelButton = wrapper.find('button.btn-default.page-container__footer-button')
       cancelButton.simulate('click')
 
@@ -96,5 +93,4 @@ describe('Add Token', () => {
       assert.equal(props.history.push.getCall(0).args[0], '/')
     })
   })
-
 })

--- a/ui/app/pages/confirm-transaction-base/tests/confirm-transaction-base.component.test.js
+++ b/ui/app/pages/confirm-transaction-base/tests/confirm-transaction-base.component.test.js
@@ -1,9 +1,9 @@
 import assert from 'assert'
 import { getMethodName } from '../confirm-transaction-base.component'
 
-describe('ConfirmTransactionBase Component', () => {
-  describe('getMethodName', () => {
-    it('should get correct method names', () => {
+describe('ConfirmTransactionBase Component', function () {
+  describe('getMethodName', function () {
+    it('should get correct method names', function () {
       assert.equal(getMethodName(undefined), '')
       assert.equal(getMethodName({}), '')
       assert.equal(getMethodName('confirm'), 'confirm')

--- a/ui/app/pages/create-account/tests/create-account.test.js
+++ b/ui/app/pages/create-account/tests/create-account.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mountWithRouter } from '../../../../../test/lib/render-helpers'
 import CreateAccountPage from '../index'
 
-describe('Create Account Page', () => {
+describe('Create Account Page', function () {
   let wrapper
 
   const props = {
@@ -16,29 +16,29 @@ describe('Create Account Page', () => {
     },
   }
 
-  before(() => {
+  before(function () {
     wrapper = mountWithRouter(
       <CreateAccountPage {...props} />
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.history.push.resetHistory()
   })
 
-  it('clicks create account and routes to new-account path', () => {
+  it('clicks create account and routes to new-account path', function () {
     const createAccount = wrapper.find('.new-account__tabs__tab').at(0)
     createAccount.simulate('click')
     assert.equal(props.history.push.getCall(0).args[0], '/new-account')
   })
 
-  it('clicks import account and routes to import new account path', () => {
+  it('clicks import account and routes to import new account path', function () {
     const importAccount = wrapper.find('.new-account__tabs__tab').at(1)
     importAccount.simulate('click')
     assert.equal(props.history.push.getCall(0).args[0], '/new-account/import')
   })
 
-  it('clicks connect HD Wallet and routes to connect new account path', () => {
+  it('clicks connect HD Wallet and routes to connect new account path', function () {
     const connectHdWallet = wrapper.find('.new-account__tabs__tab').at(2)
     connectHdWallet.simulate('click')
     assert.equal(props.history.push.getCall(0).args[0], '/new-account/connect')

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
@@ -14,8 +14,8 @@ function shallowRender (props = {}, context = {}) {
   })
 }
 
-describe('ImportWithSeedPhrase Component', () => {
-  it('should render without error', () => {
+describe('ImportWithSeedPhrase Component', function () {
+  it('should render without error', function () {
     const root = shallowRender({
       onSubmit: sinon.spy(),
     })
@@ -23,8 +23,8 @@ describe('ImportWithSeedPhrase Component', () => {
     assert.equal(textareaCount, 1, 'should render 12 seed phrases')
   })
 
-  describe('parseSeedPhrase', () => {
-    it('should handle a regular seed phrase', () => {
+  describe('parseSeedPhrase', function () {
+    it('should handle a regular seed phrase', function () {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       })
@@ -34,7 +34,7 @@ describe('ImportWithSeedPhrase Component', () => {
       assert.deepEqual(parseSeedPhrase('foo bar baz'), 'foo bar baz')
     })
 
-    it('should trim extraneous whitespace from the given seed phrase', () => {
+    it('should trim extraneous whitespace from the given seed phrase', function () {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       })
@@ -44,7 +44,7 @@ describe('ImportWithSeedPhrase Component', () => {
       assert.deepEqual(parseSeedPhrase('  foo   bar   baz  '), 'foo bar baz')
     })
 
-    it('should return an empty string when given a whitespace-only string', () => {
+    it('should return an empty string when given a whitespace-only string', function () {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       })
@@ -54,7 +54,7 @@ describe('ImportWithSeedPhrase Component', () => {
       assert.deepEqual(parseSeedPhrase('   '), '')
     })
 
-    it('should return an empty string when given a string with only symbols', () => {
+    it('should return an empty string when given a string with only symbols', function () {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       })
@@ -64,7 +64,7 @@ describe('ImportWithSeedPhrase Component', () => {
       assert.deepEqual(parseSeedPhrase('$'), '')
     })
 
-    it('should return an empty string for both null and undefined', () => {
+    it('should return an empty string for both null and undefined', function () {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       })

--- a/ui/app/pages/first-time-flow/end-of-flow/tests/end-of-flow.test.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/tests/end-of-flow.test.js
@@ -5,7 +5,7 @@ import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes'
 import EndOfFlowScreen from '../index'
 
-describe('End of Flow Screen', () => {
+describe('End of Flow Screen', function () {
   let wrapper
 
   const props = {
@@ -15,24 +15,23 @@ describe('End of Flow Screen', () => {
     completeOnboarding: sinon.spy(),
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mountWithRouter(
       <EndOfFlowScreen.WrappedComponent {...props} />
     )
   })
 
-  it('renders', () => {
+  it('renders', function () {
     assert.equal(wrapper.length, 1)
   })
 
-  it('', (done) => {
+  it('should navigate to the default route on click', function (done) {
     const endOfFlowButton = wrapper.find('.btn-primary.first-time-flow__button')
     endOfFlowButton.simulate('click')
 
     setImmediate(() => {
       assert(props.completeOnboarding.calledOnce)
-      assert(props.history.push.calledOnce)
-      assert.equal(props.history.push.getCall(0).args[0], DEFAULT_ROUTE)
+      assert(props.history.push.calledOnceWithExactly(DEFAULT_ROUTE))
       done()
     })
   })

--- a/ui/app/pages/first-time-flow/first-time-flow-switch/tests/first-time-flow-switch.test.js
+++ b/ui/app/pages/first-time-flow/first-time-flow-switch/tests/first-time-flow-switch.test.js
@@ -9,16 +9,16 @@ import {
 } from '../../../../helpers/constants/routes'
 import FirstTimeFlowSwitch from '../index'
 
-describe('FirstTimeFlowSwitch', () => {
+describe('FirstTimeFlowSwitch', function () {
 
-  it('redirects to /welcome route with no props', () => {
+  it('redirects to /welcome route with no props', function () {
     const wrapper = mountWithRouter(
       <FirstTimeFlowSwitch.WrappedComponent />
     )
     assert.equal(wrapper.find('Lifecycle').find({ to: { pathname: INITIALIZE_WELCOME_ROUTE } }).length, 1)
   })
 
-  it('redirects to / route when completedOnboarding is true', () => {
+  it('redirects to / route when completedOnboarding is true', function () {
     const props = {
       completedOnboarding: true,
     }
@@ -29,7 +29,7 @@ describe('FirstTimeFlowSwitch', () => {
     assert.equal(wrapper.find('Lifecycle').find({ to: { pathname: DEFAULT_ROUTE } }).length, 1)
   })
 
-  it('redirects to /lock route when isUnlocked is true ', () => {
+  it('redirects to /lock route when isUnlocked is true ', function () {
     const props = {
       completedOnboarding: false,
       isUnlocked: true,
@@ -42,7 +42,7 @@ describe('FirstTimeFlowSwitch', () => {
     assert.equal(wrapper.find('Lifecycle').find({ to: { pathname: LOCK_ROUTE } }).length, 1)
   })
 
-  it('redirects to /welcome route when isInitialized is false', () => {
+  it('redirects to /welcome route when isInitialized is false', function () {
     const props = {
       completedOnboarding: false,
       isUnlocked: false,
@@ -56,7 +56,7 @@ describe('FirstTimeFlowSwitch', () => {
     assert.equal(wrapper.find('Lifecycle').find({ to: { pathname: INITIALIZE_WELCOME_ROUTE } }).length, 1)
   })
 
-  it('redirects to /unlock route when isInitialized is true', () => {
+  it('redirects to /unlock route when isInitialized is true', function () {
     const props = {
       completedOnboarding: false,
       isUnlocked: false,

--- a/ui/app/pages/first-time-flow/metametrics-opt-in/tests/metametrics-opt-in.test.js
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/tests/metametrics-opt-in.test.js
@@ -5,39 +5,25 @@ import configureMockStore from 'redux-mock-store'
 import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import MetaMetricsOptIn from '../index'
 
-describe('MetaMetricsOptIn', () => {
-  let wrapper
-
-  const props = {
-    history: {
-      push: sinon.spy(),
-    },
-    setParticipateInMetaMetrics: sinon.stub().resolves(),
-    participateInMetaMetrics: false,
-  }
-
-  const mockStore = {
-    metamask: {},
-  }
-
-  const store = configureMockStore()(mockStore)
-
-  beforeEach(() => {
-    wrapper = mountWithRouter(
+describe('MetaMetricsOptIn', function () {
+  it('opt out of MetaMetrics', function () {
+    const props = {
+      history: {
+        push: sinon.spy(),
+      },
+      setParticipateInMetaMetrics: sinon.stub().resolves(),
+      participateInMetaMetrics: false,
+    }
+    const store = configureMockStore()({
+      metamask: {},
+    })
+    const wrapper = mountWithRouter(
       <MetaMetricsOptIn.WrappedComponent {...props} />, store
     )
-  })
-
-  afterEach(() => {
-    props.setParticipateInMetaMetrics.resetHistory()
-  })
-
-  it('opt out of metametrics', () => {
     const noThanksButton = wrapper.find('.btn-default.page-container__footer-button')
     noThanksButton.simulate('click')
 
-    assert(props.setParticipateInMetaMetrics.calledOnce)
-    assert.equal(props.setParticipateInMetaMetrics.getCall(0).args[0], false)
+    assert.ok(props.setParticipateInMetaMetrics.calledOnceWithExactly(false))
+    props.setParticipateInMetaMetrics.resetHistory()
   })
-
 })

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/tests/reveal-seed-phrase.test.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/tests/reveal-seed-phrase.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import RevealSeedPhrase from '../index'
 
-describe('Reveal Seed Phrase', () => {
+describe('Reveal Seed Phrase', function () {
   let wrapper
 
   const TEST_SEED = 'debris dizzy just program just float decrease vacant alarm reduce speak stadium'
@@ -18,7 +18,7 @@ describe('Reveal Seed Phrase', () => {
     setCompletedOnboarding: sinon.spy(),
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <RevealSeedPhrase.WrappedComponent {...props} />, {
         context: {
@@ -29,13 +29,13 @@ describe('Reveal Seed Phrase', () => {
     )
   })
 
-  it('seed phrase', () => {
+  it('seed phrase', function () {
     const seedPhrase = wrapper.find('.reveal-seed-phrase__secret-words--hidden')
     assert.equal(seedPhrase.length, 1)
     assert.equal(seedPhrase.text(), TEST_SEED)
   })
 
-  it('clicks to reveal', () => {
+  it('clicks to reveal', function () {
     const reveal = wrapper.find('.reveal-seed-phrase__secret-blocker')
 
     assert.equal(wrapper.state().isShowingSeedPhrase, false)

--- a/ui/app/pages/first-time-flow/seed-phrase/tests/confirm-seed-phrase-component.test.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/tests/confirm-seed-phrase-component.test.js
@@ -16,8 +16,8 @@ function shallowRender (props = {}, context = {}) {
   )
 }
 
-describe('ConfirmSeedPhrase Component', () => {
-  it('should render correctly', () => {
+describe('ConfirmSeedPhrase Component', function () {
+  it('should render correctly', function () {
     const root = shallowRender({
       seedPhrase: '鼠 牛 虎 兔 龍 蛇 馬 羊 猴 雞 狗 豬',
     })
@@ -29,7 +29,7 @@ describe('ConfirmSeedPhrase Component', () => {
     )
   })
 
-  it('should add/remove selected on click', () => {
+  it('should add/remove selected on click', function () {
     const metricsEventSpy = sinon.spy()
     const pushSpy = sinon.spy()
     const root = shallowRender(
@@ -67,7 +67,7 @@ describe('ConfirmSeedPhrase Component', () => {
     )
   })
 
-  it('should render correctly on hover', () => {
+  it('should render correctly on hover', function () {
     const metricsEventSpy = sinon.spy()
     const pushSpy = sinon.spy()
     const root = shallowRender(
@@ -100,7 +100,7 @@ describe('ConfirmSeedPhrase Component', () => {
     assert.equal(pendingSeeds.at(2).props().seedIndex, 1)
   })
 
-  it('should insert seed in place on drop', () => {
+  it('should insert seed in place on drop', function () {
     const metricsEventSpy = sinon.spy()
     const pushSpy = sinon.spy()
     const root = shallowRender(
@@ -131,7 +131,7 @@ describe('ConfirmSeedPhrase Component', () => {
     assert.deepEqual(root.state().pendingSeedIndices, [2, 0, 1])
   })
 
-  it('should submit correctly', async () => {
+  it('should submit correctly', async function () {
     const originalSeed = ['鼠', '牛', '虎', '兔', '龍', '蛇', '馬', '羊', '猴', '雞', '狗', '豬']
     const metricsEventSpy = sinon.spy()
     const pushSpy = sinon.spy()

--- a/ui/app/pages/first-time-flow/select-action/tests/select-action.test.js
+++ b/ui/app/pages/first-time-flow/select-action/tests/select-action.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import SelectAction from '../index'
 
-describe('Selection Action', () => {
+describe('Selection Action', function () {
   let wrapper
 
   const props = {
@@ -15,18 +15,18 @@ describe('Selection Action', () => {
     },
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mountWithRouter(
       <SelectAction.WrappedComponent {...props} />
     )
   })
 
-  afterEach(() => {
+  afterEach(function () {
     props.setFirstTimeFlowType.resetHistory()
     props.history.push.resetHistory()
   })
 
-  it('clicks import wallet to route to import FTF', () => {
+  it('clicks import wallet to route to import FTF', function () {
     const importWalletButton = wrapper.find('.btn-primary.first-time-flow__button').at(0)
     importWalletButton.simulate('click')
 
@@ -35,7 +35,7 @@ describe('Selection Action', () => {
     assert(props.history.push.calledOnce)
   })
 
-  it('clicks create wallet to route to create FTF ', () => {
+  it('clicks create wallet to route to create FTF ', function () {
     const createWalletButton = wrapper.find('.btn-primary.first-time-flow__button').at(1)
     createWalletButton.simulate('click')
 

--- a/ui/app/pages/first-time-flow/welcome/tests/welcome.test.js
+++ b/ui/app/pages/first-time-flow/welcome/tests/welcome.test.js
@@ -5,18 +5,18 @@ import configureMockStore from 'redux-mock-store'
 import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import Welcome from '../index'
 
-describe('Welcome', () => {
+describe('Welcome', function () {
   const mockStore = {
     metamask: {},
   }
 
   const store = configureMockStore()(mockStore)
 
-  after(() => {
+  after(function () {
     sinon.restore()
   })
 
-  it('routes to select action when participateInMetaMetrics is not initialized', () => {
+  it('routes to select action when participateInMetaMetrics is not initialized', function () {
 
     const props = {
       history: {
@@ -34,7 +34,7 @@ describe('Welcome', () => {
 
   })
 
-  it('routes to correct password when participateInMetaMetrics is initialized', () => {
+  it('routes to correct password when participateInMetaMetrics is initialized', function () {
 
     const props = {
       welcomeScreenSeen: true,

--- a/ui/app/pages/keychains/tests/reveal-seed.test.js
+++ b/ui/app/pages/keychains/tests/reveal-seed.test.js
@@ -4,27 +4,22 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import RevealSeedPage from '../reveal-seed'
 
-describe('Reveal Seed Page', () => {
-  let wrapper
-
-  const props = {
-    history: {
-      push: sinon.spy(),
-    },
-    requestRevealSeedWords: sinon.stub().resolves(),
-  }
-
-  beforeEach(() => {
-    wrapper = mount(
+describe('Reveal Seed Page', function () {
+  it('form submit', function () {
+    const props = {
+      history: {
+        push: sinon.spy(),
+      },
+      requestRevealSeedWords: sinon.stub().resolves(),
+    }
+    const wrapper = mount(
       <RevealSeedPage.WrappedComponent {...props} />, {
         context: {
           t: str => str,
         },
       }
     )
-  })
 
-  it('form submit', () => {
     wrapper.find('form').simulate('submit')
     assert(props.requestRevealSeedWords.calledOnce)
   })

--- a/ui/app/pages/lock/tests/lock.test.js
+++ b/ui/app/pages/lock/tests/lock.test.js
@@ -4,9 +4,9 @@ import sinon from 'sinon'
 import { mountWithRouter } from '../../../../../test/lib/render-helpers'
 import Lock from '../index'
 
-describe('Lock', () => {
+describe('Lock', function () {
 
-  it('replaces history with default route when isUnlocked false', () => {
+  it('replaces history with default route when isUnlocked false', function () {
 
     const props = {
       isUnlocked: false,
@@ -23,7 +23,7 @@ describe('Lock', () => {
 
   })
 
-  it('locks and pushes history with default route when isUnlocked true', (done) => {
+  it('locks and pushes history with default route when isUnlocked true', function (done) {
 
     const props = {
       isUnlocked: true,

--- a/ui/app/pages/send/account-list-item/tests/account-list-item-component.test.js
+++ b/ui/app/pages/send/account-list-item/tests/account-list-item-component.test.js
@@ -22,34 +22,34 @@ const propsMethodSpies = {
 describe('AccountListItem Component', function () {
   let wrapper
 
-  beforeEach(() => {
-    wrapper = shallow((
-      <AccountListItem
-        account={ { address: 'mockAddress', name: 'mockName', balance: 'mockBalance' } }
-        className="mockClassName"
-        conversionRate={4}
-        currentCurrency="mockCurrentyCurrency"
-        nativeCurrency="ETH"
-        displayAddress={false}
-        displayBalance={false}
-        handleClick={propsMethodSpies.handleClick}
-        icon={<i className="mockIcon" />}
-      />
-    ), { context: { t: str => str + '_t' } })
-  })
+  describe('render', function () {
+    beforeEach(function () {
+      wrapper = shallow((
+        <AccountListItem
+          account={ { address: 'mockAddress', name: 'mockName', balance: 'mockBalance' } }
+          className="mockClassName"
+          conversionRate={4}
+          currentCurrency="mockCurrentyCurrency"
+          nativeCurrency="ETH"
+          displayAddress={false}
+          displayBalance={false}
+          handleClick={propsMethodSpies.handleClick}
+          icon={<i className="mockIcon" />}
+        />
+      ), { context: { t: str => str + '_t' } })
+    })
 
-  afterEach(() => {
-    propsMethodSpies.handleClick.resetHistory()
-  })
+    afterEach(function () {
+      propsMethodSpies.handleClick.resetHistory()
+    })
 
-  describe('render', () => {
-    it('should render a div with the passed className', () => {
+    it('should render a div with the passed className', function () {
       assert.equal(wrapper.find('.mockClassName').length, 1)
       assert(wrapper.find('.mockClassName').is('div'))
       assert(wrapper.find('.mockClassName').hasClass('account-list-item'))
     })
 
-    it('should call handleClick with the expected props when the root div is clicked', () => {
+    it('should call handleClick with the expected props when the root div is clicked', function () {
       const { onClick } = wrapper.find('.mockClassName').props()
       assert.equal(propsMethodSpies.handleClick.callCount, 0)
       onClick()
@@ -60,42 +60,42 @@ describe('AccountListItem Component', function () {
       )
     })
 
-    it('should have a top row div', () => {
+    it('should have a top row div', function () {
       assert.equal(wrapper.find('.mockClassName > .account-list-item__top-row').length, 1)
       assert(wrapper.find('.mockClassName > .account-list-item__top-row').is('div'))
     })
 
-    it('should have an identicon, name and icon in the top row', () => {
+    it('should have an identicon, name and icon in the top row', function () {
       const topRow = wrapper.find('.mockClassName > .account-list-item__top-row')
       assert.equal(topRow.find(Identicon).length, 1)
       assert.equal(topRow.find('.account-list-item__account-name').length, 1)
       assert.equal(topRow.find('.account-list-item__icon').length, 1)
     })
 
-    it('should show the account name if it exists', () => {
+    it('should show the account name if it exists', function () {
       const topRow = wrapper.find('.mockClassName > .account-list-item__top-row')
       assert.equal(topRow.find('.account-list-item__account-name').text(), 'mockName')
     })
 
-    it('should show the account address if there is no name', () => {
+    it('should show the account address if there is no name', function () {
       wrapper.setProps({ account: { address: 'addressButNoName' } })
       const topRow = wrapper.find('.mockClassName > .account-list-item__top-row')
       assert.equal(topRow.find('.account-list-item__account-name').text(), 'addressButNoName')
     })
 
-    it('should render the passed icon', () => {
+    it('should render the passed icon', function () {
       const topRow = wrapper.find('.mockClassName > .account-list-item__top-row')
       assert(topRow.find('.account-list-item__icon').childAt(0).is('i'))
       assert(topRow.find('.account-list-item__icon').childAt(0).hasClass('mockIcon'))
     })
 
-    it('should not render an icon if none is passed', () => {
+    it('should not render an icon if none is passed', function () {
       wrapper.setProps({ icon: null })
       const topRow = wrapper.find('.mockClassName > .account-list-item__top-row')
       assert.equal(topRow.find('.account-list-item__icon').length, 0)
     })
 
-    it('should render the account address as a checksumAddress if displayAddress is true and name is provided', () => {
+    it('should render the account address as a checksumAddress if displayAddress is true and name is provided', function () {
       wrapper.setProps({ displayAddress: true })
       assert.equal(wrapper.find('.account-list-item__account-address').length, 1)
       assert.equal(wrapper.find('.account-list-item__account-address').text(), 'mockCheckSumAddress')
@@ -105,17 +105,17 @@ describe('AccountListItem Component', function () {
       )
     })
 
-    it('should not render the account address as a checksumAddress if displayAddress is false', () => {
+    it('should not render the account address as a checksumAddress if displayAddress is false', function () {
       wrapper.setProps({ displayAddress: false })
       assert.equal(wrapper.find('.account-list-item__account-address').length, 0)
     })
 
-    it('should not render the account address as a checksumAddress if name is not provided', () => {
+    it('should not render the account address as a checksumAddress if name is not provided', function () {
       wrapper.setProps({ account: { address: 'someAddressButNoName' } })
       assert.equal(wrapper.find('.account-list-item__account-address').length, 0)
     })
 
-    it('should render a CurrencyDisplay with the correct props if displayBalance is true', () => {
+    it('should render a CurrencyDisplay with the correct props if displayBalance is true', function () {
       wrapper.setProps({ displayBalance: true })
       assert.equal(wrapper.find(UserPreferencedCurrencyDisplay).length, 2)
       assert.deepEqual(
@@ -128,7 +128,7 @@ describe('AccountListItem Component', function () {
       )
     })
 
-    it('should only render one CurrencyDisplay if showFiat is false', () => {
+    it('should only render one CurrencyDisplay if showFiat is false', function () {
       wrapper.setProps({ showFiat: false, displayBalance: true })
       assert.equal(wrapper.find(UserPreferencedCurrencyDisplay).length, 1)
       assert.deepEqual(
@@ -141,10 +141,9 @@ describe('AccountListItem Component', function () {
       )
     })
 
-    it('should not render a CurrencyDisplay if displayBalance is false', () => {
+    it('should not render a CurrencyDisplay if displayBalance is false', function () {
       wrapper.setProps({ displayBalance: false })
       assert.equal(wrapper.find(UserPreferencedCurrencyDisplay).length, 0)
     })
-
   })
 })

--- a/ui/app/pages/send/account-list-item/tests/account-list-item-container.test.js
+++ b/ui/app/pages/send/account-list-item/tests/account-list-item-container.test.js
@@ -24,11 +24,11 @@ proxyquire('../account-list-item.container.js', {
   },
 })
 
-describe('account-list-item container', () => {
+describe('account-list-item container', function () {
 
-  describe('mapStateToProps()', () => {
+  describe('mapStateToProps()', function () {
 
-    it('should map the correct properties to props', () => {
+    it('should map the correct properties to props', function () {
       assert.deepEqual(mapStateToProps({ isMainnet: true, showFiatInTestnets: false }), {
         nativeCurrency: 'mockNativeCurrency',
         balanceIsCached: 'mockBalanceIsCached',
@@ -36,7 +36,7 @@ describe('account-list-item container', () => {
       })
     })
 
-    it('should map the correct properties to props when in mainnet and showFiatInTestnet is true', () => {
+    it('should map the correct properties to props when in mainnet and showFiatInTestnet is true', function () {
       assert.deepEqual(mapStateToProps({ isMainnet: true, showFiatInTestnets: true }), {
         nativeCurrency: 'mockNativeCurrency',
         balanceIsCached: 'mockBalanceIsCached',
@@ -44,7 +44,7 @@ describe('account-list-item container', () => {
       })
     })
 
-    it('should map the correct properties to props when not in mainnet and showFiatInTestnet is true', () => {
+    it('should map the correct properties to props when not in mainnet and showFiatInTestnet is true', function () {
       assert.deepEqual(mapStateToProps({ isMainnet: false, showFiatInTestnets: true }), {
         nativeCurrency: 'mockNativeCurrency',
         balanceIsCached: 'mockBalanceIsCached',
@@ -52,7 +52,7 @@ describe('account-list-item container', () => {
       })
     })
 
-    it('should map the correct properties to props when not in mainnet and showFiatInTestnet is false', () => {
+    it('should map the correct properties to props when not in mainnet and showFiatInTestnet is false', function () {
       assert.deepEqual(mapStateToProps({ isMainnet: false, showFiatInTestnets: false }), {
         nativeCurrency: 'mockNativeCurrency',
         balanceIsCached: 'mockBalanceIsCached',

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-component.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-component.test.js
@@ -18,7 +18,7 @@ describe('AddRecipient Component', function () {
   let wrapper
   let instance
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <AddRecipient
         closeToDropdown={propsMethodSpies.closeToDropdown}
@@ -41,7 +41,7 @@ describe('AddRecipient Component', function () {
     instance = wrapper.instance()
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.closeToDropdown.resetHistory()
     propsMethodSpies.openToDropdown.resetHistory()
     propsMethodSpies.updateSendTo.resetHistory()
@@ -50,9 +50,9 @@ describe('AddRecipient Component', function () {
     propsMethodSpies.updateGas.resetHistory()
   })
 
-  describe('selectRecipient', () => {
+  describe('selectRecipient', function () {
 
-    it('should call updateSendTo', () => {
+    it('should call updateSendTo', function () {
       assert.equal(propsMethodSpies.updateSendTo.callCount, 0)
       instance.selectRecipient('mockTo2', 'mockNickname')
       assert.equal(propsMethodSpies.updateSendTo.callCount, 1)
@@ -62,19 +62,19 @@ describe('AddRecipient Component', function () {
       )
     })
 
-    it('should call updateGas if there is no to error', () => {
+    it('should call updateGas if there is no to error', function () {
       assert.equal(propsMethodSpies.updateGas.callCount, 0)
       instance.selectRecipient(false)
       assert.equal(propsMethodSpies.updateGas.callCount, 1)
     })
   })
 
-  describe('render', () => {
-    it('should render a component', () => {
+  describe('render', function () {
+    it('should render a component', function () {
       assert.equal(wrapper.find('.send__select-recipient-wrapper').length, 1)
     })
 
-    it('should render no content if there are no recents, transfers, and contacts', () => {
+    it('should render no content if there are no recents, transfers, and contacts', function () {
       wrapper.setProps({
         ownedAccounts: [],
         addressBook: [],
@@ -84,7 +84,7 @@ describe('AddRecipient Component', function () {
       assert.equal(wrapper.find('.send__select-recipient-wrapper__group').length, 0)
     })
 
-    it('should render transfer', () => {
+    it('should render transfer', function () {
       wrapper.setProps({
         ownedAccounts: [{ address: '0x123', name: '123' }, { address: '0x124', name: '124' }],
         addressBook: [{ address: '0x456', name: 'test-name' }],
@@ -99,7 +99,7 @@ describe('AddRecipient Component', function () {
       assert.equal(groups.shallow().find('.send__select-recipient-wrapper__group').length, 1)
     })
 
-    it('should render ContactList', () => {
+    it('should render ContactList', function () {
       wrapper.setProps({
         ownedAccounts: [{ address: '0x123', name: '123' }, { address: '0x124', name: '124' }],
         addressBook: [{ address: '0x125' }],
@@ -110,7 +110,7 @@ describe('AddRecipient Component', function () {
       assert.equal(contactList.length, 1)
     })
 
-    it('should render contacts', () => {
+    it('should render contacts', function () {
       wrapper.setProps({
         addressBook: [
           { address: '0x125', name: 'alice' },
@@ -129,7 +129,7 @@ describe('AddRecipient Component', function () {
       assert.equal(groups.find('.send__select-recipient-wrapper__group-item').length, 0)
     })
 
-    it('should render error when query has no results', () => {
+    it('should render error when query has no results', function () {
       wrapper.setProps({
         addressBook: [],
         toError: 'bad',
@@ -144,7 +144,7 @@ describe('AddRecipient Component', function () {
       assert.equal(dialog.length, 1)
     })
 
-    it('should render error when query has ens does not resolve', () => {
+    it('should render error when query has ens does not resolve', function () {
       wrapper.setProps({
         addressBook: [],
         toError: 'bad',
@@ -160,7 +160,7 @@ describe('AddRecipient Component', function () {
       assert.equal(dialog.length, 1)
     })
 
-    it('should render warning', () => {
+    it('should render warning', function () {
       wrapper.setProps({
         addressBook: [],
         query: 'yo',
@@ -174,7 +174,7 @@ describe('AddRecipient Component', function () {
       assert.equal(dialog.length, 1)
     })
 
-    it('should not render error when ens resolved', () => {
+    it('should not render error when ens resolved', function () {
       wrapper.setProps({
         addressBook: [],
         toError: 'bad',
@@ -186,7 +186,7 @@ describe('AddRecipient Component', function () {
       assert.equal(dialog.length, 0)
     })
 
-    it('should not render error when query has results', () => {
+    it('should not render error when query has results', function () {
       wrapper.setProps({
         addressBook: [
           { address: '0x125', name: 'alice' },

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-container.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-container.test.js
@@ -29,11 +29,9 @@ proxyquire('../add-recipient.container.js', {
   '../../../../store/actions': actionSpies,
 })
 
-describe('add-recipient container', () => {
-
-  describe('mapStateToProps()', () => {
-
-    it('should map the correct properties to props', () => {
+describe('add-recipient container', function () {
+  describe('mapStateToProps()', function () {
+    it('should map the correct properties to props', function () {
       assert.deepEqual(mapStateToProps('mockState'), {
         addressBook: [{ name: 'mockAddressBook:mockState' }],
         contacts: [{ name: 'mockAddressBook:mockState' }],
@@ -44,20 +42,14 @@ describe('add-recipient container', () => {
         nonContacts: [],
       })
     })
-
   })
 
-  describe('mapDispatchToProps()', () => {
-    let dispatchSpy
-    let mapDispatchToPropsObject
+  describe('mapDispatchToProps()', function () {
+    describe('updateSendTo()', function () {
+      const dispatchSpy = sinon.spy()
+      const mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
 
-    beforeEach(() => {
-      dispatchSpy = sinon.spy()
-      mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
-    })
-
-    describe('updateSendTo()', () => {
-      it('should dispatch an action', () => {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.updateSendTo('mockTo', 'mockNickname')
         assert(dispatchSpy.calledOnce)
         assert(actionSpies.updateSendTo.calledOnce)
@@ -68,5 +60,4 @@ describe('add-recipient container', () => {
       })
     })
   })
-
 })

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-selectors.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-selectors.test.js
@@ -5,10 +5,10 @@ import {
   sendToIsInError,
 } from '../add-recipient.selectors.js'
 
-describe('add-recipient selectors', () => {
+describe('add-recipient selectors', function () {
 
-  describe('getToDropdownOpen()', () => {
-    it('should return send.getToDropdownOpen', () => {
+  describe('getToDropdownOpen()', function () {
+    it('should return send.getToDropdownOpen', function () {
       const state = {
         send: {
           toDropdownOpen: false,
@@ -19,8 +19,8 @@ describe('add-recipient selectors', () => {
     })
   })
 
-  describe('sendToIsInError()', () => {
-    it('should return true if send.errors.to is truthy', () => {
+  describe('sendToIsInError()', function () {
+    it('should return true if send.errors.to is truthy', function () {
       const state = {
         send: {
           errors: {
@@ -32,7 +32,7 @@ describe('add-recipient selectors', () => {
       assert.equal(sendToIsInError(state), true)
     })
 
-    it('should return false if send.errors.to is falsy', () => {
+    it('should return false if send.errors.to is falsy', function () {
       const state = {
         send: {
           errors: {
@@ -45,8 +45,8 @@ describe('add-recipient selectors', () => {
     })
   })
 
-  describe('getTokens()', () => {
-    it('should return empty array if no tokens in state', () => {
+  describe('getTokens()', function () {
+    it('should return empty array if no tokens in state', function () {
       const state = {
         metamask: {
           tokens: [],

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
@@ -22,82 +22,82 @@ const {
   getToWarningObject,
 } = toRowUtils
 
-describe('add-recipient utils', () => {
+describe('add-recipient utils', function () {
 
-  describe('getToErrorObject()', () => {
-    it('should return a required error if to is falsy', () => {
+  describe('getToErrorObject()', function () {
+    it('should return a required error if to is falsy', function () {
       assert.deepEqual(getToErrorObject(null), {
         to: REQUIRED_ERROR,
       })
     })
 
-    it('should return null if to is falsy and hexData is truthy', () => {
+    it('should return null if to is falsy and hexData is truthy', function () {
       assert.deepEqual(getToErrorObject(null, undefined, true), {
         to: null,
       })
     })
 
-    it('should return an invalid recipient error if to is truthy but invalid', () => {
+    it('should return an invalid recipient error if to is truthy but invalid', function () {
       assert.deepEqual(getToErrorObject('mockInvalidTo'), {
         to: INVALID_RECIPIENT_ADDRESS_ERROR,
       })
     })
 
-    it('should return null if to is truthy and valid', () => {
+    it('should return null if to is truthy and valid', function () {
       assert.deepEqual(getToErrorObject('0xabc123'), {
         to: null,
       })
     })
 
-    it('should return the passed error if to is truthy but invalid if to is truthy and valid', () => {
+    it('should return the passed error if to is truthy but invalid if to is truthy and valid', function () {
       assert.deepEqual(getToErrorObject('invalid #$ 345878', 'someExplicitError'), {
         to: 'someExplicitError',
       })
     })
 
-    it('should return null if to is truthy but part of state tokens', () => {
+    it('should return null if to is truthy but part of state tokens', function () {
       assert.deepEqual(getToErrorObject('0xabc123', undefined, false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: null,
       })
     })
 
-    it('should null if to is truthy part of tokens but selectedToken falsy', () => {
+    it('should null if to is truthy part of tokens but selectedToken falsy', function () {
       assert.deepEqual(getToErrorObject('0xabc123', undefined, false, [{ 'address': '0xabc123' }]), {
         to: null,
       })
     })
 
-    it('should return null if to is truthy but part of contract metadata', () => {
+    it('should return null if to is truthy but part of contract metadata', function () {
       assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: null,
       })
     })
-    it('should null if to is truthy part of contract metadata but selectedToken falsy', () => {
+    it('should null if to is truthy part of contract metadata but selectedToken falsy', function () {
       assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: null,
       })
     })
   })
 
-  describe('getToWarningObject()', () => {
-    it('should return a known address recipient if to is truthy but part of state tokens', () => {
+  describe('getToWarningObject()', function () {
+    it('should return a known address recipient if to is truthy but part of state tokens', function () {
       assert.deepEqual(getToWarningObject('0xabc123', undefined, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })
     })
 
-    it('should null if to is truthy part of tokens but selectedToken falsy', () => {
+    it('should null if to is truthy part of tokens but selectedToken falsy', function () {
       assert.deepEqual(getToWarningObject('0xabc123', undefined, [{ 'address': '0xabc123' }]), {
         to: null,
       })
     })
 
-    it('should return a known address recipient if to is truthy but part of contract metadata', () => {
+    it('should return a known address recipient if to is truthy but part of contract metadata', function () {
       assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })
     })
-    it('should null if to is truthy part of contract metadata but selectedToken falsy', () => {
+    it('should null if to is truthy part of contract metadata but selectedToken falsy', function () {
       assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
@@ -17,7 +17,7 @@ describe('AmountMaxButton Component', function () {
   let wrapper
   let instance
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <AmountMaxButton
         balance="mockBalance"
@@ -37,15 +37,15 @@ describe('AmountMaxButton Component', function () {
     instance = wrapper.instance()
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.setAmountToMax.resetHistory()
     propsMethodSpies.setMaxModeTo.resetHistory()
     AmountMaxButton.prototype.setMaxAmount.resetHistory()
   })
 
-  describe('setMaxAmount', () => {
+  describe('setMaxAmount', function () {
 
-    it('should call setAmountToMax with the correct params', () => {
+    it('should call setAmountToMax with the correct params', function () {
       assert.equal(propsMethodSpies.setAmountToMax.callCount, 0)
       instance.setMaxAmount()
       assert.equal(propsMethodSpies.setAmountToMax.callCount, 1)
@@ -62,12 +62,12 @@ describe('AmountMaxButton Component', function () {
 
   })
 
-  describe('render', () => {
-    it('should render an element with a send-v2__amount-max class', () => {
+  describe('render', function () {
+    it('should render an element with a send-v2__amount-max class', function () {
       assert(wrapper.exists('.send-v2__amount-max'))
     })
 
-    it('should call setMaxModeTo and setMaxAmount when the checkbox is checked', () => {
+    it('should call setMaxModeTo and setMaxAmount when the checkbox is checked', function () {
       const {
         onClick,
       } = wrapper.find('.send-v2__amount-max').props()
@@ -83,7 +83,7 @@ describe('AmountMaxButton Component', function () {
       )
     })
 
-    it('should render the expected text when maxModeOn is false', () => {
+    it('should render the expected text when maxModeOn is false', function () {
       wrapper.setProps({ maxModeOn: false })
       assert.equal(wrapper.find('.send-v2__amount-max').text(), 'max_t')
     })

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-container.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-container.test.js
@@ -34,11 +34,11 @@ proxyquire('../amount-max-button.container.js', {
   '../../../../../ducks/send/send.duck': duckActionSpies,
 })
 
-describe('amount-max-button container', () => {
+describe('amount-max-button container', function () {
 
-  describe('mapStateToProps()', () => {
+  describe('mapStateToProps()', function () {
 
-    it('should map the correct properties to props', () => {
+    it('should map the correct properties to props', function () {
       assert.deepEqual(mapStateToProps('mockState'), {
         balance: 'mockBalance:mockState',
         buttonDataLoading: 'mockButtonDataLoading:mockState',
@@ -51,17 +51,17 @@ describe('amount-max-button container', () => {
 
   })
 
-  describe('mapDispatchToProps()', () => {
+  describe('mapDispatchToProps()', function () {
     let dispatchSpy
     let mapDispatchToPropsObject
 
-    beforeEach(() => {
+    beforeEach(function () {
       dispatchSpy = sinon.spy()
       mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
     })
 
-    describe('setAmountToMax()', () => {
-      it('should dispatch an action', () => {
+    describe('setAmountToMax()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.setAmountToMax({ val: 11, foo: 'bar' })
         assert(dispatchSpy.calledTwice)
         assert(duckActionSpies.updateSendErrors.calledOnce)
@@ -77,8 +77,8 @@ describe('amount-max-button container', () => {
       })
     })
 
-    describe('setMaxModeTo()', () => {
-      it('should dispatch an action', () => {
+    describe('setMaxModeTo()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.setMaxModeTo('mockVal')
         assert(dispatchSpy.calledOnce)
         assert.equal(

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-selectors.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-selectors.test.js
@@ -3,10 +3,10 @@ import {
   getMaxModeOn,
 } from '../amount-max-button.selectors.js'
 
-describe('amount-max-button selectors', () => {
+describe('amount-max-button selectors', function () {
 
-  describe('getMaxModeOn()', () => {
-    it('should', () => {
+  describe('getMaxModeOn()', function () {
+    it('should', function () {
       const state = {
         metamask: {
           send: {

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-utils.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-utils.test.js
@@ -3,10 +3,10 @@ import {
   calcMaxAmount,
 } from '../amount-max-button.utils.js'
 
-describe('amount-max-button utils', () => {
+describe('amount-max-button utils', function () {
 
-  describe('calcMaxAmount()', () => {
-    it('should calculate the correct amount when no selectedToken defined', () => {
+  describe('calcMaxAmount()', function () {
+    it('should calculate the correct amount when no selectedToken defined', function () {
       assert.deepEqual(calcMaxAmount({
         balance: 'ffffff',
         gasTotal: 'ff',
@@ -14,7 +14,7 @@ describe('amount-max-button utils', () => {
       }), 'ffff00')
     })
 
-    it('should calculate the correct amount when a selectedToken is defined', () => {
+    it('should calculate the correct amount when a selectedToken is defined', function () {
       assert.deepEqual(calcMaxAmount({
         selectedToken: {
           decimals: 10,

--- a/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-component.test.js
@@ -9,8 +9,8 @@ import AmountMaxButton from '../amount-max-button/amount-max-button.container'
 import UserPreferencedTokenInput from '../../../../../components/app/user-preferenced-token-input'
 
 describe('SendAmountRow Component', function () {
-  describe('validateAmount', () => {
-    it('should call updateSendAmountError with the correct params', () => {
+  describe('validateAmount', function () {
+    it('should call updateSendAmountError with the correct params', function () {
       const { instance, propsMethodSpies: { updateSendAmountError } } = shallowRenderSendAmountRow()
 
       assert.equal(updateSendAmountError.callCount, 0)
@@ -29,7 +29,7 @@ describe('SendAmountRow Component', function () {
       }))
     })
 
-    it('should call updateGasFeeError if selectedToken is truthy', () => {
+    it('should call updateGasFeeError if selectedToken is truthy', function () {
       const { instance, propsMethodSpies: { updateGasFeeError } } = shallowRenderSendAmountRow()
 
       assert.equal(updateGasFeeError.callCount, 0)
@@ -47,7 +47,7 @@ describe('SendAmountRow Component', function () {
       }))
     })
 
-    it('should call not updateGasFeeError if selectedToken is falsey', () => {
+    it('should call not updateGasFeeError if selectedToken is falsey', function () {
       const { wrapper, instance, propsMethodSpies: { updateGasFeeError } } = shallowRenderSendAmountRow()
 
       wrapper.setProps({ selectedToken: null })
@@ -61,9 +61,9 @@ describe('SendAmountRow Component', function () {
 
   })
 
-  describe('updateAmount', () => {
+  describe('updateAmount', function () {
 
-    it('should call setMaxModeTo', () => {
+    it('should call setMaxModeTo', function () {
       const { instance, propsMethodSpies: { setMaxModeTo } } = shallowRenderSendAmountRow()
 
       assert.equal(setMaxModeTo.callCount, 0)
@@ -73,7 +73,7 @@ describe('SendAmountRow Component', function () {
       assert.ok(setMaxModeTo.calledOnceWithExactly(false))
     })
 
-    it('should call updateSendAmount', () => {
+    it('should call updateSendAmount', function () {
       const { instance, propsMethodSpies: { updateSendAmount } } = shallowRenderSendAmountRow()
 
       assert.equal(updateSendAmount.callCount, 0)
@@ -85,14 +85,14 @@ describe('SendAmountRow Component', function () {
 
   })
 
-  describe('render', () => {
-    it('should render a SendRowWrapper component', () => {
+  describe('render', function () {
+    it('should render a SendRowWrapper component', function () {
       const { wrapper } = shallowRenderSendAmountRow()
 
       assert.equal(wrapper.find(SendRowWrapper).length, 1)
     })
 
-    it('should pass the correct props to SendRowWrapper', () => {
+    it('should pass the correct props to SendRowWrapper', function () {
       const { wrapper } = shallowRenderSendAmountRow()
       const {
         errorType,
@@ -105,19 +105,19 @@ describe('SendAmountRow Component', function () {
       assert.equal(showError, false)
     })
 
-    it('should render an AmountMaxButton as the first child of the SendRowWrapper', () => {
+    it('should render an AmountMaxButton as the first child of the SendRowWrapper', function () {
       const { wrapper } = shallowRenderSendAmountRow()
 
       assert(wrapper.find(SendRowWrapper).childAt(0).is(AmountMaxButton))
     })
 
-    it('should render a UserPreferencedTokenInput as the second child of the SendRowWrapper', () => {
+    it('should render a UserPreferencedTokenInput as the second child of the SendRowWrapper', function () {
       const { wrapper } = shallowRenderSendAmountRow()
 
       assert(wrapper.find(SendRowWrapper).childAt(1).is(UserPreferencedTokenInput))
     })
 
-    it('should render the UserPreferencedTokenInput with the correct props', () => {
+    it('should render the UserPreferencedTokenInput with the correct props', function () {
       const { wrapper, instanceSpies: { updateGas, updateAmount, validateAmount } } = shallowRenderSendAmountRow()
       const {
         onChange,

--- a/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-container.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-container.test.js
@@ -28,20 +28,20 @@ proxyquire('../send-amount-row.container.js', {
   '../../../../ducks/send/send.duck': duckActionSpies,
 })
 
-describe('send-amount-row container', () => {
+describe('send-amount-row container', function () {
 
-  describe('mapDispatchToProps()', () => {
+  describe('mapDispatchToProps()', function () {
     let dispatchSpy
     let mapDispatchToPropsObject
 
-    beforeEach(() => {
+    beforeEach(function () {
       dispatchSpy = sinon.spy()
       mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
       duckActionSpies.updateSendErrors.resetHistory()
     })
 
-    describe('setMaxModeTo()', () => {
-      it('should dispatch an action', () => {
+    describe('setMaxModeTo()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.setMaxModeTo('mockBool')
         assert(dispatchSpy.calledOnce)
         assert(actionSpies.setMaxModeTo.calledOnce)
@@ -52,8 +52,8 @@ describe('send-amount-row container', () => {
       })
     })
 
-    describe('updateSendAmount()', () => {
-      it('should dispatch an action', () => {
+    describe('updateSendAmount()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.updateSendAmount('mockAmount')
         assert(dispatchSpy.calledOnce)
         assert(actionSpies.updateSendAmount.calledOnce)
@@ -64,8 +64,8 @@ describe('send-amount-row container', () => {
       })
     })
 
-    describe('updateGasFeeError()', () => {
-      it('should dispatch an action', () => {
+    describe('updateGasFeeError()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.updateGasFeeError({ some: 'data' })
         assert(dispatchSpy.calledOnce)
         assert(duckActionSpies.updateSendErrors.calledOnce)
@@ -76,8 +76,8 @@ describe('send-amount-row container', () => {
       })
     })
 
-    describe('updateSendAmountError()', () => {
-      it('should dispatch an action', () => {
+    describe('updateSendAmountError()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.updateSendAmountError({ some: 'data' })
         assert(dispatchSpy.calledOnce)
         assert(duckActionSpies.updateSendErrors.calledOnce)

--- a/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-selectors.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-selectors.test.js
@@ -3,10 +3,10 @@ import {
   sendAmountIsInError,
 } from '../send-amount-row.selectors.js'
 
-describe('send-amount-row selectors', () => {
+describe('send-amount-row selectors', function () {
 
-  describe('sendAmountIsInError()', () => {
-    it('should return true if send.errors.amount is truthy', () => {
+  describe('sendAmountIsInError()', function () {
+    it('should return true if send.errors.amount is truthy', function () {
       const state = {
         send: {
           errors: {
@@ -18,7 +18,7 @@ describe('send-amount-row selectors', () => {
       assert.equal(sendAmountIsInError(state), true)
     })
 
-    it('should return false if send.errors.amount is falsy', () => {
+    it('should return false if send.errors.amount is falsy', function () {
       const state = {
         send: {
           errors: {

--- a/ui/app/pages/send/send-content/send-dropdown-list/tests/send-dropdown-list-component.test.js
+++ b/ui/app/pages/send/send-content/send-dropdown-list/tests/send-dropdown-list-component.test.js
@@ -16,7 +16,7 @@ sinon.spy(SendDropdownList.prototype, 'getListItemIcon')
 describe('SendDropdownList Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <SendDropdownList
         accounts={[
@@ -31,21 +31,21 @@ describe('SendDropdownList Component', function () {
     ), { context: { t: str => str + '_t' } })
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.closeDropdown.resetHistory()
     propsMethodSpies.onSelect.resetHistory()
     SendDropdownList.prototype.getListItemIcon.resetHistory()
   })
 
-  describe('getListItemIcon', () => {
-    it('should return check icon if the passed addresses are the same', () => {
+  describe('getListItemIcon', function () {
+    it('should return check icon if the passed addresses are the same', function () {
       assert.deepEqual(
         wrapper.instance().getListItemIcon('mockAccount0', 'mockAccount0'),
         <i className="fa fa-check fa-lg" style={ { color: '#02c9b1' } } />
       )
     })
 
-    it('should return null if the passed addresses are different', () => {
+    it('should return null if the passed addresses are different', function () {
       assert.equal(
         wrapper.instance().getListItemIcon('mockAccount0', 'mockAccount1'),
         null
@@ -53,29 +53,29 @@ describe('SendDropdownList Component', function () {
     })
   })
 
-  describe('render', () => {
-    it('should render a single div with two children', () => {
+  describe('render', function () {
+    it('should render a single div with two children', function () {
       assert(wrapper.is('div'))
       assert.equal(wrapper.children().length, 2)
     })
 
-    it('should render the children with the correct classes', () => {
+    it('should render the children with the correct classes', function () {
       assert(wrapper.childAt(0).hasClass('send-v2__from-dropdown__close-area'))
       assert(wrapper.childAt(1).hasClass('send-v2__from-dropdown__list'))
     })
 
-    it('should call closeDropdown onClick of the send-v2__from-dropdown__close-area', () => {
+    it('should call closeDropdown onClick of the send-v2__from-dropdown__close-area', function () {
       assert.equal(propsMethodSpies.closeDropdown.callCount, 0)
       wrapper.childAt(0).props().onClick()
       assert.equal(propsMethodSpies.closeDropdown.callCount, 1)
     })
 
-    it('should render an AccountListItem for each item in accounts', () => {
+    it('should render an AccountListItem for each item in accounts', function () {
       assert.equal(wrapper.childAt(1).children().length, 3)
       assert(wrapper.childAt(1).children().every(AccountListItem))
     })
 
-    it('should pass the correct props to the AccountListItem', () => {
+    it('should pass the correct props to the AccountListItem', function () {
       wrapper.childAt(1).children().forEach((accountListItem, index) => {
         const {
           account,
@@ -98,7 +98,7 @@ describe('SendDropdownList Component', function () {
       })
     })
 
-    it('should call this.getListItemIcon for each AccountListItem', () => {
+    it('should call this.getListItemIcon for each AccountListItem', function () {
       assert.equal(SendDropdownList.prototype.getListItemIcon.callCount, 3)
       const getListItemIconCalls = SendDropdownList.prototype.getListItemIcon.getCalls()
       assert(getListItemIconCalls.every(({ args }, index) => args[0] === 'mockAccount' + index))

--- a/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-component.test.js
@@ -6,7 +6,7 @@ import AccountListItem from '../../../account-list-item'
 import SendRowWrapper from '../../send-row-wrapper/send-row-wrapper.component'
 
 describe('SendFromRow Component', function () {
-  describe('render', () => {
+  describe('render', function () {
     const wrapper = shallow(
       <SendFromRow
         from={ { address: 'mockAddress' } }
@@ -14,16 +14,16 @@ describe('SendFromRow Component', function () {
       { context: { t: str => str + '_t' } }
     )
 
-    it('should render a SendRowWrapper component', () => {
+    it('should render a SendRowWrapper component', function () {
       assert.equal(wrapper.find(SendRowWrapper).length, 1)
     })
 
-    it('should pass the correct props to SendRowWrapper', () => {
+    it('should pass the correct props to SendRowWrapper', function () {
       const { label } = wrapper.find(SendRowWrapper).props()
       assert.equal(label, 'from_t:')
     })
 
-    it('should render the FromDropdown with the correct props', () => {
+    it('should render the FromDropdown with the correct props', function () {
       const { account } = wrapper.find(AccountListItem).props()
       assert.deepEqual(account, { address: 'mockAddress' })
     })

--- a/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-container.test.js
+++ b/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-container.test.js
@@ -15,9 +15,9 @@ proxyquire('../send-from-row.container.js', {
   },
 })
 
-describe('send-from-row container', () => {
-  describe('mapStateToProps()', () => {
-    it('should map the correct properties to props', () => {
+describe('send-from-row container', function () {
+  describe('mapStateToProps()', function () {
+    it('should map the correct properties to props', function () {
       assert.deepEqual(mapStateToProps('mockState'), {
         from: 'mockFrom:mockState',
       })

--- a/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/tests/gas-fee-display.component.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/tests/gas-fee-display.component.test.js
@@ -5,7 +5,6 @@ import GasFeeDisplay from '../gas-fee-display.component'
 import UserPreferencedCurrencyDisplay from '../../../../../../components/app/user-preferenced-currency-display'
 import sinon from 'sinon'
 
-
 const propsMethodSpies = {
   showCustomizeGasModal: sinon.spy(),
   onReset: sinon.spy(),
@@ -14,29 +13,29 @@ const propsMethodSpies = {
 describe('GasFeeDisplay Component', function () {
   let wrapper
 
-  beforeEach(() => {
-    wrapper = shallow((
-      <GasFeeDisplay
-        conversionRate={20}
-        gasTotal="mockGasTotal"
-        primaryCurrency="mockPrimaryCurrency"
-        convertedCurrency="mockConvertedCurrency"
-        showGasButtonGroup={propsMethodSpies.showCustomizeGasModal}
-        onReset={propsMethodSpies.onReset}
-      />
-    ), { context: { t: str => str + '_t' } })
-  })
+  describe('render', function () {
+    beforeEach(function () {
+      wrapper = shallow((
+        <GasFeeDisplay
+          conversionRate={20}
+          gasTotal="mockGasTotal"
+          primaryCurrency="mockPrimaryCurrency"
+          convertedCurrency="mockConvertedCurrency"
+          showGasButtonGroup={propsMethodSpies.showCustomizeGasModal}
+          onReset={propsMethodSpies.onReset}
+        />
+      ), { context: { t: str => str + '_t' } })
+    })
 
-  afterEach(() => {
-    propsMethodSpies.showCustomizeGasModal.resetHistory()
-  })
+    afterEach(function () {
+      propsMethodSpies.showCustomizeGasModal.resetHistory()
+    })
 
-  describe('render', () => {
-    it('should render a CurrencyDisplay component', () => {
+    it('should render a CurrencyDisplay component', function () {
       assert.equal(wrapper.find(UserPreferencedCurrencyDisplay).length, 2)
     })
 
-    it('should render the CurrencyDisplay with the correct props', () => {
+    it('should render the CurrencyDisplay with the correct props', function () {
       const {
         type,
         value,
@@ -45,7 +44,7 @@ describe('GasFeeDisplay Component', function () {
       assert.equal(value, 'mockGasTotal')
     })
 
-    it('should render the reset button with the correct props', () => {
+    it('should render the reset button with the correct props', function () {
       const {
         onClick,
         className,
@@ -56,7 +55,7 @@ describe('GasFeeDisplay Component', function () {
       assert.equal(propsMethodSpies.onReset.callCount, 1)
     })
 
-    it('should render the reset button with the correct text', () => {
+    it('should render the reset button with the correct text', function () {
       assert.equal(wrapper.find('button').text(), 'reset_t')
     })
   })

--- a/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
@@ -16,35 +16,35 @@ const propsMethodSpies = {
 describe('SendGasRow Component', function () {
   let wrapper
 
-  beforeEach(() => {
-    wrapper = shallow((
-      <SendGasRow
-        conversionRate={20}
-        convertedCurrency="mockConvertedCurrency"
-        gasFeeError
-        gasLoadingError={false}
-        gasTotal="mockGasTotal"
-        gasButtonGroupShown={false}
-        showCustomizeGasModal={propsMethodSpies.showCustomizeGasModal}
-        resetGasButtons={propsMethodSpies.resetGasButtons}
-        gasPriceButtonGroupProps={{
-          someGasPriceButtonGroupProp: 'foo',
-          anotherGasPriceButtonGroupProp: 'bar',
-        }}
-      />
-    ), { context: { t: str => str + '_t', metricsEvent: () => ({}) } })
-  })
+  describe('render', function () {
+    beforeEach(function () {
+      wrapper = shallow((
+        <SendGasRow
+          conversionRate={20}
+          convertedCurrency="mockConvertedCurrency"
+          gasFeeError
+          gasLoadingError={false}
+          gasTotal="mockGasTotal"
+          gasButtonGroupShown={false}
+          showCustomizeGasModal={propsMethodSpies.showCustomizeGasModal}
+          resetGasButtons={propsMethodSpies.resetGasButtons}
+          gasPriceButtonGroupProps={{
+            someGasPriceButtonGroupProp: 'foo',
+            anotherGasPriceButtonGroupProp: 'bar',
+          }}
+        />
+      ), { context: { t: str => str + '_t', metricsEvent: () => ({}) } })
+    })
 
-  afterEach(() => {
-    propsMethodSpies.resetGasButtons.resetHistory()
-  })
+    afterEach(function () {
+      propsMethodSpies.resetGasButtons.resetHistory()
+    })
 
-  describe('render', () => {
-    it('should render a SendRowWrapper component', () => {
+    it('should render a SendRowWrapper component', function () {
       assert.equal(wrapper.find(SendRowWrapper).length, 1)
     })
 
-    it('should pass the correct props to SendRowWrapper', () => {
+    it('should pass the correct props to SendRowWrapper', function () {
       const {
         label,
         showError,
@@ -56,11 +56,11 @@ describe('SendGasRow Component', function () {
       assert.equal(errorType, 'gasFee')
     })
 
-    it('should render a GasFeeDisplay as a child of the SendRowWrapper', () => {
+    it('should render a GasFeeDisplay as a child of the SendRowWrapper', function () {
       assert(wrapper.find(SendRowWrapper).childAt(0).is(GasFeeDisplay))
     })
 
-    it('should render the GasFeeDisplay', () => {
+    it('should render the GasFeeDisplay', function () {
       const {
         gasLoadingError,
         gasTotal,
@@ -73,7 +73,7 @@ describe('SendGasRow Component', function () {
       assert.equal(propsMethodSpies.resetGasButtons.callCount, 1)
     })
 
-    it('should render the GasPriceButtonGroup if gasButtonGroupShown is true', () => {
+    it('should render the GasPriceButtonGroup if gasButtonGroupShown is true', function () {
       wrapper.setProps({ gasButtonGroupShown: true })
       const rendered = wrapper.find(SendRowWrapper).childAt(0)
       assert.equal(rendered.children().length, 2)
@@ -86,7 +86,7 @@ describe('SendGasRow Component', function () {
       assert.equal(gasPriceButtonGroup.props().anotherGasPriceButtonGroupProp, 'bar')
     })
 
-    it('should render an advanced options button if gasButtonGroupShown is true', () => {
+    it('should render an advanced options button if gasButtonGroupShown is true', function () {
       wrapper.setProps({ gasButtonGroupShown: true })
       const rendered = wrapper.find(SendRowWrapper).childAt(0)
       assert.equal(rendered.children().length, 2)

--- a/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
@@ -47,20 +47,20 @@ proxyquire('../send-gas-row.container.js', {
   '../../../../ducks/gas/gas.duck': gasDuckSpies,
 })
 
-describe('send-gas-row container', () => {
+describe('send-gas-row container', function () {
 
-  describe('mapDispatchToProps()', () => {
+  describe('mapDispatchToProps()', function () {
     let dispatchSpy
     let mapDispatchToPropsObject
 
-    beforeEach(() => {
+    beforeEach(function () {
       dispatchSpy = sinon.spy()
       mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
       actionSpies.setGasTotal.resetHistory()
     })
 
-    describe('showCustomizeGasModal()', () => {
-      it('should dispatch an action', () => {
+    describe('showCustomizeGasModal()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.showCustomizeGasModal()
         assert(dispatchSpy.calledOnce)
         assert.deepEqual(
@@ -70,8 +70,8 @@ describe('send-gas-row container', () => {
       })
     })
 
-    describe('setGasPrice()', () => {
-      it('should dispatch an action', () => {
+    describe('setGasPrice()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.setGasPrice('mockNewPrice', 'mockLimit')
         assert(dispatchSpy.calledThrice)
         assert(actionSpies.setGasPrice.calledOnce)
@@ -82,8 +82,8 @@ describe('send-gas-row container', () => {
       })
     })
 
-    describe('setGasLimit()', () => {
-      it('should dispatch an action', () => {
+    describe('setGasLimit()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.setGasLimit('mockNewLimit', 'mockPrice')
         assert(dispatchSpy.calledThrice)
         assert(actionSpies.setGasLimit.calledOnce)
@@ -94,45 +94,37 @@ describe('send-gas-row container', () => {
       })
     })
 
-    describe('showGasButtonGroup()', () => {
-      it('should dispatch an action', () => {
+    describe('showGasButtonGroup()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.showGasButtonGroup()
         assert(dispatchSpy.calledOnce)
         assert(sendDuckSpies.showGasButtonGroup.calledOnce)
       })
     })
 
-    describe('resetCustomData()', () => {
-      it('should dispatch an action', () => {
+    describe('resetCustomData()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.resetCustomData()
         assert(dispatchSpy.calledOnce)
         assert(gasDuckSpies.resetCustomData.calledOnce)
       })
     })
-
   })
 
-  describe('mergeProps', () => {
-    let stateProps
-    let dispatchProps
-    let ownProps
-
-    beforeEach(() => {
-      stateProps = {
+  describe('mergeProps', function () {
+    it('should return the expected props when isConfirm is true', function () {
+      const stateProps = {
         gasPriceButtonGroupProps: {
           someGasPriceButtonGroupProp: 'foo',
           anotherGasPriceButtonGroupProp: 'bar',
         },
         someOtherStateProp: 'baz',
       }
-      dispatchProps = {
+      const dispatchProps = {
         setGasPrice: sinon.spy(),
         someOtherDispatchProp: sinon.spy(),
       }
-      ownProps = { someOwnProp: 123 }
-    })
-
-    it('should return the expected props when isConfirm is true', () => {
+      const ownProps = { someOwnProp: 123 }
       const result = mergeProps(stateProps, dispatchProps, ownProps)
 
       assert.equal(result.someOtherStateProp, 'baz')
@@ -149,5 +141,4 @@ describe('send-gas-row container', () => {
       assert.equal(dispatchProps.someOtherDispatchProp.callCount, 1)
     })
   })
-
 })

--- a/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-selectors.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-selectors.test.js
@@ -5,10 +5,10 @@ import {
   getGasButtonGroupShown,
 } from '../send-gas-row.selectors.js'
 
-describe('send-gas-row selectors', () => {
+describe('send-gas-row selectors', function () {
 
-  describe('getGasLoadingError()', () => {
-    it('should return send.errors.gasLoading', () => {
+  describe('getGasLoadingError()', function () {
+    it('should return send.errors.gasLoading', function () {
       const state = {
         send: {
           errors: {
@@ -21,8 +21,8 @@ describe('send-gas-row selectors', () => {
     })
   })
 
-  describe('gasFeeIsInError()', () => {
-    it('should return true if send.errors.gasFee is truthy', () => {
+  describe('gasFeeIsInError()', function () {
+    it('should return true if send.errors.gasFee is truthy', function () {
       const state = {
         send: {
           errors: {
@@ -34,7 +34,7 @@ describe('send-gas-row selectors', () => {
       assert.equal(gasFeeIsInError(state), true)
     })
 
-    it('should return false send.errors.gasFee is falsely', () => {
+    it('should return false send.errors.gasFee is falsely', function () {
       const state = {
         send: {
           errors: {
@@ -47,8 +47,8 @@ describe('send-gas-row selectors', () => {
     })
   })
 
-  describe('getGasButtonGroupShown()', () => {
-    it('should return send.gasButtonGroupShown', () => {
+  describe('getGasButtonGroupShown()', function () {
+    it('should return send.gasButtonGroupShown', function () {
       const state = {
         send: {
           gasButtonGroupShown: 'foobar',

--- a/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-component.test.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-component.test.js
@@ -6,22 +6,22 @@ import SendRowErrorMessage from '../send-row-error-message.component.js'
 describe('SendRowErrorMessage Component', function () {
   let wrapper
 
-  beforeEach(() => {
-    wrapper = shallow((
-      <SendRowErrorMessage
-        errors={{ error1: 'abc', error2: 'def' }}
-        errorType="error3"
-      />
-    ), { context: { t: str => str + '_t' } })
-  })
+  describe('render', function () {
+    beforeEach(function () {
+      wrapper = shallow((
+        <SendRowErrorMessage
+          errors={{ error1: 'abc', error2: 'def' }}
+          errorType="error3"
+        />
+      ), { context: { t: str => str + '_t' } })
+    })
 
-  describe('render', () => {
-    it('should render null if the passed errors do not contain an error of errorType', () => {
+    it('should render null if the passed errors do not contain an error of errorType', function () {
       assert.equal(wrapper.find('.send-v2__error').length, 0)
       assert.equal(wrapper.html(), null)
     })
 
-    it('should render an error message if the passed errors contain an error of errorType', () => {
+    it('should render an error message if the passed errors contain an error of errorType', function () {
       wrapper.setProps({ errors: { error1: 'abc', error2: 'def', error3: 'xyz' } })
       assert.equal(wrapper.find('.send-v2__error').length, 1)
       assert.equal(wrapper.find('.send-v2__error').text(), 'xyz_t')

--- a/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-container.test.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-container.test.js
@@ -13,11 +13,11 @@ proxyquire('../send-row-error-message.container.js', {
   '../../../send.selectors': { getSendErrors: (s) => `mockErrors:${s}` },
 })
 
-describe('send-row-error-message container', () => {
+describe('send-row-error-message container', function () {
 
-  describe('mapStateToProps()', () => {
+  describe('mapStateToProps()', function () {
 
-    it('should map the correct properties to props', () => {
+    it('should map the correct properties to props', function () {
       assert.deepEqual(mapStateToProps('mockState', { errorType: 'someType' }), {
         errors: 'mockErrors:mockState',
         errorType: 'someType' })

--- a/ui/app/pages/send/send-content/send-row-wrapper/tests/send-row-wrapper-component.test.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/tests/send-row-wrapper-component.test.js
@@ -8,41 +8,37 @@ import SendRowErrorMessage from '../send-row-error-message/send-row-error-messag
 describe('SendContent Component', function () {
   let wrapper
 
-  beforeEach(() => {
-    wrapper = shallow((
-      <SendRowWrapper
-        errorType="mockErrorType"
-        label="mockLabel"
-        showError={false}
-      >
-        <span>Mock Form Field</span>
-      </SendRowWrapper>
-    ))
-  })
+  describe('render', function () {
+    beforeEach(function () {
+      wrapper = shallow((
+        <SendRowWrapper errorType="mockErrorType" label="mockLabel" showError={false}>
+          <span>Mock Form Field</span>
+        </SendRowWrapper>
+      ))
+    })
 
-  describe('render', () => {
-    it('should render a div with a send-v2__form-row class', () => {
+    it('should render a div with a send-v2__form-row class', function () {
       assert.equal(wrapper.find('div.send-v2__form-row').length, 1)
     })
 
-    it('should render two children of the root div, with send-v2_form label and field classes', () => {
+    it('should render two children of the root div, with send-v2_form label and field classes', function () {
       assert.equal(wrapper.find('.send-v2__form-row > .send-v2__form-label').length, 1)
       assert.equal(wrapper.find('.send-v2__form-row > .send-v2__form-field').length, 1)
     })
 
-    it('should render the label as a child of the send-v2__form-label', () => {
+    it('should render the label as a child of the send-v2__form-label', function () {
       assert.equal(wrapper.find('.send-v2__form-row > .send-v2__form-label').childAt(0).text(), 'mockLabel')
     })
 
-    it('should render its first child as a child of the send-v2__form-field', () => {
+    it('should render its first child as a child of the send-v2__form-field', function () {
       assert.equal(wrapper.find('.send-v2__form-row > .send-v2__form-field').childAt(0).text(), 'Mock Form Field')
     })
 
-    it('should not render a SendRowErrorMessage if showError is false', () => {
+    it('should not render a SendRowErrorMessage if showError is false', function () {
       assert.equal(wrapper.find(SendRowErrorMessage).length, 0)
     })
 
-    it('should render a SendRowErrorMessage with and errorType props if showError is true', () => {
+    it('should render a SendRowErrorMessage with and errorType props if showError is true', function () {
       wrapper.setProps({ showError: true })
       assert.equal(wrapper.find(SendRowErrorMessage).length, 1)
 
@@ -54,7 +50,7 @@ describe('SendContent Component', function () {
       )
     })
 
-    it('should render its second child as a child of the send-v2__form-field, if it has two children', () => {
+    it('should render its second child as a child of the send-v2__form-field, if it has two children', function () {
       wrapper = shallow((
         <SendRowWrapper
           errorType="mockErrorType"
@@ -68,7 +64,7 @@ describe('SendContent Component', function () {
       assert.equal(wrapper.find('.send-v2__form-row > .send-v2__form-field').childAt(0).text(), 'Mock Form Field')
     })
 
-    it('should render its first child as the last child of the send-v2__form-label, if it has two children', () => {
+    it('should render its first child as the last child of the send-v2__form-label, if it has two children', function () {
       wrapper = shallow((
         <SendRowWrapper
           errorType="mockErrorType"

--- a/ui/app/pages/send/send-content/tests/send-content-component.test.js
+++ b/ui/app/pages/send/send-content/tests/send-content-component.test.js
@@ -13,7 +13,7 @@ import Dialog from '../../../../components/ui/dialog'
 describe('SendContent Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow(
       <SendContent
         showHexData
@@ -22,18 +22,18 @@ describe('SendContent Component', function () {
     )
   })
 
-  describe('render', () => {
-    it('should render a PageContainerContent component', () => {
+  describe('render', function () {
+    it('should render a PageContainerContent component', function () {
       assert.equal(wrapper.find(PageContainerContent).length, 1)
     })
 
-    it('should render a div with a .send-v2__form class as a child of PageContainerContent', () => {
+    it('should render a div with a .send-v2__form class as a child of PageContainerContent', function () {
       const PageContainerContentChild = wrapper.find(PageContainerContent).children()
       PageContainerContentChild.is('div')
       PageContainerContentChild.is('.send-v2__form')
     })
 
-    it('should render the correct row components as grandchildren of the PageContainerContent component', () => {
+    it('should render the correct row components as grandchildren of the PageContainerContent component', function () {
       const PageContainerContentChild = wrapper.find(PageContainerContent).children()
       assert(PageContainerContentChild.childAt(0).is(Dialog), 'row[0] should be Dialog')
       assert(PageContainerContentChild.childAt(1).is(SendAssetRow), 'row[1] should be SendAssetRow')
@@ -42,7 +42,7 @@ describe('SendContent Component', function () {
       assert(PageContainerContentChild.childAt(4).is(SendHexDataRow), 'row[4] should be SendHexDataRow')
     })
 
-    it('should not render the SendHexDataRow if props.showHexData is false', () => {
+    it('should not render the SendHexDataRow if props.showHexData is false', function () {
       wrapper.setProps({ showHexData: false })
       const PageContainerContentChild = wrapper.find(PageContainerContent).children()
       assert(PageContainerContentChild.childAt(0).is(Dialog), 'row[0] should be Dialog')
@@ -52,7 +52,7 @@ describe('SendContent Component', function () {
       assert.equal(PageContainerContentChild.childAt(4).exists(), false)
     })
 
-    it('should not render the Dialog if contact has a name', () => {
+    it('should not render the Dialog if contact has a name', function () {
       wrapper.setProps({
         showHexData: false,
         contact: { name: 'testName' },
@@ -64,7 +64,7 @@ describe('SendContent Component', function () {
       assert.equal(PageContainerContentChild.childAt(3).exists(), false)
     })
 
-    it('should not render the Dialog if it is an ownedAccount', () => {
+    it('should not render the Dialog if it is an ownedAccount', function () {
       wrapper.setProps({
         showHexData: false,
         isOwnedAccount: true,
@@ -77,7 +77,7 @@ describe('SendContent Component', function () {
     })
   })
 
-  it('should not render the asset dropdown if token length is 0 ', () => {
+  it('should not render the asset dropdown if token length is 0 ', function () {
     wrapper.setProps({ tokens: [] })
     const PageContainerContentChild = wrapper.find(PageContainerContent).children()
     assert(PageContainerContentChild.childAt(1).is(SendAssetRow))

--- a/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
@@ -24,7 +24,7 @@ sinon.spy(SendFooter.prototype, 'onSubmit')
 describe('SendFooter Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <SendFooter
         addToAddressBookIfNew={propsMethodSpies.addToAddressBookIfNew}
@@ -51,7 +51,7 @@ describe('SendFooter Component', function () {
     ), { context: { t: str => str, metricsEvent: () => ({}) } })
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.clearSend.resetHistory()
     propsMethodSpies.addToAddressBookIfNew.resetHistory()
     propsMethodSpies.clearSend.resetHistory()
@@ -62,14 +62,14 @@ describe('SendFooter Component', function () {
     SendFooter.prototype.onSubmit.resetHistory()
   })
 
-  describe('onCancel', () => {
-    it('should call clearSend', () => {
+  describe('onCancel', function () {
+    it('should call clearSend', function () {
       assert.equal(propsMethodSpies.clearSend.callCount, 0)
       wrapper.instance().onCancel()
       assert.equal(propsMethodSpies.clearSend.callCount, 1)
     })
 
-    it('should call history.push', () => {
+    it('should call history.push', function () {
       assert.equal(historySpies.push.callCount, 0)
       wrapper.instance().onCancel()
       assert.equal(historySpies.push.callCount, 1)
@@ -78,7 +78,7 @@ describe('SendFooter Component', function () {
   })
 
 
-  describe('formShouldBeDisabled()', () => {
+  describe('formShouldBeDisabled()', function () {
     const config = {
       'should return true if inError is truthy': {
         inError: true,
@@ -123,15 +123,15 @@ describe('SendFooter Component', function () {
 
     }
     Object.entries(config).map(([description, obj]) => {
-      it(description, () => {
+      it(description, function () {
         wrapper.setProps(obj)
         assert.equal(wrapper.instance().formShouldBeDisabled(), obj.expectedResult)
       })
     })
   })
 
-  describe('onSubmit', () => {
-    it('should call addToAddressBookIfNew with the correct params', () => {
+  describe('onSubmit', function () {
+    it('should call addToAddressBookIfNew with the correct params', function () {
       wrapper.instance().onSubmit(MOCK_EVENT)
       assert(propsMethodSpies.addToAddressBookIfNew.calledOnce)
       assert.deepEqual(
@@ -140,7 +140,7 @@ describe('SendFooter Component', function () {
       )
     })
 
-    it('should call props.update if editingTransactionId is truthy', () => {
+    it('should call props.update if editingTransactionId is truthy', function () {
       wrapper.instance().onSubmit(MOCK_EVENT)
       assert(propsMethodSpies.update.calledOnce)
       assert.deepEqual(
@@ -159,11 +159,11 @@ describe('SendFooter Component', function () {
       )
     })
 
-    it('should not call props.sign if editingTransactionId is truthy', () => {
+    it('should not call props.sign if editingTransactionId is truthy', function () {
       assert.equal(propsMethodSpies.sign.callCount, 0)
     })
 
-    it('should call props.sign if editingTransactionId is falsy', () => {
+    it('should call props.sign if editingTransactionId is falsy', function () {
       wrapper.setProps({ editingTransactionId: null })
       wrapper.instance().onSubmit(MOCK_EVENT)
       assert(propsMethodSpies.sign.calledOnce)
@@ -181,11 +181,11 @@ describe('SendFooter Component', function () {
       )
     })
 
-    it('should not call props.update if editingTransactionId is falsy', () => {
+    it('should not call props.update if editingTransactionId is falsy', function () {
       assert.equal(propsMethodSpies.update.callCount, 0)
     })
 
-    it('should call history.push', done => {
+    it('should call history.push', function (done) {
       Promise.resolve(wrapper.instance().onSubmit(MOCK_EVENT))
         .then(() => {
           assert.equal(historySpies.push.callCount, 1)
@@ -195,8 +195,8 @@ describe('SendFooter Component', function () {
     })
   })
 
-  describe('render', () => {
-    beforeEach(() => {
+  describe('render', function () {
+    beforeEach(function () {
       sinon.stub(SendFooter.prototype, 'formShouldBeDisabled').returns(true)
       wrapper = shallow((
         <SendFooter
@@ -223,15 +223,15 @@ describe('SendFooter Component', function () {
       ), { context: { t: str => str, metricsEvent: () => ({}) } })
     })
 
-    afterEach(() => {
+    afterEach(function () {
       SendFooter.prototype.formShouldBeDisabled.restore()
     })
 
-    it('should render a PageContainerFooter component', () => {
+    it('should render a PageContainerFooter component', function () {
       assert.equal(wrapper.find(PageContainerFooter).length, 1)
     })
 
-    it('should pass the correct props to PageContainerFooter', () => {
+    it('should pass the correct props to PageContainerFooter', function () {
       const {
         onCancel,
         onSubmit,

--- a/ui/app/pages/send/send-footer/tests/send-footer-container.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-container.test.js
@@ -51,27 +51,27 @@ proxyquire('../send-footer.container.js', {
   },
 })
 
-describe('send-footer container', () => {
+describe('send-footer container', function () {
 
-  describe('mapDispatchToProps()', () => {
+  describe('mapDispatchToProps()', function () {
     let dispatchSpy
     let mapDispatchToPropsObject
 
-    beforeEach(() => {
+    beforeEach(function () {
       dispatchSpy = sinon.spy()
       mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
     })
 
-    describe('clearSend()', () => {
-      it('should dispatch an action', () => {
+    describe('clearSend()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.clearSend()
         assert(dispatchSpy.calledOnce)
         assert(actionSpies.clearSend.calledOnce)
       })
     })
 
-    describe('sign()', () => {
-      it('should dispatch a signTokenTx action if selectedToken is defined', () => {
+    describe('sign()', function () {
+      it('should dispatch a signTokenTx action if selectedToken is defined', function () {
         mapDispatchToPropsObject.sign({
           selectedToken: {
             address: '0xabc',
@@ -103,7 +103,7 @@ describe('send-footer container', () => {
         )
       })
 
-      it('should dispatch a sign action if selectedToken is not defined', () => {
+      it('should dispatch a sign action if selectedToken is not defined', function () {
         utilsStubs.constructTxParams.resetHistory()
         mapDispatchToPropsObject.sign({
           to: 'mockTo',
@@ -132,8 +132,8 @@ describe('send-footer container', () => {
       })
     })
 
-    describe('update()', () => {
-      it('should dispatch an updateTransaction action', () => {
+    describe('update()', function () {
+      it('should dispatch an updateTransaction action', function () {
         mapDispatchToPropsObject.update({
           to: 'mockTo',
           amount: 'mockAmount',
@@ -163,8 +163,8 @@ describe('send-footer container', () => {
       })
     })
 
-    describe('addToAddressBookIfNew()', () => {
-      it('should dispatch an action', () => {
+    describe('addToAddressBookIfNew()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.addToAddressBookIfNew('mockNewAddress', 'mockToAccounts', 'mockNickname')
         assert(dispatchSpy.calledOnce)
         assert.equal(utilsStubs.addressIsNew.getCall(0).args[0], 'mockToAccounts')

--- a/ui/app/pages/send/send-footer/tests/send-footer-selectors.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-selectors.test.js
@@ -9,14 +9,14 @@ const {
   },
 })
 
-describe('send-footer selectors', () => {
+describe('send-footer selectors', function () {
 
-  describe('getTitleKey()', () => {
-    it('should return true if any of the values of the object returned by getSendErrors are truthy', () => {
+  describe('getTitleKey()', function () {
+    it('should return true if any of the values of the object returned by getSendErrors are truthy', function () {
       assert.equal(isSendFormInError({ errors: { a: 'abc', b: false } }), true)
     })
 
-    it('should return false if all of the values of the object returned by getSendErrors are falsy', () => {
+    it('should return false if all of the values of the object returned by getSendErrors are falsy', function () {
       assert.equal(isSendFormInError({ errors: { a: false, b: null } }), false)
     })
   })

--- a/ui/app/pages/send/send-footer/tests/send-footer-utils.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-utils.test.js
@@ -21,10 +21,10 @@ const {
   addHexPrefixToObjectValues,
 } = sendUtils
 
-describe('send-footer utils', () => {
+describe('send-footer utils', function () {
 
-  describe('addHexPrefixToObjectValues()', () => {
-    it('should return a new object with the same properties with a 0x prefix', () => {
+  describe('addHexPrefixToObjectValues()', function () {
+    it('should return a new object with the same properties with a 0x prefix', function () {
       assert.deepEqual(
         addHexPrefixToObjectValues({
           prop1: '0x123',
@@ -40,8 +40,8 @@ describe('send-footer utils', () => {
     })
   })
 
-  describe('addressIsNew()', () => {
-    it('should return false if the address exists in toAccounts', () => {
+  describe('addressIsNew()', function () {
+    it('should return false if the address exists in toAccounts', function () {
       assert.equal(
         addressIsNew([
           { address: '0xabc' },
@@ -52,7 +52,7 @@ describe('send-footer utils', () => {
       )
     })
 
-    it('should return true if the address does not exists in toAccounts', () => {
+    it('should return true if the address does not exists in toAccounts', function () {
       assert.equal(
         addressIsNew([
           { address: '0xabc' },
@@ -64,8 +64,8 @@ describe('send-footer utils', () => {
     })
   })
 
-  describe('constructTxParams()', () => {
-    it('should return a new txParams object with data if there data is given', () => {
+  describe('constructTxParams()', function () {
+    it('should return a new txParams object with data if there data is given', function () {
       assert.deepEqual(
         constructTxParams({
           data: 'someData',
@@ -87,7 +87,7 @@ describe('send-footer utils', () => {
       )
     })
 
-    it('should return a new txParams object with value and to properties if there is no selectedToken', () => {
+    it('should return a new txParams object with value and to properties if there is no selectedToken', function () {
       assert.deepEqual(
         constructTxParams({
           selectedToken: false,
@@ -108,7 +108,7 @@ describe('send-footer utils', () => {
       )
     })
 
-    it('should return a new txParams object without a to property and a 0 value if there is a selectedToken', () => {
+    it('should return a new txParams object without a to property and a 0 value if there is a selectedToken', function () {
       assert.deepEqual(
         constructTxParams({
           selectedToken: true,
@@ -129,8 +129,8 @@ describe('send-footer utils', () => {
     })
   })
 
-  describe('constructUpdatedTx()', () => {
-    it('should return a new object with an updated txParams', () => {
+  describe('constructUpdatedTx()', function () {
+    it('should return a new object with an updated txParams', function () {
       const result = constructUpdatedTx({
         amount: 'mockAmount',
         editingTransactionId: '0x456',
@@ -162,7 +162,7 @@ describe('send-footer utils', () => {
       })
     })
 
-    it('should not have data property if there is non in the original tx', () => {
+    it('should not have data property if there is non in the original tx', function () {
       const result = constructUpdatedTx({
         amount: 'mockAmount',
         editingTransactionId: '0x456',
@@ -196,7 +196,7 @@ describe('send-footer utils', () => {
       })
     })
 
-    it('should have token property values if selectedToken is truthy', () => {
+    it('should have token property values if selectedToken is truthy', function () {
       const result = constructUpdatedTx({
         amount: 'mockAmount',
         editingTransactionId: '0x456',

--- a/ui/app/pages/send/send-header/tests/send-header-component.test.js
+++ b/ui/app/pages/send/send-header/tests/send-header-component.test.js
@@ -19,7 +19,7 @@ sinon.spy(SendHeader.prototype, 'onClose')
 describe('SendHeader Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <SendHeader
         clearSend={propsMethodSpies.clearSend}
@@ -29,20 +29,20 @@ describe('SendHeader Component', function () {
     ), { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } })
   })
 
-  afterEach(() => {
+  afterEach(function () {
     propsMethodSpies.clearSend.resetHistory()
     historySpies.push.resetHistory()
     SendHeader.prototype.onClose.resetHistory()
   })
 
-  describe('onClose', () => {
-    it('should call clearSend', () => {
+  describe('onClose', function () {
+    it('should call clearSend', function () {
       assert.equal(propsMethodSpies.clearSend.callCount, 0)
       wrapper.instance().onClose()
       assert.equal(propsMethodSpies.clearSend.callCount, 1)
     })
 
-    it('should call history.push', () => {
+    it('should call history.push', function () {
       assert.equal(historySpies.push.callCount, 0)
       wrapper.instance().onClose()
       assert.equal(historySpies.push.callCount, 1)
@@ -50,12 +50,12 @@ describe('SendHeader Component', function () {
     })
   })
 
-  describe('render', () => {
-    it('should render a PageContainerHeader compenent', () => {
+  describe('render', function () {
+    it('should render a PageContainerHeader compenent', function () {
       assert.equal(wrapper.find(PageContainerHeader).length, 1)
     })
 
-    it('should pass the correct props to PageContainerHeader', () => {
+    it('should pass the correct props to PageContainerHeader', function () {
       const {
         onClose,
         title,

--- a/ui/app/pages/send/send-header/tests/send-header-container.test.js
+++ b/ui/app/pages/send/send-header/tests/send-header-container.test.js
@@ -23,35 +23,25 @@ proxyquire('../send-header.container.js', {
   },
 })
 
-describe('send-header container', () => {
-
-  describe('mapStateToProps()', () => {
-
-    it('should map the correct properties to props', () => {
+describe('send-header container', function () {
+  describe('mapStateToProps()', function () {
+    it('should map the correct properties to props', function () {
       assert.deepEqual(mapStateToProps('mockState'), {
         titleKey: 'mockTitleKey:mockState',
       })
     })
-
   })
 
-  describe('mapDispatchToProps()', () => {
-    let dispatchSpy
-    let mapDispatchToPropsObject
+  describe('mapDispatchToProps()', function () {
+    describe('clearSend()', function () {
+      it('should dispatch an action', function () {
+        const dispatchSpy = sinon.spy()
+        const mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
 
-    beforeEach(() => {
-      dispatchSpy = sinon.spy()
-      mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
-    })
-
-    describe('clearSend()', () => {
-      it('should dispatch an action', () => {
         mapDispatchToPropsObject.clearSend()
         assert(dispatchSpy.calledOnce)
         assert(actionSpies.clearSend.calledOnce)
       })
     })
-
   })
-
 })

--- a/ui/app/pages/send/send-header/tests/send-header-selectors.test.js
+++ b/ui/app/pages/send/send-header/tests/send-header-selectors.test.js
@@ -11,22 +11,22 @@ const {
   },
 })
 
-describe('send-header selectors', () => {
+describe('send-header selectors', function () {
 
-  describe('getTitleKey()', () => {
-    it('should return the correct key when "to" is empty', () => {
+  describe('getTitleKey()', function () {
+    it('should return the correct key when "to" is empty', function () {
       assert.equal(getTitleKey({ e: 1, t: true, to: '' }), 'addRecipient')
     })
 
-    it('should return the correct key when getSendEditingTransactionId is truthy', () => {
+    it('should return the correct key when getSendEditingTransactionId is truthy', function () {
       assert.equal(getTitleKey({ e: 1, t: true, to: '0x123' }), 'edit')
     })
 
-    it('should return the correct key when getSendEditingTransactionId is falsy and getSelectedToken is truthy', () => {
+    it('should return the correct key when getSendEditingTransactionId is falsy and getSelectedToken is truthy', function () {
       assert.equal(getTitleKey({ e: null, t: 'abc', to: '0x123' }), 'sendTokens')
     })
 
-    it('should return the correct key when getSendEditingTransactionId is falsy and getSelectedToken is falsy', () => {
+    it('should return the correct key when getSendEditingTransactionId is falsy and getSelectedToken is falsy', function () {
       assert.equal(getTitleKey({ e: null, to: '0x123' }), 'sendETH')
     })
   })

--- a/ui/app/pages/send/tests/send-component.test.js
+++ b/ui/app/pages/send/tests/send-component.test.js
@@ -39,7 +39,7 @@ sinon.spy(SendTransactionScreen.prototype, 'updateGas')
 describe('Send Component', function () {
   let wrapper
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = shallow((
       <SendTransactionScreen
         amount="mockAmount"
@@ -76,7 +76,7 @@ describe('Send Component', function () {
     ))
   })
 
-  afterEach(() => {
+  afterEach(function () {
     SendTransactionScreen.prototype.componentDidMount.resetHistory()
     SendTransactionScreen.prototype.updateGas.resetHistory()
     utilsMethodStubs.doesAmountErrorRequireUpdate.resetHistory()
@@ -89,19 +89,19 @@ describe('Send Component', function () {
     propsMethodSpies.updateToNicknameIfNecessary.resetHistory()
   })
 
-  it('should call componentDidMount', () => {
+  it('should call componentDidMount', function () {
     assert(SendTransactionScreen.prototype.componentDidMount.calledOnce)
   })
 
-  describe('componentDidMount', () => {
-    it('should call props.fetchBasicGasAndTimeEstimates', () => {
+  describe('componentDidMount', function () {
+    it('should call props.fetchBasicGasAndTimeEstimates', function () {
       propsMethodSpies.fetchBasicGasEstimates.resetHistory()
       assert.equal(propsMethodSpies.fetchBasicGasEstimates.callCount, 0)
       wrapper.instance().componentDidMount()
       assert.equal(propsMethodSpies.fetchBasicGasEstimates.callCount, 1)
     })
 
-    it('should call this.updateGas', async () => {
+    it('should call this.updateGas', async function () {
       SendTransactionScreen.prototype.updateGas.resetHistory()
       propsMethodSpies.updateSendErrors.resetHistory()
       assert.equal(SendTransactionScreen.prototype.updateGas.callCount, 0)
@@ -111,8 +111,8 @@ describe('Send Component', function () {
     })
   })
 
-  describe('componentWillUnmount', () => {
-    it('should call this.props.resetSendState', () => {
+  describe('componentWillUnmount', function () {
+    it('should call this.props.resetSendState', function () {
       propsMethodSpies.resetSendState.resetHistory()
       assert.equal(propsMethodSpies.resetSendState.callCount, 0)
       wrapper.instance().componentWillUnmount()
@@ -120,8 +120,8 @@ describe('Send Component', function () {
     })
   })
 
-  describe('componentDidUpdate', () => {
-    it('should call doesAmountErrorRequireUpdate with the expected params', () => {
+  describe('componentDidUpdate', function () {
+    it('should call doesAmountErrorRequireUpdate with the expected params', function () {
       utilsMethodStubs.getAmountErrorObject.resetHistory()
       wrapper.instance().componentDidUpdate({
         from: {
@@ -143,7 +143,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should not call getAmountErrorObject if doesAmountErrorRequireUpdate returns false', () => {
+    it('should not call getAmountErrorObject if doesAmountErrorRequireUpdate returns false', function () {
       utilsMethodStubs.getAmountErrorObject.resetHistory()
       wrapper.instance().componentDidUpdate({
         from: {
@@ -153,7 +153,7 @@ describe('Send Component', function () {
       assert.equal(utilsMethodStubs.getAmountErrorObject.callCount, 0)
     })
 
-    it('should call getAmountErrorObject if doesAmountErrorRequireUpdate returns true', () => {
+    it('should call getAmountErrorObject if doesAmountErrorRequireUpdate returns true', function () {
       utilsMethodStubs.getAmountErrorObject.resetHistory()
       wrapper.instance().componentDidUpdate({
         from: {
@@ -176,7 +176,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should call getGasFeeErrorObject if doesAmountErrorRequireUpdate returns true and selectedToken is truthy', () => {
+    it('should call getGasFeeErrorObject if doesAmountErrorRequireUpdate returns true and selectedToken is truthy', function () {
       utilsMethodStubs.getGasFeeErrorObject.resetHistory()
       wrapper.instance().componentDidUpdate({
         from: {
@@ -197,7 +197,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should not call getGasFeeErrorObject if doesAmountErrorRequireUpdate returns false', () => {
+    it('should not call getGasFeeErrorObject if doesAmountErrorRequireUpdate returns false', function () {
       utilsMethodStubs.getGasFeeErrorObject.resetHistory()
       wrapper.instance().componentDidUpdate({
         from: { address: 'mockAddress', balance: 'mockBalance' },
@@ -205,7 +205,7 @@ describe('Send Component', function () {
       assert.equal(utilsMethodStubs.getGasFeeErrorObject.callCount, 0)
     })
 
-    it('should not call getGasFeeErrorObject if doesAmountErrorRequireUpdate returns true but selectedToken is falsy', () => {
+    it('should not call getGasFeeErrorObject if doesAmountErrorRequireUpdate returns true but selectedToken is falsy', function () {
       utilsMethodStubs.getGasFeeErrorObject.resetHistory()
       wrapper.setProps({ selectedToken: null })
       wrapper.instance().componentDidUpdate({
@@ -216,7 +216,7 @@ describe('Send Component', function () {
       assert.equal(utilsMethodStubs.getGasFeeErrorObject.callCount, 0)
     })
 
-    it('should call updateSendErrors with the expected params if selectedToken is falsy', () => {
+    it('should call updateSendErrors with the expected params if selectedToken is falsy', function () {
       propsMethodSpies.updateSendErrors.resetHistory()
       wrapper.setProps({ selectedToken: null })
       wrapper.instance().componentDidUpdate({
@@ -231,7 +231,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should call updateSendErrors with the expected params if selectedToken is truthy', () => {
+    it('should call updateSendErrors with the expected params if selectedToken is truthy', function () {
       propsMethodSpies.updateSendErrors.resetHistory()
       wrapper.setProps({ selectedToken: { address: 'mockTokenAddress', decimals: 18, symbol: 'TST' } })
       wrapper.instance().componentDidUpdate({
@@ -246,7 +246,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should not call updateSendTokenBalance or this.updateGas if network === prevNetwork', () => {
+    it('should not call updateSendTokenBalance or this.updateGas if network === prevNetwork', function () {
       SendTransactionScreen.prototype.updateGas.resetHistory()
       propsMethodSpies.updateSendTokenBalance.resetHistory()
       wrapper.instance().componentDidUpdate({
@@ -260,7 +260,7 @@ describe('Send Component', function () {
       assert.equal(SendTransactionScreen.prototype.updateGas.callCount, 0)
     })
 
-    it('should not call updateSendTokenBalance or this.updateGas if network === loading', () => {
+    it('should not call updateSendTokenBalance or this.updateGas if network === loading', function () {
       wrapper.setProps({ network: 'loading' })
       SendTransactionScreen.prototype.updateGas.resetHistory()
       propsMethodSpies.updateSendTokenBalance.resetHistory()
@@ -275,7 +275,7 @@ describe('Send Component', function () {
       assert.equal(SendTransactionScreen.prototype.updateGas.callCount, 0)
     })
 
-    it('should call updateSendTokenBalance and this.updateGas with the correct params', () => {
+    it('should call updateSendTokenBalance and this.updateGas with the correct params', function () {
       SendTransactionScreen.prototype.updateGas.resetHistory()
       propsMethodSpies.updateSendTokenBalance.resetHistory()
       wrapper.instance().componentDidUpdate({
@@ -301,7 +301,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should call updateGas when selectedToken.address is changed', () => {
+    it('should call updateGas when selectedToken.address is changed', function () {
       SendTransactionScreen.prototype.updateGas.resetHistory()
       propsMethodSpies.updateAndSetGasLimit.resetHistory()
       wrapper.instance().componentDidUpdate({
@@ -316,8 +316,8 @@ describe('Send Component', function () {
     })
   })
 
-  describe('updateGas', () => {
-    it('should call updateAndSetGasLimit with the correct params if no to prop is passed', () => {
+  describe('updateGas', function () {
+    it('should call updateAndSetGasLimit with the correct params if no to prop is passed', function () {
       propsMethodSpies.updateAndSetGasLimit.resetHistory()
       wrapper.instance().updateGas()
       assert.equal(propsMethodSpies.updateAndSetGasLimit.callCount, 1)
@@ -338,7 +338,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should call updateAndSetGasLimit with the correct params if a to prop is passed', () => {
+    it('should call updateAndSetGasLimit with the correct params if a to prop is passed', function () {
       propsMethodSpies.updateAndSetGasLimit.resetHistory()
       wrapper.setProps({ to: 'someAddress' })
       wrapper.instance().updateGas()
@@ -348,24 +348,24 @@ describe('Send Component', function () {
       )
     })
 
-    it('should call updateAndSetGasLimit with to set to lowercase if passed', () => {
+    it('should call updateAndSetGasLimit with to set to lowercase if passed', function () {
       propsMethodSpies.updateAndSetGasLimit.resetHistory()
       wrapper.instance().updateGas({ to: '0xABC' })
       assert.equal(propsMethodSpies.updateAndSetGasLimit.getCall(0).args[0].to, '0xabc')
     })
   })
 
-  describe('render', () => {
-    it('should render a page-container class', () => {
+  describe('render', function () {
+    it('should render a page-container class', function () {
       assert.equal(wrapper.find('.page-container').length, 1)
     })
 
-    it('should render SendHeader and AddRecipient', () => {
+    it('should render SendHeader and AddRecipient', function () {
       assert.equal(wrapper.find(SendHeader).length, 1)
       assert.equal(wrapper.find(AddRecipient).length, 1)
     })
 
-    it('should pass the history prop to SendHeader and SendFooter', () => {
+    it('should pass the history prop to SendHeader and SendFooter', function () {
       wrapper.setProps({
         to: '0x80F061544cC398520615B5d3e7A3BedD70cd4510',
       })
@@ -380,7 +380,7 @@ describe('Send Component', function () {
       )
     })
 
-    it('should pass showHexData to SendContent', () => {
+    it('should pass showHexData to SendContent', function () {
       wrapper.setProps({
         to: '0x80F061544cC398520615B5d3e7A3BedD70cd4510',
       })
@@ -388,18 +388,18 @@ describe('Send Component', function () {
     })
   })
 
-  describe('validate when input change', () => {
+  describe('validate when input change', function () {
     let clock
 
-    beforeEach(() => {
+    beforeEach(function () {
       clock = sinon.useFakeTimers()
     })
 
-    afterEach(() => {
+    afterEach(function () {
       clock.restore()
     })
 
-    it('should validate when input changes', () => {
+    it('should validate when input changes', function () {
       const instance = wrapper.instance()
       instance.onRecipientInputChange('0x80F061544cC398520615B5d3e7A3BedD70cd4510')
 
@@ -410,7 +410,7 @@ describe('Send Component', function () {
       })
     })
 
-    it('should validate when input changes and has error', () => {
+    it('should validate when input changes and has error', function () {
       const instance = wrapper.instance()
       instance.onRecipientInputChange('0x80F061544cC398520615B5d3e7a3BedD70cd4510')
 
@@ -422,7 +422,7 @@ describe('Send Component', function () {
       })
     })
 
-    it('should validate when input changes and has error', () => {
+    it('should validate when input changes and has error on a bad network', function () {
       wrapper.setProps({ network: 'bad' })
       const instance = wrapper.instance()
       instance.onRecipientInputChange('0x80F061544cC398520615B5d3e7a3BedD70cd4510')
@@ -435,7 +435,7 @@ describe('Send Component', function () {
       })
     })
 
-    it('should synchronously validate when input changes to ""', () => {
+    it('should synchronously validate when input changes to ""', function () {
       wrapper.setProps({ network: 'bad' })
       const instance = wrapper.instance()
       instance.onRecipientInputChange('0x80F061544cC398520615B5d3e7a3BedD70cd4510')
@@ -455,7 +455,7 @@ describe('Send Component', function () {
       })
     })
 
-    it('should warn when send to a known token contract address', () => {
+    it('should warn when send to a known token contract address', function () {
       wrapper.setProps({ address: '0x888', decimals: 18, symbol: '888' })
       const instance = wrapper.instance()
       instance.onRecipientInputChange('0x13cb85823f78Cff38f0B0E90D3e975b8CB3AAd64')

--- a/ui/app/pages/send/tests/send-container.test.js
+++ b/ui/app/pages/send/tests/send-container.test.js
@@ -31,18 +31,18 @@ proxyquire('../send.container.js', {
 
 })
 
-describe('send container', () => {
+describe('send container', function () {
 
-  describe('mapDispatchToProps()', () => {
+  describe('mapDispatchToProps()', function () {
     let dispatchSpy
     let mapDispatchToPropsObject
 
-    beforeEach(() => {
+    beforeEach(function () {
       dispatchSpy = sinon.spy()
       mapDispatchToPropsObject = mapDispatchToProps(dispatchSpy)
     })
 
-    describe('updateAndSetGasLimit()', () => {
+    describe('updateAndSetGasLimit()', function () {
       const mockProps = {
         blockGasLimit: 'mockBlockGasLimit',
         editingTransactionId: '0x2',
@@ -56,7 +56,7 @@ describe('send container', () => {
         data: undefined,
       }
 
-      it('should dispatch a setGasTotal action when editingTransactionId is truthy', () => {
+      it('should dispatch a setGasTotal action when editingTransactionId is truthy', function () {
         mapDispatchToPropsObject.updateAndSetGasLimit(mockProps)
         assert(dispatchSpy.calledOnce)
         assert.equal(
@@ -65,7 +65,7 @@ describe('send container', () => {
         )
       })
 
-      it('should dispatch an updateGasData action when editingTransactionId is falsy', () => {
+      it('should dispatch an updateGasData action when editingTransactionId is falsy', function () {
         const { gasPrice, selectedAddress, selectedToken, recentBlocks, blockGasLimit, to, value, data } = mockProps
         mapDispatchToPropsObject.updateAndSetGasLimit(
           Object.assign({}, mockProps, { editingTransactionId: false })
@@ -78,14 +78,14 @@ describe('send container', () => {
       })
     })
 
-    describe('updateSendTokenBalance()', () => {
+    describe('updateSendTokenBalance()', function () {
       const mockProps = {
         address: '0x10',
         tokenContract: '0x00a',
         selectedToken: { address: '0x1' },
       }
 
-      it('should dispatch an action', () => {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.updateSendTokenBalance(Object.assign({}, mockProps))
         assert(dispatchSpy.calledOnce)
         assert.deepEqual(
@@ -95,8 +95,8 @@ describe('send container', () => {
       })
     })
 
-    describe('updateSendErrors()', () => {
-      it('should dispatch an action', () => {
+    describe('updateSendErrors()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.updateSendErrors('mockError')
         assert(dispatchSpy.calledOnce)
         assert.equal(
@@ -106,8 +106,8 @@ describe('send container', () => {
       })
     })
 
-    describe('resetSendState()', () => {
-      it('should dispatch an action', () => {
+    describe('resetSendState()', function () {
+      it('should dispatch an action', function () {
         mapDispatchToPropsObject.resetSendState()
         assert(dispatchSpy.calledOnce)
         assert.equal(

--- a/ui/app/pages/send/tests/send-selectors.test.js
+++ b/ui/app/pages/send/tests/send-selectors.test.js
@@ -39,9 +39,9 @@ import {
 } from '../send.selectors.js'
 import mockState from './send-selectors-test-data'
 
-describe('send selectors', () => {
+describe('send selectors', function () {
   const tempGlobalEth = Object.assign({}, global.eth)
-  beforeEach(() => {
+  beforeEach(function () {
     global.eth = {
       contract: sinon.stub().returns({
         at: address => 'mockAt:' + address,
@@ -49,12 +49,12 @@ describe('send selectors', () => {
     }
   })
 
-  afterEach(() => {
+  afterEach(function () {
     global.eth = tempGlobalEth
   })
 
-  describe('accountsWithSendEtherInfoSelector()', () => {
-    it('should return an array of account objects with name info from identities', () => {
+  describe('accountsWithSendEtherInfoSelector()', function () {
+    it('should return an array of account objects with name info from identities', function () {
       assert.deepEqual(
         accountsWithSendEtherInfoSelector(mockState),
         [
@@ -100,15 +100,15 @@ describe('send selectors', () => {
   //   })
   // })
 
-  describe('getAmountConversionRate()', () => {
-    it('should return the token conversion rate if a token is selected', () => {
+  describe('getAmountConversionRate()', function () {
+    it('should return the token conversion rate if a token is selected', function () {
       assert.equal(
         getAmountConversionRate(mockState),
         2401.76400654
       )
     })
 
-    it('should return the eth conversion rate if no token is selected', () => {
+    it('should return the eth conversion rate if no token is selected', function () {
       const editedMockState = {
         metamask: Object.assign({}, mockState.metamask, { selectedTokenAddress: null }),
       }
@@ -119,8 +119,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getBlockGasLimit', () => {
-    it('should return the current block gas limit', () => {
+  describe('getBlockGasLimit', function () {
+    it('should return the current block gas limit', function () {
       assert.deepEqual(
         getBlockGasLimit(mockState),
         '0x4c1878'
@@ -128,8 +128,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getConversionRate()', () => {
-    it('should return the eth conversion rate', () => {
+  describe('getConversionRate()', function () {
+    it('should return the eth conversion rate', function () {
       assert.deepEqual(
         getConversionRate(mockState),
         1200.88200327
@@ -137,8 +137,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getCurrentAccountWithSendEtherInfo()', () => {
-    it('should return the currently selected account with identity info', () => {
+  describe('getCurrentAccountWithSendEtherInfo()', function () {
+    it('should return the currently selected account with identity info', function () {
       assert.deepEqual(
         getCurrentAccountWithSendEtherInfo(mockState),
         {
@@ -152,8 +152,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getCurrentCurrency()', () => {
-    it('should return the currently selected currency', () => {
+  describe('getCurrentCurrency()', function () {
+    it('should return the currently selected currency', function () {
       assert.equal(
         getCurrentCurrency(mockState),
         'USD'
@@ -161,8 +161,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getNativeCurrency()', () => {
-    it('should return the ticker symbol of the selected network', () => {
+  describe('getNativeCurrency()', function () {
+    it('should return the ticker symbol of the selected network', function () {
       assert.equal(
         getNativeCurrency(mockState),
         'ETH'
@@ -170,8 +170,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getCurrentNetwork()', () => {
-    it('should return the id of the currently selected network', () => {
+  describe('getCurrentNetwork()', function () {
+    it('should return the id of the currently selected network', function () {
       assert.equal(
         getCurrentNetwork(mockState),
         '3'
@@ -179,8 +179,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getForceGasMin()', () => {
-    it('should get the send.forceGasMin property', () => {
+  describe('getForceGasMin()', function () {
+    it('should get the send.forceGasMin property', function () {
       assert.equal(
         getForceGasMin(mockState),
         true
@@ -188,8 +188,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getGasLimit()', () => {
-    it('should return the send.gasLimit', () => {
+  describe('getGasLimit()', function () {
+    it('should return the send.gasLimit', function () {
       assert.equal(
         getGasLimit(mockState),
         '0xFFFF'
@@ -197,8 +197,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getGasPrice()', () => {
-    it('should return the send.gasPrice', () => {
+  describe('getGasPrice()', function () {
+    it('should return the send.gasPrice', function () {
       assert.equal(
         getGasPrice(mockState),
         '0xaa'
@@ -206,8 +206,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getGasTotal()', () => {
-    it('should return the send.gasTotal', () => {
+  describe('getGasTotal()', function () {
+    it('should return the send.gasTotal', function () {
       assert.equal(
         getGasTotal(mockState),
         'a9ff56'
@@ -215,8 +215,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getPrimaryCurrency()', () => {
-    it('should return the symbol of the selected token', () => {
+  describe('getPrimaryCurrency()', function () {
+    it('should return the symbol of the selected token', function () {
       assert.equal(
         getPrimaryCurrency(mockState),
         'DEF'
@@ -224,8 +224,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getRecentBlocks()', () => {
-    it('should return the recent blocks', () => {
+  describe('getRecentBlocks()', function () {
+    it('should return the recent blocks', function () {
       assert.deepEqual(
         getRecentBlocks(mockState),
         ['mockBlock1', 'mockBlock2', 'mockBlock3']
@@ -233,8 +233,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSelectedAccount()', () => {
-    it('should return the currently selected account', () => {
+  describe('getSelectedAccount()', function () {
+    it('should return the currently selected account', function () {
       assert.deepEqual(
         getSelectedAccount(mockState),
         {
@@ -248,8 +248,8 @@ describe('send selectors', () => {
   })
 
 
-  describe('getSelectedIdentity()', () => {
-    it('should return the identity object of the currently selected address', () => {
+  describe('getSelectedIdentity()', function () {
+    it('should return the identity object of the currently selected address', function () {
       assert.deepEqual(
         getSelectedIdentity(mockState),
         {
@@ -260,8 +260,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSelectedToken()', () => {
-    it('should return the currently selected token if selected', () => {
+  describe('getSelectedToken()', function () {
+    it('should return the currently selected token if selected', function () {
       assert.deepEqual(
         getSelectedToken(mockState),
         {
@@ -272,7 +272,7 @@ describe('send selectors', () => {
       )
     })
 
-    it('should return the send token if none is currently selected, but a send token exists', () => {
+    it('should return the send token if none is currently selected, but a send token exists', function () {
       const mockSendToken = {
         address: '0x123456708414189a58339873ab429b6c47ab92d3',
         decimals: 4,
@@ -293,15 +293,15 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSelectedTokenContract()', () => {
-    it('should return the contract at the selected token address', () => {
+  describe('getSelectedTokenContract()', function () {
+    it('should return the contract at the selected token address', function () {
       assert.equal(
         getSelectedTokenContract(mockState),
         'mockAt:0x8d6b81208414189a58339873ab429b6c47ab92d3'
       )
     })
 
-    it('should return null if no token is selected', () => {
+    it('should return null if no token is selected', function () {
       const modifiedMetamaskState = Object.assign({}, mockState.metamask, { selectedTokenAddress: false })
       assert.equal(
         getSelectedTokenContract(Object.assign({}, mockState, { metamask: modifiedMetamaskState })),
@@ -310,8 +310,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSelectedTokenExchangeRate()', () => {
-    it('should return the exchange rate for the selected token', () => {
+  describe('getSelectedTokenExchangeRate()', function () {
+    it('should return the exchange rate for the selected token', function () {
       assert.equal(
         getSelectedTokenExchangeRate(mockState),
         2.0
@@ -319,8 +319,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSelectedTokenToFiatRate()', () => {
-    it('should return rate for converting the selected token to fiat', () => {
+  describe('getSelectedTokenToFiatRate()', function () {
+    it('should return rate for converting the selected token to fiat', function () {
       assert.equal(
         getSelectedTokenToFiatRate(mockState),
         2401.76400654
@@ -328,8 +328,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendAmount()', () => {
-    it('should return the send.amount', () => {
+  describe('getSendAmount()', function () {
+    it('should return the send.amount', function () {
       assert.equal(
         getSendAmount(mockState),
         '0x080'
@@ -337,8 +337,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendEditingTransactionId()', () => {
-    it('should return the send.editingTransactionId', () => {
+  describe('getSendEditingTransactionId()', function () {
+    it('should return the send.editingTransactionId', function () {
       assert.equal(
         getSendEditingTransactionId(mockState),
         97531
@@ -346,8 +346,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendErrors()', () => {
-    it('should return the send.errors', () => {
+  describe('getSendErrors()', function () {
+    it('should return the send.errors', function () {
       assert.deepEqual(
         getSendErrors(mockState),
         { someError: null }
@@ -355,8 +355,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendHexDataFeatureFlagState()', () => {
-    it('should return the sendHexData feature flag state', () => {
+  describe('getSendHexDataFeatureFlagState()', function () {
+    it('should return the sendHexData feature flag state', function () {
       assert.deepEqual(
         getSendHexDataFeatureFlagState(mockState),
         true
@@ -364,8 +364,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendFrom()', () => {
-    it('should return the send.from', () => {
+  describe('getSendFrom()', function () {
+    it('should return the send.from', function () {
       assert.deepEqual(
         getSendFrom(mockState),
         {
@@ -376,15 +376,15 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendFromBalance()', () => {
-    it('should get the send.from balance if it exists', () => {
+  describe('getSendFromBalance()', function () {
+    it('should get the send.from balance if it exists', function () {
       assert.equal(
         getSendFromBalance(mockState),
         '0x5f4e3d2c1'
       )
     })
 
-    it('should get the selected account balance if the send.from does not exist', () => {
+    it('should get the selected account balance if the send.from does not exist', function () {
       const editedMockState = {
         metamask: Object.assign({}, mockState.metamask, {
           send: {
@@ -399,8 +399,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendFromObject()', () => {
-    it('should return send.from if it exists', () => {
+  describe('getSendFromObject()', function () {
+    it('should return send.from if it exists', function () {
       assert.deepEqual(
         getSendFromObject(mockState),
         {
@@ -410,7 +410,7 @@ describe('send selectors', () => {
       )
     })
 
-    it('should return the current account with send ether info if send.from does not exist', () => {
+    it('should return the current account with send ether info if send.from does not exist', function () {
       const editedMockState = {
         metamask: Object.assign({}, mockState.metamask, {
           send: {
@@ -431,8 +431,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendMaxModeState()', () => {
-    it('should return send.maxModeOn', () => {
+  describe('getSendMaxModeState()', function () {
+    it('should return send.maxModeOn', function () {
       assert.equal(
         getSendMaxModeState(mockState),
         false
@@ -440,8 +440,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendTo()', () => {
-    it('should return send.to', () => {
+  describe('getSendTo()', function () {
+    it('should return send.to', function () {
       assert.equal(
         getSendTo(mockState),
         '0x987fedabc'
@@ -449,8 +449,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getSendToAccounts()', () => {
-    it('should return an array including all the users accounts and the address book', () => {
+  describe('getSendToAccounts()', function () {
+    it('should return an array including all the users accounts and the address book', function () {
       assert.deepEqual(
         getSendToAccounts(mockState),
         [
@@ -492,8 +492,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getTokenBalance()', () => {
-    it('should', () => {
+  describe('getTokenBalance()', function () {
+    it('should', function () {
       assert.equal(
         getTokenBalance(mockState),
         3434
@@ -501,8 +501,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getTokenExchangeRate()', () => {
-    it('should return the passed tokens exchange rates', () => {
+  describe('getTokenExchangeRate()', function () {
+    it('should return the passed tokens exchange rates', function () {
       assert.equal(
         getTokenExchangeRate(mockState, 'GHI'),
         31.01
@@ -510,8 +510,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('getUnapprovedTxs()', () => {
-    it('should return the unapproved txs', () => {
+  describe('getUnapprovedTxs()', function () {
+    it('should return the unapproved txs', function () {
       assert.deepEqual(
         getUnapprovedTxs(mockState),
         {
@@ -541,8 +541,8 @@ describe('send selectors', () => {
     })
   })
 
-  describe('transactionsSelector()', () => {
-    it('should return the selected addresses selected token transactions', () => {
+  describe('transactionsSelector()', function () {
+    it('should return the selected addresses selected token transactions', function () {
       assert.deepEqual(
         transactionsSelector(mockState),
         [
@@ -564,7 +564,7 @@ describe('send selectors', () => {
       )
     })
 
-    it('should return all transactions if no token is selected', () => {
+    it('should return all transactions if no token is selected', function () {
       const modifiedMetamaskState = Object.assign({}, mockState.metamask, { selectedTokenAddress: false })
       const modifiedState = Object.assign({}, mockState, { metamask: modifiedMetamaskState })
       assert.deepEqual(
@@ -614,7 +614,7 @@ describe('send selectors', () => {
       )
     })
 
-    it('should return shapeshift transactions if current network is 1', () => {
+    it('should return shapeshift transactions if current network is 1', function () {
       const modifiedMetamaskState = Object.assign({}, mockState.metamask, { selectedTokenAddress: false, network: '1' })
       const modifiedState = Object.assign({}, mockState, { metamask: modifiedMetamaskState })
       assert.deepEqual(

--- a/ui/app/pages/send/tests/send-utils.test.js
+++ b/ui/app/pages/send/tests/send-utils.test.js
@@ -59,10 +59,10 @@ const {
   removeLeadingZeroes,
 } = sendUtils
 
-describe('send utils', () => {
+describe('send utils', function () {
 
-  describe('calcGasTotal()', () => {
-    it('should call multiplyCurrencies with the correct params and return the multiplyCurrencies return', () => {
+  describe('calcGasTotal()', function () {
+    it('should call multiplyCurrencies with the correct params and return the multiplyCurrencies return', function () {
       const result = calcGasTotal(12, 15)
       assert.equal(result, '12x15')
       const call_ = stubs.multiplyCurrencies.getCall(0).args
@@ -77,7 +77,7 @@ describe('send utils', () => {
     })
   })
 
-  describe('doesAmountErrorRequireUpdate()', () => {
+  describe('doesAmountErrorRequireUpdate()', function () {
     const config = {
       'should return true if balances are different': {
         balance: 0,
@@ -107,19 +107,19 @@ describe('send utils', () => {
       },
     }
     Object.entries(config).map(([description, obj]) => {
-      it(description, () => {
+      it(description, function () {
         assert.equal(doesAmountErrorRequireUpdate(obj), obj.expectedResult)
       })
     })
 
   })
 
-  describe('generateTokenTransferData()', () => {
-    it('should return undefined if not passed a selected token', () => {
+  describe('generateTokenTransferData()', function () {
+    it('should return undefined if not passed a selected token', function () {
       assert.equal(generateTokenTransferData({ toAddress: 'mockAddress', amount: '0xa', selectedToken: false }), undefined)
     })
 
-    it('should call abi.rawEncode with the correct params', () => {
+    it('should call abi.rawEncode with the correct params', function () {
       stubs.rawEncode.resetHistory()
       generateTokenTransferData({ toAddress: 'mockAddress', amount: 'ab', selectedToken: true })
       assert.deepEqual(
@@ -128,7 +128,7 @@ describe('send utils', () => {
       )
     })
 
-    it('should return encoded token transfer data', () => {
+    it('should return encoded token transfer data', function () {
       assert.equal(
         generateTokenTransferData({ toAddress: 'mockAddress', amount: '0xa', selectedToken: true }),
         '0xa9059cbb104c'
@@ -136,7 +136,7 @@ describe('send utils', () => {
     })
   })
 
-  describe('getAmountErrorObject()', () => {
+  describe('getAmountErrorObject()', function () {
     const config = {
       'should return insufficientFunds error if isBalanceSufficient returns false': {
         amount: 15,
@@ -173,13 +173,13 @@ describe('send utils', () => {
       },
     }
     Object.entries(config).map(([description, obj]) => {
-      it(description, () => {
+      it(description, function () {
         assert.deepEqual(getAmountErrorObject(obj), obj.expectedResult)
       })
     })
   })
 
-  describe('getGasFeeErrorObject()', () => {
+  describe('getGasFeeErrorObject()', function () {
     const config = {
       'should return insufficientFunds error if isBalanceSufficient returns false': {
         amountConversionRate: 2,
@@ -199,14 +199,14 @@ describe('send utils', () => {
       },
     }
     Object.entries(config).map(([description, obj]) => {
-      it(description, () => {
+      it(description, function () {
         assert.deepEqual(getGasFeeErrorObject(obj), obj.expectedResult)
       })
     })
   })
 
-  describe('calcTokenBalance()', () => {
-    it('should return the calculated token blance', () => {
+  describe('calcTokenBalance()', function () {
+    it('should return the calculated token blance', function () {
       assert.equal(calcTokenBalance({
         selectedToken: {
           decimals: 11,
@@ -218,8 +218,8 @@ describe('send utils', () => {
     })
   })
 
-  describe('isBalanceSufficient()', () => {
-    it('should correctly call addCurrencies and return the result of calling conversionGTE', () => {
+  describe('isBalanceSufficient()', function () {
+    it('should correctly call addCurrencies and return the result of calling conversionGTE', function () {
       stubs.conversionGTE.resetHistory()
       const result = isBalanceSufficient({
         amount: 15,
@@ -261,8 +261,8 @@ describe('send utils', () => {
     })
   })
 
-  describe('isTokenBalanceSufficient()', () => {
-    it('should correctly call conversionUtil and return the result of calling conversionGTE', () => {
+  describe('isTokenBalanceSufficient()', function () {
+    it('should correctly call conversionUtil and return the result of calling conversionGTE', function () {
       stubs.conversionGTE.resetHistory()
       stubs.conversionUtil.resetHistory()
       const result = isTokenBalanceSufficient({
@@ -295,7 +295,7 @@ describe('send utils', () => {
     })
   })
 
-  describe('estimateGas', () => {
+  describe('estimateGas', function () {
     const baseMockParams = {
       blockGasLimit: '0x64',
       selectedAddress: 'mockAddress',
@@ -317,7 +317,7 @@ describe('send utils', () => {
       value: '0xff',
     }
 
-    beforeEach(() => {
+    beforeEach(function () {
       global.eth = {
         getCode: sinon.stub().callsFake(
           (address) => Promise.resolve(address.match(/isContract/) ? 'not-0x' : '0x')
@@ -325,12 +325,12 @@ describe('send utils', () => {
       }
     })
 
-    afterEach(() => {
+    afterEach(function () {
       baseMockParams.estimateGasMethod.resetHistory()
       global.eth.getCode.resetHistory()
     })
 
-    it('should call ethQuery.estimateGas with the expected params', async () => {
+    it('should call ethQuery.estimateGas with the expected params', async function () {
       const result = await sendUtils.estimateGas(baseMockParams)
       assert.equal(baseMockParams.estimateGasMethod.callCount, 1)
       assert.deepEqual(
@@ -340,7 +340,7 @@ describe('send utils', () => {
       assert.equal(result, '0xabc16')
     })
 
-    it('should call ethQuery.estimateGas with the expected params when initialGasLimitHex is lower than the upperGasLimit', async () => {
+    it('should call ethQuery.estimateGas with the expected params when initialGasLimitHex is lower than the upperGasLimit', async function () {
       const result = await estimateGas(Object.assign({}, baseMockParams, { blockGasLimit: '0xbcd' }))
       assert.equal(baseMockParams.estimateGasMethod.callCount, 1)
       assert.deepEqual(
@@ -350,7 +350,7 @@ describe('send utils', () => {
       assert.equal(result, '0xabc16x1.5')
     })
 
-    it('should call ethQuery.estimateGas with a value of 0x0 and the expected data and to if passed a selectedToken', async () => {
+    it('should call ethQuery.estimateGas with a value of 0x0 and the expected data and to if passed a selectedToken', async function () {
       const result = await estimateGas(Object.assign({ data: 'mockData', selectedToken: { address: 'mockAddress' } }, baseMockParams))
       assert.equal(baseMockParams.estimateGasMethod.callCount, 1)
       assert.deepEqual(
@@ -365,7 +365,7 @@ describe('send utils', () => {
       assert.equal(result, '0xabc16')
     })
 
-    it('should call ethQuery.estimateGas without a recipient if the recipient is empty and data passed', async () => {
+    it('should call ethQuery.estimateGas without a recipient if the recipient is empty and data passed', async function () {
       const data = 'mockData'
       const to = ''
       const result = await estimateGas({ ...baseMockParams, data, to })
@@ -377,44 +377,44 @@ describe('send utils', () => {
       assert.equal(result, '0xabc16')
     })
 
-    it(`should return ${SIMPLE_GAS_COST} if ethQuery.getCode does not return '0x'`, async () => {
+    it(`should return ${SIMPLE_GAS_COST} if ethQuery.getCode does not return '0x'`, async function () {
       assert.equal(baseMockParams.estimateGasMethod.callCount, 0)
       const result = await estimateGas(Object.assign({}, baseMockParams, { to: '0x123' }))
       assert.equal(result, SIMPLE_GAS_COST)
     })
 
-    it(`should return ${SIMPLE_GAS_COST} if not passed a selectedToken or truthy to address`, async () => {
+    it(`should return ${SIMPLE_GAS_COST} if not passed a selectedToken or truthy to address`, async function () {
       assert.equal(baseMockParams.estimateGasMethod.callCount, 0)
       const result = await estimateGas(Object.assign({}, baseMockParams, { to: null }))
       assert.equal(result, SIMPLE_GAS_COST)
     })
 
-    it(`should not return ${SIMPLE_GAS_COST} if passed a selectedToken`, async () => {
+    it(`should not return ${SIMPLE_GAS_COST} if passed a selectedToken`, async function () {
       assert.equal(baseMockParams.estimateGasMethod.callCount, 0)
       const result = await estimateGas(Object.assign({}, baseMockParams, { to: '0x123', selectedToken: { address: '' } }))
       assert.notEqual(result, SIMPLE_GAS_COST)
     })
 
-    it(`should return ${BASE_TOKEN_GAS_COST} if passed a selectedToken but no to address`, async () => {
+    it(`should return ${BASE_TOKEN_GAS_COST} if passed a selectedToken but no to address`, async function () {
       const result = await estimateGas(Object.assign({}, baseMockParams, { to: null, selectedToken: { address: '' } }))
       assert.equal(result, BASE_TOKEN_GAS_COST)
     })
 
-    it(`should return the adjusted blockGasLimit if it fails with a 'Transaction execution error.'`, async () => {
+    it(`should return the adjusted blockGasLimit if it fails with a 'Transaction execution error.'`, async function () {
       const result = await estimateGas(Object.assign({}, baseMockParams, {
         to: 'isContract willFailBecauseOf:Transaction execution error.',
       }))
       assert.equal(result, '0x64x0.95')
     })
 
-    it(`should return the adjusted blockGasLimit if it fails with a 'gas required exceeds allowance or always failing transaction.'`, async () => {
+    it(`should return the adjusted blockGasLimit if it fails with a 'gas required exceeds allowance or always failing transaction.'`, async function () {
       const result = await estimateGas(Object.assign({}, baseMockParams, {
         to: 'isContract willFailBecauseOf:gas required exceeds allowance or always failing transaction.',
       }))
       assert.equal(result, '0x64x0.95')
     })
 
-    it(`should reject other errors`, async () => {
+    it(`should reject other errors`, async function () {
       try {
         await estimateGas(Object.assign({}, baseMockParams, {
           to: 'isContract willFailBecauseOf:some other error',
@@ -425,7 +425,7 @@ describe('send utils', () => {
     })
   })
 
-  describe('estimateGasPriceFromRecentBlocks', () => {
+  describe('estimateGasPriceFromRecentBlocks', function () {
     const ONE_GWEI_IN_WEI_HEX_PLUS_ONE = addCurrencies(ONE_GWEI_IN_WEI_HEX, '0x1', {
       aBase: 16,
       bBase: 16,
@@ -442,15 +442,15 @@ describe('send utils', () => {
       toNumericBase: 'hex',
     })
 
-    it(`should return ${ONE_GWEI_IN_WEI_HEX} if recentBlocks is falsy`, () => {
+    it(`should return ${ONE_GWEI_IN_WEI_HEX} if recentBlocks is falsy`, function () {
       assert.equal(estimateGasPriceFromRecentBlocks(), ONE_GWEI_IN_WEI_HEX)
     })
 
-    it(`should return ${ONE_GWEI_IN_WEI_HEX} if recentBlocks is empty`, () => {
+    it(`should return ${ONE_GWEI_IN_WEI_HEX} if recentBlocks is empty`, function () {
       assert.equal(estimateGasPriceFromRecentBlocks([]), ONE_GWEI_IN_WEI_HEX)
     })
 
-    it(`should estimate a block's gasPrice as ${ONE_GWEI_IN_WEI_HEX} if it has no gas prices`, () => {
+    it(`should estimate a block's gasPrice as ${ONE_GWEI_IN_WEI_HEX} if it has no gas prices`, function () {
       const mockRecentBlocks = [
         { gasPrices: null },
         { gasPrices: [ ONE_GWEI_IN_WEI_HEX_PLUS_ONE ] },
@@ -459,7 +459,7 @@ describe('send utils', () => {
       assert.equal(estimateGasPriceFromRecentBlocks(mockRecentBlocks), ONE_GWEI_IN_WEI_HEX)
     })
 
-    it(`should estimate a block's gasPrice as ${ONE_GWEI_IN_WEI_HEX} if it has empty gas prices`, () => {
+    it(`should estimate a block's gasPrice as ${ONE_GWEI_IN_WEI_HEX} if it has empty gas prices`, function () {
       const mockRecentBlocks = [
         { gasPrices: [] },
         { gasPrices: [ ONE_GWEI_IN_WEI_HEX_PLUS_ONE ] },
@@ -468,7 +468,7 @@ describe('send utils', () => {
       assert.equal(estimateGasPriceFromRecentBlocks(mockRecentBlocks), ONE_GWEI_IN_WEI_HEX)
     })
 
-    it(`should return the middle value of all blocks lowest prices`, () => {
+    it(`should return the middle value of all blocks lowest prices`, function () {
       const mockRecentBlocks = [
         { gasPrices: [ ONE_GWEI_IN_WEI_HEX_PLUS_TWO ] },
         { gasPrices: [ ONE_GWEI_IN_WEI_HEX_MINUS_ONE ] },
@@ -477,7 +477,7 @@ describe('send utils', () => {
       assert.equal(estimateGasPriceFromRecentBlocks(mockRecentBlocks), ONE_GWEI_IN_WEI_HEX_PLUS_ONE)
     })
 
-    it(`should work if a block has multiple gas prices`, () => {
+    it(`should work if a block has multiple gas prices`, function () {
       const mockRecentBlocks = [
         { gasPrices: [ '0x1', '0x2', '0x3', '0x4', '0x5' ] },
         { gasPrices: [ '0x101', '0x100', '0x103', '0x104', '0x102' ] },
@@ -487,30 +487,30 @@ describe('send utils', () => {
     })
   })
 
-  describe('getToAddressForGasUpdate()', () => {
-    it('should return empty string if all params are undefined or null', () => {
+  describe('getToAddressForGasUpdate()', function () {
+    it('should return empty string if all params are undefined or null', function () {
       assert.equal(getToAddressForGasUpdate(undefined, null), '')
     })
 
-    it('should return the first string that is not defined or null in lower case', () => {
+    it('should return the first string that is not defined or null in lower case', function () {
       assert.equal(getToAddressForGasUpdate('A', null), 'a')
       assert.equal(getToAddressForGasUpdate(undefined, 'B'), 'b')
     })
   })
 
-  describe('removeLeadingZeroes()', () => {
-    it('should remove leading zeroes from int when user types', () => {
+  describe('removeLeadingZeroes()', function () {
+    it('should remove leading zeroes from int when user types', function () {
       assert.equal(removeLeadingZeroes('0'), '0')
       assert.equal(removeLeadingZeroes('1'), '1')
       assert.equal(removeLeadingZeroes('00'), '0')
       assert.equal(removeLeadingZeroes('01'), '1')
     })
 
-    it('should remove leading zeroes from int when user copy/paste', () => {
+    it('should remove leading zeroes from int when user copy/paste', function () {
       assert.equal(removeLeadingZeroes('001'), '1')
     })
 
-    it('should remove leading zeroes from float when user types', () => {
+    it('should remove leading zeroes from float when user types', function () {
       assert.equal(removeLeadingZeroes('0.'), '0.')
       assert.equal(removeLeadingZeroes('0.0'), '0.0')
       assert.equal(removeLeadingZeroes('0.00'), '0.00')
@@ -518,7 +518,7 @@ describe('send utils', () => {
       assert.equal(removeLeadingZeroes('0.10'), '0.10')
     })
 
-    it('should remove leading zeroes from float when user copy/paste', () => {
+    it('should remove leading zeroes from float when user copy/paste', function () {
       assert.equal(removeLeadingZeroes('00.1'), '0.1')
     })
   })

--- a/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
+++ b/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
@@ -5,8 +5,8 @@ import { shallow } from 'enzyme'
 import AdvancedTab from '../advanced-tab.component'
 import TextField from '../../../../components/ui/text-field'
 
-describe('AdvancedTab Component', () => {
-  it('should render correctly when threeBoxFeatureFlag', () => {
+describe('AdvancedTab Component', function () {
+  it('should render correctly when threeBoxFeatureFlag', function () {
     const root = shallow(
       <AdvancedTab
         ipfsGateway=""
@@ -27,7 +27,7 @@ describe('AdvancedTab Component', () => {
     assert.equal(root.find('.settings-page__content-row').length, 10)
   })
 
-  it('should update autoLockTimeLimit', () => {
+  it('should update autoLockTimeLimit', function () {
     const setAutoLockTimeLimitSpy = sinon.spy()
     const root = shallow(
       <AdvancedTab

--- a/ui/app/pages/settings/security-tab/tests/security-tab.test.js
+++ b/ui/app/pages/settings/security-tab/tests/security-tab.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import SecurityTab from '../index'
 
-describe('Security Tab', () => {
+describe('Security Tab', function () {
   let wrapper
 
   const props = {
@@ -21,7 +21,7 @@ describe('Security Tab', () => {
     participateInMetaMetrics: false,
   }
 
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <SecurityTab.WrappedComponent {...props} />, {
         context: {
@@ -32,7 +32,7 @@ describe('Security Tab', () => {
     )
   })
 
-  it('navigates to reveal seed words page', () => {
+  it('navigates to reveal seed words page', function () {
     const seedWords = wrapper.find('.button.btn-danger.btn--large')
 
     seedWords.simulate('click')
@@ -40,13 +40,13 @@ describe('Security Tab', () => {
     assert.equal(props.history.push.getCall(0).args[0], '/seed')
   })
 
-  it('toggles incoming txs', () => {
+  it('toggles incoming txs', function () {
     const incomingTxs = wrapper.find({ type: 'checkbox' }).at(0)
     incomingTxs.simulate('click')
     assert(props.setShowIncomingTransactionsFeatureFlag.calledOnce)
   })
 
-  it('toggles metaMetrics', () => {
+  it('toggles metaMetrics', function () {
     const metaMetrics = wrapper.find({ type: 'checkbox' }).at(1)
 
     metaMetrics.simulate('click')

--- a/ui/app/pages/settings/settings-tab/tests/settings-tab.test.js
+++ b/ui/app/pages/settings/settings-tab/tests/settings-tab.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import SettingsTab from '../index'
 
-describe('Settings Tab', () => {
+describe('Settings Tab', function () {
   let wrapper
 
   const props = {
@@ -21,7 +21,7 @@ describe('Settings Tab', () => {
     nativeCurrency: 'eth',
     useNativeCurrencyAsPrimaryCurrency: true,
   }
-  beforeEach(() => {
+  beforeEach(function () {
     wrapper = mount(
       <SettingsTab.WrappedComponent {...props} />, {
         context: {
@@ -31,28 +31,28 @@ describe('Settings Tab', () => {
     )
   })
 
-  it('selects currency', async () => {
+  it('selects currency', async function () {
     const selectCurrency = wrapper.find({ placeholder: 'selectCurrency' })
 
     selectCurrency.props().onSelect('eur')
     assert(props.setCurrentCurrency.calledOnce)
   })
 
-  it('selects locale', async () => {
+  it('selects locale', async function () {
     const selectLocale = wrapper.find({ placeholder: 'selectLocale' })
 
     await selectLocale.props().onSelect('ja')
     assert(props.updateCurrentLocale.calledOnce)
   })
 
-  it('sets fiat primary currency', () => {
+  it('sets fiat primary currency', function () {
     const selectFiat = wrapper.find('#fiat-primary-currency')
 
     selectFiat.simulate('change')
     assert(props.setUseNativeCurrencyAsPrimaryCurrencyPreference.calledOnce)
   })
 
-  it('toggles blockies', () => {
+  it('toggles blockies', function () {
     const toggleBlockies = wrapper.find({ type: 'checkbox' })
 
     toggleBlockies.simulate('click')

--- a/ui/app/pages/unlock-page/tests/unlock-page.test.js
+++ b/ui/app/pages/unlock-page/tests/unlock-page.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon'
 import { mount } from 'enzyme'
 import UnlockPage from '../index'
 
-describe('Unlock Page', () => {
+describe('Unlock Page', function () {
   let wrapper
 
   const props = {
@@ -20,7 +20,7 @@ describe('Unlock Page', () => {
   }
 
 
-  beforeEach(() => {
+  beforeEach(function () {
 
     wrapper = mount(
       <UnlockPage.WrappedComponent{...props} />, {
@@ -32,15 +32,15 @@ describe('Unlock Page', () => {
 
   })
 
-  after(() => {
+  after(function () {
     sinon.restore()
   })
 
-  it('renders', () => {
+  it('renders', function () {
     assert.equal(wrapper.length, 1)
   })
 
-  it('changes password and submits', () => {
+  it('changes password and submits', function () {
     const passwordField = wrapper.find({ type: 'password', id: 'password' })
     const loginButton = wrapper.find({ type: 'submit' }).last()
 
@@ -53,7 +53,7 @@ describe('Unlock Page', () => {
     assert(props.onSubmit.calledOnce)
   })
 
-  it('clicks imports seed button', () => {
+  it('clicks imports seed button', function () {
     const importSeedButton = wrapper.find('.unlock-page__link--import')
 
     importSeedButton.simulate('click')
@@ -61,7 +61,7 @@ describe('Unlock Page', () => {
 
   })
 
-  it('clicks restore', () => {
+  it('clicks restore', function () {
     const restoreFromSeedButton = wrapper.find('.unlock-page__link').at(0)
     restoreFromSeedButton.simulate('click')
     assert(props.onRestore.calledOnce)

--- a/ui/app/selectors/custom-gas.test.js
+++ b/ui/app/selectors/custom-gas.test.js
@@ -13,45 +13,45 @@ const {
   getRenderableEstimateDataForSmallButtonsFromGWEI,
 } = proxyquire('./custom-gas', {})
 
-describe('custom-gas selectors', () => {
+describe('custom-gas selectors', function () {
 
-  describe('getCustomGasPrice()', () => {
-    it('should return gas.customData.price', () => {
+  describe('getCustomGasPrice()', function () {
+    it('should return gas.customData.price', function () {
       const mockState = { gas: { customData: { price: 'mockPrice' } } }
       assert.equal(getCustomGasPrice(mockState), 'mockPrice')
     })
   })
 
-  describe('getCustomGasLimit()', () => {
-    it('should return gas.customData.limit', () => {
+  describe('getCustomGasLimit()', function () {
+    it('should return gas.customData.limit', function () {
       const mockState = { gas: { customData: { limit: 'mockLimit' } } }
       assert.equal(getCustomGasLimit(mockState), 'mockLimit')
     })
   })
 
-  describe('getCustomGasTotal()', () => {
-    it('should return gas.customData.total', () => {
+  describe('getCustomGasTotal()', function () {
+    it('should return gas.customData.total', function () {
       const mockState = { gas: { customData: { total: 'mockTotal' } } }
       assert.equal(getCustomGasTotal(mockState), 'mockTotal')
     })
   })
 
-  describe('getCustomGasErrors()', () => {
-    it('should return gas.errors', () => {
+  describe('getCustomGasErrors()', function () {
+    it('should return gas.errors', function () {
       const mockState = { gas: { errors: 'mockErrors' } }
       assert.equal(getCustomGasErrors(mockState), 'mockErrors')
     })
   })
 
-  describe('getPriceAndTimeEstimates', () => {
-    it('should return price and time estimates', () => {
+  describe('getPriceAndTimeEstimates', function () {
+    it('should return price and time estimates', function () {
       const mockState = { gas: { priceAndTimeEstimates: 'mockPriceAndTimeEstimates' } }
       assert.equal(getPriceAndTimeEstimates(mockState), 'mockPriceAndTimeEstimates')
     })
   })
 
-  describe('getEstimatedGasPrices', () => {
-    it('should return price and time estimates', () => {
+  describe('getEstimatedGasPrices', function () {
+    it('should return price and time estimates', function () {
       const mockState = { gas: { priceAndTimeEstimates: [
         { gasprice: 12, somethingElse: 20 },
         { gasprice: 22, expectedTime: 30 },
@@ -61,8 +61,8 @@ describe('custom-gas selectors', () => {
     })
   })
 
-  describe('getEstimatedGasTimes', () => {
-    it('should return price and time estimates', () => {
+  describe('getEstimatedGasTimes', function () {
+    it('should return price and time estimates', function () {
       const mockState = { gas: { priceAndTimeEstimates: [
         { somethingElse: 12, expectedTime: 20 },
         { gasPrice: 22, expectedTime: 30 },
@@ -72,7 +72,7 @@ describe('custom-gas selectors', () => {
     })
   })
 
-  describe('getRenderableBasicEstimateData()', () => {
+  describe('getRenderableBasicEstimateData()', function () {
     const tests = [
       {
         expectedResult: [
@@ -337,7 +337,7 @@ describe('custom-gas selectors', () => {
         },
       },
     ]
-    it('should return renderable data about basic estimates', () => {
+    it('should return renderable data about basic estimates', function () {
       tests.forEach(test => {
         assert.deepEqual(
           getRenderableBasicEstimateData(test.mockState, '0x5208'),
@@ -348,7 +348,7 @@ describe('custom-gas selectors', () => {
 
   })
 
-  describe('getRenderableEstimateDataForSmallButtonsFromGWEI()', () => {
+  describe('getRenderableEstimateDataForSmallButtonsFromGWEI()', function () {
     const tests = [
       {
         expectedResult: [
@@ -601,7 +601,7 @@ describe('custom-gas selectors', () => {
         },
       },
     ]
-    it('should return renderable data about basic estimates appropriate for buttons with less info', () => {
+    it('should return renderable data about basic estimates appropriate for buttons with less info', function () {
       tests.forEach(test => {
         assert.deepEqual(
           getRenderableEstimateDataForSmallButtonsFromGWEI(test.mockState),

--- a/ui/app/selectors/tests/confirm-transaction.test.js
+++ b/ui/app/selectors/tests/confirm-transaction.test.js
@@ -7,9 +7,9 @@ import {
   contractExchangeRateSelector,
 } from '../confirm-transaction'
 
-describe('Confirm Transaction Selector', () => {
+describe('Confirm Transaction Selector', function () {
 
-  describe('unconfirmedTransactionsCountSelector', () => {
+  describe('unconfirmedTransactionsCountSelector', function () {
 
     const state = {
       metamask: {
@@ -28,13 +28,13 @@ describe('Confirm Transaction Selector', () => {
       },
     }
 
-    it('returns number of txs in unapprovedTxs state with the same network plus unapproved signing method counts', () => {
+    it('returns number of txs in unapprovedTxs state with the same network plus unapproved signing method counts', function () {
       assert.equal(unconfirmedTransactionsCountSelector(state), 4)
     })
 
   })
 
-  describe('tokenAmountAndToAddressSelector', () => {
+  describe('tokenAmountAndToAddressSelector', function () {
 
     const state = {
       confirmTransaction: {
@@ -60,14 +60,14 @@ describe('Confirm Transaction Selector', () => {
       },
     }
 
-    it('returns calulcated token amount based on token value and token decimals and recipient address', () => {
+    it('returns calulcated token amount based on token value and token decimals and recipient address', function () {
       assert.deepEqual(tokenAmountAndToAddressSelector(state),
         { toAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc', tokenAmount: 0.01 })
     })
 
   })
 
-  describe('approveTokenAmountAndToAddressSelector', () => {
+  describe('approveTokenAmountAndToAddressSelector', function () {
 
     const state = {
       confirmTransaction: {
@@ -93,14 +93,14 @@ describe('Confirm Transaction Selector', () => {
       },
     }
 
-    it('returns token amount and recipient for approve token allocation spending', () => {
+    it('returns token amount and recipient for approve token allocation spending', function () {
       assert.deepEqual(approveTokenAmountAndToAddressSelector(state),
         { toAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc', tokenAmount: 0.01 })
     })
 
   })
 
-  describe('sendTokenTokenAmountAndToAddressSelector', () => {
+  describe('sendTokenTokenAmountAndToAddressSelector', function () {
 
     const state = {
       confirmTransaction: {
@@ -126,14 +126,14 @@ describe('Confirm Transaction Selector', () => {
       },
     }
 
-    it('returns token address and calculated token amount', () => {
+    it('returns token address and calculated token amount', function () {
       assert.deepEqual(sendTokenTokenAmountAndToAddressSelector(state),
         { toAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc', tokenAmount: 0.01 })
     })
 
   })
 
-  describe('contractExchangeRateSelector', () => {
+  describe('contractExchangeRateSelector', function () {
 
     const state = {
       metamask: {
@@ -150,7 +150,7 @@ describe('Confirm Transaction Selector', () => {
       },
     }
 
-    it('returns contract exchange rate in metamask state based on confirm transaction txParams token recipient', () => {
+    it('returns contract exchange rate in metamask state based on confirm transaction txParams token recipient', function () {
       assert.equal(contractExchangeRateSelector(state), 10)
     })
 

--- a/ui/app/selectors/tests/selectors.test.js
+++ b/ui/app/selectors/tests/selectors.test.js
@@ -2,10 +2,10 @@ import assert from 'assert'
 import { getAddressBook } from '../selectors.js'
 import mockState from './selectors-test-data'
 
-describe('selectors', () => {
+describe('selectors', function () {
 
-  describe('getAddressBook()', () => {
-    it('should return the address book', () => {
+  describe('getAddressBook()', function () {
+    it('should return the address book', function () {
       assert.deepEqual(
         getAddressBook(mockState),
         [

--- a/ui/app/selectors/tests/tokens.test.js
+++ b/ui/app/selectors/tests/tokens.test.js
@@ -20,8 +20,8 @@ const state = {
     ],
   },
 }
-describe('Selected Token Selector', () => {
-  it('selects token info from tokens based on selectedTokenAddress in state', () => {
+describe('Selected Token Selector', function () {
+  it('selects token info from tokens based on selectedTokenAddress in state', function () {
     const tokenInfo = selectedTokenSelector(state)
     assert.equal(tokenInfo, metaToken)
   })

--- a/ui/app/selectors/tests/transactions.test.js
+++ b/ui/app/selectors/tests/transactions.test.js
@@ -8,10 +8,10 @@ import {
   submittedPendingTransactionsSelector,
 } from '../transactions'
 
-describe('Transaction Selectors', () => {
+describe('Transaction Selectors', function () {
 
-  describe('unapprovedMessagesSelector', () => {
-    it('returns eth sign msg from unapprovedMsgs', () => {
+  describe('unapprovedMessagesSelector', function () {
+    it('returns eth sign msg from unapprovedMsgs', function () {
 
       const msg = {
         id: 1,
@@ -39,7 +39,7 @@ describe('Transaction Selectors', () => {
       assert.deepEqual(msgSelector, [msg])
     })
 
-    it('returns personal sign from unapprovedPersonalMsgsSelector', () => {
+    it('returns personal sign from unapprovedPersonalMsgsSelector', function () {
 
       const msg = {
         id: 1,
@@ -67,7 +67,7 @@ describe('Transaction Selectors', () => {
       assert.deepEqual(msgSelector, [msg])
     })
 
-    it('returns typed message from unapprovedTypedMessagesSelector', () => {
+    it('returns typed message from unapprovedTypedMessagesSelector', function () {
 
       const msg = {
         id: 1,
@@ -98,9 +98,9 @@ describe('Transaction Selectors', () => {
     })
   })
 
-  describe('transactionsSelector', () => {
+  describe('transactionsSelector', function () {
 
-    it('selectedAddressTxList', () => {
+    it('selectedAddressTxList', function () {
 
       const state = {
         metamask: {
@@ -136,7 +136,7 @@ describe('Transaction Selectors', () => {
       assert.deepEqual(txSelector, orderedTxlist)
     })
 
-    it('returns token tx from selectedAddressTxList when selectedTokenAddress is valid', () => {
+    it('returns token tx from selectedAddressTxList when selectedTokenAddress is valid', function () {
 
       const state = {
         metamask: {
@@ -177,9 +177,9 @@ describe('Transaction Selectors', () => {
 
   })
 
-  describe('nonceSortedTransactionsSelector', () => {
+  describe('nonceSortedTransactionsSelector', function () {
 
-    it('returns transaction group nonce sorted tx from from selectedTxList wit', () => {
+    it('returns transaction group nonce sorted tx from from selectedTxList wit', function () {
 
       const tx1 = {
         id: 0,
@@ -236,7 +236,7 @@ describe('Transaction Selectors', () => {
     })
   })
 
-  describe('Sorting Transactions Selectors', () => {
+  describe('Sorting Transactions Selectors', function () {
 
     const submittedTx = {
       id: 0,
@@ -296,7 +296,7 @@ describe('Transaction Selectors', () => {
       },
     }
 
-    it('nonceSortedPendingTransactionsSelector', () => {
+    it('nonceSortedPendingTransactionsSelector', function () {
 
       const expectedResult = [
         {
@@ -328,7 +328,7 @@ describe('Transaction Selectors', () => {
       assert.deepEqual(nonceSortedPendingTransactionsSelector(state), expectedResult)
     })
 
-    it('nonceSortedCompletedTransactionsSelector', () => {
+    it('nonceSortedCompletedTransactionsSelector', function () {
 
       const expectedResult = [
         {
@@ -344,7 +344,7 @@ describe('Transaction Selectors', () => {
       assert.deepEqual(nonceSortedCompletedTransactionsSelector(state), expectedResult)
     })
 
-    it('submittedPendingTransactionsSelector', () => {
+    it('submittedPendingTransactionsSelector', function () {
 
       const expectedResult = [ submittedTx ]
       assert.deepEqual(submittedPendingTransactionsSelector(state), expectedResult)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9878,12 +9878,12 @@ eslint-plugin-json@^1.2.0:
   dependencies:
     jshint "^2.8.0"
 
-eslint-plugin-mocha@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-5.0.0.tgz#43946a7ecaf39039eb3ee20635ebd4cc19baf6dd"
-  integrity sha512-mpRWWsjxRco2bY4qE5DL8SmGoVF0Onb6DZrbgOjFoNo1YNN299K2voIozd8Kce3qC/neWNr2XF27E1ZDMl1yZg==
+eslint-plugin-mocha@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-6.2.2.tgz#6ef4b78bd12d744beb08a06e8209de330985100d"
+  integrity sha512-oNhPzfkT6Q6CJ0HMVJ2KLxEWG97VWGTmuHOoRcDLE0U88ugUyFNV9wrT2XIt5cGtqc5W9k38m4xTN34L09KhBA==
   dependencies:
-    ramda "^0.25.0"
+    ramda "^0.26.1"
 
 eslint-plugin-no-unsafe-innerhtml@1.0.16:
   version "1.0.16"
@@ -22830,10 +22830,10 @@ ramda@^0.24.1:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
   integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randexp@0.4.6:
   version "0.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,10 +1829,10 @@
     scroll "^2.0.3"
     warning "^3.0.0"
 
-"@metamask/eslint-config@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-1.0.0.tgz#046012398bb27f56395355c96ef07152925043b7"
-  integrity sha512-MmxM2sknVhIHyXCjR6LcK57OPJ30gTEX5v/jwC+qXuw4GIgUAPbxFp3AFmFRAJwty3RMjJSbRJ7YlamMq67U8w==
+"@metamask/eslint-config@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-1.1.0.tgz#03c6fbec8ba3d95fa017d8b98ab5d0701f7458a4"
+  integrity sha512-yFFHIxFn3cBd9brIW/+0fJGq16hT0xUyElP0YxiZHaY7j2T/l+X/414L9kqBOuPfPa9bIKulIcJJOfcrMJZp9w==
 
 "@metamask/forwarder@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
This PR updates our ESLint config to enable more Mocha rules targeting our test suite.

There is a bit of whitespace changes/diff noise here ([I'd recommend hiding it during review](https://github.blog/2018-05-01-ignore-white-space-in-code-review/)) but a lot of these changes are due to [`mocha/no-mocha-arrows`](https://github.com/lo1tuma/eslint-plugin-mocha/blob/6.2.2/docs/rules/no-mocha-arrows.md) which disallows arrow functions for Mocha tests. Mocha discourages passing it arrow functions as arguments.<sup>[\[1\]](http://mochajs.org/#arrow-functions)<sup>

This is based on MetaMask/eslint-config#13—we now have a shared Mocha config.