### PR TITLE
Use specified gas limit when speeding up a transaction

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -339,7 +339,17 @@ class TransactionController extends EventEmitter {
     return newTxMeta
   }
 
-  async createSpeedUpTransaction (originalTxId, customGasPrice) {
+  /**
+   * Creates a new approved transaction to attempt to speed up a previously submitted transaction. The
+   * new transaction contains the same nonce as the previous. By default, the new transaction will use
+   * the same gas limit and a 10% higher gas price, though it is possible to set a custom value for
+   * each instead.
+   * @param {number} originalTxId - the id of the txMeta that you want to speed up
+   * @param {string} [customGasPrice] - The new custom gas price, in hex
+   * @param {string} [customGasLimit] - The new custom gas limt, in hex
+   * @returns {txMeta}
+   */
+  async createSpeedUpTransaction (originalTxId, customGasPrice, customGasLimit) {
     const originalTxMeta = this.txStateManager.getTx(originalTxId)
     const { txParams } = originalTxMeta
     const { gasPrice: lastGasPrice } = txParams
@@ -356,6 +366,10 @@ class TransactionController extends EventEmitter {
       status: TRANSACTION_STATUS_APPROVED,
       type: TRANSACTION_TYPE_RETRY,
     })
+
+    if (customGasLimit) {
+      newTxMeta.txParams.gas = customGasLimit
+    }
 
     this.addTx(newTxMeta)
     await this.approveTransaction(newTxMeta.id)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1412,8 +1412,8 @@ export default class MetamaskController extends EventEmitter {
     }
   }
 
-  async createSpeedUpTransaction (originalTxId, customGasPrice) {
-    await this.txController.createSpeedUpTransaction(originalTxId, customGasPrice)
+  async createSpeedUpTransaction (originalTxId, customGasPrice, customGasLimit) {
+    await this.txController.createSpeedUpTransaction(originalTxId, customGasPrice, customGasLimit)
     const state = await this.getState()
     return state
   }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -186,11 +186,11 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(setCustomGasLimit(addHexPrefix(gasLimit.toString(16))))
       return dispatch(updateTransaction(updatedTx))
     },
-    createRetryTransaction: (txId, gasPrice) => {
-      return dispatch(createRetryTransaction(txId, gasPrice))
+    createRetryTransaction: (txId, gasPrice, gasLimit) => {
+      return dispatch(createRetryTransaction(txId, gasPrice, gasLimit))
     },
-    createSpeedUpTransaction: (txId, gasPrice) => {
-      return dispatch(createSpeedUpTransaction(txId, gasPrice))
+    createSpeedUpTransaction: (txId, gasPrice, gasLimit) => {
+      return dispatch(createSpeedUpTransaction(txId, gasPrice, gasLimit))
     },
     hideGasButtonGroup: () => dispatch(hideGasButtonGroup()),
     hideSidebar: () => dispatch(hideSidebar()),
@@ -251,11 +251,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         dispatchUpdateConfirmTxGasAndCalculate(gasLimit, gasPrice, updatedTx)
         dispatchHideModal()
       } else if (isSpeedUp) {
-        dispatchCreateSpeedUpTransaction(txId, gasPrice)
+        dispatchCreateSpeedUpTransaction(txId, gasPrice, gasLimit)
         dispatchHideSidebar()
         dispatchCancelAndClose()
       } else if (isRetry) {
-        dispatchCreateRetryTransaction(txId, gasPrice)
+        dispatchCreateRetryTransaction(txId, gasPrice, gasLimit)
         dispatchHideSidebar()
         dispatchCancelAndClose()
       } else {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1507,13 +1507,13 @@ export function createCancelTransaction (txId, customGasPrice) {
   }
 }
 
-export function createSpeedUpTransaction (txId, customGasPrice) {
+export function createSpeedUpTransaction (txId, customGasPrice, customGasLimit) {
   log.debug('background.createSpeedUpTransaction')
   let newTx
 
   return (dispatch) => {
     return new Promise((resolve, reject) => {
-      background.createSpeedUpTransaction(txId, customGasPrice, (err, newState) => {
+      background.createSpeedUpTransaction(txId, customGasPrice, customGasLimit, (err, newState) => {
         if (err) {
           dispatch(displayWarning(err.message))
           return reject(err)
@@ -1529,13 +1529,13 @@ export function createSpeedUpTransaction (txId, customGasPrice) {
   }
 }
 
-export function createRetryTransaction (txId, customGasPrice) {
+export function createRetryTransaction (txId, customGasPrice, customGasLimit) {
   log.debug('background.createRetryTransaction')
   let newTx
 
   return (dispatch) => {
     return new Promise((resolve, reject) => {
-      background.createSpeedUpTransaction(txId, customGasPrice, (err, newState) => {
+      background.createSpeedUpTransaction(txId, customGasPrice, customGasLimit, (err, newState) => {
         if (err) {
           dispatch(displayWarning(err.message))
           return reject(err)


### PR DESCRIPTION
The sidebar used to speed up a transaction while it's pending or after it has failed currently allows editing the gas limit, but that new limit is ignored. This is especially problematic for transactions that failed due to a low gas limit, as the problem becomes impossible to fix by retrying.

The gas limit specified by the user is now used in the speed up transaction.

Fixes #8156 and fixes #7977