### PR TITLE
Add messages for MetaMetrics opt-in

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3,7 +3,7 @@
     "message": "I have read and agree to the $1",
     "description": "$1 is the `terms` message"
   },
-  "agreeAffirm": {
+  "affirmAgree": {
     "message": "I Agree"
   },
   "eth_accounts": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3,6 +3,9 @@
     "message": "I have read and agree to the $1",
     "description": "$1 is the `terms` message"
   },
+  "agreeAffirm": {
+    "message": "I Agree"
+  },
   "eth_accounts": {
     "message": "View the addresses of your permitted accounts (required)",
     "description": "The description for the `eth_accounts` permission"

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -58,7 +58,7 @@ describe('MetaMask', function () {
       await driver.delay(largeDelayMs)
     })
 
-    it('clicks the "I agree" option on the metametrics opt-in screen', async function () {
+    it('clicks the "I Agree" option on the metametrics opt-in screen', async function () {
       await driver.clickElement(By.css('.btn-primary'))
       await driver.delay(largeDelayMs)
     })

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.component.js
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.component.js
@@ -11,10 +11,11 @@ export default class MetaMetricsOptInModal extends Component {
 
   static contextTypes = {
     metricsEvent: PropTypes.func,
+    t: PropTypes.func,
   }
 
   render () {
-    const { metricsEvent } = this.context
+    const { metricsEvent, t } = this.context
     const { setParticipateInMetaMetrics, hideModal } = this.props
 
     return (
@@ -103,7 +104,7 @@ export default class MetaMetricsOptInModal extends Component {
                     hideModal()
                   })
               }}
-              cancelText="No Thanks"
+              cancelText={t('noThanks')}
               hideCancel={false}
               onSubmit={() => {
                 setParticipateInMetaMetrics(true)
@@ -119,7 +120,7 @@ export default class MetaMetricsOptInModal extends Component {
                     hideModal()
                   })
               }}
-              submitText="I agree"
+              submitText={t('affirmAgree')}
               submitButtonType="confirm"
               disabled={false}
             />

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/tests/metametrics-opt-in-modal.test.js
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/tests/metametrics-opt-in-modal.test.js
@@ -41,8 +41,8 @@ describe('MetaMetrics Opt In', function () {
   })
 
   it('passes true to setParticipateInMetaMetrics and hides modal', function (done) {
-    const iAgree = wrapper.find('.btn-primary.page-container__footer-button')
-    iAgree.simulate('click')
+    const affirmAgree = wrapper.find('.btn-primary.page-container__footer-button')
+    affirmAgree.simulate('click')
 
     setImmediate(() => {
       assert(props.setParticipateInMetaMetrics.calledOnce)

--- a/ui/app/components/app/modals/metametrics-opt-in-modal/tests/metametrics-opt-in-modal.test.js
+++ b/ui/app/components/app/modals/metametrics-opt-in-modal/tests/metametrics-opt-in-modal.test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import sinon from 'sinon'
 import { mount } from 'enzyme'
 import MetaMetricsOptIn from '..'
+import messages from '../../../../../../../app/_locales/en/messages.json'
 
 describe('MetaMetrics Opt In', function () {
   let wrapper
@@ -18,6 +19,7 @@ describe('MetaMetrics Opt In', function () {
       <MetaMetricsOptIn.WrappedComponent {...props} />, {
         context: {
           metricsEvent: () => undefined,
+          t: (key) => messages[key].message,
         },
       },
     )

--- a/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
@@ -105,7 +105,7 @@ export default class MetaMetricsOptIn extends Component {
                       })
                   })
               }}
-              cancelText="No Thanks"
+              cancelText={t('noThanks')}
               hideCancel={false}
               onSubmit={() => {
                 setParticipateInMetaMetrics(true)
@@ -138,7 +138,7 @@ export default class MetaMetricsOptIn extends Component {
                       })
                   })
               }}
-              submitText="I agree"
+              submitText={t('affirmAgree')}
               submitButtonType="primary"
               disabled={false}
             />


### PR DESCRIPTION
I noticed that the MetaMetrics opt-in page has inconsistent capitalization. When fixing it, I also noticed that the button text values were inlined for the relevant components. This PR applies consistent capitalization for the buttons and converts their values to locale messages.