### PR TITLE
Prevent negative values on gas inputs.

### DIFF
--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -116,6 +116,7 @@ export default class AdvancedGasInputs extends Component {
               'advanced-gas-inputs__gas-edit-row__input--warning': errorType === 'warning',
             })}
             type="number"
+            min="0"
             value={value}
             onChange={onChange}
           />


### PR DESCRIPTION
Fixes #8492

Adds min value for input in the advanced-gas-inputs component to prevent users from entering negative values on keypress, change, etc.