### PR TITLE
replace icons with Checkbox component

### DIFF
--- a/ui/app/components/app/connected-accounts-permissions/connected-accounts-permissions.component.js
+++ b/ui/app/components/app/connected-accounts-permissions/connected-accounts-permissions.component.js
@@ -1,6 +1,7 @@
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
+import CheckBox from '../../ui/check-box'
 
 export default class ConnectedAccountsPermissions extends PureComponent {
   static contextTypes = {
@@ -57,7 +58,8 @@ export default class ConnectedAccountsPermissions extends PureComponent {
           <ul className="connected-accounts-permissions__list">
             {permissions.map(({ key: permissionName }) => (
               <li key={permissionName} className="connected-accounts-permissions__list-item">
-                <i className="fas fa-check-square" />{t(permissionName)}
+                <CheckBox checked disabled id={permissionName} className="connected-accounts-permissions__checkbox" />
+                <label htmlFor={permissionName}>{t(permissionName)}</label>
               </li>
             ))}
           </ul>

--- a/ui/app/components/app/connected-accounts-permissions/index.scss
+++ b/ui/app/components/app/connected-accounts-permissions/index.scss
@@ -41,13 +41,11 @@
 
   &__list-item {
     display: flex;
+  }
 
-    i {
-      display: block;
-      padding-right: 8px;
-      font-size: 18px;
-      color: $Grey-800;
-    }
+  & &__checkbox {
+    margin: 0 8px 0 0;
+    font-size: 18px;
   }
 
   &__list-container {

--- a/ui/app/components/app/permission-page-container/index.scss
+++ b/ui/app/components/app/permission-page-container/index.scss
@@ -62,17 +62,17 @@
       display: flex;
       align-items: center;
 
-      i {
-        font-size: 1.4rem;
-        color: $Grey-200;
-      }
-
       label {
         font-size: 14px;
         margin-left: 16px;
         color: $Black-100;
       }
     }
+  }
+
+  & &__checkbox {
+    font-size: 1.4rem;
+    margin: 0;
   }
 
   &__content-container {

--- a/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import PermissionsConnectHeader from '../../permissions-connect-header'
 import Tooltip from '../../../ui/tooltip-v2'
+import CheckBox from '../../../ui/check-box'
 
 export default class PermissionPageContainerContent extends PureComponent {
 
@@ -33,6 +34,8 @@ export default class PermissionPageContainerContent extends PureComponent {
       const description = t(permissionName)
       // don't allow deselecting eth_accounts
       const isDisabled = permissionName === 'eth_accounts'
+      const isChecked = Boolean(selectedPermissions[permissionName])
+      const title = isChecked ? t('permissionCheckedIconDescription') : t('permissionUncheckedIconDescription')
 
       return (
         <div
@@ -44,11 +47,14 @@ export default class PermissionPageContainerContent extends PureComponent {
             }
           }}
         >
-          { selectedPermissions[permissionName]
-            ? <i title={t('permissionCheckedIconDescription')} className="fa fa-check-square" />
-            : <i title={t('permissionUncheckedIconDescription')} className="fa fa-square" />
-          }
-          <label>{description}</label>
+          <CheckBox
+            disabled={isDisabled}
+            id={permissionName}
+            className="permission-approval-container__checkbox"
+            checked={isChecked}
+            title={title}
+          />
+          <label htmlFor={permissionName}>{description}</label>
         </div>
       )
     })

--- a/ui/app/components/ui/check-box/check-box.component.js
+++ b/ui/app/components/ui/check-box/check-box.component.js
@@ -10,7 +10,7 @@ const CHECKBOX_STATE = {
 
 export const { CHECKED, INDETERMINATE, UNCHECKED } = CHECKBOX_STATE
 
-const CheckBox = ({ className, disabled, id, onClick, checked }) => {
+const CheckBox = ({ className, disabled, id, onClick, checked, title }) => {
   if (typeof checked === 'boolean') {
     checked = checked
       ? CHECKBOX_STATE.CHECKED
@@ -41,6 +41,7 @@ const CheckBox = ({ className, disabled, id, onClick, checked }) => {
       }
       readOnly
       ref={ref}
+      title={title}
       type="checkbox"
     />
   )
@@ -52,6 +53,7 @@ CheckBox.propTypes = {
   id: PropTypes.string,
   onClick: PropTypes.func,
   checked: PropTypes.oneOf([...Object.keys(CHECKBOX_STATE), true, false]).isRequired,
+  title: PropTypes.string,
 }
 
 CheckBox.defaultProps = {

--- a/ui/app/components/ui/check-box/index.scss
+++ b/ui/app/components/ui/check-box/index.scss
@@ -18,6 +18,5 @@
   &:disabled {
     color: $Grey-100;
     cursor: not-allowed;
-    opacity: 0.5;
   }
 }


### PR DESCRIPTION
In both permission flows, the checkboxes were using the fa-check icon, and in the case of the connected accounts popover, the color of the icon was wrong. It occurred to me while simply fixing that color would have been easier; we will be adding permissions in the future that a user will be able to uncheck. This PR replaces the usages of those icons with the Checkbox component, equipped to handle the interactivity of checking/unchecking.

Got with @rachelcope around mismatched colors in the design system vs code, went with grey-100 for disabled state checkbox.

NOTE:
removed an opacity of 0.5 on disabled state at the check-box component level because the only usages of disabled state prior to this work were in the storybook story. the opacity makes the color appear lighter and not exact to design.

<details>
<summary>Connected Accounts</summary>

<br/>

<b>Before</b>:
<img src="https://user-images.githubusercontent.com/4448075/84948153-eb802d00-b0b0-11ea-85cb-3e70da09cf0d.png" />

<br/>

<b>After</b>:
<img src="https://user-images.githubusercontent.com/4448075/84948413-53cf0e80-b0b1-11ea-86d0-79b894e2ee1a.png" />

</details>

<details>
<summary>Permissions Approval</summary>

<br/>

<b>Before</b>:
<img src="https://user-images.githubusercontent.com/4448075/84948168-f33fd180-b0b0-11ea-8a57-7468cfd21cc2.png" />

<br/>

<b>After</b>:
<img src="https://user-images.githubusercontent.com/4448075/84948485-6ba69280-b0b1-11ea-8707-4e925e15ef9a.png" />

</details>