### PR TITLE
Account for approval gas costs in eth received

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -484,11 +484,12 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     metaMetricsEvent({ ...metaMetricsConfig })
     metaMetricsEvent({ ...metaMetricsConfig, excludeMetaMetricsId: true, properties: swapMetaData })
 
+    let finalApproveTxMeta
     const approveTxParams = getApproveTxParams(state)
     if (approveTxParams) {
       const approveTxMeta = await dispatch(addUnapprovedTransaction({ ...approveTxParams, amount: '0x0' }, 'metamask'))
       await dispatch(setApproveTxId(approveTxMeta.id))
-      const finalApproveTxMeta = await (dispatch(updateTransaction({
+      finalApproveTxMeta = await (dispatch(updateTransaction({
         ...approveTxMeta,
         transactionCategory: SWAP_APPROVAL,
         sourceTokenSymbol: sourceTokenInfo.symbol,
@@ -513,6 +514,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       destinationTokenAddress: destinationTokenInfo.address,
       swapMetaData,
       swapTokenValue,
+      approvalTxId: finalApproveTxMeta?.id,
     }, true)))
     try {
       await dispatch(updateAndApproveTx(finalTradeTxMeta, true))

--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -102,6 +102,7 @@ export default function Swap () {
     destinationTokenInfo?.address,
     selectedAccountAddress,
     destinationTokenInfo?.decimals,
+    approveTxData,
   )
   const tradeConfirmed = tradeTxData?.status === 'confirmed'
   const approveError = approveTxData?.status === 'failed' || approveTxData?.txReceipt?.status === '0x0'


### PR DESCRIPTION
This PR fixes a bug where the render ETH received value from a swap does not account for the costs of an associated approval transaction if it exists.