### PR TITLE
Stop calling _findTopQuoteAggId twice in _findTopQuoteAggId

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -166,13 +166,9 @@ export default class SwapsController {
       }
     }
 
-    const topAggIdData = await this._findTopQuoteAggId(newQuotes)
-    let { topAggId } = topAggIdData
-    const { isBest } = topAggIdData
-
-    if (isBest) {
-      newQuotes[topAggId].isBestQuote = true
-    }
+    let topAggIdData
+    let topAggId
+    let isBest
 
     // We can reduce time on the loading screen by only doing this after the
     // loading screen and best quote have rendered.
@@ -187,15 +183,21 @@ export default class SwapsController {
         this.setSwapsErrorKey(QUOTES_NOT_AVAILABLE_ERROR)
       } else {
         const {
-          topAggId: topAggIdAfterGasEstimates,
-          isBest: isBestAfterGasEstimates,
+          topAggId: topAggIdAfterModifications,
+          isBest: isBestAfterModifications,
         } = await this._findTopQuoteAggId(newQuotes)
-        topAggId = topAggIdAfterGasEstimates
-        if (isBestAfterGasEstimates) {
-          newQuotes = mapValues(newQuotes, (quote) => ({ ...quote, isBestQuote: false }))
-          newQuotes[topAggId].isBestQuote = true
-        }
+        topAggId = topAggIdAfterModifications
+        isBest = isBestAfterModifications
       }
+    } else {
+      topAggIdData = await this._findTopQuoteAggId(newQuotes)
+      topAggId = topAggIdData.topAggId
+      isBest = topAggIdData.isBest
+    }
+
+    if (isBest) {
+      newQuotes = mapValues(newQuotes, (quote) => ({ ...quote, isBestQuote: false }))
+      newQuotes[topAggId].isBestQuote = true
     }
 
     const { swapsState } = this.store.getState()

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -196,7 +196,6 @@ export default class SwapsController {
     }
 
     if (isBest) {
-      newQuotes = mapValues(newQuotes, (quote) => ({ ...quote, isBestQuote: false }))
       newQuotes[topAggId].isBestQuote = true
     }
 


### PR DESCRIPTION
This PR eliminates an unnecessary async call to `_findTopQuoteAggId` in `fetchAndSetQuotes`. It also improves and simplifies related code. 