### PR TITLE
Fix IconButton prop type

### DIFF
--- a/ui/app/components/ui/icon-button/icon-button.js
+++ b/ui/app/components/ui/icon-button/icon-button.js
@@ -28,7 +28,7 @@ export default function IconButton ({ onClick, Icon, disabled, label, tooltipRen
 
 IconButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  Icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+  Icon: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   tooltipRender: PropTypes.func,

--- a/ui/app/components/ui/icon-button/icon-button.js
+++ b/ui/app/components/ui/icon-button/icon-button.js
@@ -28,7 +28,7 @@ export default function IconButton ({ onClick, Icon, disabled, label, tooltipRen
 
 IconButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  Icon: PropTypes.element.isRequired,
+  Icon: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
   disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   tooltipRender: PropTypes.func,


### PR DESCRIPTION
`IconButton` complained over receiving a `function` `Icon` prop, which is a false positive because we're passing it functional components. This PR adds `PropTypes.func` as an acceptable type for that prop.