### PR TITLE
Use concurrently@5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "chai": "^4.1.0",
     "chalk": "^3.0.0",
     "chromedriver": "^79.0.0",
-    "concurrently": "^5.1.0",
+    "concurrently": "^5.2.0",
     "copy-webpack-plugin": "^5.1.1",
     "coveralls": "^3.0.0",
     "css-loader": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7409,10 +7409,10 @@ concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@^1.5.1, concat-stream@
     inherits "^2.0.3"
     readable-stream "^3.0.2"
 
-concurrently@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.1.0.tgz#05523986ba7aaf4b58a49ddd658fab88fa783132"
-  integrity sha512-9ViZMu3OOCID3rBgU31mjBftro2chOop0G2u1olq1OuwRBVRw/GxHTg80TVJBUTJfoswMmEUeuOg1g1yu1X2dA==
+concurrently@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.2.0.tgz#ead55121d08a0fc817085584c123cedec2e08975"
+  integrity sha512-XxcDbQ4/43d6CxR7+iV8IZXhur4KbmEJk1CetVMUqCy34z9l0DkszbY+/9wvmSnToTej0SYomc2WSRH+L0zVJw==
   dependencies:
     chalk "^2.4.2"
     date-fns "^2.0.1"


### PR DESCRIPTION
This PR updates our `concurrently` dev dependency.