### PR TITLE
Fix first time onboarding popup position

### DIFF
--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -93,7 +93,7 @@
     border-radius: 34px;
     position: absolute;
     top: 82px;
-    left: 12px;
+    left: 8px;
     opacity: 1;
     box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.2);
     background: none;


### PR DESCRIPTION
The connected status indicator had been moved left since this popup was first written. The position of the highlighted portion of the background has been updated reflect this.