### PR TITLE
Move stylelint ignore patterns into config

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,9 +1,0 @@
-/app
-/development
-/dist
-/docs
-/fonts
-/images
-/node_modules
-/notices
-/test

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,4 +1,16 @@
 module.exports = {
+  ignoreFiles: [
+    '/app',
+    '/development',
+    '/dist',
+    '/docs',
+    '/fonts',
+    '/images',
+    '/node_modules',
+    '/notices',
+    '/test',
+  ],
+
   rules: {
     // stylelint-config-standard
 


### PR DESCRIPTION
This PR moves the stylelint ignore patterns into the `stylelint.config.js` file to keep everything together.