### PR TITLE
Hide activity list retry button for failed swaps transctions

### DIFF
--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -19,6 +19,7 @@ import {
   FAILED_STATUS,
   DROPPED_STATUS,
   REJECTED_STATUS,
+  TRANSACTION_CATEGORY_SWAP,
 } from '../../../helpers/constants/transactions'
 import { useShouldShowSpeedUp } from '../../../hooks/useShouldShowSpeedUp'
 import TransactionStatus from '../transaction-status/transaction-status.component'
@@ -56,6 +57,7 @@ export default function TransactionListItem ({ transactionGroup, isEarliestNonce
   const isSignatureReq = category === TRANSACTION_CATEGORY_SIGNATURE_REQUEST
   const isApproval = category === TRANSACTION_CATEGORY_APPROVAL
   const isUnapproved = displayedStatusKey === UNAPPROVED_STATUS
+  const isSwap = category === TRANSACTION_CATEGORY_SWAP
 
   const className = classnames('transaction-list-item', {
     'transaction-list-item--unconfirmed': isPending || [FAILED_STATUS, DROPPED_STATUS, REJECTED_STATUS].includes(displayedStatusKey),
@@ -159,7 +161,7 @@ export default function TransactionListItem ({ transactionGroup, isEarliestNonce
           senderAddress={senderAddress}
           recipientAddress={recipientAddress}
           onRetry={retryTransaction}
-          showRetry={status === FAILED_STATUS}
+          showRetry={status === FAILED_STATUS && !isSwap}
           showSpeedUp={shouldShowSpeedUp}
           isEarliestNonce={isEarliestNonce}
           onCancel={cancelTransaction}


### PR DESCRIPTION
We merged a PR yesterday to hide the retry button in the transaction/activity list for transactions that failed onchain. This applies to both swaps and non-swap-transactions.

We actually need to hide that retry button for ALL swap failures, onchain or otherwise. The details of the quote for a swap become stale with time, and the same txData that might have worked 5 minutes ago probably won't work now. This PR hides that button for all swaps