### PR TITLE
Fix unbound function in swaps controller

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -515,7 +515,7 @@ export default class SwapsController {
       if (window.navigator.onLine && intervalId === null) {
         // Set the interval first to prevent race condition between listener and
         // initial call to this function.
-        intervalId = setInterval(this._fetchAndSetSwapsLiveness, TEN_MINUTES_MS)
+        intervalId = setInterval(this._fetchAndSetSwapsLiveness.bind(this), TEN_MINUTES_MS)
         this._fetchAndSetSwapsLiveness()
       }
     }


### PR DESCRIPTION
The `_fetchAndSetSwapsLiveness` was accidentally passed to `setInterval` without being bound first, so the `this` reference was
not defined when it was called. It is now bound before being passed to `setInterval`.