### PR TITLE
Delete migrations README.md

### DIFF
--- a/app/scripts/migrations/README.md
+++ b/app/scripts/migrations/README.md
@@ -1,5 +1,0 @@
-# Migrations
-
-Data (user data, config files etc.) is migrated from one version to another.
-
-Migrations are called by {} from {} during {}.


### PR DESCRIPTION
This PR deletes the README in the `migrations/` directory. It contains no useful information.