### PR TITLE
Enable core ESLint no-mixed-operators rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
 
   rules: {
     'arrow-parens': 'error',
+    'no-mixed-operators': 'error',
     'import/default': 'error',
     'import/export': 'error',
     'import/named': 'error',

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -652,7 +652,7 @@ class TransactionController extends EventEmitter {
   */
   async _determineTransactionCategory (txParams) {
     const { data, to } = txParams
-    const { name } = data && abiDecoder.decodeMethod(data) || {}
+    const { name } = (data && abiDecoder.decodeMethod(data)) || {}
     const tokenMethodName = [
       TOKEN_METHOD_APPROVE,
       TOKEN_METHOD_TRANSFER,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ const packageJSON = require('./package.json')
 
 sass.compiler = require('node-sass')
 
-const dependencies = Object.keys(packageJSON && packageJSON.dependencies || {})
+const dependencies = Object.keys((packageJSON && packageJSON.dependencies) || {})
 const materialUIDependencies = ['@material-ui/core']
 const reactDepenendencies = dependencies.filter((dep) => dep.match(/react/))
 const d3Dependencies = ['c3', 'd3']

--- a/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.component.js
+++ b/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.component.js
@@ -44,9 +44,9 @@ export default class GasPriceChart extends Component {
       const { x: yAxisX } = getCoordinateData('.c3-axis-y-label')
       const { x: tickX } = getCoordinateData('.c3-axis-x .tick')
 
-      d3.select('.c3-axis-x .tick').attr('transform', 'translate(' + (domainX - tickX) / 2 + ', 0)')
+      d3.select('.c3-axis-x .tick').attr('transform', `translate(${(domainX - tickX) / 2}, 0)`)
       d3.select('.c3-axis-x-label').attr('transform', 'translate(0,-15)')
-      d3.select('.c3-axis-y-label').attr('transform', 'translate(' + (domainX - yAxisX - 12) + ', 2) rotate(-90)')
+      d3.select('.c3-axis-y-label').attr('transform', `translate(${domainX - yAxisX - 12}, 2) rotate(-90)`)
       d3.select('.c3-xgrid-focus line').attr('y2', 98)
 
       d3.select('.c3-chart').on('mouseout', () => {

--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.util.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.util.js
@@ -90,7 +90,7 @@ export function getActivities (transaction, isFirstTransaction = false) {
         const { op, path, value, timestamp: entryTimestamp } = entry
         // Not all sub-entries in a history entry have a timestamp. If the sub-entry does not have a
         // timestamp, the first sub-entry in a history entry should.
-        const timestamp = entryTimestamp || base[0] && base[0].timestamp
+        const timestamp = entryTimestamp || (base[0] && base[0].timestamp)
 
         if (path in eventPathsHash && op === REPLACE_OP) {
           switch (path) {

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const gasLimit = typeof gasUsed === 'string' ? gasUsed : gas
 
-  const hexGasTotal = gasLimit && gasPrice && getHexGasTotal({ gasLimit, gasPrice }) || '0x0'
+  const hexGasTotal = (gasLimit && gasPrice && getHexGasTotal({ gasLimit, gasPrice })) || '0x0'
   const totalInHex = sumHexes(hexGasTotal, value)
 
   return {

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, ownProps) => {
     const entry = addressBook.find((contact) => {
       return address.toLowerCase() === contact.address.toLowerCase()
     })
-    return entry && entry.name || ''
+    return (entry && entry.name) || ''
   }
 
   return {

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -195,7 +195,7 @@ export default class TransactionListItem extends PureComponent {
     const { showTransactionDetails } = this.state
     const fromAddress = txParams.from
     const toAddress = tokenData
-      ? tokenData.params && tokenData.params[0] && tokenData.params[0].value || txParams.to
+      ? (tokenData.params && tokenData.params[0] && tokenData.params[0].value) || txParams.to
       : txParams.to
 
     const isFullScreen = getEnvironmentType() === ENVIRONMENT_TYPE_FULLSCREEN

--- a/ui/app/components/app/user-preferenced-currency-display/user-preferenced-currency-display.container.js
+++ b/ui/app/components/app/user-preferenced-currency-display/user-preferenced-currency-display.container.js
@@ -34,14 +34,14 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 
   let currency, numberOfDecimals, prefix
 
-  if (type === PRIMARY && useNativeCurrencyAsPrimaryCurrency ||
-    type === SECONDARY && !useNativeCurrencyAsPrimaryCurrency) {
+  if ((type === PRIMARY && useNativeCurrencyAsPrimaryCurrency) ||
+    (type === SECONDARY && !useNativeCurrencyAsPrimaryCurrency)) {
     // Display ETH
     currency = nativeCurrency || ETH
     numberOfDecimals = propsNumberOfDecimals || ethNumberOfDecimals || 6
     prefix = propsPrefix || ethPrefix
-  } else if (type === SECONDARY && useNativeCurrencyAsPrimaryCurrency ||
-    type === PRIMARY && !useNativeCurrencyAsPrimaryCurrency) {
+  } else if ((type === SECONDARY && useNativeCurrencyAsPrimaryCurrency) ||
+    (type === PRIMARY && !useNativeCurrencyAsPrimaryCurrency)) {
     // Display Fiat
     numberOfDecimals = propsNumberOfDecimals || fiatNumberOfDecimals || 2
     prefix = propsPrefix || fiatPrefix

--- a/ui/app/components/ui/currency-display/currency-display.component.js
+++ b/ui/app/components/ui/currency-display/currency-display.component.js
@@ -23,7 +23,7 @@ export default class CurrencyDisplay extends PureComponent {
       <div
         className={classnames('currency-display-component', className)}
         style={style}
-        title={!hideTitle && title || null}
+        title={(!hideTitle && title) || null}
       >
         { prefixComponent }
         <span className="currency-display-component__text">{ text }</span>

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -647,7 +647,7 @@ describe('Gas Duck', function () {
 
       const { type: thirdDispatchCallType, value: priceAndTimeEstimateResult } = mockDistpatch.getCall(2).args[0]
       assert.equal(thirdDispatchCallType, SET_PRICE_AND_TIME_ESTIMATES)
-      assert(priceAndTimeEstimateResult.length < mockPredictTableResponse.length * 3 - 2)
+      assert(priceAndTimeEstimateResult.length < ((mockPredictTableResponse.length * 3) - 2))
       assert(!priceAndTimeEstimateResult.find((d) => d.expectedTime > 100))
       assert(!priceAndTimeEstimateResult.find((d, _, a) => a[a + 1] && d.expectedTime > a[a + 1].expectedTime))
       assert(!priceAndTimeEstimateResult.find((d, _, a) => a[a + 1] && d.gasprice > a[a + 1].gasprice))

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -352,8 +352,8 @@ function quartiles (data) {
 function inliersByIQR (data, prop) {
   const { lowerQuartile, upperQuartile } = quartiles(data.map((d) => (prop ? d[prop] : d)))
   const IQR = upperQuartile - lowerQuartile
-  const lowerBound = lowerQuartile - 1.5 * IQR
-  const upperBound = upperQuartile + 1.5 * IQR
+  const lowerBound = lowerQuartile - (1.5 * IQR)
+  const upperBound = upperQuartile + (1.5 * IQR)
   return data.filter((d) => {
     const value = prop ? d[prop] : d
     return value >= lowerBound && value <= upperBound

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -145,7 +145,7 @@ function composeUrl (config) {
   const e_n = composeParamAddition(eventOpts.name, 'e_n')
   const new_visit = isNewVisit ? `&new_visit=1` : ''
 
-  const cvar = customVariables && composeCustomVarParamAddition(customVariables) || ''
+  const cvar = (customVariables && composeCustomVarParamAddition(customVariables)) || ''
 
   const action_name = ''
 
@@ -156,13 +156,13 @@ function composeUrl (config) {
     environmentType,
     activeCurrency,
     accountType,
-    numberOfTokens: customVariables && customVariables.numberOfTokens || numberOfTokens,
-    numberOfAccounts: customVariables && customVariables.numberOfAccounts || numberOfAccounts,
+    numberOfTokens: (customVariables && customVariables.numberOfTokens) || numberOfTokens,
+    numberOfAccounts: (customVariables && customVariables.numberOfAccounts) || numberOfAccounts,
   }) : ''
   const url = configUrl || currentPath ? `&url=${encodeURIComponent(currentPath.replace(/chrome-extension:\/\/\w+/, METAMETRICS_TRACKING_URL))}` : ''
   const _id = metaMetricsId && !excludeMetaMetricsId ? `&_id=${metaMetricsId.slice(2, 18)}` : ''
   const rand = `&rand=${String(Math.random()).slice(2)}`
-  const pv_id = (url || currentPath) && `&pv_id=${ethUtil.bufferToHex(ethUtil.sha3(url || currentPath.match(/chrome-extension:\/\/\w+\/(.+)/)[0])).slice(2, 8)}` || ''
+  const pv_id = ((url || currentPath) && `&pv_id=${ethUtil.bufferToHex(ethUtil.sha3(url || currentPath.match(/chrome-extension:\/\/\w+\/(.+)/)[0])).slice(2, 8)}`) || ''
   const uid = metaMetricsId && !excludeMetaMetricsId
     ? `&uid=${metaMetricsId.slice(2, 18)}`
     : excludeMetaMetricsId

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -77,7 +77,7 @@ const mapStateToProps = (state, ownProps) => {
     gas: gasLimit,
     value: amount,
     data,
-  } = transaction && transaction.txParams || txParams
+  } = (transaction && transaction.txParams) || txParams
   const accounts = getMetaMaskAccounts(state)
   const assetImage = assetImages[txParamsToAddress]
 

--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -22,7 +22,7 @@ class ConnectHardwareForm extends Component {
     const { accounts } = nextProps
     const newAccounts = this.state.accounts.map((a) => {
       const normalizedAddress = a.address.toLowerCase()
-      const balanceValue = accounts[normalizedAddress] && accounts[normalizedAddress].balance || null
+      const balanceValue = (accounts[normalizedAddress] && accounts[normalizedAddress].balance) || null
       a.balance = balanceValue ? formatBalance(balanceValue, 6) : '...'
       return a
     })
@@ -103,7 +103,7 @@ class ConnectHardwareForm extends Component {
           // Map accounts with balances
           newState.accounts = accounts.map((account) => {
             const normalizedAddress = account.address.toLowerCase()
-            const balanceValue = this.props.accounts[normalizedAddress] && this.props.accounts[normalizedAddress].balance || null
+            const balanceValue = (this.props.accounts[normalizedAddress] && this.props.accounts[normalizedAddress].balance) || null
             account.balance = balanceValue ? formatBalance(balanceValue, 6) : '...'
             return account
           })

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -72,9 +72,9 @@ export default class PermissionConnect extends Component {
     const { originName, page } = this.state
 
     if (!permissionsRequest && prevProps.permissionsRequest && page !== null) {
-      const permissionDataForDomain = domains && domains[originName] || {}
+      const permissionDataForDomain = (domains && domains[originName]) || {}
       const permissionsForDomain = permissionDataForDomain.permissions || []
-      const prevPermissionDataForDomain = prevProps.domains && prevProps.domains[originName] || {}
+      const prevPermissionDataForDomain = (prevProps.domains && prevProps.domains[originName]) || {}
       const prevPermissionsForDomain = prevPermissionDataForDomain.permissions || []
       const addedAPermission = permissionsForDomain.length > prevPermissionsForDomain.length
       if (addedAPermission) {

--- a/ui/app/pages/send/send.selectors.js
+++ b/ui/app/pages/send/send.selectors.js
@@ -115,7 +115,7 @@ export function getSelectedTokenExchangeRate (state) {
   const selectedToken = getSelectedToken(state) || {}
   const { symbol = '' } = selectedToken
   const pair = `${symbol.toLowerCase()}_eth`
-  const { rate: tokenExchangeRate = 0 } = tokenExchangeRates && tokenExchangeRates[pair] || {}
+  const { rate: tokenExchangeRate = 0 } = (tokenExchangeRates && tokenExchangeRates[pair]) || {}
 
   return tokenExchangeRate
 }

--- a/ui/app/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.component.js
@@ -195,7 +195,7 @@ export default class NetworksTab extends PureComponent {
                 rpcUrls={networksToRender.map((network) => network.rpcUrl)}
                 setRpcTarget={setRpcTarget}
                 editRpc={editRpc}
-                networkName={label || labelKey && t(labelKey) || ''}
+                networkName={label || (labelKey && t(labelKey)) || ''}
                 rpcUrl={rpcUrl}
                 chainId={chainId}
                 ticker={ticker}

--- a/ui/app/pages/settings/networks-tab/networks-tab.container.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.container.js
@@ -32,7 +32,7 @@ const mapStateToProps = (state) => {
       rpcUrl: rpc.rpcUrl,
       chainId: rpc.chainId,
       ticker: rpc.ticker,
-      blockExplorerUrl: rpc.rpcPrefs && rpc.rpcPrefs.blockExplorerUrl || '',
+      blockExplorerUrl: (rpc.rpcPrefs && rpc.rpcPrefs.blockExplorerUrl) || '',
     }
   })
 
@@ -43,7 +43,7 @@ const mapStateToProps = (state) => {
   let networkDefaultedToProvider = false
   if (!networkIsSelected && !networksTabIsInAddMode) {
     selectedNetwork = networksToRender.find((network) => {
-      return network.rpcUrl === provider.rpcTarget || network.providerType !== 'rpc' && network.providerType === provider.type
+      return network.rpcUrl === provider.rpcTarget || (network.providerType !== 'rpc' && network.providerType === provider.type)
     }) || {}
     networkDefaultedToProvider = true
   }

--- a/ui/app/selectors/confirm-transaction.js
+++ b/ui/app/selectors/confirm-transaction.js
@@ -118,12 +118,12 @@ const tokenDecimalsSelector = createSelector(
 
 const tokenDataParamsSelector = createSelector(
   tokenDataSelector,
-  (tokenData) => tokenData && tokenData.params || []
+  (tokenData) => (tokenData && tokenData.params) || []
 )
 
 const txParamsSelector = createSelector(
   txDataSelector,
-  (txData) => txData && txData.txParams || {}
+  (txData) => (txData && txData.txParams) || {}
 )
 
 export const tokenAddressSelector = createSelector(

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -56,7 +56,7 @@ export function getAccountType (state) {
 
 export function getSelectedAsset (state) {
   const selectedToken = getSelectedToken(state)
-  return selectedToken && selectedToken.symbol || 'ETH'
+  return (selectedToken && selectedToken.symbol) || 'ETH'
 }
 
 export function getCurrentNetworkId (state) {


### PR DESCRIPTION
This PR enables the core ESLint `no-mixed-operators` rule, which errors when different operators are used consecutively without parentheses in an expression.<sup>[\[1\]][1]</sup> This isn't `--fix`able and some of these fixes took me a second to think about, which I think is a testament to the readability improvement this brings.

  [1]:https://eslint.org/docs/rules/no-mixed-operators
