### PR TITLE
Use environment variable for MetaMetrics project ID

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -334,6 +334,7 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
     bundler.transform(envify({
       METAMASK_DEBUG: opts.devMode,
       METAMASK_ENVIRONMENT: environment,
+      METAMETRICS_PROJECT_ID: process.env.METAMETRICS_PROJECT_ID,
       NODE_ENV: opts.devMode ? 'development' : 'production',
       IN_TEST: opts.testing ? 'true' : false,
       PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY || '',

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -4,8 +4,13 @@ import ethUtil from 'ethereumjs-util'
 
 const inDevelopment = process.env.NODE_ENV === 'development'
 
+let projectId = process.env.METAMETRICS_PROJECT_ID
+if (!projectId) {
+  projectId = inDevelopment ? 1 : 2
+}
+
 const METAMETRICS_BASE_URL = 'https://chromeextensionmm.innocraft.cloud/piwik.php'
-const METAMETRICS_REQUIRED_PARAMS = `?idsite=${inDevelopment ? 1 : 2}&rec=1&apiv=1`
+const METAMETRICS_REQUIRED_PARAMS = `?idsite=${projectId}&rec=1&apiv=1`
 const METAMETRICS_BASE_FULL = METAMETRICS_BASE_URL + METAMETRICS_REQUIRED_PARAMS
 
 const METAMETRICS_TRACKING_URL = inDevelopment


### PR DESCRIPTION
The MetaMetrics project ID can now be set via environment variable. It has not been set yet in practice, so for now the old project IDs will still be used. This is in preparation for migrating to a new project.