### PR TITLE
fix #6958: fix destructuring of lastSelectedProvider

### DIFF
--- a/ui/app/components/app/loading-network-screen/loading-network-screen.container.js
+++ b/ui/app/components/app/loading-network-screen/loading-network-screen.container.js
@@ -6,10 +6,10 @@ import { getNetworkIdentifier } from '../../../selectors/selectors'
 const mapStateToProps = (state) => {
   const {
     loadingMessage,
+    lastSelectedProvider,
   } = state.appState
   const {
     provider,
-    lastSelectedProvider,
     network,
   } = state.metamask
   const { rpcTarget, chainId, ticker, nickname, type } = provider


### PR DESCRIPTION
As per #6958 I see that this issue still exists.

The desired functionality was intended, the bug occurred due to trying to pull the lastSelectedProvider out of the metamask store instead of the appState. Simply moving the variable destructuring resolves the issue in dev. 

* Fixes #6958 