### PR TITLE
Tidy up transaction-related unit tests

### DIFF
--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -145,7 +145,7 @@ describe('PendingTransactionTracker', function () {
   })
 
   describe('#_checkPendingTxs', function () {
-    it("should warp all txMeta's in #updatePendingTxs", function (done) {
+    it("should wrap all txMeta's in #updatePendingTxs", function (done) {
       const txMeta2 = txMeta3 = txMeta
       txMeta2.id = 2
       txMeta3.id = 3

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -1,13 +1,11 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
+import sinon from 'sinon'
 import { createTestProviderTools } from '../../../../stub/provider'
 import PendingTransactionTracker from '../../../../../app/scripts/controllers/transactions/pending-tx-tracker'
 import MockTxGen from '../../../../lib/mock-tx-gen'
-import sinon from 'sinon'
-
 
 describe('PendingTransactionTracker', function () {
-  let pendingTxTracker, txMeta, txMetaNoHash, providerResultStub,
-    provider, txMeta3, txList, knownErrors
+  let pendingTxTracker, txMeta, txMetaNoHash, providerResultStub, provider, txMeta3, txList, knownErrors
   this.timeout(10000)
 
   beforeEach(function () {
@@ -90,9 +88,9 @@ describe('PendingTransactionTracker', function () {
   })
 
   describe('#_checkPendingTx', function () {
-    it('should emit \'tx:failed\' if the txMeta does not have a hash', function (done) {
+    it("should emit 'tx:failed' if the txMeta does not have a hash", function (done) {
       pendingTxTracker.once('tx:failed', (txId) => {
-        assert(txId, txMetaNoHash.id, 'should pass txId')
+        assert.equal(txId, txMetaNoHash.id, 'should pass txId')
         done()
       })
       pendingTxTracker._checkPendingTx(txMetaNoHash)
@@ -116,29 +114,27 @@ describe('PendingTransactionTracker', function () {
       providerResultStub['eth_getTransactionCount'] = '0x02'
       providerResultStub['eth_getTransactionReceipt'] = {}
       pendingTxTracker.once('tx:dropped', (id) => {
-        if (id === txMeta.id) {
-          delete providerResultStub['eth_getTransactionCount']
-          delete providerResultStub['eth_getTransactionReceipt']
-          if (counter === 3) {
-            return done()
-          } else {
-            return done(new Error(`Counter does not equal 3 got ${counter} instead`))
-          }
-        } else {
+        if (id !== txMeta.id) {
           done(new Error('wrong tx Id'))
+          return
+        }
+
+        delete providerResultStub['eth_getTransactionCount']
+        delete providerResultStub['eth_getTransactionReceipt']
+        if (counter === 3) {
+          return done()
+        } else {
+          return done(new Error(`Counter does not equal 3 got ${counter} instead`))
         }
       })
 
-      pendingTxTracker._checkPendingTx(txMeta).then(() => {
-        ++counter
-        pendingTxTracker._checkPendingTx(txMeta).then(() => {
-          ++counter
-          pendingTxTracker._checkPendingTx(txMeta).then(() => {
-            ++counter
-            pendingTxTracker._checkPendingTx(txMeta)
-          })
-        })
-      }).catch(done)
+      /* eslint-disable no-sequences */
+      pendingTxTracker._checkPendingTx(txMeta)
+        .then(() => (counter++, pendingTxTracker._checkPendingTx(txMeta)))
+        .then(() => (counter++, pendingTxTracker._checkPendingTx(txMeta)))
+        .then(() => (counter++, pendingTxTracker._checkPendingTx(txMeta)))
+        .catch(done)
+      /* eslint-enable no-sequences */
     })
 
 
@@ -149,7 +145,7 @@ describe('PendingTransactionTracker', function () {
   })
 
   describe('#_checkPendingTxs', function () {
-    it('should warp all txMeta\'s in #updatePendingTxs', function (done) {
+    it("should warp all txMeta's in #updatePendingTxs", function (done) {
       const txMeta2 = txMeta3 = txMeta
       txMeta2.id = 2
       txMeta3.id = 3
@@ -196,7 +192,7 @@ describe('PendingTransactionTracker', function () {
         .catch(done)
       pendingTxTracker.resubmitPendingTxs(blockNumberStub)
     })
-    it('should not emit \'tx:failed\' if the txMeta throws a known txError', function (done) {
+    it("should not emit 'tx:failed' if the txMeta throws a known txError", function (done) {
       knownErrors = [
         // geth
         '     Replacement transaction Underpriced            ',
@@ -223,7 +219,7 @@ describe('PendingTransactionTracker', function () {
 
       pendingTxTracker.resubmitPendingTxs(blockNumberStub)
     })
-    it('should emit \'tx:warning\' if it encountered a real error', function (done) {
+    it("should emit 'tx:warning' if it encountered a real error", function (done) {
       pendingTxTracker.once('tx:warning', (txMeta, err) => {
         if (err.message === 'im some real error') {
           const matchingTx = txList.find((tx) => tx.id === txMeta.id)
@@ -269,47 +265,29 @@ describe('PendingTransactionTracker', function () {
       pendingTxTracker.publishTransaction.restore()
     })
 
-    it('should publish the transaction', function (done) {
+    it('should publish the transaction', async function () {
       enoughBalance = '0x100000'
 
       // Stubbing out current account state:
       // Adding the fake tx:
-      pendingTxTracker._resubmitTx(txMeta)
-        .then(() => done())
-        .catch((err) => {
-          assert.ifError(err, 'should not throw an error')
-          done(err)
-        })
-
-      assert.equal(pendingTxTracker.publishTransaction.callCount, 1, 'Should call publish transaction')
+      await pendingTxTracker._resubmitTx(txMeta)
+      assert.equal(pendingTxTracker.publishTransaction.callCount, 1, 'should call publish transaction')
     })
 
-    it('should not publish the transaction if the limit of retries has been exceeded', function (done) {
+    it('should not publish the transaction if the limit of retries has been exceeded', async function () {
       enoughBalance = '0x100000'
       const mockLatestBlockNumber = '0x5'
 
-      pendingTxTracker._resubmitTx(txMetaToTestExponentialBackoff, mockLatestBlockNumber)
-        .then(() => done())
-        .catch((err) => {
-          assert.ifError(err, 'should not throw an error')
-          done(err)
-        })
-
-      assert.equal(pendingTxTracker.publishTransaction.callCount, 0, 'Should NOT call publish transaction')
+      await pendingTxTracker._resubmitTx(txMetaToTestExponentialBackoff, mockLatestBlockNumber)
+      assert.equal(pendingTxTracker.publishTransaction.callCount, 0, 'should NOT call publish transaction')
     })
 
-    it('should publish the transaction if the number of blocks since last retry exceeds the last set limit', function (done) {
+    it('should publish the transaction if the number of blocks since last retry exceeds the last set limit', async function () {
       enoughBalance = '0x100000'
       const mockLatestBlockNumber = '0x11'
 
-      pendingTxTracker._resubmitTx(txMetaToTestExponentialBackoff, mockLatestBlockNumber)
-        .then(() => done())
-        .catch((err) => {
-          assert.ifError(err, 'should not throw an error')
-          done(err)
-        })
-
-      assert.equal(pendingTxTracker.publishTransaction.callCount, 1, 'Should call publish transaction')
+      await pendingTxTracker._resubmitTx(txMetaToTestExponentialBackoff, mockLatestBlockNumber)
+      assert.equal(pendingTxTracker.publishTransaction.callCount, 1, 'should call publish transaction')
     })
 
     it('should call opts.approveTransaction with the id if the tx is not signed', async function () {
@@ -318,8 +296,7 @@ describe('PendingTransactionTracker', function () {
       }
       const approveMock = sinon.stub(pendingTxTracker, 'approveTransaction')
 
-      pendingTxTracker._resubmitTx(stubTx)
-
+      await pendingTxTracker._resubmitTx(stubTx)
       assert.ok(approveMock.called)
       approveMock.restore()
     })
@@ -337,22 +314,18 @@ describe('PendingTransactionTracker', function () {
       },
       rawTx: '0xf86c808504a817c800827b0d940c62bb85faa3311a998d3aba8098c1235c564966880de0b6b3a7640000802aa08ff665feb887a25d4099e40e11f0fef93ee9608f404bd3f853dd9e84ed3317a6a02ec9d3d1d6e176d4d2593dd760e74ccac753e6a0ea0d00cc9789d0d7ff1f471d',
     }
-    it('should return false when the nonce is the suggested network nonce', function (done) {
+    it('should return false when the nonce is the suggested network nonce', async function () {
       providerResultStub['eth_getTransactionCount'] = '0x01'
       providerResultStub['eth_getTransactionReceipt'] = {}
-      pendingTxTracker._checkIftxWasDropped(txMeta, {}).then((dropped) => {
-        assert(!dropped, 'should be false')
-        done()
-      }).catch(done)
+      const dropped = await pendingTxTracker._checkIftxWasDropped(txMeta, {})
+      assert.ok(!dropped, 'should be false')
     })
 
-    it('should return true when the network nonce is higher then the txMeta nonce', function (done) {
+    it('should return true when the network nonce is higher then the txMeta nonce', async function () {
       providerResultStub['eth_getTransactionCount'] = '0x02'
       providerResultStub['eth_getTransactionReceipt'] = {}
-      pendingTxTracker._checkIftxWasDropped(txMeta, {}).then((dropped) => {
-        assert(dropped, 'should be true')
-        done()
-      }).catch(done)
+      const dropped = await pendingTxTracker._checkIftxWasDropped(txMeta, {})
+      assert.ok(dropped, 'should be true')
     })
   })
 
@@ -387,33 +360,26 @@ describe('PendingTransactionTracker', function () {
       }
     })
 
-    it('should return false if nonce has not been taken', function (done) {
-      pendingTxTracker._checkIfNonceIsTaken({
+    it('should return false if nonce has not been taken', async function () {
+      const taken = await pendingTxTracker._checkIfNonceIsTaken({
         txParams: {
           from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
           nonce: '0x3',
           value: '0xfffff',
         },
       })
-        .then((taken) => {
-          assert.ok(!taken)
-          done()
-        })
-        .catch(done)
+      assert.ok(!taken)
     })
 
-    it('should return true if nonce has been taken', function (done) {
-      pendingTxTracker._checkIfNonceIsTaken({
+    it('should return true if nonce has been taken', async function () {
+      const taken = await pendingTxTracker._checkIfNonceIsTaken({
         txParams: {
           from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
           nonce: '0x2',
           value: '0xfffff',
         },
-      }).then((taken) => {
-        assert.ok(taken)
-        done()
       })
-        .catch(done)
+      assert.ok(taken)
     })
   })
 })

--- a/test/unit/app/controllers/transactions/recipient-blacklist-checker-test.js
+++ b/test/unit/app/controllers/transactions/recipient-blacklist-checker-test.js
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
 import recipientBlackListChecker from '../../../../../app/scripts/controllers/transactions/lib/recipient-blacklist-checker'
 import { ROPSTEN_CODE, RINKEBY_CODE, KOVAN_CODE, GOERLI_CODE } from '../../../../../app/scripts/controllers/network/enums'
 import KeyringController from 'eth-keyring-controller'
@@ -22,7 +22,7 @@ describe('Recipient Blacklist Checker', function () {
     it('does not fail on test networks', function () {
       let callCount = 0
       const networks = [ROPSTEN_CODE, RINKEBY_CODE, KOVAN_CODE, GOERLI_CODE]
-      for (const networkId in networks) {
+      for (const networkId of networks) {
         publicAccounts.forEach((account) => {
           recipientBlackListChecker.checkAccount(networkId, account)
           callCount++

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
 import EventEmitter from 'events'
 import ethUtil from 'ethereumjs-util'
 import EthTx from 'ethereumjs-tx'
@@ -53,12 +53,12 @@ describe('Transaction Controller', function () {
   })
 
   describe('#getState', function () {
-    it('should return a state object with the right keys and datat types', function () {
+    it('should return a state object with the right keys and data types', function () {
       const exposedState = txController.getState()
-      assert('unapprovedTxs' in exposedState, 'state should have the key unapprovedTxs')
-      assert('currentNetworkTxList' in exposedState, 'state should have the key currentNetworkTxList')
-      assert(exposedState && typeof exposedState.unapprovedTxs === 'object', 'should be an object')
-      assert(Array.isArray(exposedState.currentNetworkTxList), 'should be an array')
+      assert.ok('unapprovedTxs' in exposedState, 'state should have the key unapprovedTxs')
+      assert.ok('currentNetworkTxList' in exposedState, 'state should have the key currentNetworkTxList')
+      assert.ok(exposedState && typeof exposedState.unapprovedTxs === 'object', 'should be an object')
+      assert.ok(Array.isArray(exposedState.currentNetworkTxList), 'should be an array')
     })
   })
 
@@ -135,37 +135,29 @@ describe('Transaction Controller', function () {
       stub.restore()
     })
 
-    it('should resolve when finished and status is submitted and resolve with the hash', function (done) {
+    it('should resolve when finished and status is submitted and resolve with the hash', async function () {
       txController.once('newUnapprovedTx', (txMetaFromEmit) => {
         setTimeout(() => {
           txController.setTxHash(txMetaFromEmit.id, '0x0')
           txController.txStateManager.setTxStatusSubmitted(txMetaFromEmit.id)
-        }, 10)
+        })
       })
 
-      txController.newUnapprovedTransaction(txParams)
-        .then((hash) => {
-          assert(hash, 'newUnapprovedTransaction needs to return the hash')
-          done()
-        })
-        .catch(done)
+      const hash = await txController.newUnapprovedTransaction(txParams)
+      assert.ok(hash, 'newUnapprovedTransaction needs to return the hash')
     })
 
-    it('should reject when finished and status is rejected', function (done) {
+    it('should reject when finished and status is rejected', async function () {
       txController.once('newUnapprovedTx', (txMetaFromEmit) => {
         setTimeout(() => {
           txController.txStateManager.setTxStatusRejected(txMetaFromEmit.id)
-        }, 10)
+        })
       })
 
-      txController.newUnapprovedTransaction(txParams)
-        .catch((err) => {
-          if (err.message === 'MetaMask Tx Signature: User denied transaction signature.') {
-            done()
-          } else {
-            done(err)
-          }
-        })
+      await assert.rejects(
+        () => txController.newUnapprovedTransaction(txParams),
+        { message: 'MetaMask Tx Signature: User denied transaction signature.' },
+      )
     })
   })
 
@@ -183,74 +175,55 @@ describe('Transaction Controller', function () {
       getPermittedAccounts.restore()
     })
 
-    it('should add an unapproved transaction and return a valid txMeta', function (done) {
-      txController.addUnapprovedTransaction({ from: selectedAddress })
-        .then((txMeta) => {
-          assert(('id' in txMeta), 'should have a id')
-          assert(('time' in txMeta), 'should have a time stamp')
-          assert(('metamaskNetworkId' in txMeta), 'should have a metamaskNetworkId')
-          assert(('txParams' in txMeta), 'should have a txParams')
-          assert(('history' in txMeta), 'should have a history')
+    it('should add an unapproved transaction and return a valid txMeta', async function () {
+      const txMeta = await txController.addUnapprovedTransaction({ from: selectedAddress })
+      assert.ok(('id' in txMeta), 'should have a id')
+      assert.ok(('time' in txMeta), 'should have a time stamp')
+      assert.ok(('metamaskNetworkId' in txMeta), 'should have a metamaskNetworkId')
+      assert.ok(('txParams' in txMeta), 'should have a txParams')
+      assert.ok(('history' in txMeta), 'should have a history')
 
-          const memTxMeta = txController.txStateManager.getTx(txMeta.id)
-          assert.deepEqual(txMeta, memTxMeta, `txMeta should be stored in txController after adding it\n  expected: ${txMeta} \n  got: ${memTxMeta}`)
-          done()
-        }).catch(done)
+      const memTxMeta = txController.txStateManager.getTx(txMeta.id)
+      assert.deepEqual(txMeta, memTxMeta)
     })
 
     it('should emit newUnapprovedTx event and pass txMeta as the first argument', function (done) {
       providerResultStub.eth_gasPrice = '4a817c800'
       txController.once('newUnapprovedTx', (txMetaFromEmit) => {
-        assert(txMetaFromEmit, 'txMeta is falsey')
+        assert.ok(txMetaFromEmit, 'txMeta is falsy')
         done()
       })
       txController.addUnapprovedTransaction({ from: selectedAddress })
         .catch(done)
     })
 
-    it('should fail if recipient is public', function (done) {
+    it('should fail if recipient is public', async function () {
       txController.networkStore = new ObservableStore(1)
-      txController.addUnapprovedTransaction({ from: selectedAddress, to: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' })
-        .catch((err) => {
-          if (err.message === 'Recipient is a public account') {
-            done()
-          } else {
-            done(err)
-          }
-        })
+      await assert.rejects(
+        () => txController.addUnapprovedTransaction({ from: selectedAddress, to: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' }),
+        { message: 'Recipient is a public account' },
+      )
     })
 
-    it('should fail if the from address isn\'t the selected address', function (done) {
-      txController.addUnapprovedTransaction({ from: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' })
-        .then(() => {
-          assert.fail('transaction should not have been added')
-          done()
-        })
-        .catch(() => {
-          assert.ok('pass')
-          done()
-        })
+    it("should fail if the from address isn't the selected address", async function () {
+      await assert.rejects(() => txController.addUnapprovedTransaction({ from: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' }))
     })
 
     it('should not fail if recipient is public but not on mainnet', function (done) {
       txController.once('newUnapprovedTx', (txMetaFromEmit) => {
-        assert(txMetaFromEmit, 'txMeta is falsey')
+        assert.ok(txMetaFromEmit, 'txMeta is falsy')
         done()
       })
       txController.addUnapprovedTransaction({ from: selectedAddress, to: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' })
         .catch(done)
     })
 
-    it('should fail if netId is loading', function (done) {
+    it('should fail if netId is loading', async function () {
       txController.networkStore = new ObservableStore('loading')
-      txController.addUnapprovedTransaction({ from: selectedAddress, to: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' })
-        .catch((err) => {
-          if (err.message === 'MetaMask is having trouble connecting to the network') {
-            done()
-          } else {
-            done(err)
-          }
-        })
+      await assert.rejects(
+        () => txController.addUnapprovedTransaction({ from: selectedAddress, to: '0x0d1d4e623D10F9FBA5Db95830F7d3839406C6AF2' }),
+        { message: 'MetaMask is having trouble connecting to the network' },
+      )
     })
   })
 
@@ -268,9 +241,9 @@ describe('Transaction Controller', function () {
       providerResultStub.eth_estimateGas = '5209'
 
       const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta)
-      assert(txMetaWithDefaults.txParams.value, '0x0', 'should have added 0x0 as the value')
-      assert(txMetaWithDefaults.txParams.gasPrice, 'should have added the gas price')
-      assert(txMetaWithDefaults.txParams.gas, 'should have added the gas field')
+      assert.equal(txMetaWithDefaults.txParams.value, '0x0', 'should have added 0x0 as the value')
+      assert.ok(txMetaWithDefaults.txParams.gasPrice, 'should have added the gas price')
+      assert.ok(txMetaWithDefaults.txParams.gas, 'should have added the gas field')
     })
   })
 
@@ -303,7 +276,7 @@ describe('Transaction Controller', function () {
   })
 
   describe('#approveTransaction', function () {
-    it('does not overwrite set values', function (done) {
+    it('does not overwrite set values', async function () {
       const originalValue = '0x01'
       const txMeta = {
         id: '1',
@@ -329,29 +302,25 @@ describe('Transaction Controller', function () {
         txController.txStateManager.setTxStatusSubmitted('1')
       })
 
-      txController.approveTransaction(txMeta.id).then(() => {
-        const result = txController.txStateManager.getTx(txMeta.id)
-        const params = result.txParams
+      await txController.approveTransaction(txMeta.id)
+      const result = txController.txStateManager.getTx(txMeta.id)
+      const params = result.txParams
 
-        assert.equal(params.gas, originalValue, 'gas unmodified')
-        assert.equal(params.gasPrice, originalValue, 'gas price unmodified')
-        assert.equal(result.hash, originalValue, `hash was set \n got: ${result.hash} \n expected: ${originalValue}`)
-        assert.equal(result.status, 'submitted', 'Should have reached the submitted status.')
-        signStub.restore()
-        pubStub.restore()
-        done()
-      }).catch(done)
+      assert.equal(params.gas, originalValue, 'gas unmodified')
+      assert.equal(params.gasPrice, originalValue, 'gas price unmodified')
+      assert.equal(result.hash, originalValue)
+      assert.equal(result.status, 'submitted', 'should have reached the submitted status.')
+      signStub.restore()
+      pubStub.restore()
     })
   })
 
   describe('#sign replay-protected tx', function () {
-    it('prepares a tx with the chainId set', function (done) {
+    it('prepares a tx with the chainId set', async function () {
       txController.addTx({ id: '1', status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }, noop)
-      txController.signTransaction('1').then((rawTx) => {
-        const ethTx = new EthTx(ethUtil.toBuffer(rawTx))
-        assert.equal(ethTx.getChainId(), currentNetworkId)
-        done()
-      }).catch(done)
+      const rawTx = await txController.signTransaction('1')
+      const ethTx = new EthTx(ethUtil.toBuffer(rawTx))
+      assert.equal(ethTx.getChainId(), currentNetworkId)
     })
   })
 
@@ -408,7 +377,6 @@ describe('Transaction Controller', function () {
 
       txController.cancelTransaction(0)
     })
-
   })
 
   describe('#createSpeedUpTransaction', function () {
@@ -511,7 +479,7 @@ describe('Transaction Controller', function () {
   })
 
   describe('#retryTransaction', function () {
-    it('should create a new txMeta with the same txParams as the original one but with a higher gasPrice', function (done) {
+    it('should create a new txMeta with the same txParams as the original one but with a higher gasPrice', async function () {
       const txParams = {
         gasPrice: '0xee6b2800',
         nonce: '0x00',
@@ -522,17 +490,14 @@ describe('Transaction Controller', function () {
       txController.txStateManager._saveTxList([
         { id: 1, status: 'submitted', metamaskNetworkId: currentNetworkId, txParams, history: [{}] },
       ])
-      txController.retryTransaction(1)
-        .then((txMeta) => {
-          assert.equal(txMeta.txParams.gasPrice, '0x10642ac00', 'gasPrice should have a %10 gasPrice bump')
-          assert.equal(txMeta.txParams.nonce, txParams.nonce, 'nonce should be the same')
-          assert.equal(txMeta.txParams.from, txParams.from, 'from should be the same')
-          assert.equal(txMeta.txParams.to, txParams.to, 'to should be the same')
-          assert.equal(txMeta.txParams.data, txParams.data, 'data should be the same')
-          assert.ok(('lastGasPrice' in txMeta), 'should have the key `lastGasPrice`')
-          assert.equal(txController.txStateManager.getTxList().length, 2)
-          done()
-        }).catch(done)
+      const txMeta = await txController.retryTransaction(1)
+      assert.equal(txMeta.txParams.gasPrice, '0x10642ac00', 'gasPrice should have a %10 gasPrice bump')
+      assert.equal(txMeta.txParams.nonce, txParams.nonce, 'nonce should be the same')
+      assert.equal(txMeta.txParams.from, txParams.from, 'from should be the same')
+      assert.equal(txMeta.txParams.to, txParams.to, 'to should be the same')
+      assert.equal(txMeta.txParams.data, txParams.data, 'data should be the same')
+      assert.ok(('lastGasPrice' in txMeta), 'should have the key `lastGasPrice`')
+      assert.equal(txController.txStateManager.getTxList().length, 2)
     })
   })
 
@@ -552,17 +517,16 @@ describe('Transaction Controller', function () {
       const droppedTxs = txController.txStateManager.getFilteredTxList({ nonce: '0x01', status: 'dropped' })
       assert.equal(confirmedTx.status, 'confirmed', 'the confirmedTx should remain confirmed')
       assert.equal(droppedTxs.length, 6, 'their should be 6 dropped txs')
-
     })
   })
 
   describe('#_determineTransactionCategory', function () {
-    it('should return a simple send transactionCategory when to is truthy but data is falsey', async function () {
+    it('should return a simple send transactionCategory when to is truthy but data is falsy', async function () {
       const result = await txController._determineTransactionCategory({
         to: '0xabc',
         data: '',
       })
-      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, getCodeResponse: undefined })
+      assert.deepEqual(result, { transactionCategory: SEND_ETHER_ACTION_KEY, getCodeResponse: null })
     })
 
     it('should return a token transfer transactionCategory when data is for the respective method call', async function () {
@@ -581,7 +545,7 @@ describe('Transaction Controller', function () {
       assert.deepEqual(result, { transactionCategory: TOKEN_METHOD_APPROVE, getCodeResponse: undefined })
     })
 
-    it('should return a contract deployment transactionCategory when to is falsey and there is data', async function () {
+    it('should return a contract deployment transactionCategory when to is falsy and there is data', async function () {
       const result = await txController._determineTransactionCategory({
         to: '',
         data: '0xabd',
@@ -637,7 +601,7 @@ describe('Transaction Controller', function () {
       assert.deepEqual(result, { transactionCategory: CONTRACT_INTERACTION_KEY, getCodeResponse: '0x0a' })
     })
 
-    it('should return a contract interaction transactionCategory with the correct getCodeResponse when to is a contract address and data is falsey', async function () {
+    it('should return a contract interaction transactionCategory with the correct getCodeResponse when to is a contract address and data is falsy', async function () {
       const _providerResultStub = {
         // 1 gwei
         eth_gasPrice: '0x0de0b6b3a7640000',
@@ -671,7 +635,7 @@ describe('Transaction Controller', function () {
   })
 
   describe('#getPendingTransactions', function () {
-    it('should show only submitted and approved transactions as pending transasction', function () {
+    it('should show only submitted and approved transactions as pending transaction', function () {
       txController.txStateManager._saveTxList([
         { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} },
         { id: 2, status: 'rejected', metamaskNetworkId: currentNetworkId, txParams: {}, history: [{}] },
@@ -682,10 +646,10 @@ describe('Transaction Controller', function () {
         { id: 7, status: 'failed', metamaskNetworkId: currentNetworkId, txParams: {}, history: [{}] },
       ])
 
-      assert(txController.pendingTxTracker.getPendingTransactions().length, 2)
+      assert.equal(txController.pendingTxTracker.getPendingTransactions().length, 2)
       const states = txController.pendingTxTracker.getPendingTransactions().map((tx) => tx.status)
-      assert(states.includes('approved'), 'includes approved')
-      assert(states.includes('submitted'), 'includes submitted')
+      assert.ok(states.includes('approved'), 'includes approved')
+      assert.ok(states.includes('submitted'), 'includes submitted')
     })
   })
 })

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -57,7 +57,7 @@ describe('Transaction Controller', function () {
       const exposedState = txController.getState()
       assert.ok('unapprovedTxs' in exposedState, 'state should have the key unapprovedTxs')
       assert.ok('currentNetworkTxList' in exposedState, 'state should have the key currentNetworkTxList')
-      assert.ok(exposedState && typeof exposedState.unapprovedTxs === 'object', 'should be an object')
+      assert.ok(typeof exposedState?.unapprovedTxs === 'object', 'should be an object')
       assert.ok(Array.isArray(exposedState.currentNetworkTxList), 'should be an array')
     })
   })
@@ -177,11 +177,11 @@ describe('Transaction Controller', function () {
 
     it('should add an unapproved transaction and return a valid txMeta', async function () {
       const txMeta = await txController.addUnapprovedTransaction({ from: selectedAddress })
-      assert.ok(('id' in txMeta), 'should have a id')
-      assert.ok(('time' in txMeta), 'should have a time stamp')
-      assert.ok(('metamaskNetworkId' in txMeta), 'should have a metamaskNetworkId')
-      assert.ok(('txParams' in txMeta), 'should have a txParams')
-      assert.ok(('history' in txMeta), 'should have a history')
+      assert.ok('id' in txMeta, 'should have a id')
+      assert.ok('time' in txMeta, 'should have a time stamp')
+      assert.ok('metamaskNetworkId' in txMeta, 'should have a metamaskNetworkId')
+      assert.ok('txParams' in txMeta, 'should have a txParams')
+      assert.ok('history' in txMeta, 'should have a history')
 
       const memTxMeta = txController.txStateManager.getTx(txMeta.id)
       assert.deepEqual(txMeta, memTxMeta)

--- a/test/unit/app/controllers/transactions/tx-gas-util-test.js
+++ b/test/unit/app/controllers/transactions/tx-gas-util-test.js
@@ -1,8 +1,7 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
 import Transaction from 'ethereumjs-tx'
 import { hexToBn, bnToHex } from '../../../../../app/scripts/lib/util'
 import TxUtils from '../../../../../app/scripts/controllers/transactions/tx-gas-utils'
-
 
 describe('txUtils', function () {
   let txUtils
@@ -42,7 +41,7 @@ describe('txUtils', function () {
       const inputBn = hexToBn(inputHex)
       const outputBn = hexToBn(output)
       const expectedBn = inputBn.muln(1.5)
-      assert(outputBn.eq(expectedBn), 'returns 1.5 the input value')
+      assert.ok(outputBn.eq(expectedBn), 'returns 1.5 the input value')
     })
 
     it('uses original estimatedGas, when above block gas limit', function () {
@@ -54,7 +53,7 @@ describe('txUtils', function () {
       // const inputBn = hexToBn(inputHex)
       const outputBn = hexToBn(output)
       const expectedBn = hexToBn(inputHex)
-      assert(outputBn.eq(expectedBn), 'returns the original estimatedGas value')
+      assert.ok(outputBn.eq(expectedBn), 'returns the original estimatedGas value')
     })
 
     it('buffers up to recommend gas limit recommended ceiling', function () {

--- a/test/unit/app/controllers/transactions/tx-helper-test.js
+++ b/test/unit/app/controllers/transactions/tx-helper-test.js
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
 import txHelper from '../../../../../ui/lib/tx-helper'
 
 describe('txHelper', function () {

--- a/test/unit/app/controllers/transactions/tx-state-history-helper-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-history-helper-test.js
@@ -1,9 +1,8 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
 import txStateHistoryHelper from '../../../../../app/scripts/controllers/transactions/lib/tx-state-history-helper'
 import testVault from '../../../../data/v17-long-history.json'
 
 describe('Transaction state history helper', function () {
-
   describe('#snapshotFromTxMeta', function () {
     it('should clone deep', function () {
       const input = {
@@ -14,16 +13,16 @@ describe('Transaction state history helper', function () {
         },
       }
       const output = txStateHistoryHelper.snapshotFromTxMeta(input)
-      assert('foo' in output, 'has a foo key')
-      assert('bar' in output.foo, 'has a bar key')
-      assert('bam' in output.foo.bar, 'has a bar key')
+      assert.ok('foo' in output, 'has a foo key')
+      assert.ok('bar' in output.foo, 'has a bar key')
+      assert.ok('bam' in output.foo.bar, 'has a bar key')
       assert.equal(output.foo.bar.bam, 'baz', 'has a baz value')
     })
 
     it('should remove the history key', function () {
       const input = { foo: 'bar', history: 'remembered' }
       const output = txStateHistoryHelper.snapshotFromTxMeta(input)
-      assert(typeof output.history, 'undefined', 'should remove history')
+      assert.equal(typeof output.history, 'undefined', 'should remove history')
     })
   })
 
@@ -47,7 +46,7 @@ describe('Transaction state history helper', function () {
   })
 
   describe('#replayHistory', function () {
-    it('replaying history does not mutate the original obj', function () {
+    it('replaying history does not mutate the original object', function () {
       const initialState = { test: true, message: 'hello', value: 1 }
       const diff1 = [{
         'op': 'replace',
@@ -64,7 +63,6 @@ describe('Transaction state history helper', function () {
       const beforeStateSnapshot = JSON.stringify(initialState)
       const latestState = txStateHistoryHelper.replayHistory(history)
       const afterStateSnapshot = JSON.stringify(initialState)
-
       assert.notEqual(initialState, latestState, 'initial state is not the same obj as the latest state')
       assert.equal(beforeStateSnapshot, afterStateSnapshot, 'initial state is not modified during run')
     })
@@ -73,7 +71,6 @@ describe('Transaction state history helper', function () {
   describe('#generateHistoryEntry', function () {
 
     function generateHistoryEntryTest (note) {
-
       const prevState = {
         someValue: 'value 1',
         foo: {
@@ -97,7 +94,6 @@ describe('Transaction state history helper', function () {
       const before = new Date().getTime()
       const result = txStateHistoryHelper.generateHistoryEntry(prevState, nextState, note)
       const after = new Date().getTime()
-
       assert.ok(Array.isArray(result))
       assert.equal(result.length, 3)
 
@@ -105,11 +101,7 @@ describe('Transaction state history helper', function () {
       assert.equal(result[0].op, expectedEntry1.op)
       assert.equal(result[0].path, expectedEntry1.path)
       assert.equal(result[0].value, expectedEntry1.value)
-      assert.equal(result[0].value, expectedEntry1.value)
-      if (note) {
-        assert.equal(result[0].note, note)
-      }
-
+      assert.equal(result[0].note, note)
       assert.ok(result[0].timestamp >= before && result[0].timestamp <= after)
 
       const expectedEntry2 = { op: 'replace', path: '/someValue', value: 'value 2' }

--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -1,4 +1,4 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
 import TxStateManager from '../../../../../app/scripts/controllers/transactions/tx-state-manager'
 import txStateHistoryHelper from '../../../../../app/scripts/controllers/transactions/lib/tx-state-history-helper'
 
@@ -33,7 +33,6 @@ describe('TransactionStateManager', function () {
     it('should emit a signed event to signal the exciton of callback', function (done) {
       const tx = { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }
       const noop = function () {
-        assert(true, 'event listener has been triggered and noop executed')
         done()
       }
       txStateManager.addTx(tx)
@@ -57,7 +56,6 @@ describe('TransactionStateManager', function () {
       const tx = { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {} }
       txStateManager.addTx(tx)
       const noop = () => {
-        assert(true, 'event listener has been triggered and noop executed')
         done()
       }
       txStateManager.on('1:rejected', noop)
@@ -352,7 +350,7 @@ describe('TransactionStateManager', function () {
     it('should remove the transaction from the storage', function () {
       txStateManager._saveTxList([ { id: 1 } ])
       txStateManager._removeTx(1)
-      assert(!txStateManager.getFullTxList().length, 'txList should be empty')
+      assert.ok(!txStateManager.getFullTxList().length, 'txList should be empty')
     })
 
     it('should only remove the transaction with ID 1 from the storage', function () {

--- a/test/unit/app/controllers/transactions/tx-utils-test.js
+++ b/test/unit/app/controllers/transactions/tx-utils-test.js
@@ -1,6 +1,5 @@
-import assert from 'assert'
+import { strict as assert } from 'assert'
 import * as txUtils from '../../../../../app/scripts/controllers/transactions/lib/util'
-
 
 describe('txUtils', function () {
   describe('#validateTxParams', function () {
@@ -37,27 +36,26 @@ describe('txUtils', function () {
 
       let normalizedTxParams = txUtils.normalizeTxParams(txParams)
 
-      assert(!normalizedTxParams.chainId, 'their should be no chainId')
-      assert(!normalizedTxParams.to, 'their should be no to address if null')
-      assert.equal(normalizedTxParams.from.slice(0, 2), '0x', 'from should be hexPrefixd')
-      assert.equal(normalizedTxParams.data.slice(0, 2), '0x', 'data should be hexPrefixd')
-      assert(!('random' in normalizedTxParams), 'their should be no random key in normalizedTxParams')
+      assert.ok(!normalizedTxParams.chainId, 'their should be no chainId')
+      assert.ok(!normalizedTxParams.to, 'their should be no to address if null')
+      assert.equal(normalizedTxParams.from.slice(0, 2), '0x', 'from should be hex-prefixed')
+      assert.equal(normalizedTxParams.data.slice(0, 2), '0x', 'data should be hex-prefixed')
+      assert.ok(!('random' in normalizedTxParams), 'their should be no random key in normalizedTxParams')
 
       txParams.to = 'a7df1beDBF813f57096dF77FCd515f0B3900e402'
       normalizedTxParams = txUtils.normalizeTxParams(txParams)
-      assert.equal(normalizedTxParams.to.slice(0, 2), '0x', 'to should be hexPrefixd')
-
+      assert.equal(normalizedTxParams.to.slice(0, 2), '0x', 'to should be hex-prefixed')
     })
   })
 
   describe('#validateRecipient', function () {
     it('removes recipient for txParams with 0x when contract data is provided', function () {
-      const zeroRecipientandDataTxParams = {
+      const zeroRecipientDataTxParams = {
         from: '0x1678a085c290ebd122dc42cba69373b5953b831d',
         to: '0x',
         data: 'bytecode',
       }
-      const sanitizedTxParams = txUtils.validateRecipient(zeroRecipientandDataTxParams)
+      const sanitizedTxParams = txUtils.validateRecipient(zeroRecipientDataTxParams)
       assert.deepEqual(sanitizedTxParams, { from: '0x1678a085c290ebd122dc42cba69373b5953b831d', data: 'bytecode' }, 'no recipient with 0x')
     })
 

--- a/test/unit/app/controllers/transactions/tx-utils-test.js
+++ b/test/unit/app/controllers/transactions/tx-utils-test.js
@@ -40,7 +40,7 @@ describe('txUtils', function () {
       assert.ok(!normalizedTxParams.to, 'there should be no to address if null')
       assert.equal(normalizedTxParams.from.slice(0, 2), '0x', 'from should be hex-prefixed')
       assert.equal(normalizedTxParams.data.slice(0, 2), '0x', 'data should be hex-prefixed')
-      assert.ok(!('random' in normalizedTxParams), 'their should be no random key in normalizedTxParams')
+      assert.ok(!('random' in normalizedTxParams), 'there should be no random key in normalizedTxParams')
 
       txParams.to = 'a7df1beDBF813f57096dF77FCd515f0B3900e402'
       normalizedTxParams = txUtils.normalizeTxParams(txParams)

--- a/test/unit/app/controllers/transactions/tx-utils-test.js
+++ b/test/unit/app/controllers/transactions/tx-utils-test.js
@@ -36,8 +36,8 @@ describe('txUtils', function () {
 
       let normalizedTxParams = txUtils.normalizeTxParams(txParams)
 
-      assert.ok(!normalizedTxParams.chainId, 'their should be no chainId')
-      assert.ok(!normalizedTxParams.to, 'their should be no to address if null')
+      assert.ok(!normalizedTxParams.chainId, 'there should be no chainId')
+      assert.ok(!normalizedTxParams.to, 'there should be no to address if null')
       assert.equal(normalizedTxParams.from.slice(0, 2), '0x', 'from should be hex-prefixed')
       assert.equal(normalizedTxParams.data.slice(0, 2), '0x', 'data should be hex-prefixed')
       assert.ok(!('random' in normalizedTxParams), 'their should be no random key in normalizedTxParams')


### PR DESCRIPTION
This PR tidies up the transaction-related unit tests.

I've tried to adhere to the following

- `async`/`await` where it was easy to switch
- Use assert's strict mode
- Fix up a few typos/spelling mistaeks
- Update incorrect usages of `assert(value[, message])`
    - Some were supposed to be `assert.equal(actual, expected[, message])`
    - Rewrote the rest to be `assert.ok(value[, message])`