### PR TITLE
Only display accounts with identities in send and permissions flows

### DIFF
--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -200,7 +200,7 @@ export function accountsWithSendEtherInfoSelector (state) {
   const { identities } = state.metamask
 
   const accountsWithSendEtherInfo = Object.entries(identities).map(([key, identity]) => {
-    return Object.assign({}, identity, accounts[key])
+    return Object.assign({}, accounts[key], identity)
   })
 
   return accountsWithSendEtherInfo

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -199,8 +199,8 @@ export function accountsWithSendEtherInfoSelector (state) {
   const accounts = getMetaMaskAccounts(state)
   const { identities } = state.metamask
 
-  const accountsWithSendEtherInfo = Object.entries(accounts).map(([key, account]) => {
-    return Object.assign({}, account, identities[key])
+  const accountsWithSendEtherInfo = Object.entries(identities).map(([key, identity]) => {
+    return Object.assign({}, identity, accounts[key])
   })
 
   return accountsWithSendEtherInfo


### PR DESCRIPTION
A tweak of `accountsWithSendEtherInfoSelector` ensures that only accounts with identities are retrieved for use in send- and permissions-related flows.

Fixes #8204 