### PR TITLE
move footer buttons to scrollable area

### DIFF
--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -4,6 +4,8 @@ import classnames from 'classnames'
 import { Tabs, Tab } from '../../../ui/tabs'
 import { ConfirmPageContainerSummary, ConfirmPageContainerWarning } from '.'
 import ErrorMessage from '../../../ui/error-message'
+import { PageContainerFooter } from '../../../ui/page-container'
+
 
 export default class ConfirmPageContainerContent extends Component {
   static propTypes = {
@@ -22,6 +24,15 @@ export default class ConfirmPageContainerContent extends Component {
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     titleComponent: PropTypes.node,
     warning: PropTypes.string,
+    // Footer
+    onCancelAll: PropTypes.func,
+    onCancel: PropTypes.func,
+    cancelText: PropTypes.string,
+    onSubmit: PropTypes.func,
+    submitText: PropTypes.string,
+    disabled: PropTypes.bool,
+    unapprovedTxCount: PropTypes.number,
+    rejectText: PropTypes.string,
   }
 
   renderContent () {
@@ -66,6 +77,14 @@ export default class ConfirmPageContainerContent extends Component {
       detailsComponent,
       dataComponent,
       warning,
+      onCancelAll,
+      onCancel,
+      cancelText,
+      onSubmit,
+      submitText,
+      disabled,
+      unapprovedTxCount,
+      rejectText,
     } = this.props
 
     return (
@@ -104,6 +123,21 @@ export default class ConfirmPageContainerContent extends Component {
             </div>
           )
         }
+        <PageContainerFooter
+          onCancel={() => onCancel()}
+          cancelText={cancelText}
+          onSubmit={() => onSubmit()}
+          submitText={submitText}
+          submitButtonType="confirm"
+          disabled={disabled}
+        >
+          {unapprovedTxCount > 1 && (
+            <a onClick={() => onCancelAll()}>
+              {rejectText}
+            </a>
+          )}
+        </PageContainerFooter>
+
       </div>
     )
   }

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -124,15 +124,15 @@ export default class ConfirmPageContainerContent extends Component {
           )
         }
         <PageContainerFooter
-          onCancel={() => onCancel()}
+          onCancel={onCancel}
           cancelText={cancelText}
-          onSubmit={() => onSubmit()}
+          onSubmit={onSubmit}
           submitText={submitText}
           submitButtonType="confirm"
           disabled={disabled}
         >
           {unapprovedTxCount > 1 && (
-            <a onClick={() => onCancelAll()}>
+            <a onClick={onCancelAll}>
               {rejectNText}
             </a>
           )}

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -32,7 +32,7 @@ export default class ConfirmPageContainerContent extends Component {
     submitText: PropTypes.string,
     disabled: PropTypes.bool,
     unapprovedTxCount: PropTypes.number,
-    rejectText: PropTypes.string,
+    rejectNText: PropTypes.string,
   }
 
   renderContent () {
@@ -84,7 +84,7 @@ export default class ConfirmPageContainerContent extends Component {
       submitText,
       disabled,
       unapprovedTxCount,
-      rejectText,
+      rejectNText,
     } = this.props
 
     return (
@@ -133,7 +133,7 @@ export default class ConfirmPageContainerContent extends Component {
         >
           {unapprovedTxCount > 1 && (
             <a onClick={() => onCancelAll()}>
-              {rejectText}
+              {rejectNText}
             </a>
           )}
         </PageContainerFooter>

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -5,6 +5,8 @@
   overflow-y: auto;
   height: 100%;
   flex: 1;
+  display: flex;
+  flex-direction: column;
 
   &__error-container {
     padding: 0 16px 16px 16px;
@@ -71,5 +73,9 @@
     color: #8c8e94;
     text-transform: uppercase;
     margin: 0 8px;
+  }
+
+  .page-container__footer {
+    margin-top: auto;
   }
 }

--- a/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import SenderToRecipient from '../../ui/sender-to-recipient'
+import { PageContainerFooter } from '../../ui/page-container'
 import { ConfirmPageContainerHeader, ConfirmPageContainerContent, ConfirmPageContainerNavigation } from '.'
 
 export default class ConfirmPageContainer extends Component {
@@ -163,8 +164,26 @@ export default class ConfirmPageContainer extends Component {
               submitText={this.context.t('confirm')}
               disabled={disabled}
               unapprovedTxCount={unapprovedTxCount}
-              rejectText={this.context.t('rejectTxsN', [unapprovedTxCount])}
+              rejectNText={this.context.t('rejectTxsN', [unapprovedTxCount])}
             />
+          )
+        }
+        {
+          contentComponent && (
+            <PageContainerFooter
+              onCancel={() => onCancel()}
+              cancelText={this.context.t('reject')}
+              onSubmit={() => onSubmit()}
+              submitText={this.context.t('confirm')}
+              submitButtonType="confirm"
+              disabled={disabled}
+            >
+              {unapprovedTxCount > 1 && (
+                <a onClick={() => onCancelAll()}>
+                  {this.context.t('rejectTxsN', [unapprovedTxCount])}
+                </a>
+              )}
+            </PageContainerFooter>
           )
         }
       </div>

--- a/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import SenderToRecipient from '../../ui/sender-to-recipient'
-import { PageContainerFooter } from '../../ui/page-container'
 import { ConfirmPageContainerHeader, ConfirmPageContainerContent, ConfirmPageContainerNavigation } from '.'
 
 export default class ConfirmPageContainer extends Component {
@@ -157,23 +156,17 @@ export default class ConfirmPageContainer extends Component {
               nonce={nonce}
               assetImage={assetImage}
               warning={warning}
+              onCancelAll={onCancelAll}
+              onCancel={onCancel}
+              cancelText={this.context.t('reject')}
+              onSubmit={onSubmit}
+              submitText={this.context.t('confirm')}
+              disabled={disabled}
+              unapprovedTxCount={unapprovedTxCount}
+              rejectText={this.context.t('rejectTxsN', [unapprovedTxCount])}
             />
           )
         }
-        <PageContainerFooter
-          onCancel={() => onCancel()}
-          cancelText={this.context.t('reject')}
-          onSubmit={() => onSubmit()}
-          submitText={this.context.t('confirm')}
-          submitButtonType="confirm"
-          disabled={disabled}
-        >
-          {unapprovedTxCount > 1 && (
-            <a onClick={() => onCancelAll()}>
-              {this.context.t('rejectTxsN', [unapprovedTxCount])}
-            </a>
-          )}
-        </PageContainerFooter>
       </div>
     )
   }

--- a/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
@@ -171,15 +171,15 @@ export default class ConfirmPageContainer extends Component {
         {
           contentComponent && (
             <PageContainerFooter
-              onCancel={() => onCancel()}
+              onCancel={onCancel}
               cancelText={this.context.t('reject')}
-              onSubmit={() => onSubmit()}
+              onSubmit={onSubmit}
               submitText={this.context.t('confirm')}
               submitButtonType="confirm"
               disabled={disabled}
             >
               {unapprovedTxCount > 1 && (
-                <a onClick={() => onCancelAll()}>
+                <a onClick={onCancelAll}>
                   {this.context.t('rejectTxsN', [unapprovedTxCount])}
                 </a>
               )}


### PR DESCRIPTION
Adds the confirm/cancel buttons to the scrollable region, so they cannot be clicked until all errors/warnings have been seen.

Fixes #9136 