### PR TITLE
Close notification UI if no unapproved confirmations

### DIFF
--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -110,7 +110,7 @@ async function getFirstParentDirectoryThatExists (directory) {
 async function main () {
   const args = process.argv.slice(2)
 
-  let pages = ['notification']
+  let pages = ['home']
   let numSamples = DEFAULT_NUM_SAMPLES
   let outputPath
   let outputDirectory

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -39,6 +39,7 @@ export default class Home extends PureComponent {
     unconfirmedTransactionsCount: PropTypes.number,
     shouldShowSeedPhraseReminder: PropTypes.bool,
     isPopup: PropTypes.bool,
+    isNotification: PropTypes.bool.isRequired,
     threeBoxSynced: PropTypes.bool,
     setupThreeBox: PropTypes.func,
     turnThreeBoxSyncingOn: PropTypes.func,
@@ -49,6 +50,7 @@ export default class Home extends PureComponent {
     threeBoxLastUpdated: PropTypes.number,
     hasDaiV1Token: PropTypes.bool,
     firstPermissionsRequestId: PropTypes.string,
+    totalUnapprovedCount: PropTypes.number.isRequired,
   }
 
   UNSAFE_componentWillMount () {
@@ -81,11 +83,18 @@ export default class Home extends PureComponent {
 
   componentDidUpdate () {
     const {
-      threeBoxSynced,
+      isNotification,
       setupThreeBox,
       showRestorePrompt,
       threeBoxLastUpdated,
+      threeBoxSynced,
+      totalUnapprovedCount,
     } = this.props
+
+    if (isNotification && totalUnapprovedCount === 0) {
+      global.platform.closeCurrentWindow()
+    }
+
     if (threeBoxSynced && showRestorePrompt && threeBoxLastUpdated === null) {
       setupThreeBox()
     }

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -72,8 +72,14 @@ export default class Home extends PureComponent {
   componentDidMount () {
     const {
       history,
+      isNotification,
       suggestedTokens = {},
+      totalUnapprovedCount,
     } = this.props
+
+    if (isNotification && totalUnapprovedCount === 0) {
+      global.platform.closeCurrentWindow()
+    }
 
     // suggested new tokens
     if (Object.keys(suggestedTokens).length > 0) {

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -2,8 +2,15 @@ import Home from './home.component'
 import { compose } from 'redux'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
-import { unconfirmedTransactionsCountSelector } from '../../selectors/confirm-transaction'
-import { getCurrentEthBalance, getDaiV1Token, getFirstPermissionRequest } from '../../selectors/selectors'
+import {
+  unconfirmedTransactionsCountSelector,
+} from '../../selectors/confirm-transaction'
+import {
+  getCurrentEthBalance,
+  getDaiV1Token,
+  getFirstPermissionRequest,
+  getTotalUnapprovedCount,
+} from '../../selectors/selectors'
 import {
   restoreFromThreeBox,
   turnThreeBoxSyncingOn,
@@ -12,7 +19,10 @@ import {
 } from '../../store/actions'
 import { setThreeBoxLastUpdated } from '../../ducks/app/app'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
-import { ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
+import {
+  ENVIRONMENT_TYPE_NOTIFICATION,
+  ENVIRONMENT_TYPE_POPUP,
+} from '../../../../app/scripts/lib/enums'
 
 const mapStateToProps = (state) => {
   const { metamask, appState } = state
@@ -26,8 +36,12 @@ const mapStateToProps = (state) => {
   } = metamask
   const accountBalance = getCurrentEthBalance(state)
   const { forgottenPassword, threeBoxLastUpdated } = appState
+  const totalUnapprovedCount = getTotalUnapprovedCount(state)
 
-  const isPopup = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
+  const envType = getEnvironmentType()
+  const isPopup = envType === ENVIRONMENT_TYPE_POPUP
+  const isNotification = envType === ENVIRONMENT_TYPE_NOTIFICATION
+
   const firstPermissionsRequest = getFirstPermissionRequest(state)
   const firstPermissionsRequestId = (firstPermissionsRequest && firstPermissionsRequest.metadata)
     ? firstPermissionsRequest.metadata.id
@@ -39,12 +53,14 @@ const mapStateToProps = (state) => {
     unconfirmedTransactionsCount: unconfirmedTransactionsCountSelector(state),
     shouldShowSeedPhraseReminder: !seedPhraseBackedUp && (parseInt(accountBalance, 16) > 0 || tokens.length > 0),
     isPopup,
+    isNotification,
     threeBoxSynced,
     showRestorePrompt,
     selectedAddress,
     threeBoxLastUpdated,
     hasDaiV1Token: Boolean(getDaiV1Token(state)),
     firstPermissionsRequestId,
+    totalUnapprovedCount,
   }
 }
 

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -308,11 +308,11 @@ export function getSelectedTokenContract (state) {
 
 export function getTotalUnapprovedCount (state) {
   const {
-    unapprovedMsgCount,
-    unapprovedPersonalMsgCount,
-    unapprovedDecryptMsgCount,
-    unapprovedEncryptionPublicKeyMsgCount,
-    unapprovedTypedMessagesCount,
+    unapprovedMsgCount = 0,
+    unapprovedPersonalMsgCount = 0,
+    unapprovedDecryptMsgCount = 0,
+    unapprovedEncryptionPublicKeyMsgCount = 0,
+    unapprovedTypedMessagesCount = 0,
   } = state.metamask
 
   return getUnapprovedTxCount() + unapprovedMsgCount + unapprovedPersonalMsgCount +

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -373,11 +373,12 @@ export function getPermissionsDescriptions (state) {
 }
 
 export function getPermissionsRequests (state) {
-  return state.metamask.permissionsRequests
+  return state.metamask.permissionsRequests || []
 }
 
 export function getPermissionsRequestCount (state) {
-  return Object.keys(state.metamask.permissionsRequests).length
+  const permissionsRequests = getPermissionsRequests(state)
+  return permissionsRequests.length
 }
 
 export function getDomainMetadata (state) {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -308,7 +308,6 @@ export function getSelectedTokenContract (state) {
 
 export function getTotalUnapprovedCount (state) {
   const {
-    unapprovedTxs = {},
     unapprovedMsgCount,
     unapprovedPersonalMsgCount,
     unapprovedDecryptMsgCount,
@@ -316,9 +315,19 @@ export function getTotalUnapprovedCount (state) {
     unapprovedTypedMessagesCount,
   } = state.metamask
 
-  return Object.keys(unapprovedTxs).length + unapprovedMsgCount + unapprovedPersonalMsgCount +
+  return getUnapprovedTxCount() + unapprovedMsgCount + unapprovedPersonalMsgCount +
     unapprovedTypedMessagesCount + unapprovedDecryptMsgCount + unapprovedEncryptionPublicKeyMsgCount +
-    getPermissionsRequestCount(state)
+    getPermissionsRequestCount(state) + getSuggestedTokenCount(state)
+}
+
+function getUnapprovedTxCount (state) {
+  const { unapprovedTxs = {} } = state
+  return Object.keys(unapprovedTxs).length
+}
+
+function getSuggestedTokenCount (state) {
+  const { suggestedTokens = {} } = state
+  return Object.keys(suggestedTokens).length
 }
 
 export function getIsMainnet (state) {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -315,18 +315,18 @@ export function getTotalUnapprovedCount (state) {
     unapprovedTypedMessagesCount = 0,
   } = state.metamask
 
-  return getUnapprovedTxCount() + unapprovedMsgCount + unapprovedPersonalMsgCount +
-    unapprovedTypedMessagesCount + unapprovedDecryptMsgCount + unapprovedEncryptionPublicKeyMsgCount +
-    getPermissionsRequestCount(state) + getSuggestedTokenCount(state)
+  return unapprovedMsgCount + unapprovedPersonalMsgCount + unapprovedDecryptMsgCount +
+    unapprovedEncryptionPublicKeyMsgCount + unapprovedTypedMessagesCount +
+    getUnapprovedTxCount(state) + getPermissionsRequestCount(state) + getSuggestedTokenCount(state)
 }
 
 function getUnapprovedTxCount (state) {
-  const { unapprovedTxs = {} } = state
+  const { unapprovedTxs = {} } = state.metamask
   return Object.keys(unapprovedTxs).length
 }
 
 function getSuggestedTokenCount (state) {
-  const { suggestedTokens = {} } = state
+  const { suggestedTokens = {} } = state.metamask
   return Object.keys(suggestedTokens).length
 }
 

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -306,7 +306,7 @@ export function getSelectedTokenContract (state) {
     : null
 }
 
-export function getTotalUnapprovedCount ({ metamask }) {
+export function getTotalUnapprovedCount (state) {
   const {
     unapprovedTxs = {},
     unapprovedMsgCount,
@@ -314,10 +314,11 @@ export function getTotalUnapprovedCount ({ metamask }) {
     unapprovedDecryptMsgCount,
     unapprovedEncryptionPublicKeyMsgCount,
     unapprovedTypedMessagesCount,
-  } = metamask
+  } = state.metamask
 
   return Object.keys(unapprovedTxs).length + unapprovedMsgCount + unapprovedPersonalMsgCount +
-    unapprovedTypedMessagesCount + unapprovedDecryptMsgCount + unapprovedEncryptionPublicKeyMsgCount
+    unapprovedTypedMessagesCount + unapprovedDecryptMsgCount + unapprovedEncryptionPublicKeyMsgCount +
+    getPermissionsRequestCount(state)
 }
 
 export function getIsMainnet (state) {
@@ -364,6 +365,10 @@ export function getPermissionsDescriptions (state) {
 
 export function getPermissionsRequests (state) {
   return state.metamask.permissionsRequests
+}
+
+export function getPermissionsRequestCount (state) {
+  return Object.keys(state.metamask.permissionsRequests).length
 }
 
 export function getDomainMetadata (state) {


### PR DESCRIPTION
Fixes #8348 (well enough)

Attempts to resolve #8348 by ensuring that the notification UI is closed if there are no unapproved confirmations to approve.

Unapproved confirmations include (exhaustively):
- unapprovedMsgCount
- unapprovedPersonalMsgCount
- unapprovedTypedMessagesCount
- unapprovedDecryptMsgCount
- unapprovedEncryptionPublicKeyMsgCount
- unapprovedTxCount
- suggestedTokenCount
- permissionsRequestCount