### PR TITLE
Force resolve all minimist versions to minimist@1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
     "generate:migration": "./development/generate-migration.sh"
   },
   "resolutions": {
+    "**/gonzales-pe/minimist": "^1.2.5",
+    "**/knex/minimist": "^1.2.5",
+    "**/mkdirp/minimist": "^1.2.5",
+    "**/optimist/minimist": "^1.2.5",
+    "**/socketcluster/minimist": "^1.2.5",
     "3box/ipfs/ipld-zcash/zcash-bitcore-lib/lodash": "^4.17.15"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19181,25 +19181,10 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@1.1.x:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
-  integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
-
-minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+minimist@~0.0.1, minimist@0.0.8, minimist@1.1.x, minimist@1.2.0, minimist@~1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR adds a Yarn resolution to force-resolve all minimist dependencies to the latest version, 1.2.5. I'm pretty sure this is safe.

minimist doesn't have a changelog in the project, but looking at [`0.0.8...1.2.5`](https://github.com/substack/minimist/compare/0.0.8...1.2.5), it seems like there aren't any public API breakages. The breaking version bump in particular, [`0.2.0...1.0.0`](https://github.com/substack/minimist/compare/0.2.0...1.0.0), doesn't seem to contain anything untoward. This all seems fine to me.

Also, mkdirp is the source of most of these advisories & the only usage of `minimist` in mkdirp is in [its bin script](https://github.com/isaacs/node-mkdirp/blob/0.5.0/bin/cmd.js).