### PR TITLE
Focus the notification popup if it's already open

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -458,7 +458,7 @@ function setupController (initState, initLangCode) {
 async function triggerUi () {
   const tabs = await platform.getActiveTabs()
   const currentlyActiveMetamaskTab = Boolean(tabs.find((tab) => openMetamaskTabsIDs[tab.id]))
-  if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
+  if (!popupIsOpen && !currentlyActiveMetamaskTab) {
     await notificationManager.showPopup()
   }
 }


### PR DESCRIPTION
Any action in the background that would have opened the notification window will now focus the window instead if it was already open. Previously it would leave the window unfocused. This was particularly inconvenient when taking multiple actions in quick succession that all require confirmations (e.g. triggering multiple transactions).