### PR TITLE
Add sort and search to AddRecipient accounts list

### DIFF
--- a/ui/app/pages/send/send-content/add-recipient/add-recipient.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/add-recipient.component.js
@@ -22,6 +22,7 @@ export default class AddRecipient extends Component {
     addressBookEntryName: PropTypes.string,
     contacts: PropTypes.array,
     nonContacts: PropTypes.array,
+    setInternalSearch: PropTypes.func,
   }
 
   constructor(props) {
@@ -139,16 +140,25 @@ export default class AddRecipient extends Component {
     )
   }
 
-  renderTransfer() {
-    const { ownedAccounts } = this.props
+  renderTransfer () {
+    let { ownedAccounts } = this.props
+    const { query, setInternalSearch } = this.props
     const { t } = this.context
+    const { isShowingTransfer } = this.state
+
+    if (isShowingTransfer && query) {
+      ownedAccounts = ownedAccounts.filter((item) => item.name.toLowerCase().indexOf(query.toLowerCase()) > -1 || item.address.toLowerCase().indexOf(query.toLowerCase()) > -1)
+    }
 
     return (
       <div className="send__select-recipient-wrapper__list">
         <Button
           type="link"
           className="send__select-recipient-wrapper__list__link"
-          onClick={() => this.setState({ isShowingTransfer: false })}
+          onClick={() => {
+            setInternalSearch(false)
+            this.setState({ isShowingTransfer: false })
+          }}
         >
           <div className="send__select-recipient-wrapper__list__back-caret" />
           {t('backToAll')}
@@ -164,7 +174,7 @@ export default class AddRecipient extends Component {
 
   renderMain() {
     const { t } = this.context
-    const { query, ownedAccounts = [], addressBook } = this.props
+    const { query, ownedAccounts = [], addressBook, setInternalSearch } = this.props
 
     return (
       <div className="send__select-recipient-wrapper__list">
@@ -174,15 +184,20 @@ export default class AddRecipient extends Component {
           searchForRecents={this.searchForRecents.bind(this)}
           selectRecipient={this.selectRecipient.bind(this)}
         >
-          {ownedAccounts && ownedAccounts.length > 1 && !query && (
-            <Button
-              type="link"
-              className="send__select-recipient-wrapper__list__link"
-              onClick={() => this.setState({ isShowingTransfer: true })}
-            >
-              {t('transferBetweenAccounts')}
-            </Button>
-          )}
+          {
+            (ownedAccounts && ownedAccounts.length > 1) && !query && (
+              <Button
+                type="link"
+                className="send__select-recipient-wrapper__list__link"
+                onClick={() => {
+                  setInternalSearch(true)
+                  this.setState({ isShowingTransfer: true })
+                }}
+              >
+                { t('transferBetweenAccounts') }
+              </Button>
+            )
+          }
         </ContactList>
       </div>
     )

--- a/ui/app/pages/send/send-content/add-recipient/add-recipient.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/add-recipient.component.js
@@ -140,14 +140,18 @@ export default class AddRecipient extends Component {
     )
   }
 
-  renderTransfer () {
+  renderTransfer() {
     let { ownedAccounts } = this.props
     const { query, setInternalSearch } = this.props
     const { t } = this.context
     const { isShowingTransfer } = this.state
 
     if (isShowingTransfer && query) {
-      ownedAccounts = ownedAccounts.filter((item) => item.name.toLowerCase().indexOf(query.toLowerCase()) > -1 || item.address.toLowerCase().indexOf(query.toLowerCase()) > -1)
+      ownedAccounts = ownedAccounts.filter(
+        (item) =>
+          item.name.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
+          item.address.toLowerCase().indexOf(query.toLowerCase()) > -1,
+      )
     }
 
     return (
@@ -174,7 +178,12 @@ export default class AddRecipient extends Component {
 
   renderMain() {
     const { t } = this.context
-    const { query, ownedAccounts = [], addressBook, setInternalSearch } = this.props
+    const {
+      query,
+      ownedAccounts = [],
+      addressBook,
+      setInternalSearch,
+    } = this.props
 
     return (
       <div className="send__select-recipient-wrapper__list">
@@ -184,20 +193,18 @@ export default class AddRecipient extends Component {
           searchForRecents={this.searchForRecents.bind(this)}
           selectRecipient={this.selectRecipient.bind(this)}
         >
-          {
-            (ownedAccounts && ownedAccounts.length > 1) && !query && (
-              <Button
-                type="link"
-                className="send__select-recipient-wrapper__list__link"
-                onClick={() => {
-                  setInternalSearch(true)
-                  this.setState({ isShowingTransfer: true })
-                }}
-              >
-                { t('transferBetweenAccounts') }
-              </Button>
-            )
-          }
+          {ownedAccounts && ownedAccounts.length > 1 && !query && (
+            <Button
+              type="link"
+              className="send__select-recipient-wrapper__list__link"
+              onClick={() => {
+                setInternalSearch(true)
+                this.setState({ isShowingTransfer: true })
+              }}
+            >
+              {t('transferBetweenAccounts')}
+            </Button>
+          )}
         </ContactList>
       </div>
     )

--- a/ui/app/pages/send/send-content/add-recipient/add-recipient.container.js
+++ b/ui/app/pages/send/send-content/add-recipient/add-recipient.container.js
@@ -23,14 +23,18 @@ function mapStateToProps(state) {
 
   const addressBook = getAddressBook(state)
 
+  const ownedAccounts = accountsWithSendEtherInfoSelector(state).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )
+
   return {
-    ownedAccounts: accountsWithSendEtherInfoSelector(state),
     addressBook,
-    ensResolution,
     addressBookEntryName,
-    ensResolutionError: getSendEnsResolutionError(state),
     contacts: addressBook.filter(({ name }) => Boolean(name)),
+    ensResolution,
+    ensResolutionError: getSendEnsResolutionError(state),
     nonContacts: addressBook.filter(({ name }) => !name),
+    ownedAccounts,
   }
 }
 

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -47,7 +47,7 @@ export default class EnsInput extends Component {
     ensResolution: undefined,
   }
 
-  componentDidMount () {
+  componentDidMount() {
     const { network, internalSearch } = this.props
     const networkHasEnsSupport = getNetworkEnsSupport(network)
     this.setState({ ensResolution: ZERO_ADDRESS })
@@ -141,7 +141,14 @@ export default class EnsInput extends Component {
   }
 
   onChange = (e) => {
-    const { network, onChange, updateEnsResolution, updateEnsResolutionError, onValidAddressTyped, internalSearch } = this.props
+    const {
+      network,
+      onChange,
+      updateEnsResolution,
+      updateEnsResolutionError,
+      onValidAddressTyped,
+      internalSearch,
+    } = this.props
     const input = e.target.value
     const networkHasEnsSupport = getNetworkEnsSupport(network)
 
@@ -158,7 +165,9 @@ export default class EnsInput extends Component {
       !isValidAddressHead(input)
     ) {
       updateEnsResolution('')
-      updateEnsResolutionError(networkHasEnsSupport ? '' : 'Network does not support ENS')
+      updateEnsResolutionError(
+        networkHasEnsSupport ? '' : 'Network does not support ENS',
+      )
       return null
     }
 

--- a/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-container.test.js
+++ b/ui/app/pages/send/send-content/add-recipient/tests/add-recipient-container.test.js
@@ -22,8 +22,10 @@ proxyquire('../add-recipient.container.js', {
     getSendEnsResolutionError: (s) => `mockSendEnsResolutionError:${s}`,
     getAddressBook: (s) => [{ name: `mockAddressBook:${s}` }],
     getAddressBookEntry: (s) => `mockAddressBookEntry:${s}`,
-    accountsWithSendEtherInfoSelector: (s) =>
-      `mockAccountsWithSendEtherInfoSelector:${s}`,
+    accountsWithSendEtherInfoSelector: (s) => [
+      { name: `account2:${s}` },
+      { name: `account1:${s}` },
+    ],
   },
   '../../../../store/actions': actionSpies,
 })
@@ -36,7 +38,10 @@ describe('add-recipient container', function () {
         contacts: [{ name: 'mockAddressBook:mockState' }],
         ensResolution: 'mockSendEnsResolution:mockState',
         ensResolutionError: 'mockSendEnsResolutionError:mockState',
-        ownedAccounts: 'mockAccountsWithSendEtherInfoSelector:mockState',
+        ownedAccounts: [
+          { name: `account1:mockState` },
+          { name: `account2:mockState` },
+        ],
         addressBookEntryName: undefined,
         nonContacts: [],
       })

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -63,6 +63,7 @@ export default class SendTransactionScreen extends Component {
     query: '',
     toError: null,
     toWarning: null,
+    internalSearch: false,
   }
 
   constructor(props) {
@@ -207,6 +208,7 @@ export default class SendTransactionScreen extends Component {
     if (query) {
       this.dValidate(query)
     } else {
+      this.dValidate.cancel()
       this.validate(query)
     }
 
@@ -215,10 +217,25 @@ export default class SendTransactionScreen extends Component {
     })
   }
 
-  validate(query) {
-    const { hasHexData, tokens, sendToken, network } = this.props
+  onInternalSearch = (query) => {
+    this.setState({ query })
+  }
 
-    if (!query) {
+  setInternalSearch (internalSearch) {
+    this.setState({ query: '', internalSearch })
+  }
+
+  validate (query) {
+    const {
+      hasHexData,
+      tokens,
+      sendToken,
+      network,
+    } = this.props
+
+    const internalSearch = this.state.internalSearch
+
+    if (!query || internalSearch) {
       this.setState({ toError: '', toWarning: '' })
       return
     }
@@ -292,7 +309,8 @@ export default class SendTransactionScreen extends Component {
     )
   }
 
-  renderInput() {
+  renderInput () {
+    const internalSearch = this.state.internalSearch
     return (
       <EnsInput
         className="send__to-row"
@@ -306,7 +324,7 @@ export default class SendTransactionScreen extends Component {
           })
           this.props.scanQrCode()
         }}
-        onChange={this.onRecipientInputChange}
+        onChange={internalSearch ? this.onRecipientInputChange : this.onInternalSearch}
         onValidAddressTyped={(address) => this.props.updateSendTo(address, '')}
         onPaste={(text) => {
           this.props.updateSendTo(text) && this.updateGas()
@@ -314,6 +332,7 @@ export default class SendTransactionScreen extends Component {
         onReset={() => this.props.updateSendTo('', '')}
         updateEnsResolution={this.props.updateSendEnsResolution}
         updateEnsResolutionError={this.props.updateSendEnsResolutionError}
+        internalSearch={internalSearch}
       />
     )
   }
@@ -327,6 +346,8 @@ export default class SendTransactionScreen extends Component {
         }
         query={this.state.query}
         toError={toError}
+        toWarning={toWarning}
+        setInternalSearch={(internalSearch) => this.setInternalSearch(internalSearch)}
       />
     )
   }

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -221,17 +221,12 @@ export default class SendTransactionScreen extends Component {
     this.setState({ query })
   }
 
-  setInternalSearch (internalSearch) {
+  setInternalSearch(internalSearch) {
     this.setState({ query: '', internalSearch })
   }
 
-  validate (query) {
-    const {
-      hasHexData,
-      tokens,
-      sendToken,
-      network,
-    } = this.props
+  validate(query) {
+    const { hasHexData, tokens, sendToken, network } = this.props
 
     const { internalSearch } = this.state
 
@@ -309,7 +304,7 @@ export default class SendTransactionScreen extends Component {
     )
   }
 
-  renderInput () {
+  renderInput() {
     const { internalSearch } = this.state
     return (
       <EnsInput
@@ -324,7 +319,9 @@ export default class SendTransactionScreen extends Component {
           })
           this.props.scanQrCode()
         }}
-        onChange={internalSearch ? this.onRecipientInputChange : this.onInternalSearch}
+        onChange={
+          internalSearch ? this.onRecipientInputChange : this.onInternalSearch
+        }
         onValidAddressTyped={(address) => this.props.updateSendTo(address, '')}
         onPaste={(text) => {
           this.props.updateSendTo(text) && this.updateGas()
@@ -338,7 +335,7 @@ export default class SendTransactionScreen extends Component {
   }
 
   renderAddRecipient() {
-    const { toError } = this.state
+    const { toError, toWarning } = this.state
     return (
       <AddRecipient
         updateGas={({ to, amount, data } = {}) =>
@@ -347,7 +344,9 @@ export default class SendTransactionScreen extends Component {
         query={this.state.query}
         toError={toError}
         toWarning={toWarning}
-        setInternalSearch={(internalSearch) => this.setInternalSearch(internalSearch)}
+        setInternalSearch={(internalSearch) =>
+          this.setInternalSearch(internalSearch)
+        }
       />
     )
   }

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -205,19 +205,17 @@ export default class SendTransactionScreen extends Component {
   }
 
   onRecipientInputChange = (query) => {
-    if (query) {
-      this.dValidate(query)
-    } else {
-      this.dValidate.cancel()
-      this.validate(query)
+    const { internalSearch } = this.state
+
+    if (!internalSearch) {
+      if (query) {
+        this.dValidate(query)
+      } else {
+        this.dValidate.cancel()
+        this.validate(query)
+      }
     }
 
-    this.setState({
-      query,
-    })
-  }
-
-  onInternalSearch = (query) => {
     this.setState({ query })
   }
 
@@ -319,9 +317,7 @@ export default class SendTransactionScreen extends Component {
           })
           this.props.scanQrCode()
         }}
-        onChange={
-          internalSearch ? this.onRecipientInputChange : this.onInternalSearch
-        }
+        onChange={this.onRecipientInputChange}
         onValidAddressTyped={(address) => this.props.updateSendTo(address, '')}
         onPaste={(text) => {
           this.props.updateSendTo(text) && this.updateGas()

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -233,7 +233,7 @@ export default class SendTransactionScreen extends Component {
       network,
     } = this.props
 
-    const internalSearch = this.state.internalSearch
+    const { internalSearch } = this.state
 
     if (!query || internalSearch) {
       this.setState({ toError: '', toWarning: '' })
@@ -310,7 +310,7 @@ export default class SendTransactionScreen extends Component {
   }
 
   renderInput () {
-    const internalSearch = this.state.internalSearch
+    const { internalSearch } = this.state
     return (
       <EnsInput
         className="send__to-row"

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -331,7 +331,7 @@ export default class SendTransactionScreen extends Component {
   }
 
   renderAddRecipient() {
-    const { toError, toWarning } = this.state
+    const { toError } = this.state
     return (
       <AddRecipient
         updateGas={({ to, amount, data } = {}) =>
@@ -339,7 +339,6 @@ export default class SendTransactionScreen extends Component {
         }
         query={this.state.query}
         toError={toError}
-        toWarning={toWarning}
         setInternalSearch={(internalSearch) =>
           this.setInternalSearch(internalSearch)
         }

--- a/ui/app/pages/send/tests/send-component.test.js
+++ b/ui/app/pages/send/tests/send-component.test.js
@@ -435,6 +435,7 @@ describe('Send Component', function () {
       )
 
       assert.deepEqual(instance.state, {
+        internalSearch: false,
         query: '0x80F061544cC398520615B5d3e7A3BedD70cd4510',
         toError: null,
         toWarning: null,
@@ -449,6 +450,7 @@ describe('Send Component', function () {
 
       clock.tick(1001)
       assert.deepEqual(instance.state, {
+        internalSearch: false,
         query: '0x80F061544cC398520615B5d3e7a3BedD70cd4510',
         toError: 'invalidAddressRecipient',
         toWarning: null,
@@ -464,6 +466,7 @@ describe('Send Component', function () {
 
       clock.tick(1001)
       assert.deepEqual(instance.state, {
+        internalSearch: false,
         query: '0x80F061544cC398520615B5d3e7a3BedD70cd4510',
         toError: 'invalidAddressRecipientNotEthNetwork',
         toWarning: null,
@@ -479,6 +482,7 @@ describe('Send Component', function () {
 
       clock.tick(1001)
       assert.deepEqual(instance.state, {
+        internalSearch: false,
         query: '0x80F061544cC398520615B5d3e7a3BedD70cd4510',
         toError: 'invalidAddressRecipientNotEthNetwork',
         toWarning: null,
@@ -486,6 +490,7 @@ describe('Send Component', function () {
 
       instance.onRecipientInputChange('')
       assert.deepEqual(instance.state, {
+        internalSearch: false,
         query: '',
         toError: '',
         toWarning: '',
@@ -501,6 +506,7 @@ describe('Send Component', function () {
 
       clock.tick(1001)
       assert.deepEqual(instance.state, {
+        internalSearch: false,
         query: '0x13cb85823f78Cff38f0B0E90D3e975b8CB3AAd64',
         toError: null,
         toWarning: 'knownAddressRecipient',

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -203,9 +203,11 @@ export function accountsWithSendEtherInfoSelector(state) {
   const accounts = getMetaMaskAccounts(state)
   const identities = getMetaMaskIdentities(state)
 
-  const accountsWithSendEtherInfo = Object.entries(identities).map(([key, identity]) => {
-    return { ...identity, ...accounts[key] }
-  }).sort((a, b) => a.name.localeCompare(b.name))
+  const accountsWithSendEtherInfo = Object.entries(identities)
+    .map(([key, identity]) => {
+      return { ...identity, ...accounts[key] }
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
 
   return accountsWithSendEtherInfo
 }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -203,11 +203,9 @@ export function accountsWithSendEtherInfoSelector(state) {
   const accounts = getMetaMaskAccounts(state)
   const identities = getMetaMaskIdentities(state)
 
-  const accountsWithSendEtherInfo = Object.entries(identities).map(
-    ([key, identity]) => {
-      return { ...identity, ...accounts[key] }
-    },
-  )
+  const accountsWithSendEtherInfo = Object.entries(identities).map(([key, identity]) => {
+    return { ...identity, ...accounts[key] }
+  }).sort((a, b) => a.name.localeCompare(b.name))
 
   return accountsWithSendEtherInfo
 }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -203,11 +203,11 @@ export function accountsWithSendEtherInfoSelector(state) {
   const accounts = getMetaMaskAccounts(state)
   const identities = getMetaMaskIdentities(state)
 
-  const accountsWithSendEtherInfo = Object.entries(identities)
-    .map(([key, identity]) => {
+  const accountsWithSendEtherInfo = Object.entries(identities).map(
+    ([key, identity]) => {
       return { ...identity, ...accounts[key] }
-    })
-    .sort((a, b) => a.name.localeCompare(b.name))
+    },
+  )
 
   return accountsWithSendEtherInfo
 }


### PR DESCRIPTION
Adds `internalSearch` option to ENS Input component, which allows to disable validation and use input for custom purpose - in this case as a search input for my accounts list.

Also adds sorting for my accounts list.
Fixes #9102 

<img width="360" alt="Screenshot 2020-08-18 at 12 57 08" src="https://user-images.githubusercontent.com/5708018/90505120-64077680-e152-11ea-8b42-14929d25edf5.png">
<img width="357" alt="Screenshot 2020-08-18 at 12 57 15" src="https://user-images.githubusercontent.com/5708018/90505138-68cc2a80-e152-11ea-9746-6cd91d47a2f4.png">
