### PR TITLE
Use networkVersion for network state; chainId for signing transactions

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -124,6 +124,7 @@ export default class NetworkController extends EventEmitter {
       return
     }
 
+    const { type } = this.getProviderConfig()
     const chainId = this.getCurrentChainId()
     if (!chainId) {
       log.warn('NetworkController - lookupNetwork aborted due to missing chainId')
@@ -142,7 +143,11 @@ export default class NetworkController extends EventEmitter {
           return
         }
 
-        this.setNetworkState(networkVersion)
+        this.setNetworkState((
+          type === 'rpc'
+            ? chainId
+            : networkVersion
+        ))
       }
     })
   }

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -142,7 +142,6 @@ export default class NetworkController extends EventEmitter {
           return
         }
 
-        // Now we set the network state to the chainId computed earlier
         this.setNetworkState(networkVersion)
       }
     })

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -124,9 +124,7 @@ export default class NetworkController extends EventEmitter {
       return
     }
 
-    const { type, chainId: configChainId } = this.getProviderConfig()
-    const chainId = NETWORK_TYPE_TO_ID_MAP[type]?.chainId || configChainId
-
+    const chainId = this.getCurrentChainId()
     if (!chainId) {
       log.warn('NetworkController - lookupNetwork aborted due to missing chainId')
       this.setNetworkState('loading')
@@ -136,7 +134,7 @@ export default class NetworkController extends EventEmitter {
     // Ping the RPC endpoint so we can confirm that it works
     const ethQuery = new EthQuery(this._provider)
     const initialNetwork = this.getNetworkState()
-    ethQuery.sendAsync({ method: 'net_version' }, (err, _networkVersion) => {
+    ethQuery.sendAsync({ method: 'net_version' }, (err, networkVersion) => {
       const currentNetwork = this.getNetworkState()
       if (initialNetwork === currentNetwork) {
         if (err) {
@@ -145,9 +143,14 @@ export default class NetworkController extends EventEmitter {
         }
 
         // Now we set the network state to the chainId computed earlier
-        this.setNetworkState(chainId)
+        this.setNetworkState(networkVersion)
       }
     })
+  }
+
+  getCurrentChainId () {
+    const { type, chainId: configChainId } = this.getProviderConfig()
+    return NETWORK_TYPE_TO_ID_MAP[type]?.chainId || configChainId
   }
 
   setRpcTarget (rpcUrl, chainId, ticker = 'ETH', nickname = '', rpcPrefs) {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -69,6 +69,7 @@ export default class TransactionController extends EventEmitter {
   constructor (opts) {
     super()
     this.networkStore = opts.networkStore || new ObservableStore({})
+    this._getCurrentChainId = opts.getCurrentChainId
     this.preferencesStore = opts.preferencesStore || new ObservableStore({})
     this.provider = opts.provider
     this.getPermittedAccounts = opts.getPermittedAccounts
@@ -132,9 +133,9 @@ export default class TransactionController extends EventEmitter {
    */
   getChainId () {
     const networkState = this.networkStore.getState()
-    // eslint-disable-next-line radix
-    const integerChainId = parseInt(networkState)
-    if (Number.isNaN(integerChainId)) {
+    const chainId = this._getCurrentChainId()
+    const integerChainId = parseInt(chainId, 16)
+    if (networkState === 'loading' || Number.isNaN(integerChainId)) {
       return 0
     }
     return integerChainId

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -383,6 +383,7 @@ export default class MetamaskController extends EventEmitter {
   createPublicConfigStore () {
     // subset of state for metamask inpage provider
     const publicConfigStore = new ObservableStore()
+    const networkController = this.networkController
 
     // setup memStore subscription hooks
     this.on('update', updatePublicConfigStore)
@@ -393,16 +394,17 @@ export default class MetamaskController extends EventEmitter {
     }
 
     function updatePublicConfigStore (memState) {
+      const chainId = networkController.getCurrentChainId()
       if (memState.network !== 'loading') {
-        publicConfigStore.putState(selectPublicState(memState))
+        publicConfigStore.putState(selectPublicState(chainId, memState))
       }
     }
 
-    function selectPublicState ({ isUnlocked, network }) {
+    function selectPublicState (chainId, { isUnlocked, network }) {
       return {
         isUnlocked,
-        chainId: network,
-        networkVersion: Number.parseInt(network, 16).toString(),
+        chainId,
+        networkVersion: network,
       }
     }
     return publicConfigStore

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -383,7 +383,7 @@ export default class MetamaskController extends EventEmitter {
   createPublicConfigStore () {
     // subset of state for metamask inpage provider
     const publicConfigStore = new ObservableStore()
-    const networkController = this.networkController
+    const { networkController } = this
 
     // setup memStore subscription hooks
     this.on('update', updatePublicConfigStore)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -231,6 +231,7 @@ export default class MetamaskController extends EventEmitter {
       initState: initState.TransactionController || initState.TransactionManager,
       getPermittedAccounts: this.permissionsController.getAccounts.bind(this.permissionsController),
       networkStore: this.networkController.networkStore,
+      getCurrentChainId: this.networkController.getCurrentChainId.bind(this.networkController),
       preferencesStore: this.preferencesController.store,
       txHistoryLimit: 40,
       getNetwork: this.networkController.getNetworkState.bind(this),

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -19,6 +19,7 @@ import { createTestProviderTools, getTestAccounts } from '../../../../stub/provi
 
 const noop = () => true
 const currentNetworkId = '42'
+const currentChainId = '0x2a'
 
 describe('Transaction Controller', function () {
   let txController, provider, providerResultStub, fromAccount
@@ -48,6 +49,7 @@ describe('Transaction Controller', function () {
         resolve()
       }),
       getPermittedAccounts: () => undefined,
+      getCurrentChainId: () => currentChainId,
     })
     txController.nonceTracker.getNonceLock = () => Promise.resolve({ nextNonce: 0, releaseLock: noop })
   })
@@ -334,7 +336,7 @@ describe('Transaction Controller', function () {
 
   describe('#getChainId', function () {
     it('returns 0 when the chainId is NaN', function () {
-      txController.networkStore = new ObservableStore(NaN)
+      txController.networkStore = new ObservableStore('loading')
       assert.equal(txController.getChainId(), 0)
     })
   })


### PR DESCRIPTION
Changes were recently made to ensure that chain IDs are used to sign transactions. It caused the `networkController.networkState` to use hexadecimal `chainId` values instead of decimal `networkVersion` values. This created unintended downstream effects.

This PR ensures the we preserve existing behavior for `NetworkController.networkState`/`state.metamask.network` to the greatest extent possible, while using explicitly specified `chainId` values for signing transactions.