### PR TITLE
Fix popup/notification when browser is in fullscreen, primarily on macOS.

### DIFF
--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -56,7 +56,8 @@ export default class NotificationManager {
       })
 
       // Firefox currently ignores left/top for create, but it works for update
-      if (popupWindow.left !== left) {
+      if (popupWindow.left !== left && popupWindow.state !== 'fullscreen') {
+      // if (popupWindow.left !== left) {
         await this.platform.updateWindowPosition(popupWindow.id, left, top)
       }
       this._popupId = popupWindow.id

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -57,7 +57,6 @@ export default class NotificationManager {
 
       // Firefox currently ignores left/top for create, but it works for update
       if (popupWindow.left !== left && popupWindow.state !== 'fullscreen') {
-      // if (popupWindow.left !== left) {
         await this.platform.updateWindowPosition(popupWindow.id, left, top)
       }
       this._popupId = popupWindow.id


### PR DESCRIPTION
The issue was reported internally via Slack. User was running macOS Chrome in fullscreen mode where Chrome is created in a new Desktop workspace.

The issue reproduced on macOS Chrome in fullscreen/maximized view overrides the explicitly set width and height for `windows.create()`. Possibly not overrides, but creates a window based off of the window that it was created from. Related Chrome bugs [<sup id="chromebug1">1</sup>](#fn1) [<sup id="chromebug2">2</sup>](#fn2)

The fullscreen `popup.left` pixel will calculate the window position incorrectly since we set and assume the width of the created window. The incorrect `left` position the window and transition the focus Desktop/Workspace incorrectly and make it seem to lose focus of the new window/workspace. Incidentally this will make the popup full width/height, and create a new workspace for the view, which we have no control over until Chrome fixes it.

This will check if the popup is 'fullscreen', which it gets passed from the origin window, if so then don't reposition the window. If Chrome fixes the issue we can revert this change.

Screenshots are of the inconsistent scoped window attributes on Chrome and Firefox. Both are in Fullscreen/Desktop/Workspace and initiating a Connect Request, or any action that triggers popup/notification ui.

<details>
<summary>Chrome lastFocused</summary>
<img width="500" height='400' alt="Screen Shot 2020-07-24 at 1 38 28 PM" src="https://user-images.githubusercontent.com/13376180/88438245-20248a00-cdbd-11ea-9639-f88c3ed5b03e.png">
</details>

<details>
<summary>Firefox lastFocused</summary>
<img width="330" height='200' alt="Screen Shot 2020-07-24 at 1 41 59 PM" src="https://user-images.githubusercontent.com/13376180/88437662-ccfe0780-cdbb-11ea-8de2-572f7551fff5.png">
</details>

<details>
<summary>Chrome created popupWindow</summary>
<img width="550" height="400" alt="Screen Shot 2020-07-24 at 1 39 23 PM" src="https://user-images.githubusercontent.com/13376180/88438277-2c104c00-cdbd-11ea-9e8c-0e79ae6cba52.png">
</details>

<details>
<summary>Firefox created popupWindow</summary>
<img width="330" height='260' alt="Screen Shot 2020-07-24 at 1 42 19 PM" src="https://user-images.githubusercontent.com/13376180/88437709-e010d780-cdbb-11ea-88c2-e3069b9021b3.png">
</details>

1. <span id="fn1"></span>[Bug 1](https://bugs.chromium.org/p/chromium/issues/detail?id=263092&q=window%20create%20width%20os%3DMac&can=2)

2. <span id="fn2"></span>[Bug 2](https://bugs.chromium.org/p/chromium/issues/detail?id=1018500&q=window%20create%20width%20os%3DMac&can=2)

