### PR TITLE
Sticky position the tabs at the top

### DIFF
--- a/ui/app/components/ui/tabs/index.scss
+++ b/ui/app/components/ui/tabs/index.scss
@@ -5,5 +5,10 @@
     display: flex;
     justify-content: flex-start;
     border-bottom: 1px solid $geyser;
+    background-color: $white;
+
+    position: sticky;
+    top: 0;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
This PR updates the home screen tabs to stick to the top of the screen when scrolling.

<details>
<summary><strong>Gif</strong></summary>

(It's slow to start, give it a second.)

<img width="357" alt="Gif of the transaction list scrolling with the tabs at the top" src="https://user-images.githubusercontent.com/1623628/82235041-c9a65580-990c-11ea-969f-8de81e49db69.gif">

</details>

<details>
<summary><strong>Screenshots</strong></summary>
<img width="357" alt="" src="https://user-images.githubusercontent.com/1623628/82235066-d1fe9080-990c-11ea-8fdc-e1c419749d0c.png">
<img width="357" alt="" src="https://user-images.githubusercontent.com/1623628/82235071-d2972700-990c-11ea-8504-f8dea596f2a2.png">

</details>

