### PR TITLE
Use @metamask/controllers@3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@formatjs/intl-relativetimeformat": "^5.2.6",
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@material-ui/core": "^4.11.0",
-    "@metamask/controllers": "^2.0.5",
+    "@metamask/controllers": "^3.0.1",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,7 +2047,7 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
-"@metamask/controllers@^2.0.2", "@metamask/controllers@^2.0.5":
+"@metamask/controllers@^2.0.2":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-2.0.5.tgz#302dbae0595b269f2660253ee40c4c7f9bce069e"
   integrity sha512-i+BjTEMy0XQFdcyXeEHmQ7xzktdNPBuw/R9QNBIllOvV4atR0JkZ9of6hi4tDFyjV40CBudqnIgS0iUVLWNGbA==
@@ -2056,6 +2056,34 @@
     eth-contract-metadata "^1.11.0"
     eth-ens-namehash "^2.0.8"
     eth-json-rpc-infura "^4.0.1"
+    eth-keyring-controller "^5.6.1"
+    eth-method-registry "1.1.0"
+    eth-phishing-detect "^1.1.13"
+    eth-query "^2.1.2"
+    eth-rpc-errors "^2.1.1"
+    eth-sig-util "^2.3.0"
+    ethereumjs-util "^6.1.0"
+    ethereumjs-wallet "0.6.0"
+    ethjs-query "^0.3.8"
+    human-standard-collectible-abi "^1.0.2"
+    human-standard-token-abi "^2.0.0"
+    isomorphic-fetch "^2.2.1"
+    jsonschema "^1.2.4"
+    percentile "^1.2.1"
+    single-call-balance-checker-abi "^1.0.0"
+    uuid "^3.3.2"
+    web3 "^0.20.7"
+    web3-provider-engine "^15.0.4"
+
+"@metamask/controllers@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-3.0.1.tgz#eea137df6c80c2590a75a057dab7d663ff462588"
+  integrity sha512-AExjqciWMQBi+HSv3ET+NbuEULaQNtYRh49RqWgTSB2YasYu+o4niTIQwnSRCjQs7Z/Gh7whuMYZQY1W4SESvw==
+  dependencies:
+    await-semaphore "^0.1.3"
+    eth-contract-metadata "^1.11.0"
+    eth-ens-namehash "^2.0.8"
+    eth-json-rpc-infura "^5.0.0"
     eth-keyring-controller "^5.6.1"
     eth-method-registry "1.1.0"
     eth-phishing-detect "^1.1.13"


### PR DESCRIPTION
This PR updates `@metamask/controllers` to the latest published version, 3.0.1.

The breaking change from `2.0.5...3.0.0` is for the `NetworkController` which isn't used in the extension. This upgrade is functionally just MetaMask/controllers#277, which fixes the phishing updates on Firefox.