### PR TITLE
Remove selectedAddress from SelectedAccount component

### DIFF
--- a/ui/app/components/app/selected-account/selected-account.component.js
+++ b/ui/app/components/app/selected-account/selected-account.component.js
@@ -15,14 +15,13 @@ class SelectedAccount extends Component {
   }
 
   static propTypes = {
-    selectedAddress: PropTypes.string,
-    selectedIdentity: PropTypes.object,
+    selectedIdentity: PropTypes.object.isRequired,
   }
 
   render () {
     const { t } = this.context
-    const { selectedAddress, selectedIdentity } = this.props
-    const checksummedAddress = checksumAddress(selectedAddress)
+    const { selectedIdentity } = this.props
+    const checksummedAddress = checksumAddress(selectedIdentity.address)
 
     return (
       <div className="selected-account">

--- a/ui/app/components/app/selected-account/selected-account.container.js
+++ b/ui/app/components/app/selected-account/selected-account.container.js
@@ -1,11 +1,10 @@
 import { connect } from 'react-redux'
 import SelectedAccount from './selected-account.component'
 
-import { getSelectedAddress, getSelectedIdentity } from '../../../selectors/selectors'
+import { getSelectedIdentity } from '../../../selectors/selectors'
 
 const mapStateToProps = (state) => {
   return {
-    selectedAddress: getSelectedAddress(state),
     selectedIdentity: getSelectedIdentity(state),
   }
 }

--- a/ui/app/components/app/selected-account/tests/selected-account-component.test.js
+++ b/ui/app/components/app/selected-account/tests/selected-account-component.test.js
@@ -7,8 +7,7 @@ describe('SelectedAccount Component', function () {
   it('should render checksummed address', function () {
     const wrapper = render((
       <SelectedAccount
-        selectedAddress="0x1b82543566f41a7db9a9a75fc933c340ffb55c9d"
-        selectedIdentity={{ name: 'testName' }}
+        selectedIdentity={{ name: 'testName', address: '0x1b82543566f41a7db9a9a75fc933c340ffb55c9d' }}
       />
     ), { context: { t: () => {} } })
     // Checksummed version of address is displayed


### PR DESCRIPTION
This PR removes `selectedAddress` from the `SelectedAccount` component, replacing it with the address that's already attached to the `selectedIdentity` prop.