### PR TITLE
Add new unit test script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:unit:global": "mocha --exit --require test/env.js --require test/setup.js --recursive mocha test/unit-global/*",
     "test:unit:lax": "mocha --exit --require test/env.js --require test/setup.js --recursive \"test/unit/{,**/!(permissions)}/*.js\" \"ui/app/**/*.test.js\"",
     "test:unit:strict": "mocha --exit --require test/env.js --require test/setup.js --recursive \"test/unit/**/permissions/*.js\"",
+    "test:unit:path": "mocha --exit --require test/env.js --require test/setup.js --recursive",
     "test:integration": "yarn test:integration:build && yarn test:flat",
     "test:integration:build": "yarn build styles",
     "test:e2e:chrome": "SELENIUM_BROWSER=chrome test/e2e/run-all.sh",


### PR DESCRIPTION
- Adds `test:unit:path` to `package.json`, a unit test script that expects one or more path arguments
  - When developing, I often end up creating temporary unit tests scripts so that I can just run the relevant unit tests, without having to wait for all 1500 unit tests to complete
  - Now, we can all do that in a standardized way