### PR TITLE
Use ISO-8601 date format for last active time

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -36,7 +36,7 @@ const mapStateToProps = (state, ownProps) => {
   const addressLastConnectedMap = lastConnectedInfo[origin] || {}
 
   Object.keys(addressLastConnectedMap).forEach((key) => {
-    addressLastConnectedMap[key] = formatDate(addressLastConnectedMap[key], 'yyyy-M-d')
+    addressLastConnectedMap[key] = formatDate(addressLastConnectedMap[key], 'yyyy-MM-dd')
   })
 
   const connectPath = `${CONNECT_ROUTE}/${permissionsRequestId}`

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -498,7 +498,7 @@ export function getRenderablePermissionsDomains (state) {
       const selectedAddressLastConnectedTime = accountsLastConnectedTime[selectedAddress]
 
       const lastConnectedTime = selectedAddressLastConnectedTime
-        ? formatDate(selectedAddressLastConnectedTime, 'yyyy-M-d')
+        ? formatDate(selectedAddressLastConnectedTime, 'yyyy-MM-dd')
         : ''
 
       return [ ...acc, {


### PR DESCRIPTION
The last active time for each account in the Connected Sites list was formatted as `yyyy-M-d` (i.e. without the zero-padding for the month and the day). This didn't match the designs, isn't compliant with
ISO-8601, and generally isn't a common date format.

The month and day are now zero-padded.