### PR TITLE
Set empty active tab if origin is invalid

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -86,6 +86,11 @@ async function queryCurrentActiveTab (windowType) {
       const { title, url } = activeTab
       const { origin, protocol } = url ? new URL(url) : {}
 
+      if (!origin || origin === 'null') {
+        resolve({})
+        return
+      }
+
       resolve({ title, origin, protocol, url })
     })
   })


### PR DESCRIPTION
The `activeTab` state is now set to an empty object if the `origin` of the active tab is missing or invalid. It can be invalid if the URL
passed to the `URL` constructor is missing a scheme (e.g. `about:blank`).

There are currently no cases where the rest of the data in `activeTab` is useful in the absence of an `origin`. This will make upcoming UI logic changes a bit simpler than they would be otherwise. Now we can assume that if any property is set on `activeTab`, it must have a valid `origin`.