### PR TITLE
Minimize inactive timer resets

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -32,8 +32,11 @@ export default class AppStateController extends EventEmitter {
 
     this._showUnlockRequest = showUnlockRequest
 
-    preferencesStore.subscribe((state) => {
-      this._setInactiveTimeout(state.preferences.autoLockTimeLimit)
+    preferencesStore.subscribe(({ preferences }) => {
+      const currentState = this.store.getState()
+      if (currentState.timeoutMinutes !== preferences.autoLockTimeLimit) {
+        this._setInactiveTimeout(preferences.autoLockTimeLimit)
+      }
     })
 
     this._setInactiveTimeout(preferences.autoLockTimeLimit)


### PR DESCRIPTION
The inactive timer was being reset upon any change to the preferences store. The intent was only to update the timer when the auto-lock timeout had changed, so the subscription was updated to only update in those cases.

There are no indications that this had any effect upon the user. It looks like the preferences store never updates while the extension is unattended, so in practice this may have been harmless. It was still pointless however. This also protects against the possibility of the preferences store being updated while unattended at some point in the future.