### PR TITLE
Handle zero nextNonce in ConfirmTransactionBase placeholder

### DIFF
--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -288,7 +288,7 @@ export default class ConfirmTransactionBase extends Component {
                   <TextField
                     type="number"
                     min="0"
-                    placeholder={ nextNonce ? nextNonce.toString() : null }
+                    placeholder={ typeof nextNonce === 'number' ? nextNonce.toString() : null }
                     onChange={({ target: { value } }) => {
                       if (!value.length || Number(value) < 0) {
                         updateCustomNonce('')


### PR DESCRIPTION
This PR updates how we render the next nonce in on the confirm screen—we now show `0` instead of an empty nonce field when the user has enabled custom nonce editing.

The PropType set in the component is `PropTypes.number` so this check is more semantically correct as well.