### PR TITLE
Ensure that external domains can only open one tab at once

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -460,7 +460,7 @@ function setupController (initState, initLangCode) {
  */
 async function triggerUi () {
   const tabs = await platform.getActiveTabs()
-  const currentlyActiveMetamaskTab = Boolean(tabs.find((tab) => openMetamaskTabIDs[tab.id]))
+  const currentlyActiveMetamaskTab = Boolean(tabs.find((tab) => openMetamaskTabIds[tab.id]))
   if (!popupIsOpen && !currentlyActiveMetamaskTab) {
     await notificationManager.showPopup()
   }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -385,7 +385,7 @@ function setupController (initState, initLangCode) {
         openMetamaskTabIds[tabId] = true
 
         endOfStream(portStream, () => {
-          delete openMetamaskTabIds[tabId]
+          handleTabRemoved(tabId)
           controller.isClientOpen = isClientOpenStatus()
         })
       }
@@ -460,7 +460,7 @@ function setupController (initState, initLangCode) {
  */
 async function triggerUi () {
   const tabs = await platform.getActiveTabs()
-  const currentlyActiveMetamaskTab = Boolean(tabs.find((tab) => openMetamaskTabsIDs[tab.id]))
+  const currentlyActiveMetamaskTab = Boolean(tabs.find((tab) => openMetamaskTabIDs[tab.id]))
   if (!popupIsOpen && !currentlyActiveMetamaskTab) {
     await notificationManager.showPopup()
   }
@@ -496,19 +496,21 @@ extension.runtime.onInstalled.addListener(({ reason }) => {
  */
 function setupBrowserListeners () {
   extension.tabs.onRemoved.addListener(handleTabRemoved)
+}
 
-  /**
-   * Register that a particular origin no longer has any open tabs.
-   * @param {string} tabId - The ID of the tab that was removed.
-   */
-  function handleTabRemoved (tabId, _removedInfo) {
+/**
+ * Register that a particular origin no longer has any open tabs.
+ * @param {string} tabId - The ID of the tab that was removed.
+ */
+function handleTabRemoved (tabId, _removedInfo) {
 
-    const origin = externallyOpenedTabIds.get(tabId)
+  delete openMetamaskTabIds[tabId]
 
-    if (origin) {
-      originsWithOpenTabs.delete(origin)
-      externallyOpenedTabIds.delete(tabId)
-    }
+  const origin = externallyOpenedTabIds.get(tabId)
+
+  if (origin) {
+    originsWithOpenTabs.delete(origin)
+    externallyOpenedTabIds.delete(tabId)
   }
 }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -94,9 +94,10 @@ export default class MetamaskController extends EventEmitter {
 
     // platform-specific api
     this.platform = opts.platform
+    this.openExtensionInBrowserExternal = opts.openExtensionInBrowserExternal
 
     this.getRequestAccountTabIds = opts.getRequestAccountTabIds
-    this.getOpenMetamaskTabsIds = opts.getOpenMetamaskTabsIds
+    this.getOpenMetamaskTabIds = opts.getOpenMetamaskTabIds
 
     // observable state store
     this.store = new ComposableObservableStore(initState)
@@ -578,7 +579,7 @@ export default class MetamaskController extends EventEmitter {
       legacyExposeAccounts: nodeify(permissionsController.legacyExposeAccounts, permissionsController),
 
       getRequestAccountTabIds: (cb) => cb(null, this.getRequestAccountTabIds()),
-      getOpenMetamaskTabsIds: (cb) => cb(null, this.getOpenMetamaskTabsIds()),
+      getOpenMetamaskTabIds: (cb) => cb(null, this.getOpenMetamaskTabIds()),
     }
   }
 

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -2,11 +2,6 @@ import extension from 'extensionizer'
 import { createExplorerLink as explorerLink } from '@metamask/etherscan-link'
 import { getEnvironmentType, checkForError } from '../lib/util'
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../lib/enums'
-import pify from 'pify'
-
-const PIFY_OPTS = {
-  errorFirst: false,
-}
 
 class ExtensionPlatform {
 
@@ -239,7 +234,7 @@ class ExtensionPlatform {
 
   _viewOnEtherscan (txId) {
     if (txId.startsWith('http://')) {
-      this.openWindow({ url: txId })
+      this.openTab({ url: txId })
     }
   }
 }

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -105,8 +105,6 @@ class ExtensionPlatform {
     if (getEnvironmentType() !== ENVIRONMENT_TYPE_BACKGROUND) {
       window.close()
     }
-
-    return await this.openWindow({ url: extensionURL })
   }
 
   getPlatformInfo (cb) {

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -2,6 +2,11 @@ import extension from 'extensionizer'
 import { createExplorerLink as explorerLink } from '@metamask/etherscan-link'
 import { getEnvironmentType, checkForError } from '../lib/util'
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../lib/enums'
+import pify from 'pify'
+
+const PIFY_OPTS = {
+  errorFirst: false,
+}
 
 class ExtensionPlatform {
 
@@ -82,7 +87,14 @@ class ExtensionPlatform {
     return extension.runtime.getManifest().version
   }
 
-  openExtensionInBrowser (route = null, queryString = null) {
+  /**
+   * Opens the extension in a new browser tab.
+   *
+   * @param {string} [route] - The route to add to the extension URL.
+   * @param {string} [queryString] - The query string to add to the extension URL.
+   * @returns {tabs.Tab} Object with information about the opened tab.
+   */
+  async openExtensionInBrowser (route = null, queryString = null) {
     let extensionURL = extension.runtime.getURL('home.html')
 
     if (queryString) {
@@ -92,10 +104,14 @@ class ExtensionPlatform {
     if (route) {
       extensionURL += `#${route}`
     }
+
     this.openTab({ url: extensionURL })
+
     if (getEnvironmentType() !== ENVIRONMENT_TYPE_BACKGROUND) {
       window.close()
     }
+
+    return await this.openWindow({ url: extensionURL })
   }
 
   getPlatformInfo (cb) {
@@ -223,7 +239,7 @@ class ExtensionPlatform {
 
   _viewOnEtherscan (txId) {
     if (txId.startsWith('http://')) {
-      extension.tabs.create({ url: txId })
+      this.openWindow({ url: txId })
     }
   }
 }

--- a/ui/app/pages/connected-sites/connected-sites.component.js
+++ b/ui/app/pages/connected-sites/connected-sites.component.js
@@ -21,7 +21,7 @@ export default class ConnectSites extends Component {
     history: PropTypes.object.isRequired,
     tabToConnect: PropTypes.object,
     legacyExposeAccount: PropTypes.func.isRequired,
-    getOpenMetamaskTabsIds: PropTypes.func.isRequired,
+    getOpenMetamaskTabIds: PropTypes.func.isRequired,
   }
 
   state = {
@@ -29,8 +29,8 @@ export default class ConnectSites extends Component {
   }
 
   UNSAFE_componentWillMount () {
-    const { getOpenMetamaskTabsIds } = this.props
-    getOpenMetamaskTabsIds()
+    const { getOpenMetamaskTabIds } = this.props
+    getOpenMetamaskTabIds()
   }
 
   setSitePendingDisconnect = (domainKey, domainName) => {

--- a/ui/app/pages/connected-sites/connected-sites.container.js
+++ b/ui/app/pages/connected-sites/connected-sites.container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import ConnectedSites from './connected-sites.component'
-import { getOpenMetamaskTabsIds, legacyExposeAccounts, removePermissionsFor } from '../../store/actions'
+import { getOpenMetamaskTabIds, legacyExposeAccounts, removePermissionsFor } from '../../store/actions'
 import {
   getConnectedDomainsForSelectedAddress,
   getCurrentAccountWithSendEtherInfo,
@@ -35,7 +35,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    getOpenMetamaskTabsIds: () => dispatch(getOpenMetamaskTabsIds()),
+    getOpenMetamaskTabIds: () => dispatch(getOpenMetamaskTabIds()),
     disconnectAccount: (domainKey, domain) => {
       const permissionMethodNames = domain.permissions.map(({ parentCapability }) => parentCapability)
       dispatch(removePermissionsFor({

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2385,7 +2385,7 @@ export function getRequestAccountTabIds () {
   }
 }
 
-export function setOpenMetamaskTabsIDs (openMetaMaskTabIDs) {
+export function setOpenMetamaskTabIDs (openMetaMaskTabIDs) {
   return {
     type: actionConstants.SET_OPEN_METAMASK_TAB_IDS,
     value: openMetaMaskTabIDs,
@@ -2394,8 +2394,8 @@ export function setOpenMetamaskTabsIDs (openMetaMaskTabIDs) {
 
 export function getOpenMetamaskTabIds () {
   return async (dispatch) => {
-    const openMetaMaskTabIDs = await promisifiedBackground.getOpenMetamaskTabsIds()
-    dispatch(setOpenMetamaskTabsIDs(openMetaMaskTabIDs))
+    const openMetaMaskTabIDs = await promisifiedBackground.getOpenMetamaskTabIds()
+    dispatch(setOpenMetamaskTabIDs(openMetaMaskTabIDs))
   }
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2385,7 +2385,7 @@ export function getRequestAccountTabIds () {
   }
 }
 
-export function setOpenMetamaskTabIDs (openMetaMaskTabIDs) {
+export function setOpenMetamaskTabIds (openMetaMaskTabIDs) {
   return {
     type: actionConstants.SET_OPEN_METAMASK_TAB_IDS,
     value: openMetaMaskTabIDs,
@@ -2394,8 +2394,8 @@ export function setOpenMetamaskTabIDs (openMetaMaskTabIDs) {
 
 export function getOpenMetamaskTabIds () {
   return async (dispatch) => {
-    const openMetaMaskTabIDs = await promisifiedBackground.getOpenMetamaskTabIds()
-    dispatch(setOpenMetamaskTabIDs(openMetaMaskTabIDs))
+    const openMetamaskTabIDs = await promisifiedBackground.getOpenMetamaskTabIds()
+    dispatch(setOpenMetamaskTabIds(openMetamaskTabIDs))
   }
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2392,7 +2392,7 @@ export function setOpenMetamaskTabsIDs (openMetaMaskTabIDs) {
   }
 }
 
-export function getOpenMetamaskTabsIds () {
+export function getOpenMetamaskTabIds () {
   return async (dispatch) => {
     const openMetaMaskTabIDs = await promisifiedBackground.getOpenMetamaskTabsIds()
     dispatch(setOpenMetamaskTabsIDs(openMetaMaskTabIDs))


### PR DESCRIPTION
### Summary

- Ensure that external domains can only cause the creation of a single tab at any one time
  - The only case I could find of this was in the permission controller's `requestUserApproval`
- Rename `MetamaskTabsIDs` to `MetamaskTabIds`, for great benefit to consistency and style
- _Note:_ The single instance I've identified where the motivating problem occurs should be eliminated by #8148, but this may nevertheless be worthwhile.

### Details
The `requestUserApproval` function for permissions requests opens the extension in a new browser tab. Currently, there is no limit to the number of tabs that an external origin can open by submitting permissions requests.

This PR establishes a "tab creation history" to track which origins have (effectively) created an open tab. If an origin already has an open tab and makes a new tab-creating request, no new tab will be created. When the tab created by an origin is closed, the origin is removed from the tab creation history, and can once again create a new tab.

The need for this was exposed when I left a faulty test dapp open in Chrome, and it spawned 10 tabs, like so:
![image](https://user-images.githubusercontent.com/25517051/75635872-89b5b900-5bce-11ea-8e16-61bb4593dcc6.png)

### Misc.

The behavior of that test dapps still creates, over time, an unbounded number of pending permission requests for the same origin, and we should consider implementing a similar logic for permissions requests (e.g., only one pending request at a time), but that would be a separate PR.  For that, see: #8148