### PR TITLE
Restrict the size of the permissions metadata store

### DIFF
--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -9,8 +9,6 @@ export const METADATA_STORE_KEY = 'domainMetadata'
 
 export const METADATA_STORE_MAX_SIZE = 100
 
-export const METADATA_STORE_TRIM_AMOUNT = 25
-
 export const CAVEAT_NAMES = {
   exposedAccounts: 'exposedAccounts',
 }

--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -7,6 +7,10 @@ export const LOG_STORE_KEY = 'permissionsLog'
 
 export const METADATA_STORE_KEY = 'domainMetadata'
 
+export const METADATA_STORE_MAX_SIZE = 100
+
+export const METADATA_STORE_TRIM_AMOUNT = 25
+
 export const CAVEAT_NAMES = {
   exposedAccounts: 'exposedAccounts',
 }

--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -7,7 +7,7 @@ export const LOG_STORE_KEY = 'permissionsLog'
 
 export const METADATA_STORE_KEY = 'domainMetadata'
 
-export const METADATA_STORE_MAX_SIZE = 100
+export const METADATA_CACHE_MAX_SIZE = 100
 
 export const CAVEAT_NAMES = {
   exposedAccounts: 'exposedAccounts',

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -75,13 +75,10 @@ export class PermissionsController {
       throw new Error('Must provide non-empty string origin.')
     }
 
-    if (extensionId) {
-      this.store.updateState({
-        [METADATA_STORE_KEY]: {
-          ...this.store.getState()[METADATA_STORE_KEY],
-          [origin]: { extensionId },
-        },
-      })
+    const metadataState = this.store.getState()[METADATA_STORE_KEY]
+
+    if (extensionId && metadataState[origin]?.extensionId !== extensionId) {
+      this.addDomainMetadata(origin, { extensionId })
     }
 
     const engine = new JsonRpcEngine()
@@ -520,17 +517,21 @@ export class PermissionsController {
     })
   }
 
