### PR TITLE
Add CLA Signature bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   CLABot:
+    if: github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Signature Bot"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Signature Bot"
-        uses: MetaMask/cla-signature-bot@v3.0.2
+        uses: MetaMask/cla-signature-bot@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -20,5 +20,5 @@ jobs:
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
           allowlist: dependabot
-          allowOrganizationMembers: true
+          allow-organization-members: true
           blockchain-storage-flag: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,22 @@
+name: "CLA Signature Bot"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLABot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Signature Bot"
+        uses: MetaMask/cla-signature-bot@v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'cla.json'
+          url-to-cladocument: 'https://metamask.io/cla.html'
+          # This branch can't have protections, commits are made directly to the specified branch.
+          branch: 'cla-signatures'
+          whitelist: dependabot
+          blockchain-storage-flag: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Signature Bot"
-        uses: MetaMask/cla-signature-bot@v3.0.0
+        uses: MetaMask/cla-signature-bot@v3.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -19,5 +19,5 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          whitelist: dependabot
+          allowlist: dependabot
           blockchain-storage-flag: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Signature Bot"
-        uses: MetaMask/cla-signature-bot@v3.0.1
+        uses: MetaMask/cla-signature-bot@v3.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -20,4 +20,5 @@ jobs:
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
           allowlist: dependabot
+          allowOrganizationMembers: true
           blockchain-storage-flag: false


### PR DESCRIPTION
The CLA signature bot will check the authors of each PR to ensure they have all signed the CLA. If any authors still need to sign the CLA, it will leave a comment explaining how it can be signed, and will check back upon each comment to see if it has been signed.

The bot used is `Metamask/cla-signature-bot`, which is a fork of `Roblox/cla-signature-bot`. The fork has a couple of improvements, and it updated the PR comment text to be more appropriate for our usage.

Currently the only whitelisted user is `dependabot`, meaning that even ConsenSys employees will need to sign the CLA. We could add all employees to the whitelist, but I figured it'd be easier to get everyone to sign individually rather than maintaining this list here.

The signatures are stored in `cla.json` on the `cla-signatures` branch, which is in this repository as a distinct root. We can consider moving this to a separate repository in the future - this was just easier to setup.