### PR TITLE
Verifies password when exporting private key

### DIFF
--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -1144,10 +1144,10 @@ describe('Actions', function () {
   })
 
   describe('#exportAccount', function () {
-    let submitPasswordSpy, exportAccountSpy
+    let verifyPasswordSpy, exportAccountSpy
 
     afterEach(function () {
-      submitPasswordSpy.restore()
+      verifyPasswordSpy.restore()
       exportAccountSpy.restore()
     })
 
@@ -1159,11 +1159,11 @@ describe('Actions', function () {
         { type: 'SHOW_PRIVATE_KEY', value: '7ec73b91bb20f209a7ff2d32f542c3420b4fccf14abcc7840d2eff0ebcb18505' },
       ]
 
-      submitPasswordSpy = sinon.spy(background, 'submitPassword')
+      verifyPasswordSpy = sinon.spy(background, 'verifyPassword')
       exportAccountSpy = sinon.spy(background, 'exportAccount')
 
       await store.dispatch(actions.exportAccount(password, '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'))
-      assert(submitPasswordSpy.calledOnce)
+      assert(verifyPasswordSpy.calledOnce)
       assert(exportAccountSpy.calledOnce)
       assert.deepEqual(store.getActions(), expectedActions)
     })
@@ -1176,8 +1176,8 @@ describe('Actions', function () {
         { type: 'DISPLAY_WARNING', value: 'Incorrect Password.' },
       ]
 
-      submitPasswordSpy = sinon.stub(background, 'submitPassword')
-      submitPasswordSpy.callsFake((_, callback) => {
+      verifyPasswordSpy = sinon.stub(background, 'verifyPassword')
+      verifyPasswordSpy.callsFake((_, callback) => {
         callback(new Error('error'))
       })
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1707,11 +1707,11 @@ export function exportAccount (password, address) {
   return function (dispatch) {
     dispatch(showLoadingIndication())
 
-    log.debug(`background.submitPassword`)
+    log.debug(`background.verifyPassword`)
     return new Promise((resolve, reject) => {
-      background.submitPassword(password, function (err) {
+      background.verifyPassword(password, function (err) {
         if (err) {
-          log.error('Error in submitting password.')
+          log.error('Error in verifying password.')
           dispatch(hideLoadingIndication())
           dispatch(displayWarning('Incorrect Password.'))
           reject(err)


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#9287

Uses the same verification method as revealing seed phrase does: https://github.com/MetaMask/metamask-extension/pull/9063