### PR TITLE
Refactor transaction list token filtering

### DIFF
--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -256,7 +256,7 @@ export default class Home extends PureComponent {
                 data-testid="home__history-tab"
                 name="History"
               >
-                <TransactionList />
+                <TransactionList tokenAddress={selectedToken?.address} />
               </Tab>
             </Tabs>
           </div>

--- a/ui/app/selectors/tests/transactions.test.js
+++ b/ui/app/selectors/tests/transactions.test.js
@@ -139,57 +139,6 @@ describe('Transaction Selectors', function () {
       assert(Array.isArray(selectedTx))
       assert.deepEqual(selectedTx, orderedTxList)
     })
-
-    it('returns token transactions from currentNetworkTxList when selectedTokenAddress is valid', function () {
-
-      const state = {
-        metamask: {
-          provider: {
-            nickname: 'mainnet',
-          },
-          featureFlags: {
-            showIncomingTransactions: false,
-          },
-          selectedAddress: '0xAddress',
-          selectedTokenAddress: '0xToken',
-          currentNetworkTxList: [
-            {
-              id: 0,
-              time: 0,
-              txParams: {
-                from: '0xAddress',
-                to: '0xToken',
-              },
-            },
-            {
-              id: 1,
-              time: 1,
-              txParams: {
-                from: '0xAddress',
-                to: '0xRecipient',
-              },
-            },
-            {
-              id: 2,
-              time: 2,
-              txParams: {
-                from: '0xAddress',
-                to: '0xToken',
-              },
-            },
-          ],
-        },
-      }
-
-      const orderedTxList = state.metamask.currentNetworkTxList
-        .filter((tx) => tx.txParams.to === '0xToken')
-        .sort((a, b) => b.time - a.time)
-
-      const selectedTx = transactionsSelector(state)
-
-      assert(Array.isArray(selectedTx))
-      assert.deepEqual(selectedTx, orderedTxList)
-    })
   })
 
   describe('nonceSortedTransactionsSelector', function () {

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -10,7 +10,6 @@ import {
   TRANSACTION_TYPE_RETRY,
 } from '../../../app/scripts/controllers/transactions/enums'
 import { hexToDecimal } from '../helpers/utils/conversions.util'
-import { selectedTokenAddressSelector } from './tokens'
 import { getFastPriceEstimateInHexWEI } from './custom-gas'
 import {
   getSelectedToken,
@@ -80,23 +79,14 @@ export const transactionSubSelector = createSelector(
   }
 )
 
-const transactionSelectorReturnHelper = (selectedTokenAddress, transactions) => {
-  return selectedTokenAddress
-    ? transactions
-      .filter(({ txParams }) => txParams && txParams.to === selectedTokenAddress)
-      .sort((a, b) => b.time - a.time)
-    : transactions
-      .sort((a, b) => b.time - a.time)
-}
-
 export const transactionsSelector = createSelector(
-  selectedTokenAddressSelector,
   transactionSubSelector,
   selectedAddressTxListSelector,
-  (selectedTokenAddress, subSelectorTxList = [], selectedAddressTxList = []) => {
+  (subSelectorTxList = [], selectedAddressTxList = []) => {
     const txsToRender = selectedAddressTxList.concat(subSelectorTxList)
 
-    return transactionSelectorReturnHelper(selectedTokenAddress, txsToRender)
+    return txsToRender
+      .sort((a, b) => b.time - a.time)
   }
 )
 


### PR DESCRIPTION
The transaction list now filters by token in the `TransactionList` component instead of in the transaction selector. This was done in preparation for the asset page work.

Technically this approach is slightly less efficient than before, as we're now filtering the transactions after they've been grouped together rather than beforehand. The difference is minimal though, and this method is more correct.

The old filtering was broken because it inappropriately filtered out cancel transactions. Cancel transactions always have the `to` address set to the same as the `from` address, and the token filter only returned transactions where the `to` address was set to the token address.

Now that we're only filtering by the `to` address of the initial transaction, token transaction groups will be included in their entirety, including any cancel transactions.