### PR TITLE
Exit with non-zero exit code upon failure

### DIFF
--- a/development/static-server.js
+++ b/development/static-server.js
@@ -89,4 +89,7 @@ const main = async () => {
 }
 
 main()
-  .catch(console.error)
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })


### PR DESCRIPTION
The `static-server` script now exits with a code of `1` upon failure. Previously it would print the error to the console but exit with a code of `0`, indicating success.