### PR TITLE
Remove obs-store babel register handling

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,4 @@
-require('@babel/register')({
-  ignore: [(name) => name.includes('node_modules') && !name.includes('obs-store')],
-})
+require('@babel/register')
 
 require('./helper')
 


### PR DESCRIPTION
Remove special handling of `obs-store` in test setup, implemented here: https://github.com/MetaMask/metamask-extension/pull/3975/files#diff-3cd91aecf53cd75ce13e593db7dfcf55R2