### PR TITLE
Attempt ENS resolution on any valid domain name

### DIFF
--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -1,6 +1,7 @@
 import abi from 'human-standard-token-abi'
 import ethUtil from 'ethereumjs-util'
 import { DateTime } from 'luxon'
+import punycode from 'punycode'
 
 // formatData :: ( date: <Unix Timestamp> ) -> String
 export function formatDate (date, format = 'M/d/y \'at\' T') {
@@ -62,8 +63,14 @@ export function isValidAddress (address) {
   return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
 }
 
-export function isValidENSAddress (address) {
-  return address.match(/^.{3,}\.(eth|test|xyz)$/)
+export function isValidDomainName (address) {
+  const match = punycode.toASCII(address)
+    .toLowerCase()
+    // Checks that the domain consists of at least one valid domain pieces separated by periods, followed by a tld
+    // Each piece of domain name has only the characters a-z, 0-9, and a hyphen (but not at the start or end of chunk)
+    // A chunk has minimum length of 1, but minimum tld is set to 2 for now (no 1-character tlds exist yet)
+    .match(/^(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.)+[a-z0-9][-a-z0-9]*[a-z0-9]$/)
+  return match !== null
 }
 
 export function isAllOneCase (address) {

--- a/ui/app/helpers/utils/util.test.js
+++ b/ui/app/helpers/utils/util.test.js
@@ -103,6 +103,64 @@ describe('util', function () {
     })
   })
 
+  describe('isValidDomainName', function () {
+    it('should return true when given a valid domain name', function () {
+      assert.strictEqual(util.isValidDomainName('foo.bar'), true)
+    })
+
+    it('should return true when given a valid subdomain', function () {
+      assert.strictEqual(util.isValidDomainName('foo.foo.bar'), true)
+    })
+
+    it('should return true when given a single-character domain', function () {
+      assert.strictEqual(util.isValidDomainName('f.bar'), true)
+    })
+
+    it('should return true when given a unicode TLD', function () {
+      assert.strictEqual(util.isValidDomainName('台灣.中国'), true)
+    })
+
+    it('should return false when given a domain with unacceptable ASCII characters', function () {
+      assert.strictEqual(util.isValidDomainName('$.bar'), false)
+    })
+
+    it('should return false when given a TLD that starts with a dash', function () {
+      assert.strictEqual(util.isValidDomainName('foo.-bar'), false)
+    })
+
+    it('should return false when given a TLD that ends with a dash', function () {
+      assert.strictEqual(util.isValidDomainName('foo.bar-'), false)
+    })
+
+    it('should return false when given a domain name with a chunk that starts with a dash', function () {
+      assert.strictEqual(util.isValidDomainName('-foo.bar'), false)
+    })
+
+    it('should return false when given a domain name with a chunk that ends with a dash', function () {
+      assert.strictEqual(util.isValidDomainName('foo-.bar'), false)
+    })
+
+    it('should return false when given a bare TLD', function () {
+      assert.strictEqual(util.isValidDomainName('bar'), false)
+    })
+
+    it('should return false when given a domain that starts with a period', function () {
+      assert.strictEqual(util.isValidDomainName('.bar'), false)
+    })
+
+    it('should return false when given a subdomain that starts with a period', function () {
+      assert.strictEqual(util.isValidDomainName('.foo.bar'), false)
+    })
+
+    it('should return false when given a domain that ends with a period', function () {
+      assert.strictEqual(util.isValidDomainName('bar.'), false)
+    })
+
+    it('should return false when given a 1-character TLD', function () {
+      assert.strictEqual(util.isValidDomainName('foo.b'), false)
+    })
+  })
+
   describe('#numericBalance', function () {
     it('should return a BN 0 if given nothing', function () {
       const result = util.numericBalance()

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import c from 'classnames'
-import { isValidENSAddress, isValidAddress, isValidAddressHead } from '../../../../helpers/utils/util'
+import { isValidDomainName, isValidAddress, isValidAddressHead } from '../../../../helpers/utils/util'
 import { ellipsify } from '../../send.utils'
 
 import { debounce } from 'lodash'
@@ -93,7 +93,7 @@ export default class EnsInput extends Component {
         this.props.updateEnsResolution(address)
       })
       .catch((reason) => {
-        if (isValidENSAddress(recipient) && reason.message === 'ENS name not defined.') {
+        if (isValidDomainName(recipient) && reason.message === 'ENS name not defined.') {
           this.props.updateEnsResolutionError(this.context.t('ensNotFoundOnCurrentNetwork'))
         } else {
           log.error(reason)
@@ -126,7 +126,7 @@ export default class EnsInput extends Component {
       return
     }
 
-    if (isValidENSAddress(input)) {
+    if (isValidDomainName(input)) {
       this.lookupEnsName(input)
     } else if (onValidAddressTyped && isValidAddress(input)) {
       onValidAddressTyped(input)

--- a/ui/app/pages/send/send.container.js
+++ b/ui/app/pages/send/send.container.js
@@ -50,7 +50,7 @@ import {
   calcGasTotal,
 } from './send.utils.js'
 import {
-  isValidENSAddress,
+  isValidDomainName,
 } from '../../helpers/utils/util'
 
 function mapStateToProps (state) {
@@ -114,7 +114,7 @@ function mapDispatchToProps (dispatch) {
     updateSendEnsResolution: (ensResolution) => dispatch(updateSendEnsResolution(ensResolution)),
     updateSendEnsResolutionError: (message) => dispatch(updateSendEnsResolutionError(message)),
     updateToNicknameIfNecessary: (to, toNickname, addressBook) => {
-      if (isValidENSAddress(toNickname)) {
+      if (isValidDomainName(toNickname)) {
         const addressBookEntry = addressBook.find(({ address }) => to === address) || {}
         if (!addressBookEntry.name !== toNickname) {
           dispatch(updateSendTo(to, addressBookEntry.name || ''))

--- a/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Identicon from '../../../../components/ui/identicon'
 import TextField from '../../../../components/ui/text-field'
 import { CONTACT_LIST_ROUTE } from '../../../../helpers/constants/routes'
-import { isValidAddress, isValidENSAddress } from '../../../../helpers/utils/util'
+import { isValidAddress, isValidDomainName } from '../../../../helpers/utils/util'
 import EnsInput from '../../../send/send-content/add-recipient/ens-input'
 import PageContainerFooter from '../../../../components/ui/page-container/page-container-footer'
 import { debounce } from 'lodash'
@@ -51,7 +51,7 @@ export default class AddContact extends PureComponent {
 
   validate = (address) => {
     const valid = isValidAddress(address)
-    const validEnsAddress = isValidENSAddress(address)
+    const validEnsAddress = isValidDomainName(address)
     if (valid || validEnsAddress || address === '') {
       this.setState({ error: '', ethAddress: address })
     } else {


### PR DESCRIPTION
ENS currently supports a variety of tlds in addition to `.eth`, and more will be supported in the future. Rather than hard-code a list of supported ENS tlds, all valid domain names will now be interpreted as potential ENS addresses in our address input component.

Closes #7978