### PR TITLE
Route to home page after connecting in popup

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -10,7 +10,6 @@ import {
 } from '../../../../app/scripts/lib/enums'
 import {
   DEFAULT_ROUTE,
-  CONNECTED_ROUTE,
 } from '../../helpers/constants/routes'
 import PermissionPageContainer from '../../components/app/permission-page-container'
 

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -116,7 +116,7 @@ export default class PermissionConnect extends Component {
         global.platform.closeCurrentWindow()
       }, 2000)
     } else if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {
-      history.push(CONNECTED_ROUTE)
+      history.push(DEFAULT_ROUTE)
     }
   }
 


### PR DESCRIPTION
Fixes #8352 

After connecting in popup, not notification, route to home page (`DEFAULT_ROUTE`), and do not show the connected sites modal (`CONNECTED_ROUTE`).