### PR TITLE
Fix ENS resolution of `.eth` URLs with query strings

### DIFF
--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -27,7 +27,7 @@ export default function setupEnsIpfsResolver ({ provider, getCurrentNetwork, get
     }
     // parse ens name
     const urlData = urlUtil.parse(url)
-    const { hostname: name, path, search, hash: fragment } = urlData
+    const { hostname: name, pathname, search, hash: fragment } = urlData
     const domainParts = name.split('.')
     const topLevelDomain = domainParts[domainParts.length - 1]
     // if unsupported TLD, abort
@@ -35,17 +35,17 @@ export default function setupEnsIpfsResolver ({ provider, getCurrentNetwork, get
       return
     }
     // otherwise attempt resolve
-    attemptResolve({ tabId, name, path, search, fragment })
+    attemptResolve({ tabId, name, pathname, search, fragment })
   }
 
-  async function attemptResolve ({ tabId, name, path, search, fragment }) {
+  async function attemptResolve ({ tabId, name, pathname, search, fragment }) {
     const ipfsGateway = getIpfsGateway()
     extension.tabs.update(tabId, { url: `loading.html` })
     let url = `https://app.ens.domains/name/${name}`
     try {
       const { type, hash } = await resolveEnsToIpfsContentId({ provider, name })
       if (type === 'ipfs-ns' || type === 'ipns-ns') {
-        const resolvedUrl = `https://${hash}.${type.slice(0, 4)}.${ipfsGateway}${path}${search || ''}${fragment || ''}`
+        const resolvedUrl = `https://${hash}.${type.slice(0, 4)}.${ipfsGateway}${pathname}${search || ''}${fragment || ''}`
         try {
           // check if ipfs gateway has result
           const response = await window.fetch(resolvedUrl, { method: 'HEAD' })
@@ -56,11 +56,11 @@ export default function setupEnsIpfsResolver ({ provider, getCurrentNetwork, get
           console.warn(err)
         }
       } else if (type === 'swarm-ns') {
-        url = `https://swarm-gateways.net/bzz:/${hash}${path}${search || ''}${fragment || ''}`
+        url = `https://swarm-gateways.net/bzz:/${hash}${pathname}${search || ''}${fragment || ''}`
       } else if (type === 'onion' || type === 'onion3') {
-        url = `http://${hash}.onion${path}${search || ''}${fragment || ''}`
+        url = `http://${hash}.onion${pathname}${search || ''}${fragment || ''}`
       } else if (type === 'zeronet') {
-        url = `http://127.0.0.1:43110/${hash}${path}${search || ''}${fragment || ''}`
+        url = `http://127.0.0.1:43110/${hash}${pathname}${search || ''}${fragment || ''}`
       }
     } catch (err) {
       console.warn(err)


### PR DESCRIPTION
Our ENS resolver for the browser address bar was incorrectly resolving addresses that included query strings. We were concatenating the `path` property with the `search` property, despite the fact that the `path` property already contains `search`. As a result, `search` was duplicated in the resolved addresses.

For example, if an IPFS content ID was found for this address, the resolved address for `metamask.eth/?foo=bar` would have the path `/?foo=bar?foo=bar`

The original intent was likely to use `pathname` in place of `path`. The resolver has been updated to use `pathname`, and the query string now appears only once in the resolved address.