### PR TITLE
Catch gas estimate errors

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 import GasModalPageContainer from './gas-modal-page-container.component'
+import { captureException } from '@sentry/browser'
 import {
   hideModal,
   setGasLimit,
@@ -124,6 +125,12 @@ const mapStateToProps = (state, ownProps) => {
     conversionRate,
   })
 
+  let currentTimeEstimate = ''
+  try {
+    currentTimeEstimate = getRenderableTimeEstimate(customGasPrice, gasPrices, estimatedTimes)
+  } catch (error) {
+    captureException(error)
+  }
 
   return {
     hideBasic,
@@ -134,7 +141,7 @@ const mapStateToProps = (state, ownProps) => {
     customGasLimit: calcCustomGasLimit(customModalGasLimitInHex),
     customGasTotal,
     newTotalFiat,
-    currentTimeEstimate: getRenderableTimeEstimate(customGasPrice, gasPrices, estimatedTimes),
+    currentTimeEstimate,
     blockTime: getBasicGasEstimateBlockTime(state),
     customPriceIsSafe: isCustomPriceSafe(state),
     maxModeOn,

--- a/ui/app/hooks/useTransactionTimeRemaining.js
+++ b/ui/app/hooks/useTransactionTimeRemaining.js
@@ -3,9 +3,9 @@ import { hexWEIToDecGWEI } from '../helpers/utils/conversions.util'
 import { useSelector } from 'react-redux'
 import { useRef, useEffect, useState, useMemo } from 'react'
 import { isEqual } from 'lodash'
+import { captureException } from '@sentry/browser'
 import { getRawTimeEstimateData } from '../helpers/utils/gas-time-estimates.util'
 import { getCurrentLocale } from '../ducks/metamask/metamask'
-
 
 /**
  * Calculate the number of minutes remaining until the transaction completes.
@@ -55,10 +55,15 @@ export function useTransactionTimeRemaining (
   // Memoize this value so it can be used as a dependency in the effect below
   const initialTimeEstimate = useMemo(() => {
     const customGasPrice = Number(hexWEIToDecGWEI(currentGasPrice))
-    const {
-      newTimeEstimate,
-    } = getRawTimeEstimateData(customGasPrice, gasPrices, estimatedTimes)
-    return newTimeEstimate
+    try {
+      const {
+        newTimeEstimate,
+      } = getRawTimeEstimateData(customGasPrice, gasPrices, estimatedTimes)
+      return newTimeEstimate
+    } catch (error) {
+      captureException(error)
+      return NaN
+    }
   }, [ currentGasPrice, gasPrices, estimatedTimes ])
 
   useEffect(() => {


### PR DESCRIPTION
There were two cases where bad gas estimate data was resulting in crashes. These two places have been wrapped in a `try ... catch` to handle the absence of gas estimate data.

The errors are still reported to Sentry so that we can track down the root cause of this corrupted gas estimate data at some point in the future. We plan on adding additional context to Sentry soon that should help with this.

Fixes #8992