### PR TITLE
Close Account Details dropdown after opening Connected Sites

### DIFF
--- a/ui/app/components/app/dropdowns/account-details-dropdown/account-details-dropdown.component.js
+++ b/ui/app/components/app/dropdowns/account-details-dropdown/account-details-dropdown.component.js
@@ -123,6 +123,7 @@ export default class AccountDetailsDropdown extends Component {
               },
             })
             history.push(CONNECTED_ROUTE)
+            this.props.onClose()
           }}
           text={this.context.t('connectedSites')}
           icon={(


### PR DESCRIPTION
This PR adds a missing call to `onClose` after navigating to the `CONNECTED_ROUTE` while showing the `AccountDetailsDropdown` dropdown.