### PR TITLE
[RFC] fix(popup): popup window relative to last focused window

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -60,6 +60,18 @@ class ExtensionPlatform {
     })
   }
 
+  getLastFocusedWindow () {
+    return new Promise((resolve, reject) => {
+      extension.windows.getLastFocused((windowObject) => {
+        const error = checkForError()
+        if (error) {
+          return reject(error)
+        }
+        return resolve(windowObject)
+      })
+    })
+  }
+
   closeCurrentWindow () {
     return extension.windows.getCurrent((windowDetails) => {
       return extension.windows.remove(windowDetails.id)


### PR DESCRIPTION
Fixes #7314

### Cause of bug
- The popup window is triggered from the background chrome process for the extension which has no height, width, left or top position (actually all are 0)
- The original logic attempted to use these to compute a good position for the popup.
- The result is that on dual displays, the popup always opened in the top left most pixel of the leftmost display 

### Suggested resolution
- use the browser extension API to grab the latest focused window
- check the left and top values for that window
- ???

I have defaulted to opening the popup perfectly aligned with the top left most pixel of the last focused window. This could end up being wonky. I would love to get an idea of what the best-case scenario would be from the product team @jacobcantele and of course would love input from the engineers on the approach here.