### PR TITLE
Data consistency swaps token balance

### DIFF
--- a/ui/app/components/app/wallet-overview/token-overview.js
+++ b/ui/app/components/app/wallet-overview/token-overview.js
@@ -38,8 +38,9 @@ const TokenOverview = ({ className, token }) => {
   const keyring = useSelector(getCurrentKeyring)
   const usingHardwareWallet = keyring.type.search('Hardware') !== -1
   const { tokensWithBalances } = useTokenTracker([token])
-  const balance = tokensWithBalances[0]?.string
-  const formattedFiatBalance = useTokenFiatAmount(token.address, balance, token.symbol)
+  const balanceToRender = tokensWithBalances[0]?.string
+  const balance = tokensWithBalances[0]?.balance
+  const formattedFiatBalance = useTokenFiatAmount(token.address, balanceToRender, token.symbol)
   const networkId = useSelector(getCurrentNetworkId)
   const enteredSwapsEvent = useNewMetricEvent({ event: 'Swaps Opened', properties: { source: 'Token View', active_currency: token.symbol }, category: 'swaps' })
   const swapsEnabled = useSelector(getSwapsFeatureLiveness)
@@ -50,7 +51,7 @@ const TokenOverview = ({ className, token }) => {
         <div className="token-overview__balance">
           <CurrencyDisplay
             className="token-overview__primary-balance"
-            displayValue={balance}
+            displayValue={balanceToRender}
             suffix={token.symbol}
           />
           {
@@ -87,7 +88,12 @@ const TokenOverview = ({ className, token }) => {
               onClick={() => {
                 if (networkId === MAINNET_NETWORK_ID) {
                   enteredSwapsEvent()
-                  dispatch(setSwapsFromToken({ ...token, iconUrl: assetImages[token.address] }))
+                  dispatch(setSwapsFromToken({
+                    ...token,
+                    iconUrl: assetImages[token.address],
+                    balance,
+                    string: balanceToRender,
+                  }))
                   if (usingHardwareWallet) {
                     global.platform.openExtensionInBrowser(BUILD_QUOTE_ROUTE)
                   } else {

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -24,7 +24,7 @@ import {
   getTopAssets,
   getFetchParams,
 } from '../../../ducks/swaps/swaps'
-import { getValueFromWeiHex } from '../../../helpers/utils/conversions.util'
+import { getValueFromWeiHex, hexToDecimal } from '../../../helpers/utils/conversions.util'
 import { calcTokenAmount } from '../../../helpers/utils/token-util'
 import { usePrevious } from '../../../hooks/usePrevious'
 import { useTokenTracker } from '../../../hooks/useTokenTracker'
@@ -168,7 +168,11 @@ export default function BuildQuote ({
   // If the eth balance changes while on build quote, we update the selected from token
   useEffect(() => {
     if (fromToken?.address === ETH_SWAPS_TOKEN_OBJECT.address && (fromToken?.balance !== ethBalance)) {
-      dispatch(setSwapsFromToken({ ...fromToken, balance: ethBalance, string: getValueFromWeiHex({ value: ethBalance, numberOfDecimals: 4, toDenomination: 'ETH' }) }))
+      dispatch(setSwapsFromToken({
+        ...fromToken,
+        balance: hexToDecimal(ethBalance),
+        string: getValueFromWeiHex({ value: ethBalance, numberOfDecimals: 4, toDenomination: 'ETH' }),
+      }))
     }
   }, [dispatch, fromToken, ethBalance])
 


### PR DESCRIPTION
This PR corrects data being set on the swaps `fromToken` object. In two locations, this data was inconsistent/incorrect.

1. This PR updates the setSwapFromToken call in token-overview to include balance and string properties, so those will be set as soon as the user hits the build quote screen.
2. This PR updates the setSwapFromToken call made in build-quote in a useEffect when the eth balance changes, so that balance is set to a decimal instead of a hex.