### PR TITLE
Dedupe eth-phishing-detect versions, use 1.1.13

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10486,17 +10486,10 @@ eth-method-registry@^1.2.0:
   dependencies:
     ethjs "^0.3.0"
 
-eth-phishing-detect@^1.1.13:
+eth-phishing-detect@^1.1.4, eth-phishing-detect@^1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/eth-phishing-detect/-/eth-phishing-detect-1.1.13.tgz#ed718b933c8a69fef0cefa6604538824b472dbea"
   integrity sha512-1KQcKvAQIjJgFMVwxaw2+BlzM9Momzl0e+/torPdMjg7WGq6LmCIS7ddg84diH5zIQp9quGyRVIEawCCuErgVQ==
-  dependencies:
-    fast-levenshtein "^2.0.6"
-
-eth-phishing-detect@^1.1.4:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/eth-phishing-detect/-/eth-phishing-detect-1.1.12.tgz#3db7e88c754510c94e6736db85108b90e227fe41"
-  integrity sha512-wzEqAB4mUY0gkrn+ZOlzyxHmsouKT6rrzYIxy/FFalqoZVvX/9McPdFwWkHCYrv4KzTKgJJh8tKzvMnTae8Naw==
   dependencies:
     fast-levenshtein "^2.0.6"
 


### PR DESCRIPTION
This PR updates our `eth-phishing-detect` versions, setting them all to use 1.1.13.