### PR TITLE
Do not check popupIsOpen on Vivaldi

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -452,7 +452,13 @@ async function triggerUi() {
   const currentlyActiveMetamaskTab = Boolean(
     tabs.find((tab) => openMetamaskTabsIDs[tab.id]),
   )
-  if (!popupIsOpen && !currentlyActiveMetamaskTab) {
+  // Vivaldi is not closing port connection on popup close, so popupIsOpen does not work correctly
+  // To be reviewed in the future if this behaviour is fixed - also the way we determine isVivaldi variable might change at some point
+  const isVivaldi =
+    tabs.length > 0 &&
+    tabs[0].extData &&
+    tabs[0].extData.indexOf('vivaldi_tab') > -1
+  if ((isVivaldi || !popupIsOpen) && !currentlyActiveMetamaskTab) {
     await notificationManager.showPopup()
   }
 }


### PR DESCRIPTION
Vivaldi is not triggering disconnect() function on port when closing the popup/notification. It is first thing being triggered after manually opening popup again. This prevents popup from being reopened (since extension thinks popup is still open).

This PR adds an exception for Vivaldi browser not to check this condition, it can trigger multiple same notifications, but it's better than no notification.

Addresses the issues brought up in #9194 