### PR TITLE
@metamask/inpage-provider@6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^2.0.0",
     "@metamask/etherscan-link": "^1.1.0",
-    "@metamask/inpage-provider": "^6.0.0",
+    "@metamask/inpage-provider": "^6.0.1",
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.3.2",
     "@sentry/browser": "^5.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/forwarder/-/forwarder-1.1.0.tgz#13829d8244bbf19ea658c0b20d21a77b67de0bdd"
   integrity sha512-Hggj4y0QIjDzKGTXzarhEPIQyFSB2bi2y6YLJNwaT4JmP30UB5Cj6gqoY0M4pj3QT57fzp0BUuGp7F/AUe28tw==
 
-"@metamask/inpage-provider@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-6.0.0.tgz#84a95d30cad77ac1d70507915f6bea04a72e6c4f"
-  integrity sha512-487gjVIdIKEgqNXu5Q7dtVvv48nwZCLSBxDVoL8NUeQOIw1HARzG5kPusWnOhcOfKdpUCZLl+Mp/c+XhEtZM6Q==
+"@metamask/inpage-provider@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-6.0.1.tgz#09bf3a3157d604fb511133c5a6e8eb1178d776bc"
+  integrity sha512-kcc2Tmq6bgjMyYxCgDJczdCAUBmAR4FPo+zmN0np02y/KNgDlzuKLdsrv3Y9B/S5XTxjuW95xYtMaxXZ5drEkQ==
   dependencies:
     eth-json-rpc-errors "^2.0.2"
     fast-deep-equal "^2.0.1"


### PR DESCRIPTION
- Fixes some provider bugs introduced in v8, see: https://github.com/MetaMask/inpage-provider/blob/master/CHANGELOG.md#601---2020-07-15