### PR TITLE
Remove unused `getToErrorObject` parameters

### DIFF
--- a/ui/app/pages/send/send-content/add-recipient/add-recipient.js
+++ b/ui/app/pages/send/send-content/add-recipient/add-recipient.js
@@ -11,7 +11,7 @@ import { checkExistingAddresses } from '../../../add-token/util'
 import ethUtil from 'ethereumjs-util'
 import contractMap from 'eth-contract-metadata'
 
-export function getToErrorObject (to, hasHexData = false, _, __, network) {
+export function getToErrorObject (to, hasHexData = false, network) {
   let toError = null
   if (!to) {
     if (!hasHexData) {

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
@@ -25,73 +25,50 @@ const {
 describe('add-recipient utils', function () {
 
   describe('getToErrorObject()', function () {
-    it('should return a required error if to is falsy', function () {
+    it('should return a required error if "to" is falsy', function () {
       assert.deepEqual(getToErrorObject(null), {
         to: REQUIRED_ERROR,
       })
     })
 
-    it('should return null if to is falsy and hexData is truthy', function () {
+    it('should return null if "to" is falsy and hexData is truthy', function () {
       assert.deepEqual(getToErrorObject(null, true), {
         to: null,
       })
     })
 
-    it('should return an invalid recipient error if to is truthy but invalid', function () {
+    it('should return an invalid recipient error if "to" is truthy but invalid', function () {
       assert.deepEqual(getToErrorObject('mockInvalidTo'), {
         to: INVALID_RECIPIENT_ADDRESS_ERROR,
       })
     })
 
-    it('should return null if to is truthy and valid', function () {
+    it('should return null if "to" is truthy and valid', function () {
       assert.deepEqual(getToErrorObject('0xabc123'), {
-        to: null,
-      })
-    })
-
-    it('should return null if to is truthy but part of state tokens', function () {
-      assert.deepEqual(getToErrorObject('0xabc123', false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
-        to: null,
-      })
-    })
-
-    it('should null if to is truthy part of tokens but sendToken falsy', function () {
-      assert.deepEqual(getToErrorObject('0xabc123', false, [{ 'address': '0xabc123' }]), {
-        to: null,
-      })
-    })
-
-    it('should return null if to is truthy but part of contract metadata', function () {
-      assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
-        to: null,
-      })
-    })
-    it('should null if to is truthy part of contract metadata but sendToken falsy', function () {
-      assert.deepEqual(getToErrorObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', false, [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: null,
       })
     })
   })
 
   describe('getToWarningObject()', function () {
-    it('should return a known address recipient if to is truthy but part of state tokens', function () {
+    it('should return a known address recipient error if "to" is a token address', function () {
       assert.deepEqual(getToWarningObject('0xabc123', [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })
     })
 
-    it('should null if to is truthy part of tokens but sendToken falsy', function () {
+    it('should null if "to" is a token address but sendToken is falsy', function () {
       assert.deepEqual(getToWarningObject('0xabc123', [{ 'address': '0xabc123' }]), {
         to: null,
       })
     })
 
-    it('should return a known address recipient if to is truthy but part of contract metadata', function () {
+    it('should return a known address recipient error if "to" is part of contract metadata', function () {
       assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })
     })
-    it('should null if to is truthy part of contract metadata but sendToken falsy', function () {
+    it('should null if "to" is part of contract metadata but sendToken is falsy', function () {
       assert.deepEqual(getToWarningObject('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', [{ 'address': '0xabc123' }], { 'address': '0xabc123' }), {
         to: KNOWN_RECIPIENT_ADDRESS_ERROR,
       })

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -228,7 +228,7 @@ export default class SendTransactionScreen extends Component {
       return this.setState({ toError: '', toWarning: '' })
     }
 
-    const toErrorObject = getToErrorObject(query, hasHexData, tokens, sendToken, network)
+    const toErrorObject = getToErrorObject(query, hasHexData, network)
     const toWarningObject = getToWarningObject(query, tokens, sendToken)
 
     this.setState({


### PR DESCRIPTION
The third and fourth parameters were unused, so they have been removed. The tests descriptions for both `getToErrorObject` and `getToWarningObject` have been improved as well.