### PR TITLE
Fix no-nested-ternary issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
     'no-eq-null': 'error',
     'no-global-assign': 'error',
     'no-loop-func': 'error',
+    'no-nested-ternary': 'error',
     'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
     'no-useless-catch': 'error',
     'no-useless-concat': 'error',

--- a/ui/app/helpers/utils/metametrics.util.js
+++ b/ui/app/helpers/utils/metametrics.util.js
@@ -170,11 +170,13 @@ function composeUrl (config) {
   const _id = metaMetricsId && !excludeMetaMetricsId ? `&_id=${metaMetricsId.slice(2, 18)}` : ''
   const rand = `&rand=${String(Math.random()).slice(2)}`
   const pv_id = currentPath ? `&pv_id=${ethUtil.bufferToHex(ethUtil.sha3(currentPath)).slice(2, 8)}` : ''
-  const uid = metaMetricsId && !excludeMetaMetricsId
-    ? `&uid=${metaMetricsId.slice(2, 18)}`
-    : excludeMetaMetricsId
-      ? '&uid=0000000000000000'
-      : ''
+
+  let uid = ''
+  if (excludeMetaMetricsId) {
+    uid = '&uid=0000000000000000'
+  } else if (metaMetricsId) {
+    uid = `&uid=${metaMetricsId.slice(2, 18)}`
+  }
 
   return [ base, e_c, e_a, e_n, cvar, action_name, urlref, dimensions, url, _id, rand, pv_id, uid, new_visit ].join('')
 }

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -181,9 +181,10 @@ export function getLatestSubmittedTxWithNonce (transactions = [], nonce = '0x0')
     const { submittedTime, txParams: { nonce: currentNonce } = {} } = current
 
     if (currentNonce === nonce) {
-      return acc.submittedTime
-        ? submittedTime > acc.submittedTime ? current : acc
-        : current
+      if (!acc.submittedTime) {
+        return current
+      }
+      return submittedTime > acc.submittedTime ? current : acc
     } else {
       return acc
     }

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -93,13 +93,10 @@ const mapStateToProps = (state, ownProps) => {
   const { balance } = accounts[fromAddress]
   const { name: fromName } = identities[fromAddress]
   const toAddress = propsToAddress || txParamsToAddress
-  const toName = identities[toAddress]
-    ? identities[toAddress].name
-    : (
-      casedContractMap[toAddress]
-        ? casedContractMap[toAddress].name
-        : shortenAddress(checksumAddress(toAddress))
-    )
+
+  const toName = identities[toAddress]?.name ||
+    casedContractMap[toAddress]?.name ||
+    shortenAddress(checksumAddress(toAddress))
 
   const checksummedAddress = checksumAddress(toAddress)
   const addressBookObject = addressBook[checksummedAddress]

--- a/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.js
@@ -20,6 +20,7 @@ export default class GasFeeDisplay extends Component {
 
     return (
       <div className="send-v2__gas-fee-display">
+        {/* eslint-disable-next-line no-nested-ternary */}
         {gasTotal
           ? (
             <div className="currency-display">


### PR DESCRIPTION
Refs #8982

See [`no-nested-ternary`](https://eslint.org/docs/rules/no-nested-ternary) for more information.

This change enables `no-nested-ternary` and fixes the issues raised by the rule. I disabled the one that was too annoying to rewrite.