### PR TITLE
Check four byte prefix object is empty

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2160,7 +2160,7 @@ export function getContractMethodData (data = '') {
     const prefixedData = ethUtil.addHexPrefix(data)
     const fourBytePrefix = prefixedData.slice(0, 10)
     const { knownMethodData } = getState().metamask
-    if (knownMethodData && knownMethodData[fourBytePrefix]) {
+    if (knownMethodData && knownMethodData[fourBytePrefix] && Object.keys(knownMethodData[fourBytePrefix]).length !== 0) {
       return Promise.resolve(knownMethodData[fourBytePrefix])
     }
 


### PR DESCRIPTION
Fixes #8835

In cases where the initial registry failed to load, and the sig is set to `{}` on this line: https://github.com/MetaMask/metamask-extension/blob/e85b162651e887d79bfd15469289abc2c6753cbc/ui/app/helpers/utils/transactions.util.js#L78 this proceeds to set the four byte method to `{}` in knownMethodData.

Additionally check if the method four byte prefix object is empty to proceed call `getMethodDataAsync` again.

I could only reproduce by intentionally failing the method registry lookup and found this solution. I could not find an instance where the registry consistently failed to lookup even on slow/throttled/high latency networks.