### PR TITLE
Hide token transfers on ETH asset page

### DIFF
--- a/ui/app/pages/asset/components/native-asset.js
+++ b/ui/app/pages/asset/components/native-asset.js
@@ -22,7 +22,7 @@ export default function NativeAsset ({ nativeCurrency }) {
         onBack={() => history.push(DEFAULT_ROUTE)}
       />
       <EthOverview className="asset__overview" />
-      <TransactionList />
+      <TransactionList hideTokenTransactions />
     </>
   )
 }


### PR DESCRIPTION
Token transfers will now be hidden on the ETH asset page. Arguably token transfers are still relevant to show on the ETH asset page because the gas for token transfers is paid in ETH, but they weren't being displayed in a way that highlighted this (only the token amount was shown inline - not the gas price).

We will likely restore token transfers to the ETH asset page at a later date, after designs have been updated to highlight their relevance to this page.