### PR TITLE
Remove unused `getActiveTab` selector

### DIFF
--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -381,10 +381,6 @@ export function getTargetDomainMetadata (state, request, defaultOrigin) {
   return targetDomainMetadata
 }
 
-export function getActiveTab (state) {
-  return state.activeTab
-}
-
 export function getMetaMetricState (state) {
   return {
     network: getCurrentNetworkId(state),


### PR DESCRIPTION
This selector was added as part of #7004, but wasn't used by the time it was merged.