### PR TITLE
Remove unnecessary tx meta properties

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -84,7 +84,6 @@ initialize().catch(log.error)
  * @property {boolean} loadingDefaults - TODO: Document
  * @property {Object} txParams - The tx params as passed to the network provider.
  * @property {Object[]} history - A history of mutations to this TransactionMeta object.
- * @property {boolean} gasPriceSpecified - True if the suggesting dapp specified a gas price, prevents auto-estimation.
  * @property {string} origin - A string representing the interface that suggested the transaction.
  * @property {Object} nonceDetails - A metadata object containing information used to derive the suggested nonce, useful for debugging nonce issues.
  * @property {string} rawTx - A hex string of the final signed transaction, ready to submit to the network.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -85,7 +85,6 @@ initialize().catch(log.error)
  * @property {Object} txParams - The tx params as passed to the network provider.
  * @property {Object[]} history - A history of mutations to this TransactionMeta object.
  * @property {boolean} gasPriceSpecified - True if the suggesting dapp specified a gas price, prevents auto-estimation.
- * @property {boolean} gasLimitSpecified - True if the suggesting dapp specified a gas limit, prevents auto-estimation.
  * @property {string} origin - A string representing the interface that suggested the transaction.
  * @property {Object} nonceDetails - A metadata object containing information used to derive the suggested nonce, useful for debugging nonce issues.
  * @property {string} rawTx - A hex string of the final signed transaction, ready to submit to the network.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -86,7 +86,6 @@ initialize().catch(log.error)
  * @property {Object[]} history - A history of mutations to this TransactionMeta object.
  * @property {boolean} gasPriceSpecified - True if the suggesting dapp specified a gas price, prevents auto-estimation.
  * @property {boolean} gasLimitSpecified - True if the suggesting dapp specified a gas limit, prevents auto-estimation.
- * @property {string} estimatedGas - A hex string represented the estimated gas limit required to complete the transaction.
  * @property {string} origin - A string representing the interface that suggested the transaction.
  * @property {Object} nonceDetails - A metadata object containing information used to derive the suggested nonce, useful for debugging nonce issues.
  * @property {string} rawTx - A hex string of the final signed transaction, ready to submit to the network.

--- a/app/scripts/controllers/transactions/README.md
+++ b/app/scripts/controllers/transactions/README.md
@@ -60,7 +60,6 @@ txMeta = {
             },
             ...], // I've removed most of history for this
   "gasPriceSpecified": false, //whether or not the user/dapp has specified gasPrice
