### PR TITLE
Fix dropshadow permissions page

### DIFF
--- a/ui/app/components/app/permission-page-container/index.scss
+++ b/ui/app/components/app/permission-page-container/index.scss
@@ -1,12 +1,14 @@
 .permission-approval-container {
-  display: flex;
-  border: none;
-  box-shadow: none;
-  width: 100%;
-  margin-top: 2px;
-  height: 100%;
-  flex-direction: column;
-  justify-content: space-between;
+  &.page-container {
+    display: flex;
+    border: none;
+    box-shadow: none;
+    width: 100%;
+    margin-top: 2px;
+    height: 100%;
+    flex-direction: column;
+    justify-content: space-between;
+  }
 
   @media screen and (min-width: 576px) {
     width: 426px;


### PR DESCRIPTION
import order shouldn't matter with scss files because you don't want to create hidden interdependencies, however, in our case the order did matter in a few places. Some of those were already caught but they continue to crop up. This is one with overriding the styles of the page-container component.

<details>
<summary>Develop</summary>

<img src="https://user-images.githubusercontent.com/4448075/93256312-c7d88b80-f760-11ea-9efc-8ca00d07ef10.png" />


</details>

<details>
<summary>This PR</summary>
<img src="https://user-images.githubusercontent.com/4448075/93256455-02dabf00-f761-11ea-8dfd-3eec6f996ce8.png"/>



</details>

