### PR TITLE
Update source map validator target files

### DIFF
--- a/development/sourcemap-validator.js
+++ b/development/sourcemap-validator.js
@@ -20,7 +20,15 @@ start().catch((error) => {
 
 
 async function start () {
-  const targetFiles = [`inpage.js`, `contentscript.js`, `ui.js`, `background.js`]
+  const targetFiles = [
+    `background.js`,
+    // `bg-libs`, skipped because source maps are invalid due to browserify bug: https://github.com/browserify/browserify/issues/1971
+    // `contentscript.js`, skipped because the validator is erroneously sampling the inlined `inpage.js` script
+    `inpage.js`,
+    'phishing-detect.js',
+    `ui.js`,
+    // `ui-libs.js`, skipped because source maps are invalid due to browserify bug: https://github.com/browserify/browserify/issues/1971
+  ]
   let valid = true
 
   for (const buildName of targetFiles) {


### PR DESCRIPTION
All JavaScript files included in the final bundle are now listed as target files. The `phishing-detect.js` file is the only new file to be validated that was not validated before.

Any files that are expected to fail validation are commented out, with a note explaining why they're expected to fail.