### PR TITLE
Use named exports in alerts ducks

### DIFF
--- a/ui/app/ducks/alerts/index.js
+++ b/ui/app/ducks/alerts/index.js
@@ -1,5 +1,1 @@
-import unconnectedAccount from './unconnected-account'
-
-export default {
-  unconnectedAccount,
-}
+export { default as unconnectedAccount } from './unconnected-account'

--- a/ui/app/ducks/index.js
+++ b/ui/app/ducks/index.js
@@ -5,7 +5,7 @@ import sendReducer from './send/send.duck'
 import appStateReducer from './app/app'
 import confirmTransactionReducer from './confirm-transaction/confirm-transaction.duck'
 import gasReducer from './gas/gas.duck'
-import alerts from './alerts'
+import * as alerts from './alerts'
 
 export default combineReducers({
   ...alerts,


### PR DESCRIPTION
Refs #8535

This PR updates the alerts ducks file to use named exports instead of an anonymous object as the default export.