### PR TITLE
Fix migration 048 chainId conversion

### DIFF
--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -92,7 +92,18 @@ function transformState (state = {}) {
   const addressBook = state.AddressBookController?.addressBook || {}
   Object.keys(addressBook).forEach((networkKey) => {
     if ((/^\d+$/ui).test(networkKey)) {
-      const chainId = `0x${networkKey.toString(16)}`
+      let chainId
+      try {
+        const parsedChainId = parseInt(networkKey, 10).toString(16)
+
+        if (Number.isNaN(parsedChainId)) {
+          return
+        }
+        chainId = `0x${parsedChainId}`
+      } catch (_) {
+        return
+      }
+
       updateChainIds(addressBook[networkKey], chainId)
 
       if (addressBook[chainId]) {

--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -92,18 +92,7 @@ function transformState (state = {}) {
   const addressBook = state.AddressBookController?.addressBook || {}
   Object.keys(addressBook).forEach((networkKey) => {
     if ((/^\d+$/ui).test(networkKey)) {
-      let chainId
-      try {
-        const parsedChainId = parseInt(networkKey, 10).toString(16)
-
-        if (Number.isNaN(parsedChainId)) {
-          return
-        }
-        chainId = `0x${parsedChainId}`
-      } catch (_) {
-        return
-      }
-
+      const chainId = `0x${parseInt(networkKey, 10).toString(16)}`
       updateChainIds(addressBook[networkKey], chainId)
 
       if (addressBook[chainId]) {

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -237,8 +237,8 @@ describe('migration #48', function () {
 
     const newStorage = await migration48.migrate(oldStorage)
     assert.deepEqual(
-      { ...oldStorage.data, ...expectedPreferencesState },
-      { ...newStorage.data, ...expectedPreferencesState },
+      { ...expectedPreferencesState, ...oldStorage.data },
+      { ...expectedPreferencesState, ...newStorage.data },
     )
   })
 
@@ -361,6 +361,12 @@ describe('migration #48', function () {
                 foo: 'bar',
               },
             },
+            '100': {
+              'address1': {
+                chainId: '100',
+                foo: 'bar',
+              },
+            },
             '0x2': {
               'address2': {
                 chainId: '0x2',
@@ -384,6 +390,12 @@ describe('migration #48', function () {
           '0x1': {
             'address1': {
               chainId: '0x1',
+              foo: 'bar',
+            },
+          },
+          '0x64': {
+            'address1': {
+              chainId: '0x64',
               foo: 'bar',
             },
           },


### PR DESCRIPTION
This ensures that the `chainId` conversion in conversion 048 correctly converts decimal number strings to hexadecimal number strings.