-  "gasLimitSpecified": false, //whether or not the user/dapp has specified gas
   "origin": "MetaMask", //debug
   "nonceDetails": {
     "params": {

--- a/app/scripts/controllers/transactions/README.md
+++ b/app/scripts/controllers/transactions/README.md
@@ -61,7 +61,6 @@ txMeta = {
             ...], // I've removed most of history for this
   "gasPriceSpecified": false, //whether or not the user/dapp has specified gasPrice
   "gasLimitSpecified": false, //whether or not the user/dapp has specified gas
-  "estimatedGas": "5208",
   "origin": "MetaMask", //debug
   "nonceDetails": {
     "params": {

--- a/app/scripts/controllers/transactions/README.md
+++ b/app/scripts/controllers/transactions/README.md
@@ -59,7 +59,6 @@ txMeta = {
               "value": "0x3b9aca00"
             },
             ...], // I've removed most of history for this
-  "gasPriceSpecified": false, //whether or not the user/dapp has specified gasPrice
   "origin": "MetaMask", //debug
   "nonceDetails": {
     "params": {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -278,7 +278,6 @@ export default class TransactionController extends EventEmitter {
     // set gasLimit
 
     if (txParams.gas) {
-      txMeta.estimatedGas = txParams.gas
       txMeta.gasLimitSpecified = Boolean(txParams.gas)
       return txMeta
     } else if (
@@ -298,7 +297,6 @@ export default class TransactionController extends EventEmitter {
 
       // This is a standard ether simple send, gas requirement is exactly 21k
       txParams.gas = SIMPLE_GAS_COST
-      txMeta.estimatedGas = SIMPLE_GAS_COST
       txMeta.simpleSend = true
       txMeta.gasLimitSpecified = Boolean(txParams.gas)
       return txMeta

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -268,7 +268,6 @@ export default class TransactionController extends EventEmitter {
   async addTxGasDefaults (txMeta, getCodeResponse) {
     const txParams = txMeta.txParams
 
-    txMeta.gasPriceSpecified = Boolean(txParams.gasPrice)
     let gasPrice = txParams.gasPrice
     if (!gasPrice) {
       gasPrice = this.getGasPrice ? this.getGasPrice() : await this.query.gasPrice()

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -295,7 +295,6 @@ export default class TransactionController extends EventEmitter {
 
       // This is a standard ether simple send, gas requirement is exactly 21k
       txParams.gas = SIMPLE_GAS_COST
-      txMeta.simpleSend = true
       return txMeta
     }
 

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -278,7 +278,6 @@ export default class TransactionController extends EventEmitter {
     // set gasLimit
 
     if (txParams.gas) {
-      txMeta.gasLimitSpecified = Boolean(txParams.gas)
       return txMeta
     } else if (
       txParams.to &&
@@ -298,7 +297,6 @@ export default class TransactionController extends EventEmitter {
       // This is a standard ether simple send, gas requirement is exactly 21k
       txParams.gas = SIMPLE_GAS_COST
       txMeta.simpleSend = true
-      txMeta.gasLimitSpecified = Boolean(txParams.gas)
       return txMeta
     }
 

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -72,12 +72,11 @@ export default class TxGasUtil {
     @param {string} estimatedGasHex - the estimated gas hex
   */
   setTxGas (txMeta, blockGasLimitHex, estimatedGasHex) {
-    txMeta.estimatedGas = addHexPrefix(estimatedGasHex)
     const txParams = txMeta.txParams
 
     // if gasLimit not originally specified,
     // try adding an additional gas buffer to our estimation for safety
-    const recommendedGasHex = this.addGasBuffer(txMeta.estimatedGas, blockGasLimitHex)
+    const recommendedGasHex = this.addGasBuffer(addHexPrefix(estimatedGasHex), blockGasLimitHex)
     txParams.gas = recommendedGasHex
     return
   }

--- a/development/states/tx-list-items.json
+++ b/development/states/tx-list-items.json
@@ -76,7 +76,6 @@
           "message": "Error: intrinsic gas too low",
           "stack": "Error: some error"
         },
-        "estimatedGas": "0xcf08",
         "gasLimitSpecified": true,
         "gasPriceSpecified": true,
         "history": [
@@ -109,11 +108,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ],
           [
@@ -280,11 +274,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ],
           [
@@ -305,11 +294,9 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
-        "estimatedGas": "0xcf08"
+        "gasLimitSpecified": true
       },
       {
-        "estimatedGas": "8d41",
         "firstRetryBlockNumber": "0x2cbc70",
         "gasLimitSpecified": false,
         "gasPriceSpecified": false,
@@ -357,11 +344,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "8d41"
             }
           ],
           [
@@ -517,7 +499,6 @@
         }
       },
       {
-        "estimatedGas": "8d41",
         "firstRetryBlockNumber": "0x2cbc70",
         "gasLimitSpecified": false,
         "gasPriceSpecified": false,
@@ -565,11 +546,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "8d41"
             }
           ],
           [
@@ -769,11 +745,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ],
           [],
@@ -875,7 +846,6 @@
         ],
         "gasPriceSpecified": true,
         "gasLimitSpecified": true,
-        "estimatedGas": "0xcf08",
         "nonceDetails": {
           "params": {
             "highestLocalNonce": 3,
@@ -946,17 +916,11 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
-        "estimatedGas": "0xcf08"
+        "gasLimitSpecified": true
       }
     ],
     "unapprovedTxs": {
@@ -1003,17 +967,11 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
-        "estimatedGas": "0xcf08"
+        "gasLimitSpecified": true
       }
     },
     "unapprovedMsgs": {

--- a/development/states/tx-list-items.json
+++ b/development/states/tx-list-items.json
@@ -76,7 +76,6 @@
           "message": "Error: intrinsic gas too low",
           "stack": "Error: some error"
         },
-        "gasLimitSpecified": true,
         "gasPriceSpecified": true,
         "history": [
           {
@@ -102,11 +101,6 @@
             {
               "op": "add",
               "path": "/gasPriceSpecified",
-              "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
               "value": true
             }
           ],
@@ -269,11 +263,6 @@
               "op": "add",
               "path": "/gasPriceSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
-              "value": true
             }
           ],
           [
@@ -293,12 +282,10 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
-        "gasLimitSpecified": true
+        "gasPriceSpecified": true
       },
       {
         "firstRetryBlockNumber": "0x2cbc70",
-        "gasLimitSpecified": false,
         "gasPriceSpecified": false,
         "hash": "0xfbd997bf9bb85ca1598952ca23e7910502d527e06cb6ee1bbe7e7dd59d6909cd",
         "history": [
@@ -338,11 +325,6 @@
             {
               "op": "add",
               "path": "/gasPriceSpecified",
-              "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
               "value": false
             }
           ],
@@ -500,7 +482,6 @@
       },
       {
         "firstRetryBlockNumber": "0x2cbc70",
-        "gasLimitSpecified": false,
         "gasPriceSpecified": false,
         "hash": "0xfbd997bf9bb85ca1598952ca23e7910502d527e06cb6ee1bbe7e7dd59d6909cd",
         "history": [
@@ -540,11 +521,6 @@
             {
               "op": "add",
               "path": "/gasPriceSpecified",
-              "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
               "value": false
             }
           ],
@@ -740,11 +716,6 @@
               "op": "add",
               "path": "/gasPriceSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
-              "value": true
             }
           ],
           [],
@@ -845,7 +816,6 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
         "nonceDetails": {
           "params": {
             "highestLocalNonce": 3,
@@ -911,16 +881,10 @@
               "op": "add",
               "path": "/gasPriceSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
-              "value": true
             }
           ]
         ],
-        "gasPriceSpecified": true,
-        "gasLimitSpecified": true
+        "gasPriceSpecified": true
       }
     ],
     "unapprovedTxs": {
@@ -962,16 +926,10 @@
               "op": "add",
               "path": "/gasPriceSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
-              "value": true
             }
           ]
         ],
-        "gasPriceSpecified": true,
-        "gasLimitSpecified": true
+        "gasPriceSpecified": true
       }
     },
     "unapprovedMsgs": {

--- a/development/states/tx-list-items.json
+++ b/development/states/tx-list-items.json
@@ -76,7 +76,6 @@
           "message": "Error: intrinsic gas too low",
           "stack": "Error: some error"
         },
-        "gasPriceSpecified": true,
         "history": [
           {
             "id": 4068311466147836,
@@ -97,11 +96,6 @@
               "op": "replace",
               "path": "/loadingDefaults",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -258,11 +252,6 @@
               "op": "replace",
               "path": "/loadingDefaults",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -281,12 +270,10 @@
               "note": "txStateManager: setting status to approved"
             }
           ]
