### PR TITLE
Create custom addHexPrefix function

### DIFF
--- a/app/scripts/account-import-strategies/index.js
+++ b/app/scripts/account-import-strategies/index.js
@@ -2,6 +2,7 @@ import log from 'loglevel'
 import Wallet from 'ethereumjs-wallet'
 import importers from 'ethereumjs-wallet/thirdparty'
 import ethUtil from 'ethereumjs-util'
+import { addHexPrefix } from '../lib/util'
 
 const accountImporter = {
   importAccount(strategy, args) {
@@ -20,7 +21,7 @@ const accountImporter = {
         throw new Error('Cannot import an empty key.')
       }
 
-      const prefixed = ethUtil.addHexPrefix(privateKey)
+      const prefixed = addHexPrefix(privateKey)
       const buffer = ethUtil.toBuffer(prefixed)
 
       if (!ethUtil.isValidPrivate(buffer)) {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -10,7 +10,12 @@ import NonceTracker from 'nonce-tracker'
 import log from 'loglevel'
 import BigNumber from 'bignumber.js'
 import cleanErrorStack from '../../lib/cleanErrorStack'
-import { hexToBn, bnToHex, BnMultiplyByFraction } from '../../lib/util'
+import {
+  hexToBn,
+  bnToHex,
+  BnMultiplyByFraction,
+  addHexPrefix,
+} from '../../lib/util'
 import { TRANSACTION_NO_CONTRACT_ERROR_KEY } from '../../../../ui/app/helpers/constants/error-keys'
 import { getSwapsTokensReceivedFromTxMeta } from '../../../../ui/app/pages/swaps/swaps.util'
 import {
@@ -264,7 +269,7 @@ export default class TransactionController extends EventEmitter {
 
     // ensure value
     txMeta.txParams.value = txMeta.txParams.value
-      ? ethUtil.addHexPrefix(txMeta.txParams.value)
+      ? addHexPrefix(txMeta.txParams.value)
       : '0x0'
 
     this.addTx(txMeta)
@@ -324,7 +329,7 @@ export default class TransactionController extends EventEmitter {
     }
     const gasPrice = await this.query.gasPrice()
 
-    return ethUtil.addHexPrefix(gasPrice.toString(16))
+    return addHexPrefix(gasPrice.toString(16))
   }
 
   /**
@@ -365,7 +370,7 @@ export default class TransactionController extends EventEmitter {
 
     // add additional gas buffer to our estimation for safety
     const gasLimit = this.txGasUtil.addGasBuffer(
-      ethUtil.addHexPrefix(estimatedGasHex),
+      addHexPrefix(estimatedGasHex),
       blockGasLimit,
     )
     return { gasLimit, simulationFails }
@@ -501,7 +506,7 @@ export default class TransactionController extends EventEmitter {
       const customOrNonce =
         customNonceValue === 0 ? customNonceValue : customNonceValue || nonce
 
-      txMeta.txParams.nonce = ethUtil.addHexPrefix(customOrNonce.toString(16))
+      txMeta.txParams.nonce = addHexPrefix(customOrNonce.toString(16))
       // add nonce debugging information to txMeta
       txMeta.nonceDetails = nonceLock.nonceDetails
       if (customNonceValue) {
@@ -582,8 +587,8 @@ export default class TransactionController extends EventEmitter {
       txHash = await this.query.sendRawTransaction(rawTx)
     } catch (error) {
       if (error.message.toLowerCase().includes('known transaction')) {
-        txHash = ethUtil.sha3(ethUtil.addHexPrefix(rawTx)).toString('hex')
-        txHash = ethUtil.addHexPrefix(txHash)
+        txHash = ethUtil.sha3(addHexPrefix(rawTx)).toString('hex')
+        txHash = addHexPrefix(txHash)
       } else {
         throw error
       }

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -1,4 +1,5 @@
-import { addHexPrefix, isValidAddress } from 'ethereumjs-util'
+import { isValidAddress } from 'ethereumjs-util'
+import { addHexPrefix } from '../../../lib/util'
 
 const normalizers = {
   from: (from) => addHexPrefix(from),

--- a/app/scripts/lib/decrypt-message-manager.js
+++ b/app/scripts/lib/decrypt-message-manager.js
@@ -3,6 +3,7 @@ import ObservableStore from 'obs-store'
 import ethUtil from 'ethereumjs-util'
 import { ethErrors } from 'eth-json-rpc-errors'
 import log from 'loglevel'
+import { addHexPrefix } from './util'
 import createId from './random-id'
 import { MESSAGE_TYPE } from './enums'
 
@@ -329,7 +330,7 @@ export default class DecryptMessageManager extends EventEmitter {
     try {
       const stripped = ethUtil.stripHexPrefix(data)
       if (stripped.match(hexRe)) {
-        return ethUtil.addHexPrefix(stripped)
+        return addHexPrefix(stripped)
       }
     } catch (e) {
       log.debug(`Message was not hex encoded, interpreting as utf8.`)

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -3,6 +3,7 @@ import ObservableStore from 'obs-store'
 import ethUtil from 'ethereumjs-util'
 import { ethErrors } from 'eth-json-rpc-errors'
 import log from 'loglevel'
+import { addHexPrefix } from './util'
 import createId from './random-id'
 import { MESSAGE_TYPE } from './enums'
 
@@ -313,7 +314,7 @@ export default class PersonalMessageManager extends EventEmitter {
     try {
       const stripped = ethUtil.stripHexPrefix(data)
       if (stripped.match(hexRe)) {
-        return ethUtil.addHexPrefix(stripped)
+        return addHexPrefix(stripped)
       }
     } catch (e) {
       log.debug(`Message was not hex encoded, interpreting as utf8.`)

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -169,7 +169,7 @@ function isPrefixedFormattedHexString(value) {
  * @returns {string}
  */
 const addHexPrefix = (str) => {
-  if (typeof str !== 'string') {
+  if (typeof str !== 'string' || str.startsWith('0x')) {
     return str
   }
 

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -163,10 +163,10 @@ function isPrefixedFormattedHexString(value) {
 }
 
 /**
- * Returns string with '0x' hex prefix
+ * Prefixes a hex string with '0x' or '-0x' and returns it. Idempotent.
  *
- * @param {string} str
- * @returns {string}
+ * @param {string} str - The string to prefix.
+ * @returns {string} The prefixed string.
  */
 const addHexPrefix = (str) => {
   if (typeof str !== 'string' || str.match(/^-?0x/u)) {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -178,7 +178,7 @@ const addHexPrefix = (str) => {
   }
 
   if (str.startsWith('-')) {
-    return `-0x${str}`
+    return str.replace('-', '-0x')
   }
 
   return `0x${str}`

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -104,17 +104,6 @@ function sufficientBalance(txParams, hexBalance) {
 }
 
 /**
- * Converts a BN object to a hex string with a '0x' prefix
- *
- * @param {BN} inputBn - The BN to convert to a hex string
- * @returns {string} - A '0x' prefixed hex string
- *
- */
-function bnToHex(inputBn) {
-  return ethUtil.addHexPrefix(inputBn.toString(16))
-}
-
-/**
  * Converts a hex string to a BN object
  *
  * @param {string} inputHex - A number represented as a hex string
@@ -173,13 +162,47 @@ function isPrefixedFormattedHexString(value) {
   return /^0x[1-9a-f]+[0-9a-f]*$/iu.test(value)
 }
 
+/**
+ * Returns string with '0x' hex prefix
+ *
+ * @param {sring} str
+ * @returns {string|Object}
+ */
+const addHexPrefix = (str) => {
+  if (
+    typeof str !== 'string' ||
+    str.toLowerCase().startsWith('-0x') ||
+    str.toLowerCase().startsWith('0x')
+  ) {
+    return str
+  }
+
+  if (str.startsWith('-')) {
+    return `-0x${str}`
+  }
+
+  return `0x${str}`
+}
+
+/**
+ * Converts a BN object to a hex string with a '0x' prefix
+ *
+ * @param {BN} inputBn - The BN to convert to a hex string
+ * @returns {string} - A '0x' prefixed hex string
+ *
+ */
+function bnToHex(inputBn) {
+  return addHexPrefix(inputBn.toString(16))
+}
+
 export {
   getPlatform,
   getEnvironmentType,
   sufficientBalance,
   hexToBn,
-  bnToHex,
   BnMultiplyByFraction,
   checkForError,
   isPrefixedFormattedHexString,
+  addHexPrefix,
+  bnToHex,
 }

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -174,7 +174,7 @@ const addHexPrefix = (str) => {
   }
 
   if (str.match(/^-?0X/u)) {
-    return str.replace(/0X/u, '0x')
+    return str.replace('0X', '0x')
   }
 
   if (str.startsWith('-')) {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -174,7 +174,7 @@ const addHexPrefix = (str) => {
     str.toLowerCase().startsWith('-0x') ||
     str.toLowerCase().startsWith('0x')
   ) {
-    return str
+    return str.replace('0X', '0x')
   }
 
   if (str.startsWith('-')) {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -166,7 +166,7 @@ function isPrefixedFormattedHexString(value) {
  * Returns string with '0x' hex prefix
  *
  * @param {string} str
- * @returns {string|Object}
+ * @returns {string}
  */
 const addHexPrefix = (str) => {
   if (

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -165,7 +165,7 @@ function isPrefixedFormattedHexString(value) {
 /**
  * Returns string with '0x' hex prefix
  *
- * @param {sring} str
+ * @param {string} str
  * @returns {string|Object}
  */
 const addHexPrefix = (str) => {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -174,7 +174,7 @@ const addHexPrefix = (str) => {
     str.toLowerCase().startsWith('-0x') ||
     str.toLowerCase().startsWith('0x')
   ) {
-    return str.replace('0X', '0x')
+    return typeof str === 'string' ? str.replace('0X', '0x') : str
   }
 
   if (str.startsWith('-')) {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -169,12 +169,12 @@ function isPrefixedFormattedHexString(value) {
  * @returns {string}
  */
 const addHexPrefix = (str) => {
-  if (
-    typeof str !== 'string' ||
-    str.toLowerCase().startsWith('-0x') ||
-    str.toLowerCase().startsWith('0x')
-  ) {
-    return typeof str === 'string' ? str.replace('0X', '0x') : str
+  if (typeof str !== 'string') {
+    return str
+  }
+
+  if (str.match(/^-?0X/u)) {
+    return str.replace(/0X/u, '0x')
   }
 
   if (str.startsWith('-')) {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -169,7 +169,7 @@ function isPrefixedFormattedHexString(value) {
  * @returns {string}
  */
 const addHexPrefix = (str) => {
-  if (typeof str !== 'string' || str.startsWith('0x')) {
+  if (typeof str !== 'string' || str.match(/^-?0x/u)) {
     return str
   }
 

--- a/app/scripts/migrations/025.js
+++ b/app/scripts/migrations/025.js
@@ -4,9 +4,8 @@
 normalizes txParams on unconfirmed txs
 
 */
-import ethUtil from 'ethereumjs-util'
-
 import { cloneDeep } from 'lodash'
+import { addHexPrefix } from '../lib/util'
 
 const version = 25
 
@@ -47,13 +46,13 @@ function transformState(state) {
 function normalizeTxParams(txParams) {
   // functions that handle normalizing of that key in txParams
   const whiteList = {
-    from: (from) => ethUtil.addHexPrefix(from).toLowerCase(),
-    to: () => ethUtil.addHexPrefix(txParams.to).toLowerCase(),
-    nonce: (nonce) => ethUtil.addHexPrefix(nonce),
-    value: (value) => ethUtil.addHexPrefix(value),
-    data: (data) => ethUtil.addHexPrefix(data),
-    gas: (gas) => ethUtil.addHexPrefix(gas),
-    gasPrice: (gasPrice) => ethUtil.addHexPrefix(gasPrice),
+    from: (from) => addHexPrefix(from).toLowerCase(),
+    to: () => addHexPrefix(txParams.to).toLowerCase(),
+    nonce: (nonce) => addHexPrefix(nonce),
+    value: (value) => addHexPrefix(value),
+    data: (data) => addHexPrefix(data),
+    gas: (gas) => addHexPrefix(gas),
+    gasPrice: (gasPrice) => addHexPrefix(gasPrice),
   }
 
   // apply only keys in the whiteList

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -8,6 +8,7 @@ import EthQuery from 'eth-query'
 import proxyquire from 'proxyquire'
 import firstTimeState from '../../localhostState'
 import createTxMeta from '../../../lib/createTxMeta'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 
 const threeBoxSpies = {
   init: sinon.stub(),
@@ -167,7 +168,7 @@ describe('MetaMaskController', function () {
       const addressBuffer = ethUtil.pubToAddress(pubKeyBuffer)
       const privKey = ethUtil.bufferToHex(privKeyBuffer)
       const pubKey = ethUtil.bufferToHex(addressBuffer)
-      assert.equal(privKey, ethUtil.addHexPrefix(importPrivkey))
+      assert.equal(privKey, addHexPrefix(importPrivkey))
       assert.equal(pubKey, '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc')
     })
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import { captureException } from '@sentry/browser'
-import { addHexPrefix } from 'ethereumjs-util'
+import { addHexPrefix } from '../../../../../../app/scripts/lib/util'
 import {
   hideModal,
   setGasLimit,

--- a/ui/app/components/app/modals/cancel-transaction/cancel-transaction.container.js
+++ b/ui/app/components/app/modals/cancel-transaction/cancel-transaction.container.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux'
 import { compose } from 'redux'
-import ethUtil from 'ethereumjs-util'
 import { multiplyCurrencies } from '../../../../helpers/utils/conversion-util'
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props'
 import { showModal, createCancelTransaction } from '../../../../store/actions'
 import { getHexGasTotal } from '../../../../helpers/utils/confirm-tx.util'
+import { addHexPrefix } from '../../../../../../app/scripts/lib/util'
 import CancelTransaction from './cancel-transaction.component'
 
 const mapStateToProps = (state, ownProps) => {
@@ -16,7 +16,7 @@ const mapStateToProps = (state, ownProps) => {
   )
   const transactionStatus = transaction ? transaction.status : ''
 
-  const defaultNewGasPrice = ethUtil.addHexPrefix(
+  const defaultNewGasPrice = addHexPrefix(
     multiplyCurrencies(originalGasPrice, 1.1, {
       toNumericBase: 'hex',
       multiplicandBase: 16,

--- a/ui/app/components/ui/token-input/token-input.component.js
+++ b/ui/app/components/ui/token-input/token-input.component.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import ethUtil from 'ethereumjs-util'
 import UnitInput from '../unit-input'
 import CurrencyDisplay from '../currency-display'
 import { getWeiHexFromDecimalValue } from '../../../helpers/utils/conversions.util'
@@ -9,6 +8,7 @@ import {
   multiplyCurrencies,
 } from '../../../helpers/utils/conversion-util'
 import { ETH } from '../../../helpers/constants/common'
+import { addHexPrefix } from '../../../../../app/scripts/lib/util'
 
 /**
  * Component that allows user to enter token values as a number, and props receive a converted
@@ -64,7 +64,7 @@ export default class TokenInput extends PureComponent {
     const { value: hexValue, token: { decimals, symbol } = {} } = props
 
     const multiplier = Math.pow(10, Number(decimals || 0))
-    const decimalValueString = conversionUtil(ethUtil.addHexPrefix(hexValue), {
+    const decimalValueString = conversionUtil(addHexPrefix(hexValue), {
       fromNumericBase: 'hex',
       toNumericBase: 'dec',
       toCurrency: symbol,

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -1,4 +1,4 @@
-import { addHexPrefix } from 'ethereumjs-util'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 import {
   conversionRateSelector,
   currentCurrencySelector,

--- a/ui/app/helpers/utils/confirm-tx.util.js
+++ b/ui/app/helpers/utils/confirm-tx.util.js
@@ -1,7 +1,7 @@
 import currencyFormatter from 'currency-formatter'
 import currencies from 'currency-formatter/currencies'
-import ethUtil from 'ethereumjs-util'
 import BigNumber from 'bignumber.js'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 
 import { unconfirmedTransactionsCountSelector } from '../../selectors'
 import {
@@ -12,7 +12,7 @@ import {
 } from './conversion-util'
 
 export function increaseLastGasPrice(lastGasPrice) {
-  return ethUtil.addHexPrefix(
+  return addHexPrefix(
     multiplyCurrencies(lastGasPrice || '0x0', 1.1, {
       multiplicandBase: 16,
       multiplierBase: 10,
@@ -29,7 +29,7 @@ export function hexGreaterThan(a, b) {
 }
 
 export function getHexGasTotal({ gasLimit, gasPrice }) {
-  return ethUtil.addHexPrefix(
+  return addHexPrefix(
     multiplyCurrencies(gasLimit || '0x0', gasPrice || '0x0', {
       toNumericBase: 'hex',
       multiplicandBase: 16,

--- a/ui/app/helpers/utils/conversions.util.js
+++ b/ui/app/helpers/utils/conversions.util.js
@@ -1,6 +1,6 @@
-import ethUtil from 'ethereumjs-util'
 import BigNumber from 'bignumber.js'
 import { ETH, GWEI, WEI } from '../constants/common'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 import {
   conversionUtil,
   addCurrencies,
@@ -9,7 +9,7 @@ import {
 import { formatCurrency } from './confirm-tx.util'
 
 export function bnToHex(inputBn) {
-  return ethUtil.addHexPrefix(inputBn.toString(16))
+  return addHexPrefix(inputBn.toString(16))
 }
 
 export function hexToDecimal(hexValue) {

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -1,8 +1,8 @@
-import ethUtil from 'ethereumjs-util'
 import MethodRegistry from 'eth-method-registry'
 import abi from 'human-standard-token-abi'
 import { ethers } from 'ethers'
 import log from 'loglevel'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 import { getEtherscanNetworkPrefix } from '../../../lib/etherscan-prefix-for-network'
 import {
   TRANSACTION_CATEGORIES,
@@ -103,7 +103,7 @@ export async function getMethodDataAsync(fourBytePrefix) {
  * @returns {string} - The four-byte method signature
  */
 export function getFourBytePrefix(data = '') {
-  const prefixedData = ethUtil.addHexPrefix(data)
+  const prefixedData = addHexPrefix(data)
   const fourBytePrefix = prefixedData.slice(0, 10)
   return fourBytePrefix
 }
@@ -157,7 +157,7 @@ export function sumHexes(...args) {
     })
   })
 
-  return ethUtil.addHexPrefix(total)
+  return addHexPrefix(total)
 }
 
 /**

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -3,6 +3,7 @@ import abi from 'human-standard-token-abi'
 import BigNumber from 'bignumber.js'
 import ethUtil from 'ethereumjs-util'
 import { DateTime } from 'luxon'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 
 // formatData :: ( date: <Unix Timestamp> ) -> String
 export function formatDate(date, format = "M/d/y 'at' T") {
@@ -87,9 +88,7 @@ export function isValidAddress(address) {
   if (!address || address === '0x0000000000000000000000000000000000000000') {
     return false
   }
-  const prefixed = address.startsWith('0X')
-    ? address
-    : ethUtil.addHexPrefix(address)
+  const prefixed = addHexPrefix(address)
   return (
     (isAllOneCase(prefixed.slice(2)) && ethUtil.isValidAddress(prefixed)) ||
     ethUtil.isValidChecksumAddress(prefixed)
@@ -415,7 +414,7 @@ export function toPrecisionWithoutTrailingZeros(n, precision) {
  */
 export function addHexPrefixToObjectValues(obj) {
   return Object.keys(obj).reduce((newObj, key) => {
-    return { ...newObj, [key]: ethUtil.addHexPrefix(obj[key]) }
+    return { ...newObj, [key]: addHexPrefix(obj[key]) }
   }, {})
 }
 

--- a/ui/app/hooks/useCancelTransaction.js
+++ b/ui/app/hooks/useCancelTransaction.js
@@ -20,10 +20,9 @@ import { getConversionRate, getSelectedAccount } from '../selectors'
  */
 export function useCancelTransaction(transactionGroup) {
   const { primaryTransaction, initialTransaction } = transactionGroup
-  const gasPrice =
-    primaryTransaction.txParams?.gasPrice?.startsWith('-')
-      ? '0x0'
-      : primaryTransaction.txParams?.gasPrice
+  const gasPrice = primaryTransaction.txParams?.gasPrice?.startsWith('-')
+    ? '0x0'
+    : primaryTransaction.txParams?.gasPrice
   const { id } = initialTransaction
   const dispatch = useDispatch()
   const selectedAccount = useSelector(getSelectedAccount)

--- a/ui/app/hooks/useCancelTransaction.js
+++ b/ui/app/hooks/useCancelTransaction.js
@@ -21,7 +21,7 @@ import { getConversionRate, getSelectedAccount } from '../selectors'
 export function useCancelTransaction(transactionGroup) {
   const { primaryTransaction, initialTransaction } = transactionGroup
   const gasPrice =
-    parseInt(primaryTransaction.txParams?.gasPrice, 16) < 0
+    primaryTransaction.txParams?.gasPrice?.startsWith('-')
       ? '0x0'
       : primaryTransaction.txParams?.gasPrice
   const { id } = initialTransaction

--- a/ui/app/hooks/useCancelTransaction.js
+++ b/ui/app/hooks/useCancelTransaction.js
@@ -20,7 +20,7 @@ import { getConversionRate, getSelectedAccount } from '../selectors'
  */
 export function useCancelTransaction(transactionGroup) {
   const { primaryTransaction, initialTransaction } = transactionGroup
-  const gasPrice = primaryTransaction.txParams?.gasPrice
+  const gasPrice = primaryTransaction.txParams?.gasPrice < 0 ? 0 : primaryTransaction.txParams?.gasPrice
   const { id } = initialTransaction
   const dispatch = useDispatch()
   const selectedAccount = useSelector(getSelectedAccount)

--- a/ui/app/hooks/useCancelTransaction.js
+++ b/ui/app/hooks/useCancelTransaction.js
@@ -20,7 +20,7 @@ import { getConversionRate, getSelectedAccount } from '../selectors'
  */
 export function useCancelTransaction(transactionGroup) {
   const { primaryTransaction, initialTransaction } = transactionGroup
-  const gasPrice = primaryTransaction.txParams?.gasPrice < 0 ? 0 : primaryTransaction.txParams?.gasPrice
+  const gasPrice = parseInt(primaryTransaction.txParams?.gasPrice, 16) < 0 ? '0x0' : primaryTransaction.txParams?.gasPrice
   const { id } = initialTransaction
   const dispatch = useDispatch()
   const selectedAccount = useSelector(getSelectedAccount)

--- a/ui/app/hooks/useCancelTransaction.js
+++ b/ui/app/hooks/useCancelTransaction.js
@@ -20,7 +20,10 @@ import { getConversionRate, getSelectedAccount } from '../selectors'
  */
 export function useCancelTransaction(transactionGroup) {
   const { primaryTransaction, initialTransaction } = transactionGroup
-  const gasPrice = parseInt(primaryTransaction.txParams?.gasPrice, 16) < 0 ? '0x0' : primaryTransaction.txParams?.gasPrice
+  const gasPrice =
+    parseInt(primaryTransaction.txParams?.gasPrice, 16) < 0
+      ? '0x0'
+      : primaryTransaction.txParams?.gasPrice
   const { id } = initialTransaction
   const dispatch = useDispatch()
   const selectedAccount = useSelector(getSelectedAccount)

--- a/ui/app/pages/add-token/add-token.component.js
+++ b/ui/app/pages/add-token/add-token.component.js
@@ -7,6 +7,7 @@ import { CONFIRM_ADD_TOKEN_ROUTE } from '../../helpers/constants/routes'
 import TextField from '../../components/ui/text-field'
 import PageContainer from '../../components/ui/page-container'
 import { Tabs, Tab } from '../../components/ui/tabs'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 import TokenList from './token-list'
 import TokenSearch from './token-search'
 
@@ -161,7 +162,7 @@ class AddToken extends Component {
     })
 
     const isValidAddress = ethUtil.isValidAddress(customAddress)
-    const standardAddress = ethUtil.addHexPrefix(customAddress).toLowerCase()
+    const standardAddress = addHexPrefix(customAddress).toLowerCase()
 
     switch (true) {
       case !isValidAddress:

--- a/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.utils.js
+++ b/ui/app/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.utils.js
@@ -1,8 +1,8 @@
-import ethUtil from 'ethereumjs-util'
 import {
   multiplyCurrencies,
   subtractCurrencies,
 } from '../../../../../helpers/utils/conversion-util'
+import { addHexPrefix } from '../../../../../../../app/scripts/lib/util'
 
 export function calcMaxAmount({ balance, gasTotal, sendToken, tokenBalance }) {
   const { decimals } = sendToken || {}
@@ -13,9 +13,7 @@ export function calcMaxAmount({ balance, gasTotal, sendToken, tokenBalance }) {
         toNumericBase: 'hex',
         multiplicandBase: 16,
       })
-    : subtractCurrencies(
-        ethUtil.addHexPrefix(balance),
-        ethUtil.addHexPrefix(gasTotal),
-        { toNumericBase: 'hex' },
-      )
+    : subtractCurrencies(addHexPrefix(balance), addHexPrefix(gasTotal), {
+        toNumericBase: 'hex',
+      })
 }

--- a/ui/app/pages/send/send-footer/send-footer.container.js
+++ b/ui/app/pages/send/send-footer/send-footer.container.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux'
-import ethUtil from 'ethereumjs-util'
 import {
   addToAddressBook,
   clearSend,
@@ -27,6 +26,7 @@ import {
   getDefaultActiveButtonIndex,
 } from '../../../selectors'
 import { getMostRecentOverviewPage } from '../../../ducks/history/history'
+import { addHexPrefix } from '../../../../../app/scripts/lib/util'
 import SendFooter from './send-footer.component'
 import {
   addressIsNew,
@@ -112,7 +112,7 @@ function mapDispatchToProps(dispatch) {
     },
 
     addToAddressBookIfNew: (newAddress, toAccounts, nickname = '') => {
-      const hexPrefixedAddress = ethUtil.addHexPrefix(newAddress)
+      const hexPrefixedAddress = addHexPrefix(newAddress)
       if (addressIsNew(toAccounts, hexPrefixedAddress)) {
         // TODO: nickname, i.e. addToAddressBook(recipient, nickname)
         dispatch(addToAddressBook(hexPrefixedAddress, nickname))

--- a/ui/app/pages/send/send-footer/send-footer.utils.js
+++ b/ui/app/pages/send/send-footer/send-footer.utils.js
@@ -1,6 +1,6 @@
 import ethAbi from 'ethereumjs-abi'
-import ethUtil from 'ethereumjs-util'
 import { TOKEN_TRANSFER_FUNCTION_SIGNATURE } from '../send.constants'
+import { addHexPrefix } from '../../../../../app/scripts/lib/util'
 import { addHexPrefixToObjectValues } from '../../../helpers/utils/util'
 
 export function constructTxParams({
@@ -71,7 +71,7 @@ export function constructUpdatedTx({
             .call(
               ethAbi.rawEncode(
                 ['address', 'uint256'],
-                [to, ethUtil.addHexPrefix(amount)],
+                [to, addHexPrefix(amount)],
               ),
               (x) => `00${x.toString(16)}`.slice(-2),
             )

--- a/ui/app/pages/send/send.constants.js
+++ b/ui/app/pages/send/send.constants.js
@@ -1,15 +1,15 @@
-import ethUtil from 'ethereumjs-util'
 import {
   conversionUtil,
   multiplyCurrencies,
 } from '../../helpers/utils/conversion-util'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 
 const MIN_GAS_PRICE_DEC = '0'
 const MIN_GAS_PRICE_HEX = parseInt(MIN_GAS_PRICE_DEC, 10).toString(16)
 const MIN_GAS_LIMIT_DEC = '21000'
 const MIN_GAS_LIMIT_HEX = parseInt(MIN_GAS_LIMIT_DEC, 10).toString(16)
 
-const MIN_GAS_PRICE_GWEI = ethUtil.addHexPrefix(
+const MIN_GAS_PRICE_GWEI = addHexPrefix(
   conversionUtil(MIN_GAS_PRICE_HEX, {
     fromDenomination: 'WEI',
     toDenomination: 'GWEI',

--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -1,5 +1,4 @@
 import abi from 'ethereumjs-abi'
-import ethUtil from 'ethereumjs-util'
 import {
   addCurrencies,
   conversionUtil,
@@ -10,6 +9,7 @@ import {
 } from '../../helpers/utils/conversion-util'
 
 import { calcTokenAmount } from '../../helpers/utils/token-util'
+import { addHexPrefix } from '../../../../app/scripts/lib/util'
 
 import {
   BASE_TOKEN_GAS_COST,
@@ -242,7 +242,7 @@ async function estimateGasForSend({
     blockGasLimit = MIN_GAS_LIMIT_HEX
   }
 
-  paramsForGasEstimate.gas = ethUtil.addHexPrefix(
+  paramsForGasEstimate.gas = addHexPrefix(
     multiplyCurrencies(blockGasLimit, 0.95, {
       multiplicandBase: 16,
       multiplierBase: 10,
@@ -259,7 +259,7 @@ async function estimateGasForSend({
       blockGasLimit,
       1.5,
     )
-    return ethUtil.addHexPrefix(estimateWithBuffer)
+    return addHexPrefix(estimateWithBuffer)
   } catch (error) {
     const simulationFailed =
       error.message.includes('Transaction execution error.') ||
@@ -272,7 +272,7 @@ async function estimateGasForSend({
         blockGasLimit,
         1.5,
       )
-      return ethUtil.addHexPrefix(estimateWithBuffer)
+      return addHexPrefix(estimateWithBuffer)
     }
     throw error
   }
@@ -336,7 +336,7 @@ function generateTokenTransferData({
       .call(
         abi.rawEncode(
           ['address', 'uint256'],
-          [toAddress, ethUtil.addHexPrefix(amount)],
+          [toAddress, addHexPrefix(amount)],
         ),
         (x) => `00${x.toString(16)}`.slice(-2),
       )

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -1,4 +1,4 @@
-import { addHexPrefix } from 'ethereumjs-util'
+import { addHexPrefix } from '../../../app/scripts/lib/util'
 import {
   conversionUtil,
   multiplyCurrencies,

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -1,5 +1,6 @@
-import { stripHexPrefix, addHexPrefix } from 'ethereumjs-util'
+import { stripHexPrefix } from 'ethereumjs-util'
 import { createSelector } from 'reselect'
+import { addHexPrefix } from '../../../app/scripts/lib/util'
 import { NETWORK_TYPES } from '../helpers/constants/common'
 import {
   shortenAddress,

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1,6 +1,5 @@
 import abi from 'human-standard-token-abi'
 import pify from 'pify'
-import ethUtil from 'ethereumjs-util'
 import log from 'loglevel'
 import { capitalize } from 'lodash'
 import getBuyEthUrl from '../../../app/scripts/lib/buy-eth-url'
@@ -17,7 +16,7 @@ import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../app/scripts/lib/enums'
 import { hasUnconfirmedTransactions } from '../helpers/utils/confirm-tx.util'
 import { setCustomGasLimit } from '../ducks/gas/gas.duck'
 import txHelper from '../../lib/tx-helper'
-import { getEnvironmentType } from '../../../app/scripts/lib/util'
+import { getEnvironmentType, addHexPrefix } from '../../../app/scripts/lib/util'
 import {
   getPermittedAccountsForCurrentTab,
   getSelectedAddress,
@@ -791,12 +790,10 @@ export function signTokenTx(tokenAddress, toAddress, amount, txData) {
   return (dispatch) => {
     dispatch(showLoadingIndication())
     const token = global.eth.contract(abi).at(tokenAddress)
-    token
-      .transfer(toAddress, ethUtil.addHexPrefix(amount), txData)
-      .catch((err) => {
-        dispatch(hideLoadingIndication())
-        dispatch(displayWarning(err.message))
-      })
+    token.transfer(toAddress, addHexPrefix(amount), txData).catch((err) => {
+      dispatch(hideLoadingIndication())
+      dispatch(displayWarning(err.message))
+    })
     dispatch(showConfTxPage())
   }
 }
@@ -2495,7 +2492,7 @@ export function loadingMethodDataFinished() {
 
 export function getContractMethodData(data = '') {
   return (dispatch, getState) => {
-    const prefixedData = ethUtil.addHexPrefix(data)
+    const prefixedData = addHexPrefix(data)
     const fourBytePrefix = prefixedData.slice(0, 10)
     const { knownMethodData } = getState().metamask
 


### PR DESCRIPTION
Creates custom addHexPrefix function. The one provided by `ethereumjs-util` does not handle incorrect eth address hex formats such us starting with `-` or `0X`.

Fixes #9262 