### PR TITLE
Use `chainId` for incoming transactions controller

### DIFF
--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -6,12 +6,18 @@ import { bnToHex } from '../lib/util'
 import fetchWithTimeout from '../lib/fetch-with-timeout'
 
 import {
-  ROPSTEN,
-  RINKEBY,
-  KOVAN,
+  CHAIN_ID_TO_NETWORK_ID_MAP,
+  CHAIN_ID_TO_TYPE_MAP,
   GOERLI,
+  GOERLI_CHAIN_ID,
+  KOVAN,
+  KOVAN_CHAIN_ID,
   MAINNET,
-  NETWORK_TYPE_TO_ID_MAP,
+  MAINNET_CHAIN_ID,
+  RINKEBY,
+  RINKEBY_CHAIN_ID,
+  ROPSTEN,
+  ROPSTEN_CHAIN_ID,
 } from './network/enums'
 
 const fetch = fetchWithTimeout({
@@ -25,6 +31,14 @@ const fetch = fetchWithTimeout({
  * Note that only the built-in Infura networks are supported (i.e. anything in `INFURA_PROVIDER_TYPES`). We will not
  * attempt to retrieve incoming transactions on any custom RPC endpoints.
  */
+const etherscanSupportedNetworks = [
+  GOERLI_CHAIN_ID,
+  KOVAN_CHAIN_ID,
+  MAINNET_CHAIN_ID,
+  RINKEBY_CHAIN_ID,
+  ROPSTEN_CHAIN_ID,
+]
+
 export default class IncomingTransactionsController {
 
   constructor (opts = {}) {
@@ -36,7 +50,6 @@ export default class IncomingTransactionsController {
     this.blockTracker = blockTracker
     this.networkController = networkController
     this.preferencesController = preferencesController
-    this.getCurrentNetwork = () => networkController.getProviderConfig().type
 
     this._onLatestBlock = async (newBlockNumberHex) => {
       const selectedAddress = this.preferencesController.getSelectedAddress()
@@ -50,11 +63,11 @@ export default class IncomingTransactionsController {
     const initState = {
       incomingTransactions: {},
       incomingTxLastFetchedBlocksByNetwork: {
-        [ROPSTEN]: null,
-        [RINKEBY]: null,
-        [KOVAN]: null,
         [GOERLI]: null,
+        [KOVAN]: null,
         [MAINNET]: null,
+        [RINKEBY]: null,
+        [ROPSTEN]: null,
       }, ...opts.initState,
     }
     this.store = new ObservableStore(initState)
@@ -88,11 +101,10 @@ export default class IncomingTransactionsController {
       })
     }))
 
-    this.networkController.on('networkDidChange', async (newType) => {
+    this.networkController.on('networkDidChange', async () => {
       const address = this.preferencesController.getSelectedAddress()
       await this._update({
         address,
-        networkType: newType,
       })
     })
   }
@@ -113,29 +125,32 @@ export default class IncomingTransactionsController {
     this.blockTracker.removeListener('latest', this._onLatestBlock)
   }
 
-  async _update ({ address, newBlockNumberDec, networkType } = {}) {
+  async _update ({ address, newBlockNumberDec } = {}) {
+    const chainId = this.networkController.getCurrentChainId()
+    if (!etherscanSupportedNetworks.includes(chainId)) {
+      return
+    }
     try {
-      const dataForUpdate = await this._getDataForUpdate({ address, newBlockNumberDec, networkType })
-      await this._updateStateWithNewTxData(dataForUpdate)
+      const dataForUpdate = await this._getDataForUpdate({ address, chainId, newBlockNumberDec })
+      this._updateStateWithNewTxData(dataForUpdate)
     } catch (err) {
       log.error(err)
     }
   }
 
-  async _getDataForUpdate ({ address, newBlockNumberDec, networkType } = {}) {
+  async _getDataForUpdate ({ address, chainId, newBlockNumberDec } = {}) {
     const {
       incomingTransactions: currentIncomingTxs,
       incomingTxLastFetchedBlocksByNetwork: currentBlocksByNetwork,
     } = this.store.getState()
 
-    const network = networkType || this.getCurrentNetwork()
-    const lastFetchBlockByCurrentNetwork = currentBlocksByNetwork[network]
+    const lastFetchBlockByCurrentNetwork = currentBlocksByNetwork[CHAIN_ID_TO_TYPE_MAP[chainId]]
     let blockToFetchFrom = lastFetchBlockByCurrentNetwork || newBlockNumberDec
     if (blockToFetchFrom === undefined) {
       blockToFetchFrom = parseInt(this.blockTracker.getCurrentBlock(), 16)
     }
 
-    const { latestIncomingTxBlockNumber, txs: newTxs } = await this._fetchAll(address, blockToFetchFrom, network)
+    const { latestIncomingTxBlockNumber, txs: newTxs } = await this._fetchAll(address, blockToFetchFrom, chainId)
 
     return {
       latestIncomingTxBlockNumber,
@@ -143,17 +158,17 @@ export default class IncomingTransactionsController {
       currentIncomingTxs,
       currentBlocksByNetwork,
       fetchedBlockNumber: blockToFetchFrom,
-      network,
+      chainId,
     }
   }
 
-  async _updateStateWithNewTxData ({
+  _updateStateWithNewTxData ({
     latestIncomingTxBlockNumber,
     newTxs,
     currentIncomingTxs,
     currentBlocksByNetwork,
     fetchedBlockNumber,
-    network,
+    chainId,
   }) {
     const newLatestBlockHashByNetwork = latestIncomingTxBlockNumber
       ? parseInt(latestIncomingTxBlockNumber, 10) + 1
@@ -168,28 +183,22 @@ export default class IncomingTransactionsController {
     this.store.updateState({
       incomingTxLastFetchedBlocksByNetwork: {
         ...currentBlocksByNetwork,
-        [network]: newLatestBlockHashByNetwork,
+        [CHAIN_ID_TO_TYPE_MAP[chainId]]: newLatestBlockHashByNetwork,
       },
       incomingTransactions: newIncomingTransactions,
     })
   }
 
-  async _fetchAll (address, fromBlock, networkType) {
-    const fetchedTxResponse = await this._fetchTxs(address, fromBlock, networkType)
+  async _fetchAll (address, fromBlock, chainId) {
+    const fetchedTxResponse = await this._fetchTxs(address, fromBlock, chainId)
     return this._processTxFetchResponse(fetchedTxResponse)
   }
 
-  async _fetchTxs (address, fromBlock, networkType) {
-    let etherscanSubdomain = 'api'
-    const currentNetworkID = NETWORK_TYPE_TO_ID_MAP[networkType]?.networkId
+  async _fetchTxs (address, fromBlock, chainId) {
+    const etherscanSubdomain = chainId === MAINNET_CHAIN_ID
+      ? 'api'
+      : `api-${CHAIN_ID_TO_TYPE_MAP[chainId]}`
 
-    if (!currentNetworkID) {
-      return {}
-    }
-
-    if (networkType !== MAINNET) {
-      etherscanSubdomain = `api-${networkType}`
-    }
     const apiUrl = `https://${etherscanSubdomain}.etherscan.io`
     let url = `${apiUrl}/api?module=account&action=txlist&address=${address}&tag=latest&page=1`
 
@@ -202,17 +211,17 @@ export default class IncomingTransactionsController {
     return {
       ...parsedResponse,
       address,
-      currentNetworkID,
+      chainId,
     }
   }
 
-  _processTxFetchResponse ({ status, result = [], address, currentNetworkID }) {
+  _processTxFetchResponse ({ status, result = [], address, chainId }) {
     if (status === '1' && Array.isArray(result) && result.length > 0) {
       const remoteTxList = {}
       const remoteTxs = []
       result.forEach((tx) => {
         if (!remoteTxList[tx.hash]) {
-          remoteTxs.push(this._normalizeTxFromEtherscan(tx, currentNetworkID))
+          remoteTxs.push(this._normalizeTxFromEtherscan(tx, chainId))
           remoteTxList[tx.hash] = 1
         }
       })
@@ -241,13 +250,13 @@ export default class IncomingTransactionsController {
     }
   }
 
-  _normalizeTxFromEtherscan (txMeta, currentNetworkID) {
+  _normalizeTxFromEtherscan (txMeta, chainId) {
     const time = parseInt(txMeta.timeStamp, 10) * 1000
     const status = txMeta.isError === '0' ? 'confirmed' : 'failed'
     return {
       blockNumber: txMeta.blockNumber,
       id: createId(),
-      metamaskNetworkId: currentNetworkID,
+      metamaskNetworkId: CHAIN_ID_TO_NETWORK_ID_MAP[chainId],
       status,
       time,
       txParams: {

--- a/app/scripts/controllers/network/enums.js
+++ b/app/scripts/controllers/network/enums.js
@@ -57,3 +57,21 @@ export const NETWORK_TO_NAME_MAP = {
   [GOERLI_CHAIN_ID]: GOERLI_DISPLAY_NAME,
   [MAINNET_CHAIN_ID]: MAINNET_DISPLAY_NAME,
 }
+
+export const CHAIN_ID_TO_TYPE_MAP = Object.entries(NETWORK_TYPE_TO_ID_MAP)
+  .reduce(
+    (chainIdToTypeMap, [networkType, { chainId }]) => {
+      chainIdToTypeMap[chainId] = networkType
+      return chainIdToTypeMap
+    },
+    {},
+  )
+
+export const CHAIN_ID_TO_NETWORK_ID_MAP = Object.values(NETWORK_TYPE_TO_ID_MAP)
+  .reduce(
+    (chainIdToNetworkIdMap, { chainId, networkId }) => {
+      chainIdToNetworkIdMap[chainId] = networkId
+      return chainIdToNetworkIdMap
+    },
+    {},
+  )


### PR DESCRIPTION
The incoming transactions controller now uses the `chainId` for the current network instead of the `networkId`. This ensures that custom RPC endpoints for the built-in supported networks do correctly receive incoming transactions.

As part of this change, the incoming transactions controller will also cease keeping track of the "last block fetched" for networks that are not supported. This piece of state never really represented the last block fetched, as _no_ blocks were fetched for any such networks. It been removed.