### PR TITLE
Fix 3box backup and e2e tests

### DIFF
--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -178,16 +178,16 @@ export default class ThreeBoxController {
 
   async migrateBackedUpState (backedUpState) {
     const migrator = new Migrator({ migrations })
-
+    const { preferences, addressBook } = JSON.parse(backedUpState)
     const formattedStateBackup = {
-      PreferencesController: backedUpState.preferences,
-      AddressBookController: backedUpState.addressBook,
+      PreferencesController: preferences,
+      AddressBookController: addressBook,
     }
     const initialMigrationState = migrator.generateInitialState(formattedStateBackup)
     const migratedState = await migrator.migrateData(initialMigrationState)
     return {
-      preferences: migratedState.PreferencesController,
-      addressBook: migratedState.AddressBookController,
+      preferences: migratedState.data.PreferencesController,
+      addressBook: migratedState.data.AddressBookController,
     }
   }
 
@@ -198,8 +198,8 @@ export default class ThreeBoxController {
       addressBook,
     } = await this.migrateBackedUpState(backedUpState)
     this.store.updateState({ threeBoxLastUpdated: backedUpState.lastUpdated })
-    preferences && this.preferencesController.store.updateState(JSON.parse(preferences))
-    addressBook && this.addressBookController.update(JSON.parse(addressBook), true)
+    preferences && this.preferencesController.store.updateState(preferences)
+    addressBook && this.addressBookController.update(addressBook, true)
     this.setShowRestorePromptToFalse()
   }
 

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -213,7 +213,6 @@ describe('MetaMask', function () {
         await driver2.clickElement(By.css('.home-notification__accept-button'))
       })
 
-      // TODO: Fix tests from here forward; they're using the wrong driver
       it('goes to the settings screen', async function () {
         await driver2.clickElement(By.css('.account-menu__icon'))
         await driver2.delay(regularDelayMs)

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -215,25 +215,25 @@ describe('MetaMask', function () {
 
       // TODO: Fix tests from here forward; they're using the wrong driver
       it('goes to the settings screen', async function () {
-        await driver.clickElement(By.css('.account-menu__icon'))
-        await driver.delay(regularDelayMs)
+        await driver2.clickElement(By.css('.account-menu__icon'))
+        await driver2.delay(regularDelayMs)
 
-        await driver.clickElement(By.xpath(`//div[contains(text(), 'Settings')]`))
+        await driver2.clickElement(By.xpath(`//div[contains(text(), 'Settings')]`))
       })
 
       it('finds the blockies toggle turned on', async function () {
-        await driver.delay(regularDelayMs)
-        const toggleLabel = await driver.findElement(By.css('.toggle-button__status'))
+        await driver2.delay(regularDelayMs)
+        const toggleLabel = await driver2.findElement(By.css('.toggle-button__status'))
         const toggleLabelText = await toggleLabel.getText()
         assert.equal(toggleLabelText, 'ON')
       })
 
       it('finds the restored address in the contact list', async function () {
-        await driver.clickElement(By.xpath(`//div[contains(text(), 'Contacts')]`))
-        await driver.delay(regularDelayMs)
+        await driver2.clickElement(By.xpath(`//div[contains(text(), 'Contacts')]`))
+        await driver2.delay(regularDelayMs)
 
-        await driver.findElement(By.xpath(`//div[contains(text(), 'Test User Name 11')]`))
-        await driver.delay(regularDelayMs)
+        await driver2.findElement(By.xpath(`//div[contains(text(), 'Test User Name 11')]`))
+        await driver2.delay(regularDelayMs)
       })
     })
   })


### PR DESCRIPTION
The 3Box e2e tests currently don't actually validate that the restored data is present in the second browser session. The tests are meant to test the entire backup and restore process, but the test for the restore process are validating that the data exists in the wrong browser session.

This PR's changes tests to validate data from correct browser and fixes the issue why restoration process was not working correctly.

Fixes #9385 