### PR TITLE
Fix require-unicode-regexp issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,7 @@ module.exports = {
     'no-useless-catch': 'error',
     'no-useless-concat': 'error',
     'prefer-spread': 'error',
+    'require-unicode-regexp': 'error',
     /* End v2 rules */
     'arrow-parens': 'error',
     'no-tabs': 'error',

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -155,8 +155,8 @@ function doctypeCheck () {
  */
 function suffixCheck () {
   const prohibitedTypes = [
-    /\.xml$/,
-    /\.pdf$/,
+    /\.xml$/u,
+    /\.pdf$/u,
   ]
   const currentUrl = window.location.pathname
   for (let i = 0; i < prohibitedTypes.length; i++) {
@@ -202,7 +202,7 @@ function blockedDomainCheck () {
   let currentRegex
   for (let i = 0; i < blockedDomains.length; i++) {
     const blockedDomain = blockedDomains[i].replace('.', '\\.')
-    currentRegex = new RegExp(`(?:https?:\\/\\/)(?:(?!${blockedDomain}).)*$`)
+    currentRegex = new RegExp(`(?:https?:\\/\\/)(?:(?!${blockedDomain}).)*$`, 'u')
     if (!currentRegex.test(currentUrl)) {
       return true
     }

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -123,7 +123,7 @@ export default class ThreeBoxController {
       const threeBoxConfig = await Box.getConfig(this.address)
       backupExists = threeBoxConfig.spaces && threeBoxConfig.spaces.metamask
     } catch (e) {
-      if (e.message.match(/^Error: Invalid response \(404\)/)) {
+      if (e.message.match(/^Error: Invalid response \(404\)/u)) {
         backupExists = false
       } else {
         throw e

--- a/app/scripts/lib/decrypt-message-manager.js
+++ b/app/scripts/lib/decrypt-message-manager.js
@@ -5,7 +5,7 @@ import { ethErrors } from 'eth-json-rpc-errors'
 import createId from './random-id'
 import { MESSAGE_TYPE } from './enums'
 
-const hexRe = /^[0-9A-Fa-f]+$/g
+const hexRe = /^[0-9A-Fa-f]+$/ug
 import log from 'loglevel'
 
 /**

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -5,7 +5,7 @@ import { ethErrors } from 'eth-json-rpc-errors'
 import createId from './random-id'
 import { MESSAGE_TYPE } from './enums'
 
-const hexRe = /^[0-9A-Fa-f]+$/g
+const hexRe = /^[0-9A-Fa-f]+$/ug
 import log from 'loglevel'
 
 /**

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -25,7 +25,7 @@ module.exports = createScriptTasks
 
 const dependencies = Object.keys((packageJSON && packageJSON.dependencies) || {})
 const materialUIDependencies = ['@material-ui/core']
-const reactDepenendencies = dependencies.filter((dep) => dep.match(/react/))
+const reactDepenendencies = dependencies.filter((dep) => dep.match(/react/u))
 const d3Dependencies = ['c3', 'd3']
 
 const externalDependenciesMap = {
@@ -365,7 +365,7 @@ function getEnvironment ({ devMode, test }) {
     return 'testing'
   } else if (process.env.CIRCLE_BRANCH === 'master') {
     return 'production'
-  } else if (/^Version-v(\d+)[.](\d+)[.](\d+)/.test(process.env.CIRCLE_BRANCH)) {
+  } else if (/^Version-v(\d+)[.](\d+)[.](\d+)/u.test(process.env.CIRCLE_BRANCH)) {
     return 'release-candidate'
   } else if (process.env.CIRCLE_BRANCH === 'develop') {
     return 'staging'

--- a/development/static-server.js
+++ b/development/static-server.js
@@ -61,7 +61,7 @@ const main = async () => {
   }
 
   while (args.length) {
-    if (/^(--port|-p)$/i.test(args[0])) {
+    if (/^(--port|-p)$/ui.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing port argument')
       }

--- a/development/static-server.js
+++ b/development/static-server.js
@@ -61,7 +61,7 @@ const main = async () => {
   }
 
   while (args.length) {
-    if (/^(--port|-p)$/ui.test(args[0])) {
+    if (/^(--port|-p)$/u.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing port argument')
       }

--- a/development/verify-locale-strings.js
+++ b/development/verify-locale-strings.js
@@ -169,11 +169,11 @@ async function verifyEnglishLocale (fix = false) {
   // match "t(`...`)" because constructing message keys from template strings
   // prevents this script from finding the messages, and then inappropriately
   // deletes them
-  const templateStringRegex = /\bt\(`.*`\)/g
+  const templateStringRegex = /\bt\(`.*`\)/ug
   const templateUsage = []
 
   // match the keys from the locale file
-  const keyRegex = /'(\w+)'|"(\w+)"/g
+  const keyRegex = /'(\w+)'|"(\w+)"/ug
   const usedMessages = new Set()
   for await (const fileContents of getFileContents(javascriptFiles)) {
     for (const match of matchAll.call(fileContents, keyRegex)) {

--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -152,7 +152,7 @@ describe('MetaMask', function () {
 
     it('balance renders', async function () {
       const balance = await driver.findElement(By.css('[data-testid="wallet-balance"] .list-item__heading'))
-      await driver.wait(until.elementTextMatches(balance, /25\s*ETH/))
+      await driver.wait(until.elementTextMatches(balance, /25\s*ETH/u))
       await driver.delay(regularDelayMs)
     })
   })
@@ -202,7 +202,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/u), 10000)
     })
   })
 
@@ -239,7 +239,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues, /-2\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues, /-2\s*ETH/u), 10000)
     })
   })
 })

--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -117,7 +117,7 @@ async function main () {
   let existingParentDirectory
 
   while (args.length) {
-    if (/^(--pages|-p)$/ui.test(args[0])) {
+    if (/^(--pages|-p)$/u.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing pages argument')
       }
@@ -128,7 +128,7 @@ async function main () {
         }
       }
       args.splice(0, 2)
-    } else if (/^(--samples|-s)$/ui.test(args[0])) {
+    } else if (/^(--samples|-s)$/u.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing number of samples')
       }
@@ -137,7 +137,7 @@ async function main () {
         throw new Error(`Invalid 'samples' argument given: '${args[1]}'`)
       }
       args.splice(0, 2)
-    } else if (/^(--out|-o)$/ui.test(args[0])) {
+    } else if (/^(--out|-o)$/u.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing output filename')
       }

--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -117,7 +117,7 @@ async function main () {
   let existingParentDirectory
 
   while (args.length) {
-    if (/^(--pages|-p)$/i.test(args[0])) {
+    if (/^(--pages|-p)$/ui.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing pages argument')
       }
@@ -128,7 +128,7 @@ async function main () {
         }
       }
       args.splice(0, 2)
-    } else if (/^(--samples|-s)$/i.test(args[0])) {
+    } else if (/^(--samples|-s)$/ui.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing number of samples')
       }
@@ -137,7 +137,7 @@ async function main () {
         throw new Error(`Invalid 'samples' argument given: '${args[1]}'`)
       }
       args.splice(0, 2)
-    } else if (/^(--out|-o)$/i.test(args[0])) {
+    } else if (/^(--out|-o)$/ui.test(args[0])) {
       if (args[1] === undefined) {
         throw new Error('Missing output filename')
       }

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -223,7 +223,7 @@ describe('Using MetaMask with an existing account', function () {
 
       const txValues = await driver.findElements(By.css('.transaction-list-item__primary-currency'))
       assert.equal(txValues.length, 1)
-      assert.ok(/-1\s*ETH/.test(await txValues[0].getText()))
+      assert.ok(/-1\s*ETH/u.test(await txValues[0].getText()))
     })
   })
 

--- a/test/e2e/incremental-security.spec.js
+++ b/test/e2e/incremental-security.spec.js
@@ -127,7 +127,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.css('#send'))
 
       const txStatus = await driver.findElement(By.css('#success'))
-      await driver.wait(until.elementTextMatches(txStatus, /Success/), 15000)
+      await driver.wait(until.elementTextMatches(txStatus, /Success/u), 15000)
     })
 
     it('switches back to MetaMask', async function () {
@@ -136,7 +136,7 @@ describe('MetaMask', function () {
 
     it('should have the correct amount of eth', async function () {
       const balances = await driver.findElements(By.css('.currency-display-component__text'))
-      await driver.wait(until.elementTextMatches(balances[0], /1/), 15000)
+      await driver.wait(until.elementTextMatches(balances[0], /1/u), 15000)
       const balance = await balances[0].getText()
 
       assert.equal(balance, '1')
@@ -193,7 +193,7 @@ describe('MetaMask', function () {
 
     it('should have the correct amount of eth', async function () {
       const balances = await driver.findElements(By.css('.currency-display-component__text'))
-      await driver.wait(until.elementTextMatches(balances[0], /1/), 15000)
+      await driver.wait(until.elementTextMatches(balances[0], /1/u), 15000)
       const balance = await balances[0].getText()
 
       assert.equal(balance, '1')

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -167,7 +167,7 @@ describe('MetaMask', function () {
 
     it('balance renders', async function () {
       const balance = await driver.findElement(By.css('[data-testid="eth-overview__primary-currency"]'))
-      await driver.wait(until.elementTextMatches(balance, /100\s*ETH/))
+      await driver.wait(until.elementTextMatches(balance, /100\s*ETH/u))
       await driver.delay(regularDelayMs)
     })
   })
@@ -218,7 +218,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/u), 10000)
     })
   })
 })

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -909,7 +909,7 @@ describe('MetaMask', function () {
       await driver.wait(until.elementTextMatches(txValues[0], /-1\s*TST/u), 10000)
 
       const txStatuses = await driver.findElements(By.css('.list-item__heading'))
-      await driver.wait(until.elementTextMatches(txStatuses[0], /Send\sTST/ui), 10000)
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Send\sTST/u), 10000)
     })
   })
 

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -208,7 +208,7 @@ describe('MetaMask', function () {
 
     it('balance renders', async function () {
       const balance = await driver.findElement(By.css('[data-testid="wallet-balance"] .list-item__heading'))
-      await driver.wait(until.elementTextMatches(balance, /100\s*ETH/))
+      await driver.wait(until.elementTextMatches(balance, /100\s*ETH/u))
       await driver.delay(regularDelayMs)
     })
   })
@@ -273,7 +273,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/u), 10000)
     })
   })
 
@@ -312,7 +312,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/u), 10000)
     })
   })
 
@@ -360,7 +360,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues, /-1\s*ETH/u), 10000)
     })
   })
 
@@ -463,7 +463,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValue = await driver.findClickableElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValue, /-3\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValue, /-3\s*ETH/u), 10000)
     })
 
     it('the transaction has the expected gas price', async function () {
@@ -471,7 +471,7 @@ describe('MetaMask', function () {
       await txValue.click()
       const popoverCloseButton = await driver.findClickableElement(By.css('.popover-header__button'))
       const txGasPrice = await driver.findElement(By.css('[data-testid="transaction-breakdown__gas-price"]'))
-      await driver.wait(until.elementTextMatches(txGasPrice, /^10$/), 10000)
+      await driver.wait(until.elementTextMatches(txGasPrice, /^10$/u), 10000)
       await popoverCloseButton.click()
     })
   })
@@ -654,7 +654,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txAction = await driver.findElements(By.css('.list-item__heading'))
-      await driver.wait(until.elementTextMatches(txAction[0], /Contract\sDeployment/), 10000)
+      await driver.wait(until.elementTextMatches(txAction[0], /Contract\sDeployment/u), 10000)
       await driver.delay(regularDelayMs)
     })
 
@@ -663,20 +663,20 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs)
 
       let contractStatus = await driver.findElement(By.css('#contractStatus'))
-      await driver.wait(until.elementTextMatches(contractStatus, /Deployed/), 15000)
+      await driver.wait(until.elementTextMatches(contractStatus, /Deployed/u), 15000)
 
       await driver.clickElement(By.css('#depositButton'))
       await driver.delay(largeDelayMs)
 
       contractStatus = await driver.findElement(By.css('#contractStatus'))
-      await driver.wait(until.elementTextMatches(contractStatus, /Deposit\sinitiated/), 10000)
+      await driver.wait(until.elementTextMatches(contractStatus, /Deposit\sinitiated/u), 10000)
 
       await driver.switchToWindow(extension)
       await driver.delay(largeDelayMs * 2)
 
       await driver.findElements(By.css('.transaction-list-item'))
       const txListValue = await driver.findClickableElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txListValue, /-4\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txListValue, /-4\s*ETH/u), 10000)
       await txListValue.click()
       await driver.delay(regularDelayMs)
 
@@ -718,7 +718,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElements(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues[0], /-4\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues[0], /-4\s*ETH/u), 10000)
     })
 
     it('calls and confirms a contract method where ETH is received', async function () {
@@ -743,7 +743,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues, /-0\s*ETH/), 10000)
+      await driver.wait(until.elementTextMatches(txValues, /-0\s*ETH/u), 10000)
 
       await driver.closeAllWindowHandlesExcept([extension, dapp])
       await driver.switchToWindow(extension)
@@ -752,9 +752,9 @@ describe('MetaMask', function () {
     it('renders the correct ETH balance', async function () {
       const balance = await driver.findElement(By.css('[data-testid="eth-overview__primary-currency"]'))
       await driver.delay(regularDelayMs)
-      await driver.wait(until.elementTextMatches(balance, /^87.*\s*ETH.*$/), 10000)
+      await driver.wait(until.elementTextMatches(balance, /^87.*\s*ETH.*$/u), 10000)
       const tokenAmount = await balance.getText()
-      assert.ok(/^87.*\s*ETH.*$/.test(tokenAmount))
+      assert.ok(/^87.*\s*ETH.*$/u.test(tokenAmount))
       await driver.delay(regularDelayMs)
     })
   })
@@ -797,7 +797,7 @@ describe('MetaMask', function () {
       await driver.delay(tinyDelayMs)
 
       const tokenContractAddress = await driver.findElement(By.css('#tokenAddress'))
-      await driver.wait(until.elementTextMatches(tokenContractAddress, /0x/))
+      await driver.wait(until.elementTextMatches(tokenContractAddress, /0x/u))
       tokenAddress = await tokenContractAddress.getText()
 
       await driver.delay(regularDelayMs)
@@ -830,9 +830,9 @@ describe('MetaMask', function () {
 
     it('renders the balance for the new token', async function () {
       const balance = await driver.findElement(By.css('.wallet-overview .token-overview__primary-balance'))
-      await driver.wait(until.elementTextMatches(balance, /^10\s*TST\s*$/))
+      await driver.wait(until.elementTextMatches(balance, /^10\s*TST\s*$/u))
       const tokenAmount = await balance.getText()
-      assert.ok(/^10\s*TST\s*$/.test(tokenAmount))
+      assert.ok(/^10\s*TST\s*$/u.test(tokenAmount))
       await driver.delay(regularDelayMs)
     })
   })
@@ -887,7 +887,7 @@ describe('MetaMask', function () {
       const confirmDataText = await confirmDataDiv.getText()
 
       await driver.delay(regularDelayMs)
-      assert(confirmDataText.match(/0xa9059cbb0000000000000000000000002f318c334780961fb129d2a6c30d0763d9a5c97/))
+      assert(confirmDataText.match(/0xa9059cbb0000000000000000000000002f318c334780961fb129d2a6c30d0763d9a5c97/u))
 
       await driver.clickElement(By.xpath(`//li[contains(text(), 'Details')]`))
       await driver.delay(regularDelayMs)
@@ -906,10 +906,10 @@ describe('MetaMask', function () {
 
       const txValues = await driver.findElements(By.css('.transaction-list-item__primary-currency'))
       assert.equal(txValues.length, 1)
-      await driver.wait(until.elementTextMatches(txValues[0], /-1\s*TST/), 10000)
+      await driver.wait(until.elementTextMatches(txValues[0], /-1\s*TST/u), 10000)
 
       const txStatuses = await driver.findElements(By.css('.list-item__heading'))
-      await driver.wait(until.elementTextMatches(txStatuses[0], /Send\sTST/i), 10000)
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Send\sTST/ui), 10000)
     })
   })
 
@@ -931,7 +931,7 @@ describe('MetaMask', function () {
 
       await driver.findElements(By.css('.transaction-list__pending-transactions'))
       const txListValue = await driver.findClickableElement(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txListValue, /-1.5\s*TST/), 10000)
+      await driver.wait(until.elementTextMatches(txListValue, /-1.5\s*TST/u), 10000)
       await txListValue.click()
       await driver.delay(regularDelayMs)
 
@@ -987,12 +987,12 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElements(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues[0], /-1.5\s*TST/))
+      await driver.wait(until.elementTextMatches(txValues[0], /-1.5\s*TST/u))
       const txStatuses = await driver.findElements(By.css('.list-item__heading'))
-      await driver.wait(until.elementTextMatches(txStatuses[0], /Send\sTST/), 10000)
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Send\sTST/u), 10000)
 
       const tokenBalanceAmount = await driver.findElements(By.css('.token-overview__primary-balance'))
-      await driver.wait(until.elementTextMatches(tokenBalanceAmount[0], /7.5\s*TST/), 10000)
+      await driver.wait(until.elementTextMatches(tokenBalanceAmount[0], /7.5\s*TST/u), 10000)
     })
   })
 
@@ -1019,7 +1019,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const [txtListHeading] = await driver.findElements(By.css('.transaction-list-item .list-item__heading'))
-      await driver.wait(until.elementTextMatches(txtListHeading, /Approve TST spend limit/))
+      await driver.wait(until.elementTextMatches(txtListHeading, /Approve TST spend limit/u))
       await driver.clickElement(By.css('.transaction-list-item'))
       await driver.delay(regularDelayMs)
     })
@@ -1034,7 +1034,7 @@ describe('MetaMask', function () {
 
       const confirmDataDiv = await driver.findElement(By.css('.confirm-approve-content__data__data-block'))
       const confirmDataText = await confirmDataDiv.getText()
-      assert(confirmDataText.match(/0x095ea7b30000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef4/))
+      assert(confirmDataText.match(/0x095ea7b30000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef4/u))
     })
 
     it('opens the gas edit modal', async function () {
@@ -1105,7 +1105,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txStatuses = await driver.findElements(By.css('.list-item__heading'))
-      await driver.wait(until.elementTextMatches(txStatuses[0], /Approve TST spend limit/))
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Approve TST spend limit/u))
     })
   })
 
@@ -1130,7 +1130,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const [txListValue] = await driver.findElements(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txListValue, /-1.5\s*TST/))
+      await driver.wait(until.elementTextMatches(txListValue, /-1.5\s*TST/u))
       await driver.clickElement(By.css('.transaction-list-item'))
       await driver.delay(regularDelayMs)
     })
@@ -1148,9 +1148,9 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txValues = await driver.findElements(By.css('.transaction-list-item__primary-currency'))
-      await driver.wait(until.elementTextMatches(txValues[0], /-1.5\s*TST/))
+      await driver.wait(until.elementTextMatches(txValues[0], /-1.5\s*TST/u))
       const txStatuses = await driver.findElements(By.css('.list-item__heading'))
-      await driver.wait(until.elementTextMatches(txStatuses[0], /Send TST/))
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Send TST/u))
     })
   })
 
@@ -1176,7 +1176,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const [txtListHeading] = await driver.findElements(By.css('.transaction-list-item .list-item__heading'))
-      await driver.wait(until.elementTextMatches(txtListHeading, /Approve TST spend limit/))
+      await driver.wait(until.elementTextMatches(txtListHeading, /Approve TST spend limit/u))
       await driver.clickElement(By.css('.transaction-list-item'))
       await driver.delay(regularDelayMs)
     })
@@ -1203,7 +1203,7 @@ describe('MetaMask', function () {
       }, 10000)
 
       const txStatuses = await driver.findElements(By.css('.list-item__heading'))
-      await driver.wait(until.elementTextMatches(txStatuses[0], /Approve TST spend limit/))
+      await driver.wait(until.elementTextMatches(txStatuses[0], /Approve TST spend limit/u))
     })
   })
 
@@ -1244,7 +1244,7 @@ describe('MetaMask', function () {
 
     it('renders the balance for the chosen token', async function () {
       const balance = await driver.findElement(By.css('.token-overview__primary-balance'))
-      await driver.wait(until.elementTextMatches(balance, /0\s*BAT/))
+      await driver.wait(until.elementTextMatches(balance, /0\s*BAT/u))
       await driver.delay(regularDelayMs)
     })
   })

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -205,7 +205,7 @@ describe('Using MetaMask with an existing account', function () {
 
       const txValues = await driver.findElements(By.css('.transaction-list-item__primary-currency'))
       assert.equal(txValues.length, 1)
-      assert.ok(/-2.2\s*ETH/.test(await txValues[0].getText()))
+      assert.ok(/-2.2\s*ETH/u.test(await txValues[0].getText()))
     })
   })
 })

--- a/test/e2e/tests/localization.spec.js
+++ b/test/e2e/tests/localization.spec.js
@@ -20,7 +20,7 @@ describe('Localization', function () {
         await passwordField.sendKeys(Key.ENTER)
         const secondaryBalance = await driver.findElement(By.css('[data-testid="eth-overview__secondary-currency"]'))
         const secondaryBalanceText = await secondaryBalance.getText()
-        const [fiatAmount, fiatUnit] = secondaryBalanceText.trim().split(/\s+/)
+        const [fiatAmount, fiatUnit] = secondaryBalanceText.trim().split(/\s+/u)
         assert.ok(fiatAmount.startsWith('₱'))
         assert.equal(fiatUnit, 'PHP')
       },

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -97,7 +97,7 @@ describe('MetaMask', function () {
 
       it('balance renders', async function () {
         const balance = await driver.findElement(By.css('[data-testid="wallet-balance"] .list-item__heading'))
-        await driver.wait(until.elementTextMatches(balance, /25\s*ETH/))
+        await driver.wait(until.elementTextMatches(balance, /25\s*ETH/u))
         await driver.delay(regularDelayMs)
       })
     })
@@ -203,7 +203,7 @@ describe('MetaMask', function () {
 
       it('balance renders', async function () {
         const balance = await driver2.findElement(By.css('[data-testid="wallet-balance"] .list-item__heading'))
-        await driver2.wait(until.elementTextMatches(balance, /25\s*ETH/))
+        await driver2.wait(until.elementTextMatches(balance, /25\s*ETH/u))
         await driver2.delay(regularDelayMs)
       })
     })

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -45,7 +45,7 @@ async function setupFetchMocking (driver) {
         return { json: async () => clone(fetchMockResponses.ethGasBasic) }
       } else if (url.match(/http(s?):\/\/ethgasstation\.info\/json\/predictTable.*/u)) {
         return { json: async () => clone(fetchMockResponses.ethGasPredictTable) }
-      } else if (url.match(/chromeextensionmm/)) {
+      } else if (url.match(/chromeextensionmm/u)) {
         return { json: async () => clone(fetchMockResponses.metametrics) }
       }
       return window.origFetch(...args)

--- a/test/unit/app/controllers/detect-tokens-test.js
+++ b/test/unit/app/controllers/detect-tokens-test.js
@@ -24,7 +24,7 @@ describe('DetectTokensController', function () {
 
 
     nock('https://api.infura.io')
-      .get(/.*/)
+      .get(/.*/u)
       .reply(200)
 
     keyringMemStore = new ObservableStore({ isUnlocked: false })

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -92,12 +92,12 @@ describe('MetaMaskController', function () {
 
     nock('https://api.infura.io')
       .persist()
-      .get(/.*/)
+      .get(/.*/u)
       .reply(200)
 
     nock('https://min-api.cryptocompare.com')
       .persist()
-      .get(/.*/)
+      .get(/.*/u)
       .reply(200, '{"JPY":12415.9}')
 
     metamaskController = new MetaMaskController({

--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -50,7 +50,7 @@ describe('migrations', function () {
       migrationNumbers = fileNames
         .reduce((acc, filename) => {
           const name = filename.split('.')[0]
-          if (/^\d+$/.test(name)) {
+          if (/^\d+$/u.test(name)) {
             acc.push(name)
           }
           return acc
@@ -70,7 +70,7 @@ describe('migrations', function () {
       const testNumbers = fileNames
         .reduce((acc, filename) => {
           const name = filename.split('-test.')[0]
-          if (/^\d+$/.test(name)) {
+          if (/^\d+$/u.test(name)) {
             acc.push(name)
           }
           return acc

--- a/ui/app/components/app/menu-bar/account-options-menu.js
+++ b/ui/app/components/app/menu-bar/account-options-menu.js
@@ -97,7 +97,7 @@ export default function AccountOptionsMenu ({ anchorElement, onClose }) {
           rpcPrefs.blockExplorerUrl
             ? (
               <span className="account-options-menu__explorer-origin">
-                { rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/)[1] }
+                { rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1] }
               </span>
             )
             : null

--- a/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/app/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -66,7 +66,7 @@ export default class AccountDetailsModal extends Component {
           }}
         >
           {rpcPrefs.blockExplorerUrl
-            ? this.context.t('blockExplorerView', [rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/)[1]])
+            ? this.context.t('blockExplorerView', [rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1]])
             : this.context.t('viewOnEtherscan')
           }
         </Button>

--- a/ui/app/components/ui/unit-input/unit-input.component.js
+++ b/ui/app/components/ui/unit-input/unit-input.component.js
@@ -58,7 +58,7 @@ export default class UnitInput extends PureComponent {
   getInputWidth (value) {
     const valueString = String(value)
     const valueLength = valueString.length || 1
-    const decimalPointDeficit = valueString.match(/\./) ? -0.5 : 0
+    const decimalPointDeficit = valueString.match(/\./u) ? -0.5 : 0
     return (valueLength + decimalPointDeficit + 0.5) + 'ch'
   }
 

--- a/ui/app/contexts/metametrics.js
+++ b/ui/app/contexts/metametrics.js
@@ -60,7 +60,7 @@ export function MetaMetricsProvider ({ children }) {
     const { eventOpts = {} } = config
     const { name = '' } = eventOpts
     const { currentPath: overrideCurrentPath = '' } = overrides
-    const isSendFlow = Boolean(name.match(/^send|^confirm/) || overrideCurrentPath.match(/send|confirm/))
+    const isSendFlow = Boolean(name.match(/^send|^confirm/u) || overrideCurrentPath.match(/send|confirm/u))
 
     if (participateInMetaMetrics || config.isOptIn) {
       return sendMetaMetricsEvent({

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -482,7 +482,7 @@ describe('Confirm Transaction Duck', function () {
     beforeEach(function () {
       global.eth = {
         getCode: sinon.stub().callsFake(
-          (address) => Promise.resolve(address && address.match(/isContract/) ? 'not-0x' : '0x'),
+          (address) => Promise.resolve(address && address.match(/isContract/u) ? 'not-0x' : '0x'),
         ),
       }
     })

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -67,7 +67,7 @@ describe('Gas Duck', function () {
     { expectedTime: 1, expectedWait: 0.5, gasprice: 20, somethingElse: 'foobar' },
   ]
   const fakeFetch = (url) => new Promise((resolve) => {
-    const dataToResolve = url.match(/ethgasAPI/)
+    const dataToResolve = url.match(/ethgasAPI/u)
       ? mockEthGasApiResponse
       : mockPredictTableResponse
     resolve({

--- a/ui/app/helpers/utils/common.util.js
+++ b/ui/app/helpers/utils/common.util.js
@@ -1,5 +1,5 @@
 export function camelCaseToCapitalize (str = '') {
   return str
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/^./, (str) => str.toUpperCase())
+    .replace(/([A-Z])/ug, ' $1')
+    .replace(/^./u, (str) => str.toUpperCase())
 }

--- a/ui/app/helpers/utils/i18n-helper.js
+++ b/ui/app/helpers/utils/i18n-helper.js
@@ -48,10 +48,10 @@ export const getMessage = (localeCode, localeMessages, key, substitutions) => {
 
   // perform substitutions
   if (hasSubstitutions) {
-    const parts = phrase.split(/(\$\d)/g)
+    const parts = phrase.split(/(\$\d)/ug)
 
     const substitutedParts = parts.map((part) => {
-      const subMatch = part.match(/\$(\d)/)
+      const subMatch = part.match(/\$(\d)/u)
       if (!subMatch) {
         return part
       }

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -237,7 +237,7 @@ export function getStatusKey (transaction) {
  */
 export function getBlockExplorerUrlForTx (networkId, hash, rpcPrefs = {}) {
   if (rpcPrefs.blockExplorerUrl) {
-    return `${rpcPrefs.blockExplorerUrl.replace(/\/+$/, '')}/tx/${hash}`
+    return `${rpcPrefs.blockExplorerUrl.replace(/\/+$/u, '')}/tx/${hash}`
   }
   const prefix = getEtherscanNetworkPrefix(networkId)
   return `https://${prefix}etherscan.io/tx/${hash}`

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -75,7 +75,7 @@ export function isValidDomainName (address) {
     // Checks that the domain consists of at least one valid domain pieces separated by periods, followed by a tld
     // Each piece of domain name has only the characters a-z, 0-9, and a hyphen (but not at the start or end of chunk)
     // A chunk has minimum length of 1, but minimum tld is set to 2 for now (no 1-character tlds exist yet)
-    .match(/^(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.)+[a-z0-9][-a-z0-9]*[a-z0-9]$/)
+    .match(/^(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.)+[a-z0-9][-a-z0-9]*[a-z0-9]$/u)
   return match !== null
 }
 
@@ -102,7 +102,7 @@ export function parseBalance (balance) {
   let afterDecimal
   const wei = numericBalance(balance)
   const weiString = wei.toString()
-  const trailingZeros = /0+$/
+  const trailingZeros = /0+$/u
 
   const beforeDecimal = weiString.length > 18 ? weiString.slice(0, weiString.length - 18) : '0'
   afterDecimal = ('000000000000000000' + wei).slice(-18).replace(trailingZeros, '')
@@ -122,7 +122,7 @@ export function formatBalance (balance, decimalsToKeep, needsParse = true, ticke
   if (decimalsToKeep === undefined) {
     if (beforeDecimal === '0') {
       if (afterDecimal !== '0') {
-        const sigFigs = afterDecimal.match(/^0*(.{2})/) // default: grabs 2 most significant digits
+        const sigFigs = afterDecimal.match(/^0*(.{2})/u) // default: grabs 2 most significant digits
         if (sigFigs) {
           afterDecimal = sigFigs[0]
         }
@@ -219,7 +219,7 @@ export function normalizeNumberToWei (n, currency) {
 }
 
 export function isHex (str) {
-  return Boolean(str.match(/^(0x)?[0-9a-fA-F]+$/))
+  return Boolean(str.match(/^(0x)?[0-9a-fA-F]+$/u))
 }
 
 export function getContractAtAddress (tokenAddress) {

--- a/ui/app/helpers/utils/util.test.js
+++ b/ui/app/helpers/utils/util.test.js
@@ -307,7 +307,7 @@ describe('util', function () {
     describe('#getRandomFileName', function () {
       it('should only return a string containing alphanumeric characters', function () {
         const result = util.getRandomFileName()
-        assert(result.match(/^[a-zA-Z0-9]*$/g))
+        assert(result.match(/^[a-zA-Z0-9]*$/ug))
       })
 
       // 50 samples

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -727,7 +727,7 @@ export function getMethodName (camelCase) {
   }
 
   return camelCase
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/([A-Z])([a-z])/g, ' $1$2')
-    .replace(/ +/g, ' ')
+    .replace(/([a-z])([A-Z])/ug, '$1 $2')
+    .replace(/([A-Z])([a-z])/ug, ' $1$2')
+    .replace(/ +/ug, ' ')
 }

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.container.js
@@ -5,7 +5,7 @@ import { unconfirmedTransactionsListSelector } from '../../selectors'
 const mapStateToProps = (state, ownProps) => {
   const { metamask: { unapprovedTxs } } = state
   const { match: { params = {}, url } } = ownProps
-  const urlId = url && url.match(/\d+/) && url.match(/\d+/)[0]
+  const urlId = url && url.match(/\d+/u) && url.match(/\d+/u)[0]
   const { id: paramsId } = params
   const transactionId = paramsId || urlId
 

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-utils.test.js
@@ -9,7 +9,7 @@ import {
 } from '../../../send.constants'
 
 const stubs = {
-  isValidAddress: sinon.stub().callsFake((to) => Boolean(to.match(/^[0xabcdef123456798]+$/))),
+  isValidAddress: sinon.stub().callsFake((to) => Boolean(to.match(/^[0xabcdef123456798]+$/u))),
 }
 
 const toRowUtils = proxyquire('../add-recipient.js', {

--- a/ui/app/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
+++ b/ui/app/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
@@ -15,7 +15,7 @@ export default class SendHexDataRow extends Component {
 
   onInput = (event) => {
     const { updateSendHexData, updateGas } = this.props
-    const data = event.target.value.replace(/\n/g, '') || null
+    const data = event.target.value.replace(/\n/ug, '') || null
     updateSendHexData(data)
     updateGas({ data })
   }

--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -314,7 +314,7 @@ function getToAddressForGasUpdate (...addresses) {
 }
 
 function removeLeadingZeroes (str) {
-  return str.replace(/^0*(?=\d)/, '')
+  return str.replace(/^0*(?=\d)/u, '')
 }
 
 function ellipsify (text, first = 6, last = 4) {

--- a/ui/app/pages/send/tests/send-utils.test.js
+++ b/ui/app/pages/send/tests/send-utils.test.js
@@ -10,10 +10,10 @@ import {
 
 const stubs = {
   addCurrencies: sinon.stub().callsFake((a, b) => {
-    if (String(a).match(/^0x.+/)) {
+    if (String(a).match(/^0x.+/u)) {
       a = Number(String(a).slice(2))
     }
-    if (String(b).match(/^0x.+/)) {
+    if (String(b).match(/^0x.+/u)) {
       b = Number(String(b).slice(2))
     }
     return a + b
@@ -294,8 +294,8 @@ describe('send utils', function () {
       to: '0xisContract',
       estimateGasMethod: sinon.stub().callsFake(
         ({ to }) => {
-          if (typeof to === 'string' && to.match(/willFailBecauseOf:/)) {
-            throw new Error(to.match(/:(.+)$/)[1])
+          if (typeof to === 'string' && to.match(/willFailBecauseOf:/u)) {
+            throw new Error(to.match(/:(.+)$/u)[1])
           }
           return { toString: (n) => `0xabc${n}` }
         },
@@ -311,7 +311,7 @@ describe('send utils', function () {
     beforeEach(function () {
       global.eth = {
         getCode: sinon.stub().callsFake(
-          (address) => Promise.resolve(address.match(/isContract/) ? 'not-0x' : '0x'),
+          (address) => Promise.resolve(address.match(/isContract/u) ? 'not-0x' : '0x'),
         ),
       }
     })

--- a/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/app/pages/settings/advanced-tab/advanced-tab.component.js
@@ -489,7 +489,7 @@ export default class AdvancedTab extends PureComponent {
 
 function addUrlProtocolPrefix (urlString) {
   if (!urlString.match(
-    /(^http:\/\/)|(^https:\/\/)/,
+    /(^http:\/\/)|(^https:\/\/)/u,
   )) {
     return 'https://' + urlString
   }

--- a/ui/app/pages/settings/contact-list-tab/contact-list-tab.container.js
+++ b/ui/app/pages/settings/contact-list-tab/contact-list-tab.container.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps
   const { pathname } = location
 
-  const pathNameTail = pathname.match(/[^/]+$/)[0]
+  const pathNameTail = pathname.match(/[^/]+$/u)[0]
   const pathNameTailIsAddress = pathNameTail.includes('0x')
 
   const viewingContact = Boolean(pathname.match(CONTACT_VIEW_ROUTE) || pathname.match(CONTACT_MY_ACCOUNTS_VIEW_ROUTE))

--- a/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
+++ b/ui/app/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
@@ -15,7 +15,7 @@ import { addToAddressBook, removeFromAddressBook, setAccountLabel } from '../../
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps
   const { pathname } = location
-  const pathNameTail = pathname.match(/[^/]+$/)[0]
+  const pathNameTail = pathname.match(/[^/]+$/u)[0]
   const pathNameTailIsAddress = pathNameTail.includes('0x')
   const address = pathNameTailIsAddress ? pathNameTail.toLowerCase() : ownProps.match.params.id
 

--- a/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.component.js
@@ -15,7 +15,7 @@ function quadSplit (address) {
     '0x ' +
     address
       .slice(2)
-      .match(/.{1,4}/g)
+      .match(/.{1,4}/ug)
       .join(' ')
   )
 }

--- a/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.container.js
+++ b/ui/app/pages/settings/contact-list-tab/view-contact/view-contact.container.js
@@ -15,7 +15,7 @@ import {
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps
   const { pathname } = location
-  const pathNameTail = pathname.match(/[^/]+$/)[0]
+  const pathNameTail = pathname.match(/[^/]+$/u)[0]
   const pathNameTailIsAddress = pathNameTail.includes('0x')
   const address = pathNameTailIsAddress ? pathNameTail.toLowerCase() : ownProps.match.params.id
 

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -214,7 +214,7 @@ export default class NetworkForm extends PureComponent {
 
   isValidWhenAppended = (url) => {
     const appendedRpc = `http://${url}`
-    return validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/)
+    return validUrl.isWebUri(appendedRpc) && !url.match(/^https?:\/\/$/u)
   }
 
   validateBlockExplorerURL = (url, stateKey) => {

--- a/ui/app/pages/settings/settings.container.js
+++ b/ui/app/pages/settings/settings.container.js
@@ -42,7 +42,7 @@ const ROUTES_TO_I18N_KEYS = {
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps
   const { pathname } = location
-  const pathNameTail = pathname.match(/[^/]+$/)[0]
+  const pathNameTail = pathname.match(/[^/]+$/u)[0]
 
   const isAddressEntryPage = pathNameTail.includes('0x')
   const isMyAccountsPage = pathname.match('my-accounts')

--- a/ui/lib/account-link.js
+++ b/ui/lib/account-link.js
@@ -1,6 +1,6 @@
 export default function getAccountLink (address, network, rpcPrefs) {
   if (rpcPrefs && rpcPrefs.blockExplorerUrl) {
-    return `${rpcPrefs.blockExplorerUrl.replace(/\/+$/, '')}/address/${address}`
+    return `${rpcPrefs.blockExplorerUrl.replace(/\/+$/u, '')}/address/${address}`
   }
 
   const net = parseInt(network)


### PR DESCRIPTION
Refs #8982

See [`require-unicode-regexp`](https://eslint.org/docs/rules/require-unicode-regexp) for more information.

This change enables `require-unicode-regexp` and fixes the issues raised by the rule.

### But what is the `u` flag?

[_Unicode-aware regular expressions in ES2015_](https://mathiasbynens.be/notes/es6-unicode-regex) covers the most of it, I'd recommend skimming the sections.

My opinionated summary:

> ECMAScript 2015 introduces [...]
> 1. [...]
> 2. `u` enables various Unicode-related features.

Impacts of the `u` flag:

- Things like `\u{1234}` are now Unicode code point escapes instead of matching 1234 consecutive u symbols
- Things like `\a` (where a is not an escape character) now error because `\a` is not a reserved escape sequence
- The `.` now matches unicode symbols
- Quantifiers e.g. `*`, `+`, `?`, and `{2}`, `{2,}`, `{2,4}` now work on unicode symbols
- Character classes and negated character classes work on unicode symbols
- Combining the `u` and `i` flags is weird because it does case folding

> Recommendations for developers
> - Use the `u` flag for every regular expression you write from now on.
> - …but don’t blindly add the `u` flag to existing regular expressions, as it might change their meaning in subtle ways.
> - Avoid combining the `u` and `i` flags. It’s better to be explicit and include all letter cases in your regular expression itself than to be surprised by implicit case folding.