### PR TITLE
Prevent user from submitting swap if they do not have enough for the max gas fee

### DIFF
--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -142,7 +142,7 @@ export default function ViewQuote () {
     )
   )
 
-  const gasTotalInWeiHex = calcGasTotal(usedGasLimit, gasPrice)
+  const gasTotalInWeiHex = calcGasTotal(maxGasLimit, gasPrice)
 
   const { tokensWithBalances } = useTokenTracker(swapsTokens)
   const balanceToken = fetchParamsSourceToken === ETH_SWAPS_TOKEN_OBJECT.address


### PR DESCRIPTION
Prior to this PR the, the `You need x more ETH to complete this swap` warning, and the disabling of the swaps button, would only show if the user did not have enough ETH to cover what is represented as the "Estimated Network Fee" in the UI. This PR changes this, and shows the warning and disabled submission if the user does not have enough for the "Max network fee".

A case where the user has enough for the estimated fee but not the max might often fail, and result in losing eth on gas spent on the transaction.

To help reviewers, the variable whose value will change as a result of this PR, `gasTotalInWeiHex` is only used to calculate `ethCost` and `insufficientEthForGas`. `ethCost` is only used to calculate `insufficientEth` and `ethBalanceNeeded`

 `insufficientEthForGas`, `insufficientEth` and `ethBalanceNeeded` are only used in rendering the warning and deciding whether to disable the swap button