### PR TITLE
Fix default gas race condition

### DIFF
--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -230,7 +230,11 @@ describe('Transaction Controller', function () {
 
   describe('#addTxGasDefaults', function () {
     it('should add the tx defaults if their are none', async function () {
+      txController.txStateManager._saveTxList([
+        { id: 1, status: 'unapproved', metamaskNetworkId: currentNetworkId, txParams: {}, history: [{}] },
+      ])
       const txMeta = {
+        id: 1,
         txParams: {
           from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
           to: '0xc684832530fcbddae4b4230a47e991ddcec2831d',


### PR DESCRIPTION
A race condition exists where after adding an unapproved transaction, it could be mutated and then replaced when the default gas parameters are set. This happens because the transaction is added to state and broadcast before the default gas parameters are set, because calculating the default gas parameters to use takes some time. Once they've been calculated, the false assumption was made that the transaction hadn't changed.

The method responsible for setting the default gas now retrieves an up-to-date copy of `txMeta`, and conditionally sets the defaults only if they haven't yet been set.

This race condition was introduced in #2962, though that PR also added a loading screen that avoided this issue by preventing the user from interacting with the transaction until after the gas had been estimated. Unfortunately this loading screen was not carried forward to the new UI.
