### PR TITLE
Fix account order on unconnected account alert

### DIFF
--- a/ui/app/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
+++ b/ui/app/components/app/alerts/unconnected-account-alert/unconnected-account-alert.js
@@ -11,7 +11,7 @@ import {
 } from '../../../../ducks/alerts/unconnected-account'
 import {
   getOriginOfCurrentTab,
-  getPermittedIdentitiesForCurrentTab,
+  getOrderedConnectedAccountsForActiveTab,
   getSelectedAddress,
   getSelectedIdentity,
 } from '../../../../selectors'
@@ -32,7 +32,7 @@ const UnconnectedAccountAlert = () => {
   const t = useI18nContext()
   const dispatch = useDispatch()
   const alertState = useSelector(getAlertState)
-  const connectedAccounts = useSelector(getPermittedIdentitiesForCurrentTab)
+  const connectedAccounts = useSelector(getOrderedConnectedAccountsForActiveTab)
   const origin = useSelector(getOriginOfCurrentTab)
   const selectedIdentity = useSelector(getSelectedIdentity)
   const selectedAddress = useSelector(getSelectedAddress)

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -1,5 +1,5 @@
 import { forOwn } from 'lodash'
-import { getMetaMaskAccountsOrdered, getMetaMaskIdentities, getOriginOfCurrentTab, getSelectedAddress } from '.'
+import { getMetaMaskAccountsOrdered, getOriginOfCurrentTab, getSelectedAddress } from '.'
 import {
   CAVEAT_NAMES,
 } from '../../../app/scripts/controllers/permissions/enums'
@@ -117,14 +117,6 @@ export function getConnectedDomainsForSelectedAddress (state) {
   })
 
   return connectedDomains
-}
-
-export function getPermittedIdentitiesForCurrentTab (state) {
-  const permittedAccounts = getPermittedAccountsForCurrentTab(state)
-  const identities = getMetaMaskIdentities(state)
-  return permittedAccounts
-    .map((address) => identities[address])
-    .filter((identity) => Boolean(identity))
 }
 
 /**


### PR DESCRIPTION
The account list on the unconnected account alert was in the wrong order; they were in the order provided by the permissions controller rather than by last active.

The accounts are now sorted correctly; first by last active, second by the keyring controller order.

The `getPermittedIdentitiesForCurrentTab` selector was removed because it is no longer used.