-        ],
-        "gasPriceSpecified": true
+        ]
       },
       {
         "firstRetryBlockNumber": "0x2cbc70",
-        "gasPriceSpecified": false,
         "hash": "0xfbd997bf9bb85ca1598952ca23e7910502d527e06cb6ee1bbe7e7dd59d6909cd",
         "history": [
           {
@@ -320,11 +307,6 @@
             {
               "op": "replace",
               "path": "/loadingDefaults",
-              "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
               "value": false
             }
           ],
@@ -482,7 +464,6 @@
       },
       {
         "firstRetryBlockNumber": "0x2cbc70",
-        "gasPriceSpecified": false,
         "hash": "0xfbd997bf9bb85ca1598952ca23e7910502d527e06cb6ee1bbe7e7dd59d6909cd",
         "history": [
           {
@@ -516,11 +497,6 @@
             {
               "op": "replace",
               "path": "/loadingDefaults",
-              "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
               "value": false
             }
           ],
@@ -711,11 +687,6 @@
               "op": "replace",
               "path": "/loadingDefaults",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [],
@@ -815,7 +786,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
         "nonceDetails": {
           "params": {
             "highestLocalNonce": 3,
@@ -876,15 +846,9 @@
               "op": "replace",
               "path": "/loadingDefaults",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ]
-        ],
-        "gasPriceSpecified": true
+        ]
       }
     ],
     "unapprovedTxs": {
@@ -921,15 +885,9 @@
               "op": "replace",
               "path": "/loadingDefaults",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ]
-        ],
-        "gasPriceSpecified": true
+        ]
       }
     },
     "unapprovedMsgs": {

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -56,11 +56,6 @@
               "op": "add",
               "path": "/gasPriceSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
-              "value": true
             }
           ],
           [
@@ -74,7 +69,6 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
         "origin": "MetaMask"
       }
     },
@@ -191,11 +185,6 @@
             {
               "op": "add",
               "path": "/gasPriceSpecified",
-              "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
               "value": true
             }
           ],
@@ -315,7 +304,6 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -383,11 +371,6 @@
             {
               "op": "add",
               "path": "/gasPriceSpecified",
-              "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
               "value": true
             }
           ],
@@ -507,7 +490,6 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -575,11 +557,6 @@
             {
               "op": "add",
               "path": "/gasPriceSpecified",
-              "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
               "value": true
             }
           ],
@@ -699,7 +676,6 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -774,11 +750,6 @@
               "op": "add",
               "path": "/gasPriceSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
-              "value": false
             }
           ],
           [
@@ -896,7 +867,6 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": false,
         "origin": "crypko.ai",
         "nonceDetails": {
           "params": {
@@ -966,11 +936,6 @@
             {
               "op": "add",
               "path": "/gasPriceSpecified",
-              "value": true
-            },
-            {
-              "op": "add",
-              "path": "/gasLimitSpecified",
               "value": true
             }
           ],
@@ -1090,7 +1055,6 @@
           ]
         ],
         "gasPriceSpecified": true,
-        "gasLimitSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -1173,11 +1137,6 @@
             },
             {
               "op": "add",
-              "path": "/gasLimitSpecified",
-              "value": false
-            },
-            {
-              "op": "add",
               "path": "/simpleSend",
               "value": true
             }
@@ -1202,7 +1161,6 @@
           ]
         ],
         "gasPriceSpecified": false,
-        "gasLimitSpecified": false,
         "simpleSend": true,
         "origin": "tmashuang.github.io"
       }

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -61,11 +61,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0x5208"
             }
           ],
           [
@@ -80,7 +75,6 @@
         ],
         "gasPriceSpecified": true,
         "gasLimitSpecified": true,
-        "estimatedGas": "0x5208",
         "origin": "MetaMask"
       }
     },
@@ -203,11 +197,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ],
           [
@@ -327,7 +316,6 @@
         ],
         "gasPriceSpecified": true,
         "gasLimitSpecified": true,
-        "estimatedGas": "0xcf08",
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -401,11 +389,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ],
           [
@@ -525,7 +508,6 @@
         ],
         "gasPriceSpecified": true,
         "gasLimitSpecified": true,
-        "estimatedGas": "0xcf08",
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -599,11 +581,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xcf08"
             }
           ],
           [
@@ -723,7 +700,6 @@
         ],
         "gasPriceSpecified": true,
         "gasLimitSpecified": true,
-        "estimatedGas": "0xcf08",
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -803,22 +779,11 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "40f14"
             }
           ],
           [
             {
-              "op": "replace",
-              "path": "/estimatedGas",
-              "value": "40f14",
               "note": "#newUnapprovedTransaction - adding the origin",
-              "timestamp": 1528133225492
-            },
-            {
               "op": "add",
               "path": "/origin",
               "value": "crypko.ai"
@@ -932,7 +897,6 @@
         ],
         "gasPriceSpecified": true,
         "gasLimitSpecified": false,
-        "estimatedGas": "40f14",
         "origin": "crypko.ai",
         "nonceDetails": {
           "params": {
@@ -1008,11 +972,6 @@
               "op": "add",
               "path": "/gasLimitSpecified",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0xd508"
             }
           ],
           [
@@ -1132,7 +1091,6 @@
         ],
         "gasPriceSpecified": true,
         "gasLimitSpecified": true,
-        "estimatedGas": "0xd508",
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -1222,11 +1180,6 @@
               "op": "add",
               "path": "/simpleSend",
               "value": true
-            },
-            {
-              "op": "add",
-              "path": "/estimatedGas",
-              "value": "0x5208"
             }
           ],
           [
@@ -1251,7 +1204,6 @@
         "gasPriceSpecified": false,
         "gasLimitSpecified": false,
         "simpleSend": true,
-        "estimatedGas": "0x5208",
         "origin": "tmashuang.github.io"
       }
     ]

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -1093,11 +1093,6 @@
               "op": "replace",
               "path": "/loadingDefaults",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/simpleSend",
