### PR TITLE
Normalize font styles to use typography mixins 

### DIFF
--- a/ui/app/components/app/account-list-item/index.scss
+++ b/ui/app/components/app/account-list-item/index.scss
@@ -7,7 +7,8 @@
   }
 
   &__account-name {
-    font-size: 16px;
+    @include Paragraph;
+
     margin-left: 8px;
   }
 

--- a/ui/app/components/app/account-menu/index.scss
+++ b/ui/app/components/app/account-menu/index.scss
@@ -56,12 +56,12 @@
     }
 
     &__text {
-      font-size: 16px;
-      line-height: 21px;
+      @include Paragraph;
     }
 
     &__subtext {
-      font-size: 12px;
+      @include H7;
+
       padding: 5px 0 0 30px;
     }
   }
@@ -98,13 +98,13 @@
   }
 
   &__lock-button {
+    @include H7;
+
     border: 1px solid $dusty-gray;
     background-color: transparent;
     color: $white;
     border-radius: 4px;
-    font-size: 12px;
-    line-height: 23px;
-    padding: 0 24px;
+    padding: 3.5px 24px;
   }
 
   &__item-icon {
@@ -138,9 +138,9 @@
     }
 
     .keyring-label {
+      @include H9;
+
       z-index: 1;
-      font-size: 8px;
-      line-height: 8px;
       border-radius: 10px;
       padding: 4px;
       text-align: center;
@@ -151,11 +151,14 @@
       color: $black;
       font-weight: normal;
       letter-spacing: 0.5px;
+      display: flex;
+      align-items: center;
     }
   }
 
   &__no-accounts {
-    font-size: 0.8em;
+    @include H6;
+
     padding: 16px 14px;
   }
 
@@ -215,8 +218,9 @@
   }
 
   &__name {
+    @include H4;
+
     color: $white;
-    font-size: 18px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -224,13 +228,14 @@
   }
 
   &__balance {
+    @include H6;
+
     color: $dusty-gray;
-    font-size: 14px;
   }
 
   &__action {
-    font-size: 16px;
-    line-height: 18px;
+    @include Paragraph;
+
     cursor: pointer;
   }
 

--- a/ui/app/components/app/alerts/unconnected-account-alert/unconnected-account-alert.scss
+++ b/ui/app/components/app/alerts/unconnected-account-alert/unconnected-account-alert.scss
@@ -26,9 +26,10 @@
   }
 
   &__error {
+    @include H6;
+
     margin-bottom: 16px;
     padding: 16px;
-    font-size: 14px;
     border: 1px solid $accent-red;
     background: #f8eae8;
     border-radius: 3px;
@@ -47,8 +48,9 @@
   }
 
   &__checkbox-label {
+    @include H7;
+
     display: flex;
-    font-size: 12px;
     margin-top: auto;
     margin-bottom: auto;
     color: $Grey-500;

--- a/ui/app/components/app/asset-list-item/asset-list-item.scss
+++ b/ui/app/components/app/asset-list-item/asset-list-item.scss
@@ -15,8 +15,9 @@
   }
 
   .list-item__subheading {
+    @include H6;
+
     margin-top: 6px;
-    font-size: 14px;
   }
 
   &__warning {
@@ -25,10 +26,11 @@
   }
 
   & &__send-token-button {
+    @include H6;
+
     display: none;
     text-transform: uppercase;
     width: fit-content;
-    font-size: 14px;
   }
 
   @media (min-width: 576px) {

--- a/ui/app/components/app/confirm-page-container/confirm-detail-row/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-detail-row/index.scss
@@ -6,7 +6,8 @@
   align-items: center;
 
   &__label {
-    font-size: 0.75rem;
+    @include H7;
+
     font-weight: 500;
     color: $scorpion;
     text-transform: uppercase;
@@ -19,7 +20,8 @@
   }
 
   &__primary {
-    font-size: 1.5rem;
+    @include H3;
+
     justify-content: flex-end;
   }
 
@@ -29,7 +31,8 @@
   }
 
   &__header-text {
-    font-size: 0.75rem;
+    @include H7;
+
     text-transform: uppercase;
     margin-bottom: 6px;
     color: $scorpion;
@@ -40,7 +43,7 @@
     }
 
     &--total {
-      font-size: 0.625rem;
+      @include H8;
     }
   }
 
@@ -50,8 +53,9 @@
 
   .custom-nonce-input {
     input {
+      @include Paragraph;
+
       width: 90px;
-      font-size: 1rem;
     }
   }
 }

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/index.scss
@@ -10,9 +10,10 @@
   }
 
   &__action {
+    @include H7;
+
     text-transform: uppercase;
     color: $oslo-gray;
-    font-size: 0.75rem;
     padding: 3px 8px;
     border: 1px solid $oslo-gray;
     border-radius: 4px;
@@ -35,7 +36,8 @@
   }
 
   &__title-text {
-    font-size: 2.25rem;
+    @include H1;
+
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/index.scss
@@ -12,7 +12,8 @@
   }
 
   &__warning {
-    font-size: 0.75rem;
+    @include H7;
+
     color: #5f5922;
   }
 }

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -23,18 +23,20 @@
   }
 
   &__data-box {
+    @include H7;
+
     background-color: #f9fafa;
     padding: 12px;
-    font-size: 0.75rem;
     margin-bottom: 16px;
     word-wrap: break-word;
     max-height: 200px;
     overflow-y: auto;
 
     &-label {
+      @include H7;
+
       text-transform: uppercase;
       padding: 8px 0 12px;
-      font-size: 12px;
     }
   }
 
@@ -61,7 +63,8 @@
   }
 
   &__function-type {
-    font-size: 0.875rem;
+    @include H6;
+
     font-weight: 500;
     text-transform: capitalize;
     color: $black;
@@ -69,7 +72,8 @@
   }
 
   &__tab {
-    font-size: 0.75rem;
+    @include H7;
+
     color: #8c8e94;
     text-transform: uppercase;
     margin: 0 8px;

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/index.scss
@@ -23,10 +23,10 @@
   }
 
   &__back-button {
+    @include Paragraph;
+
     color: #2f9ae0;
-    font-size: 1rem;
     cursor: pointer;
-    font-weight: 400;
     padding-left: 5px;
   }
 
@@ -38,7 +38,8 @@
   }
 
   &__address {
+    @include H6;
+
     margin-left: 6px;
-    font-size: 14px;
   }
 }

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-navigation/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-navigation/index.scss
@@ -36,13 +36,15 @@
   }
 
   &__navtext {
-    font-size: 9px;
+    @include H9;
+
     font-weight: bold;
   }
 
   &__longtext {
+    @include H9;
+
     color: $oslo-gray;
-    font-size: 8px;
   }
 
   &__imageflip {

--- a/ui/app/components/app/connected-accounts-list/index.scss
+++ b/ui/app/components/app/connected-accounts-list/index.scss
@@ -8,15 +8,15 @@
   }
 
   &__account-name {
+    @include H6;
+
     display: inline;
     font-weight: bold;
-    font-size: 14px;
-    line-height: 20px;
   }
 
   %account-status-typography {
-    font-size: 12px;
-    line-height: 17px;
+    @include H7;
+
     padding-top: 4px;
   }
 
@@ -67,9 +67,9 @@
 
 .connected-accounts-options {
   &__button {
+    font-size: $font-size-h4;
     background: inherit;
     color: $Grey-500;
-    font-size: 22px;
   }
 }
 

