### PR TITLE
Update `@metamask/eth-token-tracker` from `v3.0.0` to `v3.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/controllers": "^2.0.5",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
-    "@metamask/eth-token-tracker": "^3.0.0",
+    "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^1.1.0",
     "@metamask/inpage-provider": "^6.1.0",
     "@metamask/jazzicon": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     events "^2.0.0"
     hdkey "0.8.0"
 
-"@metamask/eth-token-tracker@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-token-tracker/-/eth-token-tracker-3.0.0.tgz#16ad4820abd6603d745c8cdaf7c5a9ae60e6db02"
-  integrity sha512-UxYkmEMrUYb8wzsqEY8x6QeiW2955guR/aaalqfElI2rlDyvKJ1lIaAiT7y642vcqoyIGhqYG2aejeHDpifMbA==
+"@metamask/eth-token-tracker@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-token-tracker/-/eth-token-tracker-3.0.1.tgz#36b89f39c2af2ac41aa600dcedd2341704d94484"
+  integrity sha512-vlSKnI27zMCbaDOAHG5apYXoZgO833GUOP6/gkkzuKNEE7QZZCMti/9U6DYfrE8QvgbWyt/RjZkF3cTXXjBhCA==
   dependencies:
     deep-equal "^1.1.0"
     eth-block-tracker "^4.4.2"


### PR DESCRIPTION
`v3.0.1` of `@metamask/eth-token-tracker` fixes how token balances are displayed when they are between 1 and 0.1. See here for more details: https://github.com/MetaMask/eth-token-tracker/pull/47