### PR TITLE
Use kind-of@6.0.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17117,9 +17117,9 @@ kind-of@^5.0.0, kind-of@^5.0.2:
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.1, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 klaw@^1.0.0:
   version "1.3.1"


### PR DESCRIPTION
This PR addresses 43125 low-severity security advisories of the following nature:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Validation Bypass                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ kind-of                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=6.0.3                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ 3box                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ 3box > ipfs > kind-of                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1490                        │
└───────────────┴──────────────────────────────────────────────────────────────┘

```