### PR TITLE
Return a Promise from `setProviderType` thunk

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1082,28 +1082,27 @@ describe('Actions', function () {
 
     beforeEach(function () {
       store = mockStore({ metamask: { provider: {} } })
-      setProviderTypeSpy = sinon.stub(background, 'setProviderType')
     })
 
     afterEach(function () {
       setProviderTypeSpy.restore()
     })
 
-    it('calls setProviderType', function () {
-      store.dispatch(actions.setProviderType())
+    it('calls setProviderType', async function () {
+      setProviderTypeSpy = sinon.stub(background, 'setProviderType')
+        .callsArgWith(1, null)
+      await store.dispatch(actions.setProviderType())
       assert(setProviderTypeSpy.calledOnce)
     })
 
-    it('displays warning when setProviderType throws', function () {
+    it('displays warning when setProviderType throws', async function () {
+      setProviderTypeSpy = sinon.stub(background, 'setProviderType')
+        .callsArgWith(1, new Error('error'))
       const expectedActions = [
         { type: 'DISPLAY_WARNING', value: 'Had a problem changing networks!' },
       ]
 
-      setProviderTypeSpy.callsFake((_, callback) => {
-        callback(new Error('error'))
-      })
-
-      store.dispatch(actions.setProviderType())
+      await store.dispatch(actions.setProviderType())
       assert(setProviderTypeSpy.calledOnce)
       assert.deepEqual(store.getActions(), expectedActions)
     })

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1445,19 +1445,20 @@ export function createRetryTransaction (txId, customGasPrice, customGasLimit) {
 //
 
 export function setProviderType (type) {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     const { type: currentProviderType } = getState().metamask.provider
     log.debug(`background.setProviderType`, type)
-    background.setProviderType(type, (err) => {
-      if (err) {
-        log.error(err)
-        return dispatch(displayWarning('Had a problem changing networks!'))
-      }
-      dispatch(setPreviousProvider(currentProviderType))
-      dispatch(updateProviderType(type))
-      dispatch(setSelectedToken())
-    })
 
+    try {
+      await promisifiedBackground.setProviderType(type)
+    } catch (error) {
+      log.error(error)
+      dispatch(displayWarning('Had a problem changing networks!'))
+      return
+    }
+    dispatch(setPreviousProvider(currentProviderType))
+    dispatch(updateProviderType(type))
+    dispatch(setSelectedToken())
   }
 }
 


### PR DESCRIPTION
`setProviderType` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

None of the callers of this action creator needed to know when it completed, so no changes to the call sites were made.