### PR TITLE
Tidy ConnectHardwareForm#checkIfUnlocked

### DIFF
--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -35,13 +35,13 @@ class ConnectHardwareForm extends Component {
   }
 
   async checkIfUnlocked () {
-    ['trezor', 'ledger'].forEach(async (device) => {
+    for (const device of ['trezor', 'ledger']) {
       const unlocked = await this.props.checkHardwareStatus(device, this.props.defaultHdPaths[device])
       if (unlocked) {
         this.setState({ unlocked: true })
         this.getPage(device, 0, this.props.defaultHdPaths[device])
       }
-    })
+    }
   }
 
   connectToHardwareWallet = (device) => {


### PR DESCRIPTION
This change tidies up the implementation of `ConnectHardwareForm#checkIfUnlocked`—passing an `async` function to `forEach` doesn't ensure that the one is run before the other.