### PR TITLE
Update `pify` to v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "obj-multiplex": "^1.0.0",
     "obs-store": "^4.0.3",
     "percentile": "^1.2.0",
-    "pify": "^3.0.0",
+    "pify": "^5.0.0",
     "post-message-stream": "^3.0.0",
     "promise-to-callback": "^1.0.0",
     "prop-types": "^15.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21663,6 +21663,11 @@ pify@^4.0.0, pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
+  integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"


### PR DESCRIPTION
`pify` v5.0.0 will preserve `this` references correctly, so explicit binding is no longer needed.

There are no breaking changes that affect us; the only breaking change in v4 and v5 is to update the minimum Node.js version to v10.