### PR TITLE
Use environment variable for production Sentry DSN

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -5,7 +5,6 @@ import extractEthjsErrorMessage from './extractEthjsErrorMessage'
 
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG
 const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT
-const SENTRY_DSN_PROD = 'https://3567c198f8a8412082d32655da2961d0@sentry.io/273505'
 const SENTRY_DSN_DEV = 'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496'
 
 // This describes the subset of Redux state attached to errors sent to Sentry
@@ -74,12 +73,15 @@ export default function setupSentry ({ release, getState }) {
 
   if (METAMASK_DEBUG) {
     return
-  } else if (process.env.IN_TEST) {
+  } else if (METAMASK_ENVIRONMENT === 'production') {
+    if (!process.env.SENTRY_DSN) {
+      throw new Error(`Missing SENTRY_DSN environment variable in production environment`)
+    }
+    console.log(`Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN`)
+    sentryTarget = process.env.SENTRY_DSN
+  } else {
     console.log(`Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN_DEV`)
     sentryTarget = SENTRY_DSN_DEV
-  } else {
-    console.log(`Setting up Sentry Remote Error Reporting for '${METAMASK_ENVIRONMENT}': SENTRY_DSN_PROD`)
-    sentryTarget = SENTRY_DSN_PROD
   }
 
   Sentry.init({

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -330,6 +330,10 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
       environment = 'other'
     }
 
+    if (environment === 'production' && !process.env.SENTRY_DSN) {
+      throw new Error('Missing SENTRY_DSN environment variable')
+    }
+
     // Inject variables into bundle
     bundler.transform(envify({
       METAMASK_DEBUG: opts.devMode,
@@ -341,6 +345,7 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
       PUBNUB_PUB_KEY: process.env.PUBNUB_PUB_KEY || '',
       ETH_GAS_STATION_API_KEY: process.env.ETH_GAS_STATION_API_KEY || '',
       CONF: opts.devMode ? conf : ({}),
+      SENTRY_DSN: process.env.SENTRY_DSN,
     }), {
       global: true,
     })


### PR DESCRIPTION
The Sentry DSN is now expected to be provided via environment variable for production builds. The build script will fail if it is missing, and an error will be thrown at runtime if it is missing.

The `SENTRY_DSN` environment variable has been set in CI to the old value for `SENTRY_PROD_DSN`. We can migrate to a new DSN at some point in the future.