### PR TITLE
Simplify use of promisified background connection

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -17,8 +17,10 @@ import { getEnvironmentType } from '../../../app/scripts/lib/util'
 import actionConstants from './actionConstants'
 
 let background = null
+let promisifiedBackground = null
 export function _setBackgroundConnection (backgroundConnection) {
   background = backgroundConnection
+  promisifiedBackground = pify(background)
 }
 
 export function goHome () {
@@ -301,9 +303,9 @@ export function importNewAccount (strategy, args) {
     dispatch(showLoadingIndication('This may take a while, please be patient.'))
     try {
       log.debug(`background.importAccountWithStrategy`)
-      await pify(background.importAccountWithStrategy).call(background, strategy, args)
+      await promisifiedBackground.importAccountWithStrategy(strategy, args)
       log.debug(`background.getState`)
-      newState = await pify(background.getState).call(background)
+      newState = await promisifiedBackground.getState()
     } catch (err) {
       dispatch(hideLoadingIndication())
       dispatch(displayWarning(err.message))
@@ -1874,7 +1876,7 @@ export function setCompletedOnboarding () {
     dispatch(showLoadingIndication())
 
     try {
-      await pify(background.completeOnboarding).call(background)
+      await promisifiedBackground.completeOnboarding()
     } catch (err) {
       dispatch(displayWarning(err.message))
       throw err
@@ -2448,7 +2450,7 @@ export function setRequestAccountTabIds (requestAccountTabIds) {
 
 export function getRequestAccountTabIds () {
   return async (dispatch) => {
-    const requestAccountTabIds = await pify(background.getRequestAccountTabIds).call(background)
+    const requestAccountTabIds = await promisifiedBackground.getRequestAccountTabIds()
     dispatch(setRequestAccountTabIds(requestAccountTabIds))
   }
 }
@@ -2462,7 +2464,7 @@ export function setOpenMetamaskTabsIDs (openMetaMaskTabIDs) {
 
 export function getOpenMetamaskTabsIds () {
   return async (dispatch) => {
-    const openMetaMaskTabIDs = await pify(background.getOpenMetamaskTabsIds).call(background)
+    const openMetaMaskTabIDs = await promisifiedBackground.getOpenMetamaskTabsIds()
     dispatch(setOpenMetamaskTabsIDs(openMetaMaskTabIDs))
   }
 }


### PR DESCRIPTION
The background connection used in `actions.js` was being promisified in specific actions. Instead it's now promisified once. This was made possible by changes in `pify` v5.0.0 that ensure the binding works correctly when passing in an object to `pify` (e.g. the `this` value is correctly set to the wrapped background connection).

This async background connection has been temporarily assigned to a separate variable, until we can transition all of our actions to using this. This was done to reduce the size of this PR. There are a lot of actions.