### PR TITLE
Show hostname in the disconnect confirmation

### DIFF
--- a/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
@@ -37,7 +37,7 @@ export default class ConnectedSitesList extends Component {
             <i
               className="fas fa-trash-alt connected-sites-list__trash"
               title={t('disconnect')}
-              onClick={() => onDisconnect(domain.key, domain.name)}
+              onClick={() => onDisconnect(domain.key)}
             />
           </div>
         )) }

--- a/ui/app/pages/connected-sites/connected-sites.component.js
+++ b/ui/app/pages/connected-sites/connected-sites.component.js
@@ -36,11 +36,10 @@ export default class ConnectedSites extends Component {
     getOpenMetamaskTabsIds()
   }
 
-  setPendingDisconnect = (domainKey, domainName) => {
+  setPendingDisconnect = (domainKey) => {
     this.setState({
       sitePendingDisconnect: {
         domainKey,
-        domainName,
       },
     })
   }
@@ -119,14 +118,14 @@ export default class ConnectedSites extends Component {
 
     const { closePopover, permittedAccountsByOrigin } = this.props
     const { t } = this.context
-    const { sitePendingDisconnect: { domainKey, domainName } } = this.state
+    const { sitePendingDisconnect: { domainKey } } = this.state
 
     const numPermittedAccounts = permittedAccountsByOrigin[domainKey].length
 
     return (
       <Popover
         className="connected-sites"
-        title={t('disconnectPrompt', [domainName])}
+        title={t('disconnectPrompt', [domainKey])}
         subtitle={t('disconnectAllAccountsConfirmationDescription')}
         onClose={closePopover}
         footer={(


### PR DESCRIPTION
This PR updates the disconnect confirmation modal to show the hostname instead of the document title. This aligns with the rest of the modals.

**Before vs. after:**

<img width="328" alt="" src="https://user-images.githubusercontent.com/1623628/83070889-b7cc5d00-a046-11ea-908a-d6260a97988c.png">
<img width="328" alt="" src="https://user-images.githubusercontent.com/1623628/83070891-b864f380-a046-11ea-80dd-208f8c5cd316.png">