-              "value": true
             }
           ],
           [
@@ -1119,7 +1114,6 @@
             }
           ]
         ],
-        "simpleSend": true,
         "origin": "tmashuang.github.io"
       }
     ]

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -51,11 +51,6 @@
               "path": "/loadingDefaults",
               "value": false,
               "timestamp": 1536268017685
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -68,7 +63,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
         "origin": "MetaMask"
       }
     },
@@ -181,11 +175,6 @@
               "path": "/loadingDefaults",
               "value": false,
               "timestamp": 1528133130666
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -303,7 +292,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -367,11 +355,6 @@
               "path": "/loadingDefaults",
               "value": false,
               "timestamp": 1528133150011
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -489,7 +472,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -553,11 +535,6 @@
               "path": "/loadingDefaults",
               "value": false,
               "timestamp": 1528133180720
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -675,7 +652,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -745,11 +721,6 @@
               "op": "replace",
               "path": "/loadingDefaults",
               "value": false
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -866,7 +837,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
         "origin": "crypko.ai",
         "nonceDetails": {
           "params": {
@@ -932,11 +902,6 @@
               "path": "/loadingDefaults",
               "value": false,
               "timestamp": 1528133291486
-            },
-            {
-              "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": true
             }
           ],
           [
@@ -1054,7 +1019,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": true,
         "origin": "MetaMask",
         "nonceDetails": {
           "params": {
@@ -1132,11 +1096,6 @@
             },
             {
               "op": "add",
-              "path": "/gasPriceSpecified",
-              "value": false
-            },
-            {
-              "op": "add",
               "path": "/simpleSend",
               "value": true
             }
@@ -1160,7 +1119,6 @@
             }
           ]
         ],
-        "gasPriceSpecified": false,
         "simpleSend": true,
         "origin": "tmashuang.github.io"
       }

--- a/test/data/v17-long-history.json
+++ b/test/data/v17-long-history.json
@@ -390,8 +390,7 @@
                 "value": "0x0",
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038869,
@@ -404,8 +403,7 @@
                 "value": "0x0",
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038869,
@@ -418,8 +416,7 @@
                 "value": "0x0",
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038869,
@@ -432,8 +429,7 @@
                 "value": "0x0",
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038869,
@@ -448,7 +444,6 @@
                 "gas": "0x7b0d",
                 "nonce": 0
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -469,7 +464,6 @@
                 "gas": "0x7b0d",
                 "nonce": 0
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -490,7 +484,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -511,7 +504,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -532,7 +524,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -554,7 +545,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -576,7 +566,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -599,7 +588,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -622,7 +610,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -645,7 +632,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -668,7 +654,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -692,7 +677,6 @@
                 "gas": "0x7b0d",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -704,7 +688,6 @@
               "retryCount": 1
             }
           ],
-          "gasLimitSpecified": false,
           "nonceDetails": {
             "blockNumber": "0x16643c",
             "baseCount": 0,
@@ -739,8 +722,7 @@
                 "value": "0x0",
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038870,
@@ -753,11 +735,9 @@
                 "value": "0x0",
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             }
-          ],
-          "gasLimitSpecified": false
+          ]
         },
         {
           "id": 6616756286038871,
@@ -785,8 +765,7 @@
                 "value": "0x0",
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038871,
@@ -799,8 +778,7 @@
                 "value": "0x0",
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038871,
@@ -813,8 +791,7 @@
                 "value": "0x0",
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038871,
@@ -827,8 +804,7 @@
                 "value": "0x0",
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038871,
@@ -843,7 +819,6 @@
                 "gas": "0x7b0d",
                 "nonce": 1
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -864,7 +839,6 @@
                 "gas": "0x7b0d",
                 "nonce": 1
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -886,7 +860,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -908,7 +881,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -930,7 +902,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -953,7 +924,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -976,7 +946,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1000,7 +969,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1024,7 +992,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1048,7 +1015,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1072,7 +1038,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1097,7 +1062,6 @@
                 "nonce": "0x01",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1109,7 +1073,6 @@
               "retryCount": 1
             }
           ],
-          "gasLimitSpecified": false,
           "nonceDetails": {
             "blockNumber": "0x168739",
             "baseCount": 1,
@@ -1146,8 +1109,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038872,
@@ -1160,8 +1122,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038872,
@@ -1174,8 +1135,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038872,
@@ -1188,8 +1148,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038872,
@@ -1204,7 +1163,6 @@
                 "gas": "0x7b0d",
                 "nonce": 2
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1225,7 +1183,6 @@
                 "gas": "0x7b0d",
                 "nonce": 2
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1247,7 +1204,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1269,7 +1225,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1291,7 +1246,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1314,7 +1268,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1337,7 +1290,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1361,7 +1313,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1385,7 +1336,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1409,7 +1359,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1433,7 +1382,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1458,7 +1406,6 @@
                 "nonce": "0x02",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1470,7 +1417,6 @@
               "retryCount": 1
             }
           ],
-          "gasLimitSpecified": false,
           "nonceDetails": {
             "blockNumber": "0x16b066",
             "baseCount": 2,
@@ -1507,8 +1453,7 @@
                 "value": "0x0",
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038873,
@@ -1521,8 +1466,7 @@
                 "value": "0x0",
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038873,
@@ -1535,8 +1479,7 @@
                 "value": "0x0",
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038873,
@@ -1549,8 +1492,7 @@
                 "value": "0x0",
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038873,
@@ -1565,7 +1507,6 @@
                 "gas": "0x7b0d",
                 "nonce": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1586,7 +1527,6 @@
                 "gas": "0x7b0d",
                 "nonce": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1608,7 +1548,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1630,7 +1569,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1652,7 +1590,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1675,7 +1612,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1698,7 +1634,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1722,7 +1657,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1746,7 +1680,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1770,7 +1703,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1794,7 +1726,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1819,7 +1750,6 @@
                 "nonce": "0x03",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1831,7 +1761,6 @@
               "retryCount": 2
             }
           ],
