### PR TITLE
Return Promise from `signTokenTx` thunk

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -845,11 +845,11 @@ describe('Actions', function () {
   })
 
   describe('#signTokenTx', function () {
-    it('calls eth.contract', function () {
+    it('calls eth.contract', async function () {
       global.eth = new Eth(provider)
       const tokenSpy = sinon.spy(global.eth, 'contract')
       const store = mockStore()
-      store.dispatch(actions.signTokenTx())
+      await store.dispatch(actions.signTokenTx())
       assert(tokenSpy.calledOnce)
       tokenSpy.restore()
     })

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -763,15 +763,18 @@ export function updateSendEnsResolutionError (errorMessage) {
 }
 
 export function signTokenTx (tokenAddress, toAddress, amount, txData) {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
     const token = global.eth.contract(abi).at(tokenAddress)
-    token.transfer(toAddress, ethUtil.addHexPrefix(amount), txData)
-      .catch((err) => {
-        dispatch(hideLoadingIndication())
-        dispatch(displayWarning(err.message))
-      })
-    dispatch(showConfTxPage())
+
+    try {
+      await token.transfer(toAddress, ethUtil.addHexPrefix(amount), txData)
+    } catch (error) {
+      dispatch(hideLoadingIndication())
+      dispatch(displayWarning(error.message))
+    } finally {
+      dispatch(showConfTxPage())
+    }
   }
 }
 


### PR DESCRIPTION
`signTokenTx` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

There is a slight change in behavior; the confirmation page is now shown after the operation has completed, rather than after the operation had started.