### PR TITLE
Rename _checkIfTxWasDropped

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -164,7 +164,7 @@ class PendingTransactionTracker extends EventEmitter {
     try {
       // check the network if the nonce is ahead the tx
       // and the tx has not been mined into a block
-      dropped = await this._checkIftxWasDropped(txMeta, transactionReceipt)
+      dropped = await this._checkIfTxWasDropped(txMeta, transactionReceipt)
 
       // the dropped buffer is in case we ask a node for the tx
       // that is behind the node we asked for tx count
@@ -213,7 +213,7 @@ class PendingTransactionTracker extends EventEmitter {
     @returns {boolean}
   */
 
-  async _checkIftxWasDropped (txMeta, transactionReceipt) {
+  async _checkIfTxWasDropped (txMeta, transactionReceipt) {
     const { txParams: { nonce, from } } = txMeta
     const nextNonce = await this.query.getTransactionCount(from)
     if (

--- a/test/unit/app/controllers/transactions/pending-tx-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-test.js
@@ -302,7 +302,7 @@ describe('PendingTransactionTracker', function () {
     })
   })
 
-  describe('#_checkIftxWasDropped', function () {
+  describe('#_checkIfTxWasDropped', function () {
     const txMeta = {
       id: 1,
       hash: '0x0593ee121b92e10d63150ad08b4b8f9c7857d1bd160195ee648fb9a0f8d00eeb',
@@ -317,14 +317,14 @@ describe('PendingTransactionTracker', function () {
     it('should return false when the nonce is the suggested network nonce', async function () {
       providerResultStub['eth_getTransactionCount'] = '0x01'
       providerResultStub['eth_getTransactionReceipt'] = {}
-      const dropped = await pendingTxTracker._checkIftxWasDropped(txMeta, {})
+      const dropped = await pendingTxTracker._checkIfTxWasDropped(txMeta, {})
       assert.ok(!dropped, 'should be false')
     })
 
     it('should return true when the network nonce is higher then the txMeta nonce', async function () {
       providerResultStub['eth_getTransactionCount'] = '0x02'
       providerResultStub['eth_getTransactionReceipt'] = {}
-      const dropped = await pendingTxTracker._checkIftxWasDropped(txMeta, {})
+      const dropped = await pendingTxTracker._checkIfTxWasDropped(txMeta, {})
       assert.ok(dropped, 'should be true')
     })
   })


### PR DESCRIPTION
This PR fixes the casing of the `_checkIfTxWasDropped` method name.