### PR TITLE
Fix token `decimal` type

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2216,7 +2216,7 @@ export function getTokenParams (tokenAddress) {
 
     return fetchSymbolAndDecimals(tokenAddress, existingTokens)
       .then(({ symbol, decimals }) => {
-        dispatch(addToken(tokenAddress, symbol, decimals))
+        dispatch(addToken(tokenAddress, symbol, Number(decimals)))
         dispatch(loadingTokenParamsFinished())
       })
   }


### PR DESCRIPTION
The `decimals` property of tokens was being set as a string instead of a Number for any tokens added via `getTokenParams`. It's now cast to a Number instead.

This caught my attention because of prop type warnings.