### PR TITLE
Fix node/no-deprecated-api issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,7 +91,6 @@ module.exports = {
     // TODO: re-enable these rules
     'accessor-pairs': 'off',
     'node/no-sync': 'off',
-    'node/no-deprecated-api': 'off',
     'node/no-unpublished-import': 'off',
     'node/no-unpublished-require': 'off',
     'node/no-unsupported-features/node-builtins': 'off',

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -1,4 +1,4 @@
-import punycode from 'punycode'
+import punycode from 'punycode/punycode'
 import ethUtil from 'ethereumjs-util'
 import ObservableStore from 'obs-store'
 import log from 'loglevel'

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -1,4 +1,3 @@
-import urlUtil from 'url'
 import extension from 'extensionizer'
 import resolveEnsToIpfsContentId from './resolver'
 
@@ -26,8 +25,7 @@ export default function setupEnsIpfsResolver ({ provider, getCurrentNetwork, get
       return
     }
     // parse ens name
-    const urlData = urlUtil.parse(url)
-    const { hostname: name, pathname, search, hash: fragment } = urlData
+    const { hostname: name, pathname, search, hash: fragment } = new URL(url)
     const domainParts = name.split('.')
     const topLevelDomain = domainParts[domainParts.length - 1]
     // if unsupported TLD, abort

--- a/test/e2e/mock-3box/server.js
+++ b/test/e2e/mock-3box/server.js
@@ -1,5 +1,4 @@
 const http = require('http')
-const url = require('url')
 
 const port = 8889
 
@@ -20,7 +19,7 @@ const requestHandler = (request, response) => {
       response.end('ok')
     })
   } else if (request.method === 'GET') {
-    const { key } = url.parse(request.url, true).query
+    const key = (new URL(request.url, 'https://example.org/')).searchParams.get('key')
     response.setHeader('Access-Control-Allow-Headers', '*')
     response.end(JSON.stringify(database[key] || ''))
   } else {

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -1,4 +1,4 @@
-import punycode from 'punycode'
+import punycode from 'punycode/punycode'
 import abi from 'human-standard-token-abi'
 import BigNumber from 'bignumber.js'
 import ethUtil from 'ethereumjs-util'


### PR DESCRIPTION
Refs #9663

See [`node/no-deprecated-api`][1] for more information.

This change enables `node/no-deprecated-api` and fixes the issues raised by the rule.

  [1]:https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/no-deprecated-api.md

The change to the way that `punycode` is imported is to workaround the fact that the 3rd-party version is hidden by the built-in version. Importing the file allows Node to understand that it should look in `node_modules`.