### PR TITLE
Export individual fns from tx-state-history-helpers

### DIFF
--- a/app/scripts/controllers/transactions/lib/tx-state-history-helpers.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helpers.js
@@ -1,20 +1,12 @@
 import jsonDiffer from 'fast-json-patch'
 import { cloneDeep } from 'lodash'
 
-/** @module*/
-export default {
-  generateHistoryEntry,
-  replayHistory,
-  snapshotFromTxMeta,
-  migrateFromSnapshotsToDiffs,
-}
-
 /**
   converts non-initial history entries into diffs
   @param {array} longHistory
   @returns {array}
 */
-function migrateFromSnapshotsToDiffs (longHistory) {
+export function migrateFromSnapshotsToDiffs (longHistory) {
   return (
     longHistory
     // convert non-initial history entries into diffs
@@ -39,7 +31,7 @@ function migrateFromSnapshotsToDiffs (longHistory) {
   @param {string} [note] - a optional note for the state change
   @returns {array}
 */
-function generateHistoryEntry (previousState, newState, note) {
+export function generateHistoryEntry (previousState, newState, note) {
   const entry = jsonDiffer.compare(previousState, newState)
   // Add a note to the first op, since it breaks if we append it to the entry
   if (entry[0]) {
@@ -56,7 +48,7 @@ function generateHistoryEntry (previousState, newState, note) {
   Recovers previous txMeta state obj
   @returns {Object}
 */
-function replayHistory (_shortHistory) {
+export function replayHistory (_shortHistory) {
   const shortHistory = cloneDeep(_shortHistory)
   return shortHistory.reduce((val, entry) => jsonDiffer.applyPatch(val, entry).newDocument)
 }
@@ -66,7 +58,7 @@ function replayHistory (_shortHistory) {
  * @param {Object} txMeta - the tx metadata object
  * @returns {Object} a deep clone without history
  */
-function snapshotFromTxMeta (txMeta) {
+export function snapshotFromTxMeta (txMeta) {
   const shallow = { ...txMeta }
   delete shallow.history
   return cloneDeep(shallow)

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'safe-event-emitter'
 import ObservableStore from 'obs-store'
 import log from 'loglevel'
-import txStateHistoryHelper from './lib/tx-state-history-helper'
+import { generateHistoryEntry, replayHistory, snapshotFromTxMeta } from './lib/tx-state-history-helpers'
 import createId from '../../lib/random-id'
 import { getFinalStates, normalizeTxParams } from './lib/util'
 /**
@@ -146,7 +146,7 @@ class TransactionStateManager extends EventEmitter {
     // initialize history
     txMeta.history = []
     // capture initial snapshot of txMeta for history
-    const snapshot = txStateHistoryHelper.snapshotFromTxMeta(txMeta)
+    const snapshot = snapshotFromTxMeta(txMeta)
     txMeta.history.push(snapshot)
 
     const transactions = this.getFullTxList()
@@ -197,11 +197,11 @@ class TransactionStateManager extends EventEmitter {
     }
 
     // create txMeta snapshot for history
-    const currentState = txStateHistoryHelper.snapshotFromTxMeta(txMeta)
+    const currentState = snapshotFromTxMeta(txMeta)
     // recover previous tx state obj
-    const previousState = txStateHistoryHelper.replayHistory(txMeta.history)
+    const previousState = replayHistory(txMeta.history)
     // generate history entry and add to history
-    const entry = txStateHistoryHelper.generateHistoryEntry(previousState, currentState, note)
+    const entry = generateHistoryEntry(previousState, currentState, note)
     txMeta.history.push(entry)
 
     // commit txMeta to state

--- a/app/scripts/migrations/018.js
+++ b/app/scripts/migrations/018.js
@@ -7,8 +7,10 @@ This migration updates "transaction state history" to diffs style
 */
 
 import { cloneDeep } from 'lodash'
-
-import txStateHistoryHelper from '../controllers/transactions/lib/tx-state-history-helper'
+import {
+  snapshotFromTxMeta,
+  migrateFromSnapshotsToDiffs,
+} from '../controllers/transactions/lib/tx-state-history-helpers'
 
 
 export default {
@@ -36,13 +38,13 @@ function transformState (state) {
     newState.TransactionController.transactions = transactions.map((txMeta) => {
       // no history: initialize
       if (!txMeta.history || txMeta.history.length === 0) {
-        const snapshot = txStateHistoryHelper.snapshotFromTxMeta(txMeta)
+        const snapshot = snapshotFromTxMeta(txMeta)
         txMeta.history = [snapshot]
         return txMeta
       }
       // has history: migrate
       const newHistory = (
-        txStateHistoryHelper.migrateFromSnapshotsToDiffs(txMeta.history)
+        migrateFromSnapshotsToDiffs(txMeta.history)
         // remove empty diffs
           .filter((entry) => {
             return !Array.isArray(entry) || entry.length > 0

--- a/test/lib/createTxMeta.js
+++ b/test/lib/createTxMeta.js
@@ -1,8 +1,6 @@
-import txStateHistoryHelper from '../../app/scripts/controllers/transactions/lib/tx-state-history-helper'
+import { snapshotFromTxMeta } from '../../app/scripts/controllers/transactions/lib/tx-state-history-helpers'
 
-export default createTxMeta
-
-function createTxMeta (partialMeta) {
+export default function createTxMeta (partialMeta) {
   const txMeta = Object.assign({
     status: 'unapproved',
     txParams: {},
@@ -10,7 +8,7 @@ function createTxMeta (partialMeta) {
   // initialize history
   txMeta.history = []
   // capture initial snapshot of txMeta for history
-  const snapshot = txStateHistoryHelper.snapshotFromTxMeta(txMeta)
+  const snapshot = snapshotFromTxMeta(txMeta)
   txMeta.history.push(snapshot)
   return txMeta
 }

--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert'
 import TxStateManager from '../../../../../app/scripts/controllers/transactions/tx-state-manager'
-import txStateHistoryHelper from '../../../../../app/scripts/controllers/transactions/lib/tx-state-history-helper'
+import { snapshotFromTxMeta } from '../../../../../app/scripts/controllers/transactions/lib/tx-state-history-helpers'
 
 const noop = () => true
 
@@ -229,7 +229,7 @@ describe('TransactionStateManager', function () {
       // verify tx was initialized correctly
       assert.equal(updatedTx.history.length, 1, 'one history item (initial)')
       assert.equal(Array.isArray(updatedTx.history[0]), false, 'first history item is initial state')
-      assert.deepEqual(updatedTx.history[0], txStateHistoryHelper.snapshotFromTxMeta(updatedTx), 'first history item is initial state')
+      assert.deepEqual(updatedTx.history[0], snapshotFromTxMeta(updatedTx), 'first history item is initial state')
       // modify value and updateTx
       updatedTx.txParams.gasPrice = desiredGasPrice
       const before = new Date().getTime()


### PR DESCRIPTION
This PR exports the functions from the `tx-state-history-helpers` file individually instead of together. This file doesn't need a default export.