### PR TITLE
Remove `tOrKey` and `tOrDefault` functions from i18n context

### DIFF
--- a/test/lib/render-helpers.js
+++ b/test/lib/render-helpers.js
@@ -27,14 +27,12 @@ export function mountWithRouter (component, store = {}, pathname = '/') {
     context: {
       router,
       t: (str) => str,
-      tOrKey: (str) => str,
       metricsEvent: () => {},
       store,
     },
     childContextTypes: {
       router: PropTypes.object,
       t: PropTypes.func,
-      tOrKey: PropTypes.func,
       metricsEvent: PropTypes.func,
       store: PropTypes.object,
     },

--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -4,14 +4,6 @@ import PropTypes from 'prop-types'
 import { getMessage } from '../utils/i18n-helper'
 
 class I18nProvider extends Component {
-  tOrDefault = (key, defaultValue, ...args) => {
-    if (!key) {
-      return defaultValue
-    }
-    const { localeMessages: { current, en } = {}, currentLocale } = this.props
-    return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args) || defaultValue
-  }
-
   getChildContext () {
     const { localeMessages, currentLocale } = this.props
     const { current, en } = localeMessages
@@ -24,10 +16,6 @@ class I18nProvider extends Component {
        */
       t (key, ...args) {
         return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args) || `[${key}]`
-      },
-      tOrDefault: this.tOrDefault,
-      tOrKey: (key, ...args) => {
-        return this.tOrDefault(key, key, ...args)
       },
     }
   }
@@ -45,8 +33,6 @@ I18nProvider.propTypes = {
 
 I18nProvider.childContextTypes = {
   t: PropTypes.func,
-  tOrDefault: PropTypes.func,
-  tOrKey: PropTypes.func,
 }
 
 const mapStateToProps = (state) => {

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -21,7 +21,6 @@ import TextField from '../../components/ui/text-field'
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
     t: PropTypes.func,
-    tOrKey: PropTypes.func.isRequired,
     metricsEvent: PropTypes.func,
   }
 
@@ -311,7 +310,7 @@ export default class ConfirmTransactionBase extends Component {
     )
   }
 
-  renderData () {
+  renderData (functionType) {
     const { t } = this.context
     const {
       txData: {
@@ -320,12 +319,10 @@ export default class ConfirmTransactionBase extends Component {
         } = {},
       } = {},
       methodData: {
-        name,
         params,
       } = {},
       hideData,
       dataComponent,
-      transactionCategory,
     } = this.props
 
     if (hideData) {
@@ -337,7 +334,7 @@ export default class ConfirmTransactionBase extends Component {
         <div className="confirm-page-container-content__data-box-label">
           {`${t('functionType')}:`}
           <span className="confirm-page-container-content__function-type">
-            { getMethodName(name) || this.context.tOrKey(transactionCategory) || this.context.t('contractInteraction') }
+            { functionType }
           </span>
         </div>
         {
@@ -627,6 +624,7 @@ export default class ConfirmTransactionBase extends Component {
   }
 
   render () {
+    const { t } = this.context
     const {
       isTxReprice,
       fromName,
@@ -660,6 +658,14 @@ export default class ConfirmTransactionBase extends Component {
     const { name } = methodData
     const { valid, errorKey } = this.getErrorKey()
     const { totalTx, positionOfCurrentTx, nextTxId, prevTxId, showNavigation, firstTx, lastTx, ofText, requestsWaitingText } = this.getNavigateTxData()
+
+    let functionType = getMethodName(name)
+    if (!functionType) {
+      functionType = transactionCategory
+        ? t(transactionCategory)
+        : t('contractInteraction')
+    }
+
     return (
       <ConfirmPageContainer
         fromName={fromName}
@@ -670,8 +676,7 @@ export default class ConfirmTransactionBase extends Component {
         toEns={toEns}
         toNickname={toNickname}
         showEdit={onEdit && !isTxReprice}
-        // In the event that the key is falsy (and inherently invalid), use a fallback string
-        action={getMethodName(name) || this.context.tOrKey(transactionCategory) || this.context.t('contractInteraction')}
+        action={functionType}
         title={title}
         titleComponent={this.renderTitleComponent()}
         subtitle={subtitle}
@@ -679,7 +684,7 @@ export default class ConfirmTransactionBase extends Component {
         hideSubtitle={hideSubtitle}
         summaryComponent={summaryComponent}
         detailsComponent={this.renderDetails()}
-        dataComponent={this.renderData()}
+        dataComponent={this.renderData(functionType)}
         contentComponent={contentComponent}
         nonce={customNonceValue || nonce}
         unapprovedTxCount={unapprovedTxCount}


### PR DESCRIPTION
These two functions were not especially useful. `tOrDefault` was used only by `tOrKey`, and `tOrKey` was only used in one place. All it did was return the given `key` directly if it was falsey, so it was easily
replaced by a condition.