### PR TITLE
Update menu bar account hover background color

### DIFF
--- a/ui/app/components/app/selected-account/index.scss
+++ b/ui/app/components/app/selected-account/index.scss
@@ -39,7 +39,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: #e8e6e8;
+      background-color: $Grey-000;
     }
 
     &:active {


### PR DESCRIPTION
The hover state background color of the "Account" in the popup home screen menu bar has been updated to match the hover state background color of the connected status indicator. Both hover state backgrounds now match.