### PR TITLE
Remove max mode for eth feature from swaps

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -605,7 +605,6 @@ export default class MetamaskController extends EventEmitter {
       setSwapsTokens: nodeify(swapsController.setSwapsTokens, swapsController),
       setApproveTxId: nodeify(swapsController.setApproveTxId, swapsController),
       setTradeTxId: nodeify(swapsController.setTradeTxId, swapsController),
-      setMaxMode: nodeify(swapsController.setMaxMode, swapsController),
       setSwapsTxGasPrice: nodeify(swapsController.setSwapsTxGasPrice, swapsController),
       setSwapsTxGasLimit: nodeify(swapsController.setSwapsTxGasLimit, swapsController),
       safeRefetchQuotes: nodeify(swapsController.safeRefetchQuotes, swapsController),

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -101,7 +101,6 @@ const EMPTY_INIT_STATE = {
     tokens: null,
     tradeTxId: null,
     approveTxId: null,
-    maxMode: false,
     quotesLastFetched: null,
     customMaxGas: '',
     customGasPrice: null,
@@ -194,15 +193,6 @@ describe('SwapsController', function () {
         assert.strictEqual(
           swapsController.store.getState().swapsState.tradeTxId,
           tradeTxId,
-        )
-      })
-
-      it('should set max mode', function () {
-        const maxMode = true
-        swapsController.setMaxMode(maxMode)
-        assert.strictEqual(
-          swapsController.store.getState().swapsState.maxMode,
-          maxMode,
         )
       })
 

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -32,7 +32,7 @@ import { useEthFiatAmount } from '../../../hooks/useEthFiatAmount'
 
 import { ETH_SWAPS_TOKEN_OBJECT } from '../../../helpers/constants/swaps'
 
-import { setMaxMode, resetSwapsPostFetchState, removeToken } from '../../../store/actions'
+import { resetSwapsPostFetchState, removeToken } from '../../../store/actions'
 import { fetchTokenPrice, fetchTokenBalance } from '../swaps.util'
 import SwapsFooter from '../swaps-footer'
 
@@ -139,7 +139,6 @@ export default function BuildQuote ({
         })
     }
     dispatch(setSwapsFromToken(token))
-    dispatch(setMaxMode(false))
     onInputChange(token?.address ? inputValue : '', token.string, token.decimals)
   }
 
@@ -154,6 +153,7 @@ export default function BuildQuote ({
 
   const hideDropdownItemIf = useCallback((item) => item.address === fromTokenAddress, [fromTokenAddress])
 
+  // If the eth balance changes while on build quote, we update the selected from token
   useEffect(() => {
     if (fromToken?.address === ETH_SWAPS_TOKEN_OBJECT.address && (fromToken?.balance !== ethBalance)) {
       dispatch(setSwapsFromToken({ ...fromToken, balance: ethBalance, string: getValueFromWeiHex({ value: ethBalance, numberOfDecimals: 4, toDenomination: 'ETH' }) }))
@@ -175,20 +175,18 @@ export default function BuildQuote ({
       <div className="build-quote__content">
         <div className="build-quote__dropdown-input-pair-header">
           <div className="build-quote__input-label">{t('swapSwapFrom')}</div>
-          <div
-            className="build-quote__max-button"
-            onClick={() => {
-              dispatch(setMaxMode(true))
-              onInputChange(fromTokenBalance || '0', fromTokenBalance)
-            }}
-          >{t('max')}
-          </div>
+          {fromTokenSymbol !== 'ETH' && (
+            <div
+              className="build-quote__max-button"
+              onClick={() => onInputChange(fromTokenBalance || '0', fromTokenBalance)}
+            >{t('max')}
+            </div>
+          )}
         </div>
         <DropdownInputPair
           onSelect={onFromSelect}
           itemsToSearch={tokensToSearch}
           onInputChange={(value) => {
-            dispatch(setMaxMode(false))
             onInputChange(value, fromTokenBalance)
           }}
           inputValue={inputValue}

--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -42,7 +42,7 @@ import {
   OFFLINE_FOR_MAINTENANCE,
 } from '../../helpers/constants/swaps'
 
-import { resetBackgroundSwapsState, setSwapsTokens, setMaxMode, removeToken, setBackgroundSwapRouteState, setSwapsErrorKey } from '../../store/actions'
+import { resetBackgroundSwapsState, setSwapsTokens, removeToken, setBackgroundSwapRouteState, setSwapsErrorKey } from '../../store/actions'
 import { getFastPriceEstimateInHexWEI, currentNetworkTxListSelector, getRpcPrefsForCurrentProvider } from '../../selectors'
 import { useNewMetricEvent } from '../../hooks/useMetricEvent'
 import { getValueFromWeiHex } from '../../helpers/utils/conversions.util'
@@ -268,7 +268,6 @@ export default function Swap () {
                     onInputChange={onInputChange}
                     ethBalance={ethBalance}
                     setMaxSlippage={setMaxSlippage}
-                    setMaxMode={setMaxMode}
                     selectedAccountAddress={selectedAccountAddress}
                     maxSlippage={maxSlippage}
                   />

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -19,7 +19,6 @@ import {
   setBalanceError,
   getQuotesLastFetched,
   getBalanceError,
-  getMaxMode,
   getCustomSwapsGas,
   getDestinationTokenInfo,
   getSwapsTradeTxParams,
@@ -110,7 +109,6 @@ export default function ViewQuote () {
   const currentCurrency = useSelector(getCurrentCurrency)
   const swapsTokens = useSelector(getTokens)
   const balanceError = useSelector(getBalanceError)
-  const maxMode = useSelector(getMaxMode)
   const fetchParams = useSelector(getFetchParams)
   const approveTxParams = useSelector(getApproveTxParams)
   const selectedQuote = useSelector(getSelectedQuote)
@@ -233,9 +231,6 @@ export default function ViewQuote () {
     (tokenCost).gt(new BigNumber(selectedFromToken.balance || '0x0'))
   )
 
-  const insufficientEthForGas = (new BigNumber(gasTotalInWeiHex, 16))
-    .gt(new BigNumber(ethBalance || '0x0'))
-
   const insufficientEth = (ethCost).gt(new BigNumber(ethBalance || '0x0'))
 
   const tokenBalanceNeeded = insufficientTokens
@@ -282,16 +277,9 @@ export default function ViewQuote () {
     }
   }, [originalApproveAmount, approveAmount])
 
-  const allowedMaxModeSubmit = (
-    maxMode &&
-    sourceTokenSymbol === 'ETH' &&
-    !insufficientEthForGas
-  )
-
   const showWarning = (
     (balanceError || tokenBalanceNeeded || ethBalanceNeeded) &&
-    !warningHidden &&
-    !allowedMaxModeSubmit
+    !warningHidden
   )
 
   const numberOfQuotes = Object.values(quotes).length

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2180,13 +2180,6 @@ export function resetBackgroundSwapsState () {
   }
 }
 
-export function setMaxMode (maxMode) {
-  return async (dispatch) => {
-    await promisifiedBackground.setMaxMode(maxMode)
-    await forceUpdateMetamaskState(dispatch)
-  }
-}
-
 export function setCustomApproveTxData (data) {
   return async (dispatch) => {
     await promisifiedBackground.setCustomApproveTxData(data)


### PR DESCRIPTION
This PR removes the option of letting users select "Max" for ETH in the swaps flow. This option introduce too many UX complexities and confusions in the view quote screen.