### PR TITLE
Begin consolidating network enums

### DIFF
--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -8,6 +8,7 @@ import createBlockTrackerInspectorMiddleware from 'eth-json-rpc-middleware/block
 import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddleware'
 import createInfuraMiddleware from 'eth-json-rpc-infura'
 import BlockTracker from 'eth-block-tracker'
+import * as networkEnums from './enums'
 
 export default function createInfuraClient ({ network }) {
   const infuraMiddleware = createInfuraMiddleware({ network, maxAttempts: 5, source: 'metamask' })
@@ -32,23 +33,23 @@ function createNetworkAndChainIdMiddleware ({ network }) {
 
   switch (network) {
     case 'mainnet':
-      netId = '1'
+      netId = networkEnums.MAINNET_NETWORK_ID.toString()
       chainId = '0x01'
       break
     case 'ropsten':
-      netId = '3'
+      netId = networkEnums.ROPSTEN_NETWORK_ID.toString()
       chainId = '0x03'
       break
     case 'rinkeby':
-      netId = '4'
+      netId = networkEnums.RINKEBY_NETWORK_ID.toString()
       chainId = '0x04'
       break
     case 'kovan':
-      netId = '42'
-      chainId = '0x2a'
+      netId = networkEnums.KOVAN_NETWORK_ID.toString()
+      chainId = networkEnums.KOVAN_CHAIN_ID
       break
     case 'goerli':
-      netId = '5'
+      netId = networkEnums.GOERLI_NETWORK_ID.toString()
       chainId = '0x05'
       break
     default:


### PR DESCRIPTION
This PR consolidates our network enums except the 0-padded chain IDs.

For the benefit of reviewers, you can see the replacement values here: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/controllers/network/enums.js

In a follow-up PR, the network IDs will be converted to strings in `enums.js`, and the `toString()` calls in `createInfuraClient.js` will be removed. We only return string network IDs to external domains, so converting the IDs from numbers to strings is a purely internal matter.