### PR TITLE
Fix node/no-callback-literal issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,7 +98,6 @@ module.exports = {
     'node/no-path-concat': 'off',
     'dot-notation': 'off',
     'mocha/max-top-level-suites': 'off',
-    'node/no-callback-literal': 'off',
   },
 
   overrides: [{

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -10,7 +10,7 @@ const largeDelayMs = regularDelayMs * 2
 
 const dappPort = 8080
 
-async function withFixtures (options, callback) {
+async function withFixtures (options, testSuite) {
   const { dapp, fixtures, ganacheOptions, driverOptions, title } = options
   const fixtureServer = new FixtureServer()
   const ganacheServer = new Ganache()
@@ -33,8 +33,7 @@ async function withFixtures (options, callback) {
     const { driver } = await buildWebDriver(driverOptions)
     webDriver = driver
 
-    // eslint-disable-next-line node/callback-return,node/no-callback-literal
-    await callback({
+    await testSuite({
       driver,
     })
 


### PR DESCRIPTION
Refs #9663

See [`node/no-callback-literal`][1] for more information.

This change enables `node/no-callback-literal` and fixes the issues raised by the rule.

  [1]:https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-callback-literal.md