### PR TITLE
Add a GitHub Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@metamask/*"
+    versioning-strategy: "lockfile-only"


### PR DESCRIPTION
This change adds a GitHub Dependabot configuration to enable daily checks for dependency updates.

[See the docs for more information.][1]

  [1]:https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

This config enables checking for dependencies in the root `package.json` file (`directory`) every weekday (`schedule.interval`) only for lockfile updates, ignoring any new versions that would require package manifest changes. (if necessary, `versioning-strategy`). This is all restricted to the organization's `@metamask/*` packages via `allow[0].dependency-name`.

~Blocked by #9519, #9663~

Refs https://github.com/MetaMask/metamask-module-template/issues/14