### PR TITLE
Use activeTab.origin where possible

### DIFF
--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -292,12 +292,6 @@ export function isValidAddressHead (address) {
   return addressLengthIsLessThanFull && addressIsHex
 }
 
-export function getOriginFromUrl (url) {
-  url = new URL(url)
-  const origin = url.hostname
-  return origin
-}
-
 export function getAccountByAddress (accounts = [], targetAddress) {
   return accounts.find(({ address }) => address === targetAddress)
 }

--- a/ui/app/pages/connected-sites/connected-sites.container.js
+++ b/ui/app/pages/connected-sites/connected-sites.container.js
@@ -15,11 +15,10 @@ import {
   getSelectedAddress,
 } from '../../selectors'
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes'
-import { getOriginFromUrl } from '../../helpers/utils/util'
 
 const mapStateToProps = (state) => {
   const { openMetaMaskTabs } = state.appState
-  const { title, url, id } = state.activeTab
+  const { title, id } = state.activeTab
   const connectedDomains = getConnectedDomainsForSelectedAddress(state)
   const originOfCurrentTab = getOriginOfCurrentTab(state)
   const permittedAccountsByOrigin = getPermittedAccountsByOrigin(state)
@@ -30,10 +29,10 @@ const mapStateToProps = (state) => {
   ]?.length
 
   let tabToConnect
-  if (url && currentTabHasNoAccounts && !openMetaMaskTabs[id]) {
+  if (originOfCurrentTab && currentTabHasNoAccounts && !openMetaMaskTabs[id]) {
     tabToConnect = {
       title,
-      origin: getOriginFromUrl(url),
+      origin: originOfCurrentTab,
     }
   }
 

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -4,7 +4,6 @@ import { createSelector } from 'reselect'
 import {
   shortenAddress,
   checksumAddress,
-  getOriginFromUrl,
   getAccountByAddress,
 } from '../helpers/utils/util'
 import {
@@ -375,8 +374,7 @@ export function hasPermissionRequests (state) {
 }
 
 export function getOriginOfCurrentTab (state) {
-  const { activeTab } = state
-  return activeTab && activeTab.url && getOriginFromUrl(activeTab.url)
+  return state.activeTab?.origin
 }
 
 export function getLastConnectedInfo (state) {


### PR DESCRIPTION
This PR updates the `getOriginOfCurrentTab` selector and the container for the _Connected Sites_ page to use `activeTab.origin` instead of parsing the URL.

The `activeTab` URL is parsed in `queryCurrentActiveTab` before the UI is launched and any subsequent parsing of the URL is unnecessary. See `queryCurrentActiveTab` in `ui.js:86`.<sup>[\[1\]][1]<sup>

  [1]:https://github.com/MetaMask/metamask-extension/blob/6010983/app/scripts/ui.js#L86-L104