### PR TITLE
Fix estimated network fee line split

### DIFF
--- a/ui/app/pages/swaps/fee-card/index.scss
+++ b/ui/app/pages/swaps/fee-card/index.scss
@@ -106,11 +106,8 @@
     color: $Grey-500;
   }
 
+  &__row-header-secondary,
   &__row-header-secondary--bold {
-    margin-right: 16px;
-  }
-
-  &__row-header-secondary {
     margin-right: 12px;
   }
 

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -275,7 +275,7 @@ export function getRenderableGasFeesForQuote (tradeGas, approveGas, gasPrice, cu
   const ethFee = getValueFromWeiHex({
     value: gasTotalInWeiHex,
     toDenomination: 'ETH',
-    numberOfDecimals: 6,
+    numberOfDecimals: 5,
   })
   const rawNetworkFees = getValueFromWeiHex({
     value: gasTotalInWeiHex,


### PR DESCRIPTION
The `Estimated network fee` line in the Fee Card of the View Quote component would sometimes split. This PR ensures it will never split by decreasing the network fee decimals from 6 to 5, and setting the same padding (12px) for the bold row as the non-bold row.

The alignment of the two rows is not great, but it looks even worse if the row splits.

Before:

![image](https://user-images.githubusercontent.com/25517051/96520271-8fc2dd80-1223-11eb-96e2-070016d441d8.png)

Appearance:

![image](https://user-images.githubusercontent.com/25517051/96519998-fd223e80-1222-11eb-9e72-3474bedc7c54.png)
