### PR TITLE
Extract style for Home component into separate module

### DIFF
--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -38,13 +38,6 @@ $wallet-view-bg: $alabaster;
   width: 100%;
 }
 
-//Account and transaction details
-.account-and-transaction-details {
-  display: flex;
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
 // wallet view and sidebar
 
 .wallet-view {

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -107,7 +107,7 @@ export default class Home extends PureComponent {
 
     return (
       <div className="main-container">
-        <div className="account-and-transaction-details">
+        <div className="home__container">
           <Media
             query="(min-width: 576px)"
             render={() => <WalletView />}

--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -1,0 +1,4 @@
+.home__container {
+  display: flex;
+  flex: 1 1 auto;
+}

--- a/ui/app/pages/index.scss
+++ b/ui/app/pages/index.scss
@@ -4,6 +4,8 @@
 
 @import 'error/index';
 
+@import 'home/index';
+
 @import 'send/send';
 
 @import 'confirm-add-token/index';


### PR DESCRIPTION
The styles used for the Home component were in the huge "newui-sections" SCSS file. Instead they've been moved into an SCSS module alongside the component, to follow our conventions.

The `main-container` class was left as-is because it is shared between here and the settings page.