### PR TITLE
Fix Kovan chain ID constant

### DIFF
--- a/app/scripts/controllers/network/enums.js
+++ b/app/scripts/controllers/network/enums.js
@@ -15,7 +15,7 @@ export const MAINNET_CHAIN_ID = '0x1'
 export const ROPSTEN_CHAIN_ID = '0x3'
 export const RINKEBY_CHAIN_ID = '0x4'
 export const GOERLI_CHAIN_ID = '0x5'
-export const KOVAN_CHAIN_ID = '0x42'
+export const KOVAN_CHAIN_ID = '0x2a'
 
 export const ROPSTEN_DISPLAY_NAME = 'Ropsten'
 export const RINKEBY_DISPLAY_NAME = 'Rinkeby'

--- a/test/unit/app/controllers/network/network-controller-test.js
+++ b/test/unit/app/controllers/network/network-controller-test.js
@@ -82,7 +82,7 @@ describe('NetworkController', function () {
           input: '0x4',
           expected: 'Rinkeby',
         }, {
-          input: '0x42',
+          input: '0x2a',
           expected: 'Kovan',
         }, {
           input: 'ropsten',


### PR DESCRIPTION
This restores the correct chain ID for Kovan.

I had hardcoded it to `0x42` during a momentary lapse of reason. `42` is its decimal network ID. The corresponding hex value and chain ID is `0x2a`.