### PR TITLE
Fix intermittent reject transaction test failure

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -601,8 +601,10 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Reject All')]`))
       await driver.delay(largeDelayMs * 2)
 
-      const confirmedTxes = await driver.findElements(By.css('.transaction-list__completed-transactions .transaction-list-item'))
-      assert.equal(confirmedTxes.length, 5, '5 transactions present')
+      await driver.wait(async () => {
+        const confirmedTxes = await driver.findElements(By.css('.transaction-list__completed-transactions .transaction-list-item'))
+        return confirmedTxes.length === 5
+      }, 10000)
     })
   })
 


### PR DESCRIPTION
This test would occasionally fail due to a fluke of timing, where a pending transaction would take slightly longer than expected to be rendered in the "confirmed transactions" list. This `wait` block ensures the test will try again until it has confirmed.