### PR TITLE
Remove 'Contact us' exclamation mark

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -413,7 +413,7 @@
     "message": "Add, edit, remove, and manage your contacts"
   },
   "contactUs": {
-    "message": "Contact us!"
+    "message": "Contact us"
   },
   "continueToWyre": {
     "message": "Continue to Wyre"


### PR DESCRIPTION
This PR removes the exclamation mark from the "Contact us" locale message, which is both janky and contrary to our style guide.

![image](https://user-images.githubusercontent.com/25517051/91203011-76843180-e6b7-11ea-81bc-acfa30f11603.png)
