### PR TITLE
Await the completion of setupFetchMocking for e2e tests

### DIFF
--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -9,7 +9,7 @@ async function buildWebDriver ({ responsive, port } = {}) {
   const extensionPath = `dist/${browser}`
 
   const { driver: seleniumDriver, extensionId, extensionUrl } = await buildBrowserWebDriver(browser, { extensionPath, responsive, port })
-  setupFetchMocking(seleniumDriver)
+  await setupFetchMocking(seleniumDriver)
   const driver = new Driver(seleniumDriver, browser, extensionUrl)
   await driver.navigate()
 


### PR DESCRIPTION
This PR adds an `await` I noticed was missing