### PR TITLE
Tidy up Migrator tests

### DIFF
--- a/test/unit/migrations/migrator-test.js
+++ b/test/unit/migrations/migrator-test.js
@@ -3,37 +3,36 @@ import assert from 'assert'
 import { cloneDeep } from 'lodash'
 import Migrator from '../../../app/scripts/lib/migrator'
 import liveMigrations from '../../../app/scripts/migrations'
+import data from '../../../app/scripts/first-time-state'
 
 const stubMigrations = [
   {
     version: 1,
-    migrate: (data) => {
+    migrate: (state) => {
       // clone the data just like we do in migrations
-      const clonedData = cloneDeep(data)
+      const clonedData = cloneDeep(state)
       clonedData.meta.version = 1
       return Promise.resolve(clonedData)
     },
   },
   {
     version: 2,
-    migrate: (data) => {
-      const clonedData = cloneDeep(data)
+    migrate: (state) => {
+      const clonedData = cloneDeep(state)
       clonedData.meta.version = 2
       return Promise.resolve(clonedData)
     },
   },
   {
     version: 3,
-    migrate: (data) => {
-      const clonedData = cloneDeep(data)
+    migrate: (state) => {
+      const clonedData = cloneDeep(state)
       clonedData.meta.version = 3
       return Promise.resolve(clonedData)
     },
   },
 ]
 const versionedData = { meta: { version: 0 }, data: { hello: 'world' } }
-
-import data from '../../../app/scripts/first-time-state'
 
 const firstTimeState = {
   meta: { version: 0 },


### PR DESCRIPTION
This PR tidies up the `Migrator` tests, sorting the imports and fixing `no-shadow` issues