### PR TITLE
Fix import/unambiguous issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     'implicit-arrow-linebreak': 'error',
     'import/extensions': ['error', 'never', { 'json': 'always' }],
     'import/no-extraneous-dependencies': 'error',
+    'import/unambiguous': 'error',
     'max-statements-per-line': ['error', { 'max': 1 }],
     'no-case-declarations': 'error',
     'no-constant-condition': 'error',
@@ -166,6 +167,20 @@ module.exports = {
     ],
     rules: {
       'no-process-exit': 'off',
+    },
+  }, {
+    files: [
+      '.eslintrc.js',
+      'babel.config.js',
+      'nyc.config.js',
+      'stylelint.config.js',
+      'development/**/*.js',
+      'test/e2e/**/*.js',
+      'test/env.js',
+      'test/setup.js',
+    ],
+    parserOptions: {
+      sourceType: 'script',
     },
   }],
 


### PR DESCRIPTION
Refs #8982

See [`import/unambiguous`](https://eslint.org/docs/rules/import/unambiguous) for more information.

This change enables `import/unambiguous` and fixes the issues raised by the rule.