### PR TITLE
feat: support ipns address translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Develop Branch
 - [#7912](https://github.com/MetaMask/metamask-extension/pull/7912): Disable import button for empty string/file
 - [#8246](https://github.com/MetaMask/metamask-extension/pull/8246): Make seed phrase import case-insensitive
+- [#8502](https://github.com/MetaMask/metamask-extension/pull/8502): Add support for IPFS address resolution
 
 ## 7.7.0 Thu Nov 28 2019
 - [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Connect distinct accounts per site

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -61,7 +61,7 @@ export default class PreferencesController {
       metaMetricsSendCount: 0,
 
       // ENS decentralized website resolution
-      ipfsGateway: 'ipfs.dweb.link',
+      ipfsGateway: 'dweb.link',
     }, opts.initState)
 
     this.diagnostics = opts.diagnostics

--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -32,7 +32,7 @@ export default async function resolveEnsToIpfsContentId ({ provider, name }) {
     let decodedContentHash = contentHash.decode(rawContentHash)
     const type = contentHash.getCodec(rawContentHash)
 
-    if (type === 'ipfs-ns') {
+    if (type === 'ipfs-ns' || type === 'ipns-ns') {
       decodedContentHash = contentHash.helpers.cidV0ToV1Base32(decodedContentHash)
     }
 

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -44,8 +44,8 @@ export default function setupEnsIpfsResolver ({ provider, getCurrentNetwork, get
     let url = `https://app.ens.domains/name/${name}`
     try {
       const { type, hash } = await resolveEnsToIpfsContentId({ provider, name })
-      if (type === 'ipfs-ns') {
-        const resolvedUrl = `https://${hash}.${ipfsGateway}${path}${search || ''}${fragment || ''}`
+      if (type === 'ipfs-ns' || type === 'ipns-ns') {
+        const resolvedUrl = `https://${hash}.${type.slice(0, 4)}.${ipfsGateway}${path}${search || ''}${fragment || ''}`
         try {
           // check if ipfs gateway has result
           const response = await window.fetch(resolvedUrl, { method: 'HEAD' })

--- a/app/scripts/migrations/045.js
+++ b/app/scripts/migrations/045.js
@@ -1,0 +1,32 @@
+const version = 45
+import { cloneDeep } from 'lodash'
+
+/**
+ * Replace ipfsGateway by 'dweb.link'.
+ */
+export default {
+  version,
+  migrate: async function (originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData)
+    versionedData.meta.version = version
+    const state = versionedData.data
+    versionedData.data = transformState(state)
+    return versionedData
+  },
+}
+
+const outdatedGateways = [
+  'ipfs.io',
+  'ipfs.dweb.link',
+]
+
+function transformState (state) {
+  if (!state.PreferencesController) {
+    return state
+  }
+
+  if (!state.PreferencesController.ipfsGateway || outdatedGateways.includes(state.PreferencesController.ipfsGateway)) {
+    state.PreferencesController.ipfsGateway = 'dweb.link'
+  }
+  return state
+}

--- a/app/scripts/migrations/045.js
+++ b/app/scripts/migrations/045.js
@@ -2,7 +2,7 @@ const version = 45
 import { cloneDeep } from 'lodash'
 
 /**
- * Replace ipfsGateway by 'dweb.link'.
+ * Replaces {@code PreferencesController.ipfsGateway} with 'dweb.link' if set
  */
 export default {
   version,

--- a/app/scripts/migrations/045.js
+++ b/app/scripts/migrations/045.js
@@ -21,11 +21,7 @@ const outdatedGateways = [
 ]
 
 function transformState (state) {
-  if (!state.PreferencesController) {
-    return state
-  }
-
-  if (!state.PreferencesController.ipfsGateway || outdatedGateways.includes(state.PreferencesController.ipfsGateway)) {
+  if (outdatedGateways.includes(state?.PreferencesController?.ipfsGateway)) {
     state.PreferencesController.ipfsGateway = 'dweb.link'
   }
   return state

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -55,6 +55,7 @@ const migrations = [
   require('./042').default,
   require('./043').default,
   require('./044').default,
+  require('./045').default,
 ]
 
 export default migrations

--- a/test/unit/migrations/045-test.js
+++ b/test/unit/migrations/045-test.js
@@ -1,0 +1,92 @@
+import assert from 'assert'
+import migration45 from '../../../app/scripts/migrations/045'
+
+describe('migration #45', function () {
+  it('should update the version metadata', function (done) {
+    const oldStorage = {
+      'meta': {
+        'version': 44,
+      },
+      'data': {},
+    }
+
+    migration45.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.meta, {
+          'version': 45,
+        })
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should update ipfsGateway value if outdated', function (done) {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          ipfsGateway: 'ipfs.dweb.link',
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    migration45.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data, {
+          PreferencesController: {
+            ipfsGateway: 'dweb.link',
+            bar: 'baz',
+          },
+          foo: 'bar',
+        })
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should not update ipfsGateway value if custom set', function (done) {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          ipfsGateway: 'blah',
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    migration45.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data, {
+          PreferencesController: {
+            ipfsGateway: 'blah',
+            bar: 'baz',
+          },
+          foo: 'bar',
+        })
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should do nothing if no PreferencesController key', function (done) {
+    const oldStorage = {
+      meta: {},
+      data: {
+        foo: 'bar',
+      },
+    }
+
+    migration45.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data, {
+          foo: 'bar',
+        })
+        done()
+      })
+      .catch(done)
+  })
+})


### PR DESCRIPTION
Hi! 👋

This adds support for [IPNS Links](https://docs-beta.ipfs.io/concepts/ipns/) which are also part of IPFS spec. The address resolution is exactly the same since they're encoded the same way.

I needed to change the default `ipfsGateway` from `ipfs.dweb.link` to `ipns.dweb.link` which is similar to the defaults of IPFS Companion. I added a migration to replace whatever value the user has there by the new default.

<img width="675" alt="Screenshot 2020-05-03 at 16 13 59" src="https://user-images.githubusercontent.com/5447088/80919588-b74fe780-8d62-11ea-9f86-6e3ef36292ee.png">

This **does not** add support for [DNSLink](https://docs-beta.ipfs.io/concepts/dnslink/#publish-using-a-subdomain) though. /cc @lidel