### PR TITLE
Delete forceGasMin state and related selectors

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -136,7 +136,6 @@
       "errors": {},
       "maxModeOn": false,
       "editingTransactionId": null,
-      "forceGasMin": null,
       "toNickname": ""
     },
     "currentNetworkTxList": [

--- a/test/unit/ui/app/reducers/metamask.spec.js
+++ b/test/unit/ui/app/reducers/metamask.spec.js
@@ -204,7 +204,6 @@ describe('MetaMask Reducers', function () {
       memo: '0xMemo',
       errors: {},
       editingTransactionId: 22,
-      forceGasMin: '0xGas',
       ensResolution: null,
       ensResolutionError: '',
     }
@@ -231,7 +230,6 @@ describe('MetaMask Reducers', function () {
         errors: {},
         maxModeOn: false,
         editingTransactionId: null,
-        forceGasMin: null,
         toNickname: '' },
     }
 
@@ -249,7 +247,6 @@ describe('MetaMask Reducers', function () {
         memo: '0xMemo',
         errors: {},
         editingTransactionId: 22,
-        forceGasMin: '0xGas',
       },
     }
 

--- a/test/unit/ui/app/selectors.spec.js
+++ b/test/unit/ui/app/selectors.spec.js
@@ -100,11 +100,6 @@ describe('Selectors', function () {
     assert.equal(gasIsLoading, false)
   })
 
-  it('#getForceGasMin', function () {
-    const forceGasMin = selectors.getForceGasMin(mockState)
-    assert.equal(forceGasMin, null)
-  })
-
   it('#getSendAmount', function () {
     const sendAmount = selectors.getSendAmount(mockState)
     assert.equal(sendAmount, '1bc16d674ec80000')

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -28,7 +28,6 @@ export default function reduceMetamask (state = {}, action) {
       errors: {},
       maxModeOn: false,
       editingTransactionId: null,
-      forceGasMin: null,
       toNickname: '',
       ensResolution: null,
       ensResolutionError: '',
@@ -262,7 +261,6 @@ export default function reduceMetamask (state = {}, action) {
           errors: {},
           maxModeOn: false,
           editingTransactionId: null,
-          forceGasMin: null,
           toNickname: '',
         },
       }

--- a/ui/app/pages/send/send.selectors.js
+++ b/ui/app/pages/send/send.selectors.js
@@ -36,10 +36,6 @@ export function getCurrentNetwork (state) {
   return state.metamask.network
 }
 
-export function getForceGasMin (state) {
-  return state.metamask.send.forceGasMin
-}
-
 export function getGasLimit (state) {
   return state.metamask.send.gasLimit || '0'
 }

--- a/ui/app/pages/send/tests/send-selectors-test-data.js
+++ b/ui/app/pages/send/tests/send-selectors-test-data.js
@@ -176,7 +176,6 @@ export default {
       },
       'maxModeOn': false,
       'editingTransactionId': 97531,
-      'forceGasMin': true,
     },
     'unapprovedTxs': {
       '4768706228115573': {

--- a/ui/app/pages/send/tests/send-selectors.test.js
+++ b/ui/app/pages/send/tests/send-selectors.test.js
@@ -11,7 +11,6 @@ import {
   getCurrentCurrency,
   getCurrentNetwork,
   getNativeCurrency,
-  getForceGasMin,
   getGasLimit,
   getGasPrice,
   getGasTotal,
@@ -181,15 +180,6 @@ describe('send selectors', function () {
       assert.equal(
         getCurrentNetwork(mockState),
         '3'
-      )
-    })
-  })
-
-  describe('getForceGasMin()', function () {
-    it('should get the send.forceGasMin property', function () {
-      assert.equal(
-        getForceGasMin(mockState),
-        true
       )
     })
   })

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -248,10 +248,6 @@ export function getGasIsLoading (state) {
   return state.appState.gasIsLoading
 }
 
-export function getForceGasMin (state) {
-  return state.metamask.send.forceGasMin
-}
-
 export function getSendAmount (state) {
   return state.metamask.send.amount
 }

--- a/ui/app/selectors/tests/selectors-test-data.js
+++ b/ui/app/selectors/tests/selectors-test-data.js
@@ -177,7 +177,6 @@ export default {
       },
       'maxModeOn': false,
       'editingTransactionId': 97531,
-      'forceGasMin': true,
     },
     'unapprovedTxs': {
       '4768706228115573': {


### PR DESCRIPTION
- Delete `forceGasMin` state and its related selectors
  - This was part of the `send` state, but wasn't used for anything