### PR TITLE
Replace percentage opacity value

### DIFF
--- a/ui/app/components/ui/popover/index.scss
+++ b/ui/app/components/ui/popover/index.scss
@@ -73,7 +73,7 @@
     width: 100%;
     height: 100%;
     background: black;
-    opacity: 20%;
+    opacity: .2;
   }
 
   &-content {


### PR DESCRIPTION
The CSS `opacity` rule accepts percentages on newer browsers, but some older browser versions we support (e.g. Firefox v60) doesn't support them. A number is now used instead, which is supported by all browsers we support.