### PR TITLE
Remove unnecessary optional chaining operator

### DIFF
--- a/ui/app/components/app/menu-bar/tests/menu-bar.test.js
+++ b/ui/app/components/app/menu-bar/tests/menu-bar.test.js
@@ -6,6 +6,7 @@ import { mountWithRouter } from '../../../../../../test/lib/render-helpers'
 import MenuBar from '../index'
 
 const initState = {
+  activeTab: {},
   metamask: {
     network: '1',
     selectedAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -321,7 +321,7 @@ export function getFeatureFlags (state) {
 }
 
 export function getOriginOfCurrentTab (state) {
-  return state.activeTab?.origin
+  return state.activeTab.origin
 }
 
 export function getIpfsGateway (state) {


### PR DESCRIPTION
`state.activeTab` is always guaranteed to be set to an object before the UI is initialized. This happens in `app/ui.js`.