### PR TITLE
Undefine Tooltip default wrapperClassName

### DIFF
--- a/ui/app/components/ui/tooltip-v2.js
+++ b/ui/app/components/ui/tooltip-v2.js
@@ -14,7 +14,7 @@ export default class Tooltip extends PureComponent {
     size: 'small',
     title: null,
     trigger: 'mouseenter',
-    wrapperClassName: '',
+    wrapperClassName: undefined,
   }
 
   static propTypes = {


### PR DESCRIPTION
Introduced in #5223

This PR undefines (sets as `undefined`) the default `wrapperClassName` prop for the `Tooltip` component.

Previously this would create HTML something like so:

```
<div class=""></div>
```

Where it now creates HTML like so:

```
<div></div>
```

This doesn't matter, functionally.