### PR TITLE
Fix `dapp` script in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "benchmark:firefox": "SELENIUM_BROWSER=firefox node test/e2e/benchmark.js",
     "build:test": "yarn build test",
     "test": "yarn test:unit && yarn lint",
-    "dapp": "node development/static-server.js node_modules/@metamask/test-dapp/website --port 8080",
+    "dapp": "node development/static-server.js node_modules/@metamask/test-dapp/dist --port 8080",
     "dapp-chain": "GANACHE_ARGS='-b 2' concurrently -k -n ganache,dapp -p '[{time}][{name}]' 'yarn ganache:start' 'sleep 5 && yarn dapp'",
     "forwarder": "node ./development/static-server.js ./node_modules/@metamask/forwarder/dist/ --port 9010",
     "dapp-forwarder": "concurrently -k -n forwarder,dapp -p '[{time}][{name}]' 'yarn forwarder' 'yarn dapp'",


### PR DESCRIPTION
This script is relied upon by our e2e tests. It was broken in #8888, because `@metamask/test-dapp` was updated to a version with a different directory structure. The website is now in the `dist` directory instead of the `website` directory.