### PR TITLE
Align copy tooltip text and icon

### DIFF
--- a/ui/app/css/itcss/components/request-decrypt-message.scss
+++ b/ui/app/css/itcss/components/request-decrypt-message.scss
@@ -173,12 +173,12 @@
     padding: 5px;
     border-radius: 5px;
     position: relative;
-	
+
 	&-text {
 		font-size: 0.7em;
 		height: 115px;
 	}
-	
+
 	&-cover {
 		background-color: white;
 		opacity: 0.75;
@@ -187,7 +187,7 @@
 		width: 100%;
 		top: 0px;
 	}
-	
+
 	&-lock {
 		position: absolute;
 		height: 100%;
@@ -202,12 +202,12 @@
 			top: calc(50% - 34px);
 			border-radius: 3px;
 		}
-		
+
 		&--pressed {
 			display: none;
 		}
 	}
-	
+
 	&-lock-text {
 		width: 200px;
 		font-size: 0.75em;
@@ -219,7 +219,7 @@
 		line-height: 1em;
 		border-radius: 3px;
 	}
-	
+
 	&-copy {
 		justify-content: space-evenly;
 		font-size: 0.75em;
@@ -228,12 +228,12 @@
 		display: flex;
 		cursor: pointer;
 	}
-	
+
 	&-copy-text {
 	    margin-right: 10px;
 		display: inline;
 	}
-	
+
 	&-copy-tooltip {
 		float: right;
 	}
@@ -258,7 +258,7 @@
       margin-right: 1.2rem;
     }
   }
-  
+
   &__visual {
       display: flex;
       flex-direction: row;

--- a/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -268,6 +268,7 @@ export default class ConfirmDecryptMessage extends Component {
                 position="bottom"
                 title={hasCopied ? t('copiedExclamation') : t('copyToClipboard')}
                 wrapperClassName="request-decrypt-message__message-copy-tooltip"
+                style={{ display: 'flex', alignItems: 'center' }}
               >
                 <div
                   className="request-decrypt-message__message-copy-text"


### PR DESCRIPTION
Add style prop to ReactTippy to override the inline display to flex display and align items to center

<details>
<summary>Without inline style(a little off)</summary>
<img src='https://user-images.githubusercontent.com/13376180/85630943-6f926180-b629-11ea-9813-035dace2b1f8.png'>
</details>

<details>
<summary>With inline style</summary>
<img src='https://user-images.githubusercontent.com/13376180/85630970-7c16ba00-b629-11ea-90af-88ced7a99d04.png'>
</details>