### PR TITLE
Fix popup view expanding when expanding transaction

### DIFF
--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -21,9 +21,6 @@ $wallet-view-bg: $alabaster;
 .main-container {
   z-index: $main-container-z-index;
   font-family: Roboto;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
 }
 
 .main-container::-webkit-scrollbar {


### PR DESCRIPTION
The popup view would expand beyond the width of the viewport when expanding a transaction. This bug was introduced in #8139 when I removed the `min-width: 0` property from the `home__container` class; this property was giving the parent permission to shrink that div below
the size of its content.

Instead of restoring that property, the parent component is no longer using `display: flex`. Flexbox was never useful here, as this is just a wrapper div around a wrapper div, both with identical sizes. The default display type of `block` produces the desired behaviour with less rules.

<details>
<summary>Screenshots:</summary

Before:

![before](https://user-images.githubusercontent.com/2459287/78155784-47bda400-7414-11ea-9ea4-ac820b601ddd.png)

After:

![after](https://user-images.githubusercontent.com/2459287/78155788-49876780-7414-11ea-9067-fdbeadb3e444.png)

</details>