### PR TITLE
Ensure receive ETH test selects correct transaction

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -732,7 +732,7 @@ describe('MetaMask', function () {
       await driver.switchToWindow(extension)
       await driver.delay(largeDelayMs * 2)
 
-      await driver.clickElement(By.css('.transaction-list-item'))
+      await driver.clickElement(By.css('.transaction-list__pending-transactions  .transaction-list-item'))
       await driver.delay(regularDelayMs)
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Confirm')]`))


### PR DESCRIPTION
The test for receiving ETH from a contract had been clicking on the first transaction list item, assuming it was pending. This is not necessarily true; if the pending transaction hadn't yet been rendered, this could select the first confirmed transaction instead.

The test has been updated to look for the first _pending_ transaction, rather than just the first transaction.

Note that this likely does not fix the intermittent failure we've been experiencing. The failure has been observed with this fix in place.