### PR TITLE
fix vanishing list on firefox

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html class="browser-classname">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">

--- a/app/loading.html
+++ b/app/loading.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="browser-classname">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/app/notification.html
+++ b/app/notification.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html class="browser-classname">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">

--- a/app/phishing.html
+++ b/app/phishing.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="browser-classname">
   <head>
     <title>Ethereum Phishing Detection - MetaMask</title>
     <script src="./phishing-detect.js"></script>

--- a/app/popup.html
+++ b/app/popup.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html style="width:357px; height:600px;">
+<html style="width:357px; height:600px;" class="browser-classname">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">

--- a/app/trezor-usb-permissions.html
+++ b/app/trezor-usb-permissions.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="browser-classname">
 <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/app/unsupport.html
+++ b/app/unsupport.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="browser-classname">
     <head>
         <meta charset="UTF-8">
         <title>MetaMask</title>
@@ -48,7 +48,7 @@
                 letter-spacing: 1.3px;
                 color: #33559f;
             }
-        
+
         </style>
     <body>
         <div class="unsupport">

--- a/development/index.html
+++ b/development/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html>
+<html className="browser-classname">
   <head>
     <meta charset="utf-8">
     <title>MetaMask</title>
   </head>
   <body>
     <script src="./bundle.js" type="text/javascript" charset="utf-8"></script>
-    
+
     <style>
       html, body, #test-container, .super-dev-container {
         height: 100%;

--- a/ui/app/components/ui/tabs/index.scss
+++ b/ui/app/components/ui/tabs/index.scss
@@ -7,7 +7,6 @@
     border-bottom: 1px solid $geyser;
     background-color: $white;
 
-    position: sticky;
     top: 0;
     z-index: 1;
   }

--- a/ui/app/components/ui/tabs/index.scss
+++ b/ui/app/components/ui/tabs/index.scss
@@ -7,7 +7,14 @@
     border-bottom: 1px solid $geyser;
     background-color: $white;
 
+    position: sticky;
     top: 0;
     z-index: 1;
+  }
+}
+
+.firefox-browser .tabs {
+  &__list {
+    position: relative;
   }
 }


### PR DESCRIPTION
So, this resolves the issue of disappearing components on firefox when scrolling. but I dislike removing this functionality for chrome that doesn't have a problem with it. How difficult would it be to add the browser we are building for as a classname to the HTML element during the build step? We could then enable or disable rules based on browser


Additional details:
There is interplay between position: sticky and z-index. If I change z-index to 0 less of the components disappear when scrolling, if I change it to -1 everything is great but the tabs are gone so :P 