### PR TITLE
Remove unused `customGasLimit` parameter

### DIFF
--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -292,7 +292,7 @@ export function getRenderableGasFeesForQuote (tradeGas, approveGas, gasPrice, cu
   }
 }
 
-export function quotesToRenderableData (quotes, gasPrice, conversionRate, currentCurrency, approveGas, tokenConversionRates, customGasLimit) {
+export function quotesToRenderableData (quotes, gasPrice, conversionRate, currentCurrency, approveGas, tokenConversionRates) {
   return Object.values(quotes).map((quote) => {
     const { destinationAmount = 0, sourceAmount = 0, sourceTokenInfo, destinationTokenInfo, slippage, aggType, aggregator, gasEstimateWithRefund, averageGas } = quote
     const sourceValue = calcTokenAmount(sourceAmount, sourceTokenInfo.decimals || 18).toString(10)
@@ -305,7 +305,6 @@ export function quotesToRenderableData (quotes, gasPrice, conversionRate, curren
       feeInEth,
     } = getRenderableGasFeesForQuote(
       (
-        customGasLimit ||
         gasEstimateWithRefund ||
         decimalToHex(averageGas || 800000)
       ),


### PR DESCRIPTION
This parameter to the `quotesToRenderableData` function was never passed in. It has been removed.