### PR TITLE
Fix `contentText` PropType of `InfoTooltip`

### DIFF
--- a/ui/app/components/ui/info-tooltip/info-tooltip.js
+++ b/ui/app/components/ui/info-tooltip/info-tooltip.js
@@ -36,7 +36,7 @@ export default function InfoTooltip ({
 }
 
 InfoTooltip.propTypes = {
-  contentText: PropTypes.string,
+  contentText: PropTypes.node,
   position: PropTypes.oneOf(['top', 'left', 'bottom', 'right']),
   wide: PropTypes.bool,
   containerClassName: PropTypes.string,


### PR DESCRIPTION
The `InfoTooltip` component had a `contentText` prop with a PropType of `string` that was being passed a `node` as of #9614. This resulted in a PropType error.

The `contentText` prop was being passed directly to `Tooltip` component as the prop `html`, which has a PropType of `node`. A string is a valid `node` type, which is why this worked before.

The `contentText` prop is now of type `node`, and the error no longer appears.