### PR TITLE
fix link regression

### DIFF
--- a/ui/app/components/ui/button/button.component.js
+++ b/ui/app/components/ui/button/button.component.js
@@ -25,22 +25,33 @@ const typeHash = {
   'first-time': CLASSNAME_FIRST_TIME,
 }
 
-const Button = ({ type, submit, large, children, icon, rounded, className, ...buttonProps }) => (
-  <button
-    type={submit ? 'submit' : undefined}
-    className={classnames(
-      'button',
-      typeHash[type] || CLASSNAME_DEFAULT,
-      large && CLASSNAME_LARGE,
-      rounded && CLASSNAME_ROUNDED,
-      className,
-    )}
-    { ...buttonProps }
-  >
-    {icon && <span className="button__icon">{icon}</span>}
-    { children }
-  </button>
-)
+const Button = ({ type, submit, large, children, icon, rounded, className, ...buttonProps }) => {
+  // To support using the Button component to render styled links that are semantic html
+  // we swap the html tag we use to render this component and delete any buttonProps that
+  // we know to be erroneous attributes for a link. We will likely want to extract Link
+  // to its own component in the future.
+  let Tag = 'button'
+  buttonProps.type = submit ? 'submit' : undefined
+  if (type === 'link') {
+    Tag = 'a'
+    delete buttonProps.type
+  }
+  return (
+    <Tag
+      className={classnames(
+        'button',
+        typeHash[type] || CLASSNAME_DEFAULT,
+        large && CLASSNAME_LARGE,
+        rounded && CLASSNAME_ROUNDED,
+        className,
+      )}
+      { ...buttonProps }
+    >
+      {icon && <span className="button__icon">{icon}</span>}
+      { children }
+    </Tag>
+  )
+}
 
 Button.propTypes = {
   type: PropTypes.string,

--- a/ui/app/components/ui/button/button.component.js
+++ b/ui/app/components/ui/button/button.component.js
@@ -31,10 +31,10 @@ const Button = ({ type, submit, large, children, icon, rounded, className, ...bu
   // we know to be erroneous attributes for a link. We will likely want to extract Link
   // to its own component in the future.
   let Tag = 'button'
-  buttonProps.type = submit ? 'submit' : undefined
   if (type === 'link') {
     Tag = 'a'
-    delete buttonProps.type
+  } else if (submit) {
+    buttonProps.type = 'submit'
   }
   return (
     <Tag


### PR DESCRIPTION
@jakehaugen noticed a regression in the links in both settings->about and in the add token workflow ("Learn More"). Both of these use the `Button` component with `type="link"`. I recently modified these files when doing the Typography updates, and didn't account for href not being valid HTML property on a `button` element. 