### PR TITLE
Use URL origin instead of hostname for permission domains

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -384,7 +384,7 @@ function setupController (initState, initLangCode) {
       if (remotePort.sender && remotePort.sender.tab && remotePort.sender.url) {
         const tabId = remotePort.sender.tab.id
         const url = new URL(remotePort.sender.url)
-        const origin = url.hostname
+        const { origin } = url
 
         remotePort.onMessage.addListener((msg) => {
           if (msg.data && msg.data.method === 'eth_requestAccounts') {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1487,7 +1487,7 @@ export default class MetamaskController extends EventEmitter {
    * @private
    * @param {*} connectionStream - The duplex stream to the per-page script,
    * for sending the reload attempt to.
-   * @param {string} hostname - The URL that triggered the suspicion.
+   * @param {string} hostname - The hostname that triggered the suspicion.
    */
   sendPhishingWarning (connectionStream, hostname) {
     const mux = setupMultiplex(connectionStream)
@@ -1538,7 +1538,7 @@ export default class MetamaskController extends EventEmitter {
   setupProviderConnection (outStream, sender, isInternal) {
     const origin = isInternal
       ? 'metamask'
-      : (new URL(sender.url)).hostname
+      : (new URL(sender.url)).origin
     let extensionId
     if (sender.id !== extension.runtime.id) {
       extensionId = sender.id
@@ -1577,7 +1577,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * A method for creating a provider that is safely restricted for the requesting domain.
    * @param {Object} options - Provider engine options
-   * @param {string} options.origin - The hostname of the sender
+   * @param {string} options.origin - The origin of the sender
    * @param {string} options.location - The full URL of the sender
    * @param {extensionId} [options.extensionId] - The extension ID of the sender, if the sender is an external extension
    * @param {tabId} [options.tabId] - The tab ID of the sender - if the sender is within a tab

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -95,7 +95,7 @@ async function queryCurrentActiveTab (windowType) {
     extension.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const [activeTab] = tabs
       const { title, url } = activeTab
-      const { hostname: origin, protocol } = url ? urlUtil.parse(url) : {}
+      const { origin, protocol } = url ? urlUtil.parse(url) : {}
       resolve({
         title, origin, protocol, url,
       })

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -21,7 +21,6 @@ import { EventEmitter } from 'events'
 import Dnode from 'dnode'
 import Eth from 'ethjs'
 import EthQuery from 'eth-query'
-import urlUtil from 'url'
 import launchMetaMaskUi from '../../ui'
 import StreamProvider from 'web3-stream-provider'
 import { setupMultiplex } from './lib/stream-utils.js'
@@ -95,10 +94,14 @@ async function queryCurrentActiveTab (windowType) {
     extension.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const [activeTab] = tabs
       const { title, url } = activeTab
-      const { origin, protocol } = url ? urlUtil.parse(url) : {}
-      resolve({
-        title, origin, protocol, url,
-      })
+
+      let urlData = {}
+      try {
+        urlData = new URL(url)
+      } catch (_) {}
+      const { origin, protocol } = urlData
+
+      resolve({ title, origin, protocol, url })
     })
   })
 }

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -94,12 +94,7 @@ async function queryCurrentActiveTab (windowType) {
     extension.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const [activeTab] = tabs
       const { title, url } = activeTab
-
-      let urlData = {}
-      try {
-        urlData = new URL(url)
-      } catch (_) {}
-      const { origin, protocol } = urlData
+      const { origin, protocol } = url ? new URL(url) : {}
 
       resolve({ title, origin, protocol, url })
     })

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -107,7 +107,7 @@ describe('MetaMask', function () {
       const address = content[1]
       assert.equal(await title.getText(), 'Signature Request')
       assert.equal(await name.getText(), 'Ether Mail')
-      assert.equal(await origin.getText(), '127.0.0.1')
+      assert.equal(await origin.getText(), 'http://127.0.0.1')
       assert.equal(await address.getText(), publicAddress.slice(0, 8) + '...' + publicAddress.slice(publicAddress.length - 8))
     })
 

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -107,7 +107,7 @@ describe('MetaMask', function () {
       const address = content[1]
       assert.equal(await title.getText(), 'Signature Request')
       assert.equal(await name.getText(), 'Ether Mail')
-      assert.equal(await origin.getText(), 'http://127.0.0.1')
+      assert.equal(await origin.getText(), 'http://127.0.0.1:8080')
       assert.equal(await address.getText(), publicAddress.slice(0, 8) + '...' + publicAddress.slice(publicAddress.length - 8))
     })
 

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -794,7 +794,7 @@ describe('MetaMaskController', function () {
 
     it('adds a tabId and origin to requests', function (done) {
       const messageSender = {
-        url: 'http://mycrypto.com',
+        url: 'https://mycrypto.com',
         tab: { id: 456 },
       }
       const streamTest = createThoughStream((chunk, _, cb) => {
@@ -824,7 +824,7 @@ describe('MetaMaskController', function () {
               'mock tx params',
               {
                 ...message,
-                origin: 'mycrypto.com',
+                origin: 'https://mycrypto.com',
                 tabId: 456,
               },
             ]
@@ -836,7 +836,7 @@ describe('MetaMaskController', function () {
 
     it('should add only origin to request if tabId not provided', function (done) {
       const messageSender = {
-        url: 'http://mycrypto.com',
+        url: 'https://mycrypto.com',
       }
       const streamTest = createThoughStream((chunk, _, cb) => {
         if (chunk.data && chunk.data.method) {
@@ -865,7 +865,7 @@ describe('MetaMaskController', function () {
               'mock tx params',
               {
                 ...message,
-                origin: 'mycrypto.com',
+                origin: 'https://mycrypto.com',
               },
             ]
           )
@@ -878,7 +878,7 @@ describe('MetaMaskController', function () {
   describe('#setupTrustedCommunication', function () {
     it('sets up controller dnode api for trusted communication', async function () {
       const messageSender = {
-        url: 'http://mycrypto.com',
+        url: 'https://mycrypto.com',
         tab: {},
       }
       const { promise, resolve } = deferredPromise()

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -794,7 +794,7 @@ describe('MetaMaskController', function () {
 
     it('adds a tabId and origin to requests', function (done) {
       const messageSender = {
-        url: 'https://mycrypto.com',
+        url: 'http://mycrypto.com',
         tab: { id: 456 },
       }
       const streamTest = createThoughStream((chunk, _, cb) => {
@@ -824,7 +824,7 @@ describe('MetaMaskController', function () {
               'mock tx params',
               {
                 ...message,
-                origin: 'https://mycrypto.com',
+                origin: 'http://mycrypto.com',
                 tabId: 456,
               },
             ]
@@ -836,7 +836,7 @@ describe('MetaMaskController', function () {
 
     it('should add only origin to request if tabId not provided', function (done) {
       const messageSender = {
-        url: 'https://mycrypto.com',
+        url: 'http://mycrypto.com',
       }
       const streamTest = createThoughStream((chunk, _, cb) => {
         if (chunk.data && chunk.data.method) {
@@ -865,7 +865,7 @@ describe('MetaMaskController', function () {
               'mock tx params',
               {
                 ...message,
-                origin: 'https://mycrypto.com',
+                origin: 'http://mycrypto.com',
               },
             ]
           )
@@ -878,7 +878,7 @@ describe('MetaMaskController', function () {
   describe('#setupTrustedCommunication', function () {
     it('sets up controller dnode api for trusted communication', async function () {
       const messageSender = {
-        url: 'https://mycrypto.com',
+        url: 'http://mycrypto.com',
         tab: {},
       }
       const { promise, resolve } = deferredPromise()

--- a/ui/app/selectors/tests/permissions.test.js
+++ b/ui/app/selectors/tests/permissions.test.js
@@ -17,7 +17,7 @@ describe('selectors', function () {
               'icon': 'https://peepeth.com/favicon-32x32.png',
               'name': 'Peepeth',
             },
-            'remix.ethereum.org': {
+            'https://remix.ethereum.org': {
               'icon': 'https://remix.ethereum.org/icon.png',
               'name': 'Remix - Ethereum IDE',
             },
@@ -45,7 +45,7 @@ describe('selectors', function () {
                 },
               ],
             },
-            'remix.ethereum.org': {
+            'https://remix.ethereum.org': {
               'permissions': [
                 {
                   '@context': [
@@ -62,7 +62,7 @@ describe('selectors', function () {
                   ],
                   'date': 1585685128948,
                   'id': '6b9615cc-64e4-4317-afab-3c4f8ee0244a',
-                  'invoker': 'remix.ethereum.org',
+                  'invoker': 'https://remix.ethereum.org',
                   'parentCapability': 'eth_accounts',
                 },
               ],
@@ -80,7 +80,7 @@ describe('selectors', function () {
         extensionId,
         name: 'Remix - Ethereum IDE',
         icon: 'https://remix.ethereum.org/icon.png',
-        key: 'remix.ethereum.org',
+        key: 'https://remix.ethereum.org',
       }])
     })
 
@@ -93,7 +93,7 @@ describe('selectors', function () {
               'icon': 'https://peepeth.com/favicon-32x32.png',
               'name': 'Peepeth',
             },
-            'remix.ethereum.org': {
+            'https://remix.ethereum.org': {
               'icon': 'https://remix.ethereum.org/icon.png',
               'name': 'Remix - Ethereum IDE',
             },
@@ -121,7 +121,7 @@ describe('selectors', function () {
                 },
               ],
             },
-            'remix.ethereum.org': {
+            'https://remix.ethereum.org': {
               'permissions': [
                 {
                   '@context': [
@@ -139,7 +139,7 @@ describe('selectors', function () {
                   ],
                   'date': 1585685128948,
                   'id': '6b9615cc-64e4-4317-afab-3c4f8ee0244a',
-                  'invoker': 'remix.ethereum.org',
+                  'invoker': 'https://remix.ethereum.org',
                   'parentCapability': 'eth_accounts',
                 },
               ],
@@ -152,7 +152,7 @@ describe('selectors', function () {
         extensionId,
         name: 'Remix - Ethereum IDE',
         icon: 'https://remix.ethereum.org/icon.png',
-        key: 'remix.ethereum.org',
+        key: 'https://remix.ethereum.org',
       }])
     })
   })
@@ -161,7 +161,7 @@ describe('selectors', function () {
     const mockState = {
       activeTab: {
         'title': 'Eth Sign Tests',
-        'origin': 'remix.ethereum.org',
+        'origin': 'https://remix.ethereum.org',
         'protocol': 'https:',
         'url': 'https://remix.ethereum.org/',
       },
@@ -185,7 +185,7 @@ describe('selectors', function () {
         },
         cachedBalances: {},
         domains: {
-          'remix.ethereum.org': {
+          'https://remix.ethereum.org': {
             'permissions': [
               {
                 '@context': [
@@ -206,7 +206,7 @@ describe('selectors', function () {
                 ],
                 'date': 1586359844177,
                 'id': '3aa65a8b-3bcb-4944-941b-1baa5fe0ed8b',
-                'invoker': 'remix.ethereum.org',
+                'invoker': 'https://remix.ethereum.org',
                 'parentCapability': 'eth_accounts',
               },
             ],
@@ -269,7 +269,7 @@ describe('selectors', function () {
           ],
         }],
         permissionsHistory: {
-          'remix.ethereum.org': {
+          'https://remix.ethereum.org': {
             'eth_accounts': {
               'accounts': {
                 '0x7250739de134d33ec7ab1ee592711e15098c9d2d': 1586359844192,
@@ -323,7 +323,7 @@ describe('selectors', function () {
     const mockState = {
       activeTab: {
         'title': 'Eth Sign Tests',
-        'origin': 'remix.ethereum.org',
+        'origin': 'https://remix.ethereum.org',
         'protocol': 'https:',
         'url': 'https://remix.ethereum.org/',
       },
@@ -343,7 +343,7 @@ describe('selectors', function () {
           },
         },
         domains: {
-          'remix.ethereum.org': {
+          'https://remix.ethereum.org': {
             'permissions': [
               {
                 '@context': [
@@ -361,7 +361,7 @@ describe('selectors', function () {
                 ],
                 'date': 1586359844177,
                 'id': '3aa65a8b-3bcb-4944-941b-1baa5fe0ed8b',
-                'invoker': 'remix.ethereum.org',
+                'invoker': 'https://remix.ethereum.org',
                 'parentCapability': 'eth_accounts',
               },
             ],
@@ -412,13 +412,13 @@ describe('selectors', function () {
           },
         },
         domainMetadata: {
-          'remix.ethereum.org': {
+          'https://remix.ethereum.org': {
             'icon': 'https://remix.ethereum.org/icon.png',
             'name': 'Remix - Ethereum IDE',
           },
         },
         permissionsHistory: {
-          'remix.ethereum.org': {
+          'https://remix.ethereum.org': {
             'eth_accounts': {
               'accounts': {
                 '0x7250739de134d33ec7ab1ee592711e15098c9d2d': 1586359844192,


### PR DESCRIPTION
`window.location.hostname` -> `window.location.origin`

We should include the protocol and port in permission domain origin strings, because they can point to completely different entities.