### PR TITLE
Return Promise from `signTx` thunk

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -760,32 +760,29 @@ describe('Actions', function () {
 
     let sendTransactionSpy
 
-    beforeEach(function () {
-      sendTransactionSpy = sinon.stub(global.ethQuery, 'sendTransaction')
-    })
-
     afterEach(function () {
       sendTransactionSpy.restore()
     })
 
-    it('calls sendTransaction in global ethQuery', function () {
+    it('calls sendTransaction in global ethQuery', async function () {
+      sendTransactionSpy = sinon.stub(global.ethQuery, 'sendTransaction')
+        .callsArgWith(1, null)
       const store = mockStore()
 
-      store.dispatch(actions.signTx())
+      await store.dispatch(actions.signTx())
       assert(sendTransactionSpy.calledOnce)
     })
 
-    it('errors in when sendTransaction throws', function () {
+    it('errors in when sendTransaction throws', async function () {
+      sendTransactionSpy = sinon.stub(global.ethQuery, 'sendTransaction')
+        .callsArgWith(1, new Error('error'))
       const store = mockStore()
       const expectedActions = [
         { type: 'DISPLAY_WARNING', value: 'error' },
         { type: 'SHOW_CONF_TX_PAGE', id: undefined },
       ]
-      sendTransactionSpy.callsFake((_, callback) => {
-        callback(new Error('error'))
-      })
 
-      store.dispatch(actions.signTx())
+      await store.dispatch(actions.signTx())
       assert.deepEqual(store.getActions(), expectedActions)
     })
   })

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -582,12 +582,12 @@ export function signTypedMsg (msgData) {
 }
 
 export function signTx (txData) {
-  return (dispatch) => {
-    global.ethQuery.sendTransaction(txData, (err) => {
-      if (err) {
-        return dispatch(displayWarning(err.message))
-      }
-    })
+  return async (dispatch) => {
+    try {
+      await pify(global.ethQuery.sendTransaction).call(global.ethQuery, txData)
+    } catch (error) {
+      dispatch(displayWarning(error.message))
+    }
     dispatch(showConfTxPage())
   }
 }


### PR DESCRIPTION
`signTx` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

This does result in one slight change in behavior: the next confirmation page is no longer shown immediately; it's shown after the operation completes instead.