### PR TITLE
Parse inputs to BigNumber arithmetic in conversion util

### DIFF
--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -150,17 +150,17 @@ const conversionUtil = (value, {
   value: value || '0',
 })
 
-const prepareInput = (value) => {
+const getBigNumberOperand = (value, base) => {
   // We don't include 'number' here, because BigNumber will throw if passed
   // a number primitive it considers unsafe.
   if (
     typeof value === 'string' ||
     value instanceof BigNumber
   ) {
-    return value
+    return new BigNumber(value, base)
   }
 
-  return String(value)
+  return new BigNumber(String(value), base)
 }
 
 const addCurrencies = (a, b, options = {}) => {
@@ -169,7 +169,7 @@ const addCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(prepareInput(a), aBase)).add(prepareInput(b), bBase)
+  const value = getBigNumberOperand(a, aBase).add(getBigNumberOperand(b, bBase))
 
   return converter({
     value,
@@ -183,7 +183,8 @@ const subtractCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(prepareInput(a), aBase)).minus(prepareInput(b), bBase)
+  const value = getBigNumberOperand(a, aBase)
+    .minus(getBigNumberOperand(b, bBase))
 
   return converter({
     value,
@@ -198,10 +199,8 @@ const multiplyCurrencies = (a, b, options = {}) => {
     ...conversionOptions
   } = options
 
-  const bigNumberA = new BigNumber(prepareInput(a), multiplicandBase)
-  const bigNumberB = new BigNumber(prepareInput(b), multiplierBase)
-
-  const value = bigNumberA.times(bigNumberB)
+  const value = getBigNumberOperand(a, multiplicandBase)
+    .times(getBigNumberOperand(b, multiplierBase))
 
   return converter({
     value,

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -171,13 +171,7 @@ const parseInput = (value) => {
     return value
   }
 
-  let stringValue
-  if (typeof value?.toString === 'function') {
-    stringValue = value.toString()
-  } else {
-    stringValue = String(value)
-  }
-
+  const stringValue = String(value)
   if (stringValue === '[object Object]') {
     throw new Error(errorMessage)
   }

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -150,7 +150,7 @@ const conversionUtil = (value, {
   value: value || '0',
 })
 
-const getBigNumberOperand = (value, base) => {
+const getBigNumber = (value, base) => {
   // We don't include 'number' here, because BigNumber will throw if passed
   // a number primitive it considers unsafe.
   if (
@@ -169,7 +169,7 @@ const addCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = getBigNumberOperand(a, aBase).add(getBigNumberOperand(b, bBase))
+  const value = getBigNumber(a, aBase).add(getBigNumber(b, bBase))
 
   return converter({
     value,
@@ -183,8 +183,8 @@ const subtractCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = getBigNumberOperand(a, aBase)
-    .minus(getBigNumberOperand(b, bBase))
+  const value = getBigNumber(a, aBase)
+    .minus(getBigNumber(b, bBase))
 
   return converter({
     value,
@@ -199,8 +199,8 @@ const multiplyCurrencies = (a, b, options = {}) => {
     ...conversionOptions
   } = options
 
-  const value = getBigNumberOperand(a, multiplicandBase)
-    .times(getBigNumberOperand(b, multiplierBase))
+  const value = getBigNumber(a, multiplicandBase)
+    .times(getBigNumber(b, multiplierBase))
 
   return converter({
     value,

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -150,18 +150,7 @@ const conversionUtil = (value, {
   value: value || '0',
 })
 
-const parseInput = (value) => {
-  const errorMessage = `Invalid BigNumber input: ${value}`
-
-  if (
-    value === null ||
-    value === undefined ||
-    value === '' ||
-    Array.isArray(value)
-  ) {
-    throw new Error(errorMessage)
-  }
-
+const prepareInput = (value) => {
   // We don't include 'number' here, because BigNumber will throw if passed
   // a number primitive it considers unsafe.
   if (
@@ -171,11 +160,7 @@ const parseInput = (value) => {
     return value
   }
 
-  const stringValue = String(value)
-  if (stringValue === '[object Object]') {
-    throw new Error(errorMessage)
-  }
-  return stringValue
+  return String(value)
 }
 
 const addCurrencies = (a, b, options = {}) => {
@@ -184,7 +169,7 @@ const addCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(parseInput(a), aBase)).add(parseInput(b), bBase)
+  const value = (new BigNumber(prepareInput(a), aBase)).add(prepareInput(b), bBase)
 
   return converter({
     value,
@@ -198,7 +183,7 @@ const subtractCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(parseInput(a), aBase)).minus(parseInput(b), bBase)
+  const value = (new BigNumber(prepareInput(a), aBase)).minus(prepareInput(b), bBase)
 
   return converter({
     value,
@@ -213,8 +198,8 @@ const multiplyCurrencies = (a, b, options = {}) => {
     ...conversionOptions
   } = options
 
-  const bigNumberA = new BigNumber(parseInput(a), multiplicandBase)
-  const bigNumberB = new BigNumber(parseInput(b), multiplierBase)
+  const bigNumberA = new BigNumber(prepareInput(a), multiplicandBase)
+  const bigNumberB = new BigNumber(prepareInput(b), multiplierBase)
 
   const value = bigNumberA.times(bigNumberB)
 

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -162,6 +162,8 @@ const parseInput = (value) => {
     throw new Error(errorMessage)
   }
 
+  // We don't include 'number' here, because BigNumber will throw if passed
+  // a number primitive it considers unsafe.
   if (
     typeof value === 'string' ||
     value instanceof BigNumber

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -150,13 +150,45 @@ const conversionUtil = (value, {
   value: value || '0',
 })
 
+const parseInput = (value) => {
+  const errorMessage = `Invalid BigNumber input: ${value}`
+
+  if (
+    value === null ||
+    value === undefined ||
+    value === '' ||
+    Array.isArray(value)
+  ) {
+    throw new Error(errorMessage)
+  }
+
+  if (
+    typeof value === 'string' ||
+    value instanceof BigNumber
+  ) {
+    return value
+  }
+
+  let stringValue
+  if (typeof value?.toString === 'function') {
+    stringValue = value.toString()
+  } else {
+    stringValue = String(value)
+  }
+
+  if (stringValue === '[object Object]') {
+    throw new Error(errorMessage)
+  }
+  return stringValue
+}
+
 const addCurrencies = (a, b, options = {}) => {
   const {
     aBase,
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(a.toString(), aBase)).add(b.toString(), bBase)
+  const value = (new BigNumber(parseInput(a), aBase)).add(parseInput(b), bBase)
 
   return converter({
     value,
@@ -170,7 +202,7 @@ const subtractCurrencies = (a, b, options = {}) => {
     bBase,
     ...conversionOptions
   } = options
-  const value = (new BigNumber(String(a), aBase)).minus(b, bBase)
+  const value = (new BigNumber(parseInput(a), aBase)).minus(parseInput(b), bBase)
 
   return converter({
     value,
@@ -185,8 +217,8 @@ const multiplyCurrencies = (a, b, options = {}) => {
     ...conversionOptions
   } = options
 
-  const bigNumberA = new BigNumber(String(a), multiplicandBase)
-  const bigNumberB = new BigNumber(String(b), multiplierBase)
+  const bigNumberA = new BigNumber(parseInput(a), multiplicandBase)
+  const bigNumberB = new BigNumber(parseInput(b), multiplierBase)
 
   const value = bigNumberA.times(bigNumberB)
 


### PR DESCRIPTION
We were poorly parsing inputs to BigNumber arithmetic functions in the conversion utils. On some inputs we called `.toString`, on others `String`, and on one we called nothing.

This PR adds a function `getBigNumber` that returns a new `BigNumber`, stringifying the input value before calling the `BigNumber` constructor unless the value is already a BigNumber or a string.

This ensures that we stringify all inputs in the same way, that we don't needlessly stringify `BigNumber` values, and should give us better errors in some cases.