### PR TITLE
Use verifyPassword instead of submitPassword when exporting priv key

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1144,10 +1144,10 @@ describe('Actions', function () {
   })
 
   describe('#exportAccount', function () {
-    let submitPasswordSpy, exportAccountSpy
+    let verifyPasswordSpy, exportAccountSpy
 
     afterEach(function () {
-      submitPasswordSpy.restore()
+      verifyPasswordSpy.restore()
       exportAccountSpy.restore()
     })
 
@@ -1159,11 +1159,11 @@ describe('Actions', function () {
         { type: 'SHOW_PRIVATE_KEY', value: '7ec73b91bb20f209a7ff2d32f542c3420b4fccf14abcc7840d2eff0ebcb18505' },
       ]
 
-      submitPasswordSpy = sinon.spy(background, 'submitPassword')
+      verifyPasswordSpy = sinon.spy(background, 'verifyPassword')
       exportAccountSpy = sinon.spy(background, 'exportAccount')
 
       await store.dispatch(actions.exportAccount(password, '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'))
-      assert(submitPasswordSpy.calledOnce)
+      assert(verifyPasswordSpy.calledOnce)
       assert(exportAccountSpy.calledOnce)
       assert.deepEqual(store.getActions(), expectedActions)
     })
@@ -1176,8 +1176,8 @@ describe('Actions', function () {
         { type: 'DISPLAY_WARNING', value: 'Incorrect Password.' },
       ]
 
-      submitPasswordSpy = sinon.stub(background, 'submitPassword')
-      submitPasswordSpy.callsFake((_, callback) => {
+      verifyPasswordSpy = sinon.stub(background, 'verifyPassword')
+      verifyPasswordSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 

--- a/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
+++ b/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
@@ -25,6 +25,7 @@ export default class ExportPrivateKeyModal extends Component {
     warning: PropTypes.node,
     showAccountDetailModal: PropTypes.func.isRequired,
     hideModal: PropTypes.func.isRequired,
+    hideWarning: PropTypes.func.isRequired,
     clearAccountDetails: PropTypes.func.isRequired,
     previousModalState: PropTypes.string,
   }
@@ -37,6 +38,7 @@ export default class ExportPrivateKeyModal extends Component {
 
   componentWillUnmount () {
     this.props.clearAccountDetails()
+    this.props.hideWarning()
   }
 
   exportAccountAndGetPrivateKey = (password, address) => {

--- a/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.container.js
+++ b/ui/app/components/app/modals/export-private-key-modal/export-private-key-modal.container.js
@@ -32,6 +32,7 @@ function mapDispatchToProps (dispatch) {
     },
     showAccountDetailModal: () => dispatch(showModal({ name: 'ACCOUNT_DETAILS' })),
     hideModal: () => dispatch(hideModal()),
+    hideWarning: () => dispatch(hideWarning()),
     clearAccountDetails: () => dispatch(clearAccountDetails()),
   }
 }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1709,7 +1709,7 @@ export function exportAccount (password, address) {
 
     log.debug(`background.submitPassword`)
     return new Promise((resolve, reject) => {
-      background.submitPassword(password, function (err) {
+      background.verifyPassword(password, function (err) {
         if (err) {
           log.error('Error in submitting password.')
           dispatch(hideLoadingIndication())

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1707,7 +1707,7 @@ export function exportAccount (password, address) {
   return function (dispatch) {
     dispatch(showLoadingIndication())
 
-    log.debug(`background.submitPassword`)
+    log.debug(`background.verifyPassword`)
     return new Promise((resolve, reject) => {
       background.verifyPassword(password, function (err) {
         if (err) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1711,7 +1711,7 @@ export function exportAccount (password, address) {
     return new Promise((resolve, reject) => {
       background.verifyPassword(password, function (err) {
         if (err) {
-          log.error('Error in submitting password.')
+          log.error('Error in verifying password.')
           dispatch(hideLoadingIndication())
           dispatch(displayWarning('Incorrect Password.'))
           reject(err)


### PR DESCRIPTION
Fixes #9287
Fixes #9230
Which was when submitPassword is called will fully clear the keyring state

https://github.com/MetaMask/KeyringController/blob/master/index.js#L155

Also, pass hideWarning action prop so it will clear the appState.warning if a correct password is never provided on componentWillUnmount