### PR TITLE
fix styles on tx detail popover buttons

### DIFF
--- a/ui/app/components/app/transaction-list-item-details/index.scss
+++ b/ui/app/components/app/transaction-list-item-details/index.scss
@@ -19,6 +19,11 @@
   & &__header-button {
     font-size: 0.625rem;
 
+    &-tooltip-container {
+      display: flex !important;
+      height: 100%;
+    }
+
     &:not(:last-child) {
       margin-right: 8px;
     }

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -176,21 +176,27 @@ export default class TransactionListItemDetails extends PureComponent {
                 )
               }
               { this.renderCancel() }
-              <Tooltip title={justCopied ? t('copiedTransactionId') : t('copyTransactionId')}>
+              <Tooltip
+                wrapperClassName="transaction-list-item-details__header-button"
+                containerClassName="transaction-list-item-details__header-button-tooltip-container"
+                title={justCopied ? t('copiedTransactionId') : t('copyTransactionId')}
+              >
                 <Button
                   type="raised"
                   onClick={this.handleCopyTxId}
-                  className="transaction-list-item-details__header-button"
                   disabled={!hash}
                 >
                   <Copy size={10} color="#3098DC" />
                 </Button>
               </Tooltip>
-              <Tooltip title={blockExplorerUrl ? t('viewOnCustomBlockExplorer', [blockExplorerUrl]) : t('viewOnEtherscan')}>
+              <Tooltip
+                wrapperClassName="transaction-list-item-details__header-button"
+                containerClassName="transaction-list-item-details__header-button-tooltip-container"
+                title={blockExplorerUrl ? t('viewOnCustomBlockExplorer', [blockExplorerUrl]) : t('viewOnEtherscan')}
+              >
                 <Button
                   type="raised"
                   onClick={this.handleEtherscanClick}
-                  className="transaction-list-item-details__header-button"
                   disabled={!hash}
                 >
                   <img src="/images/arrow-popout.svg" />


### PR DESCRIPTION
The transaction details popover was using the old tooltip, which was removed recently. The old tooltip did not include any additional divs to position the container element, whereas the new one does. This PR moves the class for these buttons with tooltips one level up to the tooltip wrapper class and then adds an additional class for the container. This allows positioning the element appropriately. 

<details>
<summary>Prod</summary>
<img width="319" alt="Screen Shot 2020-09-17 at 10 47 04 AM" src="https://user-images.githubusercontent.com/4448075/93498260-2e7fb580-f8d7-11ea-92d6-23573734796d.png">

</details>

<details>
<summary>Develop</summary>

<img src="https://user-images.githubusercontent.com/4448075/93498587-9a621e00-f8d7-11ea-96c3-1fb215a67509.png" />

</details>

<details>
<summary>This PR</summary>

<img src="https://user-images.githubusercontent.com/4448075/93498202-190a8b80-f8d7-11ea-88cd-4f0b3d874f32.png" />


</details>