### PR TITLE
Fix external sourcemaps reference causing error in browser console

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -313,7 +313,7 @@ function setupSourcemaps ({ bundlerOpts, events, devMode }) {
       // https://bugs.chromium.org/p/chromium/issues/detail?id=931675
       pipeline.get('sourcemaps:write').push(sourcemaps.write())
     } else {
-      pipeline.get('sourcemaps:write').push(sourcemaps.write('../sourcemaps'))
+      pipeline.get('sourcemaps:write').push(sourcemaps.write('../sourcemaps', { addComment: false }))
     }
 
   })


### PR DESCRIPTION
Blocked by https://github.com/MetaMask/metamask-extension/pull/8170/
Fixes https://github.com/MetaMask/metamask-extension/issues/8167

current PR target is `build-sys-2` to correctly show diffs for this

need to see if this causes sentry to not be able to parse callstacks. having trouble testing this. may have to merge to test in prod and revert if its a problem