### PR TITLE
Fix no-empty issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
     'global-require': 'error',
     'guard-for-in': 'error',
     'no-case-declarations': 'error',
+    'no-empty': 'error',
     'no-loop-func': 'error',
     'no-useless-catch': 'error',
     'no-useless-concat': 'error',

--- a/app/scripts/migrations/002.js
+++ b/app/scripts/migrations/002.js
@@ -14,7 +14,9 @@ export default {
         versionedData.data.config.provider.type = 'rpc'
         versionedData.data.config.provider.rpcTarget = 'https://rpc.metamask.io/'
       }
-    } catch (e) {}
+    } catch (_) {
+      // empty
+    }
     return Promise.resolve(versionedData)
   },
 }

--- a/app/scripts/migrations/003.js
+++ b/app/scripts/migrations/003.js
@@ -14,7 +14,9 @@ export default {
       if (versionedData.data.config.provider.rpcTarget === oldTestRpc) {
         versionedData.data.config.provider.rpcTarget = newTestRpc
       }
-    } catch (e) {}
+    } catch (_) {
+      // empty
+    }
     return Promise.resolve(versionedData)
   },
 }

--- a/app/scripts/migrations/004.js
+++ b/app/scripts/migrations/004.js
@@ -25,7 +25,9 @@ export default {
           break
         // No default
       }
-    } catch (_) {}
+    } catch (_) {
+      // empty
+    }
     return Promise.resolve(safeVersionedData)
   },
 }

--- a/development/sourcemap-validator.js
+++ b/development/sourcemap-validator.js
@@ -49,7 +49,9 @@ async function validateSourcemapForFile ({ buildName }) {
   try {
     const filePath = path.join(__dirname, `/../dist/${platform}/`, `${buildName}`)
     rawBuild = await fsAsync.readFile(filePath, 'utf8')
-  } catch (err) {}
+  } catch (_) {
+    // empty
+  }
   if (!rawBuild) {
     throw new Error(`SourcemapValidator - failed to load source file for "${buildName}"`)
   }
@@ -58,12 +60,16 @@ async function validateSourcemapForFile ({ buildName }) {
   try {
     const filePath = path.join(__dirname, `/../dist/sourcemaps/`, `${buildName}.map`)
     rawSourceMap = await fsAsync.readFile(filePath, 'utf8')
-  } catch (err) {}
+  } catch (_) {
+    // empty
+  }
   // attempt to load in dev mode
   try {
     const filePath = path.join(__dirname, `/../dist/${platform}/`, `${buildName}.map`)
     rawSourceMap = await fsAsync.readFile(filePath, 'utf8')
-  } catch (err) {}
+  } catch (_) {
+    // empty
+  }
   if (!rawSourceMap) {
     throw new Error(`SourcemapValidator - failed to load sourcemaps for "${buildName}"`)
   }

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -478,46 +478,16 @@ describe('preferences controller', function () {
       assert.ok(assetImages[address], `set image correctly`)
     })
     it('should validate ERC20 asset correctly', async function () {
-      const validateSpy = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpy({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC', decimals: 0 })
-      } catch (e) {}
-      assert.equal(validateSpy.threw(), false, 'correct options object')
-      const validateSpyAddress = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpyAddress({ symbol: 'ABC', decimals: 0 })
-      } catch (e) {}
-      assert.equal(validateSpyAddress.threw(), true, 'options object with no address')
-      const validateSpySymbol = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpySymbol({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', decimals: 0 })
-      } catch (e) {}
-      assert.equal(validateSpySymbol.threw(), true, 'options object with no symbol')
-      const validateSpyDecimals = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpyDecimals({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC' })
-      } catch (e) {}
-      assert.equal(validateSpyDecimals.threw(), true, 'options object with no decimals')
-      const validateSpyInvalidSymbol = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpyInvalidSymbol({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 0 })
-      } catch (e) {}
-      assert.equal(validateSpyInvalidSymbol.threw(), true, 'options object with invalid symbol')
-      const validateSpyInvalidDecimals1 = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpyInvalidDecimals1({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: -1 })
-      } catch (e) {}
-      assert.equal(validateSpyInvalidDecimals1.threw(), true, 'options object with decimals less than zero')
-      const validateSpyInvalidDecimals2 = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpyInvalidDecimals2({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 38 })
-      } catch (e) {}
-      assert.equal(validateSpyInvalidDecimals2.threw(), true, 'options object with decimals more than 36')
-      const validateSpyInvalidAddress = sandbox.spy(preferencesController._validateERC20AssetParams)
-      try {
-        validateSpyInvalidAddress({ rawAddress: '0x123', symbol: 'ABC', decimals: 0 })
-      } catch (e) {}
-      assert.equal(validateSpyInvalidAddress.threw(), true, 'options object with address invalid')
+      const validate = preferencesController._validateERC20AssetParams
+
+      assert.doesNotThrow(() => validate({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC', decimals: 0 }))
+      assert.throws(() => validate({ symbol: 'ABC', decimals: 0 }), 'missing address should fail')
+      assert.throws(() => validate({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', decimals: 0 }), 'missing symbol should fail')
+      assert.throws(() => validate({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABC' }), 'missing decimals should fail')
+      assert.throws(() => validate({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 0 }), 'invalid symbol should fail')
+      assert.throws(() => validate({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: -1 }), 'decimals < 0 should fail')
+      assert.throws(() => validate({ rawAddress: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07', symbol: 'ABCDEFGHI', decimals: 38 }), 'decimals > 36 should fail')
+      assert.throws(() => validate({ rawAddress: '0x123', symbol: 'ABC', decimals: 0 }), 'invalid address should fail')
     })
   })
 

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -189,8 +189,9 @@ export function shortenBalance (balance, decimalsToKeep = 1) {
 export function normalizeToWei (amount, currency) {
   try {
     return amount.mul(bnTable.wei).div(bnTable[currency])
-  } catch (e) {}
-  return amount
+  } catch (e) {
+    return amount
+  }
 }
 
 export function normalizeEthStringToWei (str) {


### PR DESCRIPTION
Refs #8982

See [`no-empty`](https://eslint.org/docs/rules/no-empty) for more information.

This change enables `no-empty` and fixes the issues raised by the rule.