### PR TITLE
Prevent undefined class from being added to Tabs

### DIFF
--- a/ui/app/components/ui/tabs/tab/tab.component.js
+++ b/ui/app/components/ui/tabs/tab/tab.component.js
@@ -20,7 +20,7 @@ const Tab = (props) => {
         className,
         {
           'tab--active': isActive,
-          [activeClassName]: isActive,
+          [activeClassName]: activeClassName && isActive,
         },
       )}
       data-testid={dataTestId}


### PR DESCRIPTION
I noticed an `undefined` class being applied to the "Customize Gas"'s "Basic" tab, and wanted to prevent it.