### PR TITLE
Minor permissions selector refactor

### DIFF
--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -1,5 +1,3 @@
-import { createSelector } from 'reselect'
-
 import {
   CAVEAT_NAMES,
 } from '../../../app/scripts/controllers/permissions/enums'
@@ -26,20 +24,18 @@ export function getPermittedAccounts (state, origin) {
  * @param {Object} state - The current state.
  * @returns {Object} Permitted accounts by origin.
  */
-export const getPermittedAccountsMap = createSelector(
-  allDomainsSelector,
-  (domains = {}) => {
-    return Object.keys(domains).reduce((acc, domainKey) => {
-      const accounts = getAccountsFromPermission(
-        getAccountsPermissionFromDomain(domains[domainKey])
-      )
-      if (accounts.length > 0) {
-        acc[domainKey] = accounts
-      }
-      return acc
-    }, {})
-  }
-)
+export function getPermittedAccountsByOrigin (state) {
+  const domains = allDomainsSelector(state)
+  return Object.keys(domains).reduce((acc, domainKey) => {
+    const accounts = getAccountsFromPermission(
+      getAccountsPermissionFromDomain(domains[domainKey])
+    )
+    if (accounts.length > 0) {
+      acc[domainKey] = accounts
+    }
+    return acc
+  }, [])
+}
 
 // selector helpers
 
@@ -72,7 +68,7 @@ function getAccountsCaveatFromPermission (accountsPermission = {}) {
 }
 
 function allDomainsSelector (state) {
-  return state.metamask.domains
+  return state.metamask.domains || {}
 }
 
 function domainSelector (state, origin) {

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -34,7 +34,7 @@ export function getPermittedAccountsByOrigin (state) {
       acc[domainKey] = accounts
     }
     return acc
-  }, [])
+  }, {})
 }
 
 // selector helpers

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -12,7 +12,7 @@ import {
   getAccountByAddress,
 } from '../helpers/utils/util'
 
-import { getPermittedAccountsMap } from './permissions'
+import { getPermittedAccountsByOrigin } from './permissions'
 
 export { getPermittedAccounts } from './permissions'
 
@@ -440,7 +440,7 @@ export function getAddressConnectedDomainMap (state) {
     domainMetadata,
   } = state.metamask
 
-  const accountsMap = getPermittedAccountsMap(state)
+  const accountsMap = getPermittedAccountsByOrigin(state)
   const addressConnectedIconMap = {}
 
   Object.keys(accountsMap).forEach((domainKey) => {
@@ -457,7 +457,7 @@ export function getAddressConnectedDomainMap (state) {
 }
 
 export function getPermittedAccountsForCurrentTab (state) {
-  const permittedAccountsMap = getPermittedAccountsMap(state)
+  const permittedAccountsMap = getPermittedAccountsByOrigin(state)
   const originOfCurrentTab = getOriginOfCurrentTab(state)
   return permittedAccountsMap[originOfCurrentTab] || []
 }


### PR DESCRIPTION
Removes `reselect` from permissions selectors and adds some default return values. Prepares for #8496.