### PR TITLE
Add signTypedData_v4 to safe methods

### DIFF
--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -70,6 +70,7 @@ export const SAFE_METHODS = [
   'eth_signTypedData',
   'eth_signTypedData_v1',
   'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
   'eth_submitHashrate',
   'eth_submitWork',
   'eth_syncing',


### PR DESCRIPTION
- adds `eth_signTypedData_v4` `SAFE_METHODS` in `permissions/enums.js`
  - This method fails without this