### PR TITLE
Update Seed Phrase Functionality on Account Import

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -366,7 +366,7 @@
     "message": "Confirmed"
   },
   "confirmPassword": {
-    "message": "Confirm Password"
+    "message": "Confirm password"
   },
   "confirmSecretBackupPhrase": {
     "message": "Confirm your Secret Backup Phrase"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1277,8 +1277,11 @@
   "seedPhrasePlaceholder": {
     "message": "Separate each word with a single space"
   },
-  "hideSeedPhrase": {
-    "message": "Hide seed phrase"
+  "seedPhrasePlaceholderPaste": {
+    "message": "Paste seed phrase from clipboard"
+  },
+  "showSeedPhrase": {
+    "message": "Show seed phrase"
   },
   "seedPhraseReq": {
     "message": "Seed phrases contain 12, 15, 18, 21, or 24 words"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1277,6 +1277,9 @@
   "seedPhrasePlaceholder": {
     "message": "Separate each word with a single space"
   },
+  "hideSeedPhrase": {
+    "message": "Hide seed phrase"
+  },
   "seedPhraseReq": {
     "message": "Seed phrases contain 12, 15, 18, 21, or 24 words"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -783,7 +783,7 @@
     "message": "Import an account with seed phrase"
   },
   "importWallet": {
-    "message": "Import Wallet"
+    "message": "Import wallet"
   },
   "importYourExisting": {
     "message": "Import your existing wallet using a 12 word seed phrase"
@@ -982,7 +982,7 @@
     "message": "New Contract"
   },
   "newPassword": {
-    "message": "New Password (min 8 chars)"
+    "message": "New password (min 8 chars)"
   },
   "newNetwork": {
     "message": "New Network"
@@ -1704,7 +1704,7 @@
     "message": "Visit our web site"
   },
   "walletSeed": {
-    "message": "Wallet Seed"
+    "message": "Seed phrase"
   },
   "welcomeBack": {
     "message": "Welcome Back!"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -780,7 +780,7 @@
     "message": " Imported accounts will not be associated with your originally created MetaMask account seedphrase. Learn more about imported accounts "
   },
   "importAccountSeedPhrase": {
-    "message": "Import an Account with Seed Phrase"
+    "message": "Import an account with seed phrase"
   },
   "importWallet": {
     "message": "Import Wallet"

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -74,7 +74,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('imports a seed phrase', async function () {
-      const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
+      const [seedTextArea] = await driver.findElements(By.css('input[placeholder="Paste seed phrase from clipboard"]'))
       await seedTextArea.sendKeys(testSeedPhrase)
       await driver.delay(regularDelayMs)
 
@@ -83,7 +83,7 @@ describe('Using MetaMask with an existing account', function () {
       const [confirmPassword] = await driver.findElements(By.id('confirm-password'))
       confirmPassword.sendKeys('correct horse battery staple')
 
-      await driver.clickElement(By.css('.first-time-flow__checkbox'))
+      await driver.clickElement(By.css('.first-time-flow__terms'))
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Import')]`))
       await driver.delay(regularDelayMs)

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -64,7 +64,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('clicks the "Import Wallet" option', async function () {
-      await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
+      await driver.clickElement(By.xpath(`//button[contains(text(), 'Import wallet')]`))
       await driver.delay(largeDelayMs)
     })
 

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -71,7 +71,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('imports a seed phrase', async function () {
-      const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
+      const [seedTextArea] = await driver.findElements(By.css('input[placeholder="Paste seed phrase from clipboard"]'))
       await seedTextArea.sendKeys(testSeedPhrase)
       await driver.delay(regularDelayMs)
 
@@ -80,7 +80,7 @@ describe('Using MetaMask with an existing account', function () {
       const [confirmPassword] = await driver.findElements(By.id('confirm-password'))
       confirmPassword.sendKeys('correct horse battery staple')
 
-      await driver.clickElement(By.css('.first-time-flow__checkbox'))
+      await driver.clickElement(By.css('.first-time-flow__terms'))
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Import')]`))
       await driver.delay(regularDelayMs)

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -61,7 +61,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('clicks the "Import Wallet" option', async function () {
-      await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
+      await driver.clickElement(By.xpath(`//button[contains(text(), 'Import wallet')]`))
       await driver.delay(largeDelayMs)
     })
 

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -74,7 +74,7 @@ describe('MetaMask', function () {
       })
 
       it('imports a seed phrase', async function () {
-        const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
+        const [seedTextArea] = await driver.findElements(By.css('input[placeholder="Paste seed phrase from clipboard"]'))
         await seedTextArea.sendKeys(testSeedPhrase)
         await driver.delay(regularDelayMs)
 
@@ -83,7 +83,7 @@ describe('MetaMask', function () {
         const [confirmPassword] = await driver.findElements(By.id('confirm-password'))
         confirmPassword.sendKeys('correct horse battery staple')
 
-        await driver.clickElement(By.css('.first-time-flow__checkbox'))
+        await driver.clickElement(By.css('.first-time-flow__terms'))
 
         await driver.clickElement(By.xpath(`//button[contains(text(), 'Import')]`))
         await driver.delay(regularDelayMs)
@@ -180,7 +180,7 @@ describe('MetaMask', function () {
       })
 
       it('imports a seed phrase', async function () {
-        const [seedTextArea] = await driver2.findElements(By.css('textarea.first-time-flow__textarea'))
+        const [seedTextArea] = await driver2.findElements(By.css('input[placeholder="Paste seed phrase from clipboard"]'))
         await seedTextArea.sendKeys(testSeedPhrase)
         await driver2.delay(regularDelayMs)
 
@@ -189,7 +189,7 @@ describe('MetaMask', function () {
         const [confirmPassword] = await driver2.findElements(By.id('confirm-password'))
         confirmPassword.sendKeys('correct horse battery staple')
 
-        await driver2.clickElement(By.css('.first-time-flow__checkbox'))
+        await driver2.clickElement(By.css('.first-time-flow__terms'))
 
         await driver2.clickElement(By.xpath(`//button[contains(text(), 'Import')]`))
         await driver2.delay(regularDelayMs)

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -64,7 +64,7 @@ describe('MetaMask', function () {
       })
 
       it('clicks the "Import Wallet" option', async function () {
-        await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
+        await driver.clickElement(By.xpath(`//button[contains(text(), 'Import wallet')]`))
         await driver.delay(largeDelayMs)
       })
 
@@ -170,7 +170,7 @@ describe('MetaMask', function () {
       })
 
       it('clicks the "Import Wallet" option', async function () {
-        await driver2.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
+        await driver2.clickElement(By.xpath(`//button[contains(text(), 'Import wallet')]`))
         await driver2.delay(largeDelayMs)
       })
 

--- a/test/e2e/web3.spec.js
+++ b/test/e2e/web3.spec.js
@@ -70,7 +70,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('imports a seed phrase', async function () {
-      const [seedTextArea] = await driver.findElements(By.css('textarea.first-time-flow__textarea'))
+      const [seedTextArea] = await driver.findElements(By.css('input[placeholder="Paste seed phrase from clipboard"]'))
       await seedTextArea.sendKeys(testSeedPhrase)
       await driver.delay(regularDelayMs)
 
@@ -79,7 +79,7 @@ describe('Using MetaMask with an existing account', function () {
       const [confirmPassword] = await driver.findElements(By.id('confirm-password'))
       confirmPassword.sendKeys('correct horse battery staple')
 
-      await driver.clickElement(By.css('.first-time-flow__checkbox'))
+      await driver.clickElement(By.css('.first-time-flow__terms'))
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Import')]`))
       await driver.delay(regularDelayMs)

--- a/test/e2e/web3.spec.js
+++ b/test/e2e/web3.spec.js
@@ -60,7 +60,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('clicks the "Import Wallet" option', async function () {
-      await driver.clickElement(By.xpath(`//button[contains(text(), 'Import Wallet')]`))
+      await driver.clickElement(By.xpath(`//button[contains(text(), 'Import wallet')]`))
       await driver.delay(largeDelayMs)
     })
 

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -306,7 +306,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
         />
         <div className="first-time-flow__checkbox-container" onClick={this.toggleTermsCheck}>
           <div
-            className="first-time-flow__checkbox"
+            className="first-time-flow__checkbox first-time-flow__terms"
             tabIndex="0"
             role="checkbox"
             onKeyPress={this.onTermsKeyPress}

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -257,7 +257,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
             />
           )}
           <label>Hide seed phrase <input
-            type="radio"
+            type="checkbox"
             onClick={this.toggleHideSeedPhrase}
             checked={hideSeedPhrase}
           /></label>

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -23,7 +23,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
 
   state = {
     seedPhrase: '',
-    hideSeedPhrase: false,
+    showSeedPhrase: false,
     password: '',
     confirmPassword: '',
     seedPhraseError: '',
@@ -196,15 +196,15 @@ export default class ImportWithSeedPhrase extends PureComponent {
     }))
   }
 
-  toggleHideSeedPhrase = () => {
-    this.setState(({ hideSeedPhrase }) => ({
-      hideSeedPhrase: !hideSeedPhrase,
+  toggleShowSeedPhrase = () => {
+    this.setState(({ showSeedPhrase }) => ({
+      showSeedPhrase: !showSeedPhrase,
     }))
   }
 
   render () {
     const { t } = this.context
-    const { seedPhraseError, hideSeedPhrase, passwordError, confirmPasswordError, termsChecked } = this.state
+    const { seedPhraseError, showSeedPhrase, passwordError, confirmPasswordError, termsChecked } = this.state
 
     return (
       <form
@@ -241,30 +241,37 @@ export default class ImportWithSeedPhrase extends PureComponent {
         </div>
         <div className="first-time-flow__textarea-wrapper">
           <label>{ t('walletSeed') }</label>
-          {hideSeedPhrase ? (
-            <TextField
-              className="first-time-flow__textarea"
-              type="password"
-              onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
-              value={this.state.seedPhrase}
-              placeholder={t('seedPhrasePlaceholder')}
-            />
-          ) : (
+          {showSeedPhrase ? (
             <textarea
               className="first-time-flow__textarea"
               onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
               value={this.state.seedPhrase}
               placeholder={t('seedPhrasePlaceholder')}
             />
-          )}
-          <label className="first-time-flow__label">
-            <input
-              type="checkbox"
-              onClick={this.toggleHideSeedPhrase}
-              checked={hideSeedPhrase}
+          ) : (
+            <TextField
+              className="first-time-flow__textarea first-time-flow__seedphrase"
+              type="password"
+              onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
+              value={this.state.seedPhrase}
+              placeholder={t('seedPhrasePlaceholderPaste')}
             />
-            { t('hideSeedPhrase') }
-          </label>
+          )}
+          <div className="first-time-flow__checkbox-container" onClick={this.toggleShowSeedPhrase}>
+            <div
+              className="first-time-flow__checkbox"
+              tabIndex="0"
+              role="checkbox"
+              onKeyPress={this.toggleShowSeedPhrase}
+              aria-checked={showSeedPhrase}
+              aria-labelledby="ftf-chk1-label"
+            >
+              {showSeedPhrase ? <i className="fa fa-check fa-2x" /> : null}
+            </div>
+            <span id="ftf-chk1-label" className="first-time-flow__checkbox-label">
+              { t('showSeedPhrase') }
+            </span>
+          </div>
         </div>
         {
           seedPhraseError && (

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -240,18 +240,22 @@ export default class ImportWithSeedPhrase extends PureComponent {
         </div>
         <div className="first-time-flow__textarea-wrapper">
           <label>{ t('walletSeed') }</label>
-          {hideSeedPhrase ? <TextField
-            className="first-time-flow__textarea"
-            type="password"
-            onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
-            value={this.state.seedPhrase}
-            placeholder={t('seedPhrasePlaceholder')}
-          /> : <textarea
-            className="first-time-flow__textarea"
-            onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
-            value={this.state.seedPhrase}
-            placeholder={t('seedPhrasePlaceholder')}
-          />}
+          {hideSeedPhrase ? (
+            <TextField
+              className="first-time-flow__textarea"
+              type="password"
+              onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
+              value={this.state.seedPhrase}
+              placeholder={t('seedPhrasePlaceholder')}
+            />
+          ) : (
+            <textarea
+              className="first-time-flow__textarea"
+              onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
+              value={this.state.seedPhrase}
+              placeholder={t('seedPhrasePlaceholder')}
+            />
+          )}
           <label>Hide seed phrase <input
             type="radio"
             onClick={this.toggleHideSeedPhrase}

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -263,7 +263,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
               onClick={this.toggleHideSeedPhrase}
               checked={hideSeedPhrase}
             />
-          Hide seed phrase
+            { t('hideSeedPhrase') }
           </label>
         </div>
         {

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -197,7 +197,9 @@ export default class ImportWithSeedPhrase extends PureComponent {
   }
 
   toggleHideSeedPhrase = () => {
-    this.setState(({ hideSeedPhrase }) => ({ !hideSeedPhrase }))
+    this.setState(({ hideSeedPhrase }) => ({
+      hideSeedPhrase: !hideSeedPhrase,
+    }))
   }
 
   render () {

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -257,7 +257,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
               placeholder={t('seedPhrasePlaceholder')}
             />
           )}
-          <label>
+          <label className="first-time-flow__label">
             <input
               type="checkbox"
               onClick={this.toggleHideSeedPhrase}

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -23,6 +23,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
 
   state = {
     seedPhrase: '',
+    hideSeedPhrase: false,
     password: '',
     confirmPassword: '',
     seedPhraseError: '',
@@ -195,9 +196,14 @@ export default class ImportWithSeedPhrase extends PureComponent {
     }))
   }
 
+  toggleHideSeedPhrase = () => {
+    const { hideSeedPhrase } = this.state
+    this.setState({ hideSeedPhrase: !hideSeedPhrase })
+  }
+
   render () {
     const { t } = this.context
-    const { seedPhraseError, passwordError, confirmPasswordError, termsChecked } = this.state
+    const { seedPhraseError, hideSeedPhrase, passwordError, confirmPasswordError, termsChecked } = this.state
 
     return (
       <form
@@ -234,12 +240,23 @@ export default class ImportWithSeedPhrase extends PureComponent {
         </div>
         <div className="first-time-flow__textarea-wrapper">
           <label>{ t('walletSeed') }</label>
-          <textarea
+          {hideSeedPhrase ? <TextField
+            className="first-time-flow__textarea"
+            type="password"
+            onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
+            value={this.state.seedPhrase}
+            placeholder={t('seedPhrasePlaceholder')}
+          /> : <textarea
             className="first-time-flow__textarea"
             onChange={(e) => this.handleSeedPhraseChange(e.target.value)}
             value={this.state.seedPhrase}
             placeholder={t('seedPhrasePlaceholder')}
-          />
+          />}
+          <label>Hide seed phrase <input
+            type="radio"
+            onClick={this.toggleHideSeedPhrase}
+            checked={hideSeedPhrase}
+          /></label>
         </div>
         {
           seedPhraseError && (

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -257,7 +257,6 @@ export default class ImportWithSeedPhrase extends PureComponent {
           )}
           <label>
             <input
-              name="hideSeedPhrase"
               type="checkbox"
               onClick={this.toggleHideSeedPhrase}
               checked={hideSeedPhrase}

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -263,7 +263,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
               onClick={this.toggleHideSeedPhrase}
               checked={hideSeedPhrase}
             />
-          Hide seed phrase 
+          Hide seed phrase
           </label>
         </div>
         {

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -256,11 +256,15 @@ export default class ImportWithSeedPhrase extends PureComponent {
               placeholder={t('seedPhrasePlaceholder')}
             />
           )}
-          <label>Hide seed phrase <input
-            type="checkbox"
-            onClick={this.toggleHideSeedPhrase}
-            checked={hideSeedPhrase}
-          /></label>
+          <label>
+            <input
+              name="hideSeedPhrase"
+              type="checkbox"
+              onClick={this.toggleHideSeedPhrase}
+              checked={hideSeedPhrase}
+            />
+          Hide seed phrase 
+          </label>
         </div>
         {
           seedPhraseError && (

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -197,8 +197,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
   }
 
   toggleHideSeedPhrase = () => {
-    const { hideSeedPhrase } = this.state
-    this.setState({ hideSeedPhrase: !hideSeedPhrase })
+    this.setState(({ hideSeedPhrase }) => ({ !hideSeedPhrase }))
   }
 
   render () {

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -77,7 +77,6 @@
     direction: ltr;
     font-size: 1rem;
     font-family: Roboto;
-    height: 190px;
     border: 1px solid #CDCDCD;
     border-radius: 6px;
     background-color: #FFFFFF;

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -56,11 +56,6 @@
     max-width: 350px;
   }
 
-  &__label {
-    text-align: right;
-    padding: 10px 0;
-  }
-
   &__textarea-wrapper {
     margin-bottom: 8px;
     display: inline-flex;

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -90,6 +90,10 @@
     margin-top: 8px;
   }
 
+  &__seedphrase {
+    margin-top: 9px !important;
+  }
+
   &__breadcrumbs {
     margin: 36px 0;
   }

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -56,6 +56,11 @@
     max-width: 350px;
   }
 
+  &__label {
+    text-align: right;
+    padding: 10px 0;
+  }
+
   &__textarea-wrapper {
     margin-bottom: 8px;
     display: inline-flex;


### PR DESCRIPTION
I had the thought the other day that the seed phrase input should be treated as a password; any user using something like `pass` doesn't really need to have the seed phrase visible in the UI (and likely doesn't want it to be?).

**Rational**:

I keep my seedphrase in a password manager that has a "copy to clipboard" functionality. the idea being that I never want to display my seedphrase (or passwords) on screen (in plain text). the textarea is now a password field and you can toggle back to a textarea if you need to:

**By default the seed phrase input is treated as a password field waiting to accept precious data from the user clipboard:**

![image](https://user-images.githubusercontent.com/675259/84295790-0b47ac00-ab19-11ea-87ff-d49e14026ba1.png)

**Now I can import my seedphrase without ever displaying it on screen:**

![image](https://user-images.githubusercontent.com/675259/84295861-24505d00-ab19-11ea-88f9-c0fd1eb6095a.png)

**If I need to input the seed phrase manually i can choose to show the seed phrase textarea:**

![image](https://user-images.githubusercontent.com/675259/84295939-4518b280-ab19-11ea-9601-6aeb53b4491a.png)

**Notes:**

<strike>This obviously needs some design love, some text to be translated etc. but I just wanted to open this to kick off a conversation.</strike>

This should be good now that we've had input from the design team