### PR TITLE
Fix React warning about missing key in `AwaitingSwap`

### DIFF
--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -119,7 +119,14 @@ export default function AwaitingSwap ({
 
   let countdownText
   if (timeRemainingIsNumber && !timeRemainingExpired && tradeTxData?.submittedTime) {
-    countdownText = <CountdownTimer timeStarted={tradeTxData?.submittedTime} timerBase={estimatedTransactionWaitTime} timeOnly />
+    countdownText = (
+      <CountdownTimer
+        key="countdown-timer"
+        timeStarted={tradeTxData?.submittedTime}
+        timerBase={estimatedTransactionWaitTime}
+        timeOnly
+      />
+    )
   } else if (tradeTxData?.submittedTime) {
     countdownText = t('swapsAlmostDone')
   } else {


### PR DESCRIPTION
The `AwaitingSwap` component was emitting a React warning when rendered because a component was being rendered in an array without having a `key` prop set.

A key has been added to the `CountdownTimer` component, which is passed into the translation helper in an array. The warning no longer appears.