-          "gasLimitSpecified": false,
           "nonceDetails": {
             "blockNumber": "0x16b067",
             "baseCount": 2,
@@ -1868,8 +1797,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038874,
@@ -1882,8 +1810,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038874,
@@ -1896,8 +1823,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038874,
@@ -1910,8 +1836,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038874,
@@ -1926,7 +1851,6 @@
                 "gas": "0x7b0d",
                 "nonce": 4
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1947,7 +1871,6 @@
                 "gas": "0x7b0d",
                 "nonce": 4
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1969,7 +1892,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1991,7 +1913,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2013,7 +1934,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2036,7 +1956,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2059,7 +1978,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2083,7 +2001,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2107,7 +2024,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2131,7 +2047,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2155,7 +2070,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2180,7 +2094,6 @@
                 "nonce": "0x04",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2192,7 +2105,6 @@
               "retryCount": 4
             }
           ],
-          "gasLimitSpecified": false,
           "nonceDetails": {
             "blockNumber": "0x16b067",
             "baseCount": 2,
@@ -2229,8 +2141,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038875,
@@ -2243,8 +2154,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038875,
@@ -2257,8 +2167,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038875,
@@ -2271,8 +2180,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038875,
@@ -2287,7 +2195,6 @@
                 "gas": "0x7b0d",
                 "nonce": 5
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2308,7 +2215,6 @@
                 "gas": "0x7b0d",
                 "nonce": 5
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2330,7 +2236,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2352,7 +2257,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2374,7 +2278,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2397,7 +2300,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2420,7 +2322,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2444,7 +2345,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2468,7 +2368,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2492,7 +2391,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2516,7 +2414,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2541,7 +2438,6 @@
                 "nonce": "0x05",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2553,7 +2449,6 @@
               "retryCount": 3
             }
           ],
-          "gasLimitSpecified": false,
           "nonceDetails": {
             "blockNumber": "0x16b068",
             "baseCount": 3,
@@ -2590,8 +2485,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038876,
@@ -2604,8 +2498,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038876,
@@ -2618,8 +2511,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038876,
@@ -2632,8 +2524,7 @@
                 "value": "0x0",
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
-              },
-              "gasLimitSpecified": false
+              }
             },
             {
               "id": 6616756286038876,
@@ -2648,7 +2539,6 @@
                 "gas": "0x7b0d",
                 "nonce": 6
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2669,7 +2559,6 @@
                 "gas": "0x7b0d",
                 "nonce": 6
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2691,7 +2580,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2713,7 +2601,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2735,7 +2622,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2758,7 +2644,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2781,7 +2666,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2805,7 +2689,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2829,7 +2712,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2853,7 +2735,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2877,7 +2758,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2902,7 +2782,6 @@
                 "nonce": "0x06",
                 "chainId": 3
               },
-              "gasLimitSpecified": false,
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2914,7 +2793,6 @@
               "retryCount": 5
             }
           ],
-          "gasLimitSpecified": false,
           "nonceDetails": {
             "blockNumber": "0x16b068",
             "baseCount": 3,

--- a/test/data/v17-long-history.json
+++ b/test/data/v17-long-history.json
@@ -391,8 +391,7 @@
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038869,
@@ -406,8 +405,7 @@
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038869,
@@ -421,8 +419,7 @@
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038869,
@@ -436,8 +433,7 @@
                 "gasPrice": "3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038869,
@@ -453,7 +449,6 @@
                 "nonce": 0
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -475,7 +470,6 @@
                 "nonce": 0
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -497,7 +491,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -519,7 +512,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -541,7 +533,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -564,7 +555,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -587,7 +577,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -611,7 +600,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -635,7 +623,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -659,7 +646,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -683,7 +669,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -708,7 +693,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16643c",
                 "baseCount": 0,
@@ -721,7 +705,6 @@
             }
           ],
           "gasLimitSpecified": false,
-          "estimatedGas": "5209",
           "nonceDetails": {
             "blockNumber": "0x16643c",
             "baseCount": 0,
@@ -757,8 +740,7 @@
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038870,
@@ -772,12 +754,10 @@
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             }
           ],
-          "gasLimitSpecified": false,
-          "estimatedGas": "5209"
+          "gasLimitSpecified": false
         },
         {
           "id": 6616756286038871,
@@ -806,8 +786,7 @@
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038871,
@@ -821,8 +800,7 @@
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038871,
@@ -836,8 +814,7 @@
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038871,
@@ -851,8 +828,7 @@
                 "gasPrice": "28fa6ae00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038871,
@@ -868,7 +844,6 @@
                 "nonce": 1
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -890,7 +865,6 @@
                 "nonce": 1
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -913,7 +887,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -936,7 +909,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -959,7 +931,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -983,7 +954,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1007,7 +977,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1032,7 +1001,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1057,7 +1025,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1082,7 +1049,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1107,7 +1073,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1133,7 +1098,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x168739",
                 "baseCount": 1,
@@ -1146,7 +1110,6 @@
             }
           ],
           "gasLimitSpecified": false,
