### PR TITLE
Use undefined as default prop for onClick

### DIFF
--- a/ui/app/components/app/connected-status-indicator/connected-status-indicator.component.js
+++ b/ui/app/components/app/connected-status-indicator/connected-status-indicator.component.js
@@ -19,7 +19,7 @@ export default class ConnectedStatusIndicator extends Component {
 
   static defaultProps = {
     status: STATUS_NOT_CONNECTED,
-    onClick: null,
+    onClick: undefined,
   }
 
   renderStatusCircle = () => {


### PR DESCRIPTION
Was taking a look at how this is handled in the extension, it seems this is the one instance where we're using `null` vs `undefined` which we use here: https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/components/ui/menu/menu-item.js#L32 here: https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/components/ui/metafox-logo/metafox-logo.component.js#L12 and a few other spots

thought we might as well make it consistent