### PR TITLE
getStatusKey to return an empty string when passed a falsy value

### DIFF
--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -97,8 +97,9 @@ export default function AwaitingSwap ({
     rpcPrefs,
   )
 
+  const statusKey = tradeTxData && getStatusKey(tradeTxData)
   const timeRemaining = useTransactionTimeRemaining(
-    getStatusKey(tradeTxData) === SUBMITTED_STATUS,
+    statusKey === SUBMITTED_STATUS,
     true,
     tradeTxData?.submittedTime,
     usedGasPrice,


### PR DESCRIPTION
This PR fixes a bug on develop that was introduced with https://github.com/MetaMask/metamask-extension/pull/9630

In particular, the `tradeTxData` value found here can be `null` https://github.com/MetaMask/metamask-extension/pull/9630/files#diff-c358cbd29bbbdb9db1344b7128a8a62aa73de778663856092cbb3422dc47eba9R101