### PR TITLE
Fix global-require issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
     /* TODO: Remove these when upgrading to `@metamask/eslint-config@2` */
     'array-callback-return': 'error',
     'callback-return': 'error',
+    'global-require': 'error',
     /* End v2 rules */
     'arrow-parens': 'error',
     'no-tabs': 'error',
@@ -104,6 +105,13 @@ module.exports = {
     ],
     rules: {
       'import/no-anonymous-default-export': ['error', { 'allowObject': true }],
+    },
+  }, {
+    files: [
+      'app/scripts/migrations/*.js',
+    ],
+    rules: {
+      'global-require': 'off',
     },
   }],
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,6 +3,8 @@ import nock from 'nock'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import log from 'loglevel'
+import { JSDOM } from 'jsdom'
+
 
 nock.disableNetConnect()
 nock.enableNetConnect('localhost')
@@ -45,8 +47,6 @@ global.log = log
 //
 
 // dom
-const { JSDOM } = require('jsdom')
-
 const jsdom = new JSDOM()
 global.window = jsdom.window
 
@@ -87,5 +87,6 @@ if (!window.crypto) {
   window.crypto = {}
 }
 if (!window.crypto.getRandomValues) {
+  // eslint-disable-next-line global-require
   window.crypto.getRandomValues = require('polyfill-crypto.getrandomvalues')
 }

--- a/test/unit/migrations/026-test.js
+++ b/test/unit/migrations/026-test.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import firstTimeState from '../../../app/scripts/first-time-state'
 import migration26 from '../../../app/scripts/migrations/026'
 
 const oldStorage = {
@@ -32,7 +33,7 @@ describe('migration #26', function () {
   it('should successfully migrate first time state', function (done) {
     migration26.migrate({
       meta: {},
-      data: require('../../../app/scripts/first-time-state'),
+      data: firstTimeState,
     })
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, migration26.version)

--- a/test/unit/migrations/027-test.js
+++ b/test/unit/migrations/027-test.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import firstTimeState from '../../../app/scripts/first-time-state'
 import migration27 from '../../../app/scripts/migrations/027'
 
 const oldStorage = {
@@ -42,7 +43,7 @@ describe('migration #27', function () {
   it('should successfully migrate first time state', function (done) {
     migration27.migrate({
       meta: {},
-      data: require('../../../app/scripts/first-time-state'),
+      data: firstTimeState,
     })
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, migration27.version)

--- a/test/unit/migrations/028-test.js
+++ b/test/unit/migrations/028-test.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import firstTimeState from '../../../app/scripts/first-time-state'
 import migration28 from '../../../app/scripts/migrations/028'
 
 const oldStorage = {
@@ -36,7 +37,7 @@ describe('migration #28', function () {
   it('should successfully migrate first time state', function (done) {
     migration28.migrate({
       meta: {},
-      data: require('../../../app/scripts/first-time-state'),
+      data: firstTimeState,
     })
       .then((migratedData) => {
         assert.equal(migratedData.meta.version, migration28.version)


### PR DESCRIPTION
Refs #8982

See [`global-require`](https://eslint.org/docs/rules/global-require) for more information.

This change enables `global-require` and fixes the issues raised by the rule.