### PR TITLE
Fix alert disabling type error

### DIFF
--- a/ui/app/ducks/alerts/unconnected-account.js
+++ b/ui/app/ducks/alerts/unconnected-account.js
@@ -94,7 +94,7 @@ export const dismissAndDisableAlert = () => {
   return async (dispatch) => {
     try {
       await dispatch(disableAlertRequested())
-      await dispatch(setAlertEnabledness(name), false)
+      await dispatch(setAlertEnabledness(name, false))
       await dispatch(disableAlertSucceeded())
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
When disabling an alert, the background `alertEnabledness` state of the alert was being set to `undefined` instead of `false`. This didn't have any user-facing effect, since `undefined` is falsey, but it did result in a PropType error on the Alert settings page. This mistake was made
in #8550.

The `alertEnabledness` state is now correctly set to `false` instead of `undefined`.