### PR TITLE
Return a Promise from `showAccountDetail` thunk

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -985,33 +985,30 @@ describe('Actions', function () {
   describe('#showAccountDetail', function () {
     let setSelectedAddressSpy
 
-    beforeEach(function () {
-      setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
-    })
-
     afterEach(function () {
       setSelectedAddressSpy.restore()
     })
 
-    it('#showAccountDetail', function () {
+    it('#showAccountDetail', async function () {
+      setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
+        .callsArgWith(1, null)
       const store = mockStore()
 
-      store.dispatch(actions.showAccountDetail())
+      await store.dispatch(actions.showAccountDetail())
       assert(setSelectedAddressSpy.calledOnce)
     })
 
-    it('displays warning if setSelectedAddress throws', function () {
+    it('displays warning if setSelectedAddress throws', async function () {
+      setSelectedAddressSpy = sinon.stub(background, 'setSelectedAddress')
+        .callsArgWith(1, new Error('error'))
       const store = mockStore()
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', value: undefined },
         { type: 'HIDE_LOADING_INDICATION' },
         { type: 'DISPLAY_WARNING', value: 'error' },
       ]
-      setSelectedAddressSpy.callsFake((_, callback) => {
-        callback(new Error('error'))
-      })
 
-      store.dispatch(actions.showAccountDetail())
+      await store.dispatch(actions.showAccountDetail())
       assert.deepEqual(store.getActions(), expectedActions)
     })
   })

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1191,21 +1191,25 @@ export function setSelectedAddress (address) {
 }
 
 export function showAccountDetail (address) {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch(showLoadingIndication())
     log.debug(`background.setSelectedAddress`)
-    background.setSelectedAddress(address, (err, tokens) => {
+
+    let tokens
+    try {
+      tokens = await promisifiedBackground.setSelectedAddress(address)
+    } catch (error) {
       dispatch(hideLoadingIndication())
-      if (err) {
-        return dispatch(displayWarning(err.message))
-      }
-      dispatch(updateTokens(tokens))
-      dispatch({
-        type: actionConstants.SHOW_ACCOUNT_DETAIL,
-        value: address,
-      })
-      dispatch(setSelectedToken())
+      dispatch(displayWarning(error.message))
+      return
+    }
+    dispatch(hideLoadingIndication())
+    dispatch(updateTokens(tokens))
+    dispatch({
+      type: actionConstants.SHOW_ACCOUNT_DETAIL,
+      value: address,
     })
+    dispatch(setSelectedToken())
   }
 }
 


### PR DESCRIPTION
`showAccountDetail` returned a thunk that didn't return a Promise, despite doing async work. Now it returns a Promise.

This action is only called in one place, and it looks like the actions dispatched alongside it were meant to be run in parallel, so no changes were made there.