### PR TITLE
Fix import/no-extraneous-dependencies issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
     'guard-for-in': 'error',
     'implicit-arrow-linebreak': 'error',
     'import/extensions': ['error', 'never', { 'json': 'always' }],
+    'import/no-extraneous-dependencies': 'error',
     'no-case-declarations': 'error',
     'no-constant-condition': 'error',
     'no-dupe-else-if': 'error',

--- a/test/unit/app/controllers/ens-controller-test.js
+++ b/test/unit/app/controllers/ens-controller-test.js
@@ -1,7 +1,6 @@
 import assert from 'assert'
 import sinon from 'sinon'
 import ObservableStore from 'obs-store'
-import HttpProvider from 'ethjs-provider-http'
 import EnsController from '../../../../app/scripts/controllers/ens'
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -10,11 +9,10 @@ const ZERO_X_ERROR_ADDRESS = '0x'
 describe('EnsController', function () {
   describe('#constructor', function () {
     it('should construct the controller given a provider and a network', async function () {
-      const provider = new HttpProvider('https://ropsten.infura.io')
       const currentNetworkId = '3'
       const networkStore = new ObservableStore(currentNetworkId)
       const ens = new EnsController({
-        provider,
+        provider: { },
         networkStore,
       })
 


### PR DESCRIPTION
Refs #8982

See [`import/no-extraneous-dependencies`](https://eslint.org/docs/rules/import/no-extraneous-dependencies) for more information.

This change enables `import/no-extraneous-dependencies` and fixes the issues raised by the rule.