### PR TITLE
Fix accounts menu styling

### DIFF
--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -53,8 +53,13 @@
 
   &__accounts-container {
     display: flex;
+    position: relative;
     flex-direction: column;
     z-index: 200;
+
+    @media screen and (max-width: 575px) {
+      max-height: 236px;
+    }
   }
 
   &__accounts {
@@ -158,10 +163,6 @@
     font-size: 16px;
     line-height: 18px;
     cursor: pointer;
-  }
-
-  &__accounts-container {
-    position: relative;
   }
 
   &__scroll-button {

--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -57,7 +57,7 @@
     flex-direction: column;
     z-index: 200;
 
-    @media screen and (max-width: 575px) {
+    @media (max-height: 600px) {
       max-height: 236px;
     }
   }


### PR DESCRIPTION
The accounts menu was getting clipped at the bottom in the popup under certain conditions. This has been fixed by the addition of a `max-height` property for the popup UI only.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/25517051/83340519-0ae42100-a28e-11ea-8e3d-753b397fbb6e.png" />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/25517051/83340522-27805900-a28e-11ea-8437-23f1265a818d.png" />
</details>

<details>
<summary>Appearance with < 5 Accounts Unaffected</summary>
<img src="https://user-images.githubusercontent.com/25517051/83340537-50a0e980-a28e-11ea-9175-919124c74a3a.png" />
</details>