### PR TITLE
fix tooltip issue on firefox

### DIFF
--- a/ui/app/pages/settings/alerts-tab/alerts-tab.scss
+++ b/ui/app/pages/settings/alerts-tab/alerts-tab.scss
@@ -13,7 +13,11 @@
     height: 100%;
   }
 
-  &__body > :nth-child(1n) {
+  &__body > :first-child {
+    padding-left: 32px;
+  }
+
+  &__body > :nth-child(3n+4) {
     padding-left: 32px;
   }
 


### PR DESCRIPTION
Fixes an issue where the tooltip on the alerts setting screen wasn't working on firefox. The issue was seemingly caused by an eager selector (nth-child(1n)) which was meant to target just the first-child, and every initial row of the table. I updated it to specifically target `first-child` and every third element, starting at the fourth...

To demonstrate the effect I temporarily added a dupe row and took screenshots. The duped row is not in this PR. 

<details>
<summary>Screenies</summary>

<img src="https://user-images.githubusercontent.com/4448075/93245629-301f7100-f751-11ea-8ab5-d57839804b0e.png" />
<img src="https://user-images.githubusercontent.com/4448075/93245733-56dda780-f751-11ea-87f8-dde7be85a39f.png" />

</details>

