### PR TITLE
Fix #9043 - Ensure QR code scanner works

### DIFF
--- a/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -104,14 +104,14 @@ export default class QrScanner extends Component {
   componentWillUnmount () {
     this.mounted = false
     clearTimeout(this.permissionChecker)
-    this.teardownCodeReader();
+    this.teardownCodeReader()
   }
 
-  teardownCodeReader() {
-    if(this.codeReader) {
-      this.codeReader.reset();
-      this.codeReader.stop();
-      this.codeReader = null;
+  teardownCodeReader () {
+    if (this.codeReader) {
+      this.codeReader.reset()
+      this.codeReader.stop()
+      this.codeReader = null
     }
   }
 
@@ -121,12 +121,12 @@ export default class QrScanner extends Component {
     // once we receive permission so that the video displays.
     // It's important to prevent this codeReader from being created twice;
     // Firefox otherwise starts 2 video streams, one of which cannot be stopped
-    if(!this.codeReader) {
+    if (!this.codeReader) {
       this.codeReader = new BrowserQRCodeReader()
     }
     try {
       await this.codeReader.getVideoInputDevices()
-      this.checkPermissions();
+      this.checkPermissions()
       const content = await this.codeReader.decodeFromInputVideoDevice(undefined, 'video')
       const result = this.parseContent(content.text)
       if (!this.mounted) {
@@ -176,7 +176,7 @@ export default class QrScanner extends Component {
 
   stopAndClose = () => {
     if (this.codeReader) {
-      this.teardownCodeReader();
+      this.teardownCodeReader()
     }
     this.props.hideModal()
   }

--- a/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -119,10 +119,11 @@ export default class QrScanner extends Component {
     // The `decodeFromInputVideoDevice` call prompts the browser to show
     // the user the camera permission request.  We must then call it again
     // once we receive permission so that the video displays.
-    // Removing this teardown will create 2 video streams in Firefox, one
-    // of which the user will not be able to remove without refreshing the page.
-    this.teardownCodeReader();
-    this.codeReader = new BrowserQRCodeReader()
+    // It's important to prevent this codeReader from being created twice;
+    // Firefox otherwise starts 2 video streams, one of which cannot be stopped
+    if(!this.codeReader) {
+      this.codeReader = new BrowserQRCodeReader()
+    }
     try {
       await this.codeReader.getVideoInputDevices()
       this.checkPermissions();


### PR DESCRIPTION
This pull requests ensures the QR code reader functions properly in Chrome and Firefox, with and without camera permissions at the beginning of the process.