### PR TITLE
Handle non-String web3 property access

### DIFF
--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -44,9 +44,10 @@ export default function setupWeb3 (log) {
       }
 
       if (shouldLogUsage) {
+        const name = stringifyKey(key)
         window.ethereum.request({
           method: 'metamask_logInjectedWeb3Usage',
-          params: [{ action: 'window.web3 get', name: key }],
+          params: [{ action: 'window.web3 get', name }],
         })
       }
 
@@ -54,11 +55,11 @@ export default function setupWeb3 (log) {
       return _web3[key]
     },
     set: (_web3, key, value) => {
-
+      const name = stringifyKey(key)
       if (shouldLogUsage) {
         window.ethereum.request({
           method: 'metamask_logInjectedWeb3Usage',
-          params: [{ action: 'window.web3 set', name: key }],
+          params: [{ action: 'window.web3 set', name }],
         })
       }
 
@@ -119,4 +120,16 @@ export default function setupWeb3 (log) {
 // reload the page
 function triggerReset () {
   global.location.reload()
+}
+
+/**
+ * Returns a "stringified" key. Keys that are already strings are returned
+ * unchanged, and any non-string values are returned as "typeof <type>".
+ *
+ * @param {any} key - The key to stringify
+ */
+function stringifyKey (key) {
+  return typeof key === 'string'
+    ? key
+    : `typeof ${typeof key}`
 }


### PR DESCRIPTION
The web3 usage metrics added in #9144 assumed that all web3 properties were strings. When a `Symbol` property is accessed, our `inpage.js` script crashes because the `Symbol` cannot be serialized correctly.

A check has been added for non-string property access. The metric event in these cases is set to the string "typeof ", followed by the type of the key. (e.g. `typeof symbol` for a `Symbol` property).

Fixes #9234