### PR TITLE
Remove commitment to maintain a public metrics dashboard

### DIFF
--- a/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
@@ -57,12 +57,6 @@ export default class MetaMetricsOptIn extends Component {
                   Send anonymized click & pageview events
                 </div>
               </div>
-              <div className="metametrics-opt-in__row">
-                <i className="fa fa-check" />
-                <div className="metametrics-opt-in__row-description">
-                  Maintain a public aggregate dashboard to educate the community
-                </div>
-              </div>
               <div className="metametrics-opt-in__row metametrics-opt-in__break-row">
                 <i className="fa fa-times" />
                 <div className="metametrics-opt-in__row-description">


### PR DESCRIPTION
We were unable to deliver this public dashboard as we had originally anticipated, and this is no longer a priority for the team. We may revisit this idea in the future, but for now it has been removed from our list of commitments.