### PR TITLE
Send web3 usage metrics once per origin/property

### DIFF
--- a/app/scripts/lib/createMethodMiddleware.js
+++ b/app/scripts/lib/createMethodMiddleware.js
@@ -1,3 +1,6 @@
+
+const recordedWeb3Usage = {}
+
 /**
  * Returns a middleware that implements the following RPC methods:
  * - metamask_logInjectedWeb3Usage
@@ -15,11 +18,17 @@ export default function createMethodMiddleware ({ origin, sendMetrics }) {
 
         const { action, name } = req.params[0]
 
-        sendMetrics({
-          action,
-          name,
-          customVariables: { origin },
-        })
+        if (!recordedWeb3Usage[origin]) {
+          recordedWeb3Usage[origin] = {}
+        }
+        if (!recordedWeb3Usage[origin][name]) {
+          recordedWeb3Usage[origin][name] = true
+          sendMetrics({
+            action,
+            name,
+            customVariables: { origin },
+          })
+        }
 
         res.result = true
         break


### PR DESCRIPTION
The usage metrics for the injected web3 instance were being sent upon each use, which exceeded the limits of our Matomo plan. These metrics are now only being sent upon the first usage, for each origin and property.