### PR TITLE
Remove `getTxParams`

### DIFF
--- a/ui/app/components/app/transaction-time-remaining/transaction-time-remaining.container.js
+++ b/ui/app/components/app/transaction-time-remaining/transaction-time-remaining.container.js
@@ -3,14 +3,13 @@ import TransactionTimeRemaining from './transaction-time-remaining.component'
 import {
   getEstimatedGasPrices,
   getEstimatedGasTimes,
-  getTxParams,
 } from '../../../selectors'
 import { getRawTimeEstimateData } from '../../../helpers/utils/gas-time-estimates.util'
 import { hexWEIToDecGWEI } from '../../../helpers/utils/conversions.util'
 
 const mapStateToProps = (state, ownProps) => {
   const { transaction } = ownProps
-  const { gasPrice: currentGasPrice } = getTxParams(state, transaction)
+  const { gasPrice: currentGasPrice } = transaction.txParams
   const customGasPrice = calcCustomGasPrice(currentGasPrice)
   const gasPrices = getEstimatedGasPrices(state)
   const estimatedTimes = getEstimatedGasTimes(state)

--- a/ui/app/hooks/useRetryTransaction.js
+++ b/ui/app/hooks/useRetryTransaction.js
@@ -21,8 +21,8 @@ import { useMethodData } from './useMethodData'
  */
 export function useRetryTransaction (transactionGroup) {
   const { primaryTransaction, initialTransaction } = transactionGroup
-  const gasPrice = primaryTransaction.txParams?.gasPrice
-  const methodData = useMethodData(primaryTransaction.txParams?.data)
+  const gasPrice = primaryTransaction.txParams.gasPrice
+  const methodData = useMethodData(primaryTransaction.txParams.data)
   const trackMetricsEvent = useMetricEvent(({
     eventOpts: {
       category: 'Navigation',
@@ -42,8 +42,8 @@ export function useRetryTransaction (transactionGroup) {
     await dispatch(fetchGasEstimates(basicEstimates.blockTime))
     const transaction = initialTransaction
     const increasedGasPrice = increaseLastGasPrice(gasPrice)
-    dispatch(setCustomGasPriceForRetry(increasedGasPrice || transaction.txParams?.gasPrice))
-    dispatch(setCustomGasLimit(transaction.txParams?.gas))
+    dispatch(setCustomGasPriceForRetry(increasedGasPrice || transaction.txParams.gasPrice))
+    dispatch(setCustomGasLimit(transaction.txParams.gas))
     dispatch(showSidebar({
       transitionName: 'sidebar-left',
       type: 'customize-gas',

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -10,9 +10,7 @@ import {
   TRANSACTION_TYPE_RETRY,
 } from '../../../app/scripts/controllers/transactions/enums'
 import { hexToDecimal } from '../helpers/utils/conversions.util'
-import { getFastPriceEstimateInHexWEI } from './custom-gas'
 import {
-  getSelectedToken,
   getSelectedAddress,
 } from '.'
 import txHelper from '../../lib/tx-helper'
@@ -306,15 +304,3 @@ export const submittedPendingTransactionsSelector = createSelector(
     transactions.filter((transaction) => transaction.status === SUBMITTED_STATUS)
   )
 )
-
-export const getTxParams = (state, selectedTransaction = {}) => {
-  const { metamask: { send } } = state
-  const { txParams } = selectedTransaction
-  return txParams || {
-    from: send.from,
-    gas: send.gasLimit || '0x5208',
-    gasPrice: send.gasPrice || getFastPriceEstimateInHexWEI(state, true),
-    to: send.to,
-    value: getSelectedToken(state) ? '0x0' : send.amount,
-  }
-}


### PR DESCRIPTION
This function primarily ensured that there was a reasonable fallback for `txParams` if the given transaction was missing it. This fallback was only used in one place: the customize gas modal, during the send flow specifically.

The helper function has been removed, and the default `txParams` is set in the one place it was needed. In the future we should attempt to simplify this modal so it doesn't need to know details about the context in which it's being used.