### PR TITLE
Open notification UI when eth_requestAccounts waits for unlock

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -236,6 +236,7 @@ function setupController (initState, initLangCode) {
     showUnconfirmedMessage: triggerUi,
     showUnapprovedTx: triggerUi,
     showPermissionRequest: triggerUi,
+    showUnlockRequest: triggerUi,
     openPopup,
     // initial state
     initState,

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -236,7 +236,7 @@ function setupController (initState, initLangCode) {
     showUnconfirmedMessage: triggerUi,
     showUnapprovedTx: triggerUi,
     showPermissionRequest: triggerUi,
-    openPopup: openPopup,
+    openPopup,
     // initial state
     initState,
     // initial locale code

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -12,7 +12,7 @@ class AppStateController extends EventEmitter {
       isUnlocked,
       initState,
       onInactiveTimeout,
-      openPopup,
+      showUnlockRequest,
       preferencesStore,
     } = opts
     const { preferences } = preferencesStore.getState()
@@ -30,7 +30,7 @@ class AppStateController extends EventEmitter {
     this.waitingForUnlock = []
     addUnlockListener(this.handleUnlock.bind(this))
 
-    this._openPopup = openPopup
+    this._showUnlockRequest = showUnlockRequest
 
     preferencesStore.subscribe((state) => {
       this._setInactiveTimeout(state.preferences.autoLockTimeLimit)
@@ -43,16 +43,16 @@ class AppStateController extends EventEmitter {
    * Get a Promise that resolves when the extension is unlocked.
    * This Promise will never reject.
    *
-   * @param {boolean} openPopup - Whether the extension notification popup should be opened.
+   * @param {boolean} showUnlockRequest - Whether the extension notification popup should be opened.
    * @returns {Promise<void>} A promise that resolves when the extension is
    * unlocked, or immediately if the extension is already unlocked.
    */
-  getUnlockPromise (openPopup) {
+  getUnlockPromise (showUnlockRequest) {
     return new Promise((resolve) => {
       if (this.isUnlocked()) {
         resolve()
       } else {
-        this.waitForUnlock(resolve, openPopup)
+        this.waitForUnlock(resolve, showUnlockRequest)
       }
     })
   }
@@ -63,13 +63,13 @@ class AppStateController extends EventEmitter {
    *
    * @param {Promise.resolve} resolve - A Promise's resolve function that will
    * be called when the extension is unlocked.
-   * @param {boolean} openPopup - Whether the extension notification popup should be opened.
+   * @param {boolean} showUnlockRequest - Whether the extension notification popup should be opened.
    */
-  waitForUnlock (resolve, openPopup) {
+  waitForUnlock (resolve, showUnlockRequest) {
     this.waitingForUnlock.push({ resolve })
     this.emit('updateBadge')
-    if (openPopup) {
-      this._openPopup()
+    if (showUnlockRequest) {
+      this._showUnlockRequest()
     }
   }
 

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -43,16 +43,17 @@ class AppStateController extends EventEmitter {
    * Get a Promise that resolves when the extension is unlocked.
    * This Promise will never reject.
    *
-   * @param {boolean} showUnlockRequest - Whether the extension notification popup should be opened.
+   * @param {boolean} shouldShowUnlockRequest - Whether the extension notification
+   * popup should be opened.
    * @returns {Promise<void>} A promise that resolves when the extension is
    * unlocked, or immediately if the extension is already unlocked.
    */
-  getUnlockPromise (showUnlockRequest) {
+  getUnlockPromise (shouldShowUnlockRequest) {
     return new Promise((resolve) => {
       if (this.isUnlocked()) {
         resolve()
       } else {
-        this.waitForUnlock(resolve, showUnlockRequest)
+        this.waitForUnlock(resolve, shouldShowUnlockRequest)
       }
     })
   }
@@ -63,12 +64,13 @@ class AppStateController extends EventEmitter {
    *
    * @param {Promise.resolve} resolve - A Promise's resolve function that will
    * be called when the extension is unlocked.
-   * @param {boolean} showUnlockRequest - Whether the extension notification popup should be opened.
+   * @param {boolean} shouldShowUnlockRequest - Whether the extension notification
+   * popup should be opened.
    */
-  waitForUnlock (resolve, showUnlockRequest) {
+  waitForUnlock (resolve, shouldShowUnlockRequest) {
     this.waitingForUnlock.push({ resolve })
     this.emit('updateBadge')
-    if (showUnlockRequest) {
+    if (shouldShowUnlockRequest) {
       this._showUnlockRequest()
     }
   }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -12,6 +12,7 @@ class AppStateController extends EventEmitter {
       isUnlocked,
       initState,
       onInactiveTimeout,
+      openPopup,
       preferencesStore,
     } = opts
     const { preferences } = preferencesStore.getState()
@@ -29,6 +30,8 @@ class AppStateController extends EventEmitter {
     this.waitingForUnlock = []
     addUnlockListener(this.handleUnlock.bind(this))
 
+    this._openPopup = openPopup
+
     preferencesStore.subscribe((state) => {
       this._setInactiveTimeout(state.preferences.autoLockTimeLimit)
     })
@@ -40,18 +43,34 @@ class AppStateController extends EventEmitter {
    * Get a Promise that resolves when the extension is unlocked.
    * This Promise will never reject.
    *
+   * @param {boolean} openPopup - Whether the extension notification popup should be opened.
    * @returns {Promise<void>} A promise that resolves when the extension is
    * unlocked, or immediately if the extension is already unlocked.
    */
-  getUnlockPromise () {
+  getUnlockPromise (openPopup) {
     return new Promise((resolve) => {
       if (this.isUnlocked()) {
         resolve()
       } else {
-        this.waitingForUnlock.push({ resolve })
-        this.emit('updateBadge')
+        this.waitForUnlock(resolve, openPopup)
       }
     })
+  }
+
+  /**
+   * Adds a Promise's resolve function to the waitingForUnlock queue.
+   * Also opens the extension popup if specified.
+   *
+   * @param {Promise.resolve} resolve - A Promise's resolve function that will
+   * be called when the extension is unlocked.
+   * @param {boolean} openPopup - Whether the extension notification popup should be opened.
+   */
+  waitForUnlock (resolve, openPopup) {
+    this.waitingForUnlock.push({ resolve })
+    this.emit('updateBadge')
+    if (openPopup) {
+      this._openPopup()
+    }
   }
 
   /**

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -42,7 +42,7 @@ export class PermissionsController {
     })
 
     this.getKeyringAccounts = getKeyringAccounts
-    this.getUnlockPromise = getUnlockPromise
+    this._getUnlockPromise = getUnlockPromise
     this._notifyDomain = notifyDomain
     this.notifyAllDomains = notifyAllDomains
     this._showPermissionRequest = showPermissionRequest
@@ -92,7 +92,7 @@ export class PermissionsController {
       store: this.store,
       storeKey: METADATA_STORE_KEY,
       getAccounts: this.getAccounts.bind(this, origin),
-      getUnlockPromise: this.getUnlockPromise,
+      getUnlockPromise: () => this._getUnlockPromise(true),
       hasPermission: this.hasPermission.bind(this, origin),
       requestAccountsPermission: this._requestPermissions.bind(
         this, origin, { eth_accounts: {} }
@@ -602,7 +602,7 @@ export class PermissionsController {
       this.pendingApprovals.has(id)
     ) {
       throw new Error(
-        `Pending approval with id ${id} or origin ${origin} already exists.`
+        `Pending approval with id '${id}' or origin '${origin}' already exists.`
       )
     }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -125,7 +125,7 @@ export default class MetamaskController extends EventEmitter {
       isUnlocked: this.isUnlocked.bind(this),
       initState: initState.AppStateController,
       onInactiveTimeout: () => this.setLocked(),
-      openPopup: opts.openPopup,
+      showUnlockRequest: opts.showUnlockRequest,
       preferencesStore: this.preferencesController.store,
     })
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -125,6 +125,7 @@ export default class MetamaskController extends EventEmitter {
       isUnlocked: this.isUnlocked.bind(this),
       initState: initState.AppStateController,
       onInactiveTimeout: () => this.setLocked(),
+      openPopup: opts.openPopup,
       preferencesStore: this.preferencesController.store,
     })
 

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -437,7 +437,7 @@ export const getters = deepFreeze({
     pendingApprovals: {
       duplicateOriginOrId: (id, origin) => {
         return {
-          message: `Pending approval with id ${id} or origin ${origin} already exists.`,
+          message: `Pending approval with id '${id}' or origin '${origin}' already exists.`,
         }
       },
       requestAlreadyPending: () => {


### PR DESCRIPTION
### Summary

This is a suggested feature.

Callers of `AppStateController.getUnlockPromise` can now cause the notification UI to open via a boolean parameter.

### Justification

Currently, if the user lands a dapp that has permissions when the extension is locked, the dapp can't tell whether the user is already connected. Therefore, the dapp is likely to display a "Connect" button. This is what we do in our test dapp.

If the user clicks a "Connect" button in the above case, the extension browser action icon will get a badge, but the UI won't automatically open. This is in distinction to clicking a "Connect" button in a dapp that does _not_ have permissions, which _will_ cause the UI to open.

With this PR, the UI will open when the user clicks "Connect", regardless of whether the dapp has permissions or not. If the dapp has permissions, the UI will immediately close upon unlocking.

I believe that this is _probably_ better than the UI not opening at all; it certainly feels more responsive to me.