### PR TITLE
Simplify settings tab `render` functions

### DIFF
--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -437,7 +437,7 @@ export default class AdvancedTab extends PureComponent {
     )
   }
 
-  renderContent () {
+  render () {
     const { warning } = this.props
 
     return (
@@ -455,10 +455,6 @@ export default class AdvancedTab extends PureComponent {
         { this.renderIpfsGatewayControl() }
       </div>
     )
-  }
-
-  render () {
-    return this.renderContent()
   }
 }
 

--- a/ui/app/pages/settings/info-tab/info-tab.component.js
+++ b/ui/app/pages/settings/info-tab/info-tab.component.js
@@ -89,7 +89,7 @@ export default class InfoTab extends PureComponent {
     )
   }
 
-  renderContent () {
+  render () {
     const { t } = this.context
 
     return (
@@ -120,9 +120,5 @@ export default class InfoTab extends PureComponent {
         </div>
       </div>
     )
-  }
-
-  render () {
-    return this.renderContent()
   }
 }

--- a/ui/app/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.component.js
@@ -218,7 +218,7 @@ export default class NetworksTab extends PureComponent {
     )
   }
 
-  renderContent () {
+  render () {
     const { setNetworksTabAddMode, setSelectedSettingsRpcUrl, networkIsSelected, networksTabIsInAddMode } = this.props
 
     return (
@@ -244,9 +244,5 @@ export default class NetworksTab extends PureComponent {
         }
       </div>
     )
-  }
-
-  render () {
-    return this.renderContent()
   }
 }

--- a/ui/app/pages/settings/security-tab/security-tab.component.js
+++ b/ui/app/pages/settings/security-tab/security-tab.component.js
@@ -133,7 +133,7 @@ export default class SecurityTab extends PureComponent {
     )
   }
 
-  renderContent () {
+  render () {
     const { warning } = this.props
 
     return (
@@ -145,9 +145,5 @@ export default class SecurityTab extends PureComponent {
         { this.renderMetaMetricsOptIn() }
       </div>
     )
-  }
-
-  render () {
-    return this.renderContent()
   }
 }

--- a/ui/app/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/app/pages/settings/settings-tab/settings-tab.component.js
@@ -179,7 +179,7 @@ export default class SettingsTab extends PureComponent {
     )
   }
 
-  renderContent () {
+  render () {
     const { warning } = this.props
 
     return (
@@ -191,9 +191,5 @@ export default class SettingsTab extends PureComponent {
         { this.renderBlockieOptIn() }
       </div>
     )
-  }
-
-  render () {
-    return this.renderContent()
   }
 }


### PR DESCRIPTION
These `render` functions were just calling `renderContent`. Instead the `render` function now directly renders the content.