### PR TITLE
Use error.value.message with error.message as fallback

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -79,7 +79,7 @@ export default class PendingTransactionTracker extends EventEmitter {
       try {
         await this._resubmitTx(txMeta, blockNumber)
       } catch (err) {
-        const errorMessage = err.value.message.toLowerCase()
+        const errorMessage = err.value?.message?.toLowerCase() || err.message.toLowerCase()
         const isKnownTx = (
           // geth
           errorMessage.includes('replacement transaction underpriced') ||

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -79,7 +79,7 @@ export default class PendingTransactionTracker extends EventEmitter {
       try {
         await this._resubmitTx(txMeta, blockNumber)
       } catch (err) {
-        const errorMessage = err.message.toLowerCase()
+        const errorMessage = err.value.message.toLowerCase()
         const isKnownTx = (
           // geth
           errorMessage.includes('replacement transaction underpriced') ||


### PR DESCRIPTION
Use `err.value.message` over the whole stringified error object which doesn't show the actual error message that is set as the `txMeta.warning.error`