### PR TITLE
Add description for connectedSitesDescription English message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3,7 +3,8 @@
     "message": "Connected Sites"
   },
   "connectedSitesDescription": {
-    "message": "$1 is connected to these sites. They can view your account address."
+    "message": "$1 is connected to these sites. They can view your account address.",
+    "description": "$1 is the account name"
   },
   "connectManually": {
     "message": "Manually connect to current site"


### PR DESCRIPTION
This PR adds the missing description property for the `connectedSitesDescription` message in English.