+  /**
+   * Stores domain metadata for the given origin.
+   *
+   * @param {string} origin - The origin whose domain metadata to store.
+   * @param {Object} metadata - The metadata to store.
+   */
   addDomainMetadata (origin, metadata) {
 
     const metadataState = this.store.getState()[METADATA_STORE_KEY]
-
-    const extensionId = metadataState[origin]?.extensionId
 
     this.store.updateState({
       [METADATA_STORE_KEY]: {
         ...metadataState,
         [origin]: {
-          extensionId,
+          ...metadataState[origin],
           ...metadata,
         },
       },

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -534,7 +534,7 @@ export class PermissionsController {
     const newMetadataState = { ...oldMetadataState }
 
     if (Object.keys(newMetadataState).length >= METADATA_STORE_MAX_SIZE) {
-      this._popMetadata(newMetadataState)
+      this._popDomainMetadata(newMetadataState)
     }
 
     newMetadataState[origin] = {
@@ -556,7 +556,7 @@ export class PermissionsController {
    *
    * @param {Object} metadataState - The metadata state to mutate.
    */
-  _popMetadata (metadataState) {
+  _popDomainMetadata (metadataState) {
 
     const permissionsDomains = this.permissions.getDomains()
 

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -533,8 +533,8 @@ export class PermissionsController {
     const oldMetadataState = this.store.getState()[METADATA_STORE_KEY]
     const newMetadataState = { ...oldMetadataState }
 
-    // attempt to pop metadata of a single domain without permissions if the
-    // store is too large overall
+    // delete pending metadata origin from queue, and delete its metadata if
+    // it doesn't have any permissions
     if (this._pendingSiteMetadata.size >= METADATA_CACHE_MAX_SIZE) {
       const permissionsDomains = this.permissions.getDomains()
 

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -533,12 +533,16 @@ export class PermissionsController {
     const oldMetadataState = this.store.getState()[METADATA_STORE_KEY]
     const newMetadataState = { ...oldMetadataState }
 
-    // attempt to pop domain metadata of domain without permissions if store is too large
+    // attempt to pop metadata of a single domain without permissions if the
+    // store is too large overall
     if (Object.keys(newMetadataState).length >= METADATA_STORE_MAX_SIZE) {
       const permissionsDomains = this.permissions.getDomains()
 
       for (const origin of this._newMetadataOrigins.values()) {
 
+        // We can stop keeping track of all domains we iterate over, because
+        // we will either delete 'origin' now if it does not have permissions,
+        // or we won't delete 'origin' until the next time MetaMask boots.
         this._newMetadataOrigins.delete(origin)
 
         if (!permissionsDomains[origin]) {
@@ -548,14 +552,13 @@ export class PermissionsController {
       }
     }
 
-    // add new metadata after popping
+    // add new metadata to store after popping
     newMetadataState[origin] = {
       ...oldMetadataState[origin],
       ...metadata,
       lastUpdated: Date.now(),
     }
     this._newMetadataOrigins.add(origin)
-
     this._setDomainMetadata(newMetadataState)
   }
 

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -36,6 +36,7 @@ export class PermissionsController {
     restoredPermissions = {},
     restoredState = {}) {
 
+    // additional top-level store key set in _initializeMetadataStore
     this.store = new ObservableStore({
       [LOG_STORE_KEY]: restoredState[LOG_STORE_KEY] || [],
       [HISTORY_STORE_KEY]: restoredState[HISTORY_STORE_KEY] || {},

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -14,7 +14,7 @@ import {
   SAFE_METHODS, // methods that do not require any permissions to use
   WALLET_PREFIX,
   METADATA_STORE_KEY,
-  METADATA_STORE_MAX_SIZE,
+  METADATA_CACHE_MAX_SIZE,
   LOG_STORE_KEY,
   HISTORY_STORE_KEY,
   CAVEAT_NAMES,
@@ -535,7 +535,7 @@ export class PermissionsController {
 
     // attempt to pop metadata of a single domain without permissions if the
     // store is too large overall
-    if (Object.keys(newMetadataState).length >= METADATA_STORE_MAX_SIZE) {
+    if (this._newMetadataOrigins.size >= METADATA_CACHE_MAX_SIZE) {
       const permissionsDomains = this.permissions.getDomains()
 
       for (const origin of this._newMetadataOrigins.values()) {

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -535,20 +535,13 @@ export class PermissionsController {
 
     // attempt to pop metadata of a single domain without permissions if the
     // store is too large overall
-    if (this._newMetadataOrigins.size >= METADATA_CACHE_MAX_SIZE) {
+    if (this._pendingSiteMetadata.size >= METADATA_CACHE_MAX_SIZE) {
       const permissionsDomains = this.permissions.getDomains()
 
-      for (const origin of this._newMetadataOrigins.values()) {
-
-        // We can stop keeping track of all domains we iterate over, because
-        // we will either delete 'origin' now if it does not have permissions,
-        // or we won't delete 'origin' until the next time MetaMask boots.
-        this._newMetadataOrigins.delete(origin)
-
-        if (!permissionsDomains[origin]) {
-          delete newMetadataState[origin]
-          break
-        }
+      const oldOrigin = this._pendingSiteMetadata.values().next().value
+      this._pendingSiteMetadata.delete(oldOrigin)
+      if (!permissionsDomains[oldOrigin]) {
+        delete newMetadataState[oldOrigin]
       }
     }
 
@@ -558,7 +551,7 @@ export class PermissionsController {
       ...metadata,
       lastUpdated: Date.now(),
     }
-    this._newMetadataOrigins.add(origin)
+    this._pendingSiteMetadata.add(origin)
     this._setDomainMetadata(newMetadataState)
   }
 
@@ -573,7 +566,7 @@ export class PermissionsController {
     const metadataState = restoredState[METADATA_STORE_KEY] || {}
     const newMetadataState = this._trimDomainMetadata(metadataState)
 
-    this._newMetadataOrigins = new Set()
+    this._pendingSiteMetadata = new Set()
     this._setDomainMetadata(newMetadataState)
   }
 

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -36,7 +36,6 @@ export class PermissionsController {
     restoredPermissions = {},
     restoredState = {}) {
 
-    // more state set further down
     this.store = new ObservableStore({
       [LOG_STORE_KEY]: restoredState[LOG_STORE_KEY] || [],
       [HISTORY_STORE_KEY]: restoredState[HISTORY_STORE_KEY] || {},
@@ -62,7 +61,6 @@ export class PermissionsController {
     this._lastSelectedAddress = preferences.getState().selectedAddress
     this.preferences = preferences
 
-    // _initializeMetadataStore requires _initializePermissions
     this._initializeMetadataStore(restoredState)
 
     preferences.subscribe(async ({ selectedAddress }) => {
@@ -520,10 +518,10 @@ export class PermissionsController {
 
   /**
    * Stores domain metadata for the given origin (domain).
-   * Deletes metadata for domains without permissions in a FIFO manner.
-   * Metadata is only deleted for domains with permissions on boot in order to
-   * prevent a degraded user experience, as metadata currently can't be
-   * requested on-demand.
+   * Deletes metadata for domains without permissions in a FIFO manner, once
+   * more than 100 distinct origins have been added since boot.
+   * Metadata is never deleted for domains with permissions, to prevent a
+   * degraded user experience, since metadata cannot yet be requested on demand.
    *
    * @param {string} origin - The origin whose domain metadata to store.
    * @param {Object} metadata - The domain's metadata that will be stored.
@@ -559,6 +557,8 @@ export class PermissionsController {
    * Removes all domains without permissions from the restored metadata state,
    * and rehydrates the metadata store.
    *
+   * Requires PermissionsController._initializePermissions to have been called first.
+   *
    * @param {Object} restoredState - The restored permissions controller state.
    */
   _initializeMetadataStore (restoredState) {
@@ -576,7 +576,7 @@ export class PermissionsController {
    * Returns a new object; does not mutate the argument.
    *
    * @param {Object} metadataState - The metadata store state object to trim.
-   * @returns {Object} The mutated metadata state object.
+   * @returns {Object} The new metadata state object.
    */
   _trimDomainMetadata (metadataState) {
 

--- a/app/scripts/controllers/permissions/methodMiddleware.js
+++ b/app/scripts/controllers/permissions/methodMiddleware.js
@@ -72,7 +72,7 @@ export default function createMethodMiddleware ({
         return
 
       // custom method for getting metadata from the requesting domain,
-      // sent automatically by the inpage provider
+      // sent automatically by the inpage provider when it's initialized
       case 'wallet_sendDomainMetadata':
 
         if (typeof req.domainMetadata?.name === 'string') {

--- a/app/scripts/controllers/permissions/methodMiddleware.js
+++ b/app/scripts/controllers/permissions/methodMiddleware.js
@@ -5,12 +5,11 @@ import { ethErrors } from 'eth-json-rpc-errors'
  * Create middleware for handling certain methods and preprocessing permissions requests.
  */
 export default function createMethodMiddleware ({
+  addDomainMetadata,
   getAccounts,
   getUnlockPromise,
   hasPermission,
   requestAccountsPermission,
-  store,
-  storeKey,
 }) {
 
   let isProcessingRequestAccounts = false
@@ -76,27 +75,9 @@ export default function createMethodMiddleware ({
       // sent automatically by the inpage provider
       case 'wallet_sendDomainMetadata':
 
-        const storeState = store.getState()[storeKey]
-        const extensionId = storeState[req.origin]
-          ? storeState[req.origin].extensionId
-          : undefined
-
-        if (
-          req.domainMetadata &&
-          typeof req.domainMetadata.name === 'string'
-        ) {
-
-          store.updateState({
-            [storeKey]: {
-              ...storeState,
-              [req.origin]: {
-                extensionId,
-                ...req.domainMetadata,
-              },
-            },
-          })
+        if (typeof req.domainMetadata?.name === 'string') {
+          addDomainMetadata(req.origin, req.domainMetadata)
         }
-
         res.result = true
         return
 

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -1190,10 +1190,15 @@ describe('permissions controller', function () {
   // see permissions-middleware-test for testing the middleware itself
   describe('createMiddleware', function () {
 
-    let permController
+    let permController, clock
 
     beforeEach(function () {
       permController = initPermController()
+      clock = sinon.useFakeTimers(1)
+    })
+
+    afterEach(function () {
+      clock.restore()
     })
 
     it('should throw on bad origin', function () {
@@ -1266,7 +1271,7 @@ describe('permissions controller', function () {
       const metadataStore = permController.store.getState()[METADATA_STORE_KEY]
 
       assert.deepEqual(
-        metadataStore[ORIGINS.a], { extensionId },
+        metadataStore[ORIGINS.a], { extensionId, lastUpdated: 1 },
         'metadata should be stored'
       )
     })

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -1419,7 +1419,9 @@ describe('permissions controller', function () {
       )
     })
 
-    it('pops metadata when the metadata store is too large', function () {
+    it('pops metadata on add when too many origins are pending', function () {
+
+      sinon.spy(permController._pendingSiteMetadata, 'delete')
 
       const mockMetadata = getMockMetadata(METADATA_CACHE_MAX_SIZE)
       const expectedDeletedOrigin = Object.keys(mockMetadata)[0]
@@ -1428,10 +1430,10 @@ describe('permissions controller', function () {
         [METADATA_STORE_KEY]: { ...mockMetadata },
       })
 
-      // populate permController.newMetadataOrigins, as though these origins
+      // populate permController._pendingSiteMetadata, as though these origins
       // were actually added
       Object.keys(mockMetadata).forEach((origin) => {
-        permController._newMetadataOrigins.add(origin)
+        permController._pendingSiteMetadata.add(origin)
       })
 
       permController.addDomainMetadata(ORIGINS.a, { foo: 'bar' })
@@ -1450,6 +1452,10 @@ describe('permissions controller', function () {
       }
       delete expectedMetadata[expectedDeletedOrigin]
 
+      assert.ok(
+        permController._pendingSiteMetadata.delete.calledOnceWithExactly(expectedDeletedOrigin),
+        'should have called _pendingSiteMetadata.delete once'
+      )
       assert.equal(
         permController._setDomainMetadata.getCalls().length, 1,
         'should have called _setDomainMetadata once'

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -1365,7 +1365,7 @@ describe('permissions controller', function () {
       )
       assert.equal(
         permController._setDomainMetadata.getCalls().length, 1,
-        'should have called _setDomainMetadata  once'
+        'should have called _setDomainMetadata once'
       )
       assert.deepEqual(
         permController._setDomainMetadata.lastCall.args,

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon'
 
 import {
   METADATA_STORE_KEY,
-  METADATA_STORE_MAX_SIZE,
+  METADATA_CACHE_MAX_SIZE,
   WALLET_PREFIX,
 } from '../../../../../app/scripts/controllers/permissions/enums'
 
@@ -1421,7 +1421,7 @@ describe('permissions controller', function () {
 
     it('pops metadata when the metadata store is too large', function () {
 
-      const mockMetadata = getMockMetadata(METADATA_STORE_MAX_SIZE)
+      const mockMetadata = getMockMetadata(METADATA_CACHE_MAX_SIZE)
       const expectedDeletedOrigin = Object.keys(mockMetadata)[0]
 
       permController.store.getState = sinon.fake.returns({

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -716,7 +716,7 @@ describe('permissions middleware', function () {
 
       assert.deepEqual(
         metadataStore,
-        { [ORIGINS.c]: { name, extensionId: undefined } },
+        { [ORIGINS.c]: { name } },
         'metadata should have been added to store'
       )
     })

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -1,4 +1,5 @@
 import { strict as assert } from 'assert'
+import { useFakeTimers } from 'sinon'
 
 import {
   METADATA_STORE_KEY,
@@ -690,10 +691,15 @@ describe('permissions middleware', function () {
 
   describe('wallet_sendDomainMetadata', function () {
 
-    let permController
+    let permController, clock
 
     beforeEach(function () {
       permController = initPermController()
+      clock = useFakeTimers(1)
+    })
+
+    afterEach(function () {
+      clock.restore()
     })
 
     it('records domain metadata', async function () {
@@ -716,7 +722,7 @@ describe('permissions middleware', function () {
 
       assert.deepEqual(
         metadataStore,
-        { [ORIGINS.c]: { name } },
+        { [ORIGINS.c]: { name, lastUpdated: 1 } },
         'metadata should have been added to store'
       )
     })
@@ -743,7 +749,7 @@ describe('permissions middleware', function () {
 
       assert.deepEqual(
         metadataStore,
-        { [ORIGINS.c]: { name, extensionId } },
+        { [ORIGINS.c]: { name, extensionId, lastUpdated: 1 } },
         'metadata should have been added to store'
       )
     })


### PR DESCRIPTION
Closes #8569

This PR bounds the size of the permissions metadata store to the number of domains with permissions.
- Metadata is _never_ deleted for domains with permissions
  - This should be fine in the short to medium term
  - This may be untenable in the long term, but we need to make some fundamental improvements to our JSON RPC implementation before we can address it in version `8.x`
- When rehydrating the store on boot, we delete the metadata of all domains without permissions, if any
- At runtime, we keep track of newly added metadata origins via the `_pendingSiteMetadata` set
  - If adding a new origin would ever grow this set beyond 100 in size, we delete the oldest entry in it, and _if that oldest origin has no permissions_, we also delete its metadata from the store
- We do _not_ delete metadata when permissions are removed, to prevent a degraded user experience
  - We still delete the metadata of such domains on boot, but not otherwise
  - This will be addressed when we can request permissions on demand in `8.x`