### PR TITLE
pass entire tokenData object to getTokenAddressParam

### DIFF
--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -171,7 +171,7 @@ export function useTransactionDisplayData (transactionGroup) {
   } else if (transactionCategory === TOKEN_METHOD_TRANSFER_FROM || transactionCategory === TOKEN_METHOD_TRANSFER) {
     category = TRANSACTION_CATEGORY_SEND
     title = t('sendSpecifiedTokens', [token?.symbol || t('token')])
-    recipientAddress = getTokenAddressParam(tokenData.params)
+    recipientAddress = getTokenAddressParam(tokenData)
     subtitle = t('toAddress', [shortenAddress(recipientAddress)])
 
   } else if (transactionCategory === SEND_ETHER_ACTION_KEY) {


### PR DESCRIPTION
When we converted to using Ethers we caused this regression because there is no longer a 'params' key on tokenData, instead we pass the entire tokenData object from `useTransactionDisplayData` to `getTokenAddressParam`
