### PR TITLE
Add extra owners for CircleCI and dev directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 *                                    @MetaMask/extension-team
+.circleci/                           @MetaMask/extension-team @kumavis
+development/                         @MetaMask/extension-team @kumavis


### PR DESCRIPTION
This PR adds @kumavis as well for CircleCI and `development/`