### PR TITLE
Return Promise from `setRpcTarget`

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1105,31 +1105,27 @@ describe('Actions', function () {
   describe('#setRpcTarget', function () {
     let setRpcTargetSpy
 
-    beforeEach(function () {
-      setRpcTargetSpy = sinon.stub(background, 'setCustomRpc')
-    })
-
     afterEach(function () {
       setRpcTargetSpy.restore()
     })
 
-    it('calls setRpcTarget', function () {
+    it('calls setRpcTarget', async function () {
+      setRpcTargetSpy = sinon.stub(background, 'setCustomRpc')
+        .callsArgWith(4, null)
       const store = mockStore()
-      store.dispatch(actions.setRpcTarget('http://localhost:8545'))
+      await store.dispatch(actions.setRpcTarget('http://localhost:8545'))
       assert(setRpcTargetSpy.calledOnce)
     })
 
-    it('displays warning when setRpcTarget throws', function () {
+    it('displays warning when setRpcTarget throws', async function () {
+      setRpcTargetSpy = sinon.stub(background, 'setCustomRpc')
+        .callsArgWith(4, new Error('error'))
       const store = mockStore()
       const expectedActions = [
         { type: 'DISPLAY_WARNING', value: 'Had a problem changing networks!' },
       ]
 
-      setRpcTargetSpy.callsFake((_, __, ___, ____, callback) => {
-        callback(new Error('error'))
-      })
-
-      store.dispatch(actions.setRpcTarget())
+      await store.dispatch(actions.setRpcTarget())
       assert.deepEqual(store.getActions(), expectedActions)
     })
   })

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1484,15 +1484,17 @@ export function editRpc (oldRpc, newRpc, chainId, ticker = 'ETH', nickname, rpcP
 }
 
 export function setRpcTarget (newRpc, chainId, ticker = 'ETH', nickname) {
-  return (dispatch) => {
+  return async (dispatch) => {
     log.debug(`background.setRpcTarget: ${newRpc} ${chainId} ${ticker} ${nickname}`)
-    background.setCustomRpc(newRpc, chainId, ticker, nickname || newRpc, (err) => {
-      if (err) {
-        log.error(err)
-        return dispatch(displayWarning('Had a problem changing networks!'))
-      }
-      dispatch(setSelectedToken())
-    })
+
+    try {
+      await promisifiedBackground.setCustomRpc(newRpc, chainId, ticker, nickname || newRpc)
+    } catch (error) {
+      log.error(error)
+      dispatch(displayWarning('Had a problem changing networks!'))
+      return
+    }
+    dispatch(setSelectedToken())
   }
 }
 


### PR DESCRIPTION
`setRpcTarget` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

The callers of this action creator didn't need to be updated, as they were all in event handlers that didn't require knowing when the operation had completed.