### PR TITLE
Ensure the extension can be unlocked without network access

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -766,7 +766,11 @@ export default class MetamaskController extends EventEmitter {
   async submitPassword (password) {
     await this.keyringController.submitPassword(password)
 
-    await this.blockTracker.checkForLatestBlock()
+    try {
+      await this.blockTracker.checkForLatestBlock()
+    } catch (error) {
+      log.error('Error while unlocking extension.', error)
+    }
 
     try {
       const threeBoxSyncingAllowed = this.threeBoxController.getThreeBoxSyncingState()
@@ -778,7 +782,7 @@ export default class MetamaskController extends EventEmitter {
         this.threeBoxController.turnThreeBoxSyncingOn()
       }
     } catch (error) {
-      log.error(error)
+      log.error('Error while unlocking extension.', error)
     }
 
     return this.keyringController.fullUpdate()

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -196,6 +196,17 @@ describe('MetaMaskController', function () {
       assert(threeBoxSpies.init.calledOnce)
       assert(threeBoxSpies.turnThreeBoxSyncingOn.calledOnce)
     })
+
+    it('succeeds even if blockTracker or threeBoxController throw', async function () {
+      const throwErr = sinon.fake.throws('foo')
+      metamaskController.blockTracker.checkForLatestBlock = throwErr
+      metamaskController.threeBoxController.getThreeBoxSyncingState = throwErr
+      await metamaskController.submitPassword(password)
+      assert.ok(
+        throwErr.calledTwice,
+        'should have called checkForLatestBlock and getThreeBoxSyncingState',
+      )
+    })
   })
 
   describe('#createNewVaultAndKeychain', function () {


### PR DESCRIPTION
This PR catches an error from the `blockTracker` in `submitPassword` that prevented the extension from being unlocked without Internet access.

Users should always be able to unlock the extension with the correct password.