### PR TITLE
Remove some unused state keys

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -105,7 +105,6 @@ initialize().catch(log.error)
  * @property {Object} contractExchangeRates - Info about current token prices.
  * @property {Array} tokens - Tokens held by the current user, including their balances.
  * @property {Object} send - TODO: Document
- * @property {Object} coinOptions - TODO: Document
  * @property {boolean} useBlockie - Indicates preferred user identicon format. True for blockie, false for Jazzicon.
  * @property {Object} featureFlags - An object for optional feature flags.
  * @property {boolean} welcomeScreen - True if welcome screen should be shown.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -108,7 +108,6 @@ initialize().catch(log.error)
  * @property {Object} coinOptions - TODO: Document
  * @property {boolean} useBlockie - Indicates preferred user identicon format. True for blockie, false for Jazzicon.
  * @property {Object} featureFlags - An object for optional feature flags.
- * @property {string} networkEndpointType - TODO: Document
  * @property {boolean} welcomeScreen - True if welcome screen should be shown.
  * @property {string} currentLocale - A locale string matching the user's preferred display language.
  * @property {Object} provider - The current selected network provider.

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -31,7 +31,6 @@ export default function reduceMetamask (state = {}, action) {
       ensResolution: null,
       ensResolutionError: '',
     },
-    coinOptions: {},
     useBlockie: false,
     featureFlags: {},
     welcomeScreenSeen: false,

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -34,7 +34,6 @@ export default function reduceMetamask (state = {}, action) {
     coinOptions: {},
     useBlockie: false,
     featureFlags: {},
-    networkEndpointType: undefined,
     welcomeScreenSeen: false,
     currentLocale: '',
     preferences: {


### PR DESCRIPTION
This PR removes two unused state keys, `coinOptions` and `networkEndpointType`.