### PR TITLE
Only shows the swaps intro popup on mainnet

### DIFF
--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -118,12 +118,6 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
-
-    it('closes the swaps intro popup', async function () {
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-    })
   })
 
   describe('Import seed phrase', function () {

--- a/test/e2e/ethereum-on.spec.js
+++ b/test/e2e/ethereum-on.spec.js
@@ -84,10 +84,6 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.remindMeLater.message}')]`))
       await driver.delay(regularDelayMs)
 
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-
       await driver.clickElement(By.css('[data-testid="account-options-menu-button"]'))
       await driver.clickElement(By.css('[data-testid="account-options-menu__account-details"]'))
     })

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -93,12 +93,6 @@ describe('Using MetaMask with an existing account', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
-
-    it('closes the swaps intro popup', async function () {
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-    })
   })
 
   describe('Show account information', function () {

--- a/test/e2e/incremental-security.spec.js
+++ b/test/e2e/incremental-security.spec.js
@@ -90,10 +90,6 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.remindMeLater.message}')]`))
       await driver.delay(regularDelayMs)
 
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-
       await driver.clickElement(By.css('[data-testid="account-options-menu-button"]'))
       await driver.clickElement(By.css('[data-testid="account-options-menu__account-details"]'))
     })

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -113,12 +113,6 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
-
-    it('closes the swaps intro popup', async function () {
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-    })
   })
 
   describe('Show account information', function () {

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -115,12 +115,6 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
-
-    it('closes the swaps intro popup', async function () {
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-    })
   })
 
   describe('Show account information', function () {

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -85,10 +85,6 @@ describe('MetaMask', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.remindMeLater.message}')]`))
       await driver.delay(regularDelayMs)
 
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-
       await driver.clickElement(By.css('[data-testid="account-options-menu-button"]'))
       await driver.clickElement(By.css('[data-testid="account-options-menu__account-details"]'))
     })

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -91,12 +91,6 @@ describe('Using MetaMask with an existing account', function () {
       await driver.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
       await driver.delay(regularDelayMs)
     })
-
-    it('closes the swaps intro popup', async function () {
-      await driver.findElement(By.css(`.popover-header__subtitle`))
-      await driver.clickElement(By.css('.popover-header__button'))
-      await driver.delay(regularDelayMs)
-    })
   })
 
   describe('Send ETH from inside MetaMask', function () {

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -95,12 +95,6 @@ describe('MetaMask', function () {
         await driver.delay(regularDelayMs)
       })
 
-      it('closes the swaps intro popup', async function () {
-        await driver.findElement(By.css(`.popover-header__subtitle`))
-        await driver.clickElement(By.css('.popover-header__button'))
-        await driver.delay(regularDelayMs)
-      })
-
       it('balance renders', async function () {
         const balance = await driver.findElement(By.css('[data-testid="wallet-balance"] .list-item__heading'))
         await driver.wait(until.elementTextMatches(balance, /25\s*ETH/u))
@@ -204,12 +198,6 @@ describe('MetaMask', function () {
       it('clicks through the success screen', async function () {
         await driver2.findElement(By.xpath(`//div[contains(text(), 'Congratulations')]`))
         await driver2.clickElement(By.xpath(`//button[contains(text(), '${enLocaleMessages.endOfFlowMessage10.message}')]`))
-        await driver2.delay(regularDelayMs)
-      })
-
-      it('closes the swaps intro popup', async function () {
-        await driver2.findElement(By.css(`.popover-header__subtitle`))
-        await driver2.clickElement(By.css('.popover-header__button'))
         await driver2.delay(regularDelayMs)
       })
 

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -64,6 +64,7 @@ export default class Home extends PureComponent {
     showAwaitingSwapScreen: PropTypes.bool.isRequired,
     swapsFetchParams: PropTypes.object,
     swapsEnabled: PropTypes.bool,
+    isMainNet: PropTypes.bool,
   }
 
   state = {
@@ -271,6 +272,7 @@ export default class Home extends PureComponent {
       swapsWelcomeMessageHasBeenShown,
       setSwapsWelcomeMessageHasBeenShown,
       swapsEnabled,
+      isMainNet,
     } = this.props
 
     if (forgottenPassword) {
@@ -284,7 +286,7 @@ export default class Home extends PureComponent {
         <Route path={CONNECTED_ROUTE} component={ConnectedSites} exact />
         <Route path={CONNECTED_ACCOUNTS_ROUTE} component={ConnectedAccounts} exact />
         <div className="home__container">
-          {!swapsWelcomeMessageHasBeenShown && swapsEnabled ? (
+          {!swapsWelcomeMessageHasBeenShown && swapsEnabled && isMainNet ? (
             <SwapsIntroPopup onClose={setSwapsWelcomeMessageHasBeenShown} />
           ) : null}
           { isPopup && !connectedStatusPopoverHasBeenShown ? this.renderPopover() : null }

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -64,7 +64,7 @@ export default class Home extends PureComponent {
     showAwaitingSwapScreen: PropTypes.bool.isRequired,
     swapsFetchParams: PropTypes.object,
     swapsEnabled: PropTypes.bool,
-    isMainNet: PropTypes.bool,
+    isMainnet: PropTypes.bool,
   }
 
   state = {
@@ -272,7 +272,7 @@ export default class Home extends PureComponent {
       swapsWelcomeMessageHasBeenShown,
       setSwapsWelcomeMessageHasBeenShown,
       swapsEnabled,
-      isMainNet,
+      isMainnet,
     } = this.props
 
     if (forgottenPassword) {
@@ -286,7 +286,7 @@ export default class Home extends PureComponent {
         <Route path={CONNECTED_ROUTE} component={ConnectedSites} exact />
         <Route path={CONNECTED_ACCOUNTS_ROUTE} component={ConnectedAccounts} exact />
         <div className="home__container">
-          {!swapsWelcomeMessageHasBeenShown && swapsEnabled && isMainNet ? (
+          {!swapsWelcomeMessageHasBeenShown && swapsEnabled && isMainnet ? (
             <SwapsIntroPopup onClose={setSwapsWelcomeMessageHasBeenShown} />
           ) : null}
           { isPopup && !connectedStatusPopoverHasBeenShown ? this.renderPopover() : null }

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -74,7 +74,7 @@ const mapStateToProps = (state) => {
     haveSwapsQuotes: Boolean(Object.values(swapsState.quotes || {}).length),
     swapsFetchParams: swapsState.fetchParams,
     showAwaitingSwapScreen: swapsState.routeState === 'awaiting',
-    isMainNet: getIsMainnet(state),
+    isMainnet: getIsMainnet(state),
   }
 }
 

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -6,6 +6,7 @@ import {
   getCurrentEthBalance,
   getFirstPermissionRequest,
   getTotalUnapprovedCount,
+  getIsMainnet,
 } from '../../selectors'
 
 import {
@@ -73,6 +74,7 @@ const mapStateToProps = (state) => {
     haveSwapsQuotes: Boolean(Object.values(swapsState.quotes || {}).length),
     swapsFetchParams: swapsState.fetchParams,
     showAwaitingSwapScreen: swapsState.routeState === 'awaiting',
+    isMainNet: getIsMainnet(state),
   }
 }
 


### PR DESCRIPTION
If a user is on a testnet and then metamask updates to the version with swaps, they will be shown the intro-popover. If they click the submit button of that popover, they will will be taken to the swaps feature, even though it should be disable (and will not work) on a testnet. This PR ensures the popover is only shown once the user goes to mainnet.