### PR TITLE
Use `chainId` in account tracker

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -14,7 +14,7 @@ import log from 'loglevel'
 import pify from 'pify'
 import Web3 from 'web3'
 import SINGLE_CALL_BALANCES_ABI from 'single-call-balance-checker-abi'
-import { MAINNET_NETWORK_ID, RINKEBY_NETWORK_ID, ROPSTEN_NETWORK_ID, KOVAN_NETWORK_ID } from '../controllers/network/enums'
+import { MAINNET_CHAIN_ID, RINKEBY_CHAIN_ID, ROPSTEN_CHAIN_ID, KOVAN_CHAIN_ID } from '../controllers/network/enums'
 
 import {
   SINGLE_CALL_BALANCES_ADDRESS,
@@ -61,7 +61,7 @@ export default class AccountTracker {
     })
     // bind function for easier listener syntax
     this._updateForBlock = this._updateForBlock.bind(this)
-    this.network = opts.network
+    this.getCurrentChainId = opts.getCurrentChainId
 
     this.web3 = new Web3(this._provider)
   }
@@ -196,22 +196,23 @@ export default class AccountTracker {
   async _updateAccounts () {
     const { accounts } = this.store.getState()
     const addresses = Object.keys(accounts)
-    const currentNetwork = this.network.getNetworkState()
+    const chainId = this.getCurrentChainId()
 
-    switch (currentNetwork) {
-      case MAINNET_NETWORK_ID.toString():
+    // TODO: use chain ID
+    switch (chainId) {
+      case MAINNET_CHAIN_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS)
         break
 
-      case RINKEBY_NETWORK_ID.toString():
+      case RINKEBY_CHAIN_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY)
         break
 
-      case ROPSTEN_NETWORK_ID.toString():
+      case ROPSTEN_CHAIN_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN)
         break
 
-      case KOVAN_NETWORK_ID.toString():
+      case KOVAN_CHAIN_ID.toString():
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_KOVAN)
         break
 

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -198,21 +198,20 @@ export default class AccountTracker {
     const addresses = Object.keys(accounts)
     const chainId = this.getCurrentChainId()
 
-    // TODO: use chain ID
     switch (chainId) {
-      case MAINNET_CHAIN_ID.toString():
+      case MAINNET_CHAIN_ID:
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS)
         break
 
-      case RINKEBY_CHAIN_ID.toString():
+      case RINKEBY_CHAIN_ID:
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY)
         break
 
-      case ROPSTEN_CHAIN_ID.toString():
+      case ROPSTEN_CHAIN_ID:
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN)
         break
 
-      case KOVAN_CHAIN_ID.toString():
+      case KOVAN_CHAIN_ID:
         await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_KOVAN)
         break
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -168,7 +168,7 @@ export default class MetamaskController extends EventEmitter {
     this.accountTracker = new AccountTracker({
       provider: this.provider,
       blockTracker: this.blockTracker,
-      network: this.networkController,
+      getCurrentChainId: this.networkController.getCurrentChainId.bind(this.networkController),
     })
 
     // start and stop polling for balances based on activeControllerConnections


### PR DESCRIPTION
The `chainId` is now used by the account tracker to identify the current network, instead of the `networkId`. This should have no
functional impact, aside from that different chains with the same `networkId` will now be correctly distinguished from each other.