--- a/ui/app/components/app/connected-accounts-permissions/index.scss
+++ b/ui/app/components/app/connected-accounts-permissions/index.scss
@@ -1,8 +1,8 @@
 .connected-accounts-permissions {
+  @include H7;
+
   display: flex;
   flex-direction: column;
-  font-size: 12px;
-  line-height: 17px;
   color: $Grey-500;
 
   strong {
@@ -14,18 +14,17 @@
   }
 
   &__header {
+    @include H6;
+
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
     cursor: pointer;
-    font-size: 14px;
-    line-height: 20px;
     color: #24292e;
 
     button {
-      font-size: 16px;
-      line-height: 24px;
+      font-size: $font-size-paragraph;
       background: none;
       padding: 0;
       margin-left: 8px;
@@ -41,8 +40,8 @@
   }
 
   & &__checkbox {
+    font-size: $font-size-h4;
     margin: 0 8px 0 0;
-    font-size: 18px;
   }
 
   &__list-container {

--- a/ui/app/components/app/connected-sites-list/index.scss
+++ b/ui/app/components/app/connected-sites-list/index.scss
@@ -16,11 +16,12 @@
   }
 
   &__domain-info {
+    @include H7;
+
     display: flex;
     flex-direction: row;
     align-items: center;
     min-width: 0;
-    font-size: 12px;
   }
 
   &__domain-name {

--- a/ui/app/components/app/connected-status-indicator/index.scss
+++ b/ui/app/components/app/connected-status-indicator/index.scss
@@ -51,7 +51,8 @@
   }
 
   &__text {
-    font-size: 10px;
+    @include H8;
+
     color: $Grey-500;
     margin-left: 6px;
     white-space: nowrap;

--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/index.scss
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/index.scss
@@ -11,14 +11,15 @@
     width: 47.5%;
 
     &__label {
+      @include H7;
+
       color: #313b5e;
-      font-size: 12px;
       display: flex;
       justify-content: space-between;
       align-items: center;
 
       @media screen and (max-width: 576px) {
-        font-size: 10px;
+        @include H8;
       }
 
       .fa-info-circle {
@@ -32,12 +33,14 @@
     }
 
     &__error-text {
-      font-size: 12px;
+      @include H7;
+
       color: red;
     }
 
     &__warning-text {
-      font-size: 12px;
+      @include H7;
+
       color: orange;
     }
 
@@ -47,11 +50,12 @@
 
     &__input {
       /*rtl:ignore*/
+      @include Paragraph;
+
       direction: ltr;
       border: 1px solid $dusty-gray;
       border-radius: 4px;
       color: $mid-gray;
-      font-size: 16px;
       height: 24px;
       width: 100%;
       padding-left: 8px;
@@ -68,6 +72,8 @@
     }
 
     &__input-arrows {
+      @include H6;
+
       position: absolute;
       top: 7px;
 
@@ -80,7 +86,6 @@
       display: flex;
       flex-direction: column;
       color: #9b9b9b;
-      font-size: 0.8em;
       border-bottom-right-radius: 4px;
       cursor: pointer;
 
@@ -102,7 +107,7 @@
       }
 
       i {
-        font-size: 10px;
+        font-size: $font-size-h8;
       }
     }
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/index.scss
@@ -18,42 +18,47 @@
 
     &__titles,
     &__container {
+      @include H7;
+
       display: flex;
       flex-flow: row;
       justify-content: space-between;
-      font-size: 12px;
       color: #888ea3;
     }
 
     &__container {
-      font-size: 16px;
+      @include Paragraph;
+
       margin-top: 0;
     }
 
     &__fee {
-      font-size: 16px;
+      @include Paragraph;
+
       color: #313a5e;
     }
 
     &__time-remaining {
+      @include Paragraph;
+
       /*rtl:ignore*/
       direction: ltr;
       color: #313a5e;
-      font-size: 16px;
 
       .minutes-num,
       .seconds-num {
-        font-size: 16px;
+        @include Paragraph;
       }
 
       .seconds-num {
+        @include Paragraph;
+
         margin-left: 7px;
-        font-size: 16px;
       }
 
       .minutes-label,
       .seconds-label {
-        font-size: 16px;
+        @include Paragraph;
       }
     }
   }
@@ -67,12 +72,15 @@
     position: relative;
 
     &__title {
-      font-size: 12px;
+      @include H7;
+
       color: #313a5e;
       margin-left: 22px;
     }
 
     &__speed-buttons {
+      @include H8;
+
       position: absolute;
       bottom: 13px;
       display: flex;
@@ -80,7 +88,6 @@
       padding-left: 20px;
       padding-right: 19px;
       width: 100%;
-      font-size: 10px;
       color: #888ea3;
     }
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/index.scss
@@ -8,20 +8,23 @@
   border-bottom: 1px solid #d2d8dd;
 
   &__title {
+    @include Paragraph;
+
     margin-top: 19px;
-    font-size: 16px;
     color: $black;
   }
 
   &__blurb {
-    font-size: 12px;
+    @include H7;
+
     color: $black;
     margin-top: 5px;
     margin-bottom: 15px;
   }
 
   &__footer-blurb {
-    font-size: 12px;
+    @include H7;
+
     color: #979797;
     margin-top: 15px;
   }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
@@ -31,7 +31,8 @@
     }
 
     &__header-close-text {
-      font-size: 14px;
+      @include H6;
+
       color: #4eade7;
       position: absolute;
       top: 4px;
@@ -42,10 +43,10 @@
     }
 
     &__title {
+      @include H5;
+
       color: $black;
-      font-size: 16px;
       font-weight: 500;
-      line-height: 16px;
       display: flex;
       justify-content: center;
       align-items: flex-start;
@@ -61,8 +62,9 @@
     }
 
     &__tab {
+      @include H6;
+
       width: 100%;
-      font-size: 14px;
 
       &:last-of-type {
         margin-right: 0;
@@ -88,13 +90,14 @@
 
   &__info-row,
   &__info-row--fade {
+    @include H7;
+
     width: 100%;
     background: $polar;
     padding: 15px 21px;
     display: flex;
     flex-flow: column;
     color: $scorpion;
-    font-size: 12px;
 
     @media screen and (max-width: $break-small) {
       padding: 4px 21px;
@@ -115,19 +118,20 @@
 
     &__total-info {
       &__label {
-        font-size: 16px;
+        @include Paragraph;
 
         @media screen and (max-width: $break-small) {
-          font-size: 14px;
+          @include H6;
         }
       }
 
       &__value {
-        font-size: 16px;
+        @include Paragraph;
+
         font-weight: bold;
 
         @media screen and (max-width: $break-small) {
-          font-size: 14px;
+          @include H6;
         }
       }
     }
@@ -135,11 +139,11 @@
     &__transaction-info,
     &__send-info {
       &__label {
-        font-size: 12px;
+        @include H7;
       }
 
       &__value {
-        font-size: 14px;
+        @include H6;
       }
     }
   }

--- a/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
@@ -7,7 +7,8 @@
   padding-right: 20px;
 
   &__primary-currency {
-    font-size: 18px;
+    @include H4;
+
     height: 20.5px;
     margin-bottom: 7.5px;
   }
@@ -24,9 +25,10 @@
 
   .button-group__button,
   .button-group__button--active {
+    @include H7;
+
     height: 130px;
     max-width: 108px;
-    font-size: 12px;
     flex-direction: column;
     align-items: center;
     display: flex;
@@ -66,18 +68,18 @@
 .gas-price-button-group--small {
   display: flex;
   justify-content: stretch;
-  height: 54px;
+  min-height: 54px;
 
   @media screen and (max-width: $break-small) {
     max-width: 260px;
   }
 
   &__button-fiat-price {
-    font-size: 13px;
+    @include H6;
   }
 
   &__button-label {
-    font-size: 16px;
+    @include Paragraph;
   }
 
   &__label {
@@ -87,22 +89,22 @@
   }
 
   &__primary-currency {
-    font-size: 12px;
-    line-height: 12px;
+    @include H7;
+
     padding-bottom: 2px;
 
     @media screen and (max-width: 575px) {
-      font-size: 10px;
+      @include H8;
     }
   }
 
   &__secondary-currency {
-    font-size: 12px;
-    line-height: 12px;
+    @include H7;
+
     padding-bottom: 2px;
 
     @media screen and (max-width: 575px) {
-      font-size: 10px;
+      @include H8;
     }
   }
 
@@ -114,7 +116,7 @@
   .button-group__button--active {
     background: white;
     color: $scorpion;
-    padding: 0 4px;
+    padding: 4px;
 
     div {
       display: flex;
@@ -150,26 +152,28 @@
   width: 95%;
 
   &__button-fiat-price {
-    font-size: 13px;
+    @include H6;
   }
 
   &__button-label {
-    font-size: 16px;
+    @include Paragraph;
   }
 
   &__label {
+    @include H8;
+
     font-weight: 500;
-    font-size: 10px;
     text-transform: capitalize;
   }
 
   &__primary-currency {
-    font-size: 11px;
+    @include H7;
+
     margin-top: 3px;
   }
 
   &__secondary-currency {
-    font-size: 11px;
+    @include H7;
   }
 
   &__loading-container {
@@ -177,7 +181,8 @@
   }
 
   &__time-estimate {
-    font-size: 14px;
+    @include H6;
+
     font-weight: 500;
     margin-top: 4px;
     color: $black;
@@ -234,9 +239,10 @@
     }
 
     i {
+      @include H7;
+
       display: flex;
       color: $primary-blue;
-      font-size: 12px;
     }
   }
 }

--- a/ui/app/components/app/gas-customization/gas-price-chart/index.scss
+++ b/ui/app/components/app/gas-customization/gas-price-chart/index.scss
@@ -17,10 +17,10 @@
   .tick text,
   .c3-axis-x-label,
   .c3-axis-y-label {
-    font-style: normal;
-    font-weight: bold;
+    @include H9;
+
     line-height: normal;
-    font-size: 8px;
+    font-weight: bold;
     text-align: center;
     fill: #9a9ca6 !important;
   }
@@ -52,10 +52,9 @@
   }
 
   .custom-tooltip th {
-    font-style: normal;
+    @include H8;
+
     font-weight: 500;
-    line-height: normal;
-    font-size: 10px;
     text-align: center;
     padding: 3px;
     color: #fff;

--- a/ui/app/components/app/gas-customization/gas-slider/index.scss
+++ b/ui/app/components/app/gas-customization/gas-slider/index.scss
@@ -45,9 +45,10 @@
   }
 
   &__labels {
+    @include H7;
+
     display: flex;
     justify-content: space-between;
-    font-size: 12px;
     margin-top: -6px;
     color: $mid-gray;
   }

--- a/ui/app/components/app/home-notification/index.scss
+++ b/ui/app/components/app/home-notification/index.scss
@@ -35,9 +35,8 @@
   }
 
   &__text {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 12px;
+    @include H7;
+
     color: $white;
     margin-left: 10px;
     margin-right: 8px;
@@ -111,9 +110,8 @@
   }
 
   &__content {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 12px;
+    @include H7;
+
     color: $white;
     text-align: left;
     display: inline-block;

--- a/ui/app/components/app/info-box/index.scss
+++ b/ui/app/components/app/info-box/index.scss
@@ -19,6 +19,6 @@
   }
 
   &__description {
-    font-size: 0.75rem;
+    @include H7;
   }
 }

--- a/ui/app/components/app/menu-bar/index.scss
+++ b/ui/app/components/app/menu-bar/index.scss
@@ -29,7 +29,8 @@
   }
 
   &__explorer-origin {
+    @include H7;
+
     color: $Grey-500;
-    font-size: 12px;
   }
 }

--- a/ui/app/components/app/modal/modal-content/index.scss
+++ b/ui/app/components/app/modal/modal-content/index.scss
@@ -6,14 +6,16 @@
   padding: 16px 0;
 
   &__title {
-    font-size: 1.5rem;
+    @include H3;
+
     font-weight: 500;
     padding: 16px 0;
     text-align: center;
   }
 
   &__description {
+    @include H6;
+
     text-align: center;
-    font-size: 0.875rem;
   }
 }

--- a/ui/app/components/app/modals/account-details-modal/index.scss
+++ b/ui/app/components/app/modals/account-details-modal/index.scss
@@ -1,7 +1,8 @@
 .account-details-modal {
   &__name {
+    @include H4;
+
     margin-top: 9px;
-    font-size: 20px;
   }
 
   & &__button {
@@ -18,8 +19,9 @@
   }
 
   & .qr-header {
+    @include H4;
+
     margin-top: 9px;
-    font-size: 20px;
   }
 
   & .qr-wrapper {

--- a/ui/app/components/app/modals/account-modal-container/index.scss
+++ b/ui/app/components/app/modals/account-modal-container/index.scss
@@ -22,13 +22,14 @@
   }
 
   &__back-text {
-    font-size: 14px;
-    line-height: 18px;
+    @include H6;
+
     padding-left: 3px;
   }
 
   &__close {
-    font-size: 40px;
+    @include H1;
+
     background-color: transparent;
     color: $dusty-gray;
     position: absolute;

--- a/ui/app/components/app/modals/add-to-addressbook-modal/index.scss
+++ b/ui/app/components/app/modals/add-to-addressbook-modal/index.scss
@@ -22,12 +22,13 @@
   }
 
   &__input {
+    @include H4;
+
     background: $white;
     border: 1px solid $Grey-100;
     box-sizing: border-box;
     border-radius: 8px;
     padding: 0.625rem 0.75rem;
-    font-size: 1.25rem;
     margin-top: 0.75rem;
 
     &::placeholder {

--- a/ui/app/components/app/modals/cancel-transaction/cancel-transaction-gas-fee/index.scss
+++ b/ui/app/components/app/modals/cancel-transaction/cancel-transaction-gas-fee/index.scss
@@ -7,11 +7,12 @@
   padding: 12px;
 
   &__eth {
-    font-size: 1.5rem;
+    @include H3;
+
     font-weight: 500;
   }
 
   &__fiat {
-    font-size: 0.75rem;
+    @include H7;
   }
 }

--- a/ui/app/components/app/modals/cancel-transaction/index.scss
+++ b/ui/app/components/app/modals/cancel-transaction/index.scss
@@ -8,8 +8,9 @@
   }
 
   &__description {
+    @include H6;
+
     text-align: center;
-    font-size: 0.875rem;
   }
 
   &__cancel-transaction-gas-fee-container {

--- a/ui/app/components/app/modals/confirm-remove-account/index.scss
+++ b/ui/app/components/app/modals/confirm-remove-account/index.scss
@@ -1,7 +1,8 @@
 .confirm-remove-account {
   &__description {
+    @include H6;
+
     text-align: center;
-    font-size: 0.875rem;
   }
 
   &__account {
@@ -19,8 +20,9 @@
 
     &__name,
     &__address {
+      @include H6;
+
       margin-right: 10px;
-      font-size: 14px;
     }
 
     &__name {
@@ -31,7 +33,8 @@
     }
 
     &__label {
-      font-size: 11px;
+      @include H8;
+
       display: block;
       color: #9b9b9b;
     }

--- a/ui/app/components/app/modals/deposit-ether-modal/index.scss
+++ b/ui/app/components/app/modals/deposit-ether-modal/index.scss
@@ -15,15 +15,15 @@
     align-items: flex-start;
 
     &__title {
+      @include H3;
+
       color: $white;
-      font-size: 24px;
-      line-height: 32px;
     }
 
     &__description {
+      @include Paragraph;
+
       color: $white;
-      font-size: 16px;
-      line-height: 22px;
       margin-top: 10px;
     }
 
@@ -114,13 +114,12 @@
       }
 
       &__title {
-        font-size: 20px;
-        line-height: 30px;
+        @include H4;
       }
 
       &__text {
-        font-size: 14px;
-        line-height: 22px;
+        @include H6;
+
         margin-top: 7px;
       }
     }
@@ -141,22 +140,5 @@
 
   &__deposit-button {
     width: 257px;
-  }
-
-  .simple-dropdown {
-    color: #5b5d67;
-    font-size: 16px;
-    line-height: 21px;
-    border: 1px solid #d8d8d8;
-    background-color: #fff;
-    text-align: center;
-    width: 100%;
-    height: 45px;
-    line-height: 44px;
-    font-weight: 300;
-  }
-
-  .simple-dropdown__selected {
-    text-align: center;
   }
 }

--- a/ui/app/components/app/modals/edit-approval-permission/index.scss
+++ b/ui/app/components/app/modals/edit-approval-permission/index.scss
@@ -24,9 +24,9 @@
   }
 
   &__title {
+    @include H4;
+
     font-weight: bold;
-    font-size: 18px;
-    line-height: 25px;
   }
 
   &__account-info {
@@ -35,8 +35,9 @@
 
     &__account,
     &__balance {
+      @include H6;
+
       font-weight: normal;
-      font-size: 14px;
       color: #24292e;
     }
 
@@ -59,16 +60,16 @@
     padding: 24px;
 
     &__title {
+      @include H6;
+
       font-weight: bold;
-      font-size: 14px;
-      line-height: 20px;
       color: #24292e;
     }
 
     &__description {
+      @include H7;
+
       font-weight: normal;
-      font-size: 12px;
-      line-height: 17px;
       color: #6a737d;
       margin-top: 8px;
     }
@@ -90,9 +91,9 @@
 
     &__option-label,
     &__option-label--selected {
+      @include H6;
+
       font-weight: normal;
-      font-size: 14px;
-      line-height: 20px;
       color: #474b4d;
     }
 
@@ -101,18 +102,16 @@
     }
 
     &__option-description {
-      font-weight: normal;
-      font-size: 12px;
-      line-height: 17px;
+      @include H7;
+
       color: #6a737d;
       margin-top: 8px;
       margin-bottom: 6px;
     }
 
     &__option-value {
-      font-weight: normal;
-      font-size: 18px;
-      line-height: 25px;
+      @include H4;
+
       color: #24292e;
     }
 

