### PR TITLE
Ensure all of a token is swapped when clicking max in swaps

### DIFF
--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -95,9 +95,12 @@ export default function BuildQuote ({
     symbol: fromTokenSymbol,
     string: fromTokenString,
     decimals: fromTokenDecimals,
+    balance: rawFromTokenBalance,
   } = selectedFromToken || {}
 
-  const prevFromTokenString = usePrevious(fromTokenString)
+  const fromTokenBalance = rawFromTokenBalance && calcTokenAmount(rawFromTokenBalance, fromTokenDecimals).toString(10)
+
+  const prevFromTokenBalance = usePrevious(fromTokenBalance)
 
   const swapFromTokenFiatValue = useTokenFiatAmount(
     fromTokenAddress,
@@ -158,10 +161,10 @@ export default function BuildQuote ({
   }, [dispatch, fromToken, ethBalance])
 
   useEffect(() => {
-    if (prevFromTokenString !== fromTokenString) {
-      onInputChange(inputValue, fromTokenString)
+    if (prevFromTokenBalance !== fromTokenBalance) {
+      onInputChange(inputValue, fromTokenBalance)
     }
-  }, [onInputChange, prevFromTokenString, inputValue, fromTokenString])
+  }, [onInputChange, prevFromTokenBalance, inputValue, fromTokenBalance])
 
   useEffect(() => {
     dispatch(resetSwapsPostFetchState())
@@ -176,7 +179,7 @@ export default function BuildQuote ({
             className="build-quote__max-button"
             onClick={() => {
               dispatch(setMaxMode(true))
-              onInputChange(fromTokenString || '0', fromTokenString)
+              onInputChange(fromTokenBalance || '0', fromTokenBalance)
             }}
           >{t('max')}
           </div>
@@ -186,7 +189,7 @@ export default function BuildQuote ({
           itemsToSearch={tokensToSearch}
           onInputChange={(value) => {
             dispatch(setMaxMode(false))
-            onInputChange(value, fromTokenString, fromTokenDecimals)
+            onInputChange(value, fromTokenBalance)
           }}
           inputValue={inputValue}
           leftValue={inputValue && swapFromFiatValue}


### PR DESCRIPTION
This PR fixes a bug that could result in not all of a token being swapped when a user clicks "Max" for an ERC-20 token when on the swaps-build route.

This was caused by use of the `string` property instead of the `balance` property from the tokens returned by `useTokenTracker`. The underlying library used by `useTokenTracker`, https://github.com/MetaMask/eth-token-tracker, only returns `string` properties of up to 3 decimal places (a rounded version of the balance). Meanwhile, the `balance` property contains all the decimals places, and fully represents the user's actual token balance.

The correct functioning of this functionality after this PR can be seen here: https://streamable.com/f5yl5z