### PR TITLE
Fix account name editing

### DIFF
--- a/ui/app/components/ui/editable-label.js
+++ b/ui/app/components/ui/editable-label.js
@@ -57,7 +57,7 @@ class EditableLabel extends Component {
       <div key={1} className="editable-label__value">{this.state.value}</div>
     ), (
       <div key={2} className="editable-label__icon-wrapper">
-        <i className="fa fa-pencil editable-label__icon" onClick={() => this.setState({ isEditing: true })} />
+        <i className="fas fa-pencil-alt editable-label__icon" onClick={() => this.setState({ isEditing: true })} />
       </div>
     )]
   }


### PR DESCRIPTION
Editing the name of an account was accidentally made impossible when FontAwesome was updated in #8256, because the icon we used to use for the edit button (`fa fa-pencil`) was no longer free. The icon has been switched to `fas fa-pencil-alt`, which is free.