### PR TITLE
Fix create account form styling

### DIFF
--- a/ui/app/pages/create-account/new-account.component.js
+++ b/ui/app/pages/create-account/new-account.component.js
@@ -49,31 +49,31 @@ export default class NewAccountCreateForm extends Component {
         <div className="new-account-create-form__input-label">
           {this.context.t('accountName')}
         </div>
-        <div className="new-account-create-form__input-wrapper">
+        <div className="new-account-create-form__account-name">
           <input
             className="new-account-create-form__input"
             value={newAccountName}
             placeholder={defaultAccountName}
             onChange={(event) => this.setState({ newAccountName: event.target.value })}
           />
-        </div>
-        <div className="new-account-create-form__buttons">
-          <Button
-            type="default"
-            large
-            className="new-account-create-form__button"
-            onClick={() => history.push(DEFAULT_ROUTE)}
-          >
-            {this.context.t('cancel')}
-          </Button>
-          <Button
-            type="secondary"
-            large
-            className="new-account-create-form__button"
-            onClick={createClick}
-          >
-            {this.context.t('create')}
-          </Button>
+          <div className="new-account-create-form__buttons">
+            <Button
+              type="default"
+              large
+              className="new-account-create-form__button"
+              onClick={() => history.push(DEFAULT_ROUTE)}
+            >
+              {this.context.t('cancel')}
+            </Button>
+            <Button
+              type="secondary"
+              large
+              className="new-account-create-form__button"
+              onClick={createClick}
+            >
+              {this.context.t('create')}
+            </Button>
+          </div>
         </div>
       </div>
     )

--- a/ui/app/pages/create-account/new-account.component.js
+++ b/ui/app/pages/create-account/new-account.component.js
@@ -49,7 +49,7 @@ export default class NewAccountCreateForm extends Component {
         <div className="new-account-create-form__input-label">
           {this.context.t('accountName')}
         </div>
-        <div className="new-account-create-form__account-name">
+        <div>
           <input
             className="new-account-create-form__input"
             value={newAccountName}


### PR DESCRIPTION
There was no space between the buttons in the create account form. This has been fixed.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/25517051/83184963-1d6c2800-a0df-11ea-8ddc-5394d2efc31c.png"/>
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/25517051/83184652-9a4ad200-a0de-11ea-9353-1a53f0487c5d.png"/>
</details>