### PR TITLE
Change permissions connect screen to use browser routing

### DIFF
--- a/ui/app/helpers/constants/routes.js
+++ b/ui/app/helpers/constants/routes.js
@@ -26,6 +26,7 @@ const IMPORT_ACCOUNT_ROUTE = '/new-account/import'
 const CONNECT_HARDWARE_ROUTE = '/new-account/connect'
 const SEND_ROUTE = '/send'
 const CONNECT_ROUTE = '/connect'
+const CONNECT_CONFIRM_PERMISSIONS_ROUTE = '/confirm-permissions'
 const CONNECTED_ROUTE = '/connected'
 
 const INITIALIZE_ROUTE = '/initialize'
@@ -97,5 +98,6 @@ export {
   NETWORKS_ROUTE,
   INITIALIZE_BACKUP_SEED_PHRASE_ROUTE,
   CONNECT_ROUTE,
+  CONNECT_CONFIRM_PERMISSIONS_ROUTE,
   CONNECTED_ROUTE,
 }

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -36,6 +36,7 @@ export default class PermissionConnect extends Component {
     connectPath: PropTypes.string.isRequired,
     confirmPermissionPath: PropTypes.string.isRequired,
     page: PropTypes.string.isRequired,
+    redirecting: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -46,6 +47,7 @@ export default class PermissionConnect extends Component {
     requestAccountTabs: {},
     permissionsRequestId: '',
     domains: {},
+    redirecting: false,
   }
 
   static contextTypes = {
@@ -75,10 +77,10 @@ export default class PermissionConnect extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { domains, permissionsRequest, page } = this.props
+    const { domains, permissionsRequest, redirecting } = this.props
     const { originName } = this.state
 
-    if (!permissionsRequest && prevProps.permissionsRequest && page !== null) {
+    if (!permissionsRequest && prevProps.permissionsRequest && !redirecting) {
       const permissionDataForDomain = (domains && domains[originName]) || {}
       const permissionsForDomain = permissionDataForDomain.permissions || []
       const prevPermissionDataForDomain = (prevProps.domains && prevProps.domains[originName]) || {}
@@ -95,8 +97,7 @@ export default class PermissionConnect extends Component {
   selectAccount = (address) => {
     this.setState({
       selectedAccountAddress: address,
-    })
-    this.props.history.push(this.props.confirmPermissionPath)
+    }, () => this.props.history.push(this.props.confirmPermissionPath))
   }
 
   redirectFlow (accepted) {
@@ -165,7 +166,7 @@ export default class PermissionConnect extends Component {
 
     return (
       <div className="permissions-connect">
-        { page !== null
+        { !redirecting
           ? <PermissionsConnectHeader page={page} />
           : null
         }
@@ -198,6 +199,7 @@ export default class PermissionConnect extends Component {
           />
           <Route
             path={confirmPermissionPath}
+            exact
             render={() => (
               <div>
                 <PermissionPageContainer

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import { Switch, Route } from 'react-router-dom'
 import PermissionsConnectHeader from './permissions-connect-header'
 import PermissionsConnectFooter from './permissions-connect-footer'
 import ChooseAccount from './choose-account'
@@ -9,7 +10,10 @@ import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,
 } from '../../../../app/scripts/lib/enums'
-import { DEFAULT_ROUTE, CONNECTED_ROUTE } from '../../helpers/constants/routes'
+import {
+  DEFAULT_ROUTE,
+  CONNECTED_ROUTE,
+} from '../../helpers/constants/routes'
 import PermissionPageContainer from '../../components/app/permission-page-container'
 
 export default class PermissionConnect extends Component {
@@ -29,6 +33,9 @@ export default class PermissionConnect extends Component {
     permissionsRequestId: PropTypes.string,
     domains: PropTypes.object,
     history: PropTypes.object.isRequired,
+    connectPath: PropTypes.string.isRequired,
+    confirmPermissionPath: PropTypes.string.isRequired,
+    page: PropTypes.string.isRequired,
   }
 
   static defaultProps = {
@@ -46,7 +53,7 @@ export default class PermissionConnect extends Component {
   }
 
   state = {
-    page: 1,
+    redirecting: false,
     selectedAccountAddress: '',
     permissionAccepted: null,
     originName: this.props.originName,
@@ -68,8 +75,8 @@ export default class PermissionConnect extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { domains, permissionsRequest } = this.props
-    const { originName, page } = this.state
+    const { domains, permissionsRequest, page } = this.props
+    const { originName } = this.state
 
     if (!permissionsRequest && prevProps.permissionsRequest && page !== null) {
       const permissionDataForDomain = (domains && domains[originName]) || {}
@@ -87,9 +94,9 @@ export default class PermissionConnect extends Component {
 
   selectAccount = (address) => {
     this.setState({
-      page: 2,
       selectedAccountAddress: address,
     })
+    this.props.history.push(this.props.confirmPermissionPath)
   }
 
   redirectFlow (accepted) {
@@ -97,7 +104,7 @@ export default class PermissionConnect extends Component {
     const { originName } = this.state
 
     this.setState({
-      page: null,
+      redirecting: true,
       permissionAccepted: accepted,
     })
     this.removeBeforeUnload()
@@ -150,8 +157,11 @@ export default class PermissionConnect extends Component {
       permissionsRequest,
       addressLastConnectedMap,
       permissionsRequestId,
+      connectPath,
+      confirmPermissionPath,
+      page,
     } = this.props
-    const { page, selectedAccountAddress, permissionAccepted, originName } = this.state
+    const { selectedAccountAddress, permissionAccepted, originName, redirecting } = this.state
 
     return (
       <div className="permissions-connect">
@@ -159,49 +169,56 @@ export default class PermissionConnect extends Component {
           ? <PermissionsConnectHeader page={page} />
           : null
         }
-        { page === 1
-          ? (
-            <ChooseAccount
-              accounts={accounts}
-              originName={originName}
-              nativeCurrency={nativeCurrency}
-              selectAccount={(address) => this.selectAccount(address)}
-              selectNewAccountViaModal={() => {
-                showNewAccountModal({
-                  onCreateNewAccount: this.selectAccount,
-                  newAccountNumber,
-                })
-              }}
-              addressLastConnectedMap={addressLastConnectedMap}
-              cancelPermissionsRequest={(requestId) => {
-                if (requestId) {
-                  rejectPermissionsRequest(requestId)
-                  this.redirectFlow(false)
-                }
-              }}
-              permissionsRequestId={permissionsRequestId}
-            />
-          )
-          : (
-            <div>
-              <PermissionPageContainer
-                request={permissionsRequest || {}}
-                approvePermissionsRequest={(request, accounts) => {
-                  approvePermissionsRequest(request, accounts)
-                  this.redirectFlow(true)
+        <Switch>
+          <Route
+            path={connectPath}
+            exact
+            render={() => (
+              <ChooseAccount
+                accounts={accounts}
+                originName={originName}
+                nativeCurrency={nativeCurrency}
+                selectAccount={(address) => this.selectAccount(address)}
+                selectNewAccountViaModal={() => {
+                  showNewAccountModal({
+                    onCreateNewAccount: this.selectAccount,
+                    newAccountNumber,
+                  })
                 }}
-                rejectPermissionsRequest={(requestId) => {
-                  rejectPermissionsRequest(requestId)
-                  this.redirectFlow(false)
+                addressLastConnectedMap={addressLastConnectedMap}
+                cancelPermissionsRequest={(requestId) => {
+                  if (requestId) {
+                    rejectPermissionsRequest(requestId)
+                    this.redirectFlow(false)
+                  }
                 }}
-                selectedIdentity={accounts.find((account) => account.address === selectedAccountAddress)}
-                redirect={page === null}
-                permissionRejected={ permissionAccepted === false }
+                permissionsRequestId={permissionsRequestId}
               />
-              <PermissionsConnectFooter />
-            </div>
-          )
-        }
+            )}
+          />
+          <Route
+            path={confirmPermissionPath}
+            render={() => (
+              <div>
+                <PermissionPageContainer
+                  request={permissionsRequest || {}}
+                  approvePermissionsRequest={(request, accounts) => {
+                    approvePermissionsRequest(request, accounts)
+                    this.redirectFlow(true)
+                  }}
+                  rejectPermissionsRequest={(requestId) => {
+                    rejectPermissionsRequest(requestId)
+                    this.redirectFlow(false)
+                  }}
+                  selectedIdentity={accounts.find((account) => account.address === selectedAccountAddress)}
+                  redirect={redirecting}
+                  permissionRejected={ permissionAccepted === false }
+                />
+                <PermissionsConnectFooter />
+              </div>
+            )}
+          />
+        </Switch>
       </div>
     )
   }

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -10,9 +10,16 @@ import {
 } from '../../selectors/selectors'
 import { formatDate } from '../../helpers/utils/util'
 import { approvePermissionsRequest, rejectPermissionsRequest, showModal, getCurrentWindowTab, getRequestAccountTabIds } from '../../store/actions'
+import {
+  CONNECT_ROUTE,
+  CONNECT_CONFIRM_PERMISSIONS_ROUTE,
+} from '../../helpers/constants/routes'
 
 const mapStateToProps = (state, ownProps) => {
-  const { match: { params: { id: permissionsRequestId } } } = ownProps
+  const {
+    match: { params: { id: permissionsRequestId } },
+    location: { pathname },
+  } = ownProps
   const permissionsRequests = getPermissionsRequests(state)
 
   const permissionsRequest = permissionsRequests
@@ -33,6 +40,16 @@ const mapStateToProps = (state, ownProps) => {
     addressLastConnectedMap[key] = formatDate(addressLastConnectedMap[key], 'yyyy-M-d')
   })
 
+  const connectPath = `${CONNECT_ROUTE}/${permissionsRequestId}`
+  const confirmPermissionPath = `${CONNECT_ROUTE}/${permissionsRequestId}${CONNECT_CONFIRM_PERMISSIONS_ROUTE}`
+
+  let page = null
+  if (pathname === connectPath) {
+    page = '1'
+  } else if (pathname === confirmPermissionPath) {
+    page = '2'
+  }
+
   return {
     permissionsRequest,
     permissionsRequestId,
@@ -43,6 +60,9 @@ const mapStateToProps = (state, ownProps) => {
     requestAccountTabs,
     addressLastConnectedMap,
     domains: getPermissionsDomains(state),
+    connectPath,
+    confirmPermissionPath,
+    page,
   }
 }
 

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -43,11 +43,13 @@ const mapStateToProps = (state, ownProps) => {
   const connectPath = `${CONNECT_ROUTE}/${permissionsRequestId}`
   const confirmPermissionPath = `${CONNECT_ROUTE}/${permissionsRequestId}${CONNECT_CONFIRM_PERMISSIONS_ROUTE}`
 
-  let page = null
+  let page = ''
   if (pathname === connectPath) {
     page = '1'
   } else if (pathname === confirmPermissionPath) {
     page = '2'
+  } else {
+    throw new Error('Incorrect path for permissions-connect component')
   }
 
   return {

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -141,7 +141,7 @@ class Routes extends Component {
         <Authenticated path={CONFIRM_ADD_TOKEN_ROUTE} component={ConfirmAddTokenPage} exact />
         <Authenticated path={CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE} component={ConfirmAddSuggestedTokenPage} exact />
         <Authenticated path={NEW_ACCOUNT_ROUTE} component={CreateAccountPage} />
-        <Authenticated path={`${CONNECT_ROUTE}/:id?`} component={PermissionsConnect} />
+        <Authenticated path={`${CONNECT_ROUTE}/:id`} component={PermissionsConnect} />
         <Authenticated path={CONNECTED_ROUTE} component={ConnectedSites} exact />
         <Authenticated path={DEFAULT_ROUTE} component={Home} exact />
       </Switch>

--- a/ui/app/pages/routes/index.js
+++ b/ui/app/pages/routes/index.js
@@ -141,7 +141,7 @@ class Routes extends Component {
         <Authenticated path={CONFIRM_ADD_TOKEN_ROUTE} component={ConfirmAddTokenPage} exact />
         <Authenticated path={CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE} component={ConfirmAddSuggestedTokenPage} exact />
         <Authenticated path={NEW_ACCOUNT_ROUTE} component={CreateAccountPage} />
-        <Authenticated path={`${CONNECT_ROUTE}/:id`} component={PermissionsConnect} exact />
+        <Authenticated path={`${CONNECT_ROUTE}/:id?`} component={PermissionsConnect} />
         <Authenticated path={CONNECTED_ROUTE} component={ConnectedSites} exact />
         <Authenticated path={DEFAULT_ROUTE} component={Home} exact />
       </Switch>


### PR DESCRIPTION
This PR updates the `permissions-connect.component.js` to use React Router, allow use of browser navigation buttons to navigate between screens.

Demo video here: https://streamable.com/dahyg