### PR TITLE
Update text content of invalid custom network alert

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -842,7 +842,7 @@
     "message": "Invalid Block Explorer URL"
   },
   "invalidCustomNetworkAlertContent1": {
-    "message": "The custom network '$1' is missing its chain ID.",
+    "message": "The chain ID for custom network '$1' has to be re-entered.",
     "description": "$1 is the name/identifier of the network."
   },
   "invalidCustomNetworkAlertContent2": {


### PR DESCRIPTION
This PR updates the text content of the invalid custom alert.

Instead of: `The custom network 'network_name' is missing its chain ID.`

We do: `The chain ID for custom network 'network_name' has to be re-entered.`

This is an improvement, because it's very possible that the user previously entered the correct chain ID in decimal, but we make them re-enter those anyway.