### PR TITLE
Fix negative gas crash

### DIFF
--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -185,8 +185,8 @@ const multiplyCurrencies = (a, b, options = {}) => {
     ...conversionOptions
   } = options
 
-  const bigNumberA = new BigNumber(String(a), multiplicandBase)
-  const bigNumberB = new BigNumber(String(b), multiplierBase)
+  const bigNumberA = new BigNumber(String(a).replace('0x-', '-0x'), multiplicandBase)
+  const bigNumberB = new BigNumber(String(b).replace('0x-', '-0x'), multiplierBase)
 
   const value = bigNumberA.times(bigNumberB)
 


### PR DESCRIPTION
Adds workaround for incorrect result of `ethUtil.addHexPrefix()`. This function works fine if the number is not negative and prefix is added correctly - ie. '0X' prefix will also cause unwanted behavior. Creating own `addHexPrefix` function, which will be handling such situations could be considered.

Fixes #9262 