### PR TITLE
fix issue with unmatched routes

### DIFF
--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -7,7 +7,7 @@ import React, { useRef, Component, createContext, useEffect, useCallback } from 
 import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import { useLocation, matchPath, useRouteMatch } from 'react-router-dom'
-import { captureException, captureMessage } from '@sentry/browser'
+import { captureException, captureMessage, Severity } from '@sentry/browser'
 
 import { omit } from 'lodash'
 import {
@@ -100,9 +100,11 @@ export function MetaMetricsProvider ({ children }) {
         // the contents of state.
         if (location.pathname !== '/confirm-transaction') {
           // Otherwise we are legitimately missing a matching route
-          // Ideally we'd include the details of match and previousMatch here, but breadcrumbs provides
-          // a fair bit of details that should be useful.
-          captureMessage(`Segment page tracking found unmatched route`, 'info')
+          captureMessage(`Segment page tracking found unmatched route`, {
+            level: Severity.Info,
+            previousMatch,
+            currentPath: location.pathname,
+          })
         }
       } else if (
         previousMatch.current !== match.path &&

--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -101,7 +101,6 @@ export function MetaMetricsProvider ({ children }) {
         if (location.pathname !== '/confirm-transaction') {
           // Otherwise we are legitimately missing a matching route
           captureMessage(`Segment page tracking found unmatched route`, {
-            level: Severity.Info,
             previousMatch,
             currentPath: location.pathname,
           })

--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -92,16 +92,25 @@ export function MetaMetricsProvider ({ children }) {
       const idTrait = metaMetricsId ? 'userId' : 'anonymousId'
       const idValue = metaMetricsId ?? METAMETRICS_ANONYMOUS_ID
       const match = matchPath(location.pathname, { path: PATHS_TO_CHECK, exact: true, strict: true })
-      if (
-        match &&
+      // Start by checking for a missing match route. If this falls through to the else if, then we know we
+      // have a matched route for tracking.
+      if (!match) {
+        // We have more specific pages for each type of transaction confirmation
+        // The user lands on /confirm-transaction first, then is redirected based on
+        // the contents of state.
+        if (location.pathname !== '/confirm-transaction') {
+          // Otherwise we are legitimately missing a matching route
+          // Ideally we'd include the details of match and previousMatch here, but breadcrumbs provides
+          // a fair bit of details that should be useful.
+          captureMessage(`Segment page tracking found unmatched route`, 'info')
+        }
+      } else if (
         previousMatch.current !== match.path &&
-        // If we're in a popup or notification we don't want the initial home route to track
-        !(
-          (environmentType === 'popup' || environmentType === 'notification') &&
-          match.path === '/' &&
-          previousMatch.current === undefined
-        )
+        (environmentType !== 'notification' || match.path !== '/' || previousMatch.current !== undefined)
       ) {
+        // When a notification window is open by a Dapp we do not want to track the initial home route load that can
+        // sometimes happen. To handle this we keep track of the previousMatch, and we skip the event track in the event
+        // that we are dealing with the initial load of the homepage
         const { path, params } = match
         const name = PATH_NAME_MAP[path]
         segment.page({
@@ -116,11 +125,6 @@ export function MetaMetricsProvider ({ children }) {
           },
           context,
         })
-      } else if (location.pathname !== '/confirm-transaction') {
-        // We have more specific pages for each type of transaction confirmation
-        // The user lands on /confirm-transaction first, then is redirected based on
-        // the contents of state.
-        captureMessage(`${location.pathname} would have issued a page track event to segment, but no route match was found`)
       }
       previousMatch.current = match?.path
     }

--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -7,7 +7,7 @@ import React, { useRef, Component, createContext, useEffect, useCallback } from 
 import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import { useLocation, matchPath, useRouteMatch } from 'react-router-dom'
-import { captureException, captureMessage, Severity } from '@sentry/browser'
+import { captureException, captureMessage } from '@sentry/browser'
 
 import { omit } from 'lodash'
 import {

--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -106,7 +106,7 @@ export function MetaMetricsProvider ({ children }) {
         }
       } else if (
         previousMatch.current !== match.path &&
-        (environmentType !== 'notification' || match.path !== '/' || previousMatch.current !== undefined)
+        !(environmentType === 'notification' && match.path === '/' && previousMatch.current === undefined)
       ) {
         // When a notification window is open by a Dapp we do not want to track the initial home route load that can
         // sometimes happen. To handle this we keep track of the previousMatch, and we skip the event track in the event


### PR DESCRIPTION
I *believe* the issue with the tracked page routes was due to the else if block only checking if `location.pathname !== /confirm-transaction` instead of also checking if there was actually not a match. The reason I believe this is because in the first part of the if block we only accept a percentage of actual matches (those that do not match the previous match, and that aren't the first load of the home page on specific environment types).

The fix, I think, is first to check for not having a match first, then in the else logic we can reliably know that we do have a matching route. I also removed the 'popup' environment type from the 'dont track initial home page view' I think this is eating more events then we expected and if any of the logic happens for redirection on the home page when a user manually opens the popup it might be worth while to track.

Note I want to add additional data to the sentry event but it appears we are on 5.11.x of the package and the passing extra context stuff was only added in 5.16.x. If others feel it's worth it, I can upgrade our package... or if there are other APIs for attaching extra data to an event I can do that. 