### PR TITLE
Show token symbol when token amount string is long

### DIFF
--- a/ui/app/components/app/asset-list-item/asset-list-item.js
+++ b/ui/app/components/app/asset-list-item/asset-list-item.js
@@ -95,6 +95,7 @@ const AssetListItem = ({
       className={classnames('asset-list-item', className)}
       data-testid={dataTestId}
       title={primary}
+      subTitle={tokenSymbol}
       titleIcon={titleIcon}
       subtitle={<h3 title={secondary}>{secondary}</h3>}
       onClick={onClick}

--- a/ui/app/components/app/asset-list-item/asset-list-item.js
+++ b/ui/app/components/app/asset-list-item/asset-list-item.js
@@ -94,8 +94,12 @@ const AssetListItem = ({
     <ListItem
       className={classnames('asset-list-item', className)}
       data-testid={dataTestId}
-      title={primary}
-      subTitle={tokenSymbol}
+      title={(
+        <>
+          <h2 className="asset-list-item__token-value">{primary}</h2>
+          <h2 className="asset-list-item__token-symbol">{tokenSymbol}</h2>
+        </>
+      )}
       titleIcon={titleIcon}
       subtitle={<h3 title={secondary}>{secondary}</h3>}
       onClick={onClick}

--- a/ui/app/components/app/asset-list-item/asset-list-item.scss
+++ b/ui/app/components/app/asset-list-item/asset-list-item.scss
@@ -1,4 +1,12 @@
 .asset-list-item {
+
+  &__token-value {
+    padding: 0 5px 0 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   &__chevron-right {
     color: $Grey-500;
   }

--- a/ui/app/components/app/asset-list-item/asset-list-item.scss
+++ b/ui/app/components/app/asset-list-item/asset-list-item.scss
@@ -1,5 +1,4 @@
 .asset-list-item {
-
   &__token-value {
     padding: 0 5px 0 0;
     overflow: hidden;

--- a/ui/app/components/app/token-cell/token-cell.js
+++ b/ui/app/components/app/token-cell/token-cell.js
@@ -47,7 +47,7 @@ export default function TokenCell ({
       tokenSymbol={symbol}
       tokenDecimals={decimals}
       warning={warning}
-      primary={`${string || 0} ${symbol}`}
+      primary={`${string || 0}`}
       secondary={formattedFiat}
     />
 

--- a/ui/app/components/app/token-cell/token-cell.test.js
+++ b/ui/app/components/app/token-cell/token-cell.test.js
@@ -69,11 +69,11 @@ describe('Token Cell', function () {
   })
 
   it('renders token balance', function () {
-    assert.equal(wrapper.find('.list-item__title').text(), '5.000')
+    assert.equal(wrapper.find('.asset-list-item__token-value').text(), '5.000')
   })
 
   it('renders token symbol', function () {
-    assert.equal(wrapper.find('.list-item__subTitle').text(), 'TEST')
+    assert.equal(wrapper.find('.asset-list-item__token-symbol').text(), 'TEST')
   })
 
   it('renders converted fiat amount', function () {

--- a/ui/app/components/app/token-cell/token-cell.test.js
+++ b/ui/app/components/app/token-cell/token-cell.test.js
@@ -68,8 +68,12 @@ describe('Token Cell', function () {
     assert.equal(wrapper.find(Identicon).prop('image'), './test-image')
   })
 
-  it('renders token balance and symbol', function () {
-    assert.equal(wrapper.find('.list-item__heading').text(), '5.000 TEST')
+  it('renders token balance', function () {
+    assert.equal(wrapper.find('.list-item__title').text(), '5.000')
+  })
+
+  it('renders token symbol', function () {
+    assert.equal(wrapper.find('.list-item__subTitle').text(), 'TEST')
   })
 
   it('renders converted fiat amount', function () {

--- a/ui/app/components/ui/list-item/index.scss
+++ b/ui/app/components/ui/list-item/index.scss
@@ -44,16 +44,18 @@
     display: flex;
     align-items: center;
 
-    > h2 {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
 
     &-wrap {
       display: inline-block;
       margin-left: 8px;
     }
+  }
+
+  &__title {
+    padding: 0 5px 0 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   &__subheading {

--- a/ui/app/components/ui/list-item/index.scss
+++ b/ui/app/components/ui/list-item/index.scss
@@ -51,13 +51,6 @@
     }
   }
 
-  &__title {
-    padding: 0 5px 0 0;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
-
   &__subheading {
     grid-area: sub;
     font-size: 12px;

--- a/ui/app/components/ui/list-item/index.scss
+++ b/ui/app/components/ui/list-item/index.scss
@@ -44,11 +44,16 @@
     display: flex;
     align-items: center;
 
-
     &-wrap {
       display: inline-block;
       margin-left: 8px;
     }
+  }
+
+  &__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__subheading {

--- a/ui/app/components/ui/list-item/list-item.component.js
+++ b/ui/app/components/ui/list-item/list-item.component.js
@@ -24,7 +24,7 @@ export default function ListItem ({
         </div>
       )}
       <div className="list-item__heading">
-        {React.isValidElement(title) ? title : <h2>{ title }</h2>}
+        {React.isValidElement(title) ? title : <h2 className="list-item__title">{ title }</h2>}
         {titleIcon && (
           <div className="list-item__heading-wrap">
             {titleIcon}

--- a/ui/app/components/ui/list-item/list-item.component.js
+++ b/ui/app/components/ui/list-item/list-item.component.js
@@ -4,6 +4,7 @@ import classnames from 'classnames'
 
 export default function ListItem ({
   title,
+  subTitle,
   subtitle,
   onClick,
   children,
@@ -24,7 +25,10 @@ export default function ListItem ({
         </div>
       )}
       <div className="list-item__heading" title={title}>
-        <h2>{ title }</h2>
+        <h2 className="list-item__title">{ title }</h2>
+        {subTitle && (
+          <h2 className="list-item__subTitle">{ subTitle }</h2>
+        )}
         {titleIcon && (
           <div className="list-item__heading-wrap">
             {titleIcon}
@@ -57,6 +61,7 @@ export default function ListItem ({
 
 ListItem.propTypes = {
   title: PropTypes.string.isRequired,
+  subTitle: PropTypes.string,
   titleIcon: PropTypes.node,
   subtitle: PropTypes.node,
   children: PropTypes.node,

--- a/ui/app/components/ui/list-item/list-item.component.js
+++ b/ui/app/components/ui/list-item/list-item.component.js
@@ -4,7 +4,6 @@ import classnames from 'classnames'
 
 export default function ListItem ({
   title,
-  subTitle,
   subtitle,
   onClick,
   children,
@@ -24,11 +23,8 @@ export default function ListItem ({
           {icon}
         </div>
       )}
-      <div className="list-item__heading" title={title}>
-        <h2 className="list-item__title">{ title }</h2>
-        {subTitle && (
-          <h2 className="list-item__subTitle">{ subTitle }</h2>
-        )}
+      <div className="list-item__heading">
+        {React.isValidElement(title) ? title : <h2>{ title }</h2>}
         {titleIcon && (
           <div className="list-item__heading-wrap">
             {titleIcon}
@@ -60,8 +56,7 @@ export default function ListItem ({
 }
 
 ListItem.propTypes = {
-  title: PropTypes.string.isRequired,
-  subTitle: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   titleIcon: PropTypes.node,
   subtitle: PropTypes.node,
   children: PropTypes.node,

--- a/ui/app/components/ui/list-item/tests/list-item.test.js
+++ b/ui/app/components/ui/list-item/tests/list-item.test.js
@@ -40,9 +40,6 @@ describe('ListItem', function () {
   it(`renders "${TITLE}" title`, function () {
     assert.equal(wrapper.find('.list-item__heading h2').text(), TITLE)
   })
-  it('adds html title to heading element', function () {
-    assert.equal(wrapper.find('.list-item__heading').props().title, TITLE)
-  })
   it(`renders "I am a list item" subtitle`, function () {
     assert.equal(wrapper.find('.list-item__subheading').text(), 'I am a list item')
   })


### PR DESCRIPTION
Fixes #9318

This essentially separates the token cell list item title/token amount and the token symbol.

I do request advice/recomendations on how to better handle the new `subTitle` which I set the token symbol to and the `subtitle` https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/components/app/asset-list-item/asset-list-item.js#L99.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/13376180/91757931-ff054500-eb83-11ea-8efb-2126b0c485bd.png">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/13376180/91757948-07f61680-eb84-11ea-99a1-cfd5fb95b955.png">
<div>note the 1234 is the token symbol, wasnt thinking about that confusing aspect that when creating the token</div>
</details>