### PR TITLE
Update migration 048

### DIFF
--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -22,13 +22,15 @@ export default {
   },
 }
 
+const inTest = process.env.IN_TEST === 'true'
+
 function transformState (state = {}) {
   // 1. Delete NetworkController.settings
   delete state.NetworkController?.settings
 
   // 2. Migrate NetworkController.provider to Rinkeby or rename rpcTarget key
   const providerType = state.NetworkController?.provider?.type
-  if (providerType === 'rpc' || providerType === 'localhost') {
+  if (!inTest && (providerType === 'rpc' || providerType === 'localhost')) {
     state.NetworkController.provider = {
       type: 'rinkeby',
       rpcUrl: '',

--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -8,6 +8,7 @@ const version = 48
  *     It will be re-set to Mainnet on background initialization.
  * 2b. Re-key provider.rpcTarget to provider.rpcUrl
  * 3.  Add localhost network to frequentRpcListDetail.
+ * 4.  Delete CachedBalancesController.cachedBalances
  */
 export default {
   version,
@@ -50,6 +51,9 @@ function transformState (state = {}) {
     nickname: 'Localhost 8545',
     rpcPrefs: {},
   })
+
+  // 4.  Delete CachedBalancesController.cachedBalances
+  delete state.CachedBalancesController?.cachedBalances
 
   return state
 }

--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -4,8 +4,8 @@ const version = 48
 
 /**
  * 1.  Delete NetworkController.settings
- * 2a. Delete NetworkController.provider if set to type 'rpc' or 'localhost'.
- *     It will be re-set to Mainnet on background initialization.
+ * 2a. Migrate NetworkController.provider to Rinkeby if set to type 'rpc' or
+ *     'localhost'.
  * 2b. Re-key provider.rpcTarget to provider.rpcUrl
  * 3.  Add localhost network to frequentRpcListDetail.
  * 4.  Delete CachedBalancesController.cachedBalances
@@ -25,10 +25,17 @@ function transformState (state = {}) {
   // 1. Delete NetworkController.settings
   delete state.NetworkController?.settings
 
-  // 2. Delete NetworkController.provider or rename rpcTarget key
+  // 2. Migrate NetworkController.provider to Rinkeby or rename rpcTarget key
   const providerType = state.NetworkController?.provider?.type
   if (providerType === 'rpc' || providerType === 'localhost') {
-    delete state.NetworkController.provider
+    state.NetworkController.provider = {
+      type: 'rinkeby',
+      rpcUrl: '',
+      chainId: '0x4',
+      nickname: '',
+      rpcPrefs: {},
+      ticker: 'ETH',
+    }
   } else if (state.NetworkController?.provider) {
     if ('rpcTarget' in state.NetworkController.provider) {
       const rpcUrl = state.NetworkController.provider.rpcTarget

--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -9,6 +9,7 @@ const version = 48
  * 2b. Re-key provider.rpcTarget to provider.rpcUrl
  * 3.  Add localhost network to frequentRpcListDetail.
  * 4.  Delete CachedBalancesController.cachedBalances
+ * 5.  Convert transactions metamaskNetworkId to decimal if they are hex
  */
 export default {
   version,
@@ -61,6 +62,21 @@ function transformState (state = {}) {
 
   // 4.  Delete CachedBalancesController.cachedBalances
   delete state.CachedBalancesController?.cachedBalances
+
+  // 5.  Convert transactions metamaskNetworkId to decimal if they are hex
+  const transactions = state.TransactionController?.transactions
+  if (Array.isArray(transactions)) {
+    transactions.forEach((transaction) => {
+      const metamaskNetworkId = transaction?.metamaskNetworkId
+      if (
+        typeof metamaskNetworkId === 'string' &&
+        (/^0x[0-9a-f]+$/ui).test(metamaskNetworkId)
+      ) {
+        transaction.metamaskNetworkId = parseInt(metamaskNetworkId, 16)
+          .toString(10)
+      }
+    })
+  }
 
   return state
 }

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -59,7 +59,7 @@ describe('migration #48', function () {
     })
   })
 
-  it('should delete NetworkController.provider if the type is "rpc"', async function () {
+  it('should migrate NetworkController.provider to Rinkeby if the type is "rpc"', async function () {
     const oldStorage = {
       meta: {},
       data: {
@@ -78,13 +78,21 @@ describe('migration #48', function () {
     assert.deepEqual(newStorage.data, {
       ...expectedPreferencesState,
       NetworkController: {
+        provider: {
+          type: 'rinkeby',
+          rpcUrl: '',
+          chainId: '0x4',
+          nickname: '',
+          rpcPrefs: {},
+          ticker: 'ETH',
+        },
         foo: 'bar',
       },
       foo: 'bar',
     })
   })
 
-  it('should delete NetworkController.provider if the type is "localhost"', async function () {
+  it('should migrate NetworkController.provider to Rinkeby if the type is "localhost"', async function () {
     const oldStorage = {
       meta: {},
       data: {
@@ -103,6 +111,14 @@ describe('migration #48', function () {
     assert.deepEqual(newStorage.data, {
       ...expectedPreferencesState,
       NetworkController: {
+        provider: {
+          type: 'rinkeby',
+          rpcUrl: '',
+          chainId: '0x4',
+          nickname: '',
+          rpcPrefs: {},
+          ticker: 'ETH',
+        },
         foo: 'bar',
       },
       foo: 'bar',

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -59,13 +59,14 @@ describe('migration #48', function () {
     })
   })
 
-  it('should migrate NetworkController.provider to Rinkeby if the type is "rpc"', async function () {
+  it('should migrate NetworkController.provider to Rinkeby if the type is "rpc" and the chainId is invalid (1)', async function () {
     const oldStorage = {
       meta: {},
       data: {
         NetworkController: {
           provider: {
             type: 'rpc',
+            chainId: 'foo',
             fizz: 'buzz',
           },
           foo: 'bar',
@@ -85,6 +86,71 @@ describe('migration #48', function () {
           nickname: '',
           rpcPrefs: {},
           ticker: 'ETH',
+        },
+        foo: 'bar',
+      },
+      foo: 'bar',
+    })
+  })
+
+  it('should migrate NetworkController.provider to Rinkeby if the type is "rpc" and the chainId is invalid (2)', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        NetworkController: {
+          provider: {
+            type: 'rpc',
+            chainId: '0x01',
+            fizz: 'buzz',
+          },
+          foo: 'bar',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      NetworkController: {
+        provider: {
+          type: 'rinkeby',
+          rpcUrl: '',
+          chainId: '0x4',
+          nickname: '',
+          rpcPrefs: {},
+          ticker: 'ETH',
+        },
+        foo: 'bar',
+      },
+      foo: 'bar',
+    })
+  })
+
+  it('should not migrate NetworkController.provider to Rinkeby if the type is "rpc" and the chainId is valid', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        NetworkController: {
+          provider: {
+            type: 'rpc',
+            chainId: '0x1',
+            fizz: 'buzz',
+          },
+          foo: 'bar',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      NetworkController: {
+        provider: {
+          type: 'rpc',
+          chainId: '0x1',
+          fizz: 'buzz',
         },
         foo: 'bar',
       },

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -189,4 +189,32 @@ describe('migration #48', function () {
       foo: 'bar',
     })
   })
+
+  it('should delete CachedBalancesController.cachedBalances', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        CachedBalancesController: {
+          cachedBalances: {
+            fizz: 'buzz',
+          },
+          bar: {
+            baz: 'buzz',
+          },
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      CachedBalancesController: {
+        bar: {
+          baz: 'buzz',
+        },
+      },
+      foo: 'bar',
+    })
+  })
 })

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -233,4 +233,53 @@ describe('migration #48', function () {
       foo: 'bar',
     })
   })
+
+  it('should convert hex transaction metamaskNetworkId values to decimal', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        TransactionController: {
+          transactions: [
+            { fizz: 'buzz' },
+            null,
+            undefined,
+            0,
+            '',
+            { foo: 'bar', metamaskNetworkId: '1' },
+            { foo: 'bar', metamaskNetworkId: '0x1' },
+            { foo: 'bar', metamaskNetworkId: 'kaplar' },
+            { foo: 'bar', metamaskNetworkId: '0X2a' },
+            { foo: 'bar', metamaskNetworkId: '3' },
+          ],
+          bar: {
+            baz: 'buzz',
+          },
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      TransactionController: {
+        transactions: [
+          { fizz: 'buzz' },
+          null,
+          undefined,
+          0,
+          '',
+          { foo: 'bar', metamaskNetworkId: '1' },
+          { foo: 'bar', metamaskNetworkId: '1' },
+          { foo: 'bar', metamaskNetworkId: 'kaplar' },
+          { foo: 'bar', metamaskNetworkId: '42' },
+          { foo: 'bar', metamaskNetworkId: '3' },
+        ],
+        bar: {
+          baz: 'buzz',
+        },
+      },
+      foo: 'bar',
+    })
+  })
 })


### PR DESCRIPTION
This PR makes the following changes/additions to migration 048:
- Delete `CachedBalancesController.cachedBalances`
- Replace `NetworkController.provider` with Rinkeby data, so the user get kicked to Rinkeby instead of Mainnet
  - But, don't kick custom RPC users to Rinkeby unnecessarily
- Migrate hex transactions `metamaskNetworkId` values to decimal