### PR TITLE
Permissions: Do not display HTTP/HTTPS URL schemes for unique hosts

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -513,6 +513,11 @@ export class PermissionsController {
       ...metadata,
       lastUpdated: Date.now(),
     }
+
+    if (!newMetadataState[origin].extensionId && !newMetadataState[origin].host) {
+      newMetadataState[origin].host = new URL(origin).host
+    }
+
     this._pendingSiteMetadata.add(origin)
     this._setDomainMetadata(newMetadataState)
   }

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -151,10 +151,10 @@ export const getNotifyAllDomains = (notifications = {}) => (notification) => {
  * - e.g. permissions, caveats, and permission requests
  */
 
-const ORIGINS = {
-  a: 'foo.xyz',
-  b: 'bar.abc',
-  c: 'baz.def',
+const DOMAINS = {
+  a: { origin: 'https://foo.xyz', host: 'foo.xyz' },
+  b: { origin: 'https://bar.abc', host: 'bar.abc' },
+  c: { origin: 'https://baz.def', host: 'baz.def' },
 }
 
 const PERM_NAMES = {
@@ -630,7 +630,7 @@ export const constants = deepFreeze({
     c: '3',
   },
 
-  ORIGINS: { ...ORIGINS },
+  DOMAINS: { ...DOMAINS },
 
   ACCOUNTS: { ...ACCOUNTS },
 
@@ -648,7 +648,7 @@ export const constants = deepFreeze({
 
     case1: [
       {
-        [ORIGINS.a]: {
+        [DOMAINS.a.origin]: {
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {
@@ -660,7 +660,7 @@ export const constants = deepFreeze({
         },
       },
       {
-        [ORIGINS.a]: {
+        [DOMAINS.a.origin]: {
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 2,
             accounts: {
@@ -675,7 +675,7 @@ export const constants = deepFreeze({
 
     case2: [
       {
-        [ORIGINS.a]: {
+        [DOMAINS.a.origin]: {
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {},
@@ -686,10 +686,10 @@ export const constants = deepFreeze({
 
     case3: [
       {
-        [ORIGINS.a]: {
+        [DOMAINS.a.origin]: {
           [PERM_NAMES.test_method]: { lastApproved: 1 },
         },
-        [ORIGINS.b]: {
+        [DOMAINS.b.origin]: {
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {
@@ -697,7 +697,7 @@ export const constants = deepFreeze({
             },
           },
         },
-        [ORIGINS.c]: {
+        [DOMAINS.c.origin]: {
           [PERM_NAMES.test_method]: { lastApproved: 1 },
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
@@ -708,10 +708,10 @@ export const constants = deepFreeze({
         },
       },
       {
-        [ORIGINS.a]: {
+        [DOMAINS.a.origin]: {
           [PERM_NAMES.test_method]: { lastApproved: 2 },
         },
-        [ORIGINS.b]: {
+        [DOMAINS.b.origin]: {
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 1,
             accounts: {
@@ -719,7 +719,7 @@ export const constants = deepFreeze({
             },
           },
         },
-        [ORIGINS.c]: {
+        [DOMAINS.c.origin]: {
           [PERM_NAMES.test_method]: { lastApproved: 1 },
           [PERM_NAMES.eth_accounts]: {
             lastApproved: 2,
@@ -734,7 +734,7 @@ export const constants = deepFreeze({
 
     case4: [
       {
-        [ORIGINS.a]: {
+        [DOMAINS.a.origin]: {
           [PERM_NAMES.test_method]: {
             lastApproved: 1,
           },

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -37,15 +37,15 @@ const {
   ALL_ACCOUNTS,
   ACCOUNTS,
   DUMMY_ACCOUNT,
-  ORIGINS,
+  DOMAINS,
   PERM_NAMES,
   REQUEST_IDS,
   EXTRA_ACCOUNT,
 } = constants
 
 const initNotifications = () => {
-  return Object.values(ORIGINS).reduce((acc, domain) => {
-    acc[domain] = []
+  return Object.values(DOMAINS).reduce((acc, domain) => {
+    acc[domain.origin] = []
     return acc
   }, {})
 }
@@ -73,19 +73,19 @@ describe('permissions controller', function () {
     beforeEach(function () {
       permController = initPermController()
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
     it('gets permitted accounts for permitted origins', async function () {
 
-      const aAccounts = await permController.getAccounts(ORIGINS.a)
-      const bAccounts = await permController.getAccounts(ORIGINS.b)
+      const aAccounts = await permController.getAccounts(DOMAINS.a.origin)
+      const bAccounts = await permController.getAccounts(DOMAINS.b.origin)
 
       assert.deepEqual(
         aAccounts, [ACCOUNTS.a.primary],
@@ -98,7 +98,7 @@ describe('permissions controller', function () {
     })
 
     it('does not get accounts for unpermitted origins', async function () {
-      const cAccounts = await permController.getAccounts(ORIGINS.c)
+      const cAccounts = await permController.getAccounts(DOMAINS.c.origin)
       assert.deepEqual(cAccounts, [], 'origin should have no accounts')
     })
 
@@ -114,29 +114,29 @@ describe('permissions controller', function () {
 
       const permController = initPermController()
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.test_method()
       )
 
       assert.ok(
-        permController.hasPermission(ORIGINS.a, 'eth_accounts'),
+        permController.hasPermission(DOMAINS.a.origin, 'eth_accounts'),
         'should return true for granted permission'
       )
       assert.ok(
-        permController.hasPermission(ORIGINS.b, 'test_method'),
+        permController.hasPermission(DOMAINS.b.origin, 'test_method'),
         'should return true for granted permission'
       )
 
       assert.ok(
-        !permController.hasPermission(ORIGINS.a, 'test_method'),
+        !permController.hasPermission(DOMAINS.a.origin, 'test_method'),
         'should return false for non-granted permission'
       )
       assert.ok(
-        !permController.hasPermission(ORIGINS.b, 'eth_accounts'),
+        !permController.hasPermission(DOMAINS.b.origin, 'eth_accounts'),
         'should return true for non-granted permission'
       )
 
@@ -145,7 +145,7 @@ describe('permissions controller', function () {
         'should return false for unknown origin'
       )
       assert.ok(
-        !permController.hasPermission(ORIGINS.b, 'foo'),
+        !permController.hasPermission(DOMAINS.b.origin, 'foo'),
         'should return false for unknown permission'
       )
     })
@@ -159,21 +159,21 @@ describe('permissions controller', function () {
       const permController = initPermController(notifications)
 
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.c,
+        permController, DOMAINS.c.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.c.permitted)
       )
 
-      let aAccounts = await permController.getAccounts(ORIGINS.a)
-      let bAccounts = await permController.getAccounts(ORIGINS.b)
-      let cAccounts = await permController.getAccounts(ORIGINS.c)
+      let aAccounts = await permController.getAccounts(DOMAINS.a.origin)
+      let bAccounts = await permController.getAccounts(DOMAINS.b.origin)
+      let cAccounts = await permController.getAccounts(DOMAINS.c.origin)
 
 
       assert.deepEqual(
@@ -199,9 +199,9 @@ describe('permissions controller', function () {
         )
       })
 
-      aAccounts = await permController.getAccounts(ORIGINS.a)
-      bAccounts = await permController.getAccounts(ORIGINS.b)
-      cAccounts = await permController.getAccounts(ORIGINS.c)
+      aAccounts = await permController.getAccounts(DOMAINS.a.origin)
+      bAccounts = await permController.getAccounts(DOMAINS.b.origin)
+      cAccounts = await permController.getAccounts(DOMAINS.c.origin)
 
       assert.deepEqual(aAccounts, [], 'first origin should have no accounts')
       assert.deepEqual(bAccounts, [], 'second origin should have no accounts')
@@ -230,19 +230,19 @@ describe('permissions controller', function () {
       notifications = initNotifications()
       permController = initPermController(notifications)
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
     it('removes permissions for multiple domains', async function () {
 
-      let aAccounts = await permController.getAccounts(ORIGINS.a)
-      let bAccounts = await permController.getAccounts(ORIGINS.b)
+      let aAccounts = await permController.getAccounts(DOMAINS.a.origin)
+      let bAccounts = await permController.getAccounts(DOMAINS.b.origin)
 
       assert.deepEqual(
         aAccounts, [ACCOUNTS.a.primary],
@@ -254,22 +254,22 @@ describe('permissions controller', function () {
       )
 
       permController.removePermissionsFor({
-        [ORIGINS.a]: [PERM_NAMES.eth_accounts],
-        [ORIGINS.b]: [PERM_NAMES.eth_accounts],
+        [DOMAINS.a.origin]: [PERM_NAMES.eth_accounts],
+        [DOMAINS.b.origin]: [PERM_NAMES.eth_accounts],
       })
 
-      aAccounts = await permController.getAccounts(ORIGINS.a)
-      bAccounts = await permController.getAccounts(ORIGINS.b)
+      aAccounts = await permController.getAccounts(DOMAINS.a.origin)
+      bAccounts = await permController.getAccounts(DOMAINS.b.origin)
 
       assert.deepEqual(aAccounts, [], 'first origin should have no accounts')
       assert.deepEqual(bAccounts, [], 'second origin should have no accounts')
 
       assert.deepEqual(
-        notifications[ORIGINS.a], [NOTIFICATIONS.removedAccounts()],
+        notifications[DOMAINS.a.origin], [NOTIFICATIONS.removedAccounts()],
         'first origin should have correct notification'
       )
       assert.deepEqual(
-        notifications[ORIGINS.b], [NOTIFICATIONS.removedAccounts()],
+        notifications[DOMAINS.b.origin], [NOTIFICATIONS.removedAccounts()],
         'second origin should have correct notification'
       )
 
@@ -282,10 +282,10 @@ describe('permissions controller', function () {
     it('only removes targeted permissions from single domain', async function () {
 
       grantPermissions(
-        permController, ORIGINS.b, PERMS.finalizedRequests.test_method()
+        permController, DOMAINS.b.origin, PERMS.finalizedRequests.test_method()
       )
 
-      let bPermissions = permController.permissions.getPermissionsForDomain(ORIGINS.b)
+      let bPermissions = permController.permissions.getPermissionsForDomain(DOMAINS.b.origin)
 
       assert.ok(
         (
@@ -297,10 +297,10 @@ describe('permissions controller', function () {
       )
 
       permController.removePermissionsFor({
-        [ORIGINS.b]: [PERM_NAMES.test_method],
+        [DOMAINS.b.origin]: [PERM_NAMES.test_method],
       })
 
-      bPermissions = permController.permissions.getPermissionsForDomain(ORIGINS.b)
+      bPermissions = permController.permissions.getPermissionsForDomain(DOMAINS.b.origin)
 
       assert.ok(
         (
@@ -314,11 +314,11 @@ describe('permissions controller', function () {
     it('removes permissions for a single domain, without affecting another', async function () {
 
       permController.removePermissionsFor({
-        [ORIGINS.b]: [PERM_NAMES.eth_accounts],
+        [DOMAINS.b.origin]: [PERM_NAMES.eth_accounts],
       })
 
-      const aAccounts = await permController.getAccounts(ORIGINS.a)
-      const bAccounts = await permController.getAccounts(ORIGINS.b)
+      const aAccounts = await permController.getAccounts(DOMAINS.a.origin)
+      const bAccounts = await permController.getAccounts(DOMAINS.b.origin)
 
       assert.deepEqual(
         aAccounts, [ACCOUNTS.a.primary],
@@ -327,16 +327,16 @@ describe('permissions controller', function () {
       assert.deepEqual(bAccounts, [], 'second origin should have no accounts')
 
       assert.deepEqual(
-        notifications[ORIGINS.a], [],
+        notifications[DOMAINS.a.origin], [],
         'first origin should have no notifications'
       )
       assert.deepEqual(
-        notifications[ORIGINS.b], [NOTIFICATIONS.removedAccounts()],
+        notifications[DOMAINS.b.origin], [NOTIFICATIONS.removedAccounts()],
         'second origin should have correct notification'
       )
 
       assert.deepEqual(
-        Object.keys(permController.permissions.getDomains()), [ORIGINS.a],
+        Object.keys(permController.permissions.getDomains()), [DOMAINS.a.origin],
         'only first origin should remain'
       )
     })
@@ -345,16 +345,16 @@ describe('permissions controller', function () {
 
       // it knows nothing of this origin
       permController.removePermissionsFor({
-        [ORIGINS.c]: [PERM_NAMES.eth_accounts],
+        [DOMAINS.c.origin]: [PERM_NAMES.eth_accounts],
       })
 
       assert.deepEqual(
-        notifications[ORIGINS.c], [NOTIFICATIONS.removedAccounts()],
+        notifications[DOMAINS.c.origin], [NOTIFICATIONS.removedAccounts()],
         'unknown origin should have notification'
       )
 
-      const aAccounts = await permController.getAccounts(ORIGINS.a)
-      const bAccounts = await permController.getAccounts(ORIGINS.b)
+      const aAccounts = await permController.getAccounts(DOMAINS.a.origin)
+      const bAccounts = await permController.getAccounts(DOMAINS.b.origin)
 
       assert.deepEqual(
         aAccounts, [ACCOUNTS.a.primary],
@@ -367,7 +367,7 @@ describe('permissions controller', function () {
 
       assert.deepEqual(
         Object.keys(permController.permissions.getDomains()),
-        [ORIGINS.a, ORIGINS.b],
+        [DOMAINS.a.origin, DOMAINS.b.origin],
         'should have correct domains'
       )
     })
@@ -380,11 +380,11 @@ describe('permissions controller', function () {
     beforeEach(function () {
       permController = initPermController()
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
@@ -470,18 +470,18 @@ describe('permissions controller', function () {
       notifications = initNotifications()
       permController = initPermController(notifications)
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
     it('should throw if account is not a string', async function () {
       await assert.rejects(
-        () => permController.addPermittedAccount(ORIGINS.a, {}),
+        () => permController.addPermittedAccount(DOMAINS.a.origin, {}),
         ERRORS.validatePermittedAccounts.nonKeyringAccount({}),
         'should throw on non-string account param'
       )
@@ -489,7 +489,7 @@ describe('permissions controller', function () {
 
     it('should throw if given account is not in keyring', async function () {
       await assert.rejects(
-        () => permController.addPermittedAccount(ORIGINS.a, DUMMY_ACCOUNT),
+        () => permController.addPermittedAccount(DOMAINS.a.origin, DUMMY_ACCOUNT),
         ERRORS.validatePermittedAccounts.nonKeyringAccount(DUMMY_ACCOUNT),
         'should throw on non-keyring account'
       )
@@ -505,7 +505,7 @@ describe('permissions controller', function () {
 
     it('should throw if origin lacks any permissions', async function () {
       await assert.rejects(
-        () => permController.addPermittedAccount(ORIGINS.c, EXTRA_ACCOUNT),
+        () => permController.addPermittedAccount(DOMAINS.c.origin, EXTRA_ACCOUNT),
         ERRORS.addPermittedAccount.invalidOrigin(),
         'should throw on origin without permissions'
       )
@@ -513,12 +513,12 @@ describe('permissions controller', function () {
 
     it('should throw if origin lacks eth_accounts permission', async function () {
       grantPermissions(
-        permController, ORIGINS.c,
+        permController, DOMAINS.c.origin,
         PERMS.finalizedRequests.test_method()
       )
 
       await assert.rejects(
-        () => permController.addPermittedAccount(ORIGINS.c, EXTRA_ACCOUNT),
+        () => permController.addPermittedAccount(DOMAINS.c.origin, EXTRA_ACCOUNT),
         ERRORS.addPermittedAccount.noEthAccountsPermission(),
         'should throw on origin without eth_accounts permission'
       )
@@ -526,16 +526,16 @@ describe('permissions controller', function () {
 
     it('should throw if account is already permitted', async function () {
       await assert.rejects(
-        () => permController.addPermittedAccount(ORIGINS.a, ACCOUNTS.a.permitted[0]),
+        () => permController.addPermittedAccount(DOMAINS.a.origin, ACCOUNTS.a.permitted[0]),
         ERRORS.addPermittedAccount.alreadyPermitted(),
         'should throw if account is already permitted'
       )
     })
 
     it('should successfully add permitted account', async function () {
-      await permController.addPermittedAccount(ORIGINS.a, EXTRA_ACCOUNT)
+      await permController.addPermittedAccount(DOMAINS.a.origin, EXTRA_ACCOUNT)
 
-      const accounts = await permController._getPermittedAccounts(ORIGINS.a)
+      const accounts = await permController._getPermittedAccounts(DOMAINS.a.origin)
 
       assert.deepEqual(
         accounts, [...ACCOUNTS.a.permitted, EXTRA_ACCOUNT],
@@ -543,7 +543,7 @@ describe('permissions controller', function () {
       )
 
       assert.deepEqual(
-        notifications[ORIGINS.a][0],
+        notifications[DOMAINS.a.origin][0],
         NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary]),
         'origin should have correct notification'
       )
@@ -557,18 +557,18 @@ describe('permissions controller', function () {
       notifications = initNotifications()
       permController = initPermController(notifications)
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.b.permitted)
       )
     })
 
     it('should throw if account is not a string', async function () {
       await assert.rejects(
-        () => permController.removePermittedAccount(ORIGINS.a, {}),
+        () => permController.removePermittedAccount(DOMAINS.a.origin, {}),
         ERRORS.validatePermittedAccounts.nonKeyringAccount({}),
         'should throw on non-string account param'
       )
@@ -576,7 +576,7 @@ describe('permissions controller', function () {
 
     it('should throw if given account is not in keyring', async function () {
       await assert.rejects(
-        () => permController.removePermittedAccount(ORIGINS.a, DUMMY_ACCOUNT),
+        () => permController.removePermittedAccount(DOMAINS.a.origin, DUMMY_ACCOUNT),
         ERRORS.validatePermittedAccounts.nonKeyringAccount(DUMMY_ACCOUNT),
         'should throw on non-keyring account'
       )
@@ -592,7 +592,7 @@ describe('permissions controller', function () {
 
     it('should throw if origin lacks any permissions', async function () {
       await assert.rejects(
-        () => permController.removePermittedAccount(ORIGINS.c, EXTRA_ACCOUNT),
+        () => permController.removePermittedAccount(DOMAINS.c.origin, EXTRA_ACCOUNT),
         ERRORS.removePermittedAccount.invalidOrigin(),
         'should throw on origin without permissions'
       )
@@ -600,12 +600,12 @@ describe('permissions controller', function () {
 
     it('should throw if origin lacks eth_accounts permission', async function () {
       grantPermissions(
-        permController, ORIGINS.c,
+        permController, DOMAINS.c.origin,
         PERMS.finalizedRequests.test_method()
       )
 
       await assert.rejects(
-        () => permController.removePermittedAccount(ORIGINS.c, EXTRA_ACCOUNT),
+        () => permController.removePermittedAccount(DOMAINS.c.origin, EXTRA_ACCOUNT),
         ERRORS.removePermittedAccount.noEthAccountsPermission(),
         'should throw on origin without eth_accounts permission'
       )
@@ -613,16 +613,16 @@ describe('permissions controller', function () {
 
     it('should throw if account is not permitted', async function () {
       await assert.rejects(
-        () => permController.removePermittedAccount(ORIGINS.b, ACCOUNTS.c.permitted[0]),
+        () => permController.removePermittedAccount(DOMAINS.b.origin, ACCOUNTS.c.permitted[0]),
         ERRORS.removePermittedAccount.notPermitted(),
         'should throw if account is not permitted'
       )
     })
 
     it('should successfully remove permitted account', async function () {
-      await permController.removePermittedAccount(ORIGINS.a, ACCOUNTS.a.permitted[1])
+      await permController.removePermittedAccount(DOMAINS.a.origin, ACCOUNTS.a.permitted[1])
 
-      const accounts = await permController._getPermittedAccounts(ORIGINS.a)
+      const accounts = await permController._getPermittedAccounts(DOMAINS.a.origin)
 
       assert.deepEqual(
         accounts, ACCOUNTS.a.permitted.filter((acc) => acc !== ACCOUNTS.a.permitted[1]),
@@ -630,16 +630,16 @@ describe('permissions controller', function () {
       )
 
       assert.deepEqual(
-        notifications[ORIGINS.a][0],
+        notifications[DOMAINS.a.origin][0],
         NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary]),
         'origin should have correct notification'
       )
     })
 
     it('should remove eth_accounts permission if removing only permitted account', async function () {
-      await permController.removePermittedAccount(ORIGINS.b, ACCOUNTS.b.permitted[0])
+      await permController.removePermittedAccount(DOMAINS.b.origin, ACCOUNTS.b.permitted[0])
 
-      const accounts = await permController.getAccounts(ORIGINS.b)
+      const accounts = await permController.getAccounts(DOMAINS.b.origin)
 
       assert.deepEqual(
         accounts, [],
@@ -647,13 +647,13 @@ describe('permissions controller', function () {
       )
 
       const permission = await permController.permissions.getPermission(
-        ORIGINS.b, PERM_NAMES.eth_accounts
+        DOMAINS.b.origin, PERM_NAMES.eth_accounts
       )
 
       assert.equal(permission, undefined, 'origin should not have eth_accounts permission')
 
       assert.deepEqual(
-        notifications[ORIGINS.b][0],
+        notifications[DOMAINS.b.origin][0],
         NOTIFICATIONS.removedAccounts(),
         'origin should have correct notification'
       )
@@ -744,11 +744,11 @@ describe('permissions controller', function () {
         preferences,
       })
       grantPermissions(
-        permController, ORIGINS.b,
+        permController, DOMAINS.b.origin,
         PERMS.finalizedRequests.eth_accounts([...ACCOUNTS.a.permitted, EXTRA_ACCOUNT])
       )
       grantPermissions(
-        permController, ORIGINS.c,
+        permController, DOMAINS.c.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
     })
@@ -774,11 +774,11 @@ describe('permissions controller', function () {
       await onPreferencesUpdate({ selectedAddress: DUMMY_ACCOUNT })
 
       assert.deepEqual(
-        notifications[ORIGINS.b], [],
+        notifications[DOMAINS.b.origin], [],
         'should not have emitted notification'
       )
       assert.deepEqual(
-        notifications[ORIGINS.c], [],
+        notifications[DOMAINS.c.origin], [],
         'should not have emitted notification'
       )
     })
@@ -792,12 +792,12 @@ describe('permissions controller', function () {
       await onPreferencesUpdate({ selectedAddress: ACCOUNTS.a.permitted[0] })
 
       assert.deepEqual(
-        notifications[ORIGINS.b],
+        notifications[DOMAINS.b.origin],
         [NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary])],
         'should not have emitted notification'
       )
       assert.deepEqual(
-        notifications[ORIGINS.c],
+        notifications[DOMAINS.c.origin],
         [NOTIFICATIONS.newAccounts([ACCOUNTS.a.primary])],
         'should not have emitted notification'
       )
@@ -812,12 +812,12 @@ describe('permissions controller', function () {
       await onPreferencesUpdate({ selectedAddress: EXTRA_ACCOUNT })
 
       assert.deepEqual(
-        notifications[ORIGINS.b],
+        notifications[DOMAINS.b.origin],
         [NOTIFICATIONS.newAccounts([EXTRA_ACCOUNT])],
         'should have emitted notification'
       )
       assert.deepEqual(
-        notifications[ORIGINS.c], [],
+        notifications[DOMAINS.c.origin], [],
         'should not have emitted notification'
       )
     })
@@ -831,12 +831,12 @@ describe('permissions controller', function () {
       await onPreferencesUpdate({ selectedAddress: ACCOUNTS.a.permitted[1] })
 
       assert.deepEqual(
-        notifications[ORIGINS.b],
+        notifications[DOMAINS.b.origin],
         [NOTIFICATIONS.newAccounts([ACCOUNTS.a.permitted[1]])],
         'should have emitted notification'
       )
       assert.deepEqual(
-        notifications[ORIGINS.c],
+        notifications[DOMAINS.c.origin],
         [NOTIFICATIONS.newAccounts([ACCOUNTS.c.primary])],
         'should have emitted notification'
       )
@@ -1113,7 +1113,7 @@ describe('permissions controller', function () {
       let middleware
       assert.doesNotThrow(
         () => {
-          middleware = permController.createMiddleware({ origin: ORIGINS.a })
+          middleware = permController.createMiddleware({ origin: DOMAINS.a.origin })
         },
         'should not throw'
       )
@@ -1137,7 +1137,7 @@ describe('permissions controller', function () {
       assert.doesNotThrow(
         () => {
           middleware = permController.createMiddleware({
-            origin: ORIGINS.a,
+            origin: DOMAINS.a.origin,
             extensionId,
           })
         },
@@ -1157,7 +1157,7 @@ describe('permissions controller', function () {
       const metadataStore = permController.store.getState()[METADATA_STORE_KEY]
 
       assert.deepEqual(
-        metadataStore[ORIGINS.a], { extensionId, lastUpdated: 1 },
+        metadataStore[DOMAINS.a.origin], { extensionId, lastUpdated: 1 },
         'metadata should be stored'
       )
     })
@@ -1176,7 +1176,7 @@ describe('permissions controller', function () {
     it('notifyAccountsChanged records history and sends notification', async function () {
 
       permController.notifyAccountsChanged(
-        ORIGINS.a,
+        DOMAINS.a.origin,
         ACCOUNTS.a.permitted,
       )
 
@@ -1186,7 +1186,7 @@ describe('permissions controller', function () {
       )
 
       assert.deepEqual(
-        notifications[ORIGINS.a],
+        notifications[DOMAINS.a.origin],
         [ NOTIFICATIONS.newAccounts(ACCOUNTS.a.permitted) ],
         'origin should have correct notification'
       )
@@ -1217,7 +1217,7 @@ describe('permissions controller', function () {
 
       assert.throws(
         () => permController.notifyAccountsChanged(
-          ORIGINS.a,
+          DOMAINS.a.origin,
           4,
         ),
         ERRORS.notifyAccountsChanged.invalidAccounts(),
@@ -1226,7 +1226,7 @@ describe('permissions controller', function () {
 
       assert.throws(
         () => permController.notifyAccountsChanged(
-          ORIGINS.a,
+          DOMAINS.a.origin,
           null,
         ),
         ERRORS.notifyAccountsChanged.invalidAccounts(),
@@ -1262,13 +1262,13 @@ describe('permissions controller', function () {
 
       permController.store.getState = sinon.fake.returns({
         [METADATA_STORE_KEY]: {
-          [ORIGINS.a]: {
+          [DOMAINS.a.origin]: {
             foo: 'bar',
           },
         },
       })
 
-      permController.addDomainMetadata(ORIGINS.b, { foo: 'bar' })
+      permController.addDomainMetadata(DOMAINS.b.origin, { foo: 'bar' })
 
       assert.ok(
         permController.store.getState.called,
@@ -1281,11 +1281,12 @@ describe('permissions controller', function () {
       assert.deepEqual(
         permController._setDomainMetadata.lastCall.args,
         [{
-          [ORIGINS.a]: {
+          [DOMAINS.a.origin]: {
             foo: 'bar',
           },
-          [ORIGINS.b]: {
+          [DOMAINS.b.origin]: {
             foo: 'bar',
+            host: DOMAINS.b.host,
             lastUpdated: 1,
           },
         }]
@@ -1296,16 +1297,16 @@ describe('permissions controller', function () {
 
       permController.store.getState = sinon.fake.returns({
         [METADATA_STORE_KEY]: {
-          [ORIGINS.a]: {
+          [DOMAINS.a.origin]: {
             foo: 'bar',
           },
-          [ORIGINS.b]: {
+          [DOMAINS.b.origin]: {
             bar: 'baz',
           },
         },
       })
 
-      permController.addDomainMetadata(ORIGINS.b, { foo: 'bar' })
+      permController.addDomainMetadata(DOMAINS.b.origin, { foo: 'bar' })
 
       assert.ok(
         permController.store.getState.called,
@@ -1318,12 +1319,13 @@ describe('permissions controller', function () {
       assert.deepEqual(
         permController._setDomainMetadata.lastCall.args,
         [{
-          [ORIGINS.a]: {
+          [DOMAINS.a.origin]: {
             foo: 'bar',
           },
-          [ORIGINS.b]: {
+          [DOMAINS.b.origin]: {
             foo: 'bar',
             bar: 'baz',
+            host: DOMAINS.b.host,
             lastUpdated: 1,
           },
         }]
@@ -1347,7 +1349,7 @@ describe('permissions controller', function () {
         permController._pendingSiteMetadata.add(origin)
       })
 
-      permController.addDomainMetadata(ORIGINS.a, { foo: 'bar' })
+      permController.addDomainMetadata(DOMAINS.a.origin, { foo: 'bar' })
 
       assert.ok(
         permController.store.getState.called,
@@ -1356,8 +1358,9 @@ describe('permissions controller', function () {
 
       const expectedMetadata = {
         ...mockMetadata,
-        [ORIGINS.a]: {
+        [DOMAINS.a.origin]: {
           foo: 'bar',
+          host: DOMAINS.a.host,
           lastUpdated: 1,
         },
       }
@@ -1385,12 +1388,12 @@ describe('permissions controller', function () {
     it('trims domain metadata for domains without permissions', function () {
 
       const metadataArg = {
-        [ORIGINS.a]: {},
-        [ORIGINS.b]: {},
+        [DOMAINS.a.origin]: {},
+        [DOMAINS.b.origin]: {},
       }
 
       permController.permissions.getDomains = sinon.fake.returns({
-        [ORIGINS.a]: {},
+        [DOMAINS.a.origin]: {},
       })
 
       const metadataResult = permController._trimDomainMetadata(metadataArg)
@@ -1402,7 +1405,7 @@ describe('permissions controller', function () {
       assert.deepEqual(
         metadataResult,
         {
-          [ORIGINS.a]: {},
+          [DOMAINS.a.origin]: {},
         },
         'should have produced expected state'
       )
@@ -1430,7 +1433,7 @@ describe('permissions controller', function () {
     it('_addPendingApproval: should throw if adding origin twice', function () {
 
       const id = nanoid()
-      const origin = ORIGINS.a
+      const origin = DOMAINS.a
 
       permController._addPendingApproval(id, origin, noop, noop)
 

--- a/test/unit/app/controllers/permissions/permissions-log-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-log-controller-test.js
@@ -29,7 +29,7 @@ const {
 const {
   ACCOUNTS,
   EXPECTED_HISTORIES,
-  ORIGINS,
+  DOMAINS,
   PERM_NAMES,
   REQUEST_IDS,
   RESTRICTED_METHODS,
@@ -86,7 +86,7 @@ describe('permissions log', function () {
 
       // test_method, success
 
-      req = RPC_REQUESTS.test_method(ORIGINS.a)
+      req = RPC_REQUESTS.test_method(DOMAINS.a.origin)
       req.id = REQUEST_IDS.a
       res = { foo: 'bar' }
 
@@ -103,7 +103,7 @@ describe('permissions log', function () {
 
       // eth_accounts, failure
 
-      req = RPC_REQUESTS.eth_accounts(ORIGINS.b)
+      req = RPC_REQUESTS.eth_accounts(DOMAINS.b.origin)
       req.id = REQUEST_IDS.b
       res = { error: new Error('Unauthorized.') }
 
@@ -120,7 +120,7 @@ describe('permissions log', function () {
 
       // eth_requestAccounts, success
 
-      req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.c)
+      req = RPC_REQUESTS.eth_requestAccounts(DOMAINS.c.origin)
       req.id = REQUEST_IDS.c
       res = { result: ACCOUNTS.c.permitted }
 
@@ -137,7 +137,7 @@ describe('permissions log', function () {
 
       // test_method, no response
 
-      req = RPC_REQUESTS.test_method(ORIGINS.a)
+      req = RPC_REQUESTS.test_method(DOMAINS.a.origin)
       req.id = REQUEST_IDS.a
       res = null
 
@@ -170,7 +170,7 @@ describe('permissions log', function () {
       const id2 = nanoid()
       const id3 = nanoid()
 
-      const req = RPC_REQUESTS.test_method(ORIGINS.a)
+      const req = RPC_REQUESTS.test_method(DOMAINS.a.origin)
 
       // get make requests
       req.id = id1
@@ -230,7 +230,7 @@ describe('permissions log', function () {
 
     it('handles a lack of response', function () {
 
-      let req = RPC_REQUESTS.test_method(ORIGINS.a)
+      let req = RPC_REQUESTS.test_method(DOMAINS.a.origin)
       req.id = REQUEST_IDS.a
       let res = { foo: 'bar' }
 
@@ -247,7 +247,7 @@ describe('permissions log', function () {
       )
 
       // next request should be handled as normal
-      req = RPC_REQUESTS.eth_accounts(ORIGINS.b)
+      req = RPC_REQUESTS.eth_accounts(DOMAINS.b.origin)
       req.id = REQUEST_IDS.b
       res = { result: ACCOUNTS.b.permitted }
 
@@ -272,9 +272,9 @@ describe('permissions log', function () {
       assert.equal(log.length, 0, 'log should be empty')
 
       const res = { foo: 'bar' }
-      const req1 = RPC_REQUESTS.wallet_sendDomainMetadata(ORIGINS.c, 'foobar')
-      const req2 = RPC_REQUESTS.custom(ORIGINS.b, 'eth_getBlockNumber')
-      const req3 = RPC_REQUESTS.custom(ORIGINS.b, 'net_version')
+      const req1 = RPC_REQUESTS.wallet_sendDomainMetadata(DOMAINS.c.origin, 'foobar')
+      const req2 = RPC_REQUESTS.custom(DOMAINS.b.origin, 'eth_getBlockNumber')
+      const req3 = RPC_REQUESTS.custom(DOMAINS.b.origin, 'net_version')
 
       logMiddleware(req1, res)
       logMiddleware(req2, res)
@@ -286,7 +286,7 @@ describe('permissions log', function () {
 
     it('enforces log limit', function () {
 
-      const req = RPC_REQUESTS.test_method(ORIGINS.a)
+      const req = RPC_REQUESTS.test_method(DOMAINS.a.origin)
       const res = { foo: 'bar' }
 
       // max out log
@@ -352,7 +352,7 @@ describe('permissions log', function () {
       let permHistory
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.test_method
+        DOMAINS.a.origin, PERM_NAMES.test_method
       )
       const res = { result: [ PERMS.granted.test_method() ] }
 
@@ -371,7 +371,7 @@ describe('permissions log', function () {
         'history should have single origin'
       )
       assert.ok(
-        Boolean(permHistory[ORIGINS.a]),
+        Boolean(permHistory[DOMAINS.a.origin]),
         'history should have expected origin'
       )
     })
@@ -379,7 +379,7 @@ describe('permissions log', function () {
     it('ignores malformed permissions requests', function () {
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.test_method
+        DOMAINS.a.origin, PERM_NAMES.test_method
       )
       delete req.params
       const res = { result: [ PERMS.granted.test_method() ] }
@@ -395,7 +395,7 @@ describe('permissions log', function () {
       let permHistory
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       const res = {
         result: [ PERMS.granted.eth_accounts(ACCOUNTS.a.permitted) ],
@@ -433,7 +433,7 @@ describe('permissions log', function () {
     it('handles eth_accounts response without caveats', async function () {
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       const res = {
         result: [ PERMS.granted.eth_accounts(ACCOUNTS.a.permitted) ],
@@ -453,7 +453,7 @@ describe('permissions log', function () {
     it('handles extra caveats for eth_accounts', async function () {
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       const res = {
         result: [ PERMS.granted.eth_accounts(ACCOUNTS.a.permitted) ],
@@ -476,7 +476,7 @@ describe('permissions log', function () {
     it('handles unrequested permissions on the response', async function () {
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       const res = {
         result: [
@@ -499,7 +499,7 @@ describe('permissions log', function () {
     it('does not update history if no new permissions are approved', async function () {
 
       let req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.test_method
+        DOMAINS.a.origin, PERM_NAMES.test_method
       )
       let res = {
         result: [
@@ -522,7 +522,7 @@ describe('permissions log', function () {
       clock.tick(1)
 
       req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       res = {
         result: [
@@ -553,7 +553,7 @@ describe('permissions log', function () {
       // first origin
       round1.push({
         req: RPC_REQUESTS.requestPermission(
-          ORIGINS.a, PERM_NAMES.test_method
+          DOMAINS.a.origin, PERM_NAMES.test_method
         ),
         res: {
           result: [ PERMS.granted.test_method() ],
@@ -563,7 +563,7 @@ describe('permissions log', function () {
       // second origin
       round1.push({
         req: RPC_REQUESTS.requestPermission(
-          ORIGINS.b, PERM_NAMES.eth_accounts
+          DOMAINS.b.origin, PERM_NAMES.eth_accounts
         ),
         res: {
           result: [ PERMS.granted.eth_accounts(ACCOUNTS.b.permitted) ],
@@ -572,7 +572,7 @@ describe('permissions log', function () {
 
       // third origin
       round1.push({
-        req: RPC_REQUESTS.requestPermissions(ORIGINS.c, {
+        req: RPC_REQUESTS.requestPermissions(DOMAINS.c.origin, {
           [PERM_NAMES.test_method]: {},
           [PERM_NAMES.eth_accounts]: {},
         }),
@@ -611,7 +611,7 @@ describe('permissions log', function () {
       // first origin
       round2.push({
         req: RPC_REQUESTS.requestPermission(
-          ORIGINS.a, PERM_NAMES.test_method
+          DOMAINS.a.origin, PERM_NAMES.test_method
         ),
         res: {
           result: [ PERMS.granted.test_method() ],
@@ -622,7 +622,7 @@ describe('permissions log', function () {
 
       // third origin
       round2.push({
-        req: RPC_REQUESTS.requestPermissions(ORIGINS.c, {
+        req: RPC_REQUESTS.requestPermissions(DOMAINS.c.origin, {
           [PERM_NAMES.eth_accounts]: {},
         }),
         res: {

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -30,7 +30,7 @@ const {
 
 const {
   ACCOUNTS,
-  ORIGINS,
+  DOMAINS,
   PERM_NAMES,
 } = constants
 
@@ -63,10 +63,10 @@ describe('permissions middleware', function () {
 
     it('grants permissions on user approval', async function () {
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       const res = {}
 
@@ -99,11 +99,11 @@ describe('permissions middleware', function () {
       validatePermission(
         res.result[0],
         PERM_NAMES.eth_accounts,
-        ORIGINS.a,
+        DOMAINS.a.origin,
         CAVEATS.eth_accounts(ACCOUNTS.a.permitted)
       )
 
-      const aAccounts = await permController.getAccounts(ORIGINS.a)
+      const aAccounts = await permController.getAccounts(DOMAINS.a.origin)
       assert.deepEqual(
         aAccounts, [ACCOUNTS.a.primary],
         'origin should have correct accounts'
@@ -111,7 +111,7 @@ describe('permissions middleware', function () {
 
       assert.ok(
         permController.notifyAccountsChanged.calledOnceWith(
-          ORIGINS.a, aAccounts,
+          DOMAINS.a.origin, aAccounts,
         ),
         'expected notification call should have been made'
       )
@@ -119,12 +119,12 @@ describe('permissions middleware', function () {
 
     it('handles serial approved requests that overwrite existing permissions', async function () {
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
       // create first request
 
       const req1 = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       const res1 = {}
 
@@ -155,11 +155,11 @@ describe('permissions middleware', function () {
       validatePermission(
         res1.result[0],
         PERM_NAMES.eth_accounts,
-        ORIGINS.a,
+        DOMAINS.a.origin,
         CAVEATS.eth_accounts(ACCOUNTS.a.permitted)
       )
 
-      const accounts1 = await permController.getAccounts(ORIGINS.a)
+      const accounts1 = await permController.getAccounts(DOMAINS.a.origin)
       assert.deepEqual(
         accounts1, [ACCOUNTS.a.primary],
         'origin should have correct accounts'
@@ -167,7 +167,7 @@ describe('permissions middleware', function () {
 
       assert.ok(
         permController.notifyAccountsChanged.calledOnceWith(
-          ORIGINS.a, accounts1,
+          DOMAINS.a.origin, accounts1,
         ),
         'expected notification call should have been made'
       )
@@ -180,7 +180,7 @@ describe('permissions middleware', function () {
       }
 
       const req2 = RPC_REQUESTS.requestPermissions(
-        ORIGINS.a, { ...requestedPerms2 }
+        DOMAINS.a.origin, { ...requestedPerms2 }
       )
       const res2 = {}
 
@@ -211,17 +211,17 @@ describe('permissions middleware', function () {
       validatePermission(
         res2.result[0],
         PERM_NAMES.eth_accounts,
-        ORIGINS.a,
+        DOMAINS.a.origin,
         CAVEATS.eth_accounts(ACCOUNTS.b.permitted)
       )
 
       validatePermission(
         res2.result[1],
         PERM_NAMES.test_method,
-        ORIGINS.a,
+        DOMAINS.a.origin,
       )
 
-      const accounts2 = await permController.getAccounts(ORIGINS.a)
+      const accounts2 = await permController.getAccounts(DOMAINS.a.origin)
       assert.deepEqual(
         accounts2, [ACCOUNTS.b.primary],
         'origin should have correct accounts'
@@ -234,7 +234,7 @@ describe('permissions middleware', function () {
 
       assert.ok(
         permController.notifyAccountsChanged.lastCall.calledWith(
-          ORIGINS.a, accounts2,
+          DOMAINS.a.origin, accounts2,
         ),
         'expected notification call should have been made'
       )
@@ -242,10 +242,10 @@ describe('permissions middleware', function () {
 
     it('rejects permissions on user rejection', async function () {
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
       const req = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.eth_accounts
+        DOMAINS.a.origin, PERM_NAMES.eth_accounts
       )
       const res = {}
 
@@ -275,7 +275,7 @@ describe('permissions middleware', function () {
         'response should have expected error and no result'
       )
 
-      const aAccounts = await permController.getAccounts(ORIGINS.a)
+      const aAccounts = await permController.getAccounts(DOMAINS.a.origin)
       assert.deepEqual(
         aAccounts, [], 'origin should have have correct accounts'
       )
@@ -288,10 +288,10 @@ describe('permissions middleware', function () {
 
     it('rejects requests with unknown permissions', async function () {
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
       const req = RPC_REQUESTS.requestPermissions(
-        ORIGINS.a, {
+        DOMAINS.a.origin, {
           ...PERMS.requests.does_not_exist(),
           ...PERMS.requests.test_method(),
         }
@@ -333,13 +333,13 @@ describe('permissions middleware', function () {
 
       // two middlewares for two origins
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
-      const bMiddleware = getPermissionsMiddleware(permController, ORIGINS.b)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
+      const bMiddleware = getPermissionsMiddleware(permController, DOMAINS.b.origin)
 
       // create and start processing first request for first origin
 
       const reqA1 = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.test_method
+        DOMAINS.a.origin, PERM_NAMES.test_method
       )
       const resA1 = {}
 
@@ -351,7 +351,7 @@ describe('permissions middleware', function () {
       // create and start processing first request for second origin
 
       const reqB1 = RPC_REQUESTS.requestPermission(
-        ORIGINS.b, PERM_NAMES.test_method
+        DOMAINS.b.origin, PERM_NAMES.test_method
       )
       const resB1 = {}
 
@@ -369,7 +369,7 @@ describe('permissions middleware', function () {
       // which should throw
 
       const reqA2 = RPC_REQUESTS.requestPermission(
-        ORIGINS.a, PERM_NAMES.test_method
+        DOMAINS.a.origin, PERM_NAMES.test_method
       )
       const resA2 = {}
 
@@ -439,9 +439,9 @@ describe('permissions middleware', function () {
 
     it('prevents restricted method access for unpermitted domain', async function () {
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
-      const req = RPC_REQUESTS.test_method(ORIGINS.a)
+      const req = RPC_REQUESTS.test_method(DOMAINS.a.origin)
       const res = {}
 
       const expectedError = ERRORS.rpcCap.unauthorized()
@@ -463,11 +463,11 @@ describe('permissions middleware', function () {
 
     it('allows restricted method access for permitted domain', async function () {
 
-      const bMiddleware = getPermissionsMiddleware(permController, ORIGINS.b)
+      const bMiddleware = getPermissionsMiddleware(permController, DOMAINS.b.origin)
 
-      grantPermissions(permController, ORIGINS.b, PERMS.finalizedRequests.test_method())
+      grantPermissions(permController, DOMAINS.b.origin, PERMS.finalizedRequests.test_method())
 
-      const req = RPC_REQUESTS.test_method(ORIGINS.b, true)
+      const req = RPC_REQUESTS.test_method(DOMAINS.b.origin, true)
       const res = {}
 
       await assert.doesNotReject(
@@ -492,9 +492,9 @@ describe('permissions middleware', function () {
 
     it('returns empty array for non-permitted domain', async function () {
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
-      const req = RPC_REQUESTS.eth_accounts(ORIGINS.a)
+      const req = RPC_REQUESTS.eth_accounts(DOMAINS.a.origin)
       const res = {}
 
       await assert.doesNotReject(
@@ -514,14 +514,14 @@ describe('permissions middleware', function () {
 
     it('returns correct accounts for permitted domain', async function () {
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
       grantPermissions(
-        permController, ORIGINS.a,
+        permController, DOMAINS.a.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.a.permitted)
       )
 
-      const req = RPC_REQUESTS.eth_accounts(ORIGINS.a)
+      const req = RPC_REQUESTS.eth_accounts(DOMAINS.a.origin)
       const res = {}
 
       await assert.doesNotReject(
@@ -552,9 +552,9 @@ describe('permissions middleware', function () {
 
       const userApprovalPromise = getUserApprovalPromise(permController)
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
-      const req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.a)
+      const req = RPC_REQUESTS.eth_requestAccounts(DOMAINS.a.origin)
       const res = {}
 
       const pendingApproval = assert.doesNotReject(
@@ -577,7 +577,7 @@ describe('permissions middleware', function () {
       // wait for permission to be granted
       await pendingApproval
 
-      const perms = permController.permissions.getPermissionsForDomain(ORIGINS.a)
+      const perms = permController.permissions.getPermissionsForDomain(DOMAINS.a.origin)
 
       assert.equal(
         perms.length, 1,
@@ -587,7 +587,7 @@ describe('permissions middleware', function () {
       validatePermission(
         perms[0],
         PERM_NAMES.eth_accounts,
-        ORIGINS.a,
+        DOMAINS.a.origin,
         CAVEATS.eth_accounts(ACCOUNTS.a.permitted)
       )
 
@@ -603,7 +603,7 @@ describe('permissions middleware', function () {
       )
 
       // we should also be able to get the accounts independently
-      const aAccounts = await permController.getAccounts(ORIGINS.a)
+      const aAccounts = await permController.getAccounts(DOMAINS.a.origin)
       assert.deepEqual(
         aAccounts, [ACCOUNTS.a.primary], 'origin should have have correct accounts'
       )
@@ -613,9 +613,9 @@ describe('permissions middleware', function () {
 
       const userApprovalPromise = getUserApprovalPromise(permController)
 
-      const aMiddleware = getPermissionsMiddleware(permController, ORIGINS.a)
+      const aMiddleware = getPermissionsMiddleware(permController, DOMAINS.a.origin)
 
-      const req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.a)
+      const req = RPC_REQUESTS.eth_requestAccounts(DOMAINS.a.origin)
       const res = {}
 
       const expectedError = ERRORS.rejectPermissionsRequest.rejection()
@@ -646,7 +646,7 @@ describe('permissions middleware', function () {
         'response should have expected error and no result'
       )
 
-      const aAccounts = await permController.getAccounts(ORIGINS.a)
+      const aAccounts = await permController.getAccounts(DOMAINS.a.origin)
       assert.deepEqual(
         aAccounts, [], 'origin should have have correct accounts'
       )
@@ -654,14 +654,14 @@ describe('permissions middleware', function () {
 
     it('directly returns accounts for permitted domain', async function () {
 
-      const cMiddleware = getPermissionsMiddleware(permController, ORIGINS.c)
+      const cMiddleware = getPermissionsMiddleware(permController, DOMAINS.c.origin)
 
       grantPermissions(
-        permController, ORIGINS.c,
+        permController, DOMAINS.c.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.c.permitted)
       )
 
-      const req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.c)
+      const req = RPC_REQUESTS.eth_requestAccounts(DOMAINS.c.origin)
       const res = {}
 
       await assert.doesNotReject(
@@ -688,14 +688,14 @@ describe('permissions middleware', function () {
 
       permController.getUnlockPromise = () => unlockPromise
 
-      const cMiddleware = getPermissionsMiddleware(permController, ORIGINS.c)
+      const cMiddleware = getPermissionsMiddleware(permController, DOMAINS.c.origin)
 
       grantPermissions(
-        permController, ORIGINS.c,
+        permController, DOMAINS.c.origin,
         PERMS.finalizedRequests.eth_accounts(ACCOUNTS.c.permitted)
       )
 
-      const req = RPC_REQUESTS.eth_requestAccounts(ORIGINS.c)
+      const req = RPC_REQUESTS.eth_requestAccounts(DOMAINS.c.origin)
       const res = {}
 
       // this will block until we resolve the unlock Promise
@@ -743,9 +743,9 @@ describe('permissions middleware', function () {
 
       const name = 'BAZ'
 
-      const cMiddleware = getPermissionsMiddleware(permController, ORIGINS.c)
+      const cMiddleware = getPermissionsMiddleware(permController, DOMAINS.c.origin)
 
-      const req = RPC_REQUESTS.wallet_sendDomainMetadata(ORIGINS.c, name)
+      const req = RPC_REQUESTS.wallet_sendDomainMetadata(DOMAINS.c.origin, name)
       const res = {}
 
       await assert.doesNotReject(
@@ -759,7 +759,13 @@ describe('permissions middleware', function () {
 
       assert.deepEqual(
         metadataStore,
-        { [ORIGINS.c]: { name, lastUpdated: 1 } },
+        {
+          [DOMAINS.c.origin]: {
+            name,
+            host: DOMAINS.c.host,
+            lastUpdated: 1,
+          },
+        },
         'metadata should have been added to store'
       )
     })
@@ -770,9 +776,9 @@ describe('permissions middleware', function () {
 
       const name = 'BAZ'
 
-      const cMiddleware = getPermissionsMiddleware(permController, ORIGINS.c, extensionId)
+      const cMiddleware = getPermissionsMiddleware(permController, DOMAINS.c.origin, extensionId)
 
-      const req = RPC_REQUESTS.wallet_sendDomainMetadata(ORIGINS.c, name)
+      const req = RPC_REQUESTS.wallet_sendDomainMetadata(DOMAINS.c.origin, name)
       const res = {}
 
       await assert.doesNotReject(
@@ -786,7 +792,7 @@ describe('permissions middleware', function () {
 
       assert.deepEqual(
         metadataStore,
-        { [ORIGINS.c]: { name, extensionId, lastUpdated: 1 } },
+        { [DOMAINS.c.origin]: { name, extensionId, lastUpdated: 1 } },
         'metadata should have been added to store'
       )
     })
@@ -795,9 +801,9 @@ describe('permissions middleware', function () {
 
       const name = null
 
-      const cMiddleware = getPermissionsMiddleware(permController, ORIGINS.c)
+      const cMiddleware = getPermissionsMiddleware(permController, DOMAINS.c.origin)
 
-      const req = RPC_REQUESTS.wallet_sendDomainMetadata(ORIGINS.c, name)
+      const req = RPC_REQUESTS.wallet_sendDomainMetadata(DOMAINS.c.origin, name)
       const res = {}
 
       await assert.doesNotReject(
@@ -817,9 +823,9 @@ describe('permissions middleware', function () {
 
     it('should not record domain metadata if no metadata', async function () {
 
-      const cMiddleware = getPermissionsMiddleware(permController, ORIGINS.c)
+      const cMiddleware = getPermissionsMiddleware(permController, DOMAINS.c.origin)
 
-      const req = RPC_REQUESTS.wallet_sendDomainMetadata(ORIGINS.c)
+      const req = RPC_REQUESTS.wallet_sendDomainMetadata(DOMAINS.c.origin)
       delete req.domainMetadata
       const res = {}
 

--- a/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
@@ -46,7 +46,7 @@ export default class ConnectedSitesList extends Component {
 
   getDomainDisplayName (domain) {
     if (domain.extensionId) {
-      return domain.extensionId
+      return this.context.t('externalExtension')
     }
 
     return this.props.domainHostCount[domain.host] > 1

--- a/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/app/components/app/connected-sites-list/connected-sites-list.component.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import IconWithFallBack from '../../ui/icon-with-fallback'
+import { stripHttpSchemes } from '../../../helpers/utils/util'
 
 export default class ConnectedSitesList extends Component {
   static contextTypes = {
@@ -11,9 +12,11 @@ export default class ConnectedSitesList extends Component {
     connectedDomains: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.string,
       icon: PropTypes.string,
-      key: PropTypes.string,
+      origin: PropTypes.string,
+      host: PropTypes.string,
     })).isRequired,
     onDisconnect: PropTypes.func.isRequired,
+    domainHostCount: PropTypes.objectOf(PropTypes.number).isRequired,
   }
 
   render () {
@@ -23,25 +26,31 @@ export default class ConnectedSitesList extends Component {
     return (
       <main className="connected-sites-list__content-rows">
         { connectedDomains.map((domain) => (
-          <div key={domain.key} className="connected-sites-list__content-row">
+          <div key={domain.origin} className="connected-sites-list__content-row">
             <div className="connected-sites-list__domain-info">
               <IconWithFallBack icon={domain.icon} name={domain.name} />
-              <span className="connected-sites-list__domain-name" title={domain.extensionId || domain.key}>
-                {
-                  domain.extensionId
-                    ? t('externalExtension')
-                    : domain.key
-                }
+              <span className="connected-sites-list__domain-name" title={domain.extensionId || domain.origin}>
+                {this.getDomainDisplayName(domain)}
               </span>
             </div>
             <i
               className="fas fa-trash-alt connected-sites-list__trash"
               title={t('disconnect')}
-              onClick={() => onDisconnect(domain.key)}
+              onClick={() => onDisconnect(domain.origin)}
             />
           </div>
         )) }
       </main>
     )
+  }
+
+  getDomainDisplayName (domain) {
+    if (domain.extensionId) {
+      return domain.extensionId
+    }
+
+    return this.props.domainHostCount[domain.host] > 1
+      ? domain.origin
+      : stripHttpSchemes(domain.origin)
   }
 }

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -297,3 +297,15 @@ export function isValidAddressHead (address) {
 export function getAccountByAddress (accounts = [], targetAddress) {
   return accounts.find(({ address }) => address === targetAddress)
 }
+
+/**
+ * Strips the following schemes from URL strings:
+ * - http
+ * - https
+ *
+ * @param {string} urlString - The URL string to strip the scheme from.
+ * @returns {string} The URL string, without the scheme, if it was stripped.
+ */
+export function stripHttpSchemes (urlString) {
+  return urlString.replace(/^https?:\/\//u, '')
+}

--- a/ui/app/pages/connected-accounts/connected-accounts.component.js
+++ b/ui/app/pages/connected-accounts/connected-accounts.component.js
@@ -54,7 +54,7 @@ export default class ConnectedAccounts extends PureComponent {
 
     return (
       <Popover
-        title={isActiveTabExtension ? t('currentExtension') : activeTabOrigin}
+        title={isActiveTabExtension ? t('currentExtension') : new URL(activeTabOrigin).host}
         subtitle={connectedAccounts.length ? connectedAccountsDescription : t('connectedAccountsEmptyDescription')}
         onClose={() => history.push(mostRecentOverviewPage)}
         footerClassName="connected-accounts__footer"

--- a/ui/app/pages/connected-sites/connected-sites.component.js
+++ b/ui/app/pages/connected-sites/connected-sites.component.js
@@ -17,6 +17,7 @@ export default class ConnectedSites extends Component {
     accountLabel: PropTypes.string.isRequired,
     closePopover: PropTypes.func.isRequired,
     connectedDomains: PropTypes.arrayOf(PropTypes.object).isRequired,
+    domainHostCount: PropTypes.objectOf(PropTypes.number).isRequired,
     disconnectAllAccounts: PropTypes.func.isRequired,
     disconnectAccount: PropTypes.func.isRequired,
     getOpenMetamaskTabsIds: PropTypes.func.isRequired,
@@ -69,6 +70,7 @@ export default class ConnectedSites extends Component {
   renderConnectedSitesList () {
     return (
       <ConnectedSitesList
+        domainHostCount={this.props.domainHostCount}
         connectedDomains={this.props.connectedDomains}
         onDisconnect={this.setPendingDisconnect}
       />

--- a/ui/app/pages/connected-sites/connected-sites.container.js
+++ b/ui/app/pages/connected-sites/connected-sites.container.js
@@ -11,6 +11,7 @@ import {
   getCurrentAccountWithSendEtherInfo,
   getOriginOfCurrentTab,
   getPermissionDomains,
+  getPermissionsMetadataHostCounts,
   getPermittedAccountsByOrigin,
   getSelectedAddress,
 } from '../../selectors'
@@ -40,6 +41,7 @@ const mapStateToProps = (state) => {
     accountLabel: getCurrentAccountWithSendEtherInfo(state).name,
     connectedDomains,
     domains: getPermissionDomains(state),
+    domainHostCount: getPermissionsMetadataHostCounts(state),
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     permittedAccountsByOrigin,
     selectedAddress,

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -104,13 +104,15 @@ export function getConnectedDomainsForSelectedAddress (state) {
       extensionId,
       name,
       icon,
+      host,
     } = domainMetadata[domainKey] || {}
 
     connectedDomains.push({
       extensionId,
-      key: domainKey,
+      origin: domainKey,
       name,
       icon,
+      host,
     })
   })
 
@@ -258,6 +260,21 @@ export function getLastConnectedInfo (state) {
       ...acc,
       [origin]: ethAccountsHistory,
     }
+  }, {})
+}
+
+export function getPermissionsMetadataHostCounts (state) {
+  const metadata = getPermissionDomainsMetadata(state)
+  return Object.values(metadata).reduce((acc, val) => {
+    const { host } = val
+    if (host) {
+      if (!acc[host]) {
+        acc[host] = 1
+      } else {
+        acc[host] += 1
+      }
+    }
+    return acc
   }, {})
 }
 

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -265,16 +265,15 @@ export function getLastConnectedInfo (state) {
 
 export function getPermissionsMetadataHostCounts (state) {
   const metadata = getPermissionDomainsMetadata(state)
-  return Object.values(metadata).reduce((acc, val) => {
-    const { host } = val
+  return Object.values(metadata).reduce((counts, { host }) => {
     if (host) {
-      if (!acc[host]) {
-        acc[host] = 1
+      if (!counts[host]) {
+        counts[host] = 1
       } else {
-        acc[host] += 1
+        counts[host] += 1
       }
     }
-    return acc
+    return counts
   }, {})
 }
 

--- a/ui/app/selectors/tests/permissions.test.js
+++ b/ui/app/selectors/tests/permissions.test.js
@@ -16,10 +16,12 @@ describe('selectors', function () {
             'peepeth.com': {
               'icon': 'https://peepeth.com/favicon-32x32.png',
               'name': 'Peepeth',
+              'host': 'peepeth.com',
             },
             'https://remix.ethereum.org': {
               'icon': 'https://remix.ethereum.org/icon.png',
               'name': 'Remix - Ethereum IDE',
+              'host': 'remix.ethereum.org',
             },
           },
           domains: {
@@ -74,13 +76,15 @@ describe('selectors', function () {
       assert.deepEqual(getConnectedDomainsForSelectedAddress(mockState), [{
         extensionId,
         icon: 'https://peepeth.com/favicon-32x32.png',
-        key: 'peepeth.com',
+        origin: 'peepeth.com',
         name: 'Peepeth',
+        host: 'peepeth.com',
       }, {
         extensionId,
         name: 'Remix - Ethereum IDE',
         icon: 'https://remix.ethereum.org/icon.png',
-        key: 'https://remix.ethereum.org',
+        origin: 'https://remix.ethereum.org',
+        host: 'remix.ethereum.org',
       }])
     })
 
@@ -92,10 +96,12 @@ describe('selectors', function () {
             'peepeth.com': {
               'icon': 'https://peepeth.com/favicon-32x32.png',
               'name': 'Peepeth',
+              'host': 'peepeth.com',
             },
             'https://remix.ethereum.org': {
               'icon': 'https://remix.ethereum.org/icon.png',
               'name': 'Remix - Ethereum IDE',
+              'host': 'remix.ethereum.com',
             },
           },
           domains: {
@@ -152,7 +158,8 @@ describe('selectors', function () {
         extensionId,
         name: 'Remix - Ethereum IDE',
         icon: 'https://remix.ethereum.org/icon.png',
-        key: 'https://remix.ethereum.org',
+        origin: 'https://remix.ethereum.org',
+        host: 'remix.ethereum.com',
       }])
     })
   })


### PR DESCRIPTION
### Terminology

URL components recap:
- **origin**: `https://metamask.io:9000`
- **scheme** or **protocol**: `https`
- **port**: `9000`
- **host**: `metamask.io:9000`
  - Note that in our URLs, there is usually no `port` displayed, as almost all HTTP/HTTPS websites use default ports, and the Chrome APIs don't even bother giving the default ports to us.
  - Therefore, if the port is there at all, it's some non-default value, and I think we should display it.
- **hostname**: `metamask.io`

### Changes

These changes required updates to permissions controller and selector tests. The majority of the changes (by lines) are due to changing a commonly used constant in the permissions controller tests.

Updates the permission origin string display to conform to the following:
- Show the **origin** on the connect and confirmation screens
  - We were already doing this.
- Show the **host** on the 'Connected accounts' modal title
  - Originally, it was suggested that we only show the **hostname** here. However, I decided to follow the conventions established by Chrome, and display the **host**. See also notes above on when the **port** is displayed.
- Show non-HTTP/HTTPS schemes on the connected sites list, but hide HTTP/HTTPS (except for the purpose of disambiguation, e.g. we'll show the scheme if the same **host** is connected via both HTTP and HTTPS)
  - We do this if the same **host**, not hostname, is connected to any set of accounts, under different schemes.
  - So, `http://foo.bar` can be connected to `Account 1`, and `https://foo.bar` can be connected to `Account 2`, and the schemes will be displayed for _both_ sites, even if they'll never appear in the same connected sites list.
  - `https://foo.bar:9000` and `https://foo.bar:9001` will be displayed as `foo.bar:9000` and `foo.bar:9001`, respectively.

These changes do not affect external domains that are extension (i.e., their domain metadata has a truthy `extensionId` property).