### PR TITLE
Remove fallback for missing localized messages

### DIFF
--- a/ui/app/helpers/higher-order-components/i18n-provider.js
+++ b/ui/app/helpers/higher-order-components/i18n-provider.js
@@ -15,7 +15,7 @@ class I18nProvider extends Component {
        * @returns {string|undefined|null} - The localized message if available
        */
       t (key, ...args) {
-        return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args) || `[${key}]`
+        return getMessage(currentLocale, current, key, ...args) || getMessage(currentLocale, en, key, ...args)
       },
     }
   }

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -661,9 +661,11 @@ export default class ConfirmTransactionBase extends Component {
 
     let functionType = getMethodName(name)
     if (!functionType) {
-      functionType = transactionCategory
-        ? t(transactionCategory)
-        : t('contractInteraction')
+      if (transactionCategory) {
+        functionType = t(transactionCategory) || transactionCategory
+      } else {
+        functionType = t('contractInteraction')
+      }
     }
 
     return (


### PR DESCRIPTION
The translation helper function we use everywhere (`t`) would fallback to the message `[${key}]` for any key not found in the set of localized messages. Instead it how returns `undefined` in that case.

`[${key}]` isn't something you'd typically want to show to users, so this fallback wasn't overly useful in practice. At best it served to hide errors.

The falsey return value in the case where the message is missing makes it easier to implement a fallback for that case. Such a fallback is used in the `confirm-transaction-base` component, to restore the fallback behavior accidentally changed in #8211