### PR TITLE
Reject request when subsequent request is made

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -142,14 +142,15 @@ export default class PermissionConnect extends Component {
     }
   }
 
-  _doRedirect () {
-    const { history, hasPendingPermissionsRequests } = this.props
+  _doRedirect = async () => {
+    const { history, hasPendingPermissionsRequests, rejectPermissionsRequest, permissionsRequestId } = this.props
 
     if (
       !hasPendingPermissionsRequests &&
       getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION
     ) {
       global.platform.closeCurrentWindow()
+      await rejectPermissionsRequest(permissionsRequestId)
     } else {
       history.push(DEFAULT_ROUTE)
     }


### PR DESCRIPTION
This is pretty quick and dirty fix for #8919, probably not ideal. The second connect request will result in closing and rejecting the first request, but won't trigger a new request. Clicking connect again, third time, will trigger the connect request notification/popup