### PR TITLE
Remove final stringified radix of a BigNumber returned from calcToken Amount

### DIFF
--- a/ui/app/pages/send/send.utils.js
+++ b/ui/app/pages/send/send.utils.js
@@ -173,7 +173,7 @@ function getGasFeeErrorObject ({
 
 function calcTokenBalance ({ sendToken, usersToken }) {
   const { decimals } = sendToken || {}
-  return calcTokenAmount(usersToken.balance.toString(), decimals).toString(16)
+  return calcTokenAmount(usersToken.balance.toString(), decimals).toString()
 }
 
 function doesAmountErrorRequireUpdate ({


### PR DESCRIPTION
The tokenBalance in send state does not reflect the actual decimal number of tokens.