### PR TITLE
Fix connect flow account list height

### DIFF
--- a/ui/app/pages/permissions-connect/choose-account/index.scss
+++ b/ui/app/pages/permissions-connect/choose-account/index.scss
@@ -41,8 +41,9 @@
   }
 
   &__accounts-list {
-    flex: 1 1 0;
+    flex: 2 1 0;
     width: 92%;
+    max-height: max-content;
     border: 1px solid #D0D5DA;
     box-sizing: border-box;
     border-radius: 8px;
@@ -147,7 +148,7 @@
 
   &__footer-container {
     width: 100%;
-    flex: 0;
+    flex: 1;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;


### PR DESCRIPTION
The list of accounts shown on the first page of the connect flow takes up the entire height of the window, even if there aren't enough accounts to fill the space. This looks strange because of the border around the account list, especially in the case where there are three accounts in the list.

The list now cedes space to the footer if it can't fill the space itself. The extra space is taken by whitespace between the footer and the list.