### PR TITLE
Robustify permissions controller requestUserApproval tests

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -723,7 +723,7 @@ export class PermissionsController {
        *
        * @param {string} req - The internal rpc-cap user request object.
        */
-      requestUserApproval: async (req) => {
+      requestUserApproval: (req) => {
         const { metadata: { id, origin } } = req
 
         if (this.pendingApprovalOrigins.has(origin)) {

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -724,17 +724,17 @@ export class PermissionsController {
        * @param {string} req - The internal rpc-cap user request object.
        */
       requestUserApproval: (req) => {
-        const { metadata: { id, origin } } = req
-
-        if (this.pendingApprovalOrigins.has(origin)) {
-          throw ethErrors.rpc.resourceUnavailable(
-            'Permissions request already pending; please wait.',
-          )
-        }
-
-        this._showPermissionRequest()
-
         return new Promise((resolve, reject) => {
+          const { metadata: { id, origin } } = req
+
+          if (this.pendingApprovalOrigins.has(origin)) {
+            throw ethErrors.rpc.resourceUnavailable(
+              'Permissions request already pending; please wait.',
+            )
+          }
+
+          this._showPermissionRequest()
+
           this._addPendingApproval(id, origin, resolve, reject)
         })
       },

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -723,18 +723,18 @@ export class PermissionsController {
        *
        * @param {string} req - The internal rpc-cap user request object.
        */
-      requestUserApproval: (req) => {
+      requestUserApproval: async (req) => {
+        const { metadata: { id, origin } } = req
+
+        if (this.pendingApprovalOrigins.has(origin)) {
+          throw ethErrors.rpc.resourceUnavailable(
+            'Permissions request already pending; please wait.',
+          )
+        }
+
+        this._showPermissionRequest()
+
         return new Promise((resolve, reject) => {
-          const { metadata: { id, origin } } = req
-
-          if (this.pendingApprovalOrigins.has(origin)) {
-            throw ethErrors.rpc.resourceUnavailable(
-              'Permissions request already pending; please wait.',
-            )
-          }
-
-          this._showPermissionRequest()
-
           this._addPendingApproval(id, origin, resolve, reject)
         })
       },

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -70,10 +70,14 @@ describe('permissions middleware', function () {
       )
       const res = {}
 
+      const userApprovalPromise = getUserApprovalPromise(permController)
+
       const pendingApproval = assert.doesNotReject(
         aMiddleware(req, res),
         'should not reject permissions request',
       )
+
+      await userApprovalPromise
 
       assert.equal(
         permController.pendingApprovals.size, 1,
@@ -131,10 +135,14 @@ describe('permissions middleware', function () {
       // send, approve, and validate first request
       // note use of ACCOUNTS.a.permitted
 
+      let userApprovalPromise = getUserApprovalPromise(permController)
+
       const pendingApproval1 = assert.doesNotReject(
         aMiddleware(req1, res1),
         'should not reject permissions request',
       )
+
+      await userApprovalPromise
 
       const id1 = permController.pendingApprovals.keys().next().value
       const approvedReq1 = PERMS.approvedRequest(id1, PERMS.requests.eth_accounts())
@@ -187,10 +195,14 @@ describe('permissions middleware', function () {
       // send, approve, and validate second request
       // note use of ACCOUNTS.b.permitted
 
+      userApprovalPromise = getUserApprovalPromise(permController)
+
       const pendingApproval2 = assert.doesNotReject(
         aMiddleware(req2, res2),
         'should not reject permissions request',
       )
+
+      await userApprovalPromise
 
       const id2 = permController.pendingApprovals.keys().next().value
       const approvedReq2 = PERMS.approvedRequest(id2, { ...requestedPerms2 })
@@ -251,11 +263,15 @@ describe('permissions middleware', function () {
 
       const expectedError = ERRORS.rejectPermissionsRequest.rejection()
 
+      const userApprovalPromise = getUserApprovalPromise(permController)
+
       const requestRejection = assert.rejects(
         aMiddleware(req, res),
         expectedError,
         'request should be rejected with correct error',
       )
+
+      await userApprovalPromise
 
       assert.equal(
         permController.pendingApprovals.size, 1,
@@ -343,10 +359,14 @@ describe('permissions middleware', function () {
       )
       const resA1 = {}
 
+      let userApprovalPromise = getUserApprovalPromise(permController)
+
       const requestApproval1 = assert.doesNotReject(
         aMiddleware(reqA1, resA1),
         'should not reject permissions request',
       )
+
+      await userApprovalPromise
 
       // create and start processing first request for second origin
 
@@ -355,10 +375,14 @@ describe('permissions middleware', function () {
       )
       const resB1 = {}
 
+      userApprovalPromise = getUserApprovalPromise(permController)
+
       const requestApproval2 = assert.doesNotReject(
         bMiddleware(reqB1, resB1),
         'should not reject permissions request',
       )
+
+      await userApprovalPromise
 
       assert.equal(
         permController.pendingApprovals.size, 2,

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -397,11 +397,16 @@ describe('permissions middleware', function () {
       )
       const resA2 = {}
 
-      await assert.rejects(
+      userApprovalPromise = getUserApprovalPromise(permController)
+
+      const requestApprovalFail = assert.rejects(
         aMiddleware(reqA2, resA2),
         expectedError,
         'request should be rejected with correct error',
       )
+
+      await userApprovalPromise
+      await requestApprovalFail
 
       assert.ok(
         (


### PR DESCRIPTION
This PR removes some reliance on timing artifacts in permissions controller tests that rely on `requestUserApproval`.

- Stop needlessly mocking `requestUserApproval` in permissions controller tests
  - Let's _actually_ test the underlying function!
- Await the setting of pending user approval requests in permissions controller tests, instead of just hoping that they are set are set by the time we check for them