### PR TITLE
Add address view on Ethplorer (convenient for tokens)

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -1274,6 +1274,9 @@
   "viewOnEtherscan": {
     "message": "በ Etherscan ላይ ይመልከቱ"
   },
+  "viewOnEthplorer": {
+    "message": "በ Ethplorer ላይ ይመልከቱ"
+  },
   "visitWebSite": {
     "message": "ድረ ገጻችንን ይጎብኙ"
   },

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -1270,6 +1270,9 @@
   "viewOnEtherscan": {
     "message": "عرضه على Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "عرضه على Ethplorer"
+  },
   "visitWebSite": {
     "message": "قم بزيارة موقعنا على الإنترنت"
   },

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -1273,6 +1273,9 @@
   "viewOnEtherscan": {
     "message": "Преглед на Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Преглед на Ethplorer"
+  },
   "visitWebSite": {
     "message": "Посетете нашият уеб сайт"
   },

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -1277,6 +1277,9 @@
   "viewOnEtherscan": {
     "message": "Etherscan দেখুন"
   },
+  "viewOnEthplorer": {
+    "message": "Ethplorer দেখুন"
+  },
   "visitWebSite": {
     "message": "আমাদের ওয়েবসাইট দেখুন"
   },

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -1246,6 +1246,9 @@
   "viewOnEtherscan": {
     "message": "Veure a Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Veure a Ethplorer"
+  },
   "visitWebSite": {
     "message": "Visita el nostre lloc web"
   },

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -1246,6 +1246,9 @@
   "viewOnEtherscan": {
     "message": "Se på Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Se på Ethplorer"
+  },
   "visitWebSite": {
     "message": "Besøg vores webside"
   },

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -1234,6 +1234,9 @@
   "viewOnEtherscan": {
     "message": "Auf Etherscan ansehen"
   },
