### PR TITLE
Make address display wider in Account Details

### DIFF
--- a/ui/app/css/itcss/components/sections.scss
+++ b/ui/app/css/itcss/components/sections.scss
@@ -403,10 +403,10 @@ textarea.twelve-word-phrase {
 }
 
 .qr-ellip-address, .ellip-address {
-  /*rtl:ignore*/
   direction: ltr;
   overflow: hidden;
   text-overflow: ellipsis;
+  width: 100%;
 }
 
 .qr-header {

--- a/ui/app/css/itcss/components/sections.scss
+++ b/ui/app/css/itcss/components/sections.scss
@@ -403,6 +403,7 @@ textarea.twelve-word-phrase {
 }
 
 .qr-ellip-address, .ellip-address {
+  /*rtl:ignore*/
   direction: ltr;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
This PR makes the address display wider on the Account Details page.

**Before & after:**

<img width="859" alt="" src="https://user-images.githubusercontent.com/1623628/83072136-cfa4e080-a048-11ea-89b3-a62945343f2f.png">
<img width="859" alt="" src="https://user-images.githubusercontent.com/1623628/83072147-d3386780-a048-11ea-906a-705c3b7608b4.png">
