### PR TITLE
Remove eslint-plugin-chai

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
 
   plugins: [
     'babel',
-    'chai',
     'react',
     'json',
     'import',

--- a/package.json
+++ b/package.json
@@ -206,7 +206,6 @@
     "enzyme-adapter-react-16": "^1.15.1",
     "eslint": "^6.0.1",
     "eslint-plugin-babel": "^5.3.0",
-    "eslint-plugin-chai": "0.0.1",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^6.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9900,11 +9900,6 @@ eslint-plugin-babel@^5.3.0:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-eslint-plugin-chai@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-chai/-/eslint-plugin-chai-0.0.1.tgz#9a1dea58b335c31242219d059b37ffb14309f6e1"
-  integrity sha1-mh3qWLM1wxJCIZ0Fmzf/sUMJ9uE=
-
 eslint-plugin-import@^2.19.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz#5654e10b7839d064dd0d46cd1b88ec2133a11448"


### PR DESCRIPTION
This PR removes the "chai plugin" from our deps tree. It contained nothing of use, literally.