### PR TITLE
Use Segment for web3 usage metrics; fix background Segment bugs

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -861,6 +861,7 @@ export default class TransactionController extends EventEmitter {
 
         this._trackSegmentEvent({
           event: 'Swap Completed',
+          category: 'swaps',
           properties: {
             ...txMeta.swapMetaData,
             token_to_amount_received: tokensReceived,

--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -47,7 +47,7 @@ function logWeb3UsageHandler (
     recordedWeb3Usage[origin][name] = true
 
     sendMetrics({
-      event: `window.web3 Usage`,
+      event: `Website Accessed window.web3`,
       category: 'inpage_provider',
       properties: { origin, action, web3Property: name },
     })

--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -46,13 +46,10 @@ function logWeb3UsageHandler (
   if (!recordedWeb3Usage[origin][name]) {
     recordedWeb3Usage[origin][name] = true
 
-    // "action" is either "window.web3 get" or "window.web3 set"
-    const proxyAction = action.split(' ')[1]
-
     sendMetrics({
       event: `window.web3 Usage`,
       category: 'inpage_provider',
-      properties: { origin, action: proxyAction, web3Property: name },
+      properties: { origin, action, web3Property: name },
     })
   }
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -45,10 +45,14 @@ function logWeb3UsageHandler (
   }
   if (!recordedWeb3Usage[origin][name]) {
     recordedWeb3Usage[origin][name] = true
+
+    // "action" is either "window.web3 get" or "window.web3 set"
+    const proxyAction = action.split(' ')[1]
+
     sendMetrics({
-      action,
-      name,
-      customVariables: { origin },
+      event: `window.web3 Usage`,
+      category: 'inpage_provider',
+      properties: { origin, action: proxyAction, web3Property: name },
     })
   }
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -49,7 +49,8 @@ function logWeb3UsageHandler (
     sendMetrics({
       event: `Website Accessed window.web3`,
       category: 'inpage_provider',
-      properties: { origin, action, web3Property: name },
+      properties: { action, web3Property: name },
+      referrerUrl: origin,
     })
   }
 

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -64,6 +64,7 @@ export function getTrackSegmentEvent (
    * @param {string} event - The event name.
    * @param {string} category - The event category.
    * @param {Object} [properties] - The event properties.
+   * @param {string} [referrerUrl] - The event's referrer URL, if relevant.
    * @param {boolean} [excludeMetaMetricsId] - `true` if the user's MetaMetrics id should
    * not be included, and `false` otherwise. Default: `true`
    */
@@ -72,6 +73,7 @@ export function getTrackSegmentEvent (
     category,
     properties = {},
     excludeMetaMetricsId = true,
+    referrerUrl,
   }) {
     if (!event || !category) {
       throw new Error('Must specify event and category.')
@@ -97,6 +99,12 @@ export function getTrackSegmentEvent (
       trackOptions.anonymousId = METAMETRICS_ANONYMOUS_ID
     } else {
       trackOptions.userId = metaMetricsId
+    }
+
+    if (referrerUrl) {
+      trackOptions.referrer = {
+        url: referrerUrl,
+      }
     }
 
     segment.track(trackOptions)

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -102,7 +102,7 @@ export function getTrackSegmentEvent (
     }
 
     if (referrerUrl) {
-      trackOptions.referrer = {
+      trackOptions.context.referrer = {
         url: referrerUrl,
       }
     }

--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -47,7 +47,7 @@ export default function setupWeb3 (log) {
         const name = stringifyKey(key)
         window.ethereum.request({
           method: 'metamask_logInjectedWeb3Usage',
-          params: [{ action: 'window.web3 get', name }],
+          params: [{ action: 'get', name }],
         })
       }
 
@@ -59,7 +59,7 @@ export default function setupWeb3 (log) {
       if (shouldLogUsage) {
         window.ethereum.request({
           method: 'metamask_logInjectedWeb3Usage',
-          params: [{ action: 'window.web3 set', name }],
+          params: [{ action: 'set', name }],
         })
       }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -123,7 +123,7 @@ export default class MetamaskController extends EventEmitter {
         const {
           currentLocale,
           metaMetricsId,
-        } = this.preferencesController.getState()
+        } = this.preferencesController.store.getState()
         return { currentLocale, metaMetricsId }
       },
     )

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1672,7 +1672,7 @@ export default class MetamaskController extends EventEmitter {
     }))
     engine.push(createMethodMiddleware({
       origin,
-      sendMetrics: this.sendBackgroundMetaMetrics.bind(this),
+      sendMetrics: this.trackSegmentEvent,
     }))
     // filter and subscription polyfills
     engine.push(filterMiddleware)


### PR DESCRIPTION
- Refactors our `window.web3` usage logging to use `trackSegmentEvent` instead of Matomo.
- Fixes bugs in the background Segment implementation introduced in #9509 