### PR TITLE
Refactor assignment of "Background" metrics category

### DIFF
--- a/app/scripts/lib/background-metametrics.js
+++ b/app/scripts/lib/background-metametrics.js
@@ -2,9 +2,6 @@ import { getBackgroundMetaMetricState } from '../../../ui/app/selectors'
 import { sendMetaMetricsEvent } from '../../../ui/app/helpers/utils/metametrics.util'
 
 export default function backgroundMetaMetricsEvent (metaMaskState, version, eventData) {
-
-  eventData.eventOpts['category'] = 'Background'
-
   const stateEventData = getBackgroundMetaMetricState({ metamask: metaMaskState })
   if (stateEventData.participateInMetaMetrics) {
     sendMetaMetricsEvent({

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1850,6 +1850,7 @@ export default class MetamaskController extends EventEmitter {
         customVariables,
         eventOpts: {
           action,
+          category: 'Background',
           name,
         },
       },


### PR DESCRIPTION
The "Background" metrics category was being set in the `backgroundMetaMetricsEvent` function. This function might not
necessarily include any event at all though, so setting it here seemed inappropriate. It would also crash if `eventData.eventOpts` was not set, which is not great since that property is optional.

The background category is now set in the `sendBackgroundMetaMetrics` function in `metamask-controller`. This method is used solely for event data, so it would make sense for this category to be always set.

There is no functional difference, since `backgroundMetaMetricsEvent` is called solely by `sendBackgroundMetaMetrics`.