### PR TITLE
Return Promise from `addToAddressBook` thunk

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1131,10 +1131,11 @@ describe('Actions', function () {
   })
 
   describe('#addToAddressBook', function () {
-    it('calls setAddressBook', function () {
+    it('calls setAddressBook', async function () {
       const addToAddressBookSpy = sinon.stub(background, 'setAddressBook')
+        .callsArgWith(4, null, true)
       const store = mockStore()
-      store.dispatch(actions.addToAddressBook('test'))
+      await store.dispatch(actions.addToAddressBook('test'))
       assert(addToAddressBookSpy.calledOnce)
       addToAddressBookSpy.restore()
     })

--- a/ui/app/components/app/modals/add-to-addressbook-modal/add-to-addressbook-modal.component.js
+++ b/ui/app/components/app/modals/add-to-addressbook-modal/add-to-addressbook-modal.component.js
@@ -18,9 +18,9 @@ export default class AddToAddressBookModal extends Component {
     alias: '',
   }
 
-  onSave = () => {
+  onSave = async () => {
     const { recipient, addToAddressBook, hideModal } = this.props
-    addToAddressBook(recipient, this.state.alias)
+    await addToAddressBook(recipient, this.state.alias)
     hideModal()
   }
 
@@ -30,7 +30,7 @@ export default class AddToAddressBookModal extends Component {
     })
   }
 
-  onKeyPress = (e) => {
+  onKeyPress = async (e) => {
     if (e.key === 'Enter' && this.state.alias) {
       this.onSave()
     }

--- a/ui/app/pages/send/send-footer/send-footer.component.js
+++ b/ui/app/pages/send/send-footer/send-footer.component.js
@@ -39,7 +39,7 @@ export default class SendFooter extends Component {
     this.props.history.push(DEFAULT_ROUTE)
   }
 
-  onSubmit (event) {
+  async onSubmit (event) {
     event.preventDefault()
     const {
       addToAddressBookIfNew,
@@ -69,7 +69,7 @@ export default class SendFooter extends Component {
     // }
 
     // TODO: add nickname functionality
-    addToAddressBookIfNew(to, toAccounts)
+    await addToAddressBookIfNew(to, toAccounts)
     const promise = editingTransactionId
       ? update({
         amount,

--- a/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
@@ -145,8 +145,8 @@ describe('SendFooter Component', function () {
       )
     })
 
-    it('should call props.update if editingTransactionId is truthy', function () {
-      wrapper.instance().onSubmit(MOCK_EVENT)
+    it('should call props.update if editingTransactionId is truthy', async function () {
+      await wrapper.instance().onSubmit(MOCK_EVENT)
       assert(propsMethodSpies.update.calledOnce)
       assert.deepEqual(
         propsMethodSpies.update.getCall(0).args[0],
@@ -168,9 +168,9 @@ describe('SendFooter Component', function () {
       assert.equal(propsMethodSpies.sign.callCount, 0)
     })
 
-    it('should call props.sign if editingTransactionId is falsy', function () {
+    it('should call props.sign if editingTransactionId is falsy', async function () {
       wrapper.setProps({ editingTransactionId: null })
-      wrapper.instance().onSubmit(MOCK_EVENT)
+      await wrapper.instance().onSubmit(MOCK_EVENT)
       assert(propsMethodSpies.sign.calledOnce)
       assert.deepEqual(
         propsMethodSpies.sign.getCall(0).args[0],
@@ -190,13 +190,10 @@ describe('SendFooter Component', function () {
       assert.equal(propsMethodSpies.update.callCount, 0)
     })
 
-    it('should call history.push', function (done) {
-      Promise.resolve(wrapper.instance().onSubmit(MOCK_EVENT))
-        .then(() => {
-          assert.equal(historySpies.push.callCount, 1)
-          assert.equal(historySpies.push.getCall(0).args[0], CONFIRM_TRANSACTION_ROUTE)
-          done()
-        })
+    it('should call history.push', async function () {
+      await wrapper.instance().onSubmit(MOCK_EVENT)
+      assert.equal(historySpies.push.callCount, 1)
+      assert.equal(historySpies.push.getCall(0).args[0], CONFIRM_TRANSACTION_ROUTE)
     })
   })
 

--- a/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -119,8 +119,8 @@ export default class AddContact extends PureComponent {
         <PageContainerFooter
           cancelText={this.context.t('cancel')}
           disabled={Boolean(this.state.error)}
-          onSubmit={() => {
-            addToAddressBook(this.state.ensAddress || this.state.ethAddress, this.state.newName)
+          onSubmit={async () => {
+            await addToAddressBook(this.state.ensAddress || this.state.ethAddress, this.state.newName)
             history.push(CONTACT_LIST_ROUTE)
           }}
           onCancel={() => {

--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -111,12 +111,12 @@ export default class EditContact extends PureComponent {
         </div>
         <PageContainerFooter
           cancelText={this.context.t('cancel')}
-          onSubmit={() => {
+          onSubmit={async () => {
             if (this.state.newAddress !== '' && this.state.newAddress !== address) {
               // if the user makes a valid change to the address field, remove the original address
               if (isValidAddress(this.state.newAddress)) {
                 removeFromAddressBook(chainId, address)
-                addToAddressBook(this.state.newAddress, this.state.newName || name, this.state.newMemo || memo)
+                await addToAddressBook(this.state.newAddress, this.state.newName || name, this.state.newMemo || memo)
                 setAccountLabel(this.state.newAddress, this.state.newName || name)
                 history.push(listRoute)
               } else {
@@ -124,7 +124,7 @@ export default class EditContact extends PureComponent {
               }
             } else {
               // update name
-              addToAddressBook(address, this.state.newName || name, this.state.newMemo || memo)
+              await addToAddressBook(address, this.state.newName || name, this.state.newMemo || memo)
               setAccountLabel(address, this.state.newName || name)
               history.push(listRoute)
             }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1527,19 +1527,20 @@ export function delRpcTarget (oldRpc) {
 export function addToAddressBook (recipient, nickname = '', memo = '') {
   log.debug(`background.addToAddressBook`)
 
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     const chainId = getState().metamask.network
-    background.setAddressBook(checksumAddress(recipient), nickname, chainId, memo, (err, set) => {
-      if (err) {
-        log.error(err)
-        dispatch(displayWarning('Address book failed to update'))
-        throw err
-      }
-      if (!set) {
-        return dispatch(displayWarning('Address book failed to update'))
-      }
-    })
 
+    let set
+    try {
+      set = await promisifiedBackground.setAddressBook(checksumAddress(recipient), nickname, chainId, memo)
+    } catch (error) {
+      log.error(error)
+      dispatch(displayWarning('Address book failed to update'))
+      throw error
+    }
+    if (!set) {
+      return dispatch(displayWarning('Address book failed to update'))
+    }
   }
 }
 


### PR DESCRIPTION
`addToAddressBook` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

The callers of this action creator were updated to `await` the completion of the operation. It was called just before redirecting the user to a different page or closing a modal, and it seemed appropriate to wait before doing those things.