### PR TITLE
fix grid repositioning on label change

### DIFF
--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -223,7 +223,7 @@ describe('MetaMask', function () {
 
       it('finds the blockies toggle turned on', async function () {
         await driver.delay(regularDelayMs)
-        const toggleLabel = await driver.findElement(By.css('.toggle-button__status-label'))
+        const toggleLabel = await driver.findElement(By.css('.toggle-button__status'))
         const toggleLabelText = await toggleLabel.getText()
         assert.equal(toggleLabelText, 'ON')
       })

--- a/ui/app/components/ui/toggle-button/index.scss
+++ b/ui/app/components/ui/toggle-button/index.scss
@@ -1,7 +1,8 @@
 .toggle-button {
   display: flex;
+  $self: &;
 
-  &__status-label {
+  &__status {
     font-family: Roboto;
     font-style: normal;
     font-weight: normal;
@@ -10,5 +11,28 @@
     display: flex;
     align-items: center;
     text-transform: uppercase;
+    display: grid;
+  }
+
+  &__label-off, &__label-on {
+    grid-area: 1 / 1 / 1 / 1;
+  }
+
+  &__label-off {
+    visibility: hidden;
+  }
+
+  &__label-on {
+    visibility: visible;
+  }
+
+  &--off {
+    #{ $self }__label-off {
+      visibility: visible;
+    }
+
+    #{ $self }__label-on {
+      visibility: hidden;
+    }
   }
 }

--- a/ui/app/components/ui/toggle-button/toggle-button.component.js
+++ b/ui/app/components/ui/toggle-button/toggle-button.component.js
@@ -48,8 +48,10 @@ const colors = {
 const ToggleButton = (props) => {
   const { value, onToggle, offLabel, onLabel } = props
 
+  const modifier = value ? 'on' : 'off'
+
   return (
-    <div className="toggle-button">
+    <div className={`toggle-button toggle-button--${modifier}`}>
       <ReactToggleButton
         value={value}
         onToggle={onToggle}
@@ -60,7 +62,10 @@ const ToggleButton = (props) => {
         thumbAnimateRange={[3, 18]}
         colors={colors}
       />
-      <div className="toggle-button__status-label">{ value ? onLabel : offLabel }</div>
+      <div className="toggle-button__status">
+        <span className="toggle-button__label-off">{offLabel}</span>
+        <span className="toggle-button__label-on">{onLabel}</span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
resolves #8687 

Takes advantage of visibility: hidden/visible which does not remove the space the element takes up on the screen from the dom... as well as a single column/row grid to overlap both off/on labels in the toggle button. I'm not used to BEM syntax so I'm sure the class naming could use some work. 

This works for the alert screen because max-content will include visibility: hidden items. 

For this demo i modified the HTML content to a longer off statement: 
<details>
<summary>Mixed toggles</summary>
<img src="https://user-images.githubusercontent.com/4448075/83460000-03a64a00-a42b-11ea-83c3-a7494fe1bf4b.png" />
</details>
	
<details>
<summary>Both on</summary>
<img src="https://user-images.githubusercontent.com/4448075/83460071-33555200-a42b-11ea-84d9-6911efba94b2.png" />
</details>




