### PR TITLE
Add test for PendingTransactionTracker#resubmitPendingTxs

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -52,45 +52,41 @@ class PendingTransactionTracker extends EventEmitter {
    * Resubmits each pending transaction
    * @param {string} blockNumber - the latest block number in hex
    * @emits tx:warning
+   * @returns {Promise<void>}
    */
-  resubmitPendingTxs (blockNumber) {
+  async resubmitPendingTxs (blockNumber) {
     const pending = this.getPendingTransactions()
-    // only try resubmitting if their are transactions to resubmit
     if (!pending.length) {
       return
     }
-    pending.forEach((txMeta) => this._resubmitTx(txMeta, blockNumber).catch((err) => {
-      /*
-      Dont marked as failed if the error is a "known" transaction warning
-      "there is already a transaction with the same sender-nonce
-      but higher/same gas price"
-
-      Also don't mark as failed if it has ever been broadcast successfully.
-      A successful broadcast means it may still be mined.
-      */
-      const errorMessage = err.message.toLowerCase()
-      const isKnownTx = (
-        // geth
-        errorMessage.includes('replacement transaction underpriced') ||
-        errorMessage.includes('known transaction') ||
-        // parity
-        errorMessage.includes('gas price too low to replace') ||
-        errorMessage.includes('transaction with the same hash was already imported') ||
-        // other
-        errorMessage.includes('gateway timeout') ||
-        errorMessage.includes('nonce too low')
-      )
-      // ignore resubmit warnings, return early
-      if (isKnownTx) {
-        return
+    for (const txMeta of pending) {
+      try {
+        await this._resubmitTx(txMeta, blockNumber)
+      } catch (err) {
+        const errorMessage = err.message.toLowerCase()
+        const isKnownTx = (
+          // geth
+          errorMessage.includes('replacement transaction underpriced') ||
+          errorMessage.includes('known transaction') ||
+          // parity
+          errorMessage.includes('gas price too low to replace') ||
+          errorMessage.includes('transaction with the same hash was already imported') ||
+          // other
+          errorMessage.includes('gateway timeout') ||
+          errorMessage.includes('nonce too low')
+        )
+        // ignore resubmit warnings, return early
+        if (isKnownTx) {
+          return
+        }
+        // encountered real error - transition to error state
+        txMeta.warning = {
+          error: errorMessage,
+          message: 'There was an error when resubmitting this transaction.',
+        }
+        this.emit('tx:warning', txMeta, err)
       }
-      // encountered real error - transition to error state
-      txMeta.warning = {
-        error: errorMessage,
-        message: 'There was an error when resubmitting this transaction.',
-      }
-      this.emit('tx:warning', txMeta, err)
-    }))
+    }
   }
 
   /**


### PR DESCRIPTION
This PR rewrites `PendingTransactionTracker#resubmitPendingTxs` to facilitate waiting for it to complete in tests.

It was already `await`ed in the `TransactionController`, despite not actually returning a promise: https://github.com/MetaMask/metamask-extension/blob/95489d08a8ab8fef765761479a65ab70f6ce4371/app/scripts/controllers/transactions/index.js#L743-L754