### PR TITLE
Switch gas price estimation in swaps to metaswap-api /gasPrices

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content.component.js
@@ -25,7 +25,7 @@ export default class AdvancedTabContent extends Component {
     isSpeedUp: PropTypes.bool,
     isEthereumNetwork: PropTypes.bool,
     customGasLimitMessage: PropTypes.string,
-    minimumGasLimit: PropTypes.number.isRequired,
+    minimumGasLimit: PropTypes.number,
   }
 
   renderDataSummary(transactionFee, timeRemaining) {

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/tests/advanced-tab-content-component.test.js
@@ -103,7 +103,7 @@ describe('AdvancedTabContent Component', function () {
       const renderDataSummaryArgs = AdvancedTabContent.prototype.renderDataSummary.getCall(
         0,
       ).args
-      assert.deepEqual(renderDataSummaryArgs, ['$0.25', 21500])
+      assert.deepEqual(renderDataSummaryArgs, ['$0.25', '21500'])
     })
   })
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import PageContainer from '../../../ui/page-container'
 import { Tabs, Tab } from '../../../ui/tabs'
-import { calcGasTotal } from '../../../../pages/send/send.utils'
-import { sumHexWEIsToRenderableFiat } from '../../../../helpers/utils/conversions.util'
 import AdvancedTabContent from './advanced-tab-content'
 import BasicTabContent from './basic-tab-content'
 
@@ -32,10 +30,6 @@ export default class GasModalPageContainer extends Component {
       newTotalEth: PropTypes.string,
       sendAmount: PropTypes.string,
       transactionFee: PropTypes.string,
-      extraInfoRow: PropTypes.shape({
-        label: PropTypes.string,
-        value: PropTypes.string,
-      }),
     }),
     onSubmit: PropTypes.func,
     customModalGasPriceInHex: PropTypes.string,
