### PR TITLE
Add custom hd path option

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1425,7 +1425,7 @@
     "message": "Select Locale"
   },
   "selectPathHelp": {
-    "message": "If you don't see your existing Ledger accounts below, try switching paths to \"Legacy (MEW / MyCrypto)\""
+    "message": "If you don't see your existing Ledger accounts below, try a different HD path."
   },
   "selectType": {
     "message": "Select Type"

--- a/ui/app/pages/create-account/connect-hardware/index.scss
+++ b/ui/app/pages/create-account/connect-hardware/index.scss
@@ -196,6 +196,17 @@
     margin: 0 auto 20px;
     display: flex;
   }
+
+  &__custom-input {
+    height: 54px;
+    width: 335px;
+    border: 1px solid $geyser;
+    border-radius: 4px;
+    background-color: $white;
+    color: $scorpion;
+    font-size: 16px;
+    padding: 0 20px;
+  }
 }
 
 .hw-account-list {


### PR DESCRIPTION
When adding accounts from a Ledger wallet, there are 2 options for the HD path,

- Ledger Live: m/44'/60'/0'/0/0
- Legacy (MEW / MyCrypto): m/44'/60'/0'

This PR adds an option to specify custom HD path.
<img width="998" alt="Screenshot 2020-09-07 at 11 56 33" src="https://user-images.githubusercontent.com/5708018/92381399-12c42480-f10b-11ea-95a2-19f83b4ff346.png">
<img width="989" alt="Screenshot 2020-09-07 at 11 56 43" src="https://user-images.githubusercontent.com/5708018/92381404-15267e80-f10b-11ea-89ea-7aaf62ed48fe.png">
Fixes #6716
Fixes #7486
Fixes #7238