### PR TITLE
Update nvmrc version number to lts/dubnium

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v10.18.1
+lts/dubnium


### PR DESCRIPTION
Do we want this? 

Effect:
1. If you're on anything other than the latest version of node 10, `nvm use` inside the metamask directory will warn you that you're not on the right version, and switch you to that version if you have it installed.
2. `nvm install` within the package directory will install the latest version of node 10. and activate it. 

seems helpful, except in a situation where node releases a minor or patch version that we **do not** want to use, in which case we'll need to change engines in package.json and then update this file to lock into that version as well.

Thoughs? 