### PR TITLE
fix crash on signature request

### DIFF
--- a/ui/app/hooks/useRetryTransaction.js
+++ b/ui/app/hooks/useRetryTransaction.js
@@ -19,7 +19,8 @@ import { useMetricEvent } from './useMetricEvent'
  */
 export function useRetryTransaction (transactionGroup) {
   const { primaryTransaction, initialTransaction } = transactionGroup
-  const gasPrice = primaryTransaction.txParams.gasPrice
+  // Signature requests do not have a txParams, but this hook is called indiscriminately
+  const gasPrice = primaryTransaction.txParams?.gasPrice
   const trackMetricsEvent = useMetricEvent(({
     eventOpts: {
       category: 'Navigation',


### PR DESCRIPTION
### Steps to Reproduce
1. open full-screen view
2. in a separate tab, navigate to test dapp
3. connect.
4. click sign typed data button
5. switch to full-screen tab, see screenshot

<details>
<summary>Screenshot of crash</summary>

<img src="https://user-images.githubusercontent.com/4448075/83431066-5d435000-a3fc-11ea-9de4-60d3b01dd410.png" />

</details>

txParams is not defined on signature request transactions, but hooks will still be called. I pulled gasPrice out of `primaryTransaction` instead of referencing inside the callback so that the callback isn't regenerated every time the primary transaction object changes. 