### PR TITLE
Resolve on 0x

### DIFF
--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2190,7 +2190,8 @@ export function getContractMethodData (data = '') {
     const prefixedData = ethUtil.addHexPrefix(data)
     const fourBytePrefix = prefixedData.slice(0, 10)
     const { knownMethodData } = getState().metamask
-    if (knownMethodData && knownMethodData[fourBytePrefix] && Object.keys(knownMethodData[fourBytePrefix]).length !== 0) {
+
+    if ((knownMethodData && knownMethodData[fourBytePrefix] && Object.keys(knownMethodData[fourBytePrefix]).length !== 0) || fourBytePrefix === '0x') {
       return Promise.resolve(knownMethodData[fourBytePrefix])
     }
 


### PR DESCRIPTION
Need to see which types of contract interactions and result in 0x fourBytePrefix and how we can mitigate the `getContractMethodData()` to those contracts, and/or the way we slice the tx data need adjusting https://github.com/MetaMask/metamask-extension/blob/7333d821b8fb4f42d4efa8f3eeb8792580ba7832/ui/app/store/actions.js#L2191, and/or we are setting that default tx data to 0x somewhere.

This to prevent calls to fourbyte on `knownMethod['0x']`