### PR TITLE
Delete retryTransaction action and background

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -82,11 +82,6 @@ export default class TransactionController extends EventEmitter {
     this.query = new EthQuery(this.provider)
     this.txGasUtil = new TxGasUtil(this.provider)
 
-    this._gasCache = {
-      latestBlockNumber: null,
-      latestGasPrice: null,
-    }
-
     this._mapMethods()
     this.txStateManager = new TransactionStateManager({
       initState: opts.initState,

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -84,6 +84,19 @@ export default class TransactionStateManager extends EventEmitter {
   }
 
   /**
+   * Gets the number of approved and submitted transactions, i.e. unmined
+   * unmined that will be or have been submitted to the network.
+   *
+   * @param {string} [address] - Hex-prefixed address to sort the txMetas for [optional]
+   * @returns {number} The number of approved and submitted transactions.
+   */
+  getPendingTransactionCount (address) {
+    const numApproved = this.getApprovedTransactions(address).length
+    const numSubmitted = this.getPendingTransactions(address).length
+    return numApproved + numSubmitted
+  }
+
+  /**
     @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
     @returns {array} - the tx list whos status is approved if no address is provide
     returns all txMetas who's status is approved for the current network

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -84,19 +84,6 @@ export default class TransactionStateManager extends EventEmitter {
   }
 
   /**
-   * Gets the number of approved and submitted transactions, i.e. unmined
-   * unmined that will be or have been submitted to the network.
-   *
-   * @param {string} [address] - Hex-prefixed address to sort the txMetas for [optional]
-   * @returns {number} The number of approved and submitted transactions.
-   */
-  getPendingTransactionCount (address) {
-    const numApproved = this.getApprovedTransactions(address).length
-    const numSubmitted = this.getPendingTransactions(address).length
-    return numApproved + numSubmitted
-  }
-
-  /**
     @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
     @returns {array} - the tx list whos status is approved if no address is provide
     returns all txMetas who's status is approved for the current network

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -520,7 +520,6 @@ export default class MetamaskController extends EventEmitter {
       cancelTransaction: nodeify(txController.cancelTransaction, txController),
       updateTransaction: nodeify(txController.updateTransaction, txController),
       updateAndApproveTransaction: nodeify(txController.updateAndApproveTransaction, txController),
-      retryTransaction: nodeify(this.retryTransaction, this),
       createCancelTransaction: nodeify(this.createCancelTransaction, this),
       createSpeedUpTransaction: nodeify(this.createSpeedUpTransaction, this),
       getFilteredTxList: nodeify(txController.getFilteredTxList, txController),
@@ -1372,18 +1371,6 @@ export default class MetamaskController extends EventEmitter {
   //=============================================================================
   // END (VAULT / KEYRING RELATED METHODS)
   //=============================================================================
-
-  /**
-   * Allows a user to try to speed up a transaction by retrying it
-   * with higher gas.
-   *
-   * @param {string} txId - The ID of the transaction to speed up.
-   */
-  async retryTransaction (txId, gasPrice) {
-    await this.txController.retryTransaction(txId, gasPrice)
-    const state = await this.getState()
-    return state
-  }
 
   /**
    * Allows a user to attempt to cancel a previously submitted transaction by creating a new

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -482,29 +482,6 @@ describe('Transaction Controller', function () {
     })
   })
 
-  describe('#retryTransaction', function () {
-    it('should create a new txMeta with the same txParams as the original one but with a higher gasPrice', async function () {
-      const txParams = {
-        gasPrice: '0xee6b2800',
-        nonce: '0x00',
-        from: '0xB09d8505E1F4EF1CeA089D47094f5DD3464083d4',
-        to: '0xB09d8505E1F4EF1CeA089D47094f5DD3464083d4',
-        data: '0x0',
-      }
-      txController.txStateManager._saveTxList([
-        { id: 1, status: 'submitted', metamaskNetworkId: currentNetworkId, txParams, history: [{}] },
-      ])
-      const txMeta = await txController.retryTransaction(1)
-      assert.equal(txMeta.txParams.gasPrice, '0x10642ac00', 'gasPrice should have a %10 gasPrice bump')
-      assert.equal(txMeta.txParams.nonce, txParams.nonce, 'nonce should be the same')
-      assert.equal(txMeta.txParams.from, txParams.from, 'from should be the same')
-      assert.equal(txMeta.txParams.to, txParams.to, 'to should be the same')
-      assert.equal(txMeta.txParams.data, txParams.data, 'data should be the same')
-      assert.ok(('lastGasPrice' in txMeta), 'should have the key `lastGasPrice`')
-      assert.equal(txController.txStateManager.getTxList().length, 2)
-    })
-  })
-
   describe('#_markNonceDuplicatesDropped', function () {
     it('should mark all nonce duplicates as dropped without marking the confirmed transaction as dropped', function () {
       txController.txStateManager._saveTxList([

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1350,29 +1350,6 @@ export function clearPendingTokens () {
   }
 }
 
-export function retryTransaction (txId, gasPrice) {
-  log.debug(`background.retryTransaction`)
-  let newTxId
-
-  return (dispatch) => {
-    return new Promise((resolve, reject) => {
-      background.retryTransaction(txId, gasPrice, (err, newState) => {
-        if (err) {
-          dispatch(displayWarning(err.message))
-          return reject(err)
-        }
-
-        const { currentNetworkTxList } = newState
-        const { id } = currentNetworkTxList[currentNetworkTxList.length - 1]
-        newTxId = id
-        resolve(newState)
-      })
-    })
-      .then((newState) => dispatch(updateMetamaskState(newState)))
-      .then(() => newTxId)
-  }
-}
-
 export function createCancelTransaction (txId, customGasPrice) {
   log.debug('background.cancelTransaction')
   let newTxId


### PR DESCRIPTION
`TransactionController.retryTransaction` was never called, and has been deleted.

We retry transactions using `TransactionController.createSpeedUpTransaction`, which prefers the gas price it receives from the UI (with the suggestion from ETH Gas Station), or falls back to 110% of the original gas price.

Let it be known that @Gudahtt discovered that this was unused.