### PR TITLE
Use lodash@4.17.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "**/mkdirp/minimist": "^1.2.5",
     "**/optimist/minimist": "^1.2.5",
     "**/socketcluster/minimist": "^1.2.5",
-    "3box/ipfs/ipld-zcash/zcash-bitcore-lib/lodash": "^4.17.17",
-    "ganache-core/lodash": "^4.17.17"
+    "3box/ipfs/ipld-zcash/zcash-bitcore-lib/lodash": "^4.17.19",
+    "ganache-core/lodash": "^4.17.19"
   },
   "dependencies": {
     "3box": "^1.10.2",
@@ -123,7 +123,7 @@
     "json-rpc-engine": "^5.1.8",
     "json-rpc-middleware-stream": "^2.1.1",
     "jsonschema": "^1.2.4",
-    "lodash": "^4.17.17",
+    "lodash": "^4.17.19",
     "loglevel": "^1.4.1",
     "luxon": "^1.23.0",
     "metamask-logo": "^2.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17426,10 +17426,10 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@4.17.14, lodash@=3.10.1, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.17, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.10, lodash@~4.17.2, lodash@~4.17.4:
-  version "4.17.17"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.17.tgz#d9018b3acc57a95c9dcf4a45c6b63b877b6c2d45"
-  integrity sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q==
+lodash@4.17.14, lodash@=3.10.1, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.10, lodash@~4.17.2, lodash@~4.17.4:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-driver@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
Refs #8940

This PR updates `lodash` (again) to resolve many (1784) security advisories. The security advisory was updated to show this version as the version that was patched.

See https://www.npmjs.com/advisories/1523 for more information.