### PR TITLE
Fix 9649 - Ensure QR codes work properly when adding contact

### DIFF
--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -66,14 +66,17 @@ export default class EnsInput extends Component {
     let newValue
 
     // Set the value of our input based on QR code provided by parent
-    if (input !== value && prevProps.value !== value) {
+    const newProvidedValue = input !== value && prevProps.value !== value
+    if (newProvidedValue) {
       newValue = value
     }
 
     if (prevProps.network !== network) {
       const provider = global.ethereumProvider
       this.ens = new ENS({ provider, network })
-      newValue = input
+      if (!newProvidedValue) {
+        newValue = input
+      }
     }
 
     if (newValue !== undefined) {

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -63,17 +63,21 @@ export default class EnsInput extends Component {
       value,
     } = this.props
 
+    let newValue
+
     // Set the value of our input based on QR code provided by parent
     if (input !== value && prevProps.value !== value) {
-      this.setState({ input: value })
+      newValue = value
     }
 
-    // If an address is sent without a nickname, meaning not from ENS or from
-    // the user's own accounts, a default of a one-space string is used.
     if (prevProps.network !== network) {
       const provider = global.ethereumProvider
       this.ens = new ENS({ provider, network })
-      this.onChange({ target: { value: input } })
+      newValue = input
+    }
+
+    if (newValue !== undefined) {
+      this.onChange({ target: { value: newValue } })
     }
   }
 

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -33,6 +33,7 @@ export default class EnsInput extends Component {
     onReset: PropTypes.func,
     onValidAddressTyped: PropTypes.func,
     contact: PropTypes.object,
+    value: PropTypes.string,
   }
 
   state = {
@@ -53,16 +54,22 @@ export default class EnsInput extends Component {
     }
   }
 
-  // If an address is sent without a nickname, meaning not from ENS or from
-  // the user's own accounts, a default of a one-space string is used.
   componentDidUpdate (prevProps) {
     const {
       input,
     } = this.state
     const {
       network,
+      value,
     } = this.props
 
+    // Update the value in state if its prop value changes
+    if (input !== value) {
+      this.setState({ input: value })
+    }
+
+    // If an address is sent without a nickname, meaning not from ENS or from
+    // the user's own accounts, a default of a one-space string is used.
     if (prevProps.network !== network) {
       const provider = global.ethereumProvider
       this.ens = new ENS({ provider, network })

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -63,8 +63,8 @@ export default class EnsInput extends Component {
       value,
     } = this.props
 
-    // Update the value in state if its prop value changes
-    if (input !== value) {
+    // Set the value of our input based on QR code provided by parent
+    if (input !== value && prevProps.value != value) {
       this.setState({ input: value })
     }
 

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -64,7 +64,7 @@ export default class EnsInput extends Component {
     } = this.props
 
     // Set the value of our input based on QR code provided by parent
-    if (input !== value && prevProps.value != value) {
+    if (input !== value && prevProps.value !== value) {
       this.setState({ input: value })
     }
 

--- a/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/app/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -52,6 +52,7 @@ export default class AddContact extends PureComponent {
   validate = (address) => {
     const valid = isValidAddress(address)
     const validEnsAddress = isValidDomainName(address)
+
     if (valid || validEnsAddress || address === '') {
       this.setState({ error: '', ethAddress: address })
     } else {
@@ -73,6 +74,7 @@ export default class AddContact extends PureComponent {
           this.setState({ ensAddress: address, error: '', ensError: '' })
         }}
         updateEnsResolutionError={(message) => this.setState({ ensError: message })}
+        value={this.state.ethAddress || ''}
       />
     )
   }


### PR DESCRIPTION
We were never passing a value to the ENSInput which is why it wasn't displaying.

Now you can go to the "Add Contact" screen, use the QR code scanner, and see your code in the INPUT element as you'd expect.