### PR TITLE
Add lock icon to default networks

### DIFF
--- a/ui/app/pages/settings/networks-tab/index.scss
+++ b/ui/app/pages/settings/networks-tab/index.scss
@@ -185,6 +185,11 @@
     &:hover {
       cursor: pointer;
     }
+
+    svg {
+      margin-left: 10px;
+      padding-top: 3px;
+    }
   }
 
   &__networks-list-arrow {
@@ -213,6 +218,11 @@
   &__networks-list-name--selected {
     font-weight: bold;
     color: #000;
+  }
+
+  &__networks-list-name--disabled {
+    font-weight: 300;
+    color: #cdcdcd;
   }
 }
 

--- a/ui/app/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/app/pages/settings/networks-tab/networks-tab.component.js
@@ -5,6 +5,7 @@ import { SETTINGS_ROUTE } from '../../../helpers/constants/routes'
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../../app/scripts/lib/enums'
 import { getEnvironmentType } from '../../../../../app/scripts/lib/util'
 import Button from '../../../components/ui/button'
+import LockIcon from '../../../components/ui/lock-icon'
 import NetworkDropdownIcon from '../../../components/app/dropdowns/components/network-dropdown-icon'
 import NetworkForm from './network-form'
 
@@ -117,9 +118,17 @@ export default class NetworksTab extends PureComponent {
         <div
           className={classnames('networks-tab__networks-list-name', {
             'networks-tab__networks-list-name--selected': displayNetworkListItemAsSelected,
+            'networks-tab__networks-list-name--disabled': currentProviderType !== 'rpc' && !displayNetworkListItemAsSelected,
           })}
         >
           { label || this.context.t(labelKey) }
+          { currentProviderType !== 'rpc' && (
+            <LockIcon
+              width="14px"
+              height="17px"
+              fill="#cdcdcd"
+            />
+          ) }
         </div>
         <div className="networks-tab__networks-list-arrow" />
       </div>


### PR DESCRIPTION
This PR adds lock icon next to default networks in networks list in settings. It was not clear that these networks cannot be edited nor deleted. It makes it easier to differentiate them from custom rpc networks.

Addresses the issues brought up in #8566 

Screenshot 2020-08-19 at 08.53.17