### PR TITLE
Add localization e2e test

### DIFF
--- a/test/e2e/fixtures/localization/state.json
+++ b/test/e2e/fixtures/localization/state.json
@@ -1,0 +1,125 @@
+{
+  "data": {
+    "AppStateController": {
+      "mkrMigrationReminderTimestamp": null
+    },
+    "CachedBalancesController": {
+      "cachedBalances": {
+        "4": {}
+      }
+    },
+    "CurrencyController": {
+      "conversionDate": 1594323667.203,
+      "conversionRate": 14205.88,
+      "currentCurrency": "php",
+      "nativeCurrency": "ETH"
+    },
+    "IncomingTransactionsController": {
+      "incomingTransactions": {},
+      "incomingTxLastFetchedBlocksByNetwork": {
+        "goerli": null,
+        "kovan": null,
+        "mainnet": null,
+        "rinkeby": 5570536
+      }
+    },
+    "KeyringController": {
+      "vault": "{\"data\":\"s6TpYjlUNsn7ifhEFTkuDGBUM1GyOlPrim7JSjtfIxgTt8/6MiXgiR/CtFfR4dWW2xhq85/NGIBYEeWrZThGdKGarBzeIqBfLFhw9n509jprzJ0zc2Rf+9HVFGLw+xxC4xPxgCS0IIWeAJQ+XtGcHmn0UZXriXm8Ja4kdlow6SWinB7sr/WM3R0+frYs4WgllkwggDf2/Tv6VHygvLnhtzp6hIJFyTjh+l/KnyJTyZW1TkZhDaNDzX3SCOHT\",\"iv\":\"FbeHDAW5afeWNORfNJBR0Q==\",\"salt\":\"TxZ+WbCW6891C9LK/hbMAoUsSEW1E8pyGLVBU6x5KR8=\"}"
+    },
+    "NetworkController": {
+      "network": "5777",
+      "provider": {
+        "nickname": "",
+        "rpcTarget": "",
+        "ticker": "ETH",
+        "type": "localhost"
+      },
+      "settings": {
+        "ticker": "ETH"
+      }
+    },
+    "OnboardingController": {
+      "onboardingTabs": {},
+      "seedPhraseBackedUp": false
+    },
+    "PermissionsMetadata": {
+      "domainMetadata": {
+        "metamask.github.io": {
+          "icon": null,
+          "name": "M E T A M A S K M E S H T E S T"
+        }
+      },
+      "permissionsHistory": {},
+      "permissionsLog": [
+        {
+          "id": 746677923,
+          "method": "eth_accounts",
+          "methodType": "restricted",
+          "origin": "metamask.github.io",
+          "request": {
+            "id": 746677923,
+            "jsonrpc": "2.0",
+            "method": "eth_accounts",
+            "origin": "metamask.github.io",
+            "params": []
+          },
+          "requestTime": 1575697241368,
+          "response": {
+            "id": 746677923,
+            "jsonrpc": "2.0",
+            "result": []
+          },
+          "responseTime": 1575697241370,
+          "success": true
+        }
+      ]
+    },
+    "PreferencesController": {
+      "accountTokens": {
+        "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": {
+          "rinkeby": [],
+          "ropsten": []
+        }
+      },
+      "assetImages": {},
+      "completedOnboarding": true,
+      "currentLocale": "en",
+      "featureFlags": {
+        "showIncomingTransactions": true,
+        "transactionTime": false
+      },
+      "firstTimeFlowType": "create",
+      "forgottenPassword": false,
+      "frequentRpcListDetail": [],
+      "identities": {
+        "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": {
+          "address": "0x5cfe73b6021e818b776b421b1c4db2474086a7e1",
+          "name": "Account 1"
+        }
+      },
+      "knownMethodData": {},
+      "lostIdentities": {},
+      "metaMetricsId": null,
+      "metaMetricsSendCount": 0,
+      "participateInMetaMetrics": false,
+      "preferences": {
+        "showFiatInTestnets": true,
+        "useNativeCurrencyAsPrimaryCurrency": true
+      },
+      "selectedAddress": "0x5cfe73b6021e818b776b421b1c4db2474086a7e1",
+      "suggestedTokens": {},
+      "tokens": [],
+      "useBlockie": false,
+      "useNonceField": false,
+      "usePhishDetect": true
+    },
+    "config": {},
+    "firstTimeInfo": {
+      "date": 1575697234195,
+      "version": "7.7.0"
+    }
+  },
+  "meta": {
+    "version": 40
+  }
+}

--- a/test/e2e/tests/localization.spec.js
+++ b/test/e2e/tests/localization.spec.js
@@ -1,0 +1,29 @@
+const { strict: assert } = require('assert')
+const { By, Key } = require('selenium-webdriver')
+const { withFixtures } = require('../helpers')
+
+describe('Localization', function () {
+  it('can correctly display Philippine peso symbol and code', async function () {
+    const ganacheOptions = {
+      accounts: [
+        {
+          secretKey: '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+          balance: 25000000000000000000,
+        },
+      ],
+    }
+    await withFixtures(
+      { fixtures: 'localization', ganacheOptions, title: this.test.title },
+      async ({ driver }) => {
+        const passwordField = await driver.findElement(By.css('#password'))
+        await passwordField.sendKeys('correct horse battery staple')
+        await passwordField.sendKeys(Key.ENTER)
+        const secondaryBalance = await driver.findElement(By.css('[data-testid="eth-overview__secondary-currency"]'))
+        const secondaryBalanceText = await secondaryBalance.getText()
+        const [fiatAmount, fiatUnit] = secondaryBalanceText.trim().split(/\s+/)
+        assert.ok(fiatAmount.startsWith('₱'))
+        assert.equal(fiatUnit, 'PHP')
+      }
+    )
+  })
+})


### PR DESCRIPTION
This test mirrors the `localization` integration test. It only tests the display of fiat currency on the home page, and it only tests one
currency (`php`).