### PR TITLE
Update changelog for v8.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Current Develop Branch
 
 ## 8.0.6 Wed Jul 22 2020
+- [#9030](https://github.com/MetaMask/metamask-extension/pull/9030): Hide "delete" button when editing contact of wallet account
+- [#9031](https://github.com/MetaMask/metamask-extension/pull/9031): Fix crash upon removing contact
+- [#9032](https://github.com/MetaMask/metamask-extension/pull/9032): Do not show spend limit for approvals
+- [#9046](https://github.com/MetaMask/metamask-extension/pull/9046): Update @metamask/inpage-provider@6.1.0
+- [#9048](https://github.com/MetaMask/metamask-extension/pull/9048): Skip attempts to resolve 0x contract prefix
+- [#9051](https://github.com/MetaMask/metamask-extension/pull/9051): Use content-hash@2.5.2
+- [#9056](https://github.com/MetaMask/metamask-extension/pull/9056): Display three significant digits for token balances
 
 ## 8.0.5 Thu Jul 16 2020
 - [#8942](https://github.com/MetaMask/metamask-extension/pull/8942): Fix display of incoming transactions (#8942)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [#9046](https://github.com/MetaMask/metamask-extension/pull/9046): Update @metamask/inpage-provider@6.1.0
 - [#9048](https://github.com/MetaMask/metamask-extension/pull/9048): Skip attempts to resolve 0x contract prefix
 - [#9051](https://github.com/MetaMask/metamask-extension/pull/9051): Use content-hash@2.5.2
-- [#9056](https://github.com/MetaMask/metamask-extension/pull/9056): Display three significant digits for token balances
+- [#9056](https://github.com/MetaMask/metamask-extension/pull/9056): Display at least one significant digit of small non-zero token balances
 
 ## 8.0.5 Thu Jul 16 2020
 - [#8942](https://github.com/MetaMask/metamask-extension/pull/8942): Fix display of incoming transactions (#8942)


### PR DESCRIPTION
The update of `content-hash` was included because I wasn't entirely sure whether or not that involved a functional change, or what that change might be. I also neglected to expand upon the changes made in the `inpage-provider` update, as I couldn't think of a concise way to describe them.