### PR TITLE
Refactor identicon styles

### DIFF
--- a/ui/app/components/app/asset-list/asset-list.scss
+++ b/ui/app/components/app/asset-list/asset-list.scss
@@ -62,11 +62,3 @@ $wallet-balance-breakpoint-range: "screen and (min-width: #{$break-large}) and (
     }
   }
 }
-
-.balance-icon {
-  border-radius: 25px;
-  width: 50px;
-  height: 50px;
-  border: 1px solid $alto;
-  background: $white;
-}

--- a/ui/app/components/ui/identicon/identicon.component.js
+++ b/ui/app/components/ui/identicon/identicon.component.js
@@ -98,7 +98,7 @@ export default class Identicon extends PureComponent {
 
     return (
       <img
-        className={classnames('balance-icon', className)}
+        className={classnames('identicon__eth-logo', className)}
         src="./images/eth_logo.svg"
         style={getStyles(diameter)}
       />

--- a/ui/app/components/ui/identicon/index.scss
+++ b/ui/app/components/ui/identicon/index.scss
@@ -19,4 +19,9 @@
     border-width: 2px;
     border-color: $curious-blue;
   }
+
+  &__eth-logo {
+    border: 1px solid $alto;
+    background: $white;
+  }
 }

--- a/ui/app/components/ui/identicon/tests/identicon.component.test.js
+++ b/ui/app/components/ui/identicon/tests/identicon.component.test.js
@@ -21,7 +21,7 @@ describe('Identicon', function () {
       <Identicon store={store} />
     )
 
-    assert.equal(wrapper.find('img.balance-icon').prop('src'), './images/eth_logo.svg')
+    assert.equal(wrapper.find('img.identicon__eth-logo').prop('src'), './images/eth_logo.svg')
   })
 
   it('renders custom image and add className props', function () {


### PR DESCRIPTION
The CSS class for the fallback Ethereum logo used in the identicon component was with the `AssetList` styles, and was confusingly named `balance-icon`. It has been migrated to the identicon styles, and renamed `identicon__eth-logo`.

A few redundant rules have been removed as well (they were always overridden by inline styles).