### PR TITLE
Rename preferencesSelector selector to getPreferences

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -30,7 +30,7 @@ import {
   getIsMainnet,
   getSelectedToken,
   isEthereumNetwork,
-  preferencesSelector,
+  getPreferences,
   getBasicGasEstimateLoadingStatus,
   getGasEstimatesLoadingStatus,
   getCustomGasLimit,
@@ -98,7 +98,7 @@ const mapStateToProps = (state, ownProps) => {
   const estimatedTimes = getEstimatedGasTimes(state)
   const balance = getCurrentEthBalance(state)
 
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
   const showFiat = Boolean(isMainnet || showFiatInTestnets)
 

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -1,13 +1,13 @@
 import { connect } from 'react-redux'
 import TransactionBreakdown from './transaction-breakdown.component'
-import { getIsMainnet, getNativeCurrency, preferencesSelector } from '../../../selectors'
+import { getIsMainnet, getNativeCurrency, getPreferences } from '../../../selectors'
 import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util'
 import { sumHexes } from '../../../helpers/utils/transactions.util'
 
 const mapStateToProps = (state, ownProps) => {
   const { transaction } = ownProps
   const { txParams: { gas, gasPrice, value } = {}, txReceipt: { gasUsed } = {} } = transaction
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
 
   const gasLimit = typeof gasUsed === 'string' ? gasUsed : gas

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.container.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.container.js
@@ -15,7 +15,7 @@ import {
 } from '../../../ducks/gas/gas.duck'
 import {
   getIsMainnet,
-  preferencesSelector,
+  getPreferences,
   getSelectedAddress,
   conversionRateSelector,
   getKnownMethodData,
@@ -25,7 +25,7 @@ import { isBalanceSufficient } from '../../../pages/send/send.utils'
 
 const mapStateToProps = (state, ownProps) => {
   const { metamask: { accounts, provider, frequentRpcListDetail } } = state
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
   const { transactionGroup: { primaryTransaction } = {} } = ownProps
   const { txParams: { gas: gasLimit, gasPrice, data } = {}, transactionCategory } = primaryTransaction

--- a/ui/app/components/app/user-preferenced-currency-input/user-preferenced-currency-input.container.js
+++ b/ui/app/components/app/user-preferenced-currency-input/user-preferenced-currency-input.container.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux'
 import UserPreferencedCurrencyInput from './user-preferenced-currency-input.component'
-import { preferencesSelector } from '../../../selectors'
+import { getPreferences } from '../../../selectors'
 
 const mapStateToProps = (state) => {
-  const { useNativeCurrencyAsPrimaryCurrency } = preferencesSelector(state)
+  const { useNativeCurrencyAsPrimaryCurrency } = getPreferences(state)
 
   return {
     useNativeCurrencyAsPrimaryCurrency,

--- a/ui/app/components/app/user-preferenced-token-input/user-preferenced-token-input.container.js
+++ b/ui/app/components/app/user-preferenced-token-input/user-preferenced-token-input.container.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux'
 import UserPreferencedTokenInput from './user-preferenced-token-input.component'
-import { preferencesSelector } from '../../../selectors'
+import { getPreferences } from '../../../selectors'
 
 const mapStateToProps = (state) => {
-  const { useNativeCurrencyAsPrimaryCurrency } = preferencesSelector(state)
+  const { useNativeCurrencyAsPrimaryCurrency } = getPreferences(state)
 
   return {
     useNativeCurrencyAsPrimaryCurrency,

--- a/ui/app/components/ui/currency-input/currency-input.container.js
+++ b/ui/app/components/ui/currency-input/currency-input.container.js
@@ -4,12 +4,12 @@ import { ETH } from '../../../helpers/constants/common'
 import {
   getSendMaxModeState,
   getIsMainnet,
-  preferencesSelector,
+  getPreferences,
 } from '../../../selectors'
 
 const mapStateToProps = (state) => {
   const { metamask: { nativeCurrency, currentCurrency, conversionRate } } = state
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
   const maxModeOn = getSendMaxModeState(state)
 

--- a/ui/app/components/ui/token-input/token-input.container.js
+++ b/ui/app/components/ui/token-input/token-input.container.js
@@ -4,12 +4,12 @@ import {
   getIsMainnet,
   getSelectedToken,
   getSelectedTokenExchangeRate,
-  preferencesSelector,
+  getPreferences,
 } from '../../../selectors'
 
 const mapStateToProps = (state) => {
   const { metamask: { currentCurrency } } = state
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
 
   return {

--- a/ui/app/hooks/tests/useUserPreferencedCurrency.test.js
+++ b/ui/app/hooks/tests/useUserPreferencedCurrency.test.js
@@ -2,7 +2,7 @@ import assert from 'assert'
 import { renderHook } from '@testing-library/react-hooks'
 import { useUserPreferencedCurrency } from '../useUserPreferencedCurrency'
 import * as reactRedux from 'react-redux'
-import { preferencesSelector, getShouldShowFiat } from '../../selectors'
+import { getPreferences, getShouldShowFiat } from '../../selectors'
 import sinon from 'sinon'
 
 const tests = [
@@ -113,7 +113,7 @@ const tests = [
 
 function getFakeUseSelector (state) {
   return (selector) => {
-    if (selector === preferencesSelector) {
+    if (selector === getPreferences) {
       return state
     } else if (selector === getShouldShowFiat) {
       return state.showFiat

--- a/ui/app/hooks/useUserPreferencedCurrency.js
+++ b/ui/app/hooks/useUserPreferencedCurrency.js
@@ -1,4 +1,4 @@
-import { preferencesSelector, getShouldShowFiat } from '../selectors'
+import { getPreferences, getShouldShowFiat } from '../selectors'
 import { useSelector } from 'react-redux'
 import { PRIMARY, SECONDARY, ETH } from '../helpers/constants/common'
 
@@ -33,7 +33,7 @@ export function useUserPreferencedCurrency (type, opts = {}) {
   const nativeCurrency = useSelector((state) => state.metamask.nativeCurrency)
   const {
     useNativeCurrencyAsPrimaryCurrency,
-  } = useSelector(preferencesSelector)
+  } = useSelector(getPreferences)
   const showFiat = useSelector(getShouldShowFiat)
 
   let currency, numberOfDecimals

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -34,7 +34,7 @@ import {
   getKnownMethodData,
   getMetaMaskAccounts,
   getUseNonceField,
-  preferencesSelector,
+  getPreferences,
   transactionFeeSelector,
 } from '../../selectors'
 
@@ -54,7 +54,7 @@ const customNonceMerge = (txData) => (customNonceValue ? ({
 const mapStateToProps = (state, ownProps) => {
   const { toAddress: propsToAddress, customTxParamsData, match: { params = {} } } = ownProps
   const { id: paramsTransactionId } = params
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
   const { confirmTransaction, metamask } = state
   const {

--- a/ui/app/pages/routes/routes.container.js
+++ b/ui/app/pages/routes/routes.container.js
@@ -4,7 +4,7 @@ import { compose } from 'redux'
 import {
   getNetworkIdentifier,
   hasPermissionRequests,
-  preferencesSelector,
+  getPreferences,
   submittedPendingTransactionsSelector,
 } from '../../selectors'
 import Routes from './routes.component'
@@ -25,7 +25,7 @@ function mapStateToProps (state) {
     isLoading,
     loadingMessage,
   } = appState
-  const { autoLockTimeLimit = 0 } = preferencesSelector(state)
+  const { autoLockTimeLimit = 0 } = getPreferences(state)
 
   return {
     sidebar,

--- a/ui/app/pages/send/account-list-item/account-list-item.container.js
+++ b/ui/app/pages/send/account-list-item/account-list-item.container.js
@@ -3,14 +3,14 @@ import {
   getNativeCurrency,
   getIsMainnet,
   isBalanceCached,
-  preferencesSelector,
+  getPreferences,
 } from '../../../selectors'
 import AccountListItem from './account-list-item.component'
 
 export default connect(mapStateToProps)(AccountListItem)
 
 function mapStateToProps (state) {
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
 
   return {

--- a/ui/app/pages/send/account-list-item/tests/account-list-item-container.test.js
+++ b/ui/app/pages/send/account-list-item/tests/account-list-item-container.test.js
@@ -15,7 +15,7 @@ proxyquire('../account-list-item.container.js', {
     getCurrentCurrency: () => `mockCurrentCurrency`,
     getNativeCurrency: () => `mockNativeCurrency`,
     isBalanceCached: () => `mockBalanceIsCached`,
-    preferencesSelector: ({ showFiatInTestnets }) => ({
+    getPreferences: ({ showFiatInTestnets }) => ({
       showFiatInTestnets,
     }),
     getIsMainnet: ({ isMainnet }) => isMainnet,

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.container.js
@@ -13,7 +13,7 @@ import {
   setUseNonceField,
   setIpfsGateway,
 } from '../../../store/actions'
-import { preferencesSelector } from '../../../selectors'
+import { getPreferences } from '../../../selectors'
 
 export const mapStateToProps = (state) => {
   const { appState: { warning }, metamask } = state
@@ -27,7 +27,7 @@ export const mapStateToProps = (state) => {
     useNonceField,
     ipfsGateway,
   } = metamask
-  const { showFiatInTestnets, autoLockTimeLimit } = preferencesSelector(state)
+  const { showFiatInTestnets, autoLockTimeLimit } = getPreferences(state)
 
   return {
     warning,

--- a/ui/app/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/app/pages/settings/settings-tab/settings-tab.container.js
@@ -7,7 +7,7 @@ import {
   setUseNativeCurrencyAsPrimaryCurrencyPreference,
   setParticipateInMetaMetrics,
 } from '../../../store/actions'
-import { preferencesSelector } from '../../../selectors'
+import { getPreferences } from '../../../selectors'
 
 const mapStateToProps = (state) => {
   const { appState: { warning }, metamask } = state
@@ -18,7 +18,7 @@ const mapStateToProps = (state) => {
     useBlockie,
     currentLocale,
   } = metamask
-  const { useNativeCurrencyAsPrimaryCurrency } = preferencesSelector(state)
+  const { useNativeCurrencyAsPrimaryCurrency } = getPreferences(state)
 
   return {
     warning,

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -5,7 +5,7 @@ import {
   conversionGreaterThan,
 } from '../helpers/utils/conversion-util'
 import {
-  getCurrentCurrency, getIsMainnet, preferencesSelector,
+  getCurrentCurrency, getIsMainnet, getPreferences,
 } from '.'
 import {
   formatCurrency,
@@ -208,7 +208,7 @@ export function getRenderableBasicEstimateData (state, gasLimit) {
     return []
   }
 
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
   const showFiat = (isMainnet || !!showFiatInTestnets)
   const conversionRate = state.metamask.conversionRate
@@ -262,7 +262,7 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI (state) {
     return []
   }
 
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
   const showFiat = (isMainnet || !!showFiatInTestnets)
   const gasLimit = state.metamask.send.gasLimit || getCustomGasLimit(state) || '0x5208'

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -280,13 +280,13 @@ export function isEthereumNetwork (state) {
   return [ KOVAN, MAINNET, RINKEBY, ROPSTEN, GOERLI].includes(networkType)
 }
 
-export function preferencesSelector ({ metamask }) {
+export function getPreferences ({ metamask }) {
   return metamask.preferences
 }
 
 export function getShouldShowFiat (state) {
   const isMainNet = getIsMainnet(state)
-  const { showFiatInTestnets } = preferencesSelector(state)
+  const { showFiatInTestnets } = getPreferences(state)
   return Boolean(isMainNet || showFiatInTestnets)
 }
 


### PR DESCRIPTION
Closes #8613

This PR renames `preferencesSelector` to `getPreferences` to better match the naming convention of the selectors.