### PR TITLE
Fix TypeError when `signTypedData` throws

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1414,7 +1414,7 @@ export default class MetamaskController extends EventEmitter {
     } catch (error) {
       log.info('MetaMaskController - eth_signTypedData failed.', error)
       this.typedMessageManager.errorMessage(msgId, error)
-      return undefined
+      throw error
     }
   }
 


### PR DESCRIPTION
If the `signTypedData` background function threw an exception, it would return `undefined` to the UI, which would throw another exception in the UI. It now re-throws the error if an error is thrown, which allows the UI to handle the error.

I'm not sure why this might fail, and I'm not sure we're handling this failure well, but this is an improvement at least.