### PR TITLE
Remove scroll bar from home screen

### DIFF
--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -10,7 +10,6 @@
     min-width: 0;
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
   }
 
   &__balance-wrapper {


### PR DESCRIPTION
A change made in #8284 had the unintended side-effect of making this scrollbar appear on the home screen. Previously it was scrollable without any scroll bar being visible.