### PR TITLE
Omit state snapshot from Sentry errors

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -8,8 +8,7 @@ const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT
 const SENTRY_DSN_PROD = 'https://3567c198f8a8412082d32655da2961d0@sentry.io/273505'
 const SENTRY_DSN_DEV = 'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496'
 
-export default function setupSentry (opts) {
-  const { release, getState } = opts
+export default function setupSentry ({ release }) {
   let sentryTarget
   // detect brave
   const isBrave = Boolean(window.chrome.ipcRenderer)
@@ -44,11 +43,6 @@ export default function setupSentry (opts) {
       simplifyErrorMessages(report)
       // modify report urls
       rewriteReportUrls(report)
-      // append app state
-      if (getState) {
-        const appState = getState()
-        report.extra.appState = appState
-      }
     } catch (err) {
       console.warn(err)
     }

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -35,18 +35,7 @@ async function start () {
 
   // setup sentry error reporting
   const release = global.platform.getVersion()
-  setupSentry({ release, getState })
-  // provide app state to append to error logs
-  function getState () {
-    // get app state
-    const state = window.getCleanAppState
-      ? window.getCleanAppState()
-      : {}
-    // remove unnecessary data
-    delete state.localeMessages
-    // return state to be added to request
-    return state
-  }
+  setupSentry({ release })
 
   // identify window type (popup, notification)
   const windowType = getEnvironmentType()


### PR DESCRIPTION
The state snapshot we were attaching to Sentry errors was too large. As a temporary solution, it has been removed completely. We can re-add it later after reducing its size.