--- a/ui/app/components/app/modals/export-private-key-modal/index.scss
+++ b/ui/app/components/app/modals/export-private-key-modal/index.scss
@@ -1,8 +1,9 @@
 .export-private-key-modal {
   &__body-title {
+    @include H4;
+
     margin-top: 16px;
     margin-bottom: 16px;
-    font-size: 18px;
   }
 
   &__divider {
@@ -13,8 +14,9 @@
   }
 
   &__account-name {
+    @include H4;
+
     margin-top: 9px;
-    font-size: 20px;
   }
 
   &__password {
@@ -24,9 +26,9 @@
 
   &__password-label,
   &__password--error {
+    @include H6;
+
     color: $scorpion;
-    font-size: 14px;
-    line-height: 18px;
     margin-bottom: 10px;
   }
 
@@ -36,9 +38,9 @@
   }
 
   &__password-input {
+    @include Paragraph;
+
     padding: 10px 0 13px 17px;
-    font-size: 16px;
-    line-height: 21px;
     width: 291px;
     height: 44px;
   }
@@ -48,11 +50,11 @@
   }
 
   &__password--warning {
+    @include H7;
+
     border-radius: 8px;
     background-color: #fff6f6;
-    font-size: 12px;
     font-weight: 500;
-    line-height: 15px;
     color: $crimson;
     width: 292px;
     padding: 9px 15px;
@@ -67,9 +69,9 @@
   }
 
   &__password-display-textarea {
+    @include Paragraph;
+
     color: $crimson;
-    font-size: 16px;
-    line-height: 21px;
     border: none;
     height: 75px;
     width: 100%;

--- a/ui/app/components/app/modals/hide-token-confirmation-modal/index.scss
+++ b/ui/app/components/app/modals/hide-token-confirmation-modal/index.scss
@@ -16,29 +16,29 @@
   }
 
   &__symbol {
+    @include Paragraph;
+
     color: $tundora;
-    font-size: 16px;
-    line-height: 24px;
     text-align: center;
     margin-bottom: 7.5px;
   }
 
   &__title {
+    @include H3;
+
     height: 30px;
     width: 271.28px;
     color: $tundora;
-    font-size: 22px;
-    line-height: 30px;
     text-align: center;
     margin-bottom: 10.5px;
   }
 
   &__copy {
-    height: 41px;
+    @include Paragraph;
+
+    min-height: 41px;
     width: 318px;
     color: $scorpion;
-    font-size: 14px;
-    line-height: 18px;
     text-align: center;
   }
 

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/index.scss
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/index.scss
@@ -12,7 +12,7 @@
 
 
   .metametrics-opt-in__title {
-    font-size: 38px;
+    @include H1;
   }
 
   .metametrics-opt-in__content {

--- a/ui/app/components/app/modals/new-account-modal/index.scss
+++ b/ui/app/components/app/modals/new-account-modal/index.scss
@@ -21,9 +21,10 @@
     }
 
     &__header-close {
+      @include H4;
+
       color: #24292e;
       background: none;
-      font-size: 1.1rem;
     }
   }
 
@@ -33,12 +34,13 @@
   }
 
   &__input {
+    @include H4;
+
     background: $white;
     border: 1px solid $Grey-100;
     box-sizing: border-box;
     border-radius: 8px;
     padding: 0.625rem 0.75rem;
-    font-size: 1.25rem;
     margin-top: 0.75rem;
 
     &::placeholder {

--- a/ui/app/components/app/modals/notification-modal/index.scss
+++ b/ui/app/components/app/modals/notification-modal/index.scss
@@ -10,21 +10,23 @@
   }
 
   &__header {
+    @include H4;
+
     background: $wild-sand;
     width: 100%;
     display: flex;
     justify-content: center;
     padding: 30px;
-    font-size: 22px;
     color: $nile-blue;
   }
 
   &__message {
+    @include Paragraph;
+
     padding: 20px;
     width: 100%;
     display: flex;
     justify-content: center;
-    font-size: 17px;
     color: $nile-blue;
   }
 

--- a/ui/app/components/app/modals/qr-scanner/index.scss
+++ b/ui/app/components/app/modals/qr-scanner/index.scss
@@ -7,7 +7,8 @@
   border-radius: 8px;
 
   &__title {
-    font-size: 1.5rem;
+    @include H3;
+
     font-weight: 500;
     padding: 16px 0;
     text-align: center;
@@ -34,21 +35,24 @@
   }
 
   &__status {
+    @include H6;
+
     text-align: center;
-    font-size: 14px;
     padding: 15px;
   }
 
   &__image {
-    font-size: 1.5rem;
+    @include H3;
+
     font-weight: 500;
     padding: 16px 0 0;
     text-align: center;
   }
 
   &__error {
+    @include Paragraph;
+
     text-align: center;
-    font-size: 16px;
     padding: 15px;
   }
 

--- a/ui/app/components/app/modals/reject-transactions/index.scss
+++ b/ui/app/components/app/modals/reject-transactions/index.scss
@@ -1,6 +1,7 @@
 .reject-transactions {
   &__description {
+    @include Paragraph;
+
     text-align: center;
-    font-size: 0.875rem;
   }
 }

--- a/ui/app/components/app/modals/transaction-confirmed/index.scss
+++ b/ui/app/components/app/modals/transaction-confirmed/index.scss
@@ -1,14 +1,16 @@
 .transaction-confirmed {
   &__title {
-    font-size: 1.5rem;
+    @include H3;
+
     font-weight: 500;
     padding: 16px 0;
     text-align: center;
   }
 
   &__description {
+    @include H6;
+
     text-align: center;
-    font-size: 0.875rem;
   }
 
   &__content {

--- a/ui/app/components/app/multiple-notifications/index.scss
+++ b/ui/app/components/app/multiple-notifications/index.scss
@@ -27,8 +27,9 @@
       visibility: visible;
 
       &:hover {
+        @include H4;
+
         color: #b0d7f2;
-        font-size: 1.1rem;
       }
     }
   }

--- a/ui/app/components/app/network-display/index.scss
+++ b/ui/app/components/app/network-display/index.scss
@@ -33,7 +33,8 @@
   }
 
   &__name {
-    font-size: 0.75rem;
+    @include H7;
+
     padding-left: 5px;
   }
 

--- a/ui/app/components/app/permission-page-container/index.scss
+++ b/ui/app/components/app/permission-page-container/index.scss
@@ -1,12 +1,14 @@
 .permission-approval-container {
-  display: flex;
-  border: none;
-  box-shadow: none;
-  width: 100%;
-  margin-top: 2px;
-  height: 100%;
-  flex-direction: column;
-  justify-content: space-between;
+  &.page-container {
+    display: flex;
+    border: none;
+    box-shadow: none;
+    width: 100%;
+    margin-top: 2px;
+    height: 100%;
+    flex-direction: column;
+    justify-content: space-between;
+  }
 
   @media screen and (min-width: 576px) {
     width: 426px;
@@ -33,7 +35,6 @@
   &__title {
     @include H4;
 
-    line-height: 25px;
     text-align: center;
     margin-top: 32px;
     width: 100%;
@@ -65,7 +66,8 @@
       align-items: center;
 
       label {
-        font-size: 14px;
+        @include H6;
+
         margin-left: 16px;
         color: $Black-100;
       }
@@ -86,7 +88,6 @@
   &__permissions-header {
     @include H6;
 
-    line-height: 20px;
     color: #6a737d;
   }
 

--- a/ui/app/components/app/permissions-connect-footer/index.scss
+++ b/ui/app/components/app/permissions-connect-footer/index.scss
@@ -7,7 +7,6 @@
   &__text {
     @include H7;
 
-    line-height: 17px;
     color: #6a737d;
     display: flex;
     margin-top: 10px;

--- a/ui/app/components/app/permissions-connect-header/index.scss
+++ b/ui/app/components/app/permissions-connect-header/index.scss
@@ -30,7 +30,7 @@
 
     text-align: center;
     color: $Black-100;
-    margin-top: 14px;
+    margin-top: 16px;
   }
 
   &__text,
@@ -45,6 +45,7 @@
     width: 100%;
     text-overflow: ellipsis;
     overflow: hidden;
+    margin-top: 8px;
 
     /*rtl:ignore*/
     direction: rtl;

--- a/ui/app/components/app/selected-account/index.scss
+++ b/ui/app/components/app/selected-account/index.scss
@@ -10,10 +10,10 @@
   }
 
   &__name {
+    @include H5;
+
     width: 100%;
-    font-size: 1rem;
     font-weight: 500;
-    line-height: 19px;
     color: $black;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -23,8 +23,8 @@
   }
 
   &__address {
-    font-size: 0.75rem;
-    line-height: 0.75rem;
+    @include H7;
+
     color: #989a9b;
   }
 

--- a/ui/app/components/app/sidebars/sidebar-content.scss
+++ b/ui/app/components/app/sidebars/sidebar-content.scss
@@ -57,7 +57,7 @@
           max-width: 318px;
 
           &__time-estimate {
-            font-size: 12px;
+            @include H7;
           }
         }
       }

--- a/ui/app/components/app/signature-request-original/index.scss
+++ b/ui/app/components/app/signature-request-original/index.scss
@@ -61,9 +61,9 @@
   }
 
   &__header__text {
+    @include H3;
+
     color: #5b5d67;
-    font-size: 22px;
-    line-height: 29px;
     z-index: 3;
   }
 
