### PR TITLE
Move export defaults statements alongside their objects

### DIFF
--- a/app/scripts/controllers/ab-test.js
+++ b/app/scripts/controllers/ab-test.js
@@ -13,7 +13,7 @@ import { getRandomArrayItem } from '../lib/util'
  *     browser tab
  */
 
-class ABTestController {
+export default class ABTestController {
   /**
    * @constructor
    * @param opts
@@ -51,6 +51,3 @@ class ABTestController {
 ABTestController.abTestGroupNames = {
   fullScreenVsPopup: ['control', 'fullScreen'],
 }
-
-export default ABTestController
-

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -1,7 +1,7 @@
 import ObservableStore from 'obs-store'
 import EventEmitter from 'events'
 
-class AppStateController extends EventEmitter {
+export default class AppStateController extends EventEmitter {
   /**
    * @constructor
    * @param opts
@@ -141,6 +141,3 @@ class AppStateController extends EventEmitter {
     this.timer = setTimeout(() => this.onInactiveTimeout(), timeoutMinutes * 60 * 1000)
   }
 }
-
-export default AppStateController
-

--- a/app/scripts/controllers/balance.js
+++ b/app/scripts/controllers/balance.js
@@ -2,7 +2,7 @@ import ObservableStore from 'obs-store'
 import PendingBalanceCalculator from '../lib/pending-balance-calculator'
 import { BN } from 'ethereumjs-util'
 
-class BalanceController {
+export default class BalanceController {
 
   /**
    * Controller responsible for storing and updating an account's balance.
@@ -132,5 +132,3 @@ class BalanceController {
   }
 
 }
-
-export default BalanceController

--- a/app/scripts/controllers/cached-balances.js
+++ b/app/scripts/controllers/cached-balances.js
@@ -11,7 +11,7 @@ import ObservableStore from 'obs-store'
  * Background controller responsible for maintaining
  * a cache of account balances in local storage
  */
-class CachedBalancesController {
+export default class CachedBalancesController {
   /**
    * Creates a new controller instance
    *
@@ -78,5 +78,3 @@ class CachedBalancesController {
     this.accountTracker.store.subscribe(update)
   }
 }
-
-export default CachedBalancesController

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -11,7 +11,7 @@ const SINGLE_CALL_BALANCES_ADDRESS = '0xb1f8e55c7f64d203c1400b9d8555d050f94adf39
  * A controller that polls for token exchange
  * rates based on a user's current token list
  */
-class DetectTokensController {
+export default class DetectTokensController {
   /**
    * Creates a DetectTokensController
    *
@@ -162,5 +162,3 @@ class DetectTokensController {
     return this.isOpen && this.isUnlocked
   }
 }
-
-export default DetectTokensController

--- a/app/scripts/controllers/ens/ens.js
+++ b/app/scripts/controllers/ens/ens.js
@@ -1,7 +1,7 @@
 import EthJsEns from 'ethjs-ens'
 import ensNetworkMap from 'ethereum-ens-network-map'
 
-class Ens {
+export default class Ens {
   static getNetworkEnsSupport (network) {
     return Boolean(ensNetworkMap[network])
   }
@@ -21,5 +21,3 @@ class Ens {
     return this._ethJsEns.reverse(address)
   }
 }
-
-export default Ens

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -7,7 +7,7 @@ import Ens from './ens'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const ZERO_X_ERROR_ADDRESS = '0x'
 
-class EnsController {
+export default class EnsController {
   constructor ({ ens, provider, networkStore } = {}) {
     const initState = {
       ensResolutionsByAddress: {},
@@ -90,5 +90,3 @@ class EnsController {
     })
   }
 }
-
-export default EnsController

--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -29,7 +29,7 @@ const fetch = fetchWithTimeout({
   timeout: 30000,
 })
 
-class IncomingTransactionsController {
+export default class IncomingTransactionsController {
 
   constructor (opts = {}) {
     const {
@@ -268,8 +268,6 @@ class IncomingTransactionsController {
     }
   }
 }
-
-export default IncomingTransactionsController
 
 function pairwise (fn) {
   let first = true

--- a/app/scripts/controllers/infura.js
+++ b/app/scripts/controllers/infura.js
@@ -4,7 +4,7 @@ import log from 'loglevel'
 // every ten minutes
 const POLLING_INTERVAL = 10 * 60 * 1000
 
-class InfuraController {
+export default class InfuraController {
 
   constructor (opts = {}) {
     const initState = Object.assign({
@@ -37,5 +37,3 @@ class InfuraController {
     }, POLLING_INTERVAL)
   }
 }
-
-export default InfuraController

--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -9,9 +9,7 @@ import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddlewa
 import createInfuraMiddleware from 'eth-json-rpc-infura'
 import BlockTracker from 'eth-block-tracker'
 
-export default createInfuraClient
-
-function createInfuraClient ({ network }) {
+export default function createInfuraClient ({ network }) {
   const infuraMiddleware = createInfuraMiddleware({ network, maxAttempts: 5, source: 'metamask' })
   const infuraProvider = providerFromMiddleware(infuraMiddleware)
   const blockTracker = new BlockTracker({ provider: infuraProvider })

--- a/app/scripts/controllers/network/createJsonRpcClient.js
+++ b/app/scripts/controllers/network/createJsonRpcClient.js
@@ -7,9 +7,7 @@ import createBlockTrackerInspectorMiddleware from 'eth-json-rpc-middleware/block
 import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddleware'
 import BlockTracker from 'eth-block-tracker'
 
-export default createJsonRpcClient
-
-function createJsonRpcClient ({ rpcUrl }) {
+export default function createJsonRpcClient ({ rpcUrl }) {
   const fetchMiddleware = createFetchMiddleware({ rpcUrl })
   const blockProvider = providerFromMiddleware(fetchMiddleware)
   const blockTracker = new BlockTracker({ provider: blockProvider })

--- a/app/scripts/controllers/network/createLocalhostClient.js
+++ b/app/scripts/controllers/network/createLocalhostClient.js
@@ -8,9 +8,7 @@ import BlockTracker from 'eth-block-tracker'
 
 const inTest = process.env.IN_TEST === 'true'
 
-export default createLocalhostClient
-
-function createLocalhostClient () {
+export default function createLocalhostClient () {
   const fetchMiddleware = createFetchMiddleware({ rpcUrl: 'http://localhost:8545/' })
   const blockProvider = providerFromMiddleware(fetchMiddleware)
   const blockTracker = new BlockTracker({ provider: blockProvider, pollingInterval: 1000 })

--- a/app/scripts/controllers/network/createMetamaskMiddleware.js
+++ b/app/scripts/controllers/network/createMetamaskMiddleware.js
@@ -3,9 +3,7 @@ import createScaffoldMiddleware from 'json-rpc-engine/src/createScaffoldMiddlewa
 import createWalletSubprovider from 'eth-json-rpc-middleware/wallet'
 import { createPendingNonceMiddleware, createPendingTxMiddleware } from './middleware/pending'
 
-export default createMetamaskMiddleware
-
-function createMetamaskMiddleware ({
+export default function createMetamaskMiddleware ({
   version,
   getAccounts,
   processTransaction,

--- a/app/scripts/controllers/onboarding.js
+++ b/app/scripts/controllers/onboarding.js
@@ -16,7 +16,7 @@ import log from 'loglevel'
  * Controller responsible for maintaining
  * state related to onboarding
  */
-class OnboardingController {
+export default class OnboardingController {
   /**
    * Creates a new controller instance
    *
@@ -72,5 +72,3 @@ class OnboardingController {
     }
   }
 }
-
-export default OnboardingController

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -3,7 +3,7 @@ import { addInternalMethodPrefix } from './permissions'
 import { normalize as normalizeAddress } from 'eth-sig-util'
 import { isValidAddress, sha3, bufferToHex } from 'ethereumjs-util'
 
-class PreferencesController {
+export default class PreferencesController {
 
   /**
    *
@@ -743,5 +743,3 @@ class PreferencesController {
     }
   }
 }
-
-export default PreferencesController

--- a/app/scripts/controllers/recent-blocks.js
+++ b/app/scripts/controllers/recent-blocks.js
@@ -6,8 +6,7 @@ import { ROPSTEN, RINKEBY, KOVAN, MAINNET, GOERLI } from './network/enums'
 
 const INFURA_PROVIDER_TYPES = [ROPSTEN, RINKEBY, KOVAN, MAINNET, GOERLI]
 
-
-class RecentBlocksController {
+export default class RecentBlocksController {
 
   /**
    * Controller responsible for storing, updating and managing the recent history of blocks. Blocks are back filled
@@ -174,5 +173,3 @@ class RecentBlocksController {
   }
 
 }
-
-export default RecentBlocksController

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -14,7 +14,7 @@ import createOriginMiddleware from '../lib/createOriginMiddleware'
 
 const SYNC_TIMEOUT = 60 * 1000 // one minute
 
-class ThreeBoxController {
+export default class ThreeBoxController {
   constructor (opts = {}) {
     const {
       preferencesController,
@@ -244,5 +244,3 @@ class ThreeBoxController {
     }
   }
 }
-
-export default ThreeBoxController

--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -11,7 +11,7 @@ const DEFAULT_INTERVAL = 180 * 1000
  * A controller that polls for token exchange
  * rates based on a user's current token list
  */
-class TokenRatesController {
+export default class TokenRatesController {
   /**
    * Creates a TokenRatesController
    *
@@ -86,5 +86,3 @@ class TokenRatesController {
     this.updateExchangeRates()
   }
 }
-
-export default TokenRatesController

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -4,7 +4,7 @@ import ObservableStore from 'obs-store'
  * An ObservableStore that can composes a flat
  * structure of child stores based on configuration
  */
-class ComposableObservableStore extends ObservableStore {
+export default class ComposableObservableStore extends ObservableStore {
   /**
    * Create a new store
    *
@@ -47,5 +47,3 @@ class ComposableObservableStore extends ObservableStore {
     return flatState
   }
 }
-
-export default ComposableObservableStore

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -24,8 +24,7 @@ import {
   SINGLE_CALL_BALANCES_ADDRESS_KOVAN,
 } from '../controllers/network/contract-addresses'
 
-
-class AccountTracker {
+export default class AccountTracker {
 
   /**
    * This module is responsible for tracking any number of accounts and caching their current balances & transaction
@@ -260,5 +259,3 @@ class AccountTracker {
   }
 
 }
-
-export default AccountTracker

--- a/app/scripts/lib/auto-reload.js
+++ b/app/scripts/lib/auto-reload.js
@@ -1,9 +1,7 @@
 
 // TODO:deprecate:2020
 
-export default setupDappAutoReload
-
-function setupDappAutoReload (web3, observable) {
+export default function setupDappAutoReload (web3, observable) {
   // export web3 as a global, checking for usage
   let reloadInProgress = false
   let lastTimeUsed

--- a/app/scripts/lib/backend-metametrics.js
+++ b/app/scripts/lib/backend-metametrics.js
@@ -7,7 +7,7 @@ const METAMETRICS_TRACKING_URL = inDevelopment
   ? 'http://www.metamask.io/metametrics'
   : 'http://www.metamask.io/metametrics-prod'
 
-function backEndMetaMetricsEvent (metaMaskState, eventData) {
+export default function backEndMetaMetricsEvent (metaMaskState, eventData) {
   const stateEventData = getMetaMetricState({ metamask: metaMaskState })
 
   if (stateEventData.participateInMetaMetrics) {
@@ -18,5 +18,3 @@ function backEndMetaMetricsEvent (metaMaskState, eventData) {
     })
   }
 }
-
-export default backEndMetaMetricsEvent

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -1,5 +1,3 @@
-export default getBuyEthUrl
-
 /**
  * Gives the caller a url at which the user can acquire eth, depending on the network they are in
  *
@@ -10,7 +8,7 @@ export default getBuyEthUrl
  * network does not match any of the specified cases, or if no network is given, returns undefined.
  *
  */
-function getBuyEthUrl ({ network, address, service }) {
+export default function getBuyEthUrl ({ network, address, service }) {
   // default service by network if not specified
   if (!service) {
     service = getDefaultServiceForNetwork(network)

--- a/app/scripts/lib/cleanErrorStack.js
+++ b/app/scripts/lib/cleanErrorStack.js
@@ -3,7 +3,7 @@
  * @param {Error} err - error
  * @returns {Error} - Error with clean stack trace.
  */
-function cleanErrorStack (err) {
+export default function cleanErrorStack (err) {
   let name = err.name
   name = (name === undefined) ? 'Error' : String(name)
 
@@ -20,5 +20,3 @@ function cleanErrorStack (err) {
 
   return err
 }
-
-export default cleanErrorStack

--- a/app/scripts/lib/createLoggerMiddleware.js
+++ b/app/scripts/lib/createLoggerMiddleware.js
@@ -1,13 +1,11 @@
 import log from 'loglevel'
 
-export default createLoggerMiddleware
-
 /**
  * Returns a middleware that logs RPC activity
  * @param {{ origin: string }} opts - The middleware options
  * @returns {Function}
  */
-function createLoggerMiddleware (opts) {
+export default function createLoggerMiddleware (opts) {
   return function loggerMiddleware (/** @type {any} */ req, /** @type {any} */ res, /** @type {Function} */ next) {
     next((/** @type {Function} */ cb) => {
       if (res.error) {

--- a/app/scripts/lib/createOnboardingMiddleware.js
+++ b/app/scripts/lib/createOnboardingMiddleware.js
@@ -6,7 +6,7 @@ import extension from 'extensionizer'
  * @param {{ location: string, registerOnboarding: Function }} opts - The middleware options
  * @returns {(req: any, res: any, next: Function, end: Function) => void}
  */
-function createOnboardingMiddleware ({ location, registerOnboarding }) {
+export default function createOnboardingMiddleware ({ location, registerOnboarding }) {
   return async function originMiddleware (req, res, next, end) {
     try {
       if (req.method !== 'wallet_registerOnboarding') {
@@ -25,5 +25,3 @@ function createOnboardingMiddleware ({ location, registerOnboarding }) {
     }
   }
 }
-
-export default createOnboardingMiddleware

--- a/app/scripts/lib/createOriginMiddleware.js
+++ b/app/scripts/lib/createOriginMiddleware.js
@@ -1,12 +1,9 @@
-
-export default createOriginMiddleware
-
 /**
  * Returns a middleware that appends the DApp origin to request
  * @param {{ origin: string }} opts - The middleware options
  * @returns {Function}
  */
-function createOriginMiddleware (opts) {
+export default function createOriginMiddleware (opts) {
   return function originMiddleware (/** @type {any} */ req, /** @type {any} */ _, /** @type {Function} */ next) {
     req.origin = opts.origin
     next()

--- a/app/scripts/lib/createStreamSink.js
+++ b/app/scripts/lib/createStreamSink.js
@@ -16,8 +16,6 @@ class AsyncWritableStream extends WritableStream {
 
 }
 
-function createStreamSink (asyncWriteFn, _opts) {
+export default function createStreamSink (asyncWriteFn, _opts) {
   return new AsyncWritableStream(asyncWriteFn, _opts)
 }
-
-export default createStreamSink

--- a/app/scripts/lib/createTabIdMiddleware.js
+++ b/app/scripts/lib/createTabIdMiddleware.js
@@ -1,12 +1,9 @@
-
-module.exports = createTabIdMiddleware
-
 /**
  * Returns a middleware that appends the DApp TabId to the request
  * @param {{ tabId: number }} opts - The middleware options
  * @returns {Function}
  */
-function createTabIdMiddleware (opts) {
+export default function createTabIdMiddleware (opts) {
   return function tabIdMiddleware (/** @type {any} */ req, /** @type {any} */ _, /** @type {Function} */ next) {
     req.tabId = opts.tabId
     next()

--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -5,10 +5,7 @@ import registryAbi from './contracts/registry'
 import resolverAbi from './contracts/resolver'
 import contentHash from 'content-hash'
 
-export default resolveEnsToIpfsContentId
-
-
-async function resolveEnsToIpfsContentId ({ provider, name }) {
+export default async function resolveEnsToIpfsContentId ({ provider, name }) {
   const eth = new Eth(provider)
   const hash = namehash.hash(name)
   const contract = new EthContract(eth)

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -4,9 +4,7 @@ import resolveEnsToIpfsContentId from './resolver.js'
 
 const supportedTopLevelDomains = ['eth']
 
-export default setupEnsIpfsResolver
-
-function setupEnsIpfsResolver ({ provider, getCurrentNetwork, getIpfsGateway }) {
+export default function setupEnsIpfsResolver ({ provider, getCurrentNetwork, getIpfsGateway }) {
 
   // install listener
   const urlPatterns = supportedTopLevelDomains.map((tld) => `*://*.${tld}/*`)

--- a/app/scripts/lib/extractEthjsErrorMessage.js
+++ b/app/scripts/lib/extractEthjsErrorMessage.js
@@ -1,9 +1,6 @@
 const ethJsRpcSlug = 'Error: [ethjs-rpc] rpc error with payload '
 const errorLabelPrefix = 'Error: '
 
-export default extractEthjsErrorMessage
-
-
 /**
  * Extracts the important part of an ethjs-rpc error message. If the passed error is not an isEthjsRpcError, the error
  * is returned unchanged.
@@ -16,7 +13,7 @@ export default extractEthjsErrorMessage
  * extractEthjsErrorMessage(`Error: [ethjs-rpc] rpc error with payload {"id":3947817945380,"jsonrpc":"2.0","params":["0xf8eb8208708477359400830398539406012c8cf97bead5deae237070f9587f8e7a266d80b8843d7d3f5a0000000000000000000000000000000000000000000000000000000000081d1a000000000000000000000000000000000000000000000000001ff973cafa800000000000000000000000000000000000000000000000000000038d7ea4c68000000000000000000000000000000000000000000000000000000000000003f48025a04c32a9b630e0d9e7ff361562d850c86b7a884908135956a7e4a336fa0300d19ca06830776423f25218e8d19b267161db526e66895567147015b1f3fc47aef9a3c7"],"method":"eth_sendRawTransaction"} Error: replacement transaction underpriced`)
  *
 */
-function extractEthjsErrorMessage (errorMessage) {
+export default function extractEthjsErrorMessage (errorMessage) {
   const isEthjsRpcError = errorMessage.includes(ethJsRpcSlug)
   if (isEthjsRpcError) {
     const payloadAndError = errorMessage.slice(ethJsRpcSlug.length)

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -22,7 +22,7 @@ allLocales.forEach((locale) => {
  * @returns {Promise<string>} - Promises a locale code, either one from the user's preferred list that we have a translation for, or 'en'
  *
  */
-async function getFirstPreferredLangCode () {
+export default async function getFirstPreferredLangCode () {
   let userPreferredLocaleCodes
 
   try {
@@ -44,6 +44,3 @@ async function getFirstPreferredLangCode () {
 
   return existingLocaleCodes[firstPreferredLangCode] || 'en'
 }
-
-export default getFirstPreferredLangCode
-

--- a/app/scripts/lib/getObjStructure.js
+++ b/app/scripts/lib/getObjStructure.js
@@ -1,7 +1,5 @@
 import { cloneDeep } from 'lodash'
 
-export default getObjStructure
-
 // This will create an object that represents the structure of the given object
 // it replaces all values with the result of their type
 
@@ -23,7 +21,7 @@ export default getObjStructure
  * replaced with the javascript type of that value.
  *
  */
-function getObjStructure (obj) {
+export default function getObjStructure (obj) {
   const structure = cloneDeep(obj)
   return deepMap(structure, (value) => {
     return value === null ? 'null' : typeof value

--- a/app/scripts/lib/network-store.js
+++ b/app/scripts/lib/network-store.js
@@ -7,7 +7,7 @@ const FIXTURE_SERVER_URL = `http://${FIXTURE_SERVER_HOST}:${FIXTURE_SERVER_PORT}
 /**
  * A read-only network-based storage wrapper
  */
-class ReadOnlyNetworkStore {
+export default class ReadOnlyNetworkStore {
   constructor () {
     this._initialized = false
     this._initializing = this._init()
@@ -58,5 +58,3 @@ class ReadOnlyNetworkStore {
     this._state = state
   }
 }
-
-export default ReadOnlyNetworkStore

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -3,7 +3,7 @@ import ExtensionPlatform from '../platforms/extension'
 const NOTIFICATION_HEIGHT = 620
 const NOTIFICATION_WIDTH = 360
 
-class NotificationManager {
+export default class NotificationManager {
 
   /**
    * A collection of methods for controlling the showing and hiding of the notification popup.
@@ -103,5 +103,3 @@ class NotificationManager {
   }
 
 }
-
-export default NotificationManager

--- a/app/scripts/lib/pending-balance-calculator.js
+++ b/app/scripts/lib/pending-balance-calculator.js
@@ -1,7 +1,7 @@
 import { BN } from 'ethereumjs-util'
 import { normalize } from 'eth-sig-util'
 
-class PendingBalanceCalculator {
+export default class PendingBalanceCalculator {
 
   /**
    * Used for calculating a users "pending balance": their current balance minus the total possible cost of all their
@@ -77,5 +77,3 @@ class PendingBalanceCalculator {
   }
 
 }
-
-export default PendingBalanceCalculator

--- a/app/scripts/lib/random-id.js
+++ b/app/scripts/lib/random-id.js
@@ -1,9 +1,7 @@
 const MAX = Number.MAX_SAFE_INTEGER
 
 let idCounter = Math.round(Math.random() * MAX)
-function createRandomId () {
+export default function createRandomId () {
   idCounter = idCounter % MAX
   return idCounter++
 }
-
-export default createRandomId

--- a/app/scripts/lib/reportFailedTxToSentry.js
+++ b/app/scripts/lib/reportFailedTxToSentry.js
@@ -1,13 +1,11 @@
 import extractEthjsErrorMessage from './extractEthjsErrorMessage'
 
-export default reportFailedTxToSentry
-
 //
 // utility for formatting failed transaction messages
 // for sending to sentry
 //
 
-function reportFailedTxToSentry ({ sentry, txMeta }) {
+export default function reportFailedTxToSentry ({ sentry, txMeta }) {
   const errorMessage = 'Transaction Failed: ' + extractEthjsErrorMessage(txMeta.err.message)
   sentry.captureMessage(errorMessage, {
     // "extra" key is required by Sentry

--- a/app/scripts/lib/select-chain-id.js
+++ b/app/scripts/lib/select-chain-id.js
@@ -14,9 +14,7 @@ const standardNetworkId = {
   '5': GOERLI_CHAIN_ID,
 }
 
-function selectChainId (metamaskState) {
+export default function selectChainId (metamaskState) {
   const { network, provider: { chainId } } = metamaskState
   return standardNetworkId[network] || `0x${parseInt(chainId, 10).toString(16)}`
 }
-
-export default selectChainId

--- a/app/scripts/lib/setupFetchDebugging.js
+++ b/app/scripts/lib/setupFetchDebugging.js
@@ -1,12 +1,10 @@
-export default setupFetchDebugging
-
 //
 // This is a utility to help resolve cases where `window.fetch` throws a
 // `TypeError: Failed to Fetch` without any stack or context for the request
 // https://github.com/getsentry/sentry-javascript/pull/1293
 //
 
-function setupFetchDebugging () {
+export default function setupFetchDebugging () {
   if (!window.fetch) {
     return
   }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -8,10 +8,7 @@ const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT
 const SENTRY_DSN_PROD = 'https://3567c198f8a8412082d32655da2961d0@sentry.io/273505'
 const SENTRY_DSN_DEV = 'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496'
 
-export default setupSentry
-
-// Setup sentry remote error reporting
-function setupSentry (opts) {
+export default function setupSentry (opts) {
   const { release, getState } = opts
   let sentryTarget
   // detect brave

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -3,7 +3,7 @@ import { createExplorerLink as explorerLink } from '@metamask/etherscan-link'
 import { getEnvironmentType, checkForError } from '../lib/util'
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../lib/enums'
 
-class ExtensionPlatform {
+export default class ExtensionPlatform {
 
   //
   // Public
@@ -239,5 +239,3 @@ class ExtensionPlatform {
     }
   }
 }
-
-export default ExtensionPlatform


### PR DESCRIPTION
This PR moves the `export default` statements alongside the class/function it exports.