### PR TITLE
Fix no-template-curly-in-string issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
     'no-nested-ternary': 'error',
     'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
     'no-prototype-builtins': 'error',
+    'no-template-curly-in-string': 'error',
     'no-useless-catch': 'error',
     'no-useless-concat': 'error',
     'prefer-rest-params': 'error',

--- a/app/scripts/lib/decrypt-message-manager.js
+++ b/app/scripts/lib/decrypt-message-manager.js
@@ -253,7 +253,7 @@ export default class DecryptMessageManager extends EventEmitter {
   _setMsgStatus (msgId, status) {
     const msg = this.getMsg(msgId)
     if (!msg) {
-      throw new Error('DecryptMessageManager - Message not found for id: "${msgId}".')
+      throw new Error(`DecryptMessageManager - Message not found for id: "${msgId}".`)
     }
     msg.status = status
     this._updateMsg(msg)

--- a/app/scripts/lib/encryption-public-key-manager.js
+++ b/app/scripts/lib/encryption-public-key-manager.js
@@ -247,7 +247,7 @@ export default class EncryptionPublicKeyManager extends EventEmitter {
   _setMsgStatus (msgId, status) {
     const msg = this.getMsg(msgId)
     if (!msg) {
-      throw new Error('EncryptionPublicKeyManager - Message not found for id: "${msgId}".')
+      throw new Error(`EncryptionPublicKeyManager - Message not found for id: "${msgId}".`)
     }
     msg.status = status
     this._updateMsg(msg)

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -225,7 +225,7 @@ export default class MessageManager extends EventEmitter {
   _setMsgStatus (msgId, status) {
     const msg = this.getMsg(msgId)
     if (!msg) {
-      throw new Error('MessageManager - Message not found for id: "${msgId}".')
+      throw new Error(`MessageManager - Message not found for id: "${msgId}".`)
     }
     msg.status = status
     this._updateMsg(msg)

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -292,7 +292,7 @@ export default class TypedMessageManager extends EventEmitter {
   _setMsgStatus (msgId, status) {
     const msg = this.getMsg(msgId)
     if (!msg) {
-      throw new Error('TypedMessageManager - Message not found for id: "${msgId}".')
+      throw new Error(`TypedMessageManager - Message not found for id: "${msgId}".`)
     }
     msg.status = status
     this._updateMsg(msg)


### PR DESCRIPTION
Refs #8982

See [`no-template-curly-in-string`](https://eslint.org/docs/rules/no-template-curly-in-string) for more information.

This change enables `no-template-curly-in-string` and fixes the issues raised by the rule.