### PR TITLE
Adds useUserPreferencedCurrencyDisplays hook and applies it to asset-list.js

### DIFF
--- a/ui/app/components/app/asset-list/asset-list.js
+++ b/ui/app/components/app/asset-list/asset-list.js
@@ -9,6 +9,7 @@ import AssetListItem from '../asset-list-item'
 import { useMetricEvent } from '../../../hooks/useMetricEvent'
 import { useUserPreferencedCurrencyDisplays } from '../../../hooks/useUserPreferencedCurrencyDisplays'
 import { getCurrentAccountWithSendEtherInfo, getNativeCurrency, getShouldShowFiat } from '../../../selectors'
+import { PRIMARY, SECONDARY } from '../../../helpers/constants/common'
 
 const AssetList = ({ onClickAsset }) => {
   const history = useHistory()
@@ -30,10 +31,8 @@ const AssetList = ({ onClickAsset }) => {
     },
   })
 
-  const { primaryCurrencyDisplay, secondaryCurrencyDisplay } = useUserPreferencedCurrencyDisplays(selectedAccountBalance, {
-    primaryPreferenceOpts: { ethNumberOfDecimals: 4 },
-    secondaryPreferenceOpts: { ethNumberOfDecimals: 4 },
-  })
+  const primaryCurrencyDisplay = useUserPreferencedCurrencyDisplays(selectedAccountBalance, PRIMARY, { numberOfDecimals: 4 })
+  const secondaryCurrencyDisplay = useUserPreferencedCurrencyDisplays(selectedAccountBalance, SECONDARY, { numberOfDecimals: 4 })
 
   return (
     <>

--- a/ui/app/components/app/asset-list/asset-list.js
+++ b/ui/app/components/app/asset-list/asset-list.js
@@ -6,11 +6,9 @@ import AddTokenButton from '../add-token-button'
 import TokenList from '../token-list'
 import { ADD_TOKEN_ROUTE } from '../../../helpers/constants/routes'
 import AssetListItem from '../asset-list-item'
-import { PRIMARY, SECONDARY } from '../../../helpers/constants/common'
 import { useMetricEvent } from '../../../hooks/useMetricEvent'
-import { useUserPreferencedCurrency } from '../../../hooks/useUserPreferencedCurrency'
+import { useUserPreferencedCurrencyDisplays } from '../../../hooks/useUserPreferencedCurrencyDisplays'
 import { getCurrentAccountWithSendEtherInfo, getNativeCurrency, getShouldShowFiat } from '../../../selectors'
-import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay'
 
 const AssetList = ({ onClickAsset }) => {
   const history = useHistory()
@@ -32,24 +30,10 @@ const AssetList = ({ onClickAsset }) => {
     },
   })
 
