### PR TITLE
close details when button is pressed

### DIFF
--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -63,17 +63,15 @@ export default class TransactionListItemDetails extends PureComponent {
   }
 
   handleCancel = (event) => {
-    const { transactionGroup: { initialTransaction: { id } = {} } = {}, onCancel } = this.props
-
-    event.stopPropagation()
-    onCancel(id)
+    const { onCancel, onClose } = this.props
+    onCancel(event)
+    onClose()
   }
 
   handleRetry = (event) => {
-    const { transactionGroup: { initialTransaction: { id } = {} } = {}, onRetry } = this.props
-
-    event.stopPropagation()
-    onRetry(id)
+    const { onClose, onRetry } = this.props
+    onRetry(event)
+    onClose()
   }
 
   handleCopyTxId = () => {


### PR DESCRIPTION
Button behavior was broken by redesign work. Updated the details view to first call the onRetry or onCancel props and pass in the click event which it expect, then call the onClose prop to close the popover so that there aren't two modal-like experiences active at the same time. This behavior will be updated when we do the details redesign.

fixes #8684