### PR TITLE
Fix no-invalid-this issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,10 @@ module.exports = {
       'logical': 'parens-new-line',
       'prop': 'parens-new-line',
     }],
+
+    'no-invalid-this': 'off',
+    'babel/no-invalid-this': 'error',
+
     'babel/semi': ['error', 'never'],
     'mocha/no-setup-in-describe': 'off',
   },
@@ -119,6 +123,15 @@ module.exports = {
     ],
     rules: {
       'global-require': 'off',
+    },
+  }, {
+    files: [
+      'test/**/*-test.js',
+      'test/**/*.spec.js',
+    ],
+    rules: {
+      // Mocha will re-assign `this` in a test context
+      'babel/no-invalid-this': 'off',
     },
   }],
 

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -164,10 +164,10 @@ export default class TransactionStateManager extends EventEmitter {
       txMeta.txParams = this.normalizeAndValidateTxParams(txMeta.txParams)
     }
 
-    this.once(`${txMeta.id}:signed`, function () {
+    this.once(`${txMeta.id}:signed`, () => {
       this.removeAllListeners(`${txMeta.id}:rejected`)
     })
-    this.once(`${txMeta.id}:rejected`, function () {
+    this.once(`${txMeta.id}:rejected`, () => {
       this.removeAllListeners(`${txMeta.id}:signed`)
     })
     // initialize history

--- a/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.utils.js
+++ b/ui/app/components/app/gas-customization/gas-price-chart/gas-price-chart.utils.js
@@ -124,6 +124,7 @@ export function setTickPosition (axis, n, newPosition, secondNewPosition) {
     .style('visibility', 'visible')
 }
 
+/* eslint-disable babel/no-invalid-this */
 export function appendOrUpdateCircle ({ data, itemIndex, cx, cy, cssId, appendOnly }) {
   const circle = this.main
     .select('.c3-selected-circles' + this.getTargetSelectorSuffix(data.id))
@@ -144,6 +145,7 @@ export function appendOrUpdateCircle ({ data, itemIndex, cx, cy, cssId, appendOn
       .attr('cy', cy)
   }
 }
+/* eslint-enable babel/no-invalid-this */
 
 export function setSelectedCircle ({
   chart,


### PR DESCRIPTION
Refs #8982

See [`no-invalid-this`](https://eslint.org/docs/rules/no-invalid-this) for more information.

This change enables `no-invalid-this` and fixes the issues raised by the rule.

I've replaced the ESLint core rule with the babel plugin's version as the core rule doesn't understand class properties, esp. class properties with `async`. I've also disabled the rule for Mocha tests.