### PR TITLE
Fix migration 47

### DIFF
--- a/app/scripts/migrations/047.js
+++ b/app/scripts/migrations/047.js
@@ -2,9 +2,7 @@ const version = 47
 import { cloneDeep } from 'lodash'
 
 /**
- * Stringify numbers:
- *  - PreferencesController.frequentRpcListDetail item chainId
- *  - TransactionsController.transactions item metamaskNetworkId
+ * Stringify the `metamaskNetworkId` property of all transactions
  */
 export default {
   version,
@@ -18,7 +16,7 @@ export default {
 }
 
 function transformState (state) {
-  const transactions = state?.TransactionsController?.transactions
+  const transactions = state?.TransactionController?.transactions
   if (Array.isArray(transactions)) {
     transactions.forEach((transaction) => {
       if (typeof transaction.metamaskNetworkId === 'number') {

--- a/test/unit/migrations/047-test.js
+++ b/test/unit/migrations/047-test.js
@@ -20,7 +20,7 @@ describe('migration #47', function () {
     const oldStorage = {
       meta: {},
       data: {
-        TransactionsController: {
+        TransactionController: {
           transactions: [
             { foo: 'bar', metamaskNetworkId: 2 },
             { foo: 'bar' },
@@ -34,7 +34,7 @@ describe('migration #47', function () {
 
     const newStorage = await migration47.migrate(oldStorage)
     assert.deepEqual(newStorage.data, {
-      TransactionsController: {
+      TransactionController: {
         transactions: [
           { foo: 'bar', metamaskNetworkId: '2' },
           { foo: 'bar' },
@@ -50,7 +50,7 @@ describe('migration #47', function () {
     const oldStorage = {
       meta: {},
       data: {
-        TransactionsController: {
+        TransactionController: {
           transactions: [
             { foo: 'bar', metamaskNetworkId: '2' },
             { foo: 'bar' },
@@ -70,7 +70,7 @@ describe('migration #47', function () {
     const oldStorage = {
       meta: {},
       data: {
-        TransactionsController: {
+        TransactionController: {
           bar: 'baz',
         },
         foo: 'bar',
@@ -85,7 +85,7 @@ describe('migration #47', function () {
     const oldStorage = {
       meta: {},
       data: {
-        TransactionsController: {
+        TransactionController: {
           transactions: [],
           bar: 'baz',
         },


### PR DESCRIPTION
This migration had referred to the non-existent `TransactionsController` instead of `TransactionController`, so it effectively did nothing. Now it should work.

This migration hasn't been included in any release yet, so we can fix it in-place instead of adding an additional corrected migration.

The migration comment has also been updated, as it was inaccurate.