### PR TITLE
Convert connected-status-indicator to button

### DIFF
--- a/ui/app/components/app/connected-status-indicator/index.scss
+++ b/ui/app/components/app/connected-status-indicator/index.scss
@@ -5,7 +5,16 @@
 
   background: none;
   font-size: inherit;
-  padding: 8px 0;
+  padding: 8px;
+  border-radius: 100px;
+
+  &:hover {
+    background-color: #F2F3F4;
+  }
+
+  &:active {
+    background-color: #EDEDED;
+  }
 
   &__green-circle, &__yellow-circle, &__grey-circle {
     border-radius: 4px;
@@ -28,6 +37,7 @@
   &__text {
     font-size: 10px;
     color: $Grey-500;
-    margin-left: 8px;
+    margin-left: 6px;
+    white-space: nowrap;
   }
 }

--- a/ui/app/components/app/menu-bar/index.scss
+++ b/ui/app/components/app/menu-bar/index.scss
@@ -4,13 +4,13 @@
   column-gap: 5px;
 
   margin-bottom: 24px;
-  padding: 0 24px;
+  padding: 0 8px;
   border-bottom: 1px solid $Grey-100;
 
   .menu-bar__account-options {
     background: none;
     font-size: inherit;
-    padding: 0 0 0 5px;
+    padding: 0 8px 0 5px;
 
     position: relative; // to allow the dropdown to position itself absolutely
     place-self: center end;


### PR DESCRIPTION
Adds the button styles for the connected-status-indicator button. 

As a side effect of adding the padding to the indicator hover state, I had to adjust the spacing in the menu bar. Previously the split was 30/30+/30 making the account details piece centered. To give enough space for the 'not connected' text + padding required adjusting this to 35/30+/30. Not sure if this is desired or has side effects.

Another point to note is that I did 8px padding on the left and right to allow for space for the border-radius effect. It might not be enough to match design exactly, but going higher will require more overall space in the menu bar. There is 24px padding on either side of the menu bar (to the left of connected-status and right of the three-dot menu) that we could liberate for additional space in the menu-bar.

Thoughts? Comments? Concerns? @MetaMask/design 

- fixes #8424