### PR TITLE
rename Ethereum Main Network -> Etherum Mainnet

### DIFF
--- a/app/_locales/cs/messages.json
+++ b/app/_locales/cs/messages.json
@@ -74,7 +74,7 @@
     "message": "Připojuji se k Kovan Test Network"
   },
   "connectingToMainnet": {
-    "message": "Připojuji se k Main Ethereum Network"
+    "message": "Připojuji se k Ethereum Mainnet"
   },
   "connectingToRopsten": {
     "message": "Připojuji se k Ropsten Test Network"

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -378,7 +378,7 @@
     "message": "Fehler bei der ENS-Namensregistrierung"
   },
   "ensNotFoundOnCurrentNetwork": {
-    "message": "ENS-Name wurde im aktuellen Netzwerk nicht gefunden. Versuchen Sie, zum Main Ethereum Network zu wechseln."
+    "message": "ENS-Name wurde im aktuellen Netzwerk nicht gefunden. Versuchen Sie, zum Ethereum Mainnet zu wechseln."
   },
   "enterAnAlias": {
     "message": "Ein Alias eingeben"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -392,7 +392,7 @@
     "message": "Connecting to Kovan Test Network"
   },
   "connectingToMainnet": {
-    "message": "Connecting to Main Ethereum Network"
+    "message": "Connecting to Ethereum Mainnet"
   },
   "connectingToRopsten": {
     "message": "Connecting to Ropsten Test Network"
@@ -582,7 +582,7 @@
     "message": "Error in ENS name registration"
   },
   "ensNotFoundOnCurrentNetwork": {
-    "message": "ENS name not found on the current network. Try switching to Main Ethereum Network."
+    "message": "ENS name not found on the current network. Try switching to Ethereum Mainnet."
   },
   "enterAnAlias": {
     "message": "Enter an alias"
@@ -904,7 +904,7 @@
     "message": "Lock time is too great"
   },
   "mainnet": {
-    "message": "Main Ethereum Network"
+    "message": "Ethereum Mainnet"
   },
   "memorizePhrase": {
     "message": "Memorize this phrase."
@@ -1598,7 +1598,7 @@
     "message": "Transaction Time"
   },
   "showTransactionTimeDescription": {
-    "message": "Select this to display pending transaction time estimates in the activity tab while on the Main Ethereum Network. Note: estimates are approximations based on network conditions."
+    "message": "Select this to display pending transaction time estimates in the activity tab while on the Ethereum Mainnet. Note: estimates are approximations based on network conditions."
   },
   "transfer": {
     "message": "Transfer"

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -210,7 +210,7 @@
     "message": "Kumokonekta sa Kovan Test Network"
   },
   "connectingToMainnet": {
-    "message": "Kumokonekta sa Main Ethereum Network"
+    "message": "Kumokonekta sa Ethereum Mainnet"
   },
   "connectingToRopsten": {
     "message": "Kumokonekta sa Ropsten Test Network"
@@ -366,7 +366,7 @@
     "message": "May error sa pagrerehistro ng ENS name"
   },
   "ensNotFoundOnCurrentNetwork": {
-    "message": "Hindi nakita ang ENS name sa kasalukuyang network. Subukang lumipat sa Main Ethereum Network."
+    "message": "Hindi nakita ang ENS name sa kasalukuyang network. Subukang lumipat sa Ethereum Mainnet."
   },
   "enterAnAlias": {
     "message": "Maglagay ng alias"

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -225,7 +225,7 @@
     "message": "Připojuji se k Kovan Test Network"
   },
   "connectingToMainnet": {
-    "message": "Připojuji se k Main Ethereum Network"
+    "message": "Připojuji se k Ethereum Mainnet"
   },
   "connectingToRopsten": {
     "message": "Připojuji se k Ropsten Test Network"

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -387,7 +387,7 @@
     "message": "Fel i ENS-namnregistrering"
   },
   "ensNotFoundOnCurrentNetwork": {
-    "message": "ENS-namnet hittades inte i det aktuella nätverket. Prova att byta till Main Ethereum Network."
+    "message": "ENS-namnet hittades inte i det aktuella nätverket. Prova att byta till Ethereum Mainnet."
   },
   "enterAnAlias": {
     "message": "Ange ett alias"

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -393,7 +393,7 @@
     "message": "Помилка у реєстрації ENS ім'я"
   },
   "ensNotFoundOnCurrentNetwork": {
-    "message": "Ім'я ENS не знайдено у даній мережі. Спробуйте перейти у Main Ethereum Network."
+    "message": "Ім'я ENS не знайдено у даній мережі. Спробуйте перейти у Ethereum Mainnet."
   },
   "enterAnAlias": {
     "message": "Введіть псевдонім"

--- a/app/scripts/controllers/network/enums.js
+++ b/app/scripts/controllers/network/enums.js
@@ -20,7 +20,7 @@ export const KOVAN_CHAIN_ID = '0x2a'
 export const ROPSTEN_DISPLAY_NAME = 'Ropsten'
 export const RINKEBY_DISPLAY_NAME = 'Rinkeby'
 export const KOVAN_DISPLAY_NAME = 'Kovan'
-export const MAINNET_DISPLAY_NAME = 'Main Ethereum Network'
+export const MAINNET_DISPLAY_NAME = 'Ethereum Mainnet'
 export const GOERLI_DISPLAY_NAME = 'Goerli'
 
 export const INFURA_PROVIDER_TYPES = [

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -1283,7 +1283,7 @@ describe('MetaMask', function () {
       await driver.clickElement(By.css('.network-name'))
       await driver.delay(regularDelayMs)
 
-      await driver.clickElement(By.xpath(`//span[contains(text(), 'Main Ethereum Network')]`))
+      await driver.clickElement(By.xpath(`//span[contains(text(), 'Ethereum Mainnet')]`))
       await driver.delay(largeDelayMs * 2)
     })
 

--- a/test/unit/app/controllers/network/network-controller-test.js
+++ b/test/unit/app/controllers/network/network-controller-test.js
@@ -88,7 +88,7 @@ describe('NetworkController', function () {
           expected: 'Kovan',
         }, {
           input: 'mainnet',
-          expected: 'Main Ethereum Network',
+          expected: 'Ethereum Mainnet',
         }, {
           input: 'goerli',
           expected: 'Goerli',

--- a/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
+++ b/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
@@ -70,7 +70,7 @@ describe('Network Dropdown', function () {
     })
 
     it('checks background color for first NetworkDropdownIcon', function () {
-      assert.equal(wrapper.find(NetworkDropdownIcon).at(0).prop('backgroundColor'), '#29B6AF') // Main Ethereum Network Teal
+      assert.equal(wrapper.find(NetworkDropdownIcon).at(0).prop('backgroundColor'), '#29B6AF') // Ethereum Mainnet Teal
     })
 
     it('checks background color for second NetworkDropdownIcon', function () {


### PR DESCRIPTION
Replaces the phrase 'Etherum Main Network' with 'Ethereum Mainnet'. I treated this as a proper name, and replaced it in all places it existed in all translations as well. This does result in NETWORK_NAME_MAP from enums.js but it doesn't seem widely used.

<details>
<summary>On Develop</summary>
<img src="https://user-images.githubusercontent.com/4448075/93252729-7b3e8180-f75b-11ea-87ac-9f145866df6c.png" />

</details>

<details>
<summary>This PR</summary>
<img src="https://user-images.githubusercontent.com/4448075/93252780-8d202480-f75b-11ea-8698-e83aa81b1157.png" />

</details>