### PR TITLE
Fix Storybook styles

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { addDecorator, addParameters } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs/react'
+import '../ui/app/css/index.scss'
 
 addParameters({
   backgrounds: [


### PR DESCRIPTION
When the storybook config was migrated to the new module structure in PR #8112 I forgot to include the line where the styles were imported.