### PR TITLE
Bind getApprovedAccounts via nodeify

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -578,7 +578,7 @@ export default class MetamaskController extends EventEmitter {
       // permissions
       approvePermissionsRequest: nodeify(permissionsController.approvePermissionsRequest, permissionsController),
       clearPermissions: permissionsController.clearPermissions.bind(permissionsController),
-      getApprovedAccounts: nodeify(permissionsController.getAccounts.bind(permissionsController)),
+      getApprovedAccounts: nodeify(permissionsController.getAccounts, permissionsController),
       rejectPermissionsRequest: nodeify(permissionsController.rejectPermissionsRequest, permissionsController),
       removePermissionsFor: permissionsController.removePermissionsFor.bind(permissionsController),
       addPermittedAccount: nodeify(permissionsController.addPermittedAccount, permissionsController),


### PR DESCRIPTION
This PR passes the context for `getApprovedAccounts` to `nodeify` instead of binding the function directly, as is the pattern used elsewhere.