### PR TITLE
Fix button with on Deposit Ether / Buy Screen

### DIFF
--- a/ui/app/components/app/modals/deposit-ether-modal/index.scss
+++ b/ui/app/components/app/modals/deposit-ether-modal/index.scss
@@ -140,7 +140,7 @@
   }
 
   &__deposit-button {
-    width: 257px;
+    width: 257px !important;
   }
 
   .simple-dropdown {


### PR DESCRIPTION
Issue with button width on  Deposit Ether / Buy Screen
<details>
<summary>Prod vs develop</summary>
<img src='https://user-images.githubusercontent.com/13376180/93379637-f6af3a00-f812-11ea-87d3-00d7559da264.png'/>
</details>

Adds `!important` to the `&__deposit-button` `width`.