### PR TITLE
Split `createStaticServer` from `static-server.js`

### DIFF
--- a/development/create-static-server.js
+++ b/development/create-static-server.js
@@ -1,0 +1,22 @@
+const http = require('http')
+const path = require('path')
+
+const serveHandler = require('serve-handler')
+
+const createStaticServer = (rootDirectory) => {
+  return http.createServer((request, response) => {
+    if (request.url.startsWith('/node_modules/')) {
+      request.url = request.url.substr(14)
+      return serveHandler(request, response, {
+        directoryListing: false,
+        public: path.resolve('./node_modules'),
+      })
+    }
+    return serveHandler(request, response, {
+      directoryListing: false,
+      public: rootDirectory,
+    })
+  })
+}
+
+module.exports = createStaticServer

--- a/development/static-server.js
+++ b/development/static-server.js
@@ -1,10 +1,10 @@
 const fs = require('fs')
-const http = require('http')
 const path = require('path')
 
 const chalk = require('chalk')
 const pify = require('pify')
-const serveHandler = require('serve-handler')
+
+const createStaticServer = require('./create-static-server')
 
 const fsStat = pify(fs.stat)
 const DEFAULT_PORT = 9080
@@ -24,19 +24,7 @@ const onRequest = (request, response) => {
 }
 
 const startServer = ({ port, rootDirectory }) => {
-  const server = http.createServer((request, response) => {
-    if (request.url.startsWith('/node_modules/')) {
-      request.url = request.url.substr(14)
-      return serveHandler(request, response, {
-        directoryListing: false,
-        public: path.resolve('./node_modules'),
-      })
-    }
-    return serveHandler(request, response, {
-      directoryListing: false,
-      public: rootDirectory,
-    })
-  })
+  const server = createStaticServer(rootDirectory)
 
   server.on('request', onRequest)
 


### PR DESCRIPTION
The `createStaticServer` function was split from the `static-server.js` script, so that the static server could be constructed programmatically. `static-server.js` remains responsible for the CLI.

This was done to make it easier to programmatically start the test dapp from e2e tests.