### PR TITLE
Fix timing-reliant network controller test

### DIFF
--- a/test/unit/app/controllers/network/network-controller-test.js
+++ b/test/unit/app/controllers/network/network-controller-test.js
@@ -18,7 +18,6 @@ describe('NetworkController', function () {
         .reply(200)
 
       networkController = new NetworkController()
-      networkController.initializeProvider(networkControllerProviderConfig)
     })
 
     afterEach(function () {
@@ -37,7 +36,6 @@ describe('NetworkController', function () {
 
     describe('#getNetworkState', function () {
       it('should return loading when new', function () {
-        networkController = new NetworkController()
         const networkState = networkController.getNetworkState()
         assert.equal(networkState, 'loading', 'network is loading')
       })
@@ -53,11 +51,13 @@ describe('NetworkController', function () {
 
     describe('#setProviderType', function () {
       it('should update provider.type', function () {
+        networkController.initializeProvider(networkControllerProviderConfig)
         networkController.setProviderType('mainnet')
         const type = networkController.getProviderConfig().type
         assert.equal(type, 'mainnet', 'provider type is updated')
       })
       it('should set the network to loading', function () {
+        networkController.initializeProvider(networkControllerProviderConfig)
         networkController.setProviderType('mainnet')
         const loading = networkController.isNetworkLoading()
         assert.ok(loading, 'network is loading')

--- a/test/unit/app/controllers/network/network-controller-test.js
+++ b/test/unit/app/controllers/network/network-controller-test.js
@@ -35,7 +35,7 @@ describe('NetworkController', function () {
     })
 
     describe('#getNetworkState', function () {
-      it('should return loading when new', function () {
+      it('should return "loading" when new', function () {
         const networkState = networkController.getNetworkState()
         assert.equal(networkState, 'loading', 'network is loading')
       })

--- a/test/unit/app/controllers/network/network-controller-test.js
+++ b/test/unit/app/controllers/network/network-controller-test.js
@@ -34,8 +34,10 @@ describe('NetworkController', function () {
         assert.equal(providerProxy.test, true)
       })
     })
+
     describe('#getNetworkState', function () {
       it('should return loading when new', function () {
+        networkController = new NetworkController()
         const networkState = networkController.getNetworkState()
         assert.equal(networkState, 'loading', 'network is loading')
       })


### PR DESCRIPTION
This PR prevents timing-related shenanigans for a single network controller test case, a problem exposed by #9058.