-          "estimatedGas": "5209",
           "nonceDetails": {
             "blockNumber": "0x168739",
             "baseCount": 1,
@@ -1184,8 +1147,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038872,
@@ -1199,8 +1161,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038872,
@@ -1214,8 +1175,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038872,
@@ -1229,8 +1189,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038872,
@@ -1246,7 +1205,6 @@
                 "nonce": 2
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1268,7 +1226,6 @@
                 "nonce": 2
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1291,7 +1248,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1314,7 +1270,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1337,7 +1292,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1361,7 +1315,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1385,7 +1338,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1410,7 +1362,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1435,7 +1386,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1460,7 +1410,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1485,7 +1434,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1511,7 +1459,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b066",
                 "baseCount": 2,
@@ -1524,7 +1471,6 @@
             }
           ],
           "gasLimitSpecified": false,
-          "estimatedGas": "5209",
           "nonceDetails": {
             "blockNumber": "0x16b066",
             "baseCount": 2,
@@ -1562,8 +1508,7 @@
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038873,
@@ -1577,8 +1522,7 @@
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038873,
@@ -1592,8 +1536,7 @@
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038873,
@@ -1607,8 +1550,7 @@
                 "gasPrice": "0x3b9aca00",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038873,
@@ -1624,7 +1566,6 @@
                 "nonce": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1646,7 +1587,6 @@
                 "nonce": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1669,7 +1609,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1692,7 +1631,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1715,7 +1653,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1739,7 +1676,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1763,7 +1699,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1788,7 +1723,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1813,7 +1747,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1838,7 +1771,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1863,7 +1795,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1889,7 +1820,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -1902,7 +1832,6 @@
             }
           ],
           "gasLimitSpecified": false,
-          "estimatedGas": "5209",
           "nonceDetails": {
             "blockNumber": "0x16b067",
             "baseCount": 2,
@@ -1940,8 +1869,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038874,
@@ -1955,8 +1883,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038874,
@@ -1970,8 +1897,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038874,
@@ -1985,8 +1911,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038874,
@@ -2002,7 +1927,6 @@
                 "nonce": 4
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2024,7 +1948,6 @@
                 "nonce": 4
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2047,7 +1970,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2070,7 +1992,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2093,7 +2014,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2117,7 +2037,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2141,7 +2060,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2166,7 +2084,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2191,7 +2108,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2216,7 +2132,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2241,7 +2156,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2267,7 +2181,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b067",
                 "baseCount": 2,
@@ -2280,7 +2193,6 @@
             }
           ],
           "gasLimitSpecified": false,
-          "estimatedGas": "5209",
           "nonceDetails": {
             "blockNumber": "0x16b067",
             "baseCount": 2,
@@ -2318,8 +2230,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038875,
@@ -2333,8 +2244,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038875,
@@ -2348,8 +2258,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038875,
@@ -2363,8 +2272,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038875,
@@ -2380,7 +2288,6 @@
                 "nonce": 5
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2402,7 +2309,6 @@
                 "nonce": 5
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2425,7 +2331,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2448,7 +2353,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2471,7 +2375,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2495,7 +2398,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2519,7 +2421,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2544,7 +2445,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2569,7 +2469,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2594,7 +2493,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2619,7 +2517,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2645,7 +2542,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2658,7 +2554,6 @@
             }
           ],
           "gasLimitSpecified": false,
-          "estimatedGas": "5209",
           "nonceDetails": {
             "blockNumber": "0x16b068",
             "baseCount": 3,
@@ -2696,8 +2591,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038876,
@@ -2711,8 +2605,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038876,
@@ -2726,8 +2619,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038876,
@@ -2741,8 +2633,7 @@
                 "gasPrice": "4a817c800",
                 "gas": "0x7b0d"
               },
-              "gasLimitSpecified": false,
-              "estimatedGas": "5209"
+              "gasLimitSpecified": false
             },
             {
               "id": 6616756286038876,
@@ -2758,7 +2649,6 @@
                 "nonce": 6
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2780,7 +2670,6 @@
                 "nonce": 6
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2803,7 +2692,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2826,7 +2714,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2849,7 +2736,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2873,7 +2759,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2897,7 +2782,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2922,7 +2806,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2947,7 +2830,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2972,7 +2854,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -2997,7 +2878,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -3023,7 +2903,6 @@
                 "chainId": 3
               },
               "gasLimitSpecified": false,
-              "estimatedGas": "5209",
               "nonceDetails": {
                 "blockNumber": "0x16b068",
                 "baseCount": 3,
@@ -3036,7 +2915,6 @@
             }
           ],
           "gasLimitSpecified": false,
-          "estimatedGas": "5209",
           "nonceDetails": {
             "blockNumber": "0x16b068",
             "baseCount": 3,

--- a/test/lib/migrations/004.json
+++ b/test/lib/migrations/004.json
@@ -88,7 +88,6 @@
                "nonce":"0x0",
                "gasLimit":"0x5209"
             },
-            "gasLimitSpecified":false,
             "txFee":"17e0186e60800",
             "txValue":"de0b6b3a7640000",
             "maxCost":"de234b52e4a0800",
@@ -111,7 +110,6 @@
                "gasPrice":"0x04a817c800",
                "gasLimit":"0x5209"
             },
-            "gasLimitSpecified":false,
             "txFee":"17e0186e60800",
             "txValue":"de0b6b3a7640000",
             "maxCost":"de234b52e4a0800",
@@ -131,7 +129,6 @@
                "metamaskNetworkId":"3",
                "gas":"0x5209"
             },
-            "gasLimitSpecified":false,
             "txFee":"17e0186e60800",
             "txValue":"de0b6b3a7640000",
             "maxCost":"de234b52e4a0800"

--- a/test/lib/migrations/004.json
+++ b/test/lib/migrations/004.json
@@ -89,7 +89,6 @@
                "gasLimit":"0x5209"
             },
             "gasLimitSpecified":false,
-            "estimatedGas":"0x5209",
             "txFee":"17e0186e60800",
             "txValue":"de0b6b3a7640000",
             "maxCost":"de234b52e4a0800",
