### PR TITLE
Await completion of `markPasswordForgotten`

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1481,11 +1481,11 @@ describe('Actions', function () {
   })
 
   describe('#markPasswordForgotten', function () {
-    it('calls markPasswordForgotten', function () {
+    it('calls markPasswordForgotten', async function () {
       const store = mockStore()
       const markPasswordForgottenSpy = sinon.stub(background, 'markPasswordForgotten').callsArg(0)
 
-      store.dispatch(actions.markPasswordForgotten())
+      await store.dispatch(actions.markPasswordForgotten())
 
       const resultantActions = store.getActions()
       assert.deepEqual(resultantActions[1], { type: 'FORGOT_PASSWORD', value: true })

--- a/ui/app/pages/unlock-page/unlock-page.container.js
+++ b/ui/app/pages/unlock-page/unlock-page.container.js
@@ -34,8 +34,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const { markPasswordForgotten, tryUnlockMetamask, ...restDispatchProps } = dispatchProps
   const { history, onSubmit: ownPropsSubmit, ...restOwnProps } = ownProps
 
-  const onImport = () => {
-    markPasswordForgotten()
+  const onImport = async () => {
+    await markPasswordForgotten()
     history.push(RESTORE_VAULT_ROUTE)
 
     if (getEnvironmentType() === ENVIRONMENT_TYPE_POPUP) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1083,12 +1083,22 @@ export function cancelTxs (txDataList) {
 }
 
 export function markPasswordForgotten () {
-  return (dispatch) => {
-    return background.markPasswordForgotten(() => {
+  return async (dispatch) => {
+    try {
+      await new Promise((resolve, reject) => {
+        return background.markPasswordForgotten((error) => {
+          if (error) {
+            return reject(error)
+          }
+          return resolve()
+        })
+      })
+    } finally {
+      // TODO: handle errors
       dispatch(hideLoadingIndication())
       dispatch(forgotPassword())
       forceUpdateMetamaskState(dispatch)
-    })
+    }
   }
 }
 


### PR DESCRIPTION
`markPasswordForgotten` is an asynchronous function, but it was being called synchronously. The page was redirected without waiting for the operation to complete.

We now wait for the operation to complete before continuing. Failure is still not being handled correctly, but that will be addressed in a separate PR.