### PR TITLE
Update `gulp-rename` from v1.4.0 to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "gulp-imagemin": "^6.1.0",
     "gulp-livereload": "4.0.0",
     "gulp-multi-process": "^1.3.1",
-    "gulp-rename": "^1.4.0",
+    "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "gulp-rtlcss": "^1.4.0",
     "gulp-sass": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12874,10 +12874,10 @@ gulp-multi-process@^1.3.1:
   dependencies:
     async.queue "^0.5.2"
 
-gulp-rename@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
-  integrity sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==
+gulp-rename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-2.0.0.tgz#9bbc3962b0c0f52fc67cd5eaff6c223ec5b9cf6c"
+  integrity sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==
 
 gulp-replace@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The changes between these versions don't affect us. The breaking change was related to passing in a function to `gulp-rename`, which we don't do.