### PR TITLE
Fix #9516 - Prevent duplicate increment/decrement buttons in Firefox

### DIFF
--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/index.scss
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/index.scss
@@ -114,6 +114,12 @@
       border: 1px solid $orange;
     }
 
+    input[type="number"] {
+      -webkit-appearance: textfield;
+      -moz-appearance: textfield;
+      appearance: textfield;
+    }
+
     input[type="number"]::-webkit-inner-spin-button {
       -webkit-appearance: none;
       -moz-appearance: none;


### PR DESCRIPTION
We no longer show duplicate controls as shown in #9516 

<img width="411" alt="Controls" src="https://user-images.githubusercontent.com/46655/95486076-2d7ef880-0958-11eb-98c1-935964c9bcc5.png">
