### PR TITLE
Update revealSeedWords to use "phrase"

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1196,7 +1196,7 @@
     "message": "Restore"
   },
   "revealSeedWords": {
-    "message": "Reveal Seed Words"
+    "message": "Reveal Seed Phrase"
   },
   "revealSeedWordsTitle": {
     "message": "Seed Phrase"


### PR DESCRIPTION
This PR updates the `revealSeedWords` message to use "phrase". This moves this wording in line with the rest of the `revealSeedWords*` messages.

The message keys themselves continue to use "words".