### PR TITLE
Always return a Boolean from `getShowFiatSelector`

### DIFF
--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -288,7 +288,7 @@ export function preferencesSelector ({ metamask }) {
 export function getShouldShowFiat (state) {
   const isMainNet = getIsMainnet(state)
   const { showFiatInTestnets } = preferencesSelector(state)
-  return isMainNet || showFiatInTestnets
+  return Boolean(isMainNet || showFiatInTestnets)
 }
 
 export function getAdvancedInlineGasShown (state) {


### PR DESCRIPTION
`getShowFiatSelector` would return the `showFiatInTestnets` value directly when on mainnet, which could be `undefined`. Now it is cast to a Boolean instead.

This was done to fix a PropType warning in a component that will be included in a future PR, where this selector was used for a required prop..