### PR TITLE
set home container height to auto

### DIFF
--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -119,7 +119,8 @@ $wallet-view-bg: $alabaster;
 
   .main-container {
     width: 85vw;
-    height: 90vh;
+    margin-bottom: 10vh;
+    min-height: 90vh;
     box-shadow: 0 0 7px 0 rgba(0, 0, 0, .08);
   }
 }
@@ -127,7 +128,7 @@ $wallet-view-bg: $alabaster;
 @media screen and (min-width: 769px) {
   .main-container {
     width: 80vw;
-    height: 82vh;
+    min-height: 82vh;
     box-shadow: 0 0 7px 0 rgba(0, 0, 0, .08);
   }
 }
@@ -135,7 +136,7 @@ $wallet-view-bg: $alabaster;
 @media screen and (min-width: 1281px) {
   .main-container {
     width: 62vw;
-    height: 82vh;
+    min-height: 82vh;
     box-shadow: 0 0 7px 0 rgba(0, 0, 0, .08);
   }
 }

--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -1,7 +1,7 @@
 .home {
   &__container {
     display: flex;
-    height: 100%;
+    min-height: 100%;
   }
 
   &__main-view {


### PR DESCRIPTION
Noticed while working on transaction list: 

![image](https://user-images.githubusercontent.com/4448075/81754415-beba7380-947b-11ea-8303-064b48f94fe1.png)


home container height set to 100% in #8284 to fix a sizing issue. setting it to 'auto' for some reason works whereas 100% does not. Gotta love css. @Gudahtt can you confirm this doesn't undo the fix from that PR? 
