### PR TITLE
Rename non-existent `selectedAccount` prop to `fromAccount`

### DIFF
--- a/ui/app/components/app/signature-request/signature-request-header/signature-request-header.component.js
+++ b/ui/app/components/app/signature-request/signature-request-header/signature-request-header.component.js
@@ -5,19 +5,19 @@ import NetworkDisplay from '../../network-display'
 
 export default class SignatureRequestHeader extends PureComponent {
   static propTypes = {
-    selectedAccount: PropTypes.object,
+    fromAccount: PropTypes.object,
   }
 
   render () {
-    const { selectedAccount } = this.props
+    const { fromAccount } = this.props
 
     return (
       <div className="signature-request-header">
         <div className="signature-request-header--account">
-          {selectedAccount && (
+          {fromAccount && (
             <AccountListItem
               displayBalance={false}
-              account={selectedAccount}
+              account={fromAccount}
             />
           )}
           {name}


### PR DESCRIPTION
The prop passed into the SignatureRequestHeader was changed from `selectedAccount` to `fromAccount` in #8079, but the header component itself was never updated to use the new prop name.