### PR TITLE
Fix retry transaction

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -5,6 +5,7 @@ import {
   hideModal,
   setGasLimit,
   setGasPrice,
+  createRetryTransaction,
   createSpeedUpTransaction,
   hideSidebar,
   updateSendAmount,
@@ -184,6 +185,9 @@ const mapDispatchToProps = (dispatch) => {
       updateCustomGasPrice(gasPrice)
       dispatch(setCustomGasLimit(addHexPrefix(gasLimit.toString(16))))
       return dispatch(updateTransaction(updatedTx))
+    },
+    createRetryTransaction: (txId, gasPrice) => {
+      return dispatch(createRetryTransaction(txId, gasPrice))
     },
     createSpeedUpTransaction: (txId, gasPrice) => {
       return dispatch(createSpeedUpTransaction(txId, gasPrice))


### PR DESCRIPTION
The `createRetryTransaction` was accidentally removed from the `gas-modal-page-container` component during a refactor in #7730. Attempting to retry a transaction since that change has resulted in a UI crash.