### PR TITLE
Use development metametrics project during tests

### DIFF
--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -2,7 +2,7 @@
 
 import ethUtil from 'ethereumjs-util'
 
-const inDevelopment = process.env.NODE_ENV === 'development'
+const inDevelopment = process.env.METAMASK_DEBUG || process.env.IN_TEST
 
 const METAMETRICS_BASE_URL = 'https://chromeextensionmm.innocraft.cloud/piwik.php'
 const METAMETRICS_REQUIRED_PARAMS = `?idsite=${inDevelopment ? 1 : 2}&rec=1&apiv=1`


### PR DESCRIPTION
e2e tests will now reference the development MetaMetrics project instead of the production one. The metrics endpoint should be stubbed out during e2e tests anyway, but this seemed like a better default regardless.