### PR TITLE
eth-keyring-controller@6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "eth-json-rpc-filters": "^4.1.1",
     "eth-json-rpc-infura": "^4.0.2",
     "eth-json-rpc-middleware": "^5.0.1",
-    "eth-keyring-controller": "^6.0.0",
+    "eth-keyring-controller": "^6.0.1",
     "eth-method-registry": "^1.2.0",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10215,10 +10215,10 @@ eth-keyring-controller@^5.3.0, eth-keyring-controller@^5.6.1:
     loglevel "^1.5.0"
     obs-store "^4.0.3"
 
-eth-keyring-controller@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-6.0.0.tgz#4629c7b9f08e9c2f24ecfa0a296fc40ea0fa98af"
-  integrity sha512-+tdXXwTklX0KX50YwlSriTU/6Xc0Ury0jmcp1mMcJfKSBFSKyWCmPmrhdkMxE9LRd4lbt4qx9LS5wZ3Ia05cLg==
+eth-keyring-controller@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-6.0.1.tgz#6a4cdd5802b0587320c711be6c1752b2a88221aa"
+  integrity sha512-60j71F1HgLcvwzg7U5R45bA/kgQSUlmiZrsUIIhW4qS7QOYqJn0OQ64enf0ZaxMMPVVcKSfCDersYJiqm/yrlw==
   dependencies:
     bip39 "^2.4.0"
     bluebird "^3.5.0"


### PR DESCRIPTION
Refs #8887

This update to `eth-keyring-controller` ensures that its `memStore` only updates once when the keyrings are unlocked.
This prevents the preferences controller from misclassifying identities belonging to keyrings other than the first as lost.