### PR TITLE
Remove unused `Balance` component props

### DIFF
--- a/ui/app/components/app/asset-list/asset-list.component.js
+++ b/ui/app/components/app/asset-list/asset-list.component.js
@@ -13,13 +13,11 @@ export default class AssetList extends Component {
   }
 
   static defaultProps = {
-    selectedAccount: undefined,
     selectedTokenAddress: undefined,
   }
 
   static propTypes = {
     history: PropTypes.object.isRequired,
-    selectedAccount: PropTypes.object,
     selectedTokenAddress: PropTypes.string,
     setSelectedToken: PropTypes.func.isRequired,
     unsetSelectedToken: PropTypes.func.isRequired,
@@ -28,7 +26,6 @@ export default class AssetList extends Component {
   renderWalletBalance () {
     const {
       selectedTokenAddress,
-      selectedAccount,
       unsetSelectedToken,
     } = this.props
 
@@ -44,9 +41,7 @@ export default class AssetList extends Component {
             unsetSelectedToken()
           }}
         >
-          <BalanceComponent
-            balanceValue={selectedAccount ? selectedAccount.balance : ''}
-          />
+          <BalanceComponent />
         </div>
       </div>
     )

--- a/ui/app/components/app/asset-list/asset-list.container.js
+++ b/ui/app/components/app/asset-list/asset-list.container.js
@@ -3,11 +3,9 @@ import { withRouter } from 'react-router-dom'
 import { compose } from 'redux'
 import AssetList from './asset-list.component'
 import { setSelectedToken } from '../../../store/actions'
-import { getSelectedAccount } from '../../../selectors'
 
 function mapStateToProps (state) {
   return {
-    selectedAccount: getSelectedAccount(state),
     selectedTokenAddress: state.metamask.selectedTokenAddress,
   }
 }

--- a/ui/app/components/ui/balance/balance.component.js
+++ b/ui/app/components/ui/balance/balance.component.js
@@ -1,43 +1,18 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import TokenBalance from '../token-balance'
 import Identicon from '../identicon'
 import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-display'
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common'
-import { formatBalance } from '../../../helpers/utils/util'
 
 export default class Balance extends PureComponent {
   static propTypes = {
     account: PropTypes.object,
-    assetImages: PropTypes.object,
-    nativeCurrency: PropTypes.string,
-    needsParse: PropTypes.bool,
-    network: PropTypes.string,
     showFiat: PropTypes.bool,
-    token: PropTypes.object,
-  }
-
-  static defaultProps = {
-    needsParse: true,
-    showFiat: true,
   }
 
   renderBalance () {
-    const { account, nativeCurrency, needsParse, showFiat } = this.props
+    const { account, showFiat } = this.props
     const balanceValue = account && account.balance
-    const formattedBalance = balanceValue
-      ? formatBalance(balanceValue, 6, needsParse, nativeCurrency)
-      : '...'
-
-    if (formattedBalance === 'None' || formattedBalance === '...') {
-      return (
-        <div className="flex-column balance-display">
-          <div className="token-amount">
-            { formattedBalance }
-          </div>
-        </div>
-      )
-    }
 
     return (
       <div className="flex-column balance-display">
@@ -60,32 +35,13 @@ export default class Balance extends PureComponent {
     )
   }
 
-  renderTokenBalance () {
-    const { token } = this.props
-
-    return (
-      <div className="flex-column balance-display">
-        <div className="token-amount">
-          <TokenBalance token={token} />
-        </div>
-      </div>
-    )
-  }
-
   render () {
-    const { token, network, assetImages } = this.props
-    const address = token && token.address
-    const image = assetImages && address ? assetImages[token.address] : undefined
-
     return (
       <div className="balance-container">
         <Identicon
           diameter={50}
-          address={address}
-          network={network}
-          image={image}
         />
-        { token ? this.renderTokenBalance() : this.renderBalance() }
+        { this.renderBalance() }
       </div>
     )
   }

--- a/ui/app/components/ui/balance/balance.container.js
+++ b/ui/app/components/ui/balance/balance.container.js
@@ -1,10 +1,6 @@
 import { connect } from 'react-redux'
 import Balance from './balance.component'
 import {
-  getNativeCurrency,
-  getAssetImages,
-  conversionRateSelector,
-  getCurrentCurrency,
   getMetaMaskAccounts,
   getIsMainnet,
   preferencesSelector,
@@ -14,17 +10,11 @@ const mapStateToProps = (state) => {
   const { showFiatInTestnets } = preferencesSelector(state)
   const isMainnet = getIsMainnet(state)
   const accounts = getMetaMaskAccounts(state)
-  const network = state.metamask.network
   const selectedAddress = state.metamask.selectedAddress || Object.keys(accounts)[0]
   const account = accounts[selectedAddress]
 
   return {
     account,
-    network,
-    nativeCurrency: getNativeCurrency(state),
-    conversionRate: conversionRateSelector(state),
-    currentCurrency: getCurrentCurrency(state),
-    assetImages: getAssetImages(state),
     showFiat: (isMainnet || !!showFiatInTestnets),
   }
 }


### PR DESCRIPTION
This component was indended to show both ETH/fiat and token balance, but today is not used for token balance. As a result, large pieces of this component and many props were unused in practice. The condition about `formattedBalance` returning a falsy or `None` or `...` result was also removed, as that doesn't seem to be possible.

The `balanceValue` passed into the `Balance` component in the asset list has also been removed, as it isn't used.