### PR TITLE
Fix `disabled` prop type in `AddToken` component

### DIFF
--- a/ui/app/pages/add-token/add-token.component.js
+++ b/ui/app/pages/add-token/add-token.component.js
@@ -315,7 +315,7 @@ class AddToken extends Component {
         title={this.context.t('addTokens')}
         tabsComponent={this.renderTabs()}
         onSubmit={() => this.handleNext()}
-        disabled={this.hasError() || !this.hasSelected()}
+        disabled={Boolean(this.hasError()) || !this.hasSelected()}
         onCancel={() => {
           clearPendingTokens()
           history.push(mostRecentOverviewPage)


### PR DESCRIPTION
The `disabled` prop being passed to the `PageContainer` component in the render function for the `AddToken` component was a string in some cases. It should always be a boolean. It has been cast to a boolean in the one case where it was a string.