### PR TITLE
Update Wyre ETH purchase url

### DIFF
--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -19,7 +19,7 @@ function getBuyEthUrl ({ network, amount, address, service }) {
 
   switch (service) {
     case 'wyre':
-      return `https://dash.sendwyre.com/sign-up`
+      return `https://pay.sendwyre.com/?dest=ethereum:${address}&destCurrency=ETH&accountId=AC-7AG3W4XH4N2`
     case 'coinswitch':
       return `https://metamask.coinswitch.co/?address=${address}&to=eth`
     case 'coinbase':

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -19,7 +19,7 @@ function getBuyEthUrl ({ network, amount, address, service }) {
 
   switch (service) {
     case 'wyre':
-      return `https://pay.sendwyre.com/?dest=ethereum:${address}&destCurrency=ETH&accountId=AC-7AG3W4XH4N2`
+      return `https://pay.sendwyre.com/?dest=ethereum:${address}&destCurrency=ETH&accountId=AC-7AG3W4XH4N2&paymentMethod=debit-card`
     case 'coinswitch':
       return `https://metamask.coinswitch.co/?address=${address}&to=eth`
     case 'coinbase':

--- a/test/unit/app/buy-eth-url.spec.js
+++ b/test/unit/app/buy-eth-url.spec.js
@@ -20,7 +20,7 @@ describe('buy-eth-url', function () {
   it('returns wyre url with address for network 1', function () {
     const wyreUrl = getBuyEthUrl(mainnet)
 
-    assert.equal(wyreUrl, 'https://pay.sendwyre.com/?dest=ethereum:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc&destCurrency=ETH&accountId=AC-7AG3W4XH4N2')
+    assert.equal(wyreUrl, 'https://pay.sendwyre.com/?dest=ethereum:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc&destCurrency=ETH&accountId=AC-7AG3W4XH4N2&paymentMethod=debit-card')
 
   })
 

--- a/test/unit/app/buy-eth-url.spec.js
+++ b/test/unit/app/buy-eth-url.spec.js
@@ -20,7 +20,7 @@ describe('buy-eth-url', function () {
   it('returns wyre url with address for network 1', function () {
     const wyreUrl = getBuyEthUrl(mainnet)
 
-    assert.equal(wyreUrl, 'https://dash.sendwyre.com/sign-up')
+    assert.equal(wyreUrl, 'https://pay.sendwyre.com/?dest=ethereum:0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc&destCurrency=ETH&accountId=AC-7AG3W4XH4N2')
 
   })
 


### PR DESCRIPTION
This reverts commit bc67d1eecabb123bf21445e604780d2454d52d3e (#7631), which was a revert of 015ba83c6e69dcca676d626f70ef887a38ce01b9 (#7482)

The new hosted widget is now used for Wyre deposits. It appears to allow payment with either Apple pay, or debit (in certain U.S. states only). This has not yet been tested.