### PR TITLE
Clears all of the gas duck state on entering and leaving swaps

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -38,7 +38,7 @@ import {
   SWAP_FAILED_ERROR,
 } from '../../helpers/constants/swaps'
 import { SWAP, SWAP_APPROVAL } from '../../helpers/constants/transactions'
-import { fetchBasicGasAndTimeEstimates, fetchGasEstimates, resetCustomData } from '../gas/gas.duck'
+import { fetchBasicGasAndTimeEstimates, fetchGasEstimates, resetCustomGasState } from '../gas/gas.duck'
 import { formatCurrency } from '../../helpers/utils/confirm-tx.util'
 
 const initialState = {
@@ -235,7 +235,7 @@ export const prepareForRetryGetQuotes = () => {
 
 export const prepareToLeaveSwaps = () => {
   return async (dispatch) => {
-    dispatch(resetCustomData())
+    dispatch(resetCustomGasState())
     dispatch(clearSwapsState())
     await dispatch(resetBackgroundSwapsState())
 

--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -25,6 +25,7 @@ import {
   prepareToLeaveSwaps,
   fetchAndSetSwapsGasPriceInfo,
 } from '../../ducks/swaps/swaps'
+import { resetCustomGasState } from '../../ducks/gas/gas.duck'
 import {
   AWAITING_SWAP_ROUTE,
   BUILD_QUOTE_ROUTE,
@@ -159,6 +160,7 @@ export default function Swap () {
         dispatch(setMetamaskFeeAmount(metaMaskFeeAmount))
       })
 
+    dispatch(resetCustomGasState())
     dispatch(fetchAndSetSwapsGasPriceInfo())
 
     return () => {


### PR DESCRIPTION
Extracted these changes from #9599 

- on mount of the swaps component, resetCustomGasState is called so that pre-existing gas price state does not interfere with swaps gas price state
- on unmount of the swaps component, resetCustomGasState is called so that swaps gas price state does not interfere with gas price state elsewhere in metamask

This prevents a bug where gas price could be incorrectly set on opening the gas modal if the custom gas state had already been set outside of the swaps feature.