### PR TITLE
Fix manifest version bump script

### DIFF
--- a/.circleci/scripts/release-bump-manifest-version
+++ b/.circleci/scripts/release-bump-manifest-version
@@ -19,8 +19,8 @@ fi
 printf '%s\n' 'Updating the manifest version if needed'
 
 version="${CIRCLE_BRANCH/Version-v/}"
-updated_manifest="$(jq ".version = \"$version\"" app/manifest.json)"
-printf '%s\n' "$updated_manifest" > app/manifest.json
+updated_manifest="$(jq ".version = \"$version\"" app/manifest/_base.json)"
+printf '%s\n' "$updated_manifest" > app/manifest/_base.json
 
 if [[ -z $(git status --porcelain) ]]
 then
@@ -32,7 +32,7 @@ git \
     -c user.name='MetaMask Bot' \
     -c user.email='metamaskbot@users.noreply.github.com' \
     commit --message "${CIRCLE_BRANCH/-/ }" \
-        CHANGELOG.md app/manifest.json
+        CHANGELOG.md app/manifest/_base.json
 
 repo_slug="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 git push "https://$GITHUB_TOKEN_USER:$GITHUB_TOKEN@github.com/$repo_slug" "$CIRCLE_BRANCH"


### PR DESCRIPTION
The version bump script referenced the old file path for the manifest. It was stored as a single file called `manifest.json`, but it was split into `_base.json` and platform-specific manifests in #8140.

The manifest version bump script has been updated to reference `_base.json`, which is the piece that has the version property.