### PR TITLE
Fix token cell props

### DIFF
--- a/ui/app/components/app/token-cell/token-cell.component.js
+++ b/ui/app/components/app/token-cell/token-cell.component.js
@@ -20,7 +20,7 @@ export default class TokenCell extends Component {
     selectedTokenAddress: PropTypes.string,
     contractExchangeRates: PropTypes.object,
     conversionRate: PropTypes.number,
-    hideSidebar: PropTypes.bool,
+    hideSidebar: PropTypes.func.isRequired,
     sidebarOpen: PropTypes.bool,
     currentCurrency: PropTypes.string,
     image: PropTypes.string,


### PR DESCRIPTION
The `hideSidebar` proptype of `TokenCell` was set as an optional bool, when it should have been a required function.