### PR TITLE
Convert transaction activity conversion's currency to ETH

### DIFF
--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -74,14 +74,14 @@ export default class TransactionActivityLog extends PureComponent {
     const ethValue = index === 0
       ? `${getValueFromWeiHex({
         value,
-        fromCurrency: nativeCurrency,
-        toCurrency: nativeCurrency,
+        fromCurrency: 'ETH',
+        toCurrency: 'ETH',
         conversionRate,
         numberOfDecimals: 6,
       })} ${nativeCurrency}`
       : getEthConversionFromWeiHex({
         value,
-        fromCurrency: nativeCurrency,
+        fromCurrency: 'ETH',
         conversionRate,
         numberOfDecimals: 3,
       })


### PR DESCRIPTION
Fixes #8933 where custom fromCurrency would crash the convertion utility and the UI.

This fixes in the mean time, but there still a separate issue with the nativeCurrency persisting in the background, it will reset to ETH upon background refresh.

See issue for before gif
<details>
<summary>Fix After Gif</summary>
<img src='https://user-images.githubusercontent.com/13376180/86705969-42e82d80-bfcb-11ea-999e-7e2758be1e2b.gif'>
</details>