### PR TITLE
Add missing period to localized message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1553,7 +1553,7 @@
     "message": "Not connected"
   },
   "unconnectedAccountAlertDescription": {
-    "message": "This account is not connected to this site"
+    "message": "This account is not connected to this site."
   },
   "unconnectedAccountAlertDisableTooltip": {
     "message": "This can be changed in \"Settings > Alerts\""


### PR DESCRIPTION
The description for the "Unconnected account" alert has been updated to include a period at the end of the sentence.