### PR TITLE
Ensure gas costs are accounted for when calculating the amount of eth received in a swap

### DIFF
--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -366,10 +366,16 @@ export function quotesToRenderableData (quotes, gasPrice, conversionRate, curren
 
 export function getSwapsTokensReceivedFromTxMeta (tokenSymbol, txMeta, tokenAddress, accountAddress, tokenDecimals) {
   if (tokenSymbol === 'ETH') {
-    if (!txMeta?.postTxBalance || !txMeta?.preTxBalance) {
+    if (!txMeta || !txMeta.postTxBalance || !txMeta.preTxBalance) {
       return null
     }
-    const ethReceived = subtractCurrencies(txMeta.postTxBalance, txMeta.preTxBalance, {
+    const gasCost = calcGasTotal(txMeta.txParams.gas, txMeta.txParams.gasPrice)
+    const preTxBalanceLessGasCost = subtractCurrencies(txMeta.preTxBalance, gasCost, {
+      aBase: 16,
+      bBase: 16,
+      toNumericBase: 'hex',
+    })
+    const ethReceived = subtractCurrencies(txMeta.postTxBalance, preTxBalanceLessGasCost, {
       aBase: 16,
       bBase: 16,
       fromDenomination: 'WEI',


### PR DESCRIPTION
This PR fixes the calculation of ETH received that is done in `getSwapsTokensReceivedFromTxMeta`

When swapping a token to ETH, we are calculating received amount by subtracting balance before the swap is received from balance after the tx is received. This subtraction does not also account for the ETH spent on gas. The correct calculation is `ethReceived = postTxBalance - (preTxBalance - gasCost)`. This formula makes more sense when rearranged as `postTxBalance = ethReceived + preTxBalance - gasCost`

This will fix the issues people were seeing with negative eth on the swaps confirmation screen