### PR TITLE
Update `setRpcTarget` parameter name

### DIFF
--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -34,8 +34,8 @@ function mapDispatchToProps (dispatch) {
     setProviderType: (type) => {
       dispatch(actions.setProviderType(type))
     },
-    setRpcTarget: (target, network, ticker, nickname) => {
-      dispatch(actions.setRpcTarget(target, network, ticker, nickname))
+    setRpcTarget: (target, chainId, ticker, nickname) => {
+      dispatch(actions.setRpcTarget(target, chainId, ticker, nickname))
     },
     delRpcTarget: (target) => {
       dispatch(actions.delRpcTarget(target))


### PR DESCRIPTION
The `network` parameter of `setRpcTarget` was changed to `chainId` in a recent commit, but there was an interim variable that we forgot to rename.