### PR TITLE
Fix tab content disappearing during scrolling on Firefox

### DIFF
--- a/ui/app/components/ui/tabs/index.scss
+++ b/ui/app/components/ui/tabs/index.scss
@@ -1,6 +1,9 @@
 @import 'tab/index';
 
 .tabs {
+  // Just for Firefox — https://github.com/MetaMask/metamask-extension/issues/8700
+  -moz-transform: translateZ(0);
+
   &__list {
     display: flex;
     justify-content: flex-start;


### PR DESCRIPTION
Refs https://github.com/MetaMask/metamask-extension/pull/8690#issuecomment-636051951
Fixes #8700

This PR fixes the issue with the tab content disappearing on Firefox.

With this change:

![](https://user-images.githubusercontent.com/1623628/83283219-6d1d2300-a1b5-11ea-9ace-4c027b68d7d9.gif)
