### PR TITLE
fix: handle trailing slashes in block explorer URLs

### DIFF
--- a/test/unit/lib/account-link.test.js
+++ b/test/unit/lib/account-link.test.js
@@ -1,0 +1,44 @@
+import getAccountLink from '../../../ui/lib/account-link'
+import assert from 'assert'
+
+describe('Account link', function () {
+  describe('getAccountLink', function () {
+    it('should return the correct block explorer url for an account', function () {
+      const tests = [
+        {
+          expected: 'https://etherscan.io/address/0xabcd',
+          network: 1,
+          address: '0xabcd',
+        },
+        {
+          expected: 'https://ropsten.etherscan.io/address/0xdef0',
+          network: 3,
+          address: '0xdef0',
+          rpcPrefs: {},
+        },
+        {
+          // test handling of `blockExplorerUrl` for a custom RPC
+          expected: 'https://block.explorer/address/0xabcd',
+          network: 31,
+          address: '0xabcd',
+          rpcPrefs: {
+            blockExplorerUrl: 'https://block.explorer',
+          },
+        },
+        {
+          // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+          expected: 'https://another.block.explorer/address/0xdef0',
+          network: 33,
+          address: '0xdef0',
+          rpcPrefs: {
+            blockExplorerUrl: 'https://another.block.explorer/',
+          },
+        },
+      ]
+
+      tests.forEach(({ expected, address, network, rpcPrefs }) => {
+        assert.equal(getAccountLink(address, network, rpcPrefs), expected)
+      })
+    })
+  })
+})

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -236,7 +236,7 @@ export function getStatusKey (transaction) {
  */
 export function getBlockExplorerUrlForTx (networkId, hash, rpcPrefs = {}) {
   if (rpcPrefs.blockExplorerUrl) {
-    return `${rpcPrefs.blockExplorerUrl}/tx/${hash}`
+    return `${rpcPrefs.blockExplorerUrl.replace(/\/+$/, '')}/tx/${hash}`
   }
   const prefix = prefixForNetwork(networkId)
   return `https://${prefix}etherscan.io/tx/${hash}`

--- a/ui/app/helpers/utils/transactions.util.test.js
+++ b/ui/app/helpers/utils/transactions.util.test.js
@@ -54,4 +54,44 @@ describe('Transactions utils', function () {
       })
     })
   })
+
+  describe('getBlockExplorerUrlForTx', function () {
+    it('should return the correct block explorer url for a transaction', function () {
+      const tests = [
+        {
+          expected: 'https://etherscan.io/tx/0xabcd',
+          networkId: 1,
+          hash: '0xabcd',
+        },
+        {
+          expected: 'https://ropsten.etherscan.io/tx/0xdef0',
+          networkId: 3,
+          hash: '0xdef0',
+          rpcPrefs: {},
+        },
+        {
+          // test handling of `blockExplorerUrl` for a custom RPC
+          expected: 'https://block.explorer/tx/0xabcd',
+          networkId: 31,
+          hash: '0xabcd',
+          rpcPrefs: {
+            blockExplorerUrl: 'https://block.explorer',
+          },
+        },
+        {
+          // test handling of trailing `/` in `blockExplorerUrl` for a custom RPC
+          expected: 'https://another.block.explorer/tx/0xdef0',
+          networkId: 33,
+          hash: '0xdef0',
+          rpcPrefs: {
+            blockExplorerUrl: 'https://another.block.explorer/',
+          },
+        },
+      ]
+
+      tests.forEach(({ expected, networkId, hash, rpcPrefs }) => {
+        assert.equal(utils.getBlockExplorerUrlForTx(networkId, hash, rpcPrefs), expected)
+      })
+    })
+  })
 })

--- a/ui/lib/account-link.js
+++ b/ui/lib/account-link.js
@@ -1,6 +1,6 @@
 export default function getAccountLink (address, network, rpcPrefs) {
   if (rpcPrefs && rpcPrefs.blockExplorerUrl) {
-    return `${rpcPrefs.blockExplorerUrl}/address/${address}`
+    return `${rpcPrefs.blockExplorerUrl.replace(/\/+$/, '')}/address/${address}`
   }
 
   const net = parseInt(network)


### PR DESCRIPTION
## What

- modify `ui/app/helpers/utils/transactions.util.js` and
  `ui/lib/account-link.js` to strip trailing slashes
  if they are present.
- added relevant tests not just for the new scenario,
  but also the general scenarios for these functions,
  as there previously was no test coverage for these
  two functions.

## Why

- Current behaviour, when user enters a block explorer URL
  when configuring a custom RPC, and that block explorer URL
  contains a trailing `/`.
  - e.g. `https://block.explorer/`
  - this results in a double-slash (`//`) in the transaction
    and account URLs generated by MetaMask.
  - e.g. `https://block.explorer/tx/0xabcd...`,
    `https://block.explorer/account/0xabcd...`
  - This needs to be handled using a router redirect
    on the server of the block explorer,
    and this changes would avoid that requirement.