### PR TITLE
Migrate 'localhost' tokens

### DIFF
--- a/app/scripts/migrations/048.js
+++ b/app/scripts/migrations/048.js
@@ -11,6 +11,7 @@ const version = 48
  * 4.  Delete CachedBalancesController.cachedBalances
  * 5.  Convert transactions metamaskNetworkId to decimal if they are hex
  * 6.  Convert address book keys from decimal to hex
+ * 7.  Delete localhost key in IncomingTransactionsController
  */
 export default {
   version,
@@ -103,6 +104,11 @@ function transformState (state = {}) {
       delete addressBook[networkKey]
     }
   })
+
+  // 7.  Delete localhost key in IncomingTransactionsController
+  delete state.IncomingTransactionsController
+    ?.incomingTxLastFetchedBlocksByNetwork
+    ?.localhost
 
   return state
 }

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -518,4 +518,61 @@ describe('migration #48', function () {
       foo: 'bar',
     })
   })
+
+  it('should delete localhost key in IncomingTransactionsController', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        IncomingTransactionsController: {
+          incomingTxLastFetchedBlocksByNetwork: {
+            fizz: 'buzz',
+            localhost: {},
+          },
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      IncomingTransactionsController: {
+        incomingTxLastFetchedBlocksByNetwork: {
+          fizz: 'buzz',
+        },
+        bar: 'baz',
+      },
+      foo: 'bar',
+    })
+  })
+
+  it('should not modify IncomingTransactionsController state if affected key is missing', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        IncomingTransactionsController: {
+          incomingTxLastFetchedBlocksByNetwork: {
+            fizz: 'buzz',
+            rpc: {},
+          },
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      ...expectedPreferencesState,
+      IncomingTransactionsController: {
+        incomingTxLastFetchedBlocksByNetwork: {
+          fizz: 'buzz',
+          rpc: {},
+        },
+        bar: 'baz',
+      },
+      foo: 'bar',
+    })
+  })
 })

--- a/test/unit/migrations/048-test.js
+++ b/test/unit/migrations/048-test.js
@@ -575,4 +575,62 @@ describe('migration #48', function () {
       foo: 'bar',
     })
   })
+
+  it('should merge localhost token list into rpc token list', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          accountTokens: {
+            address1: {
+              localhost: [
+                { address: '1', data1: 'stuff1' },
+                { address: '2', a: 'X', b: 'B' },
+              ],
+              rpc: [
+                { address: '2', a: 'A', c: 'C' },
+                { address: '3', data3: 'stuff3' },
+              ],
+              foo: [],
+            },
+            address2: {
+              localhost: [],
+              rpc: [],
+              foo: [],
+            },
+            address3: {},
+          },
+          bar: 'baz',
+        },
+        foo: 'bar',
+      },
+    }
+
+    const newStorage = await migration48.migrate(oldStorage)
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        accountTokens: {
+          address1: {
+            rpc: [
+              { address: '1', data1: 'stuff1' },
+              { address: '2', a: 'A', b: 'B', c: 'C' },
+              { address: '3', data3: 'stuff3' },
+            ],
+            foo: [],
+          },
+          address2: {
+            rpc: [],
+            foo: [],
+          },
+          address3: {},
+        },
+        bar: 'baz',
+        // from other migration
+        frequentRpcListDetail: [{
+          ...localhostNetwork,
+        }],
+      },
+      foo: 'bar',
+    })
+  })
 })


### PR DESCRIPTION
`PreferencesController.accountTokens` is an object of account addresses keyed to object values, which in turn consist of provider type name strings keyed to arrays of token objects. For example:

```
PreferencesController: {
  accountTokens: {
    '0xabc': {
      localhost: [ /* token objects */ ],
      rpc: [ /* token objects */ ],
    },
  },
}
```

The `localhost` provider type has been removed, and those tokens will be orphaned unless they are migrated. This PR merged the `rpc` token arrays with the `localhost` token arrays, preferring the token objects in the `rpc` array over those of `localhost`.

Eventually, we will want to store the tokens by `chainId` instead of provider type, and ideally duplicate them. Until then, however, this is all we can do to avoid orphaning the `localhost` tokens.