### PR TITLE
Replace toNumber calls on BigNumbers with toString

### DIFF
--- a/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
+++ b/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
@@ -19,7 +19,7 @@ export default class ConfirmTokenTransactionBase extends Component {
   static propTypes = {
     tokenAddress: PropTypes.string,
     toAddress: PropTypes.string,
-    tokenAmount: PropTypes.number,
+    tokenAmount: PropTypes.string,
     tokenSymbol: PropTypes.string,
     fiatTransactionTotal: PropTypes.string,
     ethTransactionTotal: PropTypes.string,
@@ -29,7 +29,7 @@ export default class ConfirmTokenTransactionBase extends Component {
   }
 
   static defaultProps = {
-    tokenAmount: 0,
+    tokenAmount: '0',
   }
 
   getFiatTransactionAmount () {
@@ -46,7 +46,7 @@ export default class ConfirmTokenTransactionBase extends Component {
   renderSubtitleComponent () {
     const { contractExchangeRate, tokenAmount } = this.props
 
-    const decimalEthValue = (tokenAmount * contractExchangeRate) || 0
+    const decimalEthValue = (tokenAmount * contractExchangeRate) || '0'
     const hexWeiValue = getWeiHexFromDecimalValue({
       value: decimalEthValue,
       fromCurrency: ETH,

--- a/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.container.js
+++ b/ui/app/pages/confirm-token-transaction-base/confirm-token-transaction-base.container.js
@@ -44,7 +44,7 @@ const mapStateToProps = (state, ownProps) => {
   const tokenData = getTokenData(data)
   const tokenValue = getTokenValueParam(tokenData)
   const toAddress = getTokenAddressParam(tokenData)
-  const tokenAmount = tokenData && calcTokenAmount(tokenValue, decimals).toNumber()
+  const tokenAmount = tokenData && calcTokenAmount(tokenValue, decimals).toString()
   const contractExchangeRate = contractExchangeRateSelector(state)
 
   return {

--- a/ui/app/selectors/confirm-transaction.js
+++ b/ui/app/selectors/confirm-transaction.js
@@ -165,10 +165,10 @@ export const tokenAmountAndToAddressSelector = createSelector(
       const toParam = args[TOKEN_PARAM_TO]
       const valueParam = args[TOKEN_PARAM_VALUE]
       toAddress = toParam || args[0]
-      const value = valueParam ? valueParam.toNumber() : args[1].toNumber()
+      const value = valueParam ? valueParam.toString() : args[1].toString()
 
       if (tokenDecimals) {
-        tokenAmount = calcTokenAmount(value, tokenDecimals).toNumber()
+        tokenAmount = calcTokenAmount(value, tokenDecimals).toString()
       }
 
       tokenAmount = roundExponential(tokenAmount)
@@ -190,10 +190,10 @@ export const approveTokenAmountAndToAddressSelector = createSelector(
 
     if (args && args.length) {
       toAddress = args[TOKEN_PARAM_SPENDER]
-      const value = args[TOKEN_PARAM_VALUE].toNumber()
+      const value = args[TOKEN_PARAM_VALUE].toString()
 
       if (tokenDecimals) {
-        tokenAmount = calcTokenAmount(value, tokenDecimals).toNumber()
+        tokenAmount = calcTokenAmount(value, tokenDecimals).toString()
       }
 
       tokenAmount = roundExponential(tokenAmount)
@@ -215,10 +215,10 @@ export const sendTokenTokenAmountAndToAddressSelector = createSelector(
 
     if (args && args.length) {
       toAddress = args[TOKEN_PARAM_TO]
-      let value = args[TOKEN_PARAM_VALUE].toNumber()
+      let value = args[TOKEN_PARAM_VALUE].toString()
 
       if (tokenDecimals) {
-        value = calcTokenAmount(value, tokenDecimals).toNumber()
+        value = calcTokenAmount(value, tokenDecimals).toString()
       }
 
       tokenAmount = roundExponential(value)

--- a/ui/app/selectors/tests/confirm-transaction.test.js
+++ b/ui/app/selectors/tests/confirm-transaction.test.js
@@ -51,7 +51,7 @@ describe('Confirm Transaction Selector', function () {
           name: 'transfer',
           args: getEthersArrayLikeFromObj({
             '_to': '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-            '_value': { toNumber: () => '1' },
+            '_value': { toString: () => '1' },
           }),
         },
         tokenProps: {
@@ -75,7 +75,7 @@ describe('Confirm Transaction Selector', function () {
           name: 'approve',
           args: getEthersArrayLikeFromObj({
             '_spender': '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-            '_value': { toNumber: () => '1' },
+            '_value': { toString: () => '1' },
           }),
         },
         tokenProps: {
@@ -99,7 +99,7 @@ describe('Confirm Transaction Selector', function () {
           name: 'transfer',
           args: getEthersArrayLikeFromObj({
             '_to': '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-            '_value': { toNumber: () => '1' },
+            '_value': { toString: () => '1' },
           }),
         },
         tokenProps: {


### PR DESCRIPTION
Fixes #9356 

Replaces calls of the form `someBigNumber.toNumber()` with `someBigNumber.toString()`. Calling `toNumber()` on a `BigNumber` is, of course, unsafe in the general case since the `BigNumber` can be larger than `MAX_SAFE_INTEGER`. `ethers` [throws an error in this case](https://docs.ethers.io/v5/api/utils/bignumber/#BigNumber--BigNumber--methods--conversion), which is why #9356 is occurring on `develop` following #9290.

All `BigNumber` implementations we use (_edit:_ at least in this PR) support a `toString()` method where the default representation is decimal. All cases where `toNumber()` was replaced could function equally well with `toString()`, with minimal or no modifications.

We still use `someBigNumber.toNumber()` in [gas.ducks.js](https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/ducks/gas/gas.duck.js/). That's probably safe, because the gas price is denominated in gwei, and if the gas price ever exceeds `MAX_SAFE_INTEGER` in gwei on any platform we're on, we have bigger problems.