### PR TITLE
Use networkVersion as the network state for all networks

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -123,7 +123,6 @@ export default class NetworkController extends EventEmitter {
       return
     }
 
-    const { type } = this.getProviderConfig()
     const chainId = this.getCurrentChainId()
     if (!chainId) {
       log.warn('NetworkController - lookupNetwork aborted due to missing chainId')
@@ -142,11 +141,7 @@ export default class NetworkController extends EventEmitter {
           return
         }
 
-        this.setNetworkState((
-          type === 'rpc'
-            ? chainId
-            : networkVersion
-        ))
+        this.setNetworkState(networkVersion)
       }
     })
   }


### PR DESCRIPTION
In #9487, we reverted to using the `networkVersion` as `state.metamask.network` for all provider types except `rpc`. This PR ensures that we're using `networkVersion` for all provider types, including `rpc`.

This ensures that we send the correct `networkVersion` to dapps for the `networkChanged` provider event.