### PR TITLE
Remove unused `useEtherscanProvider` action creator

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1574,14 +1574,6 @@ export function removeFromAddressBook (chainId, addressToRemove) {
   }
 }
 
-export function useEtherscanProvider () {
-  log.debug(`background.useEtherscanProvider`)
-  background.useEtherscanProvider()
-  return {
-    type: actionConstants.USE_ETHERSCAN_PROVIDER,
-  }
-}
-
 export function showNetworkDropdown () {
   return {
     type: actionConstants.NETWORK_DROPDOWN_OPEN,


### PR DESCRIPTION
This action creator was never called, and it was broken (the background method it called doesn't exist).