### PR TITLE
Update `@metamask/test-dapp` to v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "@babel/register": "^7.5.5",
     "@metamask/eslint-config": "^1.1.0",
     "@metamask/forwarder": "^1.1.0",
-    "@metamask/test-dapp": "3.0.0",
+    "@metamask/test-dapp": "^3.1.0",
     "@sentry/cli": "^1.49.0",
     "@storybook/addon-actions": "^5.3.14",
     "@storybook/addon-backgrounds": "^5.3.14",

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -92,7 +92,7 @@ describe('MetaMask', function () {
     })
 
     it('creates a sign typed data signature request', async function () {
-      await driver.clickElement(By.xpath(`//button[contains(text(), 'Sign')]`), 10000)
+      await driver.clickElement(By.id('signTypedData'), 10000)
       await driver.delay(largeDelayMs)
 
       await driver.delay(regularDelayMs)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,10 +1766,10 @@
     pump "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-"@metamask/test-dapp@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-3.0.0.tgz#4e9678c872e0f379b4178032a6c4bfac6131a360"
-  integrity sha512-aXiN68DDjrMpHYIx3uE47HUzLIO327zsqMPFlv/SVEmYiuZgt7Ypndb25llPBJsLQ5cWPwiln6MoTb9DbxaSeA==
+"@metamask/test-dapp@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-3.1.0.tgz#25560ff260bcf6611b30a26b09c915013576210c"
+  integrity sha512-pUKiWgEzD9+IcfYJSyz1wrNSBNMwJGynUBLfc/RE39sDw+4I3PRc4z27rn7oYGa1C65OsgrrwZ02QW7/UtTX2A==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
This updated test dapp has a new `personal_sign` button. It also fixes the `Encrypt` button, which was broken in `v3.0.0`.

The `signature-request` e2e test needed to be updated to find the 'Sign' button by id rather than by text, since there are now two buttons with the text 'Sign'.