### PR TITLE
Return Promise from `setSelectedAddress` thunk

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -949,22 +949,22 @@ describe('Actions', function () {
   describe('#setSelectedAddress', function () {
     let setSelectedAddressSpy
 
-    beforeEach(function () {
-      setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
-    })
-
     afterEach(function () {
       setSelectedAddressSpy.restore()
     })
 
-    it('calls setSelectedAddress in background', function () {
+    it('calls setSelectedAddress in background', async function () {
+      setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
+        .callsArgWith(1, null)
       const store = mockStore({ metamask: devState })
 
-      store.dispatch(actions.setSelectedAddress('0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'))
+      await store.dispatch(actions.setSelectedAddress('0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'))
       assert(setSelectedAddressSpy.calledOnce)
     })
 
-    it('errors when setSelectedAddress throws', function () {
+    it('errors when setSelectedAddress throws', async function () {
+      setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
+        .callsArgWith(1, new Error('error'))
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
@@ -972,11 +972,7 @@ describe('Actions', function () {
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
 
-      setSelectedAddressSpy.callsFake((_, callback) => {
-        callback(new Error('error'))
-      })
-
-      store.dispatch(actions.setSelectedAddress())
+      await store.dispatch(actions.setSelectedAddress())
       assert.deepEqual(store.getActions(), expectedActions)
 
     })

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1178,15 +1178,17 @@ export function setSelectedToken (tokenAddress) {
 }
 
 export function setSelectedAddress (address) {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
     log.debug(`background.setSelectedAddress`)
-    background.setSelectedAddress(address, (err) => {
+    try {
+      await promisifiedBackground.setSelectedAddress(address)
+    } catch (error) {
       dispatch(hideLoadingIndication())
-      if (err) {
-        return dispatch(displayWarning(err.message))
-      }
-    })
+      dispatch(displayWarning(error.message))
+      return
+    }
+    dispatch(hideLoadingIndication())
   }
 }
 


### PR DESCRIPTION
`setSelectedAddress` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

This action creator was only called in two places, and neither benefit from using the Promise now returned. They were both event handlers. In both cases there was an existing Promise chain, but the only thing after this set was a `catch` block that displayed any error encountered. I decided not to return the result of `setSelectedAddress` to this chain, because all it would do is set the warning a second time in the event of failure.