### PR TITLE
Limit Dapp permissions to primary account

### DIFF
--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -9,6 +9,7 @@ export const METADATA_STORE_KEY = 'domainMetadata'
 
 export const CAVEAT_NAMES = {
   exposedAccounts: 'exposedAccounts',
+  primaryAccountOnly: 'primaryAccountOnly',
 }
 
 export const NOTIFICATION_NAMES = {

--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -12,6 +12,11 @@ export const CAVEAT_NAMES = {
   primaryAccountOnly: 'primaryAccountOnly',
 }
 
+export const CAVEAT_TYPES = {
+  limitResponseLength: 'limitResponseLength',
+  filterResponse: 'filterResponse',
+}
+
 export const NOTIFICATION_NAMES = {
   accountsChanged: 'wallet_accountsChanged',
 }

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -18,6 +18,7 @@ import {
   HISTORY_STORE_KEY,
   CAVEAT_NAMES,
   NOTIFICATION_NAMES,
+  CAVEAT_TYPES,
 } from './enums'
 
 export class PermissionsController {
@@ -428,18 +429,16 @@ export class PermissionsController {
       ))
 
       ethAccounts.caveats.push({
-        type: 'limitResponseLength',
+        type: CAVEAT_TYPES.limitResponseLength,
         value: 1,
         name: CAVEAT_NAMES.primaryAccountOnly,
       })
 
-      ethAccounts.caveats.push(
-        {
-          type: 'filterResponse',
-          value: finalizedAccounts,
-          name: CAVEAT_NAMES.exposedAccounts,
-        },
-      )
+      ethAccounts.caveats.push({
+        type: CAVEAT_TYPES.filterResponse,
+        value: finalizedAccounts,
+        name: CAVEAT_NAMES.exposedAccounts,
+      })
     }
 
     return finalizedPermissions

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -424,7 +424,7 @@ export class PermissionsController {
 
       // caveat names are unique, and we will only construct this caveat here
       ethAccounts.caveats = ethAccounts.caveats.filter((c) => (
-        c.name !== CAVEAT_NAMES.exposedAccounts
+        c.name !== CAVEAT_NAMES.exposedAccounts && c.name !== CAVEAT_NAMES.primaryAccountOnly
       ))
 
       ethAccounts.caveats.push(
@@ -434,6 +434,8 @@ export class PermissionsController {
           name: CAVEAT_NAMES.exposedAccounts,
         },
       )
+
+      ethAccounts.caveats.push({ type: 'limitResponseLength', value: 1, name: CAVEAT_NAMES.primaryAccountOnly })
     }
 
     return finalizedPermissions

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -427,6 +427,12 @@ export class PermissionsController {
         c.name !== CAVEAT_NAMES.exposedAccounts && c.name !== CAVEAT_NAMES.primaryAccountOnly
       ))
 
+      ethAccounts.caveats.push({
+        type: 'limitResponseLength',
+        value: 1,
+        name: CAVEAT_NAMES.primaryAccountOnly,
+      })
+
       ethAccounts.caveats.push(
         {
           type: 'filterResponse',
@@ -434,8 +440,6 @@ export class PermissionsController {
           name: CAVEAT_NAMES.exposedAccounts,
         },
       )
-
-      ethAccounts.caveats.push({ type: 'limitResponseLength', value: 1, name: CAVEAT_NAMES.primaryAccountOnly })
     }
 
     return finalizedPermissions

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -289,9 +289,11 @@ export class PermissionsController {
         }
       })
 
+      const newPermittedAccounts = await this.getAccounts(origin)
+
       this.notifyDomain(origin, {
         method: NOTIFICATION_NAMES.accountsChanged,
-        result: accounts,
+        result: newPermittedAccounts,
       })
       this.permissionsLog.logAccountExposure(origin, accounts)
 

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1",
-    "rpc-cap": "^2.0.0",
+    "rpc-cap": "^2.1.0",
     "safe-event-emitter": "^1.0.1",
     "safe-json-stringify": "^1.2.0",
     "single-call-balance-checker-abi": "^1.0.0",

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -162,10 +162,19 @@ const PERM_NAMES = {
   does_not_exist: 'does_not_exist',
 }
 
-const ACCOUNT_ARRAYS = {
-  a: [ ...keyringAccounts.slice(0, 3) ],
-  b: [keyringAccounts[0]],
-  c: [keyringAccounts[1]],
+const ACCOUNTS = {
+  a: {
+    permitted: [...keyringAccounts.slice(0, 3)],
+    primary: keyringAccounts[0],
+  },
+  b: {
+    permitted: [keyringAccounts[0]],
+    primary: keyringAccounts[0],
+  },
+  c: {
+    permitted: [keyringAccounts[1]],
+    primary: keyringAccounts[1],
+  },
 }
 
 /**
@@ -180,11 +189,15 @@ const CAVEATS = {
    * @returns {Object} An eth_accounts exposedAccounts caveats
    */
   eth_accounts: (accounts) => {
-    return {
+    return [{
+      type: 'limitResponseLength',
+      value: 1,
+      name: CAVEAT_NAMES.primaryAccountOnly,
+    }, {
       type: 'filterResponse',
       value: accounts,
       name: CAVEAT_NAMES.exposedAccounts,
-    }
+    }]
   },
 }
 
