### PR TITLE
Gas metrics tweaks for swaps failed and completed events

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -860,7 +860,7 @@ export default class TransactionController extends EventEmitter {
 
         const estimatedVsUsedGasRatio = `${
           (new BigNumber(txMeta.txReceipt.gasUsed, 16))
-            .div(txMeta.swapMetaData.estimated_gas, 16)
+            .div(txMeta.swapMetaData.estimated_gas, 10)
             .times(100)
             .round(2)
         }%`

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -23,7 +23,7 @@ import {
 import { AWAITING_SWAP_ROUTE, BUILD_QUOTE_ROUTE, LOADING_QUOTES_ROUTE, SWAPS_ERROR_ROUTE, SWAPS_MAINTENANCE_ROUTE } from '../../helpers/constants/routes'
 import { fetchSwapsFeatureLiveness } from '../../pages/swaps/swaps.util'
 import { calcGasTotal } from '../../pages/send/send.utils'
-import { decimalToHex, getValueFromWeiHex, hexMax, decGWEIToHexWEI, hexToDecimal, decEthToConvertedCurrency } from '../../helpers/utils/conversions.util'
+import { decimalToHex, getValueFromWeiHex, hexMax, decGWEIToHexWEI, hexToDecimal, decEthToConvertedCurrency, hexWEIToDecGWEI } from '../../helpers/utils/conversions.util'
 import { calcTokenAmount } from '../../helpers/utils/token-util'
 import {
   getFastPriceEstimateInHexWEI,
@@ -482,6 +482,8 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       other_quote_selected_source: usedQuote.aggregator === getTopQuote(state)?.aggregator ? '' : usedQuote.aggregator,
       gas_fees: formatCurrency(gasEstimateTotalInEth, 'usd')?.slice(1),
       estimated_gas: estimatedGasLimit.toString(10),
+      suggested_gas_price: hexWEIToDecGWEI(usedGasPrice),
+      used_gas_price: hexWEIToDecGWEI(fastGasEstimate),
       average_savings: averageSavings,
     }
 

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -481,7 +481,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       other_quote_selected: usedQuote.aggregator !== getTopQuote(state)?.aggregator,
       other_quote_selected_source: usedQuote.aggregator === getTopQuote(state)?.aggregator ? '' : usedQuote.aggregator,
       gas_fees: formatCurrency(gasEstimateTotalInEth, 'usd')?.slice(1),
-      estimated_gas: estimatedGasLimit.toString(16),
+      estimated_gas: estimatedGasLimit.toString(10),
       average_savings: averageSavings,
     }
 


### PR DESCRIPTION
This PR makes two changes to properties of the 'Swap Completed' and 'Swap Failed' metrics events
- changes the base of the `estimated_gas` property to decimal (instead of hex)
- adds two new properties, `suggested_gas_price` and `used_gas_price`