### PR TITLE
Format manifest file after applying new version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ workflows:
   test_and_release:
     jobs:
       - create_release_pull_request:
+          requires:
+            - prep-deps
           filters:
             branches:
               only:

--- a/.circleci/scripts/release-bump-manifest-version
+++ b/.circleci/scripts/release-bump-manifest-version
@@ -21,6 +21,7 @@ printf '%s\n' 'Updating the manifest version if needed'
 version="${CIRCLE_BRANCH/Version-v/}"
 updated_manifest="$(jq ".version = \"$version\"" app/manifest/_base.json)"
 printf '%s\n' "$updated_manifest" > app/manifest/_base.json
+yarn prettier --write app/manifest/_base.json
 
 if [[ -z $(git status --porcelain) ]]
 then


### PR DESCRIPTION
This PR fixes the `.circleci/scripts/release-bump-manifest-version` script, which was writing the output of `jq` back to the file and conflicting with how Prettier wanted the file to be formatted. The script now formats the file via Prettier after the `jq` output is written.