### PR TITLE
Add 'addPermittedAccount' method to permissions controller

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -576,6 +576,7 @@ export default class MetamaskController extends EventEmitter {
       getApprovedAccounts: nodeify(permissionsController.getAccounts.bind(permissionsController)),
       rejectPermissionsRequest: nodeify(permissionsController.rejectPermissionsRequest, permissionsController),
       removePermissionsFor: permissionsController.removePermissionsFor.bind(permissionsController),
+      addPermittedAccount: nodeify(permissionsController.addPermittedAccount, permissionsController),
       legacyExposeAccounts: nodeify(permissionsController.legacyExposeAccounts, permissionsController),
 
       getRequestAccountTabIds: (cb) => cb(null, this.getRequestAccountTabIds()),

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -330,6 +330,24 @@ export const getters = deepFreeze({
       },
     },
 
+    addPermittedAccount: {
+      alreadyPermitted: () => {
+        return {
+          message: 'Account is already permitted',
+        }
+      },
+      invalidOrigin: () => {
+        return {
+          message: 'Unrecognized domain',
+        }
+      },
+      noEthAccountsPermission: () => {
+        return {
+          message: 'Origin does not have \'eth_accounts\' permission',
+        }
+      },
+    },
+
     legacyExposeAccounts: {
       badOrigin: () => {
         return {

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -461,6 +461,93 @@ describe('permissions controller', function () {
     })
   })
 
+  describe('addPermittedAccount', function () {
+    let permController, notifications
+
+    beforeEach(function () {
+      notifications = initNotifications()
+      permController = initPermController(notifications)
+      grantPermissions(
+        permController, ORIGINS.a,
+        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+      )
+      grantPermissions(
+        permController, ORIGINS.b,
+        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b)
+      )
+    })
+
+    it('should throw if account is not a string', async function () {
+      await assert.rejects(
+        () => permController.addPermittedAccount(ORIGINS.a, {}),
+        ERRORS.validatePermittedAccounts.nonKeyringAccount({}),
+        'should throw on non-string account param'
+      )
+    })
+
+    it('should throw if given account isn\'t in keyring', async function () {
+      await assert.rejects(
+        () => permController.addPermittedAccount(ORIGINS.a, DUMMY_ACCOUNT),
+        ERRORS.validatePermittedAccounts.nonKeyringAccount(DUMMY_ACCOUNT),
+        'should throw on non-keyring account'
+      )
+    })
+
+    it('should throw if origin is invalid', async function () {
+      await assert.rejects(
+        () => permController.addPermittedAccount(false, EXTRA_ACCOUNT),
+        ERRORS.addPermittedAccount.invalidOrigin(),
+        'should throw on invalid origin'
+      )
+    })
+
+    it('should throw if origin lacks any permissions', async function () {
+      await assert.rejects(
+        () => permController.addPermittedAccount(ORIGINS.c, EXTRA_ACCOUNT),
+        ERRORS.addPermittedAccount.invalidOrigin(),
+        'should throw on origin without permissions'
+      )
+    })
+
+    it('should throw if origin lacks eth_accounts permission', async function () {
+      grantPermissions(
+        permController, ORIGINS.c,
+        PERMS.finalizedRequests.test_method()
+      )
+
+      await assert.rejects(
+        () => permController.addPermittedAccount(ORIGINS.c, EXTRA_ACCOUNT),
+        ERRORS.addPermittedAccount.noEthAccountsPermission(),
+        'should throw on origin without eth_accounts permission'
+      )
+    })
+
+    it('should throw if account is already permitted', async function () {
+      await assert.rejects(
+        () => permController.addPermittedAccount(ORIGINS.a, ACCOUNT_ARRAYS.c[0]),
+        ERRORS.addPermittedAccount.alreadyPermitted(),
+        'should throw if account is already permitted'
+      )
+    })
+
+    it('should successfully add permitted account', async function () {
+      await permController.addPermittedAccount(ORIGINS.a, EXTRA_ACCOUNT)
+
+      const accounts = await permController.getAccounts(ORIGINS.a)
+
+      assert.deepEqual(
+        accounts, [...ACCOUNT_ARRAYS.a, EXTRA_ACCOUNT],
+        'origin should have correct accounts'
+      )
+
+      assert.deepEqual(
+        notifications[ORIGINS.a][0],
+        NOTIFICATIONS.newAccounts([...ACCOUNT_ARRAYS.a, EXTRA_ACCOUNT]),
+        'origin should have correct notification'
+      )
+    })
+  })
+
   describe('finalizePermissionsRequest', function () {
 
     let permController

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -485,7 +485,7 @@ describe('permissions controller', function () {
       )
     })
 
-    it('should throw if given account isn\'t in keyring', async function () {
+    it('should throw if given account is not in keyring', async function () {
       await assert.rejects(
         () => permController.addPermittedAccount(ORIGINS.a, DUMMY_ACCOUNT),
         ERRORS.validatePermittedAccounts.nonKeyringAccount(DUMMY_ACCOUNT),

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1227,6 +1227,20 @@ export function showAccountDetail (address) {
   }
 }
 
+export function addPermittedAccount (origin, address) {
+  return async (dispatch) => {
+    await new Promise((resolve, reject) => {
+      background.addPermittedAccount(origin, address, (error) => {
+        if (error) {
+          return reject(error)
+        }
+        resolve()
+      })
+    })
+    await forceUpdateMetamaskState(dispatch)
+  }
+}
+
 export function showAccountsPage () {
   return {
     type: actionConstants.SHOW_ACCOUNTS_PAGE,


### PR DESCRIPTION
This method adds the given account to the given origin's list of exposed accounts. This method is not yet used, but it will be in subsequent PRs (e.g. #8312)

This method has been added to the background API, and a wrapper action creator has been written as well.