### PR TITLE
Try disable swap button so it cannot be focused

### DIFF
--- a/ui/app/components/ui/icon-button/icon-button.js
+++ b/ui/app/components/ui/icon-button/icon-button.js
@@ -11,6 +11,7 @@ export default function IconButton ({ onClick, Icon, disabled, label, tooltipRen
       className={classNames('icon-button', className, { 'icon-button--disabled': disabled })}
       data-testid={props['data-testid'] ?? undefined}
       onClick={onClick}
+      disabled={disabled}
     >
       {renderWrapper(
         <>


### PR DESCRIPTION
Adding the `disabled` attributes prevents a user from tabbing to the disabled button, doesn't effect UI.