### PR TITLE
Capture UI state upon e2e test failure

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -171,6 +171,8 @@ class Driver {
     await fs.writeFile(`${filepathBase}-screenshot.png`, screenshot, { encoding: 'base64' })
     const htmlSource = await this.driver.getPageSource()
     await fs.writeFile(`${filepathBase}-dom.html`, htmlSource)
+    const uiState = await this.driver.executeScript(() => window.getCleanAppState())
+    await fs.writeFile(`${filepathBase}-state.json`, JSON.stringify(uiState, null, 2))
   }
 
   async checkBrowserForConsoleErrors () {


### PR DESCRIPTION
The UI state is now captured and stored as a test artifact in the event of an e2e test failure.