### PR TITLE
Add a minimumGasLimit to the gas customization modal in swaps

### DIFF
--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
@@ -41,6 +41,7 @@ export default class GasModalPageContainer extends Component {
     setSwapsCustomizationModalPrice: PropTypes.func,
     setSwapsCustomizationModalLimit: PropTypes.func,
     gasEstimateLoadingHasFailed: PropTypes.bool,
+    minimumGasLimit: PropTypes.number.isRequired,
   }
 
   state = {
@@ -79,6 +80,7 @@ export default class GasModalPageContainer extends Component {
       setSwapsCustomizationModalLimit,
       customGasPrice,
       customGasLimit,
+      minimumGasLimit,
     } = this.props
 
     return (
@@ -109,6 +111,7 @@ export default class GasModalPageContainer extends Component {
               insufficientBalance={insufficientBalance}
               customPriceIsSafe={!showCustomPriceTooLowWarning}
               customGasLimitMessage={customGasLimitMessage}
+              minimumGasLimit={minimumGasLimit}
             />
           </div>
         </div>

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
@@ -41,6 +41,7 @@ const mapStateToProps = (state) => {
     extraInfoRow = null,
     initialGasPrice,
     initialGasLimit,
+    minimumGasLimit,
   } = modalProps || {}
   const buttonDataLoading = swapGasPriceEstimateIsLoading(state)
 
@@ -120,7 +121,8 @@ const mapStateToProps = (state) => {
     customGasLimitMessage,
     customTotalSupplement,
     usdConversionRate: getUSDConversionRate(state),
-    disableSave: insufficientBalance,
+    disableSave: insufficientBalance || customGasLimit < minimumGasLimit,
+    minimumGasLimit,
   }
 }
 

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
@@ -42,7 +42,7 @@ const mapStateToProps = (state) => {
     initialGasPrice,
     initialGasLimit,
     minimumGasLimit,
-  } = modalProps || {}
+  } = modalProps
   const buttonDataLoading = swapGasPriceEstimateIsLoading(state)
 
   const swapsCustomizationModalPrice = getSwapsCustomizationModalPrice(state)

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -445,6 +445,7 @@ export default function ViewQuote() {
           : null,
         initialGasPrice: gasPrice,
         initialGasLimit: maxGasLimit,
+        minimumGasLimit: nonCustomMaxGasLimit,
       }),
     )
 


### PR DESCRIPTION
This PR extends the functionality of the gas customization modal to accept a `minimumGasLimit` and to prevent the user from setting the gas limit below that minimum. This is used in the swaps view-quote screen to ensure the gas limit is always set to an amount that will avoid 'Out of gas' errors.

Demo

<img src="https://user-images.githubusercontent.com/7499938/96010148-0f177200-0e1c-11eb-94bd-725e982e8608.gif" width="300" />