### PR TITLE
Make asset page breadcrumb clickable

### DIFF
--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -19,11 +19,11 @@
 .asset-breadcrumb {
   font-size: 14px;
   color: $Black-100;
+  background-color: inherit;
 
   &__chevron {
     padding: 0 10px 0 2px;
     font-size: 16px;
-    background-color: inherit;
   }
 
   &__asset {

--- a/ui/app/pages/asset/components/asset-breadcrumb.js
+++ b/ui/app/pages/asset/components/asset-breadcrumb.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 
 const AssetBreadcrumb = ({ accountName, assetName, onBack }) => {
   return (
-    <div className="asset-breadcrumb">
-      <button className="fas fa-chevron-left asset-breadcrumb__chevron" data-testid="asset__back" onClick={onBack} />
+    <button className="asset-breadcrumb" onClick={onBack} >
+      <i className="fas fa-chevron-left asset-breadcrumb__chevron" data-testid="asset__back" />
       <span>
         {accountName}
       </span>
@@ -12,7 +12,7 @@ const AssetBreadcrumb = ({ accountName, assetName, onBack }) => {
       <span className="asset-breadcrumb__asset">
         { assetName }
       </span>
-    </div>
+    </button>
   )
 }
 


### PR DESCRIPTION
The entire asset page breadcrumb is now clickable. Clicking it will bring the user back to the home page.