### PR TITLE
Update `@metamask/eth-ledger-bridge-keyring`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Develop Branch
 
 ## 7.7.7 Wed Mar 04 2020
+- [#8162](https://github.com/MetaMask/metamask-extension/pull/8162): Remove invalid Ledger accounts
 
 ## 7.7.6 Mon Mar 02 2020
 - [#8154](https://github.com/MetaMask/metamask-extension/pull/8154): Prevent signing from incorrect Ledger account

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "3box": "^1.10.2",
     "@babel/runtime": "^7.5.5",
     "@material-ui/core": "1.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "^0.2.2",
+    "@metamask/eth-ledger-bridge-keyring": "^0.2.5",
     "@sentry/browser": "^4.1.1",
     "@zxing/library": "^0.8.0",
     "abi-decoder": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,10 +1985,10 @@
     scroll "^2.0.3"
     warning "^3.0.0"
 
-"@metamask/eth-ledger-bridge-keyring@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.2.2.tgz#f75dd45edf17c48b02e49a96b3413e6abf14b7ef"
-  integrity sha512-c1Gfn01qIqNikx8eFz1jq2KU9Vcfpgkp62v8kYgiWebwkyxuzBKlDWMoC3JCwAV5ezl05M6MQi1EAwrcsIbUOA==
+"@metamask/eth-ledger-bridge-keyring@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.2.5.tgz#2e1753b02fe3e644985c689d79c9f0cca1ba2c77"
+  integrity sha512-DWR+wZFE33iGDvrJ02f4BE6Ha4mzWtKfQTxNAcKOeFWl3HUdK3dkK/vd4sH2XGqJp5t+cZiHTQxMsDssk8o7oQ==
   dependencies:
     eth-sig-util "^1.4.2"
     ethereumjs-tx "^1.3.4"


### PR DESCRIPTION
The Ledger keyring has been updated to ensure that any stale BIP44 accounts created prior to v7.7.6 of the extension are discarded when the extension starts. Any attempts to sign with these accounts would have failed; they needed to be re-added regardless.

WIP; temporarily pointing directly at the GitHub-hosted commit for now, until a new version of the keyring is published