### PR TITLE
Fix handling of permissions of removed accounts

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -342,6 +342,24 @@ export class PermissionsController {
   }
 
   /**
+   * Remove all permissions associated with a particular account. Any eth_accounts
+   * permissions left with no permitted accounts will be removed as well.
+   *
+   * Throws error if the account is invalid, or if the update fails.
+   *
+   * @param {string} account - The account to remove.
+   */
+  async removeAllAccountPermissions (account) {
+    this.validatePermittedAccounts([account])
+
+    const domains = this.permissions.getDomains()
+    const connectedOrigins = Object.keys(domains)
+      .filter((origin) => this._getPermittedAccounts(origin).includes(account))
+
+    await Promise.all(connectedOrigins.map((origin) => this.removePermittedAccount(origin, account)))
+  }
+
+  /**
    * Finalizes a permissions request. Throws if request validation fails.
    * Clones the passed-in parameters to prevent inadvertent modification.
    * Sets (adds or replaces) caveats for the following permissions:

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -993,6 +993,8 @@ export default class MetamaskController extends EventEmitter {
    *
    */
   async removeAccount (address) {
+    // Remove all associated permissions
+    await this.permissionsController.removeAllAccountPermissions(address)
     // Remove account from the preferences controller
     this.preferencesController.removeAddress(address)
     // Remove account from the account tracker controller

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -599,6 +599,7 @@ describe('MetaMaskController', function () {
       sinon.stub(metamaskController.preferencesController, 'removeAddress')
       sinon.stub(metamaskController.accountTracker, 'removeAccount')
       sinon.stub(metamaskController.keyringController, 'removeAccount')
+      sinon.stub(metamaskController.permissionsController, 'removeAllAccountPermissions')
 
       ret = await metamaskController.removeAccount(addressToRemove)
 
@@ -608,6 +609,7 @@ describe('MetaMaskController', function () {
       metamaskController.keyringController.removeAccount.restore()
       metamaskController.accountTracker.removeAccount.restore()
       metamaskController.preferencesController.removeAddress.restore()
+      metamaskController.permissionsController.removeAllAccountPermissions.restore()
     })
 
     it('should call preferencesController.removeAddress', async function () {
@@ -618,6 +620,9 @@ describe('MetaMaskController', function () {
     })
     it('should call keyringController.removeAccount', async function () {
       assert(metamaskController.keyringController.removeAccount.calledWith(addressToRemove))
+    })
+    it('should call permissionsController.removeAllAccountPermissions', async function () {
+      assert(metamaskController.permissionsController.removeAllAccountPermissions.calledWith(addressToRemove))
     })
     it('should return address', async function () {
       assert.equal(ret, '0x1')

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -221,10 +221,10 @@ describe('Actions', function () {
   })
 
   describe('#removeAccount', function () {
-    let removeAccountSpy
+    let removeAccountStub
 
     afterEach(function () {
-      removeAccountSpy.restore()
+      removeAccountStub.restore()
     })
 
     it('calls removeAccount in background and expect actions to show account', async function () {
@@ -238,10 +238,11 @@ describe('Actions', function () {
         'SHOW_ACCOUNTS_PAGE',
       ]
 
-      removeAccountSpy = sinon.spy(background, 'removeAccount')
+      removeAccountStub = sinon.stub(background, 'removeAccount')
+      removeAccountStub.callsFake((_, callback) => callback())
 
       await store.dispatch(actions.removeAccount('0xe18035bf8712672935fdb4e5e431b1a0183d2dfc'))
-      assert(removeAccountSpy.calledOnce)
+      assert(removeAccountStub.calledOnce)
       const actionTypes = store
         .getActions()
         .map((action) => action.type)
@@ -257,8 +258,8 @@ describe('Actions', function () {
         'HIDE_LOADING_INDICATION',
       ]
 
-      removeAccountSpy = sinon.stub(background, 'removeAccount')
-      removeAccountSpy.callsFake((_, callback) => {
+      removeAccountStub = sinon.stub(background, 'removeAccount')
+      removeAccountStub.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -122,7 +122,9 @@ export function getConnectedDomainsForSelectedAddress (state) {
 export function getPermittedIdentitiesForCurrentTab (state) {
   const permittedAccounts = getPermittedAccountsForCurrentTab(state)
   const identities = getMetaMaskIdentities(state)
-  return permittedAccounts.map((address) => identities[address])
+  return permittedAccounts
+    .map((address) => identities[address])
+    .filter((identity) => Boolean(identity))
 }
 
 /**


### PR DESCRIPTION
Imported accounts can be removed, but the permissions controller is not informed when this happens. Permissions are now removed as part of the account removal process.

Additionally, the `getPermittedIdentitiesForCurrentTab` selector now filters out any non-existent accounts, in case a render occurs in the middle of an account removal.

This was resulting in a render crash upon opening the popup on a site that was connected to the removed account.