### PR TITLE
Fix method registry initialization

### DIFF
--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -49,8 +49,7 @@ async function getMethodFrom4Byte (fourBytePrefix) {
     return null
   }
 }
-
-const registry = new MethodRegistry({ provider: global.ethereumProvider })
+let registry
 
 /**
  * Attempts to return the method data from the MethodRegistry library, the message registry library and the token abi, in that order of preference
@@ -63,6 +62,10 @@ export async function getMethodDataAsync (fourBytePrefix) {
       log.error(e)
       return null
     })
+
+    if (!registry) {
+      registry = new MethodRegistry({ provider: global.ethereumProvider })
+    }
 
     let sig = await registry.lookup(fourBytePrefix)
 


### PR DESCRIPTION
The method registry was being initialized with the global variable `ethereumProvider` before that variable was set. As a result, the method registry was falling back to an internally constructed provider that used the wrong provider URL (an obsolete Infura API). This was resulting in an error with the message "Project ID not found".

The method registry is now initialized lazily, when it's first needed. This should be well after the initialization of `ethereumProvider`, which occurs during the UI initialization.