### PR TITLE
Update `tx:dropped` return value in PendingTxTracker

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -197,7 +197,8 @@ class PendingTransactionTracker extends EventEmitter {
     }
 
     if (taken || dropped) {
-      return this.emit('tx:dropped', txId)
+      this.emit('tx:dropped', txId)
+      return
     }
 
     // get latest transaction status


### PR DESCRIPTION
This PR updates `_checkPendingTx` to not return a boolean value when emitting `tx:dropped`