### PR TITLE
Handle account selection on all domains that can view the selection

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -29,6 +29,7 @@ export class PermissionsController {
       getUnlockPromise,
       notifyDomain,
       notifyAllDomains,
+      preferences,
       showPermissionRequest,
     } = {},
     restoredPermissions = {},
@@ -54,6 +55,14 @@ export class PermissionsController {
     this.pendingApprovals = new Map()
     this.pendingApprovalOrigins = new Set()
     this._initializePermissions(restoredPermissions)
+    this._lastSelectedAddress = preferences.getState().selectedAddress
+
+    preferences.subscribe(async ({ selectedAddress }) => {
+      if (selectedAddress && selectedAddress !== this._lastSelectedAddress) {
+        this._lastSelectedAddress = selectedAddress
+        await this._handleAccountSelected(selectedAddress)
+      }
+    })
   }
 
   createMiddleware ({ origin, extensionId }) {
@@ -424,6 +433,40 @@ export class PermissionsController {
   }
 
   /**
+   * When a new account is selected in the UI, emit accountsChanged to each origin
+   * where the account order has changed.
+   *
+   * Note: This will emit "false positive" accountsChanged events, but they are
+   * handled by the inpage provider.
+   *
+   * @param {string} account - The newly selected account's address.
+   */
+  async _handleAccountSelected (account) {
+    if (typeof account !== 'string') {
+      throw new Error('Selected account should be a non-empty string.')
+    }
+
+    const domains = this.permissions.getDomains() || {}
+    const connectedDomains = Object.entries(domains)
+      .filter(([_, { permissions }]) => {
+        const ethAccounts = permissions.find((permission) => permission.parentCapability === 'eth_accounts')
+        const exposedAccounts = ethAccounts
+          ?.caveats
+          .find((caveat) => caveat.name === 'exposedAccounts')
+          ?.value
+        return exposedAccounts?.includes(account)
+      })
+      .map((entry) => entry[0])
+
+    await Promise.all(
+      connectedDomains
+        .map(
+          (origin) => this._handleConnectedAccountSelected(origin, account)
+        )
+    )
+  }
+
+  /**
    * When a new account is selected in the UI for 'origin', emit accountsChanged
    * to 'origin' if the selected account is permitted.
    *
@@ -433,15 +476,13 @@ export class PermissionsController {
    * @param {string} origin - The origin.
    * @param {string} account - The newly selected account's address.
    */
-  async handleNewAccountSelected (origin, account) {
-
+  async _handleConnectedAccountSelected (origin, account) {
     const permittedAccounts = await this.getAccounts(origin)
 
     if (
-      typeof origin !== 'string' || !origin.length ||
-      typeof account !== 'string' || !account.length
+      typeof origin !== 'string' || !origin.length
     ) {
-      throw new Error('Should provide non-empty origin and account strings.')
+      throw new Error('Origin should be a non-empty string.')
     }
 
     // do nothing if the account is not permitted for the origin, or

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -456,7 +456,7 @@ export class PermissionsController {
           ?.value
         return exposedAccounts?.includes(account)
       })
-      .map((entry) => entry[0])
+      .map(([domain]) => domain)
 
     await Promise.all(
       connectedDomains

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -216,6 +216,7 @@ export default class MetamaskController extends EventEmitter {
       getUnlockPromise: this.appStateController.getUnlockPromise.bind(this.appStateController),
       notifyDomain: this.notifyConnections.bind(this),
       notifyAllDomains: this.notifyAllConnections.bind(this),
+      preferences: this.preferencesController.store,
       showPermissionRequest: opts.showPermissionRequest,
     }, initState.PermissionsController, initState.PermissionsMetadata)
 
@@ -577,7 +578,6 @@ export default class MetamaskController extends EventEmitter {
       removePermissionsFor: permissionsController.removePermissionsFor.bind(permissionsController),
       updatePermittedAccounts: nodeify(permissionsController.updatePermittedAccounts, permissionsController),
       legacyExposeAccounts: nodeify(permissionsController.legacyExposeAccounts, permissionsController),
-      handleNewAccountSelected: nodeify(this.handleNewAccountSelected, this),
 
       getRequestAccountTabIds: (cb) => cb(null, this.getRequestAccountTabIds()),
       getOpenMetamaskTabsIds: (cb) => cb(null, this.getOpenMetamaskTabsIds()),
@@ -1039,17 +1039,6 @@ export default class MetamaskController extends EventEmitter {
     this.preferencesController.setAddresses(allAccounts)
     // set new account as selected
     await this.preferencesController.setSelectedAddress(accounts[0])
-  }
-
-  /**
-   * Handle when a new account is selected for the given origin in the UI.
-   * Stores the address by origin and notifies external providers associated
-   * with the origin.
-   * @param {string} origin - The origin for which the address was selected.
-   * @param {string} address - The new selected address.
-   */
-  async handleNewAccountSelected (origin, address) {
-    this.permissionsController.handleNewAccountSelected(origin, address)
   }
 
   // ---------------------------------------------------------------------------

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -28,6 +28,8 @@ export const noop = () => {}
 const keyringAccounts = deepFreeze([
   '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
   '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+  '0x7ae1cdd37bcbdb0e1f491974da8022bfdbf9c2bf',
+  '0xcc74c7a59194e5d9268476955650d1e285be703c',
 ])
 
 const getKeyringAccounts = async () => [ ...keyringAccounts ]
@@ -69,6 +71,12 @@ export function getPermControllerOpts () {
     getRestrictedMethods,
     notifyDomain: noop,
     notifyAllDomains: noop,
+    preferences: {
+      getState: () => {
+        return { selectedAddress: keyringAccounts[0] }
+      },
+      subscribe: noop,
+    },
   }
 }
 
@@ -142,7 +150,7 @@ const PERM_NAMES = {
 }
 
 const ACCOUNT_ARRAYS = {
-  a: [ ...keyringAccounts ],
+  a: [ ...keyringAccounts.slice(0, 3) ],
   b: [keyringAccounts[0]],
   c: [keyringAccounts[1]],
 }
@@ -331,11 +339,11 @@ export const getters = deepFreeze({
       },
     },
 
-    handleNewAccountSelected: {
+    _handleAccountSelected: {
       invalidParams: () => {
         return {
           name: 'Error',
-          message: 'Should provide non-empty origin and account strings.',
+          message: 'Selected account should be a non-empty string.',
         }
       },
     },
@@ -579,6 +587,8 @@ export const constants = deepFreeze({
 
   DUMMY_ACCOUNT: '0xabc',
 
+  EXTRA_ACCOUNT: keyringAccounts[3],
+
   REQUEST_IDS: {
     a: '1',
     b: '2',
@@ -609,6 +619,7 @@ export const constants = deepFreeze({
             accounts: {
               [ACCOUNT_ARRAYS.a[0]]: 1,
               [ACCOUNT_ARRAYS.a[1]]: 1,
+              [ACCOUNT_ARRAYS.a[2]]: 1,
             },
           },
         },
@@ -620,6 +631,7 @@ export const constants = deepFreeze({
             accounts: {
               [ACCOUNT_ARRAYS.a[0]]: 2,
               [ACCOUNT_ARRAYS.a[1]]: 1,
+              [ACCOUNT_ARRAYS.a[2]]: 1,
             },
           },
         },

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1217,8 +1217,6 @@ export function showAccountDetail (address) {
       if (err) {
         return dispatch(displayWarning(err.message))
       }
-      // TODO: Use correct `origin` here
-      background.handleNewAccountSelected(window.origin, address)
       dispatch(updateTokens(tokens))
       dispatch({
         type: actionConstants.SHOW_ACCOUNT_DETAIL,


### PR DESCRIPTION
Selecting a new account now results in all domains that can view this change being notified. Previously only the dapp in the active tab was being notified (though not correctly, as the `origin` was accidentally
set to the MetaMask chrome extension origin).

This handling of account selection has been moved into the background to minimize the gap between account selection and the notification being sent out. It's simpler for the UI to not be involved anyway.