@@ -96,14 +96,14 @@
   }
 
   &__account-text {
-    font-size: 14px;
+    @include H6;
   }
 
   &__account-item {
+    @include H7;
+
     height: 22px;
     background-color: $white;
-    line-height: 16px;
-    font-size: 12px;
     width: 124px;
 
     .account-list-item {
@@ -129,8 +129,9 @@
   }
 
   &__balance-text {
+    @include H6;
+
     text-align: right;
-    font-size: 14px;
   }
 
   &__balance-value {
@@ -157,19 +158,19 @@
   }
 
   &__headline {
+    @include H4;
+
     height: 48px;
     width: 240px;
     color: $tundora;
-    font-size: 18px;
-    line-height: 24px;
     text-align: center;
     margin-top: 20px;
   }
 
   &__notice,
   &__warning {
-    font-size: 14px;
-    line-height: 19px;
+    @include H6;
+
     text-align: center;
     margin-top: 41px;
     margin-bottom: 11px;
@@ -200,19 +201,19 @@
   }
 
   &__row-title {
+    @include H5;
+
     width: 80px;
     color: $dusty-gray;
-    font-size: 16px;
-    line-height: 22px;
     margin-top: 12px;
     margin-left: 18px;
     width: 100%;
   }
 
   &__row-value {
+    @include H6;
+
     color: $scorpion;
-    font-size: 14px;
-    line-height: 19px;
     width: 100%;
     overflow-wrap: break-word;
     border-bottom: 1px solid #d2d8dd;
@@ -227,11 +228,12 @@
   }
 
   &__footer {
+    @include H3;
+
     width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 22px;
     position: relative;
     flex: 0 0 auto;
     border-top: 1px solid $geyser;

--- a/ui/app/components/app/signature-request/index.scss
+++ b/ui/app/components/app/signature-request/index.scss
@@ -22,7 +22,8 @@
   }
 
   .network-display__name {
-    font-size: 12px;
+    @include H7;
+
     white-space: nowrap;
     font-weight: 500;
   }
@@ -38,9 +39,9 @@
   min-height: min-content;
 
   &__title {
-    font-style: normal;
+    @include H5;
+
     font-weight: 500;
-    font-size: 18px;
   }
 
   &__identicon-container {
@@ -73,17 +74,19 @@
   }
 
   &__info {
-    font-size: 12px;
+    @include H7;
   }
 
   &__info--bolded {
-    font-size: 16px;
+    @include Paragraph;
+
     font-weight: 500;
   }
 
   p {
+    @include H6;
+
     color: #999;
-    font-size: 0.8rem;
   }
 
   .identicon {}

--- a/ui/app/components/app/signature-request/signature-request-header/index.scss
+++ b/ui/app/components/app/signature-request/signature-request-header/index.scss
@@ -1,9 +1,10 @@
 .signature-request-header {
+  @include H7;
+
   display: flex;
   padding: 1rem;
   border-bottom: 1px solid $geyser;
   justify-content: space-between;
-  font-size: 0.75rem;
 
   &--account,
   &--network {
@@ -21,7 +22,8 @@
       }
 
       &__account-name {
-        font-size: 12px;
+        @include H7;
+
         font-weight: 500;
       }
 

--- a/ui/app/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/app/components/app/signature-request/signature-request-message/index.scss
@@ -4,16 +4,18 @@
   flex-direction: column;
 
   &__title {
+    @include H6;
+
     font-weight: 500;
-    font-size: 14px;
     color: #636778;
     margin-left: 12px;
   }
 
   h2 {
+    @include H6;
+
     flex: 1 1 0;
     text-align: left;
-    font-size: 0.8rem;
     border-bottom: 1px solid #d2d8dd;
     padding: 0.5rem;
     margin: 0;
@@ -35,9 +37,8 @@
   }
 
   &__type-title {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 14px;
+    @include H6;
+
     margin-left: 12px;
     margin-top: 6px;
     margin-bottom: 10px;

--- a/ui/app/components/app/tab-bar/index.scss
+++ b/ui/app/components/app/tab-bar/index.scss
@@ -5,13 +5,14 @@
 
 
   &__tab {
+    @include Paragraph;
+
     display: flex;
     flex-flow: row nowrap;
     align-items: flex-start;
     min-width: 0;
     flex: 0 0 auto;
     box-sizing: border-box;
-    font-size: 16px;
     padding: 16px 24px;
     opacity: 0.5;
     transition: opacity 200ms ease-in-out;
@@ -27,7 +28,8 @@
     }
 
     @media screen and (max-width: 575px) {
-      font-size: 18px;
+      @include H4;
+
       padding: 24px;
       border-bottom: 1px solid $alto;
       opacity: 1;
@@ -41,8 +43,9 @@
         display: none;
 
         @media screen and (max-width: 575px) {
+          @include H6;
+
           display: block;
-          font-size: 14px;
           font-weight: 300;
           margin-top: 8px;
           min-height: 14px;

--- a/ui/app/components/app/transaction-activity-log/index.scss
+++ b/ui/app/components/app/transaction-activity-log/index.scss
@@ -54,8 +54,9 @@
   }
 
   &__activity-text {
+    @include H7;
+
     color: $dusty-gray;
-    font-size: 0.75rem;
     cursor: pointer;
 
     &:hover {
@@ -73,7 +74,8 @@
   }
 
   &__action-link {
-    font-size: 0.75rem;
+    @include H7;
+
     cursor: pointer;
     color: $primary-blue;
   }

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/index.scss
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown-row/index.scss
@@ -1,5 +1,6 @@
 .transaction-breakdown-row {
-  font-size: 0.75rem;
+  @include H7;
+
   color: $scorpion;
   display: flex;
   justify-content: space-between;

--- a/ui/app/components/app/transaction-list-item-details/index.scss
+++ b/ui/app/components/app/transaction-list-item-details/index.scss
@@ -17,7 +17,7 @@
   }
 
   & &__header-button {
-    font-size: 0.625rem;
+    @include H8;
 
     &:not(:last-child) {
       margin-right: 8px;

--- a/ui/app/components/app/transaction-list-item/index.scss
+++ b/ui/app/components/app/transaction-list-item/index.scss
@@ -4,7 +4,8 @@
   }
 
   &__secondary-currency {
-    font-size: 12px;
+    @include H7;
+
     margin-top: 4px;
     color: $Grey-500;
   }
@@ -22,11 +23,11 @@
     display: flex;
 
     .button {
-      font-size: 0.625rem;
+      @include H8;
+
       padding: 8px;
       width: 75px;
       white-space: nowrap;
-      line-height: 1rem;
     }
 
     &:empty {

--- a/ui/app/components/app/transaction-list/index.scss
+++ b/ui/app/components/app/transaction-list/index.scss
@@ -10,9 +10,9 @@
   }
 
   &__header {
+    @include H6;
+
     flex: 0 0 auto;
-    font-size: 14px;
-    line-height: 20px;
     color: $Grey-400;
     border-bottom: 1px solid $Grey-100;
     padding: 8px 0 8px 20px;

--- a/ui/app/components/app/wallet-overview/index.scss
+++ b/ui/app/components/app/wallet-overview/index.scss
@@ -34,7 +34,7 @@
   }
 
   text-transform: uppercase;
-  font-weight: bold;
+  font-weight: 500;
 }
 
 .eth-overview {
@@ -54,9 +54,9 @@
   }
 
   &__primary-balance {
+    @include H2;
+
     color: $black;
-    font-size: 32px;
-    line-height: 45px;
     width: 100%;
     justify-content: center;
   }
@@ -71,15 +71,14 @@
   }
 
   &__cached-secondary-balance {
+    @include Paragraph;
+
     color: rgba(220, 153, 18, 0.6901960784313725);
-    font-size: 16px;
-    line-height: 23px;
   }
 
   &__secondary-balance {
-    font-size: 16px;
-    line-height: 23px;
-    font-weight: 400;
+    @include Paragraph;
+
     color: $Grey-400;
   }
 
@@ -101,17 +100,16 @@
   }
 
   &__primary-balance {
+    @include H2;
+
     color: $black;
-    font-size: 32px;
-    line-height: 45px;
     width: 100%;
     justify-content: center;
   }
 
   &__secondary-balance {
-    font-size: 16px;
-    line-height: 23px;
-    font-weight: 400;
+    @include H5;
+
     color: $Grey-400;
   }
 

--- a/ui/app/components/ui/alert/index.scss
+++ b/ui/app/components/ui/alert/index.scss
@@ -4,10 +4,11 @@
   background-color: #33a4e7;
 
   .msg {
+    @include H7;
+
     width: 100%;
     display: block;
     color: white;
-    font-size: 12px;
     text-align: center;
   }
 }

--- a/ui/app/components/ui/button-group/index.scss
+++ b/ui/app/components/ui/button-group/index.scss
@@ -4,7 +4,8 @@
   align-items: center;
 
   &__button {
-    font-size: 1rem;
+    @include H5;
+
     color: $tundora;
     border-style: solid;
     border-color: $alto;

--- a/ui/app/components/ui/button/buttons.scss
+++ b/ui/app/components/ui/button/buttons.scss
@@ -14,7 +14,6 @@ $warning-light-orange: #f8b588;
   @include H6;
 
   font-weight: 500;
-  line-height: 1.25rem;
   padding: 0.75rem 1rem;
   display: flex;
   justify-content: center;
@@ -170,7 +169,6 @@ $warning-light-orange: #f8b588;
   @include H4;
 
   color: $Blue-500;
-  line-height: 1.25rem;
   cursor: pointer;
   background-color: transparent;
 
@@ -211,11 +209,12 @@ $warning-light-orange: #f8b588;
 }
 
 .btn--first-time {
+  @include H4;
+
   height: 54px;
   width: 198px;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.14);
   color: $white;
-  font-size: 1.25rem;
   font-weight: 500;
   transition: 200ms ease-in-out;
   background-color: rgba(247, 134, 28, 0.9);
@@ -226,15 +225,6 @@ button[disabled],
 input[type="submit"][disabled] {
   cursor: not-allowed;
   opacity: 0.5;
-}
-
-button.primary {
-  padding: 8px 12px;
-  background: #f7861c;
-  box-shadow: 0 3px 6px rgba(247, 134, 28, 0.36);
-  color: $white;
-  font-size: 1.1em;
-  text-transform: uppercase;
 }
 
 .btn--rounded {

--- a/ui/app/components/ui/currency-input/index.scss
+++ b/ui/app/components/ui/currency-input/index.scss
@@ -1,7 +1,7 @@
 .currency-input {
   &__conversion-component {
-    font-size: 12px;
-    line-height: 12px;
+    @include H7;
+
     padding-left: 1px;
   }
 

--- a/ui/app/components/ui/dialog/dialog.scss
+++ b/ui/app/components/ui/dialog/dialog.scss
@@ -1,6 +1,6 @@
 .dialog {
-  font-size: 0.75rem;
-  line-height: 1rem;
+  @include H7;
+
   padding: 1rem;
   border: 1px solid $black;
   box-sizing: border-box;

--- a/ui/app/components/ui/dropdown/dropdown.scss
+++ b/ui/app/components/ui/dropdown/dropdown.scss
@@ -1,4 +1,6 @@
 .dropdown {
+  @include H6;
+
   appearance: none;
 
   // TODO: remove these after getting autoprefixer working in Storybook
@@ -11,7 +13,6 @@
   background-position: right 18px top 50%;
   background-color: white;
   padding: 8px 32px 8px 16px;
-  font-size: 14px;
 
   [dir='rtl'] & {
     background-position: left 18px top 50%;

--- a/ui/app/components/ui/editable-label/index.scss
+++ b/ui/app/components/ui/editable-label/index.scss
@@ -12,8 +12,9 @@
   }
 
   &__input {
+    @include H6;
+
     width: 250px;
-    font-size: 14px;
     text-align: center;
     border: 1px solid $alto;
 

--- a/ui/app/components/ui/error-message/index.scss
+++ b/ui/app/components/ui/error-message/index.scss
@@ -1,10 +1,11 @@
 .error-message {
+  @include H7;
+
   min-height: 32px;
   border: 1px solid $monzo;
   color: $monzo;
   background: lighten($monzo, 56%);
   border-radius: 4px;
-  font-size: 0.75rem;
   display: flex;
   justify-content: flex-start;
   align-items: center;

--- a/ui/app/components/ui/export-text-container/index.scss
+++ b/ui/app/components/ui/export-text-container/index.scss
@@ -17,10 +17,11 @@
   }
 
   &__text {
+    @include H4;
+
     resize: none;
     border: none;
     background: $alabaster;
-    font-size: 20px;
     text-align: center;
   }
 
@@ -32,12 +33,13 @@
   }
 
   &__button {
+    @include H7;
+
     padding: 10px;
     flex: 1;
     display: flex;
     justify-content: center;
     align-items: center;
-    font-size: 12px;
     cursor: pointer;
     color: $primary-blue;
 

--- a/ui/app/components/ui/icon-with-label/index.scss
+++ b/ui/app/components/ui/icon-with-label/index.scss
@@ -3,7 +3,8 @@
   align-items: center;
 
   &__label {
-    font-size: 10px;
+    @include H8;
+
     margin-left: 4px;
     color: $Grey-500;
   }

--- a/ui/app/components/ui/list-item/index.scss
+++ b/ui/app/components/ui/list-item/index.scss
@@ -37,9 +37,9 @@
   }
 
   &__heading {
+    @include H5;
+
     grid-area: head;
-    font-size: 16px;
-    line-height: 160%;
     position: relative;
     display: flex;
     align-items: center;
@@ -57,9 +57,9 @@
   }
 
   &__subheading {
+    @include H7;
+
     grid-area: sub;
-    font-size: 12px;
-    line-height: 14px;
     color: $Grey-500;
     margin-top: 4px;
     // all direct descendants should be truncated with ellipses
@@ -76,8 +76,9 @@
   }
 
   &__mid-content {
+    @include H7;
+
     grid-area: mid;
-    font-size: 12px;
     color: $Grey-500;
   }
 

--- a/ui/app/components/ui/loading-screen/index.scss
+++ b/ui/app/components/ui/loading-screen/index.scss
@@ -26,13 +26,6 @@
     align-items: center;
   }
 
-  &__message {
-    margin-top: 32px;
-    font-weight: 400;
-    font-size: 20px;
-    color: $manatee;
-  }
-
   &__error-screen {
     display: flex;
     flex-direction: column;

--- a/ui/app/components/ui/menu/menu.scss
+++ b/ui/app/components/ui/menu/menu.scss
@@ -1,5 +1,7 @@
 .menu {
   &__container {
+    @include H6;
+
     background: $white;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.214);
     border-radius: 8px;
@@ -9,9 +11,6 @@
     flex-direction: column;
     align-items: center;
     padding: 0 16px;
-    font-size: 14px;
-    font-weight: normal;
-    line-height: 20px;
     z-index: 1050;
   }
 

--- a/ui/app/components/ui/page-container/index.scss
+++ b/ui/app/components/ui/page-container/index.scss
@@ -73,9 +73,10 @@
 
       a,
       a:hover {
+        @include H7;
+
         text-decoration: none;
         cursor: pointer;
-        font-size: 0.75rem;
         text-transform: uppercase;
         color: #2f9ae0;
       }
@@ -91,24 +92,24 @@
   }
 
   &__back-button {
+    @include Paragraph;
+
     color: #2f9ae0;
-    font-size: 1rem;
     cursor: pointer;
-    font-weight: 400;
   }
 
   &__title {
+    @include H2;
+
     color: $black;
-    font-size: 2rem;
     font-weight: 500;
-    line-height: 2rem;
     margin-right: 1.5rem;
   }
 
   &__subtitle {
+    @include H6;
+
     padding-top: 0.5rem;
-    line-height: initial;
-    font-size: 0.9rem;
     color: $gray;
   }
 
@@ -118,9 +119,10 @@
   }
 
   &__tab {
+    @include Paragraph;
+
     min-width: 5rem;
     color: $dusty-gray;
-    font-size: 1rem;
     border-bottom: none;
     margin-right: 16px;
 

--- a/ui/app/components/ui/popover/index.scss
+++ b/ui/app/components/ui/popover/index.scss
@@ -36,7 +36,6 @@
       @include H4;
 
       font-weight: bold;
-      line-height: 25px;
       padding-bottom: 8px;
 
       h2 {
@@ -52,8 +51,6 @@
 
     &__subtitle {
       @include H6;
-
-      line-height: 20px;
     }
 
     &__button {

--- a/ui/app/components/ui/qr-code/index.scss
+++ b/ui/app/components/ui/qr-code/index.scss
@@ -5,13 +5,15 @@
   align-items: center;
 
   &__message-container > div:first-child {
+    @include Paragraph;
+
     margin-top: 18px;
-    font-size: 15px;
     color: #4d4d4d;
   }
 
   &__message {
-    font-size: 12px;
+    @include H7;
+
     color: #f7861c;
   }
 

--- a/ui/app/components/ui/sender-to-recipient/index.scss
+++ b/ui/app/components/ui/sender-to-recipient/index.scss
@@ -69,11 +69,12 @@
       }
 
       &__name {
+        @include H6;
+
         padding-left: 14px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        font-size: 0.875rem;
 
         [dir='rtl'] & {
           /*rtl:ignore*/
@@ -117,10 +118,11 @@
       }
 
       &__name {
+        @include H9;
+
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        font-size: 0.5rem;
 
         [dir='rtl'] & {
           /*rtl:ignore*/
@@ -171,10 +173,11 @@
       }
 
       &__name {
+        @include H8;
+
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        font-size: 0.6875rem;
 
         [dir='rtl'] & {
           /*rtl:ignore*/

--- a/ui/app/components/ui/snackbar/index.scss
+++ b/ui/app/components/ui/snackbar/index.scss
@@ -1,6 +1,7 @@
 .snackbar {
+  @include H7;
+
   padding: 0.75rem 1rem;
-  font-size: 0.75rem;
   color: $Blue-600;
   min-width: 360px;
   width: fit-content;

--- a/ui/app/components/ui/toggle-button/index.scss
+++ b/ui/app/components/ui/toggle-button/index.scss
@@ -3,10 +3,8 @@
   $self: &;
 
   &__status {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 16px;
-    line-height: 23px;
+    @include Paragraph;
+
     display: flex;
     align-items: center;
     text-transform: uppercase;

--- a/ui/app/components/ui/unit-input/index.scss
+++ b/ui/app/components/ui/unit-input/index.scss
@@ -1,4 +1,6 @@
 .unit-input {
+  @include Paragraph;
+
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
@@ -7,7 +9,6 @@
   border-radius: 4px;
   background-color: #fff;
   color: #4d4d4d;
-  font-size: 16px;
   padding: 8px 10px;
   position: relative;
 
@@ -34,12 +35,12 @@
   }
 
   &__input {
+    @include Paragraph;
+
     color: #4d4d4d;
-    font-size: 1rem;
     border: none;
     max-width: 22ch;
     height: 16px;
-    line-height: 18px;
 
     &__disabled {
       background-color: rgb(222, 222, 222);
@@ -48,14 +49,14 @@
 
   &__input-container {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     padding-bottom: 4px;
   }
 
   &__suffix {
+    @include Paragraph;
+
     margin-left: 3px;
-    font-size: 1rem;
-    line-height: 1rem;
   }
 
   &--error {

--- a/ui/app/css/design-system/typography.scss
+++ b/ui/app/css/design-system/typography.scss
@@ -69,11 +69,22 @@ $fa-font-path: 'fonts/fontawesome';
 
 $font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
 
+$font-size-h1: 2.5rem;
+$font-size-h2: 2rem;
+$font-size-h3: 1.5rem;
+$font-size-h4: 1.125rem;
+$font-size-h5: 1rem;
+$font-size-h6: 0.875rem;
+$font-size-paragraph: 1rem;
+$font-size-h7: 0.75rem;
+$font-size-h8: 0.625rem;
+$font-size-h9: 0.5rem;
+
 // Typography
 @mixin H1 {
   font-style: normal;
   font-weight: normal;
-  font-size: 2.5rem;
+  font-size: $font-size-h1;
   font-family: $font-family;
   line-height: 140%;
 }
@@ -82,7 +93,7 @@ $font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
 @mixin H2 {
   font-style: normal;
   font-weight: normal;
-  font-size: 2rem;
+  font-size: $font-size-h2;
   font-family: $font-family;
   line-height: 140%;
 }
@@ -90,7 +101,7 @@ $font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
 @mixin H3 {
   font-style: normal;
   font-weight: normal;
-  font-size: 1.5rem;
+  font-size: $font-size-h3;
   font-family: $font-family;
   line-height: 140%;
 }
@@ -98,7 +109,7 @@ $font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
 @mixin H4 {
   font-style: normal;
   font-weight: normal;
-  font-size: 1.125rem;
+  font-size: $font-size-h4;
   font-family: $font-family;
   line-height: 140%;
 }
@@ -106,46 +117,41 @@ $font-family: Euclid, Roboto, Helvetica, Arial, sans-serif;
 @mixin H5 {
   font-style: normal;
   font-weight: normal;
-  font-size: 1rem;
-  font-family: $font-family;
+  font-size: $font-size-h5;
   line-height: 140%;
 }
 
 @mixin H6 {
   font-style: normal;
   font-weight: normal;
-  font-size: 0.875rem; // 14px @default
+  font-size: $font-size-h6; // 14px @default
   line-height: 140%;
 }
 
 @mixin Paragraph {
   font-style: normal;
   font-weight: normal;
-  font-size: 1rem;
-  font-family: $font-family;
+  font-size: $font-size-paragraph;
   line-height: 140%;
 }
 
 @mixin H7 {
   font-style: normal;
   font-weight: normal;
-  font-size: 0.75rem;
-  font-family: $font-family;
+  font-size: $font-size-h7;
   line-height: 140%;
 }
 
 @mixin H8 {
   font-style: normal;
   font-weight: normal;
-  font-size: 0.625rem;
-  font-family: $font-family;
+  font-size: $font-size-h8;
   line-height: 140%;
 }
 
 @mixin H9 {
   font-style: normal;
   font-weight: normal;
-  font-size: 0.5rem;
-  font-family: $font-family;
+  font-size: $font-size-h9;
   line-height: 140%;
 }

--- a/ui/app/css/itcss/components/network.scss
+++ b/ui/app/css/itcss/components/network.scss
@@ -42,9 +42,10 @@
 }
 
 .network-indicator {
+  @include H8;
+
   display: flex;
   align-items: center;
-  font-size: 0.6em;
 
   &__down-arrow {
     height: 8px;
@@ -58,16 +59,16 @@
   }
 
   .fa-question-circle {
+    font-size: $font-size-paragraph;
     margin: 0 4px 0 6px;
-    font-size: 1rem;
     flex: 0 0 auto;
   }
 }
 
 .network-name {
+  @include H7;
+
   padding: 0 4px;
-  font-size: 12px;
-  line-height: 14px;
   flex: 1 1 auto;
   color: $tundora;
   font-weight: 500;
@@ -163,20 +164,20 @@
 }
 
 .network-dropdown-title {
+  @include H4;
+
   height: 25px;
   width: 120px;
   color: $white;
-  font-size: 18px;
-  line-height: 25px;
   text-align: center;
 }
 
 .network-dropdown-content {
+  @include H6;
+
   min-height: 36px;
   width: 265px;
   color: $dusty-gray;
-  font-size: 14px;
-  line-height: 18px;
 }
 
 .network-caret {

--- a/ui/app/css/itcss/components/send.scss
+++ b/ui/app/css/itcss/components/send.scss
@@ -39,8 +39,9 @@
 }
 
 .send-screen input {
+  @include H7;
+
   width: 100%;
-  font-size: 12px;
 }
 
 .send-eth-icon {
@@ -70,11 +71,11 @@
   }
 
   .large-input {
+    @include Paragraph;
+
     border: 1px solid $dusty-gray;
     border-radius: 4px;
     margin: 4px 0 20px;
-    font-size: 16px;
-    line-height: 22.4px;
   }
 
   .send-screen-gas-input {
@@ -92,22 +93,22 @@
     }
 
     .send-screen-input-wrapper__error-message {
+      @include H7;
+
       display: block;
       position: absolute;
       bottom: 4px;
-      font-size: 12px;
-      line-height: 12px;
       left: 8px;
       color: $red;
     }
   }
 
   .send-screen-input-wrapper__error-message {
+    @include H7;
+
     display: block;
     position: absolute;
     bottom: 4px;
-    font-size: 12px;
-    line-height: 12px;
     left: 8px;
     color: $red;
   }
@@ -118,6 +119,8 @@
 }
 
 .send-screen-gas-input {
+  @include Paragraph;
+
   width: 100%;
   height: 41px;
   border-radius: 3px;
@@ -129,7 +132,6 @@
   align-items: center;
   padding-left: 10px;
   padding-right: 12px;
-  font-size: 16px;
   color: $scorpion;
 }
 
@@ -158,8 +160,9 @@
 }
 
 .send-screen-gas-input-customize {
+  @include H7;
+
   color: $primary-blue;
-  font-size: 12px;
   cursor: pointer;
 }
 
@@ -173,6 +176,8 @@
 }
 
 .customize-gas-tooltip-container {
+  @include Paragraph;
+
   position: absolute;
   bottom: 50px;
   width: 237px;
@@ -182,7 +187,6 @@
   box-shadow: $alto 0 0 5px;
   z-index: 1050;
   padding: 13px 19px;
-  font-size: 16px;
   border-radius: 4px;
   font-weight: 500;
 }
@@ -219,7 +223,8 @@
 }
 
 .gas-tooltip-label {
-  font-size: 16px;
+  @include Paragraph;
+
   color: $tundora;
 }
 
@@ -237,10 +242,11 @@
 }
 
 .customize-gas-input {
+  @include Paragraph;
+
   width: 178px;
   height: 28px;
   border: 1px solid $alto;
-  font-size: 16px;
   color: $nile-blue;
   padding-left: 8px;
 }
@@ -250,14 +256,17 @@
 }
 
 .gas-tooltip-input-detail {
+  @include H7;
+
   position: absolute;
   top: 4px;
   right: 26px;
-  font-size: 12px;
   color: $silver-chalice;
 }
 
 .gas-tooltip-input-arrows {
+  @include H6;
+
   position: absolute;
   top: 0;
   right: 4px;
@@ -268,7 +277,6 @@
   display: flex;
   flex-direction: column;
   color: #9b9b9b;
-  font-size: 0.8em;
   padding: 1px 4px;
   cursor: pointer;
 }
@@ -286,15 +294,15 @@
 
 .send-screen {
   &__title {
+    @include H4;
+
     color: $scorpion;
-    font-size: 18px;
-    line-height: 29px;
   }
 
   &__subtitle {
+    @include H6;
+
     margin: 10px 0 20px;
-    font-size: 14px;
-    line-height: 24px;
   }
 
   &__send-button,
@@ -347,23 +355,23 @@
   }
 
   &__title {
+    @include H4;
+
     color: $scorpion;
-    font-size: 18px;
-    line-height: 29px;
   }
 
   &__description,
   &__balance-text,
   &__token-symbol {
+    @include H6;
+
     margin-top: 10px;
-    font-size: 14px;
-    line-height: 24px;
     text-align: center;
   }
 
   &__token-balance {
-    font-size: 40px;
-    line-height: 40px;
+    @include H1;
+
     margin-top: 13px;
 
     .token-balance__amount {
@@ -433,12 +441,13 @@
   }
 
   &__send-arrow-icon {
+    @include H4;
+
     color: #f28930;
     transform: rotate(-45deg);
     position: absolute;
     top: -2px;
     left: 0;
-    font-size: 1.12em;
   }
 
   &__arrow-background {
@@ -489,25 +498,25 @@
   }
 
   &__title {
+    @include H3;
+
     color: $scorpion;
-    font-size: 22px;
-    line-height: 29px;
     text-align: center;
     margin-top: 25px;
   }
 
   &__copy {
+    @include H6;
+
     color: $gray;
-    font-size: 14px;
-    line-height: 19px;
     text-align: center;
     margin-top: 10px;
     width: 287px;
   }
 
   &__error {
-    font-size: 12px;
-    line-height: 12px;
+    @include H7;
+
     left: 8px;
     color: $red;
   }
@@ -517,8 +526,8 @@
   }
 
   &__warning {
-    font-size: 12px;
-    line-height: 12px;
+    @include H7;
+
     left: 8px;
     color: $orange;
   }
@@ -549,6 +558,7 @@
     flex-flow: row;
     flex: 1 0 auto;
     justify-content: space-between;
+    align-items: center;
   }
 
   &__form-field-container {
@@ -582,22 +592,21 @@
   }
 
   &__form-label {
+    @include Paragraph;
+
     color: $scorpion;
-    font-size: 16px;
-    line-height: 22px;
     width: 95px;
-    font-weight: 400;
     flex: 0 0 auto;
   }
 
   &__from-dropdown,
   &__asset-dropdown {
+    @include H7;
+
     width: 100%;
     border: 1px solid $alto;
     border-radius: 4px;
     background-color: $white;
-    line-height: 16px;
-    font-size: 12px;
     color: $tundora;
     position: relative;
 
@@ -670,14 +679,16 @@
     }
 
     &__symbol {
-      font-size: 16px;
+      @include Paragraph;
+
       margin-bottom: 2px;
     }
 
     &__name {
+      @include H7;
+
       display: flex;
       flex-flow: row nowrap;
-      font-size: 12px;
 
       &__label {
         margin-right: 0.25rem;
@@ -729,6 +740,8 @@
     }
 
     &__input {
+      @include Paragraph;
+
       z-index: 1025;
       position: relative;
       height: 54px;
@@ -738,14 +751,14 @@
       background-color: $white;
       color: $tundora;
       padding: 10px;
-      font-size: 16px;
-      line-height: 21px;
     }
   }
 
   &__memo-text-area,
   &__hex-data {
     &__input {
+      @include Paragraph;
+
       z-index: 1025;
       position: relative;
       height: 54px;
@@ -755,13 +768,12 @@
       background-color: $white;
       color: $tundora;
       padding: 10px;
-      font-size: 16px;
-      line-height: 21px;
     }
   }
 
   &__amount-max {
-    font-size: 12px;
+    @include H7;
+
     position: relative;
     display: inline-block;
     width: 56px;
@@ -815,6 +827,8 @@
   }
 
   &__sliders-icon-container {
+    @include Paragraph;
+
     display: flex;
     align-items: center;
     justify-content: center;
@@ -827,7 +841,6 @@
     right: 15px;
     top: 14px;
     cursor: pointer;
-    font-size: 1em;
   }
 
   &__sliders-icon {
@@ -872,12 +885,13 @@
     }
 
     &__header {
+      @include H3;
+
       height: 52px;
       border-bottom: 1px solid $alto;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      font-size: 22px;
 
       @media screen and (max-width: $break-small) {
         flex: 0 0 auto;
@@ -913,12 +927,13 @@
     }
 
     &__footer {
+      @include H3;
+
       height: 75px;
       border-top: 1px solid $alto;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      font-size: 22px;
       position: relative;
 
       @media screen and (max-width: $break-small) {
@@ -944,8 +959,9 @@
     }
 
     &__revert {
+      @include Paragraph;
+
       color: $silver-chalice;
-      font-size: 16px;
       margin-left: 21.25px;
     }
 
@@ -962,12 +978,12 @@
     }
 
     &__error-message {
+      @include H7;
+
       display: block;
       position: absolute;
       top: -18px;
       right: 0;
-      font-size: 12px;
-      line-height: 12px;
       color: $red;
       width: 100%;
       text-align: center;
@@ -986,19 +1002,19 @@
     padding-left: 20px;
 
     &__title {
+      @include H4;
+
       height: 26px;
       color: $tundora;
-      font-size: 20px;
-      line-height: 26px;
       margin-top: 17px;
     }
 
     &__copy {
+      @include Paragraph;
+
       height: 38px;
       width: 314px;
       color: $tundora;
-      font-size: 14px;
-      line-height: 19px;
       margin-top: 17px;
     }
 
@@ -1015,10 +1031,11 @@
     }
 
     .gas-tooltip-input-arrows {
+      @include H4;
+
       width: 32px;
       height: 54px;
       border-left: 1px solid #dadada;
-      font-size: 18px;
       color: $tundora;
       right: 0;
       padding: 0;
@@ -1049,15 +1066,18 @@
 }
 
 .advanced-gas-options-btn {
+  @include H6;
+
   display: flex;
   justify-content: flex-end;
-  font-size: 14px;
   color: #2f9ae0;
   cursor: pointer;
   margin-top: 5px;
 }
 
 .sliders-icon-container {
+  @include Paragraph;
+
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1070,10 +1090,11 @@
   right: 15px;
   top: 14px;
   cursor: pointer;
-  font-size: 1em;
 }
 
 .gas-fee-reset {
+  @include H6;
+
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1084,8 +1105,6 @@
   right: 12px;
   top: 14px;
   cursor: pointer;
-  font-size: 1em;
-  font-size: 14px;
   color: #2f9ae0;
 }
 

--- a/ui/app/css/itcss/components/simple-dropdown.scss
+++ b/ui/app/css/itcss/components/simple-dropdown.scss
@@ -1,4 +1,6 @@
 .simple-dropdown {
+  @include Paragraph;
+
   height: 56px;
   display: flex;
   justify-content: flex-start;
@@ -6,7 +8,6 @@
   border: 1px solid $alto;
   border-radius: 4px;
   background-color: $white;
-  font-size: 16px;
   color: #4d4d4d;
   cursor: pointer;
   position: relative;

--- a/ui/app/pages/add-token/token-list/index.scss
+++ b/ui/app/pages/add-token/token-list/index.scss
@@ -2,7 +2,7 @@
 
 .token-list {
   &__title {
-    font-size: 0.75rem;
+    @include H7;
   }
 
   &__tokens-container {

--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -17,13 +17,14 @@
 }
 
 .asset-breadcrumb {
-  font-size: 14px;
+  @include H6;
+
   color: $Black-100;
   background-color: inherit;
 
   &__chevron {
+    font-size: $font-size-paragraph;
     padding: 0 10px 0 2px;
-    font-size: 16px;
   }
 
   &__asset {
@@ -33,13 +34,13 @@
 
 .token-options {
   &__button {
-    font-size: 20px;
+    font-size: $font-size-paragraph;
     color: $Black-100;
     background-color: inherit;
     padding: 2px 8px;
   }
 
   &__icon {
-    font-size: 16px;
+    @include Paragraph;
   }
 }

--- a/ui/app/pages/confirm-add-token/index.scss
+++ b/ui/app/pages/confirm-add-token/index.scss
@@ -2,7 +2,8 @@
   padding: 16px;
 
   &__header {
-    font-size: 0.75rem;
+    @include H7;
+
     display: flex;
   }
 
@@ -26,17 +27,16 @@
       align-items: flex-start;
 
       &__amount {
+        @include H1;
+
         color: $scorpion;
-        font-size: 43px;
-        line-height: 43px;
         margin-right: 8px;
       }
 
       &__symbol {
+        @include H5;
+
         color: $scorpion;
-        font-size: 16px;
-        font-weight: 400;
-        line-height: 24px;
       }
     }
   }

--- a/ui/app/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/app/pages/confirm-approve/confirm-approve-content/index.scss
@@ -30,9 +30,8 @@
   }
 
   &__title {
-    font-weight: normal;
-    font-size: 24px;
-    line-height: 34px;
+    @include H3;
+
     width: 100%;
     display: flex;
     justify-content: center;
@@ -43,9 +42,8 @@
   }
 
   &__description {
-    font-weight: normal;
-    font-size: 14px;
-    line-height: 20px;
+    @include H6;
+
     margin-top: 16px;
     margin-bottom: 16px;
     color: #6a737d;
@@ -64,15 +62,14 @@
     padding-right: 24px;
 
     &__bold-text {
+      @include H6;
+
       font-weight: bold;
-      font-size: 14px;
-      line-height: 20px;
     }
 
     &__thin-text {
-      font-weight: normal;
-      font-size: 12px;
-      line-height: 17px;
+      @include H7;
+
       color: #6a737d;
     }
   }
@@ -98,9 +95,9 @@
 
     &__title,
     &__title-value {
+      @include H6;
+
       font-weight: bold;
-      font-size: 14px;
-      line-height: 20px;
     }
 
     &__title {
@@ -179,16 +176,16 @@
     }
 
     &__primary-fee {
+      @include H4;
+
       font-weight: bold;
-      font-size: 18px;
-      line-height: 25px;
       color: #000;
     }
 
     &__secondary-fee {
+      @include H6;
+
       font-weight: normal;
-      font-size: 14px;
-      line-height: 20px;
       color: #8c8e94;
     }
   }
@@ -225,23 +222,22 @@
   }
 
   &__large-text {
-    font-size: 18px;
-    line-height: 25px;
+    @include H4;
+
     color: #24292e;
   }
 
   &__medium-link-text {
-    font-size: 14px;
-    line-height: 20px;
+    @include H6;
+
     font-weight: 500;
     color: $primary-blue;
   }
 
   &__medium-text,
   &__label {
-    font-weight: normal;
-    font-size: 14px;
-    line-height: 20px;
+    @include H6;
+
     color: #24292e;
   }
 
@@ -253,9 +249,8 @@
   &__small-text,
   &__small-blue-text,
   &__info-row {
-    font-weight: normal;
-    font-size: 12px;
-    line-height: 17px;
+    @include H7;
+
     color: #6a737d;
   }
 

--- a/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.scss
+++ b/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.scss
@@ -61,9 +61,9 @@
   }
 
   &__header__text {
+    @include H3;
+
     color: #5b5d67;
-    font-size: 22px;
-    line-height: 29px;
     z-index: 3;
     text-align: center;
   }
@@ -97,14 +97,14 @@
   }
 
   &__account-text {
-    font-size: 14px;
+    @include H6;
   }
 
   &__account-item {
+    @include H7;
+
     height: 22px;
     background-color: $white;
-    line-height: 16px;
-    font-size: 12px;
     width: 124px;
 
     .account-list-item {
@@ -130,8 +130,9 @@
   }
 
   &__balance-text {
+    @include H6;
+
     text-align: right;
-    font-size: 14px;
   }
 
   &__balance-value {
@@ -153,8 +154,8 @@
   }
 
   &__notice {
-    font-size: 14px;
-    line-height: 19px;
+    @include H6;
+
     text-align: center;
     margin-top: 15px;
     margin-bottom: 11px;
@@ -171,7 +172,8 @@
     position: relative;
 
     &-text {
-      font-size: 0.7em;
+      @include H7;
+
       height: 115px;
     }
 
@@ -206,20 +208,21 @@
     }
 
     &-lock-text {
+      @include H7;
+
       width: 200px;
-      font-size: 0.75em;
       position: absolute;
       top: calc(50% + 5px);
       text-align: center;
       left: calc(50% - 100px);
       background-color: white;
-      line-height: 1em;
       border-radius: 3px;
     }
 
     &-copy {
+      @include H7;
+
       justify-content: space-evenly;
-      font-size: 0.75em;
       margin-left: 20px;
       margin-right: 20px;
       display: flex;
@@ -237,11 +240,12 @@
   }
 
   &__footer {
+    @include H4;
+
     width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 22px;
     position: relative;
     flex: 0 0 auto;
     border-top: 1px solid $geyser;

--- a/ui/app/pages/confirm-encryption-public-key/confirm-encryption-public-key.scss
+++ b/ui/app/pages/confirm-encryption-public-key/confirm-encryption-public-key.scss
@@ -61,9 +61,9 @@
   }
 
   &__header__text {
+    @include H3;
+
     color: #5b5d67;
-    font-size: 22px;
-    line-height: 29px;
     z-index: 3;
     text-align: center;
   }
@@ -97,14 +97,14 @@
   }
 
   &__account-text {
-    font-size: 14px;
+    @include H6;
   }
 
   &__account-item {
+    @include H7;
+
     height: 22px;
     background-color: $white;
-    line-height: 16px;
-    font-size: 12px;
     width: 124px;
 
     .account-list-item {
@@ -130,8 +130,9 @@
   }
 
   &__balance-text {
+    @include H6;
+
     text-align: right;
-    font-size: 14px;
   }
 
   &__balance-value {
@@ -153,8 +154,8 @@
   }
 
   &__notice {
-    font-size: 14px;
-    line-height: 19px;
+    @include H6;
+
     text-align: center;
     margin-top: 41px;
     margin-bottom: 11px;
@@ -165,11 +166,12 @@
   }
 
   &__footer {
+    @include H3;
+
     width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 22px;
     position: relative;
     flex: 0 0 auto;
     border-top: 1px solid $geyser;

--- a/ui/app/pages/connected-accounts/index.scss
+++ b/ui/app/pages/connected-accounts/index.scss
@@ -2,9 +2,10 @@
   &__footer {
     a,
     a:hover {
+      @include H6;
+
       color: $primary-blue;
       cursor: pointer;
-      font-size: 14px;
     }
   }
 }

--- a/ui/app/pages/connected-sites/index.scss
+++ b/ui/app/pages/connected-sites/index.scss
@@ -26,8 +26,8 @@
 
   a,
   a:hover {
-    font-size: 14px;
-    line-height: 20px;
+    @include H6;
+
     color: $primary-blue;
     cursor: pointer;
   }

--- a/ui/app/pages/create-account/connect-hardware/index.scss
+++ b/ui/app/pages/create-account/connect-hardware/index.scss
@@ -12,13 +12,15 @@
 
   &__header {
     &__title {
+      @include H3;
+
       margin-top: 5px;
       margin-bottom: 15px;
-      font-size: 22px;
     }
 
     &__msg {
-      font-size: 14px;
+      @include H6;
+
       color: #9b9b9b;
       margin-top: 10px;
       margin-bottom: 20px;
@@ -73,11 +75,12 @@
   }
 
   &__hdPath {
+    @include H6;
+
     display: flex;
     flex-direction: row;
     margin-top: 15px;
     margin-bottom: 30px;
-    font-size: 14px;
 
     &__title {
       display: flex;
@@ -92,10 +95,10 @@
   }
 
   &__learn-more {
+    @include H6;
+
     margin-top: 15px;
-    font-size: 14px;
     color: #5b5d67;
-    line-height: 19px;
     text-align: center;
     cursor: pointer;
 
@@ -109,20 +112,23 @@
   }
 
   &__title {
+    @include H4;
+
     padding-top: 10px;
     font-weight: 400;
-    font-size: 18px;
   }
 
   &__unlock-title {
+    @include H3;
+
     padding-top: 10px;
     font-weight: 400;
-    font-size: 22px;
     margin-bottom: 15px;
   }
 
   &__msg {
-    font-size: 14px;
+    @include H6;
+
     color: #9b9b9b;
     margin-top: 10px;
     margin-bottom: 15px;
@@ -141,15 +147,17 @@
 
   &__footer {
     &__title {
+      @include H4;
+
       padding-top: 15px;
       padding-bottom: 12px;
       font-weight: 400;
-      font-size: 18px;
       text-align: center;
     }
 
     &__msg {
-      font-size: 14px;
+      @include H6;
+
       color: #9b9b9b;
       margin-top: 12px;
       margin-bottom: 27px;
@@ -170,12 +178,14 @@
     padding-top: 10px;
 
     &__msg {
-      font-size: 14px;
+      @include H6;
+
       color: #9b9b9b;
     }
 
     &__link {
-      font-size: 14px;
+      @include H4;
+
       text-align: center;
       color: #2f9ae0;
       cursor: pointer;
@@ -201,28 +211,28 @@
   }
 
   &__title {
+    @include H5;
+
     margin-bottom: 23px;
     align-self: flex-start;
     color: $scorpion;
-    font-size: 16px;
-    line-height: 21px;
     font-weight: bold;
     display: flex;
     flex: 1;
   }
 
   &__device {
+    @include Paragraph;
+
     margin-bottom: 23px;
     align-self: flex-end;
     color: $scorpion;
-    font-size: 16px;
-    line-height: 21px;
-    font-weight: normal;
     display: flex;
   }
 
   &__item {
-    font-size: 15px;
+    @include Paragraph;
+
     flex-direction: row;
     display: flex;
     padding-left: 10px;
@@ -287,12 +297,12 @@
   margin-top: 10px;
 
   &__button {
+    @include H6;
+
     background: #fff;
     height: 19px;
     display: flex;
     color: #33a4e7;
-    font-size: 14px;
-    line-height: 19px;
     border: none;
     min-width: 46px;
     margin-right: 0;
@@ -343,8 +353,9 @@
   padding: 22px;
 
   a {
+    @include H6;
+
     color: #2f9ae0;
-    font-size: 14px;
     cursor: pointer;
   }
 }

--- a/ui/app/pages/create-account/import-account/index.scss
+++ b/ui/app/pages/create-account/import-account/index.scss
@@ -1,11 +1,11 @@
 .new-account-import-disclaimer {
+  @include H7;
+
   width: 120%;
   background-color: #f4f9fc;
   display: inline-block;
   align-items: center;
   padding: 20px 30px 20px;
-  font-size: 12px;
-  line-height: 1.5;
 }
 
 .new-account-import-form {
@@ -23,9 +23,9 @@
   }
 
   &__select-label {
+    @include Paragraph;
+
     color: $scorpion;
-    font-size: 16px;
-    line-height: 21px;
   }
 
   &__select {
@@ -58,9 +58,9 @@
   }
 
   &__instruction {
+    @include Paragraph;
+
     color: $scorpion;
-    font-size: 16px;
-    line-height: 21px;
     align-self: flex-start;
   }
 
@@ -72,6 +72,8 @@
   }
 
   &__input-password {
+    @include Paragraph;
+
     height: 54px;
     width: 315px;
     border: 1px solid $geyser;
@@ -79,7 +81,6 @@
     background-color: $white;
     margin-top: 16px;
     color: $scorpion;
-    font-size: 16px;
     padding: 0 20px;
   }
 

--- a/ui/app/pages/create-account/index.scss
+++ b/ui/app/pages/create-account/index.scss
@@ -25,10 +25,10 @@
   }
 
   &__title {
+    @include H2;
+
     color: $tundora;
-    font-size: 32px;
     font-weight: 500;
-    line-height: 43px;
     margin-top: 22px;
     margin-left: 29px;
   }
@@ -39,11 +39,11 @@
     margin-top: 10px;
 
     &__tab {
+      @include H4;
+
       height: 54px;
       padding: 15px 10px;
       color: $dusty-gray;
-      font-size: 18px;
-      line-height: 24px;
       text-align: center;
       cursor: pointer;
     }
@@ -70,21 +70,21 @@
   padding: 30px;
 
   &__input-label {
+    @include Paragraph;
+
     color: $scorpion;
-    font-size: 16px;
-    line-height: 21px;
     align-self: flex-start;
   }
 
   &__input {
+    @include Paragraph;
+
     height: 54px;
     width: 315.84px;
     border: 1px solid $geyser;
     border-radius: 4px;
     background-color: $white;
     color: $scorpion;
-    font-size: 16px;
-    line-height: 21px;
     margin-top: 15px;
     padding: 0 20px;
   }

--- a/ui/app/pages/error/index.scss
+++ b/ui/app/pages/error/index.scss
@@ -8,15 +8,17 @@
   height: 100%;
 
   &__header {
+    @include H1;
+
     display: flex;
     justify-content: center;
-    font-size: 42px;
     padding: 10px 0;
     text-align: center;
   }
 
   &__subheader {
-    font-size: 19px;
+    @include H4;
+
     padding: 10px 0;
     width: 100%;
     max-width: 720px;
@@ -24,7 +26,8 @@
   }
 
   &__details {
-    font-size: 18px;
+    @include H4;
+
     overflow-y: auto;
     width: 100%;
     max-width: 720px;

--- a/ui/app/pages/first-time-flow/end-of-flow/index.scss
+++ b/ui/app/pages/first-time-flow/end-of-flow/index.scss
@@ -13,14 +13,16 @@
 
   &__text-1,
   &__text-3 {
+    @include Paragraph;
+
     font-weight: normal;
-    font-size: 16px;
     margin-top: 18px;
   }
 
   &__text-2 {
+    @include Paragraph;
+
     font-weight: bold;
-    font-size: 16px;
     margin-top: 26px;
   }
 
@@ -29,8 +31,9 @@
     margin-bottom: 2px;
 
     @media screen and (max-width: $break-small) {
+      @include H6;
+
       margin-bottom: 16px;
-      font-size: 0.875rem;
     }
   }
 

--- a/ui/app/pages/first-time-flow/index.scss
+++ b/ui/app/pages/first-time-flow/index.scss
@@ -39,7 +39,8 @@
   }
 
   &__header {
-    font-size: 2.5rem;
+    @include H1;
+
     margin-bottom: 24px;
     color: black;
   }
@@ -63,15 +64,17 @@
   }
 
   &__textarea-label {
+    @include H4;
+
     margin-bottom: 9px;
     color: #1b344d;
-    font-size: 18px;
   }
 
   &__textarea {
+    @include Paragraph;
+
     /*rtl:ignore*/
     direction: ltr;
-    font-size: 1rem;
     border: 1px solid #cdcdcd;
     border-radius: 6px;
     background-color: #fff;
@@ -91,28 +94,14 @@
     margin-bottom: 20px;
   }
 
-  &__markdown {
-    border: 1px solid #979797;
-    border-radius: 8px;
-    background-color: $white;
-    height: 200px;
-    overflow-y: auto;
-    color: #757575;
-    font-size: 0.75rem;
-    line-height: 15px;
-    text-align: justify;
-    margin: 0;
-    padding: 16px 20px;
-    height: 30vh;
-  }
-
   &__text-block {
     margin-bottom: 24px;
     color: black;
 
     @media screen and (max-width: $break-small) {
+      @include H6;
+
       margin-bottom: 16px;
-      font-size: 0.875rem;
     }
   }
 
@@ -148,10 +137,8 @@
   }
 
   &__checkbox-label {
-    font-style: normal;
-    font-weight: normal;
-    line-height: normal;
-    font-size: 18px;
+    @include H4;
+
     color: #939090;
     margin-left: 18px;
   }

--- a/ui/app/pages/first-time-flow/metametrics-opt-in/index.scss
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/index.scss
@@ -25,12 +25,10 @@
   }
 
   &__title {
+    @include H1;
+
     position: relative;
     margin-top: 20px;
-    font-style: normal;
-    font-weight: normal;
-    line-height: normal;
-    font-size: 42px;
   }
 
   &__body-graphic {
@@ -42,10 +40,8 @@
   }
 
   &__description {
-    font-style: normal;
-    font-weight: normal;
-    line-height: 21px;
-    font-size: 16px;
+    @include Paragraph;
+
     margin-top: 12px;
   }
 

--- a/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/index.scss
+++ b/ui/app/pages/first-time-flow/seed-phrase/confirm-seed-phrase/index.scss
@@ -58,7 +58,8 @@
     }
 
     @media screen and (max-width: 575px) {
-      font-size: 0.875rem;
+      @include H6;
+
       padding: 6px 18px;
     }
   }

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/index.scss
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/index.scss
@@ -20,8 +20,9 @@
   }
 
   &__secret-words {
+    @include H4;
+
     width: 310px;
-    font-size: 1.25rem;
     text-align: center;
 
     &--hidden {
@@ -45,8 +46,9 @@
   }
 
   &__reveal-button {
+    @include H7;
+
     color: $white;
-    font-size: 0.75rem;
     font-weight: 500;
     text-transform: uppercase;
     margin-top: 8px;

--- a/ui/app/pages/first-time-flow/select-action/index.scss
+++ b/ui/app/pages/first-time-flow/select-action/index.scss
@@ -11,10 +11,8 @@
   }
 
   &__body-header {
-    font-style: normal;
-    font-weight: normal;
-    line-height: 39px;
-    font-size: 28px;
+    @include H3;
+
     text-align: center;
     margin-top: 65px;
     color: black;
@@ -58,20 +56,16 @@
   }
 
   &__button-text-big {
-    font-style: normal;
-    font-weight: normal;
-    line-height: 28px;
-    font-size: 20px;
+    @include H4;
+
     color: #000;
     margin-top: 12px;
     text-align: center;
   }
 
   &__button-text-small {
-    font-style: normal;
-    font-weight: normal;
-    line-height: 20px;
-    font-size: 14px;
+    @include H6;
+
     color: #7a7a7b;
     margin-top: 10px;
     text-align: center;

--- a/ui/app/pages/first-time-flow/welcome/index.scss
+++ b/ui/app/pages/first-time-flow/welcome/index.scss
@@ -17,7 +17,8 @@
   }
 
   &__header {
-    font-size: 28px;
+    @include H3;
+
     margin-bottom: 22px;
     margin-top: 50px;
     text-align: center;
@@ -27,7 +28,7 @@
     text-align: center;
 
     div {
-      font-size: 16px;
+      @include Paragraph;
     }
 
     @media screen and (max-width: 575px) {

--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -27,12 +27,12 @@
   }
 
   &__main-view &__tab {
+    @include H6;
+
     flex-grow: 1;
     color: $Grey-500;
     padding: 16px 8px;
-    font-size: 14px;
     font-weight: 500;
-    line-height: 130%;
   }
 
   &__main-view &__tab--active {
@@ -80,11 +80,12 @@
     }
 
     .popover-footer {
+      @include H6;
+
       border-top: 0;
       justify-content: space-between;
       align-items: center;
       padding-top: 20px;
-      font-size: 14px;
 
       & :only-child {
         margin: 0;

--- a/ui/app/pages/keychains/index.scss
+++ b/ui/app/pages/keychains/index.scss
@@ -70,29 +70,30 @@
 
 .import-account {
   &__title {
+    @include H1;
+
     color: #1b344d;
-    font-size: 40px;
-    line-height: 51px;
     margin-bottom: 10px;
   }
 
   &__back-button {
+    @include Paragraph;
+
     margin-bottom: 18px;
     color: #22232c;
-    font-size: 16px;
-    line-height: 21px;
     position: absolute;
     top: -25px;
   }
 
   &__secret-phrase {
+    @include Paragraph;
+
     height: 190px;
     width: 495px;
     border: 1px solid #cdcdcd;
     border-radius: 6px;
     background-color: #fff;
     padding: 17px;
-    font-size: 16px;
   }
 
   &__secret-phrase::placeholder {
@@ -100,58 +101,16 @@
     font-weight: 200;
   }
 
-  &__faq-link {
-    font-size: 18px;
-    line-height: 23px;
-  }
-
   &__selector-label {
+    @include Paragraph;
+
     color: #1b344d;
-    font-size: 16px;
-  }
-
-  &__dropdown {
-    width: 325px;
-    border: 1px solid #cdcdcd;
-    border-radius: 4px;
-    background-color: #fff;
-    margin-top: 14px;
-    color: #5b5d67;
-    font-size: 18px;
-    line-height: 23px;
-    padding: 14px 21px;
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    cursor: pointer;
-  }
-
-  &__description-text {
-    color: #757575;
-    font-size: 18px;
-    line-height: 23px;
-    margin-top: 21px;
   }
 
   &__input-wrapper {
     display: flex;
     flex-flow: column nowrap;
     margin-top: 30px;
-  }
-
-  &__input-error-message {
-    margin-top: 10px;
-    width: 422px;
-    color: #ff001f;
-    font-size: 16px;
-    line-height: 21px;
-  }
-
-  &__input-label {
-    margin-bottom: 9px;
-    color: #1b344d;
-    font-size: 18px;
-    line-height: 23px;
   }
 
   &__input {
@@ -185,10 +144,8 @@
   }
 
   &__checkbox-label {
-    font-style: normal;
-    font-weight: normal;
-    line-height: normal;
-    font-size: 18px;
+    @include H4;
+
     color: #939090;
     margin-left: 18px;
   }
@@ -197,31 +154,10 @@
     display: none;
   }
 
-  &__file-input-label {
-    height: 53px;
-    width: 148px;
-    border: 1px solid #1b344d;
-    border-radius: 4px;
-    color: #1b344d;
-    font-size: 18px;
-    display: flex;
-    flex-flow: column nowrap;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-  }
-
   &__file-picker-wrapper {
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-  }
-
-  &__file-name {
-    color: #000;
-    font-size: 18px;
-    line-height: 23px;
-    margin-left: 22px;
   }
 }
 
@@ -237,8 +173,9 @@
   }
 
   &__error {
+    @include H6;
+
     color: $crimson;
-    font-size: 14px;
     padding-top: 5px;
   }
 }

--- a/ui/app/pages/permissions-connect/index.scss
+++ b/ui/app/pages/permissions-connect/index.scss
@@ -41,6 +41,5 @@
     grid-column: 2;
     justify-self: end;
     font-weight: bold;
-    line-height: 21px;
   }
 }

--- a/ui/app/pages/permissions-connect/redirect/index.scss
+++ b/ui/app/pages/permissions-connect/redirect/index.scss
@@ -20,11 +20,12 @@
   }
 
   &__center-icon {
+    @include H7;
+
     display: flex;
     position: relative;
     justify-content: center;
     align-items: center;
-    font-size: 12px;
   }
 
   &__check {

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -116,7 +116,6 @@ export default class SendGasRow extends Component {
             }
           }}
         />
