### PR TITLE
Prevent swaps value input placeholder from jumping when focused

### DIFF
--- a/ui/app/pages/swaps/dropdown-input-pair/index.scss
+++ b/ui/app/pages/swaps/dropdown-input-pair/index.scss
@@ -17,7 +17,7 @@
       border: 1px solid $Grey-100;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-      border-left: none;
+      border-left-color: transparent;
       height: 60px;
     }
 


### PR DESCRIPTION
This is a very minor change but, at present, clicking into the value input on the swaps screen shifts the "0" placeholder to the right 1 pixel, due to the focus border.

Adding a transparent border to the left of the input prevents this shift.