### PR TITLE
Fix no-prototype-builtins issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
     'no-global-assign': 'error',
     'no-loop-func': 'error',
     'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
+    'no-prototype-builtins': 'error',
     'no-useless-catch': 'error',
     'no-useless-concat': 'error',
     'prefer-spread': 'error',

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -25,7 +25,7 @@ export default class ComposableObservableStore extends ObservableStore {
     this.config = config
     this.removeAllListeners()
     for (const key in config) {
-      if (config.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(config, key)) {
         config[key].subscribe((state) => {
           this.updateState({ [key]: state })
         })
@@ -42,7 +42,7 @@ export default class ComposableObservableStore extends ObservableStore {
   getFlatState () {
     let flatState = {}
     for (const key in this.config) {
-      if (this.config.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(this.config, key)) {
         const controller = this.config[key]
         const state = controller.getState ? controller.getState() : controller.state
         flatState = { ...flatState, ...state }

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -40,7 +40,7 @@ export default async function getFirstPreferredLangCode () {
 
   const firstPreferredLangCode = userPreferredLocaleCodes
     .map((code) => code.toLowerCase().replace('_', '-'))
-    .find((code) => existingLocaleCodes.hasOwnProperty(code))
+    .find((code) => Object.prototype.hasOwnProperty.call(existingLocaleCodes, code))
 
   return existingLocaleCodes[firstPreferredLangCode] || 'en'
 }


### PR DESCRIPTION
Refs #8982

See [`no-prototype-builtins`](https://eslint.org/docs/rules/no-prototype-builtins) for more information.

This change enables `no-prototype-builtins` and fixes the issues raised by the rule.