### PR TITLE
Re-render `jazzicon` component when diameter changes

### DIFF
--- a/ui/app/components/ui/jazzicon/jazzicon.component.js
+++ b/ui/app/components/ui/jazzicon/jazzicon.component.js
@@ -28,10 +28,10 @@ export default class Jazzicon extends PureComponent {
   }
 
   componentDidUpdate (prevProps) {
-    const { address: prevAddress } = prevProps
-    const { address } = this.props
+    const { address: prevAddress, diameter: prevDiameter } = prevProps
+    const { address, diameter } = this.props
 
-    if (address !== prevAddress) {
+    if (address !== prevAddress || diameter !== prevDiameter) {
       this.removeExistingChildren()
       this.appendJazzicon()
     }


### PR DESCRIPTION
Previously when the `diameter` prop of the `jazzicon` component was changed, the new diameter would be ignored. The jazzicon is now redrawn upon each change, as you would expect.

I don't think it's possible for this bug to manifest itself in the extension. This was discovered through tinkering with the Storybook for this component.