### PR TITLE
Fix exception upon failure to get next nonce

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1864,12 +1864,8 @@ export default class MetamaskController extends EventEmitter {
    * @returns {Promise<number>}
    */
   async getNextNonce (address) {
-    let nonceLock
-    try {
-      nonceLock = await this.txController.nonceTracker.getNonceLock(address)
-    } finally {
-      nonceLock.releaseLock()
-    }
+    const nonceLock = await this.txController.nonceTracker.getNonceLock(address)
+    nonceLock.releaseLock()
     return nonceLock.nextNonce
   }
 


### PR DESCRIPTION
An attempt to safely release the `nonceLock` upon failure has instead made failure worse by masking it with a new error. If the call to get the `nonceLock` throws an exception, then the `finally` block here would attempt to call `releaseLock` on the `nonceLock` variable, which is guaranteed to be `undefined` if the previous call failed. The attempt to call a method on `undefined` throws another error, masking the original error.

It is safer to obtain the `nonceLock` and release it without using any `try` or `finally` block. The `nonceLock` is synchronously released immediately after it is obtained, and any errors bubble up correctly without being masked. There is no case where the lock is left unreleased.