### PR TITLE
Noedify removeFromAddressBook

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -484,7 +484,7 @@ export default class MetamaskController extends EventEmitter {
 
       // AddressController
       setAddressBook: nodeify(this.addressBookController.set, this.addressBookController),
-      removeFromAddressBook: this.addressBookController.delete.bind(this.addressBookController),
+      removeFromAddressBook: nodeify(this.addressBookController.delete, this.addressBookController),
 
       // AppStateController
       setLastActiveTime: nodeify(this.appStateController.setLastActiveTime, this.appStateController),


### PR DESCRIPTION
Right now when editing an address in "Settings > Contact", the contact
is lost after saving. This is because the code awaits
`removeFromAddressBook()` before creating the new contact but
`removeFromAddressBook()` never resolves. This PR fixes this bug.