### PR TITLE
Throw error upon currency update failure

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -267,7 +267,14 @@ export default class MetamaskController extends EventEmitter {
     })
 
     this.networkController.on('networkDidChange', () => {
-      this.setCurrentCurrency(this.currencyRateController.state.currentCurrency, function () {})
+      this.setCurrentCurrency(
+        this.currencyRateController.state.currentCurrency,
+        (error) => {
+          if (error) {
+            throw error
+          }
+        }
+      )
     })
 
     this.networkController.lookupNetwork()


### PR DESCRIPTION
The currency rate controller is updated upon each network change, as the "native currency" is network-dependent and might have changed. However, any thrown errors were being caught and passed to an empty callback.

The errors are now re-thrown in the callback. As a result, the errors will now be printed to the console and sent to Sentry.