### PR TITLE
Prevent confirming blank suggested token

### DIFF
--- a/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -122,6 +122,7 @@ export default class ConfirmAddSuggestedToken extends Component {
               type="secondary"
               large
               className="page-container__footer-button"
+              disabled={pendingTokens.length === 0}
               onClick={() => {
                 addToken(pendingToken)
                   .then(() => removeSuggestedTokens())


### PR DESCRIPTION
The "confirm suggested token" page allowed the confirm button to be pressed even when there were no tokens to confirm. This can happen sometimes when the page is in the process of redirecting.