### PR TITLE
Fix account modal back button styling

### DIFF
--- a/ui/app/components/app/modals/account-modal-container/account-modal-container.component.js
+++ b/ui/app/components/app/modals/account-modal-container/account-modal-container.component.js
@@ -25,7 +25,7 @@ export default function AccountModalContainer (props, context) {
         {showBackButton && (
           <div className="account-modal__back" onClick={backButtonAction}>
             <i className="fa fa-angle-left fa-lg" />
-            <span className="account-modal__text">{' ' + context.t('back')}</span>
+            <span className="account-modal__back-text">{context.t('back')}</span>
           </div>
         )}
         <button className="account-modal__close" onClick={hideModal} />

--- a/ui/app/components/app/modals/account-modal-container/index.scss
+++ b/ui/app/components/app/modals/account-modal-container/index.scss
@@ -17,12 +17,14 @@
     top: 13px;
     left: 17px;
     cursor: pointer;
+    display: flex;
+    align-items: center;
   }
 
-  &__text {
-    margin-top: 2px;
+  &__back-text {
     font-size: 14px;
     line-height: 18px;
+    padding-left: 3px;
   }
 
   &__close {


### PR DESCRIPTION
Fix the "back" caret and text alignment in the account details modal.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/25517051/89922294-af9aad00-dbb3-11ea-85f9-1a6fab9b6106.png" width=357 />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/25517051/89922327-bd503280-dbb3-11ea-8a31-b3fb22eb240b.png" width=357 />
</details>