### PR TITLE
Fix hide token e2e test

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -1223,8 +1223,7 @@ describe('MetaMask', function () {
 
       const confirmHideModal = await driver.findElement(By.css('span .modal'))
 
-      const byHideTokenConfirmationButton = By.css('.hide-token-confirmation__button')
-      await driver.clickElement(byHideTokenConfirmationButton)
+      await driver.clickElement(By.css('[data-testid="hide-token-confirmation__hide"]'))
 
       await driver.wait(until.stalenessOf(confirmHideModal))
     })
@@ -1232,7 +1231,6 @@ describe('MetaMask', function () {
 
   describe('Add existing token using search', function () {
     it('clicks on the Add Token button', async function () {
-      await driver.clickElement(By.css('[data-testid="asset__back"]'))
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Add Token')]`))
       await driver.delay(regularDelayMs)
     })

--- a/ui/app/components/app/modals/hide-token-confirmation-modal.js
+++ b/ui/app/components/app/modals/hide-token-confirmation-modal.js
@@ -65,12 +65,14 @@ class HideTokenConfirmationModal extends Component {
           <div className="hide-token-confirmation__buttons">
             <button
               className="btn-default hide-token-confirmation__button btn--large"
+              data-testid="hide-token-confirmation__cancel"
               onClick={() => hideModal()}
             >
               {this.context.t('cancel')}
             </button>
             <button
               className="btn-secondary hide-token-confirmation__button btn--large"
+              data-testid="hide-token-confirmation__hide"
               onClick={() => hideToken(address)}
             >
               {this.context.t('hide')}


### PR DESCRIPTION
The e2e test for the "Hide token" functionality was incorrectly clicking "Cancel" on the "Hide token" modal, thus not actually testing that that token was hidden at all.

The "Confirm" button is now selected using a test id, to ensure the wrong button isn't selected.