### PR TITLE
Rename 'History' tab to 'Activity'

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -148,6 +148,9 @@
   "accountSelectionRequired": {
     "message": "You need to select an account!"
   },
+  "activity": {
+    "message": "Activity"
+  },
   "activityLog": {
     "message": "activity log"
   },

--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -195,7 +195,7 @@ describe('MetaMask', function () {
     })
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.clickElement(By.css('[data-testid="home__history-tab"]'))
+      await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
       await driver.wait(async () => {
         const confirmedTxes = await driver.findElements(By.css('.transaction-list__completed-transactions .transaction-list-item'))
         return confirmedTxes.length === 1

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -215,7 +215,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.clickElement(By.css('[data-testid="home__history-tab"]'))
+      await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
       await driver.wait(async () => {
         const confirmedTxes = await driver.findElements(By.css('.transaction-list__completed-transactions .transaction-list-item'))
         return confirmedTxes.length === 1

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -211,7 +211,7 @@ describe('MetaMask', function () {
     })
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.clickElement(By.css('[data-testid="home__history-tab"]'))
+      await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
       await driver.wait(async () => {
         const confirmedTxes = await driver.findElements(By.css('.transaction-list__completed-transactions .transaction-list-item'))
         return confirmedTxes.length === 1

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -266,7 +266,7 @@ describe('MetaMask', function () {
     })
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.clickElement(By.css('[data-testid="home__history-tab"]'))
+      await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
       await driver.wait(async () => {
         const confirmedTxes = await driver.findElements(By.css('.transaction-list__completed-transactions .transaction-list-item'))
         return confirmedTxes.length === 1

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -197,7 +197,7 @@ describe('Using MetaMask with an existing account', function () {
     })
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.clickElement(By.css('[data-testid="home__history-tab"]'))
+      await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
       await driver.wait(async () => {
         const confirmedTxes = await driver.findElements(By.css('.transaction-list__completed-transactions .transaction-list-item'))
         return confirmedTxes.length === 1

--- a/test/e2e/tests/simple-send.spec.js
+++ b/test/e2e/tests/simple-send.spec.js
@@ -22,7 +22,7 @@ describe('MetaMask Browser Extension', function () {
       await amountField.sendKeys('1')
       await driver.clickElement(By.css('[data-testid="page-container-footer-next"]'))
       await driver.clickElement(By.css('[data-testid="page-container-footer-next"]'))
-      await driver.clickElement(By.css('[data-testid="home__history-tab"]'))
+      await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
       await driver.findElement(By.css('.transaction-list-item'))
     })
   })

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -247,8 +247,8 @@ export default class Home extends PureComponent {
               <Tab
                 activeClassName="home__tab--active"
                 className="home__tab"
-                data-testid="home__history-tab"
-                name={t('history')}
+                data-testid="home__activity-tab"
+                name={t('activity')}
               >
                 <TransactionList />
               </Tab>


### PR DESCRIPTION
'Activity' is a better name for this tab because it contains more than just transactions. Signature requests are also included, and more non-transaction activity may be included in the future.