### PR TITLE
colocate notification-modal styles

### DIFF
--- a/ui/app/components/app/modals/index.scss
+++ b/ui/app/components/app/modals/index.scss
@@ -1,5 +1,6 @@
 @import 'cancel-transaction/index';
 @import 'confirm-remove-account/index';
+@import 'notification-modal/index';
 @import 'qr-scanner/index';
 @import 'transaction-confirmed/index';
 @import 'metametrics-opt-in-modal/index';

--- a/ui/app/components/app/modals/notification-modal/index.js
+++ b/ui/app/components/app/modals/notification-modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './notification-modal'

--- a/ui/app/components/app/modals/notification-modal/index.scss
+++ b/ui/app/components/app/modals/notification-modal/index.scss
@@ -1,0 +1,56 @@
+.notification-modal {
+  &__wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    position: relative;
+    border: 1px solid $alto;
+    box-shadow: 0 0 2px 2px $alto;
+  }
+
+  &__header {
+    background: $wild-sand;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    padding: 30px;
+    font-size: 22px;
+    color: $nile-blue;
+  }
+
+  &__message {
+    padding: 20px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    font-size: 17px;
+    color: $nile-blue;
+  }
+
+  &__buttons {
+    display: flex;
+    justify-content: space-evenly;
+    width: 100%;
+    margin-bottom: 24px;
+    padding: 0 42px;
+
+    &__btn {
+      cursor: pointer;
+    }
+  }
+
+  &__link {
+    color: $primary-blue;
+  }
+
+  .modal-close-x::after {
+    content: '\00D7';
+    font-size: 2em;
+    color: $dusty-gray;
+    position: absolute;
+    top: 25px;
+    right: 17.5px;
+    cursor: pointer;
+  }
+}

--- a/ui/app/components/app/modals/notification-modal/notification-modal.js
+++ b/ui/app/components/app/modals/notification-modal/notification-modal.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { hideModal } from '../../../store/actions'
+import { hideModal } from '../../../../store/actions'
 
 class NotificationModal extends Component {
   static contextProps = {

--- a/ui/app/css/itcss/components/modal.scss
+++ b/ui/app/css/itcss/components/modal.scss
@@ -212,16 +212,6 @@
   padding: 9px 13px 8px;
 }
 
-.modal-close-x::after {
-  content: '\00D7';
-  font-size: 2em;
-  color: $dusty-gray;
-  position: absolute;
-  top: 25px;
-  right: 17.5px;
-  cursor: pointer;
-}
-
 // Hide token confirmation
 
 .hide-token-confirmation {
@@ -283,55 +273,6 @@
 
     width: 141px;
     margin: 0 5px;
-  }
-}
-
-//Notification Modal
-
-.notification-modal {
-  &__wrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-    position: relative;
-    border: 1px solid $alto;
-    box-shadow: 0 0 2px 2px $alto;
-  }
-
-  &__header {
-    background: $wild-sand;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    padding: 30px;
-    font-size: 22px;
-    color: $nile-blue;
-  }
-
-  &__message {
-    padding: 20px;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    font-size: 17px;
-    color: $nile-blue;
-  }
-
-  &__buttons {
-    display: flex;
-    justify-content: space-evenly;
-    width: 100%;
-    margin-bottom: 24px;
-    padding: 0 42px;
-
-    &__btn {
-      cursor: pointer;
-    }
-  }
-
-  &__link {
-    color: $primary-blue;
   }
 }
 
@@ -497,39 +438,4 @@
   .simple-dropdown__selected {
     text-align: center;
   }
-}
-
-//Notification Modal
-
-.notification-modal-wrapper {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  position: relative;
-  border: 1px solid $alto;
-  box-shadow: 0 0 2px 2px $alto;
-}
-
-.notification-modal-header {
-  background: $wild-sand;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 30px;
-  font-size: 22px;
-  color: $nile-blue;
-}
-
-.notification-modal-message {
-  padding: 20px;
-}
-
-.notification-modal-message {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  font-size: 17px;
-  color: $nile-blue;
 }


### PR DESCRIPTION
### Background
As I was working on Typography I gained a tremendous amount of knowledge on the old styles in the `itcss/` folder by way of having to hunt down usages of these classNames to make sure they weren't used. thus began this epic journey into cleaning up of styles and aligning scss to match v8 paradigms.

This pull request follows former examples of colocating styles with the modals that use them, by examining the other modals defined in `components/app/modals/`. Enjoy, as you embark upon this five-part journey into the oft-forgotten, very lamented land of itcss.

##### Additional Work
- #9148 
- #9149 
- #9150 
- #9151

![image](https://media.giphy.com/media/ElSNi8FdSB7RS/giphy.gif)