### PR TITLE
Move default white background from `body` to root element

### DIFF
--- a/ui/app/css/itcss/generic/index.scss
+++ b/ui/app/css/itcss/generic/index.scss
@@ -13,7 +13,6 @@ body {
   font-family: Roboto, Arial;
   color: #4d4d4d;
   font-weight: 400;
-  background: #f7f7f7;
   width: 100%;
   height: 100%;
   margin: 0;
@@ -57,6 +56,7 @@ html {
   height: 100%;
   display: flex;
   flex-direction: column;
+  background: #f7f7f7;
 
   @media screen and (max-width: $break-small) {
     background-color: $white;


### PR DESCRIPTION
In our base stylesheets we set the `body` background color to white. This unfortunately also affected the preview area of Storybook. The Storybook preview only renders isolated components, but it does
include all styles.

To avoid this problem, the white background color has been moved to the `#app-content` div instead. All of our UI is inside this div.