### PR TITLE
Backport "Don't updatePendingTxs outside of block updates (#8445)"

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -724,7 +724,6 @@ class TransactionController extends EventEmitter {
     Updates the memStore in transaction controller
   */
   _updateMemstore () {
-    this.pendingTxTracker.updatePendingTxs()
     const unapprovedTxs = this.txStateManager.getUnapprovedTxList()
     const selectedAddressTxList = this.txStateManager.getFilteredTxList({
       from: this.getSelectedAddress(),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -767,7 +767,7 @@ module.exports = class MetamaskController extends EventEmitter {
     }
 
     await this.preferencesController.syncAddresses(accounts)
-    await this.txController.pendingTxTracker.updatePendingTxs()
+    await this.blockTracker.checkForLatestBlock()
 
     try {
       const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()


### PR DESCRIPTION
Backport #8445 to v7.7.9. Original commit description:

* Don't updatePendingTxs outside of block updates

Refs #8377

Reverts 507397f6c (#5431)

* Check for new block data on unlock