### PR TITLE
Update allow list for CLA, fix Dependabot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,6 +19,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: dependabot
+          allowlist: 'dependabot[bot]'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
This change updates the Dependabot name in the allow list of the CLA workflow.