### PR TITLE
remove top/bottom margin on info icon

### DIFF
--- a/ui/app/components/ui/icon/index.scss
+++ b/ui/app/components/ui/icon/index.scss
@@ -1,5 +1,5 @@
 .info-icon {
-  margin: 4px;
+  margin: 0 4px;
 
   &--success {
     fill: $success-green;


### PR DESCRIPTION
The top/bottom margin was unintentional in the first place, and this was throwing the positioning off on some views. 

<details>
<summary>Screenshots</summary>

before:
<img src="https://user-images.githubusercontent.com/4448075/84807256-9b2f9f00-afcc-11ea-9d1c-13993dd601f9.png" />

After:
<img src="https://user-images.githubusercontent.com/4448075/84807400-cb773d80-afcc-11ea-838e-11441974821d.png" />

<img src="https://user-images.githubusercontent.com/4448075/84806992-29efec00-afcc-11ea-9d9e-2427941ada68.png" />

<img src="https://user-images.githubusercontent.com/4448075/84807206-82bf8480-afcc-11ea-88a4-c55b5e7896f9.png" />



</details>