### PR TITLE
Update tokens after importing account

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1159,12 +1159,18 @@ export function setSelectedToken (tokenAddress) {
   }
 }
 
+async function _setSelectedAddress (dispatch, address) {
+  log.debug(`background.setSelectedAddress`)
+  const tokens = await promisifiedBackground.setSelectedAddress(address)
+  dispatch(updateTokens(tokens))
+}
+
 export function setSelectedAddress (address) {
   return async (dispatch) => {
     dispatch(showLoadingIndication())
     log.debug(`background.setSelectedAddress`)
     try {
-      await promisifiedBackground.setSelectedAddress(address)
+      await _setSelectedAddress(dispatch, address)
     } catch (error) {
       dispatch(hideLoadingIndication())
       dispatch(displayWarning(error.message))
@@ -1186,16 +1192,14 @@ export function showAccountDetail (address) {
     const currentTabIsConnectedToNextAddress = permittedAccountsForCurrentTab.includes(address)
     const switchingToUnconnectedAddress = currentTabIsConnectedToPreviousAddress && !currentTabIsConnectedToNextAddress
 
-    let tokens
     try {
-      tokens = await promisifiedBackground.setSelectedAddress(address)
+      await _setSelectedAddress(dispatch, address)
     } catch (error) {
       dispatch(hideLoadingIndication())
       dispatch(displayWarning(error.message))
       return
     }
     dispatch(hideLoadingIndication())
-    dispatch(updateTokens(tokens))
     dispatch({
       type: actionConstants.SHOW_ACCOUNT_DETAIL,
       value: address,


### PR DESCRIPTION
Tokens are now updated when the account switches after a failed account import. The usual account switching flow (via the account menu) already updated tokens, but this step was omitted when the account switched after a failed import.