### PR TITLE
Fix MetaMaskController test network access

### DIFF
--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -4,7 +4,6 @@ import { cloneDeep } from 'lodash'
 import nock from 'nock'
 import ethUtil from 'ethereumjs-util'
 import { obj as createThoughStream } from 'through2'
-import blacklistJSON from 'eth-phishing-detect/src/config'
 import firstTimeState from '../../localhostState'
 import createTxMeta from '../../../lib/createTxMeta'
 import EthQuery from 'eth-query'
@@ -58,11 +57,6 @@ describe('MetaMaskController', function () {
   const noop = () => {}
 
   beforeEach(function () {
-
-    nock('https://api.infura.io')
-      .persist()
-      .get('/v2/blacklist')
-      .reply(200, blacklistJSON)
 
     nock('https://api.infura.io')
       .get('/v1/ticker/ethusd')
@@ -803,12 +797,11 @@ describe('MetaMaskController', function () {
   })
 
   describe('#setupUntrustedCommunication', function () {
-    it('sets up phishing stream for untrusted communication ', async function () {
+    it('sets up phishing stream for untrusted communication', async function () {
       const phishingMessageSender = {
         url: 'http://myethereumwalletntw.com',
         tab: {},
       }
-      await metamaskController.phishingController.updatePhishingLists()
 
       const { promise, resolve } = deferredPromise()
       const streamTest = createThoughStream((chunk, _, cb) => {


### PR DESCRIPTION
This PR removes the call to `PhishingController#updatePhishingLists` from the `MetaMaskController` tests. The call isn't required as the state is initialized from `eth-phishing-detect` config on construction.

I've also updated the test title to remove a trailing space.

```diff
  1) MetaMaskController
       #setupUntrustedCommunication
-         sets up phishing stream for untrusted communication :
+         sets up phishing stream for untrusted communication:
```
