### PR TITLE
Backport "Add Dai/Sai to currency display (#7986)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#8460](https://github.com/MetaMask/metamask-extension/pull/8460): Update deposit copy for Wyre
 - [#8458](https://github.com/MetaMask/metamask-extension/pull/8458): Snapshot txMeta without cloning history
 - [#8459](https://github.com/MetaMask/metamask-extension/pull/8459): Fix method registry initialization
+- [#8455](https://github.com/MetaMask/metamask-extension/pull/8455): Add Dai/Sai to currency display
 
 ## 7.7.8 Wed Mar 11 2020
 - [#8176](https://github.com/MetaMask/metamask-extension/pull/8176): Handle and set gas estimation when max mode is clicked

--- a/ui/app/helpers/constants/available-conversions.json
+++ b/ui/app/helpers/constants/available-conversions.json
@@ -234,5 +234,13 @@
   {
     "code": "zec",
     "name": "Zcash"
+  },
+  {
+    "code": "dai",
+    "name": "DAI"
+  },
+  {
+    "code": "sai",
+    "name": "SAI"
   }
 ]


### PR DESCRIPTION
Backport #7986 onto v7.7.9. The original commit message follows:

With the change from infura to cryptocompare https://github.com/MetaMask/gaba/pull/30/files#diff-50c3c47cc5fa12e5213a6cc900476f41L41-R48 we have numerous conversion rates to go through and add if we like to.