### PR TITLE
Return Promise from `updateAndSetCustomRpc` thunk

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1445,17 +1445,20 @@ export function setPreviousProvider (type) {
 }
 
 export function updateAndSetCustomRpc (newRpc, chainId, ticker = 'ETH', nickname, rpcPrefs) {
-  return (dispatch) => {
+  return async (dispatch) => {
     log.debug(`background.updateAndSetCustomRpc: ${newRpc} ${chainId} ${ticker} ${nickname}`)
-    background.updateAndSetCustomRpc(newRpc, chainId, ticker, nickname || newRpc, rpcPrefs, (err) => {
-      if (err) {
-        log.error(err)
-        return dispatch(displayWarning('Had a problem changing networks!'))
-      }
-      dispatch({
-        type: actionConstants.SET_RPC_TARGET,
-        value: newRpc,
-      })
+
+    try {
+      await promisifiedBackground.updateAndSetCustomRpc(newRpc, chainId, ticker, nickname || newRpc, rpcPrefs)
+    } catch (error) {
+      log.error(error)
+      dispatch(displayWarning('Had a problem changing networks!'))
+      return
+    }
+
+    dispatch({
+      type: actionConstants.SET_RPC_TARGET,
+      value: newRpc,
     })
   }
 }


### PR DESCRIPTION
`updateAndSetCustomRpc` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

In the one place where this is used, it didn't seem important to update the callsite to block on this finishing. Only one call followed it in the event handler, and it didn't seem to depend on this.