### PR TITLE
Fix Segment version used by TransactionController#confirmTransaction

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -586,7 +586,7 @@ export default class TransactionController extends EventEmitter {
       }
 
       if (txMeta.swapMetaData) {
-        let { version } = this.platform
+        let { version } = this
         if (process.env.METAMASK_ENVIRONMENT !== 'production') {
           version = `${version}-${process.env.METAMASK_ENVIRONMENT}`
         }


### PR DESCRIPTION
This PR fixes the version that we send to Segment. There is no `this.platform` only `this.version` in the `NetworkController`.