### PR TITLE
Fix lookAtDirection prop passed to Mascot

### DIFF
--- a/ui/app/components/ui/mascot/mascot.component.js
+++ b/ui/app/components/ui/mascot/mascot.component.js
@@ -30,7 +30,7 @@ export default class Mascot extends Component {
     height: '200',
     followMouse: true,
     lookAtTarget: {},
-    lookAtDirection: '',
+    lookAtDirection: null,
   }
 
   constructor (props) {
@@ -81,7 +81,7 @@ export default class Mascot extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { lookAtTarget: prevTarget = {}, lookAtDirection: prevDirection = '', followMouse: prevFollowMouse } = prevProps
+    const { lookAtTarget: prevTarget = {}, lookAtDirection: prevDirection = null, followMouse: prevFollowMouse } = prevProps
     const { lookAtTarget = {}, followMouse, lookAtDirection } = this.props
 
     if (lookAtDirection && prevDirection !== lookAtDirection) {


### PR DESCRIPTION
Refs #9166

This PR fixes the default value for `lookAtDirection` in the `Mascot` component. The default value was a string which wasn't a valid value from the prop typing, resulting in the following error:

```
Warning: Failed prop type: Invalid prop `lookAtDirection` of value `` supplied to `Mascot`, expected one of ["up","down","left","right","middle"].
    in Mascot (created by Welcome)
    in Welcome (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(Welcome)) (created by Context.Consumer)
    in Route (created by FirstTimeFlow)
    in Switch (created by FirstTimeFlow)
    in div (created by FirstTimeFlow)
    in FirstTimeFlow (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in Route (created by Routes)
    in Switch (created by Routes)
    in div (created by Routes)
    in div (created by Routes)
    in Routes (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(Routes)) (created by Index)
    in LegacyI18nProvider (created by Index)
    in I18nProvider (created by Index)
    in LegacyMetaMetricsProvider (created by Index)
    in MetaMetricsProvider (created by Index)
    in Router (created by HashRouter)
    in HashRouter (created by Index)
    in Provider (created by Index)
    in Index
```

This change updates the default value to be `null`.