### PR TITLE
Fix account tracker optimization

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -191,19 +191,19 @@ export default class AccountTracker {
     const currentNetwork = this.network.getNetworkState()
 
     switch (currentNetwork) {
-      case MAINNET_NETWORK_ID:
+      case MAINNET_NETWORK_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS)
         break
 
-      case RINKEBY_NETWORK_ID:
+      case RINKEBY_NETWORK_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY)
         break
 
-      case ROPSTEN_NETWORK_ID:
+      case ROPSTEN_NETWORK_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN)
         break
 
-      case KOVAN_NETWORK_ID:
+      case KOVAN_NETWORK_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_KOVAN)
         break
 


### PR DESCRIPTION
An optimization in `account-tracker.js` was being skipped consistently due to a type error (a number was being compared to a string).

The optimization in this case was to update the balances for all accounts with a single request, rather than one request per account.