### PR TITLE
Fix permissions connect close and redirect behavior

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -32,6 +32,9 @@ export default class PermissionConnect extends Component {
     confirmPermissionPath: PropTypes.string.isRequired,
     page: PropTypes.string.isRequired,
     targetDomainMetadata: PropTypes.object,
+    location: PropTypes.shape({
+      pathname: PropTypes.string,
+    }).isRequired,
   }
 
   static defaultProps = {
@@ -100,7 +103,7 @@ export default class PermissionConnect extends Component {
   }
 
   redirectFlow (accepted) {
-    const { history } = this.props
+    const { history, location, confirmPermissionPath } = this.props
 
     this.setState({
       redirecting: true,
@@ -111,7 +114,11 @@ export default class PermissionConnect extends Component {
     if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       setTimeout(async () => {
         global.platform.closeCurrentWindow()
-      }, 2000)
+      }, 1500)
+    } else if (location.pathname === confirmPermissionPath) {
+      setTimeout(async () => {
+        history.push(DEFAULT_ROUTE)
+      }, 1500)
     } else {
       history.push(DEFAULT_ROUTE)
     }
@@ -140,11 +147,10 @@ export default class PermissionConnect extends Component {
     }
   }
 
-  cancelPermissionsRequest = async (requestId) => {
+  cancelPermissionsRequest = (requestId) => {
     const { history, rejectPermissionsRequest } = this.props
     if (requestId) {
-      await rejectPermissionsRequest(requestId)
-
+      rejectPermissionsRequest(requestId)
       if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
         window.close()
       } else {

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -144,10 +144,13 @@ export default class PermissionConnect extends Component {
     }
   }
 
-  cancelPermissionsRequest = (requestId) => {
+  cancelPermissionsRequest = async (requestId) => {
+
     const { history, rejectPermissionsRequest } = this.props
+
     if (requestId) {
-      rejectPermissionsRequest(requestId)
+      await rejectPermissionsRequest(requestId)
+
       if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
         window.close()
       } else {

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -19,14 +19,14 @@ export default class PermissionConnect extends Component {
     getRequestAccountTabIds: PropTypes.func.isRequired,
     getCurrentWindowTab: PropTypes.func.isRequired,
     accounts: PropTypes.array.isRequired,
-    originName: PropTypes.string,
+    origin: PropTypes.string,
     showNewAccountModal: PropTypes.func.isRequired,
     newAccountNumber: PropTypes.number.isRequired,
     nativeCurrency: PropTypes.string,
     permissionsRequest: PropTypes.object,
-    addressLastConnectedMap: PropTypes.object,
+    addressLastConnectedMap: PropTypes.object.isRequired,
+    lastConnectedInfo: PropTypes.object.isRequired,
     permissionsRequestId: PropTypes.string,
-    domains: PropTypes.object,
     history: PropTypes.object.isRequired,
     connectPath: PropTypes.string.isRequired,
     confirmPermissionPath: PropTypes.string.isRequired,
@@ -38,12 +38,10 @@ export default class PermissionConnect extends Component {
   }
 
   static defaultProps = {
-    originName: '',
+    origin: '',
     nativeCurrency: '',
     permissionsRequest: undefined,
-    addressLastConnectedMap: {},
     permissionsRequestId: '',
-    domains: {},
   }
 
   static contextTypes = {
@@ -56,7 +54,7 @@ export default class PermissionConnect extends Component {
       ? new Set([this.props.accounts[0].address])
       : new Set(),
     permissionAccepted: null,
-    originName: this.props.originName,
+    origin: this.props.origin,
   }
 
   beforeUnload = () => {
@@ -79,16 +77,15 @@ export default class PermissionConnect extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { domains, permissionsRequest } = this.props
-    const { originName, redirecting } = this.state
+    const { permissionsRequest, lastConnectedInfo } = this.props
+    const { redirecting, origin } = this.state
 
     if (!permissionsRequest && prevProps.permissionsRequest && !redirecting) {
-      const permissionDataForDomain = (domains && domains[originName]) || {}
-      const permissionsForDomain = permissionDataForDomain.permissions || []
-      const prevPermissionDataForDomain = (prevProps.domains && prevProps.domains[originName]) || {}
-      const prevPermissionsForDomain = prevPermissionDataForDomain.permissions || []
-      const addedAPermission = permissionsForDomain.length > prevPermissionsForDomain.length
-      if (addedAPermission) {
+
+      const accountsLastApprovedTime = lastConnectedInfo[origin]?.lastApproved || 0
+      const initialAccountsLastApprovedTime = prevProps.lastConnectedInfo[origin]?.lastApproved || 0
+
+      if (accountsLastApprovedTime > initialAccountsLastApprovedTime) {
         this.redirectFlow(true)
       } else {
         this.redirectFlow(false)
@@ -208,7 +205,7 @@ export default class PermissionConnect extends Component {
     const {
       selectedAccountAddresses,
       permissionAccepted,
-      originName,
+      origin,
       redirecting,
     } = this.state
 
@@ -222,7 +219,6 @@ export default class PermissionConnect extends Component {
             render={() => (
               <ChooseAccount
                 accounts={accounts}
-                originName={originName}
                 nativeCurrency={nativeCurrency}
                 selectAccounts={(addresses) => this.selectAccounts(addresses)}
                 selectNewAccountViaModal={(handleAccountClick) => {
@@ -256,7 +252,7 @@ export default class PermissionConnect extends Component {
                 selectedIdentities={accounts.filter((account) => selectedAccountAddresses.has(account.address))}
                 redirect={redirecting}
                 permissionRejected={ permissionAccepted === false }
-                cachedOrigin={originName}
+                cachedOrigin={origin}
               />
             )}
           />

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -7,7 +7,6 @@ import {
   getAccountsWithLabels,
   getLastConnectedInfo,
   getTargetDomainMetadata,
-  getPermissionDomains,
 } from '../../selectors'
 
 import { formatDate } from '../../helpers/utils/util'
@@ -40,7 +39,7 @@ const mapStateToProps = (state, ownProps) => {
   const accountsWithLabels = getAccountsWithLabels(state)
 
   const lastConnectedInfo = getLastConnectedInfo(state) || {}
-  const addressLastConnectedMap = lastConnectedInfo[origin] || {}
+  const addressLastConnectedMap = lastConnectedInfo[origin]?.accounts || {}
 
   Object.keys(addressLastConnectedMap).forEach((key) => {
     addressLastConnectedMap[key] = formatDate(addressLastConnectedMap[key], 'yyyy-MM-dd')
@@ -64,11 +63,11 @@ const mapStateToProps = (state, ownProps) => {
     permissionsRequest,
     permissionsRequestId,
     accounts: accountsWithLabels,
-    originName: origin,
+    origin,
     newAccountNumber: accountsWithLabels.length + 1,
     nativeCurrency,
     addressLastConnectedMap,
-    domains: getPermissionDomains(state),
+    lastConnectedInfo,
     connectPath,
     confirmPermissionPath,
     page,

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -11,7 +11,13 @@ import {
 } from '../../selectors'
 
 import { formatDate } from '../../helpers/utils/util'
-import { approvePermissionsRequest, rejectPermissionsRequest, showModal, getCurrentWindowTab, getRequestAccountTabIds } from '../../store/actions'
+import {
+  approvePermissionsRequest,
+  rejectPermissionsRequest,
+  showModal,
+  getCurrentWindowTab,
+  getRequestAccountTabIds,
+} from '../../store/actions'
 import {
   CONNECT_ROUTE,
   CONNECT_CONFIRM_PERMISSIONS_ROUTE,

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -249,3 +249,32 @@ export function getPermissionsForActiveTab (state) {
     }
   })
 }
+
+export function getLastConnectedInfo (state) {
+  const { permissionsHistory = {} } = state.metamask
+  return Object.keys(permissionsHistory).reduce((acc, origin) => {
+    const ethAccountsHistory = JSON.parse(JSON.stringify(permissionsHistory[origin]['eth_accounts']))
+    return {
+      ...acc,
+      [origin]: ethAccountsHistory,
+    }
+  }, {})
+}
+
+export function getPermissionsRequests (state) {
+  return state.metamask.permissionsRequests || []
+}
+
+export function getPermissionsRequestCount (state) {
+  const permissionsRequests = getPermissionsRequests(state)
+  return permissionsRequests.length
+}
+
+export function getFirstPermissionRequest (state) {
+  const requests = getPermissionsRequests(state)
+  return requests && requests[0] ? requests[0] : null
+}
+
+export function hasPermissionRequests (state) {
+  return Boolean(getFirstPermissionRequest(state))
+}

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -6,6 +6,7 @@ import {
   checksumAddress,
   getAccountByAddress,
 } from '../helpers/utils/util'
+import { getPermissionsRequestCount } from './permissions'
 
 export function getNetworkIdentifier (state) {
   const { metamask: { provider: { type, nickname, rpcTarget } } } = state
@@ -282,15 +283,6 @@ export function getCustomNonceValue (state) {
   return String(state.metamask.customNonceValue)
 }
 
-export function getPermissionsRequests (state) {
-  return state.metamask.permissionsRequests || []
-}
-
-export function getPermissionsRequestCount (state) {
-  const permissionsRequests = getPermissionsRequests(state)
-  return permissionsRequests.length
-}
-
 export function getDomainMetadata (state) {
   return state.metamask.domainMetadata
 }
@@ -339,29 +331,8 @@ export function getFeatureFlags (state) {
   return state.metamask.featureFlags
 }
 
-export function getFirstPermissionRequest (state) {
-  const requests = getPermissionsRequests(state)
-  return requests && requests[0] ? requests[0] : null
-}
-
-export function hasPermissionRequests (state) {
-  return Boolean(getFirstPermissionRequest(state))
-}
-
 export function getOriginOfCurrentTab (state) {
   return state.activeTab?.origin
-}
-
-export function getLastConnectedInfo (state) {
-  const { permissionsHistory = {} } = state.metamask
-  const lastConnectedInfoData = Object.keys(permissionsHistory).reduce((acc, origin) => {
-    const ethAccountsHistory = JSON.parse(JSON.stringify(permissionsHistory[origin]['eth_accounts']))
-    return {
-      ...acc,
-      [origin]: ethAccountsHistory.accounts,
-    }
-  }, {})
-  return lastConnectedInfoData
 }
 
 export function getIpfsGateway (state) {


### PR DESCRIPTION
This PR fixes two issues with the `permissions-connect` page behavior:
- Correctly display `Connecting...` and `Cancelling...` in the redirect flow, depending on whether permissions were rejected or approved
  - If a dapp connected with `wallet_requestPermissions` and approved the same accounts, the redirect flow would display the `Cancelling...` message
  - This would happen for two reasons:
    - The `redirecting` component state was incorrectly used as a `prop`
    - If multiple UI instances displayed the confirmation, the logic computing whether permissions were approved or rejected didn't anticipate that the same permissions could be re-approved
- Stop closing the fullscreen UI after rejecting or approving a permissions confirmation
  - If the fullscreen UI displayed a permissions confirmation, it would close when the confirmation was removed (i.e. rejected or approved)
  - Since the fullscreen UI currently as always opened by direct user action, it should _never_ close due to confirmations

Additional changes:
- A bunch of permissions selectors had been put in `selectors/selectors`. They've been moved to `selectors/permissions`.

Fixes #8741 