### PR TITLE
Use eth-phishing-detect@1.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eth-json-rpc-middleware": "^5.0.3",
     "eth-keyring-controller": "^6.1.0",
     "eth-method-registry": "^1.2.0",
-    "eth-phishing-detect": "^1.1.4",
+    "eth-phishing-detect": "^1.1.14",
     "eth-query": "^2.1.2",
     "eth-sig-util": "^2.3.0",
     "eth-trezor-keyring": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10553,10 +10553,10 @@ eth-method-registry@^1.2.0:
   dependencies:
     ethjs "^0.3.0"
 
-eth-phishing-detect@^1.1.13, eth-phishing-detect@^1.1.4:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/eth-phishing-detect/-/eth-phishing-detect-1.1.13.tgz#ed718b933c8a69fef0cefa6604538824b472dbea"
-  integrity sha512-1KQcKvAQIjJgFMVwxaw2+BlzM9Momzl0e+/torPdMjg7WGq6LmCIS7ddg84diH5zIQp9quGyRVIEawCCuErgVQ==
+eth-phishing-detect@^1.1.13, eth-phishing-detect@^1.1.14:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/eth-phishing-detect/-/eth-phishing-detect-1.1.14.tgz#64dcd35dd3a7a95266d875cbc5280842cda133d7"
+  integrity sha512-nMQmzrgYabZ52YpuKZ38lStJy9Lozww2WBhyFbu/oepjsZzPvnl2KwJ6TJ78kk14USdl8Htt+eEMk2WAdAjlWg==
   dependencies:
     fast-levenshtein "^2.0.6"
 


### PR DESCRIPTION
This PR updates our phishing lists to the latest published version, 1.1.14.