### PR TITLE
Add nonce to transaction details

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -474,7 +474,7 @@ describe('MetaMask', function () {
       const popoverCloseButton = await driver.findClickableElement(By.css('.popover-header__button'))
       const txGasPrices = await driver.findElements(By.css('.transaction-breakdown__value'))
       const txGasPriceLabels = await driver.findElements(By.css('.transaction-breakdown-row__title'))
-      await driver.wait(until.elementTextMatches(txGasPrices[3], /^10$/), 10000)
+      await driver.wait(until.elementTextMatches(txGasPrices[4], /^10$/), 10000)
       assert(txGasPriceLabels[2])
       await popoverCloseButton.click()
     })

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -16,6 +16,7 @@ export default class TransactionBreakdown extends PureComponent {
     className: PropTypes.string,
     nativeCurrency: PropTypes.string,
     showFiat: PropTypes.bool,
+    nonce: PropTypes.string,
     gas: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -29,13 +30,22 @@ export default class TransactionBreakdown extends PureComponent {
 
   render () {
     const { t } = this.context
-    const { gas, gasPrice, value, className, nativeCurrency, showFiat, totalInHex, gasUsed } = this.props
-
+    const { gas, gasPrice, value, className, nonce, nativeCurrency, showFiat, totalInHex, gasUsed } = this.props
     return (
       <div className={classnames('transaction-breakdown', className)}>
         <div className="transaction-breakdown__title">
           { t('transaction') }
         </div>
+        <TransactionBreakdownRow title="Nonce">
+          {typeof nonce !== 'undefined'
+            ? (
+              <HexToDecimal
+                className="transaction-breakdown__value"
+                value={nonce}
+              />
+            ) : null
+          }
+        </TransactionBreakdownRow>
         <TransactionBreakdownRow title={t('amount')}>
           <UserPreferencedCurrencyDisplay
             className="transaction-breakdown__value"

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -246,6 +246,7 @@ export default class TransactionListItemDetails extends PureComponent {
             </div>
             <div className="transaction-list-item-details__cards-container">
               <TransactionBreakdown
+                nonce={transactionGroup.initialTransaction.txParams.nonce}
                 transaction={transaction}
                 className="transaction-list-item-details__transaction-breakdown"
               />


### PR DESCRIPTION
#8564 removed the nonce from the transaction list item UI as per the design, but the design intended for the nonce to be relocated into the new transaction details view. #8564 used an incremental approach for implementing new designs and simply moved the details into a popover but did not implement the new UI. Therefore, the nonce was erroneously removed from the user's view. 

This PR is extending the old details UI to add the nonce to it until I can implement the new design. 