### PR TITLE
Add Idle Timeout for Sync with mobile

### DIFF
--- a/ui/app/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.component.js
@@ -48,7 +48,7 @@ export default class MobileSyncPage extends Component {
     }
   }
 
-  handleIdleTimeout () {
+  startIdleTimeout () {
     this.idleTimeout = setTimeout(() => {
       this.clearTimeouts()
       this.goBack()
@@ -61,7 +61,7 @@ export default class MobileSyncPage extends Component {
     this.props.requestRevealSeedWords(this.state.password)
       .then((seedWords) => {
         this.startKeysGeneration()
-        this.handleIdleTimeout()
+        this.startIdleTimeout()
         this.setState({ seedWords, screen: REVEAL_SEED_SCREEN })
       })
       .catch((error) => this.setState({ error: error.message }))

--- a/ui/app/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.component.js
@@ -49,14 +49,10 @@ export default class MobileSyncPage extends Component {
   }
 
   handleIdleTimeout () {
-    let timeout
-    const { history } = this.props
-    const timeoutFunc = () => {
-      clearTimeout(timeout)
-      history.push(DEFAULT_ROUTE)
-      console.log('tock')
-    }
-    timeout = setTimeout(timeoutFunc, IDLE_TIME)
+    this.idleTimeout = setTimeout(() => {
+      this.clearTimeouts()
+      this.goBack()
+    }, IDLE_TIME)
   }
 
   handleSubmit (event) {
@@ -72,14 +68,23 @@ export default class MobileSyncPage extends Component {
   }
 
   startKeysGeneration () {
-    console.log('tick')
-    this.handle && clearTimeout(this.handle)
+    this.keysGenerationTimeout && clearTimeout(this.keysGenerationTimeout)
     this.disconnectWebsockets()
     this.generateCipherKeyAndChannelName()
     this.initWebsockets()
-    this.handle = setTimeout(() => {
+    this.keysGenerationTimeout = setTimeout(() => {
       this.startKeysGeneration()
     }, KEYS_GENERATION_TIME)
+  }
+
+  goBack() {
+    const { history } = this.props
+    history.push(DEFAULT_ROUTE)
+  }
+
+  clearTimeouts() {
+    this.keysGenerationTimeout && clearTimeout(this.keysGenerationTimeout)
+    this.idleTimeout && clearTimeout(this.idleTimeout)
   }
 
   generateCipherKeyAndChannelName () {
@@ -115,7 +120,7 @@ export default class MobileSyncPage extends Component {
         if (message.event === 'start-sync') {
           this.startSyncing()
         } else if (message.event === 'connection-info') {
-          this.handle && clearTimeout(this.handle)
+          this.keysGenerationTimeout && clearTimeout(this.keysGenerationTimeout)
           this.disconnectWebsockets()
           this.initWithCipherKeyAndChannelName(message.cipher, message.channel)
           this.initWebsockets()
@@ -240,7 +245,7 @@ export default class MobileSyncPage extends Component {
 
 
   componentWillUnmount () {
-    this.handle && clearTimeout(this.handle)
+    this.clearTimeouts()
     this.disconnectWebsockets()
   }
 
@@ -367,7 +372,6 @@ export default class MobileSyncPage extends Component {
 
   renderPasswordPromptFooter () {
     const { t } = this.context
-    const { history } = this.props
     const { password } = this.state
 
     return (
@@ -376,7 +380,7 @@ export default class MobileSyncPage extends Component {
           type="default"
           large
           className="new-account-create-form__button"
-          onClick={() => history.push(DEFAULT_ROUTE)}
+          onClick={() => this.goBack()}
         >
           {t('cancel')}
         </Button>
@@ -395,7 +399,6 @@ export default class MobileSyncPage extends Component {
 
   renderRevealSeedFooter () {
     const { t } = this.context
-    const { history } = this.props
 
     return (
       <div className="page-container__footer" style={{ padding: 30 }}>
@@ -403,7 +406,7 @@ export default class MobileSyncPage extends Component {
           type="default"
           large
           className="page-container__footer-button"
-          onClick={() => history.push(DEFAULT_ROUTE)}
+          onClick={() => this.goBack()}
         >
           {t('close')}
         </Button>

--- a/ui/app/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.component.js
@@ -12,6 +12,7 @@ import LoadingScreen from '../../components/ui/loading-screen'
 const PASSWORD_PROMPT_SCREEN = 'PASSWORD_PROMPT_SCREEN'
 const REVEAL_SEED_SCREEN = 'REVEAL_SEED_SCREEN'
 const KEYS_GENERATION_TIME = 30000
+const IDLE_TIME = KEYS_GENERATION_TIME * 4
 
 export default class MobileSyncPage extends Component {
   static contextTypes = {
@@ -47,18 +48,31 @@ export default class MobileSyncPage extends Component {
     }
   }
 
+  handleIdleTimeout () {
+    let timeout
+    const { history } = this.props
+    const timeoutFunc = () => {
+      clearTimeout(timeout)
+      history.push(DEFAULT_ROUTE)
+      console.log('tock')
+    }
+    timeout = setTimeout(timeoutFunc, IDLE_TIME)
+  }
+
   handleSubmit (event) {
     event.preventDefault()
     this.setState({ seedWords: null, error: null })
     this.props.requestRevealSeedWords(this.state.password)
       .then((seedWords) => {
         this.startKeysGeneration()
+        this.handleIdleTimeout()
         this.setState({ seedWords, screen: REVEAL_SEED_SCREEN })
       })
       .catch((error) => this.setState({ error: error.message }))
   }
 
   startKeysGeneration () {
+    console.log('tick')
     this.handle && clearTimeout(this.handle)
     this.disconnectWebsockets()
     this.generateCipherKeyAndChannelName()

--- a/ui/app/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.component.js
@@ -77,12 +77,12 @@ export default class MobileSyncPage extends Component {
     }, KEYS_GENERATION_TIME)
   }
 
-  goBack() {
+  goBack () {
     const { history } = this.props
     history.push(DEFAULT_ROUTE)
   }
 
-  clearTimeouts() {
+  clearTimeouts () {
     this.keysGenerationTimeout && clearTimeout(this.keysGenerationTimeout)
     this.idleTimeout && clearTimeout(this.idleTimeout)
   }


### PR DESCRIPTION
When the user opens up the "Sync with mobile" section and enters their password they're presented with a QR code that can be scanned. At this point the end user is vulnerable to anybody else that can see the aforementioned QR code...

My thinking with adding this is that it's just an additional safety mechanism. If a user opens this area and somehow forgets (gets distracted, walks away from their computer leaving it unlocked) this mechanism will ensure the amount of time the QR code is displayed on the screen is limited.