### PR TITLE
Use consistent variable name for classnames import

### DIFF
--- a/ui/app/components/ui/dialog/index.js
+++ b/ui/app/components/ui/dialog/index.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import c from 'classnames'
+import classnames from 'classnames'
 
 export default function Dialog (props) {
   const { children, type, className, onClick } = props
   return (
     <div
-      className={c('dialog', className, {
+      className={classnames('dialog', className, {
         'dialog--message': type === 'message',
         'dialog--error': type === 'error',
         'dialog--warning': type === 'warning',

--- a/ui/app/components/ui/page-container/page-container-header/page-container-header.component.js
+++ b/ui/app/components/ui/page-container/page-container-header/page-container-header.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import c from 'classnames'
+import classnames from 'classnames'
 
 export default class PageContainerHeader extends Component {
   static propTypes = {
@@ -47,7 +47,7 @@ export default class PageContainerHeader extends Component {
 
     return (
       <div
-        className={c('page-container__header', className, {
+        className={classnames('page-container__header', className, {
           'page-container__header--no-padding-bottom': Boolean(tabs),
         })}
       >

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import c from 'classnames'
+import classnames from 'classnames'
 import { isValidDomainName, isValidAddress, isValidAddressHead } from '../../../../helpers/utils/util'
 import { ellipsify } from '../../send.utils'
 
@@ -146,9 +146,9 @@ export default class EnsInput extends Component {
     }
 
     return (
-      <div className={c('ens-input', className)}>
+      <div className={classnames('ens-input', className)}>
         <div
-          className={c('ens-input__wrapper', {
+          className={classnames('ens-input__wrapper', {
             'ens-input__wrapper__status-icon--error': false,
             'ens-input__wrapper__status-icon--valid': false,
           })}
@@ -166,7 +166,7 @@ export default class EnsInput extends Component {
             data-testid="ens-input"
           />
           <div
-            className={c('ens-input__wrapper__action-icon', {
+            className={classnames('ens-input__wrapper__action-icon', {
               'ens-input__wrapper__action-icon--erase': input,
               'ens-input__wrapper__action-icon--qrcode': !input,
             })}
@@ -190,7 +190,7 @@ export default class EnsInput extends Component {
 
 
     return (
-      <div className={c('ens-input', className)}>
+      <div className={classnames('ens-input', className)}>
         <div
           className="ens-input__wrapper ens-input__wrapper--valid"
         >

--- a/ui/app/pages/settings/settings.component.js
+++ b/ui/app/pages/settings/settings.component.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { Switch, Route, matchPath } from 'react-router-dom'
 import TabBar from '../../components/app/tab-bar'
-import c from 'classnames'
+import classnames from 'classnames'
 import SettingsTab from './settings-tab'
 import NetworksTab from './networks-tab'
 import AdvancedTab from './advanced-tab'
@@ -49,7 +49,7 @@ class SettingsPage extends PureComponent {
 
     return (
       <div
-        className={c('main-container settings-page', {
+        className={classnames('main-container settings-page', {
           'settings-page--selected': currentPath !== SETTINGS_ROUTE,
         })}
       >
@@ -129,7 +129,7 @@ class SettingsPage extends PureComponent {
     return currentPath !== NETWORKS_ROUTE && (
       <div className="settings-page__subheader">
         <div
-          className={c({ 'settings-page__subheader--link': initialBreadCrumbRoute })}
+          className={classnames({ 'settings-page__subheader--link': initialBreadCrumbRoute })}
           onClick={() => initialBreadCrumbRoute && history.push(initialBreadCrumbRoute)}
         >
           {subheaderText}


### PR DESCRIPTION
The variable name `classnames` is generally what we use for this module, and single-letter variable names are generally frowned upon.