### PR TITLE
Refactor Menubar and AccountDetailsDropdown styles

### DIFF
--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -117,7 +117,7 @@ describe('MetaMask', function () {
 
   describe('Show account information', function () {
     it('show account details dropdown menu', async function () {
-      await driver.clickElement(By.css('div.menu-bar__open-in-browser'))
+      await driver.clickElement(By.css('button.menu-bar__account-options'))
       const options = await driver.findElements(By.css('div.menu.account-details-dropdown div.menu__item'))
       assert.equal(options.length, 4) // HD Wallet type does not have to show the Remove Account option
       await driver.delay(regularDelayMs)

--- a/ui/app/components/app/connected-status-indicator/index.scss
+++ b/ui/app/components/app/connected-status-indicator/index.scss
@@ -1,8 +1,7 @@
 .connected-status-indicator {
   display:flex;
   align-items: center;
-  position: absolute;
-  left: 22px;
+  place-self: center start;
 
   &__green-circle, &__yellow-circle, &__grey-circle {
     border-radius: 4px;

--- a/ui/app/components/app/dropdowns/account-details-dropdown/index.scss
+++ b/ui/app/components/app/dropdowns/account-details-dropdown/index.scss
@@ -1,0 +1,6 @@
+.account-details-dropdown {
+  position: absolute;
+  top: 120px;
+  right: 24px;
+  z-index: 1;
+}

--- a/ui/app/components/app/index.scss
+++ b/ui/app/components/app/index.scss
@@ -92,4 +92,6 @@
 
 @import '../ui/alert-circle-icon/index';
 
-@import './connected-status-indicator/index'
+@import './connected-status-indicator/index';
+
+@import './dropdowns/account-details-dropdown/index';

--- a/ui/app/components/app/menu-bar/index.scss
+++ b/ui/app/components/app/menu-bar/index.scss
@@ -1,40 +1,23 @@
 .menu-bar {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  flex: 0 0 auto;
-  margin-bottom: 16px;
-  padding: 0 22px;
+  display: grid;
+  grid-template-columns: 30% minmax(30%, 1fr) 30%;
+  column-gap: 10px;
+
+  margin-bottom: 24px;
+  padding: 0 24px;
   border-bottom: 1px solid $Grey-100;
-  position: relative;
 
-  &__sidebar-button {
-    width: 20px;
-    height: 20px;
-    background-image: url(/images/icons/hamburger.svg);
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-position: center;
-    cursor: pointer;
-  }
+  .menu-bar__account-options {
+    background: none;
+    font-size: inherit;
+    padding: 0 0 0 5px;
 
-  &__open-in-browser {
-    width: 20px;
-    height: 20px;
-    background-image: url(/images/icons/3dots.svg);
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-position: center;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    position: absolute;
-    right: 16px;
-    transform: rotate(90deg);
+    position: relative; // to allow the dropdown to position itself absolutely
+    place-self: center end;
   }
 
   .selected-account {
-    flex: none;
+    grid-column: 2 / span 1;
+    place-self: center stretch;
   }
 }

--- a/ui/app/components/app/menu-bar/index.scss
+++ b/ui/app/components/app/menu-bar/index.scss
@@ -1,7 +1,7 @@
 .menu-bar {
   display: grid;
   grid-template-columns: 30% minmax(30%, 1fr) 30%;
-  column-gap: 10px;
+  column-gap: 5px;
 
   margin-bottom: 24px;
   padding: 0 24px;

--- a/ui/app/components/app/menu-bar/menu-bar.component.js
+++ b/ui/app/components/app/menu-bar/menu-bar.component.js
@@ -29,12 +29,10 @@ export default class MenuBar extends PureComponent {
 
         <SelectedAccount />
 
-        <Tooltip
-          title={t('accountOptions')}
-          position="bottom"
-        >
-          <div
-            className="menu-bar__open-in-browser"
+        <Tooltip title={t('accountOptions')} position="left">
+          <button
+            className="fas fa-ellipsis-v menu-bar__account-options"
+            title={t('accountOptions')}
             onClick={() => {
               this.context.metricsEvent({
                 eventOpts: {
@@ -43,10 +41,12 @@ export default class MenuBar extends PureComponent {
                   name: 'Opened Account Options',
                 },
               })
-              this.setState({ accountDetailsMenuOpen: true })
+              this.setState((prevState) => ({
+                accountDetailsMenuOpen: !prevState.accountDetailsMenuOpen,
+              }))
             }}
           >
-          </div>
+          </button>
         </Tooltip>
 
         {

--- a/ui/app/components/app/menu-bar/tests/menu-bar.test.js
+++ b/ui/app/components/app/menu-bar/tests/menu-bar.test.js
@@ -36,7 +36,7 @@ describe('MenuBar', function () {
         <MenuBar />
       </Provider>
     )
-    const accountOptions = wrapper.find('.menu-bar__open-in-browser')
+    const accountOptions = wrapper.find('.menu-bar__account-options')
     accountOptions.simulate('click')
     assert.equal(wrapper.find('MenuBar').instance().state.accountDetailsMenuOpen, true)
   })

--- a/ui/app/components/app/selected-account/index.scss
+++ b/ui/app/components/app/selected-account/index.scss
@@ -5,8 +5,12 @@
   align-items: center;
   flex: 1;
 
+  &__tooltip-wrapper {
+    width: 100%;
+  }
+
   &__name {
-    max-width: 200px;
+    width: 100%;
     font-size: 1rem;
     font-weight: 500;
     line-height: 19px;

--- a/ui/app/components/app/selected-account/index.scss
+++ b/ui/app/components/app/selected-account/index.scss
@@ -34,7 +34,7 @@
     align-items: center;
     justify-content: center;
     margin: 4px 0;
-    padding: 6px 15px;
+    padding: 6px 1px;
     border-radius: 10px;
     cursor: pointer;
 

--- a/ui/app/components/app/selected-account/selected-account.component.js
+++ b/ui/app/components/app/selected-account/selected-account.component.js
@@ -28,6 +28,7 @@ class SelectedAccount extends Component {
     return (
       <div className="selected-account">
         <Tooltip
+          wrapperClassName="selected-account__tooltip-wrapper"
           position="bottom"
           title={this.state.copied ? t('copiedExclamation') : t('copyToClipboard')}
         >

--- a/ui/app/css/itcss/components/account-details-dropdown.scss
+++ b/ui/app/css/itcss/components/account-details-dropdown.scss
@@ -1,7 +1,0 @@
-.account-details-dropdown {
-	width: 60%;
-	position: absolute;
-  top: 40px;
-	right: 15px;
-	z-index: 2000;
-}

--- a/ui/app/css/itcss/components/index.scss
+++ b/ui/app/css/itcss/components/index.scss
@@ -44,8 +44,6 @@
 
 @import './request-decrypt-message.scss';
 
-@import './account-details-dropdown.scss';
-
 @import './editable-label.scss';
 
 @import './pages/index.scss';


### PR DESCRIPTION
Refs #8270 and #8274

This PR refactors the `Menubar` and `AccountDetailsDropdown` components and their styles with the goal of getting the positioning to be more good. This change drops the absolute positioning and replaces it with a grid that is always positioned correctly. Note that the padding was previously inconsistent, the connected status indicator was 22px from the left and the icon was 16px from the right.

While I was at it:

- Moved the AccountDetailsDropdown styles alongside the component
- Made the account options a button that you can tab to (you can't tab through the menu it opens but, hey, 1 step at a time 🤦‍♂)
- Moved the account options button tooltip to the left

### Screenshots

<img width="357" alt="" src="https://user-images.githubusercontent.com/1623628/78186626-9df80a80-7447-11ea-88e7-6243d8d84252.png">
<img width="357" alt="" src="https://user-images.githubusercontent.com/1623628/78186627-9df80a80-7447-11ea-95ef-634655e6a367.png">
<img width="357" alt="" src="https://user-images.githubusercontent.com/1623628/78186628-9e90a100-7447-11ea-9667-cebbb2fd5b4f.png">

### Screenshot of the grid

<img width="357" alt="" src="https://user-images.githubusercontent.com/1623628/78187030-4a39f100-7448-11ea-996d-413c96969c74.png">

### Screenshot without indicator

For demonstration purposes, this is the popup without the indicator, also what you'd see in full-screen on a small viewport. (I took the screenshot of the popup with it removed in devtools because it was easier.) As of #8275 we don't render it at all, leaving just two children in the `.menu-bar` container.

<img width="357" alt="" src="https://user-images.githubusercontent.com/1623628/78187352-d2b89180-7448-11ea-9c3c-bac8fdd336b4.png">
