### PR TITLE
fix prop name for disconnect icon

### DIFF
--- a/ui/app/components/app/connected-accounts-list/connected-accounts-list.component.js
+++ b/ui/app/components/app/connected-accounts-list/connected-accounts-list.component.js
@@ -121,7 +121,7 @@ export default class ConnectedAccountsList extends PureComponent {
                     )
                   }
                   <MenuItem
-                    iconClassNames="disconnect-icon"
+                    iconClassName="disconnect-icon"
                     onClick={this.disconnectAccount}
                   >
                     {t('disconnectThisAccount')}


### PR DESCRIPTION
I seemed to have missed a plurality typo in the prop name for the disconnect icon during the rebase of #8630 😬 