### PR TITLE
Use abortcontroller-polyfill@1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@sentry/integrations": "^5.11.1",
     "@zxing/library": "^0.8.0",
     "abi-decoder": "^1.2.0",
-    "abortcontroller-polyfill": "^1.3.0",
+    "abortcontroller-polyfill": "^1.4.0",
     "await-semaphore": "^0.1.1",
     "bignumber.js": "^4.1.0",
     "bip39": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,10 +2928,10 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abortcontroller-polyfill@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz#de69af32ae926c210b7efbcc29bf644ee4838b00"
-  integrity sha512-lbWQgf+eRvku3va8poBlDBO12FigTQr9Zb7NIjXrePrhxWVKdCP2wbDl1tLDaYa18PWTom3UEWwdH13S46I+yA==
+abortcontroller-polyfill@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz#0d5eb58e522a461774af8086414f68e1dda7a6c4"
+  integrity sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==
 
 abstract-leveldown@0.12.3:
   version "0.12.3"


### PR DESCRIPTION
This PR updates the `abortcontroller-polyfill` dependency to the latest published version, 1.4.0.

The changes in [`v1.3.0...v1.4.0`](https://github.com/mo/abortcontroller-polyfill/compare/v1.3.0...v1.4.0) are wholly uninteresting.