### PR TITLE
Remove redux-test-utils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
     "react-test-renderer": "^16.12.0",
     "read-installed": "^4.0.3",
     "redux-mock-store": "^1.5.4",
-    "redux-test-utils": "^0.2.2",
     "remote-redux-devtools": "^0.5.16",
     "remotedev-server": "^0.3.1",
     "resolve-url-loader": "^2.3.0",

--- a/test/unit/responsive/components/dropdown-test.js
+++ b/test/unit/responsive/components/dropdown-test.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import assert from 'assert'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 import sinon from 'sinon'
-import { createMockStore } from 'redux-test-utils'
 import { mountWithStore } from '../../../lib/render-helpers'
 import { Dropdown } from '../../../../ui/app/components/app/dropdowns/components/dropdown'
 
@@ -13,6 +14,8 @@ const mockState = {
 describe('Dropdown components', function () {
   let onClickOutside
   let onClick
+
+  const createMockStore = configureMockStore([thunk])
 
   const dropdownComponentProps = {
     isOpen: true,

--- a/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
+++ b/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import assert from 'assert'
-import { createMockStore } from 'redux-test-utils'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import NetworkDropdown from '../network-dropdown'
 import { DropdownMenuItem } from '../components/dropdown'
@@ -8,6 +9,7 @@ import NetworkDropdownIcon from '../components/network-dropdown-icon'
 
 describe('Network Dropdown', function () {
   let wrapper
+  const createMockStore = configureMockStore([thunk])
 
   describe('NetworkDropdown in appState in false', function () {
     const mockState = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23809,11 +23809,6 @@ redux-mock-store@^1.5.4:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-test-utils@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/redux-test-utils/-/redux-test-utils-0.2.2.tgz#593213f30173c5908f72315f08b705e1606094fe"
-  integrity sha512-+YsUHpzZJ7G85wYgllmGLJ75opIlWrCuKThaVTsHW5xLOrzaLE4abQ3AbYcHkx/vFOReG2D8XUwMfGnFKH8hGw==
-
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"


### PR DESCRIPTION
Closes #8067

This PR removes `redux-test-utils` from the project.