### PR TITLE
Update "Connected accounts" empty description

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -26,7 +26,7 @@
     "description": "$1 is the number of accounts"
   },
   "connectedAccountsEmptyDescription": {
-    "message": "MetaMask is not connected this site. To connect to a decentralized app (dapp), find the connect button on their site."
+    "message": "MetaMask is not connected this site. To connect to a Web3 site, find the connect button on their site."
   },
   "primary": {
     "message": "Primary"


### PR DESCRIPTION
The copy has been updated to use the term "Web3 site" instead of "decentralized site".