### PR TITLE
Minor fix on pt-br translation

### DIFF
--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -270,7 +270,7 @@
     "message": "ID da Transação Copiado"
   },
   "copyToClipboard": {
-    "message": "Copiar para a área de trabalho"
+    "message": "Copiar para a área de transferência"
   },
   "copyButton": {
     "message": "Copiar"


### PR DESCRIPTION
The Brazilian Portuguese translation translates "Copy to clipboard" as "Copiar para a área de trabalho".

![image](https://user-images.githubusercontent.com/3002249/78718445-ae512f00-78f8-11ea-841c-202c7d0d7c2d.png)

However, the correct translation would be "Copiar para a área de transferência", as "área de trabalho" means _desktop_ and not _clipboard_.

This small PR fixes this.