### PR TITLE
Clear input elements in e2e tests instead of relying on Keys

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -434,17 +434,15 @@ describe('MetaMask', function () {
       await driver.assertElementNotPresent(By.xpath(`//li[contains(text(), 'Data')]`))
 
       const [gasPriceInput, gasLimitInput] = await driver.findElements(By.css('.advanced-gas-inputs__gas-edit-row__input'))
-      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
-
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await gasPriceInput.clear()
       await driver.delay(50)
       await gasPriceInput.sendKeys('10')
       await driver.delay(50)
       await driver.delay(tinyDelayMs)
       await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
+
+      await gasLimitInput.clear()
       await driver.delay(50)
       await gasLimitInput.sendKeys('25000')
 
@@ -693,16 +691,13 @@ describe('MetaMask', function () {
       const [gasPriceInput, gasLimitInput] = await driver.findElements(By.css('.advanced-gas-inputs__gas-edit-row__input'))
       const gasLimitValue = await gasLimitInput.getAttribute('value')
       assert(Number(gasLimitValue) < 100000, 'Gas Limit too high')
-      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await gasPriceInput.clear()
       await driver.delay(50)
       await gasPriceInput.sendKeys('10')
       await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+
+      await gasLimitInput.clear()
       await driver.delay(50)
       await gasLimitInput.sendKeys('60001')
 
@@ -954,16 +949,13 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
 
       const [gasPriceInput, gasLimitInput] = await driver.findElements(By.css('.advanced-gas-inputs__gas-edit-row__input'))
-      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await gasPriceInput.clear()
       await driver.delay(50)
       await gasPriceInput.sendKeys('10')
       await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+
+      await gasLimitInput.clear()
       await driver.delay(50)
       await gasLimitInput.sendKeys('60000')
 
@@ -1060,16 +1052,13 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
 
       const [gasPriceInput, gasLimitInput] = await driver.findElements(By.css('.advanced-gas-inputs__gas-edit-row__input'))
-      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await gasPriceInput.clear()
       await driver.delay(50)
       await gasPriceInput.sendKeys('10')
       await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.BACK_SPACE)
+
+      await gasLimitInput.clear()
       await driver.delay(50)
       await gasLimitInput.sendKeys('60001')
 

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const webdriver = require('selenium-webdriver')
 
-const { By, Key, until } = webdriver
+const { By, until } = webdriver
 const {
   tinyDelayMs,
   regularDelayMs,
@@ -111,21 +111,16 @@ describe('Using MetaMask with an existing account', function () {
       const gasModal = await driver.findElement(By.css('span .modal'))
 
       const [gasPriceInput, gasLimitInput] = await driver.findElements(By.css('.advanced-gas-inputs__gas-edit-row__input'))
-      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
-
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
-      await driver.delay(50)
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await gasPriceInput.clear()
       await driver.delay(50)
       await gasPriceInput.sendKeys('10')
       await driver.delay(50)
       await driver.delay(tinyDelayMs)
       await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
+      await gasLimitInput.clear()
+      await driver.delay(50)
       await gasLimitInput.sendKeys('25000')
 
       await driver.delay(1000)
@@ -154,9 +149,8 @@ describe('Using MetaMask with an existing account', function () {
       await driver.delay(regularDelayMs)
 
       const inputAmount = await driver.findElement(By.css('.unit-input__input'))
-      await inputAmount.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
-      await inputAmount.sendKeys(Key.BACK_SPACE)
+
+      await inputAmount.clear()
       await driver.delay(50)
       await inputAmount.sendKeys('2.2')
 
@@ -166,20 +160,16 @@ describe('Using MetaMask with an existing account', function () {
       const gasModal = await driver.findElement(By.css('span .modal'))
 
       const [gasPriceInput, gasLimitInput] = await driver.findElements(By.css('.advanced-gas-inputs__gas-edit-row__input'))
-      await gasPriceInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
-      await driver.delay(50)
-      await gasPriceInput.sendKeys(Key.BACK_SPACE)
+      await gasPriceInput.clear()
       await driver.delay(50)
       await gasPriceInput.sendKeys('8')
       await driver.delay(50)
       await driver.delay(tinyDelayMs)
       await driver.delay(50)
-      await gasLimitInput.sendKeys(Key.chord(Key.CONTROL, 'a'))
-      await driver.delay(50)
 
+      await gasLimitInput.clear()
+      await driver.delay(50)
       await gasLimitInput.sendKeys('100000')
 
       await driver.delay(1000)


### PR DESCRIPTION
Use `WebElement.clear()` instead of e.g. `WebElement.sendKeys(Key.chord(Key.CONTROL, 'a'))` to clear input elements.
- See [here](https://www.selenium.dev/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_WebElement.html#clear) for docs.

This appears to behave more sanely, which is to say that the affected tests pass on my system with this change, but not without. Perhaps it even gets rid of some intermittent failures in CI, who knows?