### PR TITLE
Prevent manually connecting to extension UI

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -83,7 +83,7 @@ async function queryCurrentActiveTab (windowType) {
 
     extension.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const [activeTab] = tabs
-      const { title, url } = activeTab
+      const { id, title, url } = activeTab
       const { origin, protocol } = url ? new URL(url) : {}
 
       if (!origin || origin === 'null') {
@@ -91,7 +91,7 @@ async function queryCurrentActiveTab (windowType) {
         return
       }
 
-      resolve({ title, origin, protocol, url })
+      resolve({ id, title, origin, protocol, url })
     })
   })
 }


### PR DESCRIPTION
The `activeTab.id` property is relied upon in the connected sites modal to prevent the user from manually connecting to the MetaMask extension itself. Unfortunately the `id` property was never set.

`id` is now set on the `activeTab` state, so manually connecting to the extension UI is now impossible.