### PR TITLE
Replace METAMASK_UI_TYPE global with helper function

### DIFF
--- a/app/scripts/phishing-detect.js
+++ b/app/scripts/phishing-detect.js
@@ -10,16 +10,14 @@ import ExtensionPlatform from './platforms/extension'
 document.addEventListener('DOMContentLoaded', start)
 
 function start () {
-  const windowType = getEnvironmentType()
   const hash = window.location.hash.substring(1)
   const suspect = querystring.parse(hash)
 
   document.getElementById('csdbLink').href = `https://cryptoscamdb.org/search`
 
   global.platform = new ExtensionPlatform()
-  global.METAMASK_UI_TYPE = windowType
 
-  const extensionPort = extension.runtime.connect({ name: windowType })
+  const extensionPort = extension.runtime.connect({ name: getEnvironmentType() })
   const connectionStream = new PortStream(extensionPort)
   const mx = setupMultiplex(connectionStream)
   setupControllerConnection(mx.createStream('controller'), (err, metaMaskController) => {

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -55,7 +55,6 @@ async function start () {
 
   // identify window type (popup, notification)
   const windowType = getEnvironmentType()
-  global.METAMASK_UI_TYPE = windowType
   closePopupIfOpen(windowType)
 
   // setup stream to background

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
@@ -4,6 +4,7 @@ import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_NOTIFICATION,
 } from '../../../../../../app/scripts/lib/enums'
+import { getEnvironmentType } from '../../../../../../app/scripts/lib/util'
 import NetworkDisplay from '../../network-display'
 import Identicon from '../../../ui/identicon'
 import { addressSlicer } from '../../../../helpers/utils/util'
@@ -23,7 +24,7 @@ export default class ConfirmPageContainerHeader extends Component {
 
   renderTop () {
     const { onEdit, showEdit, accountAddress, showAccountInHeader } = this.props
-    const windowType = window.METAMASK_UI_TYPE
+    const windowType = getEnvironmentType()
     const isFullScreen = windowType !== ENVIRONMENT_TYPE_NOTIFICATION &&
       windowType !== ENVIRONMENT_TYPE_POPUP
 

--- a/ui/app/pages/routes/routes.component.js
+++ b/ui/app/pages/routes/routes.component.js
@@ -50,6 +50,7 @@ import {
 } from '../../helpers/constants/routes'
 
 import { ENVIRONMENT_TYPE_NOTIFICATION, ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
+import { getEnvironmentType } from '../../../../app/scripts/lib/util'
 
 export default class Routes extends Component {
   static propTypes = {
@@ -160,11 +161,13 @@ export default class Routes extends Component {
       return true
     }
 
-    if (window.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION) {
+    const windowType = getEnvironmentType()
+
+    if (windowType === ENVIRONMENT_TYPE_NOTIFICATION) {
       return true
     }
 
-    if (window.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_POPUP) {
+    if (windowType === ENVIRONMENT_TYPE_POPUP) {
       return this.onConfirmPage() || hasPermissionsRequests
     }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -13,6 +13,7 @@ import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../app/scripts/lib/enums'
 import { hasUnconfirmedTransactions } from '../helpers/utils/confirm-tx.util'
 import { setCustomGasLimit } from '../ducks/gas/gas.duck'
 import txHelper from '../../lib/tx-helper'
+import { getEnvironmentType } from '../../../app/scripts/lib/util'
 
 export const actionConstants = {
   GO_HOME: 'GO_HOME',
@@ -1194,7 +1195,7 @@ export function cancelTxs (txDataList) {
 
     dispatch(hideLoadingIndication())
 
-    if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION) {
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       return global.platform.closeCurrentWindow()
     }
   }
@@ -1431,7 +1432,7 @@ export function removeSuggestedTokens () {
           dispatch(displayWarning(err.message))
         }
         dispatch(clearPendingTokens())
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION) {
+        if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
           return global.platform.closeCurrentWindow()
         }
         resolve(suggestedTokens)
@@ -1724,7 +1725,7 @@ export function hideModal (payload) {
 
 export function closeCurrentNotificationWindow () {
   return (dispatch, getState) => {
-    if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
+    if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION &&
       !hasUnconfirmedTransactions(getState())) {
       global.platform.closeCurrentWindow()
 


### PR DESCRIPTION
We don't need to store the current UI type as a global. We're already using the `getEnvironmentType` helper function throughout the UI, so we'd might as well use that instead of this global state.