### PR TITLE
Fix propType for Home defaultHomeActiveTabName

### DIFF
--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -54,7 +54,7 @@ export default class Home extends PureComponent {
       decimals: PropTypes.number,
       symbol: PropTypes.string,
     }),
-    defaultHomeActiveTabName: PropTypes.string.isRequired,
+    defaultHomeActiveTabName: PropTypes.string,
     onTabClick: PropTypes.func.isRequired,
   }
 


### PR DESCRIPTION
The `defaultHomeActiveTabName` prop isn't supposed to be required—it is `null` by default.