### PR TITLE
Permit all-caps addresses

### DIFF
--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -62,10 +62,10 @@ export function addressSummary (address, firstSegLength = 10, lastSegLength = 4,
 }
 
 export function isValidAddress (address) {
-  const prefixed = address.startsWith('0X') ? address : ethUtil.addHexPrefix(address)
-  if (address === '0x0000000000000000000000000000000000000000') {
+  if (!address || address === '0x0000000000000000000000000000000000000000') {
     return false
   }
+  const prefixed = address.startsWith('0X') ? address : ethUtil.addHexPrefix(address)
   return (isAllOneCase(prefixed.slice(2)) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
 }
 

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -62,11 +62,11 @@ export function addressSummary (address, firstSegLength = 10, lastSegLength = 4,
 }
 
 export function isValidAddress (address) {
-  const prefixed = ethUtil.addHexPrefix(address)
+  const prefixed = address.startsWith('0X') ? address : ethUtil.addHexPrefix(address)
   if (address === '0x0000000000000000000000000000000000000000') {
     return false
   }
-  return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
+  return (isAllOneCase(prefixed.slice(2)) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
 }
 
 export function isValidDomainName (address) {


### PR DESCRIPTION
Allows to use all-caps addresses - was not sure about '0X' prefix, but I checked that Etherscan allows to use such prefix, so added it here as well.

Fixes #9175 