### PR TITLE
Fix retry transaction button tooltip

### DIFF
--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -204,7 +204,7 @@ export default class TransactionListItemDetails extends PureComponent {
               </Tooltip>
               {
                 showRetry && (
-                  <Tooltip title={blockExplorerUrl ? t('viewOnCustomBlockExplorer', [blockExplorerUrl]) : t('retryTransaction')}>
+                  <Tooltip title={t('retryTransaction')}>
                     <Button
                       type="raised"
                       onClick={this.handleRetry}


### PR DESCRIPTION
The tooltip for the Retry Transaction button would be erroneously set to display a custom block explorer, if one was set for the current network. It now displays the intended retry transaction text in all cases.