### PR TITLE
Remove redundant `.scss` file extension from SCSS imports

### DIFF
--- a/ui/app/components/app/alerts/alerts.scss
+++ b/ui/app/components/app/alerts/alerts.scss
@@ -1,3 +1,3 @@
-@import './unconnected-account-alert/unconnected-account-alert.scss';
+@import './unconnected-account-alert/unconnected-account-alert';
 
-@import './switch-to-connected-alert/switch-to-connected-alert.scss';
+@import './switch-to-connected-alert/switch-to-connected-alert';

--- a/ui/app/components/app/index.scss
+++ b/ui/app/components/app/index.scss
@@ -4,11 +4,11 @@
 
 @import 'add-token-button/index';
 
-@import 'alerts/alerts.scss';
+@import 'alerts/alerts';
 
 @import 'app-header/index';
 
-@import 'asset-list/asset-list.scss';
+@import 'asset-list/asset-list';
 
 @import '../ui/breadcrumbs/index';
 

--- a/ui/app/css/index.scss
+++ b/ui/app/css/index.scss
@@ -5,16 +5,16 @@
   https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/
  */
 
-@import './itcss/settings/index.scss';
+@import './itcss/settings/index';
 
-@import './itcss/tools/index.scss';
+@import './itcss/tools/index';
 
-@import './itcss/generic/index.scss';
+@import './itcss/generic/index';
 
-@import './itcss/objects/index.scss';
+@import './itcss/objects/index';
 
-@import './itcss/components/index.scss';
+@import './itcss/components/index';
 
-@import './itcss/trumps/index.scss';
+@import './itcss/trumps/index';
 
 @import '../../../node_modules/react-select/dist/react-select';

--- a/ui/app/css/itcss/components/index.scss
+++ b/ui/app/css/itcss/components/index.scss
@@ -5,51 +5,51 @@
 @import '../../../components/ui/popover/index';
 @import '../../../components/ui/icon/preloader/index';
 
-@import './footer.scss';
+@import './footer';
 
-@import './network.scss';
+@import './network';
 
-@import './modal.scss';
+@import './modal';
 
-@import './alert.scss';
+@import './alert';
 
-@import './newui-sections.scss';
+@import './newui-sections';
 
-@import './account-dropdown.scss';
+@import './account-dropdown';
 
-@import './send.scss';
+@import './send';
 
-@import './confirm.scss';
+@import './confirm';
 
-@import './loading-overlay.scss';
+@import './loading-overlay';
 
 // Tx List and Sections
-@import './transaction-list.scss';
+@import './transaction-list';
 
-@import './sections.scss';
+@import './sections';
 
-@import './currency-display.scss';
+@import './currency-display';
 
-@import './menu.scss';
+@import './menu';
 
-@import './gas-slider.scss';
+@import './gas-slider';
 
-@import './tab-bar.scss';
+@import './tab-bar';
 
-@import './simple-dropdown.scss';
+@import './simple-dropdown';
 
-@import './request-signature.scss';
+@import './request-signature';
 
-@import './request-encryption-public-key.scss';
+@import './request-encryption-public-key';
 
-@import './request-decrypt-message.scss';
+@import './request-decrypt-message';
 
-@import './editable-label.scss';
+@import './editable-label';
 
-@import './pages/index.scss';
+@import './pages/index';
 
-@import './new-account.scss';
+@import './new-account';
 
-@import './tooltip.scss';
+@import './tooltip';
 
 @import '../../../components/app/index';

--- a/ui/app/css/itcss/components/pages/index.scss
+++ b/ui/app/css/itcss/components/pages/index.scss
@@ -1,3 +1,3 @@
-@import './reveal-seed.scss';
+@import './reveal-seed';
 
-@import './permission-approval.scss';
+@import './permission-approval';

--- a/ui/app/css/itcss/generic/index.scss
+++ b/ui/app/css/itcss/generic/index.scss
@@ -2,7 +2,7 @@
   Generic
  */
 
-@import './reset.scss';
+@import './reset';
 
 * {
   box-sizing: border-box;

--- a/ui/app/css/itcss/settings/index.scss
+++ b/ui/app/css/itcss/settings/index.scss
@@ -1,3 +1,3 @@
-@import './variables.scss';
+@import './variables';
 
-@import './typography.scss';
+@import './typography';

--- a/ui/app/css/itcss/settings/typography.scss
+++ b/ui/app/css/itcss/settings/typography.scss
@@ -1,8 +1,8 @@
 $fa-font-path: 'fonts/fontawesome';
 
-@import '../../../../../node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss';
-@import '../../../../../node_modules/@fortawesome/fontawesome-free/scss/solid.scss';
-@import '../../../../../node_modules/@fortawesome/fontawesome-free/scss/regular.scss';
+@import '../../../../../node_modules/@fortawesome/fontawesome-free/scss/fontawesome';
+@import '../../../../../node_modules/@fortawesome/fontawesome-free/scss/solid';
+@import '../../../../../node_modules/@fortawesome/fontawesome-free/scss/regular';
 
 @font-face {
   font-family: 'Roboto';

--- a/ui/app/css/itcss/tools/index.scss
+++ b/ui/app/css/itcss/tools/index.scss
@@ -1,1 +1,1 @@
-@import './utilities.scss';
+@import './utilities';


### PR DESCRIPTION
The `.scss` file extension is not required when importing SCSS files. It has been removed from all imports, for consistency. I chose to remove it rather than add it everywhere because imports without the extension seem to be more common.