### PR TITLE
Make ConnectedStatusIndicator clickable

### DIFF
--- a/ui/app/components/app/connected-status-indicator/connected-status-indicator.component.js
+++ b/ui/app/components/app/connected-status-indicator/connected-status-indicator.component.js
@@ -14,10 +14,12 @@ export default class ConnectedStatusIndicator extends Component {
 
   static propTypes = {
     status: PropTypes.oneOf([ STATUS_CONNECTED, STATUS_CONNECTED_TO_ANOTHER_ACCOUNT, STATUS_NOT_CONNECTED ]),
+    onClick: PropTypes.func,
   }
 
   static defaultProps = {
     status: STATUS_NOT_CONNECTED,
+    onClick: null,
   }
 
   renderStatusCircle = () => {
@@ -49,10 +51,10 @@ export default class ConnectedStatusIndicator extends Component {
 
   render () {
     return (
-      <div className="connected-status-indicator">
+      <button className="connected-status-indicator" onClick={this.props.onClick}>
         { this.renderStatusCircle() }
         { this.renderStatusText() }
-      </div>
+      </button>
     )
   }
 }

--- a/ui/app/components/app/connected-status-indicator/index.scss
+++ b/ui/app/components/app/connected-status-indicator/index.scss
@@ -3,6 +3,10 @@
   align-items: center;
   place-self: center start;
 
+  background: none;
+  font-size: inherit;
+  padding: 8px 0;
+
   &__green-circle, &__yellow-circle, &__grey-circle {
     border-radius: 4px;
     height: 8px;


### PR DESCRIPTION
This PR adds an `onClick` prop to the `ConnectedStatusIndicator`, making it a button