### PR TITLE
Add dropdown component

### DIFF
--- a/ui/app/components/app/index.scss
+++ b/ui/app/components/app/index.scss
@@ -100,6 +100,8 @@
 
 @import '../ui/check-box/index';
 
+@import '../ui/dropdown/dropdown';
+
 @import 'permissions-connect-header/index';
 
 @import 'permissions-connect-footer/index';

--- a/ui/app/components/ui/dropdown/dropdown.js
+++ b/ui/app/components/ui/dropdown/dropdown.js
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
-const Dropdown = ({ className, disabled, name, onChange, options, selectedOption, style }) => {
+const Dropdown = ({ className, disabled, onChange, options, selectedOption, style, title }) => {
   const _onChange = useCallback(
     (event) => {
       event.preventDefault()
@@ -16,7 +16,7 @@ const Dropdown = ({ className, disabled, name, onChange, options, selectedOption
     <select
       className={classnames('dropdown', className)}
       disabled={disabled}
-      name={name}
+      title={title}
       onChange={_onChange}
       style={style}
       value={selectedOption}
@@ -40,7 +40,7 @@ const Dropdown = ({ className, disabled, name, onChange, options, selectedOption
 Dropdown.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  name: PropTypes.string,
+  title: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.exact({
@@ -55,7 +55,7 @@ Dropdown.propTypes = {
 Dropdown.defaultProps = {
   className: undefined,
   disabled: false,
-  name: undefined,
+  title: undefined,
   selectedOption: null,
   style: undefined,
 }

--- a/ui/app/components/ui/dropdown/dropdown.js
+++ b/ui/app/components/ui/dropdown/dropdown.js
@@ -1,0 +1,63 @@
+import React, { useCallback } from 'react'
+import PropTypes from 'prop-types'
+import classnames from 'classnames'
+
+const Dropdown = ({ className, disabled, name, onChange, options, selectedOption, style }) => {
+  const _onChange = useCallback(
+    (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      onChange(event.target.value)
+    },
+    [onChange],
+  )
+
+  return (
+    <select
+      className={classnames('dropdown', className)}
+      disabled={disabled}
+      name={name}
+      onChange={_onChange}
+      style={style}
+      value={selectedOption}
+    >
+      {
+        options.map((option) => {
+          return (
+            <option
+              key={option.value}
+              value={option.value}
+            >
+              { option.name || option.value }
+            </option>
+          )
+        })
+      }
+    </select>
+  )
+}
+
+Dropdown.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.exact({
+      name: PropTypes.string,
+      value: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  selectedOption: PropTypes.string,
+  style: PropTypes.object,
+}
+
+Dropdown.defaultProps = {
+  className: undefined,
+  disabled: false,
+  name: undefined,
+  selectedOption: null,
+  style: undefined,
+}
+
+export default Dropdown

--- a/ui/app/components/ui/dropdown/dropdown.scss
+++ b/ui/app/components/ui/dropdown/dropdown.scss
@@ -1,0 +1,22 @@
+.dropdown {
+  appearance: none;
+
+  // TODO: remove these after getting autoprefixer working in Storybook
+  -moz-appearance: none;
+  -webkit-appearance: none;
+
+  border: 1px solid $Grey-500;
+  border-radius: 6px;
+	background-image: url('/images/icons/caret-down.svg');
+	background-repeat: no-repeat, repeat;
+  background-position: right 18px top 50%;
+  background-color: white;
+  padding: 8px 32px 8px 16px;
+  font-family: Roboto, 'sans-serif';
+  font-size: 14px;
+
+  [dir='rtl'] & {
+    background-position: left 18px top 50%;
+    padding: 8px 16px 8px 32px;
+  }
+}

--- a/ui/app/components/ui/dropdown/dropdown.stories.js
+++ b/ui/app/components/ui/dropdown/dropdown.stories.js
@@ -23,7 +23,7 @@ const namedOptionsWithVeryLongNames = unnamedOptions.map((option, index) => {
 export const simple = () => (
   <Dropdown
     disabled={boolean('Disabled', false)}
-    name={text('Name', 'Test dropdown name')}
+    title={text('Title', 'Test dropdown name')}
     onChange={action('Selection changed')}
     options={namedOptions}
     required={boolean('Required', false)}
@@ -40,7 +40,7 @@ export const simple = () => (
 export const optionsWithoutNames = () => (
   <Dropdown
     disabled={boolean('Disabled', false)}
-    name={text('Name', 'Test dropdown name')}
+    title={text('Title', 'Test dropdown name')}
     onChange={action('Selection changed')}
     options={unnamedOptions}
     required={boolean('Required', false)}
@@ -57,7 +57,7 @@ export const optionsWithoutNames = () => (
 export const optionsWithLongNames = () => (
   <Dropdown
     disabled={boolean('Disabled', false)}
-    name={text('Name', 'Test dropdown name')}
+    title={text('Title', 'Test dropdown name')}
     onChange={action('Selection changed')}
     options={namedOptionsWithVeryLongNames}
     required={boolean('Required', false)}
@@ -74,7 +74,7 @@ export const optionsWithLongNames = () => (
 export const optionsWithLongNamesAndShortWidth = () => (
   <Dropdown
     disabled={boolean('Disabled', false)}
-    name={text('Name', 'Test dropdown name')}
+    title={text('Title', 'Test dropdown name')}
     onChange={action('Selection changed')}
     options={namedOptionsWithVeryLongNames}
     required={boolean('Required', false)}

--- a/ui/app/components/ui/dropdown/dropdown.stories.js
+++ b/ui/app/components/ui/dropdown/dropdown.stories.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import Dropdown from '.'
+import { boolean, select, text } from '@storybook/addon-knobs/react'
+
+export default {
+  title: 'Dropdown',
+}
+
+const unnamedOptions = [...Array(10).keys()].map((index) => {
+  return { value: `option${index}` }
+})
+
+const namedOptions = unnamedOptions.map((option, index) => {
+  return Object.assign({}, option, { name: `Option ${index}` })
+})
+
+const namedOptionsWithVeryLongNames = unnamedOptions.map((option, index) => {
+  return Object.assign({}, option, { name: `Option ${index} with a very${', very'.repeat(index)} long name` })
+})
+
+
+export const simple = () => (
+  <Dropdown
+    disabled={boolean('Disabled', false)}
+    name={text('Name', 'Test dropdown name')}
+    onChange={action('Selection changed')}
+    options={namedOptions}
+    required={boolean('Required', false)}
+    selectedOption={
+      select(
+        'Selected Option',
+        namedOptions.map((option) => option.value),
+        namedOptions[0].value
+      )
+    }
+  />
+)
+
+export const optionsWithoutNames = () => (
+  <Dropdown
+    disabled={boolean('Disabled', false)}
+    name={text('Name', 'Test dropdown name')}
+    onChange={action('Selection changed')}
+    options={unnamedOptions}
+    required={boolean('Required', false)}
+    selectedOption={
+      select(
+        'Selected Option',
+        unnamedOptions.map((option) => option.value),
+        unnamedOptions[0].value
+      )
+    }
+  />
+)
+
+export const optionsWithLongNames = () => (
+  <Dropdown
+    disabled={boolean('Disabled', false)}
+    name={text('Name', 'Test dropdown name')}
+    onChange={action('Selection changed')}
+    options={namedOptionsWithVeryLongNames}
+    required={boolean('Required', false)}
+    selectedOption={
+      select(
+        'Selected Option',
+        namedOptionsWithVeryLongNames.map((option) => option.value),
+        namedOptionsWithVeryLongNames[0].value
+      )
+    }
+  />
+)
+
+export const optionsWithLongNamesAndShortWidth = () => (
+  <Dropdown
+    disabled={boolean('Disabled', false)}
+    name={text('Name', 'Test dropdown name')}
+    onChange={action('Selection changed')}
+    options={namedOptionsWithVeryLongNames}
+    required={boolean('Required', false)}
+    selectedOption={
+      select(
+        'Selected Option',
+        namedOptionsWithVeryLongNames.map((option) => option.value),
+        namedOptionsWithVeryLongNames[0].value
+      )
+    }
+    style={{ width: '200px' }}
+  />
+)

--- a/ui/app/components/ui/dropdown/index.js
+++ b/ui/app/components/ui/dropdown/index.js
@@ -1,0 +1,1 @@
+export { default } from './dropdown'


### PR DESCRIPTION
This new dropdown component uses a native `select` element, thus avoiding various issues encountered in attempting to reuse our existing dropdown components for the new permission system alert modal.

The prefixed forms of `appearance` have been added temporarily so that the component can be used in Storybook, as our Storybook config isn't setup to do autoprefixing yet. Our real build system does handle autoprefixing for this rule correctly already.