### PR TITLE
Fix FF overflow list-item right-content/primaryCurrency wrapper

### DIFF
--- a/ui/app/components/app/transaction-list-item/index.scss
+++ b/ui/app/components/app/transaction-list-item/index.scss
@@ -3,6 +3,7 @@
     color: $Black-100;
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 100px;
   }
 
   &__secondary-currency {

--- a/ui/app/components/app/transaction-list-item/index.scss
+++ b/ui/app/components/app/transaction-list-item/index.scss
@@ -3,7 +3,9 @@
     color: $Black-100;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 100px;
+    @media screen and (max-width: 575px) {
+      max-width: 100px;
+    }
   }
 
   &__secondary-currency {

--- a/ui/app/components/app/transaction-list-item/index.scss
+++ b/ui/app/components/app/transaction-list-item/index.scss
@@ -3,10 +3,6 @@
     color: $Black-100;
     overflow: hidden;
     text-overflow: ellipsis;
-
-    @media screen and (max-width: 575px) {
-      max-width: 100px;
-    }
   }
 
   &__secondary-currency {

--- a/ui/app/components/app/transaction-list-item/index.scss
+++ b/ui/app/components/app/transaction-list-item/index.scss
@@ -3,6 +3,7 @@
     color: $Black-100;
     overflow: hidden;
     text-overflow: ellipsis;
+
     @media screen and (max-width: 575px) {
       max-width: 100px;
     }

--- a/ui/app/components/ui/list-item/index.scss
+++ b/ui/app/components/ui/list-item/index.scss
@@ -87,7 +87,6 @@
     align-items: flex-end;
     overflow: hidden;
     white-space: nowrap;
-    text-overflow: ellipsis;
   }
 
   @media (max-width: 575px) {

--- a/ui/app/components/ui/list-item/index.scss
+++ b/ui/app/components/ui/list-item/index.scss
@@ -85,6 +85,9 @@
     grid-area: right;
     text-align: right;
     align-items: flex-end;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   @media (max-width: 575px) {


### PR DESCRIPTION
Primarily fix for Firefox primaryCurrency going out of bounds of the grid template.

<details>
<summary>Out of bounds</summary>
<img src='https://user-images.githubusercontent.com/13376180/95908995-a57f6100-0d52-11eb-818f-d6d59df8bbf2.png'>
</details>

<details>
<summary>Before</summary>
<img src='https://user-images.githubusercontent.com/13376180/95908893-8254b180-0d52-11eb-97cb-7dbaec294073.png'>
</details>

<details>
<summary>After</summary>
<img src='https://user-images.githubusercontent.com/13376180/95909203-f1320a80-0d52-11eb-9004-d74cad0ac0b8.png'>
</details>

EDIT: AFTER screenshots in a later comment of fix.
