### PR TITLE
Fix `TokenRatesController`

### DIFF
--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -27,9 +27,6 @@ export default class TokenRatesController {
    * Updates exchange rates for all tokens
    */
   async updateExchangeRates () {
-    if (!this.isActive) {
-      return
-    }
     const contractExchangeRates = {}
     const nativeCurrency = this.currency ? this.currency.state.nativeCurrency.toLowerCase() : 'eth'
     const pairs = this._tokens.map((token) => token.address).join(',')

--- a/test/unit/app/controllers/token-rates-controller.js
+++ b/test/unit/app/controllers/token-rates-controller.js
@@ -6,18 +6,20 @@ import ObservableStore from 'obs-store'
 describe('TokenRatesController', function () {
   it('should listen for preferences store updates', function () {
     const preferences = new ObservableStore({ tokens: [] })
-    const controller = new TokenRatesController({ preferences })
     preferences.putState({ tokens: ['foo'] })
+    const controller = new TokenRatesController({ preferences })
     assert.deepEqual(controller._tokens, ['foo'])
   })
 
   it('should poll on correct interval', async function () {
     const stub = sinon.stub(global, 'setInterval')
-    const rateController = new TokenRatesController() // eslint-disable-line no-new
-    rateController.start(1337)
+    const preferences = new ObservableStore({ tokens: [] })
+    preferences.putState({ tokens: ['foo'] })
+    const controller = new TokenRatesController({ preferences })
+    controller.start(1337)
 
     assert.strictEqual(stub.getCall(0).args[1], 1337)
     stub.restore()
-    rateController.stop()
+    controller.stop()
   })
 })


### PR DESCRIPTION
The `TokenRatesController` was accidentally broken in #8744, when the logic for starting and stopping polling was moved from the `isActive` property to start/stop functions.

A reference to the now-obsolete `isActive` property was accidentally left behind, resulting in no exchange rate updates.