-        { this.renderAdvancedOptionsButton() }
       </div>
     )
     const gasFeeDisplay = (
@@ -143,7 +142,6 @@ export default class SendGasRow extends Component {
           customPriceIsSafe
           isSpeedUp={false}
         />
-        { this.renderAdvancedOptionsButton() }
       </div>
     )
     // Tests should behave in same way as mainnet, but are using Localhost
@@ -156,16 +154,19 @@ export default class SendGasRow extends Component {
   }
 
   render () {
-    const { gasFeeError } = this.props
+    const { gasFeeError, gasButtonGroupShown } = this.props
 
     return (
-      <SendRowWrapper
-        label={`${this.context.t('transactionFee')}:`}
-        showError={gasFeeError}
-        errorType="gasFee"
-      >
-        { this.renderContent() }
-      </SendRowWrapper>
+      <>
+        <SendRowWrapper
+          label={`${this.context.t('transactionFee')}:`}
+          showError={gasFeeError}
+          errorType="gasFee"
+        >
+          { this.renderContent() }
+        </SendRowWrapper>
+        {gasButtonGroupShown && <SendRowWrapper>{ this.renderAdvancedOptionsButton() }</SendRowWrapper>}
+      </>
     )
   }
 

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.scss
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.scss
@@ -1,10 +1,11 @@
 .currency-display {
+  @include Paragraph;
+
   height: 54px;
   border: 1px solid $alto;
   border-radius: 4px;
   background-color: $white;
   color: $scorpion;
-  font-size: 16px;
   padding: 8px 10px;
   position: relative;
 
@@ -13,18 +14,18 @@
   }
 
   &__input {
+    @include Paragraph;
+
     color: $scorpion;
-    font-size: 16px;
-    line-height: 22px;
     border: none;
     max-width: 22ch;
   }
 
   &__primary-currency {
+    @include Paragraph;
+
     color: $scorpion;
     font-weight: 400;
-    font-size: 16px;
-    line-height: 22px;
   }
 
   &__converted-row {
@@ -33,9 +34,9 @@
 
   &__converted-value,
   &__converted-currency {
+    @include H7;
+
     color: $dusty-gray;
-    font-size: 12px;
-    line-height: 12px;
   }
 
   &__input-wrapper {

--- a/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-component.test.js
@@ -42,7 +42,8 @@ describe('SendGasRow Component', function () {
     })
 
     it('should render a SendRowWrapper component', function () {
-      assert.equal(wrapper.find(SendRowWrapper).length, 1)
+      assert.equal(wrapper.name(), 'Fragment')
+      assert.equal(wrapper.at(0).find(SendRowWrapper).length, 1)
     })
 
     it('should pass the correct props to SendRowWrapper', function () {
@@ -50,7 +51,7 @@ describe('SendGasRow Component', function () {
         label,
         showError,
         errorType,
-      } = wrapper.find(SendRowWrapper).props()
+      } = wrapper.find(SendRowWrapper).first().props()
 
       assert.equal(label, 'transactionFee_t:')
       assert.equal(showError, true)
@@ -58,7 +59,7 @@ describe('SendGasRow Component', function () {
     })
 
     it('should render a GasFeeDisplay as a child of the SendRowWrapper', function () {
-      assert(wrapper.find(SendRowWrapper).childAt(0).is(GasFeeDisplay))
+      assert(wrapper.find(SendRowWrapper).first().childAt(0).is(GasFeeDisplay))
     })
 
     it('should render the GasFeeDisplay', function () {
@@ -66,7 +67,7 @@ describe('SendGasRow Component', function () {
         gasLoadingError,
         gasTotal,
         onReset,
-      } = wrapper.find(SendRowWrapper).childAt(0).props()
+      } = wrapper.find(SendRowWrapper).first().childAt(0).props()
       assert.equal(gasLoadingError, false)
       assert.equal(gasTotal, 'mockGasTotal')
       assert.equal(propsMethodSpies.resetGasButtons.callCount, 0)
@@ -76,8 +77,8 @@ describe('SendGasRow Component', function () {
 
     it('should render the GasPriceButtonGroup if gasButtonGroupShown is true', function () {
       wrapper.setProps({ gasButtonGroupShown: true })
-      const rendered = wrapper.find(SendRowWrapper).childAt(0)
-      assert.equal(rendered.children().length, 2)
+      const rendered = wrapper.find(SendRowWrapper).first().childAt(0)
+      assert.equal(wrapper.children().length, 2)
 
       const gasPriceButtonGroup = rendered.childAt(0)
       assert(gasPriceButtonGroup.is(GasPriceButtonGroup))
@@ -89,10 +90,10 @@ describe('SendGasRow Component', function () {
 
     it('should render an advanced options button if gasButtonGroupShown is true', function () {
       wrapper.setProps({ gasButtonGroupShown: true })
-      const rendered = wrapper.find(SendRowWrapper).childAt(0)
-      assert.equal(rendered.children().length, 2)
+      const rendered = wrapper.find(SendRowWrapper).last()
+      assert.equal(wrapper.children().length, 2)
 
-      const advancedOptionsButton = rendered.childAt(1)
+      const advancedOptionsButton = rendered.childAt(0)
       assert.equal(advancedOptionsButton.text(), 'advancedOptions_t')
 
       assert.equal(propsMethodSpies.showCustomizeGasModal.callCount, 0)

--- a/ui/app/pages/send/send.scss
+++ b/ui/app/pages/send/send.scss
@@ -14,11 +14,10 @@
     }
 
     .page-container__header-close-text {
-      font-size: 1rem;
-      line-height: 1.1875rem;
+      @include H5;
+
       position: absolute;
       right: 1rem;
-      top: 6px;
       width: min-content;
     }
   }
@@ -50,10 +49,11 @@
       overflow-y: auto;
 
       &__link {
+        @include Paragraph;
+
         @extend %row-nowrap;
 
         padding: 1rem;
-        font-size: 1rem;
         border-bottom: 1px solid $alto;
         align-items: center;
         justify-content: flex-start;
@@ -78,8 +78,8 @@
       @extend %col-nowrap;
 
       &__load-more {
-        font-size: 0.75rem;
-        line-height: 1.0625rem;
+        @include H7;
+
         padding: 0.5rem;
         text-align: center;
         border-bottom: 1px solid $alto;
@@ -96,7 +96,6 @@
 
       background-color: $Grey-000;
       color: $Grey-600;
-      line-height: 0.875rem;
       padding: 0.5rem 1rem;
       border-bottom: 1px solid $alto;
 
@@ -131,8 +130,8 @@
       }
 
       &__title {
-        font-size: 0.875rem;
-        line-height: 1.25rem;
+        @include H6;
+
         color: $black;
       }
 
@@ -230,9 +229,8 @@
         &__input {
           @extend %col-nowrap;
 
-          font-size: 0.75rem;
-          line-height: 0.75rem;
-          font-weight: 400;
+          @include H7;
+
           color: $Blue-500;
         }
       }
@@ -241,13 +239,14 @@
 
   &__selected-input {
     &__title {
-      @extend %ellipsify;
+      @include H6;
 
-      font-size: 0.875rem;
+      @extend %ellipsify;
     }
 
     &__subtitle {
-      font-size: 0.75rem;
+      @include H7;
+
       color: $Grey-500;
       margin-top: 0.25rem;
     }

--- a/ui/app/pages/settings/alerts-tab/alerts-tab.scss
+++ b/ui/app/pages/settings/alerts-tab/alerts-tab.scss
@@ -1,9 +1,10 @@
 .alerts-tab {
   &__body {
+    @include H6;
+
     display: grid;
     grid-template-columns: 8fr 30px max-content;
     grid-template-rows: 1fr 1fr;
-    font-size: 14px;
     align-items: center;
   }
 

--- a/ui/app/pages/settings/contact-list-tab/index.scss
+++ b/ui/app/pages/settings/contact-list-tab/index.scss
@@ -33,10 +33,8 @@
   &__header,
   &__header--edit {
     &__name {
-      font-style: normal;
-      font-weight: normal;
-      font-size: 24px;
-      line-height: 34px;
+      @include H3;
+
       margin-left: 24px;
     }
   }
@@ -46,18 +44,20 @@
     justify-content: space-between;
 
     .button {
+      @include H6;
+
       justify-content: flex-end;
       color: $accent-red;
-      font-size: 14px;
     }
   }
 
   &__input {
+    @include H4;
+
     border: 2px solid $Grey-200;
     border-radius: 6px;
     color: $Grey-800;
     padding: 0.875rem 1rem;
-    font-size: 1.125rem;
 
     &:focus-within {
       border-color: $Blue-500;
@@ -66,7 +66,7 @@
     margin-top: 0.25rem;
 
     &--address {
-      font-size: 0.875rem;
+      @include H6;
     }
   }
 
@@ -86,7 +86,8 @@
 
       &__label,
       &__label--capitalized {
-        font-size: 0.75rem;
+        @include H7;
+
         color: $Grey-500;
         margin-bottom: 0.25rem;
       }
@@ -97,14 +98,15 @@
 
       &__value,
       &__static-address {
+        @include H4;
+
         display: flex;
         flex-flow: row nowrap;
-        font-size: 1.125rem;
         color: $Grey-800;
         word-break: break-word;
 
         &--address {
-          font-size: 0.875rem;
+          @include H6;
         }
 
         &--copy-icon {
@@ -119,7 +121,7 @@
       }
 
       &__static-address {
-        font-size: 0.875rem;
+        @include H6;
 
         &--copy-icon {
           cursor: pointer;
@@ -168,8 +170,8 @@
     }
 
     &__error {
-      font-size: 12px;
-      line-height: 12px;
+      @include H7;
+
       left: 8px;
       color: $red;
     }
@@ -186,10 +188,8 @@
     }
 
     &__header {
-      font-style: normal;
-      font-weight: normal;
-      font-size: 18px;
-      line-height: 25px;
+      @include H4;
+
       color: #000;
     }
 
@@ -199,10 +199,8 @@
     }
 
     &__text {
-      font-style: normal;
-      font-weight: normal;
-      font-size: 14px;
-      line-height: 20px;
+      @include Paragraph;
+
       color: #6a737d;
     }
 

--- a/ui/app/pages/settings/index.scss
+++ b/ui/app/pages/settings/index.scss
@@ -18,15 +18,17 @@
     flex: 0 0 auto;
 
     &__title {
+      @include H3;
+
       flex: 1 0 auto;
-      font-size: 24px;
     }
   }
 
   &__subheader,
   &__subheader--link {
+    @include H4;
+
     padding: 16px 4px;
-    font-size: 20px;
     border-bottom: 1px solid $alto;
     margin-right: 24px;
     height: 72px;
@@ -70,12 +72,11 @@
   }
 
   &__sub-header-text {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 20px;
+    @include H4;
 
     @media screen and (max-width: 575px) {
-      font-size: 16px;
+      @include H5;
+
       width: 100%;
     }
   }
@@ -186,7 +187,8 @@
   }
 
   &__content-description {
-    font-size: 14px;
+    @include H6;
+
     color: $dusty-gray;
     padding-top: 5px;
   }
@@ -212,8 +214,8 @@
   }
 
   &__address-book-button {
-    font-size: 1rem;
-    line-height: 1.1875rem;
+    @include H5;
+
     padding: 0;
   }
 

--- a/ui/app/pages/settings/info-tab/index.scss
+++ b/ui/app/pages/settings/info-tab/index.scss
@@ -35,8 +35,9 @@
   }
 
   &__version-number {
+    @include H6;
+
     padding-top: 5px;
-    font-size: 13px;
     color: $dusty-gray;
   }
 

--- a/ui/app/pages/settings/networks-tab/index.scss
+++ b/ui/app/pages/settings/networks-tab/index.scss
@@ -84,6 +84,8 @@
     }
 
     &--warning {
+      @include H7;
+
       background-color: #fefae8;
       border: 1px solid #ffd33d;
       width: 93%;
@@ -91,15 +93,12 @@
       box-sizing: border-box;
       padding: 12px;
       margin: 12px 0;
-      font-size: 12px;
     }
   }
 
   &__network-form-label {
-    font-style: normal;
-    font-weight: normal;
-    font-size: 14px;
-    line-height: 20px;
+    @include H6;
+
     color: #000;
   }
 
@@ -137,7 +136,6 @@
     .button {
       width: 138px;
       padding: 10px;
-      line-height: 20px;
     }
 
     @media screen and (max-width: 575px) {
@@ -175,11 +173,9 @@
   }
 
   &__networks-list-name {
+    @include Paragraph;
+
     margin-left: 11px;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 16px;
-    line-height: 23px;
     color: #6a737d;
 
     &:hover {

--- a/ui/app/pages/unlock-page/index.scss
+++ b/ui/app/pages/unlock-page/index.scss
@@ -21,8 +21,9 @@
   }
 
   &__title {
+    @include H2;
+
     margin-top: 5px;
-    font-size: 2rem;
     font-weight: 800;
     color: $tundora;
   }


### PR DESCRIPTION
Attempt at normalizing all existing font styles to use our typography settings from the design system. I have added comments to all lines that I believe to result in changes to the presentation of the extension with screenshots of the changes

depends on:
1. ~#9018~
2. ~#9071~
3. ~#9072~
4. ~#9073~ 