### PR TITLE
Wait for extension unlock before processing eth_requestAccounts

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -421,6 +421,7 @@ function setupController (initState, initLangCode) {
   controller.encryptionPublicKeyManager.on('updateBadge', updateBadge)
   controller.typedMessageManager.on('updateBadge', updateBadge)
   controller.permissionsController.permissions.subscribe(updateBadge)
+  controller.appStateController.on('updateBadge', updateBadge)
 
   /**
    * Updates the Web Extension's "badge" number, on the little fox in the toolbar.
@@ -435,8 +436,9 @@ function setupController (initState, initLangCode) {
     const unapprovedEncryptionPublicKeyMsgCount = controller.encryptionPublicKeyManager.unapprovedEncryptionPublicKeyMsgCount
     const unapprovedTypedMessagesCount = controller.typedMessageManager.unapprovedTypedMessagesCount
     const pendingPermissionRequests = Object.keys(controller.permissionsController.permissions.state.permissionsRequests).length
+    const waitingForUnlockCount = controller.appStateController.waitingForUnlock.length
     const count = unapprovedTxCount + unapprovedMsgCount + unapprovedPersonalMsgCount + unapprovedDecryptMsgCount + unapprovedEncryptionPublicKeyMsgCount +
-                 unapprovedTypedMessagesCount + pendingPermissionRequests
+                 unapprovedTypedMessagesCount + pendingPermissionRequests + waitingForUnlockCount
     if (count) {
       label = String(count)
     }

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -79,6 +79,7 @@ export class PermissionsController {
       storeKey: METADATA_STORE_KEY,
       getAccounts: this.getAccounts.bind(this, origin),
       getUnlockPromise: this.getUnlockPromise,
+      hasPermission: this.hasPermission.bind(this, origin),
       requestAccountsPermission: this._requestPermissions.bind(
         this, origin, { eth_accounts: {} }
       ),
@@ -115,6 +116,10 @@ export class PermissionsController {
         }
       }
     })
+  }
+
+  hasPermission (origin, permission) {
+    return Boolean(this.permissions.getPermission(origin, permission))
   }
 
   /**

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -24,8 +24,12 @@ export class PermissionsController {
 
   constructor (
     {
-      platform, notifyDomain, notifyAllDomains,
-      getKeyringAccounts, getRestrictedMethods,
+      getKeyringAccounts,
+      getRestrictedMethods,
+      getUnlockPromise,
+      notifyDomain,
+      notifyAllDomains,
+      platform,
     } = {},
     restoredPermissions = {},
     restoredState = {}) {
@@ -38,6 +42,7 @@ export class PermissionsController {
 
     this._notifyDomain = notifyDomain
     this.notifyAllDomains = notifyAllDomains
+    this.getUnlockPromise = getUnlockPromise
     this.getKeyringAccounts = getKeyringAccounts
     this._platform = platform
     this._restrictedMethods = getRestrictedMethods(this)
@@ -73,6 +78,7 @@ export class PermissionsController {
       store: this.store,
       storeKey: METADATA_STORE_KEY,
       getAccounts: this.getAccounts.bind(this, origin),
+      getUnlockPromise: this.getUnlockPromise,
       requestAccountsPermission: this._requestPermissions.bind(
         this, origin, { eth_accounts: {} }
       ),

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -40,11 +40,12 @@ export class PermissionsController {
       [HISTORY_STORE_KEY]: restoredState[HISTORY_STORE_KEY] || {},
     })
 
+    this.getKeyringAccounts = getKeyringAccounts
+    this.getUnlockPromise = getUnlockPromise
     this._notifyDomain = notifyDomain
     this.notifyAllDomains = notifyAllDomains
-    this.getUnlockPromise = getUnlockPromise
-    this.getKeyringAccounts = getKeyringAccounts
     this._platform = platform
+
     this._restrictedMethods = getRestrictedMethods(this)
     this.permissionsLog = new PermissionsLogController({
       restrictedMethods: Object.keys(this._restrictedMethods),

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -119,6 +119,13 @@ export class PermissionsController {
     })
   }
 
+  /**
+   * Returns whether the given origin has the given permission.
+   *
+   * @param {string} origin - The origin to check.
+   * @param {string} permission - The permission to check for.
+   * @returns {boolean} Whether the origin has the permission.
+   */
   hasPermission (origin, permission) {
     return Boolean(this.permissions.getPermission(origin, permission))
   }

--- a/app/scripts/controllers/permissions/methodMiddleware.js
+++ b/app/scripts/controllers/permissions/methodMiddleware.js
@@ -5,8 +5,15 @@ import { ethErrors } from 'eth-json-rpc-errors'
  * Create middleware for handling certain methods and preprocessing permissions requests.
  */
 export default function createMethodMiddleware ({
-  store, storeKey, getAccounts, requestAccountsPermission,
+  getAccounts,
+  getUnlockPromise,
+  requestAccountsPermission,
+  store,
+  storeKey,
 }) {
+
+  let isProcessingRequestAccounts = false
+
   return createAsyncMiddleware(async (req, res, next) => {
 
     switch (req.method) {
@@ -20,6 +27,18 @@ export default function createMethodMiddleware ({
         return
 
       case 'eth_requestAccounts':
+
+        if (isProcessingRequestAccounts) {
+          res.error = ethErrors.rpc.resourceUnavailable(
+            'Already processing eth_requestAccounts. Please wait.'
+          )
+          return
+        }
+
+        isProcessingRequestAccounts = true
+        await getUnlockPromise()
+
+        isProcessingRequestAccounts = false
 
         // first, just try to get accounts
         let accounts = await getAccounts()

--- a/app/scripts/controllers/permissions/methodMiddleware.js
+++ b/app/scripts/controllers/permissions/methodMiddleware.js
@@ -7,6 +7,7 @@ import { ethErrors } from 'eth-json-rpc-errors'
 export default function createMethodMiddleware ({
   getAccounts,
   getUnlockPromise,
+  hasPermission,
   requestAccountsPermission,
   store,
   storeKey,
@@ -35,10 +36,11 @@ export default function createMethodMiddleware ({
           return
         }
 
-        isProcessingRequestAccounts = true
-        await getUnlockPromise()
-
-        isProcessingRequestAccounts = false
+        if (hasPermission('eth_accounts')) {
+          isProcessingRequestAccounts = true
+          await getUnlockPromise()
+          isProcessingRequestAccounts = false
+        }
 
         // first, just try to get accounts
         let accounts = await getAccounts()

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -208,6 +208,7 @@ export default class MetamaskController extends EventEmitter {
       encryptor: opts.encryptor || undefined,
     })
     this.keyringController.memStore.subscribe((s) => this._onKeyringControllerUpdate(s))
+    this.addUnlockListener(this._onUnlock.bind(this))
 
     this.permissionsController = new PermissionsController({
       getKeyringAccounts: this.keyringController.getAccounts.bind(this.keyringController),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1805,7 +1805,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {Function} handler - The event handler.
    */
   addUnlockListener (handler) {
-    this.on('unlocked', handler)
+    this.keyringController.on('unlock', handler)
   }
 
   //=============================================================================

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -614,11 +614,11 @@ export default class MetamaskController extends EventEmitter {
         this.preferencesController.setAddresses(accounts)
         this.selectFirstIdentity()
       }
-      releaseLock()
       return vault
     } catch (err) {
-      releaseLock()
       throw err
+    } finally {
+      releaseLock()
     }
   }
 
@@ -658,11 +658,11 @@ export default class MetamaskController extends EventEmitter {
       // set new identities
       this.preferencesController.setAddresses(accounts)
       this.selectFirstIdentity()
-      releaseLock()
       return vault
     } catch (err) {
-      releaseLock()
       throw err
+    } finally {
+      releaseLock()
     }
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -119,7 +119,6 @@ export default class MetamaskController extends EventEmitter {
       openPopup: opts.openPopup,
       network: this.networkController,
     })
-    this.on('unlock', this._onUnlock)
 
     this.appStateController = new AppStateController({
       addUnlockListener: this.on.bind(this, 'unlock'),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -213,6 +213,7 @@ export default class MetamaskController extends EventEmitter {
       notifyDomain: this.notifyConnections.bind(this),
       notifyAllDomains: this.notifyAllConnections.bind(this),
       getRestrictedMethods,
+      getUnlockPromise: this.getUnlockPromise.bind(this),
     }, initState.PermissionsController, initState.PermissionsMetadata)
 
     this.detectTokensController = new DetectTokensController({
@@ -352,9 +353,7 @@ export default class MetamaskController extends EventEmitter {
         if (origin === 'metamask') {
           const selectedAddress = this.preferencesController.getSelectedAddress()
           return selectedAddress ? [selectedAddress] : []
-        } else if (
-          this.keyringController.memStore.getState().isUnlocked
-        ) {
+        } else if (this.isUnlocked()) {
           return await this.permissionsController.getAccounts(origin)
         }
         return [] // changing this is a breaking change
@@ -1730,9 +1729,8 @@ export default class MetamaskController extends EventEmitter {
    */
   notifyConnections (origin, payload) {
 
-    const { isUnlocked } = this.getState()
     const connections = this.connections[origin]
-    if (!isUnlocked || !connections) {
+    if (!this.isUnlocked() || !connections) {
       return
     }
 
@@ -1750,8 +1748,7 @@ export default class MetamaskController extends EventEmitter {
    */
   notifyAllConnections (payload) {
 
-    const { isUnlocked } = this.getState()
-    if (!isUnlocked) {
+    if (!this.isUnlocked()) {
       return
     }
 
@@ -1791,6 +1788,30 @@ export default class MetamaskController extends EventEmitter {
    */
   privateSendUpdate () {
     this.emit('update', this.getState())
+  }
+
+  /**
+   * Get a Promise that resolves when the extension is unlocked.
+   * This Promise will never reject.
+   *
+   * @returns {Promise<void>} A promise that resolves when the extension is
+   * unlocked, or immediately if the extension is already unlocked.
+   */
+  getUnlockPromise () {
+    return new Promise((resolve) => {
+      if (this.isUnlocked()) {
+        resolve()
+      } else {
+        this.once('unlock', resolve)
+      }
+    })
+  }
+
+  /**
+   * @returns {boolean} Whether the extension is unlocked.
+   */
+  isUnlocked () {
+    return this.keyringController.memStore.getState().isUnlocked
   }
 
   //=============================================================================
@@ -2083,7 +2104,7 @@ export default class MetamaskController extends EventEmitter {
    */
   set isClientOpen (open) {
     this._isClientOpen = open
-    this.isClientOpenAndUnlocked = this.getState().isUnlocked && open
+    this.isClientOpenAndUnlocked = this.isUnlocked() && open
     this.detectTokensController.isOpen = open
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -119,9 +119,10 @@ export default class MetamaskController extends EventEmitter {
       openPopup: opts.openPopup,
       network: this.networkController,
     })
+    this.on('unlock', this._onUnlock)
 
     this.appStateController = new AppStateController({
-      addUnlockListener: this.addUnlockListener.bind(this),
+      addUnlockListener: this.on.bind(this, 'unlock'),
       isUnlocked: this.isUnlocked.bind(this),
       initState: initState.AppStateController,
       onInactiveTimeout: () => this.setLocked(),
@@ -208,7 +209,7 @@ export default class MetamaskController extends EventEmitter {
       encryptor: opts.encryptor || undefined,
     })
     this.keyringController.memStore.subscribe((s) => this._onKeyringControllerUpdate(s))
-    this.addUnlockListener(this._onUnlock.bind(this))
+    this.keyringController.on('unlock', () => this.emit('unlock'))
 
     this.permissionsController = new PermissionsController({
       getKeyringAccounts: this.keyringController.getAccounts.bind(this.keyringController),
@@ -1798,15 +1799,6 @@ export default class MetamaskController extends EventEmitter {
    */
   isUnlocked () {
     return this.keyringController.memStore.getState().isUnlocked
-  }
-
-  /**
-   * Adds an 'unlock' event listener to the MetaMask Controller with the
-   * given handler.
-   * @param {Function} handler - The event handler.
-   */
-  addUnlockListener (handler) {
-    this.keyringController.on('unlock', handler)
   }
 
   //=============================================================================

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eth-json-rpc-filters": "^4.1.1",
     "eth-json-rpc-infura": "^4.0.2",
     "eth-json-rpc-middleware": "^4.4.1",
-    "eth-keyring-controller": "^5.5.0",
+    "eth-keyring-controller": "^5.6.0",
     "eth-method-registry": "^1.2.0",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eth-json-rpc-filters": "^4.1.1",
     "eth-json-rpc-infura": "^4.0.2",
     "eth-json-rpc-middleware": "^4.4.1",
-    "eth-keyring-controller": "^5.6.0",
+    "eth-keyring-controller": "^5.6.1",
     "eth-method-registry": "^1.2.0",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -58,6 +58,8 @@ const getRestrictedMethods = (permController) => {
   }
 }
 
+const getUnlockPromise = () => Promise.resolve()
+
 /**
  * Gets default mock constructor options for a permissions controller.
  *
@@ -67,9 +69,10 @@ export function getPermControllerOpts () {
   return {
     platform,
     getKeyringAccounts,
+    getUnlockPromise,
+    getRestrictedMethods,
     notifyDomain: noop,
     notifyAllDomains: noop,
-    getRestrictedMethods,
   }
 }
 

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -401,6 +401,14 @@ export const getters = deepFreeze({
         }
       },
     },
+
+    eth_requestAccounts: {
+      requestAlreadyPending: () => {
+        return {
+          message: 'Already processing eth_requestAccounts. Please wait.',
+        }
+      },
+    },
   },
 
   /**

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -105,6 +105,49 @@ describe('permissions controller', function () {
     })
   })
 
+  describe('hasPermission', function () {
+
+    it('returns correct values', async function () {
+
+      const permController = initPermController()
+      grantPermissions(
+        permController, ORIGINS.a,
+        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+      )
+      grantPermissions(
+        permController, ORIGINS.b,
+        PERMS.finalizedRequests.test_method()
+      )
+
+      assert.ok(
+        permController.hasPermission(ORIGINS.a, 'eth_accounts'),
+        'should return true for granted permission'
+      )
+      assert.ok(
+        permController.hasPermission(ORIGINS.b, 'test_method'),
+        'should return true for granted permission'
+      )
+
+      assert.ok(
+        !permController.hasPermission(ORIGINS.a, 'test_method'),
+        'should return false for non-granted permission'
+      )
+      assert.ok(
+        !permController.hasPermission(ORIGINS.b, 'eth_accounts'),
+        'should return true for non-granted permission'
+      )
+
+      assert.ok(
+        !permController.hasPermission('foo', 'eth_accounts'),
+        'should return false for unknown origin'
+      )
+      assert.ok(
+        !permController.hasPermission(ORIGINS.b, 'foo'),
+        'should return false for unknown permission'
+      )
+    })
+  })
+
   describe('clearPermissions', function () {
 
     it('notifies all appropriate domains and removes permissions', async function () {

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -43,10 +43,9 @@ const validatePermission = (perm, name, origin, caveats) => {
   }
 }
 
-const initPermController = (opts) => {
+const initPermController = () => {
   return new PermissionsController({
     ...getPermControllerOpts(),
-    ...opts,
   })
 }
 

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -662,20 +662,10 @@ describe('permissions middleware', function () {
       const res = {}
 
       // this will block until we resolve the unlock Promise
-      assert.doesNotReject(
+      const requestApproval = assert.doesNotReject(
         cMiddleware(req, res),
         'should not reject'
       )
-        .then(() => {
-          assert.ok(
-            res.result && !res.error,
-            'response should have result and no error'
-          )
-          assert.deepEqual(
-            res.result, ACCOUNT_ARRAYS.c,
-            'response should have correct result'
-          )
-        })
 
       // this will reject because of the already pending request
       await assert.rejects(
@@ -685,6 +675,17 @@ describe('permissions middleware', function () {
 
       // now unlock and let through the first request
       unlock()
+
+      await requestApproval
+
+      assert.ok(
+        res.result && !res.error,
+        'response should have result and no error'
+      )
+      assert.deepEqual(
+        res.result, ACCOUNT_ARRAYS.c,
+        'response should have correct result'
+      )
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10386,10 +10386,25 @@ eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5, eth-json-rpc-mid
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-keyring-controller@^5.3.0, eth-keyring-controller@^5.5.0:
+eth-keyring-controller@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.5.0.tgz#f8b78f69a0b0005873af2d1a6b2c655d6de51351"
   integrity sha512-kWaukiHLMYNYtB/1vZyj1r1G6wU8u+DIYVMq8QUyFAxwcBnemsKISVPIXgltgXkuUiB/t9oXsA54bWBredgrVg==
+  dependencies:
+    bip39 "^2.4.0"
+    bluebird "^3.5.0"
+    browser-passworder "^2.0.3"
+    eth-hd-keyring "^3.5.0"
+    eth-sig-util "^1.4.0"
+    eth-simple-keyring "^3.5.0"
+    ethereumjs-util "^5.1.2"
+    loglevel "^1.5.0"
+    obs-store "^4.0.3"
+
+eth-keyring-controller@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.6.0.tgz#2c851c9b2e6fe5b16285c1a82056577375ac32f4"
+  integrity sha512-KVoC9dGU1V+VrnNJ9DkXgxEYmXPnAbwsLVdKNgiHGEsxk1/y3gO79HFeoWnjZgfapsMm1lTRdjSWW2xYVyreoA==
   dependencies:
     bip39 "^2.4.0"
     bluebird "^3.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10386,22 +10386,7 @@ eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5, eth-json-rpc-mid
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-keyring-controller@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.5.0.tgz#f8b78f69a0b0005873af2d1a6b2c655d6de51351"
-  integrity sha512-kWaukiHLMYNYtB/1vZyj1r1G6wU8u+DIYVMq8QUyFAxwcBnemsKISVPIXgltgXkuUiB/t9oXsA54bWBredgrVg==
-  dependencies:
-    bip39 "^2.4.0"
-    bluebird "^3.5.0"
-    browser-passworder "^2.0.3"
-    eth-hd-keyring "^3.5.0"
-    eth-sig-util "^1.4.0"
-    eth-simple-keyring "^3.5.0"
-    ethereumjs-util "^5.1.2"
-    loglevel "^1.5.0"
-    obs-store "^4.0.3"
-
-eth-keyring-controller@^5.6.0:
+eth-keyring-controller@^5.3.0, eth-keyring-controller@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.6.0.tgz#2c851c9b2e6fe5b16285c1a82056577375ac32f4"
   integrity sha512-KVoC9dGU1V+VrnNJ9DkXgxEYmXPnAbwsLVdKNgiHGEsxk1/y3gO79HFeoWnjZgfapsMm1lTRdjSWW2xYVyreoA==
@@ -19176,7 +19161,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@~0.0.1, minimist@0.0.8, minimist@1.1.x, minimist@1.2.0, minimist@~1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8, minimist@1.1.x, minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~0.0.1, minimist@~1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10386,10 +10386,10 @@ eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5, eth-json-rpc-mid
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-keyring-controller@^5.3.0, eth-keyring-controller@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.6.0.tgz#2c851c9b2e6fe5b16285c1a82056577375ac32f4"
-  integrity sha512-KVoC9dGU1V+VrnNJ9DkXgxEYmXPnAbwsLVdKNgiHGEsxk1/y3gO79HFeoWnjZgfapsMm1lTRdjSWW2xYVyreoA==
+eth-keyring-controller@^5.3.0, eth-keyring-controller@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.6.1.tgz#7b7268400704c8f5ce98a055910341177dd207ca"
+  integrity sha512-sxJ87bJg7PvvPzj1sY1jJYHQL1HVUhh84Q/a4QPrcnzAAng1yibvvUfww0pCez4XJfHuMkJvUxfF8eAusJM8fQ==
   dependencies:
     bip39 "^2.4.0"
     bluebird "^3.5.0"


### PR DESCRIPTION
### Summary

- Adds `unlock` event and related functionality to controllers:
  - Updates `eth-keyring-controller` to version with `unlock` event
  - `MetamaskController`
    - Add `addUnlockListener` method
  - `AppStateController`
    - Add functionality for waiting on extension unlock
    - Add methods: `getUnlockPromise`, `handleUnlock`
  - Adds to notification badge count for every request waiting on unlock
- `PermissionsController`: Waits for the extension to become unlocked before attempting to process `eth_requestAccounts`, _if_ the `eth_accounts` permission is already granted
  - Returns a `resourceUnavailable` Ethereum JSON RPC error for all requests following the first while waiting
    - This avoids memory leaks in case we get spammed with a bunch of requests while the extension is locked
  - If the `eth_accounts` permission is _not_ granted, this is handled by functionality introduced in #8148 

### Details

- Does _not_ open the extension popup when receiving `eth_requestAccounts` if the `eth_accounts` permission is already granted
  - We should create a separate PR if we want to support this functionality, as we have to make the popup close on unlock if there are no notifications/confirmations to attend to, which is its own set of work