### PR TITLE
Update swaps average savings calculation

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -175,7 +175,7 @@ export default class SwapsController {
     if (Object.values(newQuotes).length === 0) {
       this.setSwapsErrorKey(QUOTES_NOT_AVAILABLE_ERROR)
     } else {
-      topAggId = await this._addTopQuoteAndTradeData(newQuotes)
+      [topAggId, newQuotes] = await this._calculateSavingsData(newQuotes)
     }
 
     const { swapsState } = this.store.getState()
@@ -390,7 +390,7 @@ export default class SwapsController {
   }
 
   /**
-   * Calculates trade data in order to identify the best quotes and its savings.
+   * Calculates data in order to identify the best quotes and its savings.
    * Modifies the passed-in quotes in place, adding the following decimal string
    * properties:
    *  - ethFee
@@ -405,9 +405,10 @@ export default class SwapsController {
    *   - total (decimal string)
    *
    * @param {Object} quotes - A set of quotes to be modified in-place.
-   * @returns {string|null} The aggregator ID of the best quote, if any.
+   * @returns {[string|null, Object]} The aggregator ID of the best quote, if any,
+   * and the quotes with the added savings data.
    */
-  async _addTopQuoteAndTradeData (quotes = {}) {
+  async _calculateSavingsData (quotes = {}) {
     const tokenConversionRates = this.tokenRatesStore.getState()
       .contractExchangeRates
     const {
@@ -558,7 +559,7 @@ export default class SwapsController {
       topQuote.savings = savings
     }
 
-    return topAggId
+    return [topAggId, quotes]
   }
 
   async _getERC20Allowance (contractAddress, walletAddress) {

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -396,14 +396,14 @@ export default class SwapsController {
    *  - ethFee
    *  - ethValueReceived
    *  - ethValueOfTrade
-   * 
+   *
    * In addition, adds the following properties to the best quote:
    *  - isBestQuote (boolean)
    *  - savings (Object)
    *   - fee (decimal string)
    *   - performance (decimal string)
    *   - total (decimal string)
-   * 
+   *
    * @param {Object} quotes - A set of quotes to be modified in-place.
    * @returns {string|null} The aggregator ID of the best quote, if any.
    */
@@ -507,14 +507,16 @@ export default class SwapsController {
           ? ethValueReceived.minus(totalEthCost, 10)
           : ethValueReceived.minus(tokenConversionRate ? totalEthCost : 0, 10)
 
+      // Collect values for savings calculation
+      allEthReceivedValues.push(ethValueReceived)
+      allEthFees.push(ethFee)
+
+      // Add the stringified values to the quote
       quote.ethFee = ethFee.toString(10)
       quote.ethValueReceived = ethValueReceived.toString(10)
       quote.ethValueOfTrade = ethValueOfTrade.toString(10)
 
-      // collect values for savings calculation
-      allEthReceivedValues.push(ethValueReceived)
-      allEthFees.push(ethFee)
-
+      // Update best quote
       if (
         ethTradeValueOfBestQuote === null ||
         ethValueOfTrade.gt(ethTradeValueOfBestQuote)

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -253,14 +253,14 @@ describe('SwapsController', function () {
       })
     })
 
-    describe('_findTopQuoteAndCalculateSavings', function () {
+    describe('_addTopQuoteAndTradeData', function () {
       it('returns empty object if passed undefined or empty object', async function () {
         assert.deepStrictEqual(
-          await swapsController._findTopQuoteAndCalculateSavings(),
+          await swapsController._addTopQuoteAndTradeData(),
           {},
         )
         assert.deepStrictEqual(
-          await swapsController._findTopQuoteAndCalculateSavings({}),
+          await swapsController._addTopQuoteAndTradeData({}),
           {},
         )
       })
@@ -293,14 +293,17 @@ describe('SwapsController', function () {
             decimals: 18,
           },
           isBestQuote: true,
-          // TODO: find a way to calculate these values dynamically
-          gasEstimate: 2000000,
-          gasEstimateWithRefund: 'b8cae',
+          ethFee: '33554432',
+          ethValueOfTrade: '-33554382',
+          ethValueReceived: '50',
           savings: {
             fee: '0',
             performance: '6',
             total: '6',
           },
+          // TODO: find a way to calculate these values dynamically
+          gasEstimate: 2000000,
+          gasEstimateWithRefund: 'b8cae',
         })
 
         assert.strictEqual(
@@ -419,7 +422,10 @@ describe('SwapsController', function () {
           MOCK_FETCH_METADATA,
         )
 
-        assert.strictEqual(newQuotes[topAggId].isBestQuote, false)
+        assert.ok(
+          !newQuotes[topAggId].isBestQuote,
+          'should not have marked as best quote',
+        )
       })
     })
 

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -253,14 +253,14 @@ describe('SwapsController', function () {
       })
     })
 
-    describe('_addTopQuoteAndTradeData', function () {
+    describe('_calculateSavingsData', function () {
       it('returns empty object if passed undefined or empty object', async function () {
         assert.deepStrictEqual(
-          await swapsController._addTopQuoteAndTradeData(),
+          await swapsController._calculateSavingsData(),
           {},
         )
         assert.deepStrictEqual(
-          await swapsController._addTopQuoteAndTradeData({}),
+          await swapsController._calculateSavingsData({}),
           {},
         )
       })


### PR DESCRIPTION
@danjm noticed that we were effectively doubling the size of the fee savings (whether negative or positive) by calculating performance savings using `ethValueOfTrade`, which already has the fees subtracted.

This PR fixes our average savings calculation by using the existing intermediate value, `ethValueReceived`, and its median to calculate performance savings.

In addition, we add the following properties to all quotes, to avoid recalculating their values in the UI:
- `ethFee`
- `ethValueReceived`
- `ethValueOfTrade`