### PR TITLE
Don't render the ConnectedStatusIndicator outside of the popup

### DIFF
--- a/ui/app/components/app/connected-status-indicator/connected-status-indicator.component.js
+++ b/ui/app/components/app/connected-status-indicator/connected-status-indicator.component.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
-import { ENVIRONMENT_TYPE_POPUP } from '../../../../../app/scripts/lib/enums'
-import { getEnvironmentType } from '../../../../../app/scripts/lib/util'
 import {
   STATUS_CONNECTED,
   STATUS_CONNECTED_TO_ANOTHER_ACCOUNT,
@@ -50,10 +48,7 @@ export default class ConnectedStatusIndicator extends Component {
 
   render () {
     return (
-      <div className={classnames('connected-status-indicator', {
-        invisible: getEnvironmentType() !== ENVIRONMENT_TYPE_POPUP,
-      })}
-      >
+      <div className="connected-status-indicator">
         { this.renderStatusCircle() }
         { this.renderStatusText() }
       </div>

--- a/ui/app/components/app/menu-bar/menu-bar.component.js
+++ b/ui/app/components/app/menu-bar/menu-bar.component.js
@@ -4,6 +4,8 @@ import Tooltip from '../../ui/tooltip'
 import SelectedAccount from '../selected-account'
 import ConnectedStatusIndicator from '../connected-status-indicator'
 import AccountDetailsDropdown from '../dropdowns/account-details-dropdown'
+import { getEnvironmentType } from '../../../../../app/scripts/lib/util'
+import { ENVIRONMENT_TYPE_POPUP } from '../../../../../app/scripts/lib/enums'
 
 export default class MenuBar extends PureComponent {
   static contextTypes = {
@@ -19,7 +21,11 @@ export default class MenuBar extends PureComponent {
 
     return (
       <div className="menu-bar">
-        <ConnectedStatusIndicator />
+        {
+          getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
+            ? <ConnectedStatusIndicator />
+            : null
+        }
 
         <SelectedAccount />
 


### PR DESCRIPTION
This PR updates the `MenuBar` component to not render the `ConnectedStatusIndicator` outside of the popup environment, instead of rendering it and marking it as invisible.