### PR TITLE
Use ethers to validate mnemonic, one less dep!

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "analytics-node": "^3.4.0-beta.2",
     "await-semaphore": "^0.1.1",
     "bignumber.js": "^4.1.0",
-    "bip39": "^2.2.0",
     "bn.js": "^4.11.7",
     "c3": "^0.7.10",
     "classnames": "^2.2.6",

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -1,4 +1,4 @@
-import { validateMnemonic } from 'bip39'
+import { ethers } from 'ethers'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import TextField from '../../../../components/ui/text-field'
@@ -7,6 +7,8 @@ import {
   INITIALIZE_SELECT_ACTION_ROUTE,
   INITIALIZE_END_OF_FLOW_ROUTE,
 } from '../../../../helpers/constants/routes'
+
+const { isValidMnemonic } = ethers.utils
 
 export default class ImportWithSeedPhrase extends PureComponent {
   static contextTypes = {
@@ -62,7 +64,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
       const wordCount = parsedSeedPhrase.split(/\s/u).length
       if (wordCount % 3 !== 0 || wordCount > 24 || wordCount < 12) {
         seedPhraseError = this.context.t('seedPhraseReq')
-      } else if (!validateMnemonic(parsedSeedPhrase)) {
+      } else if (!isValidMnemonic(parsedSeedPhrase)) {
         seedPhraseError = this.context.t('invalidSeedPhrase')
       }
     }


### PR DESCRIPTION
so, after looking at this seed phrase stuff for far too long, I realized that `ethers` has a similar util for validating mnemonic phrases. 

figured we should just use that here and remove the `bip39` as it appears this is the only place we're using it?

thoughts?