### PR TITLE
Rename addressSlicer function to shortenAddress

### DIFF
--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
@@ -7,7 +7,7 @@ import {
 import { getEnvironmentType } from '../../../../../../app/scripts/lib/util'
 import NetworkDisplay from '../../network-display'
 import Identicon from '../../../ui/identicon'
-import { addressSlicer } from '../../../../helpers/utils/util'
+import { shortenAddress } from '../../../../helpers/utils/util'
 
 export default class ConfirmPageContainerHeader extends Component {
   static contextTypes = {
@@ -65,7 +65,7 @@ export default class ConfirmPageContainerHeader extends Component {
                 />
               </div>
               <div className="confirm-page-container-header__address">
-                { addressSlicer(accountAddress) }
+                { shortenAddress(accountAddress) }
               </div>
             </div>
           )

--- a/ui/app/components/app/selected-account/selected-account.component.js
+++ b/ui/app/components/app/selected-account/selected-account.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import copyToClipboard from 'copy-to-clipboard'
-import { addressSlicer, checksumAddress } from '../../../helpers/utils/util'
+import { shortenAddress, checksumAddress } from '../../../helpers/utils/util'
 
 import Tooltip from '../../ui/tooltip-v2.js'
 
@@ -42,7 +42,7 @@ class SelectedAccount extends Component {
               { selectedIdentity.name }
             </div>
             <div className="selected-account__address">
-              { addressSlicer(checksummedAddress) }
+              { shortenAddress(checksummedAddress) }
             </div>
           </div>
         </Tooltip>

--- a/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/app/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -5,7 +5,7 @@ import Identicon from '../identicon'
 import Tooltip from '../tooltip-v2'
 import copyToClipboard from 'copy-to-clipboard'
 import { DEFAULT_VARIANT, CARDS_VARIANT, FLAT_VARIANT } from './sender-to-recipient.constants'
-import { checksumAddress, addressSlicer } from '../../../helpers/utils/util'
+import { checksumAddress, shortenAddress } from '../../../helpers/utils/util'
 
 const variantHash = {
   [DEFAULT_VARIANT]: 'sender-to-recipient--default',
@@ -66,7 +66,7 @@ export default class SenderToRecipient extends PureComponent {
               ? <p>{t('copyAddress')}</p>
               : (
                 <p>
-                  {addressSlicer(checksummedSenderAddress)}<br />
+                  {shortenAddress(checksummedSenderAddress)}<br />
                   {t('copyAddress')}
                 </p>
               )
@@ -126,7 +126,7 @@ export default class SenderToRecipient extends PureComponent {
                 ? <p>{t('copyAddress')}</p>
                 : (
                   <p>
-                    {addressSlicer(checksummedRecipientAddress)}<br />
+                    {shortenAddress(checksummedRecipientAddress)}<br />
                     {t('copyAddress')}
                   </p>
                 )

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -267,7 +267,7 @@ export function checksumAddress (address) {
   return checksummed
 }
 
-export function addressSlicer (address = '') {
+export function shortenAddress (address = '') {
   if (address.length < 11) {
     return address
   }

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -26,7 +26,7 @@ import { getHexGasTotal } from '../../helpers/utils/confirm-tx.util'
 import { isBalanceSufficient, calcGasTotal } from '../send/send.utils'
 import { conversionGreaterThan } from '../../helpers/utils/conversion-util'
 import { MIN_GAS_LIMIT_DEC } from '../send/send.constants'
-import { checksumAddress, addressSlicer, valuesFor } from '../../helpers/utils/util'
+import { checksumAddress, shortenAddress, valuesFor } from '../../helpers/utils/util'
 import { getMetaMaskAccounts, getCustomNonceValue, getUseNonceField, getAdvancedInlineGasShown, preferencesSelector, getIsMainnet, getKnownMethodData } from '../../selectors/selectors'
 import { transactionFeeSelector } from '../../selectors/confirm-transaction'
 
@@ -89,7 +89,7 @@ const mapStateToProps = (state, ownProps) => {
     : (
       casedContractMap[toAddress]
         ? casedContractMap[toAddress].name
-        : addressSlicer(checksumAddress(toAddress))
+        : shortenAddress(checksumAddress(toAddress))
     )
 
   const checksummedAddress = checksumAddress(toAddress)

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -6,7 +6,7 @@ import { createSelector } from 'reselect'
 import abi from 'human-standard-token-abi'
 import { multiplyCurrencies } from '../helpers/utils/conversion-util'
 import {
-  addressSlicer,
+  shortenAddress,
   checksumAddress,
   getOriginFromUrl,
   getAccountByAddress,
@@ -217,7 +217,7 @@ export function getAddressBookEntry (state, address) {
 
 export function getAddressBookEntryName (state, address) {
   const entry = getAddressBookEntry(state, address) || state.metamask.identities[address]
-  return entry && entry.name !== '' ? entry.name : addressSlicer(address)
+  return entry && entry.name !== '' ? entry.name : shortenAddress(address)
 }
 
 export function getDaiV1Token (state) {


### PR DESCRIPTION
In light of another upcoming PR with a similar function, this PR renames `addressSlicer` to `shortenAddress`, so that it starts with a verb.