### PR TITLE
Fix comment above `callBackgroundThenUpdateNoSpinner` function

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1910,14 +1910,16 @@ export function setMouseUserState (isMouseUser) {
   }
 }
 
-// Call Background Then Update
-//
-// A function generator for a common pattern wherein:
-// We show loading indication.
-// We call a background method.
-// We hide loading indication.
-// If it errored, we show a warning.
-// If it didn't, we update the state.
+
+/**
+ * A function generator for a common pattern wherein:
+ * * We call a background method.
+ * * If it errored, we show a warning.
+ * * If it didn't, we update the state.
+ *
+ * @param {*} method - The background method to call
+ * @param  {...any} args - The args to invoke the background method with
+ */
 export function callBackgroundThenUpdateNoSpinner (method, ...args) {
   return (dispatch) => {
     method.call(background, ...args, (err) => {


### PR DESCRIPTION
The comment above this function was originally written for a different function: `callBackgroundThenUpdate`. It was mistakenly left above `callBackgroundThenUpdateNoSpinner` in #1603 when this function was added.

The original `callBackgroundThenUpdate` function this was written for was removed recently in #7675, as it was no longer used.

The format of the comment has also been updated to match our conventions, and JSDoc params have been added.