### PR TITLE
Limit number of transactions passed outside of TransactionController

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -37,6 +37,7 @@ import { hexToBn, bnToHex, BnMultiplyByFraction } from '../../lib/util'
 import { TRANSACTION_NO_CONTRACT_ERROR_KEY } from '../../../../ui/app/helpers/constants/error-keys'
 
 const SIMPLE_GAS_COST = '0x5208' // Hex for 21000, cost of a simple send.
+const MAX_MEMSTORE_TX_LIST_SIZE = 100 // Number of transactions (by unique nonces) to keep in memory
 
 /**
   Transaction Controller is an aggregate of sub-controllers and trackers
@@ -789,9 +790,7 @@ export default class TransactionController extends EventEmitter {
   */
   _updateMemstore () {
     const unapprovedTxs = this.txStateManager.getUnapprovedTxList()
-    const currentNetworkTxList = this.txStateManager.getFilteredTxList({
-      metamaskNetworkId: this.getNetwork(),
-    })
+    const currentNetworkTxList = this.txStateManager.getTxList(MAX_MEMSTORE_TX_LIST_SIZE)
     this.memStore.updateState({ unapprovedTxs, currentNetworkTxList })
   }
 }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -57,12 +57,39 @@ export default class TransactionStateManager extends EventEmitter {
   }
 
   /**
-    @returns {array} - of txMetas that have been filtered for only the current network
-  */
-  getTxList () {
+   * Returns the full tx list for the current network
+   *
+   * The list is iterated backwards as new transactions are pushed onto it.
+   *
+   * @param {number} [limit] a limit for the number of transactions to return
+   * @returns {Object[]} The {@code txMeta}s, filtered to the current network
+   */
+  getTxList (limit) {
     const network = this.getNetwork()
     const fullTxList = this.getFullTxList()
-    return fullTxList.filter((txMeta) => txMeta.metamaskNetworkId === network)
+
+    const nonces = new Set()
+    const txs = []
+    for (let i = fullTxList.length - 1; i > -1; i--) {
+      const txMeta = fullTxList[i]
+      if (txMeta.metamaskNetworkId !== network) {
+        continue
+      }
+
+      if (limit !== undefined) {
+        const { nonce } = txMeta.txParams
+        if (!nonces.has(nonce)) {
+          if (nonces.size < limit) {
+            nonces.add(nonce)
+          } else {
+            continue
+          }
+        }
+      }
+
+      txs.unshift(txMeta)
+    }
+    return txs
   }
 
   /**


### PR DESCRIPTION
Refs #8377
Refs #8572
Refs #8991

This change limits the number of transactions (`txMeta`s) that are passed outside of the `TransactionController`, resulting in shorter serialization and deserialization times when state is moved between the background and UI contexts.

### `TransactionController#_updateMemstore`

The `currentNetworkTxList` state of the `TransactionController` is used externally (i.e. outside of the controller) as the canonical source for the full transaction history. Prior to this change, the method would iterate the full transaction history and possibly return all of it.

This change limits it to `MAX_MEMSTORE_TX_LIST_SIZE` to make sure that:

1. Calls to `_updateMemstore` are fast(er)
2. Passing `currentNetworkTxList` around is fast(er)

(Shown in #8377, `_updateMemstore`, is called _frequently_ when a transaction is pending.)

The list is iterated backwards because it is possible that new transactions are at the end of the list.<sup>[\[1\]][1]</sup>

### Results

In profiles before this change, with ~3k transactions locally, `PortDuplexStream._onMessage` took up to ~4.5s to complete when the set of transactions is included.<sup>[\[2\]][2]</sup>

In profiles after this change, `PortDuplexStream._onMessage` took ~90ms to complete.<sup>[\[3\]][3]</sup>

<details>
<summary>Before vs. after profile screenshots</summary>
<img width="1526" alt="" src="https://user-images.githubusercontent.com/1623628/87613203-36f51d80-c6e7-11ea-89bc-11a1cc2f3b1e.png">
<img width="1526" alt="" src="https://user-images.githubusercontent.com/1623628/87613215-3bb9d180-c6e7-11ea-8d85-aff3acbd0374.png">
</details>

  [1]:https://github.com/MetaMask/metamask-extension/blob/5a3ae85b728096cb45c8cc6822249eed5555ee25/app/scripts/controllers/transactions/tx-state-manager.js#L172-L174
  [2]:https://user-images.githubusercontent.com/1623628/87613203-36f51d80-c6e7-11ea-89bc-11a1cc2f3b1e.png
  [3]:https://user-images.githubusercontent.com/1623628/87613215-3bb9d180-c6e7-11ea-8d85-aff3acbd0374.png
  [8337]:https://github.com/MetaMask/metamask-extension/issues/8377
  [8572]:https://github.com/MetaMask/metamask-extension/issues/8572
  [8991]:https://github.com/MetaMask/metamask-extension/issues/8991