### PR TITLE
Create new tabs instead of windows in most cases

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1894,7 +1894,7 @@ export default class MetamaskController extends EventEmitter {
     const network = this.networkController.getNetworkState()
     const url = getBuyEthUrl({ network, address, amount })
     if (url) {
-      this.platform.openWindow({ url })
+      this.platform.openTab({ url })
     }
   }
 

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -12,6 +12,18 @@ class ExtensionPlatform {
     extension.runtime.reload()
   }
 
+  openTab (options) {
+    return new Promise((resolve, reject) => {
+      extension.tabs.create(options, (newTab) => {
+        const error = checkForError()
+        if (error) {
+          return reject(error)
+        }
+        return resolve(newTab)
+      })
+    })
+  }
+
   openWindow (options) {
     return new Promise((resolve, reject) => {
       extension.windows.create(options, (newWindow) => {
@@ -68,7 +80,7 @@ class ExtensionPlatform {
     if (route) {
       extensionURL += `#${route}`
     }
-    this.openWindow({ url: extensionURL })
+    this.openTab({ url: extensionURL })
     if (getEnvironmentType() !== ENVIRONMENT_TYPE_BACKGROUND) {
       window.close()
     }

--- a/ui/app/components/app/dropdowns/account-details-dropdown/account-details-dropdown.container.js
+++ b/ui/app/components/app/dropdowns/account-details-dropdown/account-details-dropdown.container.js
@@ -21,7 +21,7 @@ function mapDispatchToProps (dispatch) {
       dispatch(actions.showModal({ name: 'ACCOUNT_DETAILS' }))
     },
     viewOnEtherscan: (address, network, rpcPrefs) => {
-      global.platform.openWindow({ url: genAccountLink(address, network, rpcPrefs) })
+      global.platform.openTab({ url: genAccountLink(address, network, rpcPrefs) })
     },
     showRemoveAccountConfirmationModal: (identity) => {
       return dispatch(actions.showModal({ name: 'CONFIRM_REMOVE_ACCOUNT', identity }))

--- a/ui/app/components/app/dropdowns/token-menu-dropdown.js
+++ b/ui/app/components/app/dropdowns/token-menu-dropdown.js
@@ -40,7 +40,7 @@ class TokenMenuDropdown extends Component {
           onClick={(e) => {
             e.stopPropagation()
             const url = genAccountLink(this.props.token.address, this.props.network)
-            global.platform.openWindow({ url })
+            global.platform.openTab({ url })
             this.props.onClose()
           }}
           text={this.context.t('viewOnEtherscan')}

--- a/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -62,7 +62,7 @@ export default class AccountDetailsModal extends Component {
           type="secondary"
           className="account-modal__button"
           onClick={() => {
-            global.platform.openWindow({ url: genAccountLink(address, network, rpcPrefs) })
+            global.platform.openTab({ url: genAccountLink(address, network, rpcPrefs) })
           }}
         >
           {rpcPrefs.blockExplorerUrl

--- a/ui/app/components/app/modals/tests/account-details-modal.test.js
+++ b/ui/app/components/app/modals/tests/account-details-modal.test.js
@@ -58,7 +58,7 @@ describe('Account Details Modal', function () {
     const etherscanLink = modalButton.first()
 
     etherscanLink.simulate('click')
-    assert(global.platform.openWindow.calledOnce)
+    assert(global.platform.openTab.calledOnce)
   })
 
   it('shows export private key modal when clicked', function () {

--- a/ui/app/components/app/modals/tests/account-details-modal.test.js
+++ b/ui/app/components/app/modals/tests/account-details-modal.test.js
@@ -7,7 +7,7 @@ import AccountDetailsModal from '../account-details-modal'
 describe('Account Details Modal', function () {
   let wrapper
 
-  global.platform = { openWindow: sinon.spy() }
+  global.platform = { openTab: sinon.spy() }
 
   const props = {
     hideModal: sinon.spy(),
@@ -53,7 +53,7 @@ describe('Account Details Modal', function () {
     assert.equal(props.setAccountLabel.getCall(0).args[1], 'New Label')
   })
 
-  it('opens new window when view block explorer is clicked', function () {
+  it('opens new tab when view block explorer is clicked', function () {
     const modalButton = wrapper.find('.account-modal__button')
     const etherscanLink = modalButton.first()
 

--- a/ui/app/components/app/permissions-connect-footer/permissions-connect-footer.component.js
+++ b/ui/app/components/app/permissions-connect-footer/permissions-connect-footer.component.js
@@ -15,7 +15,7 @@ export default class PermissionsConnectFooter extends Component {
           <div
             className="permissions-connect-footer__text--link"
             onClick={() => {
-              global.platform.openWindow({ url: 'https://medium.com/metamask/privacy-mode-is-now-enabled-by-default-1c1c957f4d57' })
+              global.platform.openTab({ url: 'https://medium.com/metamask/privacy-mode-is-now-enabled-by-default-1c1c957f4d57' })
             }}
           >{ t('learnMore') }
           </div>

--- a/ui/app/components/app/shift-list-item/shift-list-item.component.js
+++ b/ui/app/components/app/shift-list-item/shift-list-item.component.js
@@ -146,7 +146,7 @@ export default class ShiftListItem extends Component {
               width: '200px',
               overflow: 'hidden',
             }}
-            onClick={() => global.platform.openWindow({ url })}
+            onClick={() => global.platform.openTab({ url })}
           >
             <div
               style={{

--- a/ui/app/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/app/components/app/signature-request-original/signature-request-original.component.js
@@ -233,7 +233,7 @@ export default class SignatureRequestOriginal extends Component {
                 <span
                   className="request-signature__help-link"
                   onClick={() => {
-                    global.platform.openWindow({
+                    global.platform.openTab({
                       url: 'https://metamask.zendesk.com/hc/en-us/articles/360015488751',
                     })
                   }}

--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -33,7 +33,7 @@ export default class TransactionActivityLog extends PureComponent {
     const prefix = prefixForNetwork(metamaskNetworkId)
     const etherscanUrl = `https://${prefix}etherscan.io/tx/${hash}`
 
-    global.platform.openWindow({ url: etherscanUrl })
+    global.platform.openTab({ url: etherscanUrl })
   }
 
   renderInlineRetry (index, activity) {

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -56,7 +56,7 @@ export default class TransactionListItemDetails extends PureComponent {
       },
     })
 
-    global.platform.openWindow({ url: getBlockExplorerUrlForTx(metamaskNetworkId, hash, rpcPrefs) })
+    global.platform.openTab({ url: getBlockExplorerUrlForTx(metamaskNetworkId, hash, rpcPrefs) })
   }
 
   handleCancel = (event) => {

--- a/ui/app/pages/create-account/connect-hardware/connect-screen.js
+++ b/ui/app/pages/create-account/connect-hardware/connect-screen.js
@@ -88,7 +88,7 @@ class ConnectScreen extends Component {
         <Button
           type="primary"
           large
-          onClick={() => global.platform.openWindow({
+          onClick={() => global.platform.openTab({
             url: 'https://google.com/chrome',
           })}
         >

--- a/ui/app/pages/create-account/import-account/index.js
+++ b/ui/app/pages/create-account/import-account/index.js
@@ -50,7 +50,7 @@ export default class AccountImportSubview extends Component {
               textDecoration: 'underline',
             }}
             onClick={() => {
-              global.platform.openWindow({
+              global.platform.openTab({
                 url: 'https://metamask.zendesk.com/hc/en-us/articles/360015289932',
               })
             }}

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1761,7 +1761,7 @@ export function showSendTokenPage () {
 export function buyEth (opts) {
   return (dispatch) => {
     const url = getBuyEthUrl(opts)
-    global.platform.openWindow({ url })
+    global.platform.openTab({ url })
     dispatch({
       type: actionConstants.BUY_ETH,
     })


### PR DESCRIPTION
Fixes #8346 

All instances of `platform.openWindow` changed to `openTab` except [this one](https://github.com/MetaMask/metamask-extension/pull/8317/files#diff-2e6398a9a8ac20a1e54703b7e7dbb57dR36) from #8317.

#### Original Text

`platform.openExtensionInBrowser` currently creates a new window instead of a new tab in the same window, by calling `platform.openWindow()`. This PR adds a new method, `platform.openTab()`, and calls that instead in `openExtensionInBrowser`.

There are numerous other calls to `openWindow` in the extension code. We may want to consider which ones are valid and which ones should be converted to tabs instead.