### PR TITLE
Fix Firefox account menu styling

### DIFF
--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -67,6 +67,7 @@
   &__accounts {
     overflow-y: auto;
     position: relative;
+    scrollbar-width: none;
 
     &::-webkit-scrollbar {
       display: none;

--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -55,22 +55,20 @@
     display: flex;
     flex-direction: column;
     z-index: 200;
-    scrollbar-width: none;
-
-    max-height: 256px;
-
-    @media screen and (max-width: 575px) {
-      max-height: 228px;
-    }
   }
 
   &__accounts {
     overflow-y: auto;
     position: relative;
+    max-height: 256px;
     scrollbar-width: none;
 
     &::-webkit-scrollbar {
       display: none;
+    }
+
+    @media screen and (max-width: 575px) {
+      max-height: 228px;
     }
 
     .keyring-label {


### PR DESCRIPTION
Firefox was displaying a scrollbar in the account menu. `scrollbar-width: none;` fixes this.