### PR TITLE
Fix various style issues

### DIFF
--- a/app/notification.html
+++ b/app/notification.html
@@ -1,14 +1,10 @@
 <!doctype html>
-<html style="height:600px;">
+<html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">
     <title>MetaMask Notification</title>
     <style>
-      body {
-        overflow: hidden;
-      }
-
       #app-content {
         display: flex;
         flex-flow: column;
@@ -31,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="./index.css" title="ltr">
     <link rel="stylesheet" type="text/css" href="./index-rtl.css" title="rtl" disabled>
   </head>
-  <body class="notification" style="height:600px;">
+  <body class="notification">
     <div id="app-content">
       <img id="loading__logo" src="./images/logo/metamask-fox.svg" />
       <img id="loading__spinner" src="./images/spinner.gif" />

--- a/ui/app/components/app/permission-page-container/index.scss
+++ b/ui/app/components/app/permission-page-container/index.scss
@@ -52,6 +52,7 @@
       display: flex;
       align-items: center;
       padding-top: 8px;
+      height: 144px;
     }
 
     a, a:hover {
@@ -156,7 +157,6 @@
   align-items: center;
   text-align: center;
   color: $Black-100;
-  height: 114px;
 
   &__icons {
     display: flex;

--- a/ui/app/css/itcss/generic/index.scss
+++ b/ui/app/css/itcss/generic/index.scss
@@ -18,10 +18,7 @@ body {
   margin: 0;
   padding: 0;
   font-size: 16px;
-
-  @media screen and (max-width: $break-small) {
-    overflow-y: overlay;
-  }
+  overflow: auto;
 }
 
 html {

--- a/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
+++ b/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
@@ -110,10 +110,9 @@ export default class ChooseAccount extends Component {
                 </div>
                 { addressLastConnectedMap[address]
                   ? (
-                    <div className="permissions-connect-choose-account__account__last-connected">
-                      <span>{ this.context.t('lastConnected') }</span>
-                      { addressLastConnectedMap[address] }
-                    </div>
+                    <Tooltip title={`${this.context.t('lastConnected')} ${addressLastConnectedMap[address]}`}>
+                      <i className="fa fa-info-circle" />
+                    </Tooltip>
                   )
                   : null
                 }

--- a/ui/app/pages/permissions-connect/choose-account/index.scss
+++ b/ui/app/pages/permissions-connect/choose-account/index.scss
@@ -71,6 +71,7 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    min-width:0;
   }
 
   &__list-check-box {
@@ -111,11 +112,15 @@
       display: flex;
       flex-direction: column;
       margin-left: 16px;
+      min-width: 0;
     }
 
     &__label {
       @extend %content-text;
       color: $Black-100;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
     }
 
     &__balance {

--- a/ui/app/pages/permissions-connect/choose-account/index.scss
+++ b/ui/app/pages/permissions-connect/choose-account/index.scss
@@ -7,6 +7,17 @@
   margin-right: auto;
   height: 100%;
 
+  .fa-info-circle {
+    color: $Grey-200;
+    cursor: pointer;
+    margin-left: 8px;
+    font-size: 0.9rem;
+  }
+
+  .fa-info-circle:hover {
+    color: $Grey-300;
+  }
+
   @media screen and (min-width: 576px) {
     width: 426px;
   }
@@ -78,21 +89,6 @@
     display: flex;
     margin-left: 16px;
     align-items: center;
-
-    .fa-info-circle, .fa-info-circle:hover {
-      color: $silver;
-      cursor: pointer;
-      margin-left: 8px;
-      font-size: 0.9rem;
-    }
-
-    .fa-info-circle {
-      cursor: pointer;
-    }
-
-    .fa-info-circle:hover {
-      color: $mid-gray;
-    }
   }
 
   &__account {


### PR DESCRIPTION
Fixes #8353 

> Connect Screen 1
Notice the Last Connected string of Account 1
The string appears the same way every account it appears for

<details>
<summary>Screenshot of issue</summary>
<img src="https://user-images.githubusercontent.com/25517051/79591426-57ccb900-808d-11ea-98b5-688a1629065d.png" />
</details>

Discussed with @rachelcope and we moved this info behind a tooltip and icon:

![image](https://user-images.githubusercontent.com/4448075/80641014-d9c3c700-8a29-11ea-9d68-b9dc6de33384.png)

![image](https://user-images.githubusercontent.com/4448075/80641069-ecd69700-8a29-11ea-819d-40af4eb686a3.png)

---

>- Notice how all content appears off-center (due to scroll bar) 
See especially the lack of right margin/padding of the `2 of 2` string in the top right
Suggested solution: Make rest of content take scroll bar width into account

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/25517051/79591457-63b87b00-808d-11ea-9447-d1eabe1892c9.png">
</details>

For this one, I noticed that the body element has `overflow: overlay` on it. This causes the scroll bar to be painted on top of the application rather than reducing the application's total available space. Changing to `overflow: auto` completely solves this issue though I'm not sure if there are unintended consequences from the original implementation @danjm was the last to touch so looking for some guidance on possible side effects 


![Screen-Recording-2020-04-27-at-5 59 07-PM](https://user-images.githubusercontent.com/4448075/80429904-c510f300-88b2-11ea-80d2-f99831f3a59a.gif)


---

> - Notice how the icon shadows are clipped at the bottom

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/25517051/79592036-40420000-808e-11ea-8781-37cb6dc97a80.png">
</details>

the `.permission-result` selector had a height set intended to extend the box property to allow for the drop shadow on icons to be visible. However, in order for the height to be respected, it needed to be added to the parent container `.permission-approval-container__content`. @danjm  any thoughts on if this would have unintended side effects? 

![Screen Shot 2020-04-27 at 6 06 33 PM](https://user-images.githubusercontent.com/4448075/80429951-e07bfe00-88b2-11ea-809a-abb1f501838f.png)

---

Also resolved some inconsistencies with the design system on icon coloration.

