### PR TITLE
select current address in permissions connect

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -415,8 +415,6 @@ describe('MetaMask', function () {
 
       await driver.delay(regularDelayMs)
 
-      await driver.clickElement(By.css('.permissions-connect-choose-account__account'))
-
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Next')]`))
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Connect')]`))
 

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -17,6 +17,7 @@ export default class PermissionConnect extends Component {
     getRequestAccountTabIds: PropTypes.func.isRequired,
     getCurrentWindowTab: PropTypes.func.isRequired,
     accounts: PropTypes.array.isRequired,
+    currentAddress: PropTypes.string.isRequired,
     origin: PropTypes.string,
     showNewAccountModal: PropTypes.func.isRequired,
     newAccountNumber: PropTypes.number.isRequired,
@@ -46,9 +47,7 @@ export default class PermissionConnect extends Component {
 
   state = {
     redirecting: false,
-    selectedAccountAddresses: this.props.accounts.length === 1
-      ? new Set([this.props.accounts[0].address])
-      : new Set(),
+    selectedAccountAddresses: new Set([this.props.currentAddress]),
     permissionsApproved: null,
     origin: this.props.origin,
     targetDomainMetadata: this.props.targetDomainMetadata || {},

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -7,6 +7,7 @@ import {
   getAccountsWithLabels,
   getLastConnectedInfo,
   getTargetDomainMetadata,
+  getSelectedAddress,
 } from '../../selectors'
 
 import { formatDate } from '../../helpers/utils/util'
@@ -28,6 +29,7 @@ const mapStateToProps = (state, ownProps) => {
     location: { pathname },
   } = ownProps
   const permissionsRequests = getPermissionsRequests(state)
+  const currentAddress = getSelectedAddress(state)
 
   const permissionsRequest = permissionsRequests
     .find((permissionsRequest) => permissionsRequest.metadata.id === permissionsRequestId)
@@ -68,6 +70,7 @@ const mapStateToProps = (state, ownProps) => {
     permissionsRequestId,
     hasPendingPermissionsRequests,
     accounts: accountsWithLabels,
+    currentAddress,
     origin,
     newAccountNumber: accountsWithLabels.length + 1,
     nativeCurrency,


### PR DESCRIPTION
When initiating a permissions request, automatically select the
currently selected account in the metamask UI.