### PR TITLE
Fix highlighting of selected asset

### DIFF
--- a/ui/app/components/app/wallet-view/wallet-view.component.js
+++ b/ui/app/components/app/wallet-view/wallet-view.component.js
@@ -46,7 +46,7 @@ export default class WalletView extends Component {
     return (
       <div
         className={classnames('flex-column', 'wallet-balance-wrapper', {
-          'wallet-balance-wrapper--active': Boolean(selectedTokenAddress),
+          'wallet-balance-wrapper--active': !selectedTokenAddress,
         })}
       >
         <div


### PR DESCRIPTION
The current selected asset in the asset list should be highlighted, but this highlighting was broken for `ETH`. `ETH` was not highlighted when it was selected, but it would be highlighted when anything else was.

This was broken accidentally in #7546