### PR TITLE
Remove ineffectual close popup function

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -9,16 +9,13 @@ import PortStream from 'extension-port-stream'
 import { getEnvironmentType } from './lib/util'
 
 import {
-  ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_POPUP,
 } from './lib/enums'
 
 import extension from 'extensionizer'
 import ExtensionPlatform from './platforms/extension'
-import NotificationManager from './lib/notification-manager'
 
-const notificationManager = new NotificationManager()
 import setupSentry from './lib/setupSentry'
 import { EventEmitter } from 'events'
 import Dnode from 'dnode'
@@ -55,7 +52,6 @@ async function start () {
 
   // identify window type (popup, notification)
   const windowType = getEnvironmentType()
-  closePopupIfOpen(windowType)
 
   // setup stream to background
   const extensionPort = extension.runtime.connect({ name: windowType })
@@ -63,13 +59,6 @@ async function start () {
 
   const activeTab = await queryCurrentActiveTab(windowType)
   initializeUiWithTab(activeTab)
-
-  function closePopupIfOpen (windowType) {
-    if (windowType !== ENVIRONMENT_TYPE_NOTIFICATION) {
-      // should close only chrome popup
-      notificationManager.closePopup()
-    }
-  }
 
   function displayCriticalError (container, err) {
     container.innerHTML = '<div class="critical-error">The MetaMask app failed to load: please open and close MetaMask again to restart.</div>'


### PR DESCRIPTION
During the initialization of the full-screen or popup UI, we attempted to close the notification popup (if it was open). This never worked (or at least hasn't in a long time).

The method used to attempt closing the notification popup was `closePopup` from the `notificationManager`, which keeps track internally of the id of the notification popup window, and can close the window by using this id.

However, this id is only set in the first place if the popup is opened with this specific instance of the `notificationManager`. The popup is never opened from the UI in practice; it's only opened from the background (which has its own instance of `notificationManager`). The popup id is never set for this `notificationManager` instance in the UI.

It's not entirely clear that we'd always want to close the notification popup in this circumstance anyway. The user might want to open MetaMask alongside the popup to check something else.