### PR TITLE
Fix order of accounts in `eth_accounts` response

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -24,7 +24,6 @@ export class PermissionsController {
 
   constructor (
     {
-      getIdentities,
       getKeyringAccounts,
       getRestrictedMethods,
       getUnlockPromise,
@@ -42,14 +41,16 @@ export class PermissionsController {
       [HISTORY_STORE_KEY]: restoredState[HISTORY_STORE_KEY] || {},
     })
 
-    this.getIdentities = getIdentities
     this.getKeyringAccounts = getKeyringAccounts
     this.getUnlockPromise = getUnlockPromise
     this._notifyDomain = notifyDomain
     this.notifyAllDomains = notifyAllDomains
     this._showPermissionRequest = showPermissionRequest
 
-    this._restrictedMethods = getRestrictedMethods(this)
+    this._restrictedMethods = getRestrictedMethods({
+      getKeyringAccounts: this.getKeyringAccounts.bind(this),
+      getIdentities: this._getIdentities.bind(this),
+    })
     this.permissionsLog = new PermissionsLogController({
       restrictedMethods: Object.keys(this._restrictedMethods),
       store: this.store,
@@ -58,6 +59,7 @@ export class PermissionsController {
     this.pendingApprovalOrigins = new Set()
     this._initializePermissions(restoredPermissions)
     this._lastSelectedAddress = preferences.getState().selectedAddress
+    this.preferences = preferences
 
     preferences.subscribe(async ({ selectedAddress }) => {
       if (selectedAddress && selectedAddress !== this._lastSelectedAddress) {
@@ -139,6 +141,15 @@ export class PermissionsController {
    */
   hasPermission (origin, permission) {
     return Boolean(this.permissions.getPermission(origin, permission))
+  }
+
+  /**
+   * Gets the identities from the preferences controller store
+   *
+   * @returns {Object} identities
+   */
+  _getIdentities () {
+    return this.preferences.getState().identities
   }
 
   /**

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -4,7 +4,7 @@ import ObservableStore from 'obs-store'
 import log from 'loglevel'
 import { CapabilitiesController as RpcCap } from 'rpc-cap'
 import { ethErrors } from 'eth-json-rpc-errors'
-import { cloneDeep, isEqual } from 'lodash'
+import { cloneDeep } from 'lodash'
 
 import createMethodMiddleware from './methodMiddleware'
 import PermissionsLogController from './permissionsLog'
@@ -411,7 +411,7 @@ export class PermissionsController {
 
   /**
    * When a new account is selected in the UI, emit accountsChanged to each origin
-   * where the account order has changed.
+   * where the selected account is exposed.
    *
    * Note: This will emit "false positive" accountsChanged events, but they are
    * handled by the inpage provider.
@@ -445,7 +445,6 @@ export class PermissionsController {
 
   /**
    * When a new account is selected in the UI, emit accountsChanged to 'origin'
-   * if the exposed accounts have changed.
    *
    * Note: This will emit "false positive" accountsChanged events, but they are
    * handled by the inpage provider.
@@ -454,21 +453,6 @@ export class PermissionsController {
    */
   async _handleConnectedAccountSelected (origin) {
     const permittedAccounts = await this.getAccounts(origin)
-
-    const oldPermittedAccounts = this.permissions
-      .getPermission(origin, 'eth_accounts')
-      ?.caveats
-      ?.find((caveat) => caveat.name === CAVEAT_NAMES.exposedAccounts)
-      ?.value
-
-    // Do nothing if the exposed accounts haven't changed
-    // This can happen when:
-    // * The new selected account is not permitted for the origin, or
-    // * It's already first in the array of permitted accounts, or
-    // * The given account isn't the current selected account anymore
-    if (isEqual(permittedAccounts, oldPermittedAccounts)) {
-      return
-    }
 
     this.notifyDomain(origin, {
       method: NOTIFICATION_NAMES.accountsChanged,

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -470,10 +470,6 @@ export class PermissionsController {
       return
     }
 
-    this.permissions.updateCaveatFor(
-      origin, 'eth_accounts', CAVEAT_NAMES.exposedAccounts, permittedAccounts
-    )
-
     this.notifyDomain(origin, {
       method: NOTIFICATION_NAMES.accountsChanged,
       result: permittedAccounts,

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -1,12 +1,28 @@
-export default function getRestrictedMethods (permissionsController) {
+export default function getRestrictedMethods ({ getIdentities, getKeyringAccounts }) {
   return {
 
     'eth_accounts': {
       description: `View the addresses of the user's chosen accounts.`,
       method: (_, res, __, end) => {
-        permissionsController.getKeyringAccounts()
+        getKeyringAccounts()
           .then((accounts) => {
+            const identities = getIdentities()
             res.result = accounts
+              .sort((firstAddress, secondAddress) => {
+                if (!identities[firstAddress]) {
+                  throw new Error(`Missing identity for address ${firstAddress}`)
+                } else if (!identities[secondAddress]) {
+                  throw new Error(`Missing identity for address ${secondAddress}`)
+                } else if (identities[firstAddress].lastSelected === identities[secondAddress].lastSelected) {
+                  return 0
+                } else if (identities[firstAddress].lastSelected === undefined) {
+                  return 1
+                } else if (identities[secondAddress].lastSelected === undefined) {
+                  return -1
+                }
+
+                return identities[secondAddress].lastSelected - identities[firstAddress].lastSelected
+              })
             end()
           })
           .catch(

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -370,8 +370,15 @@ class PreferencesController {
   setSelectedAddress (_address) {
     const address = normalizeAddress(_address)
     this._updateTokens(address)
-    this.store.updateState({ selectedAddress: address })
-    const tokens = this.store.getState().tokens
+
+    const { identities, tokens } = this.store.getState()
+    const selectedIdentity = identities[address]
+    if (!selectedIdentity) {
+      throw new Error(`Identity for '${address} not found`)
+    }
+
+    selectedIdentity.lastSelected = Date.now()
+    this.store.updateState({ identities, selectedAddress: address })
     return Promise.resolve(tokens)
   }
 
@@ -383,6 +390,16 @@ class PreferencesController {
    */
   getSelectedAddress () {
     return this.store.getState().selectedAddress
+  }
+
+  /**
+   * Getter for the `identities` property
+   *
+   * @returns {Object} An object matching lower-case hex addresses to Identity objects with "address" and "name" (nickname) keys.
+   *
+   */
+  getIdentities () {
+    return this.store.getState().identities
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -393,16 +393,6 @@ class PreferencesController {
   }
 
   /**
-   * Getter for the `identities` property
-   *
-   * @returns {Object} An object matching lower-case hex addresses to Identity objects with "address" and "name" (nickname) keys.
-   *
-   */
-  getIdentities () {
-    return this.store.getState().identities
-  }
-
-  /**
    * Contains data about tokens users add to their account.
    * @typedef {Object} AddedToken
    * @property {string} address - The hex address for the token contract. Will be all lower cased and hex-prefixed.

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -211,6 +211,7 @@ export default class MetamaskController extends EventEmitter {
     this.keyringController.on('unlock', () => this.emit('unlock'))
 
     this.permissionsController = new PermissionsController({
+      getIdentities: this.preferencesController.getIdentities.bind(this.preferencesController),
       getKeyringAccounts: this.keyringController.getAccounts.bind(this.keyringController),
       getRestrictedMethods,
       getUnlockPromise: this.appStateController.getUnlockPromise.bind(this.appStateController),
@@ -576,7 +577,6 @@ export default class MetamaskController extends EventEmitter {
       getApprovedAccounts: nodeify(permissionsController.getAccounts.bind(permissionsController)),
       rejectPermissionsRequest: nodeify(permissionsController.rejectPermissionsRequest, permissionsController),
       removePermissionsFor: permissionsController.removePermissionsFor.bind(permissionsController),
-      updatePermittedAccounts: nodeify(permissionsController.updatePermittedAccounts, permissionsController),
       legacyExposeAccounts: nodeify(permissionsController.legacyExposeAccounts, permissionsController),
 
       getRequestAccountTabIds: (cb) => cb(null, this.getRequestAccountTabIds()),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -211,7 +211,6 @@ export default class MetamaskController extends EventEmitter {
     this.keyringController.on('unlock', () => this.emit('unlock'))
 
     this.permissionsController = new PermissionsController({
-      getIdentities: this.preferencesController.getIdentities.bind(this.preferencesController),
       getKeyringAccounts: this.keyringController.getAccounts.bind(this.keyringController),
       getRestrictedMethods,
       getUnlockPromise: this.appStateController.getUnlockPromise.bind(this.appStateController),

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -243,18 +243,45 @@ describe('MetaMaskController', function () {
         return Promise.resolve('0x0')
       })
 
+      let startTime = Date.now()
       await metamaskController.createNewVaultAndRestore('foobar1337', TEST_SEED)
-      assert.deepEqual(metamaskController.getState().identities, {
+      let endTime = Date.now()
+
+      const firstVaultIdentities = cloneDeep(metamaskController.getState().identities)
+      assert.ok(
+        (
+          firstVaultIdentities[TEST_ADDRESS].lastSelected >= startTime &&
+          firstVaultIdentities[TEST_ADDRESS].lastSelected <= endTime
+        ),
+        `'${firstVaultIdentities[TEST_ADDRESS].lastSelected}' expected to be between '${startTime}' and '${endTime}'`
+      )
+      delete firstVaultIdentities[TEST_ADDRESS].lastSelected
+      assert.deepEqual(firstVaultIdentities, {
         [TEST_ADDRESS]: { address: TEST_ADDRESS, name: DEFAULT_LABEL },
       })
 
       await metamaskController.preferencesController.setAccountLabel(TEST_ADDRESS, 'Account Foo')
-      assert.deepEqual(metamaskController.getState().identities, {
+
+      const labelledFirstVaultIdentities = cloneDeep(metamaskController.getState().identities)
+      delete labelledFirstVaultIdentities[TEST_ADDRESS].lastSelected
+      assert.deepEqual(labelledFirstVaultIdentities, {
         [TEST_ADDRESS]: { address: TEST_ADDRESS, name: 'Account Foo' },
       })
 
+      startTime = Date.now()
       await metamaskController.createNewVaultAndRestore('foobar1337', TEST_SEED_ALT)
-      assert.deepEqual(metamaskController.getState().identities, {
+      endTime = Date.now()
+
+      const secondVaultIdentities = cloneDeep(metamaskController.getState().identities)
+      assert.ok(
+        (
+          secondVaultIdentities[TEST_ADDRESS_ALT].lastSelected >= startTime &&
+          secondVaultIdentities[TEST_ADDRESS_ALT].lastSelected <= endTime
+        ),
+        `'${secondVaultIdentities[TEST_ADDRESS_ALT].lastSelected}' expected to be between '${startTime}' and '${endTime}'`
+      )
+      delete secondVaultIdentities[TEST_ADDRESS_ALT].lastSelected
+      assert.deepEqual(secondVaultIdentities, {
         [TEST_ADDRESS_ALT]: { address: TEST_ADDRESS_ALT, name: DEFAULT_LABEL },
       })
     })
@@ -271,8 +298,13 @@ describe('MetaMaskController', function () {
         return Promise.resolve('0x14ced5122ce0a000')
       })
 
+      const startTime = Date.now()
       await metamaskController.createNewVaultAndRestore('foobar1337', TEST_SEED)
-      assert.deepEqual(metamaskController.getState().identities, {
+
+      const identities = cloneDeep(metamaskController.getState().identities)
+      assert.ok(identities[TEST_ADDRESS].lastSelected >= startTime && identities[TEST_ADDRESS].lastSelected <= Date.now())
+      delete identities[TEST_ADDRESS].lastSelected
+      assert.deepEqual(identities, {
         [TEST_ADDRESS]: { address: TEST_ADDRESS, name: DEFAULT_LABEL },
         [TEST_ADDRESS_2]: { address: TEST_ADDRESS_2, name: DEFAULT_LABEL_2 },
       })

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -35,10 +35,13 @@ const keyringAccounts = deepFreeze([
 const getKeyringAccounts = async () => [ ...keyringAccounts ]
 
 const getIdentities = () => {
-  return keyringAccounts.reduce((identities, address, index) => {
-    identities[address] = { address, name: `Account ${index}` }
-    return identities
-  }, {})
+  return keyringAccounts.reduce(
+    (identities, address, index) => {
+      identities[address] = { address, name: `Account ${index}` }
+      return identities
+    },
+    {}
+  )
 }
 
 // perm controller initialization helper
@@ -73,7 +76,6 @@ const getUnlockPromise = () => Promise.resolve()
 export function getPermControllerOpts () {
   return {
     showPermissionRequest: noop,
-    getIdentities,
     getKeyringAccounts,
     getUnlockPromise,
     getRestrictedMethods,
@@ -81,7 +83,10 @@ export function getPermControllerOpts () {
     notifyAllDomains: noop,
     preferences: {
       getState: () => {
-        return { selectedAddress: keyringAccounts[0] }
+        return {
+          identities: getIdentities(),
+          selectedAddress: keyringAccounts[0],
+        }
       },
       subscribe: noop,
     },

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -34,6 +34,13 @@ const keyringAccounts = deepFreeze([
 
 const getKeyringAccounts = async () => [ ...keyringAccounts ]
 
+const getIdentities = () => {
+  return keyringAccounts.reduce((identities, address, index) => {
+    identities[address] = { address, name: `Account ${index}` }
+    return identities
+  }, {})
+}
+
 // perm controller initialization helper
 const getRestrictedMethods = (permController) => {
   return {
@@ -66,6 +73,7 @@ const getUnlockPromise = () => Promise.resolve()
 export function getPermControllerOpts () {
   return {
     showPermissionRequest: noop,
+    getIdentities,
     getKeyringAccounts,
     getUnlockPromise,
     getRestrictedMethods,
@@ -313,14 +321,6 @@ export const getters = deepFreeze({
           // name: 'EthereumRpcError',
           message: `Failed to add 'eth_accounts' to '${origin}'.`,
           code: ERROR_CODES.rpc.internal,
-        }
-      },
-    },
-
-    updatePermittedAccounts: {
-      invalidOrigin: () => {
-        return {
-          message: 'No such permission exists for the given domain.',
         }
       },
     },
@@ -584,6 +584,7 @@ export const getters = deepFreeze({
  * Objects with immutable mock values.
  */
 export const constants = deepFreeze({
+  ALL_ACCOUNTS: keyringAccounts,
 
   DUMMY_ACCOUNT: '0xabc',
 

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -630,7 +630,7 @@ describe('permissions controller', function () {
     })
   })
 
-  describe('preferences state update', function () {
+  describe.only('preferences state update', function () {
 
     let permController, notifications, preferences, getIdentities
 
@@ -722,11 +722,13 @@ describe('permissions controller', function () {
       await onPreferencesUpdate({ selectedAddress: ACCOUNT_ARRAYS.a[0] })
 
       assert.deepEqual(
-        notifications[ORIGINS.b], [],
+        notifications[ORIGINS.b],
+        [NOTIFICATIONS.newAccounts([...ACCOUNT_ARRAYS.a, EXTRA_ACCOUNT])],
         'should not have emitted notification'
       )
       assert.deepEqual(
-        notifications[ORIGINS.c], [],
+        notifications[ORIGINS.c],
+        [NOTIFICATIONS.newAccounts(ACCOUNT_ARRAYS.a)],
         'should not have emitted notification'
       )
     })

--- a/test/unit/app/controllers/permissions/restricted-methods-test.js
+++ b/test/unit/app/controllers/permissions/restricted-methods-test.js
@@ -1,35 +1,147 @@
 import { strict as assert } from 'assert'
+import pify from 'pify'
 
 import getRestrictedMethods
   from '../../../../../app/scripts/controllers/permissions/restrictedMethods'
 
 describe('restricted methods', function () {
-
-  // this method is tested extensively in other permissions tests
   describe('eth_accounts', function () {
-
-    it('handles failure', async function () {
+    it('should handle getKeyringAccounts error', async function () {
       const restrictedMethods = getRestrictedMethods({
         getKeyringAccounts: async () => {
           throw new Error('foo')
         },
       })
+      const ethAccountsMethod = pify(restrictedMethods.eth_accounts.method)
 
       const res = {}
-      restrictedMethods.eth_accounts.method(null, res, null, (err) => {
+      const fooError = new Error('foo')
+      await assert.rejects(
+        ethAccountsMethod(null, res, null),
+        fooError,
+        'Should reject with expected error'
+      )
 
-        const fooError = new Error('foo')
+      assert.deepEqual(
+        res, { error: fooError },
+        'response should have expected error and no result'
+      )
+    })
 
-        assert.deepEqual(
-          err, fooError,
-          'should end with expected error'
-        )
-
-        assert.deepEqual(
-          res, { error: fooError },
-          'response should have expected error and no result'
-        )
+    it('should handle missing identity for first account when sorting', async function () {
+      const restrictedMethods = getRestrictedMethods({
+        getIdentities: () => {
+          return { '0x7e57e2': {} }
+        },
+        getKeyringAccounts: async () => ['0x7e57e2', '0x7e57e3'],
       })
+      const ethAccountsMethod = pify(restrictedMethods.eth_accounts.method)
+
+      const res = {}
+      await assert.rejects(ethAccountsMethod(null, res, null))
+      assert.ok(res.error instanceof Error, 'result should have error')
+      assert.deepEqual(Object.keys(res), ['error'], 'result should only contain error')
+    })
+
+    it('should handle missing identity for second account when sorting', async function () {
+      const restrictedMethods = getRestrictedMethods({
+        getIdentities: () => {
+          return { '0x7e57e3': {} }
+        },
+        getKeyringAccounts: async () => ['0x7e57e2', '0x7e57e3'],
+      })
+      const ethAccountsMethod = pify(restrictedMethods.eth_accounts.method)
+
+      const res = {}
+      await assert.rejects(ethAccountsMethod(null, res, null))
+      assert.ok(res.error instanceof Error, 'result should have error')
+      assert.deepEqual(Object.keys(res), ['error'], 'result should only contain error')
+    })
+
+    it('should return accounts in keyring order when none are selected', async function () {
+      const keyringAccounts = ['0x7e57e2', '0x7e57e3', '0x7e57e4', '0x7e57e5']
+      const restrictedMethods = getRestrictedMethods({
+        getIdentities: () => {
+          return keyringAccounts.reduce(
+            (identities, address) => {
+              identities[address] = {}
+              return identities
+            },
+            {}
+          )
+        },
+        getKeyringAccounts: async () => [...keyringAccounts],
+      })
+      const ethAccountsMethod = pify(restrictedMethods.eth_accounts.method)
+
+      const res = {}
+      await ethAccountsMethod(null, res, null)
+      assert.deepEqual(res, { result: keyringAccounts }, 'should return accounts in correct order')
+    })
+
+    it('should return accounts in keyring order when all have same last selected time', async function () {
+      const keyringAccounts = ['0x7e57e2', '0x7e57e3', '0x7e57e4', '0x7e57e5']
+      const restrictedMethods = getRestrictedMethods({
+        getIdentities: () => {
+          return keyringAccounts.reduce(
+            (identities, address) => {
+              identities[address] = { lastSelected: 1000 }
+              return identities
+            },
+            {}
+          )
+        },
+        getKeyringAccounts: async () => [...keyringAccounts],
+      })
+      const ethAccountsMethod = pify(restrictedMethods.eth_accounts.method)
+
+      const res = {}
+      await ethAccountsMethod(null, res, null)
+      assert.deepEqual(res, { result: keyringAccounts }, 'should return accounts in correct order')
+    })
+
+    it('should return accounts sorted by last selected (descending)', async function () {
+      const keyringAccounts = ['0x7e57e2', '0x7e57e3', '0x7e57e4', '0x7e57e5']
+      const expectedResult = keyringAccounts.slice().reverse()
+      const restrictedMethods = getRestrictedMethods({
+        getIdentities: () => {
+          return keyringAccounts.reduce(
+            (identities, address, index) => {
+              identities[address] = { lastSelected: index * 1000 }
+              return identities
+            },
+            {}
+          )
+        },
+        getKeyringAccounts: async () => [...keyringAccounts],
+      })
+      const ethAccountsMethod = pify(restrictedMethods.eth_accounts.method)
+
+      const res = {}
+      await ethAccountsMethod(null, res, null)
+      assert.deepEqual(res, { result: expectedResult }, 'should return accounts in correct order')
+    })
+
+    it('should return accounts sorted by last selected (descending) with unselected accounts last, in keyring order', async function () {
+      const keyringAccounts = ['0x7e57e2', '0x7e57e3', '0x7e57e4', '0x7e57e5', '0x7e57e6']
+      const expectedResult = ['0x7e57e4', '0x7e57e2', '0x7e57e3', '0x7e57e5', '0x7e57e6']
+      const restrictedMethods = getRestrictedMethods({
+        getIdentities: () => {
+          return {
+            '0x7e57e2': { lastSelected: 1000 },
+            '0x7e57e3': {},
+            '0x7e57e4': { lastSelected: 2000 },
+            '0x7e57e5': {},
+            '0x7e57e6': {},
+          }
+        },
+        getKeyringAccounts: async () => [...keyringAccounts],
+      })
+      const ethAccountsMethod = pify(restrictedMethods.eth_accounts.method)
+
+      const res = {}
+      await ethAccountsMethod(null, res, null)
+      assert.deepEqual(res, { result: expectedResult }, 'should return accounts in correct order')
     })
   })
 })


### PR DESCRIPTION
The accounts returned by `eth_accounts` were in a fixed order - the order in which the keyring returned them - rather than ordered with the selected account first. The accounts returned by the `accountsChanged` event were ordered with the selected account first, but the same order wasn't used for `eth_accounts`.

We needed to store additional state in order to determine the correct account order correctly on all dapps. We had only been storing the current selected account, but since we also need to determine the primary account per dapp (i.e. the last "selected" account among the accounts exposed to that dapp), that wasn't enough.

A `lastSelected` property has been added to each identity in the preferences controller to keep track of the last selected time. This property is set to the current time (in milliseconds) whenever a new selection is made. The accounts returned with `accountsChanged` and by `eth_accounts` are both ordered by this property.

The `updatePermittedAccounts` function was merged with the internal methods for responding to account selection, to keep things simpler. It wasn't called externally anyway, so it wasn't needed in the public API.