### PR TITLE
Use async/await for getRestrictedMethods

### DIFF
--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -1,34 +1,30 @@
 export default function getRestrictedMethods ({ getIdentities, getKeyringAccounts }) {
   return {
     'eth_accounts': {
-      method: (_, res, __, end) => {
-        getKeyringAccounts()
-          .then((accounts) => {
-            const identities = getIdentities()
-            res.result = accounts
-              .sort((firstAddress, secondAddress) => {
-                if (!identities[firstAddress]) {
-                  throw new Error(`Missing identity for address ${firstAddress}`)
-                } else if (!identities[secondAddress]) {
-                  throw new Error(`Missing identity for address ${secondAddress}`)
-                } else if (identities[firstAddress].lastSelected === identities[secondAddress].lastSelected) {
-                  return 0
-                } else if (identities[firstAddress].lastSelected === undefined) {
-                  return 1
-                } else if (identities[secondAddress].lastSelected === undefined) {
-                  return -1
-                }
+      method: async (_, res, __, end) => {
+        try {
+          const accounts = await getKeyringAccounts()
+          const identities = getIdentities()
+          res.result = accounts.sort((firstAddress, secondAddress) => {
+            if (!identities[firstAddress]) {
+              throw new Error(`Missing identity for address ${firstAddress}`)
+            } else if (!identities[secondAddress]) {
+              throw new Error(`Missing identity for address ${secondAddress}`)
+            } else if (identities[firstAddress].lastSelected === identities[secondAddress].lastSelected) {
+              return 0
+            } else if (identities[firstAddress].lastSelected === undefined) {
+              return 1
+            } else if (identities[secondAddress].lastSelected === undefined) {
+              return -1
+            }
 
-                return identities[secondAddress].lastSelected - identities[firstAddress].lastSelected
-              })
-            end()
+            return identities[secondAddress].lastSelected - identities[firstAddress].lastSelected
           })
-          .catch(
-            (err) => {
-              res.error = err
-              end(err)
-            },
-          )
+          end()
+        } catch (err) {
+          res.error = err
+          end(err)
+        }
       },
     },
   }


### PR DESCRIPTION
This PR updates `getRestrictedMethods` to use async/await in line with most of the background scripts.

The result of the method call (which is now `Promise<undefined>` instead of `undefined`) is not used by rpc-cap.<sup>[\[1\]](https://github.com/MetaMask/rpc-cap/blob/23561a5d4369613900bece54b6f8b4de13f5585e/index.ts#L210)</sup>

([_Hide whitespace changes_](https://user-images.githubusercontent.com/1623628/88818224-0a3a0f00-d199-11ea-95ba-8897e05ab514.png) might be useful for this diff.)