### PR TITLE
Add data point to 'Swaps Completed' segment event: estimated vs used gas

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -860,7 +860,7 @@ export default class TransactionController extends EventEmitter {
 
         const estimatedVsUsedGasRatio = `${
           (new BigNumber(txMeta.txReceipt.gasUsed, 16))
-            .div(txMeta.swapMetaData.estimatedGas, 10)
+            .div(txMeta.swapMetaData.estimated_gas, 10)
             .times(100)
             .round(2)
         }%`

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -858,6 +858,13 @@ export default class TransactionController extends EventEmitter {
             .round(2)
         }%`
 
+        const estimatedVsUsedGasRatio = `${
+          (new BigNumber(txMeta.txReceipt.gasUsed, 16))
+            .div(txMeta.swapMetaData.estimatedGas, 10)
+            .times(100)
+            .round(2)
+        }%`
+
         this._trackSegmentEvent({
           event: 'Swap Completed',
           category: 'swaps',
@@ -871,6 +878,7 @@ export default class TransactionController extends EventEmitter {
             ...txMeta.swapMetaData,
             token_to_amount_received: tokensReceived,
             quote_vs_executionRatio: quoteVsExecutionRatio,
+            estimated_vs_used_gasRatio: estimatedVsUsedGasRatio,
           },
           excludeMetaMetricsId: true,
         })

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -860,7 +860,7 @@ export default class TransactionController extends EventEmitter {
 
         const estimatedVsUsedGasRatio = `${
           (new BigNumber(txMeta.txReceipt.gasUsed, 16))
-            .div(txMeta.swapMetaData.estimated_gas, 10)
+            .div(txMeta.swapMetaData.estimated_gas, 16)
             .times(100)
             .round(2)
         }%`

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -474,7 +474,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       other_quote_selected: usedQuote.aggregator !== getTopQuote(state)?.aggregator,
       other_quote_selected_source: usedQuote.aggregator === getTopQuote(state)?.aggregator ? '' : usedQuote.aggregator,
       gas_fees: formatCurrency(gasEstimateTotalInEth, 'usd')?.slice(1),
-      estimated_gas: estimatedGasLimit,
+      estimated_gas: estimatedGasLimit.toString(16),
     }
 
     const metaMetricsConfig = {

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -474,6 +474,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       other_quote_selected: usedQuote.aggregator !== getTopQuote(state)?.aggregator,
       other_quote_selected_source: usedQuote.aggregator === getTopQuote(state)?.aggregator ? '' : usedQuote.aggregator,
       gas_fees: formatCurrency(gasEstimateTotalInEth, 'usd')?.slice(1),
+      estimated_gas: estimatedGasLimit,
     }
 
     const metaMetricsConfig = {
@@ -486,7 +487,8 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
 
     let finalApproveTxMeta
     const approveTxParams = getApproveTxParams(state)
-    if (approveTxParams) {
+    if (approveTxParams
+    ) {
       const approveTxMeta = await dispatch(addUnapprovedTransaction({ ...approveTxParams, amount: '0x0' }, 'metamask'))
       await dispatch(setApproveTxId(approveTxMeta.id))
       finalApproveTxMeta = await (dispatch(updateTransaction({

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -487,8 +487,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
 
     let finalApproveTxMeta
     const approveTxParams = getApproveTxParams(state)
-    if (approveTxParams
-    ) {
+    if (approveTxParams) {
       const approveTxMeta = await dispatch(addUnapprovedTransaction({ ...approveTxParams, amount: '0x0' }, 'metamask'))
       await dispatch(setApproveTxId(approveTxMeta.id))
       finalApproveTxMeta = await (dispatch(updateTransaction({


### PR DESCRIPTION
An addition to our analytics. Records estimatedGas, and the ratio between estimated gas and gas used (as per the tx receipt), with the 'Swaps Completed' event.