### PR TITLE
Clear AccountTracker accounts and CachedBalances on createNewVaultAndRestore

### DIFF
--- a/app/scripts/controllers/cached-balances.js
+++ b/app/scripts/controllers/cached-balances.js
@@ -66,6 +66,14 @@ export default class CachedBalancesController {
   }
 
   /**
+   * Removes cachedBalances
+   */
+
+  clearCachedBalances () {
+    this.store.updateState({ cachedBalances: {} })
+  }
+
+  /**
    * Sets up listeners and subscriptions which should trigger an update of cached balances. These updates will
    * happen when the current account changes. Which happens on block updates, as well as on network and account
    * selections.

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -152,6 +152,14 @@ export default class AccountTracker {
   }
 
   /**
+   * Removes all addresses and associated balances
+   */
+
+  clearAccounts () {
+    this.store.updateState({ accounts: {} })
+  }
+
+  /**
    * Given a block, updates this AccountTracker's currentBlockGasLimit, and then updates each local account's balance
    * via EthQuery
    *

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -631,6 +631,12 @@ export default class MetamaskController extends EventEmitter {
       // clear permissions
       this.permissionsController.clearPermissions()
 
+      // clear accounts in accountTracker
+      this.accountTracker.clearAccounts()
+
+      // clear cachedBalances
+      this.cachedBalancesController.clearCachedBalances()
+
       // create new vault
       const vault = await keyringController.createNewVaultAndRestore(password, seed)
 


### PR DESCRIPTION
Resets accounts in AccountTracker and CachedBalances when importing a new seed phrase, createNewVaultAndRestore is called.