### PR TITLE
call this.txStateManager.setTxStatusConfirmed before async call in confirmTransaction

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -585,14 +585,13 @@ export default class TransactionController extends EventEmitter {
 
       this.txStateManager.updateTx(initialTxMeta, 'transactions#confirmTransaction - add txReceipt')
 
-      let txMeta
       if (initialTxMeta.transactionCategory === SWAP) {
-        txMeta = cloneDeep(initialTxMeta)
+        const txMeta = cloneDeep(initialTxMeta)
         const postTxBalance = await this.query.getBalance(txMeta.txParams.from)
         txMeta.postTxBalance = postTxBalance.toString(16)
+        this._trackSwapsMetrics(txMeta)
       }
 
-      this._trackSwapsMetrics(txMeta)
     } catch (err) {
       log.error(err)
     }

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -580,6 +580,9 @@ export default class TransactionController extends EventEmitter {
         gasUsed,
       }
 
+      this.txStateManager.setTxStatusConfirmed(txId)
+      this._markNonceDuplicatesDropped(txId)
+
       if (txMeta.transactionCategory === SWAP) {
         const postTxBalance = await this.query.getBalance(txMeta.txParams.from)
         txMeta.postTxBalance = postTxBalance.toString(16)
@@ -590,9 +593,6 @@ export default class TransactionController extends EventEmitter {
     } catch (err) {
       log.error(err)
     }
-
-    this.txStateManager.setTxStatusConfirmed(txId)
-    this._markNonceDuplicatesDropped(txId)
   }
 
   /**

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -9,6 +9,7 @@ import { ethers } from 'ethers'
 import NonceTracker from 'nonce-tracker'
 import log from 'loglevel'
 import BigNumber from 'bignumber.js'
+import { cloneDeep } from 'lodash'
 import {
   TOKEN_METHOD_APPROVE,
   TOKEN_METHOD_TRANSFER,
@@ -562,9 +563,9 @@ export default class TransactionController extends EventEmitter {
   async confirmTransaction (txId, txReceipt) {
     // get the txReceipt before marking the transaction confirmed
     // to ensure the receipt is gotten before the ui revives the tx
-    const txMeta = this.txStateManager.getTx(txId)
+    const initialTxMeta = this.txStateManager.getTx(txId)
 
-    if (!txMeta) {
+    if (!initialTxMeta) {
       return
     }
 
@@ -575,10 +576,12 @@ export default class TransactionController extends EventEmitter {
         ? txReceipt.gasUsed
         : txReceipt.gasUsed.toString(16)
 
-      txMeta.txReceipt = {
+      initialTxMeta.txReceipt = {
         ...txReceipt,
         gasUsed,
       }
+
+      const txMeta = cloneDeep(initialTxMeta)
 
       this.txStateManager.setTxStatusConfirmed(txId)
       this._markNonceDuplicatesDropped(txId)

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -580,18 +580,18 @@ export default class TransactionController extends EventEmitter {
         ...txReceipt,
         gasUsed,
       }
-
-      const txMeta = cloneDeep(initialTxMeta)
-
       this.txStateManager.setTxStatusConfirmed(txId)
       this._markNonceDuplicatesDropped(txId)
 
-      if (txMeta.transactionCategory === SWAP) {
+      this.txStateManager.updateTx(initialTxMeta, 'transactions#confirmTransaction - add txReceipt')
+
+      let txMeta
+      if (initialTxMeta.transactionCategory === SWAP) {
+        txMeta = cloneDeep(initialTxMeta)
         const postTxBalance = await this.query.getBalance(txMeta.txParams.from)
         txMeta.postTxBalance = postTxBalance.toString(16)
       }
 
-      this.txStateManager.updateTx(txMeta, 'transactions#confirmTransaction - add txReceipt')
       this._trackSwapsMetrics(txMeta)
     } catch (err) {
       log.error(err)


### PR DESCRIPTION
`this.txStateManager.setTxStatusConfirmed(txId)` should not have been called after the await for get balance. This caused a race condition with `_resubmitTx` that resulted in `confirmTransaction` being called twice.