### PR TITLE
Hide loading indication after `personal_sign`

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -475,6 +475,7 @@ export function signPersonalMsg (msgData) {
       dispatch(displayWarning(error.message))
       throw error
     }
+    dispatch(hideLoadingIndication())
     dispatch(updateMetamaskState(newState))
     dispatch(completedTx(msgData.metamaskId))
     dispatch(closeCurrentNotificationWindow())


### PR DESCRIPTION
The loading indication had remained after successfully signing with `personal_sign`. This mistake was introduced accidentally in #8434.

This is noticeable if you confirm the signature in the popup UI or fullscreen UI, as they remain open after signing. The notification UI
closes after signing without waiting for this loading indicator to be removed.