### PR TITLE
Ensure tx has value before it's added

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -233,6 +233,12 @@ export default class TransactionController extends EventEmitter {
 
     const { transactionCategory, getCodeResponse } = await this._determineTransactionCategory(txParams)
     txMeta.transactionCategory = transactionCategory
+
+    // ensure value
+    txMeta.txParams.value = txMeta.txParams.value
+      ? ethUtil.addHexPrefix(txMeta.txParams.value)
+      : '0x0'
+
     this.addTx(txMeta)
     this.emit('newUnapprovedTx', txMeta)
 
@@ -262,9 +268,6 @@ export default class TransactionController extends EventEmitter {
   async addTxGasDefaults (txMeta, getCodeResponse) {
     const txParams = txMeta.txParams
 
-    // ensure value
-
-    txParams.value = txParams.value ? ethUtil.addHexPrefix(txParams.value) : '0x0'
     txMeta.gasPriceSpecified = Boolean(txParams.gasPrice)
     let gasPrice = txParams.gasPrice
     if (!gasPrice) {

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -182,6 +182,7 @@ describe('Transaction Controller', function () {
       assert.ok('metamaskNetworkId' in txMeta, 'should have a metamaskNetworkId')
       assert.ok('txParams' in txMeta, 'should have a txParams')
       assert.ok('history' in txMeta, 'should have a history')
+      assert.equal(txMeta.txParams.value, '0x0', 'should have added 0x0 as the value')
 
       const memTxMeta = txController.txStateManager.getTx(txMeta.id)
       assert.deepEqual(txMeta, memTxMeta)
@@ -241,7 +242,6 @@ describe('Transaction Controller', function () {
       providerResultStub.eth_estimateGas = '5209'
 
       const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta)
-      assert.equal(txMetaWithDefaults.txParams.value, '0x0', 'should have added 0x0 as the value')
       assert.ok(txMetaWithDefaults.txParams.gasPrice, 'should have added the gas price')
       assert.ok(txMetaWithDefaults.txParams.gas, 'should have added the gas field')
     })


### PR DESCRIPTION
Previously a transaction would get assigned a default value during the `addTxGasDefaults` function, after the transaction was added and sent to the UI.

Instead the transaction is assigned a default value before it gets added. This flow is simpler to follow, and it avoids the race condition where the transaction is assigned a value from the UI before this default is set. In that situation, the UI-assigned value would be overridden, which is obviously not desired.