### PR TITLE
Spawn yarn processes in a cmd subshell on Windows

### DIFF
--- a/development/build/task.js
+++ b/development/build/task.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events')
-const { spawn } = require('child_process')
+const spawn = require('cross-spawn')
 
 const tasks = {}
 const taskEvents = new EventEmitter()

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "concurrently": "^5.2.0",
     "copy-webpack-plugin": "^6.0.3",
     "coveralls": "^3.0.0",
+    "cross-spawn": "^7.0.3",
     "css-loader": "^2.1.1",
     "del": "^3.0.0",
     "deps-dump": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7972,6 +7972,15 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypt@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7963,16 +7963,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
-  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
-cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
In Windows, the "command" passed to spawn must be
The exact filename of an executable.
e.g. .\yarn.cmd can't be spawned by `spawn("yarn")`.
Instead, we launch cmd and use a subshell.

This allows `yarn start` to succeed on Windows.
This fixes the previously closed unresolved issue https://github.com/MetaMask/metamask-extension/issues/9127 on my machine on Windows 10.


This issue was first reported in 2011: https://github.com/nodejs/node-v0.x-archive/issues/2318
There's precedent (100+ references in the above issue) in the nodejs ecosystem to work around this issue by either spawning a cmd subshell on Windows, or using [`cross-spawn`](https://github.com/fusionjs/fusion-scaffolder/blob/master/index.js#L116) (which does the same thing).
