### PR TITLE
Make permissions selectors less bad

### DIFF
--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -6,9 +6,18 @@ import {
 
 // selectors
 
+export function getPermissionDomains (state) {
+  return state.metamask.domains || {}
+}
+
+export function getPermissionDomainsMetadata (state) {
+  return state.metamask.domainMetadata || {}
+}
+
 /**
  * Selects the permitted accounts from the eth_accounts permission given state
  * and an origin.
+ *
  * @param {Object} state - The current state.
  * @param {string} origin - The origin/domain to get the permitted accounts for.
  * @returns {Array<string>} An empty array or an array of accounts.
@@ -22,7 +31,22 @@ export function getPermittedAccounts (state, origin) {
 }
 
 /**
+ * Selects the permitted accounts from the eth_accounts permission for the
+ * origin of the current tab.
+ *
+ * @param {Object} state - The current state.
+ * @returns {Array<string>} An empty array or an array of accounts.
+ */
+export function getPermittedAccountsForCurrentTab (state) {
+  return getPermittedAccounts(
+    state,
+    getOriginOfCurrentTab(state)
+  )
+}
+
+/**
  * Returns a map of permitted accounts by origin for all origins.
+ *
  * @param {Object} state - The current state.
  * @returns {Object} Permitted accounts by origin.
  */
@@ -39,6 +63,16 @@ export function getPermittedAccountsByOrigin (state) {
   }, {})
 }
 
+/**
+ * Returns an array of connected domain objects, with the following properties:
+ * - extensionId
+ * - key (i.e. origin)
+ * - name
+ * - icon
+ *
+ * @param {Object} state - The current state.
+ * @returns {Array<Object>} An array of connected domain objects.
+ */
 export function getConnectedDomainsForSelectedAddress (state) {
   const {
     selectedAddress,
@@ -71,15 +105,18 @@ export function getConnectedDomainsForSelectedAddress (state) {
   return connectedDomains
 }
 
-export function getPermittedAccountsForCurrentTab (state) {
-  const permittedAccountsMap = getPermittedAccountsByOrigin(state)
-  const originOfCurrentTab = getOriginOfCurrentTab(state)
-  return permittedAccountsMap[originOfCurrentTab] || []
-}
-
+/**
+ * Returns an object mapping addresses to objects mapping origins to connected
+ * domain info. Domain info objects have the following properties:
+ * - icon
+ * - name
+ *
+ * @param {Object} state - The current state.
+ * @returns {Object} A mapping of addresses to a mapping of origins to
+ * connected domain info.
+ */
 export function getAddressConnectedDomainMap (state) {
   const domainMetadata = getPermissionDomainsMetadata(state)
-
   const accountsMap = getPermittedAccountsByOrigin(state)
   const addressConnectedIconMap = {}
 
@@ -134,14 +171,6 @@ function getAccountsCaveatFromPermission (accountsPermission = {}) {
       (c) => c.name === CAVEAT_NAMES.exposedAccounts
     )
   )
-}
-
-export function getPermissionDomains (state) {
-  return state.metamask.domains || {}
-}
-
-export function getPermissionDomainsMetadata (state) {
-  return state.metamask.domainMetadata || {}
 }
 
 function domainSelector (state, origin) {

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -6,10 +6,22 @@ import {
 
 // selectors
 
+/**
+ * Get the permission domains object.
+ *
+ * @param {Object} state - The current state.
+ * @returns {Object} The permissions domains object.
+ */
 export function getPermissionDomains (state) {
   return state.metamask.domains || {}
 }
 
+/**
+ * Get the permission domains metadata object.
+ *
+ * @param {Object} state - The current state.
+ * @returns {Object} The permission domains metadata object.
+ */
 export function getPermissionDomainsMetadata (state) {
   return state.metamask.domainMetadata || {}
 }


### PR DESCRIPTION
- Reorganize permissions selectors
- Make the `getPermittedAccountsForCurrentTab` more efficient
- Add docstrings for all exports

Tests will be added in a follow-up.