### PR TITLE
Fix implicit-arrow-linebreak issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,6 +47,7 @@ module.exports = {
     'consistent-return': 'error',
     'global-require': 'error',
     'guard-for-in': 'error',
+    'implicit-arrow-linebreak': 'error',
     'no-case-declarations': 'error',
     'no-useless-catch': 'error',
     /* End v2 rules */

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -239,11 +239,11 @@ export default class PendingTransactionTracker extends EventEmitter {
   async _checkIfNonceIsTaken (txMeta) {
     const address = txMeta.txParams.from
     const completed = this.getCompletedTransactions(address)
-    return completed.some((other) =>
+    return completed.some(
       // This is called while the transaction is in-flight, so it is possible that the
       // list of completed transactions now includes the transaction we were looking at
       // and if that is the case, don't consider the transaction to have taken its own nonce
-      !(other.id === txMeta.id) && other.txParams.nonce === txMeta.txParams.nonce,
+      (other) => !(other.id === txMeta.id) && other.txParams.nonce === txMeta.txParams.nonce,
     )
   }
 }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1756,20 +1756,18 @@ export function exportAccounts (password, addresses) {
           return
         }
         log.debug(`background.exportAccounts`)
-        const accountPromises = addresses.map((address) =>
-          new Promise(
-            (resolve, reject) => background.exportAccount(address, function (err, result) {
-              if (err) {
-                log.error(err)
-                dispatch(displayWarning('Had a problem exporting the account.'))
-                reject(err)
-                return
-              }
-              resolve(result)
+        const accountPromises = addresses.map((address) => new Promise(
+          (resolve, reject) => background.exportAccount(address, function (err, result) {
+            if (err) {
+              log.error(err)
+              dispatch(displayWarning('Had a problem exporting the account.'))
+              reject(err)
               return
-            }),
-          ),
-        )
+            }
+            resolve(result)
+            return
+          }),
+        ))
         resolve(Promise.all(accountPromises))
         return
       })


### PR DESCRIPTION
Refs #8982

See [`implicit-arrow-linebreak`](https://eslint.org/docs/rules/implicit-arrow-linebreak) for more information.

This change enables `implicit-arrow-linebreak` and fixes the issues raised by the rule.