### PR TITLE
Use luxon@1.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.19",
     "loglevel": "^1.4.1",
-    "luxon": "^1.23.0",
+    "luxon": "^1.24.1",
     "metamask-logo": "^2.1.4",
     "multihashes": "^0.4.12",
     "nanoid": "^2.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17590,10 +17590,10 @@ ltgt@~2.1.1:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
   integrity sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=
 
-luxon@^1.23.0:
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.23.0.tgz#23b748ad0f2d5494dc4d2878c19278c1e651410c"
-  integrity sha512-+6a/bXsCWrrR8vfbL41iM92es12zwV2Rum/KPkT+ubOZnnU3Sqbqok/FmD1xsWlWN2Y9Hu0fU/vNgU24ns7bpA==
+luxon@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.24.1.tgz#a8383266131ed4eaed4b5f430f96f3695403a52a"
+  integrity sha512-CgnIMKAWT0ghcuWFfCWBnWGOddM0zu6c4wZAWmD0NN7MZTnro0+833DF6tJep+xlxRPg4KtsYEHYLfTMBQKwYg==
 
 mafmt@^6.0.0, mafmt@^6.0.2, mafmt@^6.0.4, mafmt@^6.0.7:
   version "6.0.7"


### PR DESCRIPTION
This PR updates the luxon dependency to the latest published version, `1.24.1`.

The changelog:

```
## 1.24.1 (2020-05-04)

 * Remove erroneous `console.log` call

## 1.24.0 (2020-05-03)

 * Update polyfills for pollyfilled build

```

Nothing particularly important here.