### PR TITLE
Fix Sentry error processing for errors missing a stack

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -95,9 +95,11 @@ function rewriteReportUrls (report) {
   // update exception stack trace
   if (report.exception && report.exception.values) {
     report.exception.values.forEach((item) => {
-      item.stacktrace.frames.forEach((frame) => {
-        frame.filename = toMetamaskUrl(frame.filename)
-      })
+      if (item.stacktrace) {
+        item.stacktrace.frames.forEach((frame) => {
+          frame.filename = toMetamaskUrl(frame.filename)
+        })
+      }
     })
   }
 }


### PR DESCRIPTION
Errors without stack traces would break the Sentry error processing, which assumes the presence of a stack trace. Many errors don't have any stack trace though, such as uncaught promises.

This breakage resulting in the app state being missing from the error report, and a console warning.