### PR TITLE
Remove unnecessary token list update

### DIFF
--- a/ui/app/components/app/token-list.js
+++ b/ui/app/components/app/token-list.js
@@ -73,19 +73,9 @@ class TokenList extends Component {
     this.tracker.on('error', this.showError)
 
     this.tracker.updateBalances()
-      .then(() => {
-        this.updateBalances(this.tracker.serialize())
-      })
-      .catch((reason) => {
-        log.error(`Problem updating balances`, reason)
-        this.setState({ isLoading: false })
-      })
   }
 
   updateBalances = function (tokens) {
-    if (!this.tracker.running) {
-      return
-    }
     this.setState({ tokens, isLoading: false })
   }
 


### PR DESCRIPTION
When the token tracker is first constructed and the first balance update is triggered, we manually serialize the tracker state and call our update function. This is _in addition_ to the update event handler though, so the balances get updated twice. Similarly, we also catch any errors during this first update to handle them, but this is done via an event as well, so is redundant.

These steps have been removed; updates and errors are now handled solely through events. We were able to drop a check from `updateBalances` as well to ensure the tracker is still running, as the event cannot be emitted unless it's running.