### PR TITLE
Fix useTokenTracker useEffect bug

### DIFF
--- a/ui/app/hooks/useEqualityCheck.js
+++ b/ui/app/hooks/useEqualityCheck.js
@@ -1,0 +1,27 @@
+import { useState, useLayoutEffect } from 'react'
+
+import { isEqual } from 'lodash'
+
+/**
+ * Given a value and a function to determine equality, return a
+ * referentially equal value if the equality function returns true.
+ * This hook is helpful in avoiding re-renders and effects running
+ * based on an object or value that always changes references but
+ * infrequently changes it's value. By default, uses isEqual from
+ * lodash. This is typically only useful with objects and arrays.
+ *
+ * @param {T}                 value      - any value to check equality of
+ * @param {(T, T) => boolean} equalityFn - A function to determine equality
+ * @returns {T}
+ */
+export function useEqualityCheck (value, equalityFn = isEqual) {
+  const [computedValue, setComputedValue] = useState(() => value)
+
+  useLayoutEffect(() => {
+    if (!equalityFn(value, computedValue)) {
+      setComputedValue(value)
+    }
+  }, [value, equalityFn, computedValue])
+
+  return computedValue
+}

--- a/ui/app/hooks/useEqualityCheck.js
+++ b/ui/app/hooks/useEqualityCheck.js
@@ -15,7 +15,7 @@ import { isEqual } from 'lodash'
  * @returns {T}
  */
 export function useEqualityCheck (value, equalityFn = isEqual) {
-  const [computedValue, setComputedValue] = useState(() => value)
+  const [computedValue, setComputedValue] = useState(value)
 
   useLayoutEffect(() => {
     if (!equalityFn(value, computedValue)) {

--- a/ui/app/hooks/useTokenTracker.js
+++ b/ui/app/hooks/useTokenTracker.js
@@ -1,7 +1,16 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import TokenTracker from '@metamask/eth-token-tracker'
 import { useSelector } from 'react-redux'
+import { isEqual } from 'lodash'
 import { getCurrentNetwork, getSelectedAddress } from '../selectors'
+
+const usePrevious = (value) => {
+  const ref = useRef()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}
 
 export function useTokenTracker (tokens) {
   const network = useSelector(getCurrentNetwork)
@@ -56,6 +65,10 @@ export function useTokenTracker (tokens) {
     return teardownTracker
   }, [teardownTracker])
 
+  const previousTokens = usePrevious(tokens)
+  const previousUserAddress = usePrevious(userAddress)
+  const previousNetwork = usePrevious(network)
+
   // Effect to set loading state and initialize tracker when values change
   useEffect(() => {
     // This effect will only run initially and when:
@@ -64,23 +77,25 @@ export function useTokenTracker (tokens) {
     // 3. token list is updated and not equal to previous list
     // in any of these scenarios, we should indicate to the user that their token
     // values are in the process of updating by setting loading state.
-    setLoading(true)
+    if (!isEqual(tokens, previousTokens) || previousUserAddress !== userAddress || previousNetwork !== network) {
+      setLoading(true)
 
-    if (!userAddress || network === 'loading' || !global.ethereumProvider) {
-      // If we do not have enough information to build a TokenTracker, we exit early
-      // When the values above change, the effect will be restarted. We also teardown
-      // tracker because inevitably this effect will run again momentarily.
-      teardownTracker()
-      return
+      if (!userAddress || network === 'loading' || !global.ethereumProvider) {
+        // If we do not have enough information to build a TokenTracker, we exit early
+        // When the values above change, the effect will be restarted. We also teardown
+        // tracker because inevitably this effect will run again momentarily.
+        teardownTracker()
+        return
+      }
+
+      if (tokens.length === 0) {
+        // sets loading state to false and token list to empty
+        updateBalances([])
+      }
+
+      buildTracker(userAddress, tokens)
     }
-
-    if (tokens.length === 0) {
-      // sets loading state to false and token list to empty
-      updateBalances([])
-    }
-
-    buildTracker(userAddress, tokens)
-  }, [userAddress, teardownTracker, network, tokens, updateBalances, buildTracker])
+  }, [userAddress, previousUserAddress, teardownTracker, network, previousNetwork, tokens, previousTokens, updateBalances, buildTracker])
 
   return { loading, tokensWithBalances, error }
 }


### PR DESCRIPTION
On develop, if selecting a token on the main asset list to go to the token asset view triggers an infinite loop of renders. This seems to be because the last `useEffect` hook inside the custom `useTokenTracker` hook will run whenever the `tokens` object changes, even if it does not _deeply_ change. This ultimately leads to a new `tokensWithBalances` object being set and returned.

This PR corrects this by ensuring that the token `useEffect` hook does not unnecessarily fire when receiving tokens objects that are deeply equal to the previous tokens object received.

This is a naive solution that can probably be made more elegant by those with more hooks expertise than me.

As a demo of the problem, I console.logged the tokens from inside the useEffect hook:
![tokens-bug-unfixed](https://user-images.githubusercontent.com/7499938/91779313-c3906800-ebcf-11ea-9385-231e7521d57c.gif)

But with this fix applied:
![tokens-bug-fixed](https://user-images.githubusercontent.com/7499938/91779333-cf7c2a00-ebcf-11ea-8d4b-0ec1a718bc44.gif)

