### PR TITLE
feat - add down caret on asset list

### DIFF
--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -673,6 +673,7 @@
       display: flex;
       flex-flow: column nowrap;
       margin-left: 8px;
+      flex-grow: 1;
     }
 
     &__symbol {

--- a/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -86,14 +86,14 @@ export default class SendAssetRow extends Component {
           onClick={this.closeDropdown}
         />
         <div className="send-v2__asset-dropdown__list">
-          { this.renderEth() }
-          { this.props.tokens.map((token) => this.renderAsset(token)) }
+          { this.renderEth(true) }
+          { this.props.tokens.map((token) => this.renderAsset(token, true)) }
         </div>
       </div>
     )
   }
 
-  renderEth () {
+  renderEth (insideDropdown = false) {
     const { t } = this.context
     const { accounts, selectedAddress } = this.props
 
@@ -117,12 +117,15 @@ export default class SendAssetRow extends Component {
             />
           </div>
         </div>
+        { !insideDropdown && this.props.tokens.length > 0 && (
+          <i className="fa fa-caret-down fa-lg simple-dropdown__caret" />
+        )}
       </div>
     )
   }
 
 
-  renderAsset (token) {
+  renderAsset (token, insideDropdown = false) {
     const { address, symbol } = token
     const { t } = this.context
 
@@ -147,6 +150,9 @@ export default class SendAssetRow extends Component {
             />
           </div>
         </div>
+        { !insideDropdown && (
+          <i className="fa fa-caret-down fa-lg simple-dropdown__caret" />
+        )}
       </div>
     )
   }


### PR DESCRIPTION
Fixes #6638

**Approach**
Saw that there exists a simple-dropdown.js that uses the down caret, but the dropdown for changing currency renders icons in the menu so couldn't directly utilize that without modification. Instead, dropped in the icon into the existing implementation.

CSS changes:
* had to add flex-grow: 1 to the currency info to allow it to fill all available space between currency logo and dropdown. Should have 0 regressions. 

Function signature changes:
renderToken and renderEth are used to render both into the selected item as well as the available options so I added an argument to these functions to indicate whether rendering *inside* the dropdown to avoid rendering the caret. 

Open to requests for revision.

Sidenote: I cannot get tests to run locally.
Error:
```
$ mocha --exit --require test/env.js --require test/setup.js --recursive "test/unit/**/*.js" "ui/app/**/*.test.js"
Error: Cannot find module './build/Release/scrypt'
```
any help would be appreciated :) 