### PR TITLE
Remove z-index from IconWithFallBack

### DIFF
--- a/ui/app/components/ui/icon-with-fallback/index.scss
+++ b/ui/app/components/ui/icon-with-fallback/index.scss
@@ -18,12 +18,12 @@
   }
 
   &__identicon {
+    position: relative;
     width: 24px;
     height: 24px;
-    z-index: 1;
 
     &--default {
-      z-index: 1;
+      position: relative;
       color: black;
     }
   }

--- a/ui/app/pages/connected-sites/index.scss
+++ b/ui/app/pages/connected-sites/index.scss
@@ -22,7 +22,6 @@
     border-radius: 0 0 10px 10px;
     font-size: 14px;
     line-height: 20px;
-    z-index: 1;
 
     a, a:hover {
       cursor: pointer;


### PR DESCRIPTION
This PR removes the `z-index` rule from the `IconWithFallBack` component, and as a result, removes the `z-index` from the `ConnectedSites` footer.