### PR TITLE
Export blacklist direct from recipient-blacklist

### DIFF
--- a/app/scripts/controllers/transactions/lib/recipient-blacklist-checker.js
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist-checker.js
@@ -1,4 +1,4 @@
-import Config from './recipient-blacklist.js'
+import blacklist from './recipient-blacklist'
 
 /** @module*/
 export default {
@@ -18,7 +18,7 @@ function checkAccount (networkId, account) {
   }
 
   const accountToCheck = account.toLowerCase()
-  if (Config.blacklist.includes(accountToCheck)) {
+  if (blacklist.includes(accountToCheck)) {
     throw new Error('Recipient is a public account')
   }
 }

--- a/app/scripts/controllers/transactions/lib/recipient-blacklist.js
+++ b/app/scripts/controllers/transactions/lib/recipient-blacklist.js
@@ -1,17 +1,17 @@
-export default {
-  'blacklist': [
-    // IDEX phisher
-    '0x9bcb0A9d99d815Bb87ee3191b1399b1Bcc46dc77',
-    // Ganache default seed phrases
-    '0x627306090abab3a6e1400e9345bc60c78a8bef57',
-    '0xf17f52151ebef6c7334fad080c5704d77216b732',
-    '0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef',
-    '0x821aea9a577a9b44299b9c15c88cf3087f3b5544',
-    '0x0d1d4e623d10f9fba5db95830f7d3839406c6af2',
-    '0x2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e',
-    '0x2191ef87e392377ec08e7c08eb105ef5448eced5',
-    '0x0f4f2ac550a1b4e2280d04c21cea7ebd822934b5',
-    '0x6330a553fc93768f612722bb8c2ec78ac90b3bbc',
-    '0x5aeda56215b167893e80b4fe645ba6d5bab767de',
-  ],
-}
+const blacklist = [
+  // IDEX phisher
+  '0x9bcb0A9d99d815Bb87ee3191b1399b1Bcc46dc77',
+  // Ganache default seed phrases
+  '0x627306090abab3a6e1400e9345bc60c78a8bef57',
+  '0xf17f52151ebef6c7334fad080c5704d77216b732',
+  '0xc5fdf4076b8f3a5357c5e395ab970b5b54098fef',
+  '0x821aea9a577a9b44299b9c15c88cf3087f3b5544',
+  '0x0d1d4e623d10f9fba5db95830f7d3839406c6af2',
+  '0x2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e',
+  '0x2191ef87e392377ec08e7c08eb105ef5448eced5',
+  '0x0f4f2ac550a1b4e2280d04c21cea7ebd822934b5',
+  '0x6330a553fc93768f612722bb8c2ec78ac90b3bbc',
+  '0x5aeda56215b167893e80b4fe645ba6d5bab767de',
+]
+
+export default blacklist


### PR DESCRIPTION
This PR updates the recipient-blacklist module exports to export the blacklist array directly instead of as a property on an object.