### PR TITLE
Prevent showing connected accounts without origin

### DIFF
--- a/ui/app/components/app/menu-bar/menu-bar.js
+++ b/ui/app/components/app/menu-bar/menu-bar.js
@@ -26,7 +26,7 @@ export default function MenuBar () {
   const [accountOptionsMenuOpen, setAccountOptionsMenuOpen] = useState(false)
   const origin = useSelector(getOriginOfCurrentTab)
 
-  const showStatus = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP && origin !== extension.runtime.id
+  const showStatus = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP && origin && origin !== extension.runtime.id
 
   return (
     <div className="menu-bar">

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1191,8 +1191,8 @@ export function showAccountDetail (address) {
     const activeTabOrigin = state.activeTab.origin
     const selectedAddress = getSelectedAddress(state)
     const permittedAccountsForCurrentTab = getPermittedAccountsForCurrentTab(state)
-    const currentTabIsConnectedToPreviousAddress = permittedAccountsForCurrentTab.includes(selectedAddress)
-    const currentTabIsConnectedToNextAddress = permittedAccountsForCurrentTab.includes(address)
+    const currentTabIsConnectedToPreviousAddress = Boolean(activeTabOrigin) && permittedAccountsForCurrentTab.includes(selectedAddress)
+    const currentTabIsConnectedToNextAddress = Boolean(activeTabOrigin) && permittedAccountsForCurrentTab.includes(address)
     const switchingToUnconnectedAddress = currentTabIsConnectedToPreviousAddress && !currentTabIsConnectedToNextAddress
 
     try {


### PR DESCRIPTION
There was a case where the `activeTab.origin` was not set, yet the user could still navigate to the "Connected accounts" modal, which assumes that `activeTab.origin` is set. This would happen in Firefox when the user opened the popup on a page internal to Firefox (e.g. `about:blank`). The connected status indicator would still be shown, but the UI would crash when it was clicked.

The connected status indicator is now hidden whenever `activeTab.origin` is falsy. The 'Unconnected account' alert has also
been made impossible to trigger in that circumstance.