### PR TITLE
Remove redundant PropTypes

### DIFF
--- a/ui/app/components/app/modals/fade-modal.js
+++ b/ui/app/components/app/modals/fade-modal.js
@@ -129,10 +129,7 @@ class FadeModal extends Component {
     modalStyle: PropTypes.object,
     onShow: PropTypes.func,
     onHide: PropTypes.func,
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
+    children: PropTypes.node,
   }
 
   static defaultProps = {


### PR DESCRIPTION
Specifying a PropType of either type `node` or type `arrayOf(PropTypes.node)` is redundant, because an array of nodes is itself a node.