### PR TITLE
Add no-tabs ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
 
   rules: {
     'arrow-parens': 'error',
+    'no-tabs': 'error',
     'no-mixed-operators': 'error',
     'import/default': 'error',
     'import/export': 'error',

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -10,7 +10,7 @@ class PreferencesController {
    * @typedef {Object} PreferencesController
    * @param {Object} opts - Overrides the defaults for the initial state of this.store
    * @property {object} store The stored object containing a users preferences, stored in local storage
-	 * @property {array} store.frequentRpcList A list of custom rpcs to provide the user
+   * @property {array} store.frequentRpcList A list of custom rpcs to provide the user
    * @property {array} store.tokens The tokens the user wants display in their token lists
    * @property {object} store.accountTokens The tokens stored per account and then per network type
    * @property {object} store.assetImages Contains assets objects related to assets added


### PR DESCRIPTION
This PR enables the no-tabs ESLint rule. (This rule is enabled in v2 of the shared config, but we aren't yet using that.)