### PR TITLE
Fix .network-name alignment

### DIFF
--- a/ui/app/css/itcss/components/network.scss
+++ b/ui/app/css/itcss/components/network.scss
@@ -74,7 +74,6 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  height: 16px;
 }
 
 .dropdown-menu-item .fa.delete {


### PR DESCRIPTION
Fix .network-name alignment by removing its height property.

Screenshots from Chrome. Also tested in Firefox.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/25517051/89590067-ebbcbf00-d7fb-11ea-8e07-a03c75e1474a.png" width=357 />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/25517051/89590145-10b13200-d7fc-11ea-9a5f-26672ce342a9.png" width=357 />
</details>