### PR TITLE
Retry e2e tests N times

### DIFF
--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 retry () {
   retry=0
-  limit="${METAMASK_E2E_RETRY_LIMIT:-5}"
+  limit="${METAMASK_E2E_RETRY_LIMIT:-3}"
   while [[ $retry -lt $limit ]]
   do
     "$@" && break

--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -23,7 +23,10 @@ retry () {
 
 export PATH="$PATH:./node_modules/.bin"
 
-retry mocha --no-timeouts test/e2e/tests/*.spec.js
+for spec in test/e2e/tests/*.spec.js
+do
+  retry mocha --no-timeouts "${spec}"
+done
 
 retry concurrently --kill-others \
   --names 'dapp,e2e' \

--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -5,72 +5,88 @@ set -e
 set -u
 set -o pipefail
 
+retry () {
+  retry=0
+  limit="${METAMASK_E2E_RETRY_LIMIT:-5}"
+  while [[ $retry -lt $limit ]]
+  do
+    "$@" && break
+    retry=$(( retry + 1 ))
+    sleep 1
+  done
+
+  if [[ $retry == "$limit" ]]
+  then
+    exit 1
+  fi
+}
+
 export PATH="$PATH:./node_modules/.bin"
 
-mocha --no-timeouts test/e2e/tests/*.spec.js
+retry mocha --no-timeouts test/e2e/tests/*.spec.js
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'yarn dapp' \
   'mocha test/e2e/metamask-ui.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'yarn dapp' \
   'mocha test/e2e/metamask-responsive-ui.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'yarn dapp' \
   'mocha test/e2e/signature-request.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'mocha test/e2e/from-import-ui.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'mocha test/e2e/send-edit.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'yarn dapp' \
   'mocha test/e2e/ethereum-on.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'yarn dapp' \
   'mocha test/e2e/permissions.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'sendwithprivatedapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'yarn sendwithprivatedapp' \
   'mocha test/e2e/incremental-security.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names 'dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \
   'yarn dapp' \
   'mocha test/e2e/address-book.spec'
 
-concurrently --kill-others \
+retry concurrently --kill-others \
   --names '3box,dapp,e2e' \
   --prefix '[{time}][{name}]' \
   --success first \


### PR DESCRIPTION
Factored out of #9044

This PR updates our e2e test runner script to retry the e2e commands N times (currently 3, configurable via `METAMASK_E2E_RETRY_LIMIT`).

As we've seen, the e2e tests are (inherently?) flaky and will often require rerunning a CI workflow from the failed state. This is a waste of everyone's time—our time and CircleCI's time—and ends up running long tests again if, for example, the last test command fails (we've got to run the whole job). This workaround is simple: retry the tests some low number of times before failing.