### PR TITLE
Add migration to initialize AlertController.alertEnabledness

### DIFF
--- a/app/scripts/migrations/047.js
+++ b/app/scripts/migrations/047.js
@@ -1,0 +1,35 @@
+const version = 47
+import { cloneDeep } from 'lodash'
+import { ALERT_TYPES } from '../controllers/alert'
+
+/**
+ * Initialize `AlertController.alertEnabledness` state if it hasn't yet been set
+ */
+export default {
+  version,
+  migrate: async function (originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData)
+    versionedData.meta.version = version
+    const state = versionedData.data
+    versionedData.data = transformState(state)
+    return versionedData
+  },
+}
+
+function transformState (state) {
+  if (typeof state?.AlertController?.alertEnabledness === 'undefined') {
+    const AlertControllerState = {
+      alertEnabledness: Object.keys(ALERT_TYPES)
+        .reduce(
+          (alertEnabledness, alertType) => {
+            alertEnabledness[alertType] = true
+            return alertEnabledness
+          },
+          {}
+        ),
+      unconnectedAccountAlertShownOrigins: {},
+    }
+    state.AlertController = AlertControllerState
+  }
+  return state
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -57,6 +57,7 @@ const migrations = [
   require('./044').default,
   require('./045').default,
   require('./046').default,
+  require('./047').default,
 ]
 
 export default migrations

--- a/test/unit/migrations/047-test.js
+++ b/test/unit/migrations/047-test.js
@@ -1,0 +1,47 @@
+import assert from 'assert'
+import migration47 from '../../../app/scripts/migrations/047'
+
+describe('migration #47', function () {
+
+  it('should update the version metadata', function (done) {
+    const oldStorage = {
+      'meta': {
+        'version': 46,
+      },
+      'data': {},
+    }
+
+    migration47.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.meta, {
+          'version': 47,
+        })
+        done()
+      })
+      .catch(done)
+  })
+
+  it('should initialize AlertController state', function (done) {
+    const oldStorage = {
+      meta: {},
+      data: {
+        foo: 'bar',
+      },
+    }
+
+    migration47.migrate(oldStorage)
+      .then((newStorage) => {
+        assert.deepEqual(newStorage.data, {
+          AlertController: {
+            alertEnabledness: {
+              unconnectedAccount: true,
+            },
+            unconnectedAccountAlertShownOrigins: {},
+          },
+          foo: 'bar',
+        })
+        done()
+      })
+      .catch(done)
+  })
+})


### PR DESCRIPTION
This PR adds a migration to ensure that `AlertController` data gets correctly initialized on a version change.

This was motivated by the following error that I saw updating my local development version:

![Screenshot from 2020-06-24 06-03-31](https://user-images.githubusercontent.com/7499938/85545744-cc285900-b5f6-11ea-9754-bc0bbcaf1218.png)