+  "viewOnEthplorer": {
+    "message": "Auf Ethplorer ansehen"
+  },
   "visitWebSite": {
     "message": "Gehe zu unserer Webseite"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -1271,6 +1271,9 @@
   "viewOnEtherscan": {
     "message": "Προβολή στο Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Προβολή στο Ethplorer"
+  },
   "visitWebSite": {
     "message": "Επισκεφθείτε τον ιστότοπό μας"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -187,11 +187,11 @@
   "alertsSettingsDescription": {
     "message": "Enable or disable each alert"
   },
-  "alertSettingsUnconnectedAccount": {	
-    "message": "Browsing a website with an unconnected account selected"	
-  },	
-  "alertSettingsUnconnectedAccountDescription": {	
-    "message": "This alert is shown in the popup when you are browsing a connected Web3 site, but the currently selected account is not connected."	
+  "alertSettingsUnconnectedAccount": {
+    "message": "Browsing a website with an unconnected account selected"
+  },
+  "alertSettingsUnconnectedAccountDescription": {
+    "message": "This alert is shown in the popup when you are browsing a connected Web3 site, but the currently selected account is not connected."
   },
   "allowOriginSpendToken": {
     "message": "Allow $1 to spend your $2?",
@@ -1684,6 +1684,9 @@
   },
   "viewOnEtherscan": {
     "message": "View on Etherscan"
+  },
+  "viewOnEthplorer": {
+    "message": "View on Ethplorer"
   },
   "retryTransaction": {
     "message": "Retry Transaction"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1009,6 +1009,9 @@
   "viewOnEtherscan": {
     "message": "Ver en Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Ver en Ethplorer"
+  },
   "visitWebSite": {
     "message": "Visita nuestro sitio web"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1256,6 +1256,9 @@
   "viewOnEtherscan": {
     "message": "Ver en Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Ver en Ethplorer"
+  },
   "visitWebSite": {
     "message": "Visita nuestro sitio web"
   },

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -1267,6 +1267,9 @@
   "viewOnEtherscan": {
     "message": "Kuva Etherscanil"
   },
+  "viewOnEthplorer": {
+    "message": "Kuva Ethplorer"
+  },
   "visitWebSite": {
     "message": "Külastage meie veebilehte"
   },

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -1277,6 +1277,9 @@
   "viewOnEtherscan": {
     "message": "مشاهده در ایترسکن"
   },
+  "viewOnEthplorer": {
+    "message": "Ethplorer مشاهده در"
+  },
   "visitWebSite": {
     "message": "از وب سایت ما دیدن نمایید"
   },

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -1274,6 +1274,9 @@
   "viewOnEtherscan": {
     "message": "Näytä Etherscanissa"
   },
+  "viewOnEthplorer": {
+    "message": "Näytä Ethplorerissa"
+  },
   "visitWebSite": {
     "message": "Vieraile verkkosivustollamme"
   },

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -1171,6 +1171,9 @@
   "viewOnEtherscan": {
     "message": "Tingnan sa Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Tingnan sa Ethplorer"
+  },
   "visitWebSite": {
     "message": "Bisitahin ang aming web site"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -1253,6 +1253,9 @@
   "viewOnEtherscan": {
     "message": "Voir sur Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Voir sur Ethplorer"
+  },
   "visitWebSite": {
     "message": "Visitez notre site web"
   },

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -1271,6 +1271,9 @@
   "viewOnEtherscan": {
     "message": "הצג ב-Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "הצג ב-Ethplorer"
+  },
   "visitWebSite": {
     "message": "בקר/י באתר שלנו"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1271,6 +1271,9 @@
   "viewOnEtherscan": {
     "message": "इथरस्कैन पर देखें"
   },
+  "viewOnEthplorer": {
+    "message": "जातीयता पर देखें"
+  },
   "visitWebSite": {
     "message": "हमारी वेबसाइट पर जाएँ"
   },

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -1267,6 +1267,9 @@
   "viewOnEtherscan": {
     "message": "Prikaži na Etherscanu"
   },
+  "viewOnEthplorer": {
+    "message": "Prikaži na Ethplorer"
+  },
   "visitWebSite": {
     "message": "Posjetite naše mrežno mjesto"
   },

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -781,6 +781,9 @@
   "viewOnEtherscan": {
     "message": "Wè sou Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Wè sou Ethplorer"
+  },
   "visitWebSite": {
     "message": "Vizite sit entènèt nou an"
   },

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -1267,6 +1267,9 @@
   "viewOnEtherscan": {
     "message": "Nézze meg Etherscanen"
   },
+  "viewOnEthplorer": {
+    "message": "Nézze meg Ethplorerben"
+  },
   "visitWebSite": {
     "message": "Látogass el weboldalunkra"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1249,6 +1249,9 @@
   "viewOnEtherscan": {
     "message": "Lihat di Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Lihat di Ethplorer"
+  },
   "visitWebSite": {
     "message": "Kunjungi website kami"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1685,6 +1685,9 @@
   "viewOnEtherscan": {
     "message": "Vedi su Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Vedi su Ethplorer"
+  },
   "retryTransaction": {
     "message": "Retry Transaction"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -481,6 +481,9 @@
   "viewOnEtherscan": {
     "message": "Etherscan で見る"
   },
+  "viewOnEthplorer": {
+    "message": "Ethplorer で見る"
+  },
   "walletSeed": {
     "message": "ウォレットのパスフレーズ"
   },

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -1277,6 +1277,9 @@
   "viewOnEtherscan": {
     "message": "ಎಥೆರ್‌ಸ್ಕ್ಯಾನ್‌ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ"
   },
+  "viewOnEthplorer": {
+    "message": "ಎಥ್‌ಪ್ಲೋರರ್‌ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ"
+  },
   "visitWebSite": {
     "message": "ನಮ್ಮ ವೆಬ್ ಸೈಟ್ ಅನ್ನು ಭೇಟಿ ಮಾಡಿ"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1268,6 +1268,9 @@
   "viewOnEtherscan": {
     "message": "이더스캔에서 보기"
   },
+  "viewOnEthplorer": {
+    "message": "Ethplorer에서보기"
+  },
   "visitWebSite": {
     "message": "웹사이트 방문"
   },

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -1277,6 +1277,9 @@
   "viewOnEtherscan": {
     "message": "Peržiūrėti „Etherscan“"
   },
+  "viewOnEthplorer": {
+    "message": "Peržiūrėti „Ethplorer“"
+  },
   "visitWebSite": {
     "message": "Apsilankykite mūsų svetainėje"
   },

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -1273,6 +1273,9 @@
   "viewOnEtherscan": {
     "message": "Skatīt Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Skatīt Ethplorer"
+  },
   "visitWebSite": {
     "message": "Apmeklējiet mūsu tīmekļa vietni"
   },

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -1248,6 +1248,9 @@
   "viewOnEtherscan": {
     "message": "Lihat di Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Lihat di Ethplorer"
+  },
   "visitWebSite": {
     "message": "Kunjungi laman web kami"
   },

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -1249,6 +1249,9 @@
   "viewOnEtherscan": {
     "message": "Vis på Etherscan "
   },
+  "viewOnEthplorer": {
+    "message": "Vis på Ethplorer "
+  },
   "visitWebSite": {
     "message": "Besøk nettsiden vår "
   },

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -1265,6 +1265,9 @@
   "viewOnEtherscan": {
     "message": "Zobacz na Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Zobacz na Ethplorer"
+  },
   "visitWebSite": {
     "message": "Odwiedź naszą stronę"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -1259,6 +1259,9 @@
   "viewOnEtherscan": {
     "message": "Ver no Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Ver no Ethplorer"
+  },
   "visitWebSite": {
     "message": "Visite nosso site"
   },

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -1258,6 +1258,9 @@
   "viewOnEtherscan": {
     "message": "Vizualizați pe Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Vizualizați pe Ethplorer"
+  },
   "visitWebSite": {
     "message": "Accesați site-ul nostru"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1298,6 +1298,9 @@
   "viewOnEtherscan": {
     "message": "Посмотреть на Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Посмотреть на Ethplorer"
+  },
   "welcomeBack": {
     "message": "Рад видеть вас снова!"
   },

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -1234,6 +1234,9 @@
   "viewOnEtherscan": {
     "message": "Zobraziť na Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Zobraziť na Ethplorer"
+  },
   "visitWebSite": {
     "message": "Navštivte naši stránku"
   },

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -1259,6 +1259,9 @@
   "viewOnEtherscan": {
     "message": "Poglej na Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Poglej na Ethplorer"
+  },
   "visitWebSite": {
     "message": "Obiščite našo spletno stran"
   },

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -1262,6 +1262,9 @@
   "viewOnEtherscan": {
     "message": "Pogledaj na Etherscan-u"
   },
+  "viewOnEthplorer": {
+    "message": "Pogledaj na Ethplorer-u"
+  },
   "visitWebSite": {
     "message": "Posetite našu veb lokaciju"
   },

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -1252,6 +1252,9 @@
   "viewOnEtherscan": {
     "message": "Visa på Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Visa på Ethplorer"
+  },
   "visitWebSite": {
     "message": "Besök vår hemsida"
   },

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -1255,6 +1255,9 @@
   "viewOnEtherscan": {
     "message": "Tazama kwenye Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Tazama kwenye Ethplorer"
+  },
   "visitWebSite": {
     "message": "Tembelea Tovuti yetu"
   },

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -1277,6 +1277,9 @@
   "viewOnEtherscan": {
     "message": "Дивитись на Etherscan"
   },
+  "viewOnEthplorer": {
+    "message": "Дивитись на Ethplorer"
+  },
   "visitWebSite": {
     "message": "Відвідайте наш веб-сайт"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1256,6 +1256,9 @@
   "viewOnEtherscan": {
     "message": "在 Etherscan 上查看"
   },
+  "viewOnEthplorer": {
+    "message": "在 Ethplorer 上查看"
+  },
   "visitWebSite": {
     "message": "访问我们的网站"
   },

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -1256,6 +1256,9 @@
   "viewOnEtherscan": {
     "message": "在 Etherscan 上瀏覽"
   },
+  "viewOnEthplorer": {
+    "message": "在 Ethplorer 上瀏覽"
+  },
   "visitWebSite": {
     "message": "造訪我們的網站"
   },

--- a/ui/app/components/app/menu-bar/tests/menu-bar.test.js
+++ b/ui/app/components/app/menu-bar/tests/menu-bar.test.js
@@ -59,4 +59,46 @@ describe('MenuBar', function () {
     wrapper.update()
     assert.ok(!wrapper.exists('AccountOptionsMenu'))
   })
+
+  it('should contains Ethplorer menu item for main net', function () {
+    const store = mockStore(initState)
+    const wrapper = mountWithRouter(
+      <Provider store={store}>
+        <MenuBar />
+      </Provider>
+    )
+    const accountOptions = wrapper.find('.menu-bar__account-options')
+    accountOptions.simulate('click')
+    wrapper.update()
+
+    const ethplorerMenuItem = wrapper
+      .find('MenuItem')
+      .findWhere(item => item.key() === 'ethplorer')
+
+    assert.equal(ethplorerMenuItem.length, 1)
+  })
+
+  it('should not contains Ethplorer menu item for not main net', function () {
+    const store = mockStore({
+      ...initState,
+      metamask: {
+        ...initState.metamask,
+        network: '2'
+      }
+    })
+    const wrapper = mountWithRouter(
+      <Provider store={store}>
+        <MenuBar />
+      </Provider>
+    )
+    const accountOptions = wrapper.find('.menu-bar__account-options')
+    accountOptions.simulate('click')
+    wrapper.update()
+
+    const ethplorerMenuItem = wrapper
+      .find('MenuItem')
+      .findWhere(item => item.key() === 'ethplorer')
+
+    assert.equal(ethplorerMenuItem.length, 0)
+  })
 })

--- a/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import AccountModalContainer from '../account-modal-container'
 import genAccountLink from '../../../../../lib/account-link.js'
+import getExtraExplorerAccounts from '../../../../../lib/explorer-accounts'
 import QrView from '../../../ui/qr-code'
 import EditableLabel from '../../../ui/editable-label'
 import Button from '../../../ui/button'
@@ -30,6 +31,7 @@ export default class AccountDetailsModal extends Component {
       rpcPrefs,
     } = this.props
     const { name, address } = selectedIdentity
+    const explorerAccounts = getExtraExplorerAccounts(network)
 
     const keyring = keyrings.find((kr) => {
       return kr.accounts.includes(address)
@@ -70,6 +72,19 @@ export default class AccountDetailsModal extends Component {
             : this.context.t('viewOnEtherscan')
           }
         </Button>
+
+        {explorerAccounts.map(item => (
+          <Button
+            key={item.name}
+            type="secondary"
+            className="account-modal__button"
+            onClick={() => {
+              global.platform.openTab({ url: item.addressExplorerLink(address) })
+            }}
+          >
+            {this.context.t(item.title)}
+          </Button>
+        ))}
 
         {exportPrivateKeyFeatureEnabled
           ? (

--- a/ui/app/components/app/modals/tests/account-details-modal.test.js
+++ b/ui/app/components/app/modals/tests/account-details-modal.test.js
@@ -78,4 +78,26 @@ describe('Account Details Modal', function () {
 
     assert.equal(blockExplorerLink.html(), '<button class="button btn-secondary account-modal__button">blockExplorerView</button>')
   })
+
+  it('should contains Ethplorer menu item for main net', function () {
+    wrapper.setProps({ network: '1' })
+    wrapper.update()
+
+    const ethplorerButton = wrapper
+      .find('.account-modal__button')
+      .findWhere(item => item.key() === 'ethplorer')
+
+    assert.equal(ethplorerButton.length, 1)
+  })
+
+  it('should not contains Ethplorer menu item for not main net', function () {
+    wrapper.setProps({ network: '2' })
+    wrapper.update()
+
+    const ethplorerButton = wrapper
+      .find('.account-modal__button')
+      .findWhere(item => item.key() === 'ethplorer')
+
+    assert.equal(ethplorerButton.length, 0)
+  })
 })

--- a/ui/lib/explorer-accounts.js
+++ b/ui/lib/explorer-accounts.js
@@ -1,0 +1,19 @@
+import getAccountLink from './account-link'
+
+export default function getExplorerAccounts (network) {
+  const net = parseInt(network, 10)
+  const accounts = []
+
+  switch (net) {
+    case 1: // main net
+      accounts.push({
+        name: 'ethplorer',
+        title: 'viewOnEthplorer',
+        eventName: 'Clicked View on Ethplorer',
+        addressExplorerLink: address => `https://ethplorer.io/address/${address}`
+      })
+      break
+  }
+
+  return accounts
+}


### PR DESCRIPTION
This PR does the following (only for mainnet):
- add additional menu item to view address on Ethplorer on Menu Bar below Etherscan
- add additional button to view address on Ethplorer on Account Details Modal below Etherscan