### PR TITLE
Use gonzales-pe@4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "generate:migration": "./development/generate-migration.sh"
   },
   "resolutions": {
-    "**/gonzales-pe/minimist": "^1.2.5",
     "**/knex/minimist": "^1.2.5",
     "**/mkdirp/minimist": "^1.2.5",
     "**/optimist/minimist": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12695,11 +12695,11 @@ glogg@^1.0.0:
     sparkles "^1.0.0"
 
 gonzales-pe@^4.2.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.2.4.tgz#356ae36a312c46fe0f1026dd6cb539039f8500d2"
-  integrity sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.3.0.tgz#fe9dec5f3c557eead09ff868c65826be54d067b3"
+  integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
   dependencies:
-    minimist "1.1.x"
+    minimist "^1.2.5"
 
 good-listener@^1.2.2:
   version "1.2.2"
@@ -18185,7 +18185,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8, minimist@1.1.x, minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
+minimist@0.0.8, minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
This PR updates the `gonzales-pe` sub-dependency in service of removing the `.resolutions` entry in the `package.json` file.

[The set of changes in `v4.2.4...v4.3.0`](https://github.com/tonyganch/gonzales-pe/blob/ab2e8ae6142d6fa95b77864f608a8add8abffaec/CHANGELOG.md#30032020-version-430) seem safe.