### PR TITLE
Fix no-global-assign issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     'no-case-declarations': 'error',
     'no-empty': 'error',
     'no-eq-null': 'error',
+    'no-global-assign': 'error',
     'no-loop-func': 'error',
     'no-useless-catch': 'error',
     'no-useless-concat': 'error',

--- a/test/unit-global/frozenPromise.js
+++ b/test/unit-global/frozenPromise.js
@@ -1,7 +1,3 @@
-
-/* eslint-disable no-native-reassign */
-
-// this is what we're testing
 import '../../app/scripts/lib/freezeGlobals'
 
 import assert from 'assert'
@@ -10,6 +6,7 @@ describe('Promise global is immutable', function () {
 
   it('throws when reassinging promise (syntax 1)', function () {
     try {
+      // eslint-disable-next-line no-global-assign,no-native-reassign
       Promise = {}
       assert.fail('did not throw error')
     } catch (err) {


### PR DESCRIPTION
Refs #8982

See [`no-global-assign`](https://eslint.org/docs/rules/no-global-assign) for more information.

This change enables `no-global-assign` and fixes the issues raised by the rule.