### PR TITLE
fix language code format mismatch

### DIFF
--- a/ui/app/hooks/useTransactionTimeRemaining.js
+++ b/ui/app/hooks/useTransactionTimeRemaining.js
@@ -50,7 +50,7 @@ export function useTransactionTimeRemaining (
   const featureFlags = useSelector(getFeatureFlags)
   const transactionTimeFeatureActive = featureFlags?.transactionTime
 
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto', style: 'narrow' })
+  const rtf = new Intl.RelativeTimeFormat(locale.replace('_', '-'), { numeric: 'auto', style: 'narrow' })
 
   // Memoize this value so it can be used as a dependency in the effect below
   const initialTimeEstimate = useMemo(() => {


### PR DESCRIPTION
replace underscores with dashes to prevent bug resulting from `Intl.RelativeTimeFormat` expecting 'zh-CN' versus 'zh_CN' 

see: https://sentry.io/share/issue/f2b717159e814ff7ba7331429b5850b4/