### PR TITLE
Change MetaMetrics category for background events

### DIFF
--- a/app/scripts/lib/backend-metametrics.js
+++ b/app/scripts/lib/backend-metametrics.js
@@ -14,7 +14,7 @@ export default function backEndMetaMetricsEvent (metaMaskState, eventData) {
     sendMetaMetricsEvent({
       ...stateEventData,
       ...eventData,
-      url: METAMETRICS_TRACKING_URL + '/backend',
+      url: METAMETRICS_TRACKING_URL + '/background',
     })
   }
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -257,7 +257,7 @@ export default class MetamaskController extends EventEmitter {
               errorMessage: txMeta.simulationFails?.reason,
             },
             eventOpts: {
-              category: 'backend',
+              category: 'Background',
               action: 'Transactions',
               name: 'On Chain Failure',
             },


### PR DESCRIPTION
Background events are now sent in the `Background` category, rather than `backend`. Conventionally we use the term "background" over "backend", as it's not really a "backend" in the normal sense since it's a client background process. Also it's capitalized because all of the other event categories are capitalized as well.

The metrics URL has been updated to use `background` instead of `backend` as well, for consistency.

Luckily we don't have to worry about our metrics being disjointed due to this name change, because the background metrics never worked to begin with! So there will be none under the old name. The metrics will be made functional in a separate PR.