### PR TITLE
Return Promise from `removeFromAddressBook` thunk

### DIFF
--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -49,8 +49,8 @@ export default class EditContact extends PureComponent {
           <Button
             type="link"
             className="settings-page__address-book-button"
-            onClick={() => {
-              removeFromAddressBook(chainId, address)
+            onClick={async () => {
+              await removeFromAddressBook(chainId, address)
               history.push(listRoute)
             }}
           >
@@ -115,7 +115,7 @@ export default class EditContact extends PureComponent {
             if (this.state.newAddress !== '' && this.state.newAddress !== address) {
               // if the user makes a valid change to the address field, remove the original address
               if (isValidAddress(this.state.newAddress)) {
-                removeFromAddressBook(chainId, address)
+                await removeFromAddressBook(chainId, address)
                 await addToAddressBook(this.state.newAddress, this.state.newName || name, this.state.newMemo || memo)
                 setAccountLabel(this.state.newAddress, this.state.newName || name)
                 history.push(listRoute)

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1551,8 +1551,8 @@ export function addToAddressBook (recipient, nickname = '', memo = '') {
 export function removeFromAddressBook (chainId, addressToRemove) {
   log.debug(`background.removeFromAddressBook`)
 
-  return () => {
-    background.removeFromAddressBook(chainId, checksumAddress(addressToRemove))
+  return async () => {
+    await promisifiedBackground.removeFromAddressBook(chainId, checksumAddress(addressToRemove))
   }
 }
 


### PR DESCRIPTION
`removeFromAddressBook` returned a thunk that didn't return a Promise, despite doing async work. It now returns a Promise.

The callers were updated to `await` the completion of this operation.