### PR TITLE
fixes firefox popup location

### DIFF
--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -54,6 +54,11 @@ class NotificationManager {
         left,
         top,
       })
+
+      // Firefox currently ignores left/top for create, but it works for update
+      if (popupWindow.left !== left) {
+        await this.platform.updateWindowPosition(left, top, popupWindow.id)
+      }
       this._popupId = popupWindow.id
     }
   }

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -57,7 +57,7 @@ class NotificationManager {
 
       // Firefox currently ignores left/top for create, but it works for update
       if (popupWindow.left !== left) {
-        await this.platform.updateWindowPosition(left, top, popupWindow.id)
+        await this.platform.updateWindowPosition(popupWindow.id, left, top)
       }
       this._popupId = popupWindow.id
     }

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -60,6 +60,18 @@ class ExtensionPlatform {
     })
   }
 
+  updateWindowPosition (left, top, windowId) {
+    return new Promise((resolve, reject) => {
+      extension.windows.update(windowId, { left, top }, () => {
+        const error = checkForError()
+        if (error) {
+          return reject(error)
+        }
+        return resolve()
+      })
+    })
+  }
+
   getLastFocusedWindow () {
     return new Promise((resolve, reject) => {
       extension.windows.getLastFocused((windowObject) => {

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -60,7 +60,7 @@ class ExtensionPlatform {
     })
   }
 
-  updateWindowPosition (left, top, windowId) {
+  updateWindowPosition (windowId, left, top) {
     return new Promise((resolve, reject) => {
       extension.windows.update(windowId, { left, top }, () => {
         const error = checkForError()


### PR DESCRIPTION
Found that firefox doesn't have the proper popup location, but that's because firefox doesn't respect top and left on `windows.create`. https://bugzilla.mozilla.org/show_bug.cgi?id=1271047

It does, however, respect `windows.update`. This PR adds a method for moving the popup window if `popupWindow.left !== left`. Has a flash of the popup opening wherever firefox says it should, but ends up in the right place.

![fowm](https://user-images.githubusercontent.com/4448075/80644297-08906c00-8a2f-11ea-8667-fdac21d25c58.gif)
