### PR TITLE
Add web3 usage metrics, prepare for web3 removal

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -7,7 +7,7 @@ import { CapabilitiesController as RpcCap } from 'rpc-cap'
 import { ethErrors } from 'eth-json-rpc-errors'
 import { cloneDeep } from 'lodash'
 
-import createMethodMiddleware from './methodMiddleware'
+import createPermissionsMethodMiddleware from './permissionsMethodMiddleware'
 import PermissionsLogController from './permissionsLog'
 
 // Methods that do not require any permissions to use:
@@ -90,7 +90,7 @@ export class PermissionsController {
 
     engine.push(this.permissionsLog.createMiddleware())
 
-    engine.push(createMethodMiddleware({
+    engine.push(createPermissionsMethodMiddleware({
       addDomainMetadata: this.addDomainMetadata.bind(this),
       getAccounts: this.getAccounts.bind(this, origin),
       getUnlockPromise: () => this._getUnlockPromise(true),

--- a/app/scripts/controllers/permissions/permissionsMethodMiddleware.js
+++ b/app/scripts/controllers/permissions/permissionsMethodMiddleware.js
@@ -4,7 +4,7 @@ import { ethErrors } from 'eth-json-rpc-errors'
 /**
  * Create middleware for handling certain methods and preprocessing permissions requests.
  */
-export default function createMethodMiddleware ({
+export default function createPermissionsMethodMiddleware ({
   addDomainMetadata,
   getAccounts,
   getUnlockPromise,

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -1,5 +1,3 @@
-/*global Web3*/
-
 // need to make sure we aren't affected by overlapping namespaces
 // and that we dont affect the app with our namespace
 // mostly a fix for web3's BigNumber if AMD's "define" is defined...
@@ -37,9 +35,7 @@ import LocalMessageDuplexStream from 'post-message-stream'
 import { initProvider } from '@metamask/inpage-provider'
 
 // TODO:deprecate:2020
-import 'web3/dist/web3.min.js'
-
-import setupDappAutoReload from './lib/auto-reload.js'
+import setupWeb3 from './lib/setupWeb3.js'
 
 restoreContextAfterImports()
 
@@ -59,11 +55,9 @@ initProvider({
   connectionStream: metamaskStream,
 })
 
-//
 // TODO:deprecate:2020
-//
+// Setup web3
 
-// setup web3
 
 if (typeof window.web3 !== 'undefined') {
   throw new Error(`MetaMask detected another web3.
@@ -73,18 +67,5 @@ if (typeof window.web3 !== 'undefined') {
      and try again.`)
 }
 
-const web3 = new Web3(window.ethereum)
-web3.setProvider = function () {
-  log.debug('MetaMask - overrode web3.setProvider')
-}
-log.debug('MetaMask - injected web3')
-
-Object.defineProperty(window.ethereum, '_web3Ref', {
-  enumerable: false,
-  writable: true,
-  configurable: true,
-  value: web3.eth,
-})
-
-// setup dapp auto reload AND proxy web3
-setupDappAutoReload(web3, window.ethereum._publicConfigStore)
+// proxy web3, assign to window, and set up site auto reload
+setupWeb3(log)

--- a/app/scripts/lib/backend-metametrics.js
+++ b/app/scripts/lib/backend-metametrics.js
@@ -8,6 +8,7 @@ export default function backEndMetaMetricsEvent (metaMaskState, eventData) {
     sendMetaMetricsEvent({
       ...stateEventData,
       ...eventData,
+      category: 'Background',
       currentPath: '/background',
     })
   }

--- a/app/scripts/lib/background-metametrics.js
+++ b/app/scripts/lib/background-metametrics.js
@@ -1,9 +1,8 @@
 import { getBackgroundMetaMetricState } from '../../../ui/app/selectors'
 import { sendMetaMetricsEvent } from '../../../ui/app/helpers/utils/metametrics.util'
 
-export default function backEndMetaMetricsEvent (metaMaskState, eventData) {
+export default function backgroundMetaMetricsEvent (metaMaskState, eventData) {
   const stateEventData = getBackgroundMetaMetricState({ metamask: metaMaskState })
-
   if (stateEventData.participateInMetaMetrics) {
     sendMetaMetricsEvent({
       ...stateEventData,

--- a/app/scripts/lib/createMethodMiddleware.js
+++ b/app/scripts/lib/createMethodMiddleware.js
@@ -1,0 +1,32 @@
+/**
+ * Returns a middleware that implements the following RPC methods:
+ * - metamask_logInjectedWeb3Usage
+ *
+ * @param {Object} opts - The middleware options
+ * @param {string} opts.origin - The origin for the middleware stack
+ * @param {Function} opts.sendMetrics - A function for sending a metrics event
+ * @returns {(req: any, res: any, next: Function, end: Function) => void}
+ */
+export default function createMethodMiddleware ({ origin, sendMetrics }) {
+  return function methodMiddleware (req, res, next, end) {
+    switch (req.method) {
+
+      case 'metamask_logInjectedWeb3Usage':
+
+        const { action, name } = req.params[0]
+
+        sendMetrics({
+          action,
+          name,
+          customVariables: { origin },
+        })
+
+        res.result = true
+        break
+
+      default:
+        return next()
+    }
+    return end()
+  }
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -67,7 +67,7 @@ import {
   PhishingController,
 } from '@metamask/controllers'
 
-import backEndMetaMetricsEvent from './lib/background-metametrics'
+import backgroundMetaMetricsEvent from './lib/background-metametrics'
 
 export default class MetamaskController extends EventEmitter {
 
@@ -1841,16 +1841,14 @@ export default class MetamaskController extends EventEmitter {
       throw new Error('Must provide action and name.')
     }
 
-    if (this.preferencesController.getParticipateInMetaMetrics()) {
-      const metamaskState = await this.getState()
-      backEndMetaMetricsEvent(metamaskState, {
-        customVariables,
-        eventOpts: {
-          action,
-          name,
-        },
-      })
-    }
+    const metamaskState = await this.getState()
+    backgroundMetaMetricsEvent(metamaskState, {
+      customVariables,
+      eventOpts: {
+        action,
+        name,
+      },
+    })
   }
 
   //=============================================================================

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -67,7 +67,7 @@ import {
   PhishingController,
 } from '@metamask/controllers'
 
-import backEndMetaMetricsEvent from './lib/backend-metametrics'
+import backEndMetaMetricsEvent from './lib/background-metametrics'
 
 export default class MetamaskController extends EventEmitter {
 
@@ -251,7 +251,7 @@ export default class MetamaskController extends EventEmitter {
 
         const { txReceipt } = txMeta
         if (txReceipt && txReceipt.status === '0x0') {
-          this.sendBackendMetaMetrics({
+          this.sendBackgroundMetaMetrics({
             action: 'Transactions',
             name: 'On Chain Failure',
             customVariables: { errorMessage: txMeta.simulationFails?.reason },
@@ -1633,7 +1633,7 @@ export default class MetamaskController extends EventEmitter {
     }))
     engine.push(createMethodMiddleware({
       origin,
-      sendMetrics: this.sendBackendMetaMetrics.bind(this),
+      sendMetrics: this.sendBackgroundMetaMetrics.bind(this),
     }))
     // filter and subscription polyfills
     engine.push(filterMiddleware)
@@ -1835,7 +1835,7 @@ export default class MetamaskController extends EventEmitter {
     return nonceLock.nextNonce
   }
 
-  async sendBackendMetaMetrics ({ action, name, customVariables } = {}) {
+  async sendBackgroundMetaMetrics ({ action, name, customVariables } = {}) {
 
     if (!action || !name) {
       throw new Error('Must provide action and name.')

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -23,7 +23,7 @@ const METAMETRICS_CUSTOM_GAS_LIMIT_CHANGE = 'gasLimitChange'
 const METAMETRICS_CUSTOM_GAS_PRICE_CHANGE = 'gasPriceChange'
 const METAMETRICS_CUSTOM_FUNCTION_TYPE = 'functionType'
 const METAMETRICS_CUSTOM_RECIPIENT_KNOWN = 'recipientKnown'
-const METAMETRICS_CUSTOM_CONFIRM_SCREEN_ORIGIN = 'origin'
+const METAMETRICS_REQUEST_ORIGIN = 'origin'
 const METAMETRICS_CUSTOM_FROM_NETWORK = 'fromNetwork'
 const METAMETRICS_CUSTOM_TO_NETWORK = 'toNetwork'
 const METAMETRICS_CUSTOM_ERROR_FIELD = 'errorField'
@@ -36,7 +36,7 @@ const METAMETRICS_CUSTOM_ASSET_SELECTED = 'assetSelected'
 const customVariableNameIdMap = {
   [METAMETRICS_CUSTOM_FUNCTION_TYPE]: 1,
   [METAMETRICS_CUSTOM_RECIPIENT_KNOWN]: 2,
-  [METAMETRICS_CUSTOM_CONFIRM_SCREEN_ORIGIN]: 3,
+  [METAMETRICS_REQUEST_ORIGIN]: 3,
   [METAMETRICS_CUSTOM_GAS_LIMIT_CHANGE]: 4,
   [METAMETRICS_CUSTOM_GAS_PRICE_CHANGE]: 5,
 
@@ -137,7 +137,7 @@ function composeUrl (config) {
     numberOfAccounts,
     version,
     previousPath = '',
-    currentPath,
+    currentPath = '',
     metaMetricsId,
     confirmTransactionOrigin,
     excludeMetaMetricsId,

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -137,7 +137,7 @@ function composeUrl (config) {
     numberOfAccounts,
     version,
     previousPath = '',
-    currentPath = '',
+    currentPath,
     metaMetricsId,
     confirmTransactionOrigin,
     excludeMetaMetricsId,


### PR DESCRIPTION
This PR adds `window.web3` usage metrics for users that opted in to metrics. It also consolidates some `web3`-related functionality, and adds a method and a middleware to perform the metrics-sending work.

- Add `window.web3` usage metrics via new RPC method: `metamask_logInjectedWeb3Usage`
- Send `window.web3` usage metrics on `window.web3` property access and assignment, via proxy handlers
- Consolidate inpage `web3`-related code into `auto-reload.js`; rename file to `setupWeb3.js`
- Create new, top-level RPC method middleware for the `metamask_logInjectedWeb3Usage` implementation
- Create new, top-level `metamask-controller` method for sending backend metrics
  - For great DRYness
- Rename permissions controller `methodMiddleware.js` to `permissionsMethodMiddleware.js` to distinguish from new top-level `methodMiddleware`