### PR TITLE
Use gaba@1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "extensionizer": "^1.0.1",
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
-    "gaba": "^1.9.3",
+    "gaba": "^1.11.0",
     "human-standard-token-abi": "^2.0.0",
     "jazzicon": "^2.0.0",
     "json-rpc-engine": "^5.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12477,14 +12477,15 @@ fuse.js@^3.4.6:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.6.tgz#545c3411fed88bf2e27c457cab6e73e7af697a45"
   integrity sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==
 
-gaba@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.9.3.tgz#4e0e106f3640930f1f06ffe72546903b4c51813e"
-  integrity sha512-zC9CpaksncAT9SSc4QAxozUE+SKIWN+r9YwhjAJoSeh9joqPJsXlJOHg1/CrHABpvN68QdE00wAYSabYM02EqQ==
+gaba@^1.11.0, gaba@^1.9.3:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/gaba/-/gaba-1.11.0.tgz#7ff49cad2f2b95941222121a1984bb63783fe076"
+  integrity sha512-rQcLgR/FHQ8W6oNza/vxFnkbav0vgauBxm6LKqK6BkbjJGB979qoBRVja9fU/H5dUMiYmHJO9CrHjL0ofG/ukA==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.11.0"
     eth-ens-namehash "^2.0.8"
+    eth-json-rpc-errors "^2.0.2"
     eth-json-rpc-infura "^4.0.1"
     eth-keyring-controller "^5.3.0"
     eth-method-registry "1.1.0"


### PR DESCRIPTION
This PR updates our gaba dependency to the latest published in-range.