### PR TITLE
Compare the networkId against the correct enum in eth and token overview components

### DIFF
--- a/ui/app/components/app/wallet-overview/eth-overview.js
+++ b/ui/app/components/app/wallet-overview/eth-overview.js
@@ -20,6 +20,7 @@ import SendIcon from '../../ui/icon/overview-send-icon.component'
 import { getSwapsFeatureLiveness, setSwapsFromToken } from '../../../ducks/swaps/swaps'
 import { ETH_SWAPS_TOKEN_OBJECT } from '../../../helpers/constants/swaps'
 import IconButton from '../../ui/icon-button'
+import { MAINNET_NETWORK_ID } from '../../../../../app/scripts/controllers/network/enums'
 import WalletOverview from './wallet-overview'
 
 const EthOverview = ({ className }) => {
@@ -112,10 +113,10 @@ const EthOverview = ({ className }) => {
           {swapsEnabled ? (
             <IconButton
               className="eth-overview__button"
-              disabled={networkId !== '1'}
+              disabled={networkId !== MAINNET_NETWORK_ID}
               Icon={SwapIcon}
               onClick={() => {
-                if (networkId === '1') {
+                if (networkId === MAINNET_NETWORK_ID) {
                   enteredSwapsEvent()
                   dispatch(setSwapsFromToken({
                     ...ETH_SWAPS_TOKEN_OBJECT,

--- a/ui/app/components/app/wallet-overview/token-overview.js
+++ b/ui/app/components/app/wallet-overview/token-overview.js
@@ -14,6 +14,7 @@ import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount'
 import { updateSendToken } from '../../../store/actions'
 import { getSwapsFeatureLiveness, setSwapsFromToken } from '../../../ducks/swaps/swaps'
 import { getAssetImages, getCurrentKeyring, getCurrentNetworkId } from '../../../selectors/selectors'
+import { MAINNET_NETWORK_ID } from '../../../../../app/scripts/controllers/network/enums'
 
 import SwapIcon from '../../ui/icon/swap-icon.component'
 import SendIcon from '../../ui/icon/overview-send-icon.component'
@@ -81,10 +82,10 @@ const TokenOverview = ({ className, token }) => {
           {swapsEnabled ? (
             <IconButton
               className="token-overview__button"
-              disabled={networkId !== '1'}
+              disabled={networkId !== MAINNET_NETWORK_ID}
               Icon={SwapIcon}
               onClick={() => {
-                if (networkId === '1') {
+                if (networkId === MAINNET_NETWORK_ID) {
                   enteredSwapsEvent()
                   dispatch(setSwapsFromToken({ ...token, iconUrl: assetImages[token.address] }))
                   if (usingHardwareWallet) {


### PR DESCRIPTION
This PR fixes a bug that caused the swaps button to be disabled.