### PR TITLE
Add strictExportPresence to webpack config

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path')
 
 module.exports = {
   module: {
+    strictExportPresence: true,
     rules: [
       {
         test: /\.(woff(2)?|ttf|eot|otf)(\?v=\d+\.\d+\.\d+)?$/,


### PR DESCRIPTION
This gets the `yarn storybook:build` script to "properly" fail with `exit code 1` by making missing exports an error instead of warning.

Documented here: https://webpack.js.org/configuration/module/#module-contexts

**Before:**

(When the `i18n-provider` wasn't being imported correctly).

```
yarn storybook:build && echo "the exit code is $?"
...
Done in 12.28s.
the exit code is 0
```

**After:**

(When the `i18n-provider` wasn't being imported correctly. It is being imported properly now on `develop` since https://github.com/MetaMask/metamask-extension/pull/8232).

```
yarn storybook:build && echo "the exit code is $?"
...
error Command failed with exit code 1.
```

This also means I can go ahead and close #8231 as it's completely unnecessary.