@@ -47,16 +41,6 @@ export default class GasModalPageContainer extends Component {
     isRetry: PropTypes.bool,
     disableSave: PropTypes.bool,
     isEthereumNetwork: PropTypes.bool,
-    customGasLimitMessage: PropTypes.string,
-    customTotalSupplement: PropTypes.string,
-    isSwap: PropTypes.bool,
-    value: PropTypes.string,
-    conversionRate: PropTypes.number,
-    minimumGasLimit: PropTypes.number.isRequired,
-  }
-
-  state = {
-    selectedTab: 'Basic',
   }
 
   componentDidMount() {
@@ -92,8 +76,6 @@ export default class GasModalPageContainer extends Component {
       isRetry,
       infoRowProps: { transactionFee },
       isEthereumNetwork,
-      customGasLimitMessage,
-      minimumGasLimit,
     } = this.props
 
     return (
@@ -102,7 +84,6 @@ export default class GasModalPageContainer extends Component {
         updateCustomGasLimit={updateCustomGasLimit}
         customModalGasPriceInHex={customModalGasPriceInHex}
         customModalGasLimitInHex={customModalGasLimitInHex}
-        customGasLimitMessage={customGasLimitMessage}
         timeRemaining={currentTimeEstimate}
         transactionFee={transactionFee}
         gasChartProps={gasChartProps}
@@ -112,18 +93,11 @@ export default class GasModalPageContainer extends Component {
         isSpeedUp={isSpeedUp}
         isRetry={isRetry}
         isEthereumNetwork={isEthereumNetwork}
-        minimumGasLimit={minimumGasLimit}
       />
     )
   }
 
-  renderInfoRows(
-    newTotalFiat,
-    newTotalEth,
-    sendAmount,
-    transactionFee,
-    extraInfoRow,
-  ) {
+  renderInfoRows(newTotalFiat, newTotalEth, sendAmount, transactionFee) {
     return (
       <div className="gas-modal-content__info-row-wrapper">
         <div className="gas-modal-content__info-row">
@@ -143,16 +117,6 @@ export default class GasModalPageContainer extends Component {
               {transactionFee}
             </span>
           </div>
-          {extraInfoRow && (
-            <div className="gas-modal-content__info-row__transaction-info">
-              <span className="gas-modal-content__info-row__transaction-info__label">
-                {extraInfoRow.label}
-              </span>
-              <span className="gas-modal-content__info-row__transaction-info__value">
-                {extraInfoRow.value}
-              </span>
-            </div>
-          )}
           <div className="gas-modal-content__info-row__total-info">
             <span className="gas-modal-content__info-row__total-info__label">
               {this.context.t('newTotal')}
@@ -175,13 +139,7 @@ export default class GasModalPageContainer extends Component {
     const {
       gasPriceButtonGroupProps,
       hideBasic,
-      infoRowProps: {
-        newTotalFiat,
-        newTotalEth,
-        sendAmount,
-        transactionFee,
-        extraInfoRow,
-      },
+      infoRowProps: { newTotalFiat, newTotalEth, sendAmount, transactionFee },
     } = this.props
 
     let tabsToRender = [
@@ -200,7 +158,7 @@ export default class GasModalPageContainer extends Component {
     }
 
     return (
-      <Tabs onTabClick={(tabName) => this.setState({ selectedTab: tabName })}>
+      <Tabs>
         {tabsToRender.map(({ name, content }, i) => (
           <Tab name={name} key={`gas-modal-tab-${i}`}>
             <div className="gas-modal-content">
@@ -210,7 +168,6 @@ export default class GasModalPageContainer extends Component {
                 newTotalEth,
                 sendAmount,
                 transactionFee,
-                extraInfoRow,
               )}
             </div>
           </Tab>
@@ -248,45 +205,7 @@ export default class GasModalPageContainer extends Component {
                 },
               })
             }
-            if (this.props.isSwap) {
-              const newSwapGasTotal = calcGasTotal(
-                customModalGasLimitInHex,
-                customModalGasPriceInHex,
-              )
-              let speedSet = ''
-              if (this.state.selectedTab === 'Basic') {
-                const { gasButtonInfo } = this.props.gasPriceButtonGroupProps
-                const selectedGasButtonInfo = gasButtonInfo.find(
-                  ({ priceInHexWei }) =>
-                    priceInHexWei === customModalGasPriceInHex,
-                )
-                speedSet = selectedGasButtonInfo?.gasEstimateType || ''
-              }
-
-              this.context.trackEvent({
-                event: 'Gas Fees Changed',
-                category: 'swaps',
-                properties: {
-                  speed_set: speedSet,
-                  gas_mode: this.state.selectedTab,
-                  gas_fees: sumHexWEIsToRenderableFiat(
-                    [
-                      this.props.value,
-                      newSwapGasTotal,
-                      this.props.customTotalSupplement,
-                    ],
-                    'usd',
-                    this.props.conversionRate,
-                  )?.slice(1),
-                },
-              })
-            }
-            onSubmit(
-              customModalGasLimitInHex,
-              customModalGasPriceInHex,
-              this.state.selectedTab,
-              this.context.mixPanelTrack,
-            )
+            onSubmit(customModalGasLimitInHex, customModalGasPriceInHex)
           }}
           submitText={this.context.t('save')}
           headerCloseText={this.context.t('close')}

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-component.test.js
@@ -194,14 +194,12 @@ describe('GasModalPageContainer Component', function () {
         'mockNewTotalEth',
         'mockSendAmount',
         'mockTransactionFee',
-        { label: 'mockLabel', value: 'mockValue' },
       ])
       assert.deepEqual(GP.renderInfoRows.getCall(1).args, [
         'mockNewTotalFiat',
         'mockNewTotalEth',
         'mockSendAmount',
         'mockTransactionFee',
-        { label: 'mockLabel', value: 'mockValue' },
       ])
     })
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -63,8 +63,6 @@ describe('gas-modal-page-container container', function () {
                 txData: {
                   id: 34,
                 },
-                extraInfoRow: { label: 'mockLabel', value: 'mockValue' },
-                minimumGasLimit: 21000,
               },
             },
           },
@@ -131,8 +129,6 @@ describe('gas-modal-page-container container', function () {
         newTotalFiat: '637.41',
         blockTime: 12,
         conversionRate: 50,
-        customGasLimitMessage: '',
-        customTotalSupplement: '',
         customModalGasLimitInHex: 'aaaaaaaa',
         customModalGasPriceInHex: 'ffffffff',
         customGasTotal: 'aaaaaaa955555556',
@@ -152,7 +148,6 @@ describe('gas-modal-page-container container', function () {
         gasEstimatesLoading: false,
         hideBasic: true,
         infoRowProps: {
-          extraInfoRow: { label: 'mockLabel', value: 'mockValue' },
           originalTotalFiat: '637.41',
           originalTotalEth: '12.748189 ETH',
           newTotalFiat: '637.41',
@@ -163,7 +158,6 @@ describe('gas-modal-page-container container', function () {
         insufficientBalance: true,
         isSpeedUp: false,
         isRetry: false,
-        isSwap: false,
         txId: 34,
         isEthereumNetwork: true,
         isMainnet: true,
@@ -174,7 +168,6 @@ describe('gas-modal-page-container container', function () {
           id: 34,
         },
         value: '0x640000000000000',
-        minimumGasLimit: 21000,
       }
       const baseMockOwnProps = { transaction: { id: 34 } }
       const tests = [

--- a/ui/app/components/app/gas-customization/gas-price-button-group/gas-price-button-group.component.js
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/gas-price-button-group.component.js
@@ -93,7 +93,12 @@ export default class GasPriceButtonGroup extends Component {
   ) {
     return (
       <Button
-        onClick={() => handleGasPriceSelection(priceInHexWei)}
+        onClick={() =>
+          handleGasPriceSelection(
+            priceInHexWei,
+            renderableGasInfo.gasEstimateType,
+          )
+        }
         key={`gas-price-button-${index}`}
       >
         {this.renderButtonContent(

--- a/ui/app/components/app/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import sinon from 'sinon'
 import shallow from '../../../../../../lib/shallow-with-context'
 import GasPriceButtonGroup from '../gas-price-button-group.component'
+import { GAS_ESTIMATE_TYPES } from '../../../../../helpers/constants/common'
 
 import ButtonGroup from '../../../../ui/button-group'
 
@@ -17,18 +18,21 @@ describe('GasPriceButtonGroup Component', function () {
       className: 'gas-price-button-group',
       gasButtonInfo: [
         {
+          gasEstimateType: GAS_ESTIMATE_TYPES.SLOW,
           feeInPrimaryCurrency: '$0.52',
           feeInSecondaryCurrency: '0.0048 ETH',
           timeEstimate: '~ 1 min 0 sec',
           priceInHexWei: '0xa1b2c3f',
         },
         {
+          gasEstimateType: GAS_ESTIMATE_TYPES.AVERAGE,
           feeInPrimaryCurrency: '$0.39',
           feeInSecondaryCurrency: '0.004 ETH',
           timeEstimate: '~ 1 min 30 sec',
           priceInHexWei: '0xa1b2c39',
         },
         {
+          gasEstimateType: GAS_ESTIMATE_TYPES.FAST,
           feeInPrimaryCurrency: '$0.30',
           feeInSecondaryCurrency: '0.00354 ETH',
           timeEstimate: '~ 2 min 1 sec',
@@ -105,10 +109,12 @@ describe('GasPriceButtonGroup Component', function () {
 
     beforeEach(function () {
       GasPriceButtonGroup.prototype.renderButtonContent.resetHistory()
-      const renderButtonResult = GasPriceButtonGroup.prototype.renderButton(
-        { ...mockGasPriceButtonGroupProps.gasButtonInfo[0] },
-        mockButtonPropsAndFlags,
-      )
+      const renderButtonResult = wrapper
+        .instance()
+        .renderButton(
+          { ...mockGasPriceButtonGroupProps.gasButtonInfo[0] },
+          mockButtonPropsAndFlags,
+        )
       wrappedRenderButtonResult = shallow(renderButtonResult)
     })
 
@@ -128,7 +134,10 @@ describe('GasPriceButtonGroup Component', function () {
       )
       assert.deepEqual(
         mockGasPriceButtonGroupProps.handleGasPriceSelection.getCall(0).args,
-        [mockGasPriceButtonGroupProps.gasButtonInfo[0].priceInHexWei],
+        [
+          mockGasPriceButtonGroupProps.gasButtonInfo[0].priceInHexWei,
+          mockGasPriceButtonGroupProps.gasButtonInfo[0].gasEstimateType,
+        ],
       )
     })
 
@@ -141,12 +150,14 @@ describe('GasPriceButtonGroup Component', function () {
         feeInPrimaryCurrency,
         feeInSecondaryCurrency,
         timeEstimate,
+        gasEstimateType,
       } = mockGasPriceButtonGroupProps.gasButtonInfo[0]
       const { showCheck, className } = mockGasPriceButtonGroupProps
       assert.deepEqual(
         GasPriceButtonGroup.prototype.renderButtonContent.getCall(0).args,
         [
           {
+            gasEstimateType,
             feeInPrimaryCurrency,
             feeInSecondaryCurrency,
             timeEstimate,

--- a/ui/app/components/app/modals/modal.js
+++ b/ui/app/components/app/modals/modal.js
@@ -10,6 +10,7 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../../app/scripts/lib/enums'
 
 // Modal Components
 import ConfirmCustomizeGasModal from '../gas-customization/gas-modal-page-container'
+import SwapsGasCustomizationModal from '../../../pages/swaps/swaps-gas-customization-modal'
 import DepositEtherModal from './deposit-ether-modal'
 import AccountDetailsModal from './account-details-modal'
 import ExportPrivateKeyModal from './export-private-key-modal'
@@ -269,6 +270,31 @@ const MODALS = {
     customOnHideOpts: {
       action: resetCustomGasData,
       args: [],
+    },
+  },
+
+  CUSTOMIZE_METASWAP_GAS: {
+    contents: <SwapsGasCustomizationModal />,
+    mobileModalStyle: {
+      width: '100vw',
+      height: '100vh',
+      top: '0',
+      transform: 'none',
+      left: '0',
+      right: '0',
+      margin: '0 auto',
+    },
+    laptopModalStyle: {
+      width: 'auto',
+      height: '0px',
+      top: '80px',
+      left: '0px',
+      transform: 'none',
+      margin: '0 auto',
+      position: 'relative',
+    },
+    contentStyle: {
+      borderRadius: '8px',
     },
   },
 

--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -12,7 +12,7 @@ import {
   getUsedQuote,
   getFetchParams,
   getApproveTxParams,
-  getSwapsTradeTxParams,
+  getUsedSwapsGasPrice,
   fetchQuotesAndSetQuoteState,
   navigateBackToBuildQuote,
   prepareForRetryGetQuotes,
@@ -67,7 +67,7 @@ export default function AwaitingSwap({
   const { destinationTokenInfo, sourceTokenInfo } = fetchParams?.metaData || {}
   const usedQuote = useSelector(getUsedQuote)
   const approveTxParams = useSelector(getApproveTxParams)
-  const tradeTxParams = useSelector(getSwapsTradeTxParams)
+  const swapsGasPrice = useSelector(getUsedSwapsGasPrice)
   const currentCurrency = useSelector(getCurrentCurrency)
   const conversionRate = useSelector(conversionRateSelector)
 
@@ -77,14 +77,15 @@ export default function AwaitingSwap({
   )
 
   let feeinFiat
-  if (usedQuote && tradeTxParams) {
+
+  if (usedQuote && swapsGasPrice) {
     const renderableNetworkFees = getRenderableNetworkFeesForQuote(
       usedQuote.gasEstimateWithRefund || usedQuote.averageGas,
       approveTxParams?.gas || '0x0',
-      tradeTxParams.gasPrice,
+      swapsGasPrice,
       currentCurrency,
       conversionRate,
-      tradeTxParams.value,
+      usedQuote?.trade?.value,
       sourceTokenInfo?.symbol,
       usedQuote.sourceAmount,
     )

--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -21,9 +21,8 @@ import {
   getApproveTxId,
   getFetchingQuotes,
   setBalanceError,
-  getCustomSwapsGasPrice,
   setTopAssets,
-  getSwapsTradeTxParams,
+  getUsedSwapsGasPrice,
   getFetchParams,
   setAggregatorMetadata,
   getAggregatorMetadata,
@@ -33,7 +32,6 @@ import {
   prepareToLeaveSwaps,
   fetchAndSetSwapsGasPriceInfo,
 } from '../../ducks/swaps/swaps'
-import { resetCustomGasState } from '../../ducks/gas/gas.duck'
 import {
   AWAITING_SWAP_ROUTE,
   BUILD_QUOTE_ROUTE,
@@ -59,7 +57,6 @@ import {
   setSwapsErrorKey,
 } from '../../store/actions'
 import {
-  getFastPriceEstimateInHexWEI,
   currentNetworkTxListSelector,
   getRpcPrefsForCurrentProvider,
 } from '../../selectors'
@@ -96,11 +93,9 @@ export default function Swap() {
   const [maxSlippage, setMaxSlippage] = useState(fetchParams?.slippage || 2)
 
   const routeState = useSelector(getBackgroundSwapRouteState)
-  const tradeTxParams = useSelector(getSwapsTradeTxParams)
+  const usedGasPrice = useSelector(getUsedSwapsGasPrice)
   const selectedAccount = useSelector(getSelectedAccount)
   const quotes = useSelector(getQuotes)
-  const fastGasEstimate = useSelector(getFastPriceEstimateInHexWEI)
-  const customConvertGasPrice = useSelector(getCustomSwapsGasPrice)
   const txList = useSelector(currentNetworkTxListSelector)
   const tradeTxId = useSelector(getTradeTxId)
   const approveTxId = useSelector(getApproveTxId)
@@ -131,8 +126,6 @@ export default function Swap() {
     useSelector(getFromToken) || fetchParamsFromToken || {}
   const { destinationTokenAddedForSwap } = fetchParams || {}
 
-  const usedGasPrice =
-    customConvertGasPrice || tradeTxParams?.gasPrice || fastGasEstimate
   const approveTxData =
     approveTxId && txList.find(({ id }) => approveTxId === id)
   const tradeTxData = tradeTxId && txList.find(({ id }) => tradeTxId === id)
@@ -197,7 +190,6 @@ export default function Swap() {
       dispatch(setAggregatorMetadata(newAggregatorMetadata))
     })
 
-    dispatch(resetCustomGasState())
     dispatch(fetchAndSetSwapsGasPriceInfo())
 
     return () => {

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/index.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './swaps-gas-customization-modal.container'

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
@@ -1,0 +1,269 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import PageContainer from '../../../components/ui/page-container'
+import { Tabs, Tab } from '../../../components/ui/tabs'
+import { calcGasTotal } from '../../send/send.utils'
+import { sumHexWEIsToRenderableFiat } from '../../../helpers/utils/conversions.util'
+import AdvancedGasInputs from '../../../components/app/gas-customization/advanced-gas-inputs'
+import BasicTabContent from '../../../components/app/gas-customization/gas-modal-page-container/basic-tab-content'
+import { GAS_ESTIMATE_TYPES } from '../../../helpers/constants/common'
+
+export default class GasModalPageContainer extends Component {
+  static contextTypes = {
+    t: PropTypes.func,
+    trackEvent: PropTypes.func,
+  }
+
+  static propTypes = {
+    insufficientBalance: PropTypes.bool,
+    gasPriceButtonGroupProps: PropTypes.object,
+    infoRowProps: PropTypes.shape({
+      originalTotalFiat: PropTypes.string,
+      originalTotalEth: PropTypes.string,
+      newTotalFiat: PropTypes.string,
+      newTotalEth: PropTypes.string,
+      sendAmount: PropTypes.string,
+      transactionFee: PropTypes.string,
+      extraInfoRow: PropTypes.shape({
+        label: PropTypes.string,
+        value: PropTypes.string,
+      }),
+    }),
+    onSubmit: PropTypes.func,
+    cancelAndClose: PropTypes.func,
+    showCustomPriceTooLowWarning: PropTypes.bool,
+    disableSave: PropTypes.bool,
+    customGasLimitMessage: PropTypes.string,
+    customTotalSupplement: PropTypes.string,
+    value: PropTypes.string,
+    conversionRate: PropTypes.string,
+    customGasPrice: PropTypes.string,
+    customGasLimit: PropTypes.string,
+    setSwapsCustomizationModalPrice: PropTypes.func,
+    setSwapsCustomizationModalLimit: PropTypes.func,
+    gasEstimateLoadingHasFailed: PropTypes.bool,
+  }
+
+  state = {
+    gasSpeedType: '',
+  }
+
+  setGasSpeedType(gasEstimateType) {
+    if (gasEstimateType === GAS_ESTIMATE_TYPES.AVERAGE) {
+      this.setState({ gasSpeedType: 'average' })
+    } else {
+      this.setState({ gasSpeedType: 'fast' })
+    }
+  }
+
+  renderBasicTabContent(gasPriceButtonGroupProps) {
+    return (
+      <BasicTabContent
+        gasPriceButtonGroupProps={{
+          ...gasPriceButtonGroupProps,
+          handleGasPriceSelection: (gasPriceInHexWei, gasEstimateType) => {
+            this.setGasSpeedType(gasEstimateType)
+            this.props.setSwapsCustomizationModalPrice(gasPriceInHexWei)
+          },
+        }}
+      />
+    )
+  }
+
+  renderAdvancedTabContent() {
+    const {
+      insufficientBalance,
+      showCustomPriceTooLowWarning,
+      infoRowProps: { transactionFee },
+      customGasLimitMessage,
+      setSwapsCustomizationModalPrice,
+      setSwapsCustomizationModalLimit,
+      customGasPrice,
+      customGasLimit,
+    } = this.props
+
+    return (
+      <div className="advanced-tab">
+        <div className="advanced-tab__transaction-data-summary">
+          <div className="advanced-tab__transaction-data-summary__titles">
+            <span>{this.context.t('newTransactionFee')}</span>
+          </div>
+          <div className="advanced-tab__transaction-data-summary__container">
+            <div className="advanced-tab__transaction-data-summary__fee">
+              {transactionFee}
+            </div>
+          </div>
+        </div>
+        <div className="advanced-tab__fee-chart">
+          <div className="advanced-tab__gas-inputs">
+            <AdvancedGasInputs
+              updateCustomGasPrice={(updatedPrice) => {
+                this.setState({ gasSpeedType: 'custom' })
+                setSwapsCustomizationModalPrice(updatedPrice)
+              }}
+              updateCustomGasLimit={(updatedLimit) => {
+                this.setState({ gasSpeedType: 'custom' })
+                setSwapsCustomizationModalLimit(updatedLimit)
+              }}
+              customGasPrice={customGasPrice}
+              customGasLimit={customGasLimit}
+              insufficientBalance={insufficientBalance}
+              customPriceIsSafe={!showCustomPriceTooLowWarning}
+              customGasLimitMessage={customGasLimitMessage}
+            />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  renderInfoRows(
+    newTotalFiat,
+    newTotalEth,
+    sendAmount,
+    transactionFee,
+    extraInfoRow,
+  ) {
+    return (
+      <div className="gas-modal-content__info-row-wrapper">
+        <div className="gas-modal-content__info-row">
+          <div className="gas-modal-content__info-row__send-info">
+            <span className="gas-modal-content__info-row__send-info__label">
+              {this.context.t('sendAmount')}
+            </span>
+            <span className="gas-modal-content__info-row__send-info__value">
+              {sendAmount}
+            </span>
+          </div>
+          <div className="gas-modal-content__info-row__transaction-info">
+            <span className="gas-modal-content__info-row__transaction-info__label">
+              {this.context.t('transactionFee')}
+            </span>
+            <span className="gas-modal-content__info-row__transaction-info__value">
+              {transactionFee}
+            </span>
+          </div>
+          {extraInfoRow && (
+            <div className="gas-modal-content__info-row__transaction-info">
+              <span className="gas-modal-content__info-row__transaction-info__label">
+                {extraInfoRow.label}
+              </span>
+              <span className="gas-modal-content__info-row__transaction-info__value">
+                {extraInfoRow.value}
+              </span>
+            </div>
+          )}
+          <div className="gas-modal-content__info-row__total-info">
+            <span className="gas-modal-content__info-row__total-info__label">
+              {this.context.t('newTotal')}
+            </span>
+            <span className="gas-modal-content__info-row__total-info__value">
+              {newTotalEth}
+            </span>
+          </div>
+          <div className="gas-modal-content__info-row__fiat-total-info">
+            <span className="gas-modal-content__info-row__fiat-total-info__value">
+              {newTotalFiat}
+            </span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  renderTabs() {
+    const {
+      gasPriceButtonGroupProps,
+      infoRowProps: {
+        newTotalFiat,
+        newTotalEth,
+        sendAmount,
+        transactionFee,
+        extraInfoRow,
+      },
+      gasEstimateLoadingHasFailed,
+    } = this.props
+
+    const basicTabInfo = {
+      name: this.context.t('basic'),
+      content: this.renderBasicTabContent({
+        ...gasPriceButtonGroupProps,
+        handleGasPriceSelection: this.props.setSwapsCustomizationModalPrice,
+      }),
+    }
+    const advancedTabInfo = {
+      name: this.context.t('advanced'),
+      content: this.renderAdvancedTabContent(),
+    }
+
+    const tabsToRender = gasEstimateLoadingHasFailed
+      ? [advancedTabInfo]
+      : [basicTabInfo, advancedTabInfo]
+
+    return (
+      <Tabs>
+        {tabsToRender.map(({ name, content }, i) => (
+          <Tab name={name} key={`gas-modal-tab-${i}`}>
+            <div className="gas-modal-content">
+              {content}
+              {this.renderInfoRows(
+                newTotalFiat,
+                newTotalEth,
+                sendAmount,
+                transactionFee,
+                extraInfoRow,
+              )}
+            </div>
+          </Tab>
+        ))}
+      </Tabs>
+    )
+  }
+
+  render() {
+    const {
+      cancelAndClose,
+      onSubmit,
+      disableSave,
+      customGasPrice,
+      customGasLimit,
+    } = this.props
+
+    return (
+      <div className="gas-modal-page-container">
+        <PageContainer
+          title={this.context.t('customGas')}
+          subtitle={this.context.t('customGasSubTitle')}
+          tabsComponent={this.renderTabs()}
+          disabled={disableSave}
+          onCancel={() => cancelAndClose()}
+          onClose={() => cancelAndClose()}
+          onSubmit={() => {
+            const newSwapGasTotal = calcGasTotal(customGasLimit, customGasPrice)
+
+            this.context.trackEvent({
+              event: 'Gas Fees Changed',
+              category: 'swaps',
+              properties: {
+                speed_set: this.state.gasSpeedType,
+                gas_fees: sumHexWEIsToRenderableFiat(
+                  [
+                    this.props.value,
+                    newSwapGasTotal,
+                    this.props.customTotalSupplement,
+                  ],
+                  'usd',
+                  this.props.conversionRate,
+                )?.slice(1),
+              },
+            })
+            onSubmit(customGasLimit, customGasPrice)
+          }}
+          submitText={this.context.t('save')}
+          headerCloseText={this.context.t('close')}
+          hideCancel
+        />
+      </div>
+    )
+  }
+}

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
@@ -1,0 +1,159 @@
+import { connect } from 'react-redux'
+import { hideModal, customSwapsGasParamsUpdated } from '../../../store/actions'
+import {
+  conversionRateSelector as getConversionRate,
+  getCurrentCurrency,
+  getCurrentEthBalance,
+  getDefaultActiveButtonIndex,
+  getRenderableGasButtonData,
+} from '../../../selectors'
+
+import {
+  getSwapsCustomizationModalPrice,
+  getSwapsCustomizationModalLimit,
+  swapGasEstimateLoadingHasFailed,
+  swapGasPriceEstimateIsLoading,
+  getSwapGasPriceEstimateData,
+  swapCustomGasModalPriceEdited,
+  swapCustomGasModalLimitEdited,
+  shouldShowCustomPriceTooLowWarning,
+} from '../../../ducks/swaps/swaps'
+
+import {
+  addHexes,
+  getValueFromWeiHex,
+  sumHexWEIsToRenderableFiat,
+} from '../../../helpers/utils/conversions.util'
+import { formatETHFee } from '../../../helpers/utils/formatters'
+import { calcGasTotal, isBalanceSufficient } from '../../send/send.utils'
+import SwapsGasCustomizationModalComponent from './swaps-gas-customization-modal.component'
+
+const mapStateToProps = (state) => {
+  const currentCurrency = getCurrentCurrency(state)
+  const conversionRate = getConversionRate(state)
+
+  const { modalState: { props: modalProps } = {} } = state.appState.modal || {}
+  const {
+    value,
+    customGasLimitMessage = '',
+    customTotalSupplement = '',
+    extraInfoRow = null,
+    initialGasPrice,
+    initialGasLimit,
+  } = modalProps || {}
+  const buttonDataLoading = swapGasPriceEstimateIsLoading(state)
+
+  const swapsCustomizationModalPrice = getSwapsCustomizationModalPrice(state)
+  const swapsCustomizationModalLimit = getSwapsCustomizationModalLimit(state)
+
+  const customGasPrice = swapsCustomizationModalPrice || initialGasPrice
+  const customGasLimit = swapsCustomizationModalLimit || initialGasLimit
+
+  const customGasTotal = calcGasTotal(customGasLimit, customGasPrice)
+
+  const swapsGasPriceEstimates = getSwapGasPriceEstimateData(state)
+
+  const { averageEstimateData, fastEstimateData } = getRenderableGasButtonData(
+    swapsGasPriceEstimates,
+    customGasLimit,
+    true,
+    conversionRate,
+    currentCurrency,
+  )
+  const gasButtonInfo = [averageEstimateData, fastEstimateData]
+
+  const newTotalFiat = sumHexWEIsToRenderableFiat(
+    [value, customGasTotal, customTotalSupplement],
+    currentCurrency,
+    conversionRate,
+  )
+
+  const balance = getCurrentEthBalance(state)
+
+  const newTotalEth = sumHexWEIsToRenderableEth([
+    value,
+    customGasTotal,
+    customTotalSupplement,
+  ])
+
+  const sendAmount = sumHexWEIsToRenderableEth([value, '0x0'])
+
+  const insufficientBalance = !isBalanceSufficient({
+    amount: value,
+    gasTotal: customGasTotal,
+    balance,
+    conversionRate,
+  })
+
+  return {
+    customGasPrice,
+    customGasLimit,
+    showCustomPriceTooLowWarning: shouldShowCustomPriceTooLowWarning(state),
+    gasPriceButtonGroupProps: {
+      buttonDataLoading,
+      defaultActiveButtonIndex: getDefaultActiveButtonIndex(
+        gasButtonInfo,
+        customGasPrice,
+      ),
+      gasButtonInfo,
+    },
+    infoRowProps: {
+      originalTotalFiat: sumHexWEIsToRenderableFiat(
+        [value, customGasTotal, customTotalSupplement],
+        currentCurrency,
+        conversionRate,
+      ),
+      originalTotalEth: sumHexWEIsToRenderableEth([
+        value,
+        customGasTotal,
+        customTotalSupplement,
+      ]),
+      newTotalFiat,
+      newTotalEth,
+      transactionFee: sumHexWEIsToRenderableEth(['0x0', customGasTotal]),
+      sendAmount,
+      extraInfoRow,
+    },
+    gasEstimateLoadingHasFailed: swapGasEstimateLoadingHasFailed(state),
+    insufficientBalance,
+    customGasLimitMessage,
+    customTotalSupplement,
+    conversionRate,
+    value,
+    disableSave: insufficientBalance,
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    cancelAndClose: () => {
+      dispatch(hideModal())
+    },
+    onSubmit: (gasLimit, gasPrice) => {
+      dispatch(customSwapsGasParamsUpdated(gasLimit, gasPrice))
+      dispatch(hideModal())
+    },
+    setSwapsCustomizationModalPrice: (newPrice) => {
+      dispatch(swapCustomGasModalPriceEdited(newPrice))
+    },
+    setSwapsCustomizationModalLimit: (newLimit) => {
+      dispatch(swapCustomGasModalLimitEdited(newLimit))
+    },
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SwapsGasCustomizationModalComponent)
+
+function sumHexWEIsToRenderableEth(hexWEIs) {
+  const hexWEIsSum = hexWEIs.filter((n) => n).reduce(addHexes)
+  return formatETHFee(
+    getValueFromWeiHex({
+      value: hexWEIsSum,
+      toCurrency: 'ETH',
+      numberOfDecimals: 6,
+    }),
+  )
+}

--- a/ui/app/selectors/tests/custom-gas.test.js
+++ b/ui/app/selectors/tests/custom-gas.test.js
@@ -348,53 +348,6 @@ describe('custom-gas selectors', function () {
           },
         },
       },
-      {
-        expectedResult: [
-          {
-            gasEstimateType: 'FAST',
-            feeInSecondaryCurrency: '$0.54',
-            feeInPrimaryCurrency: '0.00021 ETH',
-            timeEstimate: '~6 min 36 sec',
-            priceInHexWei: '0x2540be400',
-          },
-          {
-            feeInPrimaryCurrency: '0.00042 ETH',
-            feeInSecondaryCurrency: '$1.07',
-            gasEstimateType: 'FASTEST',
-            priceInHexWei: '0x4a817c800',
-            timeEstimate: '~1 min',
-          },
-        ],
-        mockState: {
-          metamask: {
-            conversionRate: 2557.1,
-            currentCurrency: 'usd',
-            send: {
-              gasLimit: '0x5208',
-            },
-            preferences: {
-              showFiatInTestnets: true,
-            },
-            provider: {
-              type: 'mainnet',
-            },
-          },
-          gas: {
-            basicEstimates: {
-              blockTime: 14.16326530612245,
-              safeLow: 5,
-              safeLowWait: 13.2,
-              average: 7,
-              avgWait: 10.1,
-              fast: 10,
-              fastWait: 6.6,
-              fastest: 20,
-              fastestWait: 1.0,
-            },
-          },
-        },
-        useFastestButtons: true,
-      },
     ]
     it('should return renderable data about basic estimates', function () {
       tests.forEach((test) => {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2288,7 +2288,7 @@ export function setSwapsTxGasLimit(gasLimit) {
   }
 }
 
-export function setSwapsTxGasParams(gasLimit, gasPrice) {
+export function customSwapsGasParamsUpdated(gasLimit, gasPrice) {
   return async (dispatch) => {
     await promisifiedBackground.setSwapsTxGasPrice(gasPrice)
     await promisifiedBackground.setSwapsTxGasLimit(gasLimit, true)


### PR DESCRIPTION
This PR updates the gas price estimation api for swaps. We now use the the metaswap-api /gasPrices endpoint.

The follow changes are included:

- If the gas customization modal props include a truthy `hideAdvancedTimeEstimates` boolean, then the gas price chart and the time estimate on the advanced tab will be hidden. This is utilized in swaps.
- If the gas customization modal props include a truthy `noFetchOnMount` boolean, then the gas customization modal component will not dispatch gas duck actions to fetch new gas prices on mount

Here is a demo:

![etherscan-gas-api](https://user-images.githubusercontent.com/7499938/95983771-c603f580-0dfc-11eb-8305-44f9e7facfb9.gif)
