### PR TITLE
Replace static popover height with responsive max-height

### DIFF
--- a/ui/app/components/ui/popover/index.scss
+++ b/ui/app/components/ui/popover/index.scss
@@ -14,7 +14,7 @@
     flex-direction: column;
     position: absolute;
     width: 328px;
-    height: 564px;
+    max-height: 94vh;
 
     box-shadow: 0px 4px 30px rgba(0, 0, 0, 0.25);
     border-radius: 10px;


### PR DESCRIPTION
The height of the popover is now set to a maximum of 94% of the viewport height, rather than a static height of 564px. This setting ensures that the popover has a maximum height of exactly 564px in the
popup, which matches the designs. However it is now able to shrink or grow to accommodate larger viewports or smaller popovers.

<details>
<summary>Screenshots:</summary>

Before (fullscreen):

![before-fullscreen](https://user-images.githubusercontent.com/2459287/78267138-034a0b00-74dd-11ea-92bc-a1b7dec61c43.png)

Before (list in popup):

![before-popup-list](https://user-images.githubusercontent.com/2459287/78267151-0513ce80-74dd-11ea-8e57-172812c500b2.png)

Before (disconnect in popup):

![before-popup-disconnect](https://user-images.githubusercontent.com/2459287/78267152-0644fb80-74dd-11ea-9a73-90fc4b4ff7e4.png)

After (fullscreen):

![after-fullscreen](https://user-images.githubusercontent.com/2459287/78267158-080ebf00-74dd-11ea-9f55-f32c5f32f3a8.png)

After (list in popup):
(Sorry for the highlighting - that was an accident. I don't want to re-take this though :sweat_smile: )

![after-popup-list](https://user-images.githubusercontent.com/2459287/78267161-093fec00-74dd-11ea-947b-ba0aa9261aee.png)

After (disconnect in popup):

![after-popup-disconnect](https://user-images.githubusercontent.com/2459287/78267165-0a711900-74dd-11ea-903a-cb226a47612a.png)

</details>