### PR TITLE
Backport "Snapshot txMeta without cloning history (#8363)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#8449](https://github.com/MetaMask/metamask-extension/pull/8449): Skip adding history entry for empty txMeta diffs
 - [#8447](https://github.com/MetaMask/metamask-extension/pull/8447): Delete Dai/Sai migration notification
 - [#8460](https://github.com/MetaMask/metamask-extension/pull/8460): Update deposit copy for Wyre
+- [#8458](https://github.com/MetaMask/metamask-extension/pull/8458): Snapshot txMeta without cloning history
 
 ## 7.7.8 Wed Mar 11 2020
 - [#8176](https://github.com/MetaMask/metamask-extension/pull/8176): Handle and set gas estimation when max mode is clicked

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helper.js
@@ -57,13 +57,12 @@ function replayHistory (_shortHistory) {
 }
 
 /**
-  @param txMeta {Object}
-  @returns {object} a clone object of the txMeta with out history
-*/
+ * Snapshot {@code txMeta}
+ * @param {Object} txMeta - the tx metadata object
+ * @returns {Object} a deep clone without history
+ */
 function snapshotFromTxMeta (txMeta) {
-  // create txMeta snapshot for history
-  const snapshot = clone(txMeta)
-  // dont include previous history in this snapshot
-  delete snapshot.history
-  return snapshot
+  const shallow = { ...txMeta }
+  delete shallow.history
+  return clone(shallow)
 }


### PR DESCRIPTION
Backport #8363 to v7.7.9. Note that this uses `clone` instead of `cloneDeep`, because `clone` hadn't yet been replaced by `cloneDeep` on `master`.

Backporting that change as well would have been very disruptive, so I've updated this to use `clone` instead to minimize conflicts. It is functionally equivalent.