### PR TITLE
 Use approval controller for permissions requests

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -119,6 +119,7 @@ initialize().catch(log.error)
  * @property {number} unapprovedDecryptMsgCount - The number of messages in unapprovedDecryptMsgs.
  * @property {Object} unapprovedTypedMsgs - An object of messages pending approval, mapping a unique ID to the options.
  * @property {number} unapprovedTypedMsgCount - The number of messages in unapprovedTypedMsgs.
+ * @property {number} pendingApprovalCount - The number of pending request in the approval controller.
  * @property {string[]} keyringTypes - An array of unique keyring identifying strings, representing available strategies for creating accounts.
  * @property {Keyring[]} keyrings - An array of keyring descriptions, summarizing the accounts that are available for use, and what keyrings they belong to.
  * @property {string} selectedAddress - A lower case hex string of the currently selected address.
@@ -394,7 +395,7 @@ function setupController(initState, initLangCode) {
   controller.decryptMessageManager.on('updateBadge', updateBadge)
   controller.encryptionPublicKeyManager.on('updateBadge', updateBadge)
   controller.typedMessageManager.on('updateBadge', updateBadge)
-  controller.permissionsController.permissions.subscribe(updateBadge)
+  controller.approvalController.subscribe(updateBadge)
   controller.appStateController.on('updateBadge', updateBadge)
 
   /**
@@ -411,9 +412,7 @@ function setupController(initState, initLangCode) {
       unapprovedEncryptionPublicKeyMsgCount,
     } = controller.encryptionPublicKeyManager
     const { unapprovedTypedMessagesCount } = controller.typedMessageManager
-    const pendingPermissionRequests = Object.keys(
-      controller.permissionsController.permissions.state.permissionsRequests,
-    ).length
+    const pendingApprovalCount = controller.approvalController.getTotalApprovalCount()
     const waitingForUnlockCount =
       controller.appStateController.waitingForUnlock.length
     const count =
@@ -423,7 +422,7 @@ function setupController(initState, initLangCode) {
       unapprovedDecryptMsgCount +
       unapprovedEncryptionPublicKeyMsgCount +
       unapprovedTypedMessagesCount +
-      pendingPermissionRequests +
+      pendingApprovalCount +
       waitingForUnlockCount
     if (count) {
       label = String(count)

--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -1,3 +1,5 @@
+export const APPROVAL_TYPE = 'wallet_requestPermissions'
+
 export const WALLET_PREFIX = 'wallet_'
 
 export const HISTORY_STORE_KEY = 'permissionsHistory'

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -18,6 +18,7 @@ import nanoid from 'nanoid'
 import contractMap from '@metamask/contract-metadata'
 import {
   AddressBookController,
+  ApprovalController,
   CurrencyRateController,
   PhishingController,
 } from '@metamask/controllers'
@@ -101,6 +102,10 @@ export default class MetamaskController extends EventEmitter {
 
     // next, we will initialize the controllers
     // controller initialization order matters
+
+    this.approvalController = new ApprovalController({
+      showApprovalRequest: opts.showUserConfirmation,
+    })
 
     this.networkController = new NetworkController(initState.NetworkController)
     this.networkController.setInfuraProjectId(opts.infuraProjectId)
@@ -225,6 +230,7 @@ export default class MetamaskController extends EventEmitter {
 
     this.permissionsController = new PermissionsController(
       {
+        approvals: this.approvalController,
         getKeyringAccounts: this.keyringController.getAccounts.bind(
           this.keyringController,
         ),
@@ -393,8 +399,8 @@ export default class MetamaskController extends EventEmitter {
       PermissionsMetadata: this.permissionsController.store,
       ThreeBoxController: this.threeBoxController.store,
       SwapsController: this.swapsController.store,
-      // ENS Controller
       EnsController: this.ensController.store,
+      ApprovalController: this.approvalController,
     })
     this.memStore.subscribe(this.sendUpdate.bind(this))
 

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -1,6 +1,8 @@
 import { ethErrors, ERROR_CODES } from 'eth-json-rpc-errors'
 import deepFreeze from 'deep-freeze-strict'
 
+import { ApprovalController } from '@metamask/controllers'
+
 import _getRestrictedMethods from '../../../../../app/scripts/controllers/permissions/restrictedMethods'
 
 import {
@@ -67,6 +69,9 @@ const getRestrictedMethods = (permController) => {
  */
 export function getPermControllerOpts() {
   return {
+    approvals: new ApprovalController({
+      showApprovalRequest: noop,
+    }),
     getKeyringAccounts: async () => [...keyringAccounts],
     getUnlockPromise: () => Promise.resolve(),
     getRestrictedMethods,
@@ -423,9 +428,9 @@ export const getters = deepFreeze({
           message: `Pending approval with id '${id}' or origin '${origin}' already exists.`,
         }
       },
-      requestAlreadyPending: () => {
+      requestAlreadyPending: (origin) => {
         return {
-          message: 'Permissions request already pending; please wait.',
+          message: `Request of type 'wallet_requestPermissions' already pending for origin ${origin}. Please wait.`,
         }
       },
     },

--- a/test/unit/app/controllers/permissions/permissions-middleware-test.js
+++ b/test/unit/app/controllers/permissions/permissions-middleware-test.js
@@ -18,6 +18,20 @@ const { CAVEATS, ERRORS, PERMS, RPC_REQUESTS } = getters
 
 const { ACCOUNTS, DOMAINS, PERM_NAMES } = constants
 
+const initPermController = () => {
+  return new PermissionsController({
+    ...getPermControllerOpts(),
+  })
+}
+
+const createApprovalSpies = (permController) => {
+  sinon.spy(permController.approvals, '_add')
+}
+
+const getNextApprovalId = (permController) => {
+  return permController.approvals._approvals.keys().next().value
+}
+
 const validatePermission = (perm, name, origin, caveats) => {
   assert.equal(
     name,
@@ -36,12 +50,6 @@ const validatePermission = (perm, name, origin, caveats) => {
   }
 }
 
-const initPermController = () => {
-  return new PermissionsController({
-    ...getPermControllerOpts(),
-  })
-}
-
 describe('permissions middleware', function () {
   describe('wallet_requestPermissions', function () {
     let permController
@@ -52,6 +60,8 @@ describe('permissions middleware', function () {
     })
 
     it('grants permissions on user approval', async function () {
+      createApprovalSpies(permController)
+
       const aMiddleware = getPermissionsMiddleware(
         permController,
         DOMAINS.a.origin,
@@ -72,13 +82,12 @@ describe('permissions middleware', function () {
 
       await userApprovalPromise
 
-      assert.equal(
-        permController.pendingApprovals.size,
-        1,
-        'perm controller should have single pending approval',
+      assert.ok(
+        permController.approvals._add.calledOnce,
+        'should have added single approval request',
       )
 
-      const id = permController.pendingApprovals.keys().next().value
+      const id = getNextApprovalId(permController)
       const approvedReq = PERMS.approvedRequest(
         id,
         PERMS.requests.eth_accounts(),
@@ -150,7 +159,7 @@ describe('permissions middleware', function () {
 
       await userApprovalPromise
 
-      const id1 = permController.pendingApprovals.keys().next().value
+      const id1 = getNextApprovalId(permController)
       const approvedReq1 = PERMS.approvedRequest(
         id1,
         PERMS.requests.eth_accounts(),
@@ -219,7 +228,7 @@ describe('permissions middleware', function () {
 
       await userApprovalPromise
 
-      const id2 = permController.pendingApprovals.keys().next().value
+      const id2 = getNextApprovalId(permController)
       const approvedReq2 = PERMS.approvedRequest(id2, { ...requestedPerms2 })
 
       await permController.approvePermissionsRequest(
@@ -275,6 +284,8 @@ describe('permissions middleware', function () {
     })
 
     it('rejects permissions on user rejection', async function () {
+      createApprovalSpies(permController)
+
       const aMiddleware = getPermissionsMiddleware(
         permController,
         DOMAINS.a.origin,
@@ -298,13 +309,12 @@ describe('permissions middleware', function () {
 
       await userApprovalPromise
 
-      assert.equal(
-        permController.pendingApprovals.size,
-        1,
-        'perm controller should have single pending approval',
+      assert.ok(
+        permController.approvals._add.calledOnce,
+        'should have added single approval request',
       )
 
-      const id = permController.pendingApprovals.keys().next().value
+      const id = getNextApprovalId(permController)
 
       await permController.rejectPermissionsRequest(id)
       await requestRejection
@@ -328,6 +338,8 @@ describe('permissions middleware', function () {
     })
 
     it('rejects requests with unknown permissions', async function () {
+      createApprovalSpies(permController)
+
       const aMiddleware = getPermissionsMiddleware(
         permController,
         DOMAINS.a.origin,
@@ -349,10 +361,9 @@ describe('permissions middleware', function () {
         'request should be rejected with correct error',
       )
 
-      assert.equal(
-        permController.pendingApprovals.size,
-        0,
-        'perm controller should have no pending approvals',
+      assert.ok(
+        permController.approvals._add.notCalled,
+        'no approval requests should have been added',
       )
 
       assert.ok(
@@ -367,7 +378,7 @@ describe('permissions middleware', function () {
     })
 
     it('accepts only a single pending permissions request per origin', async function () {
-      const expectedError = ERRORS.pendingApprovals.requestAlreadyPending()
+      createApprovalSpies(permController)
 
       // two middlewares for two origins
 
@@ -414,10 +425,9 @@ describe('permissions middleware', function () {
 
       await userApprovalPromise
 
-      assert.equal(
-        permController.pendingApprovals.size,
-        2,
-        'perm controller should have expected number of pending approvals',
+      assert.ok(
+        permController.approvals._add.calledTwice,
+        'should have added two approval requests',
       )
 
       // create and start processing second request for first origin,
@@ -430,6 +440,10 @@ describe('permissions middleware', function () {
       const resA2 = {}
 
       userApprovalPromise = getUserApprovalPromise(permController)
+
+      const expectedError = ERRORS.pendingApprovals.requestAlreadyPending(
+        DOMAINS.a.origin,
+      )
 
       const requestApprovalFail = assert.rejects(
         aMiddleware(reqA2, resA2),
@@ -447,17 +461,20 @@ describe('permissions middleware', function () {
         'response should have expected error and no result',
       )
 
-      // first requests for both origins should remain
-
       assert.equal(
-        permController.pendingApprovals.size,
+        permController.approvals._add.callCount,
+        3,
+        'should have attempted to create three pending approvals',
+      )
+      assert.equal(
+        permController.approvals._approvals.size,
         2,
-        'perm controller should have expected number of pending approvals',
+        'should only have created two pending approvals',
       )
 
       // now, remaining pending requests should be approved without issue
 
-      for (const id of permController.pendingApprovals.keys()) {
+      for (const id of permController.approvals._approvals.keys()) {
         await permController.approvePermissionsRequest(
           PERMS.approvedRequest(id, PERMS.requests.test_method()),
         )
@@ -483,12 +500,6 @@ describe('permissions middleware', function () {
         resB1.result.length,
         1,
         'second origin should have single approved permission',
-      )
-
-      assert.equal(
-        permController.pendingApprovals.size,
-        0,
-        'perm controller should have expected number of pending approvals',
       )
     })
   })
@@ -609,6 +620,8 @@ describe('permissions middleware', function () {
     })
 
     it('requests accounts for unpermitted origin, and approves on user approval', async function () {
+      createApprovalSpies(permController)
+
       const userApprovalPromise = getUserApprovalPromise(permController)
 
       const aMiddleware = getPermissionsMiddleware(
@@ -626,13 +639,12 @@ describe('permissions middleware', function () {
 
       await userApprovalPromise
 
-      assert.equal(
-        permController.pendingApprovals.size,
-        1,
-        'perm controller should have single pending approval',
+      assert.ok(
+        permController.approvals._add.calledOnce,
+        'should have added single approval request',
       )
 
-      const id = permController.pendingApprovals.keys().next().value
+      const id = getNextApprovalId(permController)
       const approvedReq = PERMS.approvedRequest(
         id,
         PERMS.requests.eth_accounts(),
@@ -685,6 +697,8 @@ describe('permissions middleware', function () {
     })
 
     it('requests accounts for unpermitted origin, and rejects on user rejection', async function () {
+      createApprovalSpies(permController)
+
       const userApprovalPromise = getUserApprovalPromise(permController)
 
       const aMiddleware = getPermissionsMiddleware(
@@ -705,13 +719,12 @@ describe('permissions middleware', function () {
 
       await userApprovalPromise
 
-      assert.equal(
-        permController.pendingApprovals.size,
-        1,
-        'perm controller should have single pending approval',
+      assert.ok(
+        permController.approvals._add.calledOnce,
+        'should have added single approval request',
       )
 
-      const id = permController.pendingApprovals.keys().next().value
+      const id = getNextApprovalId(permController)
 
       await permController.rejectPermissionsRequest(id)
       await requestRejection
@@ -788,7 +801,7 @@ describe('permissions middleware', function () {
       // this will reject because of the already pending request
       await assert.rejects(
         cMiddleware({ ...req }, {}),
-        ERRORS.eth_requestAccounts.requestAlreadyPending(),
+        ERRORS.eth_requestAccounts.requestAlreadyPending(DOMAINS.c.origin),
       )
 
       // now unlock and let through the first request


### PR DESCRIPTION
This PR introduces the new approval controller to the extension codebase. We use it for the permissions controller's pending approval functionality.

The approval controller sets us up for a new pattern of requesting and managing user confirmations in RPC methods. Along with the generic RPC method middleware, the approval controller will allow us to eliminate our message managers, and decouple [these method handlers](https://github.com/MetaMask/metamask-extension/blob/95acee95b542274095035e04cd1efef166289476/app/scripts/metamask-controller.js/#L348-L354) from our provider stack, making the implementations more portable between the extension and mobile.