### PR TITLE
Add sink middleware to terminate wayward internal RPC requests

### DIFF
--- a/app/scripts/lib/createSinkMiddleware.js
+++ b/app/scripts/lib/createSinkMiddleware.js
@@ -1,9 +1,14 @@
 import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware'
+import log from 'loglevel'
 
 export const METHOD_PREFIXES_TO_DRAIN = [
   'wallet_',
   'metamask_',
 ]
+
+export const METHODS_TO_DRAIN = new Set([
+  'eth_requestAccounts',
+])
 
 function shouldDrain (methodName = '') {
   for (const prefix of METHOD_PREFIXES_TO_DRAIN) {
@@ -11,12 +16,13 @@ function shouldDrain (methodName = '') {
       return true
     }
   }
-  return false
+  return METHODS_TO_DRAIN.has(methodName)
 }
 
 export default function createSinkMiddleware () {
   return createAsyncMiddleware(async (req, res, next) => {
     if (shouldDrain(req.method)) {
+      log.warn(`Sink Middleware: Draining request for '${req.method}'`)
       if (res.result === undefined) {
         res.result = null
       }

--- a/app/scripts/lib/createSinkMiddleware.js
+++ b/app/scripts/lib/createSinkMiddleware.js
@@ -1,0 +1,27 @@
+import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware'
+
+export const METHOD_PREFIXES_TO_DRAIN = [
+  'wallet_',
+  'metamask_',
+]
+
+function shouldDrain (methodName = '') {
+  for (const prefix of METHOD_PREFIXES_TO_DRAIN) {
+    if (methodName.startsWith(prefix)) {
+      return true
+    }
+  }
+  return false
+}
+
+export default function createSinkMiddleware () {
+  return createAsyncMiddleware(async (req, res, next) => {
+    if (shouldDrain(req.method)) {
+      if (res.result === undefined) {
+        res.result = null
+      }
+      return
+    }
+    next()
+  })
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -22,6 +22,7 @@ import createLoggerMiddleware from './lib/createLoggerMiddleware'
 import createOriginMiddleware from './lib/createOriginMiddleware'
 import createTabIdMiddleware from './lib/createTabIdMiddleware'
 import createOnboardingMiddleware from './lib/createOnboardingMiddleware'
+import createSinkMiddleware from './lib/createSinkMiddleware'
 import providerAsMiddleware from 'eth-json-rpc-middleware/providerAsMiddleware'
 import { setupMultiplex } from './lib/stream-utils.js'
 import KeyringController from 'eth-keyring-controller'
@@ -1628,6 +1629,8 @@ export default class MetamaskController extends EventEmitter {
     engine.push(this.permissionsController.createMiddleware({ origin, extensionId }))
     // watch asset
     engine.push(this.preferencesController.requestWatchAsset.bind(this.preferencesController))
+    // drain methods that should never hit the provider
+    engine.push(createSinkMiddleware())
     // forward to metamask primary provider
     engine.push(providerAsMiddleware(provider))
     return engine

--- a/test/unit/app/sink-middleware.spec.js
+++ b/test/unit/app/sink-middleware.spec.js
@@ -1,0 +1,73 @@
+import assert from 'assert'
+import sinon from 'sinon'
+import pify from 'pify'
+import JsonRpcEngine from 'json-rpc-engine'
+import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware'
+
+import createSinkMiddleware, { METHOD_PREFIXES_TO_DRAIN } from '../../../app/scripts/lib/createSinkMiddleware'
+
+const createMockMiddleware = (fake) => {
+  return createAsyncMiddleware(async (req, res, _next) => {
+    fake(req.method)
+    res.result = true
+    return
+  })
+}
+
+const createMockEngine = (fake) => {
+  const engine = new JsonRpcEngine()
+  engine.push(createSinkMiddleware())
+  engine.push(createMockMiddleware(fake))
+  engine.handleAsync = pify(engine.handle)
+  return engine
+}
+
+const getMockPayload = (method) => {
+  return {
+    method,
+    jsonrpc: '2.0',
+    id: 1,
+  }
+}
+
+describe('Sink middleware', function () {
+
+  it('terminates requests for methods with target prefixes', async function () {
+
+    const methods = METHOD_PREFIXES_TO_DRAIN.map((prefix) => prefix + 'foo')
+
+    const fake = sinon.fake()
+    const engine = createMockEngine(fake)
+
+    for (const method of methods) {
+
+      const payload = getMockPayload(method)
+      const response = await engine.handleAsync(payload)
+      assert.ok(fake.notCalled, 'fake should not have been called')
+      assert.equal(
+        response.result, null,
+        'response should have null result'
+      )
+    }
+  })
+
+  it('passes through methods without target prefixes', async function () {
+
+    const method = 'eth_foo'
+
+    const fake = sinon.fake()
+    const engine = createMockEngine(fake)
+
+    const payload = getMockPayload(method)
+    const response = await engine.handleAsync(payload)
+    assert.ok(fake.calledOnce, 'fake should have been called once')
+    assert.equal(
+      fake.lastCall.args[0], method,
+      'fake should have been called with expected arg'
+    )
+    assert.equal(
+      response.result, true,
+      'response should have true result'
+    )
+  })
+})

--- a/test/unit/app/sink-middleware.spec.js
+++ b/test/unit/app/sink-middleware.spec.js
@@ -4,7 +4,10 @@ import pify from 'pify'
 import JsonRpcEngine from 'json-rpc-engine'
 import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware'
 
-import createSinkMiddleware, { METHOD_PREFIXES_TO_DRAIN } from '../../../app/scripts/lib/createSinkMiddleware'
+import createSinkMiddleware, {
+  METHOD_PREFIXES_TO_DRAIN,
+  METHODS_TO_DRAIN,
+} from '../../../app/scripts/lib/createSinkMiddleware'
 
 const createMockEngine = (fake) => {
   const engine = new JsonRpcEngine()
@@ -38,6 +41,23 @@ describe('Sink middleware', function () {
     const engine = createMockEngine(fake)
 
     for (const method of methods) {
+
+      const payload = createMockPayload(method)
+      const response = await engine.handleAsync(payload)
+      assert.ok(fake.notCalled, 'fake should not have been called')
+      assert.equal(
+        response.result, null,
+        'response should have null result'
+      )
+    }
+  })
+
+  it('terminates requests for target methods', async function () {
+
+    const fake = sinon.fake()
+    const engine = createMockEngine(fake)
+
+    for (const method of METHODS_TO_DRAIN) {
 
       const payload = createMockPayload(method)
       const response = await engine.handleAsync(payload)


### PR DESCRIPTION
Adds a simple sink middleware that ends any `wallet_`- or `metamask_`-prefixed methods before they're handed off to the network.