### PR TITLE
Support using Tabs as an controlled component

### DIFF
--- a/ui/app/components/ui/tabs/tabs.component.js
+++ b/ui/app/components/ui/tabs/tabs.component.js
@@ -4,21 +4,40 @@ import PropTypes from 'prop-types'
 export default class Tabs extends Component {
   static defaultProps = {
     defaultActiveTabIndex: 0,
+    onClick: undefined,
+    tabIndex: undefined,
   }
 
   static propTypes = {
-    defaultActiveTabIndex: PropTypes.number,
     children: PropTypes.node.isRequired,
+    defaultActiveTabIndex: PropTypes.number,
+    onClick: PropTypes.func,
+    tabIndex: PropTypes.number,
   }
 
   state = {
     activeTabIndex: this.props.defaultActiveTabIndex,
   }
 
+  static getDerivedStateFromProps (nextProps, currentState) {
+    if (
+      nextProps.tabIndex !== undefined &&
+      nextProps.tabIndex !== currentState.activeTabIndex
+    ) {
+      return {
+        activeTabIndex: nextProps.tabIndex,
+      }
+    }
+    return null
+  }
+
   handleTabClick (tabIndex) {
+    const { onClick } = this.props
     const { activeTabIndex } = this.state
 
-    if (tabIndex !== activeTabIndex) {
+    if (onClick) {
+      onClick(tabIndex)
+    } else if (tabIndex !== activeTabIndex) {
       this.setState({
         activeTabIndex: tabIndex,
       })

--- a/ui/app/components/ui/tabs/tabs.stories.js
+++ b/ui/app/components/ui/tabs/tabs.stories.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Tab from './tab/tab.component'
 import Tabs from './tabs.component'
 import { number, text } from '@storybook/addon-knobs/react'
+import { action } from '@storybook/addon-actions'
 
 export default {
   title: 'Tabs',
@@ -52,6 +53,20 @@ export const singleTab = () => {
       >
         {text('Contents', 'Contents of tab')}
       </Tab>
+    </Tabs>
+  )
+}
+
+export const controlledTab = () => {
+  return (
+    <Tabs
+      tabIndex={number('Tab Index', 0, { min: 0, max: 4 })}
+      onClick={action('tab-click')}
+    >
+      {
+        ['A', 'B', 'C', 'D', 'E']
+          .map(renderTab)
+      }
     </Tabs>
   )
 }


### PR DESCRIPTION
Previously the Tabs component was an 'ucontrolled' component, as it managed the current selected tab internally using component state.

Tabs now accepts optional `tabIndex` and `onClick` props that allow the parent component to fully control the current active tab state.