### PR TITLE
Allow localized messages to not use substitutions

### DIFF
--- a/ui/app/helpers/utils/i18n-helper.js
+++ b/ui/app/helpers/utils/i18n-helper.js
@@ -48,15 +48,17 @@ export const getMessage = (localeCode, localeMessages, key, substitutions) => {
   // perform substitutions
   if (hasSubstitutions) {
     const parts = phrase.split(/(\$\d)/g)
-    const partsToReplace = phrase.match(/(\$\d)/g)
-
-    if (partsToReplace.length > substitutions.length) {
-      throw new Error(`Insufficient number of substitutions for message: '${phrase}'`)
-    }
 
     const substitutedParts = parts.map((part) => {
       const subMatch = part.match(/\$(\d)/)
-      return subMatch ? substitutions[Number(subMatch[1]) - 1] : part
+      if (!subMatch) {
+        return part
+      }
+      const substituteIndex = Number(subMatch[1]) - 1
+      if (substitutions[substituteIndex]) {
+        return substitutions[substituteIndex]
+      }
+      throw new Error(`Insufficient number of substitutions for message: '${phrase}'`)
     })
 
     phrase = hasReactSubstitutions


### PR DESCRIPTION
The `getMessage` function in `i18n-helper` was assuming that any substitutions passed into the transaction function were used by the corresponding localized message. However, some messages are intentionally ignoring substitutions passed in. This was done to simplify the UI logic, so the same substitutions could be passed in for many different messages, even if some don't use them.

For example, `transactionCancelSuccess` is passed two substitutions but only uses the second one. `transactionErrored` is passed in two, but uses neither.

`getMessage` has been updated to no longer make that assumption. It will now only throw an error if the localized message expects a substitution that was not given. A given substitution that is unused results in no error.