### PR TITLE
Use `async/await` for `forceUpdateMetamaskState`

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1861,19 +1861,19 @@ export function setMouseUserState (isMouseUser) {
   }
 }
 
-export function forceUpdateMetamaskState (dispatch) {
+export async function forceUpdateMetamaskState (dispatch) {
   log.debug(`background.getState`)
-  return new Promise((resolve, reject) => {
-    background.getState((err, newState) => {
-      if (err) {
-        dispatch(displayWarning(err.message))
-        return reject(err)
-      }
 
-      dispatch(updateMetamaskState(newState))
-      resolve(newState)
-    })
-  })
+  let newState
+  try {
+    newState = await promisifiedBackground.getState()
+  } catch (error) {
+    dispatch(displayWarning(error.message))
+    throw error
+  }
+
+  dispatch(updateMetamaskState(newState))
+  return newState
 }
 
 export function toggleAccountMenu () {


### PR DESCRIPTION
The `forceUpdateMetamaskState` function now uses `async/await` instead of a Promise constructor. This was done to make an upcoming change easier (making `updateMetamaskState` async).