### PR TITLE
Check browser logs in `withFixtures` e2e test helper

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -23,6 +23,15 @@ async function withFixtures (options, callback) {
     await callback({
       driver,
     })
+
+    if (process.env.SELENIUM_BROWSER === 'chrome') {
+      const errors = await driver.checkBrowserForConsoleErrors(driver)
+      if (errors.length) {
+        const errorReports = errors.map((err) => err.message)
+        const errorMessage = `Errors found in browser console:\n${errorReports.join('\n')}`
+        throw new Error(errorMessage)
+      }
+    }
   } finally {
     await fixtureServer.stop()
     await ganacheServer.quit()


### PR DESCRIPTION
e2e test that use the `withFixtures` helper now check for console errors after each successful test. If any errors are found, the test
fails.

It's currently enabled for Chrome only, because the Firefox driver throws an error when you attempt to get the browser logs. Not sure why exactly, but it's a long-standing problem.