### PR TITLE
fix overflow issue on approval container

### DIFF
--- a/ui/app/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/app/pages/confirm-approve/confirm-approve-content/index.scss
@@ -19,10 +19,8 @@
     display: flex;
     flex-flow: column;
     align-items: center;
-    width: 390px;
+    max-width: 100%;
     font-style: normal;
-    padding-left: 24px;
-    padding-right: 24px;
   }
 
   &__card-wrapper {


### PR DESCRIPTION
Fixes an issue when viewing full transaction details on approval notification. This issue exists in prod.

<details>
<summary>Prod</summary>

<img src="https://user-images.githubusercontent.com/4448075/93262079-3f121d80-f769-11ea-99dc-cf8cdf26c289.png" />


</details>

<details>
<summary>This PR</summary>

<img src="https://user-images.githubusercontent.com/4448075/93262053-3588b580-f769-11ea-8c92-4f59d3173290.png" />


</details>