### PR TITLE
Fix 9638 - Prevent excessive overflow from swap dropdowns

### DIFF
--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -241,22 +241,23 @@ export default function BuildQuote ({
         <div className="build-quote__dropdown-swap-to-header">
           <div className="build-quote__input-label">{t('swapSwapTo')}</div>
         </div>
-        <DropdownSearchList
-          startingItem={selectedToToken}
-          itemsToSearch={tokensToSearch}
-          searchPlaceholderText={t('swapSearchForAToken')}
-          fuseSearchKeys={fuseSearchKeys}
-          selectPlaceHolderText={t('swapSelectAToken')}
-          maxListItems={30}
-          onSelect={onToSelect}
-          loading={loading && (!tokensToSearch?.length || !topAssets || !Object.keys(topAssets).length)}
-          externallySelectedItem={selectedToToken}
-          hideItemIf={hideDropdownItemIf}
-          listContainerClassName="build-quote__open-to-dropdown"
-          hideRightLabels
-          defaultToAll
-
-        />
+        <div className="dropdown-input-pair dropdown-input-pair__to">
+          <DropdownSearchList
+            startingItem={selectedToToken}
+            itemsToSearch={tokensToSearch}
+            searchPlaceholderText={t('swapSearchForAToken')}
+            fuseSearchKeys={fuseSearchKeys}
+            selectPlaceHolderText={t('swapSelectAToken')}
+            maxListItems={30}
+            onSelect={onToSelect}
+            loading={loading && (!tokensToSearch?.length || !topAssets || !Object.keys(topAssets).length)}
+            externallySelectedItem={selectedToToken}
+            hideItemIf={hideDropdownItemIf}
+            listContainerClassName="build-quote__open-to-dropdown"
+            hideRightLabels
+            defaultToAll
+          />
+        </div>
         <div className="build-quote__slippage-buttons-container">
           <SlippageButtons
             onSelect={(newSlippage) => {

--- a/ui/app/pages/swaps/build-quote/index.scss
+++ b/ui/app/pages/swaps/build-quote/index.scss
@@ -118,4 +118,9 @@
       max-height: 276px;
     }
   }
+
+  /* Prevents the swaps "Swap to" field from overflowing */
+  .dropdown-input-pair__to .dropdown-search-list {
+    width: 100%;
+  }
 }

--- a/ui/app/pages/swaps/dropdown-search-list/index.scss
+++ b/ui/app/pages/swaps/dropdown-search-list/index.scss
@@ -126,6 +126,8 @@
     background: white;
     border-radius: 6px;
     min-height: 194px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__loading-item {


### PR DESCRIPTION
Prevents both the 'from' and 'to' dropdown inputs from overflowing, both in the widget itself and the dropdown.