### PR TITLE
Fix height / overflow behaviour of add token list

### DIFF
--- a/ui/app/components/ui/page-container/index.scss
+++ b/ui/app/components/ui/page-container/index.scss
@@ -46,6 +46,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    min-height: 0;
   }
 
   &__footer {


### PR DESCRIPTION
This PR fixes the problem with the height / overflow of the add token lists that causes the page footer buttons to be hidden by the scroll. This can be seen below:

![add-token-height-overflow](https://user-images.githubusercontent.com/7499938/86119670-75ff5e00-baad-11ea-9ece-6bccdfac0422.gif)

By setting `min-height: 0;` on the parent div of the overflowing elements, the problem is fixed (for reasons explained here: https://stackoverflow.com/a/26916542/4727685). The fix can be seen below:

![add-token-height-overflow-fixed](https://user-images.githubusercontent.com/7499938/86119840-ca0a4280-baad-11ea-9e91-4a268248921f.gif)

The changed css rule is only used on the add token screen and in the gas modal. The gas modal remains unchanged after this change.