### PR TITLE
Remove unused seed phrase action

### DIFF
--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -5,7 +5,6 @@ import Button from '../../../../components/ui/button'
 import {
   INITIALIZE_END_OF_FLOW_ROUTE,
   INITIALIZE_SEED_PHRASE_ROUTE,
-  DEFAULT_ROUTE,
 } from '../../../../helpers/constants/routes'
 import { exportAsFile } from '../../../../helpers/utils/util'
 import DraggableSeed from './draggable-seed.component'
@@ -23,12 +22,10 @@ export default class ConfirmSeedPhrase extends PureComponent {
   }
 
   static propTypes = {
-    hideSeedPhraseBackupAfterOnboarding: PropTypes.func,
     history: PropTypes.object,
     seedPhrase: PropTypes.string,
     initializeThreeBox: PropTypes.func,
     setSeedPhraseBackedUp: PropTypes.func,
-    showingSeedPhraseBackupAfterOnboarding: PropTypes.bool,
   }
 
   state = {
@@ -73,8 +70,6 @@ export default class ConfirmSeedPhrase extends PureComponent {
     const {
       history,
       setSeedPhraseBackedUp,
-      showingSeedPhraseBackupAfterOnboarding,
-      hideSeedPhraseBackupAfterOnboarding,
       initializeThreeBox,
     } = this.props
 
@@ -92,13 +87,8 @@ export default class ConfirmSeedPhrase extends PureComponent {
       })
 
       setSeedPhraseBackedUp(true).then(() => {
-        if (showingSeedPhraseBackupAfterOnboarding) {
-          hideSeedPhraseBackupAfterOnboarding()
-          history.push(DEFAULT_ROUTE)
-        } else {
-          initializeThreeBox()
-          history.push(INITIALIZE_END_OF_FLOW_ROUTE)
-        }
+        initializeThreeBox()
+        history.push(INITIALIZE_END_OF_FLOW_ROUTE)
       })
     } catch (error) {
       console.error(error.message)

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.container.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.container.js
@@ -2,24 +2,14 @@ import { connect } from 'react-redux'
 import ConfirmSeedPhrase from './confirm-seed-phrase.component'
 import {
   setSeedPhraseBackedUp,
-  hideSeedPhraseBackupAfterOnboarding,
   initializeThreeBox,
 } from '../../../../store/actions'
-
-const mapStateToProps = (state) => {
-  const { appState: { showingSeedPhraseBackupAfterOnboarding } } = state
-
-  return {
-    showingSeedPhraseBackupAfterOnboarding,
-  }
-}
 
 const mapDispatchToProps = (dispatch) => {
   return {
     setSeedPhraseBackedUp: (seedPhraseBackupState) => dispatch(setSeedPhraseBackedUp(seedPhraseBackupState)),
-    hideSeedPhraseBackupAfterOnboarding: () => dispatch(hideSeedPhraseBackupAfterOnboarding()),
     initializeThreeBox: () => dispatch(initializeThreeBox()),
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ConfirmSeedPhrase)
+export default connect(null, mapDispatchToProps)(ConfirmSeedPhrase)

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2242,12 +2242,6 @@ export function setSeedPhraseBackedUp (seedPhraseBackupState) {
   }
 }
 
-export function hideSeedPhraseBackupAfterOnboarding () {
-  return {
-    type: actionConstants.HIDE_SEED_PHRASE_BACKUP_AFTER_ONBOARDING,
-  }
-}
-
 export function initializeThreeBox () {
   return (dispatch) => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Refs #8536, that changed exposed this.

1. The `HIDE_SEED_PHRASE_BACKUP_AFTER_ONBOARDING` action doesn't exist.
2. That `showingSeedPhraseBackupAfterOnboarding` state doesn't exist in `appState`.