### PR TITLE
Inline the source text not the binary encoding for inpage script

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -9,7 +9,7 @@ import PortStream from 'extension-port-stream'
 const fs = require('fs')
 const path = require('path')
 
-const inpageContent = fs.readFileSync(path.join(__dirname, '..', '..', 'dist', 'chrome', 'inpage.js')).toString()
+const inpageContent = fs.readFileSync(path.join(__dirname, '..', '..', 'dist', 'chrome', 'inpage.js'), 'utf8')
 const inpageSuffix = '//# sourceURL=' + extension.runtime.getURL('inpage.js') + '\n'
 const inpageBundle = inpageContent + inpageSuffix
 


### PR DESCRIPTION
This PR updates the way we're inlining the inpage script into the contentscript to no longer write it as a base64 encoded string. The inpage script is now inlined as utf-8.

This should address the Chrome Web Store's policies against "obsfucation".