### PR TITLE
Remove unused 2nd argument to checksumAddress

### DIFF
--- a/ui/app/components/app/selected-account/selected-account.component.js
+++ b/ui/app/components/app/selected-account/selected-account.component.js
@@ -17,13 +17,12 @@ class SelectedAccount extends Component {
   static propTypes = {
     selectedAddress: PropTypes.string,
     selectedIdentity: PropTypes.object,
-    network: PropTypes.string,
   }
 
   render () {
     const { t } = this.context
-    const { selectedAddress, selectedIdentity, network } = this.props
-    const checksummedAddress = checksumAddress(selectedAddress, network)
+    const { selectedAddress, selectedIdentity } = this.props
+    const checksummedAddress = checksumAddress(selectedAddress)
 
     return (
       <div className="selected-account">

--- a/ui/app/components/app/selected-account/selected-account.container.js
+++ b/ui/app/components/app/selected-account/selected-account.container.js
@@ -7,7 +7,6 @@ const mapStateToProps = (state) => {
   return {
     selectedAddress: getSelectedAddress(state),
     selectedIdentity: getSelectedIdentity(state),
-    network: state.metamask.network,
   }
 }
 


### PR DESCRIPTION
This PR removes the unused 2nd argument to `checksumAddress` and the `network` prop from the `SelectedAccount` component.