### PR TITLE
Skip running e2e tests when commit is tagged with '[skip e2e]'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,11 @@ jobs:
           command: mv ./dist-test ./dist
       - run:
           name: test:e2e:chrome
-          command: yarn test:e2e:chrome
+          command: |
+            if .circleci/scripts/test-run-e2e
+            then
+              yarn test:e2e:chrome
+            fi
           no_output_timeout: 20m
       - store_artifacts:
           path: test-artifacts
@@ -248,7 +252,11 @@ jobs:
           command: mv ./dist-test ./dist
       - run:
           name: test:e2e:firefox
-          command: yarn test:e2e:firefox
+          command: |
+            if .circleci/scripts/test-run-e2e
+            then
+              yarn test:e2e:firefox
+            fi
           no_output_timeout: 20m
       - store_artifacts:
           path: test-artifacts

--- a/.circleci/scripts/test-run-e2e
+++ b/.circleci/scripts/test-run-e2e
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+# Skip running e2e tests if the HEAD commit is tagged correctly
+if git show --format='%B' --no-patch "$CIRCLE_SHA1" | grep --fixed-strings --quiet '[skip e2e]'
+then
+    printf '%s\n' "$CIRCLE_SHA1 contains the tag '[skip e2e]' so e2e tests will not run"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This PR adds logic to skip running e2e tests when commit is tagged with `[skip e2e]`.