### PR TITLE
Ensure proper hover display for accounts in main menu

### DIFF
--- a/ui/app/components/app/account-menu/account-menu.component.js
+++ b/ui/app/components/app/account-menu/account-menu.component.js
@@ -179,7 +179,7 @@ export default class AccountMenu extends Component {
 
       return (
         <div
-          className="account-menu__account menu__item--clickable"
+          className="account-menu__account account-menu__item--clickable"
           onClick={() => {
             this.context.metricsEvent({
               eventOpts: {

--- a/ui/app/components/app/account-menu/tests/account-menu.test.js
+++ b/ui/app/components/app/account-menu/tests/account-menu.test.js
@@ -88,7 +88,7 @@ describe('Account Menu', function () {
     })
 
     it('simulate click', function () {
-      const click = wrapper.find('.account-menu__account.menu__item--clickable')
+      const click = wrapper.find('.account-menu__account.account-menu__item--clickable')
       click.first().simulate('click')
 
       assert(props.showAccountDetail.calledOnce)


### PR DESCRIPTION
I noticed that the account items in the top dropdown weren't showing a pointer cursor or hover background, so I fixed it.

<img width="438" alt="Hover" src="https://user-images.githubusercontent.com/46655/95884407-acea3e80-0d41-11eb-8a0a-9ee3580d2822.png">
