### PR TITLE
Disallow all anonymous default exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ module.exports = {
     'import/newline-after-import': 'error',
     'import/no-absolute-path': 'error',
     'import/no-amd': 'error',
-    'import/no-anonymous-default-export': ['error', { 'allowObject': true }],
+    'import/no-anonymous-default-export': 'error',
     'import/no-duplicates': 'error',
     'import/no-dynamic-require': 'error',
     'import/no-mutable-exports': 'error',
@@ -91,6 +91,16 @@ module.exports = {
     'babel/semi': ['error', 'never'],
     'mocha/no-setup-in-describe': 'off',
   },
+
+  overrides: [{
+    files: [
+      'app/scripts/migrations/*.js',
+      '*.stories.js',
+    ],
+    rules: {
+      'import/no-anonymous-default-export': ['error', { 'allowObject': true }],
+    },
+  }],
 
   settings: {
     'react': {

--- a/test/lib/mock-encryptor.js
+++ b/test/lib/mock-encryptor.js
@@ -2,7 +2,7 @@ const mockHex = '0xabcdef0123456789'
 const mockKey = Buffer.alloc(32)
 let cacheVal
 
-export default {
+const mockEncryptor = {
 
   encrypt (_, dataObj) {
     cacheVal = dataObj
@@ -34,3 +34,5 @@ export default {
   },
 
 }
+
+export default mockEncryptor

--- a/ui/app/selectors/tests/send-selectors-test-data.js
+++ b/ui/app/selectors/tests/send-selectors-test-data.js
@@ -1,4 +1,4 @@
-export default {
+const state = {
   'metamask': {
     'isInitialized': true,
     'isUnlocked': true,
@@ -218,3 +218,5 @@ export default {
     'errors': { 'someError': null },
   },
 }
+
+export default state


### PR DESCRIPTION
This PR disallows all anonymous default exports outside of Storybook-related files. [Storybook’s Component Story Format (CSF)](https://storybook.js.org/docs/formats/component-story-format/) has a "required default export" the defines metadata about the component.

From the docs for the ESLint rule:<sup>[\[1\]][1]</sup>

> Reports if a module's default export is unnamed. This includes several types of unnamed data types; literals, object expressions, arrays, anonymous functions, arrow functions, and anonymous class declarations.
>
> Ensuring that default exports are named helps improve the grepability of the codebase by encouraging the re-use of the same identifier for the module's default export at its declaration site and at its import sites.

  [1]:https://github.com/benmosher/eslint-plugin-import/blob/v2.20.1/docs/rules/no-anonymous-default-export.md
