### PR TITLE
Refactor webdriver method `verboseReportOnFailure`

### DIFF
--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -43,7 +43,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/ethereum-on.spec.js
+++ b/test/e2e/ethereum-on.spec.js
@@ -42,7 +42,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -46,7 +46,7 @@ describe('Using MetaMask with an existing account', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/incremental-security.spec.js
+++ b/test/e2e/incremental-security.spec.js
@@ -47,7 +47,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -37,7 +37,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -38,7 +38,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -42,7 +42,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -44,7 +44,7 @@ describe('Using MetaMask with an existing account', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -41,7 +41,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -45,7 +45,7 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/web3.spec.js
+++ b/test/e2e/web3.spec.js
@@ -44,7 +44,7 @@ describe('Using MetaMask with an existing account', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
-      await driver.verboseReportOnFailure(this.currentTest)
+      await driver.verboseReportOnFailure(this.currentTest.title)
     }
   })
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -172,8 +172,8 @@ class Driver {
 
   // Error handling
 
-  async verboseReportOnFailure (test) {
-    const artifactDir = `./test-artifacts/${this.browser}/${test.title}`
+  async verboseReportOnFailure (title) {
+    const artifactDir = `./test-artifacts/${this.browser}/${title}`
     const filepathBase = `${artifactDir}/test-failure`
     await fs.mkdir(artifactDir, { recursive: true })
     const screenshot = await this.driver.takeScreenshot()


### PR DESCRIPTION
The webdriver method `verboseReportOnFailure` had previously taken a single parameter, `test`, which was an object representing the current Mocha test. However, only one property was used (`title`).

Instead the `title` is now passed through directly. This was done to make this function easier to use outside of a Mocha context.