### PR TITLE
Skip adding history entry for empty txMeta diffs

### DIFF
--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -202,7 +202,9 @@ class TransactionStateManager extends EventEmitter {
     const previousState = replayHistory(txMeta.history)
     // generate history entry and add to history
     const entry = generateHistoryEntry(previousState, currentState, note)
-    txMeta.history.push(entry)
+    if (entry.length) {
+      txMeta.history.push(entry)
+    }
 
     // commit txMeta to state
     const txId = txMeta.id

--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -256,6 +256,23 @@ describe('TransactionStateManager', function () {
       assert.deepEqual(result.history[1][0].value, expectedEntry.value, 'two history items (initial + diff) value')
       assert.ok(result.history[1][0].timestamp >= before && result.history[1][0].timestamp <= after)
     })
+
+    it('does NOT add empty history items', function () {
+      const txMeta = {
+        id: '1',
+        status: 'unapproved',
+        metamaskNetworkId: currentNetworkId,
+        txParams: {
+          gasPrice: '0x01',
+        },
+      }
+
+      txStateManager.addTx(txMeta)
+      txStateManager.updateTx(txMeta)
+
+      const { history } = txStateManager.getTx('1')
+      assert.equal(history.length, 1, 'two history items (initial + diff)')
+    })
   })
 
   describe('#getUnapprovedTxList', function () {


### PR DESCRIPTION
This PR updates the `TransactionStateManager` update logic to skip adding a history entry when the diff is empty.

As shown in #8377, there are cases when `updateTx` is called without a diff in the metadata. Both on v7.7.8 and here on `develop`, the `txMeta.history` can contain empty arrays. This isn't useful behaviour, as the history is used for debugging and an empty entry doesn't provide any information.