@@ -113,7 +112,6 @@
                "gasLimit":"0x5209"
             },
             "gasLimitSpecified":false,
-            "estimatedGas":"0x5209",
             "txFee":"17e0186e60800",
             "txValue":"de0b6b3a7640000",
             "maxCost":"de234b52e4a0800",
@@ -134,7 +132,6 @@
                "gas":"0x5209"
             },
             "gasLimitSpecified":false,
-            "estimatedGas":"0x5209",
             "txFee":"17e0186e60800",
             "txValue":"de0b6b3a7640000",
             "maxCost":"de234b52e4a0800"

--- a/test/unit/app/controllers/network/stubs.js
+++ b/test/unit/app/controllers/network/stubs.js
@@ -7,7 +7,6 @@ export default {}
 
 // for pending middlewares test
 export const txMetaStub = {
-  'estimatedGas': '0x5208',
   'firstRetryBlockNumber': '0x51a402',
   'gasLimitSpecified': true,
   'gasPriceSpecified': true,
@@ -45,11 +44,6 @@ export const txMetaStub = {
         'op': 'add',
         'path': '/gasLimitSpecified',
         'value': true,
-      },
-      {
-        'op': 'add',
-        'path': '/estimatedGas',
-        'value': '0x5208',
       },
     ],
     [

--- a/test/unit/app/controllers/network/stubs.js
+++ b/test/unit/app/controllers/network/stubs.js
@@ -8,7 +8,6 @@ export default {}
 // for pending middlewares test
 export const txMetaStub = {
   'firstRetryBlockNumber': '0x51a402',
-  'gasPriceSpecified': true,
   'hash': '0x2cc5a25744486f7383edebbf32003e5a66e18135799593d6b5cdd2bb43674f09',
   'history': [
     {
@@ -33,11 +32,6 @@ export const txMetaStub = {
         'path': '/loadingDefaults',
         'timestamp': 1572395156645,
         'value': false,
-      },
-      {
-        'op': 'add',
-        'path': '/gasPriceSpecified',
-        'value': true,
       },
     ],
     [

--- a/test/unit/app/controllers/network/stubs.js
+++ b/test/unit/app/controllers/network/stubs.js
@@ -8,7 +8,6 @@ export default {}
 // for pending middlewares test
 export const txMetaStub = {
   'firstRetryBlockNumber': '0x51a402',
-  'gasLimitSpecified': true,
   'gasPriceSpecified': true,
   'hash': '0x2cc5a25744486f7383edebbf32003e5a66e18135799593d6b5cdd2bb43674f09',
   'history': [
@@ -38,11 +37,6 @@ export const txMetaStub = {
       {
         'op': 'add',
         'path': '/gasPriceSpecified',
-        'value': true,
-      },
-      {
-        'op': 'add',
-        'path': '/gasLimitSpecified',
         'value': true,
       },
     ],

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
@@ -10,7 +10,6 @@ describe('TransactionActivityLog utils', function () {
     it('should return activities for an array of transactions', function () {
       const transactions = [
         {
-          estimatedGas: '0x5208',
           hash: '0xa14f13d36b3901e352ce3a7acb9b47b001e5a3370f06232a0953c6fc6fad91b3',
           history: [
             {
@@ -180,11 +179,6 @@ describe('TransactionActivityLog utils', function () {
               op: 'add',
               path: '/gasLimitSpecified',
               value: true,
-            },
-            {
-              op: 'add',
-              path: '/estimatedGas',
-              value: '0x5208',
             },
           ],
           [

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
@@ -175,11 +175,6 @@ describe('TransactionActivityLog utils', function () {
               path: '/gasPriceSpecified',
               value: true,
             },
-            {
-              op: 'add',
-              path: '/gasLimitSpecified',
-              value: true,
-            },
           ],
           [
             {

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.util.test.js
@@ -170,11 +170,6 @@ describe('TransactionActivityLog utils', function () {
               timestamp: 1535507561515,
               value: false,
             },
-            {
-              op: 'add',
-              path: '/gasPriceSpecified',
-              value: true,
-            },
           ],
           [
             {

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -514,7 +514,6 @@ describe('Confirm Transaction Duck', function () {
             tokenSymbol: '',
           },
           txData: {
-            gasLimitSpecified: false,
             gasPriceSpecified: false,
             history: [],
             id: 2603411941761054,
@@ -547,7 +546,6 @@ describe('Confirm Transaction Duck', function () {
 
     it('updates txData and updates gas values in confirmTransaction', function () {
       const txData = {
-        gasLimitSpecified: false,
         gasPriceSpecified: false,
         history: [],
         id: 2603411941761054,
@@ -620,7 +618,6 @@ describe('Confirm Transaction Duck', function () {
           network: '3',
           unapprovedTxs: {
             2603411941761054: {
-              gasLimitSpecified: false,
               gasPriceSpecified: false,
               history: [],
               id: 2603411941761054,

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -519,7 +519,6 @@ describe('Confirm Transaction Duck', function () {
             loadingDefaults: false,
             metamaskNetworkId: '3',
             origin: 'faucet.metamask.io',
-            simpleSend: true,
             status: 'unapproved',
             time: 1530838113716,
           },
@@ -550,7 +549,6 @@ describe('Confirm Transaction Duck', function () {
         loadingDefaults: false,
         metamaskNetworkId: '3',
         origin: 'faucet.metamask.io',
-        simpleSend: true,
         status: 'unapproved',
         time: 1530838113716,
         txParams: {
@@ -621,7 +619,6 @@ describe('Confirm Transaction Duck', function () {
               loadingDefaults: false,
               metamaskNetworkId: '3',
               origin: 'faucet.metamask.io',
-              simpleSend: true,
               status: 'unapproved',
               time: 1530838113716,
               txParams: {

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -514,7 +514,6 @@ describe('Confirm Transaction Duck', function () {
             tokenSymbol: '',
           },
           txData: {
-            estimatedGas: '0x5208',
             gasLimitSpecified: false,
             gasPriceSpecified: false,
             history: [],
@@ -548,7 +547,6 @@ describe('Confirm Transaction Duck', function () {
 
     it('updates txData and updates gas values in confirmTransaction', function () {
       const txData = {
-        estimatedGas: '0x5208',
         gasLimitSpecified: false,
         gasPriceSpecified: false,
         history: [],
@@ -622,7 +620,6 @@ describe('Confirm Transaction Duck', function () {
           network: '3',
           unapprovedTxs: {
             2603411941761054: {
-              estimatedGas: '0x5208',
               gasLimitSpecified: false,
               gasPriceSpecified: false,
               history: [],

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -514,7 +514,6 @@ describe('Confirm Transaction Duck', function () {
             tokenSymbol: '',
           },
           txData: {
-            gasPriceSpecified: false,
             history: [],
             id: 2603411941761054,
             loadingDefaults: false,
@@ -546,7 +545,6 @@ describe('Confirm Transaction Duck', function () {
 
     it('updates txData and updates gas values in confirmTransaction', function () {
       const txData = {
-        gasPriceSpecified: false,
         history: [],
         id: 2603411941761054,
         loadingDefaults: false,
@@ -618,7 +616,6 @@ describe('Confirm Transaction Duck', function () {
           network: '3',
           unapprovedTxs: {
             2603411941761054: {
-              gasPriceSpecified: false,
               history: [],
               id: 2603411941761054,
               loadingDefaults: false,

--- a/ui/app/pages/send/tests/send-selectors-test-data.js
+++ b/ui/app/pages/send/tests/send-selectors-test-data.js
@@ -193,7 +193,6 @@ export default {
           'metamaskNetworkId': '3',
           'gas': '0x5209',
         },
-        'gasLimitSpecified': false,
         'txFee': '17e0186e60800',
         'txValue': 'de0b6b3a7640000',
         'maxCost': 'de234b52e4a0800',

--- a/ui/app/pages/send/tests/send-selectors-test-data.js
+++ b/ui/app/pages/send/tests/send-selectors-test-data.js
@@ -194,7 +194,6 @@ export default {
           'gas': '0x5209',
         },
         'gasLimitSpecified': false,
-        'estimatedGas': '0x5209',
         'txFee': '17e0186e60800',
         'txValue': 'de0b6b3a7640000',
         'maxCost': 'de234b52e4a0800',

--- a/ui/app/pages/send/tests/send-selectors.test.js
+++ b/ui/app/pages/send/tests/send-selectors.test.js
@@ -511,7 +511,6 @@ describe('send selectors', function () {
               metamaskNetworkId: '3',
               gas: '0x5209',
             },
-            gasLimitSpecified: false,
             txFee: '17e0186e60800',
             txValue: 'de0b6b3a7640000',
             maxCost: 'de234b52e4a0800',

--- a/ui/app/pages/send/tests/send-selectors.test.js
+++ b/ui/app/pages/send/tests/send-selectors.test.js
@@ -512,7 +512,6 @@ describe('send selectors', function () {
               gas: '0x5209',
             },
             gasLimitSpecified: false,
-            estimatedGas: '0x5209',
             txFee: '17e0186e60800',
             txValue: 'de0b6b3a7640000',
             maxCost: 'de234b52e4a0800',

--- a/ui/app/selectors/tests/selectors-test-data.js
+++ b/ui/app/selectors/tests/selectors-test-data.js
@@ -195,7 +195,6 @@ export default {
           'gas': '0x5209',
         },
         'gasLimitSpecified': false,
-        'estimatedGas': '0x5209',
         'txFee': '17e0186e60800',
         'txValue': 'de0b6b3a7640000',
         'maxCost': 'de234b52e4a0800',

--- a/ui/app/selectors/tests/selectors-test-data.js
+++ b/ui/app/selectors/tests/selectors-test-data.js
@@ -194,7 +194,6 @@ export default {
           'metamaskNetworkId': '3',
           'gas': '0x5209',
         },
-        'gasLimitSpecified': false,
         'txFee': '17e0186e60800',
         'txValue': 'de0b6b3a7640000',
         'maxCost': 'de234b52e4a0800',


### PR DESCRIPTION
Remove unnecessary properties from `txMeta`. This was done to simplify the default gas logic, which will make it easier to fix the underlying bug causing the intermittent e2e test failures.

* Remove `estimatedGas` property from `txMeta`

  The `estimatedGas` property was a cache of the gas value estimated for a transaction when the default gas limit was set. This property wasn't used anywhere. It may have been useful for debugging purposes, but the same gas estimate is already stored on the `history` property so it should be present in state logs regardless.

* Remove `gasLimitSpecified` txMeta property

  The `gasLimitSpecified` property of `txMeta` wasn't used for anything. It might have been useful for debugging purposes, but whether or not the gas limit was specified can also be determined from looking at the transaction history, so it's not a huge loss.

* Remove `gasPriceSpecified` txMeta property

  The `gasPriceSpecified` property of `txMeta` wasn't used for anything. It might have been useful for debugging purposes, but whether or not the gas price was specified can also be determined from looking at the transaction history, so it's not a huge loss.

* Remove `simpleSend` txMeta property

  The `simpleSend` property of `txMeta` was used to ensure a buffer was not added to the gas limit during gas estimation for simple send transactions. It was made redundant by #8484, which accomplishes this without the use of this property.