### PR TITLE
support longer text in network dropdown

### DIFF
--- a/ui/app/css/itcss/components/network.scss
+++ b/ui/app/css/itcss/components/network.scss
@@ -175,7 +175,7 @@
 }
 
 .network-dropdown-content {
-  height: 36px;
+  min-height: 36px;
   width: 265px;
   color: $dusty-gray;
   font-family: Roboto;


### PR DESCRIPTION
Fixes #6587

Verifying the issue was still active led to changing one line of css to fix the issue.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/4448075/88575044-e2b43c80-d008-11ea-888e-4e0c98212f73.png" />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/4448075/88575121-fb245700-d008-11ea-9557-73eb84cc5ca3.png" />
</details>