### PR TITLE
Fix PropType of `network` prop of `TokenMenuDropdown`.

### DIFF
--- a/ui/app/components/app/dropdowns/token-menu-dropdown.js
+++ b/ui/app/components/app/dropdowns/token-menu-dropdown.js
@@ -14,7 +14,7 @@ class TokenMenuDropdown extends Component {
     onClose: PropTypes.func.isRequired,
     showHideTokenConfirmationModal: PropTypes.func.isRequired,
     token: PropTypes.object.isRequired,
-    network: PropTypes.number.isRequired,
+    network: PropTypes.string.isRequired,
   }
 
   onClose = (e) => {


### PR DESCRIPTION
The `network` prop of the `TokenMenuDropdown` component was mistakenly set to "number" in #7779.