### PR TITLE
Remove unused `addNewKeyring` action

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -520,7 +520,6 @@ export default class MetamaskController extends EventEmitter {
       setLocked: nodeify(this.setLocked, this),
       createNewVaultAndKeychain: nodeify(this.createNewVaultAndKeychain, this),
       createNewVaultAndRestore: nodeify(this.createNewVaultAndRestore, this),
-      addNewKeyring: nodeify(keyringController.addNewKeyring, keyringController),
       exportAccount: nodeify(keyringController.exportAccount, keyringController),
 
       // txController

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -274,39 +274,6 @@ describe('Actions', function () {
     })
   })
 
-  describe('#addNewKeyring', function () {
-    let addNewKeyringSpy
-
-    afterEach(function () {
-      addNewKeyringSpy.restore()
-    })
-
-    it('calls addNewKeyring', async function () {
-      addNewKeyringSpy = sinon.stub(background, 'addNewKeyring')
-        .callsArgWith(2, null)
-      const privateKey = 'c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
-
-      const store = mockStore()
-      await store.dispatch(actions.addNewKeyring('Simple Key Pair', [ privateKey ]))
-      assert(addNewKeyringSpy.calledOnce)
-    })
-
-    it('errors then addNewKeyring in background throws', async function () {
-      addNewKeyringSpy = sinon.stub(background, 'addNewKeyring')
-        .callsArgWith(2, new Error('error'))
-      const store = mockStore()
-      const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', value: undefined },
-        { type: 'HIDE_LOADING_INDICATION' },
-        { type: 'DISPLAY_WARNING', value: 'error' },
-      ]
-
-      await store.dispatch(actions.addNewKeyring())
-      assert.deepEqual(store.getActions(), expectedActions)
-    })
-
-  })
-
   describe('#resetAccount', function () {
 
     let resetAccountSpy

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -283,20 +283,6 @@ export function removeAccount (address) {
   }
 }
 
-export function addNewKeyring (type, opts) {
-  return (dispatch) => {
-    dispatch(showLoadingIndication())
-    log.debug(`background.addNewKeyring`)
-    background.addNewKeyring(type, opts, (err) => {
-      dispatch(hideLoadingIndication())
-      if (err) {
-        return dispatch(displayWarning(err.message))
-      }
-      dispatch(showAccountsPage())
-    })
-  }
-}
-
 export function importNewAccount (strategy, args) {
   return async (dispatch) => {
     let newState


### PR DESCRIPTION
Keyrings are added either through the `getKeyringForDevice` background method (as part of the hardware wallet connect flow), or via `importAccountWithStrategy` (when importing an account). The `addNewKeyring` action and corresponding background method has not been used in a long time.