### PR TITLE
Export anonymous obj from account-import-strategies

### DIFF
--- a/app/scripts/account-import-strategies/index.js
+++ b/app/scripts/account-import-strategies/index.js
@@ -3,7 +3,7 @@ import Wallet from 'ethereumjs-wallet'
 import importers from 'ethereumjs-wallet/thirdparty'
 import ethUtil from 'ethereumjs-util'
 
-const accountImporter = {
+export default {
 
   importAccount (strategy, args) {
     try {
@@ -50,5 +50,3 @@ function walletToPrivateKey (wallet) {
   const privateKeyBuffer = wallet.getPrivateKey()
   return ethUtil.bufferToHex(privateKeyBuffer)
 }
-
-export default accountImporter


### PR DESCRIPTION
Related to #8525

This PR moves the default export for the account-import-strategies file, dropping the name.