### PR TITLE
Fix prefer-rest-params issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
     'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
     'no-useless-catch': 'error',
     'no-useless-concat': 'error',
+    'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     /* End v2 rules */
     'arrow-parens': 'error',

--- a/app/scripts/lib/nodeify.js
+++ b/app/scripts/lib/nodeify.js
@@ -15,9 +15,7 @@ const callbackNoop = function (err) {
  *
  */
 export default function nodeify (fn, context) {
-  return function () {
-    // parse arguments
-    const args = [].slice.call(arguments)
+  return function (...args) {
     const lastArg = args[args.length - 1]
     const lastArgIsCallback = typeof lastArg === 'function'
     let callback


### PR DESCRIPTION
Refs #8982

See [`prefer-rest-params`](https://eslint.org/docs/rules/prefer-rest-params) for more information.

This change enables `prefer-rest-params` and fixes the issues raised by the rule.