### PR TITLE
Order accounts on connect page

### DIFF
--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -177,17 +177,17 @@ export function getAddressBookEntryName (state, address) {
 
 export function accountsWithSendEtherInfoSelector (state) {
   const accounts = getMetaMaskAccounts(state)
-  const { identities } = state.metamask
+  const identities = getMetaMaskIdentities(state)
 
   const accountsWithSendEtherInfo = Object.entries(identities).map(([key, identity]) => {
-    return Object.assign({}, accounts[key], identity)
+    return Object.assign({}, identity, accounts[key])
   })
 
   return accountsWithSendEtherInfo
 }
 
 export function getAccountsWithLabels (state) {
-  return accountsWithSendEtherInfoSelector(state).map(({ address, name, balance }) => ({
+  return getMetaMaskAccountsOrdered(state).map(({ address, name, balance }) => ({
     address,
     addressLabel: `${name} (...${address.slice(address.length - 4)})`,
     label: name,


### PR DESCRIPTION
Fixes #8710 

- Accounts on connect page were unordered. This was fixed by updating the `getAccountsWithLabels` selector to depend on `getMetaMaskAccountsOrdered` instead of `accountsWithSendEtherInfoSelector`.
- `accountsWithSendEtherInfoSelector` and `getMetaMaskAccountsOrdered` were functionally equivalent, except that the latter returned the account objects in keyring controller order.
  - Non-functional changes were made to `accountsWithSendEtherInfoSelector` to make its implementation more closely match `getMetaMaskAccountsOrdered`.