### PR TITLE
Remove unneeded globals from ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,9 +34,7 @@ module.exports = {
   ],
 
   globals: {
-    '$': 'readonly',
     document: 'readonly',
-    QUnit: 'readonly',
     window: 'readonly',
   },
 


### PR DESCRIPTION
This PR removes QUnit-related globals from the ESLint config, which are no longer needed as of #8959.