### PR TITLE
Remove fallback selected address

### DIFF
--- a/test/unit/ui/app/selectors.spec.js
+++ b/test/unit/ui/app/selectors.spec.js
@@ -9,27 +9,13 @@ const provider = createTestProviderTools({ scaffold: {} }).provider
 describe('Selectors', function () {
 
   describe('#getSelectedAddress', function () {
-    let state
-    beforeEach(function () {
-      state = {
-        metamask: {
-          accounts: {
-            '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
-              'balance': '0x0',
-              'address': '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-            },
-          },
-          cachedBalances: {},
-        },
-      }
-    })
-
-    it('returns first account if selectedAddress is undefined', function () {
-      assert.equal(selectors.getSelectedAddress(state), '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc')
+    it('returns undefined if selectedAddress is undefined', function () {
+      assert.equal(selectors.getSelectedAddress({ metamask: {} }), undefined)
     })
 
     it('returns selectedAddress', function () {
-      assert.equal(selectors.getSelectedAddress(mockState), '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc')
+      const selectedAddress = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'
+      assert.equal(selectors.getSelectedAddress({ metamask: { selectedAddress } }), selectedAddress)
     })
 
   })

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -86,7 +86,7 @@ export const getMetaMaskAccounts = createSelector(
 )
 
 export function getSelectedAddress (state) {
-  const selectedAddress = state.metamask.selectedAddress || Object.keys(getMetaMaskAccounts(state))[0]
+  const selectedAddress = state.metamask.selectedAddress
 
   return selectedAddress
 }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -86,9 +86,7 @@ export const getMetaMaskAccounts = createSelector(
 )
 
 export function getSelectedAddress (state) {
-  const selectedAddress = state.metamask.selectedAddress
-
-  return selectedAddress
+  return state.metamask.selectedAddress
 }
 
 export function getSelectedIdentity (state) {


### PR DESCRIPTION
The `getSelectedAddress` selector has a fallback of selecting the first MetaMask account. This is not useful. The only time the `selectedAddress` is not set is during onboarding, before any accounts exist, so selecting the first account wouldn't be useful anyway.