### PR TITLE
Remove unnecessary functions

### DIFF
--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -7,23 +7,11 @@ import {
   TRANSACTION_TYPE_CANCEL,
   TRANSACTION_STATUS_CONFIRMED,
 } from '../../../../app/scripts/controllers/transactions/enums'
-import { MESSAGE_TYPE } from '../../../../app/scripts/lib/enums'
 import { getEtherscanNetworkPrefix } from '../../../lib/etherscan-prefix-for-network'
 import {
   TOKEN_METHOD_TRANSFER,
   TOKEN_METHOD_APPROVE,
   TOKEN_METHOD_TRANSFER_FROM,
-  SEND_ETHER_ACTION_KEY,
-  DEPLOY_CONTRACT_ACTION_KEY,
-  APPROVE_ACTION_KEY,
-  SEND_TOKEN_ACTION_KEY,
-  TRANSFER_FROM_ACTION_KEY,
-  SIGNATURE_REQUEST_KEY,
-  DECRYPT_REQUEST_KEY,
-  ENCRYPTION_PUBLIC_KEY_REQUEST_KEY,
-  CONTRACT_INTERACTION_KEY,
-  CANCEL_ATTEMPT_ACTION_KEY,
-  DEPOSIT_TRANSACTION_KEY,
 } from '../constants/transactions'
 import fetchWithCache from './fetch-with-cache'
 
@@ -109,11 +97,6 @@ export async function getMethodDataAsync (fourBytePrefix) {
   }
 }
 
-export function isConfirmDeployContract (txData = {}) {
-  const { txParams = {} } = txData
-  return !txParams.to
-}
-
 /**
  * Returns four-byte method signature from data
  *
@@ -138,56 +121,6 @@ export function isTokenMethodAction (transactionCategory) {
     TOKEN_METHOD_APPROVE,
     TOKEN_METHOD_TRANSFER_FROM,
   ].includes(transactionCategory)
-}
-
-/**
- * Returns the action of a transaction as a key to be passed into the translator.
- * @param {Object} transaction - txData object
- * @returns {string|undefined}
- */
-export function getTransactionActionKey (transaction) {
-  const { msgParams, type, transactionCategory } = transaction
-
-  if (transactionCategory === 'incoming') {
-    return DEPOSIT_TRANSACTION_KEY
-  }
-
-  if (type === 'cancel') {
-    return CANCEL_ATTEMPT_ACTION_KEY
-  }
-
-  if (msgParams) {
-    if (type === MESSAGE_TYPE.ETH_DECRYPT) {
-      return DECRYPT_REQUEST_KEY
-    } else if (type === MESSAGE_TYPE.ETH_GET_ENCRYPTION_PUBLIC_KEY) {
-      return ENCRYPTION_PUBLIC_KEY_REQUEST_KEY
-    }
-    return SIGNATURE_REQUEST_KEY
-  }
-
-  if (isConfirmDeployContract(transaction)) {
-    return DEPLOY_CONTRACT_ACTION_KEY
-  }
-
-  const isTokenAction = isTokenMethodAction(transactionCategory)
-  const isNonTokenSmartContract = transactionCategory === CONTRACT_INTERACTION_KEY
-
-  if (isTokenAction || isNonTokenSmartContract) {
-    switch (transactionCategory) {
-      case TOKEN_METHOD_TRANSFER:
-        return SEND_TOKEN_ACTION_KEY
-      case TOKEN_METHOD_APPROVE:
-        return APPROVE_ACTION_KEY
-      case TOKEN_METHOD_TRANSFER_FROM:
-        return TRANSFER_FROM_ACTION_KEY
-      case CONTRACT_INTERACTION_KEY:
-        return CONTRACT_INTERACTION_KEY
-      default:
-        return undefined
-    }
-  } else {
-    return SEND_ETHER_ACTION_KEY
-  }
 }
 
 export function getLatestSubmittedTxWithNonce (transactions = [], nonce = '0x0') {

--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux'
 import { getKnownMethodData } from '../selectors/selectors'
-import { getTransactionActionKey, getStatusKey } from '../helpers/utils/transactions.util'
+import { getStatusKey } from '../helpers/utils/transactions.util'
 import { camelCaseToCapitalize } from '../helpers/utils/common.util'
 import { PRIMARY, SECONDARY } from '../helpers/constants/common'
 import { getTokenAddressParam } from '../helpers/utils/token-util'
@@ -64,7 +64,6 @@ export function useTransactionDisplayData (transactionGroup) {
   // for smart contract interactions, methodData can be used to derive the name of the action being taken
   const methodData = useSelector((state) => getKnownMethodData(state, initialTransaction?.txParams?.data)) || {}
 
-  const actionKey = getTransactionActionKey(initialTransaction)
   const status = getStatusKey(primaryTransaction)
 
   const primaryValue = primaryTransaction.txParams?.value
@@ -111,7 +110,7 @@ export function useTransactionDisplayData (transactionGroup) {
     subtitleContainsOrigin = true
   } else if (transactionCategory === DEPLOY_CONTRACT_ACTION_KEY || transactionCategory === CONTRACT_INTERACTION_KEY) {
     category = TRANSACTION_CATEGORY_INTERACTION
-    title = (methodData?.name && camelCaseToCapitalize(methodData.name)) || (actionKey && t(actionKey)) || ''
+    title = (methodData?.name && camelCaseToCapitalize(methodData.name)) || t(transactionCategory)
     subtitle = origin
     subtitleContainsOrigin = true
   } else if (transactionCategory === INCOMING_TRANSACTION) {

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.util.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.util.js
@@ -1,4 +1,0 @@
-export function isConfirmDeployContract (txData = {}) {
-  const { txParams = {} } = txData
-  return !txParams.to
-}


### PR DESCRIPTION
### Description
1. getActionKey was only used in one place, and only when dealing with transactions of contractDeploy and `contractInteraction` -- both of which would inevitably return a key that was either `contractDeploy` or 'contractInteraction' respectively. This makes the function rather unuseful. Removing this usage allowed its removal
2. a 'isContractDeployment' function existed in two places, one of which was unused, the other was only used as a part of `getActionKey` which was unnecessary because we already know at the call site that we are working with a contract deployment or interaction. 