### PR TITLE
Delete unused token rate state and selectors

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -103,7 +103,7 @@ initialize().catch(log.error)
  * @property {Array} frequentRpcList - A list of frequently used RPCs, including custom user-provided ones.
  * @property {Array} addressBook - A list of previously sent to addresses.
  * @property {address} selectedTokenAddress - Used to indicate if a token is globally selected. Should be deprecated in favor of UI-centric token selection.
- * @property {Object} tokenExchangeRates - Info about current token prices.
+ * @property {Object} contractExchangeRates - Info about current token prices.
  * @property {Array} tokens - Tokens held by the current user, including their balances.
  * @property {Object} send - TODO: Document
  * @property {Object} coinOptions - TODO: Document

--- a/test/unit/ui/app/selectors.spec.js
+++ b/test/unit/ui/app/selectors.spec.js
@@ -46,30 +46,6 @@ describe('Selectors', function () {
     })
   })
 
-
-  describe('#getTokenExchangeRate', function () {
-    let missingTokenRate
-
-    beforeEach(function () {
-      missingTokenRate = {
-        metamask: {
-          'contractExchangeRates': {},
-        },
-      }
-    })
-
-    it('returns 0 token exchange rate for a token not in state', function () {
-      const tokenRate = selectors.getTokenExchangeRate(missingTokenRate, '0xd8f6a2ffb0fc5952d16c9768b71cfd35b6399aa5')
-      assert.equal(tokenRate, 0)
-    })
-
-    it('returns token exchange rate for specified token in state', function () {
-      const tokenRate = selectors.getTokenExchangeRate(mockState, '0xd8f6a2ffb0fc5952d16c9768b71cfd35b6399aa5')
-      assert.equal(tokenRate, 0.00008189274407698049)
-    })
-
-  })
-
   it('returns conversionRate from state', function () {
     assert.equal(selectors.conversionRateSelector(mockState), 556.12)
   })

--- a/ui/app/components/ui/token-input/token-input.container.js
+++ b/ui/app/components/ui/token-input/token-input.container.js
@@ -1,6 +1,11 @@
 import { connect } from 'react-redux'
 import TokenInput from './token-input.component'
