### PR TITLE
Return promise from `setCurrentCurrency` thunk

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -415,23 +415,26 @@ export function showQrScanner () {
 }
 
 export function setCurrentCurrency (currencyCode) {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
     log.debug(`background.setCurrentCurrency`)
-    background.setCurrentCurrency(currencyCode, (err, data) => {
+    let data
+    try {
+      data = await promisifiedBackground.setCurrentCurrency(currencyCode)
+    } catch (error) {
       dispatch(hideLoadingIndication())
-      if (err) {
-        log.error(err.stack)
-        return dispatch(displayWarning(err.message))
-      }
-      dispatch({
-        type: actionConstants.SET_CURRENT_FIAT,
-        value: {
-          currentCurrency: data.currentCurrency,
-          conversionRate: data.conversionRate,
-          conversionDate: data.conversionDate,
-        },
-      })
+      log.error(error.stack)
+      dispatch(displayWarning(error.message))
+      return
+    }
+    dispatch(hideLoadingIndication())
+    dispatch({
+      type: actionConstants.SET_CURRENT_FIAT,
+      value: {
+        currentCurrency: data.currentCurrency,
+        conversionRate: data.conversionRate,
+        conversionDate: data.conversionDate,
+      },
     })
   }
 }


### PR DESCRIPTION
`setCurrentCurrency` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

The callers in this case never needed to know when this action had completed, but at least this makes our tests more reliable. They were already `await`-ing this action, despite the lack of Promise.