### PR TITLE
Fix left border of 1st button in the gas modal basic tab

### DIFF
--- a/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
@@ -219,6 +219,10 @@
     background: #f7fcff;
     border: 2px solid #2c8bdc;
 
+    &:first-child {
+      border: 2px solid #2c8bdc;
+    }
+
     .button-check-wrapper {
       height: 16px;
       width: 16px;


### PR DESCRIPTION
Before:
![Screenshot from 2020-09-15 05-24-33](https://user-images.githubusercontent.com/7499938/93182653-87532080-f714-11ea-8c5b-753b0f7505bf.png)

After:
![Screenshot from 2020-09-15 05-26-34](https://user-images.githubusercontent.com/7499938/93182672-8cb06b00-f714-11ea-97b6-bb85786c1837.png)
