### PR TITLE
bugfix: check whether keyring is null

### DIFF
--- a/ui/app/components/app/dropdowns/account-details-dropdown/account-details-dropdown.component.js
+++ b/ui/app/components/app/dropdowns/account-details-dropdown/account-details-dropdown.component.js
@@ -44,7 +44,7 @@ export default class AccountDetailsDropdown extends Component {
       return kr.accounts.includes(address)
     })
 
-    const isRemovable = keyring.type !== 'HD Key Tree'
+    const isRemovable = keyring && keyring.type !== 'HD Key Tree'
 
     return (
       <Menu className="account-details-dropdown" isShowing>


### PR DESCRIPTION
[Video for this bug](https://www.loom.com/share/ab5b9e6b9f9e4288b0fc456ccaf37fe0)

Or you can follow these steps:
1. Click the 'Settings' -> 'Security & Privacy' 
2. Click the 'Reveal Seed Words' Button
3. Type a wrong password
4. Click this button
![image](https://user-images.githubusercontent.com/16474758/82318647-c7262780-9a02-11ea-9956-b58b6b3a927b.png)

The error message:
![image](https://user-images.githubusercontent.com/16474758/82318733-eb820400-9a02-11ea-9b0f-40021a9d7aa7.png)
