### PR TITLE
Backport "Fix popup not opening"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Develop Branch
 
 ## 7.7.9 Tue Apr 28 2020
+- [#8446](https://github.com/MetaMask/metamask-extension/pull/8446): Fix popup not opening
 
 ## 7.7.8 Wed Mar 11 2020
 - [#8176](https://github.com/MetaMask/metamask-extension/pull/8176): Handle and set gas estimation when max mode is clicked

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -447,7 +447,6 @@ function triggerUi () {
     const currentlyActiveMetamaskTab = Boolean(tabs.find(tab => openMetamaskTabsIDs[tab.id]))
     if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
       notificationManager.showPopup()
-      notificationIsOpen = true
     }
   })
 }


### PR DESCRIPTION
This is a backport of #8314. Here's the original description:

MetaMask would sometimes get into a state where the notification popup would never open. This could happen if the notification window was closed shortly after being opened. After this happened, no popups would show up until after the extension was reset.

This was happening because the background thought the popup was already open. The variable it uses to track whether the popup was open or not was being set to `true` immediately after the background asked the browser to open a new window, before a handler was attached that could respond to the window being closed.

Removing this line seems to solve the problem.

This line was added originally in #5437, which dealt with batch transactions. Batches of transactions seem to work just fine without this line though (from local testing), and I can't think of why this would be required.

Closes #7051