### PR TITLE
Display pending notifications after connect flow

### DIFF
--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -26,7 +26,6 @@ export default class PermissionConnect extends Component {
     addressLastConnectedMap: PropTypes.object.isRequired,
     lastConnectedInfo: PropTypes.object.isRequired,
     permissionsRequestId: PropTypes.string,
-    hasAdditionalPermissionsRequests: PropTypes.bool.isRequired,
     history: PropTypes.object.isRequired,
     connectPath: PropTypes.string.isRequired,
     confirmPermissionPath: PropTypes.string.isRequired,
@@ -129,6 +128,7 @@ export default class PermissionConnect extends Component {
   }
 
   redirect (approved) {
+    const { history } = this.props
     this.setState({
       redirecting: true,
       permissionsApproved: approved,
@@ -136,20 +136,7 @@ export default class PermissionConnect extends Component {
     this.removeBeforeUnload()
 
     if (approved) {
-      setTimeout(this._doRedirect.bind(this), APPROVE_TIMEOUT)
-    } else {
-      this._doRedirect()
-    }
-  }
-
-  _doRedirect () {
-    const { history, hasAdditionalPermissionsRequests } = this.props
-
-    if (
-      !hasAdditionalPermissionsRequests &&
-      getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION
-    ) {
-      global.platform.closeCurrentWindow()
+      setTimeout(() => history.push(DEFAULT_ROUTE), APPROVE_TIMEOUT)
     } else {
       history.push(DEFAULT_ROUTE)
     }

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -34,11 +34,6 @@ const mapStateToProps = (state, ownProps) => {
   const permissionsRequest = permissionsRequests
     .find((permissionsRequest) => permissionsRequest.metadata.id === permissionsRequestId)
 
-  // used to determine whether to redirect or show the next permissions request
-  const hasAdditionalPermissionsRequests = permissionsRequest
-    ? permissionsRequests.length > 1
-    : permissionsRequests.length > 0
-
   const { metadata = {} } = permissionsRequest || {}
   const { origin } = metadata
   const nativeCurrency = getNativeCurrency(state)
@@ -83,7 +78,6 @@ const mapStateToProps = (state, ownProps) => {
   return {
     permissionsRequest,
     permissionsRequestId,
-    hasAdditionalPermissionsRequests,
     accounts: accountsWithLabels,
     currentAddress,
     origin,


### PR DESCRIPTION
The notification window is now kept open after the connect flow if there are still pending confirmations. Previously, the notification
window would be closed after the connect flow no matter what, and any pending confirmations would never be shown to the user.

This was accomplished by redirecting to the home screen after the connect flow. The logic for deciding whether or not to close the window is already handled by the home page. This does have the unfortunate side-effect of briefly rendering the home page before the window closes, but this is a minor problem that exists already in a number of other scenarios, and it will be fixed in a subsequent PR.

Fixes #8973