### PR TITLE
Adds toPrecisionWithoutTrailingZeros utility

### DIFF
--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -1,5 +1,6 @@
 import punycode from 'punycode'
 import abi from 'human-standard-token-abi'
+import BigNumber from 'bignumber.js'
 import ethUtil from 'ethereumjs-util'
 import { DateTime } from 'luxon'
 
@@ -354,4 +355,19 @@ export function checkExistingAddresses (address, list = []) {
   }
 
   return list.some(matchesAddress)
+}
+
+/**
+ * Given a number and specified precision, returns that number in base 10 with a maximum of precision
+ * significant digits, but without any trailing zeros after the decimal point To be used when wishing
+ * to display only as much digits to the user as necessary
+ *
+ * @param {string | number | BigNumber} n - The number to format
+ * @param {number} precision - The maximum number of significant digits in the return value
+ * @returns {string} The number in decimal form, with <= precision significant digits and no decimal trailing zeros
+ */
+export function toPrecisionWithoutTrailingZeros (n, precision) {
+  return (new BigNumber(n))
+    .toPrecision(precision)
+    .replace(/(\.[0-9]*[1-9])0*|(\.0*)/u, '$1')
 }

--- a/ui/app/helpers/utils/util.test.js
+++ b/ui/app/helpers/utils/util.test.js
@@ -348,4 +348,48 @@ describe('util', function () {
       assert(util.checkExistingAddresses('b', tokenList) === false)
     })
   })
+
+  describe('toPrecisionWithoutTrailingZeros', function () {
+    const testData = [
+      { args: ['0', 9], result: '0' },
+      { args: [0, 9], result: '0' },
+      { args: ['0.0', 9], result: '0' },
+      { args: ['0.000000000000', 9], result: '0' },
+      { args: ['1', 9], result: '1' },
+      { args: [1 ], result: '1' },
+      { args: ['1.0', 9], result: '1' },
+      { args: ['1.000000000', 9], result: '1' },
+      { args: ['000000001', 9], result: '1' },
+      { args: ['000000001.0', 9], result: '1' },
+      { args: ['100000000', 9], result: '100000000' },
+      { args: ['100000000.00001', 9], result: '100000000' },
+      { args: ['100.00001', 9], result: '100.00001' },
+      { args: ['100.00001000', 9], result: '100.00001' },
+      { args: ['100.000010001', 9], result: '100.00001' },
+      { args: ['10.010101', 9], result: '10.010101' },
+      { args: ['0.1', 5], result: '0.1' },
+      { args: ['0.10', 5], result: '0.1' },
+      { args: ['0.1010', 5], result: '0.101' },
+      { args: ['0.01001', 5], result: '0.01001' },
+      { args: ['0.010010', 5], result: '0.01001' },
+      { args: ['0.010011', 5], result: '0.010011' },
+      { args: ['1.01005', 5], result: '1.0101' },
+      { args: ['1.000049', 5], result: '1' },
+      { args: ['1.00005', 5], result: '1.0001' },
+      { args: ['0.0000123456789', 9], result: '0.0000123456789' },
+      { args: ['1.0000123456789', 10], result: '1.000012346' },
+      { args: ['10000.0000012345679', 10], result: '10000' },
+      { args: ['1000000000000', 10], result: '1e+12' },
+      { args: ['1000050000000', 10], result: '1.00005e+12' },
+      { args: ['100000000000000000000', 10], result: '1e+20' },
+      { args: ['100005000000000000000', 10], result: '1.00005e+20' },
+      { args: ['100005000000000000000.0', 10], result: '1.00005e+20' },
+    ]
+
+    testData.forEach(({ args, result }) => {
+      it(`should return ${result} when passed number ${args[0]} and precision ${args[1]}`, function () {
+        assert.equal(util.toPrecisionWithoutTrailingZeros(...args), result)
+      })
+    })
+  })
 })


### PR DESCRIPTION
Adds a new utility function `toPrecisionWithoutTrailingZeros`

Given a number and specified precision, returns that number in base 10 with a maximum of precision significant digits, but without any trailing zeros after the decimal point To be used when wishing to display only as much digits to the user as necessary