### PR TITLE
Clear sync timeout on unmount

### DIFF
--- a/ui/app/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.component.js
@@ -226,6 +226,7 @@ export default class MobileSyncPage extends Component {
 
 
   componentWillUnmount () {
+    this.handle && clearTimeout(this.handle)
     this.disconnectWebsockets()
   }
 


### PR DESCRIPTION
It looks like once the password is entered for mobile sync a `setTimeout` is kicked off...

once the component is unmounted the `setTimeout` continues looping _forever_

![image](https://user-images.githubusercontent.com/675259/76806124-fc21be00-67b6-11ea-9159-8386fbdb7758.png)

this ensures we clear it when unmounting the component
