### PR TITLE
Fix localhost provider support

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -133,9 +133,9 @@ export default class TransactionController extends EventEmitter {
    *
    * @returns {number} The numerical chainId.
    */
-  getChainId () {
+  async getChainId () {
     const networkState = this.networkStore.getState()
-    const chainId = this._getCurrentChainId()
+    const chainId = await this._getCurrentChainId()
     const integerChainId = parseInt(chainId, 16)
     if (networkState === 'loading' || Number.isNaN(integerChainId)) {
       return 0
@@ -498,7 +498,7 @@ export default class TransactionController extends EventEmitter {
   async signTransaction (txId) {
     const txMeta = this.txStateManager.getTx(txId)
     // add network/chain id
-    const chainId = this.getChainId()
+    const chainId = await this.getChainId()
     const txParams = { ...txMeta.txParams, chainId }
     // sign tx
     const fromAddress = txParams.from

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -409,8 +409,8 @@ export default class MetamaskController extends EventEmitter {
       this.removeEventListener && this.removeEventListener('update', updatePublicConfigStore)
     }
 
-    function updatePublicConfigStore (memState) {
-      const chainId = networkController.getCurrentChainId()
+    async function updatePublicConfigStore (memState) {
+      const chainId = await networkController.getCurrentChainId()
       if (memState.network !== 'loading') {
         publicConfigStore.putState(selectPublicState(chainId, memState))
       }

--- a/test/unit/app/controllers/transactions/tx-controller-test.js
+++ b/test/unit/app/controllers/transactions/tx-controller-test.js
@@ -336,9 +336,9 @@ describe('Transaction Controller', function () {
   })
 
   describe('#getChainId', function () {
-    it('returns 0 when the chainId is NaN', function () {
+    it('returns 0 when the chainId is NaN', async function () {
       txController.networkStore = new ObservableStore('loading')
-      assert.equal(txController.getChainId(), 0)
+      assert.equal(await txController.getChainId(), 0)
     })
   })
 


### PR DESCRIPTION
### Superseded by #9551

Recent changes to the network controller broke support for providers of type `'localhost'` (i.e. "Localhost 8545") in the network dropdown.

This PR fixes our support for the `localhost` provider type by always getting the `chainId` for such networks by querying `eth_chainId`. `NetworkController.getCurrentChainId` is now an async function to support this.