### PR TITLE
update eth-token-tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/controllers": "^2.0.1",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
-    "@metamask/eth-token-tracker": "^2.0.0",
+    "@metamask/eth-token-tracker": "^3.0.0",
     "@metamask/etherscan-link": "^1.1.0",
     "@metamask/inpage-provider": "^6.1.0",
     "@popperjs/core": "^2.4.0",

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -830,9 +830,9 @@ describe('MetaMask', function () {
 
     it('renders the balance for the new token', async function () {
       const balance = await driver.findElement(By.css('.wallet-overview .token-overview__primary-balance'))
-      await driver.wait(until.elementTextMatches(balance, /^10.000\s*TST\s*$/))
+      await driver.wait(until.elementTextMatches(balance, /^10\s*TST\s*$/))
       const tokenAmount = await balance.getText()
-      assert.ok(/^10.000\s*TST\s*$/.test(tokenAmount))
+      assert.ok(/^10\s*TST\s*$/.test(tokenAmount))
       await driver.delay(regularDelayMs)
     })
   })
@@ -992,7 +992,7 @@ describe('MetaMask', function () {
       await driver.wait(until.elementTextMatches(txStatuses[0], /Send\sTST/), 10000)
 
       const tokenBalanceAmount = await driver.findElements(By.css('.token-overview__primary-balance'))
-      await driver.wait(until.elementTextMatches(tokenBalanceAmount[0], /7.500\s*TST/), 10000)
+      await driver.wait(until.elementTextMatches(tokenBalanceAmount[0], /7.5\s*TST/), 10000)
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,10 +1730,10 @@
     events "^2.0.0"
     hdkey "0.8.0"
 
-"@metamask/eth-token-tracker@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-token-tracker/-/eth-token-tracker-2.0.0.tgz#a94a99bd3160ee85ec5feace29fbb02f80f5c826"
-  integrity sha512-PTiUbx7JulDREswWmebRyIj2wNUV8eLTZWGEA2Duca8IGVP1r8q+kb163tXT4FNNAGR+6JoVvkJ8SpIN+XoiNQ==
+"@metamask/eth-token-tracker@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-token-tracker/-/eth-token-tracker-3.0.0.tgz#16ad4820abd6603d745c8cdaf7c5a9ae60e6db02"
+  integrity sha512-UxYkmEMrUYb8wzsqEY8x6QeiW2955guR/aaalqfElI2rlDyvKJ1lIaAiT7y642vcqoyIGhqYG2aejeHDpifMbA==
   dependencies:
     deep-equal "^1.1.0"
     eth-block-tracker "^4.4.2"


### PR DESCRIPTION
Updates our eth-token-tracker dependency that was recently updated as a partial solution for #5055, namely the value of tokens showing as `0.000` when the value is greater than 0.000

MetaMask/eth-token-tracker#44

**Work Remaining**
~Fix E2E tests that are broken by this. I guess it **was** a breaking change.~