### PR TITLE
Allow running CircleCI locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,12 @@ workflows:
               only:
                 - /^Version-v(\d+)[.](\d+)[.](\d+)/
       - test-deps
-      - prep-build-test
       - prep-build-storybook
       - test-lint
       - test-lint-shellcheck
       - test-lint-lockfile
-      - test-e2e-chrome:
-          requires:
-            - prep-build-test
-      - test-e2e-firefox:
-          requires:
-            - prep-build-test
+      - test-e2e-chrome
+      - test-e2e-firefox
       - test-unit
       - test-unit-global
       - validate-source-maps
@@ -35,9 +30,7 @@ workflows:
             - test-mozilla-lint
             - test-e2e-chrome
             - test-e2e-firefox
-      - benchmark:
-          requires:
-            - prep-build-test
+      - benchmark
       - job-publish-prerelease:
           requires:
             - benchmark
@@ -70,32 +63,6 @@ jobs:
             .circleci/scripts/release-bump-changelog-version
             .circleci/scripts/release-bump-manifest-version
             .circleci/scripts/release-create-release-pr
-
-  prep-build-test:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
-    steps:
-      - checkout
-      - run:
-          name: Install deps
-          command: |
-            .circleci/scripts/deps-install.sh
-      - run:
-          name: Collect yarn install HAR logs
-          command: |
-            .circleci/scripts/collect-har-artifact.sh
-      - run:
-          name: Build extension for testing
-          command: yarn build:test
-      - run:
-          name: Move test build to 'dist-test' to avoid conflict with production build
-          command: mv ./dist ./dist-test
-      - persist_to_workspace:
-          root: .
-          paths:
-            - node_modules
-            - build-artifacts
-            - dist-test
 
   prep-build-storybook:
     docker:
@@ -193,15 +160,27 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
       - run:
-          name: Move test build to dist
-          command: mv ./dist-test ./dist
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
+      - run:
+          name: Build extension for testing
+          command: yarn build:test
       - run:
           name: test:e2e:chrome
           command: yarn test:e2e:chrome
           no_output_timeout: 20m
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+            - build-artifacts
+            - dist-test
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -212,17 +191,29 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
+      - run:
+          name: Build extension for testing
+          command: yarn build:test
+      - run:
           name: Install Firefox
           command: ./.circleci/scripts/firefox-install
-      - attach_workspace:
-          at: .
-      - run:
-          name: Move test build to dist
-          command: mv ./dist-test ./dist
       - run:
           name: test:e2e:firefox
           command: yarn test:e2e:firefox
           no_output_timeout: 20m
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+            - build-artifacts
+            - dist-test
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
@@ -232,11 +223,17 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
       - run:
-          name: Move test build to dist
-          command: mv ./dist-test ./dist
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
+      - run:
+          name: Build extension for testing
+          command: yarn build:test
       - run:
           name: Run page load benchmark
           command: yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json
@@ -246,6 +243,9 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - node_modules
+            - build-artifacts
+            - dist-test
             - test-artifacts
 
   job-publish-prerelease:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ workflows:
               only:
                 - /^Version-v(\d+)[.](\d+)[.](\d+)/
       - test-deps
-      - prep-build
       - prep-build-test
       - prep-build-storybook
       - test-lint
@@ -23,12 +22,8 @@ workflows:
             - prep-build-test
       - test-unit
       - test-unit-global
-      - validate-source-maps:
-          requires:
-            - prep-build
-      - test-mozilla-lint:
-          requires:
-            - prep-build
+      - validate-source-maps
+      - test-mozilla-lint
       - all-tests-pass:
           requires:
             - test-lint
@@ -75,33 +70,6 @@ jobs:
             .circleci/scripts/release-bump-changelog-version
             .circleci/scripts/release-bump-manifest-version
             .circleci/scripts/release-create-release-pr
-
-  prep-build:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
-    steps:
-      - checkout
-      - run:
-          name: Install deps
-          command: |
-            .circleci/scripts/deps-install.sh
-      - run:
-          name: Collect yarn install HAR logs
-          command: |
-            .circleci/scripts/collect-har-artifact.sh
-      - run:
-          name: build:dist
-          command: yarn dist
-      - run:
-          name: build:debug
-          command: find dist/ -type f -exec md5sum {} \; | sort -k 2
-      - persist_to_workspace:
-          root: .
-          paths:
-            - node_modules
-            - build-artifacts
-            - dist
-            - builds
 
   prep-build-test:
     docker:
@@ -394,22 +362,60 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
+      - run:
+          name: build:dist
+          command: yarn dist
+      - run:
+          name: build:debug
+          command: find dist/ -type f -exec md5sum {} \; | sort -k 2
       - run:
           name: Validate source maps
           command: yarn validate-source-maps
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+            - build-artifacts
+            - dist
+            - builds
 
   test-mozilla-lint:
     docker:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
