### PR TITLE
Use @metamask/controllers@2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@formatjs/intl-relativetimeformat": "^5.2.6",
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@material-ui/core": "1.0.0",
-    "@metamask/controllers": "^2.0.0",
+    "@metamask/controllers": "^2.0.1",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^2.0.0",
     "@metamask/etherscan-link": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,10 +1629,10 @@
     scroll "^2.0.3"
     warning "^3.0.0"
 
-"@metamask/controllers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-2.0.0.tgz#e57762c213d2722fd178d4c5c288ad98a2ee8bdf"
-  integrity sha512-J2DSoyyPRAilTdohl43O5tZdqOSMvB94Kx1ApRpkPZxQwtDUIzWHRpTXptyCEwkhaOdkNz9BvWMoaRQxjktfKw==
+"@metamask/controllers@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-2.0.1.tgz#33b0e2826fb6d4aa582acaff6b347e6abe0f54f5"
+  integrity sha512-xioh4h+4D2pUSJ9H2CaffxKGmlg0kUK2bbRJ8c9GXPVTo8KhRHryvNKfkVCyoSt35FLROzzwTEdVJ4dmUFuELQ==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.11.0"


### PR DESCRIPTION
This PR updates the `@metamask/controllers` package to the latest version, v2.0.1.

[See the changelog for v2.0.1](https://github.com/MetaMask/controllers/blob/develop/CHANGELOG.md#201---2020-06-18)—the important change here is switching the PhishingController to use the GitHub API (refs https://github.com/MetaMask/controllers/pull/244).