### PR TITLE
Refactor background Segment usage

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -22,7 +22,6 @@ import cleanErrorStack from '../../lib/cleanErrorStack'
 import { hexToBn, bnToHex, BnMultiplyByFraction } from '../../lib/util'
 import { TRANSACTION_NO_CONTRACT_ERROR_KEY } from '../../../../ui/app/helpers/constants/error-keys'
 import { getSwapsTokensReceivedFromTxMeta } from '../../../../ui/app/pages/swaps/swaps.util'
-import { segment, METAMETRICS_ANONYMOUS_ID } from '../../lib/segment'
 import TransactionStateManager from './tx-state-manager'
 import TxGasUtil from './tx-gas-utils'
 import PendingTransactionTracker from './pending-tx-tracker'
@@ -77,7 +76,8 @@ export default class TransactionController extends EventEmitter {
     this.blockTracker = opts.blockTracker
     this.signEthTx = opts.signTransaction
     this.inProcessOfSigning = new Set()
-    this.version = opts.version
+    this._trackSegmentEvent = opts.trackSegmentEvent
+    this._getParticipateInMetrics = opts.getParticipateInMetrics
 
     this.memStore = new ObservableStore({})
     this.query = new EthQuery(this.provider)
@@ -586,27 +586,21 @@ export default class TransactionController extends EventEmitter {
         txMeta.postTxBalance = postTxBalance.toString(16)
       }
 
-      if (txMeta.swapMetaData) {
-        let { version } = this
-        if (process.env.METAMASK_ENVIRONMENT !== 'production') {
-          version = `${version}-${process.env.METAMASK_ENVIRONMENT}`
-        }
-        const segmentContext = {
-          app: {
-            version,
-            name: 'MetaMask Extension',
-          },
-          locale: this.preferencesStore.getState().currentLocale.replace('_', '-'),
-          page: {
-            path: '/background-process',
-            title: 'Background Process',
-            url: '/background-process',
-          },
-          userAgent: window.navigator.userAgent,
-        }
+      if (this._getParticipateInMetrics() && txMeta.swapMetaData) {
+        if (txReceipt.status === '0x0') {
+          this._trackSegmentEvent({
+            event: 'Swap Failed',
+            category: 'swaps',
+            anonymous: false,
+          })
 
-        const metametricsId = this.preferencesStore.getState().metaMetricsId
-        if (metametricsId && txMeta.swapMetaData && txReceipt.status !== '0x0') {
+          this._trackSegmentEvent({
+            event: 'Swap Failed',
+            properties: { ...txMeta.swapMetaData },
+            category: 'swaps',
+            anonymous: true,
+          })
+        } else {
           const tokensReceived = getSwapsTokensReceivedFromTxMeta(
             txMeta.destinationTokenSymbol,
             txMeta,
@@ -614,31 +608,28 @@ export default class TransactionController extends EventEmitter {
             txMeta.txParams.from,
             txMeta.destinationTokenDecimals,
           )
-          const quoteVsExecutionRatio = `${(new BigNumber(tokensReceived, 10))
-            .div(txMeta.swapMetaData?.['token_to_amount'], 10).times(100).round(2)}%`
 
-          segment.track({ event: 'Swap Completed', userId: metametricsId, context: segmentContext, category: 'swaps' })
-          segment.track({
+          const quoteVsExecutionRatio = `${
+            (new BigNumber(tokensReceived, 10))
+              .div(txMeta.swapMetaData['token_to_amount'] ?? 1, 10)
+              .times(100)
+              .round(2)
+          }%`
+
+          this._trackSegmentEvent({
+            event: 'Swap Completed',
+            category: 'swaps',
+            anonymous: false,
+          })
+
+          this._trackSegmentEvent({
             event: 'Swap Completed',
             properties: {
               ...txMeta.swapMetaData,
               token_to_amount_received: tokensReceived,
               quote_vs_executionRatio: quoteVsExecutionRatio,
             },
-            context: segmentContext,
-            anonymousId: METAMETRICS_ANONYMOUS_ID,
-            excludeMetaMetricsId: true,
-            category: 'swaps',
-          })
-        } else if (metametricsId && txMeta.swapMetaData) {
-          segment.track({ event: 'Swap Failed', userId: metametricsId, context: segmentContext, category: 'swaps' })
-          segment.track({
-            event: 'Swap Failed',
-            properties: { ...txMeta.swapMetaData },
-            anonymousId: METAMETRICS_ANONYMOUS_ID,
-            excludeMetaMetricsId: true,
-            context: segmentContext,
-            category: 'swaps',
+            anonymous: true,
           })
         }
       }

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -848,7 +848,7 @@ export default class TransactionController extends EventEmitter {
 
         const quoteVsExecutionRatio = `${
           (new BigNumber(tokensReceived, 10))
-            .div(txMeta.swapMetaData.token_to_amount ?? 1, 10)
+            .div(txMeta.swapMetaData.token_to_amount, 10)
             .times(100)
             .round(2)
         }%`

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -828,14 +828,14 @@ export default class TransactionController extends EventEmitter {
         this._trackSegmentEvent({
           event: 'Swap Failed',
           category: 'swaps',
-          anonymous: false,
+          excludeMetaMetricsId: false,
         })
 
         this._trackSegmentEvent({
           event: 'Swap Failed',
           properties: { ...txMeta.swapMetaData },
           category: 'swaps',
-          anonymous: true,
+          excludeMetaMetricsId: true,
         })
       } else {
         const tokensReceived = getSwapsTokensReceivedFromTxMeta(
@@ -856,7 +856,7 @@ export default class TransactionController extends EventEmitter {
         this._trackSegmentEvent({
           event: 'Swap Completed',
           category: 'swaps',
-          anonymous: false,
+          excludeMetaMetricsId: false,
         })
 
         this._trackSegmentEvent({
@@ -866,7 +866,7 @@ export default class TransactionController extends EventEmitter {
             token_to_amount_received: tokensReceived,
             quote_vs_executionRatio: quoteVsExecutionRatio,
           },
-          anonymous: true,
+          excludeMetaMetricsId: true,
         })
       }
     }

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -75,6 +75,10 @@ export function getTrackSegmentEvent (
     properties = {},
     anonymous = true,
   }) {
+    if (!event || !category) {
+      throw new Error('Must specify event and category.')
+    }
+
     if (!getParticipateInMetrics()) {
       return
     }
@@ -82,8 +86,8 @@ export function getTrackSegmentEvent (
     const { currentLocale, metaMetricsId } = getMetricsState()
 
     const trackOptions = {
-      event: event || 'DEFAULT_SEGMENT_EVENT',
-      category: category || 'DEFAULT_SEGMENT_CATEGORY',
+      event,
+      category,
       context: {
         ...segmentContext,
         app: {

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -29,28 +29,26 @@ const segment = process.env.SEGMENT_WRITE_KEY
 /**
  * Returns a function for tracking Segment events.
  *
- * @property {Function} getParticipateInMetrics - A function that returns
+ * @param {string} metamaskVersion - The current version of the MetaMask
+ * extension.
+ * @param {Function} getParticipateInMetrics - A function that returns
  * whether the user participates in MetaMetrics.
- * @property {Function} getMetaMaskVersion - A function for getting the current
- * version of the MetaMask extension.
- * @property {Function} getMetricsState - A function for getting state relevant
+ * @param {Function} getMetricsState - A function for getting state relevant
  * to MetaMetrics/Segment.
  */
 export function getTrackSegmentEvent (
+  metamaskVersion,
   getParticipateInMetrics,
-  getMetaMaskVersion,
   getMetricsState,
 ) {
-  const getVersion = () => {
-    const metamaskVersion = getMetaMaskVersion()
-    return process.env.METAMASK_ENVIRONMENT === 'production'
-      ? metamaskVersion
-      : `${metamaskVersion}-${process.env.METAMASK_ENVIRONMENT}`
-  }
+  const version = process.env.METAMASK_ENVIRONMENT === 'production'
+    ? metamaskVersion
+    : `${metamaskVersion}-${process.env.METAMASK_ENVIRONMENT}`
 
   const segmentContext = {
     app: {
       name: 'MetaMask Extension',
+      version,
     },
     page: {
       path: '/background-process',
@@ -90,10 +88,6 @@ export function getTrackSegmentEvent (
       category,
       context: {
         ...segmentContext,
-        app: {
-          ...segmentContext.app,
-          version: getVersion(),
-        },
         locale: currentLocale.replace('_', '-'),
       },
       properties,

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -26,6 +26,16 @@ const segment = process.env.SEGMENT_WRITE_KEY
   ? new Analytics(process.env.SEGMENT_WRITE_KEY, { flushAt })
   : segmentNoop
 
+/**
+ * Returns a function for tracking Segment events.
+ *
+ * @property {Function} getParticipateInMetrics - A function that returns
+ * whether the user participates in MetaMetrics.
+ * @property {Function} getMetaMaskVersion - A function for getting the current
+ * version of the MetaMask extension.
+ * @property {Function} getMetricsState - A function for getting state relevant
+ * to MetaMetrics/Segment.
+ */
 export function getTrackSegmentEvent (
   getParticipateInMetrics,
   getMetaMaskVersion,
@@ -50,9 +60,18 @@ export function getTrackSegmentEvent (
     userAgent: window.navigator.userAgent,
   }
 
+  /**
+   * Tracks a Segment event per the given arguments.
+   *
+   * @param {string} event - The event name.
+   * @param {string} category - The event category.
+   * @param {Object} [properties] - The event properties.
+   * @param {boolean} [anonymous] - `true` if the user's MetaMetrics id should
+   * not be included, and `false` otherwise. Default: `true`
+   */
   return function trackSegmentEvent ({
-    event = 'DEFAULT_SEGMENT_EVENT',
-    category = 'DEFAULT_SEGMENT_CATEGORY',
+    event,
+    category,
     properties = {},
     anonymous = true,
   }) {
@@ -63,8 +82,8 @@ export function getTrackSegmentEvent (
     const { currentLocale, metaMetricsId } = getMetricsState()
 
     const trackOptions = {
-      event,
-      category,
+      event: event || 'DEFAULT_SEGMENT_EVENT',
+      category: category || 'DEFAULT_SEGMENT_CATEGORY',
       context: {
         ...segmentContext,
         app: {

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -64,14 +64,14 @@ export function getTrackSegmentEvent (
    * @param {string} event - The event name.
    * @param {string} category - The event category.
    * @param {Object} [properties] - The event properties.
-   * @param {boolean} [anonymous] - `true` if the user's MetaMetrics id should
+   * @param {boolean} [excludeMetaMetricsId] - `true` if the user's MetaMetrics id should
    * not be included, and `false` otherwise. Default: `true`
    */
   return function trackSegmentEvent ({
     event,
     category,
     properties = {},
-    anonymous = true,
+    excludeMetaMetricsId = true,
   }) {
     if (!event || !category) {
       throw new Error('Must specify event and category.')
@@ -93,9 +93,8 @@ export function getTrackSegmentEvent (
       properties,
     }
 
-    if (anonymous) {
+    if (excludeMetaMetricsId) {
       trackOptions.anonymousId = METAMETRICS_ANONYMOUS_ID
-      trackOptions.excludeMetaMetricsId = true
     } else {
       trackOptions.userId = metaMetricsId
     }

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -4,6 +4,8 @@ const inDevelopment = process.env.METAMASK_DEBUG || process.env.IN_TEST
 
 const flushAt = inDevelopment ? 1 : undefined
 
+const METAMETRICS_ANONYMOUS_ID = '0x0000000000000000'
+
 const segmentNoop = {
   track () {
     // noop
@@ -20,8 +22,67 @@ const segmentNoop = {
 // provided a SEGMENT_WRITE_KEY. This also holds true for test environments and
 // E2E, which is handled in the build process by never providing the SEGMENT_WRITE_KEY
 // which process.env.IN_TEST is true
-export const segment = process.env.SEGMENT_WRITE_KEY
+const segment = process.env.SEGMENT_WRITE_KEY
   ? new Analytics(process.env.SEGMENT_WRITE_KEY, { flushAt })
   : segmentNoop
 
-export const METAMETRICS_ANONYMOUS_ID = '0x0000000000000000'
+export function getTrackSegmentEvent (
+  getParticipateInMetrics,
+  getMetaMaskVersion,
+  getMetricsState,
+) {
+  const getVersion = () => {
+    const metamaskVersion = getMetaMaskVersion()
+    return process.env.METAMASK_ENVIRONMENT === 'production'
+      ? metamaskVersion
+      : `${metamaskVersion}-${process.env.METAMASK_ENVIRONMENT}`
+  }
+
+  const segmentContext = {
+    app: {
+      name: 'MetaMask Extension',
+    },
+    page: {
+      path: '/background-process',
+      title: 'Background Process',
+      url: '/background-process',
+    },
+    userAgent: window.navigator.userAgent,
+  }
+
+  return function trackSegmentEvent ({
+    event = 'DEFAULT_SEGMENT_EVENT',
+    category = 'DEFAULT_SEGMENT_CATEGORY',
+    properties = {},
+    anonymous = true,
+  }) {
+    if (!getParticipateInMetrics()) {
+      return
+    }
+
+    const { currentLocale, metaMetricsId } = getMetricsState()
+
+    const trackOptions = {
+      event,
+      category,
+      context: {
+        ...segmentContext,
+        app: {
+          ...segmentContext.app,
+          version: getVersion(),
+        },
+        locale: currentLocale.replace('_', '-'),
+      },
+      properties,
+    }
+
+    if (anonymous) {
+      trackOptions.anonymousId = METAMETRICS_ANONYMOUS_ID
+      trackOptions.excludeMetaMetricsId = true
+    } else {
+      trackOptions.userId = metaMetricsId
+    }
+
+    segment.track(trackOptions)
+  }
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -121,8 +121,8 @@ export default class MetamaskController extends EventEmitter {
       () => this.preferencesController.getParticipateInMetaMetrics(),
       () => {
         const {
-          currentLocale = '',
-          metaMetricsId = '',
+          currentLocale,
+          metaMetricsId,
         } = this.preferencesController.getState()
         return { currentLocale, metaMetricsId }
       },

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -55,6 +55,7 @@ import getRestrictedMethods from './controllers/permissions/restrictedMethods'
 import nodeify from './lib/nodeify'
 import accountImporter from './account-import-strategies'
 import seedPhraseVerifier from './lib/seed-phrase-verifier'
+import { getTrackSegmentEvent } from './lib/segment'
 
 import backgroundMetaMetricsEvent from './lib/background-metametrics'
 
@@ -113,6 +114,19 @@ export default class MetamaskController extends EventEmitter {
       network: this.networkController,
       migrateAddressBookState: this.migrateAddressBookState.bind(this),
     })
+
+    // This depends on the currentLocale from the preferences controller
+    this.trackSegmentEvent = getTrackSegmentEvent(
+      () => this.preferencesController.getParticipateInMetaMetrics(),
+      () => this.platform.getVersion(),
+      () => {
+        const {
+          currentLocale = '',
+          metaMetricsId = '',
+        } = this.preferencesController.getState()
+        return { currentLocale, metaMetricsId }
+      },
+    )
 
     this.appStateController = new AppStateController({
       addUnlockListener: this.on.bind(this, 'unlock'),
@@ -239,7 +253,8 @@ export default class MetamaskController extends EventEmitter {
       signTransaction: this.keyringController.signTransaction.bind(this.keyringController),
       provider: this.provider,
       blockTracker: this.blockTracker,
-      version: this.platform.getVersion(),
+      trackSegmentEvent: this.trackSegmentEvent,
+      getParticipateInMetrics: () => this.preferencesController.getParticipateInMetaMetrics(),
     })
     this.txController.on('newUnapprovedTx', () => opts.showUnapprovedTx())
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -117,8 +117,8 @@ export default class MetamaskController extends EventEmitter {
 
     // This depends on preferences controller state
     this.trackSegmentEvent = getTrackSegmentEvent(
+      this.platform.getVersion(),
       () => this.preferencesController.getParticipateInMetaMetrics(),
-      () => this.platform.getVersion(),
       () => {
         const {
           currentLocale = '',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -115,7 +115,7 @@ export default class MetamaskController extends EventEmitter {
       migrateAddressBookState: this.migrateAddressBookState.bind(this),
     })
 
-    // This depends on the currentLocale from the preferences controller
+    // This depends on preferences controller state
     this.trackSegmentEvent = getTrackSegmentEvent(
       () => this.preferencesController.getParticipateInMetaMetrics(),
       () => this.platform.getVersion(),

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -50,6 +50,7 @@ describe('Transaction Controller', function () {
       }),
       getPermittedAccounts: () => undefined,
       getCurrentChainId: () => currentChainId,
+      getParticipateInMetrics: () => false,
     })
     txController.nonceTracker.getNonceLock = () => Promise.resolve({ nextNonce: 0, releaseLock: noop })
   })
@@ -558,6 +559,7 @@ describe('Transaction Controller', function () {
           ethTx.sign(_fromAccount.key)
           resolve()
         }),
+        getParticipateInMetrics: () => false,
       })
       const result = await _txController._determineTransactionCategory({
         to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
@@ -590,6 +592,7 @@ describe('Transaction Controller', function () {
           ethTx.sign(_fromAccount.key)
           resolve()
         }),
+        getParticipateInMetrics: () => false,
       })
       const result = await _txController._determineTransactionCategory({
         to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',


### PR DESCRIPTION
In the background, we currently only use Segment to track data about swaps. However, will soon have cause to record other background metrics using Segment.

This PR refactors our use of Segment in the background such that the caller only has to concern themselves with information relevant to the event being tracked, not metadata that's common to all background events. It also cleans up the metrics functionality in the transactions controller and moves it to its own function. The calculation of the various values sent to Segment is unchanged.