### PR TITLE
Fix bug preventing dropdown close upon outside click

### DIFF
--- a/ui/app/components/app/menu-droppo.js
+++ b/ui/app/components/app/menu-droppo.js
@@ -56,7 +56,7 @@ export default class MenuDroppoComponent extends Component {
 
   componentDidMount () {
     if (this && document.body) {
-      document.body.addEventListener('click', this.globalClickHandler)
+      document.body.addEventListener('click', this.globalClickOccurred)
       // eslint-disable-next-line react/no-find-dom-node
       const container = findDOMNode(this)
       this.container = container
@@ -65,7 +65,7 @@ export default class MenuDroppoComponent extends Component {
 
   componentWillUnmount () {
     if (this && document.body) {
-      document.body.removeEventListener('click', this.globalClickHandler)
+      document.body.removeEventListener('click', this.globalClickOccurred)
     }
   }
 


### PR DESCRIPTION
The base component we use for dropdowns handles ensuring the dropdown is closed when the user clicks outside the dropdown. This functionality was accidentally broken in #7781 when converting it to an ES6 class.