### PR TITLE
Clear unapprovedTxs on createNewVaultAndRestore

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -793,4 +793,9 @@ export default class TransactionController extends EventEmitter {
     const currentNetworkTxList = this.txStateManager.getTxList(MAX_MEMSTORE_TX_LIST_SIZE)
     this.memStore.updateState({ unapprovedTxs, currentNetworkTxList })
   }
+
+  clearUnapprovedTxs () {
+    this.memStore.updateState({ unapprovedTxs: {}, currentNetworkTxList: [] })
+    this.txStateManager.clearTxs()
+  }
 }

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -794,8 +794,4 @@ export default class TransactionController extends EventEmitter {
     this.memStore.updateState({ unapprovedTxs, currentNetworkTxList })
   }
 
-  clearUnapprovedTxs () {
-    this.memStore.updateState({ unapprovedTxs: {}, currentNetworkTxList: [] })
-    this.txStateManager.clearTxs()
-  }
 }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -509,7 +509,13 @@ export default class TransactionStateManager extends EventEmitter {
     this._saveTxList(transactionList.filter((txMeta) => txMeta.id !== txId))
   }
 
-  clearTxs () {
-    this.store.updateState({ transactions: [] })
+  /**
+   * Filters out the unapproved transactions
+   */
+
+  clearUnapprovedTxs () {
+    const transactions = this.getFullTxList()
+    const nonUnapprovedTxs = transactions.filter((tx) => tx.status !== 'unapproved')
+    this._saveTxList(nonUnapprovedTxs)
   }
 }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -508,4 +508,8 @@ export default class TransactionStateManager extends EventEmitter {
     const transactionList = this.getFullTxList()
     this._saveTxList(transactionList.filter((txMeta) => txMeta.id !== txId))
   }
+
+  clearTxs () {
+    this.store.updateState({ transactions: [] })
+  }
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -632,7 +632,7 @@ export default class MetamaskController extends EventEmitter {
       this.permissionsController.clearPermissions()
 
       // clear unapproved transactions
-      this.txController.clearUnapprovedTxs()
+      this.txController.txStateManager.clearUnapprovedTxs()
 
       // create new vault
       const vault = await keyringController.createNewVaultAndRestore(password, seed)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -631,6 +631,9 @@ export default class MetamaskController extends EventEmitter {
       // clear permissions
       this.permissionsController.clearPermissions()
 
+      // clear unapproved transactions
+      this.txController.clearUnapprovedTxs()
+
       // create new vault
       const vault = await keyringController.createNewVaultAndRestore(password, seed)
 

--- a/test/unit/app/controllers/transactions/tx-state-manager-test.js
+++ b/test/unit/app/controllers/transactions/tx-state-manager-test.js
@@ -598,4 +598,23 @@ describe('TransactionStateManager', function () {
       assert.equal(txStateManager.getFullTxList()[0].id, 2, 'txList should have a id of 2')
     })
   })
+
+  describe('#clearUnapprovedTxs', function () {
+    it('removes unapproved transactions', function () {
+      const txMetas = [
+        { id: 0, status: 'unapproved', txParams: { from: '0xaa', to: '0xbb' }, metamaskNetworkId: currentNetworkId },
+        { id: 1, status: 'unapproved', txParams: { from: '0xaa', to: '0xbb' }, metamaskNetworkId: currentNetworkId },
+        { id: 2, status: 'confirmed', txParams: { from: '0xaa', to: '0xbb' }, metamaskNetworkId: otherNetworkId },
+        { id: 3, status: 'confirmed', txParams: { from: '0xaa', to: '0xbb' }, metamaskNetworkId: otherNetworkId },
+      ]
+
+      txMetas.forEach((txMeta) => txStateManager.addTx(txMeta, noop))
+
+      txStateManager.clearUnapprovedTxs()
+
+      const unapprovedTxList = txStateManager.getFullTxList().filter((tx) => tx.status === 'unapproved')
+
+      assert.equal(unapprovedTxList.length, 0)
+    })
+  })
 })


### PR DESCRIPTION
Reported via support ticket with error in the screenshot.

Reproduction of the issue is:
Have an unapproved, waiting to be confirmed, and import a seed phrase via refreshing the extension.  

<details> 
<summary>Screenshot of the error</summary>
<img src='https://user-images.githubusercontent.com/13376180/87733287-437b8380-c784-11ea-9097-7f47253bd1f3.png'>
</summary>
</details>