### PR TITLE
Fix #9577 - Use contained button type for unlock button

### DIFF
--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -122,7 +122,7 @@ export default class UnlockPage extends Component {
         style={style}
         disabled={!this.state.password}
         fullWidth
-        variant="raised"
+        variant="contained"
         size="large"
         onClick={this.handleSubmit}
         disableRipple


### PR DESCRIPTION
Button looks the same and no longer triggers a React warning.