### PR TITLE
Fix array-callback-return issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,9 @@ module.exports = {
   },
 
   rules: {
+    /* TODO: Remove these when upgrading to `@metamask/eslint-config@2` */
+    'array-callback-return': 'error',
+    /* End v2 rules */
     'arrow-parens': 'error',
     'no-tabs': 'error',
     'no-mixed-operators': 'error',

--- a/development/build/display.js
+++ b/development/build/display.js
@@ -47,7 +47,7 @@ function displayChart (data) {
   console.log(`\nbuild completed. task timeline:`)
 
   // build bars for bounds
-  data.map((entry, index) => {
+  data.forEach((entry, index) => {
     const [label, start, end] = entry
     const [start2, end2] = [start, end].map((value) => adjust(value, first, last, 40))
     const barString = barBuilder(start2, end2)

--- a/ui/app/components/app/contact-list/contact-list.component.js
+++ b/ui/app/components/app/contact-list/contact-list.component.js
@@ -67,7 +67,7 @@ export default class ContactList extends PureComponent {
           return 1
         } else if (letter1 === letter2) {
           return 0
-        } else if (letter1 < letter2) {
+        } else {
           return -1
         }
       })

--- a/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-component.test.js
@@ -128,7 +128,7 @@ describe('SendFooter Component', function () {
       },
 
     }
-    Object.entries(config).map(([description, obj]) => {
+    Object.entries(config).forEach(([description, obj]) => {
       it(description, function () {
         wrapper.setProps(obj)
         assert.equal(wrapper.instance().formShouldBeDisabled(), obj.expectedResult)

--- a/ui/app/pages/send/tests/send-utils.test.js
+++ b/ui/app/pages/send/tests/send-utils.test.js
@@ -103,7 +103,7 @@ describe('send utils', function () {
         expectedResult: false,
       },
     }
-    Object.entries(config).map(([description, obj]) => {
+    Object.entries(config).forEach(([description, obj]) => {
       it(description, function () {
         assert.equal(doesAmountErrorRequireUpdate(obj), obj.expectedResult)
       })
@@ -166,7 +166,7 @@ describe('send utils', function () {
         expectedResult: { amount: INSUFFICIENT_TOKENS_ERROR },
       },
     }
-    Object.entries(config).map(([description, obj]) => {
+    Object.entries(config).forEach(([description, obj]) => {
       it(description, function () {
         assert.deepEqual(getAmountErrorObject(obj), obj.expectedResult)
       })
@@ -190,7 +190,7 @@ describe('send utils', function () {
         expectedResult: { gasFee: null },
       },
     }
-    Object.entries(config).map(([description, obj]) => {
+    Object.entries(config).forEach(([description, obj]) => {
       it(description, function () {
         assert.deepEqual(getGasFeeErrorObject(obj), obj.expectedResult)
       })


### PR DESCRIPTION
Refs #8982

See [`array-callback-return`](https://eslint.org/docs/rules/array-callback-return) for more information.

This change enables `array-callback-return` and fixes the issues raised by the rule.