### PR TITLE
Fix 'Remove account' in Account Options menu

### DIFF
--- a/ui/app/components/app/menu-bar/account-options-menu.js
+++ b/ui/app/components/app/menu-bar/account-options-menu.js
@@ -118,7 +118,7 @@ export default function AccountOptionsMenu ({ anchorElement, onClose }) {
           ? (
             <MenuItem
               onClick={() => {
-                dispatch(showModal({ name: 'CONFIRM_REMOVE_ACCOUNT', selectedIdentity }))
+                dispatch(showModal({ name: 'CONFIRM_REMOVE_ACCOUNT', identity: selectedIdentity }))
                 onClose()
               }}
               iconClassName="fas fa-trash-alt"


### PR DESCRIPTION
The 'Remove account' button in the Account Options menu was broken. Clicking it would crash the UI. It now correctly opens the 'Remove Account' modal.