### PR TITLE
Remove unused `currentAccountTab` state

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -134,7 +134,6 @@ initialize().catch(log.error)
  * @property {number} unapprovedTypedMsgCount - The number of messages in unapprovedTypedMsgs.
  * @property {string[]} keyringTypes - An array of unique keyring identifying strings, representing available strategies for creating accounts.
  * @property {Keyring[]} keyrings - An array of keyring descriptions, summarizing the accounts that are available for use, and what keyrings they belong to.
- * @property {string} currentAccountTab - A view identifying string for displaying the current displayed view, allows user to have a preferred tab in the old UI (between tokens and history).
  * @property {string} selectedAddress - A lower case hex string of the currently selected address.
  * @property {string} currentCurrency - A string identifying the user's preferred display currency, for use in showing conversion rates.
  * @property {number} conversionRate - A number representing the current exchange rate from the user's preferred currency to Ether.

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -11,7 +11,6 @@ class PreferencesController {
    * @param {Object} opts - Overrides the defaults for the initial state of this.store
    * @property {object} store The stored object containing a users preferences, stored in local storage
 	 * @property {array} store.frequentRpcList A list of custom rpcs to provide the user
-   * @property {string} store.currentAccountTab Indicates the selected tab in the ui
    * @property {array} store.tokens The tokens the user wants display in their token lists
    * @property {object} store.accountTokens The tokens stored per account and then per network type
    * @property {object} store.assetImages Contains assets objects related to assets added
@@ -29,7 +28,6 @@ class PreferencesController {
   constructor (opts = {}) {
     const initState = Object.assign({
       frequentRpcListDetail: [],
-      currentAccountTab: 'history',
       accountTokens: {},
       assetImages: {},
       tokens: [],
@@ -475,20 +473,6 @@ class PreferencesController {
     identities[address].name = label
     this.store.updateState({ identities })
     return Promise.resolve(label)
-  }
-
-  /**
-   * Setter for the `currentAccountTab` property
-   *
-   * @param {string} currentAccountTab - Specifies the new tab to be marked as current
-   * @returns {Promise<void>} - Promise resolves with undefined
-   *
-   */
-  setCurrentAccountTab (currentAccountTab) {
-    return new Promise((resolve) => {
-      this.store.updateState({ currentAccountTab })
-      resolve()
-    })
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -492,7 +492,6 @@ export default class MetamaskController extends EventEmitter {
       addToken: nodeify(preferencesController.addToken, preferencesController),
       removeToken: nodeify(preferencesController.removeToken, preferencesController),
       removeSuggestedTokens: nodeify(preferencesController.removeSuggestedTokens, preferencesController),
-      setCurrentAccountTab: nodeify(preferencesController.setCurrentAccountTab, preferencesController),
       setAccountLabel: nodeify(preferencesController.setAccountLabel, preferencesController),
       setFeatureFlag: nodeify(preferencesController.setFeatureFlag, preferencesController),
       setPreference: nodeify(preferencesController.setPreference, preferencesController),

--- a/app/scripts/migrations/043.js
+++ b/app/scripts/migrations/043.js
@@ -1,0 +1,23 @@
+const version = 43
+import { cloneDeep } from 'lodash'
+
+/**
+ * Remove unused 'currentAccountTab' state
+ */
+export default {
+  version,
+  migrate: async function (originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData)
+    versionedData.meta.version = version
+    const state = versionedData.data
+    versionedData.data = transformState(state)
+    return versionedData
+  },
+}
+
+function transformState (state) {
+  if (state?.PreferencesController?.currentAccountTab) {
+    delete state.PreferencesController.currentAccountTab
+  }
+  return state
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -53,6 +53,7 @@ const migrations = [
   require('./040').default,
   require('./041').default,
   require('./042').default,
+  require('./043').default,
 ]
 
 export default migrations

--- a/test/data/2-state.json
+++ b/test/data/2-state.json
@@ -38,7 +38,6 @@
     }
     ],
   "frequentRpcList": [],
-  "currentAccountTab": "history",
   "tokens": [],
   "useBlockie": false,
   "featureFlags": {},

--- a/test/data/v17-long-history.json
+++ b/test/data/v17-long-history.json
@@ -44,7 +44,6 @@
     },
     "PreferencesController": {
       "frequentRpcList": [],
-      "currentAccountTab": "history",
       "tokens": [],
       "selectedAddress": "0x3ae39e89dc7e736cce53091057a45bf44b1a566c"
     },

--- a/test/e2e/fixtures/imported-account/state.json
+++ b/test/e2e/fixtures/imported-account/state.json
@@ -83,7 +83,6 @@
       },
       "assetImages": {},
       "completedOnboarding": true,
-      "currentAccountTab": "history",
       "currentLocale": "en",
       "featureFlags": {
         "showIncomingTransactions": true,

--- a/test/unit/migrations/035-test.js
+++ b/test/unit/migrations/035-test.js
@@ -62,7 +62,6 @@ describe('migration #35', function () {
       data: {
         PreferencesController: {
           frequentRpcListDetail: [],
-          currentAccountTab: 'history',
           accountTokens: {},
           assetImages: {},
           tokens: [],

--- a/test/unit/migrations/043-test.js
+++ b/test/unit/migrations/043-test.js
@@ -1,0 +1,55 @@
+import { strict as assert } from 'assert'
+import migration43 from '../../../app/scripts/migrations/043'
+
+describe('migration #43', function () {
+
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      'meta': {
+        'version': 42,
+      },
+      'data': {},
+    }
+
+    const newStorage = await migration43.migrate(oldStorage)
+    assert.deepEqual(newStorage.meta, {
+      'version': 43,
+    })
+  })
+
+  it('should delete currentAccountTab state', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          currentAccountTab: 'history',
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration43.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        bar: 'baz',
+      },
+      foo: 'bar',
+    })
+  })
+
+  it('should do nothing if currentAccountTab state does not exist', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration43.migrate(oldStorage)
+    assert.deepEqual(oldStorage.data, newStorage.data)
+  })
+})

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1174,11 +1174,6 @@ export function lockMetamask () {
   }
 }
 
-export function setCurrentAccountTab (newTabName) {
-  log.debug(`background.setCurrentAccountTab: ${newTabName}`)
-  return callBackgroundThenUpdateNoSpinner(background.setCurrentAccountTab, newTabName)
-}
-
 export function setSelectedToken (tokenAddress) {
   return {
     type: actionConstants.SET_SELECTED_TOKEN,
@@ -1875,27 +1870,6 @@ export function setMouseUserState (isMouseUser) {
   return {
     type: actionConstants.SET_MOUSE_USER_STATE,
     value: isMouseUser,
-  }
-}
-
-
-/**
- * A function generator for a common pattern wherein:
- * * We call a background method.
- * * If it errored, we show a warning.
- * * If it didn't, we update the state.
- *
- * @param {*} method - The background method to call
- * @param  {...any} args - The args to invoke the background method with
- */
-export function callBackgroundThenUpdateNoSpinner (method, ...args) {
-  return (dispatch) => {
-    method.call(background, ...args, (err) => {
-      if (err) {
-        return dispatch(displayWarning(err.message))
-      }
-      forceUpdateMetamaskState(dispatch)
-    })
   }
 }
 


### PR DESCRIPTION
This state has been removed from the background. It was used for the old UI, and has been unused for some time. A migration has been added to delete this state as well.

The action creator responsible for updating this state has been removed from the UI as well, along with the `callBackgroundThenUpdateNoSpinner` convenience function, which was only used for this action.