### PR TITLE
Sync `master` with `develop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Develop Branch
 
+## 8.0.2 Fri Jul 03 2020
+
 ## 8.0.1 Thu Jul 02 2020
 - [#8874](https://github.com/MetaMask/metamask-extension/pull/8874): Fx overflow behaviour of add token list
 - [#8885](https://github.com/MetaMask/metamask-extension/pull/8885): Show `origin` in connect flow rather than site name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Current Develop Branch
 
 ## 8.0.2 Fri Jul 03 2020
+- [#8907](https://github.com/MetaMask/metamask-extension/pull/8907): Tolerate missing or falsey substitutions
+- [#8908](https://github.com/MetaMask/metamask-extension/pull/8908): Fix activity log inline buttons
+- [#8909](https://github.com/MetaMask/metamask-extension/pull/8909): Prevent confirming blank suggested token
+- [#8910](https://github.com/MetaMask/metamask-extension/pull/8910): Handle suggested token resolved elsewhere
+- [#8913](https://github.com/MetaMask/metamask-extension/pull/8913): Fix Kovan chain ID constant
 
 ## 8.0.1 Thu Jul 02 2020
 - [#8874](https://github.com/MetaMask/metamask-extension/pull/8874): Fx overflow behaviour of add token list

--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "manifest_version": 2,
   "author": "https://metamask.io",
   "description": "__MSG_appDescription__",


### PR DESCRIPTION
This brings `develop` up-to-date with release v8.0.2