### PR TITLE
json-rpc-engine@5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
     "human-standard-token-abi": "^2.0.0",
-    "json-rpc-engine": "^5.2.0",
+    "json-rpc-engine": "^5.3.0",
     "json-rpc-middleware-stream": "^2.1.1",
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16101,6 +16101,14 @@ json-rpc-engine@^5.2.0:
     eth-rpc-errors "^2.1.1"
     safe-event-emitter "^1.0.1"
 
+json-rpc-engine@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-5.3.0.tgz#7dc7291766b28766ebda33eb6d3f4c6301c44ff4"
+  integrity sha512-+diJ9s8rxB+fbJhT7ZEf8r8spaLRignLd8jTgQ/h5JSGppAHGtNMZtCoabipCaleR1B3GTGxbXBOqhaJSGmPGQ==
+  dependencies:
+    eth-rpc-errors "^3.0.0"
+    safe-event-emitter "^1.0.1"
+
 json-rpc-error@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/json-rpc-error/-/json-rpc-error-2.0.0.tgz#a7af9c202838b5e905c7250e547f1aff77258a02"


### PR DESCRIPTION
RPC errors will no longer include a `stack` property. This is good, because it was almost always useless.