### PR TITLE
Fix popup not opening

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -461,7 +461,6 @@ function triggerUi () {
     const currentlyActiveMetamaskTab = Boolean(tabs.find((tab) => openMetamaskTabsIDs[tab.id]))
     if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
       notificationManager.showPopup()
-      notificationIsOpen = true
     }
   })
 }


### PR DESCRIPTION
MetaMask would sometimes get into a state where the notification popup would never open. This could happen if the notification window was closed shortly after being opened. After this happened, no popups would show up until after the extension was reset.

This was happening because the background thought the popup was already open. The variable it uses to track whether the popup was open or not was being set to `true` immediately after the background asked the browser to open a new window, before a handler was attached that could respond to the window being closed.

Removing this line seems to solve the problem.

This line was added originally in #5437, which dealt with batch transactions. Batches of transactions seem to work just fine without this line though (from local testing), and I can't think of why this would be required.

Closes #7051 