### PR TITLE
Use new Copy icon

### DIFF
--- a/app/images/copy-to-clipboard.svg
+++ b/app/images/copy-to-clipboard.svg
@@ -1,7 +1,0 @@
-<svg height="17" width="18" xmlns="http://www.w3.org/2000/svg">
-    <g fill="none" fill-rule="evenodd">
-        <path d="M1.745 1h12.022v12H1.745z" stroke="#3098dc" stroke-width="2"/>
-        <path d="M2.903 2h14.022v14H2.903z" fill="#fff"/>
-        <path d="M4.981 4h12.022v12H4.981z" stroke="#3098dc" stroke-width="2"/>
-    </g>
-</svg>

--- a/ui/app/components/app/transaction-list-item-details/index.scss
+++ b/ui/app/components/app/transaction-list-item-details/index.scss
@@ -22,11 +22,6 @@
     &:not(:last-child) {
       margin-right: 8px;
     }
-
-    &__copy-icon {
-      width: 10px;
-      height: 10px;
-    }
   }
 
   &__sender-to-recipient-container {

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -10,6 +10,7 @@ import TransactionActivityLog from '../transaction-activity-log'
 import TransactionBreakdown from '../transaction-breakdown'
 import Button from '../../ui/button'
 import Tooltip from '../../ui/tooltip'
+import Copy from '../../ui/icon/copy-icon.component'
 
 export default class TransactionListItemDetails extends PureComponent {
   static contextTypes = {
@@ -178,10 +179,7 @@ export default class TransactionListItemDetails extends PureComponent {
                 className="transaction-list-item-details__header-button"
                 disabled={!hash}
               >
-                <img
-                  className="transaction-list-item-details__header-button__copy-icon"
-                  src="/images/copy-to-clipboard.svg"
-                />
+                <Copy size={10} color="#3098DC" />
               </Button>
             </Tooltip>
             <Tooltip title={blockExplorerUrl ? t('viewOnCustomBlockExplorer', [blockExplorerUrl]) : t('viewOnEtherscan')}>

--- a/ui/app/pages/settings/contact-list-tab/index.scss
+++ b/ui/app/pages/settings/contact-list-tab/index.scss
@@ -102,6 +102,7 @@
           height: 20px;
           padding: 0;
           background: none;
+          padding-left: 10px;
         }
       }
 

--- a/ui/app/pages/settings/contact-list-tab/index.scss
+++ b/ui/app/pages/settings/contact-list-tab/index.scss
@@ -97,9 +97,11 @@
         }
 
         &--copy-icon {
-          padding-left: 4px;
-          width: 30px;
+          display: inline-block;
+          width: 20px;
           height: 20px;
+          padding: 0;
+          background: none;
         }
       }
 

--- a/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.component.js
@@ -56,7 +56,10 @@ export default class ViewContact extends PureComponent {
               >
                 { quadSplit(checkSummedAddress) }
               </div>
-              <button className="address-book__view-contact__group__static-address--copy-icon" onClick={() => copyToClipboard(checkSummedAddress)}>
+              <button
+                className="address-book__view-contact__group__static-address--copy-icon"
+                onClick={() => copyToClipboard(checkSummedAddress)}
+              >
                 <Copy size={20} color="#3098DC" />
               </button>
             </div>

--- a/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.component.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Identicon from '../../../../components/ui/identicon'
+import Copy from '../../../../components/ui/icon/copy-icon.component'
 
 import Button from '../../../../components/ui/button/button.component'
 import copyToClipboard from 'copy-to-clipboard'
@@ -55,11 +56,9 @@ export default class ViewContact extends PureComponent {
               >
                 { quadSplit(checkSummedAddress) }
               </div>
-              <img
-                className="address-book__view-contact__group__static-address--copy-icon"
-                onClick={() => copyToClipboard(checkSummedAddress)}
-                src="/images/copy-to-clipboard.svg"
-              />
+              <button className="address-book__view-contact__group__static-address--copy-icon" onClick={() => copyToClipboard(checkSummedAddress)}>
+                <Copy size={20} color="#3098DC" />
+              </button>
             </div>
           </div>
           <div className="address-book__view-contact__group">


### PR DESCRIPTION
Update copy-to-clipboard to use new tx-history icon added in #8180

I noticed we're not using the tooltip for the copy button in the contact list, we probably should? I can add that if we want it in another PR