### PR TITLE
Tidy tx test stubs

### DIFF
--- a/test/unit/app/controllers/network/stubs.js
+++ b/test/unit/app/controllers/network/stubs.js
@@ -1,11 +1,3 @@
-/*
-  this file is for all my big stubs because i don't want to
-  to mingle with my tests
-*/
-
-export default {}
-
-// for pending middlewares test
 export const txMetaStub = {
   'firstRetryBlockNumber': '0x51a402',
   'hash': '0x2cc5a25744486f7383edebbf32003e5a66e18135799593d6b5cdd2bb43674f09',


### PR DESCRIPTION
This PR tidies the tx test stubs:

1. Deleted unneeded comments
2. The default export is unused

This is in service of #8535.