### PR TITLE
rpc-cap@3.0.0

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -110,8 +110,8 @@ export class PermissionsController {
 
   /**
    * Request {@code eth_accounts} permissions
-   * @param {string} origin - The origin
-   * @returns {Promise<string>} the request ID
+   * @param {string} origin - The requesting origin
+   * @returns {Promise<string>} The permissions request ID
    */
   async requestAccountsPermissionWithId (origin) {
     const id = nanoid()

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -113,9 +113,9 @@ export class PermissionsController {
    * @param {string} origin - The origin
    * @returns {Promise<string>} the request ID
    */
-  async requestAccountsPermission (origin) {
+  async requestAccountsPermissionWithId (origin) {
     const id = nanoid()
-    this._requestPermissions({ origin, id }, { eth_accounts: {} })
+    this._requestPermissions({ origin }, { eth_accounts: {} }, id)
     return id
   }
 
@@ -168,18 +168,26 @@ export class PermissionsController {
   /**
    * Submits a permissions request to rpc-cap. Internal, background use only.
    *
-   * @param {IOriginMetadata} metadata - The origin metadata.
+   * @param {IOriginMetadata} domain - The external domain metadata.
    * @param {IRequestedPermissions} permissions - The requested permissions.
+   * @param {string} [id] - The desired id of the permissions request, if any.
+   * @returns {Promise<IOcapLdCapability[]>} A Promise that resolves with the
+   * approved permissions, or rejects with an error.
    */
-  _requestPermissions (metadata, permissions) {
+  _requestPermissions (domain, permissions, id) {
     return new Promise((resolve, reject) => {
 
       // rpc-cap assigns an id to the request if there is none, as expected by
       // requestUserApproval below
-      const req = { method: 'wallet_requestPermissions', params: [permissions] }
+      const req = {
+        id,
+        method: 'wallet_requestPermissions',
+        params: [permissions],
+      }
       const res = {}
+
       this.permissions.providerMiddlewareFunction(
-        metadata, req, res, () => {}, _end
+        domain, req, res, () => {}, _end
       )
 
       function _end (_err) {
@@ -716,7 +724,7 @@ export class PermissionsController {
        * @param {string} req - The internal rpc-cap user request object.
        */
       requestUserApproval: async (req) => {
-        const { origin, metadata: { id } } = req
+        const { metadata: { id, origin } } = req
 
         if (this.pendingApprovalOrigins.has(origin)) {
           throw ethErrors.rpc.resourceUnavailable(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -563,7 +563,7 @@ export default class MetamaskController extends EventEmitter {
       removePermissionsFor: permissionsController.removePermissionsFor.bind(permissionsController),
       addPermittedAccount: nodeify(permissionsController.addPermittedAccount, permissionsController),
       removePermittedAccount: nodeify(permissionsController.removePermittedAccount, permissionsController),
-      requestAccountsPermission: nodeify(permissionsController.requestAccountsPermission, permissionsController),
+      requestAccountsPermissionWithId: nodeify(permissionsController.requestAccountsPermissionWithId, permissionsController),
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1",
-    "rpc-cap": "^2.1.0",
+    "rpc-cap": "^3.0.0",
     "safe-event-emitter": "^1.0.1",
     "safe-json-stringify": "^1.2.0",
     "single-call-balance-checker-abi": "^1.0.0",

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -1526,12 +1526,13 @@ describe('permissions controller', function () {
       permController = initPermController()
     })
 
-    it('requestAccountsPermission calls _requestAccountsPermission with an explicit request ID', async function () {
+    it('requestAccountsPermissionWithId calls _requestAccountsPermission with an explicit request ID', async function () {
       const _requestPermissions = sinon.stub(permController, '_requestPermissions').resolves()
-      await permController.requestAccountsPermission('example.com')
+      await permController.requestAccountsPermissionWithId('example.com')
       assert.ok(_requestPermissions.calledOnceWithExactly(
-        sinon.match.object.and(sinon.match.has('origin')).and(sinon.match.has('id')),
+        sinon.match.object.and(sinon.match.has('origin')),
         { eth_accounts: {} },
+        sinon.match.string.and(sinon.match.truthy),
       ))
       _requestPermissions.restore()
     })

--- a/ui/app/pages/connected-sites/connected-sites.container.js
+++ b/ui/app/pages/connected-sites/connected-sites.container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import ConnectedSites from './connected-sites.component'
 import {
   getOpenMetamaskTabsIds,
-  requestAccountsPermission,
+  requestAccountsPermissionWithId,
   removePermissionsFor,
   removePermittedAccount,
 } from '../../store/actions'
@@ -61,7 +61,7 @@ const mapDispatchToProps = (dispatch) => {
         [domainKey]: permissionMethodNames,
       }))
     },
-    requestAccountsPermission: (origin) => dispatch(requestAccountsPermission(origin)),
+    requestAccountsPermissionWithId: (origin) => dispatch(requestAccountsPermissionWithId(origin)),
   }
 }
 
@@ -76,7 +76,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const {
     disconnectAccount,
     disconnectAllAccounts,
-    requestAccountsPermission: dispatchRequestAccountsPermission,
+    requestAccountsPermissionWithId,
   } = dispatchProps
   const { history } = ownProps
 
@@ -100,7 +100,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       }
     },
     requestAccountsPermission: async () => {
-      const id = await dispatchRequestAccountsPermission(tabToConnect.origin)
+      const id = await requestAccountsPermissionWithId(tabToConnect.origin)
       history.push(`${CONNECT_ROUTE}/${id}`)
     },
   }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2056,9 +2056,9 @@ export function setPendingTokens (pendingTokens) {
 
 // Permissions
 
-export function requestAccountsPermission (origin) {
+export function requestAccountsPermissionWithId (origin) {
   return async (dispatch) => {
-    const id = await promisifiedBackground.requestAccountsPermission(origin)
+    const id = await promisifiedBackground.requestAccountsPermissionWithId(origin)
     await forceUpdateMetamaskState(dispatch)
     return id
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23895,10 +23895,10 @@ rn-host-detect@^1.1.5:
   resolved "https://registry.yarnpkg.com/rn-host-detect/-/rn-host-detect-1.1.5.tgz#fbecb982b73932f34529e97932b9a63e58d8deb6"
   integrity sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg==
 
-rpc-cap@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/rpc-cap/-/rpc-cap-2.1.0.tgz#c53e9bd925cb23c86b1591d621a68692c58070c0"
-  integrity sha512-k4GLWk3IT6r5zETyhiH9tjHqX2sEJ8MdGWv5C4v7wL32hCsx+AnEykbkeVG+EfMox+Vf32C9ieTQPNLKzKwS7A==
+rpc-cap@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rpc-cap/-/rpc-cap-3.0.0.tgz#d929573d687d018403a10f0009e470b70b3dd857"
+  integrity sha512-YU8/0WFDlYDmxseaP5VQjY8SB/iGq6RRTJHko5PXVOeNfns5BZOumxiYj4sVRqS4uZ8q/VTG11yHGVZAzEaHjw==
   dependencies:
     clone "^2.1.2"
     eth-json-rpc-errors "^2.0.2"


### PR DESCRIPTION
- `rpc-cap@3.0.0`
- Adapt usage of `rpc-cap` per breaking changes
- Rename `PermissionsController.requestAccountsPermission` to `requestAccountsPermissionWithId`, to highlight its purpose and distinguish it from other identically named functions


Fixes #8919 