### PR TITLE
Use lockfile-lint@4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-qunit": "^1.2.1",
     "koa": "^2.7.0",
-    "lockfile-lint": "^3.0.5",
+    "lockfile-lint": "^4.0.0",
     "mocha": "^7.0.1",
     "nock": "^9.0.14",
     "node-fetch": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18069,21 +18069,22 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lockfile-lint-api@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/lockfile-lint-api/-/lockfile-lint-api-5.0.4.tgz#1c1b7b92eccd56e0c707ff188a3dc8bce6ab3206"
-  integrity sha512-RnqWgWTWIiX+rF7PUKWci3KEznTwJxp5em0CttLBRaCYH1LS1A0pl0mdTKjcoOQ4A65GtfmHWNTrAgfdjdSU1g==
+lockfile-lint-api@^5.0.12:
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/lockfile-lint-api/-/lockfile-lint-api-5.0.12.tgz#6ad928126dc2f87762bb520695f58c73a501b7fd"
+  integrity sha512-8OSMww33l0xghDl1aK450UHYzKZjMaPjdbtvt7A/iEdD2AAH6h3xyVkVIHSJmD2KfD1lh819tdpOukui+qSEsw==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     debug "^4.1.1"
+    object-hash "^2.0.1"
 
-lockfile-lint@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/lockfile-lint/-/lockfile-lint-3.0.5.tgz#dd9dc746dc3635404223feeeeae43d1b1d61138c"
-  integrity sha512-5d7Mjo80SgCVTRyEiyKMyLfOi8E6lTTpfkWKTEL228Jia8LF2wd8NRc2fTLSxAP0HwZYEy76jbrzfhCp6K+nmQ==
+lockfile-lint@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lockfile-lint/-/lockfile-lint-4.0.0.tgz#42a6048d860172cad015c1288652fd777792f651"
+  integrity sha512-QJim4IGvIXlFnYNwK/QMO1mqQM1uLxxoFt0nS2XCHf74htm1RtWT3eDm6vZLocRid+O2KYXgIkbp5V1xDOeuTw==
   dependencies:
     debug "^4.1.1"
-    lockfile-lint-api "^5.0.4"
+    lockfile-lint-api "^5.0.12"
     yargs "^15.0.2"
 
 lodash._baseassign@^3.0.0:
@@ -20344,6 +20345,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
+  integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
 
 object-inspect@^1.6.0, object-inspect@~1.6.0:
   version "1.6.0"


### PR DESCRIPTION
This PR bumps our `lockfile-lint` dependency version to 4.0.0. From their CL:<sup>[\[1\]][1]</sup>

> ### BREAKING CHANGES
> 
> * **cli:** CLI may show an error when arguments
> conflict and the order of short and long options was reversed
> to be more descriptive on CLI options errors.

  [1]:https://github.com/lirantal/lockfile-lint/blob/lockfile-lint%404.0.0/packages/lockfile-lint/CHANGELOG.md#400-2020-02-20