### PR TITLE
Backport "Fix method registry initialization (#8200)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#8447](https://github.com/MetaMask/metamask-extension/pull/8447): Delete Dai/Sai migration notification
 - [#8460](https://github.com/MetaMask/metamask-extension/pull/8460): Update deposit copy for Wyre
 - [#8458](https://github.com/MetaMask/metamask-extension/pull/8458): Snapshot txMeta without cloning history
+- [#8459](https://github.com/MetaMask/metamask-extension/pull/8459): Fix method registry initialization
 
 ## 7.7.8 Wed Mar 11 2020
 - [#8176](https://github.com/MetaMask/metamask-extension/pull/8176): Handle and set gas estimation when max mode is clicked

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -47,8 +47,7 @@ async function getMethodFrom4Byte (fourBytePrefix) {
     return null
   }
 }
-
-const registry = new MethodRegistry({ provider: global.ethereumProvider })
+let registry
 
 /**
  * Attempts to return the method data from the MethodRegistry library, the message registry library and the token abi, in that order of preference
@@ -61,6 +60,10 @@ export async function getMethodDataAsync (fourBytePrefix) {
       log.error(e)
       return null
     })
+
+    if (!registry) {
+      registry = new MethodRegistry({ provider: global.ethereumProvider })
+    }
 
     let sig = await registry.lookup(fourBytePrefix)
 


### PR DESCRIPTION
Backport #8200 to v7.7.9. Original commit description:

The method registry was being initialized with the global variable `ethereumProvider` before that variable was set. As a result, the method registry was falling back to an internally constructed provider that used the wrong provider URL (an obsolete Infura API). This was resulting in an error with the message "Project ID not found".

The method registry is now initialized lazily, when it's first needed. This should be well after the initialization of `ethereumProvider`, which occurs during the UI initialization.