### PR TITLE
Use node-forge@0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "**/socketcluster/minimist": "^1.2.5",
     "3box/ipfs/ipld-zcash/zcash-bitcore-lib/lodash": "^4.17.19",
     "3box/ipfs/ipld-zcash/zcash-bitcore-lib/elliptic": "^6.5.3",
+    "3box/**/libp2p-crypto/node-forge": "^0.10.0",
+    "3box/**/libp2p-keychain/node-forge": "^0.10.0",
     "browserify-derequire/derequire": "^2.1.1",
     "ganache-core/lodash": "^4.17.19",
     "ganache-core/websocket": "^1.0.32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19096,10 +19096,10 @@ node-fetch@^2.1.2, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-forge@^0.7.1, node-forge@^0.7.5, node-forge@~0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
-  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
+node-forge@^0.10.0, node-forge@^0.7.1, node-forge@^0.7.5, node-forge@~0.7.6:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-gyp-build@~3.7.0:
   version "3.7.0"


### PR DESCRIPTION
This change updates `node-forge` to the latest published version, 0.10.0. This update resolves [a security advisory][1] brought in via our `3box` dependency.

For more information see: https://www.npmjs.com/advisories/1561

The `yarn audit` output:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Prototype Pollution in node-forge                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ node-forge                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >= 0.10.0                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ 3box                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ 3box > ipfs > libp2p-kad-dht > peer-info > peer-id >         │
│               │ libp2p-crypto > node-forge                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1561                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

### `node-forge@0.10.0` includes breaking changes

From the `CHANGELOG`:<sup>[\[2\]][2]</sup>

>## 0.10.0 - 2020-09-01
>
>### Changed
>- **BREAKING**: Node.js 4 no longer supported. The code *may* still work, and
>  non-invasive patches to keep it working will be considered. However, more
>  modern tools no longer support old Node.js versions making testing difficult.
>
>### Removed
>- **BREAKING**: Remove `util.getPath`, `util.setPath`, and `util.deletePath`.
>  `util.setPath` had a potential prototype pollution security issue when used
>  with unsafe inputs. These functions are not used by `forge` itself. They date
>  from an early time when `forge` was targeted at providing general helper
>  functions. The library direction changed to be more focused on cryptography.
>  Many other excellent libraries are more suitable for general utilities. If
>  you need a replacement for these functions, consier `get`, `set`, and `unset`
>  from [lodash](https://lodash.com/). But also consider the potential similar
>  security issues with those APIs.

I've confirmed that there are no usages of the removed method in either [`js-libp2p-crypto`](https://github.com/libp2p/js-libp2p-crypto) or [`js-libp2p-keychain`](https://github.com/libp2p/js-libp2p-keychain).

Also `0.7.6…0.9.2` doesn't seem to include breaking changes documented in the `CHANGELOG`.

  [1]:https://www.npmjs.com/advisories/1561
  [2]:https://github.com/digitalbazaar/forge/blob/588c41062d9a13f8dc91be3723b159c6cc434b15/CHANGELOG.md#0100---2020-09-01
