### PR TITLE
Add `personal_sign` e2e test

### DIFF
--- a/test/e2e/fixtures/personal-sign/state.json
+++ b/test/e2e/fixtures/personal-sign/state.json
@@ -1,0 +1,175 @@
+{
+  "data": {
+    "AppStateController": {
+      "connectedStatusPopoverHasBeenShown": false
+    },
+    "CachedBalancesController": {
+      "cachedBalances": {
+        "4": {},
+        "5777": {
+          "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": "0x15af1d78b58c40000"
+        }
+      }
+    },
+    "CurrencyController": {
+      "conversionDate": 1594348502.519,
+      "conversionRate": 240.09,
+      "currentCurrency": "usd",
+      "nativeCurrency": "ETH"
+    },
+    "IncomingTransactionsController": {
+      "incomingTransactions": {},
+      "incomingTxLastFetchedBlocksByNetwork": {
+        "goerli": null,
+        "kovan": null,
+        "mainnet": null,
+        "rinkeby": 5570536,
+        "localhost": 98
+      }
+    },
+    "KeyringController": {
+      "vault": "{\"data\":\"s6TpYjlUNsn7ifhEFTkuDGBUM1GyOlPrim7JSjtfIxgTt8/6MiXgiR/CtFfR4dWW2xhq85/NGIBYEeWrZThGdKGarBzeIqBfLFhw9n509jprzJ0zc2Rf+9HVFGLw+xxC4xPxgCS0IIWeAJQ+XtGcHmn0UZXriXm8Ja4kdlow6SWinB7sr/WM3R0+frYs4WgllkwggDf2/Tv6VHygvLnhtzp6hIJFyTjh+l/KnyJTyZW1TkZhDaNDzX3SCOHT\",\"iv\":\"FbeHDAW5afeWNORfNJBR0Q==\",\"salt\":\"TxZ+WbCW6891C9LK/hbMAoUsSEW1E8pyGLVBU6x5KR8=\"}"
+    },
+    "NetworkController": {
+      "provider": {
+        "nickname": "",
+        "rpcTarget": "",
+        "ticker": "ETH",
+        "type": "localhost"
+      },
+      "network": "5777",
+      "settings": {
+        "ticker": "ETH"
+      }
+    },
+    "OnboardingController": {
+      "onboardingTabs": {},
+      "seedPhraseBackedUp": false
+    },
+    "PermissionsMetadata": {
+      "permissionsLog": [
+        {
+          "id": 1764280960,
+          "method": "eth_requestAccounts",
+          "methodType": "restricted",
+          "origin": "http://127.0.0.1:8080",
+          "request": {
+            "method": "eth_requestAccounts",
+            "jsonrpc": "2.0",
+            "id": 1764280960,
+            "origin": "http://127.0.0.1:8080",
+            "tabId": 2
+          },
+          "requestTime": 1594348329232,
+          "response": {
+            "id": 1764280960,
+            "jsonrpc": "2.0",
+            "result": [
+              "0x5cfe73b6021e818b776b421b1c4db2474086a7e1"
+            ]
+          },
+          "responseTime": 1594348332276,
+          "success": true
+        }
+      ],
+      "permissionsHistory": {
+        "http://127.0.0.1:8080": {
+          "eth_accounts": {
+            "accounts": {
+              "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": 1594348332276
+            },
+            "lastApproved": 1594348332276
+          }
+        }
+      },
+      "domainMetadata": {
+        "http://127.0.0.1:8080": {
+          "name": "E2E Test Dapp",
+          "icon": "http://127.0.0.1:8080/metamask-fox.svg",
+          "lastUpdated": 1594348323811,
+          "host": "127.0.0.1:8080"
+        }
+      }
+    },
+    "PreferencesController": {
+      "frequentRpcListDetail": [],
+      "accountTokens": {
+        "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": {
+          "rinkeby": [],
+          "ropsten": []
+        }
+      },
+      "assetImages": {},
+      "tokens": [],
+      "suggestedTokens": {},
+      "useBlockie": false,
+      "useNonceField": false,
+      "usePhishDetect": true,
+      "featureFlags": {
+        "showIncomingTransactions": true,
+        "transactionTime": false
+      },
+      "knownMethodData": {},
+      "participateInMetaMetrics": false,
+      "firstTimeFlowType": "create",
+      "currentLocale": "en",
+      "identities": {
+        "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": {
+          "address": "0x5cfe73b6021e818b776b421b1c4db2474086a7e1",
+          "name": "Account 1"
+        }
+      },
+      "lostIdentities": {},
+      "forgottenPassword": false,
+      "preferences": {
+        "useNativeCurrencyAsPrimaryCurrency": true
+      },
+      "completedOnboarding": true,
+      "metaMetricsId": null,
+      "metaMetricsSendCount": 0,
+      "ipfsGateway": "dweb.link",
+      "selectedAddress": "0x5cfe73b6021e818b776b421b1c4db2474086a7e1"
+    },
+    "config": {},
+    "firstTimeInfo": {
+      "date": 1575697234195,
+      "version": "7.7.0"
+    },
+    "PermissionsController": {
+      "permissionsRequests": [],
+      "permissionsDescriptions": {},
+      "domains": {
+        "http://127.0.0.1:8080": {
+          "permissions": [
+            {
+              "@context": [
+                "https://github.com/MetaMask/rpc-cap"
+              ],
+              "parentCapability": "eth_accounts",
+              "id": "f55a1c15-ea48-4088-968e-63be474d42fa",
+              "date": 1594348332268,
+              "invoker": "http://127.0.0.1:8080",
+              "caveats": [
+                {
+                  "type": "limitResponseLength",
+                  "value": 1,
+                  "name": "primaryAccountOnly"
+                },
+                {
+                  "type": "filterResponse",
+                  "value": [
+                    "0x5cfe73b6021e818b776b421b1c4db2474086a7e1"
+                  ],
+                  "name": "exposedAccounts"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "meta": {
+    "version": 47
+  }
+}

--- a/test/e2e/tests/personal-sign.spec.js
+++ b/test/e2e/tests/personal-sign.spec.js
@@ -1,0 +1,40 @@
+const { strict: assert } = require('assert')
+const { By, Key } = require('selenium-webdriver')
+const { withFixtures } = require('../helpers')
+
+describe('Personal sign', function () {
+  it('can initiate and confirm a personal sign', async function () {
+    const ganacheOptions = {
+      accounts: [
+        {
+          secretKey: '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+          balance: 25000000000000000000,
+        },
+      ],
+    }
+    await withFixtures(
+      { dapp: true, fixtures: 'personal-sign', ganacheOptions, title: this.test.title },
+      async ({ driver }) => {
+        const passwordField = await driver.findElement(By.css('#password'))
+        await passwordField.sendKeys('correct horse battery staple')
+        await passwordField.sendKeys(Key.ENTER)
+
+        await driver.openNewPage('http://127.0.0.1:8080/')
+        await driver.clickElement(By.id('personalSign'))
+
+        await driver.waitUntilXWindowHandles(3)
+
+        const windowHandles = await driver.getAllWindowHandles()
+        await driver.switchToWindowWithTitle('MetaMask Notification', windowHandles)
+
+        const personalMessageRow = await driver.findElement(By.css('.request-signature__row-value'))
+        const personalMessage = await personalMessageRow.getText()
+        assert.equal(personalMessage, 'Example `personal_sign` message')
+
+        await driver.clickElement(By.css('[data-testid="request-signature__sign"]'))
+
+        await driver.waitUntilXWindowHandles(2)
+      }
+    )
+  })
+})

--- a/ui/app/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/app/components/app/signature-request-original/signature-request-original.component.js
@@ -293,6 +293,7 @@ export default class SignatureRequestOriginal extends Component {
           { this.context.t('cancel') }
         </Button>
         <Button
+          data-testid="request-signature__sign"
           type="secondary"
           large
           className="request-signature__footer__sign-button"


### PR DESCRIPTION
This tests the `personal_sign` method using the test dapp. This test reflects part of the `confirm-sig-requests` integration test, which tests the confirmation of a `personal_sign` signature request.

A `data-testid` prop was added to the 'Sign' button on the signature request confirmation page, to make it easier to select the 'Sign' button reliably.