### PR TITLE
Hide token fiat amounts on testnets

### DIFF
--- a/ui/app/components/app/token-cell/token-cell.test.js
+++ b/ui/app/components/app/token-cell/token-cell.test.js
@@ -20,6 +20,12 @@ describe('Token Cell', function () {
         '0xAnotherToken': 0.015,
       },
       conversionRate: 7.00,
+      preferences: {},
+      provider: {
+        chainId: '1',
+        ticker: 'ETH',
+        type: 'mainnet',
+      },
     },
     appState: {
       sidebar: {

--- a/ui/app/hooks/useTokenFiatAmount.js
+++ b/ui/app/hooks/useTokenFiatAmount.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { getTokenExchangeRates, getConversionRate, getCurrentCurrency } from '../selectors'
+import { getTokenExchangeRates, getConversionRate, getCurrentCurrency, getShouldShowFiat } from '../selectors'
 import { getFormattedTokenFiatAmount } from '../helpers/utils/token-util'
 
 /**
@@ -15,6 +15,7 @@ export function useTokenFiatAmount (tokenAddress, tokenAmount, tokenSymbol) {
   const contractExchangeRates = useSelector(getTokenExchangeRates)
   const conversionRate = useSelector(getConversionRate)
   const currentCurrency = useSelector(getCurrentCurrency)
+  const showFiat = useSelector(getShouldShowFiat)
 
   const tokenExchangeRate = contractExchangeRates[tokenAddress]
 
@@ -29,7 +30,7 @@ export function useTokenFiatAmount (tokenAddress, tokenAmount, tokenSymbol) {
     [tokenExchangeRate, conversionRate, currentCurrency, tokenAmount, tokenSymbol]
   )
 
-  if (currentCurrency.toUpperCase() === tokenSymbol) {
+  if (!showFiat || currentCurrency.toUpperCase() === tokenSymbol) {
     return undefined
   }
 


### PR DESCRIPTION
The token amount is no longer shown in fiat on testnets, unless the user has enabled the "Show fiat on testnets" setting.