### PR TITLE
Remove badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # MetaMask Browser Extension
 
-[![Build Status](https://circleci.com/gh/MetaMask/metamask-extension.svg?style=shield&circle-token=a1ddcf3cd38e29267f254c9c59d556d513e3a1fd)](https://circleci.com/gh/MetaMask/metamask-extension) [![Coverage Status](https://coveralls.io/repos/github/MetaMask/metamask-extension/badge.svg?branch=master)](https://coveralls.io/github/MetaMask/metamask-extension?branch=master)
-
 You can find the latest version of MetaMask on [our official website](https://metamask.io/). For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/hc/en-us).
 
 MetaMask supports Firefox, Google Chrome, and Chromium-based browsers. We recommend using the latest available browser version.


### PR DESCRIPTION
This PR removes the badges from the README:

1. The build status isn't a refection of the state of `develop`/`master` since failure is intermittent
2. The code coverage isn't reflective of anything (some of our tests aren't great)