### PR TITLE
Permit all caps addresses

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -98,7 +98,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const newTotalFiat = addHexWEIsToRenderableFiat(value, customGasTotal, currentCurrency, conversionRate)
 
-  const hideBasic = state.appState.modal.modalState.props.hideBasic || state.metamask.featureFlags.advancedInlineGas
+  const hideBasic = state.appState.modal.modalState.props.hideBasic || (state.metamask.featureFlags.advancedInlineGas && !process.env.IN_TEST)
 
   const customGasPrice = calcCustomGasPrice(customModalGasPriceInHex)
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -98,7 +98,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const newTotalFiat = addHexWEIsToRenderableFiat(value, customGasTotal, currentCurrency, conversionRate)
 
-  const hideBasic = state.appState.modal.modalState.props.hideBasic
+  const hideBasic = state.appState.modal.modalState.props.hideBasic || state.metamask.featureFlags.advancedInlineGas
 
   const customGasPrice = calcCustomGasPrice(customModalGasPriceInHex)
 

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -62,11 +62,11 @@ export function addressSummary (address, firstSegLength = 10, lastSegLength = 4,
 }
 
 export function isValidAddress (address) {
-  const prefixed = ethUtil.addHexPrefix(address)
+  const prefixed = address.startsWith('0X') ? address : ethUtil.addHexPrefix(address)
   if (address === '0x0000000000000000000000000000000000000000') {
     return false
   }
-  return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
+  return (isAllOneCase(prefixed.slice(2)) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
 }
 
 export function isValidDomainName (address) {

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -36,7 +36,9 @@ export default class SendGasRow extends Component {
   renderAdvancedOptionsButton () {
     const { metricsEvent } = this.context
     const { showCustomizeGasModal, advancedInlineGasShown } = this.props
-    if (advancedInlineGasShown === true) return
+    if (advancedInlineGasShown === true) {
+      return
+    }
     return (
       <div
         className="advanced-gas-options-btn"

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -36,7 +36,8 @@ export default class SendGasRow extends Component {
   renderAdvancedOptionsButton () {
     const { metricsEvent } = this.context
     const { showCustomizeGasModal, advancedInlineGasShown } = this.props
-    if (advancedInlineGasShown === true) {
+    // Tests should behave in same way as mainnet, but are using Localhost
+    if (advancedInlineGasShown === true && !process.env.IN_TEST) {
       return
     }
     return (

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -38,7 +38,7 @@ export default class SendGasRow extends Component {
     const { showCustomizeGasModal, advancedInlineGasShown } = this.props
     // Tests should behave in same way as mainnet, but are using Localhost
     if (advancedInlineGasShown === true && !process.env.IN_TEST) {
-      return
+      return null
     }
     return (
       <div

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -35,7 +35,8 @@ export default class SendGasRow extends Component {
 
   renderAdvancedOptionsButton () {
     const { metricsEvent } = this.context
-    const { showCustomizeGasModal } = this.props
+    const { showCustomizeGasModal, advancedInlineGasShown } = this.props
+    if (advancedInlineGasShown === true) return
     return (
       <div
         className="advanced-gas-options-btn"

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1464,7 +1464,7 @@ export function setProviderType (type) {
     }
     dispatch(setPreviousProvider(currentProviderType))
     dispatch(updateProviderType(type))
-    dispatch(setFeatureFlag('advancedInlineGas', type !== 'mainnet' || !process.env.IN_TEST))
+    dispatch(setFeatureFlag('advancedInlineGas', type !== 'mainnet' && !process.env.IN_TEST))
   }
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1464,7 +1464,7 @@ export function setProviderType (type) {
     }
     dispatch(setPreviousProvider(currentProviderType))
     dispatch(updateProviderType(type))
-    dispatch(setFeatureFlag('advancedInlineGas', type !== 'mainnet'))
+    dispatch(setFeatureFlag('advancedInlineGas', type !== 'mainnet' || !process.env.IN_TEST))
   }
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1464,6 +1464,7 @@ export function setProviderType (type) {
     }
     dispatch(setPreviousProvider(currentProviderType))
     dispatch(updateProviderType(type))
+    dispatch(setFeatureFlag('advancedInlineGas', type !== 'mainnet'))
   }
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1464,7 +1464,10 @@ export function setProviderType (type) {
     }
     dispatch(setPreviousProvider(currentProviderType))
     dispatch(updateProviderType(type))
-    dispatch(setFeatureFlag('advancedInlineGas', type !== 'mainnet' && !process.env.IN_TEST))
+    // Tests should behave in same way as mainnet, but are using Localhost
+    if (!process.env.IN_TEST) {
+      dispatch(setFeatureFlag('advancedInlineGas', type !== 'mainnet'))
+    }
   }
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -111,7 +111,7 @@ async function startApp (metamaskState, backgroundConnection, opts) {
       id: unapprovedTxsAll[0].id,
     }))
   }
-  store.dispatch(actions.setFeatureFlag('advancedInlineGas', metamaskState.provider.type !== 'mainnet'))
+  store.dispatch(actions.setFeatureFlag('advancedInlineGas', metamaskState.provider.type !== 'mainnet' || !process.env.IN_TEST))
   backgroundConnection.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
   })

--- a/ui/index.js
+++ b/ui/index.js
@@ -111,7 +111,7 @@ async function startApp (metamaskState, backgroundConnection, opts) {
       id: unapprovedTxsAll[0].id,
     }))
   }
-  store.dispatch(actions.setFeatureFlag('advancedInlineGas', metamaskState.provider.type !== 'mainnet' || !process.env.IN_TEST))
+  store.dispatch(actions.setFeatureFlag('advancedInlineGas', metamaskState.provider.type !== 'mainnet' && !process.env.IN_TEST))
   backgroundConnection.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
   })

--- a/ui/index.js
+++ b/ui/index.js
@@ -111,7 +111,7 @@ async function startApp (metamaskState, backgroundConnection, opts) {
       id: unapprovedTxsAll[0].id,
     }))
   }
-
+  store.dispatch(actions.setFeatureFlag('advancedInlineGas', metamaskState.provider.type !== 'mainnet'))
   backgroundConnection.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
   })

--- a/ui/index.js
+++ b/ui/index.js
@@ -111,7 +111,10 @@ async function startApp (metamaskState, backgroundConnection, opts) {
       id: unapprovedTxsAll[0].id,
     }))
   }
-  store.dispatch(actions.setFeatureFlag('advancedInlineGas', metamaskState.provider.type !== 'mainnet' && !process.env.IN_TEST))
+  // Tests should behave in same way as mainnet, but are using Localhost
+  if (!process.env.IN_TEST) {
+    store.dispatch(actions.setFeatureFlag('advancedInlineGas', metamaskState.provider.type !== 'mainnet'))
+  }
   backgroundConnection.on('update', function (metamaskState) {
     store.dispatch(actions.updateMetamaskState(metamaskState))
   })


### PR DESCRIPTION
Allows to use all-caps addresses - was not sure about '0X' prefix, but I checked that Etherscan allows to use such prefix, so added it here as well.

Fixes #9175 