### PR TITLE
Use correct `history` object on Permissions Connect page

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -140,7 +140,7 @@ export default class PermissionConnect extends Component {
   }
 
   cancelPermissionsRequest = async (requestId) => {
-    const { rejectPermissionsRequest } = this.props
+    const { history, rejectPermissionsRequest } = this.props
     if (requestId) {
       await rejectPermissionsRequest(requestId)
 


### PR DESCRIPTION
The browser global `history` was being used here instead of the React Router `history` object. This was accidentally broken when refactoring in #8269