### PR TITLE
move activation logic into token rates controller

### DIFF
--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -17,11 +17,10 @@ export default class TokenRatesController {
    *
    * @param {Object} [config] - Options to configure controller
    */
-  constructor ({ interval = DEFAULT_INTERVAL, currency, preferences } = {}) {
+  constructor ({ currency, preferences } = {}) {
     this.store = new ObservableStore()
     this.currency = currency
     this.preferences = preferences
-    this.interval = interval
   }
 
   /**
@@ -51,19 +50,6 @@ export default class TokenRatesController {
   }
 
   /**
-   * @type {Number}
-   */
-  set interval (interval) {
-    this._handle && clearInterval(this._handle)
-    if (!interval) {
-      return
-    }
-    this._handle = setInterval(() => {
-      this.updateExchangeRates()
-    }, interval)
-  }
-
-  /**
    * @type {Object}
    */
   set preferences (preferences) {
@@ -84,5 +70,20 @@ export default class TokenRatesController {
   set tokens (tokens) {
     this._tokens = tokens
     this.updateExchangeRates()
+  }
+
+  start (interval = DEFAULT_INTERVAL) {
+    this._handle && clearInterval(this._handle)
+    if (!interval) {
+      return
+    }
+    this._handle = setInterval(() => {
+      this.updateExchangeRates()
+    }, interval)
+    this.updateExchangeRates()
+  }
+
+  stop () {
+    this._handle && clearInterval(this._handle)
   }
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -170,9 +170,11 @@ export default class MetamaskController extends EventEmitter {
       if (activeControllerConnections > 0) {
         this.accountTracker.start()
         this.incomingTransactionsController.start()
+        this.tokenRatesController.start()
       } else {
         this.accountTracker.stop()
         this.incomingTransactionsController.stop()
+        this.tokenRatesController.stop()
       }
     })
 
@@ -281,10 +283,6 @@ export default class MetamaskController extends EventEmitter {
     this.encryptionPublicKeyManager = new EncryptionPublicKeyManager()
     this.typedMessageManager = new TypedMessageManager({ networkController: this.networkController })
 
-    // ensure isClientOpenAndUnlocked is updated when memState updates
-    this.on('update', (memState) => {
-      this.isClientOpenAndUnlocked = memState.isUnlocked && this._isClientOpen
-    })
 
     this.store.updateStructure({
       AppStateController: this.appStateController.store,
@@ -2032,18 +2030,7 @@ export default class MetamaskController extends EventEmitter {
    */
   set isClientOpen (open) {
     this._isClientOpen = open
-    this.isClientOpenAndUnlocked = this.isUnlocked() && open
     this.detectTokensController.isOpen = open
-  }
-
-  /**
-   * A method for activating the retrieval of price data,
-   * which should only be fetched when the UI is visible.
-   * @private
-   * @param {boolean} active - True if price data should be getting fetched.
-   */
-  set isClientOpenAndUnlocked (active) {
-    this.tokenRatesController.isActive = active
   }
 
   /**

--- a/test/unit/app/controllers/token-rates-controller.js
+++ b/test/unit/app/controllers/token-rates-controller.js
@@ -13,8 +13,11 @@ describe('TokenRatesController', function () {
 
   it('should poll on correct interval', async function () {
     const stub = sinon.stub(global, 'setInterval')
-    new TokenRatesController({ interval: 1337 }) // eslint-disable-line no-new
+    const rateController = new TokenRatesController() // eslint-disable-line no-new
+    rateController.start(1337)
+
     assert.strictEqual(stub.getCall(0).args[1], 1337)
     stub.restore()
+    rateController.stop()
   })
 })


### PR DESCRIPTION
I had previously witnessed an issue where token rates were not fetched until 3 minutes (current default interval in the token rates controller) after the user unlocked their account. I updated this by moving to a start/stop system instead of creating an interval on construction. This allows an immediate fetch of token rates when the user unlocks and then kicking off an interval that ticks every 3 minutes. When the account is locked the interval is cleared.