### PR TITLE
Always use null Infura project ID in testing

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -328,10 +328,10 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
       ETH_GAS_STATION_API_KEY: process.env.ETH_GAS_STATION_API_KEY || '',
       CONF: opts.devMode ? conf : ({}),
       SENTRY_DSN: process.env.SENTRY_DSN,
-      INFURA_PROJECT_ID: conf.INFURA_PROJECT_ID || (
+      INFURA_PROJECT_ID: (
         opts.testing
           ? '00000000000000000000000000000000'
-          : undefined
+          : conf.INFURA_PROJECT_ID
       ),
     }), {
       global: true,


### PR DESCRIPTION
This PR updates the order in which we look for Infura project IDs.

We should:

1. Use a null ID (`'00000000000000000000000000000000'`) when running e2e tests
2. Use the environment `INFURA_PROJECT_ID` if and only if the local `rc` config doesn't have a value
3. If both the environment _and_ local rc config don't have a value the initialization of the app fails