### PR TITLE
Fix JSDoc for Tabs#_findChildByName

### DIFF
--- a/ui/app/components/ui/tabs/tabs.component.js
+++ b/ui/app/components/ui/tabs/tabs.component.js
@@ -75,9 +75,9 @@ export default class Tabs extends Component {
   }
 
   /**
-   * Returns the index of the child with the given key
-   * @param {string} key - the child key to search for
-   * @returns {number}
+   * Returns the index of the child with the given name
+   * @param {string} name - the name to search for
+   * @returns {number} the index of the child with the given name
    * @private
    */
   _findChildByName (name) {


### PR DESCRIPTION
Refs #8612

Small fix for the `Tabs#_findChildByName` JSDoc