### PR TITLE
Refactor gas limit estimation when gas limit specified

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -274,10 +274,13 @@ export default class TransactionController extends EventEmitter {
 
     // set gasLimit
 
-    if (
+    if (txParams.gas) {
+      txMeta.estimatedGas = txParams.gas
+      txMeta.gasLimitSpecified = Boolean(txParams.gas)
+      return txMeta
+    } else if (
       txParams.to &&
-      txMeta.transactionCategory === SEND_ETHER_ACTION_KEY &&
-      !txParams.gas
+      txMeta.transactionCategory === SEND_ETHER_ACTION_KEY
     ) {
       // if there's data in the params, but there's no contract code, it's not a valid transaction
       if (txParams.data) {

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -48,14 +48,6 @@ export default class TxGasUtil {
   async estimateTxGas (txMeta, blockGasLimitHex) {
     const txParams = txMeta.txParams
 
-    // check if gasLimit is already specified
-    txMeta.gasLimitSpecified = Boolean(txParams.gas)
-
-    // if it is, use that value
-    if (txMeta.gasLimitSpecified) {
-      return txParams.gas
-    }
-
     // fallback to block gasLimit
     const blockGasLimitBN = hexToBn(blockGasLimitHex)
     const saferGasLimitBN = BnMultiplyByFraction(blockGasLimitBN, 19, 20)
@@ -75,12 +67,6 @@ export default class TxGasUtil {
     txMeta.estimatedGas = addHexPrefix(estimatedGasHex)
     const txParams = txMeta.txParams
 
-    // if gasLimit was specified and doesnt OOG,
-    // use original specified amount
-    if (txMeta.gasLimitSpecified) {
-      txMeta.estimatedGas = txParams.gas
-      return
-    }
     // if gasLimit not originally specified,
     // try adding an additional gas buffer to our estimation for safety
     const recommendedGasHex = this.addGasBuffer(txMeta.estimatedGas, blockGasLimitHex)


### PR DESCRIPTION
The `analyzeGasUsage` function is skipped entirely now when the gas limit is specified. This is functionally equivalent to how it worked before.