### PR TITLE
Replace removed 'copy-to-clipboard' icon

### DIFF
--- a/ui/app/components/ui/export-text-container/export-text-container.component.js
+++ b/ui/app/components/ui/export-text-container/export-text-container.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import copyToClipboard from 'copy-to-clipboard'
 import { exportAsFile } from '../../../helpers/utils/util'
+import Copy from '../icon/copy-icon.component'
 
 class ExportTextContainer extends Component {
   render () {
@@ -20,7 +21,7 @@ class ExportTextContainer extends Component {
             className="export-text-container__button export-text-container__button--copy"
             onClick={() => copyToClipboard(text)}
           >
-            <img src="images/copy-to-clipboard.svg" alt="" />
+            <Copy size={17} color="#3098DC" />
             <div className="export-text-container__button-text">
               {t('copyToClipboard')}
             </div>

--- a/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -7,6 +7,7 @@ import AccountListItem from '../send/account-list-item/account-list-item.compone
 import Button from '../../components/ui/button'
 import Identicon from '../../components/ui/identicon'
 import Tooltip from '../../components/ui/tooltip-v2'
+import Copy from '../../components/ui/icon/copy-icon.component'
 
 import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../../app/scripts/lib/enums'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
@@ -273,7 +274,7 @@ export default class ConfirmDecryptMessage extends Component {
                 >
                   {t('decryptCopy')}
                 </div>
-                <img src="images/copy-to-clipboard.svg" />
+                <Copy size={17} color="#3098DC" />
               </Tooltip>
             </div>
           )


### PR DESCRIPTION
The 'copy-to-clipboard' icon was removed in #8190, and replaced with a new 'Copy' icon component. It was still being used in two places though, on the confirmation page for decryption and on the reveal seed phrase screen..

The new Copy icon is now used in these two places instead. It has been given a size of '17' to match the old icon size.