### PR TITLE
Fix `web3_clientVersion` method

### DIFF
--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -36,6 +36,7 @@ export const LOG_LIMIT = 100
 
 export const SAFE_METHODS = [
   'web3_sha3',
+  'web3_clientVersion',
   'net_listening',
   'net_peerCount',
   'net_version',


### PR DESCRIPTION
This method was accidentally broken with the introduction of the permissions controller, as this was missing from the list of safe
methods.

It is now included in the list of safe methods.

Fixes #8993