### PR TITLE
Add title to transaction action component

### DIFF
--- a/ui/app/components/app/transaction-action/tests/transaction-action.component.test.js
+++ b/ui/app/components/app/transaction-action/tests/transaction-action.component.test.js
@@ -46,6 +46,7 @@ describe('TransactionAction Component', function () {
       assert.equal(wrapper.find('.transaction-action').length, 1)
       wrapper.setState({ transactionAction: 'sentEther' })
       assert.equal(wrapper.text(), 'sentEther')
+      assert.equal(wrapper.find('.transaction-action').props().title.trim(), 'sentEther')
     })
 
     it('should render Approved', async function () {
@@ -81,6 +82,7 @@ describe('TransactionAction Component', function () {
       assert.ok(wrapper)
       assert.equal(wrapper.find('.transaction-action').length, 1)
       assert.equal(wrapper.find('.transaction-action').text().trim(), 'Approve')
+      assert.equal(wrapper.find('.transaction-action').props().title.trim(), 'Approve')
     })
 
     it('should render contractInteraction', async function () {
@@ -114,6 +116,7 @@ describe('TransactionAction Component', function () {
       assert.ok(wrapper)
       assert.equal(wrapper.find('.transaction-action').length, 1)
       assert.equal(wrapper.find('.transaction-action').text().trim(), 'contractInteraction')
+      assert.equal(wrapper.find('.transaction-action').props().title.trim(), 'contractInteraction')
     })
   })
 })

--- a/ui/app/components/app/transaction-action/transaction-action.component.js
+++ b/ui/app/components/app/transaction-action/transaction-action.component.js
@@ -29,9 +29,11 @@ export default class TransactionAction extends PureComponent {
   render () {
     const { className } = this.props
 
+    const action = this.getTransactionAction()
+
     return (
-      <div className={classnames('transaction-action', className)}>
-        { this.getTransactionAction() }
+      <div className={classnames('transaction-action', className)} title={action}>
+        { action }
       </div>
     )
   }


### PR DESCRIPTION
## Summary

I can't read transaction action in Russia, because it's too long
<img width="1271" alt="Screenshot 2020-02-14 at 17 14 41" src="https://user-images.githubusercontent.com/14371261/74541050-f0da3900-4f51-11ea-831a-9890c2d3b0f6.png">

To fix it i simply add "title" attribute to this element

<img width="421" alt="Screenshot 2020-02-14 at 17 40 06" src="https://user-images.githubusercontent.com/14371261/74541072-00598200-4f52-11ea-8309-1a55f7ff330a.png">

