### PR TITLE
Remove unused ExtensionPlatform#closeWindow fn

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -36,18 +36,6 @@ class ExtensionPlatform {
     })
   }
 
-  closeWindow (windowId) {
-    return new Promise((resolve, reject) => {
-      extension.windows.remove(windowId, () => {
-        const error = checkForError()
-        if (error) {
-          return reject(error)
-        }
-        return resolve()
-      })
-    })
-  }
-
   focusWindow (windowId) {
     return new Promise((resolve, reject) => {
       extension.windows.update(windowId, { focused: true }, () => {


### PR DESCRIPTION
This PR removes the unused `ExtensionPlatform#closeWindow` function