### PR TITLE
increase specifity of button style overrides on notifications

### DIFF
--- a/ui/app/components/app/home-notification/home-notification.component.js
+++ b/ui/app/components/app/home-notification/home-notification.component.js
@@ -66,7 +66,7 @@ export default class HomeNotification extends PureComponent {
                 animation="none"
                 position="top"
                 arrow
-                theme="info"
+                theme="tippy-tooltip-home"
               >
                 <img
                   alt=""

--- a/ui/app/components/app/home-notification/index.scss
+++ b/ui/app/components/app/home-notification/index.scss
@@ -1,7 +1,11 @@
-.tippy-tooltip.info-theme {
-  background: rgba(36, 41, 46, 0.9);
-  color: $white;
-  border-radius: 8px;
+.tippy-tooltip {
+  // This looks weird, but its repeating the class name
+  // using interpolation for higher specificity.
+  &#{&}-home-theme {
+    background: rgba(36, 41, 46, 0.9);
+    color: $white;
+    border-radius: 8px;
+  }
 }
 
 .home-notification {

--- a/ui/app/components/app/home-notification/index.scss
+++ b/ui/app/components/app/home-notification/index.scss
@@ -47,7 +47,7 @@
     color: #6a737d;
   }
 
-  &__ignore-button {
+  & &__ignore-button {
     border: 2px solid #6a737d;
     box-sizing: border-box;
     border-radius: 6px;
@@ -71,7 +71,7 @@
     }
   }
 
-  &__accept-button {
+  & &__accept-button {
     border: 2px solid #6a737d;
     box-sizing: border-box;
     border-radius: 6px;

--- a/ui/app/components/ui/info-tooltip/index.scss
+++ b/ui/app/components/ui/info-tooltip/index.scss
@@ -5,35 +5,37 @@
   }
 }
 
-.tippy-popper[x-placement^=top] .info-theme [x-arrow] {
+.tippy-popper[x-placement^=top] .tippy-tooltip-info-theme [x-arrow] {
   border-top-color: $white;
 }
 
-.tippy-popper[x-placement^=right] .info-theme [x-arrow] {
+.tippy-popper[x-placement^=right] .tippy-tooltip-info-theme [x-arrow] {
   border-right-color: $white;
 }
 
-.tippy-popper[x-placement^=left] .info-theme [x-arrow] {
+.tippy-popper[x-placement^=left] .tippy-tooltip-info-theme [x-arrow] {
   border-left-color: $white;
 }
 
-.tippy-popper[x-placement^=bottom] .info-theme [x-arrow] {
+.tippy-popper[x-placement^=bottom] .tippy-tooltip-info-theme [x-arrow] {
   border-bottom-color: $white;
 }
 
-.tippy-tooltip.info-theme {
-  background: white;
-  color: black;
-  box-shadow: 0 0 14px rgba(0, 0, 0, 0.18);
-  border-radius: 8px;
-  max-width: 203px;
-  padding: 16px;
-  padding-bottom: 15px;
+.tippy-tooltip {
+  &#{&}-info-theme {
+    background: white;
+    color: black;
+    box-shadow: 0 0 14px rgba(0, 0, 0, 0.18);
+    border-radius: 8px;
+    max-width: 203px;
+    padding: 16px;
+    padding-bottom: 15px;
 
-  .tippy-tooltip-content {
-    @include H8;
+    .tippy-tooltip-content {
+      @include H8;
 
-    text-align: left;
-    color: $Grey-500;
+      text-align: left;
+      color: $Grey-500;
+    }
   }
 }

--- a/ui/app/components/ui/info-tooltip/info-tooltip.js
+++ b/ui/app/components/ui/info-tooltip/info-tooltip.js
@@ -22,7 +22,7 @@ export default function InfoTooltip ({
         tooltipInnerClassName="info-tooltip__tooltip-content"
         tooltipArrowClassName={positionArrowClassMap[position]}
         html={contentText}
-        theme="info"
+        theme="tippy-tooltip-info"
       >
         <img src="images/mm-info-icon.svg" />
       </Tooltip>


### PR DESCRIPTION
ReactTippy accepts a 'theme' prop that defaults to 'dark'
![image](https://user-images.githubusercontent.com/4448075/93384615-b065d500-f82a-11ea-96d9-f2db78e1692b.png)

this prop is used to append a class to the root container for the tooltip 'dark-theme' for example.

Previously we were using 'info' in two places: on the homepage notification as well as the new `info-tooltip` @danjm. Both of these components added styles around the `info-theme` class creating an unintended interdependency.

This PR:
1. Uses string interpolation in scss to repeat selectors for specificity `&&` is invalid, but `&#{&}` looks wonky but does what it needs to. Repeating the same class name multiple times increases specificity and the repetitive classes are ignored. 
2. Changes the `info` theme on the home page notification to `tippy-tooltip-home` which allows nesting the selector for the home theme using scss.
3. Changes the 'info' theme on the `info-tooltip` component to be `tippy-tooltip-info` for similar reasons.
4. Fixes tooltip styling on notification using string interpolation for specificity method above.
5. Fixes specificity of notification buttons by using a nested selector
5. Takes care not to break `info-tooltip` styles  
**Screenies**

<details>
<summary>v8.0.9</summary>

<img src="https://user-images.githubusercontent.com/4448075/93379098-f6b73600-f822-11ea-8ee9-c4f13069cd97.png" />
<img src="https://user-images.githubusercontent.com/4448075/93382277-87901080-f827-11ea-99aa-cc476f35b5ce.png" />



</details>

<details>
<summary>develop</summary>
<img src="https://user-images.githubusercontent.com/4448075/93379255-3120d300-f823-11ea-8cc6-52ec01af5fb1.png" />



</details>

<details>
<summary>This PR</summary>

![image](https://user-images.githubusercontent.com/4448075/93384089-31709c80-f82a-11ea-93be-9d928e2897bd.png)

<br />
<b>Care was taken to not break the info-tooltip styles @danjm </b>
<br />
<img src="https://user-images.githubusercontent.com/4448075/93384483-80b6cd00-f82a-11ea-9477-a1c4cae16744.png" />


</details>

