### PR TITLE
Create release PRs as a draft, initially

### DIFF
--- a/.circleci/scripts/release-create-release-pr
+++ b/.circleci/scripts/release-create-release-pr
@@ -45,6 +45,7 @@ install_github_cli
 printf '%s\n' "Creating a Pull Request for $version on GitHub"
 
 if ! hub pull-request \
+    --draft \
     --message "${CIRCLE_BRANCH/-/ } RC" --message ':package: :rocket:' \
     --base "$CIRCLE_PROJECT_USERNAME:$base_branch" \
     --head "$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH";


### PR DESCRIPTION
This change updates the command used to create RC pull requests to create [draft PRs][1].

See also: [`hub-pull-request(1)`][2]

  [1]:https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests
  [2]:https://hub.github.com/hub-pull-request.1.html