### PR TITLE
Add category in eventOpts

### DIFF
--- a/app/scripts/lib/background-metametrics.js
+++ b/app/scripts/lib/background-metametrics.js
@@ -2,12 +2,14 @@ import { getBackgroundMetaMetricState } from '../../../ui/app/selectors'
 import { sendMetaMetricsEvent } from '../../../ui/app/helpers/utils/metametrics.util'
 
 export default function backgroundMetaMetricsEvent (metaMaskState, eventData) {
+
+  eventData.eventOpts['category'] = 'Background'
+
   const stateEventData = getBackgroundMetaMetricState({ metamask: metaMaskState })
   if (stateEventData.participateInMetaMetrics) {
     sendMetaMetricsEvent({
       ...stateEventData,
       ...eventData,
-      category: 'Background',
       currentPath: '/background',
     })
   }


### PR DESCRIPTION
Add category into config.eventOpts where we use it to compose the url with the action and name, instead of the top level config.