### PR TITLE
Initialize extra report property

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -101,6 +101,9 @@ export default function setupSentry ({ release, getState }) {
       // append app state
       if (getState) {
         const appState = getState()
+        if (!report.extra) {
+          report.extra = {}
+        }
         report.extra.appState = appState
       }
     } catch (err) {


### PR DESCRIPTION
The `extra` property of errors sent to Sentry is sometimes not initialized when we add the application state. A check has been added to initialize it if it's missing.

I suspect that this changed with v5 of `@sentry/browser`, though I can't find any explicit confirmation of this in their changelog.