### PR TITLE
Include trade.value in calculation of displayed network fees

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -82,6 +82,9 @@
   "affirmAgree": {
     "message": "I Agree"
   },
+  "aggregatorFeeCost": {
+    "message": "Aggregator network fee"
+  },
   "alertDisableTooltip": {
     "message": "This can be changed in \"Settings > Alerts\""
   },
@@ -129,14 +132,11 @@
     "message": "MetaMask",
     "description": "The name of the application"
   },
-  "approvalTxGasCost": {
-    "message": "Approval Tx Gas Cost"
-  },
   "approvalAndAggregatorTxFeeCost": {
     "message": "Approval and aggregator network fee"
   },
-  "aggregatorFeeCost": {
-    "message": "Aggregator network fee"
+  "approvalTxGasCost": {
+    "message": "Approval Tx Gas Cost"
   },
   "approve": {
     "message": "Approve spend limit"
@@ -1691,9 +1691,6 @@
   "swapFinalizing": {
     "message": "Finalizing..."
   },
-  "swapNetworkFeeSummary": {
-    "message": "The network fee covers the cost of processing your swap and storing it on the Ethereum network. MetaMask does not profit from this fee."
-  },
   "swapGetQuotes": {
     "message": "Get quotes"
   },
@@ -1741,6 +1738,9 @@
   "swapNQuotesAvailable": {
     "message": "$1 quotes available",
     "description": "$1 is the number of quotes that the user can select from when opening the list of quotes on the 'view quote' screen"
+  },
+  "swapNetworkFeeSummary": {
+    "message": "The network fee covers the cost of processing your swap and storing it on the Ethereum network. MetaMask does not profit from this fee."
   },
   "swapNewQuoteIn": {
     "message": "New quotes in $1",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -132,6 +132,12 @@
   "approvalTxGasCost": {
     "message": "Approval Tx Gas Cost"
   },
+  "approvalAndAggregatorTxFeeCost": {
+    "message": "Approval and aggregator network fee"
+  },
+  "aggregatorFeeCost": {
+    "message": "Aggregator network fee"
+  },
   "approve": {
     "message": "Approve spend limit"
   },
@@ -1685,8 +1691,8 @@
   "swapFinalizing": {
     "message": "Finalizing..."
   },
-  "swapGasFeeSummary": {
-    "message": "The gas fee covers the cost of processing your swap and storing it on the Ethereum network. MetaMask does not profit from this fee."
+  "swapNetworkFeeSummary": {
+    "message": "The network fee covers the cost of processing your swap and storing it on the Ethereum network. MetaMask does not profit from this fee."
   },
   "swapGetQuotes": {
     "message": "Get quotes"

--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -31,7 +31,7 @@ import {
 import { SUBMITTED_STATUS } from '../../../helpers/constants/transactions'
 import { ASSET_ROUTE, DEFAULT_ROUTE } from '../../../helpers/constants/routes'
 
-import { getRenderableGasFeesForQuote } from '../swaps.util'
+import { getRenderableNetworkFeesForQuote } from '../swaps.util'
 import SwapsFooter from '../swaps-footer'
 import SwapFailureIcon from './swap-failure-icon'
 import SwapSuccessIcon from './swap-success-icon'
@@ -70,8 +70,17 @@ export default function AwaitingSwap ({
 
   let feeinFiat
   if (usedQuote && tradeTxParams) {
-    const renderableGasFees = getRenderableGasFeesForQuote(usedQuote.gasEstimateWithRefund || usedQuote.averageGas, approveTxParams?.gas || '0x0', tradeTxParams.gasPrice, currentCurrency, conversionRate)
-    feeinFiat = renderableGasFees.feeinFiat?.slice(1)
+    const renderableNetworkFees = getRenderableNetworkFeesForQuote(
+      usedQuote.gasEstimateWithRefund || usedQuote.averageGas,
+      approveTxParams?.gas || '0x0',
+      tradeTxParams.gasPrice,
+      currentCurrency,
+      conversionRate,
+      tradeTxParams.value,
+      sourceTokenInfo?.symbol,
+      usedQuote.sourceAmount,
+    )
+    feeinFiat = renderableNetworkFees.feeinFiat?.slice(1)
   }
 
   const quotesExpiredEvent = useNewMetricEvent({

--- a/ui/app/pages/swaps/fee-card/fee-card.js
+++ b/ui/app/pages/swaps/fee-card/fee-card.js
@@ -26,7 +26,7 @@ export default function FeeCard ({
               position="top"
               contentText={(
                 <>
-                  <p className="fee-card__info-tooltip-paragraph">{ t('swapGasFeeSummary') }</p>
+                  <p className="fee-card__info-tooltip-paragraph">{ t('swapNetworkFeeSummary') }</p>
                   <p className="fee-card__info-tooltip-paragraph">{ t('swapEstimatedNetworkFeeSummary', [
                     <span className="fee-card__bold" key="fee-card-bold-1">
                       { t('swapEstimatedNetworkFee') }

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -284,6 +284,10 @@ export function getRenderableNetworkFeesForQuote (
     .minus(sourceSymbol === 'ETH' ? sourceAmount : 0, 10)
     .toString(16)
 
+  const nonGasFee = new BigNumber(totalWeiCost, 16)
+    .minus(gasTotalInWeiHex, 16)
+    .toString(16)
+
   const ethFee = getValueFromWeiHex({
     value: totalWeiCost,
     toDenomination: 'ETH',
@@ -301,6 +305,7 @@ export function getRenderableNetworkFeesForQuote (
     rawEthFee: ethFee,
     feeInFiat: formattedNetworkFee,
     feeInEth: `${ethFee} ETH`,
+    nonGasFee,
   }
 }
 

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -279,13 +279,12 @@ export function getRenderableNetworkFeesForQuote (
   const totalGasLimitForCalculation = (new BigNumber(tradeGas || '0x0', 16)).plus(approveGas || '0x0', 16).toString(16)
   const gasTotalInWeiHex = calcGasTotal(totalGasLimitForCalculation, gasPrice)
 
-  const totalWeiCost = new BigNumber(gasTotalInWeiHex, 16)
-    .plus(tradeValue, 16)
+  const nonGasFee = new BigNumber(tradeValue, 16)
     .minus(sourceSymbol === 'ETH' ? sourceAmount : 0, 10)
     .toString(16)
 
-  const nonGasFee = new BigNumber(totalWeiCost, 16)
-    .minus(gasTotalInWeiHex, 16)
+  const totalWeiCost = new BigNumber(gasTotalInWeiHex, 16)
+    .plus(nonGasFee, 16)
     .toString(16)
 
   const ethFee = getValueFromWeiHex({

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -6,8 +6,8 @@ import { ETH_SWAPS_TOKEN_OBJECT } from '../../helpers/constants/swaps'
 import { calcTokenValue, calcTokenAmount } from '../../helpers/utils/token-util'
 import { constructTxParams, toPrecisionWithoutTrailingZeros } from '../../helpers/utils/util'
 import { decimalToHex, getValueFromWeiHex } from '../../helpers/utils/conversions.util'
-import { ETH_SWAPS_TOKEN_ADDRESS } from '../../helpers/constants/swaps'
-import { subtractCurrencies, conversionUtil } from '../../helpers/utils/conversion-util'
+
+import { subtractCurrencies } from '../../helpers/utils/conversion-util'
 import { formatCurrency } from '../../helpers/utils/confirm-tx.util'
 import fetchWithCache from '../../helpers/utils/fetch-with-cache'
 
@@ -264,37 +264,6 @@ export async function fetchTokenBalance (address, userAddress) {
     : Promise.resolve()
   const usersToken = await tokenBalancePromise
   return usersToken
-}
-
-export function getTotalEthCost (gasTotalInWeiHex, tradeValue, sourceAmount, sourceTokenAddress) {
-  const totalWeiCost = new BigNumber(gasTotalInWeiHex, 16)
-    .plus(tradeValue, 16)
-
-  const totalEthCost = conversionUtil(totalWeiCost, {
-    fromCurrency: 'ETH',
-    fromDenomination: 'WEI',
-    toDenomination: 'ETH',
-    fromNumericBase: 'BN',
-    numberOfDecimals: 6,
-  })
-
-  // The total fee is aggregator/exchange fees plus gas fees.
-  // If the swap is from ETH, subtract the sourceAmount from the total cost.
-  // Otherwise, the total fee is simply trade.value plus gas fees.
-  const ethFee = sourceTokenAddress === ETH_SWAPS_TOKEN_ADDRESS
-    ? conversionUtil(
-      totalWeiCost.minus(sourceAmount, 10), // sourceAmount is in wei
-      {
-        fromCurrency: 'ETH',
-        fromDenomination: 'WEI',
-        toDenomination: 'ETH',
-        fromNumericBase: 'BN',
-        numberOfDecimals: 6,
-      },
-    )
-    : totalEthCost
-
-  return ethFee
 }
 
 export function getRenderableNetworkFeesForQuote (

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -67,7 +67,7 @@ import MainQuoteSummary from '../main-quote-summary'
 import { calcGasTotal } from '../../send/send.utils'
 import { getCustomTxParamsData } from '../../confirm-approve/confirm-approve.util'
 import ActionableMessage from '../actionable-message'
-import { quotesToRenderableData, getRenderableGasFeesForQuote } from '../swaps.util'
+import { quotesToRenderableData, getRenderableNetworkFeesForQuote } from '../swaps.util'
 import { useTokenTracker } from '../../../hooks/useTokenTracker'
 import { QUOTES_EXPIRED_ERROR } from '../../../helpers/constants/swaps'
 import CountdownTimer from '../countdown-timer'
@@ -99,7 +99,7 @@ export default function ViewQuote () {
 
   // Select necessary data
   const tradeTxParams = useSelector(getSwapsTradeTxParams)
-  const { gasPrice } = tradeTxParams || {}
+  const { gasPrice, value: tradeValue } = tradeTxParams || {}
   const customMaxGas = useSelector(getCustomSwapsGas)
   const tokenConversionRates = useSelector(getTokenExchangeRates)
   const memoizedTokenConversionRates = useEqualityCheck(tokenConversionRates)
@@ -203,23 +203,29 @@ export default function ViewQuote () {
     sourceTokenIconUrl,
   } = renderableDataForUsedQuote
 
-  const { feeInFiat, feeInEth } = getRenderableGasFeesForQuote(
+  const { feeInFiat, feeInEth } = getRenderableNetworkFeesForQuote(
     usedGasLimit,
     approveGas,
     gasPrice,
     currentCurrency,
     conversionRate,
+    tradeValue,
+    sourceTokenSymbol,
+    usedQuote.sourceAmount,
   )
 
   const {
     feeInFiat: maxFeeInFiat,
     feeInEth: maxFeeInEth,
-  } = getRenderableGasFeesForQuote(
+  } = getRenderableNetworkFeesForQuote(
     maxGasLimit,
     approveGas,
     gasPrice,
     currentCurrency,
     conversionRate,
+    tradeValue,
+    sourceTokenSymbol,
+    usedQuote.sourceAmount,
   )
 
   const tokenCost = (new BigNumber(usedQuote.sourceAmount))


### PR DESCRIPTION
This PR corrects an error in how we were rendering the displayed network fees on the view quote screen. For some aggregators, trade.value can be greater than the amount of eth being swapped (0 in the case of swapping an ERC-20, and `sourceAmount` in the case of swapping ETH). We weren't properly factoring this in before, and this could cause some rendered  networks fees to be a little lower than they should be.