### PR TITLE
Use initial transaction for settings swap transaction title params

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -366,11 +366,6 @@ export default class TransactionController extends EventEmitter {
       type: TRANSACTION_TYPE_CANCEL,
     })
 
-    if (originalTxMeta.transactionCategory === SWAP) {
-      newTxMeta.sourceTokenSymbol = originalTxMeta.sourceTokenSymbol
-      newTxMeta.destinationTokenSymbol = originalTxMeta.destinationTokenSymbol
-    }
-
     this.addTx(newTxMeta)
     await this.approveTransaction(newTxMeta.id)
     return newTxMeta

--- a/test/data/transaction-data.json
+++ b/test/data/transaction-data.json
@@ -512,6 +512,8 @@
         "value": "0xde0b6b3a7640000"
       },
       "hash": "0xbcb195f393f4468945b4045cd41bcdbc2f19ad75ae92a32cf153a3004e42009a",
+      "destinationTokenSymbol": "ABC",
+      "sourceTokenSymbol": "ETH",
       "transactionCategory": "swap"
     },
     "primaryTransaction": {

--- a/ui/app/components/app/transaction-list/transaction-list.component.js
+++ b/ui/app/components/app/transaction-list/transaction-list.component.js
@@ -29,8 +29,6 @@ const getTransactionGroupRecipientAddressFilter = (recipientAddress) => {
 const tokenTransactionFilter = ({
   initialTransaction: {
     transactionCategory,
-  },
-  primaryTransaction: {
     destinationTokenSymbol,
     sourceTokenSymbol,
   },

--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -133,14 +133,14 @@ export function useTransactionDisplayData (transactionGroup) {
   } else if (transactionCategory === SWAP) {
     category = TRANSACTION_CATEGORY_SWAP
     title = t('swapTokenToToken', [
-      primaryTransaction.sourceTokenSymbol,
-      primaryTransaction.destinationTokenSymbol,
+      initialTransaction.sourceTokenSymbol,
+      initialTransaction.destinationTokenSymbol,
     ])
     subtitle = origin
     subtitleContainsOrigin = true
     primarySuffix = isViewingReceivedTokenFromSwap
       ? currentAsset.symbol
-      : primaryTransaction.sourceTokenSymbol
+      : initialTransaction.sourceTokenSymbol
     primaryDisplayValue = swapTokenValue
     secondaryDisplayValue = swapTokenFiatAmount
     prefix = isViewingReceivedTokenFromSwap ? '+' : '-'


### PR DESCRIPTION
We need these params for correct title display in the activity list for a cancel transaction, but they will always be available on the `initialTransaction` so no need to set them on the cancel transaction. This PR updates the useTransactionDisplayData to support this change.