### PR TITLE
Simplify logic in PTT helper fns

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -220,13 +220,7 @@ export default class PendingTransactionTracker extends EventEmitter {
   async _checkIfTxWasDropped (txMeta, transactionReceipt) {
     const { txParams: { nonce, from } } = txMeta
     const nextNonce = await this.query.getTransactionCount(from)
-    if (
-      !transactionReceipt?.blockNumber &&
-      parseInt(nextNonce) > parseInt(nonce)
-    ) {
-      return true
-    }
-    return false
+    return !transactionReceipt?.blockNumber && parseInt(nextNonce) > parseInt(nonce)
   }
 
   /**
@@ -238,12 +232,11 @@ export default class PendingTransactionTracker extends EventEmitter {
   async _checkIfNonceIsTaken (txMeta) {
     const address = txMeta.txParams.from
     const completed = this.getCompletedTransactions(address)
-    const sameNonce = completed.filter((otherMeta) => {
-      if (otherMeta.id === txMeta.id) {
-        return false
-      }
-      return otherMeta.txParams.nonce === txMeta.txParams.nonce
-    })
-    return sameNonce.length > 0
+    return completed.some((other) =>
+      // This is called while the transaction is in-flight, so it is possible that the
+      // list of completed transactions now includes the transaction we were looking at
+      // and if that is the case, don't consider the transaction to have taken its own nonce
+      !(other.id === txMeta.id) && other.txParams.nonce === txMeta.txParams.nonce
+    )
   }
 }


### PR DESCRIPTION
This PR simplifies the return logic in two small `PendingTransactionTracker` helpers