### PR TITLE
Make seed phrase import case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Develop Branch
 - [#7912](https://github.com/MetaMask/metamask-extension/pull/7912): Disable import button for empty string/file
+- [#8246](https://github.com/MetaMask/metamask-extension/pull/8246): Make seed phrase import case-insensitive
 
 ## 7.7.0 Thu Nov 28 2019
 - [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Connect distinct accounts per site

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -41,7 +41,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
       return ''
     }
 
-    const words = trimmed.match(/\w+/g)
+    const words = trimmed.toLowerCase().match(/\w+/g)
     if (!words) {
       return ''
     }

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/tests/import-with-seed-phrase.component.test.js
@@ -34,6 +34,26 @@ describe('ImportWithSeedPhrase Component', function () {
       assert.deepEqual(parseSeedPhrase('foo bar baz'), 'foo bar baz')
     })
 
+    it('should handle a mixed-case seed phrase', function () {
+      const root = shallowRender({
+        onSubmit: sinon.spy(),
+      })
+
+      const { parseSeedPhrase } = root.instance()
+
+      assert.deepEqual(parseSeedPhrase('FOO bAr baZ'), 'foo bar baz')
+    })
+
+    it('should handle an upper-case seed phrase', function () {
+      const root = shallowRender({
+        onSubmit: sinon.spy(),
+      })
+
+      const { parseSeedPhrase } = root.instance()
+
+      assert.deepEqual(parseSeedPhrase('FOO BAR BAZ'), 'foo bar baz')
+    })
+
     it('should trim extraneous whitespace from the given seed phrase', function () {
       const root = shallowRender({
         onSubmit: sinon.spy(),


### PR DESCRIPTION
The user-specified seed phrase during the first-time-flow import step
required the phrase to be entered in all lowercase. The case does not
add any extra entropy to the seed, so there's no reason to be case
sensitive. Flexibility here will improve the onboarding UX.

This commit makes the entered seed phrase case insensitive.

Fixes #8171