### PR TITLE
Remove unused parameters

### DIFF
--- a/ui/app/pages/send/send-content/add-recipient/add-recipient.js
+++ b/ui/app/pages/send/send-content/add-recipient/add-recipient.js
@@ -11,7 +11,8 @@ import { checkExistingAddresses } from '../../../add-token/util'
 import ethUtil from 'ethereumjs-util'
 import contractMap from 'eth-contract-metadata'
 
-export function getToErrorObject (to, toError = null, hasHexData = false, _, __, network) {
+export function getToErrorObject (to, hasHexData = false, _, __, network) {
+  let toError = null
   if (!to) {
     if (!hasHexData) {
       toError = REQUIRED_ERROR
@@ -23,7 +24,8 @@ export function getToErrorObject (to, toError = null, hasHexData = false, _, __,
   return { to: toError }
 }
 
-export function getToWarningObject (to, toWarning = null, tokens = [], selectedToken = null) {
+export function getToWarningObject (to, tokens = [], selectedToken = null) {
+  let toWarning = null
   if (selectedToken && (ethUtil.toChecksumAddress(to) in contractMap || checkExistingAddresses(to, tokens))) {
     toWarning = KNOWN_RECIPIENT_ADDRESS_ERROR
   }

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
@@ -32,7 +32,7 @@ describe('add-recipient utils', function () {
     })
 
     it('should return null if to is falsy and hexData is truthy', function () {
-      assert.deepEqual(getToErrorObject(null, undefined, true), {
+      assert.deepEqual(getToErrorObject(null, true), {
         to: null,
       })
     })
@@ -49,31 +49,25 @@ describe('add-recipient utils', function () {
       })
     })
 
-    it('should return the passed error if to is truthy but invalid if to is truthy and valid', function () {
-      assert.deepEqual(getToErrorObject('invalid #$ 345878', 'someExplicitError'), {
-        to: 'someExplicitError',
-      })
-    })
-
     it('should return null if to is truthy but part of state tokens', function () {
-      assert.deepEqual(getToErrorObject('0xabc123', undefined, false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
+      assert.deepEqual(getToErrorObject('0xabc123', false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: null,
       })
     })
 
     it('should null if to is truthy part of tokens but selectedToken falsy', function () {
-      assert.deepEqual(getToErrorObject('0xabc123', undefined, false, [{ 'address': '0xabc123' }]), {
+      assert.deepEqual(getToErrorObject('0xabc123', false, [{ 'address': '0xabc123' }]), {
         to: null,
       })
     })
 
     it('should return null if to is truthy but part of contract metadata', function () {
-      assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
+      assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: null,
       })
     })
     it('should null if to is truthy part of contract metadata but selectedToken falsy', function () {
-      assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
+      assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: null,
       })
     })
@@ -81,24 +75,24 @@ describe('add-recipient utils', function () {
 
   describe('getToWarningObject()', function () {
     it('should return a known address recipient if to is truthy but part of state tokens', function () {
-      assert.deepEqual(getToWarningObject('0xabc123', undefined, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
+      assert.deepEqual(getToWarningObject('0xabc123', [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })
     })
 
     it('should null if to is truthy part of tokens but selectedToken falsy', function () {
-      assert.deepEqual(getToWarningObject('0xabc123', undefined, [{ 'address': '0xabc123' }]), {
+      assert.deepEqual(getToWarningObject('0xabc123', [{ 'address': '0xabc123' }]), {
         to: null,
       })
     })
 
     it('should return a known address recipient if to is truthy but part of contract metadata', function () {
-      assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
+      assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })
     })
     it('should null if to is truthy part of contract metadata but selectedToken falsy', function () {
-      assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', undefined, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
+      assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })
     })

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -236,8 +236,8 @@ export default class SendTransactionScreen extends Component {
       return this.setState({ toError: '', toWarning: '' })
     }
 
-    const toErrorObject = getToErrorObject(query, null, hasHexData, tokens, selectedToken, network)
-    const toWarningObject = getToWarningObject(query, null, tokens, selectedToken)
+    const toErrorObject = getToErrorObject(query, hasHexData, tokens, selectedToken, network)
+    const toWarningObject = getToWarningObject(query, tokens, selectedToken)
 
     this.setState({
       toError: toErrorObject.to,


### PR DESCRIPTION
These two parameters were never used in practice - a `null` was being passed in explicitly.