### PR TITLE
Add border none for moz-focus-inner

### DIFF
--- a/ui/app/components/ui/popover/index.scss
+++ b/ui/app/components/ui/popover/index.scss
@@ -37,9 +37,6 @@
       margin: 10px;
       background: none;
       padding: 0;
-      &::-moz-focus-inner {
-        border: none;
-      }
     }
   }
 

--- a/ui/app/css/itcss/generic/reset.scss
+++ b/ui/app/css/itcss/generic/reset.scss
@@ -138,6 +138,9 @@ table {
 button {
   border-style: none;
   cursor: pointer;
+  &::-moz-focus-inner {
+    border: none;
+  }
 }
 
 /* stylelint-enable */


### PR DESCRIPTION
This removes the dotted border that we're seeing in Firefox:

![image](https://user-images.githubusercontent.com/675259/77089181-e17c5e80-69db-11ea-9c34-9676bdd09743.png)

![image](https://user-images.githubusercontent.com/675259/77089223-ee00b700-69db-11ea-9da3-36fbe406c922.png)

