### PR TITLE
Handle failure to build webDriver instance

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -47,7 +47,9 @@ async function withFixtures (options, callback) {
       }
     }
   } catch (error) {
-    await webDriver.verboseReportOnFailure(title)
+    if (webDriver) {
+      await webDriver.verboseReportOnFailure(title)
+    }
     throw error
   } finally {
     await fixtureServer.stop()


### PR DESCRIPTION
Extracted from #9044

This PR updates the e2e test helpers to only call `verboseReportOnFailure` when the webdriver instance exists.