### PR TITLE
Remove unused token cell methods and props

### DIFF
--- a/test/unit/ui/app/components/token-cell.spec.js
+++ b/test/unit/ui/app/components/token-cell.spec.js
@@ -13,7 +13,6 @@ describe('Token Cell', function () {
 
   const state = {
     metamask: {
-      network: 'test',
       currentCurrency: 'usd',
       selectedTokenAddress: '0xToken',
       selectedAddress: '0xAddress',
@@ -40,7 +39,6 @@ describe('Token Cell', function () {
           address="0xAnotherToken"
           symbol="TEST"
           string="5.000"
-          network={22}
           currentCurrency="usd"
           image="./test-image"
         />
@@ -50,7 +48,6 @@ describe('Token Cell', function () {
 
   it('renders Identicon with props from token cell', function () {
     assert.equal(wrapper.find(Identicon).prop('address'), '0xAnotherToken')
-    assert.equal(wrapper.find(Identicon).prop('network'), 'test')
     assert.equal(wrapper.find(Identicon).prop('image'), './test-image')
   })
 

--- a/ui/app/components/app/token-cell/token-cell.component.js
+++ b/ui/app/components/app/token-cell/token-cell.component.js
@@ -2,7 +2,6 @@ import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Identicon from '../../ui/identicon'
-import prefixForNetwork from '../../../../lib/etherscan-prefix-for-network'
 import { conversionUtil, multiplyCurrencies } from '../../../helpers/utils/conversion-util'
 import TokenMenuDropdown from '../dropdowns/token-menu-dropdown.js'
 
@@ -15,7 +14,6 @@ export default class TokenCell extends Component {
     address: PropTypes.string,
     symbol: PropTypes.string,
     string: PropTypes.string,
-    network: PropTypes.string,
     setSelectedToken: PropTypes.func.isRequired,
     selectedTokenAddress: PropTypes.string,
     contractExchangeRates: PropTypes.object,
@@ -30,29 +28,12 @@ export default class TokenCell extends Component {
     tokenMenuOpen: false,
   }
 
-  send (address, event) {
-    event.preventDefault()
-    event.stopPropagation()
-    const url = tokenFactoryFor(address)
-    if (url) {
-      navigateTo(url)
-    }
-  }
-
-  view (address, userAddress, network) {
-    const url = etherscanLinkFor(address, userAddress, network)
-    if (url) {
-      navigateTo(url)
-    }
-  }
-
   render () {
     const { tokenMenuOpen } = this.state
     const {
       address,
       symbol,
       string,
-      network,
       setSelectedToken,
       selectedTokenAddress,
       contractExchangeRates,
@@ -106,7 +87,6 @@ export default class TokenCell extends Component {
           className="token-list-item__identicon"
           diameter={50}
           address={address}
-          network={network}
           image={image}
         />
         <div className="token-list-item__balance-ellipsis">
@@ -137,17 +117,3 @@ export default class TokenCell extends Component {
     )
   }
 }
-
-function navigateTo (url) {
-  global.platform.openWindow({ url })
-}
-
-function etherscanLinkFor (tokenAddress, address, network) {
-  const prefix = prefixForNetwork(network)
-  return `https://${prefix}etherscan.io/token/${tokenAddress}?a=${address}`
-}
-
-function tokenFactoryFor (tokenAddress) {
-  return `https://tokenfactory.surge.sh/#/token/${tokenAddress}`
-}
-

--- a/ui/app/components/app/token-cell/token-cell.container.js
+++ b/ui/app/components/app/token-cell/token-cell.container.js
@@ -1,16 +1,13 @@
 import { connect } from 'react-redux'
 import { setSelectedToken, hideSidebar } from '../../../store/actions'
-import { getSelectedAddress } from '../../../selectors/selectors'
 import TokenCell from './token-cell.component'
 
 function mapStateToProps (state) {
   return {
-    network: state.metamask.network,
-    currentCurrency: state.metamask.currentCurrency,
-    selectedTokenAddress: state.metamask.selectedTokenAddress,
-    userAddress: getSelectedAddress(state),
     contractExchangeRates: state.metamask.contractExchangeRates,
     conversionRate: state.metamask.conversionRate,
+    currentCurrency: state.metamask.currentCurrency,
+    selectedTokenAddress: state.metamask.selectedTokenAddress,
     sidebarOpen: state.appState.sidebar.isOpen,
   }
 }


### PR DESCRIPTION
The `network` prop was being passed to the Identicon despite that not being an Identicon prop, and the `userAddress` prop was being passed down by the container but was unused. The methods removed were not called anywhere.