### PR TITLE
Tidy getAccountsWithLabels selector

### DIFF
--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -238,18 +238,12 @@ export function accountsWithSendEtherInfoSelector (state) {
 }
 
 export function getAccountsWithLabels (state) {
-  const accountsWithoutLabel = accountsWithSendEtherInfoSelector(state)
-  const accountsWithLabels = accountsWithoutLabel.map((account) => {
-    const { address, name, balance } = account
-    return {
-      address,
-      truncatedAddress: `${address.slice(0, 6)}...${address.slice(-4)}`,
-      addressLabel: `${name} (...${address.slice(address.length - 4)})`,
-      label: name,
-      balance,
-    }
-  })
-  return accountsWithLabels
+  return accountsWithSendEtherInfoSelector(state).map(({ address, name, balance }) => ({
+    address,
+    addressLabel: `${name} (...${address.slice(address.length - 4)})`,
+    label: name,
+    balance,
+  }))
 }
 
 export function getCurrentAccountWithSendEtherInfo (state) {


### PR DESCRIPTION
This PR tidies the `getAccountsWithLabels` selector:

1. `truncatedAddress` wasn't used
2. There were a few redundant variables