### PR TITLE
Avoid mutating module export

### DIFF
--- a/ui/app/components/app/token-list/token-list.js
+++ b/ui/app/components/app/token-list/token-list.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import contracts from 'eth-contract-metadata'
 import { isEqual } from 'lodash'
 
 import TokenCell from '../token-cell'
@@ -9,15 +8,6 @@ import { useTokenTracker } from '../../../hooks/useTokenTracker'
 import { useSelector } from 'react-redux'
 import { getAssetImages } from '../../../selectors'
 import { getTokens } from '../../../ducks/metamask/metamask'
-
-const defaultTokens = []
-for (const address in contracts) {
-  const contract = contracts[address]
-  if (contract.erc20) {
-    contract.address = address
-    defaultTokens.push(contract)
-  }
-}
 
 export default function TokenList ({ onTokenClick }) {
   const t = useI18nContext()

--- a/ui/app/pages/add-token/token-search/token-search.component.js
+++ b/ui/app/pages/add-token/token-search/token-search.component.js
@@ -6,7 +6,7 @@ import InputAdornment from '@material-ui/core/InputAdornment'
 import TextField from '../../../components/ui/text-field'
 
 const contractList = Object.entries(contractMap)
-  .map(([ _, tokenData]) => tokenData)
+  .map(([address, tokenData]) => Object.assign({}, tokenData, { address }))
   .filter((tokenData) => Boolean(tokenData.erc20))
 
 const fuse = new Fuse(contractList, {


### PR DESCRIPTION
The `eth-contracts-metadata` export was mutated in `token-list.js` to add the token address to the contract metadata, and this was taken advantage of in the token search component.

Instead, the address is now added to a copy of the token metadata in the one place it's used. The module export is no longer mutated, and the unused `defaultTokens` variable in `token-list.js` has been removed.