### PR TITLE
hide connected-status on metamask ext

### DIFF
--- a/ui/app/components/app/menu-bar/menu-bar.js
+++ b/ui/app/components/app/menu-bar/menu-bar.js
@@ -10,7 +10,6 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../../app/scripts/lib/enums'
 import { CONNECTED_ACCOUNTS_ROUTE } from '../../../helpers/constants/routes'
 import { useI18nContext } from '../../../hooks/useI18nContext'
 import { useMetricEvent } from '../../../hooks/useMetricEvent'
-
 import { getOriginOfCurrentTab } from '../../../selectors'
 
 export default function MenuBar () {

--- a/ui/app/components/app/menu-bar/menu-bar.js
+++ b/ui/app/components/app/menu-bar/menu-bar.js
@@ -1,4 +1,7 @@
 import React, { useState } from 'react'
+import extension from 'extensionizer'
+import { useHistory } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 import SelectedAccount from '../selected-account'
 import ConnectedStatusIndicator from '../connected-status-indicator'
 import AccountOptionsMenu from './account-options-menu'
@@ -7,7 +10,8 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../../app/scripts/lib/enums'
 import { CONNECTED_ACCOUNTS_ROUTE } from '../../../helpers/constants/routes'
 import { useI18nContext } from '../../../hooks/useI18nContext'
 import { useMetricEvent } from '../../../hooks/useMetricEvent'
-import { useHistory } from 'react-router-dom'
+
+import { getOriginOfCurrentTab } from '../../../selectors'
 
 export default function MenuBar () {
   const t = useI18nContext()
@@ -21,11 +25,14 @@ export default function MenuBar () {
   const history = useHistory()
   const [accountOptionsButtonElement, setAccountOptionsButtonElement] = useState(null)
   const [accountOptionsMenuOpen, setAccountOptionsMenuOpen] = useState(false)
+  const origin = useSelector(getOriginOfCurrentTab)
+
+  const showStatus = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP && origin !== extension.runtime.id
 
   return (
     <div className="menu-bar">
       {
-        getEnvironmentType() === ENVIRONMENT_TYPE_POPUP
+        showStatus
           ? <ConnectedStatusIndicator onClick={() => history.push(CONNECTED_ACCOUNTS_ROUTE)} />
           : null
       }


### PR DESCRIPTION
Extends the logic added by @Gudahtt to not show the connected-status-indicator on fullscreen to also apply when the currently active tab origin matches the extension id.