### PR TITLE
Fix `message` PropType of `ActionableMessage`

### DIFF
--- a/ui/app/pages/swaps/actionable-message/actionable-message.js
+++ b/ui/app/pages/swaps/actionable-message/actionable-message.js
@@ -38,7 +38,7 @@ export default function ActionableMessage ({
 }
 
 ActionableMessage.propTypes = {
-  message: PropTypes.string.isRequired,
+  message: PropTypes.node.isRequired,
   primaryAction: PropTypes.shape({
     label: PropTypes.string,
     onClick: PropTypes.func,


### PR DESCRIPTION
The `message` prop of `ActionableMessage` had a PropType of `string`, but it was being passed a `node`. This was resulting in a PropType error in the console on the view quote page.

The PropType has been changed to `node`, and the error is now gone.