### PR TITLE
Don't updatePendingTxs outside of block updates

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -757,7 +757,6 @@ export default class TransactionController extends EventEmitter {
     Updates the memStore in transaction controller
   */
   _updateMemstore () {
-    this.pendingTxTracker.updatePendingTxs()
     const unapprovedTxs = this.txStateManager.getUnapprovedTxList()
     const currentNetworkTxList = this.txStateManager.getFilteredTxList({
       metamaskNetworkId: this.getNetwork(),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -779,6 +779,8 @@ export default class MetamaskController extends EventEmitter {
       await this.diagnostics.reportMultipleKeyrings(nonSimpleKeyrings)
     }
 
+    await this.blockTracker.checkForLatestBlock()
+
     try {
       const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
       if (threeBoxSyncingAllowed && !this.threeBoxController.box) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -779,8 +779,6 @@ export default class MetamaskController extends EventEmitter {
       await this.diagnostics.reportMultipleKeyrings(nonSimpleKeyrings)
     }
 
-    await this.txController.pendingTxTracker.updatePendingTxs()
-
     try {
       const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
       if (threeBoxSyncingAllowed && !this.threeBoxController.box) {


### PR DESCRIPTION
Refs #8377

This PR reverts 507397f6c (#5431)—the call to `updatePendingTxs`, in `_updateMemstore` in particular, caused an update to the store, resulting in a loop (further detailed in #8377). This removes the update there and switches the call in `#submitPassword` to a less-specific request for block updates. All updates to the pending transactions _should_ happen in the transactions "subsystem", where we currently update pending transactions each block.