### PR TITLE
Increase padding of empty transaction list

### DIFF
--- a/ui/app/components/app/transaction-list/index.scss
+++ b/ui/app/components/app/transaction-list/index.scss
@@ -34,7 +34,7 @@
     flex: 1;
     display: grid;
     grid-template-rows: auto;
-    padding-top: 8px;
+    padding-top: 24px;
   }
 
   &__empty-text {


### PR DESCRIPTION
The top padding of the empty transaction list now mirrors the space below the buttons in the overview.