### PR TITLE
Snapshot txMeta without cloning history

### DIFF
--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -62,13 +62,12 @@ function replayHistory (_shortHistory) {
 }
 
 /**
-  @param {Object} txMeta
-  @returns {Object} - a clone object of the txMeta with out history
-*/
+ * Snapshot {@code txMeta}
+ * @param {Object} txMeta - the tx metadata object
+ * @returns {Object} a deep clone without history
+ */
 function snapshotFromTxMeta (txMeta) {
-  // create txMeta snapshot for history
-  const snapshot = cloneDeep(txMeta)
-  // dont include previous history in this snapshot
-  delete snapshot.history
-  return snapshot
+  const shallow = { ...txMeta }
+  delete shallow.history
+  return cloneDeep(shallow)
 }


### PR DESCRIPTION
Refs https://github.com/MetaMask/metamask-extension/issues/6547#issuecomment-614537947

This PR updates how we snapshot `txMeta` objects, cloning them _without_ the history instead of cloning the history and then throwing it away. This should improve the performance of `TransactionStateManager#updateTx` when the transaction has a particularly large history.

There is a test to confirm that the history property is excluded—this is an implementation detail.