### PR TITLE
Drop unused reviewers from CI scripts

### DIFF
--- a/.circleci/scripts/release-create-master-pr
+++ b/.circleci/scripts/release-create-master-pr
@@ -44,7 +44,6 @@ install_github_cli
 printf '%s\n' "Creating a Pull Request to sync 'master' with 'develop'"
 
 if ! hub pull-request \
-    --reviewer '@MetaMask/extension-release-team' \
     --message "Master => develop" --message 'Merge latest release back into develop' \
     --base "$CIRCLE_PROJECT_USERNAME:$base_branch" \
     --head "$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH";

--- a/.circleci/scripts/release-create-release-pr
+++ b/.circleci/scripts/release-create-release-pr
@@ -45,7 +45,6 @@ install_github_cli
 printf '%s\n' "Creating a Pull Request for $version on GitHub"
 
 if ! hub pull-request \
-    --reviewer '@MetaMask/extension-release-team' \
     --message "${CIRCLE_BRANCH/-/ } RC" --message ':package: :rocket:' \
     --base "$CIRCLE_PROJECT_USERNAME:$base_branch" \
     --head "$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH";


### PR DESCRIPTION
This PR drops the @MetaMask/extension-release-team from the reviewers for the release PRs as we've updated our codeowners to a superset of that team.