@@ -245,7 +258,7 @@ const PERMS = {
     eth_accounts: (accounts) => {
       return {
         eth_accounts: {
-          caveats: [CAVEATS.eth_accounts(accounts)],
+          caveats: CAVEATS.eth_accounts(accounts),
         } }
     },
 
@@ -273,7 +286,7 @@ const PERMS = {
     eth_accounts: (accounts) => {
       return {
         parentCapability: PERM_NAMES.eth_accounts,
-        caveats: [CAVEATS.eth_accounts(accounts)],
+        caveats: CAVEATS.eth_accounts(accounts),
       }
     },
 
@@ -639,7 +652,7 @@ export const constants = deepFreeze({
 
   ORIGINS: { ...ORIGINS },
 
-  ACCOUNT_ARRAYS: { ...ACCOUNT_ARRAYS },
+  ACCOUNTS: { ...ACCOUNTS },
 
   PERM_NAMES: { ...PERM_NAMES },
 
@@ -659,9 +672,9 @@ export const constants = deepFreeze({
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {
-              [ACCOUNT_ARRAYS.a[0]]: 1,
-              [ACCOUNT_ARRAYS.a[1]]: 1,
-              [ACCOUNT_ARRAYS.a[2]]: 1,
+              [ACCOUNTS.a.permitted[0]]: 1,
+              [ACCOUNTS.a.permitted[1]]: 1,
+              [ACCOUNTS.a.permitted[2]]: 1,
             },
           },
         },
@@ -671,9 +684,9 @@ export const constants = deepFreeze({
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 2,
             accounts: {
-              [ACCOUNT_ARRAYS.a[0]]: 2,
-              [ACCOUNT_ARRAYS.a[1]]: 1,
-              [ACCOUNT_ARRAYS.a[2]]: 1,
+              [ACCOUNTS.a.permitted[0]]: 2,
+              [ACCOUNTS.a.permitted[1]]: 1,
+              [ACCOUNTS.a.permitted[2]]: 1,
             },
           },
         },
@@ -700,7 +713,7 @@ export const constants = deepFreeze({
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {
-              [ACCOUNT_ARRAYS.b[0]]: 1,
+              [ACCOUNTS.b.permitted[0]]: 1,
             },
           },
         },
@@ -709,7 +722,7 @@ export const constants = deepFreeze({
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {
-              [ACCOUNT_ARRAYS.c[0]]: 1,
+              [ACCOUNTS.c.permitted[0]]: 1,
             },
           },
         },
@@ -722,7 +735,7 @@ export const constants = deepFreeze({
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {
-              [ACCOUNT_ARRAYS.b[0]]: 1,
+              [ACCOUNTS.b.permitted[0]]: 1,
             },
           },
         },
@@ -731,8 +744,8 @@ export const constants = deepFreeze({
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 2,
             accounts: {
-              [ACCOUNT_ARRAYS.c[0]]: 1,
-              [ACCOUNT_ARRAYS.b[0]]: 2,
+              [ACCOUNTS.c.permitted[0]]: 1,
+              [ACCOUNTS.b.permitted[0]]: 2,
             },
           },
         },

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -6,6 +6,7 @@ import _getRestrictedMethods
 
 import {
   CAVEAT_NAMES,
+  CAVEAT_TYPES,
   NOTIFICATION_NAMES,
 } from '../../../../../app/scripts/controllers/permissions/enums'
 
@@ -164,7 +165,7 @@ const PERM_NAMES = {
 
 const ACCOUNTS = {
   a: {
-    permitted: [...keyringAccounts.slice(0, 3)],
+    permitted: keyringAccounts.slice(0, 3),
     primary: keyringAccounts[0],
   },
   b: {
@@ -190,11 +191,11 @@ const CAVEATS = {
    */
   eth_accounts: (accounts) => {
     return [{
-      type: 'limitResponseLength',
+      type: CAVEAT_TYPES.limitResponseLength,
       value: 1,
       name: CAVEAT_NAMES.primaryAccountOnly,
     }, {
-      type: 'filterResponse',
+      type: CAVEAT_TYPES.filterResponse,
       value: accounts,
       name: CAVEAT_NAMES.exposedAccounts,
     }]

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -34,7 +34,7 @@ const {
 
 const {
   ALL_ACCOUNTS,
-  ACCOUNT_ARRAYS,
+  ACCOUNTS,
   DUMMY_ACCOUNT,
   ORIGINS,
   PERM_NAMES,
@@ -73,11 +73,11 @@ describe('permissions controller', function () {
       permController = initPermController()
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
         permController, ORIGINS.b,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
@@ -87,11 +87,11 @@ describe('permissions controller', function () {
       const bAccounts = await permController.getAccounts(ORIGINS.b)
 
       assert.deepEqual(
-        aAccounts, ACCOUNT_ARRAYS.a,
+        aAccounts, [ACCOUNTS.a.primary],
         'first origin should have correct accounts'
       )
       assert.deepEqual(
-        bAccounts, ACCOUNT_ARRAYS.b,
+        bAccounts, [ACCOUNTS.b.primary],
         'second origin should have correct accounts'
       )
     })
@@ -114,7 +114,7 @@ describe('permissions controller', function () {
       const permController = initPermController()
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
         permController, ORIGINS.b,
@@ -159,31 +159,32 @@ describe('permissions controller', function () {
 
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
         permController, ORIGINS.b,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
       grantPermissions(
         permController, ORIGINS.c,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.c)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.c.permitted)
       )
 
       let aAccounts = await permController.getAccounts(ORIGINS.a)
       let bAccounts = await permController.getAccounts(ORIGINS.b)
       let cAccounts = await permController.getAccounts(ORIGINS.c)
 
+
       assert.deepEqual(
-        aAccounts, ACCOUNT_ARRAYS.a,
+        aAccounts, [ACCOUNTS.a.primary],
         'first origin should have correct accounts'
       )
       assert.deepEqual(
-        bAccounts, ACCOUNT_ARRAYS.b,
+        bAccounts, [ACCOUNTS.b.primary],
         'second origin should have correct accounts'
       )
       assert.deepEqual(
-        cAccounts, ACCOUNT_ARRAYS.c,
+        cAccounts, [ACCOUNTS.c.primary],
         'third origin should have correct accounts'
       )
 
@@ -229,11 +230,11 @@ describe('permissions controller', function () {
       permController = initPermController(notifications)
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
         permController, ORIGINS.b,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
@@ -243,11 +244,11 @@ describe('permissions controller', function () {
       let bAccounts = await permController.getAccounts(ORIGINS.b)
 
       assert.deepEqual(
-        aAccounts, ACCOUNT_ARRAYS.a,
+        aAccounts, [ACCOUNTS.a.primary],
         'first origin should have correct accounts'
       )
       assert.deepEqual(
-        bAccounts, ACCOUNT_ARRAYS.b,
+        bAccounts, [ACCOUNTS.b.primary],
         'second origin should have correct accounts'
       )
 
@@ -319,7 +320,7 @@ describe('permissions controller', function () {
       const bAccounts = await permController.getAccounts(ORIGINS.b)
 
       assert.deepEqual(
-        aAccounts, ACCOUNT_ARRAYS.a,
+        aAccounts, [ACCOUNTS.a.primary],
         'first origin should have correct accounts'
       )
       assert.deepEqual(bAccounts, [], 'second origin should have no accounts')
@@ -355,11 +356,11 @@ describe('permissions controller', function () {
       const bAccounts = await permController.getAccounts(ORIGINS.b)
 
       assert.deepEqual(
-        aAccounts, ACCOUNT_ARRAYS.a,
+        aAccounts, [ACCOUNTS.a.primary],
         'first origin should have correct accounts'
       )
       assert.deepEqual(
-        bAccounts, ACCOUNT_ARRAYS.b,
+        bAccounts, [ACCOUNTS.b.primary],
         'second origin should have correct accounts'
       )
 
@@ -379,11 +380,11 @@ describe('permissions controller', function () {
       permController = initPermController()
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
         permController, ORIGINS.b,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
@@ -469,11 +470,11 @@ describe('permissions controller', function () {
       permController = initPermController(notifications)
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
         permController, ORIGINS.b,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
@@ -524,7 +525,7 @@ describe('permissions controller', function () {
 
     it('should throw if account is already permitted', async function () {
       await assert.rejects(
-        () => permController.addPermittedAccount(ORIGINS.a, ACCOUNT_ARRAYS.a[0]),
+        () => permController.addPermittedAccount(ORIGINS.a, ACCOUNTS.a.permitted[0]),
         ERRORS.addPermittedAccount.alreadyPermitted(),
         'should throw if account is already permitted'
       )
@@ -533,16 +534,16 @@ describe('permissions controller', function () {
     it('should successfully add permitted account', async function () {
       await permController.addPermittedAccount(ORIGINS.a, EXTRA_ACCOUNT)
 
-      const accounts = await permController.getAccounts(ORIGINS.a)
+      const accounts = await permController._getPermittedAccounts(ORIGINS.a)
 
       assert.deepEqual(
-        accounts, [...ACCOUNT_ARRAYS.a, EXTRA_ACCOUNT],
+        accounts, [...ACCOUNTS.a.permitted, EXTRA_ACCOUNT],
         'origin should have correct accounts'
       )
 
       assert.deepEqual(
         notifications[ORIGINS.a][0],
-        NOTIFICATIONS.newAccounts([...ACCOUNT_ARRAYS.a, EXTRA_ACCOUNT]),
+        NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary /* EXTRA_ACCOUNT */]),
         'origin should have correct notification'
       )
     })
@@ -556,11 +557,11 @@ describe('permissions controller', function () {
       permController = initPermController(notifications)
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
         permController, ORIGINS.b,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
@@ -611,31 +612,32 @@ describe('permissions controller', function () {
 
     it('should throw if account is not permitted', async function () {
       await assert.rejects(
-        () => permController.removePermittedAccount(ORIGINS.b, ACCOUNT_ARRAYS.c[0]),
+        () => permController.removePermittedAccount(ORIGINS.b, ACCOUNTS.c.permitted[0]),
         ERRORS.removePermittedAccount.notPermitted(),
         'should throw if account is not permitted'
       )
     })
 
     it('should successfully remove permitted account', async function () {
-      await permController.removePermittedAccount(ORIGINS.a, ACCOUNT_ARRAYS.a[1])
+      await permController.removePermittedAccount(ORIGINS.a, ACCOUNTS.a.permitted[1])
 
-      const accounts = await permController.getAccounts(ORIGINS.a)
+      const accounts = await permController._getPermittedAccounts(ORIGINS.a)
 
       assert.deepEqual(
-        accounts, ACCOUNT_ARRAYS.a.filter((acc) => acc !== ACCOUNT_ARRAYS.a[1]),
+        accounts, ACCOUNTS.a.permitted.filter((acc) => acc !== ACCOUNTS.a.permitted[1]),
         'origin should have correct accounts'
       )
 
       assert.deepEqual(
         notifications[ORIGINS.a][0],
-        NOTIFICATIONS.newAccounts(ACCOUNT_ARRAYS.a.filter((acc) => acc !== ACCOUNT_ARRAYS.a[1])),
+        NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary]),
+        // NOTIFICATIONS.newAccounts(ACCOUNTS.a.permitted.filter((acc) => acc !== ACCOUNTS.a.permitted[1])),
         'origin should have correct notification'
       )
     })
 
     it('should remove eth_accounts permission if removing only permitted account', async function () {
-      await permController.removePermittedAccount(ORIGINS.b, ACCOUNT_ARRAYS.b[0])
+      await permController.removePermittedAccount(ORIGINS.b, ACCOUNTS.b.permitted[0])
 
       const accounts = await permController.getAccounts(ORIGINS.b)
 
@@ -681,21 +683,21 @@ describe('permissions controller', function () {
 
       const perm = await permController.finalizePermissionsRequest(
         PERMS.requests.eth_accounts(),
-        ACCOUNT_ARRAYS.a,
+        ACCOUNTS.a.permitted,
       )
 
-      assert.deepEqual(perm, PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a))
+      assert.deepEqual(perm, PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted))
     })
 
     it('replaces caveat of eth_accounts permission', async function () {
 
       const perm = await permController.finalizePermissionsRequest(
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a),
-        ACCOUNT_ARRAYS.b,
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted),
+        ACCOUNTS.b.permitted,
       )
 
       assert.deepEqual(
-        perm, PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b),
+        perm, PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted),
         'permission should have correct caveat'
       )
     })
@@ -704,7 +706,7 @@ describe('permissions controller', function () {
 
       const perm = await permController.finalizePermissionsRequest(
         PERMS.finalizedRequests.test_method(),
-        ACCOUNT_ARRAYS.b,
+        ACCOUNTS.b.permitted,
       )
 
       assert.deepEqual(
@@ -728,10 +730,10 @@ describe('permissions controller', function () {
       let aAccounts = await permController.getAccounts(ORIGINS.a)
       assert.deepEqual(aAccounts, [], 'origin should have no accounts')
 
-      await permController.legacyExposeAccounts(ORIGINS.a, ACCOUNT_ARRAYS.a)
+      await permController.legacyExposeAccounts(ORIGINS.a, ACCOUNTS.a.permitted)
 
       aAccounts = await permController.getAccounts(ORIGINS.a)
-      assert.deepEqual(aAccounts, ACCOUNT_ARRAYS.a, 'origin should have correct accounts')
+      assert.deepEqual(aAccounts, [ACCOUNTS.a.primary], 'origin should have correct accounts')
 
       // now, permissions history should be updated
       const permissionsHistory = permController.permissionsLog.getHistory()
@@ -747,14 +749,14 @@ describe('permissions controller', function () {
 
       assert.deepEqual(
         Object.keys(permissionsHistory[ORIGINS.a].eth_accounts.accounts),
-        ACCOUNT_ARRAYS.a,
+        ACCOUNTS.a.permitted,
         'should have expected eth_accounts entry accounts'
       )
 
       // notification should also have been sent
       assert.deepEqual(
         notifications[ORIGINS.a][0],
-        NOTIFICATIONS.newAccounts(ACCOUNT_ARRAYS.a),
+        NOTIFICATIONS.newAccounts(ACCOUNTS.a.permitted),
         'first origin should have correct notification'
       )
     })
@@ -763,14 +765,14 @@ describe('permissions controller', function () {
 
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
 
       const aAccounts = await permController.getAccounts(ORIGINS.a)
-      assert.deepEqual(aAccounts, ACCOUNT_ARRAYS.a, 'origin should have correct accounts')
+      assert.deepEqual(aAccounts, [ACCOUNTS.a.primary], 'origin should have correct accounts')
 
       await assert.rejects(
-        permController.legacyExposeAccounts(ORIGINS.a, ACCOUNT_ARRAYS.b),
+        permController.legacyExposeAccounts(ORIGINS.a, ACCOUNTS.b.permitted),
         ERRORS.legacyExposeAccounts.forbiddenUsage(),
         'should throw if called on origin with existing exposed accounts'
       )
@@ -808,7 +810,7 @@ describe('permissions controller', function () {
     it('throws if called with bad origin', async function () {
 
       await assert.rejects(
-        permController.legacyExposeAccounts(null, ACCOUNT_ARRAYS.a),
+        permController.legacyExposeAccounts(null, ACCOUNTS.a.permitted),
         ERRORS.legacyExposeAccounts.badOrigin(),
         'should throw if called with invalid origin'
       )
@@ -856,11 +858,11 @@ describe('permissions controller', function () {
       })
       grantPermissions(
         permController, ORIGINS.b,
-        PERMS.finalizedRequests.eth_accounts([...ACCOUNT_ARRAYS.a, EXTRA_ACCOUNT])
+        PERMS.finalizedRequests.eth_accounts([...ACCOUNTS.a.permitted, EXTRA_ACCOUNT])
       )
       grantPermissions(
         permController, ORIGINS.c,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
     })
 
@@ -895,21 +897,21 @@ describe('permissions controller', function () {
     })
 
     it('should emit notification if account already first in array for each connected site', async function () {
-      identities[ACCOUNT_ARRAYS.a[0]] = { lastSelected: 1000 }
+      identities[ACCOUNTS.a.permitted[0]] = { lastSelected: 1000 }
       assert(preferences.subscribe.calledOnce)
       assert(preferences.subscribe.firstCall.args.length === 1)
       const onPreferencesUpdate = preferences.subscribe.firstCall.args[0]
 
-      await onPreferencesUpdate({ selectedAddress: ACCOUNT_ARRAYS.a[0] })
+      await onPreferencesUpdate({ selectedAddress: ACCOUNTS.a.permitted[0] })
 
       assert.deepEqual(
         notifications[ORIGINS.b],
-        [NOTIFICATIONS.newAccounts([...ACCOUNT_ARRAYS.a, EXTRA_ACCOUNT])],
+        [NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary])],
         'should not have emitted notification'
       )
       assert.deepEqual(
         notifications[ORIGINS.c],
-        [NOTIFICATIONS.newAccounts(ACCOUNT_ARRAYS.a)],
+        [NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary])],
         'should not have emitted notification'
       )
     })
@@ -924,7 +926,8 @@ describe('permissions controller', function () {
 
       assert.deepEqual(
         notifications[ORIGINS.b],
-        [NOTIFICATIONS.newAccounts([ EXTRA_ACCOUNT, ...ACCOUNT_ARRAYS.a ])],
+        [NOTIFICATIONS.newAccounts([EXTRA_ACCOUNT])],
+        // [NOTIFICATIONS.newAccounts([ EXTRA_ACCOUNT, ...ACCOUNTS.a.permitted ])],
         'should have emitted notification'
       )
       assert.deepEqual(
@@ -934,24 +937,24 @@ describe('permissions controller', function () {
     })
 
     it('should emit notification for multiple connected domains', async function () {
-      identities[ACCOUNT_ARRAYS.a[1]] = { lastSelected: 1000 }
+      identities[ACCOUNTS.a.permitted[1]] = { lastSelected: 1000 }
       assert(preferences.subscribe.calledOnce)
       assert(preferences.subscribe.firstCall.args.length === 1)
       const onPreferencesUpdate = preferences.subscribe.firstCall.args[0]
 
-      await onPreferencesUpdate({ selectedAddress: ACCOUNT_ARRAYS.a[1] })
+      await onPreferencesUpdate({ selectedAddress: ACCOUNTS.a.permitted[1] })
 
-      const accountsWithoutFirst = ACCOUNT_ARRAYS.a
-        .filter((account) => account !== ACCOUNT_ARRAYS.a[1])
-      const expectedAccounts = [ ACCOUNT_ARRAYS.a[1], ...accountsWithoutFirst ]
+      // const accountsWithoutFirst = ACCOUNTS.a.permitted
+      //   .filter((account) => account !== ACCOUNTS.a.permitted[1])
+      // const expectedAccounts = [ ACCOUNTS.a.permitted[1], ...accountsWithoutFirst ]
       assert.deepEqual(
         notifications[ORIGINS.b],
-        [NOTIFICATIONS.newAccounts([ ...expectedAccounts, EXTRA_ACCOUNT ])],
+        [NOTIFICATIONS.newAccounts([ACCOUNTS.a.permitted[1]])],
         'should have emitted notification'
       )
       assert.deepEqual(
         notifications[ORIGINS.c],
-        [NOTIFICATIONS.newAccounts(expectedAccounts)],
+        [NOTIFICATIONS.newAccounts([ACCOUNTS.c.primary])],
         'should have emitted notification'
       )
     })
@@ -1027,7 +1030,7 @@ describe('permissions controller', function () {
         'should reject if no permissions in request'
       )
 
-      await permController.approvePermissionsRequest(request, ACCOUNT_ARRAYS.a)
+      await permController.approvePermissionsRequest(request, ACCOUNTS.a.permitted)
       await requestRejection
 
       assert.equal(
@@ -1049,11 +1052,11 @@ describe('permissions controller', function () {
         'should not reject single valid request'
       )
 
-      await permController.approvePermissionsRequest(request, ACCOUNT_ARRAYS.a)
+      await permController.approvePermissionsRequest(request, ACCOUNTS.a.permitted)
       await requestApproval
 
       assert.deepEqual(
-        perms, PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a),
+        perms, PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted),
         'should produce expected approved permissions'
       )
 
@@ -1086,21 +1089,21 @@ describe('permissions controller', function () {
       )
 
       // approve out of order
-      await permController.approvePermissionsRequest(request2, ACCOUNT_ARRAYS.b)
+      await permController.approvePermissionsRequest(request2, ACCOUNTS.b.permitted)
       // add a non-existing request to the mix
-      await permController.approvePermissionsRequest(request3, ACCOUNT_ARRAYS.c)
-      await permController.approvePermissionsRequest(request1, ACCOUNT_ARRAYS.a)
+      await permController.approvePermissionsRequest(request3, ACCOUNTS.c.permitted)
+      await permController.approvePermissionsRequest(request1, ACCOUNTS.a.permitted)
 
       await approval1
       await approval2
 
       assert.deepEqual(
-        perms1, PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a),
+        perms1, PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted),
         'first request should produce expected approved permissions'
       )
 
       assert.deepEqual(
-        perms2, PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.b),
+        perms2, PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted),
         'second request should produce expected approved permissions'
       )
 
@@ -1286,7 +1289,7 @@ describe('permissions controller', function () {
 
       permController.notifyDomain(
         ORIGINS.a,
-        NOTIFICATIONS.newAccounts(ACCOUNT_ARRAYS.a),
+        NOTIFICATIONS.newAccounts(ACCOUNTS.a.permitted),
       )
 
       assert.ok(
@@ -1296,7 +1299,7 @@ describe('permissions controller', function () {
 
       assert.deepEqual(
         notifications[ORIGINS.a],
-        [ NOTIFICATIONS.newAccounts(ACCOUNT_ARRAYS.a) ],
+        [ NOTIFICATIONS.newAccounts(ACCOUNTS.a.permitted) ],
         'origin should have correct notification'
       )
     })

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -543,7 +543,7 @@ describe('permissions controller', function () {
 
       assert.deepEqual(
         notifications[ORIGINS.a][0],
-        NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary /* EXTRA_ACCOUNT */]),
+        NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary]),
         'origin should have correct notification'
       )
     })
@@ -631,7 +631,6 @@ describe('permissions controller', function () {
       assert.deepEqual(
         notifications[ORIGINS.a][0],
         NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary]),
-        // NOTIFICATIONS.newAccounts(ACCOUNTS.a.permitted.filter((acc) => acc !== ACCOUNTS.a.permitted[1])),
         'origin should have correct notification'
       )
     })
@@ -927,7 +926,6 @@ describe('permissions controller', function () {
       assert.deepEqual(
         notifications[ORIGINS.b],
         [NOTIFICATIONS.newAccounts([EXTRA_ACCOUNT])],
-        // [NOTIFICATIONS.newAccounts([ EXTRA_ACCOUNT, ...ACCOUNTS.a.permitted ])],
         'should have emitted notification'
       )
       assert.deepEqual(
@@ -944,9 +942,6 @@ describe('permissions controller', function () {
 
       await onPreferencesUpdate({ selectedAddress: ACCOUNTS.a.permitted[1] })
 
-      // const accountsWithoutFirst = ACCOUNTS.a.permitted
-      //   .filter((account) => account !== ACCOUNTS.a.permitted[1])
-      // const expectedAccounts = [ ACCOUNTS.a.permitted[1], ...accountsWithoutFirst ]
       assert.deepEqual(
         notifications[ORIGINS.b],
         [NOTIFICATIONS.newAccounts([ACCOUNTS.a.permitted[1]])],

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -756,7 +756,7 @@ describe('permissions controller', function () {
       // notification should also have been sent
       assert.deepEqual(
         notifications[ORIGINS.a][0],
-        NOTIFICATIONS.newAccounts(ACCOUNTS.a.permitted),
+        NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary]),
         'first origin should have correct notification'
       )
     })

--- a/test/unit/app/controllers/permissions/permissions-log-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-log-controller-test.js
@@ -28,7 +28,7 @@ const {
 } = getters
 
 const {
-  ACCOUNT_ARRAYS,
+  ACCOUNTS,
   EXPECTED_HISTORIES,
   ORIGINS,
   PERM_NAMES,
@@ -123,7 +123,7 @@ describe('permissions log', function () {
 
       req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.c)
       req.id = REQUEST_IDS.c
-      res = { result: ACCOUNT_ARRAYS.c }
+      res = { result: ACCOUNTS.c.permitted }
 
       logMiddleware({ ...req }, res)
 
@@ -250,7 +250,7 @@ describe('permissions log', function () {
       // next request should be handled as normal
       req = RPC_REQUESTS.eth_accounts(ORIGINS.b)
       req.id = REQUEST_IDS.b
-      res = { result: ACCOUNT_ARRAYS.b }
+      res = { result: ACCOUNTS.b.permitted }
 
       logMiddleware({ ...req }, res)
 
@@ -399,7 +399,7 @@ describe('permissions log', function () {
         ORIGINS.a, PERM_NAMES.eth_accounts
       )
       const res = {
-        result: [ PERMS.granted.eth_accounts(ACCOUNT_ARRAYS.a) ],
+        result: [ PERMS.granted.eth_accounts(ACCOUNTS.a.permitted) ],
       }
 
       logMiddleware({ ...req }, { ...res })
@@ -418,7 +418,7 @@ describe('permissions log', function () {
 
       clock.tick(1)
 
-      res.result = [ PERMS.granted.eth_accounts([ ACCOUNT_ARRAYS.a[0] ]) ]
+      res.result = [ PERMS.granted.eth_accounts([ ACCOUNTS.a.permitted[0] ]) ]
 
       logMiddleware({ ...req }, { ...res })
 
@@ -437,7 +437,7 @@ describe('permissions log', function () {
         ORIGINS.a, PERM_NAMES.eth_accounts
       )
       const res = {
-        result: [ PERMS.granted.eth_accounts(ACCOUNT_ARRAYS.a) ],
+        result: [ PERMS.granted.eth_accounts(ACCOUNTS.a.permitted) ],
       }
       delete res.result[0].caveats
 
@@ -457,7 +457,7 @@ describe('permissions log', function () {
         ORIGINS.a, PERM_NAMES.eth_accounts
       )
       const res = {
-        result: [ PERMS.granted.eth_accounts(ACCOUNT_ARRAYS.a) ],
+        result: [ PERMS.granted.eth_accounts(ACCOUNTS.a.permitted) ],
       }
       res.result[0].caveats.push({ foo: 'bar' })
 
@@ -481,7 +481,7 @@ describe('permissions log', function () {
       )
       const res = {
         result: [
-          PERMS.granted.eth_accounts(ACCOUNT_ARRAYS.a),
+          PERMS.granted.eth_accounts(ACCOUNTS.a.permitted),
           PERMS.granted.test_method(),
         ],
       }
@@ -567,7 +567,7 @@ describe('permissions log', function () {
           ORIGINS.b, PERM_NAMES.eth_accounts
         ),
         res: {
-          result: [ PERMS.granted.eth_accounts(ACCOUNT_ARRAYS.b) ],
+          result: [ PERMS.granted.eth_accounts(ACCOUNTS.b.permitted) ],
         },
       })
 
@@ -580,7 +580,7 @@ describe('permissions log', function () {
         res: {
           result: [
             PERMS.granted.test_method(),
-            PERMS.granted.eth_accounts(ACCOUNT_ARRAYS.c),
+            PERMS.granted.eth_accounts(ACCOUNTS.c.permitted),
           ],
         },
       })
@@ -628,7 +628,7 @@ describe('permissions log', function () {
         }),
         res: {
           result: [
-            PERMS.granted.eth_accounts(ACCOUNT_ARRAYS.b),
+            PERMS.granted.eth_accounts(ACCOUNTS.b.permitted),
           ],
         },
       })
@@ -656,7 +656,7 @@ describe('permissions log', function () {
 
       assert.throws(
         () => {
-          permLog.logAccountExposure('', ACCOUNT_ARRAYS.a)
+          permLog.logAccountExposure('', ACCOUNTS.a.permitted)
         },
         ERRORS.logAccountExposure.invalidParams(),
         'should throw expected error'
@@ -664,7 +664,7 @@ describe('permissions log', function () {
 
       assert.throws(
         () => {
-          permLog.logAccountExposure(null, ACCOUNT_ARRAYS.a)
+          permLog.logAccountExposure(null, ACCOUNTS.a.permitted)
         },
         ERRORS.logAccountExposure.invalidParams(),
         'should throw expected error'

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -28,7 +28,7 @@ const {
 } = getters
 
 const {
-  ACCOUNT_ARRAYS,
+  ACCOUNTS,
   ORIGINS,
   PERM_NAMES,
 } = constants
@@ -81,7 +81,7 @@ describe('permissions middleware', function () {
       const id = permController.pendingApprovals.keys().next().value
       const approvedReq = PERMS.approvedRequest(id, PERMS.requests.eth_accounts())
 
-      await permController.approvePermissionsRequest(approvedReq, ACCOUNT_ARRAYS.a)
+      await permController.approvePermissionsRequest(approvedReq, ACCOUNTS.a.permitted)
       await pendingApproval
 
       assert.ok(
@@ -98,12 +98,12 @@ describe('permissions middleware', function () {
         res.result[0],
         PERM_NAMES.eth_accounts,
         ORIGINS.a,
-        [CAVEATS.eth_accounts(ACCOUNT_ARRAYS.a)]
+        CAVEATS.eth_accounts(ACCOUNTS.a.permitted)
       )
 
       const aAccounts = await permController.getAccounts(ORIGINS.a)
       assert.deepEqual(
-        aAccounts, ACCOUNT_ARRAYS.a,
+        aAccounts, [ACCOUNTS.a.primary],
         'origin should have correct accounts'
       )
     })
@@ -120,7 +120,7 @@ describe('permissions middleware', function () {
       const res1 = {}
 
       // send, approve, and validate first request
-      // note use of ACCOUNT_ARRAYS.a
+      // note use of ACCOUNTS.a.permitted
 
       const pendingApproval1 = assert.doesNotReject(
         aMiddleware(req1, res1),
@@ -130,7 +130,7 @@ describe('permissions middleware', function () {
       const id1 = permController.pendingApprovals.keys().next().value
       const approvedReq1 = PERMS.approvedRequest(id1, PERMS.requests.eth_accounts())
 
-      await permController.approvePermissionsRequest(approvedReq1, ACCOUNT_ARRAYS.a)
+      await permController.approvePermissionsRequest(approvedReq1, ACCOUNTS.a.permitted)
       await pendingApproval1
 
       assert.ok(
@@ -147,12 +147,12 @@ describe('permissions middleware', function () {
         res1.result[0],
         PERM_NAMES.eth_accounts,
         ORIGINS.a,
-        [CAVEATS.eth_accounts(ACCOUNT_ARRAYS.a)]
+        CAVEATS.eth_accounts(ACCOUNTS.a.permitted)
       )
 
       const accounts1 = await permController.getAccounts(ORIGINS.a)
       assert.deepEqual(
-        accounts1, ACCOUNT_ARRAYS.a,
+        accounts1, [ACCOUNTS.a.primary],
         'origin should have correct accounts'
       )
 
@@ -169,7 +169,7 @@ describe('permissions middleware', function () {
       const res2 = {}
 
       // send, approve, and validate second request
-      // note use of ACCOUNT_ARRAYS.b
+      // note use of ACCOUNTS.b.permitted
 
       const pendingApproval2 = assert.doesNotReject(
         aMiddleware(req2, res2),
@@ -179,7 +179,7 @@ describe('permissions middleware', function () {
       const id2 = permController.pendingApprovals.keys().next().value
       const approvedReq2 = PERMS.approvedRequest(id2, { ...requestedPerms2 })
 
-      await permController.approvePermissionsRequest(approvedReq2, ACCOUNT_ARRAYS.b)
+      await permController.approvePermissionsRequest(approvedReq2, ACCOUNTS.b.permitted)
       await pendingApproval2
 
       assert.ok(
@@ -196,7 +196,7 @@ describe('permissions middleware', function () {
         res2.result[0],
         PERM_NAMES.eth_accounts,
         ORIGINS.a,
-        [CAVEATS.eth_accounts(ACCOUNT_ARRAYS.b)]
+        CAVEATS.eth_accounts(ACCOUNTS.b.permitted)
       )
 
       validatePermission(
@@ -207,7 +207,7 @@ describe('permissions middleware', function () {
 
       const accounts2 = await permController.getAccounts(ORIGINS.a)
       assert.deepEqual(
-        accounts2, ACCOUNT_ARRAYS.b,
+        accounts2, [ACCOUNTS.b.primary],
         'origin should have correct accounts'
       )
     })
@@ -480,7 +480,7 @@ describe('permissions middleware', function () {
 
       grantPermissions(
         permController, ORIGINS.a,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.a)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
 
       const req = RPC_REQUESTS.eth_accounts(ORIGINS.a)
@@ -496,7 +496,7 @@ describe('permissions middleware', function () {
         'response should have result and no error'
       )
       assert.deepEqual(
-        res.result, ACCOUNT_ARRAYS.a,
+        res.result, [ACCOUNTS.a.primary],
         'response should have correct result'
       )
     })
@@ -534,7 +534,7 @@ describe('permissions middleware', function () {
       const id = permController.pendingApprovals.keys().next().value
       const approvedReq = PERMS.approvedRequest(id, PERMS.requests.eth_accounts())
 
-      await permController.approvePermissionsRequest(approvedReq, ACCOUNT_ARRAYS.a)
+      await permController.approvePermissionsRequest(approvedReq, ACCOUNTS.a.permitted)
 
       // wait for permission to be granted
       await pendingApproval
@@ -550,7 +550,7 @@ describe('permissions middleware', function () {
         perms[0],
         PERM_NAMES.eth_accounts,
         ORIGINS.a,
-        [CAVEATS.eth_accounts(ACCOUNT_ARRAYS.a)]
+        CAVEATS.eth_accounts(ACCOUNTS.a.permitted)
       )
 
       // we should also see the accounts on the response
@@ -560,14 +560,14 @@ describe('permissions middleware', function () {
       )
 
       assert.deepEqual(
-        res.result, ACCOUNT_ARRAYS.a,
+        res.result, [ACCOUNTS.a.primary],
         'result should have correct accounts'
       )
 
       // we should also be able to get the accounts independently
       const aAccounts = await permController.getAccounts(ORIGINS.a)
       assert.deepEqual(
-        aAccounts, ACCOUNT_ARRAYS.a, 'origin should have have correct accounts'
+        aAccounts, [ACCOUNTS.a.primary], 'origin should have have correct accounts'
       )
     })
 
@@ -620,7 +620,7 @@ describe('permissions middleware', function () {
 
       grantPermissions(
         permController, ORIGINS.c,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.c)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.c.permitted)
       )
 
       const req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.c)
@@ -636,7 +636,7 @@ describe('permissions middleware', function () {
         'response should have result and no error'
       )
       assert.deepEqual(
-        res.result, ACCOUNT_ARRAYS.c,
+        res.result, [ACCOUNTS.c.primary],
         'response should have correct result'
       )
     })
@@ -654,7 +654,7 @@ describe('permissions middleware', function () {
 
       grantPermissions(
         permController, ORIGINS.c,
-        PERMS.finalizedRequests.eth_accounts(ACCOUNT_ARRAYS.c)
+        PERMS.finalizedRequests.eth_accounts(ACCOUNTS.c.permitted)
       )
 
       const req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.c)
@@ -682,7 +682,7 @@ describe('permissions middleware', function () {
         'response should have result and no error'
       )
       assert.deepEqual(
-        res.result, ACCOUNT_ARRAYS.c,
+        res.result, [ACCOUNTS.c.primary],
         'response should have correct result'
       )
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -24781,10 +24781,10 @@ rn-host-detect@^1.1.5:
   resolved "https://registry.yarnpkg.com/rn-host-detect/-/rn-host-detect-1.1.5.tgz#fbecb982b73932f34529e97932b9a63e58d8deb6"
   integrity sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg==
 
-rpc-cap@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/rpc-cap/-/rpc-cap-2.0.0.tgz#575ff22417bdea9526292b8989c7b7af5e664bfa"
-  integrity sha512-P78tE+fIOxIkxcfZ8S1ge+Mt02AH4vMXdcFjr2uWLOdouDosgJOvJP5oROYx6qiUYbECuyKrsmETU7e+MA8vpg==
+rpc-cap@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rpc-cap/-/rpc-cap-2.1.0.tgz#c53e9bd925cb23c86b1591d621a68692c58070c0"
+  integrity sha512-k4GLWk3IT6r5zETyhiH9tjHqX2sEJ8MdGWv5C4v7wL32hCsx+AnEykbkeVG+EfMox+Vf32C9ieTQPNLKzKwS7A==
   dependencies:
     clone "^2.1.2"
     eth-json-rpc-errors "^2.0.2"


### PR DESCRIPTION
Closes #8651

Uses the new limitResponseLength caveat exposed in rpc-cap to limit the Dapp's permission to only be able to access the primary account. This is step 1 of a two PR(+) contribution to add the ability for Dapp authors to request permission to interact with all connected accounts. This PR is a requirement for v8 RC