### PR TITLE
Delete localhost state from incoming transactions controller

### DIFF
--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -11,6 +11,7 @@ const version = 48
  * 4.  Delete CachedBalancesController.cachedBalances
  * 5.  Convert transactions metamaskNetworkId to decimal if they are hex
  * 6.  Convert address book keys from decimal to hex
+ * 7.  Delete localhost key in IncomingTransactionsController
  */
 export default {
   version,
@@ -103,6 +104,11 @@ function transformState (state = {}) {
       delete addressBook[networkKey]
     }
   })
+
+  // 7.  Delete localhost key in IncomingTransactionsController
+  delete state.IncomingTransactionsController
+    ?.incomingTxLastFetchedBlocksByNetwork
+    ?.localhost
 
   return state
 }

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -518,4 +518,61 @@ describe('migration #48', function () {
       foo: 'bar',
     })
   })
+
+  it('should delete localhost key in IncomingTransactionsController', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        IncomingTransactionsController: {
+          incomingTxLastFetchedBlocksByNetwork: {
+            fizz: 'buzz',
+            localhost: {},
+          },
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      IncomingTransactionsController: {
+        incomingTxLastFetchedBlocksByNetwork: {
+          fizz: 'buzz',
+        },
+        bar: 'baz',
+      },
+      foo: 'bar',
+    })
+  })
+
+  it('should not modify IncomingTransactionsController state if affected key is missing', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        IncomingTransactionsController: {
+          incomingTxLastFetchedBlocksByNetwork: {
+            fizz: 'buzz',
+            rpc: {},
+          },
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      IncomingTransactionsController: {
+        incomingTxLastFetchedBlocksByNetwork: {
+          fizz: 'buzz',
+          rpc: {},
+        },
+        bar: 'baz',
+      },
+      foo: 'bar',
+    })
+  })
 })


### PR DESCRIPTION
The `IncomingTransactionsController` had some leftover state keyed by the `localhost` provider type that's no longer relevant. This PR deletes this state in a migration.