### PR TITLE
Autofocus the appropriate text fields in the Create/Import/Hardware screen

### DIFF
--- a/ui/app/pages/create-account/import-account/private-key.js
+++ b/ui/app/pages/create-account/import-account/private-key.js
@@ -91,6 +91,7 @@ class PrivateKeyImportView extends Component {
             onKeyPress={(e) => this.createKeyringOnEnter(e)}
             onChange={() => this.checkInputEmpty()}
             ref={this.inputRef}
+            autoFocus
           />
         </div>
         <div className="new-account-import-form__buttons">

--- a/ui/app/pages/create-account/new-account.component.js
+++ b/ui/app/pages/create-account/new-account.component.js
@@ -54,6 +54,7 @@ export default class NewAccountCreateForm extends Component {
             value={newAccountName}
             placeholder={defaultAccountName}
             onChange={(event) => this.setState({ newAccountName: event.target.value })}
+            autoFocus
           />
           <div className="new-account-create-form__buttons">
             <Button


### PR DESCRIPTION
Another usability win for creating and importing accounts -- focusing on the likely input field.

<img width="387" alt="MoreMoreAuto" src="https://user-images.githubusercontent.com/46655/95887332-52eb7800-0d45-11eb-82df-47b28b1ef944.png">
<img width="393" alt="MoreAutofocus" src="https://user-images.githubusercontent.com/46655/95887335-541ca500-0d45-11eb-97bd-4c147c2cb15d.png">
