### PR TITLE
Add envar for ETH Gas Station API key

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -338,6 +338,7 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
       IN_TEST: opts.testing ? 'true' : false,
       PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY || '',
       PUBNUB_PUB_KEY: process.env.PUBNUB_PUB_KEY || '',
+      ETH_GAS_STATION_API_KEY: process.env.ETH_GAS_STATION_API_KEY || '',
       CONF: opts.devMode ? conf : ({}),
     }), {
       global: true,

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -41,9 +41,9 @@ async function setupFetchMocking (driver) {
     window.origFetch = window.fetch.bind(window)
     window.fetch = async (...args) => {
       const url = args[0]
-      if (url === 'https://ethgasstation.info/json/ethgasAPI.json') {
+      if (url.match(/^http(s)?:\/\/ethgasstation\.info\/json\/ethgasAPI.*/u)) {
         return { json: async () => clone(fetchMockResponses.ethGasBasic) }
-      } else if (url === 'https://ethgasstation.info/json/predictTable.json') {
+      } else if (url.match(/http(s?):\/\/ethgasstation\.info\/json\/predictTable.*/u)) {
         return { json: async () => clone(fetchMockResponses.ethGasPredictTable) }
       } else if (url.match(/chromeextensionmm/)) {
         return { json: async () => clone(fetchMockResponses.metametrics) }

--- a/test/integration/lib/confirm-sig-requests.js
+++ b/test/integration/lib/confirm-sig-requests.js
@@ -24,9 +24,9 @@ async function runConfirmSigRequestsTest (assert) {
 
   const realFetch = window.fetch.bind(window)
   window.fetch = (...args) => {
-    if (args[0] === 'https://ethgasstation.info/json/ethgasAPI.json') {
+    if (args[0].match(/^http(s)?:\/\/ethgasstation\.info\/json\/ethgasAPI.*/u)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
-    } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
+    } else if (args[0].match(/http(s?):\/\/ethgasstation\.info\/json\/predictTable.*/u)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
     } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })

--- a/test/integration/lib/currency-localization.js
+++ b/test/integration/lib/currency-localization.js
@@ -23,9 +23,9 @@ async function runCurrencyLocalizationTest (assert) {
 
   const realFetch = window.fetch.bind(window)
   window.fetch = (...args) => {
-    if (args[0] === 'https://ethgasstation.info/json/ethgasAPI.json') {
+    if (args[0].match(/^http(s)?:\/\/ethgasstation\.info\/json\/ethgasAPI.*/u)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasBasic)) })
-    } else if (args[0] === 'https://ethgasstation.info/json/predictTable.json') {
+    } else if (args[0].match(/http(s?):\/\/ethgasstation\.info\/json\/predictTable.*/u)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.ethGasPredictTable)) })
     } else if (args[0].match(/chromeextensionmm/)) {
       return Promise.resolve({ json: () => Promise.resolve(JSON.parse(fetchMockResponses.metametrics)) })

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -290,19 +290,9 @@ describe('Gas Duck', function () {
         mockDistpatch.getCall(0).args,
         [{ type: BASIC_GAS_ESTIMATE_LOADING_STARTED } ]
       )
-      assert.deepEqual(
-        window.fetch.getCall(0).args,
-        [
-          'https://ethgasstation.info/json/ethgasAPI.json',
-          {
-            'headers': {},
-            'referrer': 'http://ethgasstation.info/json/',
-            'referrerPolicy': 'no-referrer-when-downgrade',
-            'body': null,
-            'method': 'GET',
-            'mode': 'cors',
-          },
-        ]
+      assert.ok(
+        window.fetch.getCall(0).args[0].startsWith('https://ethgasstation.info/json/ethgasAPI.json'),
+        'should fetch ETH Gas Station',
       )
       assert.deepEqual(
         mockDistpatch.getCall(1).args,
@@ -389,19 +379,9 @@ describe('Gas Duck', function () {
         mockDistpatch.getCall(0).args,
         [{ type: BASIC_GAS_ESTIMATE_LOADING_STARTED } ]
       )
-      assert.deepEqual(
-        window.fetch.getCall(0).args,
-        [
-          'https://ethgasstation.info/json/ethgasAPI.json',
-          {
-            'headers': {},
-            'referrer': 'http://ethgasstation.info/json/',
-            'referrerPolicy': 'no-referrer-when-downgrade',
-            'body': null,
-            'method': 'GET',
-            'mode': 'cors',
-          },
-        ]
+      assert.ok(
+        window.fetch.getCall(0).args[0].startsWith('https://ethgasstation.info/json/ethgasAPI.json'),
+        'should fetch ETH Gas Station',
       )
       assert.deepEqual(
         mockDistpatch.getCall(1).args,
@@ -443,19 +423,9 @@ describe('Gas Duck', function () {
         mockDistpatch.getCall(0).args,
         [{ type: BASIC_GAS_ESTIMATE_LOADING_STARTED } ]
       )
-      assert.deepEqual(
-        window.fetch.getCall(0).args,
-        [
-          'https://ethgasstation.info/json/ethgasAPI.json',
-          {
-            'headers': {},
-            'referrer': 'http://ethgasstation.info/json/',
-            'referrerPolicy': 'no-referrer-when-downgrade',
-            'body': null,
-            'method': 'GET',
-            'mode': 'cors',
-          },
-        ]
+      assert.ok(
+        window.fetch.getCall(0).args[0].startsWith('https://ethgasstation.info/json/ethgasAPI.json'),
+        'should fetch ETH Gas Station',
       )
 
       assert.deepEqual(
@@ -564,19 +534,9 @@ describe('Gas Duck', function () {
         mockDistpatch.getCall(0).args,
         [{ type: BASIC_GAS_ESTIMATE_LOADING_STARTED } ]
       )
-      assert.deepEqual(
-        window.fetch.getCall(0).args,
-        [
-          'https://ethgasstation.info/json/ethgasAPI.json',
-          {
-            'headers': {},
-            'referrer': 'http://ethgasstation.info/json/',
-            'referrerPolicy': 'no-referrer-when-downgrade',
-            'body': null,
-            'method': 'GET',
-            'mode': 'cors',
-          },
-        ]
+      assert.ok(
+        window.fetch.getCall(0).args[0].startsWith('https://ethgasstation.info/json/ethgasAPI.json'),
+        'should fetch ETH Gas Station',
       )
 
       assert.deepEqual(
@@ -625,19 +585,9 @@ describe('Gas Duck', function () {
         mockDistpatch.getCall(0).args,
         [{ type: GAS_ESTIMATE_LOADING_STARTED } ]
       )
-      assert.deepEqual(
-        window.fetch.getCall(0).args,
-        [
-          'https://ethgasstation.info/json/predictTable.json',
-          {
-            'headers': {},
-            'referrer': 'http://ethgasstation.info/json/',
-            'referrerPolicy': 'no-referrer-when-downgrade',
-            'body': null,
-            'method': 'GET',
-            'mode': 'cors',
-          },
-        ]
+      assert.ok(
+        window.fetch.getCall(0).args[0].startsWith('https://ethgasstation.info/json/predictTable.json'),
+        'should fetch ETH Gas Station',
       )
 
       assert.deepEqual(

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -172,6 +172,32 @@ export function gasEstimatesLoadingFinished () {
   }
 }
 
+async function queryEthGasStationBasic () {
+  const apiKey = process.env.ETH_GAS_STATION_API_KEY ? `?api-key=${process.env.ETH_GAS_STATION_API_KEY}` : ''
+  const url = `https://ethgasstation.info/json/ethgasAPI.json${apiKey}`
+  return await window.fetch(url, {
+    'headers': {},
+    'referrer': 'http://ethgasstation.info/json/',
+    'referrerPolicy': 'no-referrer-when-downgrade',
+    'body': null,
+    'method': 'GET',
+    'mode': 'cors',
+  })
+}
+
+async function queryEthGasStationPredictionTable () {
+  const apiKey = process.env.ETH_GAS_STATION_API_KEY ? `?api-key=${process.env.ETH_GAS_STATION_API_KEY}` : ''
+  const url = `https://ethgasstation.info/json/predictTable.json${apiKey}`
+  return await window.fetch(url, {
+    'headers': {},
+    'referrer': 'http://ethgasstation.info/json/',
+    'referrerPolicy': 'no-referrer-when-downgrade',
+    'body': null,
+    'method': 'GET',
+    'mode': 'cors' }
+  )
+}
+
 export function fetchBasicGasEstimates () {
   return async (dispatch, getState) => {
     const { basicPriceEstimatesLastRetrieved } = getState().gas
@@ -195,14 +221,7 @@ export function fetchBasicGasEstimates () {
 }
 
 async function fetchExternalBasicGasEstimates (dispatch) {
-  const response = await window.fetch('https://ethgasstation.info/json/ethgasAPI.json', {
-    'headers': {},
-    'referrer': 'http://ethgasstation.info/json/',
-    'referrerPolicy': 'no-referrer-when-downgrade',
-    'body': null,
-    'method': 'GET',
-    'mode': 'cors',
-  })
+  const response = await queryEthGasStationBasic()
 
   const {
     safeLow: safeLowTimes10,
@@ -259,14 +278,7 @@ export function fetchBasicGasAndTimeEstimates () {
 }
 
 async function fetchExternalBasicGasAndTimeEstimates (dispatch) {
-  const response = await window.fetch('https://ethgasstation.info/json/ethgasAPI.json', {
-    'headers': {},
-    'referrer': 'http://ethgasstation.info/json/',
-    'referrerPolicy': 'no-referrer-when-downgrade',
-    'body': null,
-    'method': 'GET',
-    'mode': 'cors',
-  })
+  const response = await queryEthGasStationBasic()
 
   const {
     average: averageTimes10,
@@ -377,14 +389,7 @@ export function fetchGasEstimates (blockTime) {
     dispatch(gasEstimatesLoadingStarted())
 
     const promiseToFetch = Date.now() - timeLastRetrieved > 75000
-      ? window.fetch('https://ethgasstation.info/json/predictTable.json', {
-        'headers': {},
-        'referrer': 'http://ethgasstation.info/json/',
-        'referrerPolicy': 'no-referrer-when-downgrade',
-        'body': null,
-        'method': 'GET',
-        'mode': 'cors' }
-      )
+      ? queryEthGasStationPredictionTable()
         .then((r) => r.json())
         .then((r) => {
           const estimatedPricesAndTimes = r.map(({ expectedTime, expectedWait, gasprice }) => ({ expectedTime, expectedWait, gasprice }))


### PR DESCRIPTION
This PR adds an environment variable for setting an ETH Gas Station API key, `ETH_GAS_STATION_API_KEY`.

> **Starting July 1st, 2020, use of ETH Gas Station’s API will require an API Key from DeFi Pulse Data.** API users can acquire a key for free by simply signing up for a DeFi Pulse Data account. To make the transition as smooth as possible, accounts will be provided with ample credits initially.

  [1]:https://ethgasstation.info/blog/eth-gas-station-api-will-require-an-api-key-starting-july-1st-2020/
  [2]:https://web.archive.org/web/20200629160501/https://ethgasstation.info/blog/eth-gas-station-api-will-require-an-api-key-starting-july-1st-2020/