### PR TITLE
_checkIfTxWasDropped nextworkNextNonce type correction

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -211,7 +211,7 @@ export default class PendingTransactionTracker extends EventEmitter {
     const { hash: txHash, txParams: { nonce, from } } = txMeta
     const networkNextNonce = await this.query.getTransactionCount(from)
 
-    if (parseInt(nonce) >= parseInt(networkNextNonce)) {
+    if (parseInt(nonce, 16) >= parseInt(networkNextNonce.toString())) {
       return false
     }
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -211,7 +211,7 @@ export default class PendingTransactionTracker extends EventEmitter {
     const { hash: txHash, txParams: { nonce, from } } = txMeta
     const networkNextNonce = await this.query.getTransactionCount(from)
 
-    if (parseInt(nonce, 16) >= parseInt(networkNextNonce.toString())) {
+    if (parseInt(nonce, 16) >= parseInt(networkNextNonce) {
       return false
     }
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -211,7 +211,7 @@ export default class PendingTransactionTracker extends EventEmitter {
     const { hash: txHash, txParams: { nonce, from } } = txMeta
     const networkNextNonce = await this.query.getTransactionCount(from)
 
-    if (parseInt(nonce, 16) >= parseInt(networkNextNonce, 10)) {
+    if (parseInt(nonce, 16) >= networkNextNonce.toNumber()) {
       return false
     }
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -211,7 +211,7 @@ export default class PendingTransactionTracker extends EventEmitter {
     const { hash: txHash, txParams: { nonce, from } } = txMeta
     const networkNextNonce = await this.query.getTransactionCount(from)
 
-    if (parseInt(nonce, 16) >= parseInt(networkNextNonce, 16)) {
+    if (parseInt(nonce) >= parseInt(networkNextNonce)) {
       return false
     }
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -211,7 +211,7 @@ export default class PendingTransactionTracker extends EventEmitter {
     const { hash: txHash, txParams: { nonce, from } } = txMeta
     const networkNextNonce = await this.query.getTransactionCount(from)
 
-    if (parseInt(nonce, 16) >= parseInt(networkNextNonce, 10) {
+    if (parseInt(nonce, 16) >= parseInt(networkNextNonce, 10)) {
       return false
     }
 

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -211,7 +211,7 @@ export default class PendingTransactionTracker extends EventEmitter {
     const { hash: txHash, txParams: { nonce, from } } = txMeta
     const networkNextNonce = await this.query.getTransactionCount(from)
 
-    if (parseInt(nonce, 16) >= parseInt(networkNextNonce) {
+    if (parseInt(nonce, 16) >= parseInt(networkNextNonce, 10) {
       return false
     }
 

--- a/test/unit/app/controllers/transactions/pending-tx-tracker-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-tracker-test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon'
 import { strict as assert } from 'assert'
+import BN from 'bn.js'
 import PendingTransactionTracker from '../../../../../app/scripts/controllers/transactions/pending-tx-tracker'
 
 describe('PendingTransactionTracker', function () {
@@ -19,7 +20,7 @@ describe('PendingTransactionTracker', function () {
         getCompletedTransactions: sinon.stub().returns([]),
         approveTransaction: sinon.spy(),
         publishTransaction: sinon.spy(),
-        confirmTransaction: sinon.spy(),
+      confirmTransaction: sinon.spy(),
       })
       const resubmitTx = sinon.stub(pendingTxTracker, '_resubmitTx').rejects()
       const warningListener = sinon.spy()
@@ -311,10 +312,11 @@ describe('PendingTransactionTracker', function () {
 
   describe('#_checkIfTxWasDropped', function () {
     it('should return true when the given nonce is lower than the network nonce', async function () {
+      const nonceBN = new BN(2)
       const pendingTxTracker = new PendingTransactionTracker({
         query: {
           getTransactionReceipt: sinon.stub(),
-          getTransactionCount: sinon.stub().resolves('0x02'),
+          getTransactionCount: sinon.stub().resolves(nonceBN),
         },
         nonceTracker: {
           getGlobalLock: sinon.stub().resolves({
@@ -647,6 +649,7 @@ describe('PendingTransactionTracker', function () {
     })
 
     it("should emit 'tx:dropped' with the txMetas id only after the fourth call", async function () {
+      const nonceBN = new BN(2)
       const txMeta = {
         id: 1,
         hash: '0x0593ee121b92e10d63150ad08b4b8f9c7857d1bd160195ee648fb9a0f8d00eeb',
@@ -662,7 +665,7 @@ describe('PendingTransactionTracker', function () {
       const pendingTxTracker = new PendingTransactionTracker({
         query: {
           getTransactionReceipt: sinon.stub().resolves(null),
-          getTransactionCount: sinon.stub().resolves('0x02'),
+          getTransactionCount: sinon.stub().resolves(nonceBN),
         },
         nonceTracker: {
           getGlobalLock: sinon.stub().resolves({

--- a/test/unit/app/controllers/transactions/pending-tx-tracker-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-tracker-test.js
@@ -345,10 +345,11 @@ describe('PendingTransactionTracker', function () {
     })
 
     it('should return false when the given nonce is the network nonce', async function () {
+      const nonceBN = new BN(1)
       const pendingTxTracker = new PendingTransactionTracker({
         query: {
           getTransactionReceipt: sinon.stub(),
-          getTransactionCount: sinon.stub().resolves('0x01'),
+          getTransactionCount: sinon.stub().resolves(nonceBN),
         },
         nonceTracker: {
           getGlobalLock: sinon.stub().resolves({
@@ -489,10 +490,11 @@ describe('PendingTransactionTracker', function () {
         history: [{}],
         rawTx: '0xf86c808504a817c80082471d',
       }
+      const nonceBN = new BN(2)
       const pendingTxTracker = new PendingTransactionTracker({
         query: {
           getTransactionReceipt: sinon.stub().rejects(),
-          getTransactionCount: sinon.stub().resolves('0x02'),
+          getTransactionCount: sinon.stub().resolves(nonceBN),
         },
         nonceTracker: {
           getGlobalLock: sinon.stub().resolves({

--- a/test/unit/app/controllers/transactions/pending-tx-tracker-test.js
+++ b/test/unit/app/controllers/transactions/pending-tx-tracker-test.js
@@ -20,7 +20,7 @@ describe('PendingTransactionTracker', function () {
         getCompletedTransactions: sinon.stub().returns([]),
         approveTransaction: sinon.spy(),
         publishTransaction: sinon.spy(),
-      confirmTransaction: sinon.spy(),
+        confirmTransaction: sinon.spy(),
       })
       const resubmitTx = sinon.stub(pendingTxTracker, '_resubmitTx').rejects()
       const warningListener = sinon.spy()


### PR DESCRIPTION
~~No radix-16 needed for nonce, already done,. NextNetworkNonce BN doesn't need it either, returns number when parsed.~~

~~Stringify on networkNonce before parseInt.~~

~~Just remove radix-16 on nextNetworkNonce.~~

~~Radix-10 on nextworkNextNonce BN.~~

networkNextNonce.toNumber()

Fixes #8688.