### PR TITLE
Use @metamask/eslint-config@3.1.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
     }, {
       'enforceForRenamedProperties': false,
     }],
+    'prefer-object-spread': 'error',
     'react/no-unused-prop-types': 'error',
     'react/no-unused-state': 'error',
     'react/jsx-boolean-value': 'error',

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.5.5",
-    "@metamask/eslint-config": "^3.0.0",
+    "@metamask/eslint-config": "^3.1.0",
     "@metamask/forwarder": "^1.1.0",
     "@metamask/test-dapp": "^3.1.0",
     "@sentry/cli": "^1.49.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,10 +1730,10 @@
     web3 "^0.20.7"
     web3-provider-engine "^15.0.4"
 
-"@metamask/eslint-config@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.0.0.tgz#39c4275e440cfc690524d328a0bda8227bd69326"
-  integrity sha512-AYnNopj+K0YyWuCXY4mflgMQzIcm/Jc+HiXzBzY8SJ3fMlnBXjQjsbu0B78zxLR9HZ2uW9IrCj0VG7hMj1b4og==
+"@metamask/eslint-config@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.1.0.tgz#8412ddd3f660748598902fd8dbef6fadc060f25e"
+  integrity sha512-He/zV0Cb5W421mEQveaqSegLarONJbJPReJppQkwhi239PCE7j+6eRji/j2Unwq8TBuOlgQtqL49+dtvks+lPQ==
 
 "@metamask/eth-ledger-bridge-keyring@^0.2.6":
   version "0.2.6"


### PR DESCRIPTION
This change updates the shared ESLint config to the latest published version, v3.1.0.

From the config [`CHANGELOG.md`][1]: v3.0.1 has disabled `prefer-object-spread` by default, so it has been re-enabled for this project.

  [1]:https://github.com/MetaMask/eslint-config/blob/master/CHANGELOG.md