### PR TITLE
Disable Sentry in development

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -72,7 +72,9 @@ export const SENTRY_STATE = {
 export default function setupSentry ({ release, getState }) {
   let sentryTarget
 
-  if (METAMASK_DEBUG || process.env.IN_TEST) {
+  if (METAMASK_DEBUG) {
+    return
+  } else if (process.env.IN_TEST) {
     console.log(`Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN_DEV`)
     sentryTarget = SENTRY_DSN_DEV
   } else {


### PR DESCRIPTION
In a non-production environment, Sentry was configured to send error reports to a "test" MetaMask project. It will still do this during e2e tests, but in development Sentry is now disabled completely.

In practice this was never useful in development.