+      - run:
+          name: build:dist
+          command: yarn dist
+      - run:
+          name: build:debug
+          command: find dist/ -type f -exec md5sum {} \; | sort -k 2
       - run:
           name: test:mozilla-lint
           command: NODE_OPTIONS=--max_old_space_size=3072 yarn mozilla-lint
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+            - build-artifacts
+            - dist
+            - builds
 
   all-tests-pass:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,42 +8,26 @@ workflows:
             branches:
               only:
                 - /^Version-v(\d+)[.](\d+)[.](\d+)/
-      - prep-deps
       - test-deps
-      - prep-build:
-          requires:
-            - prep-deps
-      - prep-build-test:
-          requires:
-            - prep-deps
-      - prep-build-storybook:
-          requires:
-            - prep-deps
-      - test-lint:
-          requires:
-            - prep-deps
+      - prep-build
+      - prep-build-test
+      - prep-build-storybook
+      - test-lint
       - test-lint-shellcheck
-      - test-lint-lockfile:
-          requires:
-            - prep-deps
+      - test-lint-lockfile
       - test-e2e-chrome:
           requires:
             - prep-build-test
       - test-e2e-firefox:
           requires:
             - prep-build-test
-      - test-unit:
-          requires:
-            - prep-deps
-      - test-unit-global:
-          requires:
-            - prep-deps
+      - test-unit
+      - test-unit-global
       - validate-source-maps:
           requires:
             - prep-build
       - test-mozilla-lint:
           requires:
-            - prep-deps
             - prep-build
       - all-tests-pass:
           requires:
@@ -61,8 +45,6 @@ workflows:
             - prep-build-test
       - job-publish-prerelease:
           requires:
-            - prep-deps
-            - prep-build
             - benchmark
             - all-tests-pass
       - job-publish-release:
@@ -70,8 +52,6 @@ workflows:
             branches:
               only: master
           requires:
-            - prep-deps
-            - prep-build
             - all-tests-pass
       - job-publish-storybook:
           filters:
@@ -96,7 +76,7 @@ jobs:
             .circleci/scripts/release-bump-manifest-version
             .circleci/scripts/release-create-release-pr
 
-  prep-deps:
+  prep-build:
     docker:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
@@ -109,19 +89,6 @@ jobs:
           name: Collect yarn install HAR logs
           command: |
             .circleci/scripts/collect-har-artifact.sh
-      - persist_to_workspace:
-          root: .
-          paths:
-          - node_modules
-          - build-artifacts
-
-  prep-build:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
       - run:
           name: build:dist
           command: yarn dist
@@ -131,6 +98,8 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - node_modules
+            - build-artifacts
             - dist
             - builds
 
@@ -139,8 +108,14 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
       - run:
           name: Build extension for testing
           command: yarn build:test
@@ -150,6 +125,8 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - node_modules
+            - build-artifacts
             - dist-test
 
   prep-build-storybook:
@@ -157,14 +134,22 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
       - run:
           name: Build Storybook
           command: yarn storybook:build
       - persist_to_workspace:
           root: .
           paths:
+            - node_modules
+            - build-artifacts
             - .out
 
   test-lint:
@@ -172,14 +157,25 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
       - run:
           name: Lint
           command: yarn lint
       - run:
           name: Verify locales
           command: yarn verify-locales --quiet
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+            - build-artifacts
 
   test-lint-shellcheck:
     docker:
@@ -196,11 +192,22 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
       - run:
           name: lockfile-lint
           command: yarn lint:lockfile
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+            - build-artifacts
 
   test-deps:
     docker:
@@ -342,14 +349,22 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
       - run:
           name: test:coverage
           command: yarn test:coverage
       - persist_to_workspace:
           root: .
           paths:
+            - node_modules
+            - build-artifacts
             - .nyc_output
             - coverage
   test-unit-global:
@@ -357,11 +372,22 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
-      - attach_workspace:
-          at: .
+      - run:
+          name: Install deps
+          command: |
+            .circleci/scripts/deps-install.sh
+      - run:
+          name: Collect yarn install HAR logs
+          command: |
+            .circleci/scripts/collect-har-artifact.sh
       - run:
           name: test:unit:global
           command: yarn test:unit:global
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+            - build-artifacts
 
   validate-source-maps:
     docker:


### PR DESCRIPTION
🚧 This is a draft PR used only for its build status 🚧

This PR inlines the requisite jobs to allow for easy CircleCI local execution. This is a proof-of-concept, showing how this can be done.

### CircleCI Local CLI

- [Overview ➚](https://circleci.com/docs/2.0/local-cli/#overview)
- [Installation ➚](https://circleci.com/docs/2.0/local-cli/#installation)
    - [Manual Download ➚](https://circleci.com/docs/2.0/local-cli/#manual-download)

Running a job locally with the CircleCI Local CLI:

```
$ circleci config process .circleci/config.yml > .tmp
$ circleci local execute --config .tmp --job test-unit
```

You can only run a single job at a time, without its dependencies, hence the inlining here.

The workflow before vs. after:

<img width="1922" alt="" src="https://user-images.githubusercontent.com/1623628/94947612-79ddba80-04b8-11eb-932a-9e4e4d666a82.png">

<img width="1922" alt="" src="https://user-images.githubusercontent.com/1623628/94950184-c3300900-04bc-11eb-80b8-45c83232142a.png">
