### PR TITLE
Update simple send test description

### DIFF
--- a/test/e2e/tests/simple-send.spec.js
+++ b/test/e2e/tests/simple-send.spec.js
@@ -1,7 +1,7 @@
 const { By, Key } = require('selenium-webdriver')
 const { withFixtures } = require('../helpers')
 
-describe('MetaMask Browser Extension', function () {
+describe('Simple send', function () {
   it('can send a simple transaction from one account to another', async function () {
     const ganacheOptions = {
       accounts: [


### PR DESCRIPTION
The description 'Simple send' seemed more appropriate than 'MetaMask Browser Extension'.