### PR TITLE
Fix permissions domain metadata retrieval

### DIFF
--- a/ui/app/components/app/permission-page-container/permission-page-container.container.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.container.js
@@ -1,19 +1,14 @@
 import { connect } from 'react-redux'
 import PermissionPageContainer from './permission-page-container.component'
-import {
-  getTargetDomainMetadata,
-  getMetaMaskIdentities,
-} from '../../../selectors'
+import { getMetaMaskIdentities } from '../../../selectors'
 
 const mapStateToProps = (state, ownProps) => {
-  const { request, cachedOrigin, selectedIdentities } = ownProps
-  const targetDomainMetadata = getTargetDomainMetadata(state, request, cachedOrigin)
+  const { selectedIdentities } = ownProps
 
   const allIdentities = getMetaMaskIdentities(state)
   const allIdentitiesSelected = Object.keys(selectedIdentities).length === Object.keys(allIdentities).length && selectedIdentities.length > 1
 
   return {
-    targetDomainMetadata,
     allIdentitiesSelected,
   }
 }

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -206,7 +206,6 @@ export default class PermissionConnect extends Component {
     const {
       selectedAccountAddresses,
       permissionsApproved,
-      origin,
       redirecting,
       targetDomainMetadata,
     } = this.state
@@ -257,7 +256,7 @@ export default class PermissionConnect extends Component {
                       }}
                       rejectPermissionsRequest={(requestId) => this.cancelPermissionsRequest(requestId)}
                       selectedIdentities={accounts.filter((account) => selectedAccountAddresses.has(account.address))}
-                      cachedOrigin={origin}
+                      targetDomainMetadata={targetDomainMetadata}
                     />
                   )}
                 />

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -6,7 +6,7 @@ import {
   getNativeCurrency,
   getAccountsWithLabels,
   getLastConnectedInfo,
-  getTargetDomainMetadata,
+  getDomainMetadata,
   getSelectedAddress,
 } from '../../selectors'
 
@@ -42,6 +42,15 @@ const mapStateToProps = (state, ownProps) => {
   const { origin } = metadata
   const nativeCurrency = getNativeCurrency(state)
 
+  const domainMetadata = getDomainMetadata(state)
+  const targetDomainMetadata = origin
+    ? domainMetadata[origin] || {
+      origin,
+      name: (new URL(origin)).hostname,
+      icon: null,
+    }
+    : null
+
   const accountsWithLabels = getAccountsWithLabels(state)
 
   const lastConnectedInfo = getLastConnectedInfo(state) || {}
@@ -62,8 +71,6 @@ const mapStateToProps = (state, ownProps) => {
   } else {
     throw new Error('Incorrect path for permissions-connect component')
   }
-
-  const targetDomainMetadata = getTargetDomainMetadata(state, permissionsRequest, origin)
 
   return {
     permissionsRequest,

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -292,6 +292,11 @@ export function getTargetDomainMetadata (state, request, defaultOrigin) {
 
   const { metadata: requestMetadata = {} } = request || {}
   const origin = requestMetadata.origin || defaultOrigin
+
+  if (!origin) {
+    return null
+  }
+
   const hostname = (new URL(origin).hostname)
   const targetDomainMetadata = (domainMetadata[origin] || { name: hostname, icon: null })
   targetDomainMetadata.origin = origin

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -287,23 +287,6 @@ export function getDomainMetadata (state) {
   return state.metamask.domainMetadata
 }
 
-export function getTargetDomainMetadata (state, request, defaultOrigin) {
-  const domainMetadata = getDomainMetadata(state)
-
-  const { metadata: requestMetadata = {} } = request || {}
-  const origin = requestMetadata.origin || defaultOrigin
-
-  if (!origin) {
-    return null
-  }
-
-  const hostname = (new URL(origin).hostname)
-  const targetDomainMetadata = (domainMetadata[origin] || { name: hostname, icon: null })
-  targetDomainMetadata.origin = origin
-
-  return targetDomainMetadata
-}
-
 export const getBackgroundMetaMetricState = (state) => {
   return {
     network: getCurrentNetworkId(state),


### PR DESCRIPTION
When a permissions request has been approved, we called `getTargetDomainMetadata` in `permissions-connect.container` for a permissions request that no longer exists. We also called that selector in `permission-page-container` (a child of the former).

`getTargetDomainMetadata` has been removed. Its logic has been simplified and implemented in the `mapStateToProps` of `permissions-connect.container`. Instead of recomputing domain metadata in `permission-page-container`, we pass it as a prop.

