### PR TITLE
Move default exports for all tx classes

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -65,7 +65,7 @@ import { hexToBn, bnToHex, BnMultiplyByFraction } from '../../lib/util'
   @param {Object}  opts.preferencesStore
 */
 
-class TransactionController extends EventEmitter {
+export default class TransactionController extends EventEmitter {
   constructor (opts) {
     super()
     this.networkStore = opts.networkStore || new ObservableStore({})
@@ -765,5 +765,3 @@ class TransactionController extends EventEmitter {
     this.memStore.updateState({ unapprovedTxs, currentNetworkTxList })
   }
 }
-
-export default TransactionController

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -19,7 +19,7 @@ import EthQuery from 'ethjs-query'
 @class
 */
 
-class PendingTransactionTracker extends EventEmitter {
+export default class PendingTransactionTracker extends EventEmitter {
   constructor (config) {
     super()
     this.droppedBuffer = {}
@@ -251,5 +251,3 @@ class PendingTransactionTracker extends EventEmitter {
     return sameNonce.length > 0
   }
 }
-
-export default PendingTransactionTracker

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -15,7 +15,7 @@ and used to do things like calculate gas of a tx.
 @param {Object} provider - A network provider.
 */
 
-class TxGasUtil {
+export default class TxGasUtil {
 
   constructor (provider) {
     this.query = new EthQuery(provider)
@@ -150,5 +150,3 @@ class TxGasUtil {
     return bnToHex(upperGasLimitBn)
   }
 }
-
-export default TxGasUtil

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -26,7 +26,7 @@ import { getFinalStates, normalizeTxParams } from './lib/util'
   @param {function} opts.getNetwork return network number
   @class
 */
-class TransactionStateManager extends EventEmitter {
+export default class TransactionStateManager extends EventEmitter {
   constructor ({ initState, txHistoryLimit, getNetwork }) {
     super()
 
@@ -484,5 +484,3 @@ class TransactionStateManager extends EventEmitter {
     this._saveTxList(transactionList.filter((txMeta) => txMeta.id !== txId))
   }
 }
-
-export default TransactionStateManager


### PR DESCRIPTION
This PR moves the `export default` declarations alongside their classes for all of the `transactions/` classes