### PR TITLE
Add `version` dimension to background metrics

### DIFF
--- a/app/scripts/lib/background-metametrics.js
+++ b/app/scripts/lib/background-metametrics.js
@@ -1,7 +1,7 @@
 import { getBackgroundMetaMetricState } from '../../../ui/app/selectors'
 import { sendMetaMetricsEvent } from '../../../ui/app/helpers/utils/metametrics.util'
 
-export default function backgroundMetaMetricsEvent (metaMaskState, eventData) {
+export default function backgroundMetaMetricsEvent (metaMaskState, version, eventData) {
 
   eventData.eventOpts['category'] = 'Background'
 
@@ -10,6 +10,7 @@ export default function backgroundMetaMetricsEvent (metaMaskState, eventData) {
     sendMetaMetricsEvent({
       ...stateEventData,
       ...eventData,
+      version,
       currentPath: '/background',
     })
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1842,13 +1842,18 @@ export default class MetamaskController extends EventEmitter {
     }
 
     const metamaskState = await this.getState()
-    backgroundMetaMetricsEvent(metamaskState, {
-      customVariables,
-      eventOpts: {
-        action,
-        name,
+    const version = this.platform.getVersion()
+    backgroundMetaMetricsEvent(
+      metamaskState,
+      version,
+      {
+        customVariables,
+        eventOpts: {
+          action,
+          name,
+        },
       },
-    })
+    )
   }
 
   //=============================================================================

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -115,6 +115,7 @@ function composeParamAddition (paramValue, paramName) {
   * @property {string} config.accountType The account type being used at the time of the event: 'hardware', 'imported' or 'default'
   * @property {number} config.numberOfTokens The number of tokens that the user has added at the time of the event
   * @property {number} config.numberOfAccounts The number of accounts the user has added at the time of the event
+  * @property {string} config.version The current version of the MetaMask extension
   * @property {string} config.previousPath The pathname of the URL the user was on prior to the URL they are on at the time of the event
   * @property {string} config.currentPath The pathname of the URL the user is on at the time of the event
   * @property {string} config.metaMetricsId A random id assigned to a user at the time of opting in to metametrics. A hexadecimal number


### PR DESCRIPTION
The background metrics were missing the `version` custom dimension. It has now been added to all background metric events.