### PR TITLE
Prevent redirecting to swaps in notification

### DIFF
--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -86,11 +86,11 @@ export default class Home extends PureComponent {
     this.setState({ mounted: true })
     if (isNotification && totalUnapprovedCount === 0) {
       global.platform.closeCurrentWindow()
-    } else if (showAwaitingSwapScreen) {
+    } else if (!isNotification && showAwaitingSwapScreen) {
       history.push(AWAITING_SWAP_ROUTE)
-    } else if (haveSwapsQuotes) {
+    } else if (!isNotification && haveSwapsQuotes) {
       history.push(VIEW_QUOTE_ROUTE)
-    } else if (swapsFetchParams) {
+    } else if (!isNotification && swapsFetchParams) {
       history.push(BUILD_QUOTE_ROUTE)
     } else if (firstPermissionsRequestId) {
       history.push(`${CONNECT_ROUTE}/${firstPermissionsRequestId}`)
@@ -117,7 +117,18 @@ export default class Home extends PureComponent {
     if (!mounted) {
       if (isNotification && totalUnapprovedCount === 0) {
         return { closing: true }
-      } else if (firstPermissionsRequestId || unconfirmedTransactionsCount > 0 || Object.keys(suggestedTokens).length > 0 || showAwaitingSwapScreen || haveSwapsQuotes || swapsFetchParams) {
+      } else if (
+        firstPermissionsRequestId ||
+        unconfirmedTransactionsCount > 0 ||
+        Object.keys(suggestedTokens).length > 0 ||
+        (
+          !isNotification && (
+            showAwaitingSwapScreen ||
+            haveSwapsQuotes ||
+            swapsFetchParams
+          )
+        )
+      ) {
         return { redirecting: true }
       }
     }


### PR DESCRIPTION
If a notification popup was opened while the user was partway through the swaps flow, the notification would display the swaps flow instead of whatever action triggered the popup (e.g. a connect request or a confirmation). This is confusing and potentially dangerous, as the user might mistakenly think the swap was triggered by a dapp.

The swap redirects are now prevented in the notification UI. The user will still be redirected to an in-progress swap flow if they open the browser action popup or the fullscreen UI, but not on the notification popup that is triggered by dapp actions.