### PR TITLE
Autofocus the currency input when sending tokens

### DIFF
--- a/ui/app/components/ui/currency-input/currency-input.component.js
+++ b/ui/app/components/ui/currency-input/currency-input.component.js
@@ -148,6 +148,7 @@ export default class CurrencyInput extends PureComponent {
             onClick={this.swap}
           />
         )}
+        autoFocus
       >
         { this.renderConversionComponent() }
       </UnitInput>

--- a/ui/app/components/ui/token-input/token-input.component.js
+++ b/ui/app/components/ui/token-input/token-input.component.js
@@ -136,6 +136,7 @@ export default class TokenInput extends PureComponent {
         suffix={token.symbol}
         onChange={this.handleChange}
         value={decimalValue}
+        autoFocus
       >
         { this.renderConversionComponent() }
       </UnitInput>

--- a/ui/app/components/ui/unit-input/unit-input.component.js
+++ b/ui/app/components/ui/unit-input/unit-input.component.js
@@ -10,6 +10,7 @@ import { removeLeadingZeroes } from '../../../pages/send/send.utils'
  */
 export default class UnitInput extends PureComponent {
   static propTypes = {
+    autoFocus: PropTypes.bool,
     children: PropTypes.node,
     actionComponent: PropTypes.node,
     error: PropTypes.bool,
@@ -63,7 +64,7 @@ export default class UnitInput extends PureComponent {
   }
 
   render () {
-    const { error, placeholder, suffix, actionComponent, children, maxModeOn } = this.props
+    const { autoFocus, error, placeholder, suffix, actionComponent, children, maxModeOn } = this.props
     const { value } = this.state
 
     return (
@@ -85,6 +86,7 @@ export default class UnitInput extends PureComponent {
                 this.unitInput = ref
               }}
               disabled={maxModeOn}
+              autoFocus={autoFocus}
             />
             {
               suffix && (


### PR DESCRIPTION
This focuses the user on the send screen's value input -- saves a click!