### PR TITLE
fix prop type mismatch

### DIFF
--- a/ui/app/components/app/asset-list/asset-list.js
+++ b/ui/app/components/app/asset-list/asset-list.js
@@ -57,7 +57,7 @@ const AssetList = ({ onClickAsset }) => {
         onClick={() => onClickAsset(nativeCurrency)}
         data-testid="wallet-balance"
         primary={primaryCurrencyDisplay}
-        secondary={showFiat && secondaryCurrencyDisplay}
+        secondary={showFiat ? secondaryCurrencyDisplay : undefined}
       />
       <TokenList
         onTokenClick={(tokenAddress) => {


### PR DESCRIPTION
Use ternary and pass undefined explicitly instead of potentially passing `false` when the && logic fails. 