### PR TITLE
Fix `conversionRate` PropType of `GasModalPageContainer`

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -53,7 +53,7 @@ export default class GasModalPageContainer extends Component {
     customTotalSupplement: PropTypes.string,
     isSwap: PropTypes.bool,
     value: PropTypes.string,
-    conversionRate: PropTypes.string,
+    conversionRate: PropTypes.number,
     minimumGasLimit: PropTypes.number.isRequired,
   }
 


### PR DESCRIPTION
The `conversionRate` prop of `GasModalPageContainer` was updated recently in PR #9623 to have a PropType of `string` instead of `number`. This resulted in a PropType error whenever this modal was rendered, as `conversionRate` is always a `number`.

The PropType has been reverted to the correct type, `number`.