### PR TITLE
Update `@metamask/eth-ledger-bridge-keyring`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/runtime": "^7.5.5",
     "@download/blockies": "^1.0.3",
     "@material-ui/core": "1.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "^0.2.2",
+    "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@sentry/browser": "^5.11.1",
     "@sentry/integrations": "^5.11.1",
     "@zxing/library": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-1.1.0.tgz#03c6fbec8ba3d95fa017d8b98ab5d0701f7458a4"
   integrity sha512-yFFHIxFn3cBd9brIW/+0fJGq16hT0xUyElP0YxiZHaY7j2T/l+X/414L9kqBOuPfPa9bIKulIcJJOfcrMJZp9w==
 
-"@metamask/eth-ledger-bridge-keyring@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.2.2.tgz#f75dd45edf17c48b02e49a96b3413e6abf14b7ef"
-  integrity sha512-c1Gfn01qIqNikx8eFz1jq2KU9Vcfpgkp62v8kYgiWebwkyxuzBKlDWMoC3JCwAV5ezl05M6MQi1EAwrcsIbUOA==
+"@metamask/eth-ledger-bridge-keyring@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.2.6.tgz#2721c118a5eeb3685d372d0258f2a3b03dd01315"
+  integrity sha512-7OtX24lHSCioFZM+x4ZCsndT1wkI7cf8+ua3UntYqHFSRu/SDf6xVNBuD8isvWidNbVdcJKhfJuO3vFCDNsPBw==
   dependencies:
     eth-sig-util "^1.4.2"
     ethereumjs-tx "^1.3.4"


### PR DESCRIPTION
This updates the package to match the version used on `master`

See #8162 and #8163 for details