### PR TITLE
Fix missing app header on Home screen

### DIFF
--- a/ui/app/pages/routes/routes.component.js
+++ b/ui/app/pages/routes/routes.component.js
@@ -80,7 +80,6 @@ export default class Routes extends Component {
     isMouseUser: PropTypes.bool,
     setMouseUserState: PropTypes.func,
     providerId: PropTypes.string,
-    hasPermissionsRequests: PropTypes.bool,
     autoLockTimeLimit: PropTypes.number,
     pageChanged: PropTypes.func.isRequired,
     prepareToLeaveSwaps: PropTypes.func,
@@ -163,7 +162,7 @@ export default class Routes extends Component {
   }
 
   hideAppHeader () {
-    const { location, hasPermissionsRequests } = this.props
+    const { location } = this.props
 
     const isInitializing = Boolean(matchPath(location.pathname, {
       path: INITIALIZE_ROUTE, exact: false,
@@ -185,7 +184,7 @@ export default class Routes extends Component {
 
     const isHandlingPermissionsRequest = Boolean(matchPath(location.pathname, {
       path: CONNECT_ROUTE, exact: false,
-    })) || hasPermissionsRequests
+    }))
 
     return isHandlingPermissionsRequest
   }

--- a/ui/app/pages/routes/routes.container.js
+++ b/ui/app/pages/routes/routes.container.js
@@ -3,7 +3,6 @@ import { withRouter } from 'react-router-dom'
 import { compose } from 'redux'
 import {
   getNetworkIdentifier,
-  hasPermissionRequests,
   getPreferences,
   submittedPendingTransactionsSelector,
 } from '../../selectors'
@@ -45,7 +44,6 @@ function mapStateToProps (state) {
     isMouseUser: state.appState.isMouseUser,
     providerId: getNetworkIdentifier(state),
     autoLockTimeLimit,
-    hasPermissionsRequests: hasPermissionRequests(state),
   }
 }
 

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -284,7 +284,3 @@ export function getFirstPermissionRequest (state) {
   const requests = getPermissionsRequests(state)
   return requests && requests[0] ? requests[0] : null
 }
-
-export function hasPermissionRequests (state) {
-  return Boolean(getFirstPermissionRequest(state))
-}


### PR DESCRIPTION
The app header would sometimes mistakenly not get rendered while on the Home screen. This could happen when a permission request was made while the UI was open, to either the browser action popup or the fullscreen UI.

This was caused by faulty logic in the top-level router component. It would hide the app header if there was a pending permission request, presumably because the author assumed that a redirect to the permission flow would shortly follow. This redirect only happens on mount though, not if the UI was already open when the permission request was submitted.

The intent of this logic was to hide a brief flash of the app header prior to rendering the permission flow. This brief flash has now been restored, which is unfortunate, but is better than the missing app header bug. We can revisit a solution to removing this flash in the future, hopefully in a manner that avoids this bug and works for all notification UI cases.