### PR TITLE
Use caniuse-lite@1.0.30001036

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6417,15 +6417,10 @@ can-use-dom@^0.1.0:
   resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
-caniuse-lite@^1.0.30000810, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000955, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000989:
-  version "1.0.30001005"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001005.tgz#823054210be638c725521edcb869435dae46728d"
-  integrity sha512-g78miZm1Z5njjYR216a5812oPiLgV1ssndgGxITHWUopmjUrCswMisA0a2kSB7a0vZRox6JOKhM51+efmYN8Mg==
-
-caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001022:
-  version "1.0.30001023"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz#b82155827f3f5009077bdd2df3d8968bcbcc6fc4"
-  integrity sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==
+caniuse-lite@^1.0.30000810, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000955, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001022, caniuse-lite@^1.0.30001036:
+  version "1.0.30001036"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz#930ea5272010d8bf190d859159d757c0b398caf0"
+  integrity sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR updates [`caniuse-lite`](https://www.npmjs.com/package/caniuse-lite) to remove a handful of warning messages that appear in the console during tests & builds:

From the test output:

```
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
```

From the build output:

```
[build] scripts:core:dev:background: Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
[build] scripts:core:dev:contentscript: Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
[build] scripts:core:dev:phishing-detect: Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
[build] scripts:core:dev:ui: Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
[build] scripts:core:dev:contentscript: [21:27:48] scripts:core:dev:contentscript: 1819071 bytes written (1.35 seconds)
[build] scripts:core:dev:phishing-detect: [21:27:48] scripts:core:dev:phishing-detect: 1870500 bytes written (1.73 seconds)
[build] scripts:core:dev:contentscript: [21:27:49] 4080112 bytes written (1.41 seconds)
[build] scripts:core:dev:background: [21:28:01] scripts:core:dev:background: 30423019 bytes written (14.10 seconds)
[build] scripts:core:dev:ui: [21:28:07] scripts:core:dev:ui: 28733803 bytes written (20.80 seconds)
```