### PR TITLE
Overflow primaryCurrency in tx-list-item & use primaryCurrency for tx breakdown details.

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1498,7 +1498,7 @@
   "speedUpTransaction": {
     "message": "Speed up this transaction"
   },
-  "spendingLimitAmount": {
+  "spendLimitAmount": {
     "message": "Spend limit amount"
   },
   "spendLimitInsufficient": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1498,6 +1498,9 @@
   "speedUpTransaction": {
     "message": "Speed up this transaction"
   },
+  "spendingLimitAmount": {
+    "message": "Spend limit amount"
+  },
   "spendLimitInsufficient": {
     "message": "Spend limit insufficient"
   },

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -51,7 +51,7 @@ export default class TransactionBreakdown extends PureComponent {
         <TransactionBreakdownRow
           title={
             isTokenApprove
-              ? t('spendingLimitAmount')
+              ? t('spendLimitAmount')
               : t('amount')
           }
         >

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -48,18 +48,15 @@ export default class TransactionBreakdown extends PureComponent {
             )
           }
         </TransactionBreakdownRow>
-        {isTokenApprove
-          ? (
-            <TransactionBreakdownRow title={t('spendingLimitAmount')}>
-              <span className="transaction-breakdown__value">{primaryCurrency}</span>
-            </TransactionBreakdownRow>
-          )
-          : (
-            <TransactionBreakdownRow title={t('amount')}>
-              <span className="transaction-breakdown__value">{primaryCurrency}</span>
-            </TransactionBreakdownRow>
-          )
-        }
+        <TransactionBreakdownRow
+          title={
+            isTokenApprove
+              ? t('spendingLimitAmount')
+              : t('amount')
+          }
+        >
+          <span className="transaction-breakdown__value">{primaryCurrency}</span>
+        </TransactionBreakdownRow>
         <TransactionBreakdownRow
           title={`${t('gasLimit')} (${t('units')})`}
           className="transaction-breakdown__row-title"

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -18,6 +18,7 @@ export default class TransactionBreakdown extends PureComponent {
     showFiat: PropTypes.bool,
     nonce: PropTypes.string,
     primaryCurrency: PropTypes.string,
+    isTokenApprove: PropTypes.bool,
     gas: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasUsed: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -30,7 +31,7 @@ export default class TransactionBreakdown extends PureComponent {
 
   render () {
     const { t } = this.context
-    const { gas, gasPrice, primaryCurrency, className, nonce, nativeCurrency, showFiat, totalInHex, gasUsed } = this.props
+    const { gas, gasPrice, primaryCurrency, className, nonce, nativeCurrency, showFiat, totalInHex, gasUsed, isTokenApprove } = this.props
     return (
       <div className={classnames('transaction-breakdown', className)}>
         <div className="transaction-breakdown__title">
@@ -47,9 +48,18 @@ export default class TransactionBreakdown extends PureComponent {
             )
           }
         </TransactionBreakdownRow>
-        <TransactionBreakdownRow title={t('amount')}>
-          <span className="transaction-breakdown__value">{primaryCurrency}</span>
-        </TransactionBreakdownRow>
+        {isTokenApprove
+          ? (
+            <TransactionBreakdownRow title={t('spendingLimitAmount')}>
+              <span className="transaction-breakdown__value">{primaryCurrency}</span>
+            </TransactionBreakdownRow>
+          )
+          : (
+            <TransactionBreakdownRow title={t('amount')}>
+              <span className="transaction-breakdown__value">{primaryCurrency}</span>
+            </TransactionBreakdownRow>
+          )
+        }
         <TransactionBreakdownRow
           title={`${t('gasLimit')} (${t('units')})`}
           className="transaction-breakdown__row-title"

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -20,7 +20,6 @@ export default class TransactionBreakdown extends PureComponent {
     primaryCurrency: PropTypes.string,
     gas: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasUsed: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     totalInHex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }
@@ -31,7 +30,7 @@ export default class TransactionBreakdown extends PureComponent {
 
   render () {
     const { t } = this.context
-    const { gas, gasPrice, primaryCurrency, className, nonce, nativeCurrency, showFiat, totalInHex, gasUsed, isTokenMethodAction } = this.props
+    const { gas, gasPrice, primaryCurrency, className, nonce, nativeCurrency, showFiat, totalInHex, gasUsed } = this.props
     return (
       <div className={classnames('transaction-breakdown', className)}>
         <div className="transaction-breakdown__title">

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -17,6 +17,7 @@ export default class TransactionBreakdown extends PureComponent {
     nativeCurrency: PropTypes.string,
     showFiat: PropTypes.bool,
     nonce: PropTypes.string,
+    primaryCurrency: PropTypes.string,
     gas: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -30,7 +31,7 @@ export default class TransactionBreakdown extends PureComponent {
 
   render () {
     const { t } = this.context
-    const { gas, gasPrice, value, className, nonce, nativeCurrency, showFiat, totalInHex, gasUsed } = this.props
+    const { gas, gasPrice, primaryCurrency, className, nonce, nativeCurrency, showFiat, totalInHex, gasUsed, isTokenMethodAction } = this.props
     return (
       <div className={classnames('transaction-breakdown', className)}>
         <div className="transaction-breakdown__title">
@@ -48,11 +49,7 @@ export default class TransactionBreakdown extends PureComponent {
           }
         </TransactionBreakdownRow>
         <TransactionBreakdownRow title={t('amount')}>
-          <UserPreferencedCurrencyDisplay
-            className="transaction-breakdown__value"
-            type={PRIMARY}
-            value={value}
-          />
+          <span className="transaction-breakdown__value">{primaryCurrency}</span>
         </TransactionBreakdownRow>
         <TransactionBreakdownRow
           title={`${t('gasLimit')} (${t('units')})`}

--- a/ui/app/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/app/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -2,13 +2,15 @@ import { connect } from 'react-redux'
 import { getIsMainnet, getNativeCurrency, getPreferences } from '../../../selectors'
 import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util'
 import { sumHexes } from '../../../helpers/utils/transactions.util'
+import { TOKEN_METHOD_APPROVE } from '../../../helpers/constants/transactions'
 import TransactionBreakdown from './transaction-breakdown.component'
 
 const mapStateToProps = (state, ownProps) => {
-  const { transaction } = ownProps
+  const { transaction, transactionCategory } = ownProps
   const { txParams: { gas, gasPrice, value } = {}, txReceipt: { gasUsed } = {} } = transaction
   const { showFiatInTestnets } = getPreferences(state)
   const isMainnet = getIsMainnet(state)
+  const isTokenApprove = transactionCategory === TOKEN_METHOD_APPROVE
 
   const gasLimit = typeof gasUsed === 'string' ? gasUsed : gas
 
@@ -21,8 +23,8 @@ const mapStateToProps = (state, ownProps) => {
     totalInHex,
     gas,
     gasPrice,
-    value,
     gasUsed,
+    isTokenApprove,
   }
 }
 

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -157,7 +157,7 @@ export default class TransactionListItemDetails extends PureComponent {
       onClose,
       recipientNickname,
     } = this.props
-    const { primaryTransaction: transaction } = transactionGroup
+    const { primaryTransaction: transaction, initialTransaction: { transactionCategory } } = transactionGroup
     const { hash } = transaction
 
     return (
@@ -253,6 +253,7 @@ export default class TransactionListItemDetails extends PureComponent {
             <div className="transaction-list-item-details__cards-container">
               <TransactionBreakdown
                 nonce={transactionGroup.initialTransaction.txParams.nonce}
+                transactionCategory={transactionCategory}
                 transaction={transaction}
                 primaryCurrency={primaryCurrency}
                 className="transaction-list-item-details__transaction-breakdown"

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import copyToClipboard from 'copy-to-clipboard'
 import {
   getBlockExplorerUrlForTx,
+  isTokenMethodAction,
 } from '../../../helpers/utils/transactions.util'
 import SenderToRecipient from '../../ui/sender-to-recipient'
 import { FLAT_VARIANT } from '../../ui/sender-to-recipient/sender-to-recipient.constants'
@@ -31,6 +32,7 @@ export default class TransactionListItemDetails extends PureComponent {
     showRetry: PropTypes.bool,
     isEarliestNonce: PropTypes.bool,
     cancelDisabled: PropTypes.bool,
+    primaryCurrency: PropTypes.string,
     transactionGroup: PropTypes.object,
     title: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -143,6 +145,7 @@ export default class TransactionListItemDetails extends PureComponent {
     const { justCopied } = this.state
     const {
       transactionGroup,
+      primaryCurrency,
       showSpeedUp,
       showRetry,
       recipientEns,
@@ -252,6 +255,7 @@ export default class TransactionListItemDetails extends PureComponent {
               <TransactionBreakdown
                 nonce={transactionGroup.initialTransaction.txParams.nonce}
                 transaction={transaction}
+                primaryCurrency={primaryCurrency}
                 className="transaction-list-item-details__transaction-breakdown"
               />
               <TransactionActivityLog

--- a/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/app/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import copyToClipboard from 'copy-to-clipboard'
 import {
   getBlockExplorerUrlForTx,
-  isTokenMethodAction,
 } from '../../../helpers/utils/transactions.util'
 import SenderToRecipient from '../../ui/sender-to-recipient'
 import { FLAT_VARIANT } from '../../ui/sender-to-recipient/sender-to-recipient.constants'

--- a/ui/app/components/app/transaction-list-item/index.scss
+++ b/ui/app/components/app/transaction-list-item/index.scss
@@ -1,6 +1,8 @@
 .transaction-list-item {
   &__primary-currency {
     color: $Black-100;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__secondary-currency {

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -158,6 +158,7 @@ export default function TransactionListItem ({ transactionGroup, isEarliestNonce
           title={title}
           onClose={toggleShowDetails}
           transactionGroup={transactionGroup}
+          primaryCurrency={primaryCurrency}
           senderAddress={senderAddress}
           recipientAddress={recipientAddress}
           onRetry={retryTransaction}

--- a/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/app/components/app/transaction-list-item/transaction-list-item.component.js
@@ -143,7 +143,7 @@ export default function TransactionListItem ({ transactionGroup, isEarliestNonce
         )}
         rightContent={!isSignatureReq && !isApproval && (
           <>
-            <h2 className="transaction-list-item__primary-currency">{primaryCurrency}</h2>
+            <h2 title={primaryCurrency} className="transaction-list-item__primary-currency">{primaryCurrency}</h2>
             <h3 className="transaction-list-item__secondary-currency">{secondaryCurrency}</h3>
           </>
         )}

--- a/ui/app/hooks/useTokenDisplayValue.js
+++ b/ui/app/hooks/useTokenDisplayValue.js
@@ -42,7 +42,7 @@ export function useTokenDisplayValue (transactionData, token, isTokenTransaction
       return null
     }
     const tokenValue = getTokenValueParam(tokenData)
-    return calcTokenAmount(tokenValue, token.decimals).toString()
+    return calcTokenAmount(tokenValue, token.decimals).toString(10)
   }, [shouldCalculateTokenValue, tokenData, token])
 
   return displayValue

--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -153,6 +153,7 @@ export function useTransactionDisplayData (transactionGroup) {
     primarySuffix = primaryTransaction.sourceTokenSymbol
   } else if (transactionCategory === TOKEN_METHOD_APPROVE) {
     category = TRANSACTION_CATEGORY_APPROVAL
+    prefix = ''
     title = t('approveSpendLimit', [token?.symbol || t('token')])
     subtitle = origin
     subtitleContainsOrigin = true


### PR DESCRIPTION
Fixes #9505 
Set result of calculated token to base 10 string. (Don't see/know if there are any adverse side effects of this change).
Swap out `value` in tx breakdown for `primaryCurrency` from tx-list-item for more consistent information. 
Overflow hide and text overflow ellipsis on tx-list-item `primaryCurrency` for extra long  

<details>
<summary>Before</summary>
<img src='https://user-images.githubusercontent.com/13376180/95570914-7aa4ae00-09dc-11eb-9321-a9c0b8b50ce8.png'>
</details>

<details>
<summary>After</summary>
<img src='https://user-images.githubusercontent.com/13376180/95570886-724c7300-09dc-11eb-8704-0e86cdae49b9.png'>
</details>

<details>
<summary>Long decimal Swapped Asset </summary>
<img src='https://user-images.githubusercontent.com/13376180/95573274-0cfa8100-09e0-11eb-8f70-ffd109e1179d.png'>
</details>

<details>
<summary>Approve spend limit</summary>
<img src='https://user-images.githubusercontent.com/13376180/95573512-6ebaeb00-09e0-11eb-851c-623e660c6741.png'>
</details>

The only question I had was on the tx detail/breakdown would it make sense to show the amount of approval in the screenshot above, in prod we just show `0 ETH` as the amount for approval of spend limit?