-  const {
-    currency: primaryCurrency,
-    numberOfDecimals: primaryNumberOfDecimals,
-  } = useUserPreferencedCurrency(PRIMARY, { ethNumberOfDecimals: 4 })
-  const {
-    currency: secondaryCurrency,
-    numberOfDecimals: secondaryNumberOfDecimals,
-  } = useUserPreferencedCurrency(SECONDARY, { ethNumberOfDecimals: 4 })
-
-  const [primaryCurrencyDisplay] = useCurrencyDisplay(
-    selectedAccountBalance,
-    { numberOfDecimals: primaryNumberOfDecimals, currency: primaryCurrency },
-  )
-
-  const [secondaryCurrencyDisplay] = useCurrencyDisplay(
-    selectedAccountBalance,
-    { numberOfDecimals: secondaryNumberOfDecimals, currency: secondaryCurrency },
-  )
+  const { primaryCurrencyDisplay, secondaryCurrencyDisplay } = useUserPreferencedCurrencyDisplays(selectedAccountBalance, {
+    primaryPreferenceOpts: { ethNumberOfDecimals: 4 },
+    secondaryPreferenceOpts: { ethNumberOfDecimals: 4 },
+  })
 
   return (
     <>

--- a/ui/app/hooks/tests/useUserPreferencedCurrencyDisplays.test.js
+++ b/ui/app/hooks/tests/useUserPreferencedCurrencyDisplays.test.js
@@ -1,0 +1,95 @@
+import assert from 'assert'
+import { renderHook } from '@testing-library/react-hooks'
+import * as reactRedux from 'react-redux'
+import { useUserPreferencedCurrencyDisplays } from '../useUserPreferencedCurrencyDisplays'
+import sinon from 'sinon'
+import { getCurrentCurrency, getNativeCurrency, getConversionRate, getPreferences, getShouldShowFiat } from '../../selectors'
+
+const tests = [
+  {
+    state: {
+      preferences: {
+        useNativeCurrencyAsPrimaryCurrency: true,
+        nativeCurrency: 'ETH',
+        showFiat: true,
+      },
+    },
+    input: {
+      value: '0x10f699ca86b32800',
+    },
+    result: {
+      primaryCurrencyDisplay: '1.222333 ETH',
+      secondaryCurrencyDisplay: '$342.80 USD',
+    },
+  },
+  {
+    state: {
+      preferences: {
+        useNativeCurrencyAsPrimaryCurrency: true,
+        nativeCurrency: 'ETH',
+        showFiat: true,
+      },
+    },
+    input: {
+      value: '0x10f699ca86b32800',
+      primaryPreferenceOpts: { ethNumberOfDecimals: 4 },
+    },
+    result: {
+      primaryCurrencyDisplay: '1.2223 ETH',
+      secondaryCurrencyDisplay: '$342.80 USD',
+    },
+  },
+  {
+    state: {
+      preferences: {
+        useNativeCurrencyAsPrimaryCurrency: false,
+        nativeCurrency: 'BTC',
+        showFiat: true,
+        conversionRate: 50,
+        currentCurrency: 'eth',
+      },
+    },
+    input: {
+      value: '0x10f699ca86b32800',
+      primaryPreferenceOpts: { numberOfDecimals: 4 },
+      secondaryPreferenceOpts: { numberOfDecimals: 2 },
+      primaryCurrencyOpts: { prefix: '!!!' },
+      secondaryCurrencyOpts: { prefix: '!!!' },
+    },
+    result: {
+      primaryCurrencyDisplay: '!!!61.1167 ETH',
+      secondaryCurrencyDisplay: '!!!1.22Ƀ BTC',
+    },
+  },
+]
+
+
+describe('useUserPreferencedCurrencyDisplays', function () {
+  tests.forEach(({ input: { value, ...restProps }, result, state }) => {
+    describe(`when input is { value: ${value}, decimals: ${restProps.numberOfDecimals}, denomation: ${restProps.denomination} }`, function () {
+      const stub = sinon.stub(reactRedux, 'useSelector')
+      stub.callsFake((selector) => {
+        if (selector === getCurrentCurrency) {
+          return state?.preferences?.currentCurrency || 'usd'
+        } else if (selector === getNativeCurrency) {
+          return state?.preferences?.nativeCurrency
+        } else if (selector === getConversionRate) {
+          return state?.preferences?.conversionRate || 280.45
+        } else if (selector === getPreferences) {
+          return state?.preferences
+        } else if (selector === getShouldShowFiat) {
+          return state?.preferences?.showFiat
+        }
+      })
+      const hookReturn = renderHook(() => useUserPreferencedCurrencyDisplays(value, restProps))
+      const { primaryCurrencyDisplay, secondaryCurrencyDisplay } = hookReturn.result.current
+      stub.restore()
+      it(`should return ${result.primaryCurrencyDisplay} as primaryCurrencyDisplay`, function () {
+        assert.equal(primaryCurrencyDisplay, result.primaryCurrencyDisplay)
+      })
+      it(`should return ${result.secondaryCurrencyDisplay} as secondaryCurrencyDisplay`, function () {
+        assert.equal(secondaryCurrencyDisplay, result.secondaryCurrencyDisplay)
+      })
+    })
+  })
+})

--- a/ui/app/hooks/tests/useUserPreferencedCurrencyDisplays.test.js
+++ b/ui/app/hooks/tests/useUserPreferencedCurrencyDisplays.test.js
@@ -4,6 +4,7 @@ import * as reactRedux from 'react-redux'
 import { useUserPreferencedCurrencyDisplays } from '../useUserPreferencedCurrencyDisplays'
 import sinon from 'sinon'
 import { getCurrentCurrency, getNativeCurrency, getConversionRate, getPreferences, getShouldShowFiat } from '../../selectors'
+import { PRIMARY, SECONDARY } from '../../helpers/constants/common'
 
 const tests = [
   {
@@ -16,11 +17,9 @@ const tests = [
     },
     input: {
       value: '0x10f699ca86b32800',
+      type: PRIMARY,
     },
-    result: {
-      primaryCurrencyDisplay: '1.222333 ETH',
-      secondaryCurrencyDisplay: '$342.80 USD',
-    },
+    result: '1.222333 ETH',
   },
   {
     state: {
@@ -32,12 +31,10 @@ const tests = [
     },
     input: {
       value: '0x10f699ca86b32800',
-      primaryPreferenceOpts: { ethNumberOfDecimals: 4 },
+      type: SECONDARY,
+      opts: { numberOfDecimals: 4 },
     },
-    result: {
-      primaryCurrencyDisplay: '1.2223 ETH',
-      secondaryCurrencyDisplay: '$342.80 USD',
-    },
+    result: '$342.80 USD',
   },
   {
     state: {
@@ -51,22 +48,17 @@ const tests = [
     },
     input: {
       value: '0x10f699ca86b32800',
-      primaryPreferenceOpts: { numberOfDecimals: 4 },
-      secondaryPreferenceOpts: { numberOfDecimals: 2 },
-      primaryCurrencyOpts: { prefix: '!!!' },
-      secondaryCurrencyOpts: { prefix: '!!!' },
+      type: SECONDARY,
+      opts: { numberOfDecimals: 2 },
     },
-    result: {
-      primaryCurrencyDisplay: '!!!61.1167 ETH',
-      secondaryCurrencyDisplay: '!!!1.22Ƀ BTC',
-    },
+    result: '1.22Ƀ BTC',
   },
 ]
 
 
 describe('useUserPreferencedCurrencyDisplays', function () {
-  tests.forEach(({ input: { value, ...restProps }, result, state }) => {
-    describe(`when input is { value: ${value}, decimals: ${restProps.numberOfDecimals}, denomation: ${restProps.denomination} }`, function () {
+  tests.forEach(({ input: { value, type, opts }, result, state }) => {
+    describe(`when input is { value: ${value}, type: ${type}, decimals: ${opts?.numberOfDecimals || 'n/a'} }`, function () {
       const stub = sinon.stub(reactRedux, 'useSelector')
       stub.callsFake((selector) => {
         if (selector === getCurrentCurrency) {
@@ -81,14 +73,11 @@ describe('useUserPreferencedCurrencyDisplays', function () {
           return state?.preferences?.showFiat
         }
       })
-      const hookReturn = renderHook(() => useUserPreferencedCurrencyDisplays(value, restProps))
-      const { primaryCurrencyDisplay, secondaryCurrencyDisplay } = hookReturn.result.current
+      const hookReturn = renderHook(() => useUserPreferencedCurrencyDisplays(value, type, opts))
+      const resultDisplay = hookReturn.result.current
       stub.restore()
-      it(`should return ${result.primaryCurrencyDisplay} as primaryCurrencyDisplay`, function () {
-        assert.equal(primaryCurrencyDisplay, result.primaryCurrencyDisplay)
-      })
-      it(`should return ${result.secondaryCurrencyDisplay} as secondaryCurrencyDisplay`, function () {
-        assert.equal(secondaryCurrencyDisplay, result.secondaryCurrencyDisplay)
+      it(`should return ${result}`, function () {
+        assert.equal(resultDisplay, result)
       })
     })
   })

--- a/ui/app/hooks/useUserPreferencedCurrencyDisplays.js
+++ b/ui/app/hooks/useUserPreferencedCurrencyDisplays.js
@@ -1,0 +1,56 @@
+import { useCurrencyDisplay } from './useCurrencyDisplay'
+import { useUserPreferencedCurrency } from './useUserPreferencedCurrency'
+import { PRIMARY, SECONDARY } from '../helpers/constants/common'
+
+/**
+* Defines the shape of the options parameter for useUserPreferencedCurrencyDisplays
+* @typedef {Object} UseUserPreferencedCurrencyDisplayOptions
+* @property {UseUserPreferencedCurrencyOptions} [primaryPreferenceOpts]    - The configuration options for getting the primary currency user preferences
+* @property {UseUserPreferencedCurrencyOptions} [secondaryPreferenceOpts]  - The configuration options for getting the secondary currency user preferences
+* @property {UseCurrencyOptions} [primaryCurrencyOpts]                     - The configuration options for getting the primary currency display
+* @property {UseCurrencyOptions} [secondaryCurrencyOpts]                   - The configuration options for getting the secondary currency display
+*/
+
+/**
+ * Defines the return shape of useUserPreferencedCurrencyDisplays
+ * @typedef {Object} UserPreferencedCurrencyDisplays
+ * @property {string} primaryCurrencyDisplay   - a display string of the PRIMARY type
+ * @property {string} secondaryCurrencyDisplay - a display string of the SECONDARY type
+ */
+
+/**
+* useUserPreferencedCurrencyDisplays hook
+*
+* Given a hexadecimal encoded value string and optional objects of parameters used for formatting the
+* displays, produces two fully formed strings: one for the primary display type and one for the secondary
+* display type
+* @param {string} inputValue                                - The value to format for display
+* @param {UseUserPreferencedCurrencyDisplayOptions} opts    - An object of options for formatting the return values
+* @return {[string, CurrencyDisplayParts]}
+*/
+export function useUserPreferencedCurrencyDisplays (inputValue, {
+  primaryPreferenceOpts = {},
+  secondaryPreferenceOpts = {},
+  primaryCurrencyOpts = {},
+  secondaryCurrencyOpts = {},
+}) {
+  const {
+    currency: primaryCurrency,
+    numberOfDecimals: primaryNumberOfDecimals,
+  } = useUserPreferencedCurrency(PRIMARY, primaryPreferenceOpts)
+  const {
+    currency: secondaryCurrency,
+    numberOfDecimals: secondaryNumberOfDecimals,
+  } = useUserPreferencedCurrency(SECONDARY, secondaryPreferenceOpts)
+
+  const [primaryCurrencyDisplay] = useCurrencyDisplay(
+    inputValue,
+    { numberOfDecimals: primaryNumberOfDecimals, currency: primaryCurrency, ...primaryCurrencyOpts },
+  )
+  const [secondaryCurrencyDisplay] = useCurrencyDisplay(
+    inputValue,
+    { numberOfDecimals: secondaryNumberOfDecimals, currency: secondaryCurrency, ...secondaryCurrencyOpts },
+  )
+
+  return { primaryCurrencyDisplay, secondaryCurrencyDisplay }
+}


### PR DESCRIPTION
This PR adds a useUserPreferencedCurrencyDisplays hook to encapsulate the logic necessary for converting a given amount of eth in hex wei into two strings meant for displaying that amount according to the user's currency preferences. It then substitutes this hook for useCurrencyDisplay and useUserPreferencedCurrent in asset-list.js.