### PR TITLE
Fix checkbox color when checked or indeterminate

### DIFF
--- a/ui/app/components/ui/check-box/check-box.component.js
+++ b/ui/app/components/ui/check-box/check-box.component.js
@@ -26,8 +26,8 @@ const CheckBox = ({ className, disabled, onClick, checked }) => {
       checked={checked === CHECKBOX_STATE.CHECKED}
       className={classnames('check-box', className, {
         'far fa-square': checked === CHECKBOX_STATE.UNCHECKED,
-        'fa fa-check-square': checked === CHECKBOX_STATE.CHECKED,
-        'fa fa-minus-square': checked === CHECKBOX_STATE.INDETERMINATE,
+        'fa fa-check-square check-box__checked': checked === CHECKBOX_STATE.CHECKED,
+        'fa fa-minus-square check-box__indeterminate': checked === CHECKBOX_STATE.INDETERMINATE,
       })}
       disabled={disabled}
       onClick={

--- a/ui/app/components/ui/check-box/index.scss
+++ b/ui/app/components/ui/check-box/index.scss
@@ -10,7 +10,7 @@
   border-radius: 2px;
   display: flex;
 
-  &:checked, &:indeterminate {
+  &__checked, &__indeterminate {
     color: $curious-blue;
     border-color: $curious-blue;
   }


### PR DESCRIPTION
The checkbox color was sometimes incorrect after it was checked. I'm not sure how to consistently reproduce this issue, but I was able to make this happen most of the time if I clicked the checkbox while some text was highlighted.

It seems that the `:checked` and `:indeterminate` pseudo-selectors were not being applied right away for some reason. Either that or React wasn't setting the `checked` state of the `input` element right away.

This problem has been worked around by using CSS classes instead of pseudo-selectors. I am no longer able to reproduce the issue now.