### PR TITLE
Add `build-artifacts` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ builds.zip
 
 test-artifacts
 test-builds
+build-artifacts
 
 #ignore css output and sourcemaps
 ui/app/css/output/


### PR DESCRIPTION
The `build-artifacts` directory is created on CI (as of #7151), and is used to store the sesify visualization and dependency logs. It's useful to have this ignored locally as well, for when those scripts are being tested.