### PR TITLE
Use async/await for seedPhraseVerifier.verifyAccounts

### DIFF
--- a/app/scripts/lib/seed-phrase-verifier.js
+++ b/app/scripts/lib/seed-phrase-verifier.js
@@ -16,41 +16,33 @@ const seedPhraseVerifier = {
    * @returns {Promise<void>} - Promises undefined
    *
   */
-  verifyAccounts (createdAccounts, seedWords) {
+  async verifyAccounts (createdAccounts, seedWords) {
+    if (!createdAccounts || createdAccounts.length < 1) {
+      throw new Error('No created accounts defined.')
+    }
 
-    return new Promise((resolve, reject) => {
+    const keyringController = new KeyringController({})
+    const Keyring = keyringController.getKeyringClassForType('HD Key Tree')
+    const opts = {
+      mnemonic: seedWords,
+      numberOfAccounts: createdAccounts.length,
+    }
 
-      if (!createdAccounts || createdAccounts.length < 1) {
-        return reject(new Error('No created accounts defined.'))
+    const keyring = new Keyring(opts)
+    const restoredAccounts = await keyring.getAccounts()
+    log.debug('Created accounts: ' + JSON.stringify(createdAccounts))
+    log.debug('Restored accounts: ' + JSON.stringify(restoredAccounts))
+
+    if (restoredAccounts.length !== createdAccounts.length) {
+      // this should not happen...
+      throw new Error('Wrong number of accounts')
+    }
+
+    for (let i = 0; i < restoredAccounts.length; i++) {
+      if (restoredAccounts[i].toLowerCase() !== createdAccounts[i].toLowerCase()) {
+        throw new Error('Not identical accounts! Original: ' + createdAccounts[i] + ', Restored: ' + restoredAccounts[i])
       }
-
-      const keyringController = new KeyringController({})
-      const Keyring = keyringController.getKeyringClassForType('HD Key Tree')
-      const opts = {
-        mnemonic: seedWords,
-        numberOfAccounts: createdAccounts.length,
-      }
-
-      const keyring = new Keyring(opts)
-      keyring.getAccounts()
-        .then((restoredAccounts) => {
-
-          log.debug('Created accounts: ' + JSON.stringify(createdAccounts))
-          log.debug('Restored accounts: ' + JSON.stringify(restoredAccounts))
-
-          if (restoredAccounts.length !== createdAccounts.length) {
-            // this should not happen...
-            return reject(new Error('Wrong number of accounts'))
-          }
-
-          for (let i = 0; i < restoredAccounts.length; i++) {
-            if (restoredAccounts[i].toLowerCase() !== createdAccounts[i].toLowerCase()) {
-              return reject(new Error('Not identical accounts! Original: ' + createdAccounts[i] + ', Restored: ' + restoredAccounts[i]))
-            }
-          }
-          return resolve()
-        })
-    })
+    }
   },
 }
 


### PR DESCRIPTION
This PR updates `seedPhraseVerifier.verifyAccounts` to use async/await in line with most of the background scripts.

The result of the method call (which is now `Promise<undefined>` instead of `undefined`) is not used by its call site.<sup>[\[1\]](https://github.com/MetaMask/metamask-extension/blob/b001da2df86f972ea9da83f425c9b3a27aeb3043/app/scripts/metamask-controller.js#L1001)</sup>

([_Hide whitespace changes_](https://user-images.githubusercontent.com/1623628/88818224-0a3a0f00-d199-11ea-95ba-8897e05ab514.png) might be useful for this diff.)