### PR TITLE
@metamask/inpage-provider@6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^2.0.0",
     "@metamask/etherscan-link": "^1.1.0",
-    "@metamask/inpage-provider": "^5.2.1",
+    "@metamask/inpage-provider": "^6.0.0",
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.3.2",
     "@sentry/browser": "^5.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1696,10 +1696,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/forwarder/-/forwarder-1.1.0.tgz#13829d8244bbf19ea658c0b20d21a77b67de0bdd"
   integrity sha512-Hggj4y0QIjDzKGTXzarhEPIQyFSB2bi2y6YLJNwaT4JmP30UB5Cj6gqoY0M4pj3QT57fzp0BUuGp7F/AUe28tw==
 
-"@metamask/inpage-provider@^5.2.1":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-5.2.1.tgz#526352fae3541da0952dbf7caa97763558e2d20c"
-  integrity sha512-GP0XuPCxtkAJ+mtOj5CEaSTncXDsMS79pyTiIbIC5RcZ2AMKGCyKcEovQlFm5fkbO6fE5uFnco4fpgMmY7XsTQ==
+"@metamask/inpage-provider@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-6.0.0.tgz#84a95d30cad77ac1d70507915f6bea04a72e6c4f"
+  integrity sha512-487gjVIdIKEgqNXu5Q7dtVvv48nwZCLSBxDVoL8NUeQOIw1HARzG5kPusWnOhcOfKdpUCZLl+Mp/c+XhEtZM6Q==
   dependencies:
     eth-json-rpc-errors "^2.0.2"
     fast-deep-equal "^2.0.1"


### PR DESCRIPTION
This restores the `data` event, and rolls back an accidental change made to the `notification` event. Both of these provider events should now behave exactly as they had in v7.7.9.

Fixes #8916