### PR TITLE
Help users avoid insufficient gas prices in swaps

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -158,7 +158,7 @@ const mapStateToProps = (state, ownProps) => {
     newTotalFiat,
     currentTimeEstimate,
     blockTime: getBasicGasEstimateBlockTime(state),
-    customPriceIsSafe: isCustomPriceSafe(state),
+    customPriceIsSafe: isCustomPriceSafe(state, isSwap),
     maxModeOn,
     gasPriceButtonGroupProps: {
       buttonDataLoading,

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -254,7 +254,7 @@ export function getRenderableBasicEstimateData (state, gasLimit, useFastestButto
   }
 
   return useFastestButtons
-    ? [averageEstimateData, fastEstimatData, fastestEstimateData]
+    ? [fastEstimatData, fastestEstimateData]
     : [slowEstimatData, averageEstimateData, fastEstimatData]
 }
 

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -112,7 +112,7 @@ export function isCustomPriceSafe (state, averageIsSafe) {
   }
 
   if (safeMinimumPrice === null) {
-    return null
+    return false
   }
 
   const customPriceSafe = conversionGreaterThan(

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -231,7 +231,7 @@ export function getRenderableBasicEstimateData (state, gasLimit, useFastestButto
     },
   } = state
 
-  const slowEstimatData = {
+  const slowEstimateData = {
     gasEstimateType: GAS_ESTIMATE_TYPES.SLOW,
     feeInPrimaryCurrency: getRenderableEthFee(safeLow, gasLimit),
     feeInSecondaryCurrency: showFiat
@@ -249,7 +249,7 @@ export function getRenderableBasicEstimateData (state, gasLimit, useFastestButto
     timeEstimate: avgWait && getRenderableTimeEstimate(avgWait),
     priceInHexWei: getGasPriceInHexWei(average),
   }
-  const fastEstimatData = {
+  const fastEstimateData = {
     gasEstimateType: GAS_ESTIMATE_TYPES.FAST,
     feeInPrimaryCurrency: getRenderableEthFee(fast, gasLimit),
     feeInSecondaryCurrency: showFiat
@@ -269,8 +269,8 @@ export function getRenderableBasicEstimateData (state, gasLimit, useFastestButto
   }
 
   return useFastestButtons
-    ? [fastEstimatData, fastestEstimateData]
-    : [slowEstimatData, averageEstimateData, fastEstimatData]
+    ? [fastEstimateData, fastestEstimateData]
+    : [slowEstimateData, averageEstimateData, fastEstimateData]
 }
 
 export function getRenderableEstimateDataForSmallButtonsFromGWEI (state) {

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -88,15 +88,30 @@ export function getSafeLowEstimate (state) {
   return safeLow
 }
 
-export function isCustomPriceSafe (state) {
+export function getAverageEstimate (state) {
+  const {
+    gas: {
+      basicEstimates: {
+        average,
+      },
+    },
+  } = state
+
+  return average
+}
+
+export function isCustomPriceSafe (state, averageIsSafe) {
   const safeLow = getSafeLowEstimate(state)
+  const average = getAverageEstimate(state)
+  const safeMinimumPrice = averageIsSafe ? average : safeLow
+
   const customGasPrice = getCustomGasPrice(state)
 
   if (!customGasPrice) {
     return true
   }
 
-  if (safeLow === null) {
+  if (safeMinimumPrice === null) {
     return null
   }
 
@@ -107,7 +122,7 @@ export function isCustomPriceSafe (state) {
       fromDenomination: 'WEI',
       toDenomination: 'GWEI',
     },
-    { value: safeLow, fromNumericBase: 'dec' },
+    { value: safeMinimumPrice, fromNumericBase: 'dec' },
   )
 
   return customPriceSafe

--- a/ui/app/selectors/tests/custom-gas.test.js
+++ b/ui/app/selectors/tests/custom-gas.test.js
@@ -347,13 +347,6 @@ describe('custom-gas selectors', function () {
       {
         expectedResult: [
           {
-            gasEstimateType: 'AVERAGE',
-            feeInPrimaryCurrency: '0.000147 ETH',
-            feeInSecondaryCurrency: '$0.38',
-            priceInHexWei: '0x1a13b8600',
-            timeEstimate: '~10 min 6 sec',
-          },
-          {
             gasEstimateType: 'FAST',
             feeInSecondaryCurrency: '$0.54',
             feeInPrimaryCurrency: '0.00021 ETH',


### PR DESCRIPTION
This PR makes two changes to gas prices in swaps:

- hides the lowest of the custom price buttons so that only the "Fast" and "Fastest" options are available
- shows a warning message if the price is set below the "average" price from eth gas station

![Peek 2020-10-16 15-21](https://user-images.githubusercontent.com/7499938/96292846-65bfb000-0fc4-11eb-9441-5481e6dc4708.gif)
