### PR TITLE
Fix environment variable inlining

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -21,7 +21,6 @@ import {
 } from './enums'
 
 const env = process.env.METAMASK_ENV
-const { METAMASK_DEBUG } = process.env
 
 let defaultProviderConfigType
 let defaultProviderChainId
@@ -29,7 +28,7 @@ if (process.env.IN_TEST === 'true') {
   defaultProviderConfigType = LOCALHOST
   // Decimal 5777, an arbitrary chain ID we use for testing
   defaultProviderChainId = '0x1691'
-} else if (METAMASK_DEBUG || env === 'test') {
+} else if (process.env.METAMASK_DEBUG || env === 'test') {
   defaultProviderConfigType = RINKEBY
 } else {
   defaultProviderConfigType = MAINNET

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -3,7 +3,11 @@ import { Dedupe, ExtraErrorData } from '@sentry/integrations'
 
 import extractEthjsErrorMessage from './extractEthjsErrorMessage'
 
-const { METAMASK_DEBUG, METAMASK_ENVIRONMENT } = process.env
+/* eslint-disable prefer-destructuring */
+// Destructuring breaks the inlining of the environment variables
+const METAMASK_DEBUG = process.env.METAMASK_DEBUG
+const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT
+/* eslint-enable prefer-destructuring */
 const SENTRY_DSN_DEV = 'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496'
 
 // This describes the subset of Redux state attached to errors sent to Sentry


### PR DESCRIPTION
This PR fixes instances of `process.env` that were being destructured. The `process.env` values are not _set_ but instead inlined into instances of `process.env.FOO` and destructuring breaks that.