### PR TITLE
Stop adding permissions middleware to trusted connections

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1548,7 +1548,7 @@ export default class MetamaskController extends EventEmitter {
       tabId = sender.tab.id
     }
 
-    const engine = this.setupProviderEngine({ origin, location: sender.url, extensionId, tabId })
+    const engine = this.setupProviderEngine({ origin, location: sender.url, extensionId, tabId, isInternal })
 
     // setup connection
     const providerStream = createEngineStream({ engine })
@@ -1581,8 +1581,9 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} options.location - The full URL of the sender
    * @param {extensionId} [options.extensionId] - The extension ID of the sender, if the sender is an external extension
    * @param {tabId} [options.tabId] - The tab ID of the sender - if the sender is within a tab
+   * @param {boolean} [options.isInternal] - True if called for a connection to an internal process
    **/
-  setupProviderEngine ({ origin, location, extensionId, tabId }) {
+  setupProviderEngine ({ origin, location, extensionId, tabId, isInternal = false }) {
     // setup json rpc engine stack
     const engine = new RpcEngine()
     const provider = this.provider
@@ -1610,8 +1611,10 @@ export default class MetamaskController extends EventEmitter {
     // filter and subscription polyfills
     engine.push(filterMiddleware)
     engine.push(subscriptionManager.middleware)
-    // permissions
-    engine.push(this.permissionsController.createMiddleware({ origin, extensionId }))
+    if (!isInternal) {
+      // permissions
+      engine.push(this.permissionsController.createMiddleware({ origin, extensionId }))
+    }
     // watch asset
     engine.push(this.preferencesController.requestWatchAsset.bind(this.preferencesController))
     // forward to metamask primary provider

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -102,10 +102,8 @@ describe('permissions controller', function () {
       assert.deepEqual(cAccounts, [], 'origin should have no accounts')
     })
 
-    it('does not handle "MetaMask" or "metamask" origins as special cases', async function () {
-      let metamaskAccounts = await permController.getAccounts('MetaMask')
-      assert.deepEqual(metamaskAccounts, [], 'origin should have no accounts')
-      metamaskAccounts = await permController.getAccounts('metamask')
+    it('does not handle "metamask" origin as special case', async function () {
+      const metamaskAccounts = await permController.getAccounts('metamask')
       assert.deepEqual(metamaskAccounts, [], 'origin should have no accounts')
     })
   })

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -102,8 +102,10 @@ describe('permissions controller', function () {
       assert.deepEqual(cAccounts, [], 'origin should have no accounts')
     })
 
-    it('does not handle "MetaMask" origin as special case', async function () {
-      const metamaskAccounts = await permController.getAccounts('MetaMask')
+    it('does not handle "MetaMask" or "metamask" origins as special cases', async function () {
+      let metamaskAccounts = await permController.getAccounts('MetaMask')
+      assert.deepEqual(metamaskAccounts, [], 'origin should have no accounts')
+      metamaskAccounts = await permController.getAccounts('metamask')
       assert.deepEqual(metamaskAccounts, [], 'origin should have no accounts')
     })
   })


### PR DESCRIPTION
Stops adding the permissions controller middleware to trusted connections.

This has the added benefit of preventing the extension from requesting permissions from itself, which was previously possible by sending e.g. `wallet_requestPermissions` over `ethereumProvider` from the UI.

Also fixes a test case that provided the wrong special origin value.