### PR TITLE
Cast MIN_GAS_LIMIT_DEC to number before passing to minimumGasLimit

### DIFF
--- a/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/app/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -23,7 +23,7 @@ export default class AdvancedGasInputs extends Component {
   }
 
   static defaultProps = {
-    minimumGasLimit: MIN_GAS_LIMIT_DEC,
+    minimumGasLimit: Number(MIN_GAS_LIMIT_DEC),
   }
 
   constructor (props) {

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -76,7 +76,7 @@ const mapStateToProps = (state, ownProps) => {
     customTotalSupplement = '',
     extraInfoRow = null,
     useFastestButtons = false,
-    minimumGasLimit = MIN_GAS_LIMIT_DEC,
+    minimumGasLimit = Number(MIN_GAS_LIMIT_DEC),
   } = modalProps || {}
   const { transaction = {} } = ownProps
   const selectedTransaction = isSwap


### PR DESCRIPTION
Fixes a proptype warning introduced with https://github.com/MetaMask/metamask-extension/pull/9623