### PR TITLE
Fix mobile sync redirect

### DIFF
--- a/ui/app/pages/mobile-sync/mobile-sync.container.js
+++ b/ui/app/pages/mobile-sync/mobile-sync.container.js
@@ -19,7 +19,7 @@ const mapStateToProps = (state) => {
   } = state
 
   return {
-    mostRecentOverviewpage: getMostRecentOverviewPage(state),
+    mostRecentOverviewPage: getMostRecentOverviewPage(state),
     selectedAddress,
   }
 }


### PR DESCRIPTION
The mobile sync redirect was failing due to a typo in a prop. It would fail to redirect correctly in the event of a timeout, or after pressing 'Cancel'.