### PR TITLE
Add verbose reporting on failure to `withFixtures`

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -8,7 +8,7 @@ const regularDelayMs = tinyDelayMs * 2
 const largeDelayMs = regularDelayMs * 2
 
 async function withFixtures (options, callback) {
-  const { fixtures, ganacheOptions, driverOptions } = options
+  const { fixtures, ganacheOptions, driverOptions, title } = options
   const fixtureServer = new FixtureServer()
   const ganacheServer = new Ganache()
 
@@ -32,6 +32,9 @@ async function withFixtures (options, callback) {
         throw new Error(errorMessage)
       }
     }
+  } catch (error) {
+    await webDriver.verboseReportOnFailure(title)
+    throw error
   } finally {
     await fixtureServer.stop()
     await ganacheServer.quit()

--- a/test/e2e/tests/simple-send.spec.js
+++ b/test/e2e/tests/simple-send.spec.js
@@ -11,19 +11,22 @@ describe('MetaMask Browser Extension', function () {
         },
       ],
     }
-    await withFixtures({ fixtures: 'imported-account', ganacheOptions }, async ({ driver }) => {
-      const passwordField = await driver.findElement(By.css('#password'))
-      await passwordField.sendKeys('correct horse battery staple')
-      await passwordField.sendKeys(Key.ENTER)
-      await driver.clickElement(By.css('[data-testid="eth-overview-send"]'))
-      const recipientAddressField = await driver.findElement(By.css('[data-testid="ens-input"]'))
-      await recipientAddressField.sendKeys('0x985c30949c92df7a0bd42e0f3e3d539ece98db24')
-      const amountField = await driver.findElement(By.css('.unit-input__input'))
-      await amountField.sendKeys('1')
-      await driver.clickElement(By.css('[data-testid="page-container-footer-next"]'))
-      await driver.clickElement(By.css('[data-testid="page-container-footer-next"]'))
-      await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
-      await driver.findElement(By.css('.transaction-list-item'))
-    })
+    await withFixtures(
+      { fixtures: 'imported-account', ganacheOptions, title: this.test.title },
+      async ({ driver }) => {
+        const passwordField = await driver.findElement(By.css('#password'))
+        await passwordField.sendKeys('correct horse battery staple')
+        await passwordField.sendKeys(Key.ENTER)
+        await driver.clickElement(By.css('[data-testid="eth-overview-send"]'))
+        const recipientAddressField = await driver.findElement(By.css('[data-testid="ens-input"]'))
+        await recipientAddressField.sendKeys('0x985c30949c92df7a0bd42e0f3e3d539ece98db24')
+        const amountField = await driver.findElement(By.css('.unit-input__input'))
+        await amountField.sendKeys('1')
+        await driver.clickElement(By.css('[data-testid="page-container-footer-next"]'))
+        await driver.clickElement(By.css('[data-testid="page-container-footer-next"]'))
+        await driver.clickElement(By.css('[data-testid="home__activity-tab"]'))
+        await driver.findElement(By.css('.transaction-list-item'))
+      }
+    )
   })
 })


### PR DESCRIPTION
The e2e test helper function `withFixtures` now includes verbose reporting on failure. Whenever a test fails, debugging information will be saved to disk, just as with the other e2e test modules.