### PR TITLE
Define global `web3` as non-enumerable

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -79,7 +79,12 @@ web3.setProvider = function () {
 }
 log.debug('MetaMask - injected web3')
 
-window.ethereum._web3Ref = web3.eth
+Object.defineProperty(window.ethereum, '_web3Ref', {
+  enumerable: false,
+  writable: true,
+  configurable: true,
+  value: web3.eth,
+})
 
 // setup dapp auto reload AND proxy web3
 setupDappAutoReload(web3, window.ethereum._publicConfigStore)

--- a/app/scripts/lib/auto-reload.js
+++ b/app/scripts/lib/auto-reload.js
@@ -8,7 +8,7 @@ export default function setupDappAutoReload (web3, observable) {
   let lastSeenNetwork
   let hasBeenWarned = false
 
-  global.web3 = new Proxy(web3, {
+  const web3Proxy = new Proxy(web3, {
     get: (_web3, key) => {
       // get the time of use
       lastTimeUsed = Date.now()
@@ -24,6 +24,13 @@ export default function setupDappAutoReload (web3, observable) {
       // set value normally
       _web3[key] = value
     },
+  })
+
+  Object.defineProperty(global, 'web3', {
+    enumerable: false,
+    writable: true,
+    configurable: true,
+    value: web3Proxy,
   })
 
   observable.subscribe(function (state) {


### PR DESCRIPTION
We inject `web3` globally on most websites. This has been breaking websites that attempted to serialize the `window` object, because any attempt to access certain `web3` properties (such as `web3.eth.mining`) would throw an error. This is because `web3` defined a getter for these properties that would call `.send([method])`, which doesn't work for most methods.

An example of a site that this breaks is `Storybook`, when the `@storybook/addon-actions` addon is being used. When using storybook with this addon and with the MetaMask extension installed, actions would not be properly dispatched because an error would be thrown in the attempt to serialize the event (which includes a reference to the `window`).

The `web3` global we inject is now defined as non-enumerable, so it will be skipped automatically in any attempt to serialize the `window` object.