### PR TITLE
Skip ENS reverse resolution when address is blank

### DIFF
--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -113,12 +113,19 @@ export default class ConfirmTransactionBase extends Component {
       clearConfirmTransaction,
       nextNonce,
       customNonceValue,
+      toAddress,
+      tryReverseResolveAddress,
     } = this.props
-    const { transactionStatus: prevTxStatus } = prevProps
+    const {
+      customNonceValue: prevCustomNonceValue,
+      nextNonce: prevNextNonce,
+      toAddress: prevToAddress,
+      transactionStatus: prevTxStatus,
+    } = prevProps
     const statusUpdated = transactionStatus !== prevTxStatus
     const txDroppedOrConfirmed = transactionStatus === DROPPED_STATUS || transactionStatus === CONFIRMED_STATUS
 
-    if (nextNonce !== prevProps.nextNonce || customNonceValue !== prevProps.customNonceValue) {
+    if (nextNonce !== prevNextNonce || customNonceValue !== prevCustomNonceValue) {
       if (customNonceValue > nextNonce) {
         this.setState({ submitWarning: this.context.t('nextNonceWarning', [nextNonce]) })
       } else {
@@ -133,8 +140,10 @@ export default class ConfirmTransactionBase extends Component {
           history.push(DEFAULT_ROUTE)
         },
       })
+    }
 
-      return
+    if (toAddress && toAddress !== prevToAddress) {
+      tryReverseResolveAddress(toAddress)
     }
   }
 
@@ -608,7 +617,9 @@ export default class ConfirmTransactionBase extends Component {
     }
 
     getNextNonce()
-    tryReverseResolveAddress(toAddress)
+    if (toAddress) {
+      tryReverseResolveAddress(toAddress)
+    }
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
The address is blank momentarily when navigating to the confirmation screen when sending a token. The address is updated in a subsequent render.

The ENS reverse resolution is now only attempted if the address is given. It has also been updated to attempt resolution when the address is finally set, which fixes the reverse resolution for token sends.

I had hoped to get rid of this interim render-without-address, but that turned out to be a bit more challenging. The problem is that the UI submits transactions through the provider just as a dapp would, and the provider doesn't say when the transaction is submitted. The promise
returned doesn't resolve until after confirmation. We would have to start calling the background methods directly and bypass the provider to get the feedback we need, and that sounded potentially dangerous. Definitely a challenge for another day.