### PR TITLE
Update eth_accounts permission description

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "eth_accounts": {
-    "message": "Interact with your permitted address(es) [required]",
+    "message": "View its permitted addresses (required)",
     "description": "The description for the `eth_accounts` permission"
   },
   "connectedSites": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "eth_accounts": {
-    "message": "View your public address (required)",
+    "message": "Interact with your permitted address(es) [required]",
     "description": "The description for the `eth_accounts` permission"
   },
   "connectedSites": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "eth_accounts": {
-    "message": "View its permitted addresses (required)",
+    "message": "View your permitted accounts (required)",
     "description": "The description for the `eth_accounts` permission"
   },
   "connectedSites": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "eth_accounts": {
-    "message": "View your permitted accounts (required)",
+    "message": "View the addresses of your permitted accounts (required)",
     "description": "The description for the `eth_accounts` permission"
   },
   "connectedSites": {

--- a/ui/app/components/app/connected-accounts-list/connected-accounts-list-permissions/connected-accounts-list-permissions.component.js
+++ b/ui/app/components/app/connected-accounts-list/connected-accounts-list-permissions/connected-accounts-list-permissions.component.js
@@ -57,7 +57,7 @@ export default class ConnectedAccountsListPermissions extends PureComponent {
           <ul className="connected-accounts-permissions__list">
             {permissions.map(({ key: permissionName }) => (
               <li key={permissionName} className="connected-accounts-permissions__list-item">
-                <i className="fas fa-check-square" />&nbsp;{t(permissionName)}
+                <i className="fas fa-check-square" />{t(permissionName)}
               </li>
             ))}
           </ul>

--- a/ui/app/components/app/connected-accounts-list/connected-accounts-list-permissions/connected-accounts-list-permissions.component.js
+++ b/ui/app/components/app/connected-accounts-list/connected-accounts-list-permissions/connected-accounts-list-permissions.component.js
@@ -55,9 +55,9 @@ export default class ConnectedAccountsListPermissions extends PureComponent {
         >
           <p>{t('authorizedPermissions')}:</p>
           <ul className="connected-accounts-permissions__list">
-            {permissions.map(({ key }) => (
-              <li key={key} className="connected-accounts-permissions__list-item">
-                <i className="fas fa-check-square" />&nbsp;{t(key)}
+            {permissions.map(({ key: permissionName }) => (
+              <li key={permissionName} className="connected-accounts-permissions__list-item">
+                <i className="fas fa-check-square" />&nbsp;{t(permissionName)}
               </li>
             ))}
           </ul>

--- a/ui/app/components/app/connected-accounts-list/index.scss
+++ b/ui/app/components/app/connected-accounts-list/index.scss
@@ -113,7 +113,10 @@
   }
 
   &__list-item {
+    display: flex;
+
     i {
+      display: block;
       padding-right: 8px;
       font-size: 18px;
       color: $Grey-800;

--- a/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -67,23 +67,23 @@ export default class PermissionPageContainerContent extends PureComponent {
     } = this.props
     const { t } = this.context
 
-    const items = Object.keys(selectedPermissions).map((methodName) => {
+    const items = Object.keys(selectedPermissions).map((permissionName) => {
 
-      const description = t(methodName)
+      const description = t(permissionName)
       // don't allow deselecting eth_accounts
-      const isDisabled = methodName === 'eth_accounts'
+      const isDisabled = permissionName === 'eth_accounts'
 
       return (
         <div
           className="permission-approval-container__content__permission"
-          key={methodName}
+          key={permissionName}
           onClick={() => {
             if (!isDisabled) {
-              onPermissionToggle(methodName)
+              onPermissionToggle(permissionName)
             }
           }}
         >
-          { selectedPermissions[methodName]
+          { selectedPermissions[permissionName]
             ? <i title={t('permissionCheckedIconDescription')} className="fa fa-check-square" />
             : <i title={t('permissionUncheckedIconDescription')} className="fa fa-square" />
           }


### PR DESCRIPTION
### Permissions Description

#### Original
`View your public address (required)`

- Does not convey that multiple addresses can be viewed
- What does "public" mean?

#### New
`View the addresses of your permitted accounts (required)`

- Conveys that multiple addresses can be viewed
- Conveys that we're talking about account addresses
- "permitted" addresses (as opposed to "public") are the addresses that you're permitting!
  - Optionally, could change to "Connected" for now, but I don't like the term
    - I'd love for us to change the language of "Connected" to "Permitted" in some auspicious future

### Additional Changes

- Changes the names of variables used with `t` to get permissions description locale messages to `permissionName`, so that they're easier to search for.
- Ensures that the connected accounts popover permissions list handles longer permission names.