-import { getIsMainnet, getSelectedToken, getSelectedTokenExchangeRate, preferencesSelector } from '../../../selectors'
+import {
+  getIsMainnet,
+  getSelectedToken,
+  getSelectedTokenExchangeRate,
+  preferencesSelector,
+} from '../../../selectors'
 
 const mapStateToProps = (state) => {
   const { metamask: { currentCurrency } } = state

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -12,7 +12,6 @@ export default function reduceMetamask (state = {}, action) {
     addressBook: [],
     selectedTokenAddress: null,
     contractExchangeRates: {},
-    tokenExchangeRates: {},
     tokens: [],
     pendingTokens: {},
     customNonceValue: '',

--- a/ui/app/pages/send/send-content/send-amount-row/send-amount-row.component.js
+++ b/ui/app/pages/send/send-content/send-amount-row/send-amount-row.component.js
@@ -10,10 +10,6 @@ export default class SendAmountRow extends Component {
 
   static propTypes = {
     amount: PropTypes.string,
-    amountConversionRate: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
     balance: PropTypes.string,
     conversionRate: PropTypes.number,
     gasTotal: PropTypes.string,
@@ -50,7 +46,6 @@ export default class SendAmountRow extends Component {
 
   validateAmount (amount) {
     const {
-      amountConversionRate,
       balance,
       conversionRate,
       gasTotal,
@@ -63,7 +58,6 @@ export default class SendAmountRow extends Component {
 
     updateSendAmountError({
       amount,
-      amountConversionRate,
       balance,
       conversionRate,
       gasTotal,
@@ -74,7 +68,6 @@ export default class SendAmountRow extends Component {
 
     if (selectedToken) {
       updateGasFeeError({
-        amountConversionRate,
         balance,
         conversionRate,
         gasTotal,

--- a/ui/app/pages/send/send-content/send-amount-row/send-amount-row.container.js
+++ b/ui/app/pages/send/send-content/send-amount-row/send-amount-row.container.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux'
 import {
-  getAmountConversionRate,
   getConversionRate,
   getGasTotal,
   getPrimaryCurrency,
@@ -26,7 +25,6 @@ export default connect(mapStateToProps, mapDispatchToProps)(SendAmountRow)
 function mapStateToProps (state) {
   return {
     amount: getSendAmount(state),
-    amountConversionRate: getAmountConversionRate(state),
     balance: getSendFromBalance(state),
     conversionRate: getConversionRate(state),
     gasTotal: getGasTotal(state),

--- a/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-amount-row/tests/send-amount-row-component.test.js
@@ -19,7 +19,6 @@ describe('SendAmountRow Component', function () {
 
       assert.ok(updateSendAmountError.calledOnceWithExactly({
         amount: 'someAmount',
-        amountConversionRate: 'mockAmountConversionRate',
         balance: 'mockBalance',
         conversionRate: 7,
         gasTotal: 'mockGasTotal',
@@ -37,7 +36,6 @@ describe('SendAmountRow Component', function () {
       instance.validateAmount('someAmount')
 
       assert.ok(updateGasFeeError.calledOnceWithExactly({
-        amountConversionRate: 'mockAmountConversionRate',
         balance: 'mockBalance',
         conversionRate: 7,
         gasTotal: 'mockGasTotal',
@@ -148,7 +146,6 @@ function shallowRenderSendAmountRow () {
   const wrapper = shallow((
     <SendAmountRow
       amount="mockAmount"
-      amountConversionRate="mockAmountConversionRate"
       balance="mockBalance"
       conversionRate={7}
       convertedCurrency="mockConvertedCurrency"

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -20,10 +20,6 @@ export default class SendTransactionScreen extends Component {
   static propTypes = {
     addressBook: PropTypes.arrayOf(PropTypes.object),
     amount: PropTypes.string,
-    amountConversionRate: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
     blockGasLimit: PropTypes.string,
     conversionRate: PropTypes.number,
     editingTransactionId: PropTypes.string,
@@ -77,7 +73,6 @@ export default class SendTransactionScreen extends Component {
   componentDidUpdate (prevProps) {
     const {
       amount,
-      amountConversionRate,
       conversionRate,
       from: { address, balance },
       gasTotal,
@@ -122,7 +117,6 @@ export default class SendTransactionScreen extends Component {
     if (amountErrorRequiresUpdate) {
       const amountErrorObject = getAmountErrorObject({
         amount,
-        amountConversionRate,
         balance,
         conversionRate,
         gasTotal,
@@ -132,7 +126,6 @@ export default class SendTransactionScreen extends Component {
       })
       const gasFeeErrorObject = selectedToken
         ? getGasFeeErrorObject({
-          amountConversionRate,
           balance,
           conversionRate,
           gasTotal,

--- a/ui/app/pages/send/send.container.js
+++ b/ui/app/pages/send/send.container.js
@@ -4,7 +4,6 @@ import { withRouter } from 'react-router-dom'
 import { compose } from 'redux'
 
 import {
-  getAmountConversionRate,
   getBlockGasLimit,
   getConversionRate,
   getCurrentNetwork,
@@ -59,7 +58,6 @@ function mapStateToProps (state) {
   return {
     addressBook: getAddressBook(state),
     amount: getSendAmount(state),
-    amountConversionRate: getAmountConversionRate(state),
     blockGasLimit: getBlockGasLimit(state),
     conversionRate: getConversionRate(state),
     editingTransactionId,

--- a/ui/app/pages/send/send.selectors.js
+++ b/ui/app/pages/send/send.selectors.js
@@ -1,5 +1,4 @@
 import abi from 'human-standard-token-abi'
-import { multiplyCurrencies } from '../../helpers/utils/conversion-util'
 import {
   accountsWithSendEtherInfoSelector,
   getAddressBook,
@@ -9,12 +8,6 @@ import {
   getAveragePriceEstimateInHexWEI,
 } from '../../selectors'
 import { estimateGasPriceFromRecentBlocks, calcGasTotal } from './send.utils'
-
-export function getAmountConversionRate (state) {
-  return getSelectedToken(state)
-    ? getSelectedTokenToFiatRate(state)
-    : getConversionRate(state)
-}
 
 export function getBlockGasLimit (state) {
   return state.metamask.currentBlockGasLimit
@@ -89,29 +82,6 @@ export function getSelectedTokenContract (state) {
     : null
 }
 
-export function getSelectedTokenExchangeRate (state) {
-  const tokenExchangeRates = state.metamask.tokenExchangeRates
-  const selectedToken = getSelectedToken(state) || {}
-  const { symbol = '' } = selectedToken
-  const pair = `${symbol.toLowerCase()}_eth`
-  const { rate: tokenExchangeRate = 0 } = (tokenExchangeRates && tokenExchangeRates[pair]) || {}
-
-  return tokenExchangeRate
-}
-
-export function getSelectedTokenToFiatRate (state) {
-  const selectedTokenExchangeRate = getSelectedTokenExchangeRate(state)
-  const conversionRate = getConversionRate(state)
-
-  const tokenToFiatRate = multiplyCurrencies(
-    conversionRate,
-    selectedTokenExchangeRate,
-    { toNumericBase: 'dec' }
-  )
-
-  return tokenToFiatRate
-}
-
 export function getSendAmount (state) {
   return state.metamask.send.amount
 }
@@ -179,14 +149,6 @@ export function getSendEnsResolution (state) {
 
 export function getSendEnsResolutionError (state) {
   return state.metamask.send.ensResolutionError
-}
-
-export function getTokenExchangeRate (state, tokenSymbol) {
-  const pair = `${tokenSymbol.toLowerCase()}_eth`
-  const tokenExchangeRates = state.metamask.tokenExchangeRates
-  const { rate: tokenExchangeRate = 0 } = tokenExchangeRates[pair] || {}
-
-  return tokenExchangeRate
 }
 
 export function getUnapprovedTxs (state) {

--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -50,7 +50,6 @@ function calcGasTotal (gasLimit = '0', gasPrice = '0') {
 
 function isBalanceSufficient ({
   amount = '0x0',
-  amountConversionRate = 1,
   balance = '0x0',
   conversionRate = 1,
   gasTotal = '0x0',
@@ -72,7 +71,7 @@ function isBalanceSufficient ({
     {
       value: totalAmount,
       fromNumericBase: 'hex',
-      conversionRate: Number(amountConversionRate) || conversionRate,
+      conversionRate: conversionRate,
       fromCurrency: primaryCurrency,
     },
   )
@@ -104,7 +103,6 @@ function isTokenBalanceSufficient ({
 
 function getAmountErrorObject ({
   amount,
-  amountConversionRate,
   balance,
   conversionRate,
   gasTotal,
@@ -116,7 +114,6 @@ function getAmountErrorObject ({
   if (gasTotal && conversionRate && !selectedToken) {
     insufficientFunds = !isBalanceSufficient({
       amount,
-      amountConversionRate,
       balance,
       conversionRate,
       gasTotal,
@@ -153,7 +150,6 @@ function getAmountErrorObject ({
 }
 
 function getGasFeeErrorObject ({
-  amountConversionRate,
   balance,
   conversionRate,
   gasTotal,
@@ -164,7 +160,6 @@ function getGasFeeErrorObject ({
   if (gasTotal && conversionRate) {
     const insufficientFunds = !isBalanceSufficient({
       amount: '0x0',
-      amountConversionRate,
       balance,
       conversionRate,
       gasTotal,

--- a/ui/app/pages/send/tests/send-component.test.js
+++ b/ui/app/pages/send/tests/send-component.test.js
@@ -45,7 +45,6 @@ describe('Send Component', function () {
     wrapper = shallow((
       <SendTransactionScreen
         amount="mockAmount"
-        amountConversionRate="mockAmountConversionRate"
         blockGasLimit="mockBlockGasLimit"
         conversionRate={10}
         editingTransactionId="mockEditingTransactionId"
@@ -171,7 +170,6 @@ describe('Send Component', function () {
         utilsMethodStubs.getAmountErrorObject.getCall(0).args[0],
         {
           amount: 'mockAmount',
-          amountConversionRate: 'mockAmountConversionRate',
           balance: 'mockBalance',
           conversionRate: 10,
           gasTotal: 'mockGasTotal',
@@ -193,7 +191,6 @@ describe('Send Component', function () {
       assert.deepEqual(
         utilsMethodStubs.getGasFeeErrorObject.getCall(0).args[0],
         {
-          amountConversionRate: 'mockAmountConversionRate',
           balance: 'mockBalance',
           conversionRate: 10,
           gasTotal: 'mockGasTotal',

--- a/ui/app/pages/send/tests/send-selectors-test-data.js
+++ b/ui/app/pages/send/tests/send-selectors-test-data.js
@@ -82,14 +82,6 @@ export default {
         'symbol': 'GHI',
       },
     ],
-    'tokenExchangeRates': {
-      'def_eth': {
-        rate: 2.0,
-      },
-      'ghi_eth': {
-        rate: 31.01,
-      },
-    },
     'transactions': {},
     'currentNetworkTxList': [
       {

--- a/ui/app/pages/send/tests/send-selectors.test.js
+++ b/ui/app/pages/send/tests/send-selectors.test.js
@@ -6,7 +6,6 @@ import {
 } from '../../../selectors'
 import {
   getBlockGasLimit,
-  getAmountConversionRate,
   getConversionRate,
   getCurrentCurrency,
   getCurrentNetwork,
@@ -20,8 +19,6 @@ import {
   getSelectedIdentity,
   getSelectedToken,
   getSelectedTokenContract,
-  getSelectedTokenExchangeRate,
-  getSelectedTokenToFiatRate,
   getSendAmount,
   sendAmountIsInError,
   getSendEditingTransactionId,
@@ -34,7 +31,6 @@ import {
   getSendTo,
   getSendToAccounts,
   getTokenBalance,
-  getTokenExchangeRate,
   getUnapprovedTxs,
   gasFeeIsInError,
   getGasLoadingError,
@@ -93,34 +89,6 @@ describe('send selectors', function () {
             name: 'Send Account 4',
           },
         ]
-      )
-    })
-  })
-
-  // describe('autoAddToBetaUI()', () => {
-  //   it('should', () => {
-  //     assert.deepEqual(
-  //       autoAddToBetaUI(mockState),
-
-  //     )
-  //   })
-  // })
-
-  describe('getAmountConversionRate()', function () {
-    it('should return the token conversion rate if a token is selected', function () {
-      assert.equal(
-        getAmountConversionRate(mockState),
-        2401.76400654
-      )
-    })
-
-    it('should return the eth conversion rate if no token is selected', function () {
-      const editedMockState = {
-        metamask: Object.assign({}, mockState.metamask, { selectedTokenAddress: null }),
-      }
-      assert.equal(
-        getAmountConversionRate(editedMockState),
-        1200.88200327
       )
     })
   })
@@ -301,24 +269,6 @@ describe('send selectors', function () {
     })
   })
 
-  describe('getSelectedTokenExchangeRate()', function () {
-    it('should return the exchange rate for the selected token', function () {
-      assert.equal(
-        getSelectedTokenExchangeRate(mockState),
-        2.0
-      )
-    })
-  })
-
-  describe('getSelectedTokenToFiatRate()', function () {
-    it('should return rate for converting the selected token to fiat', function () {
-      assert.equal(
-        getSelectedTokenToFiatRate(mockState),
-        2401.76400654
-      )
-    })
-  })
-
   describe('getSendAmount()', function () {
     it('should return the send.amount', function () {
       assert.equal(
@@ -486,15 +436,6 @@ describe('send selectors', function () {
       assert.equal(
         getTokenBalance(mockState),
         3434
-      )
-    })
-  })
-
-  describe('getTokenExchangeRate()', function () {
-    it('should return the passed tokens exchange rates', function () {
-      assert.equal(
-        getTokenExchangeRate(mockState, 'GHI'),
-        31.01
       )
     })
   })

--- a/ui/app/pages/send/tests/send-utils.test.js
+++ b/ui/app/pages/send/tests/send-utils.test.js
@@ -140,7 +140,6 @@ describe('send utils', function () {
     const config = {
       'should return insufficientFunds error if isBalanceSufficient returns false': {
         amount: 15,
-        amountConversionRate: 2,
         balance: 1,
         conversionRate: 3,
         gasTotal: 17,
@@ -149,7 +148,6 @@ describe('send utils', function () {
       },
       'should not return insufficientFunds error if selectedToken is truthy': {
         amount: '0x0',
-        amountConversionRate: 2,
         balance: 1,
         conversionRate: 3,
         gasTotal: 17,
@@ -161,7 +159,6 @@ describe('send utils', function () {
       },
       'should return insufficientTokens error if token is selected and isTokenBalanceSufficient returns false': {
         amount: '0x10',
-        amountConversionRate: 2,
         balance: 100,
         conversionRate: 3,
         decimals: 10,
@@ -182,7 +179,6 @@ describe('send utils', function () {
   describe('getGasFeeErrorObject()', function () {
     const config = {
       'should return insufficientFunds error if isBalanceSufficient returns false': {
-        amountConversionRate: 2,
         balance: 16,
         conversionRate: 3,
         gasTotal: 17,
@@ -190,7 +186,6 @@ describe('send utils', function () {
         expectedResult: { gasFee: INSUFFICIENT_FUNDS_ERROR },
       },
       'should return null error if isBalanceSufficient returns true': {
-        amountConversionRate: 2,
         balance: 16,
         conversionRate: 3,
         gasTotal: 15,
@@ -223,7 +218,6 @@ describe('send utils', function () {
       stubs.conversionGTE.resetHistory()
       const result = isBalanceSufficient({
         amount: 15,
-        amountConversionRate: 2,
         balance: 100,
         conversionRate: 3,
         gasTotal: 17,
@@ -251,7 +245,7 @@ describe('send utils', function () {
           {
             value: 32,
             fromNumericBase: 'hex',
-            conversionRate: 2,
+            conversionRate: 3,
             fromCurrency: 'ABC',
           },
         ]

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -184,11 +184,6 @@ export function getAssetImages (state) {
   return assetImages
 }
 
-export function getTokenExchangeRate (state, address) {
-  const contractExchangeRates = state.metamask.contractExchangeRates
-  return contractExchangeRates[address] || 0
-}
-
 export function getAddressBook (state) {
   const network = state.metamask.network
   if (!state.metamask.addressBook[network]) {

--- a/ui/app/selectors/tests/selectors-test-data.js
+++ b/ui/app/selectors/tests/selectors-test-data.js
@@ -84,13 +84,9 @@ export default {
         'symbol': 'GHI',
       },
     ],
-    'tokenExchangeRates': {
-      'def_eth': {
-        rate: 2.0,
-      },
-      'ghi_eth': {
-        rate: 31.01,
-      },
+    'contractExchangeRates': {
+      '0x8d6b81208414189a58339873ab429b6c47ab92d3': 0.00039345803819379796,
+      '0xd8f6a2ffb0fc5952d16c9768b71cfd35b6399aa5': 0.00008189274407698049,
     },
     'transactions': {},
     'currentNetworkTxList': [


### PR DESCRIPTION
Deletes unused UI state and selectors related to token rates.

- Delete related `tokenExchangeRates` states and selectors
  - This appears to have been long-since superseded by `contractExchangeRates`
- Delete `amountConversionRate` state and its related selectors
  - This was part of the `send` state, but appears to have only been displayed in errors
  - Whatever it was for, its data was likely garbage, because it depending on the `tokenExchangeRates` state via the implementation of `getSelectedTokenExchangeRate` in `send.selectors`
    - That selector is now deleted