### PR TITLE
Remove unnecessary branch from home render

### DIFF
--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -112,60 +112,56 @@ export default class Home extends PureComponent {
             query="(min-width: 576px)"
             render={() => <WalletView />}
           />
-          { !history.location.pathname.match(/^\/confirm-transaction/)
-            ? (
-              <TransactionView>
-                <MultipleNotifications>
-                  {
-                    shouldShowSeedPhraseReminder
-                      ? (
-                        <HomeNotification
-                          descriptionText={t('backupApprovalNotice')}
-                          acceptText={t('backupNow')}
-                          onAccept={() => {
-                            if (isPopup) {
-                              global.platform.openExtensionInBrowser(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
-                            } else {
-                              history.push(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
-                            }
-                          }}
-                          infoText={t('backupApprovalInfo')}
-                          key="home-backupApprovalNotice"
-                        />
-                      )
-                      : null
-                  }
-                  {
-                    threeBoxLastUpdated && showRestorePrompt
-                      ? (
-                        <HomeNotification
-                          descriptionText={t('restoreWalletPreferences', [ formatDate(threeBoxLastUpdated, 'M/d/y') ])}
-                          acceptText={t('restore')}
-                          ignoreText={t('noThanks')}
-                          infoText={t('dataBackupFoundInfo')}
-                          onAccept={() => {
-                            restoreFromThreeBox(selectedAddress)
-                              .then(() => {
-                                turnThreeBoxSyncingOn()
-                              })
-                          }}
-                          onIgnore={() => {
-                            setShowRestorePromptToFalse()
-                          }}
-                          key="home-privacyModeDefault"
-                        />
-                      )
-                      : null
-                  }
-                  {
-                    hasDaiV1Token
-                      ? <DaiMigrationNotification />
-                      : null
-                  }
-                </MultipleNotifications>
-              </TransactionView>
-            )
-            : null }
+          <TransactionView>
+            <MultipleNotifications>
+              {
+                shouldShowSeedPhraseReminder
+                  ? (
+                    <HomeNotification
+                      descriptionText={t('backupApprovalNotice')}
+                      acceptText={t('backupNow')}
+                      onAccept={() => {
+                        if (isPopup) {
+                          global.platform.openExtensionInBrowser(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
+                        } else {
+                          history.push(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
+                        }
+                      }}
+                      infoText={t('backupApprovalInfo')}
+                      key="home-backupApprovalNotice"
+                    />
+                  )
+                  : null
+              }
+              {
+                threeBoxLastUpdated && showRestorePrompt
+                  ? (
+                    <HomeNotification
+                      descriptionText={t('restoreWalletPreferences', [ formatDate(threeBoxLastUpdated, 'M/d/y') ])}
+                      acceptText={t('restore')}
+                      ignoreText={t('noThanks')}
+                      infoText={t('dataBackupFoundInfo')}
+                      onAccept={() => {
+                        restoreFromThreeBox(selectedAddress)
+                          .then(() => {
+                            turnThreeBoxSyncingOn()
+                          })
+                      }}
+                      onIgnore={() => {
+                        setShowRestorePromptToFalse()
+                      }}
+                      key="home-privacyModeDefault"
+                    />
+                  )
+                  : null
+              }
+              {
+                hasDaiV1Token
+                  ? <DaiMigrationNotification />
+                  : null
+              }
+            </MultipleNotifications>
+          </TransactionView>
         </div>
       </div>
     )


### PR DESCRIPTION
The Home screen had a check for whether the current path is `/confirm-transaction`, but the router wouldn't have routed there if that was the case.

This was done in #6501 as a performance improvement, but I suspect this line in particular never worked.