### PR TITLE
Hex prefix newly fetched token balances in build-quote

### DIFF
--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
+import { addHexPrefix } from 'ethereumjs-util'
 import classnames from 'classnames'
 import { uniqBy } from 'lodash'
 import { useHistory } from 'react-router-dom'
@@ -132,7 +133,7 @@ export default function BuildQuote ({
         .then((fetchedBalance) => {
           if (fetchedBalance?.balance) {
             const balanceAsDecString = fetchedBalance.balance.toString(10)
-            const balanceAsHexString = fetchedBalance.balance.toString(16)
+            const balanceAsHexString = addHexPrefix(fetchedBalance.balance.toString(16))
             const userTokenBalance = calcTokenAmount(balanceAsDecString, token.decimals)
             dispatch(setSwapsFromToken({ ...token, string: userTokenBalance.toString(10), balance: balanceAsHexString }))
           }

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
-import { addHexPrefix } from 'ethereumjs-util'
 import classnames from 'classnames'
 import { uniqBy } from 'lodash'
 import { useHistory } from 'react-router-dom'
@@ -133,9 +132,8 @@ export default function BuildQuote ({
         .then((fetchedBalance) => {
           if (fetchedBalance?.balance) {
             const balanceAsDecString = fetchedBalance.balance.toString(10)
-            const balanceAsHexString = addHexPrefix(fetchedBalance.balance.toString(16))
             const userTokenBalance = calcTokenAmount(balanceAsDecString, token.decimals)
-            dispatch(setSwapsFromToken({ ...token, string: userTokenBalance.toString(10), balance: balanceAsHexString }))
+            dispatch(setSwapsFromToken({ ...token, string: userTokenBalance.toString(10), balance: balanceAsDecString }))
           }
         })
     }


### PR DESCRIPTION
This PR fixes a bug that can be observed when user selects, as a 'Swap from' token in the build quote swap screen, a token in which they have balance but which has not been explicitly added to their account.

This was happening because the newly fetched balance was not hex prefixed, causes a 'not a BigNumber' error on the next render. This PR corrects this.

Before:

![before-bq-hp](https://user-images.githubusercontent.com/7499938/95902862-f5b8ec00-0d6f-11eb-9d76-0e79032a7fd4.gif)

After:

![after-bq-hp](https://user-images.githubusercontent.com/7499938/95902872-fb163680-0d6f-11eb-84e1-4c084c4e23fa.gif)
