### PR TITLE
Stop upper-casing exported private key

### DIFF
--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -216,7 +216,6 @@
   overflow: hidden;
   resize: none;
   padding: 9px 13px 8px;
-  text-transform: uppercase;
 }
 
 .modal-close-x::after {


### PR DESCRIPTION
We were showing exported private keys in all upper case. This is atypical, and many other wallets (e.g. MyCrypto) expect private keys for imported accounts to be lower-cased. Our own account import is tolerant of either case.