### PR TITLE
Allow changing Storybook preview backgrounds

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,5 +3,6 @@ module.exports = {
   addons: [
     '@storybook/addon-knobs',
     '@storybook/addon-actions',
+    '@storybook/addon-backgrounds'
   ],
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,13 @@
 import React from 'react'
-import { addDecorator } from '@storybook/react'
+import { addDecorator, addParameters } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs/react'
+
+addParameters({
+  backgrounds: [
+    { name: 'light', value: '#FFFFFF'},
+    { name: 'dark', value: '#333333' },
+  ],
+})
 
 const styles = {
   height: '100vh',

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "@metamask/onboarding": "^0.2.0",
     "@sentry/cli": "^1.49.0",
     "@storybook/addon-actions": "^5.3.14",
+    "@storybook/addon-backgrounds": "^5.3.14",
     "@storybook/addon-knobs": "^5.3.14",
     "@storybook/core": "^5.3.14",
     "@storybook/react": "^5.3.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,6 +2048,22 @@
     react-inspector "^4.0.0"
     uuid "^3.3.2"
 
+"@storybook/addon-backgrounds@^5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-5.3.14.tgz#b1b7fb77a82cbdb30a995f2afba2c488c6f43647"
+  integrity sha512-wrrbVrXV81+iHSf0Ejf9E9vwzVYhvVn0WoqY1ccneEWVWgiPwnptOCS5yYzsCQ2Riye2QutqBvZtaa0k88oKFA==
+  dependencies:
+    "@storybook/addons" "5.3.14"
+    "@storybook/api" "5.3.14"
+    "@storybook/client-logger" "5.3.14"
+    "@storybook/components" "5.3.14"
+    "@storybook/core-events" "5.3.14"
+    "@storybook/theming" "5.3.14"
+    core-js "^3.0.1"
+    memoizerific "^1.11.3"
+    react "^16.8.3"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-knobs@^5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-5.3.14.tgz#b8b753c7e64f7087668396d66aee253a51717a2d"


### PR DESCRIPTION
The `@storybook/addon-backgrounds' addon has been added, which allows changing the component preview background. By default no background colors are defined, though there is a helpful grid button. A "light" and "dark" background option has been added globally. Additional story-specific backgrounds or global backgrounds can be added later if necessary.