### PR TITLE
Deprecate itcss

### DIFF
--- a/ui/app/css/itcss/README.md
+++ b/ui/app/css/itcss/README.md
@@ -1,0 +1,2 @@
+### Deprecated
+The [itcss](https://www.freecodecamp.org/news/managing-large-s-css-projects-using-the-inverted-triangle-architecture-3c03e4b1e6df/) folder is deprecated. The infrastructure here is from a former era of the extension. The files and some sporadic styling are still used in the codebase but should not be extended. The MetaMask team will gradually move the valid styles from this folder into the [css](/css) folder. Eventually the itcss folder will be removed.


### PR DESCRIPTION
Adds a simple message to the itcss folder about not extending the usage of the folder itself. 