### PR TITLE
Fix alignment of restore vault screen

### DIFF
--- a/ui/app/pages/keychains/index.scss
+++ b/ui/app/pages/keychains/index.scss
@@ -10,7 +10,6 @@
     flex-direction: row;
     justify-content: flex-start;
   }
-
 }
 
 

--- a/ui/app/pages/keychains/index.scss
+++ b/ui/app/pages/keychains/index.scss
@@ -4,13 +4,15 @@
   height: 100%;
   justify-content: center;
   padding: 0 10px;
+
+  > .first-view-main {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+  }
+
 }
 
-.first-view-main {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-}
 
 @media screen and (min-width: 1281px) {
   .first-view-main {


### PR DESCRIPTION
Fixes #9324

Possibly missed when #9183 was merged. The issue is that the same className is overriding the intended flex-direction.

https://github.com/MetaMask/metamask-extension/blob/46ba1ef1008d5111924132229c281a449ea1a13a/ui/app/css/itcss/components/newui-sections.scss#L98