### PR TITLE
Increase preferences store max listener count

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -65,6 +65,7 @@ export default class PreferencesController {
     this.diagnostics = opts.diagnostics
     this.network = opts.network
     this.store = new ObservableStore(initState)
+    this.store.setMaxListeners(12)
     this.openPopup = opts.openPopup
     this._subscribeProviderType()
 


### PR DESCRIPTION
The max listener count of the preferences store has been increased to 12. Recently the 12th listener was added, which resulted in console warnings during the unit tests - this prevents those warnings.

The default max listener value is 10; we didn't see this warning until now because one of the twelve listeners is only setup when 3Box is enabled, which doesn't occur during our unit tests.