### PR TITLE
Update PreferencesController tests

### DIFF
--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -130,6 +130,7 @@ describe('preferences controller', function () {
 
   describe('getTokens', function () {
     it('should return an empty list initially', async function () {
+      preferencesController.setAddresses([ '0x7e57e2' ])
       await preferencesController.setSelectedAddress('0x7e57e2')
 
       const tokens = preferencesController.getTokens()
@@ -143,6 +144,7 @@ describe('preferences controller', function () {
       const symbol = 'ABBR'
       const decimals = 5
 
+      preferencesController.setAddresses([ '0x7e57e2' ])
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken(address, symbol, decimals)
 
@@ -160,6 +162,7 @@ describe('preferences controller', function () {
       const symbol = 'ABBR'
       const decimals = 5
 
+      preferencesController.setAddresses([ '0x7e57e2' ])
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken(address, symbol, decimals)
 
@@ -180,6 +183,11 @@ describe('preferences controller', function () {
       const symbol = 'ABBR'
       const decimals = 5
 
+      preferencesController.setAddresses([
+        '0x7e57e2',
+        '0xda22le',
+      ])
+
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken(address, symbol, decimals)
       assert.equal(preferencesController.getTokens().length, 1, 'one token added for 1st address')
@@ -195,6 +203,11 @@ describe('preferences controller', function () {
       const symbolFirst = 'ABBR'
       const symbolSecond = 'ABBB'
       const decimals = 5
+
+      preferencesController.setAddresses([
+        '0x7e57e2',
+        '0xda22le',
+      ])
 
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken(addressFirst, symbolFirst, decimals)
@@ -228,6 +241,7 @@ describe('preferences controller', function () {
 
   describe('removeToken', function () {
     it('should remove the only token from its state', async function () {
+      preferencesController.setAddresses([ '0x7e57e2' ])
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken('0xa', 'A', 5)
       await preferencesController.removeToken('0xa')
@@ -237,6 +251,7 @@ describe('preferences controller', function () {
     })
 
     it('should remove a token from its state', async function () {
+      preferencesController.setAddresses([ '0x7e57e2' ])
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken('0xa', 'A', 4)
       await preferencesController.addToken('0xb', 'B', 5)
@@ -250,6 +265,10 @@ describe('preferences controller', function () {
     })
 
     it('should remove a token from its state on corresponding address', async function () {
+      preferencesController.setAddresses([
+        '0x7e57e2',
+        '0x7e57e3',
+      ])
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken('0xa', 'A', 4)
       await preferencesController.addToken('0xb', 'B', 5)
@@ -296,6 +315,10 @@ describe('preferences controller', function () {
 
   describe('on setSelectedAddress', function () {
     it('should update tokens from its state on corresponding address', async function () {
+      preferencesController.setAddresses([
+        '0x7e57e2',
+        '0x7e57e3',
+      ])
       await preferencesController.setSelectedAddress('0x7e57e2')
       await preferencesController.addToken('0xa', 'A', 4)
       await preferencesController.addToken('0xb', 'B', 5)


### PR DESCRIPTION
Refs 8ea37d068937b70a83124871d8b8887ebbf3b1ae

This PR updates the `PreferencesController` tests to correctly add the addresses they use before they use them. The API of the controller is such that you should only select available addresses.