### PR TITLE
Check if getCleanAppState is defined before calling

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -180,7 +180,9 @@ class Driver {
     await fs.writeFile(`${filepathBase}-screenshot.png`, screenshot, { encoding: 'base64' })
     const htmlSource = await this.driver.getPageSource()
     await fs.writeFile(`${filepathBase}-dom.html`, htmlSource)
-    const uiState = await this.driver.executeScript(() => window.getCleanAppState())
+    const uiState = await this.driver.executeScript(
+      () => window.getCleanAppState && window.getCleanAppState(),
+    )
     await fs.writeFile(`${filepathBase}-state.json`, JSON.stringify(uiState, null, 2))
   }
 


### PR DESCRIPTION
In tests, checks if `window.getCleanAppState` is defined before calling it.

This was an issue for some test failures in #9156.