### PR TITLE
Replace remaining img copy svg to component copy svg

### DIFF
--- a/ui/app/components/ui/export-text-container/export-text-container.component.js
+++ b/ui/app/components/ui/export-text-container/export-text-container.component.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import copyToClipboard from 'copy-to-clipboard'
+import Copy from '../icon/copy-icon.component'
 import { exportAsFile } from '../../../helpers/utils/util'
 
 class ExportTextContainer extends Component {
@@ -20,7 +21,7 @@ class ExportTextContainer extends Component {
             className="export-text-container__button export-text-container__button--copy"
             onClick={() => copyToClipboard(text)}
           >
-            <img src="images/copy-to-clipboard.svg" alt="" />
+            <Copy size={20} color="#3098DC" />
             <div className="export-text-container__button-text">
               {t('copyToClipboard')}
             </div>

--- a/ui/app/css/itcss/components/request-decrypt-message.scss
+++ b/ui/app/css/itcss/components/request-decrypt-message.scss
@@ -173,12 +173,12 @@
     padding: 5px;
     border-radius: 5px;
     position: relative;
-	
+
 	&-text {
 		font-size: 0.7em;
 		height: 115px;
 	}
-	
+
 	&-cover {
 		background-color: white;
 		opacity: 0.75;
@@ -187,7 +187,7 @@
 		width: 100%;
 		top: 0px;
 	}
-	
+
 	&-lock {
 		position: absolute;
 		height: 100%;
@@ -202,12 +202,12 @@
 			top: calc(50% - 34px);
 			border-radius: 3px;
 		}
-		
+
 		&--pressed {
 			display: none;
 		}
 	}
-	
+
 	&-lock-text {
 		width: 200px;
 		font-size: 0.75em;
@@ -219,7 +219,7 @@
 		line-height: 1em;
 		border-radius: 3px;
 	}
-	
+
 	&-copy {
 		justify-content: space-evenly;
 		font-size: 0.75em;
@@ -228,12 +228,12 @@
 		display: flex;
 		cursor: pointer;
 	}
-	
+
 	&-copy-text {
-	    margin-right: 10px;
+	  margin-right: 10px;
 		display: inline;
 	}
-	
+
 	&-copy-tooltip {
 		float: right;
 	}
@@ -258,7 +258,7 @@
       margin-right: 1.2rem;
     }
   }
-  
+
   &__visual {
       display: flex;
       flex-direction: row;

--- a/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -7,6 +7,7 @@ import AccountListItem from '../send/account-list-item/account-list-item.compone
 import Button from '../../components/ui/button'
 import Identicon from '../../components/ui/identicon'
 import Tooltip from '../../components/ui/tooltip-v2'
+import Copy from '../../components/ui/icon/copy-icon.component'
 
 import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../../app/scripts/lib/enums'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
@@ -267,13 +268,14 @@ export default class ConfirmDecryptMessage extends Component {
                 position="bottom"
                 title={hasCopied ? t('copiedExclamation') : t('copyToClipboard')}
                 wrapperClassName="request-decrypt-message__message-copy-tooltip"
+                style={{ display: 'flex', alignItems: 'center' }}
               >
                 <div
                   className="request-decrypt-message__message-copy-text"
                 >
                   {t('decryptCopy')}
                 </div>
-                <img src="images/copy-to-clipboard.svg" />
+                <Copy size={15} color="#3098DC" />
               </Tooltip>
             </div>
           )


### PR DESCRIPTION
Extension of #8190

Inline style for decrypt copy text and icon. Needed to override the ReactTippy default `display: inline` to `flex` and align the text and icon.
<details>
<summary>Without inline style(a little off)</summary>
<img src='https://user-images.githubusercontent.com/13376180/85630943-6f926180-b629-11ea-9813-035dace2b1f8.png'>
</details>

<details>
<summary>With inline style</summary>
<img src='https://user-images.githubusercontent.com/13376180/85630970-7c16ba00-b629-11ea-90af-88ced7a99d04.png'>
</details>