### PR TITLE
Move home notifications upwards in DOM

### DIFF
--- a/ui/app/components/app/transaction-list/transaction-list.component.js
+++ b/ui/app/components/app/transaction-list/transaction-list.component.js
@@ -10,13 +10,11 @@ export default class TransactionList extends PureComponent {
   }
 
   static defaultProps = {
-    children: null,
     pendingTransactions: [],
     completedTransactions: [],
   }
 
   static propTypes = {
-    children: PropTypes.node,
     pendingTransactions: PropTypes.array,
     completedTransactions: PropTypes.array,
     selectedToken: PropTypes.object,
@@ -155,7 +153,6 @@ export default class TransactionList extends PureComponent {
     return (
       <div className="transaction-list">
         { this.renderTransactions() }
-        { this.props.children }
       </div>
     )
   }

--- a/ui/app/components/app/transaction-view/transaction-view.component.js
+++ b/ui/app/components/app/transaction-view/transaction-view.component.js
@@ -10,14 +10,6 @@ export default class TransactionView extends PureComponent {
     t: PropTypes.func,
   }
 
-  static propTypes = {
-    children: PropTypes.node,
-  }
-
-  static defaultProps = {
-    children: null,
-  }
-
   render () {
     return (
       <div className="transaction-view">
@@ -28,9 +20,7 @@ export default class TransactionView extends PureComponent {
         <div className="transaction-view__balance-wrapper">
           <TransactionViewBalance />
         </div>
-        <TransactionList>
-          { this.props.children }
-        </TransactionList>
+        <TransactionList />
       </div>
     )
   }

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -85,10 +85,9 @@ export default class Home extends PureComponent {
     }
   }
 
-  render () {
+  renderNotifications () {
     const { t } = this.context
     const {
-      forgottenPassword,
       history,
       hasDaiV1Token,
       shouldShowSeedPhraseReminder,
@@ -99,6 +98,64 @@ export default class Home extends PureComponent {
       setShowRestorePromptToFalse,
       showRestorePrompt,
       threeBoxLastUpdated,
+    } = this.props
+
+    return (
+      <MultipleNotifications>
+        {
+          shouldShowSeedPhraseReminder
+            ? (
+              <HomeNotification
+                descriptionText={t('backupApprovalNotice')}
+                acceptText={t('backupNow')}
+                onAccept={() => {
+                  if (isPopup) {
+                    global.platform.openExtensionInBrowser(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
+                  } else {
+                    history.push(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
+                  }
+                }}
+                infoText={t('backupApprovalInfo')}
+                key="home-backupApprovalNotice"
+              />
+            )
+            : null
+        }
+        {
+          threeBoxLastUpdated && showRestorePrompt
+            ? (
+              <HomeNotification
+                descriptionText={t('restoreWalletPreferences', [ formatDate(threeBoxLastUpdated, 'M/d/y') ])}
+                acceptText={t('restore')}
+                ignoreText={t('noThanks')}
+                infoText={t('dataBackupFoundInfo')}
+                onAccept={() => {
+                  restoreFromThreeBox(selectedAddress)
+                    .then(() => {
+                      turnThreeBoxSyncingOn()
+                    })
+                }}
+                onIgnore={() => {
+                  setShowRestorePromptToFalse()
+                }}
+                key="home-privacyModeDefault"
+              />
+            )
+            : null
+        }
+        {
+          hasDaiV1Token
+            ? <DaiMigrationNotification />
+            : null
+        }
+      </MultipleNotifications>
+    )
+  }
+
+  render () {
+    const {
+      forgottenPassword,
+      history,
     } = this.props
 
     if (forgottenPassword) {
@@ -114,58 +171,10 @@ export default class Home extends PureComponent {
           />
           { !history.location.pathname.match(/^\/confirm-transaction/)
             ? (
-              <TransactionView>
-                <MultipleNotifications>
-                  {
-                    shouldShowSeedPhraseReminder
-                      ? (
-                        <HomeNotification
-                          descriptionText={t('backupApprovalNotice')}
-                          acceptText={t('backupNow')}
-                          onAccept={() => {
-                            if (isPopup) {
-                              global.platform.openExtensionInBrowser(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
-                            } else {
-                              history.push(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE)
-                            }
-                          }}
-                          infoText={t('backupApprovalInfo')}
-                          key="home-backupApprovalNotice"
-                        />
-                      )
-                      : null
-                  }
-                  {
-                    threeBoxLastUpdated && showRestorePrompt
-                      ? (
-                        <HomeNotification
-                          descriptionText={t('restoreWalletPreferences', [ formatDate(threeBoxLastUpdated, 'M/d/y') ])}
-                          acceptText={t('restore')}
-                          ignoreText={t('noThanks')}
-                          infoText={t('dataBackupFoundInfo')}
-                          onAccept={() => {
-                            restoreFromThreeBox(selectedAddress)
-                              .then(() => {
-                                turnThreeBoxSyncingOn()
-                              })
-                          }}
-                          onIgnore={() => {
-                            setShowRestorePromptToFalse()
-                          }}
-                          key="home-privacyModeDefault"
-                        />
-                      )
-                      : null
-                  }
-                  {
-                    hasDaiV1Token
-                      ? <DaiMigrationNotification />
-                      : null
-                  }
-                </MultipleNotifications>
-              </TransactionView>
+              <TransactionView />
             )
             : null }
+          { this.renderNotifications() }
         </div>
       </div>
     )


### PR DESCRIPTION
The notifications displayed on the home screen were being passed through the `TransactionView` and `TransactionList` components before being rendered. This was unnecessary because the notifications are absolutely positioned.

They are now rendered directly in the home component where they're defined. A helper function has been written to improve readability.