### PR TITLE
Fix `ListItem` styles

### DIFF
--- a/ui/app/components/ui/list-item/index.scss
+++ b/ui/app/components/ui/list-item/index.scss
@@ -11,7 +11,7 @@
   border-bottom: 1px solid $mercury;
   color: $Black-100;
   display: grid;
-  grid-template-columns: 0 repeat(11, 1fr);
+  grid-template-columns: 0fr repeat(11, 1fr);
   grid-template-areas:
     'icon head     head     head     head     head     head     head     right right right right'
     'icon sub      sub      sub      sub      sub      sub      sub      right right right right'


### PR DESCRIPTION
The styles for the `ListItem` component were recently broken in #8989 because of a change made by `stylelint`. It incorrectly removed the `fr` unit because of the `length-zero-no-unit` rule. This was a bug that has since been fixed in `stylelint`; it should have left the `fr` unit in this case.