### PR TITLE
Gas modal styling fixes

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/index.scss
@@ -14,6 +14,7 @@
   }
 
   &__blurb {
+    width: 95%;
     font-size: 12px;
     color: $black;
     margin-top: 5px;
@@ -21,6 +22,7 @@
   }
 
   &__footer-blurb {
+    width: 95%;
     font-size: 12px;
     color: #979797;
     margin-top: 15px;

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
@@ -96,10 +96,6 @@
     color: $scorpion;
     font-size: 12px;
 
-    @media screen and (max-width: $break-small) {
-      padding: 4px 21px;
-    }
-
     &__send-info,
     &__transaction-info,
     &__total-info,
@@ -139,7 +135,7 @@
       }
 
       &__value {
-        font-size: 14px;
+        font-size: 12px;
       }
     }
   }

--- a/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
@@ -177,7 +177,7 @@
   }
 
   &__time-estimate {
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 500;
     margin-top: 4px;
     color: $black;


### PR DESCRIPTION
This PR fixes various style issues in the basic gas modal. The whole thing is due for an overhaul, but this will improve things in the meantime.

- Set the `width` of the `__blurb` text content divs to `95%`, matching the button group
- Decreases the gas button time estimate font size to prevent it from exceeding the size of the button
  - Wrapping the text does not work
- Add padding to the `info-row` in the popup to give it some breathing room
  - Padding was previously decreased for the popup; the popup now has the same padding as the fullscreen view
- Make the `info-row` ETH `__value` font sizes match the `__label` font sizes for less janky appearance

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/25517051/93514454-12cade00-f8dc-11ea-9328-dd1dfc110467.png" width=351 />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/25517051/93514259-d7301400-f8db-11ea-873e-e2d189968218.png" width=351 />
</details>
