### PR TITLE
Fix create_release_pull_request build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ jobs:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - run:
           name: Create GitHub Pull Request for version
           command: |


### PR DESCRIPTION
This PR fixes an issue with #9480, which updated the script to depend on `prep-deps` but did not attach the workspace.