### PR TITLE
Hide 'Expand view' button in fullscreen

### DIFF
--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -119,7 +119,7 @@ describe('MetaMask', function () {
     it('show account details dropdown menu', async function () {
       await driver.clickElement(By.css('[data-testid="account-options-menu-button"]'))
       const options = await driver.findElements(By.css('.account-options-menu .menu-item'))
-      assert.equal(options.length, 4) // HD Wallet type does not have to show the Remove Account option
+      assert.equal(options.length, 3) // HD Wallet type does not have to show the Remove Account option
       // click outside of menu to dismiss
       // account menu button chosen because the menu never covers it.
       await driver.clickPoint(By.css('.account-menu__icon'), 0, 0)

--- a/ui/app/components/app/menu-bar/account-options-menu.js
+++ b/ui/app/components/app/menu-bar/account-options-menu.js
@@ -10,6 +10,8 @@ import genAccountLink from '../../../../lib/account-link'
 import { getCurrentKeyring, getCurrentNetwork, getRpcPrefsForCurrentProvider, getSelectedIdentity } from '../../../selectors'
 import { useI18nContext } from '../../../hooks/useI18nContext'
 import { useMetricEvent } from '../../../hooks/useMetricEvent'
+import { getEnvironmentType } from '../../../../../app/scripts/lib/util'
+import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../app/scripts/lib/enums'
 
 export default function AccountOptionsMenu ({ anchorElement, onClose }) {
   const t = useI18nContext()
@@ -58,16 +60,22 @@ export default function AccountOptionsMenu ({ anchorElement, onClose }) {
       className="account-options-menu"
       onHide={onClose}
     >
-      <MenuItem
-        onClick={() => {
-          openFullscreenEvent()
-          global.platform.openExtensionInBrowser()
-          onClose()
-        }}
-        iconClassName="fas fa-expand-alt"
-      >
-        { t('expandView') }
-      </MenuItem>
+      {
+        getEnvironmentType() === ENVIRONMENT_TYPE_FULLSCREEN
+          ? null
+          : (
+            <MenuItem
+              onClick={() => {
+                openFullscreenEvent()
+                global.platform.openExtensionInBrowser()
+                onClose()
+              }}
+              iconClassName="fas fa-expand-alt"
+            >
+              { t('expandView') }
+            </MenuItem>
+          )
+      }
       <MenuItem
         data-testid="account-options-menu__account-details"
         onClick={() => {


### PR DESCRIPTION
The 'Expand view' button in the 'Account Options' menu was still being shown on the fullscreen UI. This button is not useful in fullscreen, as all it does is open the fullscreen UI. It is now hidden on the
fullscreen UI.