### PR TITLE
Enable arrow-parens ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
   },
 
   rules: {
+    'arrow-parens': 'error',
     'import/default': 'error',
     'import/export': 'error',
     'import/named': 'error',

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -389,7 +389,7 @@ function setupController (initState, initLangCode) {
         const url = new URL(remotePort.sender.url)
         const origin = url.hostname
 
-        remotePort.onMessage.addListener(msg => {
+        remotePort.onMessage.addListener((msg) => {
           if (msg.data && msg.data.method === 'eth_requestAccounts') {
             requestAccountTabIds[origin] = tabId
           }
@@ -446,8 +446,8 @@ function setupController (initState, initLangCode) {
  * Opens the browser popup for user confirmation
  */
 function triggerUi () {
-  extension.tabs.query({ active: true }, tabs => {
-    const currentlyActiveMetamaskTab = Boolean(tabs.find(tab => openMetamaskTabsIDs[tab.id]))
+  extension.tabs.query({ active: true }, (tabs) => {
+    const currentlyActiveMetamaskTab = Boolean(tabs.find((tab) => openMetamaskTabsIDs[tab.id]))
     if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
       notificationManager.showPopup()
       notificationIsOpen = true

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -231,5 +231,5 @@ async function domIsReady () {
     return
   }
   // wait for load
-  return new Promise(resolve => window.addEventListener('DOMContentLoaded', resolve, { once: true }))
+  return new Promise((resolve) => window.addEventListener('DOMContentLoaded', resolve, { once: true }))
 }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -16,7 +16,7 @@ class AppStateController {
     }, initState))
     this.timer = null
 
-    preferencesStore.subscribe(state => {
+    preferencesStore.subscribe((state) => {
       this._setInactiveTimeout(state.preferences.autoLockTimeLimit)
     })
 

--- a/app/scripts/controllers/cached-balances.js
+++ b/app/scripts/controllers/cached-balances.js
@@ -50,7 +50,7 @@ class CachedBalancesController {
     const { cachedBalances } = this.store.getState()
     const currentNetworkBalancesToCache = { ...cachedBalances[currentNetwork] }
 
-    Object.keys(newAccounts).forEach(accountID => {
+    Object.keys(newAccounts).forEach((accountID) => {
       const account = newAccounts[accountID]
 
       if (account.balance) {

--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -165,7 +165,7 @@ class IncomingTransactionsController {
     const newIncomingTransactions = {
       ...currentIncomingTxs,
     }
-    newTxs.forEach(tx => {
+    newTxs.forEach((tx) => {
       newIncomingTransactions[tx.hash] = tx
     })
 
@@ -222,7 +222,7 @@ class IncomingTransactionsController {
         }
       })
 
-      const incomingTxs = remoteTxs.filter(tx => tx.txParams.to && tx.txParams.to.toLowerCase() === address.toLowerCase())
+      const incomingTxs = remoteTxs.filter((tx) => tx.txParams.to && tx.txParams.to.toLowerCase() === address.toLowerCase())
       incomingTxs.sort((a, b) => (a.time < b.time ? -1 : 1))
 
       let latestIncomingTxBlockNumber = null

--- a/app/scripts/controllers/network/createLocalhostClient.js
+++ b/app/scripts/controllers/network/createLocalhostClient.js
@@ -25,7 +25,7 @@ function createLocalhostClient () {
 }
 
 function delay (time) {
-  return new Promise(resolve => setTimeout(resolve, time))
+  return new Promise((resolve) => setTimeout(resolve, time))
 }
 
 

--- a/app/scripts/controllers/network/util.js
+++ b/app/scripts/controllers/network/util.js
@@ -27,7 +27,7 @@ const networkToNameMap = {
   [GOERLI_CODE]: GOERLI_DISPLAY_NAME,
 }
 
-export const getNetworkDisplayName = key => networkToNameMap[key]
+export const getNetworkDisplayName = (key) => networkToNameMap[key]
 
 export function formatTxMetaForRpcResult (txMeta) {
   return {

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -197,7 +197,7 @@ export class PermissionsController {
     let error
     try {
       await new Promise((resolve, reject) => {
-        this.permissions.grantNewPermissions(origin, permissions, {}, err => (err ? resolve() : reject(err)))
+        this.permissions.grantNewPermissions(origin, permissions, {}, (err) => (err ? resolve() : reject(err)))
       })
     } catch (err) {
       error = err
@@ -263,7 +263,7 @@ export class PermissionsController {
       }
 
       // caveat names are unique, and we will only construct this caveat here
-      ethAccounts.caveats = ethAccounts.caveats.filter(c => (
+      ethAccounts.caveats = ethAccounts.caveats.filter((c) => (
         c.name !== CAVEAT_NAMES.exposedAccounts
       ))
 
@@ -291,7 +291,7 @@ export class PermissionsController {
 
     // assert accounts exist
     const allAccounts = await this.getKeyringAccounts()
-    accounts.forEach(acc => {
+    accounts.forEach((acc) => {
       if (!allAccounts.includes(acc)) {
         throw new Error(`Unknown account: ${acc}`)
       }
@@ -331,7 +331,7 @@ export class PermissionsController {
 
       this.permissions.removePermissionsFor(
         origin,
-        perms.map(methodName => {
+        perms.map((methodName) => {
 
           if (methodName === 'eth_accounts') {
             this.notifyDomain(
@@ -366,7 +366,7 @@ export class PermissionsController {
     }
 
     const newPermittedAccounts = [account].concat(
-      permittedAccounts.filter(_account => _account !== account)
+      permittedAccounts.filter((_account) => _account !== account)
     )
 
     // update permitted accounts to ensure that accounts are returned

--- a/app/scripts/controllers/permissions/permissionsLog.js
+++ b/app/scripts/controllers/permissions/permissionsLog.js
@@ -116,7 +116,7 @@ export default class PermissionsLogController {
       }
 
       // call next with a return handler for capturing the response
-      next(cb => {
+      next((cb) => {
 
         const time = Date.now()
         this.logActivityResponse(requestId, res, time)
@@ -234,7 +234,7 @@ export default class PermissionsLogController {
       // accounts were last seen or approved by the origin.
       newEntries = result
         ? result
-          .map(perm => {
+          .map((perm) => {
 
             if (perm.parentCapability === 'eth_accounts') {
               accounts = this.getAccountsFromPermission(perm)

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -408,7 +408,7 @@ class PreferencesController {
 
     const { lastSelectedAddressByOrigin } = this.store.getState()
 
-    origins.forEach(origin => {
+    origins.forEach((origin) => {
       delete lastSelectedAddressByOrigin[origin]
     })
     this.store.updateState({ lastSelectedAddressByOrigin })
@@ -472,7 +472,7 @@ class PreferencesController {
   removeToken (rawAddress) {
     const tokens = this.store.getState().tokens
     const assetImages = this.getAssetImages()
-    const updatedTokens = tokens.filter(token => token.address !== rawAddress)
+    const updatedTokens = tokens.filter((token) => token.address !== rawAddress)
     delete assetImages[rawAddress]
     this._updateAccountTokens(updatedTokens, assetImages)
     return Promise.resolve(updatedTokens)
@@ -758,7 +758,7 @@ class PreferencesController {
     const tokenOpts = { rawAddress, decimals, symbol, image }
     this.addSuggestedERC20Asset(tokenOpts)
     return this.openPopup().then(() => {
-      const tokenAddresses = this.getTokens().filter(token => token.address === normalizeAddress(rawAddress))
+      const tokenAddresses = this.getTokens().filter((token) => token.address === normalizeAddress(rawAddress))
       return tokenAddresses.length > 0
     })
   }

--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -33,13 +33,13 @@ class TokenRatesController {
     }
     const contractExchangeRates = {}
     const nativeCurrency = this.currency ? this.currency.state.nativeCurrency.toLowerCase() : 'eth'
-    const pairs = this._tokens.map(token => token.address).join(',')
+    const pairs = this._tokens.map((token) => token.address).join(',')
     const query = `contract_addresses=${pairs}&vs_currencies=${nativeCurrency}`
     if (this._tokens.length > 0) {
       try {
         const response = await fetch(`https://api.coingecko.com/api/v3/simple/token_price/ethereum?${query}`)
         const prices = await response.json()
-        this._tokens.forEach(token => {
+        this._tokens.forEach((token) => {
           const price = prices[token.address.toLowerCase()] || prices[ethUtil.toChecksumAddress(token.address)]
           contractExchangeRates[normalizeAddress(token.address)] = price ? price[nativeCurrency] : 0
         })

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -657,7 +657,7 @@ class TransactionController extends EventEmitter {
       TOKEN_METHOD_APPROVE,
       TOKEN_METHOD_TRANSFER,
       TOKEN_METHOD_TRANSFER_FROM,
-    ].find(tokenMethodName => tokenMethodName === name && name.toLowerCase())
+    ].find((tokenMethodName) => tokenMethodName === name && name.toLowerCase())
 
     let result
     if (txParams.data && tokenMethodName) {

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -5,11 +5,11 @@ import { addHexPrefix, isValidAddress } from 'ethereumjs-util'
 const normalizers = {
   from: (from, LowerCase = true) => (LowerCase ? addHexPrefix(from).toLowerCase() : addHexPrefix(from)),
   to: (to, LowerCase = true) => (LowerCase ? addHexPrefix(to).toLowerCase() : addHexPrefix(to)),
-  nonce: nonce => addHexPrefix(nonce),
-  value: value => addHexPrefix(value),
-  data: data => addHexPrefix(data),
-  gas: gas => addHexPrefix(gas),
-  gasPrice: gasPrice => addHexPrefix(gasPrice),
+  nonce: (nonce) => addHexPrefix(nonce),
+  value: (value) => addHexPrefix(value),
+  data: (data) => addHexPrefix(data),
+  gas: (gas) => addHexPrefix(gas),
+  gasPrice: (gasPrice) => addHexPrefix(gasPrice),
 }
 
 /**

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -207,7 +207,7 @@ class TransactionStateManager extends EventEmitter {
     // commit txMeta to state
     const txId = txMeta.id
     const txList = this.getFullTxList()
-    const index = txList.findIndex(txData => txData.id === txId)
+    const index = txList.findIndex((txData) => txData.id === txId)
     txList[index] = txMeta
     this._saveTxList(txList)
   }

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -57,7 +57,7 @@ class AccountTracker {
     this._blockTracker = opts.blockTracker
     // blockTracker.currentBlock may be null
     this._currentBlockNumber = this._blockTracker.getCurrentBlock()
-    this._blockTracker.once('latest', blockNumber => {
+    this._blockTracker.once('latest', (blockNumber) => {
       this._currentBlockNumber = blockNumber
     })
     // bind function for easier listener syntax
@@ -124,7 +124,7 @@ class AccountTracker {
   addAccounts (addresses) {
     const accounts = this.store.getState().accounts
     // add initial state for addresses
-    addresses.forEach(address => {
+    addresses.forEach((address) => {
       accounts[address] = {}
     })
     // save accounts state
@@ -145,7 +145,7 @@ class AccountTracker {
   removeAccount (addresses) {
     const accounts = this.store.getState().accounts
     // remove each state object
-    addresses.forEach(address => {
+    addresses.forEach((address) => {
       delete accounts[address]
     })
     // save accounts state

--- a/app/scripts/lib/createDnodeRemoteGetter.js
+++ b/app/scripts/lib/createDnodeRemoteGetter.js
@@ -11,7 +11,7 @@ function createDnodeRemoteGetter (dnode) {
     if (remote) {
       return remote
     }
-    return await new Promise(resolve => dnode.once('remote', resolve))
+    return await new Promise((resolve) => dnode.once('remote', resolve))
   }
 
   return getRemote

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -9,7 +9,7 @@ export default setupEnsIpfsResolver
 function setupEnsIpfsResolver ({ provider, getCurrentNetwork, getIpfsGateway }) {
 
   // install listener
-  const urlPatterns = supportedTopLevelDomains.map(tld => `*://*.${tld}/*`)
+  const urlPatterns = supportedTopLevelDomains.map((tld) => `*://*.${tld}/*`)
   extension.webRequest.onErrorOccurred.addListener(webRequestDidFail, { urls: urlPatterns, types: ['main_frame'] })
 
   // return api object

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -9,7 +9,7 @@ const getPreferredLocales = extension.i18n ? promisify(
 
 // mapping some browsers return hyphen instead underscore in locale codes (e.g. zh_TW -> zh-tw)
 const existingLocaleCodes = {}
-allLocales.forEach(locale => {
+allLocales.forEach((locale) => {
   if (locale && locale.code) {
     existingLocaleCodes[locale.code.toLowerCase().replace('_', '-')] = locale.code
   }
@@ -39,8 +39,8 @@ async function getFirstPreferredLangCode () {
   }
 
   const firstPreferredLangCode = userPreferredLocaleCodes
-    .map(code => code.toLowerCase().replace('_', '-'))
-    .find(code => existingLocaleCodes.hasOwnProperty(code))
+    .map((code) => code.toLowerCase().replace('_', '-'))
+    .find((code) => existingLocaleCodes.hasOwnProperty(code))
 
   return existingLocaleCodes[firstPreferredLangCode] || 'en'
 }

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -61,7 +61,7 @@ export default class MessageManager extends EventEmitter {
    *
    */
   getUnapprovedMsgs () {
-    return this.messages.filter(msg => msg.status === 'unapproved')
+    return this.messages.filter((msg) => msg.status === 'unapproved')
       .reduce((result, msg) => {
         result[msg.id] = msg; return result
       }, {})
@@ -145,7 +145,7 @@ export default class MessageManager extends EventEmitter {
    *
    */
   getMsg (msgId) {
-    return this.messages.find(msg => msg.id === msgId)
+    return this.messages.find((msg) => msg.id === msgId)
   }
 
   /**

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -65,7 +65,7 @@ export default class PersonalMessageManager extends EventEmitter {
    *
    */
   getUnapprovedMsgs () {
-    return this.messages.filter(msg => msg.status === 'unapproved')
+    return this.messages.filter((msg) => msg.status === 'unapproved')
       .reduce((result, msg) => {
         result[msg.id] = msg; return result
       }, {})
@@ -155,7 +155,7 @@ export default class PersonalMessageManager extends EventEmitter {
    *
    */
   getMsg (msgId) {
-    return this.messages.find(msg => msg.id === msgId)
+    return this.messages.find((msg) => msg.id === msgId)
   }
 
   /**

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -37,7 +37,7 @@ function setupSentry (opts) {
     beforeSend: (report) => rewriteReport(report),
   })
 
-  Sentry.configureScope(scope => {
+  Sentry.configureScope((scope) => {
     scope.setExtra('isBrave', isBrave)
   })
 
@@ -81,7 +81,7 @@ function rewriteErrorMessages (report, rewriteFn) {
   }
   // rewrite each exception message
   if (report.exception && report.exception.values) {
-    report.exception.values.forEach(item => {
+    report.exception.values.forEach((item) => {
       if (typeof item.value === 'string') {
         item.value = rewriteFn(item.value)
       }
@@ -94,8 +94,8 @@ function rewriteReportUrls (report) {
   report.request.url = toMetamaskUrl(report.request.url)
   // update exception stack trace
   if (report.exception && report.exception.values) {
-    report.exception.values.forEach(item => {
-      item.stacktrace.frames.forEach(frame => {
+    report.exception.values.forEach((item) => {
+      item.stacktrace.frames.forEach((frame) => {
         frame.filename = toMetamaskUrl(frame.filename)
       })
     })

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -57,7 +57,7 @@ export default class TypedMessageManager extends EventEmitter {
    *
    */
   getUnapprovedMsgs () {
-    return this.messages.filter(msg => msg.status === 'unapproved')
+    return this.messages.filter((msg) => msg.status === 'unapproved')
       .reduce((result, msg) => {
         result[msg.id] = msg; return result
       }, {})
@@ -189,7 +189,7 @@ export default class TypedMessageManager extends EventEmitter {
    *
    */
   getMsg (msgId) {
-    return this.messages.find(msg => msg.id === msgId)
+    return this.messages.find((msg) => msg.id === msgId)
   }
 
   /**

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -44,7 +44,7 @@ const getEnvironmentType = (url = window.location.href) => {
  * @returns {string} - the platform ENUM
  *
  */
-const getPlatform = _ => {
+const getPlatform = (_) => {
   const ua = navigator.userAgent
   if (ua.search('Firefox') !== -1) {
     return PLATFORM_FIREFOX
@@ -135,7 +135,7 @@ function getRandomArrayItem (array) {
 
 function mapObjectValues (object, cb) {
   const mappedObject = {}
-  Object.keys(object).forEach(key => {
+  Object.keys(object).forEach((key) => {
     mappedObject[key] = cb(key, object[key])
   })
   return mappedObject

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -697,11 +697,11 @@ export default class MetamaskController extends EventEmitter {
 
     // Filter ERC20 tokens
     const filteredAccountTokens = {}
-    Object.keys(accountTokens).forEach(address => {
+    Object.keys(accountTokens).forEach((address) => {
       const checksummedAddress = ethUtil.toChecksumAddress(address)
       filteredAccountTokens[checksummedAddress] = {}
       Object.keys(accountTokens[address]).forEach(
-        networkType => (filteredAccountTokens[checksummedAddress][networkType] = networkType !== 'mainnet' ?
+        (networkType) => (filteredAccountTokens[checksummedAddress][networkType] = networkType !== 'mainnet' ?
           accountTokens[address][networkType] :
           accountTokens[address][networkType].filter(({ address }) => {
             const tokenAddress = ethUtil.toChecksumAddress(address)
@@ -724,7 +724,7 @@ export default class MetamaskController extends EventEmitter {
     const hdKeyring = this.keyringController.getKeyringsByType('HD Key Tree')[0]
     const hdAccounts = await hdKeyring.getAccounts()
     const accounts = {
-      hd: hdAccounts.filter((item, pos) => (hdAccounts.indexOf(item) === pos)).map(address => ethUtil.toChecksumAddress(address)),
+      hd: hdAccounts.filter((item, pos) => (hdAccounts.indexOf(item) === pos)).map((address) => ethUtil.toChecksumAddress(address)),
       simpleKeyPair: [],
       ledger: [],
       trezor: [],
@@ -734,7 +734,7 @@ export default class MetamaskController extends EventEmitter {
 
     let transactions = this.txController.store.getState().transactions
     // delete tx for other accounts that we're not importing
-    transactions = transactions.filter(tx => {
+    transactions = transactions.filter((tx) => {
       const checksummedTxFrom = ethUtil.toChecksumAddress(tx.txParams.from)
       return (
         accounts.hd.includes(checksummedTxFrom)
@@ -762,7 +762,7 @@ export default class MetamaskController extends EventEmitter {
     const accounts = await this.keyringController.getAccounts()
 
     // verify keyrings
-    const nonSimpleKeyrings = this.keyringController.keyrings.filter(keyring => keyring.type !== 'Simple Key Pair')
+    const nonSimpleKeyrings = this.keyringController.keyrings.filter((keyring) => keyring.type !== 'Simple Key Pair')
     if (nonSimpleKeyrings.length > 1 && this.diagnostics) {
       await this.diagnostics.reportMultipleKeyrings(nonSimpleKeyrings)
     }
@@ -855,7 +855,7 @@ export default class MetamaskController extends EventEmitter {
     // Merge with existing accounts
     // and make sure addresses are not repeated
     const oldAccounts = await this.keyringController.getAccounts()
-    const accountsToTrack = [...new Set(oldAccounts.concat(accounts.map(a => a.address.toLowerCase())))]
+    const accountsToTrack = [...new Set(oldAccounts.concat(accounts.map((a) => a.address.toLowerCase())))]
     this.accountTracker.syncWithAddresses(accountsToTrack)
     return accounts
   }
@@ -895,7 +895,7 @@ export default class MetamaskController extends EventEmitter {
     const keyState = await this.keyringController.addNewAccount(keyring)
     const newAccounts = await this.keyringController.getAccounts()
     this.preferencesController.setAddresses(newAccounts)
-    newAccounts.forEach(address => {
+    newAccounts.forEach((address) => {
       if (!oldAccounts.includes(address)) {
         // Set the account label to Trezor 1 /  Ledger 1, etc
         this.preferencesController.setAccountLabel(address, `${deviceName[0].toUpperCase()}${deviceName.slice(1)} ${parseInt(index, 10) + 1}`)
@@ -1580,7 +1580,7 @@ export default class MetamaskController extends EventEmitter {
       return
     }
 
-    Object.values(connections).forEach(conn => {
+    Object.values(connections).forEach((conn) => {
       conn.engine && conn.engine.emit('notification', payload)
     })
   }
@@ -1599,8 +1599,8 @@ export default class MetamaskController extends EventEmitter {
       return
     }
 
-    Object.values(this.connections).forEach(origin => {
-      Object.values(origin).forEach(conn => {
+    Object.values(this.connections).forEach((origin) => {
+      Object.values(origin).forEach((conn) => {
         conn.engine && conn.engine.emit('notification', payload)
       })
     })
@@ -1671,13 +1671,13 @@ export default class MetamaskController extends EventEmitter {
         return GWEI_BN
       }
       return block.gasPrices
-        .map(hexPrefix => hexPrefix.substr(2))
-        .map(hex => new BN(hex, 16))
+        .map((hexPrefix) => hexPrefix.substr(2))
+        .map((hex) => new BN(hex, 16))
         .sort((a, b) => {
           return a.gt(b) ? 1 : -1
         })[0]
     })
-      .map(number => number.div(GWEI_BN).toNumber())
+      .map((number) => number.div(GWEI_BN).toNumber())
 
     const percentileNum = percentile(65, lowestPrices)
     const percentileNumBn = new BN(percentileNum)

--- a/app/scripts/migrations/025.js
+++ b/app/scripts/migrations/025.js
@@ -45,13 +45,13 @@ function transformState (state) {
 function normalizeTxParams (txParams) {
   // functions that handle normalizing of that key in txParams
   const whiteList = {
-    from: from => ethUtil.addHexPrefix(from).toLowerCase(),
+    from: (from) => ethUtil.addHexPrefix(from).toLowerCase(),
     to: () => ethUtil.addHexPrefix(txParams.to).toLowerCase(),
-    nonce: nonce => ethUtil.addHexPrefix(nonce),
-    value: value => ethUtil.addHexPrefix(value),
-    data: data => ethUtil.addHexPrefix(data),
-    gas: gas => ethUtil.addHexPrefix(gas),
-    gasPrice: gasPrice => ethUtil.addHexPrefix(gasPrice),
+    nonce: (nonce) => ethUtil.addHexPrefix(nonce),
+    value: (value) => ethUtil.addHexPrefix(value),
+    data: (data) => ethUtil.addHexPrefix(data),
+    gas: (gas) => ethUtil.addHexPrefix(gas),
+    gasPrice: (gasPrice) => ethUtil.addHexPrefix(gasPrice),
   }
 
   // apply only keys in the whiteList

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -67,7 +67,7 @@ class ExtensionPlatform {
 
   currentTab () {
     return new Promise((resolve, reject) => {
-      extension.tabs.getCurrent(tab => {
+      extension.tabs.getCurrent((tab) => {
         const err = checkForError()
         if (err) {
           reject(err)

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -33,14 +33,14 @@ async function start () {
 
   // links to extension builds
   const platforms = ['chrome', 'firefox', 'opera']
-  const buildLinks = platforms.map(platform => {
+  const buildLinks = platforms.map((platform) => {
     const url = `${BUILD_LINK_BASE}/builds/metamask-${platform}-${VERSION}.zip`
     return `<a href="${url}">${platform}</a>`
   }).join(', ')
 
   // links to bundle browser builds
   const bundles = ['background', 'ui', 'inpage', 'contentscript', 'ui-libs', 'bg-libs', 'phishing-detect']
-  const bundleLinks = bundles.map(bundle => {
+  const bundleLinks = bundles.map((bundle) => {
     const url = `${BUILD_LINK_BASE}/build-artifacts/source-map-explorer/${bundle}.html`
     return `<a href="${url}">${bundle}</a>`
   }).join(', ')
@@ -58,7 +58,7 @@ async function start () {
     `dep viz: ${depVizLink}`,
     `<a href="${allArtifactsUrl}">all artifacts</a>`,
   ]
-  const hiddenContent = `<ul>` + contentRows.map(row => `<li>${row}</li>`).join('\n') + `</ul>`
+  const hiddenContent = `<ul>` + contentRows.map((row) => `<li>${row}</li>`).join('\n') + `</ul>`
   const exposedContent = `Builds ready [${SHORT_SHA1}]`
   const artifactsBody = `<details><summary>${exposedContent}</summary>${hiddenContent}</details>`
 
@@ -136,7 +136,7 @@ async function start () {
       for (const measure of allMeasures) {
         benchmarkTableHeaders.push(`${capitalizeFirstLetter(measure)} (ms)`)
       }
-      const benchmarkTableHeader = `<thead><tr>${benchmarkTableHeaders.map(header => `<th>${header}</th>`).join('')}</tr></thead>`
+      const benchmarkTableHeader = `<thead><tr>${benchmarkTableHeaders.map((header) => `<th>${header}</th>`).join('')}</tr></thead>`
       const benchmarkTableBody = `<tbody>${tableRows.join('')}</tbody>`
       const benchmarkTable = `<table>${benchmarkTableHeader}${benchmarkTableBody}</table>`
       const benchmarkBody = `<details><summary>${benchmarkSummary}</summary>${benchmarkTable}</details>`

--- a/development/mock-3box.js
+++ b/development/mock-3box.js
@@ -1,5 +1,5 @@
 function delay (time) {
-  return new Promise(resolve => setTimeout(resolve, time))
+  return new Promise((resolve) => setTimeout(resolve, time))
 }
 
 async function loadFromMock3Box (key) {
@@ -24,7 +24,7 @@ class Mock3Box {
   static openBox (address) {
     this.address = address
     return Promise.resolve({
-      onSyncDone: cb => {
+      onSyncDone: (cb) => {
         setTimeout(cb, 200)
       },
       openSpace: async (spaceName, config) => {

--- a/development/show-deps-install-scripts.js
+++ b/development/show-deps-install-scripts.js
@@ -14,7 +14,7 @@ readInstalled('./', { dev: true }, function (err, data) {
     const packageScripts = packageData.scripts || {}
     const scriptKeys = Reflect.ownKeys(packageScripts)
 
-    const hasInstallScript = installScripts.some(installKey => scriptKeys.includes(installKey))
+    const hasInstallScript = installScripts.some((installKey) => scriptKeys.includes(installKey))
     if (!hasInstallScript) {
       return
     }

--- a/development/sourcemap-validator.js
+++ b/development/sourcemap-validator.js
@@ -63,7 +63,7 @@ async function validateSourcemapForFile ({ buildName }) {
   const buildLines = rawBuild.split('\n')
   const targetString = 'new Error'
   // const targetString = 'null'
-  const matchesPerLine = buildLines.map(line => indicesOf(targetString, line))
+  const matchesPerLine = buildLines.map((line) => indicesOf(targetString, line))
   matchesPerLine.forEach((matchIndices, lineIndex) => {
     matchIndices.forEach((matchColumn) => {
       sampleCount++

--- a/development/verify-locale-strings.js
+++ b/development/verify-locale-strings.js
@@ -47,7 +47,7 @@ for (const arg of process.argv.slice(2)) {
 }
 
 main(specifiedLocale, fix)
-  .catch(error => {
+  .catch((error) => {
     log.error(error)
     process.exit(1)
   })
@@ -55,7 +55,7 @@ main(specifiedLocale, fix)
 async function main (specifiedLocale, fix) {
   if (specifiedLocale) {
     log.info(`Verifying selected locale "${specifiedLocale}":\n`)
-    const locale = localeIndex.find(localeMeta => localeMeta.code === specifiedLocale)
+    const locale = localeIndex.find((localeMeta) => localeMeta.code === specifiedLocale)
     const failed = locale.code === 'en' ?
       await verifyEnglishLocale(fix) :
       await verifyLocale(locale, fix)
@@ -66,8 +66,8 @@ async function main (specifiedLocale, fix) {
     log.info('Verifying all locales:\n')
     let failed = await verifyEnglishLocale(fix)
     const localeCodes = localeIndex
-      .filter(localeMeta => localeMeta.code !== 'en')
-      .map(localeMeta => localeMeta.code)
+      .filter((localeMeta) => localeMeta.code !== 'en')
+      .map((localeMeta) => localeMeta.code)
 
     for (const code of localeCodes) {
       log.info() // Separate each locale report by a newline when not in '--quiet' mode
@@ -179,7 +179,7 @@ async function verifyEnglishLocale (fix = false) {
     const templateMatches = fileContents.match(templateStringRegex)
     if (templateMatches) {
       // concat doesn't work here for some reason
-      templateMatches.forEach(match => templateUsage.push(match))
+      templateMatches.forEach((match) => templateUsage.push(match))
     }
   }
 
@@ -188,7 +188,7 @@ async function verifyEnglishLocale (fix = false) {
 
   const englishMessages = Object.keys(englishLocale)
   const unusedMessages = englishMessages
-    .filter(message => !messageExceptions.includes(message) && !usedMessages.has(message))
+    .filter((message) => !messageExceptions.includes(message) && !usedMessages.has(message))
 
   if (unusedMessages.length) {
     console.log(`**en**: ${unusedMessages.length} unused messages`)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ sass.compiler = require('node-sass')
 
 const dependencies = Object.keys(packageJSON && packageJSON.dependencies || {})
 const materialUIDependencies = ['@material-ui/core']
-const reactDepenendencies = dependencies.filter(dep => dep.match(/react/))
+const reactDepenendencies = dependencies.filter((dep) => dep.match(/react/))
 const d3Dependencies = ['c3', 'd3']
 
 const externalDependenciesMap = {
@@ -77,38 +77,38 @@ const copyDevTaskNames = []
 
 createCopyTasks('locales', {
   source: './app/_locales/',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}/_locales`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}/_locales`),
 })
 createCopyTasks('images', {
   source: './app/images/',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}/images`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}/images`),
 })
 createCopyTasks('contractImages', {
   source: './node_modules/eth-contract-metadata/images/',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}/images/contract`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}/images/contract`),
 })
 createCopyTasks('fonts', {
   source: './app/fonts/',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}/fonts`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}/fonts`),
 })
 createCopyTasks('vendor', {
   source: './app/vendor/',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}/vendor`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}/vendor`),
 })
 createCopyTasks('css', {
   source: './ui/app/css/output/',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}`),
 })
 createCopyTasks('reload', {
   devOnly: true,
   source: './app/scripts/',
   pattern: '/chromereload.js',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}`),
 })
 createCopyTasks('html', {
   source: './app/',
   pattern: '/*.html',
-  destinations: commonPlatforms.map(platform => `./dist/${platform}`),
+  destinations: commonPlatforms.map((platform) => `./dist/${platform}`),
 })
 
 // copy extension
@@ -116,7 +116,7 @@ createCopyTasks('html', {
 createCopyTasks('manifest', {
   source: './app/',
   pattern: '/*.json',
-  destinations: browserPlatforms.map(platform => `./dist/${platform}`),
+  destinations: browserPlatforms.map((platform) => `./dist/${platform}`),
 })
 
 function createCopyTasks (label, opts) {
@@ -235,7 +235,7 @@ gulp.task('manifest:testing-local', function () {
     .pipe(jsoneditor(function (json) {
       json.background = {
         ...json.background,
-        scripts: json.background.scripts.filter(scriptName => !scriptsToExcludeFromBackgroundDevBuild[scriptName]),
+        scripts: json.background.scripts.filter((scriptName) => !scriptsToExcludeFromBackgroundDevBuild[scriptName]),
       }
       json.permissions = [...json.permissions, 'webRequestBlocking', 'http://localhost/*']
       return json
@@ -254,7 +254,7 @@ gulp.task('manifest:dev', function () {
     .pipe(jsoneditor(function (json) {
       json.background = {
         ...json.background,
-        scripts: json.background.scripts.filter(scriptName => !scriptsToExcludeFromBackgroundDevBuild[scriptName]),
+        scripts: json.background.scripts.filter((scriptName) => !scriptsToExcludeFromBackgroundDevBuild[scriptName]),
       }
       json.permissions = [...json.permissions, 'webRequestBlocking']
       return json
@@ -378,7 +378,7 @@ createTasksForBuildJsExtension({ buildJsFiles, taskPrefix: 'build:extension:js' 
 createTasksForBuildJsExtension({ buildJsFiles, taskPrefix: 'build:test:extension:js', testing: 'true' })
 
 function createTasksForBuildJsDeps ({ key, filename }) {
-  const destinations = browserPlatforms.map(platform => `./dist/${platform}`)
+  const destinations = browserPlatforms.map((platform) => `./dist/${platform}`)
 
   const bundleTaskOpts = Object.assign({
     buildSourceMaps: true,
@@ -400,10 +400,10 @@ function createTasksForBuildJsDeps ({ key, filename }) {
 function createTasksForBuildJsExtension ({ buildJsFiles, taskPrefix, devMode, testing, bundleTaskOpts = {} }) {
   // inpage must be built before all other scripts:
   const rootDir = './app/scripts'
-  const nonInpageFiles = buildJsFiles.filter(file => file !== 'inpage')
+  const nonInpageFiles = buildJsFiles.filter((file) => file !== 'inpage')
   const buildPhase1 = ['inpage']
   const buildPhase2 = nonInpageFiles
-  const destinations = browserPlatforms.map(platform => `./dist/${platform}`)
+  const destinations = browserPlatforms.map((platform) => `./dist/${platform}`)
   bundleTaskOpts = Object.assign({
     buildSourceMaps: true,
     sourceMapDir: '../sourcemaps',
@@ -430,9 +430,9 @@ function createTasksForBuildJs ({ rootDir, taskPrefix, bundleTaskOpts, destinati
   })
   // compose into larger task
   const subtasks = []
-  subtasks.push(gulp.parallel(buildPhase1.map(file => `${taskPrefix}:${file}`)))
+  subtasks.push(gulp.parallel(buildPhase1.map((file) => `${taskPrefix}:${file}`)))
   if (buildPhase2.length) {
-    subtasks.push(gulp.parallel(buildPhase2.map(file => `${taskPrefix}:${file}`)))
+    subtasks.push(gulp.parallel(buildPhase2.map((file) => `${taskPrefix}:${file}`)))
   }
 
   gulp.task(taskPrefix, gulp.series(subtasks))

--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -37,7 +37,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors()
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }

--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -37,10 +37,10 @@ const calculateSum = (array) => array.reduce((sum, val) => sum + val)
 const calculateAverage = (array) => calculateSum(array) / array.length
 const minResult = calculateResult((array) => Math.min(...array))
 const maxResult = calculateResult((array) => Math.max(...array))
-const averageResult = calculateResult(array => calculateAverage(array))
+const averageResult = calculateResult((array) => calculateAverage(array))
 const standardDeviationResult = calculateResult((array) => {
   const average = calculateAverage(array)
-  const squareDiffs = array.map(value => Math.pow(value - average, 2))
+  const squareDiffs = array.map((value) => Math.pow(value - average, 2))
   return Math.sqrt(calculateAverage(squareDiffs))
 })
 // 95% margin of error calculated using Student's t-distrbution
@@ -55,17 +55,17 @@ async function profilePageLoad (pages, numSamples) {
       runResults.push(await measurePage(pageName))
     }
 
-    if (runResults.some(result => result.navigation.lenth > 1)) {
+    if (runResults.some((result) => result.navigation.lenth > 1)) {
       throw new Error(`Multiple navigations not supported`)
-    } else if (runResults.some(result => result.navigation[0].type !== 'navigate')) {
-      throw new Error(`Navigation type ${runResults.find(result => result.navigation[0].type !== 'navigate').navigation[0].type} not supported`)
+    } else if (runResults.some((result) => result.navigation[0].type !== 'navigate')) {
+      throw new Error(`Navigation type ${runResults.find((result) => result.navigation[0].type !== 'navigate').navigation[0].type} not supported`)
     }
 
     const result = {
-      firstPaint: runResults.map(result => result.paint['first-paint']),
-      domContentLoaded: runResults.map(result => result.navigation[0] && result.navigation[0].domContentLoaded),
-      load: runResults.map(result => result.navigation[0] && result.navigation[0].load),
-      domInteractive: runResults.map(result => result.navigation[0] && result.navigation[0].domInteractive),
+      firstPaint: runResults.map((result) => result.paint['first-paint']),
+      domContentLoaded: runResults.map((result) => result.navigation[0] && result.navigation[0].domContentLoaded),
+      load: runResults.map((result) => result.navigation[0] && result.navigation[0].load),
+      domInteractive: runResults.map((result) => result.navigation[0] && result.navigation[0].domInteractive),
     }
 
     results[pageName] = {
@@ -166,7 +166,7 @@ async function main () {
 }
 
 main()
-  .catch(e => {
+  .catch((e) => {
     console.error(e)
     process.exit(1)
   })

--- a/test/e2e/ethereum-on.spec.js
+++ b/test/e2e/ethereum-on.spec.js
@@ -36,7 +36,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }
@@ -119,7 +119,7 @@ describe('MetaMask', function () {
 
       extension = windowHandles[0]
       dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
-      popup = windowHandles.find(handle => handle !== extension && handle !== dapp)
+      popup = windowHandles.find((handle) => handle !== extension && handle !== dapp)
 
       await driver.switchToWindow(popup)
 

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -41,7 +41,7 @@ describe('Using MetaMask with an existing account', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }

--- a/test/e2e/incremental-security.spec.js
+++ b/test/e2e/incremental-security.spec.js
@@ -41,7 +41,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -31,7 +31,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -32,7 +32,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }
@@ -407,7 +407,7 @@ describe('MetaMask', function () {
 
       extension = windowHandles[0]
       dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
-      popup = windowHandles.find(handle => handle !== extension && handle !== dapp)
+      popup = windowHandles.find((handle) => handle !== extension && handle !== dapp)
 
       await driver.switchToWindow(popup)
 
@@ -1273,7 +1273,7 @@ describe('MetaMask', function () {
       'http://127.0.0.1:8545/4',
     ]
 
-    customRpcUrls.forEach(customRpcUrl => {
+    customRpcUrls.forEach((customRpcUrl) => {
       it(`creates custom RPC: ${customRpcUrl}`, async function () {
         await driver.clickElement(By.css('.network-name'))
         await driver.delay(regularDelayMs)

--- a/test/e2e/mock-3box/server.js
+++ b/test/e2e/mock-3box/server.js
@@ -9,7 +9,7 @@ const requestHandler = (request, response) => {
   response.setHeader('Content-Type', 'application/json')
   if (request.method === 'POST') {
     let body = ''
-    request.on('data', chunk => {
+    request.on('data', (chunk) => {
       body += chunk.toString() // convert Buffer to string
     })
     request.on('end', () => {

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -36,7 +36,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }
@@ -117,7 +117,7 @@ describe('MetaMask', function () {
 
       extension = windowHandles[0]
       dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
-      popup = windowHandles.find(handle => handle !== extension && handle !== dapp)
+      popup = windowHandles.find((handle) => handle !== extension && handle !== dapp)
 
       await driver.switchToWindow(popup)
 

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -38,7 +38,7 @@ describe('Using MetaMask with an existing account', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -35,7 +35,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }
@@ -78,7 +78,7 @@ describe('MetaMask', function () {
 
       extension = windowHandles[0]
       dapp = await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles)
-      popup = windowHandles.find(handle => handle !== extension && handle !== dapp)
+      popup = windowHandles.find((handle) => handle !== extension && handle !== dapp)
 
       await driver.switchToWindow(popup)
 

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -39,7 +39,7 @@ describe('MetaMask', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }

--- a/test/e2e/web3.spec.js
+++ b/test/e2e/web3.spec.js
@@ -38,7 +38,7 @@ describe('Using MetaMask with an existing account', function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       const errors = await driver.checkBrowserForConsoleErrors(driver)
       if (errors.length) {
-        const errorReports = errors.map(err => err.message)
+        const errorReports = errors.map((err) => err.message)
         const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
         console.error(new Error(errorMessage))
       }
@@ -116,7 +116,7 @@ describe('Using MetaMask with an existing account', function () {
 
       const extension = windowHandles[0]
       const popup = await driver.switchToWindowWithTitle('MetaMask Notification', windowHandles)
-      const dapp = windowHandles.find(handle => handle !== extension && handle !== popup)
+      const dapp = windowHandles.find((handle) => handle !== extension && handle !== popup)
 
       await driver.delay(regularDelayMs)
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Connect')]`))

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -16,7 +16,7 @@ class Driver {
   }
 
   async delay (time) {
-    await new Promise(resolve => setTimeout(resolve, time))
+    await new Promise((resolve) => setTimeout(resolve, time))
   }
 
   async wait (condition, timeout = this.timeout) {
@@ -180,9 +180,9 @@ class Driver {
       'favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)',
     ]
     const browserLogs = await this.driver.manage().logs().get('browser')
-    const errorEntries = browserLogs.filter(entry => !ignoredLogTypes.includes(entry.level.toString()))
-    const errorObjects = errorEntries.map(entry => entry.toJSON())
-    return errorObjects.filter(entry => !ignoredErrorMessages.some(message => entry.message.includes(message)))
+    const errorEntries = browserLogs.filter((entry) => !ignoredLogTypes.includes(entry.level.toString()))
+    const errorObjects = errorEntries.map((entry) => entry.toJSON())
+    return errorObjects.filter((entry) => !ignoredErrorMessages.some((message) => entry.message.includes(message)))
   }
 }
 

--- a/test/lib/render-helpers.js
+++ b/test/lib/render-helpers.js
@@ -26,8 +26,8 @@ export function mountWithRouter (component, store = {}, pathname = '/') {
   const createContext = () => ({
     context: {
       router,
-      t: str => str,
-      tOrKey: str => str,
+      t: (str) => str,
+      tOrKey: (str) => str,
       metricsEvent: () => {},
       store,
     },

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,5 @@
 require('@babel/register')({
-  ignore: [name => name.includes('node_modules') && !name.includes('obs-store')],
+  ignore: [(name) => name.includes('node_modules') && !name.includes('obs-store')],
 })
 
 require('./helper')

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -903,7 +903,7 @@ describe('MetaMaskController', function () {
 
 function deferredPromise () {
   let resolve
-  const promise = new Promise(_resolve => {
+  const promise = new Promise((_resolve) => {
     resolve = _resolve
   })
   return { promise, resolve }

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -226,7 +226,7 @@ describe('PendingTransactionTracker', function () {
     it('should emit \'tx:warning\' if it encountered a real error', function (done) {
       pendingTxTracker.once('tx:warning', (txMeta, err) => {
         if (err.message === 'im some real error') {
-          const matchingTx = txList.find(tx => tx.id === txMeta.id)
+          const matchingTx = txList.find((tx) => tx.id === txMeta.id)
           matchingTx.resolve()
         } else {
           done(err)

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -683,7 +683,7 @@ describe('Transaction Controller', function () {
       ])
 
       assert(txController.pendingTxTracker.getPendingTransactions().length, 2)
-      const states = txController.pendingTxTracker.getPendingTransactions().map(tx => tx.status)
+      const states = txController.pendingTxTracker.getPendingTransactions().map((tx) => tx.status)
       assert(states.includes('approved'), 'includes approved')
       assert(states.includes('submitted'), 'includes submitted')
     })

--- a/test/unit/app/fetch-with-timeout.test.js
+++ b/test/unit/app/fetch-with-timeout.test.js
@@ -27,7 +27,7 @@ describe('fetchWithTimeout', function () {
     })
 
     try {
-      await fetch('https://api.infura.io/moon').then(r => r.json())
+      await fetch('https://api.infura.io/moon').then((r) => r.json())
       assert.fail('Request should throw')
     } catch (e) {
       assert.ok(e)
@@ -45,7 +45,7 @@ describe('fetchWithTimeout', function () {
     })
 
     try {
-      await fetch('https://api.infura.io/moon').then(r => r.json())
+      await fetch('https://api.infura.io/moon').then((r) => r.json())
       assert.fail('Request should be aborted')
     } catch (e) {
       assert.deepEqual(e.message, 'Aborted')

--- a/test/unit/migrations/031-test.js
+++ b/test/unit/migrations/031-test.js
@@ -24,7 +24,7 @@ describe('migration #31', function () {
     }
 
     migration31.migrate(oldStorage)
-      .then(newStorage => {
+      .then((newStorage) => {
         assert.equal(newStorage.data.PreferencesController.completedOnboarding, true)
         done()
       })
@@ -47,7 +47,7 @@ describe('migration #31', function () {
     }
 
     migration31.migrate(oldStorage)
-      .then(newStorage => {
+      .then((newStorage) => {
         assert.equal(newStorage.data.PreferencesController.completedOnboarding, false)
         done()
       })

--- a/test/unit/migrations/033-test.js
+++ b/test/unit/migrations/033-test.js
@@ -33,7 +33,7 @@ describe('Migration to delete notice controller', function () {
 
   it('removes notice controller from state', function () {
     migration33.migrate(oldStorage)
-      .then(newStorage => {
+      .then((newStorage) => {
         assert.equal(newStorage.data.NoticeController, undefined)
       })
   })

--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -44,7 +44,7 @@ const firstTimeState = {
 describe('migrations', function () {
   describe('liveMigrations require list', function () {
     it('should include all the migrations', async function () {
-      const fileNames = await pify(cb => fs.readdir('./app/scripts/migrations/', cb))()
+      const fileNames = await pify((cb) => fs.readdir('./app/scripts/migrations/', cb))()
       const migrationNumbers = fileNames.reduce((agg, filename) => {
         const name = filename.split('.')[0]
         if (/^\d+$/.test(name)) {

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -119,7 +119,7 @@ describe('Actions', function () {
       const unlockFailedError = [ { type: 'UNLOCK_FAILED', value: 'error' } ]
 
       verifySeedPhraseSpy = sinon.stub(background, 'verifySeedPhrase')
-      verifySeedPhraseSpy.callsFake(callback => {
+      verifySeedPhraseSpy.callsFake((callback) => {
         callback(new Error('error'))
       })
 
@@ -128,8 +128,8 @@ describe('Actions', function () {
         assert.fail('Should have thrown error')
       } catch (_) {
         const actions1 = store.getActions()
-        const warning = actions1.filter(action => action.type === 'DISPLAY_WARNING')
-        const unlockFailed = actions1.filter(action => action.type === 'UNLOCK_FAILED')
+        const warning = actions1.filter((action) => action.type === 'DISPLAY_WARNING')
+        const unlockFailed = actions1.filter((action) => action.type === 'UNLOCK_FAILED')
         assert.deepEqual(warning, displayWarningError)
         assert.deepEqual(unlockFailed, unlockFailedError)
       }
@@ -245,7 +245,7 @@ describe('Actions', function () {
       assert(removeAccountSpy.calledOnce)
       const actionTypes = store
         .getActions()
-        .map(action => action.type)
+        .map((action) => action.type)
       assert.deepEqual(actionTypes, expectedActions)
     })
 
@@ -269,7 +269,7 @@ describe('Actions', function () {
       } catch (_) {
         const actionTypes = store
           .getActions()
-          .map(action => action.type)
+          .map((action) => action.type)
         assert.deepEqual(actionTypes, expectedActions)
       }
 
@@ -995,7 +995,7 @@ describe('Actions', function () {
         { type: 'LOCK_METAMASK' },
       ]
       backgroundSetLockedSpy = sinon.stub(background, 'setLocked')
-      backgroundSetLockedSpy.callsFake(callback => {
+      backgroundSetLockedSpy.callsFake((callback) => {
         callback(new Error('error'))
       })
 
@@ -1375,7 +1375,7 @@ describe('Actions', function () {
   describe('#setCompletedOnboarding', function () {
     it('completes onboarding', async function () {
       const completeOnboardingSpy = sinon.stub(background, 'completeOnboarding')
-      completeOnboardingSpy.callsFake(cb => cb())
+      completeOnboardingSpy.callsFake((cb) => cb())
       const store = mockStore()
       await store.dispatch(actions.setCompletedOnboarding())
       assert.equal(completeOnboardingSpy.callCount, 1)

--- a/test/web3/web3.js
+++ b/test/web3/web3.js
@@ -4,12 +4,12 @@ const json = methods
 
 web3.currentProvider.enable().then(() => {
 
-  Object.keys(json).forEach(methodGroupKey => {
+  Object.keys(json).forEach((methodGroupKey) => {
 
     console.log(methodGroupKey)
     const methodGroup = json[methodGroupKey]
     console.log(methodGroup)
-    Object.keys(methodGroup).forEach(methodKey => {
+    Object.keys(methodGroup).forEach((methodKey) => {
 
       const methodButton = document.getElementById(methodKey)
       methodButton.addEventListener('click', () => {

--- a/ui/app/components/app/account-menu/account-menu.component.js
+++ b/ui/app/components/app/account-menu/account-menu.component.js
@@ -103,7 +103,7 @@ export default class AccountMenu extends Component {
         placeholder={this.context.t('searchAccounts')}
         type="text"
         value={this.state.searchQuery}
-        onChange={e => this.setSearchQuery(e.target.value)}
+        onChange={(e) => this.setSearchQuery(e.target.value)}
         startAdornment={inputAdornment}
         fullWidth
         theme="material-white-padded"
@@ -133,12 +133,12 @@ export default class AccountMenu extends Component {
       return <p className="account-menu__no-accounts">{this.context.t('noAccountsFound')}</p>
     }
 
-    return filteredIdentities.map(identity => {
+    return filteredIdentities.map((identity) => {
       const isSelected = identity.address === selectedAddress
 
       const simpleAddress = identity.address.substring(2).toLowerCase()
 
-      const keyring = keyrings.find(kr => {
+      const keyring = keyrings.find((kr) => {
         return kr.accounts.includes(simpleAddress) || kr.accounts.includes(identity.address)
       })
       const addressDomains = addressConnectedDomainMap[identity.address] || {}
@@ -210,7 +210,7 @@ export default class AccountMenu extends Component {
       >
         <a
           className="remove-account-icon"
-          onClick={e => this.removeAccount(e, identity)}
+          onClick={(e) => this.removeAccount(e, identity)}
         />
       </Tooltip>
     )
@@ -275,7 +275,7 @@ export default class AccountMenu extends Component {
 
   onScroll = debounce(this.setShouldShowScrollButton, 25)
 
-  handleScrollDown = e => {
+  handleScrollDown = (e) => {
     e.stopPropagation()
 
     const { scrollHeight } = this.accountsRef
@@ -336,7 +336,7 @@ export default class AccountMenu extends Component {
           <div
             className="account-menu__accounts"
             onScroll={this.onScroll}
-            ref={ref => {
+            ref={(ref) => {
               this.accountsRef = ref
             }}
           >

--- a/ui/app/components/app/account-menu/account-menu.container.js
+++ b/ui/app/components/app/account-menu/account-menu.container.js
@@ -53,7 +53,7 @@ function mapStateToProps (state) {
 function mapDispatchToProps (dispatch) {
   return {
     toggleAccountMenu: () => dispatch(toggleAccountMenu()),
-    showAccountDetail: address => {
+    showAccountDetail: (address) => {
       dispatch(showAccountDetail(address))
       dispatch(hideSidebar())
       dispatch(toggleAccountMenu())
@@ -64,7 +64,7 @@ function mapDispatchToProps (dispatch) {
       dispatch(hideSidebar())
       dispatch(toggleAccountMenu())
     },
-    showRemoveAccountConfirmationModal: identity => {
+    showRemoveAccountConfirmationModal: (identity) => {
       return dispatch(showModal({ name: 'CONFIRM_REMOVE_ACCOUNT', identity }))
     },
   }

--- a/ui/app/components/app/app-header/app-header.component.js
+++ b/ui/app/components/app/app-header/app-header.component.js
@@ -103,7 +103,7 @@ export default class AppHeader extends PureComponent {
                   <NetworkIndicator
                     network={network}
                     provider={provider}
-                    onClick={event => this.handleNetworkIndicatorClick(event)}
+                    onClick={(event) => this.handleNetworkIndicatorClick(event)}
                     disabled={disabled}
                   />
                 </div>

--- a/ui/app/components/app/app-header/app-header.container.js
+++ b/ui/app/components/app/app-header/app-header.container.js
@@ -5,7 +5,7 @@ import { compose } from 'recompose'
 import AppHeader from './app-header.component'
 import * as actions from '../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { appState, metamask } = state
   const { networkDropdownOpen } = appState
   const {
@@ -26,7 +26,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     showNetworkDropdown: () => dispatch(actions.showNetworkDropdown()),
     hideNetworkDropdown: () => dispatch(actions.hideNetworkDropdown()),

--- a/ui/app/components/app/app-header/tests/app-header.test.js
+++ b/ui/app/components/app/app-header/tests/app-header.test.js
@@ -29,7 +29,7 @@ describe('App Header', function () {
     wrapper = shallow(
       <AppHeader.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
           metricsEvent: () => {},
         },
       }

--- a/ui/app/components/app/confirm-page-container/confirm-detail-row/confirm-detail-row.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-detail-row/confirm-detail-row.component.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import UserPreferencedCurrencyDisplay from '../../user-preferenced-currency-display'
 import { PRIMARY, SECONDARY } from '../../../../helpers/constants/common'
 
-const ConfirmDetailRow = props => {
+const ConfirmDetailRow = (props) => {
   const {
     label,
     primaryText,

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import Identicon from '../../../../ui/identicon'
 
-const ConfirmPageContainerSummary = props => {
+const ConfirmPageContainerSummary = (props) => {
   const {
     action,
     title,

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/confirm-page-container-warning.component.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ConfirmPageContainerWarning = props => {
+const ConfirmPageContainerWarning = (props) => {
   return (
     <div className="confirm-page-container-warning">
       <img

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-navigation/confirm-page-container-navigation.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-navigation/confirm-page-container-navigation.component.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ConfirmPageContainerNavigation = props => {
+const ConfirmPageContainerNavigation = (props) => {
   const { onNextTx, totalTx, positionOfCurrentTx, nextTxId, prevTxId, showNavigation, firstTx, lastTx, ofText, requestsWaitingText } = props
 
   return (

--- a/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.container.js
@@ -14,7 +14,7 @@ import {
 } from '../../../selectors/selectors'
 import { getOriginFromUrl } from '../../../helpers/utils/util'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const addressConnectedToCurrentTab = getAddressConnectedToCurrentTab(state)
   const { openMetaMaskTabs } = state.appState
   const { title, url, id } = state.activeTab
@@ -36,7 +36,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     showDisconnectAccountModal: (domainKey, domain) => {
       dispatch(showModal({ name: 'DISCONNECT_ACCOUNT', domainKey, domain }))

--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -39,7 +39,7 @@ function mapDispatchToProps (dispatch) {
       dispatch(actions.delRpcTarget(target))
     },
     hideNetworkDropdown: () => dispatch(actions.hideNetworkDropdown()),
-    setNetworksTabAddMode: isInAddMode => dispatch(actions.setNetworksTabAddMode(isInAddMode)),
+    setNetworksTabAddMode: (isInAddMode) => dispatch(actions.setNetworksTabAddMode(isInAddMode)),
   }
 }
 
@@ -216,7 +216,7 @@ class NetworkDropdown extends Component {
         isOpen={isOpen}
         onClickOutside={(event) => {
           const { classList } = event.target
-          const isInClassList = className => classList.contains(className)
+          const isInClassList = (className) => classList.contains(className)
           const notToggleElementIndex = R.findIndex(isInClassList)(notToggleElementClassnames)
 
           if (notToggleElementIndex === -1) {

--- a/ui/app/components/app/dropdowns/simple-dropdown.js
+++ b/ui/app/components/app/dropdowns/simple-dropdown.js
@@ -17,7 +17,7 @@ class SimpleDropdown extends Component {
 
   getDisplayValue () {
     const { selectedOption, options } = this.props
-    const matchesOption = option => option.value === selectedOption
+    const matchesOption = (option) => option.value === selectedOption
     const matchingOption = R.find(matchesOption)(options)
     return matchingOption
       ? matchingOption.displayValue || matchingOption.value
@@ -41,7 +41,7 @@ class SimpleDropdown extends Component {
       <div>
         <div
           className="simple-dropdown__close-area"
-          onClick={event => {
+          onClick={(event) => {
             event.stopPropagation()
             this.handleClose()
           }}

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
@@ -15,7 +15,7 @@ function convertGasLimitForInputs (gasLimitInHexWEI) {
   return parseInt(gasLimitInHexWEI, 16) || 0
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     showGasPriceInfoModal: () => dispatch(showModal({ name: 'GAS_PRICE_INFO_MODAL' })),
     showGasLimitInfoModal: () => dispatch(showModal({ name: 'GAS_LIMIT_INFO_MODAL' })),

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/tests/advanced-gas-input-component.test.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/tests/advanced-gas-input-component.test.js
@@ -27,7 +27,7 @@ describe('Advanced Gas Inputs', function () {
         {...props}
       />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       })
   })

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
@@ -32,7 +32,7 @@ const mockGasPriceButtonGroupProps = {
       gasEstimateType: GAS_ESTIMATE_TYPES.AVERAGE,
     },
   ],
-  handleGasPriceSelection: newPrice => console.log('NewPrice: ', newPrice),
+  handleGasPriceSelection: (newPrice) => console.log('NewPrice: ', newPrice),
   noButtonActiveByDefault: true,
   showCheck: true,
 }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -49,10 +49,10 @@ export default class GasModalPageContainer extends Component {
     const promise = this.props.hideBasic
       ? Promise.resolve(this.props.blockTime)
       : this.props.fetchBasicGasAndTimeEstimates()
-        .then(basicEstimates => basicEstimates.blockTime)
+        .then((basicEstimates) => basicEstimates.blockTime)
 
     promise
-      .then(blockTime => {
+      .then((blockTime) => {
         this.props.fetchGasEstimates(blockTime)
       })
   }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -165,8 +165,8 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
-  const updateCustomGasPrice = newPrice => dispatch(setCustomGasPrice(addHexPrefix(newPrice)))
+const mapDispatchToProps = (dispatch) => {
+  const updateCustomGasPrice = (newPrice) => dispatch(setCustomGasPrice(addHexPrefix(newPrice)))
 
   return {
     cancelAndClose: () => {
@@ -175,7 +175,7 @@ const mapDispatchToProps = dispatch => {
     },
     hideModal: () => dispatch(hideModal()),
     updateCustomGasPrice,
-    updateCustomGasLimit: newLimit => dispatch(setCustomGasLimit(addHexPrefix(newLimit))),
+    updateCustomGasLimit: (newLimit) => dispatch(setCustomGasLimit(addHexPrefix(newLimit))),
     setGasData: (newLimit, newPrice) => {
       dispatch(setGasLimit(newLimit))
       dispatch(setGasPrice(newPrice))

--- a/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.utils.js
+++ b/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.utils.js
@@ -261,7 +261,7 @@ export function generateChart (gasPrices, estimatedTimes, gasPricesMax, estimate
       contents: function (d) {
         const titleFormat = this.config.tooltip_format_title
         let text
-        d.forEach(el => {
+        d.forEach((el) => {
           if (el && (el.value || el.value === 0) && !text) {
             text = "<table class='" + 'custom-tooltip' + "'>" + "<tr><th colspan='2'>" + titleFormat(el.x) + '</th></tr>'
           }

--- a/ui/app/components/app/gas-customization/gas-slider/gas-slider.component.js
+++ b/ui/app/components/app/gas-customization/gas-slider/gas-slider.component.js
@@ -33,7 +33,7 @@ export default class GasSlider extends Component {
           min={min}
           value={value}
           id="gasSlider"
-          onChange={event => onChange(event.target.value)}
+          onChange={(event) => onChange(event.target.value)}
         />
         <div className="gas-slider__bar">
           <div className="gas-slider__colored" />

--- a/ui/app/components/app/loading-network-screen/loading-network-screen.container.js
+++ b/ui/app/components/app/loading-network-screen/loading-network-screen.container.js
@@ -3,7 +3,7 @@ import LoadingNetworkScreen from './loading-network-screen.component'
 import * as actions from '../../../store/actions'
 import { getNetworkIdentifier } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const {
     loadingMessage,
   } = state.appState
@@ -28,7 +28,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setProviderType: (type) => {
       dispatch(actions.setProviderType(type))

--- a/ui/app/components/app/menu-bar/menu-bar.container.js
+++ b/ui/app/components/app/menu-bar/menu-bar.container.js
@@ -3,7 +3,7 @@ import { WALLET_VIEW_SIDEBAR } from '../sidebars/sidebar.constants'
 import MenuBar from './menu-bar.component'
 import { showSidebar, hideSidebar } from '../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { appState: { sidebar: { isOpen } } } = state
 
   return {
@@ -11,7 +11,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     showSidebar: () => {
       dispatch(showSidebar({

--- a/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -46,7 +46,7 @@ export default class AccountDetailsModal extends Component {
         <EditableLabel
           className="account-modal__name"
           defaultValue={name}
-          onSubmit={label => setAccountLabel(address, label)}
+          onSubmit={(label) => setAccountLabel(address, label)}
         />
 
         <QrView

--- a/ui/app/components/app/modals/add-to-addressbook-modal/add-to-addressbook-modal.component.js
+++ b/ui/app/components/app/modals/add-to-addressbook-modal/add-to-addressbook-modal.component.js
@@ -24,13 +24,13 @@ export default class AddToAddressBookModal extends Component {
     hideModal()
   }
 
-  onChange = e => {
+  onChange = (e) => {
     this.setState({
       alias: e.target.value,
     })
   }
 
-  onKeyPress = e => {
+  onKeyPress = (e) => {
     if (e.key === 'Enter' && this.state.alias) {
       this.onSave()
     }

--- a/ui/app/components/app/modals/cancel-transaction/cancel-transaction.container.js
+++ b/ui/app/components/app/modals/cancel-transaction/cancel-transaction.container.js
@@ -33,7 +33,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     createCancelTransaction: (txId, customGasPrice) => {
       return dispatch(createCancelTransaction(txId, customGasPrice))

--- a/ui/app/components/app/modals/cancel-transaction/tests/cancel-transaction.component.test.js
+++ b/ui/app/components/app/modals/cancel-transaction/tests/cancel-transaction.component.test.js
@@ -7,7 +7,7 @@ import CancelTransactionGasFee from '../cancel-transaction-gas-fee'
 import Modal from '../../../modal'
 
 describe('CancelTransaction Component', function () {
-  const t = key => key
+  const t = (key) => key
 
   it('should render a CancelTransaction modal', function () {
     const wrapper = shallow(

--- a/ui/app/components/app/modals/confirm-delete-network/confirm-delete-network.container.js
+++ b/ui/app/components/app/modals/confirm-delete-network/confirm-delete-network.container.js
@@ -4,7 +4,7 @@ import withModalProps from '../../../../helpers/higher-order-components/with-mod
 import ConfirmDeleteNetwork from './confirm-delete-network.component'
 import { delRpcTarget } from '../../../../store/actions'
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     delRpcTarget: (target) => dispatch(delRpcTarget(target)),
   }

--- a/ui/app/components/app/modals/confirm-delete-network/tests/confirm-delete-network.test.js
+++ b/ui/app/components/app/modals/confirm-delete-network/tests/confirm-delete-network.test.js
@@ -18,7 +18,7 @@ describe('Confirm Delete Network', function () {
     wrapper = mount(
       <ConfirmDeleteNetwork.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/components/app/modals/confirm-remove-account/confirm-remove-account.container.js
+++ b/ui/app/components/app/modals/confirm-remove-account/confirm-remove-account.container.js
@@ -4,13 +4,13 @@ import ConfirmRemoveAccount from './confirm-remove-account.component'
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props'
 import { removeAccount } from '../../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     network: state.metamask.network,
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     removeAccount: (address) => dispatch(removeAccount(address)),
   }

--- a/ui/app/components/app/modals/confirm-remove-account/tests/confirm-remove-account.test.js
+++ b/ui/app/components/app/modals/confirm-remove-account/tests/confirm-remove-account.test.js
@@ -37,7 +37,7 @@ describe('Confirm Remove Account', function () {
         <ConfirmRemoveAccount.WrappedComponent {...props} />
       </Provider>, {
         context: {
-          t: str => str,
+          t: (str) => str,
           store,
         },
         childContextTypes: {

--- a/ui/app/components/app/modals/confirm-reset-account/confirm-reset-account.container.js
+++ b/ui/app/components/app/modals/confirm-reset-account/confirm-reset-account.container.js
@@ -4,7 +4,7 @@ import withModalProps from '../../../../helpers/higher-order-components/with-mod
 import ConfirmResetAccount from './confirm-reset-account.component'
 import { resetAccount } from '../../../../store/actions'
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     resetAccount: () => dispatch(resetAccount()),
   }

--- a/ui/app/components/app/modals/confirm-reset-account/tests/confirm-reset-account.test.js
+++ b/ui/app/components/app/modals/confirm-reset-account/tests/confirm-reset-account.test.js
@@ -16,7 +16,7 @@ describe('Confirm Reset Account', function () {
     wrapper = mount(
       <ConfirmResetAccount.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
+++ b/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
@@ -79,7 +79,7 @@ export default class DepositEtherModal extends Component {
   render () {
     const { network, toWyre, toCoinSwitch, address, toFaucet } = this.props
 
-    const isTestNetwork = ['3', '4', '5', '42'].find(n => n === network)
+    const isTestNetwork = ['3', '4', '5', '42'].find((n) => n === network)
     const networkName = getNetworkDisplayName(network)
 
     return (

--- a/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.container.js
+++ b/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.container.js
@@ -26,7 +26,7 @@ function mapDispatchToProps (dispatch) {
     showAccountDetailModal: () => {
       dispatch(showModal({ name: 'ACCOUNT_DETAILS' }))
     },
-    toFaucet: network => dispatch(buyEth({ network })),
+    toFaucet: (network) => dispatch(buyEth({ network })),
   }
 }
 

--- a/ui/app/components/app/modals/disconnect-account/disconnect-account.container.js
+++ b/ui/app/components/app/modals/disconnect-account/disconnect-account.container.js
@@ -5,17 +5,17 @@ import DisconnectAccount from './disconnect-account.component'
 import { getCurrentAccountWithSendEtherInfo } from '../../../../selectors/selectors'
 import { removePermissionsFor } from '../../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     ...(state.appState.modal.modalState.props || {}),
     accountLabel: getCurrentAccountWithSendEtherInfo(state).name,
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     disconnectAccount: (domainKey, domain) => {
-      const permissionMethodNames = domain.permissions.map(perm => perm.parentCapability)
+      const permissionMethodNames = domain.permissions.map((perm) => perm.parentCapability)
       dispatch(removePermissionsFor({ [domainKey]: permissionMethodNames }))
     },
   }

--- a/ui/app/components/app/modals/disconnect-all/disconnect-all.container.js
+++ b/ui/app/components/app/modals/disconnect-all/disconnect-all.container.js
@@ -5,7 +5,7 @@ import withModalProps from '../../../../helpers/higher-order-components/with-mod
 import DisconnectAll from './disconnect-all.component'
 import { clearPermissions } from '../../../../store/actions'
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     disconnectAll: () => {
       dispatch(clearPermissions())

--- a/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
+++ b/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
@@ -38,7 +38,7 @@ export default class ExportPrivateKeyModal extends Component {
     const { exportAccount } = this.props
 
     exportAccount(password, address)
-      .then(privateKey => this.setState({
+      .then((privateKey) => this.setState({
         privateKey,
         showWarning: false,
       }))
@@ -65,7 +65,7 @@ export default class ExportPrivateKeyModal extends Component {
         <input
           type="password"
           className="private-key-password-input"
-          onChange={event => this.setState({ password: event.target.value })}
+          onChange={(event) => this.setState({ password: event.target.value })}
         />
       )
     }

--- a/ui/app/components/app/modals/fade-modal.js
+++ b/ui/app/components/app/modals/fade-modal.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 let index = 0
 let extraSheet
 
-const insertRule = css => {
+const insertRule = (css) => {
 
   if (!extraSheet) {
     // First time, create an extra stylesheet for adding rules
@@ -20,7 +20,7 @@ const insertRule = css => {
   return extraSheet
 }
 
-const insertKeyframesRule = keyframes => {
+const insertKeyframesRule = (keyframes) => {
   // random name
   const name = 'anim_' + (++index) + (+new Date())
   let css = '@' + 'keyframes ' + name + ' {'
@@ -212,7 +212,7 @@ class FadeModal extends Component {
         <div className="modal" style={modalStyle}>
           <div
             className="content"
-            ref={el => (this.content = el)}
+            ref={(el) => (this.content = el)}
             tabIndex="-1"
             style={contentStyle}
           >

--- a/ui/app/components/app/modals/hide-token-confirmation-modal.js
+++ b/ui/app/components/app/modals/hide-token-confirmation-modal.js
@@ -15,7 +15,7 @@ function mapStateToProps (state) {
 function mapDispatchToProps (dispatch) {
   return {
     hideModal: () => dispatch(actions.hideModal()),
-    hideToken: address => {
+    hideToken: (address) => {
       dispatch(actions.removeToken(address))
         .then(() => {
           dispatch(actions.hideModal())

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.container.js
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.container.js
@@ -12,7 +12,7 @@ const mapStateToProps = (_, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setParticipateInMetaMetrics: (val) => dispatch(setParticipateInMetaMetrics(val)),
   }

--- a/ui/app/components/app/modals/new-account-modal/new-account-modal.component.js
+++ b/ui/app/components/app/modals/new-account-modal/new-account-modal.component.js
@@ -18,7 +18,7 @@ export default class NewAccountModal extends Component {
     alias: '',
   }
 
-  onChange = e => {
+  onChange = (e) => {
     this.setState({
       alias: e.target.value,
     })
@@ -29,7 +29,7 @@ export default class NewAccountModal extends Component {
       .then(this.props.hideModal)
   }
 
-  onKeyPress = e => {
+  onKeyPress = (e) => {
     if (e.key === 'Enter' && this.state.alias) {
       this.onSubmit()
     }

--- a/ui/app/components/app/modals/new-account-modal/new-account-modal.container.js
+++ b/ui/app/components/app/modals/new-account-modal/new-account-modal.container.js
@@ -11,9 +11,9 @@ function mapStateToProps (state) {
 function mapDispatchToProps (dispatch) {
   return {
     hideModal: () => dispatch(actions.hideModal()),
-    createAccount: newAccountName => {
+    createAccount: (newAccountName) => {
       return dispatch(actions.addNewAccount())
-        .then(newAccountAddress => {
+        .then((newAccountAddress) => {
           if (newAccountName) {
             dispatch(actions.setAccountLabel(newAccountAddress, newAccountName))
           }
@@ -36,7 +36,7 @@ function mergeProps (stateProps, dispatchProps) {
     ...dispatchProps,
     onSave: (newAccountName) => {
       return createAccount(newAccountName)
-        .then(newAccountAddress => onCreateNewAccount(newAccountAddress))
+        .then((newAccountAddress) => onCreateNewAccount(newAccountAddress))
     },
   }
 }

--- a/ui/app/components/app/modals/notification-modal.js
+++ b/ui/app/components/app/modals/notification-modal.js
@@ -72,7 +72,7 @@ NotificationModal.propTypes = {
   onConfirm: PropTypes.func,
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     hideModal: () => {
       dispatch(hideModal())

--- a/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -85,7 +85,7 @@ export default class QrScanner extends Component {
       const { permissions } = await WebcamUtils.checkStatus()
       if (permissions) {
         // Let the video stream load first...
-        await new Promise(resolve => setTimeout(resolve, 2000))
+        await new Promise((resolve) => setTimeout(resolve, 2000))
         if (!this.mounted) {
           return
         }

--- a/ui/app/components/app/modals/qr-scanner/qr-scanner.container.js
+++ b/ui/app/components/app/modals/qr-scanner/qr-scanner.container.js
@@ -3,7 +3,7 @@ import QrScanner from './qr-scanner.component'
 
 import { hideModal, qrCodeDetected } from '../../../../store/actions'
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     hideModal: () => dispatch(hideModal()),
     qrCodeDetected: (data) => dispatch(qrCodeDetected(data)),

--- a/ui/app/components/app/modals/reject-transactions/tests/reject-transactions.test.js
+++ b/ui/app/components/app/modals/reject-transactions/tests/reject-transactions.test.js
@@ -17,7 +17,7 @@ describe('Reject Transactions Model', function () {
     wrapper = mount(
       <RejectTransactionsModal.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/components/app/modals/tests/account-details-modal.test.js
+++ b/ui/app/components/app/modals/tests/account-details-modal.test.js
@@ -40,7 +40,7 @@ describe('Account Details Modal', function () {
     wrapper = shallow(
       <AccountDetailsModal.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/components/app/modals/transaction-confirmed/tests/transaction-confirmed.test.js
+++ b/ui/app/components/app/modals/transaction-confirmed/tests/transaction-confirmed.test.js
@@ -13,7 +13,7 @@ describe('Transaction Confirmed', function () {
     const wrapper = mount(
       <TransactionConfirmed.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/components/app/multiple-notifications/multiple-notifications.component.js
+++ b/ui/app/components/app/multiple-notifications/multiple-notifications.component.js
@@ -21,7 +21,7 @@ export default class MultipleNotifications extends PureComponent {
     const { showAll } = this.state
     const { children, classNames } = this.props
 
-    const childrenToRender = children.filter(child => child)
+    const childrenToRender = children.filter((child) => child)
     if (childrenToRender.length === 0) {
       return null
     }

--- a/ui/app/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.component.js
@@ -62,7 +62,7 @@ export default class PermissionPageContainer extends Component {
     return Object.keys(props.request.permissions || {})
   }
 
-  onPermissionToggle = methodName => {
+  onPermissionToggle = (methodName) => {
     this.setState({
       selectedPermissions: {
         ...this.state.selectedPermissions,
@@ -96,7 +96,7 @@ export default class PermissionPageContainer extends Component {
       permissions: { ..._request.permissions },
     }
 
-    Object.keys(this.state.selectedPermissions).forEach(key => {
+    Object.keys(this.state.selectedPermissions).forEach((key) => {
       if (!this.state.selectedPermissions[key]) {
         delete request.permissions[key]
       }

--- a/ui/app/components/app/selected-account/selected-account.container.js
+++ b/ui/app/components/app/selected-account/selected-account.container.js
@@ -3,7 +3,7 @@ import SelectedAccount from './selected-account.component'
 
 import { getSelectedAddress, getSelectedIdentity } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     selectedAddress: getSelectedAddress(state),
     selectedIdentity: getSelectedIdentity(state),

--- a/ui/app/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/app/components/app/signature-request-original/signature-request-original.component.js
@@ -272,7 +272,7 @@ export default class SignatureRequestOriginal extends Component {
           type="default"
           large
           className="request-signature__footer__cancel-button"
-          onClick={async event => {
+          onClick={async (event) => {
             this._removeBeforeUnload()
             await cancel(event)
             this.context.metricsEvent({
@@ -292,7 +292,7 @@ export default class SignatureRequestOriginal extends Component {
           type="secondary"
           large
           className="request-signature__footer__sign-button"
-          onClick={async event => {
+          onClick={async (event) => {
             this._removeBeforeUnload()
             await sign(event)
             this.context.metricsEvent({

--- a/ui/app/components/app/tab-bar.js
+++ b/ui/app/components/app/tab-bar.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
-const TabBar = props => {
+const TabBar = (props) => {
   const { tabs = [], onSelect, isActive } = props
 
   return (

--- a/ui/app/components/app/token-cell/token-cell.container.js
+++ b/ui/app/components/app/token-cell/token-cell.container.js
@@ -17,7 +17,7 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    setSelectedToken: address => dispatch(setSelectedToken(address)),
+    setSelectedToken: (address) => dispatch(setSelectedToken(address)),
     hideSidebar: () => dispatch(hideSidebar()),
   }
 }

--- a/ui/app/components/app/transaction-action/tests/transaction-action.component.test.js
+++ b/ui/app/components/app/transaction-action/tests/transaction-action.component.test.js
@@ -5,13 +5,13 @@ import sinon from 'sinon'
 import TransactionAction from '../transaction-action.component'
 
 describe('TransactionAction Component', function () {
-  const t = key => key
+  const t = (key) => key
 
 
   describe('Outgoing transaction', function () {
     beforeEach(function () {
       global.eth = {
-        getCode: sinon.stub().callsFake(address => {
+        getCode: sinon.stub().callsFake((address) => {
           const code = address === 'approveAddress' ? 'contract' : '0x'
           return Promise.resolve(code)
         }),

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.container.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../transaction-activity-log.container.js', {
   'react-redux': {
-    connect: ms => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -26,7 +26,7 @@ export default class TransactionActivityLog extends PureComponent {
     isEarliestNonce: PropTypes.bool,
   }
 
-  handleActivityClick = hash => {
+  handleActivityClick = (hash) => {
     const { primaryTransaction } = this.props
     const { metamaskNetworkId } = primaryTransaction
 

--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.container.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.container.js
@@ -8,9 +8,9 @@ import {
   TRANSACTION_CANCEL_ATTEMPTED_EVENT,
 } from './transaction-activity-log.constants'
 
-const matchesEventKey = matchEventKey => ({ eventKey }) => eventKey === matchEventKey
+const matchesEventKey = (matchEventKey) => ({ eventKey }) => eventKey === matchEventKey
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     conversionRate: conversionRateSelector(state),
     nativeCurrency: getNativeCurrency(state),

--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.util.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.util.js
@@ -86,7 +86,7 @@ export function getActivities (transaction, isFirstTransaction = false) {
     } else if (Array.isArray(base)) {
       const events = []
 
-      base.forEach(entry => {
+      base.forEach((entry) => {
         const { op, path, value, timestamp: entryTimestamp } = entry
         // Not all sub-entries in a history entry have a timestamp. If the sub-entry does not have a
         // timestamp, the first sub-entry in a history entry should.
@@ -194,7 +194,7 @@ function filterSortedActivities (activities) {
   )))
   let addedDroppedActivity = false
 
-  activities.forEach(activity => {
+  activities.forEach((activity) => {
     if (activity.eventKey === TRANSACTION_DROPPED_EVENT) {
       if (!hasConfirmedActivity && !addedDroppedActivity) {
         filteredActivities.push(activity)

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -58,14 +58,14 @@ export default class TransactionListItemDetails extends PureComponent {
     global.platform.openWindow({ url: getBlockExplorerUrlForTx(metamaskNetworkId, hash, rpcPrefs) })
   }
 
-  handleCancel = event => {
+  handleCancel = (event) => {
     const { transactionGroup: { initialTransaction: { id } = {} } = {}, onCancel } = this.props
 
     event.stopPropagation()
     onCancel(id)
   }
 
-  handleRetry = event => {
+  handleRetry = (event) => {
     const { transactionGroup: { initialTransaction: { id } = {} } = {}, onRetry } = this.props
 
     event.stopPropagation()

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -90,7 +90,7 @@ export default class TransactionListItem extends PureComponent {
     this.setState({ showTransactionDetails: !showTransactionDetails })
   }
 
-  handleCancel = id => {
+  handleCancel = (id) => {
     const {
       primaryTransaction: { txParams: { gasPrice } } = {},
       transaction: { id: initialTransactionId },
@@ -108,7 +108,7 @@ export default class TransactionListItem extends PureComponent {
    * transaction.
    * @param {number} id - Transaction id
    */
-  handleRetry = id => {
+  handleRetry = (id) => {
     const {
       primaryTransaction: { txParams: { gasPrice } } = {},
       transaction: { txParams: { to } = {}, id: initialTransactionId },
@@ -134,7 +134,7 @@ export default class TransactionListItem extends PureComponent {
     })
 
     return fetchBasicGasAndTimeEstimates()
-      .then(basicEstimates => fetchGasEstimates(basicEstimates.blockTime))
+      .then((basicEstimates) => fetchGasEstimates(basicEstimates.blockTime))
       .then(retryTransaction(retryId, gasPrice))
   }
 

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.container.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.container.js
@@ -32,7 +32,7 @@ const mapStateToProps = (state, ownProps) => {
   const selectedAddress = getSelectedAddress(state)
   const selectedAccountBalance = accounts[selectedAddress].balance
   const isDeposit = transactionCategory === 'incoming'
-  const selectRpcInfo = frequentRpcListDetail.find(rpcInfo => rpcInfo.rpcUrl === provider.rpcTarget)
+  const selectRpcInfo = frequentRpcListDetail.find((rpcInfo) => rpcInfo.rpcUrl === provider.rpcTarget)
   const { rpcPrefs } = selectRpcInfo || {}
 
   const hasEnoughCancelGas = primaryTransaction.txParams && isBalanceSufficient({
@@ -58,12 +58,12 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     fetchBasicGasAndTimeEstimates: () => dispatch(fetchBasicGasAndTimeEstimates()),
     fetchGasEstimates: (blockTime) => dispatch(fetchGasEstimates(blockTime)),
-    setSelectedToken: tokenAddress => dispatch(setSelectedToken(tokenAddress)),
-    getContractMethodData: methodData => dispatch(getContractMethodData(methodData)),
+    setSelectedToken: (tokenAddress) => dispatch(setSelectedToken(tokenAddress)),
+    getContractMethodData: (methodData) => dispatch(getContractMethodData(methodData)),
     retryTransaction: (transaction, gasPrice) => {
       dispatch(setCustomGasPriceForRetry(gasPrice || transaction.txParams.gasPrice))
       dispatch(setCustomGasLimit(transaction.txParams.gas))
@@ -100,7 +100,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     primaryTransaction,
     retryTransaction: (transactionId, gasPrice) => {
       const { transactionGroup: { transactions = [] } } = ownProps
-      const transaction = transactions.find(tx => tx.id === transactionId) || {}
+      const transaction = transactions.find((tx) => tx.id === transactionId) || {}
       const increasedGasPrice = increaseLastGasPrice(gasPrice)
       retryTransaction(transaction, increasedGasPrice)
     },

--- a/ui/app/components/app/transaction-list/transaction-list.container.js
+++ b/ui/app/components/app/transaction-list/transaction-list.container.js
@@ -23,9 +23,9 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    updateNetworkNonce: address => dispatch(updateNetworkNonce(address)),
+    updateNetworkNonce: (address) => dispatch(updateNetworkNonce(address)),
     fetchGasEstimates: (blockTime) => dispatch(fetchGasEstimates(blockTime)),
     fetchBasicGasAndTimeEstimates: () => dispatch(fetchBasicGasAndTimeEstimates()),
   }

--- a/ui/app/components/app/transaction-status/tests/transaction-status.component.test.js
+++ b/ui/app/components/app/transaction-status/tests/transaction-status.component.test.js
@@ -11,7 +11,7 @@ describe('TransactionStatus Component', function () {
         statusKey="approved"
         title="test-title"
       />,
-      { context: { t: str => str.toUpperCase() } }
+      { context: { t: (str) => str.toUpperCase() } }
     )
 
     assert.ok(wrapper)
@@ -24,7 +24,7 @@ describe('TransactionStatus Component', function () {
       <TransactionStatus
         statusKey="submitted"
       />,
-      { context: { t: str => str.toUpperCase() } }
+      { context: { t: (str) => str.toUpperCase() } }
     )
 
     assert.ok(wrapper)

--- a/ui/app/components/app/transaction-view-balance/transaction-view-balance.container.js
+++ b/ui/app/components/app/transaction-view-balance/transaction-view-balance.container.js
@@ -14,7 +14,7 @@ import {
 } from '../../../selectors/selectors'
 import { showModal } from '../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { showFiatInTestnets } = preferencesSelector(state)
   const isMainnet = getIsMainnet(state)
   const selectedAddress = getSelectedAddress(state)
@@ -34,7 +34,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     showDepositModal: () => dispatch(showModal({ name: 'DEPOSIT_ETHER' })),
   }

--- a/ui/app/components/app/user-preferenced-currency-input/tests/user-preferenced-currency-input.container.test.js
+++ b/ui/app/components/app/user-preferenced-currency-input/tests/user-preferenced-currency-input.container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../user-preferenced-currency-input.container.js', {
   'react-redux': {
-    connect: ms => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/components/app/user-preferenced-currency-input/user-preferenced-currency-input.container.js
+++ b/ui/app/components/app/user-preferenced-currency-input/user-preferenced-currency-input.container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import UserPreferencedCurrencyInput from './user-preferenced-currency-input.component'
 import { preferencesSelector } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { useNativeCurrencyAsPrimaryCurrency } = preferencesSelector(state)
 
   return {

--- a/ui/app/components/app/user-preferenced-token-input/tests/user-preferenced-token-input.container.test.js
+++ b/ui/app/components/app/user-preferenced-token-input/tests/user-preferenced-token-input.container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../user-preferenced-token-input.container.js', {
   'react-redux': {
-    connect: ms => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/components/app/user-preferenced-token-input/user-preferenced-token-input.container.js
+++ b/ui/app/components/app/user-preferenced-token-input/user-preferenced-token-input.container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import UserPreferencedTokenInput from './user-preferenced-token-input.component'
 import { preferencesSelector } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { useNativeCurrencyAsPrimaryCurrency } = preferencesSelector(state)
 
   return {

--- a/ui/app/components/ui/alert/index.js
+++ b/ui/app/components/ui/alert/index.js
@@ -31,7 +31,7 @@ class Alert extends Component {
       className: 'hidden',
     })
 
-    setTimeout(_ => {
+    setTimeout((_) => {
       this.setState({ visible: false })
     }, 500)
 

--- a/ui/app/components/ui/balance/balance.container.js
+++ b/ui/app/components/ui/balance/balance.container.js
@@ -10,7 +10,7 @@ import {
   preferencesSelector,
 } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { showFiatInTestnets } = preferencesSelector(state)
   const isMainnet = getIsMainnet(state)
   const accounts = getMetaMaskAccounts(state)

--- a/ui/app/components/ui/button-group/tests/button-group-component.test.js
+++ b/ui/app/components/ui/button-group/tests/button-group-component.test.js
@@ -92,7 +92,7 @@ describe('ButtonGroup Component', function () {
 
     it('should render all child buttons as disabled if props.disabled is true', function () {
       const childButtons = wrapper.find('.button-group__button')
-      childButtons.forEach(button => {
+      childButtons.forEach((button) => {
         assert.equal(button.props().disabled, undefined)
       })
       wrapper.setProps({ disabled: true })

--- a/ui/app/components/ui/currency-display/currency-display.container.js
+++ b/ui/app/components/ui/currency-display/currency-display.container.js
@@ -4,7 +4,7 @@ import CurrencyDisplay from './currency-display.component'
 import { getValueFromWeiHex, formatCurrency } from '../../../helpers/utils/confirm-tx.util'
 import { GWEI } from '../../../helpers/constants/common'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { nativeCurrency, currentCurrency, conversionRate } } = state
 
   return {

--- a/ui/app/components/ui/currency-input/currency-input.component.js
+++ b/ui/app/components/ui/currency-input/currency-input.component.js
@@ -83,7 +83,7 @@ export default class CurrencyInput extends PureComponent {
     })
   }
 
-  handleChange = decimalValue => {
+  handleChange = (decimalValue) => {
     const { currentCurrency: fromCurrency, conversionRate, onChange } = this.props
 
     const hexValue = this.shouldUseFiat()

--- a/ui/app/components/ui/currency-input/currency-input.container.js
+++ b/ui/app/components/ui/currency-input/currency-input.container.js
@@ -4,7 +4,7 @@ import { ETH } from '../../../helpers/constants/common'
 import { getMaxModeOn } from '../../../pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.selectors'
 import { getIsMainnet, preferencesSelector } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { nativeCurrency, currentCurrency, conversionRate } } = state
   const { showFiatInTestnets } = preferencesSelector(state)
   const isMainnet = getIsMainnet(state)

--- a/ui/app/components/ui/currency-input/tests/currency-input.component.test.js
+++ b/ui/app/components/ui/currency-input/tests/currency-input.component.test.js
@@ -137,7 +137,7 @@ describe('CurrencyInput Component', function () {
           />
         </Provider>,
         {
-          context: { t: str => str + '_t' },
+          context: { t: (str) => str + '_t' },
           childContextTypes: { t: PropTypes.func },
         }
       )

--- a/ui/app/components/ui/editable-label.js
+++ b/ui/app/components/ui/editable-label.js
@@ -40,7 +40,7 @@ class EditableLabel extends Component {
             this.handleSubmit()
           }
         }}
-        onChange={event => this.setState({ value: event.target.value })}
+        onChange={(event) => this.setState({ value: event.target.value })}
         className={classnames('large-input', 'editable-label__input', {
           'editable-label__input--error': value === '',
         })}

--- a/ui/app/components/ui/error-message/tests/error-message.component.test.js
+++ b/ui/app/components/ui/error-message/tests/error-message.component.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme'
 import ErrorMessage from '../error-message.component'
 
 describe('ErrorMessage Component', function () {
-  const t = key => `translate ${key}`
+  const t = (key) => `translate ${key}`
 
   it('should render a message from props.errorMessage', function () {
     const wrapper = shallow(

--- a/ui/app/components/ui/identicon/identicon.component.js
+++ b/ui/app/components/ui/identicon/identicon.component.js
@@ -7,7 +7,7 @@ import BlockieIdenticon from './blockieIdenticon'
 import { checksumAddress } from '../../../helpers/utils/util'
 import Jazzicon from '../jazzicon'
 
-const getStyles = diameter => (
+const getStyles = (diameter) => (
   {
     height: diameter,
     width: diameter,

--- a/ui/app/components/ui/identicon/identicon.container.js
+++ b/ui/app/components/ui/identicon/identicon.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import Identicon from './identicon.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { useBlockie } } = state
 
   return {

--- a/ui/app/components/ui/page-container/page-container-footer/page-container-footer.component.js
+++ b/ui/app/components/ui/page-container/page-container-footer/page-container-footer.component.js
@@ -44,7 +44,7 @@ export default class PageContainerFooter extends Component {
               type={cancelButtonType || 'default'}
               large={buttonSizeLarge}
               className="page-container__footer-button"
-              onClick={e => onCancel(e)}
+              onClick={(e) => onCancel(e)}
               data-testid="page-container-footer-cancel"
             >
               { cancelText || this.context.t('cancel') }
@@ -56,7 +56,7 @@ export default class PageContainerFooter extends Component {
             large={buttonSizeLarge}
             className="page-container__footer-button"
             disabled={disabled}
-            onClick={e => onSubmit(e)}
+            onClick={(e) => onSubmit(e)}
             data-testid="page-container-footer-next"
           >
             { submitText || this.context.t('next') }

--- a/ui/app/components/ui/page-container/page-container.component.js
+++ b/ui/app/components/ui/page-container/page-container.component.js
@@ -48,7 +48,7 @@ export default class PageContainer extends PureComponent {
 
     return React.Children.map(tabsComponent.props.children, (child, tabIndex) => {
       return child && React.cloneElement(child, {
-        onClick: index => this.handleTabClick(index),
+        onClick: (index) => this.handleTabClick(index),
         tabIndex,
         isActive: numberOfTabs > 1 && tabIndex === this.state.activeTabIndex,
         key: tabIndex,
@@ -61,7 +61,7 @@ export default class PageContainer extends PureComponent {
   renderActiveTabContent () {
     const { tabsComponent } = this.props
     let { children } = tabsComponent.props
-    children = children.filter(child => child)
+    children = children.filter((child) => child)
     const { activeTabIndex } = this.state
 
     return children[activeTabIndex]

--- a/ui/app/components/ui/readonly-input.js
+++ b/ui/app/components/ui/readonly-input.js
@@ -18,7 +18,7 @@ export default function ReadOnlyInput (props) {
         className={inputClass}
         value={value}
         readOnly
-        onFocus={event => event.target.select()}
+        onFocus={(event) => event.target.select()}
         onClick={onClick}
       />
     </div>

--- a/ui/app/components/ui/tabs/tab/tab.component.js
+++ b/ui/app/components/ui/tabs/tab/tab.component.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
-const Tab = props => {
+const Tab = (props) => {
   const { name, onClick, isActive, tabIndex, className, activeClassName } = props
 
   return (
@@ -11,7 +11,7 @@ const Tab = props => {
         className,
         { [activeClassName]: isActive },
       )}
-      onClick={event => {
+      onClick={(event) => {
         event.preventDefault()
         onClick(tabIndex)
       }}

--- a/ui/app/components/ui/tabs/tabs.component.js
+++ b/ui/app/components/ui/tabs/tabs.component.js
@@ -30,7 +30,7 @@ export default class Tabs extends Component {
 
     return React.Children.map(this.props.children, (child, index) => {
       return child && React.cloneElement(child, {
-        onClick: index => this.handleTabClick(index),
+        onClick: (index) => this.handleTabClick(index),
         tabIndex: index,
         isActive: numberOfTabs > 1 && index === this.state.activeTabIndex,
         key: index,

--- a/ui/app/components/ui/toggle-button/toggle-button.component.js
+++ b/ui/app/components/ui/toggle-button/toggle-button.component.js
@@ -45,7 +45,7 @@ const colors = {
   },
 }
 
-const ToggleButton = props => {
+const ToggleButton = (props) => {
   const { value, onToggle, offLabel, onLabel } = props
 
   return (

--- a/ui/app/components/ui/token-balance/token-balance.container.js
+++ b/ui/app/components/ui/token-balance/token-balance.container.js
@@ -4,7 +4,7 @@ import withTokenTracker from '../../../helpers/higher-order-components/with-toke
 import TokenBalance from './token-balance.component'
 import { getSelectedAddress } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     userAddress: getSelectedAddress(state),
   }

--- a/ui/app/components/ui/token-input/tests/token-input.component.test.js
+++ b/ui/app/components/ui/token-input/tests/token-input.component.test.js
@@ -10,7 +10,7 @@ import UnitInput from '../../unit-input'
 import CurrencyDisplay from '../../currency-display'
 
 describe('TokenInput Component', function () {
-  const t = key => `translate ${key}`
+  const t = (key) => `translate ${key}`
 
   describe('rendering', function () {
     it('should render properly without a token', function () {

--- a/ui/app/components/ui/token-input/token-input.component.js
+++ b/ui/app/components/ui/token-input/token-input.component.js
@@ -66,7 +66,7 @@ export default class TokenInput extends PureComponent {
     return Number(decimalValueString) ? decimalValueString : ''
   }
 
-  handleChange = decimalValue => {
+  handleChange = (decimalValue) => {
     const { selectedToken: { decimals } = {}, onChange } = this.props
 
     const multiplier = Math.pow(10, Number(decimals || 0))

--- a/ui/app/components/ui/token-input/token-input.container.js
+++ b/ui/app/components/ui/token-input/token-input.container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import TokenInput from './token-input.component'
 import { getIsMainnet, getSelectedToken, getSelectedTokenExchangeRate, preferencesSelector } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { currentCurrency } } = state
   const { showFiatInTestnets } = preferencesSelector(state)
   const isMainnet = getIsMainnet(state)

--- a/ui/app/components/ui/unit-input/unit-input.component.js
+++ b/ui/app/components/ui/unit-input/unit-input.component.js
@@ -43,7 +43,7 @@ export default class UnitInput extends PureComponent {
     this.unitInput.focus()
   }
 
-  handleChange = event => {
+  handleChange = (event) => {
     const { value: userInput } = event.target
     let value = userInput
 
@@ -81,7 +81,7 @@ export default class UnitInput extends PureComponent {
               placeholder={placeholder}
               onChange={this.handleChange}
               style={{ width: this.getInputWidth(value) }}
-              ref={ref => {
+              ref={(ref) => {
                 this.unitInput = ref
               }}
               disabled={maxModeOn}

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -24,7 +24,7 @@ import { conversionUtil } from '../../helpers/utils/conversion-util'
 import { addHexPrefix } from 'ethereumjs-util'
 
 // Actions
-const createActionType = action => `metamask/confirm-transaction/${action}`
+const createActionType = (action) => `metamask/confirm-transaction/${action}`
 
 const UPDATE_TX_DATA = createActionType('UPDATE_TX_DATA')
 const CLEAR_TX_DATA = createActionType('CLEAR_TX_DATA')

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -482,7 +482,7 @@ describe('Confirm Transaction Duck', function () {
     beforeEach(function () {
       global.eth = {
         getCode: sinon.stub().callsFake(
-          address => Promise.resolve(address && address.match(/isContract/) ? 'not-0x' : '0x')
+          (address) => Promise.resolve(address && address.match(/isContract/) ? 'not-0x' : '0x')
         ),
       }
     })

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -66,12 +66,12 @@ describe('Gas Duck', function () {
     { expectedTime: 1.1, expectedWait: 0.6, gasprice: 19.9, somethingElse: 'foobar' },
     { expectedTime: 1, expectedWait: 0.5, gasprice: 20, somethingElse: 'foobar' },
   ]
-  const fakeFetch = (url) => new Promise(resolve => {
+  const fakeFetch = (url) => new Promise((resolve) => {
     const dataToResolve = url.match(/ethgasAPI/)
       ? mockEthGasApiResponse
       : mockPredictTableResponse
     resolve({
-      json: () => new Promise(resolve => resolve(dataToResolve)),
+      json: () => new Promise((resolve) => resolve(dataToResolve)),
     })
   })
 
@@ -648,7 +648,7 @@ describe('Gas Duck', function () {
       const { type: thirdDispatchCallType, value: priceAndTimeEstimateResult } = mockDistpatch.getCall(2).args[0]
       assert.equal(thirdDispatchCallType, SET_PRICE_AND_TIME_ESTIMATES)
       assert(priceAndTimeEstimateResult.length < mockPredictTableResponse.length * 3 - 2)
-      assert(!priceAndTimeEstimateResult.find(d => d.expectedTime > 100))
+      assert(!priceAndTimeEstimateResult.find((d) => d.expectedTime > 100))
       assert(!priceAndTimeEstimateResult.find((d, _, a) => a[a + 1] && d.expectedTime > a[a + 1].expectedTime))
       assert(!priceAndTimeEstimateResult.find((d, _, a) => a[a + 1] && d.gasprice > a[a + 1].gasprice))
 

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -218,7 +218,7 @@ async function fetchExternalBasicGasEstimates (dispatch) {
     fastTimes10,
     fastestTimes10,
     safeLowTimes10,
-  ].map(price => (new BigNumber(price)).div(10).toNumber())
+  ].map((price) => (new BigNumber(price)).div(10).toNumber())
 
   const basicEstimates = {
     safeLow,
@@ -286,7 +286,7 @@ async function fetchExternalBasicGasAndTimeEstimates (dispatch) {
     fastTimes10,
     fastestTimes10,
     safeLowTimes10,
-  ].map(price => (new BigNumber(price)).div(10).toNumber())
+  ].map((price) => (new BigNumber(price)).div(10).toNumber())
 
   const basicEstimates = {
     average,
@@ -350,11 +350,11 @@ function quartiles (data) {
 }
 
 function inliersByIQR (data, prop) {
-  const { lowerQuartile, upperQuartile } = quartiles(data.map(d => (prop ? d[prop] : d)))
+  const { lowerQuartile, upperQuartile } = quartiles(data.map((d) => (prop ? d[prop] : d)))
   const IQR = upperQuartile - lowerQuartile
   const lowerBound = lowerQuartile - 1.5 * IQR
   const upperBound = upperQuartile + 1.5 * IQR
-  return data.filter(d => {
+  return data.filter((d) => {
     const value = prop ? d[prop] : d
     return value >= lowerBound && value <= upperBound
   })
@@ -385,8 +385,8 @@ export function fetchGasEstimates (blockTime) {
         'method': 'GET',
         'mode': 'cors' }
       )
-        .then(r => r.json())
-        .then(r => {
+        .then((r) => r.json())
+        .then((r) => {
           const estimatedPricesAndTimes = r.map(({ expectedTime, expectedWait, gasprice }) => ({ expectedTime, expectedWait, gasprice }))
           const estimatedTimeWithUniquePrices = uniqBy(({ expectedTime }) => expectedTime, estimatedPricesAndTimes)
 
@@ -439,7 +439,7 @@ export function fetchGasEstimates (blockTime) {
         : loadLocalStorageData('GAS_API_ESTIMATES')
       )
 
-    return promiseToFetch.then(estimates => {
+    return promiseToFetch.then((estimates) => {
       dispatch(setPricesAndTimeEstimates(estimates))
       dispatch(gasEstimatesLoadingFinished())
     })

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -280,7 +280,7 @@ export default function reduceMetamask (state = {}, action) {
     case actions.UPDATE_TRANSACTION_PARAMS:
       const { id: txId, value } = action
       let { selectedAddressTxList } = metamaskState
-      selectedAddressTxList = selectedAddressTxList.map(tx => {
+      selectedAddressTxList = selectedAddressTxList.map((tx) => {
         if (tx.id === txId) {
           const newTx = Object.assign({}, tx)
           newTx.txParams = value

--- a/ui/app/helpers/higher-order-components/authenticated/authenticated.container.js
+++ b/ui/app/helpers/higher-order-components/authenticated/authenticated.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import Authenticated from './authenticated.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { isUnlocked, completedOnboarding } } = state
 
   return {

--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -49,7 +49,7 @@ I18nProvider.childContextTypes = {
   tOrKey: PropTypes.func,
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { localeMessages, metamask: { currentLocale } } = state
   return {
     currentLocale,

--- a/ui/app/helpers/higher-order-components/initialized/initialized.container.js
+++ b/ui/app/helpers/higher-order-components/initialized/initialized.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import Initialized from './initialized.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { completedOnboarding } } = state
 
   return {

--- a/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
+++ b/ui/app/helpers/higher-order-components/metametrics/metametrics.provider.js
@@ -103,7 +103,7 @@ class MetaMetricsProvider extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const txData = txDataSelector(state) || {}
 
   return {

--- a/ui/app/helpers/higher-order-components/with-modal-props/with-modal-props.js
+++ b/ui/app/helpers/higher-order-components/with-modal-props/with-modal-props.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { hideModal } from '../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { appState } = state
   const { props: modalProps } = appState.modal.modalState
 
@@ -10,7 +10,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     hideModal: () => dispatch(hideModal()),
   }

--- a/ui/app/helpers/higher-order-components/with-token-tracker/with-token-tracker.component.js
+++ b/ui/app/helpers/higher-order-components/with-token-tracker/with-token-tracker.component.js
@@ -62,10 +62,10 @@ export default function withTokenTracker (WrappedComponent) {
 
       this.tracker.updateBalances()
         .then(() => this.updateBalance(this.tracker.serialize()))
-        .catch(error => this.setState({ error: error.message }))
+        .catch((error) => this.setState({ error: error.message }))
     }
 
-    setError = error => {
+    setError = (error) => {
       this.setState({ error })
     }
 

--- a/ui/app/helpers/utils/common.util.js
+++ b/ui/app/helpers/utils/common.util.js
@@ -1,5 +1,5 @@
 export function camelCaseToCapitalize (str = '') {
   return str
     .replace(/([A-Z])/g, ' $1')
-    .replace(/^./, str => str.toUpperCase())
+    .replace(/^./, (str) => str.toUpperCase())
 }

--- a/ui/app/helpers/utils/confirm-tx.util.js
+++ b/ui/app/helpers/utils/confirm-tx.util.js
@@ -94,7 +94,7 @@ export function getTransactionFee ({
 export function formatCurrency (value, currencyCode) {
   const upperCaseCurrencyCode = currencyCode.toUpperCase()
 
-  return currencies.find(currency => currency.code === upperCaseCurrencyCode)
+  return currencies.find((currency) => currency.code === upperCaseCurrencyCode)
     ? currencyFormatter.format(Number(value), { code: upperCaseCurrencyCode, style: 'currency' })
     : value
 }

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -40,31 +40,31 @@ const BIG_NUMBER_ETH_MULTIPLIER = new BigNumber('1')
 
 // Setter Maps
 const toBigNumber = {
-  hex: n => new BigNumber(stripHexPrefix(n), 16),
-  dec: n => new BigNumber(String(n), 10),
-  BN: n => new BigNumber(n.toString(16), 16),
+  hex: (n) => new BigNumber(stripHexPrefix(n), 16),
+  dec: (n) => new BigNumber(String(n), 10),
+  BN: (n) => new BigNumber(n.toString(16), 16),
 }
 const toNormalizedDenomination = {
-  WEI: bigNumber => bigNumber.div(BIG_NUMBER_WEI_MULTIPLIER),
-  GWEI: bigNumber => bigNumber.div(BIG_NUMBER_GWEI_MULTIPLIER),
-  ETH: bigNumber => bigNumber.div(BIG_NUMBER_ETH_MULTIPLIER),
+  WEI: (bigNumber) => bigNumber.div(BIG_NUMBER_WEI_MULTIPLIER),
+  GWEI: (bigNumber) => bigNumber.div(BIG_NUMBER_GWEI_MULTIPLIER),
+  ETH: (bigNumber) => bigNumber.div(BIG_NUMBER_ETH_MULTIPLIER),
 }
 const toSpecifiedDenomination = {
-  WEI: bigNumber => bigNumber.times(BIG_NUMBER_WEI_MULTIPLIER).round(),
-  GWEI: bigNumber => bigNumber.times(BIG_NUMBER_GWEI_MULTIPLIER).round(9),
-  ETH: bigNumber => bigNumber.times(BIG_NUMBER_ETH_MULTIPLIER).round(9),
+  WEI: (bigNumber) => bigNumber.times(BIG_NUMBER_WEI_MULTIPLIER).round(),
+  GWEI: (bigNumber) => bigNumber.times(BIG_NUMBER_GWEI_MULTIPLIER).round(9),
+  ETH: (bigNumber) => bigNumber.times(BIG_NUMBER_ETH_MULTIPLIER).round(9),
 }
 const baseChange = {
-  hex: n => n.toString(16),
-  dec: n => (new BigNumber(n)).toString(10),
-  BN: n => new BN(n.toString(16)),
+  hex: (n) => n.toString(16),
+  dec: (n) => (new BigNumber(n)).toString(10),
+  BN: (n) => new BN(n.toString(16)),
 }
 
 // Individual Setters
 const convert = R.invoker(1, 'times')
 const round = R.invoker(2, 'round')(R.__, BigNumber.ROUND_HALF_DOWN)
 const roundDown = R.invoker(2, 'round')(R.__, BigNumber.ROUND_DOWN)
-const invertConversionRate = conversionRate => () => new BigNumber(1.0).div(conversionRate)
+const invertConversionRate = (conversionRate) => () => new BigNumber(1.0).div(conversionRate)
 const decToBigNumberViaString = () => R.pipe(String, toBigNumber['dec'])
 
 // Predicates

--- a/ui/app/helpers/utils/switch-direction.js
+++ b/ui/app/helpers/utils/switch-direction.js
@@ -8,8 +8,8 @@ const switchDirection = async (direction) => {
   }
   let updatedLink
   Array.from(document.getElementsByTagName('link'))
-    .filter(link => link.rel === 'stylesheet')
-    .forEach(link => {
+    .filter((link) => link.rel === 'stylesheet')
+    .forEach((link) => {
       if (link.title === direction && link.disabled) {
         link.disabled = false
         updatedLink = link

--- a/ui/app/helpers/utils/token-util.js
+++ b/ui/app/helpers/utils/token-util.js
@@ -134,11 +134,11 @@ export function calcTokenValue (value, decimals) {
 }
 
 export function getTokenValue (tokenParams = []) {
-  const valueData = tokenParams.find(param => param.name === '_value')
+  const valueData = tokenParams.find((param) => param.name === '_value')
   return valueData && valueData.value
 }
 
 export function getTokenToAddress (tokenParams = []) {
-  const toAddressData = tokenParams.find(param => param.name === '_to')
+  const toAddressData = tokenParams.find((param) => param.name === '_to')
   return toAddressData ? toAddressData.value : tokenParams[0].value
 }

--- a/ui/app/pages/add-token/add-token.component.js
+++ b/ui/app/pages/add-token/add-token.component.js
@@ -49,7 +49,7 @@ class AddToken extends Component {
       let selectedTokens = {}
       let customToken = {}
 
-      pendingTokenKeys.forEach(tokenAddress => {
+      pendingTokenKeys.forEach((tokenAddress) => {
         const token = pendingTokens[tokenAddress]
         const { isCustom } = token
 
@@ -228,7 +228,7 @@ class AddToken extends Component {
           label={this.context.t('tokenContractAddress')}
           type="text"
           value={customAddress}
-          onChange={e => this.handleCustomAddressChange(e.target.value)}
+          onChange={(e) => this.handleCustomAddressChange(e.target.value)}
           error={customAddressError}
           fullWidth
           margin="normal"
@@ -252,7 +252,7 @@ class AddToken extends Component {
           )}
           type="text"
           value={customSymbol}
-          onChange={e => this.handleCustomSymbolChange(e.target.value)}
+          onChange={(e) => this.handleCustomSymbolChange(e.target.value)}
           error={customSymbolError}
           fullWidth
           margin="normal"
@@ -263,7 +263,7 @@ class AddToken extends Component {
           label={this.context.t('decimal')}
           type="number"
           value={customDecimals}
-          onChange={e => this.handleCustomDecimalsChange(e.target.value)}
+          onChange={(e) => this.handleCustomDecimalsChange(e.target.value)}
           error={customDecimalsError}
           fullWidth
           margin="normal"
@@ -286,7 +286,7 @@ class AddToken extends Component {
           <TokenList
             results={searchResults}
             selectedTokens={selectedTokens}
-            onToggleToken={token => this.handleToggleToken(token)}
+            onToggleToken={(token) => this.handleToggleToken(token)}
           />
         </div>
       </div>

--- a/ui/app/pages/add-token/add-token.container.js
+++ b/ui/app/pages/add-token/add-token.container.js
@@ -12,9 +12,9 @@ const mapStateToProps = ({ metamask }) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    setPendingTokens: tokens => dispatch(setPendingTokens(tokens)),
+    setPendingTokens: (tokens) => dispatch(setPendingTokens(tokens)),
     clearPendingTokens: () => dispatch(clearPendingTokens()),
   }
 }

--- a/ui/app/pages/add-token/token-search/token-search.component.js
+++ b/ui/app/pages/add-token/token-search/token-search.component.js
@@ -7,7 +7,7 @@ import TextField from '../../../components/ui/text-field'
 
 const contractList = Object.entries(contractMap)
   .map(([ _, tokenData]) => tokenData)
-  .filter(tokenData => Boolean(tokenData.erc20))
+  .filter((tokenData) => Boolean(tokenData.erc20))
 
 const fuse = new Fuse(contractList, {
   shouldSort: true,
@@ -43,7 +43,7 @@ export default class TokenSearch extends Component {
   handleSearch (searchQuery) {
     this.setState({ searchQuery })
     const fuseSearchResult = fuse.search(searchQuery)
-    const addressSearchResult = contractList.filter(token => {
+    const addressSearchResult = contractList.filter((token) => {
       return token.address.toLowerCase() === searchQuery.toLowerCase()
     })
     const results = [...addressSearchResult, ...fuseSearchResult]
@@ -71,7 +71,7 @@ export default class TokenSearch extends Component {
         placeholder={this.context.t('searchTokens')}
         type="text"
         value={searchQuery}
-        onChange={e => this.handleSearch(e.target.value)}
+        onChange={(e) => this.handleSearch(e.target.value)}
         error={error}
         fullWidth
         startAdornment={this.renderAdornment()}

--- a/ui/app/pages/add-token/util.js
+++ b/ui/app/pages/add-token/util.js
@@ -5,7 +5,7 @@ export function checkExistingAddresses (address, tokenList = []) {
     return false
   }
 
-  const matchesAddress = existingToken => {
+  const matchesAddress = (existingToken) => {
     return existingToken.address.toLowerCase() === address.toLowerCase()
   }
 

--- a/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.container.js
+++ b/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.container.js
@@ -13,7 +13,7 @@ const mapStateToProps = ({ metamask }) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     addToken: ({ address, symbol, decimals, image }) => dispatch(addToken(address, symbol, Number(decimals), image)),
     removeSuggestedTokens: () => dispatch(removeSuggestedTokens()),

--- a/ui/app/pages/confirm-add-token/confirm-add-token.container.js
+++ b/ui/app/pages/confirm-add-token/confirm-add-token.container.js
@@ -10,9 +10,9 @@ const mapStateToProps = ({ metamask }) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    addTokens: tokens => dispatch(addTokens(tokens)),
+    addTokens: (tokens) => dispatch(addTokens(tokens)),
     clearPendingTokens: () => dispatch(clearPendingTokens()),
   }
 }

--- a/ui/app/pages/confirm-deploy-contract/confirm-deploy-contract.container.js
+++ b/ui/app/pages/confirm-deploy-contract/confirm-deploy-contract.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import ConfirmDeployContract from './confirm-deploy-contract.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { confirmTransaction: { txData } = {} } = state
 
   return {

--- a/ui/app/pages/confirm-send-ether/confirm-send-ether.component.js
+++ b/ui/app/pages/confirm-send-ether/confirm-send-ether.component.js
@@ -32,7 +32,7 @@ export default class ConfirmSendEther extends Component {
       <ConfirmTransactionBase
         actionKey="confirm"
         hideData={hideData}
-        onEdit={confirmTransactionData => this.handleEdit(confirmTransactionData)}
+        onEdit={(confirmTransactionData) => this.handleEdit(confirmTransactionData)}
       />
     )
   }

--- a/ui/app/pages/confirm-send-ether/confirm-send-ether.container.js
+++ b/ui/app/pages/confirm-send-ether/confirm-send-ether.container.js
@@ -5,7 +5,7 @@ import { updateSend } from '../../store/actions'
 import { clearConfirmTransaction } from '../../ducks/confirm-transaction/confirm-transaction.duck'
 import ConfirmSendEther from './confirm-send-ether.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { confirmTransaction: { txData: { txParams } = {} } } = state
 
   return {
@@ -13,9 +13,9 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    editTransaction: txData => {
+    editTransaction: (txData) => {
       const { id, txParams } = txData
       const {
         gas: gasLimit,

--- a/ui/app/pages/confirm-send-token/confirm-send-token.component.js
+++ b/ui/app/pages/confirm-send-token/confirm-send-token.component.js
@@ -21,7 +21,7 @@ export default class ConfirmSendToken extends Component {
 
     return (
       <ConfirmTokenTransactionBaseContainer
-        onEdit={confirmTransactionData => this.handleEdit(confirmTransactionData)}
+        onEdit={(confirmTransactionData) => this.handleEdit(confirmTransactionData)}
         tokenAmount={tokenAmount}
       />
     )

--- a/ui/app/pages/confirm-send-token/confirm-send-token.container.js
+++ b/ui/app/pages/confirm-send-token/confirm-send-token.container.js
@@ -7,7 +7,7 @@ import { setSelectedToken, updateSend, showSendTokenPage } from '../../store/act
 import { conversionUtil } from '../../helpers/utils/conversion-util'
 import { sendTokenTokenAmountAndToAddressSelector } from '../../selectors/confirm-transaction'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { tokenAmount } = sendTokenTokenAmountAndToAddressSelector(state)
 
   return {
@@ -15,7 +15,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     editTransaction: ({ txData, tokenData, tokenProps }) => {
       const { txParams: { to: tokenAddress, gas: gasLimit, gasPrice } = {}, id } = txData

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -247,8 +247,8 @@ export default class ConfirmTransactionBase extends Component {
             {advancedInlineGasShown
               ? (
                 <AdvancedGasInputs
-                  updateCustomGasPrice={newGasPrice => updateGasAndCalculate({ ...customGas, gasPrice: newGasPrice })}
-                  updateCustomGasLimit={newGasLimit => updateGasAndCalculate({ ...customGas, gasLimit: newGasLimit })}
+                  updateCustomGasPrice={(newGasPrice) => updateGasAndCalculate({ ...customGas, gasPrice: newGasPrice })}
+                  updateCustomGasLimit={(newGasLimit) => updateGasAndCalculate({ ...customGas, gasLimit: newGasLimit })}
                   customGasPrice={customGas.gasPrice}
                   customGasLimit={customGas.gasLimit}
                   insufficientBalance={insufficientBalance}
@@ -491,7 +491,7 @@ export default class ConfirmTransactionBase extends Component {
                   updateCustomNonce('')
                 })
               })
-              .catch(error => {
+              .catch((error) => {
                 this.setState({
                   submitting: false,
                   submitError: error.message,

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -38,7 +38,7 @@ const casedContractMap = Object.keys(contractMap).reduce((acc, base) => {
 }, {})
 
 let customNonceValue = ''
-const customNonceMerge = txData => (customNonceValue ? ({
+const customNonceMerge = (txData) => (customNonceValue ? ({
   ...txData,
   customNonceValue,
 }) : txData)
@@ -110,7 +110,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   const currentNetworkUnapprovedTxs = Object.keys(unapprovedTxs)
-    .filter(key => unapprovedTxs[key].metamaskNetworkId === network)
+    .filter((key) => unapprovedTxs[key].metamaskNetworkId === network)
     .reduce((acc, key) => ({ ...acc, [key]: unapprovedTxs[key] }), {})
   const unapprovedTxCount = valuesFor(currentNetworkUnapprovedTxs).length
 
@@ -173,12 +173,12 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export const mapDispatchToProps = dispatch => {
+export const mapDispatchToProps = (dispatch) => {
   return {
     tryReverseResolveAddress: (address) => {
       return dispatch(tryReverseResolveAddress(address))
     },
-    updateCustomNonce: value => {
+    updateCustomNonce: (value) => {
       customNonceValue = value
       dispatch(updateCustomNonce(value))
     },
@@ -197,8 +197,8 @@ export const mapDispatchToProps = dispatch => {
     },
     cancelTransaction: ({ id }) => dispatch(cancelTx({ id })),
     cancelAllTransactions: (txList) => dispatch(cancelTxs(txList)),
-    sendTransaction: txData => dispatch(updateAndApproveTx(customNonceMerge(txData))),
-    setMetaMetricsSendCount: val => dispatch(setMetaMetricsSendCount(val)),
+    sendTransaction: (txData) => dispatch(updateAndApproveTx(customNonceMerge(txData))),
+    setMetaMetricsSendCount: (val) => dispatch(setMetaMetricsSendCount(val)),
     getNextNonce: () => dispatch(getNextNonce()),
   }
 }
@@ -264,7 +264,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...ownProps,
     showCustomizeGasModal: () => dispatchShowCustomizeGasModal({
       txData,
-      onSubmit: customGas => dispatchUpdateGasAndCalculate(customGas),
+      onSubmit: (customGas) => dispatchUpdateGasAndCalculate(customGas),
       validate: validateEditGas,
     }),
     cancelAllTransactions: () => dispatchCancelAllTransactions(valuesFor(unapprovedTxs)),

--- a/ui/app/pages/confirm-transaction/confirm-transaction.container.js
+++ b/ui/app/pages/confirm-transaction/confirm-transaction.container.js
@@ -53,9 +53,9 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    setTransactionToConfirm: transactionId => {
+    setTransactionToConfirm: (transactionId) => {
       dispatch(setTransactionToConfirm(transactionId))
     },
     clearConfirmTransaction: () => dispatch(clearConfirmTransaction()),

--- a/ui/app/pages/create-account/connect-hardware/connect-screen.js
+++ b/ui/app/pages/create-account/connect-hardware/connect-screen.js
@@ -30,7 +30,7 @@ class ConnectScreen extends Component {
         className={classnames('hw-connect__btn', {
           'selected': this.state.selectedDevice === 'trezor',
         })}
-        onClick={_ => this.setState({ selectedDevice: 'trezor' })}
+        onClick={(_) => this.setState({ selectedDevice: 'trezor' })}
       >
         <img
           className="hw-connect__btn__img"
@@ -47,7 +47,7 @@ class ConnectScreen extends Component {
         className={classnames('hw-connect__btn', {
           'selected': this.state.selectedDevice === 'ledger',
         })}
-        onClick={_ => this.setState({ selectedDevice: 'ledger' })}
+        onClick={(_) => this.setState({ selectedDevice: 'ledger' })}
       >
         <img
           className="hw-connect__btn__img"
@@ -174,7 +174,7 @@ class ConnectScreen extends Component {
     return (
       <div
         className="hw-tutorial"
-        ref={node => {
+        ref={(node) => {
           this.referenceNode = node
         }}
       >

--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -20,7 +20,7 @@ class ConnectHardwareForm extends Component {
 
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { accounts } = nextProps
-    const newAccounts = this.state.accounts.map(a => {
+    const newAccounts = this.state.accounts.map((a) => {
       const normalizedAddress = a.address.toLowerCase()
       const balanceValue = accounts[normalizedAddress] && accounts[normalizedAddress].balance || null
       a.balance = balanceValue ? formatBalance(balanceValue, 6) : '...'
@@ -35,7 +35,7 @@ class ConnectHardwareForm extends Component {
   }
 
   async checkIfUnlocked () {
-    ['trezor', 'ledger'].forEach(async device => {
+    ['trezor', 'ledger'].forEach(async (device) => {
       const unlocked = await this.props.checkHardwareStatus(device, this.props.defaultHdPaths[device])
       if (unlocked) {
         this.setState({ unlocked: true })
@@ -69,7 +69,7 @@ class ConnectHardwareForm extends Component {
   showTemporaryAlert () {
     this.props.showAlert(this.context.t('hardwareWalletConnected'))
     // Autohide the alert after 5 seconds
-    setTimeout(_ => {
+    setTimeout((_) => {
       this.props.hideAlert()
     }, 5000)
   }
@@ -77,7 +77,7 @@ class ConnectHardwareForm extends Component {
   getPage = (device, page, hdPath) => {
     this.props
       .connectHardware(device, page, hdPath)
-      .then(accounts => {
+      .then((accounts) => {
         if (accounts.length) {
 
           // If we just loaded the accounts for the first time
@@ -95,13 +95,13 @@ class ConnectHardwareForm extends Component {
               }
             })
           // If the page doesn't contain the selected account, let's deselect it
-          } else if (!accounts.filter(a => a.index.toString() === this.state.selectedAccount).length) {
+          } else if (!accounts.filter((a) => a.index.toString() === this.state.selectedAccount).length) {
             newState.selectedAccount = null
           }
 
 
           // Map accounts with balances
-          newState.accounts = accounts.map(account => {
+          newState.accounts = accounts.map((account) => {
             const normalizedAddress = account.address.toLowerCase()
             const balanceValue = this.props.accounts[normalizedAddress] && this.props.accounts[normalizedAddress].balance || null
             account.balance = balanceValue ? formatBalance(balanceValue, 6) : '...'
@@ -111,7 +111,7 @@ class ConnectHardwareForm extends Component {
           this.setState(newState)
         }
       })
-      .catch(e => {
+      .catch((e) => {
         const errorMessage = e.message
         if (errorMessage === 'Window blocked') {
           this.setState({ browserSupported: false, error: null })
@@ -123,14 +123,14 @@ class ConnectHardwareForm extends Component {
 
   onForgetDevice = (device) => {
     this.props.forgetDevice(device)
-      .then(_ => {
+      .then((_) => {
         this.setState({
           error: null,
           selectedAccount: null,
           accounts: [],
           unlocked: false,
         })
-      }).catch(e => {
+      }).catch((e) => {
         this.setState({ error: e.message })
       })
   }
@@ -142,7 +142,7 @@ class ConnectHardwareForm extends Component {
     }
 
     this.props.unlockHardwareWalletAccount(this.state.selectedAccount, device)
-      .then(_ => {
+      .then((_) => {
         this.context.metricsEvent({
           eventOpts: {
             category: 'Accounts',
@@ -151,7 +151,7 @@ class ConnectHardwareForm extends Component {
           },
         })
         this.props.history.push(DEFAULT_ROUTE)
-      }).catch(e => {
+      }).catch((e) => {
         this.context.metricsEvent({
           eventOpts: {
             category: 'Accounts',
@@ -236,7 +236,7 @@ ConnectHardwareForm.propTypes = {
   defaultHdPaths: PropTypes.object,
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const {
     metamask: { network, selectedAddress },
   } = state
@@ -253,7 +253,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setHardwareWalletDefaultHdPath: ({ device, path }) => {
       return dispatch(actions.setHardwareWalletDefaultHdPath({ device, path }))

--- a/ui/app/pages/create-account/create-account.component.js
+++ b/ui/app/pages/create-account/create-account.component.js
@@ -14,7 +14,7 @@ import {
 export default class CreateAccountPage extends Component {
   renderTabs () {
     const { history, location: { pathname } } = this.props
-    const getClassNames = path => classnames('new-account__tabs__tab', {
+    const getClassNames = (path) => classnames('new-account__tabs__tab', {
       'new-account__tabs__selected': matchPath(pathname, {
         path,
         exact: true,

--- a/ui/app/pages/create-account/import-account/json.js
+++ b/ui/app/pages/create-account/import-account/json.js
@@ -123,7 +123,7 @@ class JsonImportSubview extends Component {
           setSelectedAddress(firstAddress)
         }
       })
-      .catch(err => err && displayWarning(err.message || err))
+      .catch((err) => err && displayWarning(err.message || err))
   }
 
   checkInputEmpty () {
@@ -145,17 +145,17 @@ JsonImportSubview.propTypes = {
   setSelectedAddress: PropTypes.func,
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     error: state.appState.warning,
     firstAddress: Object.keys(getMetaMaskAccounts(state))[0],
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    displayWarning: warning => dispatch(actions.displayWarning(warning)),
-    importNewJsonAccount: options => dispatch(actions.importNewAccount('JSON File', options)),
+    displayWarning: (warning) => dispatch(actions.displayWarning(warning)),
+    importNewJsonAccount: (options) => dispatch(actions.importNewAccount('JSON File', options)),
     setSelectedAddress: (address) => dispatch(actions.setSelectedAddress(address)),
   }
 }

--- a/ui/app/pages/create-account/import-account/private-key.js
+++ b/ui/app/pages/create-account/import-account/private-key.js
@@ -55,7 +55,7 @@ class PrivateKeyImportView extends Component {
           setSelectedAddress(firstAddress)
         }
       })
-      .catch(err => err && displayWarning(err.message || err))
+      .catch((err) => err && displayWarning(err.message || err))
   }
 
   createKeyringOnEnter = (event) => {
@@ -87,7 +87,7 @@ class PrivateKeyImportView extends Component {
             className="new-account-import-form__input-password"
             type="password"
             id="private-key-box"
-            onKeyPress={e => this.createKeyringOnEnter(e)}
+            onKeyPress={(e) => this.createKeyringOnEnter(e)}
             onChange={() => this.checkInputEmpty()}
             ref={this.inputRef}
           />

--- a/ui/app/pages/create-account/new-account.component.js
+++ b/ui/app/pages/create-account/new-account.component.js
@@ -18,7 +18,7 @@ export default class NewAccountCreateForm extends Component {
   render () {
     const { newAccountName, defaultAccountName } = this.state
     const { history, createAccount } = this.props
-    const createClick = _ => {
+    const createClick = (_) => {
       createAccount(newAccountName || defaultAccountName)
         .then(() => {
           this.context.metricsEvent({
@@ -54,7 +54,7 @@ export default class NewAccountCreateForm extends Component {
             className="new-account-create-form__input"
             value={newAccountName}
             placeholder={defaultAccountName}
-            onChange={event => this.setState({ newAccountName: event.target.value })}
+            onChange={(event) => this.setState({ newAccountName: event.target.value })}
           />
         </div>
         <div className="new-account-create-form__buttons">

--- a/ui/app/pages/create-account/new-account.container.js
+++ b/ui/app/pages/create-account/new-account.container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import * as actions from '../../store/actions'
 import NewAccountCreateForm from './new-account.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { network, selectedAddress, identities = {} } } = state
   const numberOfExistingAccounts = Object.keys(identities).length
   const newAccountNumber = numberOfExistingAccounts + 1
@@ -14,12 +14,12 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    toCoinbase: address => dispatch(actions.buyEth({ network: '1', address, amount: 0 })),
-    createAccount: newAccountName => {
+    toCoinbase: (address) => dispatch(actions.buyEth({ network: '1', address, amount: 0 })),
+    createAccount: (newAccountName) => {
       return dispatch(actions.addNewAccount())
-        .then(newAccountAddress => {
+        .then((newAccountAddress) => {
           if (newAccountName) {
             dispatch(actions.setAccountLabel(newAccountAddress, newAccountName))
           }

--- a/ui/app/pages/first-time-flow/create-password/create-password.component.js
+++ b/ui/app/pages/first-time-flow/create-password/create-password.component.js
@@ -36,7 +36,7 @@ export default class CreatePassword extends PureComponent {
           <Route
             exact
             path={INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE}
-            render={routeProps => (
+            render={(routeProps) => (
               <ImportWithSeedPhrase
                 { ...routeProps }
                 onSubmit={onCreateNewAccountFromSeed}
@@ -46,7 +46,7 @@ export default class CreatePassword extends PureComponent {
           <Route
             exact
             path={INITIALIZE_CREATE_PASSWORD_ROUTE}
-            render={routeProps => (
+            render={(routeProps) => (
               <NewAccount
                 { ...routeProps }
                 onSubmit={onCreateNewAccount}

--- a/ui/app/pages/first-time-flow/create-password/create-password.container.js
+++ b/ui/app/pages/first-time-flow/create-password/create-password.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import CreatePassword from './create-password.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { isInitialized } } = state
 
   return {

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -87,7 +87,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
   handlePasswordChange (password) {
     const { t } = this.context
 
-    this.setState(state => {
+    this.setState((state) => {
       const { confirmPassword } = state
       let confirmPasswordError = ''
       let passwordError = ''
@@ -111,7 +111,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
   handleConfirmPasswordChange (confirmPassword) {
     const { t } = this.context
 
-    this.setState(state => {
+    this.setState((state) => {
       const { password } = state
       let confirmPasswordError = ''
 
@@ -126,7 +126,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
     })
   }
 
-  handleImport = async event => {
+  handleImport = async (event) => {
     event.preventDefault()
 
     if (!this.isValid()) {
@@ -206,7 +206,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
       >
         <div className="first-time-flow__create-back">
           <a
-            onClick={e => {
+            onClick={(e) => {
               e.preventDefault()
               this.context.metricsEvent({
                 eventOpts: {
@@ -236,7 +236,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
           <label>{ t('walletSeed') }</label>
           <textarea
             className="first-time-flow__textarea"
-            onChange={e => this.handleSeedPhraseChange(e.target.value)}
+            onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
             value={this.state.seedPhrase}
             placeholder={t('seedPhrasePlaceholder')}
           />
@@ -254,7 +254,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
           type="password"
           className="first-time-flow__input"
           value={this.state.password}
-          onChange={event => this.handlePasswordChange(event.target.value)}
+          onChange={(event) => this.handlePasswordChange(event.target.value)}
           error={passwordError}
           autoComplete="new-password"
           margin="normal"
@@ -266,7 +266,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
           type="password"
           className="first-time-flow__input"
           value={this.state.confirmPassword}
-          onChange={event => this.handleConfirmPasswordChange(event.target.value)}
+          onChange={(event) => this.handleConfirmPasswordChange(event.target.value)}
           error={confirmPasswordError}
           autoComplete="confirm-password"
           margin="normal"

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.container.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.container.js
@@ -5,7 +5,7 @@ import {
   initializeThreeBox,
 } from '../../../../store/actions'
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setSeedPhraseBackedUp: (seedPhraseBackupState) => dispatch(setSeedPhraseBackedUp(seedPhraseBackupState)),
     initializeThreeBox: () => dispatch(initializeThreeBox()),

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
@@ -7,7 +7,7 @@ import ImportWithSeedPhrase from '../import-with-seed-phrase.component'
 function shallowRender (props = {}, context = {}) {
   return shallow(<ImportWithSeedPhrase {...props} />, {
     context: {
-      t: str => str + '_t',
+      t: (str) => str + '_t',
       metricsEvent: sinon.spy(),
       ...context,
     },

--- a/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -48,7 +48,7 @@ export default class NewAccount extends PureComponent {
   handlePasswordChange (password) {
     const { t } = this.context
 
-    this.setState(state => {
+    this.setState((state) => {
       const { confirmPassword } = state
       let passwordError = ''
       let confirmPasswordError = ''
@@ -72,7 +72,7 @@ export default class NewAccount extends PureComponent {
   handleConfirmPasswordChange (confirmPassword) {
     const { t } = this.context
 
-    this.setState(state => {
+    this.setState((state) => {
       const { password } = state
       let confirmPasswordError = ''
 
@@ -87,7 +87,7 @@ export default class NewAccount extends PureComponent {
     })
   }
 
-  handleCreate = async event => {
+  handleCreate = async (event) => {
     event.preventDefault()
 
     if (!this.isValid()) {
@@ -142,7 +142,7 @@ export default class NewAccount extends PureComponent {
       <div>
         <div className="first-time-flow__create-back">
           <a
-            onClick={e => {
+            onClick={(e) => {
               e.preventDefault()
               this.context.metricsEvent({
                 eventOpts: {
@@ -171,7 +171,7 @@ export default class NewAccount extends PureComponent {
             type="password"
             className="first-time-flow__input"
             value={password}
-            onChange={event => this.handlePasswordChange(event.target.value)}
+            onChange={(event) => this.handlePasswordChange(event.target.value)}
             error={passwordError}
             autoFocus
             autoComplete="new-password"
@@ -185,7 +185,7 @@ export default class NewAccount extends PureComponent {
             type="password"
             className="first-time-flow__input"
             value={confirmPassword}
-            onChange={event => this.handleConfirmPasswordChange(event.target.value)}
+            onChange={(event) => this.handleConfirmPasswordChange(event.target.value)}
             error={confirmPasswordError}
             autoComplete="confirm-password"
             margin="normal"

--- a/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.container.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.container.js
@@ -17,7 +17,7 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     completeOnboarding: () => dispatch(setCompletedOnboarding()),
   }

--- a/ui/app/pages/first-time-flow/first-time-flow.component.js
+++ b/ui/app/pages/first-time-flow/first-time-flow.component.js
@@ -62,7 +62,7 @@ export default class FirstTimeFlow extends PureComponent {
     }
   }
 
-  handleCreateNewAccount = async password => {
+  handleCreateNewAccount = async (password) => {
     const { createNewAccount } = this.props
 
     try {
@@ -85,7 +85,7 @@ export default class FirstTimeFlow extends PureComponent {
     }
   }
 
-  handleUnlock = async password => {
+  handleUnlock = async (password) => {
     const { unlockAccount, history, nextRoute } = this.props
 
     try {
@@ -107,7 +107,7 @@ export default class FirstTimeFlow extends PureComponent {
         <Switch>
           <Route
             path={INITIALIZE_SEED_PHRASE_ROUTE}
-            render={routeProps => (
+            render={(routeProps) => (
               <SeedPhrase
                 { ...routeProps }
                 seedPhrase={seedPhrase}
@@ -117,7 +117,7 @@ export default class FirstTimeFlow extends PureComponent {
           />
           <Route
             path={INITIALIZE_BACKUP_SEED_PHRASE_ROUTE}
-            render={routeProps => (
+            render={(routeProps) => (
               <SeedPhrase
                 { ...routeProps }
                 seedPhrase={seedPhrase}
@@ -127,7 +127,7 @@ export default class FirstTimeFlow extends PureComponent {
           />
           <Route
             path={INITIALIZE_CREATE_PASSWORD_ROUTE}
-            render={routeProps => (
+            render={(routeProps) => (
               <CreatePassword
                 { ...routeProps }
                 isImportedKeyring={isImportedKeyring}
@@ -142,7 +142,7 @@ export default class FirstTimeFlow extends PureComponent {
           />
           <Route
             path={INITIALIZE_UNLOCK_ROUTE}
-            render={routeProps => (
+            render={(routeProps) => (
               <Unlock
                 { ...routeProps }
                 onSubmit={this.handleUnlock}

--- a/ui/app/pages/first-time-flow/first-time-flow.container.js
+++ b/ui/app/pages/first-time-flow/first-time-flow.container.js
@@ -25,13 +25,13 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    createNewAccount: password => dispatch(createNewVaultAndGetSeedPhrase(password)),
+    createNewAccount: (password) => dispatch(createNewVaultAndGetSeedPhrase(password)),
     createNewAccountFromSeed: (password, seedPhrase) => {
       return dispatch(createNewVaultAndRestore(password, seedPhrase))
     },
-    unlockAccount: password => dispatch(unlockAndGetSeedPhrase(password)),
+    unlockAccount: (password) => dispatch(unlockAndGetSeedPhrase(password)),
     verifySeedPhrase: () => verifySeedPhrase(),
   }
 }

--- a/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.container.js
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.container.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setParticipateInMetaMetrics: (val) => dispatch(setParticipateInMetaMetrics(val)),
   }

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -45,11 +45,11 @@ export default class ConfirmSeedPhrase extends PureComponent {
     this.setState({ sortedSeedWords })
   }
 
-  setDraggingSeedIndex = draggingSeedIndex => this.setState({ draggingSeedIndex })
+  setDraggingSeedIndex = (draggingSeedIndex) => this.setState({ draggingSeedIndex })
 
-  setHoveringIndex = hoveringIndex => this.setState({ hoveringIndex })
+  setHoveringIndex = (hoveringIndex) => this.setState({ hoveringIndex })
 
-  onDrop = targetIndex => {
+  onDrop = (targetIndex) => {
     const {
       selectedSeedIndices,
       draggingSeedIndex,
@@ -114,15 +114,15 @@ export default class ConfirmSeedPhrase extends PureComponent {
 
   handleDeselectSeedWord = (index) => {
     this.setState({
-      selectedSeedIndices: this.state.selectedSeedIndices.filter(i => index !== i),
-      pendingSeedIndices: this.state.pendingSeedIndices.filter(i => index !== i),
+      selectedSeedIndices: this.state.selectedSeedIndices.filter((i) => index !== i),
+      pendingSeedIndices: this.state.pendingSeedIndices.filter((i) => index !== i),
     })
   }
 
   isValid () {
     const { seedPhrase } = this.props
     const { selectedSeedIndices, sortedSeedWords } = this.state
-    const selectedSeedWords = selectedSeedIndices.map(i => sortedSeedWords[i])
+    const selectedSeedWords = selectedSeedIndices.map((i) => sortedSeedWords[i])
     return seedPhrase === selectedSeedWords.join(' ')
   }
 
@@ -139,7 +139,7 @@ export default class ConfirmSeedPhrase extends PureComponent {
       <div className="confirm-seed-phrase">
         <div className="confirm-seed-phrase__back-button">
           <a
-            onClick={e => {
+            onClick={(e) => {
               e.preventDefault()
               history.push(INITIALIZE_SEED_PHRASE_ROUTE)
             }}

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.container.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.container.js
@@ -6,7 +6,7 @@ import {
   initializeThreeBox,
 } from '../../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { appState: { showingSeedPhraseBackupAfterOnboarding } } = state
 
   return {
@@ -14,7 +14,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setSeedPhraseBackedUp: (seedPhraseBackupState) => dispatch(setSeedPhraseBackedUp(seedPhraseBackupState)),
     hideSeedPhraseBackupAfterOnboarding: () => dispatch(hideSeedPhraseBackupAfterOnboarding()),

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.container.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.container.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setSeedPhraseBackedUp: (seedPhraseBackupState) => dispatch(setSeedPhraseBackedUp(seedPhraseBackupState)),
     setCompletedOnboarding: () => dispatch(setCompletedOnboarding()),

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/tests/reveal-seed-phrase.test.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/tests/reveal-seed-phrase.test.js
@@ -22,7 +22,7 @@ describe('Reveal Seed Phrase', function () {
     wrapper = mount(
       <RevealSeedPhrase.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
           metricsEvent: () => {},
         },
       }

--- a/ui/app/pages/first-time-flow/seed-phrase/seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/seed-phrase.component.js
@@ -29,7 +29,7 @@ export default class SeedPhrase extends PureComponent {
 
     if (!seedPhrase) {
       verifySeedPhrase()
-        .then(verifiedSeedPhrase => {
+        .then((verifiedSeedPhrase) => {
           if (!verifiedSeedPhrase) {
             history.push(DEFAULT_ROUTE)
           } else {
@@ -51,7 +51,7 @@ export default class SeedPhrase extends PureComponent {
             <Route
               exact
               path={INITIALIZE_CONFIRM_SEED_PHRASE_ROUTE}
-              render={routeProps => (
+              render={(routeProps) => (
                 <ConfirmSeedPhrase
                   { ...routeProps }
                   seedPhrase={seedPhrase || verifiedSeedPhrase}
@@ -61,7 +61,7 @@ export default class SeedPhrase extends PureComponent {
             <Route
               exact
               path={INITIALIZE_SEED_PHRASE_ROUTE}
-              render={routeProps => (
+              render={(routeProps) => (
                 <RevealSeedPhrase
                   { ...routeProps }
                   seedPhrase={seedPhrase || verifiedSeedPhrase}
@@ -71,7 +71,7 @@ export default class SeedPhrase extends PureComponent {
             <Route
               exact
               path={INITIALIZE_BACKUP_SEED_PHRASE_ROUTE}
-              render={routeProps => (
+              render={(routeProps) => (
                 <RevealSeedPhrase
                   { ...routeProps }
                   seedPhrase={seedPhrase || verifiedSeedPhrase}

--- a/ui/app/pages/first-time-flow/seed-phrase/tests/confirm-seed-phrase-component.test.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/tests/confirm-seed-phrase-component.test.js
@@ -9,7 +9,7 @@ function shallowRender (props = {}, context = {}) {
     <ConfirmSeedPhrase {...props} />,
     {
       context: {
-        t: str => str + '_t',
+        t: (str) => str + '_t',
         ...context,
       },
     }
@@ -152,8 +152,8 @@ describe('ConfirmSeedPhrase Component', function () {
     const seeds = root.find('.confirm-seed-phrase__seed-word--sorted')
 
 
-    originalSeed.forEach(seed => {
-      const seedIndex = sorted.findIndex(s => s === seed)
+    originalSeed.forEach((seed) => {
+      const seedIndex = sorted.findIndex((s) => s === seed)
       seeds.at(seedIndex).simulate('click')
     })
 
@@ -161,7 +161,7 @@ describe('ConfirmSeedPhrase Component', function () {
 
     root.find('.first-time-flow__button').simulate('click')
 
-    await (new Promise(resolve => setTimeout(resolve, 100)))
+    await (new Promise((resolve) => setTimeout(resolve, 100)))
 
     assert.deepEqual(metricsEventSpy.args[0][0], {
       eventOpts: {

--- a/ui/app/pages/first-time-flow/select-action/select-action.container.js
+++ b/ui/app/pages/first-time-flow/select-action/select-action.container.js
@@ -11,9 +11,9 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    setFirstTimeFlowType: type => dispatch(setFirstTimeFlowType(type)),
+    setFirstTimeFlowType: (type) => dispatch(setFirstTimeFlowType(type)),
   }
 }
 

--- a/ui/app/pages/first-time-flow/welcome/welcome.container.js
+++ b/ui/app/pages/first-time-flow/welcome/welcome.container.js
@@ -13,7 +13,7 @@ const mapStateToProps = ({ metamask }) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     closeWelcomeScreen: () => dispatch(closeWelcomeScreen()),
   }

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -14,7 +14,7 @@ import { setThreeBoxLastUpdated } from '../../ducks/app/app'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { activeTab, metamask, appState } = state
   const {
     suggestedTokens,
@@ -53,7 +53,7 @@ const mapDispatchToProps = (dispatch) => ({
   turnThreeBoxSyncingOn: () => dispatch(turnThreeBoxSyncingOn()),
   setupThreeBox: () => {
     dispatch(getThreeBoxLastUpdated())
-      .then(lastUpdated => {
+      .then((lastUpdated) => {
         if (lastUpdated) {
           dispatch(setThreeBoxLastUpdated(lastUpdated))
         } else {

--- a/ui/app/pages/keychains/restore-vault.js
+++ b/ui/app/pages/keychains/restore-vault.js
@@ -125,7 +125,7 @@ class RestoreVaultPage extends Component {
           <div className="import-account">
             <a
               className="import-account__back-button"
-              onClick={e => {
+              onClick={(e) => {
                 e.preventDefault()
                 this.props.leaveImportSeedScreenState()
                 this.props.history.goBack()
@@ -144,7 +144,7 @@ class RestoreVaultPage extends Component {
               <label className="import-account__input-label">Wallet Seed</label>
               <textarea
                 className="import-account__secret-phrase"
-                onChange={e => this.handleSeedPhraseChange(e.target.value)}
+                onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
                 value={this.state.seedPhrase}
                 placeholder={this.context.t('separateEachWord')}
               />
@@ -158,7 +158,7 @@ class RestoreVaultPage extends Component {
               type="password"
               className="first-time-flow__input"
               value={this.state.password}
-              onChange={event => this.handlePasswordChange(event.target.value)}
+              onChange={(event) => this.handlePasswordChange(event.target.value)}
               error={passwordError}
               autoComplete="new-password"
               margin="normal"
@@ -170,7 +170,7 @@ class RestoreVaultPage extends Component {
               type="password"
               className="first-time-flow__input"
               value={this.state.confirmPassword}
-              onChange={event => this.handleConfirmPasswordChange(event.target.value)}
+              onChange={(event) => this.handleConfirmPasswordChange(event.target.value)}
               error={confirmPasswordError}
               autoComplete="confirm-password"
               margin="normal"
@@ -193,7 +193,7 @@ class RestoreVaultPage extends Component {
 
 export default connect(
   ({ appState: { isLoading } }) => ({ isLoading }),
-  dispatch => ({
+  (dispatch) => ({
     leaveImportSeedScreenState: () => {
       dispatch(unMarkPasswordForgotten())
     },

--- a/ui/app/pages/keychains/reveal-seed.js
+++ b/ui/app/pages/keychains/reveal-seed.js
@@ -30,8 +30,8 @@ class RevealSeedPage extends Component {
     event.preventDefault()
     this.setState({ seedWords: null, error: null })
     this.props.requestRevealSeedWords(this.state.password)
-      .then(seedWords => this.setState({ seedWords, screen: REVEAL_SEED_SCREEN }))
-      .catch(error => this.setState({ error: error.message }))
+      .then((seedWords) => this.setState({ seedWords, screen: REVEAL_SEED_SCREEN }))
+      .catch((error) => this.setState({ error: error.message }))
   }
 
   renderWarning () {
@@ -60,7 +60,7 @@ class RevealSeedPage extends Component {
     const { t } = this.context
 
     return (
-      <form onSubmit={event => this.handleSubmit(event)}>
+      <form onSubmit={(event) => this.handleSubmit(event)}>
         <label className="input-label" htmlFor="password-box">{t('enterPasswordContinue')}</label>
         <div className="input-group">
           <input
@@ -68,7 +68,7 @@ class RevealSeedPage extends Component {
             placeholder={t('password')}
             id="password-box"
             value={this.state.password}
-            onChange={event => this.setState({ password: event.target.value })}
+            onChange={(event) => this.setState({ password: event.target.value })}
             className={classnames('form-control', { 'form-control--error': this.state.error })}
           />
         </div>
@@ -115,7 +115,7 @@ class RevealSeedPage extends Component {
             type="secondary"
             large
             className="page-container__footer-button"
-            onClick={event => this.handleSubmit(event)}
+            onClick={(event) => this.handleSubmit(event)}
             disabled={this.state.password === ''}
           >
             {this.context.t('next')}
@@ -172,9 +172,9 @@ RevealSeedPage.contextTypes = {
   t: PropTypes.func,
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    requestRevealSeedWords: password => dispatch(requestRevealSeedWords(password)),
+    requestRevealSeedWords: (password) => dispatch(requestRevealSeedWords(password)),
   }
 }
 

--- a/ui/app/pages/keychains/tests/reveal-seed.test.js
+++ b/ui/app/pages/keychains/tests/reveal-seed.test.js
@@ -15,7 +15,7 @@ describe('Reveal Seed Page', function () {
     const wrapper = mount(
       <RevealSeedPage.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/pages/lock/lock.container.js
+++ b/ui/app/pages/lock/lock.container.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { lockMetamask } from '../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { isUnlocked } } = state
 
   return {
@@ -12,7 +12,7 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     lockMetamask: () => dispatch(lockMetamask()),
   }

--- a/ui/app/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.component.js
@@ -51,11 +51,11 @@ export default class MobileSyncPage extends Component {
     event.preventDefault()
     this.setState({ seedWords: null, error: null })
     this.props.requestRevealSeedWords(this.state.password)
-      .then(seedWords => {
+      .then((seedWords) => {
         this.startKeysGeneration()
         this.setState({ seedWords, screen: REVEAL_SEED_SCREEN })
       })
-      .catch(error => this.setState({ error: error.message }))
+      .catch((error) => this.setState({ error: error.message }))
   }
 
   startKeysGeneration () {
@@ -288,7 +288,7 @@ export default class MobileSyncPage extends Component {
     const { t } = this.context
 
     return (
-      <form onSubmit={event => this.handleSubmit(event)}>
+      <form onSubmit={(event) => this.handleSubmit(event)}>
         <label className="input-label" htmlFor="password-box">
           {t('enterPasswordContinue')}
         </label>
@@ -298,7 +298,7 @@ export default class MobileSyncPage extends Component {
             placeholder={t('password')}
             id="password-box"
             value={this.state.password}
-            onChange={event => this.setState({ password: event.target.value })}
+            onChange={(event) => this.setState({ password: event.target.value })}
             className={classnames('form-control', {
               'form-control--error': this.state.error,
             })}
@@ -369,7 +369,7 @@ export default class MobileSyncPage extends Component {
           type="secondary"
           large
           className="new-account-create-form__button"
-          onClick={event => this.handleSubmit(event)}
+          onClick={(event) => this.handleSubmit(event)}
           disabled={password === ''}
         >
           {t('next')}

--- a/ui/app/pages/mobile-sync/mobile-sync.container.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.container.js
@@ -4,13 +4,13 @@ import MobileSyncPage from './mobile-sync.component'
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    requestRevealSeedWords: password => dispatch(requestRevealSeedWords(password)),
+    requestRevealSeedWords: (password) => dispatch(requestRevealSeedWords(password)),
     fetchInfoToSync: () => dispatch(fetchInfoToSync()),
     displayWarning: (message) => dispatch(displayWarning(message || null)),
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const {
     metamask: {
       selectedAddress,

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -173,7 +173,7 @@ export default class PermissionConnect extends Component {
                 })
               }}
               addressLastConnectedMap={addressLastConnectedMap}
-              cancelPermissionsRequest={requestId => {
+              cancelPermissionsRequest={(requestId) => {
                 if (requestId) {
                   rejectPermissionsRequest(requestId)
                   this.redirectFlow(false)
@@ -190,11 +190,11 @@ export default class PermissionConnect extends Component {
                   approvePermissionsRequest(request, accounts)
                   this.redirectFlow(true)
                 }}
-                rejectPermissionsRequest={requestId => {
+                rejectPermissionsRequest={(requestId) => {
                   rejectPermissionsRequest(requestId)
                   this.redirectFlow(false)
                 }}
-                selectedIdentity={accounts.find(account => account.address === selectedAccountAddress)}
+                selectedIdentity={accounts.find((account) => account.address === selectedAccountAddress)}
                 redirect={page === null}
                 permissionRejected={ permissionAccepted === false }
               />

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -16,7 +16,7 @@ const mapStateToProps = (state, ownProps) => {
   const permissionsRequests = getPermissionsRequests(state)
 
   const permissionsRequest = permissionsRequests
-    .find(permissionsRequest => permissionsRequest.metadata.id === permissionsRequestId)
+    .find((permissionsRequest) => permissionsRequest.metadata.id === permissionsRequestId)
 
   const { metadata = {} } = permissionsRequest || {}
   const { origin } = metadata
@@ -29,7 +29,7 @@ const mapStateToProps = (state, ownProps) => {
   const lastConnectedInfo = getLastConnectedInfo(state) || {}
   const addressLastConnectedMap = lastConnectedInfo[origin] || {}
 
-  Object.keys(addressLastConnectedMap).forEach(key => {
+  Object.keys(addressLastConnectedMap).forEach((key) => {
     addressLastConnectedMap[key] = formatDate(addressLastConnectedMap[key], 'yyyy-M-d')
   })
 
@@ -46,10 +46,10 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     approvePermissionsRequest: (request, accounts) => dispatch(approvePermissionsRequest(request, accounts)),
-    rejectPermissionsRequest: requestId => dispatch(rejectPermissionsRequest(requestId)),
+    rejectPermissionsRequest: (requestId) => dispatch(rejectPermissionsRequest(requestId)),
     showNewAccountModal: ({ onCreateNewAccount, newAccountNumber }) => {
       return dispatch(showModal({
         name: 'NEW_ACCOUNT',

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -244,7 +244,7 @@ class Routes extends Component {
         className={classnames('app', { 'mouse-user-styles': isMouseUser })}
         dir={textDirection}
         onClick={() => setMouseUserState(true)}
-        onKeyDown={e => {
+        onKeyDown={(e) => {
           if (e.keyCode === 9) {
             setMouseUserState(false)
           }
@@ -429,7 +429,7 @@ function mapDispatchToProps (dispatch) {
     setCurrentCurrencyToUSD: () => dispatch(actions.setCurrentCurrency('usd')),
     setMouseUserState: (isMouseUser) => dispatch(actions.setMouseUserState(isMouseUser)),
     setLastActiveTime: () => dispatch(actions.setLastActiveTime()),
-    showAccountDetail: address => dispatch(actions.showAccountDetail(address)),
+    showAccountDetail: (address) => dispatch(actions.showAccountDetail(address)),
   }
 }
 

--- a/ui/app/pages/send/account-list-item/tests/account-list-item-component.test.js
+++ b/ui/app/pages/send/account-list-item/tests/account-list-item-component.test.js
@@ -36,7 +36,7 @@ describe('AccountListItem Component', function () {
           handleClick={propsMethodSpies.handleClick}
           icon={<i className="mockIcon" />}
         />
-      ), { context: { t: str => str + '_t' } })
+      ), { context: { t: (str) => str + '_t' } })
     })
 
     afterEach(function () {

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -102,15 +102,15 @@ export default class EnsInput extends Component {
       })
   }
 
-  onPaste = event => {
-    event.clipboardData.items[0].getAsString(text => {
+  onPaste = (event) => {
+    event.clipboardData.items[0].getAsString((text) => {
       if (isValidAddress(text)) {
         this.props.onPaste(text)
       }
     })
   }
 
-  onChange = e => {
+  onChange = (e) => {
     const { network, onChange, updateEnsResolution, updateEnsResolutionError, onValidAddressTyped } = this.props
     const input = e.target.value
     const networkHasEnsSupport = getNetworkEnsSupport(network)
@@ -261,7 +261,7 @@ export default class EnsInput extends Component {
         <i
           className="fa fa-check-circle fa-lg cursor-pointer"
           style={{ color: 'green' }}
-          onClick={event => {
+          onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()
             copyToClipboard(ensResolution)

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.container.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.container.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux'
 
 
 export default connect(
-  state => {
+  (state) => {
     const selectedAddress = getSendTo(state)
     return {
       network: getCurrentNetwork(state),

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-component.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-component.test.js
@@ -37,7 +37,7 @@ describe('AddRecipient Component', function () {
         nonContacts={[{ address: '0x70F061544cC398520615B5d3e7A3BedD70cd4510', name: 'Fav 7' }]}
         contacts={[{ address: '0x60F061544cC398520615B5d3e7A3BedD70cd4510', name: 'Fav 6' }]}
       />
-    ), { context: { t: str => str + '_t' } })
+    ), { context: { t: (str) => str + '_t' } })
     instance = wrapper.instance()
   })
 

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
@@ -9,7 +9,7 @@ import {
 } from '../../../send.constants'
 
 const stubs = {
-  isValidAddress: sinon.stub().callsFake(to => Boolean(to.match(/^[0xabcdef123456798]+$/))),
+  isValidAddress: sinon.stub().callsFake((to) => Boolean(to.match(/^[0xabcdef123456798]+$/))),
 }
 
 const toRowUtils = proxyquire('../add-recipient.js', {

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.container.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.container.js
@@ -33,13 +33,13 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    setAmountToMax: maxAmountDataObject => {
+    setAmountToMax: (maxAmountDataObject) => {
       dispatch(updateSendErrors({ amount: null }))
       dispatch(updateSendAmount(calcMaxAmount(maxAmountDataObject)))
     },
     clearMaxAmount: () => {
       dispatch(updateSendAmount('0'))
     },
-    setMaxModeTo: bool => dispatch(setMaxModeTo(bool)),
+    setMaxModeTo: (bool) => dispatch(setMaxModeTo(bool)),
   }
 }

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/tests/amount-max-button-component.test.js
@@ -32,7 +32,7 @@ describe('AmountMaxButton Component', function () {
       />
     ), {
       context: {
-        t: str => str + '_t',
+        t: (str) => str + '_t',
         metricsEvent: () => {},
       },
     })

--- a/ui/app/pages/send/send-content/send-amount-row/send-amount-row.component.js
+++ b/ui/app/pages/send/send-content/send-amount-row/send-amount-row.component.js
@@ -92,7 +92,7 @@ export default class SendAmountRow extends Component {
 
     return (
       <Component
-        onChange={newAmount => {
+        onChange={(newAmount) => {
           this.validateAmount(newAmount)
           this.updateGas(newAmount)
           this.updateAmount(newAmount)

--- a/ui/app/pages/send/send-content/send-amount-row/send-amount-row.container.js
+++ b/ui/app/pages/send/send-content/send-amount-row/send-amount-row.container.js
@@ -40,8 +40,8 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    setMaxModeTo: bool => dispatch(setMaxModeTo(bool)),
-    updateSendAmount: newAmount => dispatch(updateSendAmount(newAmount)),
+    setMaxModeTo: (bool) => dispatch(setMaxModeTo(bool)),
+    updateSendAmount: (newAmount) => dispatch(updateSendAmount(newAmount)),
     updateGasFeeError: (amountDataObject) => {
       dispatch(updateSendErrors(getGasFeeErrorObject(amountDataObject)))
     },

--- a/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-component.test.js
@@ -163,7 +163,7 @@ function shallowRenderSendAmountRow () {
       updateSendAmountError={updateSendAmountError}
       updateGas={() => {}}
     />
-  ), { context: { t: str => str + '_t' } })
+  ), { context: { t: (str) => str + '_t' } })
   const instance = wrapper.instance()
   const updateAmount = sinon.spy(instance, 'updateAmount')
   const updateGas = sinon.spy(instance, 'updateGas')

--- a/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -34,7 +34,7 @@ export default class SendAssetRow extends Component {
 
   closeDropdown = () => this.setState({ isShowingDropdown: false })
 
-  selectToken = address => {
+  selectToken = (address) => {
     this.setState({
       isShowingDropdown: false,
     }, () => {
@@ -87,7 +87,7 @@ export default class SendAssetRow extends Component {
         />
         <div className="send-v2__asset-dropdown__list">
           { this.renderEth() }
-          { this.props.tokens.map(token => this.renderAsset(token)) }
+          { this.props.tokens.map((token) => this.renderAsset(token)) }
         </div>
       </div>
     )

--- a/ui/app/pages/send/send-content/send-asset-row/send-asset-row.container.js
+++ b/ui/app/pages/send/send-content/send-asset-row/send-asset-row.container.js
@@ -14,7 +14,7 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    setSelectedToken: address => dispatch(setSelectedToken(address)),
+    setSelectedToken: (address) => dispatch(setSelectedToken(address)),
   }
 }
 

--- a/ui/app/pages/send/send-content/send-dropdown-list/tests/send-dropdown-list-component.test.js
+++ b/ui/app/pages/send/send-content/send-dropdown-list/tests/send-dropdown-list-component.test.js
@@ -29,7 +29,7 @@ describe('SendDropdownList Component', function () {
         onSelect={propsMethodSpies.onSelect}
         activeAddress="mockAddress2"
       />
-    ), { context: { t: str => str + '_t' } })
+    ), { context: { t: (str) => str + '_t' } })
   })
 
   afterEach(function () {

--- a/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-component.test.js
@@ -11,7 +11,7 @@ describe('SendFromRow Component', function () {
       <SendFromRow
         from={ { address: 'mockAddress' } }
       />,
-      { context: { t: str => str + '_t' } }
+      { context: { t: (str) => str + '_t' } }
     )
 
     it('should render a SendRowWrapper component', function () {

--- a/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-container.test.js
+++ b/ui/app/pages/send/send-content/send-from-row/tests/send-from-row-container.test.js
@@ -5,7 +5,7 @@ let mapStateToProps
 
 proxyquire('../send-from-row.container.js', {
   'react-redux': {
-    connect: ms => {
+    connect: (ms) => {
       mapStateToProps = ms
       return () => ({})
     },

--- a/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/tests/gas-fee-display.component.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/tests/gas-fee-display.component.test.js
@@ -24,7 +24,7 @@ describe('GasFeeDisplay Component', function () {
           showGasButtonGroup={propsMethodSpies.showCustomizeGasModal}
           onReset={propsMethodSpies.onReset}
         />
-      ), { context: { t: str => str + '_t' } })
+      ), { context: { t: (str) => str + '_t' } })
     })
 
     afterEach(function () {

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -129,8 +129,8 @@ export default class SendGasRow extends Component {
     const advancedGasInputs = (
       <div>
         <AdvancedGasInputs
-          updateCustomGasPrice={newGasPrice => setGasPrice(newGasPrice, gasLimit)}
-          updateCustomGasLimit={newGasLimit => setGasLimit(newGasLimit, gasPrice)}
+          updateCustomGasPrice={(newGasPrice) => setGasPrice(newGasPrice, gasLimit)}
+          updateCustomGasLimit={(newGasLimit) => setGasLimit(newGasLimit, gasPrice)}
           customGasPrice={gasPrice}
           customGasLimit={gasLimit}
           insufficientBalance={insufficientBalance}

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
@@ -94,7 +94,7 @@ function mapDispatchToProps (dispatch) {
         dispatch(setGasTotal(calcGasTotal(newLimit, gasPrice)))
       }
     },
-    setAmountToMax: maxAmountDataObject => {
+    setAmountToMax: (maxAmountDataObject) => {
       dispatch(updateSendErrors({ amount: null }))
       dispatch(updateSendAmount(calcMaxAmount(maxAmountDataObject)))
     },

--- a/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
@@ -33,7 +33,7 @@ describe('SendGasRow Component', function () {
             anotherGasPriceButtonGroupProp: 'bar',
           }}
         />
-      ), { context: { t: str => str + '_t', metricsEvent: () => ({}) } })
+      ), { context: { t: (str) => str + '_t', metricsEvent: () => ({}) } })
     })
 
     afterEach(function () {

--- a/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-component.test.js
+++ b/ui/app/pages/send/send-content/send-row-wrapper/send-row-error-message/tests/send-row-error-message-component.test.js
@@ -13,7 +13,7 @@ describe('SendRowErrorMessage Component', function () {
           errors={{ error1: 'abc', error2: 'def' }}
           errorType="error3"
         />
-      ), { context: { t: str => str + '_t' } })
+      ), { context: { t: (str) => str + '_t' } })
     })
 
     it('should render null if the passed errors do not contain an error of errorType', function () {

--- a/ui/app/pages/send/send-content/tests/send-content-component.test.js
+++ b/ui/app/pages/send/send-content/tests/send-content-component.test.js
@@ -18,7 +18,7 @@ describe('SendContent Component', function () {
       <SendContent
         showHexData
       />,
-      { context: { t: str => str + '_t' } }
+      { context: { t: (str) => str + '_t' } }
     )
   })
 

--- a/ui/app/pages/send/send-footer/send-footer.component.js
+++ b/ui/app/pages/send/send-footer/send-footer.component.js
@@ -112,7 +112,7 @@ export default class SendFooter extends Component {
     const { inError, sendErrors } = this.props
     const { metricsEvent } = this.context
     if (!prevProps.inError && inError) {
-      const errorField = Object.keys(sendErrors).find(key => sendErrors[key])
+      const errorField = Object.keys(sendErrors).find((key) => sendErrors[key])
       const errorMessage = sendErrors[errorField]
 
       metricsEvent({
@@ -133,7 +133,7 @@ export default class SendFooter extends Component {
     return (
       <PageContainerFooter
         onCancel={() => this.onCancel()}
-        onSubmit={e => this.onSubmit(e)}
+        onSubmit={(e) => this.onSubmit(e)}
         disabled={this.formShouldBeDisabled()}
       />
     )

--- a/ui/app/pages/send/send-footer/send-footer.selectors.js
+++ b/ui/app/pages/send/send-footer/send-footer.selectors.js
@@ -1,5 +1,5 @@
 import { getSendErrors } from '../send.selectors'
 
 export function isSendFormInError (state) {
-  return Object.values(getSendErrors(state)).some(n => n)
+  return Object.values(getSendErrors(state)).some((n) => n)
 }

--- a/ui/app/pages/send/send-footer/send-footer.utils.js
+++ b/ui/app/pages/send/send-footer/send-footer.utils.js
@@ -57,7 +57,7 @@ export function constructUpdatedTx ({
   if (selectedToken) {
     const data = TOKEN_TRANSFER_FUNCTION_SIGNATURE + Array.prototype.map.call(
       ethAbi.rawEncode(['address', 'uint256'], [to, ethUtil.addHexPrefix(amount)]),
-      x => ('00' + x.toString(16)).slice(-2)
+      (x) => ('00' + x.toString(16)).slice(-2)
     ).join('')
 
     Object.assign(editingTx.txParams, addHexPrefixToObjectValues({

--- a/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
@@ -49,7 +49,7 @@ describe('SendFooter Component', function () {
         update={propsMethodSpies.update}
         sendErrors={{}}
       />
-    ), { context: { t: str => str, metricsEvent: () => ({}) } })
+    ), { context: { t: (str) => str, metricsEvent: () => ({}) } })
   })
 
   afterEach(function () {
@@ -225,7 +225,7 @@ describe('SendFooter Component', function () {
           unapprovedTxs={{}}
           update={propsMethodSpies.update}
         />
-      ), { context: { t: str => str, metricsEvent: () => ({}) } })
+      ), { context: { t: (str) => str, metricsEvent: () => ({}) } })
     })
 
     afterEach(function () {

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -107,7 +107,7 @@ export default class SendTransactionScreen extends Component {
       to: prevTo,
     } = prevProps
 
-    const uninitialized = [prevBalance, prevGasTotal].every(n => n === null)
+    const uninitialized = [prevBalance, prevGasTotal].every((n) => n === null)
 
     const amountErrorRequiresUpdate = doesAmountErrorRequireUpdate({
       balance,
@@ -212,7 +212,7 @@ export default class SendTransactionScreen extends Component {
     this.props.resetSendState()
   }
 
-  onRecipientInputChange = query => {
+  onRecipientInputChange = (query) => {
     if (query) {
       this.dValidate(query)
     } else {
@@ -311,7 +311,7 @@ export default class SendTransactionScreen extends Component {
     return (
       <EnsInput
         className="send__to-row"
-        scanQrCode={_ => {
+        scanQrCode={(_) => {
           this.context.metricsEvent({
             eventOpts: {
               category: 'Transactions',
@@ -323,7 +323,7 @@ export default class SendTransactionScreen extends Component {
         }}
         onChange={this.onRecipientInputChange}
         onValidAddressTyped={(address) => this.props.updateSendTo(address, '')}
-        onPaste={text => {
+        onPaste={(text) => {
           this.props.updateSendTo(text) && this.updateGas()
         }}
         onReset={() => this.props.updateSendTo('', '')}

--- a/ui/app/pages/send/send.container.js
+++ b/ui/app/pages/send/send.container.js
@@ -105,7 +105,7 @@ function mapDispatchToProps (dispatch) {
         address,
       }))
     },
-    updateSendErrors: newError => dispatch(updateSendErrors(newError)),
+    updateSendErrors: (newError) => dispatch(updateSendErrors(newError)),
     resetSendState: () => dispatch(resetSendState()),
     scanQrCode: () => dispatch(showQrScanner()),
     qrCodeDetected: (data) => dispatch(qrCodeDetected(data)),

--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -314,7 +314,7 @@ function generateTokenTransferData ({ toAddress = '0x0', amount = '0x0', selecte
   }
   return TOKEN_TRANSFER_FUNCTION_SIGNATURE + Array.prototype.map.call(
     abi.rawEncode(['address', 'uint256'], [toAddress, ethUtil.addHexPrefix(amount)]),
-    x => ('00' + x.toString(16)).slice(-2)
+    (x) => ('00' + x.toString(16)).slice(-2)
   ).join('')
 }
 
@@ -338,7 +338,7 @@ function estimateGasPriceFromRecentBlocks (recentBlocks) {
 }
 
 function getToAddressForGasUpdate (...addresses) {
-  return [...addresses, ''].find(str => str !== undefined && str !== null).toLowerCase()
+  return [...addresses, ''].find((str) => str !== undefined && str !== null).toLowerCase()
 }
 
 function removeLeadingZeroes (str) {

--- a/ui/app/pages/send/tests/send-component.test.js
+++ b/ui/app/pages/send/tests/send-component.test.js
@@ -29,7 +29,7 @@ describe('Send Component', function () {
   const utilsMethodStubs = {
     getAmountErrorObject: sinon.stub().returns({ amount: 'mockAmountError' }),
     getGasFeeErrorObject: sinon.stub().returns({ gasFee: 'mockGasFeeError' }),
-    doesAmountErrorRequireUpdate: sinon.stub().callsFake(obj => obj.balance !== obj.prevBalance),
+    doesAmountErrorRequireUpdate: sinon.stub().callsFake((obj) => obj.balance !== obj.prevBalance),
   }
 
   const SendTransactionScreen = proxyquire('../send.component.js', {

--- a/ui/app/pages/send/tests/send-selectors.test.js
+++ b/ui/app/pages/send/tests/send-selectors.test.js
@@ -44,7 +44,7 @@ describe('send selectors', function () {
   beforeEach(function () {
     global.eth = {
       contract: sinon.stub().returns({
-        at: address => 'mockAt:' + address,
+        at: (address) => 'mockAt:' + address,
       }),
     }
   })

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -56,7 +56,7 @@ export default class AdvancedTab extends PureComponent {
             <Button
               type="secondary"
               large
-              onClick={event => {
+              onClick={(event) => {
                 event.preventDefault()
                 history.push(MOBILE_SYNC_ROUTE)
               }}
@@ -122,7 +122,7 @@ export default class AdvancedTab extends PureComponent {
               type="warning"
               large
               className="settings-tab__button--red"
-              onClick={event => {
+              onClick={(event) => {
                 event.preventDefault()
                 this.context.metricsEvent({
                   eventOpts: {
@@ -158,7 +158,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={sendHexData}
-              onToggle={value => setHexDataFeatureFlag(!value)}
+              onToggle={(value) => setHexDataFeatureFlag(!value)}
               offLabel={t('off')}
               onLabel={t('on')}
             />
@@ -184,7 +184,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={advancedInlineGas}
-              onToggle={value => setAdvancedInlineGasFeatureFlag(!value)}
+              onToggle={(value) => setAdvancedInlineGasFeatureFlag(!value)}
               offLabel={t('off')}
               onLabel={t('on')}
             />
@@ -213,7 +213,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={showFiatInTestnets}
-              onToggle={value => setShowFiatConversionOnTestnetsPreference(!value)}
+              onToggle={(value) => setShowFiatConversionOnTestnetsPreference(!value)}
               offLabel={t('off')}
               onLabel={t('on')}
             />
@@ -239,7 +239,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={useNonceField}
-              onToggle={value => setUseNonceField(!value)}
+              onToggle={(value) => setUseNonceField(!value)}
               offLabel={t('off')}
               onLabel={t('on')}
             />
@@ -291,7 +291,7 @@ export default class AdvancedTab extends PureComponent {
               placeholder="5"
               value={this.state.autoLockTimeLimit}
               defaultValue={autoLockTimeLimit}
-              onChange={e => this.handleLockChange(e.target.value)}
+              onChange={(e) => this.handleLockChange(e.target.value)}
               error={lockTimeError}
               fullWidth
               margin="dense"
@@ -344,7 +344,7 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={allowed}
-              onToggle={value => {
+              onToggle={(value) => {
                 if (!threeBoxDisabled) {
                   setThreeBoxSyncingPermission(!value)
                 }
@@ -416,7 +416,7 @@ export default class AdvancedTab extends PureComponent {
             <TextField
               type="text"
               value={this.state.ipfsGateway}
-              onChange={e => this.handleIpfsGatewayChange(e.target.value)}
+              onChange={(e) => this.handleIpfsGatewayChange(e.target.value)}
               error={ipfsGatewayError}
               fullWidth
               margin="dense"

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
@@ -15,7 +15,7 @@ import {
 } from '../../../store/actions'
 import { preferencesSelector } from '../../../selectors/selectors'
 
-export const mapStateToProps = state => {
+export const mapStateToProps = (state) => {
   const { appState: { warning }, metamask } = state
   const {
     featureFlags: {
@@ -42,27 +42,27 @@ export const mapStateToProps = state => {
   }
 }
 
-export const mapDispatchToProps = dispatch => {
+export const mapDispatchToProps = (dispatch) => {
   return {
-    setHexDataFeatureFlag: shouldShow => dispatch(setFeatureFlag('sendHexData', shouldShow)),
-    displayWarning: warning => dispatch(displayWarning(warning)),
+    setHexDataFeatureFlag: (shouldShow) => dispatch(setFeatureFlag('sendHexData', shouldShow)),
+    displayWarning: (warning) => dispatch(displayWarning(warning)),
     showResetAccountConfirmationModal: () => dispatch(showModal({ name: 'CONFIRM_RESET_ACCOUNT' })),
-    setAdvancedInlineGasFeatureFlag: shouldShow => dispatch(setFeatureFlag('advancedInlineGas', shouldShow)),
-    setUseNonceField: value => dispatch(setUseNonceField(value)),
-    setShowFiatConversionOnTestnetsPreference: value => {
+    setAdvancedInlineGasFeatureFlag: (shouldShow) => dispatch(setFeatureFlag('advancedInlineGas', shouldShow)),
+    setUseNonceField: (value) => dispatch(setUseNonceField(value)),
+    setShowFiatConversionOnTestnetsPreference: (value) => {
       return dispatch(setShowFiatConversionOnTestnetsPreference(value))
     },
-    setAutoLockTimeLimit: value => {
+    setAutoLockTimeLimit: (value) => {
       return dispatch(setAutoLockTimeLimit(value))
     },
-    setThreeBoxSyncingPermission: newThreeBoxSyncingState => {
+    setThreeBoxSyncingPermission: (newThreeBoxSyncingState) => {
       if (newThreeBoxSyncingState) {
         dispatch(turnThreeBoxSyncingOnAndInitialize())
       } else {
         dispatch(setThreeBoxSyncingPermission(newThreeBoxSyncingState))
       }
     },
-    setIpfsGateway: value => {
+    setIpfsGateway: (value) => {
       return dispatch(setIpfsGateway(value))
     },
   }

--- a/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
+++ b/ui/app/pages/settings/advanced-tab/tests/advanced-tab-component.test.js
@@ -19,7 +19,7 @@ describe('AdvancedTab Component', function () {
       />,
       {
         context: {
-          t: s => `_${s}`,
+          t: (s) => `_${s}`,
         },
       }
     )
@@ -41,7 +41,7 @@ describe('AdvancedTab Component', function () {
       />,
       {
         context: {
-          t: s => `_${s}`,
+          t: (s) => `_${s}`,
         },
       }
     )

--- a/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -49,7 +49,7 @@ export default class AddContact extends PureComponent {
     }
   }
 
-  validate = address => {
+  validate = (address) => {
     const valid = isValidAddress(address)
     const validEnsAddress = isValidENSAddress(address)
     if (valid || validEnsAddress || address === '') {
@@ -63,16 +63,16 @@ export default class AddContact extends PureComponent {
     return (
       <EnsInput
         className="send__to-row"
-        scanQrCode={_ => {
+        scanQrCode={(_) => {
           this.props.scanQrCode()
         }}
         onChange={this.dValidate}
-        onPaste={text => this.setState({ ethAddress: text })}
+        onPaste={(text) => this.setState({ ethAddress: text })}
         onReset={() => this.setState({ ethAddress: '', ensAddress: '' })}
-        updateEnsResolution={address => {
+        updateEnsResolution={(address) => {
           this.setState({ ensAddress: address, error: '', ensError: '' })
         }}
-        updateEnsResolutionError={message => this.setState({ ensError: message })}
+        updateEnsResolutionError={(message) => this.setState({ ensError: message })}
       />
     )
   }
@@ -102,7 +102,7 @@ export default class AddContact extends PureComponent {
               type="text"
               id="nickname"
               value={this.state.newName}
-              onChange={e => this.setState({ newName: e.target.value })}
+              onChange={(e) => this.setState({ newName: e.target.value })}
               fullWidth
               margin="dense"
             />

--- a/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.container.js
+++ b/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.container.js
@@ -7,13 +7,13 @@ import {
   getQrCodeData,
 } from '../../../send/send.selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     qrCodeData: getQrCodeData(state),
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     addToAddressBook: (recipient, nickname) => dispatch(addToAddressBook(recipient, nickname)),
     scanQrCode: () => dispatch(showQrScanner()),

--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -67,7 +67,7 @@ export default class EditContact extends PureComponent {
               id="nickname"
               placeholder={this.context.t('addAlias')}
               value={this.state.newName}
-              onChange={e => this.setState({ newName: e.target.value })}
+              onChange={(e) => this.setState({ newName: e.target.value })}
               fullWidth
               margin="dense"
             />
@@ -82,7 +82,7 @@ export default class EditContact extends PureComponent {
               id="address"
               value={this.state.newAddress}
               error={this.state.error}
-              onChange={e => this.setState({ newAddress: e.target.value })}
+              onChange={(e) => this.setState({ newAddress: e.target.value })}
               fullWidth
               margin="dense"
             />
@@ -97,7 +97,7 @@ export default class EditContact extends PureComponent {
               id="memo"
               placeholder={memo}
               value={this.state.newMemo}
-              onChange={e => this.setState({ newMemo: e.target.value })}
+              onChange={(e) => this.setState({ newMemo: e.target.value })}
               fullWidth
               margin="dense"
               multiline

--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
@@ -36,7 +36,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     addToAddressBook: (recipient, nickname, memo) => dispatch(addToAddressBook(recipient, nickname, memo)),
     removeFromAddressBook: (chainId, addressToRemove) => dispatch(removeFromAddressBook(chainId, addressToRemove)),

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -212,7 +212,7 @@ export default class NetworkForm extends PureComponent {
     )
   }
 
-  isValidWhenAppended = url => {
+  isValidWhenAppended = (url) => {
     const appendedRpc = `http://${url}`
     return validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
   }
@@ -253,7 +253,7 @@ export default class NetworkForm extends PureComponent {
       errors,
     } = this.state
 
-    const isSubmitDisabled = viewOnly || this.stateIsUnchanged() || Object.values(errors).some(x => x) || !rpcUrl
+    const isSubmitDisabled = viewOnly || this.stateIsUnchanged() || Object.values(errors).some((x) => x) || !rpcUrl
     const deletable = !networksTabIsInAddMode && !isCurrentRpcTarget && !viewOnly
 
     return (

--- a/ui/app/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.component.js
@@ -64,7 +64,7 @@ export default class NetworksTab extends PureComponent {
         <div className="networks-tab__add-network-header-button-wrapper">
           <Button
             type="secondary"
-            onClick={event => {
+            onClick={(event) => {
               event.preventDefault()
               setSelectedSettingsRpcUrl(null)
               setNetworksTabAddMode(true)
@@ -135,7 +135,7 @@ export default class NetworksTab extends PureComponent {
           'networks-tab__networks-list--selection': (networkIsSelected && !networkDefaultedToProvider) || networksTabIsInAddMode,
         })}
       >
-        { networksToRender.map(network => this.renderNetworkListItem(network, selectedNetwork.rpcUrl)) }
+        { networksToRender.map((network) => this.renderNetworkListItem(network, selectedNetwork.rpcUrl)) }
         {
           networksTabIsInAddMode && (
             <div
@@ -192,7 +192,7 @@ export default class NetworksTab extends PureComponent {
           shouldRenderNetworkForm
             ? (
               <NetworkForm
-                rpcUrls={networksToRender.map(network => network.rpcUrl)}
+                rpcUrls={networksToRender.map((network) => network.rpcUrl)}
                 setRpcTarget={setRpcTarget}
                 editRpc={editRpc}
                 networkName={label || labelKey && t(labelKey) || ''}
@@ -230,7 +230,7 @@ export default class NetworksTab extends PureComponent {
             <div className="networks-tab__add-network-button-wrapper">
               <Button
                 type="primary"
-                onClick={event => {
+                onClick={(event) => {
                   event.preventDefault()
                   setSelectedSettingsRpcUrl(null)
                   setNetworksTabAddMode(true)

--- a/ui/app/pages/settings/networks-tab/networks-tab.container.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.container.js
@@ -12,9 +12,9 @@ import {
 } from '../../../store/actions'
 import { defaultNetworksData } from './networks-tab.constants'
 
-const defaultNetworks = defaultNetworksData.map(network => ({ ...network, viewOnly: true }))
+const defaultNetworks = defaultNetworksData.map((network) => ({ ...network, viewOnly: true }))
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const {
     frequentRpcListDetail,
     provider,
@@ -24,7 +24,7 @@ const mapStateToProps = state => {
     networksTabIsInAddMode,
   } = state.appState
 
-  const frequentRpcNetworkListDetails = frequentRpcListDetail.map(rpc => {
+  const frequentRpcNetworkListDetails = frequentRpcListDetail.map((rpc) => {
     return {
       label: rpc.nickname,
       iconColor: '#6A737D',
@@ -37,12 +37,12 @@ const mapStateToProps = state => {
   })
 
   const networksToRender = [ ...defaultNetworks, ...frequentRpcNetworkListDetails ]
-  let selectedNetwork = networksToRender.find(network => network.rpcUrl === networksTabSelectedRpcUrl) || {}
+  let selectedNetwork = networksToRender.find((network) => network.rpcUrl === networksTabSelectedRpcUrl) || {}
   const networkIsSelected = Boolean(selectedNetwork.rpcUrl)
 
   let networkDefaultedToProvider = false
   if (!networkIsSelected && !networksTabIsInAddMode) {
-    selectedNetwork = networksToRender.find(network => {
+    selectedNetwork = networksToRender.find((network) => {
       return network.rpcUrl === provider.rpcTarget || network.providerType !== 'rpc' && network.providerType === provider.type
     }) || {}
     networkDefaultedToProvider = true
@@ -59,17 +59,17 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    setSelectedSettingsRpcUrl: newRpcUrl => dispatch(setSelectedSettingsRpcUrl(newRpcUrl)),
+    setSelectedSettingsRpcUrl: (newRpcUrl) => dispatch(setSelectedSettingsRpcUrl(newRpcUrl)),
     setRpcTarget: (newRpc, chainId, ticker, nickname, rpcPrefs) => {
       dispatch(updateAndSetCustomRpc(newRpc, chainId, ticker, nickname, rpcPrefs))
     },
     showConfirmDeleteNetworkModal: ({ target, onConfirm }) => {
       return dispatch(showModal({ name: 'CONFIRM_DELETE_NETWORK', target, onConfirm }))
     },
-    displayWarning: warning => dispatch(displayWarning(warning)),
-    setNetworksTabAddMode: isInAddMode => dispatch(setNetworksTabAddMode(isInAddMode)),
+    displayWarning: (warning) => dispatch(displayWarning(warning)),
+    setNetworksTabAddMode: (isInAddMode) => dispatch(setNetworksTabAddMode(isInAddMode)),
     editRpc: (oldRpc, newRpc, chainId, ticker, nickname, rpcPrefs) => {
       dispatch(editRpc(oldRpc, newRpc, chainId, ticker, nickname, rpcPrefs))
     },

--- a/ui/app/pages/settings/security-tab/security-tab.component.js
+++ b/ui/app/pages/settings/security-tab/security-tab.component.js
@@ -33,7 +33,7 @@ export default class SecurityTab extends PureComponent {
             <Button
               type="danger"
               large
-              onClick={event => {
+              onClick={(event) => {
                 event.preventDefault()
                 this.context.metricsEvent({
                   eventOpts: {
@@ -69,7 +69,7 @@ export default class SecurityTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={participateInMetaMetrics}
-              onToggle={value => setParticipateInMetaMetrics(!value)}
+              onToggle={(value) => setParticipateInMetaMetrics(!value)}
               offLabel={t('off')}
               onLabel={t('on')}
             />
@@ -95,7 +95,7 @@ export default class SecurityTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={showIncomingTransactions}
-              onToggle={value => setShowIncomingTransactionsFeatureFlag(!value)}
+              onToggle={(value) => setShowIncomingTransactionsFeatureFlag(!value)}
               offLabel={t('off')}
               onLabel={t('on')}
             />

--- a/ui/app/pages/settings/security-tab/security-tab.container.js
+++ b/ui/app/pages/settings/security-tab/security-tab.container.js
@@ -7,7 +7,7 @@ import {
   setParticipateInMetaMetrics,
 } from '../../../store/actions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { appState: { warning }, metamask } = state
   const {
     featureFlags: {
@@ -23,10 +23,10 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     setParticipateInMetaMetrics: (val) => dispatch(setParticipateInMetaMetrics(val)),
-    setShowIncomingTransactionsFeatureFlag: shouldShow => dispatch(setFeatureFlag('showIncomingTransactions', shouldShow)),
+    setShowIncomingTransactionsFeatureFlag: (shouldShow) => dispatch(setFeatureFlag('showIncomingTransactions', shouldShow)),
   }
 }
 

--- a/ui/app/pages/settings/security-tab/tests/security-tab.test.js
+++ b/ui/app/pages/settings/security-tab/tests/security-tab.test.js
@@ -25,7 +25,7 @@ describe('Security Tab', function () {
     wrapper = mount(
       <SecurityTab.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
           metricsEvent: () => {},
         },
       }

--- a/ui/app/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/app/pages/settings/settings-tab/settings-tab.component.js
@@ -17,7 +17,7 @@ const currencyOptions = sortedCurrencies.map(({ code, name }) => {
   }
 })
 
-const localeOptions = locales.map(locale => {
+const localeOptions = locales.map((locale) => {
   return {
     displayValue: `${locale.name}`,
     key: locale.code,
@@ -63,7 +63,7 @@ export default class SettingsTab extends PureComponent {
               placeholder={t('selectCurrency')}
               options={currencyOptions}
               selectedOption={currentCurrency}
-              onSelect={newCurrency => setCurrentCurrency(newCurrency)}
+              onSelect={(newCurrency) => setCurrentCurrency(newCurrency)}
             />
           </div>
         </div>
@@ -74,7 +74,7 @@ export default class SettingsTab extends PureComponent {
   renderCurrentLocale () {
     const { t } = this.context
     const { updateCurrentLocale, currentLocale } = this.props
-    const currentLocaleMeta = locales.find(locale => locale.code === currentLocale)
+    const currentLocaleMeta = locales.find((locale) => locale.code === currentLocale)
     const currentLocaleName = currentLocaleMeta ? currentLocaleMeta.name : ''
 
     return (
@@ -93,7 +93,7 @@ export default class SettingsTab extends PureComponent {
               placeholder={t('selectLocale')}
               options={localeOptions}
               selectedOption={currentLocale}
-              onSelect={async newLocale => updateCurrentLocale(newLocale)}
+              onSelect={async (newLocale) => updateCurrentLocale(newLocale)}
             />
           </div>
         </div>
@@ -115,7 +115,7 @@ export default class SettingsTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={useBlockie}
-              onToggle={value => setUseBlockie(!value)}
+              onToggle={(value) => setUseBlockie(!value)}
               offLabel={t('off')}
               onLabel={t('on')}
             />

--- a/ui/app/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/app/pages/settings/settings-tab/settings-tab.container.js
@@ -9,7 +9,7 @@ import {
 } from '../../../store/actions'
 import { preferencesSelector } from '../../../selectors/selectors'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { appState: { warning }, metamask } = state
   const {
     currentCurrency,
@@ -31,12 +31,12 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    setCurrentCurrency: currency => dispatch(setCurrentCurrency(currency)),
-    setUseBlockie: value => dispatch(setUseBlockie(value)),
-    updateCurrentLocale: key => dispatch(updateCurrentLocale(key)),
-    setUseNativeCurrencyAsPrimaryCurrencyPreference: value => {
+    setCurrentCurrency: (currency) => dispatch(setCurrentCurrency(currency)),
+    setUseBlockie: (value) => dispatch(setUseBlockie(value)),
+    updateCurrentLocale: (key) => dispatch(updateCurrentLocale(key)),
+    setUseNativeCurrencyAsPrimaryCurrencyPreference: (value) => {
       return dispatch(setUseNativeCurrencyAsPrimaryCurrencyPreference(value))
     },
     setParticipateInMetaMetrics: (val) => dispatch(setParticipateInMetaMetrics(val)),

--- a/ui/app/pages/settings/settings-tab/tests/settings-tab.test.js
+++ b/ui/app/pages/settings/settings-tab/tests/settings-tab.test.js
@@ -25,7 +25,7 @@ describe('Settings Tab', function () {
     wrapper = mount(
       <SettingsTab.WrappedComponent {...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/pages/settings/settings.component.js
+++ b/ui/app/pages/settings/settings.component.js
@@ -162,13 +162,13 @@ class SettingsPage extends PureComponent {
           { content: t('networks'), description: t('networkSettingsDescription'), key: NETWORKS_ROUTE },
           { content: t('about'), description: t('aboutSettingsDescription'), key: ABOUT_US_ROUTE },
         ]}
-        isActive={key => {
+        isActive={(key) => {
           if (key === GENERAL_ROUTE && currentPath === SETTINGS_ROUTE) {
             return true
           }
           return matchPath(currentPath, { path: key, exact: true })
         }}
-        onSelect={key => history.push(key)}
+        onSelect={(key) => history.push(key)}
       />
     )
   }

--- a/ui/app/pages/unlock-page/tests/unlock-page.test.js
+++ b/ui/app/pages/unlock-page/tests/unlock-page.test.js
@@ -25,7 +25,7 @@ describe('Unlock Page', function () {
     wrapper = mount(
       <UnlockPage.WrappedComponent{...props} />, {
         context: {
-          t: str => str,
+          t: (str) => str,
         },
       }
     )

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -40,7 +40,7 @@ export default class UnlockPage extends Component {
     }
   }
 
-  handleSubmit = async event => {
+  handleSubmit = async (event) => {
     event.preventDefault()
     event.stopPropagation()
 
@@ -160,7 +160,7 @@ export default class UnlockPage extends Component {
               label={t('password')}
               type="password"
               value={password}
-              onChange={event => this.handleInputChange(event)}
+              onChange={(event) => this.handleInputChange(event)}
               error={error}
               autoFocus
               autoComplete="current-password"

--- a/ui/app/pages/unlock-page/unlock-page.container.js
+++ b/ui/app/pages/unlock-page/unlock-page.container.js
@@ -13,17 +13,17 @@ import {
 } from '../../store/actions'
 import UnlockPage from './unlock-page.component'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   const { metamask: { isUnlocked } } = state
   return {
     isUnlocked,
   }
 }
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     forgotPassword: () => dispatch(forgotPassword()),
-    tryUnlockMetamask: password => dispatch(tryUnlockMetamask(password)),
+    tryUnlockMetamask: (password) => dispatch(tryUnlockMetamask(password)),
     markPasswordForgotten: () => dispatch(markPasswordForgotten()),
     forceUpdateMetamaskState: () => forceUpdateMetamaskState(dispatch),
     showOptInModal: () => dispatch(showModal({ name: 'METAMETRICS_OPT_IN_MODAL' })),
@@ -43,7 +43,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     }
   }
 
-  const onSubmit = async password => {
+  const onSubmit = async (password) => {
     await tryUnlockMetamask(password)
     history.push(DEFAULT_ROUTE)
   }

--- a/ui/app/selectors/confirm-transaction.js
+++ b/ui/app/selectors/confirm-transaction.js
@@ -13,11 +13,11 @@ import {
   sumHexes,
 } from '../helpers/utils/transactions.util'
 
-const unapprovedTxsSelector = state => state.metamask.unapprovedTxs
-const unapprovedMsgsSelector = state => state.metamask.unapprovedMsgs
-const unapprovedPersonalMsgsSelector = state => state.metamask.unapprovedPersonalMsgs
-const unapprovedTypedMessagesSelector = state => state.metamask.unapprovedTypedMessages
-const networkSelector = state => state.metamask.network
+const unapprovedTxsSelector = (state) => state.metamask.unapprovedTxs
+const unapprovedMsgsSelector = (state) => state.metamask.unapprovedMsgs
+const unapprovedPersonalMsgsSelector = (state) => state.metamask.unapprovedPersonalMsgs
+const unapprovedTypedMessagesSelector = (state) => state.metamask.unapprovedTypedMessages
+const networkSelector = (state) => state.metamask.network
 
 export const unconfirmedTransactionsListSelector = createSelector(
   unapprovedTxsSelector,
@@ -73,9 +73,9 @@ export const unconfirmedTransactionsHashSelector = createSelector(
   }
 )
 
-const unapprovedMsgCountSelector = state => state.metamask.unapprovedMsgCount
-const unapprovedPersonalMsgCountSelector = state => state.metamask.unapprovedPersonalMsgCount
-const unapprovedTypedMessagesCountSelector = state => state.metamask.unapprovedTypedMessagesCount
+const unapprovedMsgCountSelector = (state) => state.metamask.unapprovedMsgCount
+const unapprovedPersonalMsgCountSelector = (state) => state.metamask.unapprovedPersonalMsgCount
+const unapprovedTypedMessagesCountSelector = (state) => state.metamask.unapprovedTypedMessagesCount
 
 export const unconfirmedTransactionsCountSelector = createSelector(
   unapprovedTxsSelector,
@@ -90,7 +90,7 @@ export const unconfirmedTransactionsCountSelector = createSelector(
     unapprovedTypedMessagesCount = 0,
     network
   ) => {
-    const filteredUnapprovedTxIds = Object.keys(unapprovedTxs).filter(txId => {
+    const filteredUnapprovedTxIds = Object.keys(unapprovedTxs).filter((txId) => {
       const { metamaskNetworkId } = unapprovedTxs[txId]
       return metamaskNetworkId === network
     })
@@ -101,34 +101,34 @@ export const unconfirmedTransactionsCountSelector = createSelector(
 )
 
 
-export const currentCurrencySelector = state => state.metamask.currentCurrency
-export const conversionRateSelector = state => state.metamask.conversionRate
-export const getNativeCurrency = state => state.metamask.nativeCurrency
+export const currentCurrencySelector = (state) => state.metamask.currentCurrency
+export const conversionRateSelector = (state) => state.metamask.conversionRate
+export const getNativeCurrency = (state) => state.metamask.nativeCurrency
 
-export const txDataSelector = state => state.confirmTransaction.txData
-const tokenDataSelector = state => state.confirmTransaction.tokenData
-const tokenPropsSelector = state => state.confirmTransaction.tokenProps
+export const txDataSelector = (state) => state.confirmTransaction.txData
+const tokenDataSelector = (state) => state.confirmTransaction.tokenData
+const tokenPropsSelector = (state) => state.confirmTransaction.tokenProps
 
-const contractExchangeRatesSelector = state => state.metamask.contractExchangeRates
+const contractExchangeRatesSelector = (state) => state.metamask.contractExchangeRates
 
 const tokenDecimalsSelector = createSelector(
   tokenPropsSelector,
-  tokenProps => tokenProps && tokenProps.tokenDecimals
+  (tokenProps) => tokenProps && tokenProps.tokenDecimals
 )
 
 const tokenDataParamsSelector = createSelector(
   tokenDataSelector,
-  tokenData => tokenData && tokenData.params || []
+  (tokenData) => tokenData && tokenData.params || []
 )
 
 const txParamsSelector = createSelector(
   txDataSelector,
-  txData => txData && txData.txParams || {}
+  (txData) => txData && txData.txParams || {}
 )
 
 export const tokenAddressSelector = createSelector(
   txParamsSelector,
-  txParams => txParams && txParams.to
+  (txParams) => txParams && txParams.to
 )
 
 const TOKEN_PARAM_SPENDER = '_spender'
@@ -143,8 +143,8 @@ export const tokenAmountAndToAddressSelector = createSelector(
     let tokenAmount = 0
 
     if (params && params.length) {
-      const toParam = params.find(param => param.name === TOKEN_PARAM_TO)
-      const valueParam = params.find(param => param.name === TOKEN_PARAM_VALUE)
+      const toParam = params.find((param) => param.name === TOKEN_PARAM_TO)
+      const valueParam = params.find((param) => param.name === TOKEN_PARAM_VALUE)
       toAddress = toParam ? toParam.value : params[0].value
       const value = valueParam ? Number(valueParam.value) : Number(params[1].value)
 
@@ -170,8 +170,8 @@ export const approveTokenAmountAndToAddressSelector = createSelector(
     let tokenAmount = 0
 
     if (params && params.length) {
-      toAddress = params.find(param => param.name === TOKEN_PARAM_SPENDER).value
-      const value = Number(params.find(param => param.name === TOKEN_PARAM_VALUE).value)
+      toAddress = params.find((param) => param.name === TOKEN_PARAM_SPENDER).value
+      const value = Number(params.find((param) => param.name === TOKEN_PARAM_VALUE).value)
 
       if (tokenDecimals) {
         tokenAmount = calcTokenAmount(value, tokenDecimals).toNumber()
@@ -195,8 +195,8 @@ export const sendTokenTokenAmountAndToAddressSelector = createSelector(
     let tokenAmount = 0
 
     if (params && params.length) {
-      toAddress = params.find(param => param.name === TOKEN_PARAM_TO).value
-      let value = Number(params.find(param => param.name === TOKEN_PARAM_VALUE).value)
+      toAddress = params.find((param) => param.name === TOKEN_PARAM_TO).value
+      let value = Number(params.find((param) => param.name === TOKEN_PARAM_VALUE).value)
 
       if (tokenDecimals) {
         value = calcTokenAmount(value, tokenDecimals).toNumber()

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -129,7 +129,7 @@ export function basicPriceEstimateToETHTotal (estimate, gasLimit, numberOfDecima
 
 export function getRenderableEthFee (estimate, gasLimit, numberOfDecimals = 9) {
   return pipe(
-    x => conversionUtil(x, { fromNumericBase: 'dec', toNumericBase: 'hex' }),
+    (x) => conversionUtil(x, { fromNumericBase: 'dec', toNumericBase: 'hex' }),
     partialRight(basicPriceEstimateToETHTotal, [gasLimit, numberOfDecimals]),
     formatETHFee
   )(estimate, gasLimit)
@@ -138,7 +138,7 @@ export function getRenderableEthFee (estimate, gasLimit, numberOfDecimals = 9) {
 
 export function getRenderableConvertedCurrencyFee (estimate, gasLimit, convertedCurrency, conversionRate) {
   return pipe(
-    x => conversionUtil(x, { fromNumericBase: 'dec', toNumericBase: 'hex' }),
+    (x) => conversionUtil(x, { fromNumericBase: 'dec', toNumericBase: 'hex' }),
     partialRight(basicPriceEstimateToETHTotal, [gasLimit]),
     partialRight(ethTotalToConvertedCurrency, [convertedCurrency, conversionRate]),
     partialRight(formatCurrency, [convertedCurrency])
@@ -173,7 +173,7 @@ export function formatTimeEstimate (totalSeconds, greaterThanMax, lessThanMin) {
   const formattedSec = `${seconds ? seconds + ' sec' : ''}`
   const formattedCombined = formattedMin && formattedSec
     ? `${symbol}${formattedMin} ${formattedSec}`
-    : symbol + [formattedMin, formattedSec].find(t => t)
+    : symbol + [formattedMin, formattedSec].find((t) => t)
 
   return formattedCombined
 }
@@ -197,7 +197,7 @@ export function priceEstimateToWei (priceEstimate) {
 
 export function getGasPriceInHexWei (price) {
   return pipe(
-    x => conversionUtil(x, { fromNumericBase: 'dec', toNumericBase: 'hex' }),
+    (x) => conversionUtil(x, { fromNumericBase: 'dec', toNumericBase: 'hex' }),
     priceEstimateToWei,
     addHexPrefix
   )(price)

--- a/ui/app/selectors/custom-gas.test.js
+++ b/ui/app/selectors/custom-gas.test.js
@@ -338,7 +338,7 @@ describe('custom-gas selectors', function () {
       },
     ]
     it('should return renderable data about basic estimates', function () {
-      tests.forEach(test => {
+      tests.forEach((test) => {
         assert.deepEqual(
           getRenderableBasicEstimateData(test.mockState, '0x5208'),
           test.expectedResult
@@ -602,7 +602,7 @@ describe('custom-gas selectors', function () {
       },
     ]
     it('should return renderable data about basic estimates appropriate for buttons with less info', function () {
-      tests.forEach(test => {
+      tests.forEach((test) => {
         assert.deepEqual(
           getRenderableEstimateDataForSmallButtonsFromGWEI(test.mockState),
           test.expectedResult

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -16,7 +16,7 @@ const accountsPermissionSelector = createSelector(
     return (
       Array.isArray(domain.permissions)
         ? domain.permissions.find(
-          perm => perm.parentCapability === 'eth_accounts'
+          (perm) => perm.parentCapability === 'eth_accounts'
         )
         : {}
     )
@@ -35,7 +35,7 @@ export const getPermittedAccounts = createSelector(
     const accountsCaveat = (
       Array.isArray(accountsPermission.caveats) &&
       accountsPermission.caveats.find(
-        c => c.name === CAVEAT_NAMES.exposedAccounts
+        (c) => c.name === CAVEAT_NAMES.exposedAccounts
       )
     )
 

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -149,8 +149,8 @@ export const getMetaMaskAccountsOrdered = createSelector(
   getMetaMaskAccounts,
   (keyrings, identities, accounts) => keyrings
     .reduce((list, keyring) => list.concat(keyring.accounts), [])
-    .filter(address => !!identities[address])
-    .map(address => ({ ...identities[address], ...accounts[address] }))
+    .filter((address) => !!identities[address])
+    .map((address) => ({ ...identities[address], ...accounts[address] }))
 )
 
 export function isBalanceCached (state) {
@@ -221,7 +221,7 @@ export function getAddressBook (state) {
 
 export function getAddressBookEntry (state, address) {
   const addressBook = getAddressBook(state)
-  const entry = addressBook.find(contact => contact.address === checksumAddress(address))
+  const entry = addressBook.find((contact) => contact.address === checksumAddress(address))
   return entry
 }
 
@@ -249,7 +249,7 @@ export function accountsWithSendEtherInfoSelector (state) {
 
 export function getAccountsWithLabels (state) {
   const accountsWithoutLabel = accountsWithSendEtherInfoSelector(state)
-  const accountsWithLabels = accountsWithoutLabel.map(account => {
+  const accountsWithLabels = accountsWithoutLabel.map((account) => {
     const { address, name, balance } = account
     return {
       address,
@@ -397,7 +397,7 @@ export function getMetaMetricState (state) {
 
 export function getRpcPrefsForCurrentProvider (state) {
   const { frequentRpcListDetail, provider } = state.metamask
-  const selectRpcInfo = frequentRpcListDetail.find(rpcInfo => rpcInfo.rpcUrl === provider.rpcTarget)
+  const selectRpcInfo = frequentRpcListDetail.find((rpcInfo) => rpcInfo.rpcUrl === provider.rpcTarget)
   const { rpcPrefs = {} } = selectRpcInfo || {}
   return rpcPrefs
 }
@@ -439,14 +439,14 @@ export function getAddressConnectedDomainMap (state) {
   const addressConnectedIconMap = {}
 
   if (domains) {
-    Object.keys(domains).forEach(domainKey => {
+    Object.keys(domains).forEach((domainKey) => {
       const { permissions } = domains[domainKey]
       const { icon, name } = domainMetadata[domainKey] || {}
-      permissions.forEach(perm => {
+      permissions.forEach((perm) => {
         const caveats = perm.caveats || []
-        const exposedAccountCaveat = caveats.find(caveat => caveat.name === 'exposedAccounts')
+        const exposedAccountCaveat = caveats.find((caveat) => caveat.name === 'exposedAccounts')
         if (exposedAccountCaveat && exposedAccountCaveat.value && exposedAccountCaveat.value.length) {
-          exposedAccountCaveat.value.forEach(address => {
+          exposedAccountCaveat.value.forEach((address) => {
             const nameToRender = name || domainKey
             addressConnectedIconMap[address] = addressConnectedIconMap[address]
               ? { ...addressConnectedIconMap[address], [domainKey]: { icon, name: nameToRender } }
@@ -464,11 +464,11 @@ export function getDomainToConnectedAddressMap (state) {
   const { domains = {} } = state.metamask
 
   const domainToConnectedAddressMap = mapObjectValues(domains, (_, { permissions }) => {
-    const ethAccountsPermissions = permissions.filter(permission => permission.parentCapability === 'eth_accounts')
-    const ethAccountsPermissionsExposedAccountAddresses = ethAccountsPermissions.map(permission => {
+    const ethAccountsPermissions = permissions.filter((permission) => permission.parentCapability === 'eth_accounts')
+    const ethAccountsPermissionsExposedAccountAddresses = ethAccountsPermissions.map((permission) => {
       const caveats = permission.caveats
-      const exposedAccountsCaveats = caveats.filter(caveat => caveat.name === 'exposedAccounts')
-      const exposedAccountsAddresses = exposedAccountsCaveats.map(caveat => caveat.value[0])
+      const exposedAccountsCaveats = caveats.filter((caveat) => caveat.name === 'exposedAccounts')
+      const exposedAccountsAddresses = exposedAccountsCaveats.map((caveat) => caveat.value[0])
       return exposedAccountsAddresses
     })
     const allAddressesConnectedToDomain = ethAccountsPermissionsExposedAccountAddresses.reduce((acc, arrayOfAddresses) => {
@@ -499,9 +499,9 @@ export function getRenderablePermissionsDomains (state) {
 
   const renderableDomains = Object.keys(domains).reduce((acc, domainKey) => {
     const { permissions } = domains[domainKey]
-    const permissionsWithCaveatsForSelectedAddress = permissions.filter(perm => {
+    const permissionsWithCaveatsForSelectedAddress = permissions.filter((perm) => {
       const caveats = perm.caveats || []
-      const exposedAccountCaveat = caveats.find(caveat => caveat.name === 'exposedAccounts')
+      const exposedAccountCaveat = caveats.find((caveat) => caveat.name === 'exposedAccounts')
       const exposedAccountCaveatValue = exposedAccountCaveat && exposedAccountCaveat.value && exposedAccountCaveat.value.length
         ? exposedAccountCaveat.value[0]
         : {}
@@ -509,7 +509,7 @@ export function getRenderablePermissionsDomains (state) {
     })
 
     if (permissionsWithCaveatsForSelectedAddress.length) {
-      const permissionKeys = permissions.map(permission => permission.parentCapability)
+      const permissionKeys = permissions.map((permission) => permission.parentCapability)
       const {
         name,
         icon,
@@ -530,7 +530,7 @@ export function getRenderablePermissionsDomains (state) {
         icon,
         key: domainKey,
         lastConnectedTime,
-        permissionDescriptions: permissionKeys.map(permissionKey => permissionsDescriptions[permissionKey]),
+        permissionDescriptions: permissionKeys.map((permissionKey) => permissionsDescriptions[permissionKey]),
         extensionId,
       }]
     } else {

--- a/ui/app/selectors/tokens.js
+++ b/ui/app/selectors/tokens.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect'
 
-export const selectedTokenAddressSelector = state => state.metamask.selectedTokenAddress
-export const tokenSelector = state => state.metamask.tokens
+export const selectedTokenAddressSelector = (state) => state.metamask.selectedTokenAddress
+export const tokenSelector = (state) => state.metamask.tokens
 export const selectedTokenSelector = createSelector(
   tokenSelector,
   selectedTokenAddressSelector,

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -15,9 +15,9 @@ import { getFastPriceEstimateInHexWEI } from './custom-gas'
 import { getSelectedToken } from './selectors'
 import txHelper from '../../lib/tx-helper'
 
-export const shapeShiftTxListSelector = state => state.metamask.shapeShiftTxList
+export const shapeShiftTxListSelector = (state) => state.metamask.shapeShiftTxList
 
-export const incomingTxListSelector = state => {
+export const incomingTxListSelector = (state) => {
   const { showIncomingTransactions } = state.metamask.featureFlags
   if (!showIncomingTransactions) {
     return []
@@ -30,11 +30,11 @@ export const incomingTxListSelector = state => {
       txParams.to === selectedAddress && metamaskNetworkId === network
     ))
 }
-export const unapprovedMsgsSelector = state => state.metamask.unapprovedMsgs
-export const selectedAddressTxListSelector = state => state.metamask.selectedAddressTxList
-export const unapprovedPersonalMsgsSelector = state => state.metamask.unapprovedPersonalMsgs
-export const unapprovedTypedMessagesSelector = state => state.metamask.unapprovedTypedMessages
-export const networkSelector = state => state.metamask.network
+export const unapprovedMsgsSelector = (state) => state.metamask.unapprovedMsgs
+export const selectedAddressTxListSelector = (state) => state.metamask.selectedAddressTxList
+export const unapprovedPersonalMsgsSelector = (state) => state.metamask.unapprovedPersonalMsgs
+export const unapprovedTypedMessagesSelector = (state) => state.metamask.unapprovedTypedMessages
+export const networkSelector = (state) => state.metamask.network
 
 export const unapprovedMessagesSelector = createSelector(
   unapprovedMsgsSelector,
@@ -185,7 +185,7 @@ const insertTransactionGroupByTime = (transactionGroups, transactionGroup) => {
  * but intended to be ordered by timestamp
  */
 const mergeNonNonceTransactionGroups = (orderedTransactionGroups, nonNonceTransactionGroups) => {
-  nonNonceTransactionGroups.forEach(shapeshiftGroup => {
+  nonNonceTransactionGroups.forEach((shapeshiftGroup) => {
     insertTransactionGroupByTime(orderedTransactionGroups, shapeshiftGroup)
   })
 }
@@ -204,7 +204,7 @@ export const nonceSortedTransactionsSelector = createSelector(
     const orderedNonces = []
     const nonceToTransactionsMap = {}
 
-    transactions.forEach(transaction => {
+    transactions.forEach((transaction) => {
       const { txParams: { nonce } = {}, status, type, time: txTime, key, transactionCategory } = transaction
 
       if (typeof nonce === 'undefined' || transactionCategory === 'incoming') {
@@ -264,7 +264,7 @@ export const nonceSortedTransactionsSelector = createSelector(
       }
     })
 
-    const orderedTransactionGroups = orderedNonces.map(nonce => nonceToTransactionsMap[nonce])
+    const orderedTransactionGroups = orderedNonces.map((nonce) => nonceToTransactionsMap[nonce])
     mergeNonNonceTransactionGroups(orderedTransactionGroups, shapeshiftTransactionGroups)
     mergeNonNonceTransactionGroups(orderedTransactionGroups, incomingTransactionGroups)
     return unapprovedTransactionGroups.concat(orderedTransactionGroups)
@@ -302,7 +302,7 @@ export const nonceSortedCompletedTransactionsSelector = createSelector(
 export const submittedPendingTransactionsSelector = createSelector(
   transactionsSelector,
   (transactions = []) => (
-    transactions.filter(transaction => transaction.status === SUBMITTED_STATUS)
+    transactions.filter((transaction) => transaction.status === SUBMITTED_STATUS)
   )
 )
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -154,13 +154,13 @@ export function goHome () {
 // async actions
 
 export function tryUnlockMetamask (password) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(showLoadingIndication())
     dispatch(unlockInProgress())
     log.debug(`background.submitPassword`)
 
     return new Promise((resolve, reject) => {
-      background.submitPassword(password, error => {
+      background.submitPassword(password, (error) => {
         if (error) {
           return reject(error)
         }
@@ -174,7 +174,7 @@ export function tryUnlockMetamask (password) {
       })
       .then(() => {
         return new Promise((resolve, reject) => {
-          background.verifySeedPhrase(err => {
+          background.verifySeedPhrase((err) => {
             if (err) {
               dispatch(displayWarning(err.message))
               return reject(err)
@@ -188,7 +188,7 @@ export function tryUnlockMetamask (password) {
         dispatch(transitionForward())
         dispatch(hideLoadingIndication())
       })
-      .catch(err => {
+      .catch((err) => {
         dispatch(unlockFailed(err.message))
         dispatch(hideLoadingIndication())
         return Promise.reject(err)
@@ -222,7 +222,7 @@ export function createNewVaultAndRestore (password, seed) {
         dispatch(hideLoadingIndication())
         return vault
       })
-      .catch(err => {
+      .catch((err) => {
         dispatch(displayWarning(err.message))
         dispatch(hideLoadingIndication())
         return Promise.reject(err)
@@ -231,7 +231,7 @@ export function createNewVaultAndRestore (password, seed) {
 }
 
 export function createNewVaultAndGetSeedPhrase (password) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
 
     try {
@@ -248,7 +248,7 @@ export function createNewVaultAndGetSeedPhrase (password) {
 }
 
 export function unlockAndGetSeedPhrase (password) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
 
     try {
@@ -267,7 +267,7 @@ export function unlockAndGetSeedPhrase (password) {
 
 export function submitPassword (password) {
   return new Promise((resolve, reject) => {
-    background.submitPassword(password, error => {
+    background.submitPassword(password, (error) => {
       if (error) {
         return reject(error)
       }
@@ -279,7 +279,7 @@ export function submitPassword (password) {
 
 export function createNewVault (password) {
   return new Promise((resolve, reject) => {
-    background.createNewVaultAndKeychain(password, error => {
+    background.createNewVaultAndKeychain(password, (error) => {
       if (error) {
         return reject(error)
       }
@@ -291,7 +291,7 @@ export function createNewVault (password) {
 
 export function verifyPassword (password) {
   return new Promise((resolve, reject) => {
-    background.submitPassword(password, error => {
+    background.submitPassword(password, (error) => {
       if (error) {
         return reject(error)
       }
@@ -314,7 +314,7 @@ export function verifySeedPhrase () {
 }
 
 export function requestRevealSeedWords (password) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
     log.debug(`background.submitPassword`)
 
@@ -345,7 +345,7 @@ export function tryReverseResolveAddress (address) {
 }
 
 export function fetchInfoToSync () {
-  return dispatch => {
+  return (dispatch) => {
     log.debug(`background.fetchInfoToSync`)
     return new Promise((resolve, reject) => {
       background.fetchInfoToSync((err, result) => {
@@ -360,7 +360,7 @@ export function fetchInfoToSync () {
 }
 
 export function resetAccount () {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(showLoadingIndication())
 
     return new Promise((resolve, reject) => {
@@ -380,7 +380,7 @@ export function resetAccount () {
 }
 
 export function removeAccount (address) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
 
     try {
@@ -456,7 +456,7 @@ export function addNewAccount () {
           dispatch(displayWarning(err.message))
           return reject(err)
         }
-        const newAccountAddress = Object.keys(newIdentities).find(address => !oldIdentities[address])
+        const newAccountAddress = Object.keys(newIdentities).find((address) => !oldIdentities[address])
 
         dispatch(hideLoadingIndication())
 
@@ -710,13 +710,13 @@ export function updateGasData ({
       estimateGasPrice: gasPrice,
       data,
     })
-      .then(gas => {
+      .then((gas) => {
         dispatch(setGasLimit(gas))
         dispatch(setCustomGasLimit(gas))
         dispatch(updateSendErrors({ gasLoadingError: null }))
         dispatch(gasLoadingFinished())
       })
-      .catch(err => {
+      .catch((err) => {
         log.error(err)
         dispatch(updateSendErrors({ gasLoadingError: 'gasLoadingError' }))
         dispatch(gasLoadingFinished())
@@ -746,13 +746,13 @@ export function updateSendTokenBalance ({
       ? tokenContract.balanceOf(address)
       : Promise.resolve()
     return tokenBalancePromise
-      .then(usersToken => {
+      .then((usersToken) => {
         if (usersToken) {
           const newTokenBalance = calcTokenBalance({ selectedToken, usersToken })
           dispatch(setSendTokenBalance(newTokenBalance))
         }
       })
-      .catch(err => {
+      .catch((err) => {
         log.error(err)
         updateSendErrors({ tokenBalance: 'tokenBalanceError' })
       })
@@ -836,11 +836,11 @@ export function updateSendEnsResolutionError (errorMessage) {
 }
 
 export function signTokenTx (tokenAddress, toAddress, amount, txData) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(showLoadingIndication())
     const token = global.eth.contract(abi).at(tokenAddress)
     token.transfer(toAddress, ethUtil.addHexPrefix(amount), txData)
-      .catch(err => {
+      .catch((err) => {
         dispatch(hideLoadingIndication())
         dispatch(displayWarning(err.message))
       })
@@ -863,7 +863,7 @@ const updateMetamaskStateFromBackground = () => {
 }
 
 export function updateTransaction (txData) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(showLoadingIndication())
 
     return new Promise((resolve, reject) => {
@@ -880,7 +880,7 @@ export function updateTransaction (txData) {
       })
     })
       .then(() => updateMetamaskStateFromBackground())
-      .then(newState => dispatch(updateMetamaskState(newState)))
+      .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => {
         dispatch(showConfTxPage({ id: txData.id }))
         dispatch(hideLoadingIndication())
@@ -893,7 +893,7 @@ export function updateAndApproveTx (txData) {
   return (dispatch) => {
     dispatch(showLoadingIndication())
     return new Promise((resolve, reject) => {
-      background.updateAndApproveTransaction(txData, err => {
+      background.updateAndApproveTransaction(txData, (err) => {
         dispatch(updateTransactionParams(txData.id, txData.txParams))
         dispatch(clearSend())
 
@@ -908,7 +908,7 @@ export function updateAndApproveTx (txData) {
       })
     })
       .then(() => updateMetamaskStateFromBackground())
-      .then(newState => dispatch(updateMetamaskState(newState)))
+      .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => {
         dispatch(clearSend())
         dispatch(completedTx(txData.id))
@@ -936,7 +936,7 @@ export function completedTx (id) {
       network,
     } = state.metamask
     const unconfirmedActions = txHelper(unapprovedTxs, unapprovedMsgs, unapprovedPersonalMsgs, unapprovedTypedMessages, network)
-    const otherUnconfirmedActions = unconfirmedActions.filter(tx => tx.id !== id)
+    const otherUnconfirmedActions = unconfirmedActions.filter((tx) => tx.id !== id)
     dispatch({
       type: actionConstants.COMPLETED_TX,
       value: {
@@ -1031,7 +1031,7 @@ export function cancelTx (txData) {
   return (dispatch) => {
     dispatch(showLoadingIndication())
     return new Promise((resolve, reject) => {
-      background.cancelTransaction(txData.id, err => {
+      background.cancelTransaction(txData.id, (err) => {
         if (err) {
           return reject(err)
         }
@@ -1040,7 +1040,7 @@ export function cancelTx (txData) {
       })
     })
       .then(() => updateMetamaskStateFromBackground())
-      .then(newState => dispatch(updateMetamaskState(newState)))
+      .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => {
         dispatch(clearSend())
         dispatch(completedTx(txData.id))
@@ -1099,8 +1099,8 @@ export function markPasswordForgotten () {
 }
 
 export function unMarkPasswordForgotten () {
-  return dispatch => {
-    return new Promise(resolve => {
+  return (dispatch) => {
+    return new Promise((resolve) => {
       background.unMarkPasswordForgotten(() => {
         dispatch(forgotPassword(false))
         resolve()
@@ -1163,7 +1163,7 @@ export function updateMetamaskState (newState) {
 
 const backgroundSetLocked = () => {
   return new Promise((resolve, reject) => {
-    background.setLocked(error => {
+    background.setLocked((error) => {
       if (error) {
         return reject(error)
       }
@@ -1175,16 +1175,16 @@ const backgroundSetLocked = () => {
 export function lockMetamask () {
   log.debug(`background.setLocked`)
 
-  return dispatch => {
+  return (dispatch) => {
     dispatch(showLoadingIndication())
 
     return backgroundSetLocked()
       .then(() => updateMetamaskStateFromBackground())
-      .catch(error => {
+      .catch((error) => {
         dispatch(displayWarning(error.message))
         return Promise.reject(error)
       })
-      .then(newState => {
+      .then((newState) => {
         dispatch(updateMetamaskState(newState))
         dispatch(hideLoadingIndication())
         dispatch({ type: actionConstants.LOCK_METAMASK })
@@ -1290,7 +1290,7 @@ export function removeToken (address) {
 }
 
 export function addTokens (tokens) {
-  return dispatch => {
+  return (dispatch) => {
     if (Array.isArray(tokens)) {
       dispatch(setSelectedToken(getTokenAddressFromTokenObject(tokens[0])))
       return Promise.all(tokens.map(({ address, symbol, decimals }) => (
@@ -1326,7 +1326,7 @@ export function removeSuggestedTokens () {
       })
     })
       .then(() => updateMetamaskStateFromBackground())
-      .then(suggestedTokens => dispatch(updateMetamaskState({ ...suggestedTokens })))
+      .then((suggestedTokens) => dispatch(updateMetamaskState({ ...suggestedTokens })))
   }
 }
 
@@ -1353,7 +1353,7 @@ export function retryTransaction (txId, gasPrice) {
   log.debug(`background.retryTransaction`)
   let newTxId
 
-  return dispatch => {
+  return (dispatch) => {
     return new Promise((resolve, reject) => {
       background.retryTransaction(txId, gasPrice, (err, newState) => {
         if (err) {
@@ -1367,7 +1367,7 @@ export function retryTransaction (txId, gasPrice) {
         resolve(newState)
       })
     })
-      .then(newState => dispatch(updateMetamaskState(newState)))
+      .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => newTxId)
   }
 }
@@ -1376,7 +1376,7 @@ export function createCancelTransaction (txId, customGasPrice) {
   log.debug('background.cancelTransaction')
   let newTxId
 
-  return dispatch => {
+  return (dispatch) => {
     return new Promise((resolve, reject) => {
       background.createCancelTransaction(txId, customGasPrice, (err, newState) => {
         if (err) {
@@ -1390,7 +1390,7 @@ export function createCancelTransaction (txId, customGasPrice) {
         resolve(newState)
       })
     })
-      .then(newState => dispatch(updateMetamaskState(newState)))
+      .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => newTxId)
   }
 }
@@ -1399,7 +1399,7 @@ export function createSpeedUpTransaction (txId, customGasPrice) {
   log.debug('background.createSpeedUpTransaction')
   let newTx
 
-  return dispatch => {
+  return (dispatch) => {
     return new Promise((resolve, reject) => {
       background.createSpeedUpTransaction(txId, customGasPrice, (err, newState) => {
         if (err) {
@@ -1412,7 +1412,7 @@ export function createSpeedUpTransaction (txId, customGasPrice) {
         resolve(newState)
       })
     })
-      .then(newState => dispatch(updateMetamaskState(newState)))
+      .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => newTx)
   }
 }
@@ -1421,7 +1421,7 @@ export function createRetryTransaction (txId, customGasPrice) {
   log.debug('background.createRetryTransaction')
   let newTx
 
-  return dispatch => {
+  return (dispatch) => {
     return new Promise((resolve, reject) => {
       background.createSpeedUpTransaction(txId, customGasPrice, (err, newState) => {
         if (err) {
@@ -1434,7 +1434,7 @@ export function createRetryTransaction (txId, customGasPrice) {
         resolve(newState)
       })
     })
-      .then(newState => dispatch(updateMetamaskState(newState)))
+      .then((newState) => dispatch(updateMetamaskState(newState)))
       .then(() => newTx)
   }
 }
@@ -1900,7 +1900,7 @@ export function updateFeatureFlags (updatedFeatureFlags) {
 }
 
 export function setPreference (preference, value) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(showLoadingIndication())
     return new Promise((resolve, reject) => {
       background.setPreference(preference, value, (err, updatedPreferences) => {
@@ -1938,7 +1938,7 @@ export function setAutoLockTimeLimit (value) {
 }
 
 export function setCompletedOnboarding () {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
 
     try {

--- a/ui/lib/tx-helper.js
+++ b/ui/lib/tx-helper.js
@@ -5,7 +5,7 @@ export default function txHelper (unapprovedTxs, unapprovedMsgs, personalMsgs, t
   log.debug('tx-helper called with params:')
   log.debug({ unapprovedTxs, unapprovedMsgs, personalMsgs, typedMessages, network })
 
-  const txValues = network ? valuesFor(unapprovedTxs).filter(txMeta => txMeta.metamaskNetworkId === network) : valuesFor(unapprovedTxs)
+  const txValues = network ? valuesFor(unapprovedTxs).filter((txMeta) => txMeta.metamaskNetworkId === network) : valuesFor(unapprovedTxs)
   log.debug(`tx helper found ${txValues.length} unapproved txs`)
 
   const msgValues = valuesFor(unapprovedMsgs)

--- a/ui/lib/webcam-utils.js
+++ b/ui/lib/webcam-utils.js
@@ -10,11 +10,11 @@ class WebcamUtils {
     const isFirefoxOrBrave = getPlatform() === (PLATFORM_FIREFOX || PLATFORM_BRAVE)
 
     const devices = await window.navigator.mediaDevices.enumerateDevices()
-    const webcams = devices.filter(device => device.kind === 'videoinput')
+    const webcams = devices.filter((device) => device.kind === 'videoinput')
     const hasWebcam = webcams.length > 0
     // A non-empty-string label implies that the webcam has been granted permission, as
     // otherwise the label is kept blank to prevent fingerprinting
-    const hasWebcamPermissions = webcams.some(webcam => webcam.label && webcam.label.length > 0)
+    const hasWebcamPermissions = webcams.some((webcam) => webcam.label && webcam.label.length > 0)
 
     if (hasWebcam) {
       let environmentReady = true


### PR DESCRIPTION
This PR enables the core ESLint `arrow-parens` rule, which enforces parentheses around arrow function parameters regardless of arity.<sup>[\[1\]][1]</sup>

This will allow introduces type annotations where needed with less noise.

  [1]:https://eslint.org/docs/rules/arrow-parens