### PR TITLE
Remove 2nd parameter from the call of estimateTxGas function

### DIFF
--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -37,7 +37,7 @@ export default class TxGasUtil {
     let estimatedGasHex = bnToHex(saferGasLimitBN)
     let simulationFails
     try {
-      estimatedGasHex = await this.estimateTxGas(txMeta, block.gasLimit)
+      estimatedGasHex = await this.estimateTxGas(txMeta)
     } catch (error) {
       log.warn(error)
       simulationFails = {


### PR DESCRIPTION
*estimateTxGas* function accepts a single parameter https://github.com/MetaMask/metamask-extension/blob/a4e5fc934dedec74dbb3991de77361cfbb8c302b/app/scripts/controllers/transactions/tx-gas-utils.js#L58