### PR TITLE
Fix Tab prop type warning

### DIFF
--- a/ui/app/components/ui/tabs/tab/tab.component.js
+++ b/ui/app/components/ui/tabs/tab/tab.component.js
@@ -24,10 +24,10 @@ const Tab = (props) => {
 
 Tab.propTypes = {
   className: PropTypes.string,
-  isActive: PropTypes.bool.isRequired,
+  isActive: PropTypes.bool, // required, but added using React.cloneElement
   name: PropTypes.string.isRequired,
   onClick: PropTypes.func,
-  tabIndex: PropTypes.number.isRequired,
+  tabIndex: PropTypes.number, // required, but added using React.cloneElement
 }
 
 Tab.defaultProps = {


### PR DESCRIPTION
The props `isActive` and `tabIndex` of the Tab component are required and are always passed in, but the prop type warning is triggered because the tabs are rendered without these props first, then cloned by the `Tabs` component, where these props are added.

To silence the warning, the props have been made optional.