### PR TITLE
Remove unused NotificationManager#closePopup

### DIFF
--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -64,18 +64,6 @@ class NotificationManager {
   }
 
   /**
-   * Closes a MetaMask notification if it window exists.
-   *
-   */
-  async closePopup () {
-    const popup = this._getPopup()
-    if (!popup) {
-      return
-    }
-    await this.platform.removeWindow(popup.id)
-  }
-
-  /**
    * Checks all open MetaMask windows, and returns the first one it finds that is a notification window (i.e. has the
    * type 'popup')
    *


### PR DESCRIPTION
This PR removes the unused `NotificationManager#closePopup` method.