### PR TITLE
Remove outdated comment from MetamaskController

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1,9 +1,3 @@
-/**
- * @file      The central metamask controller. Aggregates other controllers and exports an api.
- * @copyright Copyright (c) 2018 MetaMask
- * @license   MIT
- */
-
 import EventEmitter from 'events'
 
 import pump from 'pump'


### PR DESCRIPTION
This PR removes an outdated comment from atop the `MetamaskController` file.