### PR TITLE
Fix display of incoming transactions

### DIFF
--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -240,7 +240,7 @@ export default class IncomingTransactionsController {
     return {
       blockNumber: txMeta.blockNumber,
       id: createId(),
-      metamaskNetworkId: currentNetworkID,
+      metamaskNetworkId: currentNetworkID.toString(),
       status,
       time,
       txParams: {

--- a/app/scripts/migrations/047.js
+++ b/app/scripts/migrations/047.js
@@ -1,0 +1,30 @@
+const version = 47
+import { cloneDeep } from 'lodash'
+
+/**
+ * Stringify numbers:
+ *  - PreferencesController.frequentRpcListDetail item chainId
+ *  - TransactionsController.transactions item metamaskNetworkId
+ */
+export default {
+  version,
+  migrate: async function (originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData)
+    versionedData.meta.version = version
+    const state = versionedData.data
+    versionedData.data = transformState(state)
+    return versionedData
+  },
+}
+
+function transformState (state) {
+  const transactions = state?.TransactionsController?.transactions
+  if (Array.isArray(transactions)) {
+    transactions.forEach((transaction) => {
+      if (typeof transaction.metamaskNetworkId === 'number') {
+        transaction.metamaskNetworkId = transaction.metamaskNetworkId.toString()
+      }
+    })
+  }
+  return state
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -57,6 +57,7 @@ const migrations = [
   require('./044').default,
   require('./045').default,
   require('./046').default,
+  require('./047').default,
 ]
 
 export default migrations

--- a/test/unit/migrations/047-test.js
+++ b/test/unit/migrations/047-test.js
@@ -1,0 +1,109 @@
+import { strict as assert } from 'assert'
+import migration47 from '../../../app/scripts/migrations/047'
+
+describe('migration #47', function () {
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      'meta': {
+        'version': 46,
+      },
+      'data': {},
+    }
+
+    const newStorage = await migration47.migrate(oldStorage)
+    assert.deepEqual(newStorage.meta, {
+      'version': 47,
+    })
+  })
+
+  it('should stringify transactions metamaskNetworkId values', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        TransactionsController: {
+          transactions: [
+            { foo: 'bar', metamaskNetworkId: 2 },
+            { foo: 'bar' },
+            { foo: 'bar', metamaskNetworkId: 0 },
+            { foo: 'bar', metamaskNetworkId: 42 },
+          ],
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration47.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      TransactionsController: {
+        transactions: [
+          { foo: 'bar', metamaskNetworkId: '2' },
+          { foo: 'bar' },
+          { foo: 'bar', metamaskNetworkId: '0' },
+          { foo: 'bar', metamaskNetworkId: '42' },
+        ],
+      },
+      foo: 'bar',
+    })
+  })
+
+  it('should do nothing if transactions metamaskNetworkId values are already strings', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        TransactionsController: {
+          transactions: [
+            { foo: 'bar', metamaskNetworkId: '2' },
+            { foo: 'bar' },
+            { foo: 'bar', metamaskNetworkId: '0' },
+            { foo: 'bar', metamaskNetworkId: '42' },
+          ],
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration47.migrate(oldStorage)
+    assert.deepEqual(oldStorage.data, newStorage.data)
+  })
+
+  it('should do nothing if transactions state does not exist', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        TransactionsController: {
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration47.migrate(oldStorage)
+    assert.deepEqual(oldStorage.data, newStorage.data)
+  })
+
+  it('should do nothing if transactions state is empty', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        TransactionsController: {
+          transactions: [],
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration47.migrate(oldStorage)
+    assert.deepEqual(oldStorage.data, newStorage.data)
+  })
+
+  it('should do nothing if state is empty', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {},
+    }
+
+    const newStorage = await migration47.migrate(oldStorage)
+    assert.deepEqual(oldStorage.data, newStorage.data)
+  })
+})


### PR DESCRIPTION
The `metamaskNetworkId` property in the `txMeta` for incoming transactions was incorrectly set as a Number instead of a String. This change was made accidentally as part of #8627.

As a result incoming transactions were being excluded from the transaction list, as they didn't have a matching network ID.

`metamaskNetworkId` is now set to a string, and a migration has been added to ensure `metamaskNetworkId` is converted to a string for any incoming transactions in state.