### PR TITLE
Refactor `analyzeGasUsage` to return results

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -300,7 +300,14 @@ export default class TransactionController extends EventEmitter {
       txMeta.gasLimitSpecified = Boolean(txParams.gas)
       return txMeta
     }
-    return await this.txGasUtil.analyzeGasUsage(txMeta)
+
+    const { blockGasLimit, estimatedGasHex, simulationFails } = await this.txGasUtil.analyzeGasUsage(txMeta)
+    if (simulationFails) {
+      txMeta.simulationFails = simulationFails
+    } else {
+      this.txGasUtil.setTxGas(txMeta, blockGasLimit, estimatedGasHex)
+    }
+    return txMeta
   }
 
   /**


### PR DESCRIPTION
`analyzeGasUsage` now returns the results of the analysis rather than setting them directly on `txMeta`. The caller is now responsible for mutating `txMeta` instead. Functionally this should be identical to before.