### PR TITLE
Remove undeclared `name` variable from render

### DIFF
--- a/ui/app/components/app/signature-request/signature-request-header/signature-request-header.component.js
+++ b/ui/app/components/app/signature-request/signature-request-header/signature-request-header.component.js
@@ -20,7 +20,6 @@ export default class SignatureRequestHeader extends PureComponent {
               account={selectedAccount}
             />
           )}
-          {name}
         </div>
         <div className="signature-request-header--network">
           <NetworkDisplay colored={false} />


### PR DESCRIPTION
The header component for the new Signature Request screen has an undeclared variable called `name` in it. This was present in the original implementation of this component in #6891. It's unclear what this was supposed to be, and it doesn't seem to reference anything that exists.