### PR TITLE
json-rpc-engine@5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "fuse.js": "^3.2.0",
     "human-standard-token-abi": "^2.0.0",
     "jazzicon": "^2.0.0",
-    "json-rpc-engine": "^5.1.8",
+    "json-rpc-engine": "^5.2.0",
     "json-rpc-middleware-stream": "^2.1.1",
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15765,6 +15765,14 @@ json-rpc-engine@^5.1.3, json-rpc-engine@^5.1.5, json-rpc-engine@^5.1.8:
     promise-to-callback "^1.0.0"
     safe-event-emitter "^1.0.1"
 
+json-rpc-engine@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-5.2.0.tgz#0ea1162f56de53a41d47a4995168b56dc82bbf47"
+  integrity sha512-F9xjrIjMqPNCxzk9jtOgJMs9mt+80p03IbJALnO278grtSU+Sh/fSqb7gNk/gwlTxavO2+ABKenyz4ZP3kwKIQ==
+  dependencies:
+    eth-rpc-errors "^2.1.1"
+    safe-event-emitter "^1.0.1"
+
 json-rpc-error@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/json-rpc-error/-/json-rpc-error-2.0.0.tgz#a7af9c202838b5e905c7250e547f1aff77258a02"


### PR DESCRIPTION
It's faster, it's better, it's stronger; it's `json-rpc-engine@5.2.0`!

Lots of under-the-hood improvements, and `async` `engine.handle`, so that you can do e.g. `const result = await engine.handle(request)`.