### PR TITLE
Remove unused diagnostics property

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -64,7 +64,6 @@ export default class PreferencesController {
       ipfsGateway: 'dweb.link', ...opts.initState,
     }
 
-    this.diagnostics = opts.diagnostics
     this.network = opts.network
     this.store = new ObservableStore(initState)
     this.store.setMaxListeners(12)
@@ -327,11 +326,6 @@ export default class PreferencesController {
 
     // Identities are no longer present.
     if (Object.keys(newlyLost).length > 0) {
-
-      // Notify our servers:
-      if (this.diagnostics) {
-        this.diagnostics.reportOrphans(newlyLost)
-      }
 
       // store lost accounts
       Object.keys(newlyLost).forEach((key) => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -766,12 +766,6 @@ export default class MetamaskController extends EventEmitter {
   async submitPassword (password) {
     await this.keyringController.submitPassword(password)
 
-    // verify keyrings
-    const nonSimpleKeyrings = this.keyringController.keyrings.filter((keyring) => keyring.type !== 'Simple Key Pair')
-    if (nonSimpleKeyrings.length > 1 && this.diagnostics) {
-      await this.diagnostics.reportMultipleKeyrings(nonSimpleKeyrings)
-    }
-
     await this.blockTracker.checkForLatestBlock()
 
     try {

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -115,8 +115,7 @@ describe('MetaMaskController', function () {
       initState: cloneDeep(firstTimeState),
       platform: { showTransactionNotification: () => undefined, getVersion: () => 'foo' },
     })
-    // disable diagnostics
-    metamaskController.diagnostics = null
+
     // add sinon method spies
     sandbox.spy(metamaskController.keyringController, 'createNewVaultAndKeychain')
     sandbox.spy(metamaskController.keyringController, 'createNewVaultAndRestore')


### PR DESCRIPTION
The main and preferences controllers both referenced a `this.diagnostics` property that was never set, and not referred to elsewhere (except in a test, where it was set to `null`).

This PR removes all remaining references to the property.