### PR TITLE
Fix dropped tx detection

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -209,9 +209,9 @@ export default class PendingTransactionTracker extends EventEmitter {
    */
   async _checkIfTxWasDropped (txMeta) {
     const { hash: txHash, txParams: { nonce, from } } = txMeta
-    const networkNonce = await this.query.getTransactionCount(from)
+    const networkNextNonce = await this.query.getTransactionCount(from)
 
-    if (parseInt(nonce) > parseInt(networkNonce)) {
+    if (parseInt(nonce, 16) >= parseInt(networkNextNonce, 16)) {
       return false
     }
 


### PR DESCRIPTION
The code for checking whether a transaction was dropped or not was refactored in #8398, but in the process an off-by-one error was introduced.

The old version of `_checkIfTxWasDropped` would query for an updated transaction count from the network, and would consider the pending transaction to be dropped if the count was above the nonce. However, the version introduced in #8398 considers the transaction to be dropped if the count is above *or equal to* the nonce.

The pending transaction nonce is expected to be equal to the transaction count, because the nonce starts at zero. The transaction count is equal to the expected next nonce.

The variable name has been updated to make this more clear (`networkNextNonce` is how the `nonce-tracker` refers to this value).

`parseInt` is now called with an explicit radix of `16` as well, to ensure both nonce strings are always parsed as hex. In all cases I am aware of, these nonce strings were prefixed by `0x`, meaning that `parseInt` would default to a radix of `16`, so this likely doesn't constitute a functional change.

Fixes #8688 