### PR TITLE
Fix home container height

### DIFF
--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -1,7 +1,6 @@
 .home {
   &__container {
     display: flex;
-    flex: 1 1 auto;
     height: 100%;
   }
 

--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -2,6 +2,7 @@
   &__container {
     display: flex;
     flex: 1 1 auto;
+    height: 100%;
   }
 
   &__main-view {


### PR DESCRIPTION
The home container element's height was not set, so the lower half of the home component was showing as the wrong color when the user had no transactions or tokens.

This was broken in #8271, which was a fix for a different CSS problem. Both problems should remain fixed now with height being set explicitly.