### PR TITLE
ci/scripts/deps-install - exit if any command fails

### DIFF
--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
+
+# Print commands and their arguments as they are executed.
 set -x
+# Exit immediately if a command exits with a non-zero status.
+set -e
 
 yarn --frozen-lockfile --ignore-scripts --har
 


### PR DESCRIPTION
noticed even if `yarn install` failed, this build step would pass