### PR TITLE
Update address book state upon custom RPC chainId edit

### DIFF
--- a/test/unit/app/typed-message-manager.spec.js
+++ b/test/unit/app/typed-message-manager.spec.js
@@ -7,10 +7,11 @@ describe('Typed Message Manager', function () {
   let typedMessageManager, msgParamsV1, msgParamsV3, typedMsgs, messages, msgId, numberMsgId
 
   const address = '0xc42edfcc21ed14dda456aa0756c153f7985d8813'
-  const networkController = new NetworkController()
-  sinon.stub(networkController, 'getNetworkState').returns('1')
 
-  beforeEach(function () {
+  beforeEach(async function () {
+    const networkController = new NetworkController()
+    sinon.stub(networkController, 'getNetworkState').returns('0x1')
+
     typedMessageManager = new TypedMessageManager({
       networkController,
     })
@@ -64,7 +65,7 @@ describe('Typed Message Manager', function () {
       }),
     }
 
-    typedMessageManager.addUnapprovedMessage(msgParamsV3, null, 'V3')
+    await typedMessageManager.addUnapprovedMessage(msgParamsV3, null, 'V3')
     typedMsgs = typedMessageManager.getUnapprovedMsgs()
     messages = typedMessageManager.messages
     msgId = Object.keys(typedMsgs)[0]


### PR DESCRIPTION
When the `chainId` for a custom RPC endpoint is edited, we now migrate the corresponding address book entries to ensure they are not orphaned.

The address book entries are grouped by the `metamask.network` state, which unfortunately was sometimes the `chainId`, and sometimes the `networkId`. It was always the `networkId` for built-in Infura networks, but for custom RPC endpoints it would be set to the user-set `chainId` field, with a fallback to the `networkId` of the network.

A recent change will force users to enter valid `chainId`s on all custom networks, which will be normalized to be hex-prefixed. As a result, address book contacts will now be keyed by a different string. The contact entries are now migrated when this edit takes place.

There are some edge cases where two separate entries share the same set of contacts. For example, if two entries have the same `chainId`, or if they had the same `networkId` and had no `chainId` set. When the `chainId` is edited in such cases, the contacts are duplicated on both networks. This is the best we can do, as we don't have any way to know which network the contacts _should_ be on.

The `typed-message-manager` unit tests have also been updated as part of this commit because the addition of `sinon.restore()` to the preferences controller tests ended up clearing a test object in-between individual tests in that file. The test object is now re-constructed before each individual test.