### PR TITLE
Add default values for preferences

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -52,6 +52,8 @@ export default class PreferencesController {
       lostIdentities: {},
       forgottenPassword: false,
       preferences: {
+        autoLockTimeLimit: undefined,
+        showFiatInTestnets: false,
         useNativeCurrencyAsPrimaryCurrency: true,
       },
       completedOnboarding: false,

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -39,8 +39,9 @@ export default function reduceMetamask (state = {}, action) {
     welcomeScreenSeen: false,
     currentLocale: '',
     preferences: {
-      useNativeCurrencyAsPrimaryCurrency: true,
+      autoLockTimeLimit: undefined,
       showFiatInTestnets: false,
+      useNativeCurrencyAsPrimaryCurrency: true,
     },
     firstTimeFlowType: null,
     completedOnboarding: false,


### PR DESCRIPTION
Defaults have been added for all three preferences. The default values added are both falsey, so this shouldn't result in any functional change. This was done to help make this preferences more easily discoverable.