### PR TITLE
Fix centering of account info in menu bar

### DIFF
--- a/ui/app/components/app/menu-bar/index.scss
+++ b/ui/app/components/app/menu-bar/index.scss
@@ -7,6 +7,7 @@
   margin-bottom: 16px;
   padding: 0 22px;
   border-bottom: 1px solid $Grey-100;
+  position: relative;
 
   &__sidebar-button {
     width: 20px;
@@ -28,5 +29,12 @@
     cursor: pointer;
     display: flex;
     justify-content: center;
+    position: absolute;
+    right: 16px;
+    transform: rotate(90deg);
+  }
+
+  .selected-account {
+    flex: none;
   }
 }

--- a/ui/app/css/itcss/components/account-details-dropdown.scss
+++ b/ui/app/css/itcss/components/account-details-dropdown.scss
@@ -1,7 +1,7 @@
 .account-details-dropdown {
 	width: 60%;
 	position: absolute;
-	top: 120px;
+  top: 40px;
 	right: 15px;
 	z-index: 2000;
 }


### PR DESCRIPTION
https://github.com/MetaMask/metamask-extension/pull/8270 was merged with a small visual bug. The account info in the menu bar is not centered.

![Screenshot from 2020-04-01 16-18-17](https://user-images.githubusercontent.com/7499938/78176151-9f6d0700-7436-11ea-8c92-b5d42de881ef.png)

This PR corrects that. Now it looks like
![Screenshot from 2020-04-01 16-31-26](https://user-images.githubusercontent.com/7499938/78176210-b7dd2180-7436-11ea-929b-b19f86cb3249.png)

This PR also ensures that this change keeps the position of the account details dropdown menu consistent and correct. Demo video: https://streamable.com/um2n4

The rotation of the account details icon also matches the figma designs. 

- [ ] An improvement can still be made with the tooltip's position and width relative to the account details icon, but its off centeredness is not inconsistent with that is on develop and present, also it is more pronounced due to the rotation of the icon