### PR TITLE
Use local ETH_SWAPS_TOKEN_OBJECT in swaps token array

### DIFF
--- a/ui/app/pages/swaps/swaps-util-test-constants.js
+++ b/ui/app/pages/swaps/swaps-util-test-constants.js
@@ -1,3 +1,5 @@
+import { ETH_SWAPS_TOKEN_OBJECT } from '../../helpers/constants/swaps'
+
 export const TRADES_BASE_PROD_URL = 'https://api.metaswap.codefi.network/trades?'
 export const TOKENS_BASE_PROD_URL = 'https://api.metaswap.codefi.network/tokens'
 export const AGGREGATOR_METADATA_BASE_PROD_URL = 'https://api.metaswap.codefi.network/aggregatorMetadata'
@@ -16,6 +18,7 @@ export const TOKENS = [
   { erc20: true, symbol: 'USDT', decimals: 6, address: '0xdAC17F958D2ee523a2206206994597C13D831ec7' },
   { erc20: true, symbol: 'WED', decimals: 18, address: '0x7848ae8F19671Dc05966dafBeFbBbb0308BDfAbD' },
   { erc20: true, symbol: 'WBTC', decimals: 8, address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599' },
+  ETH_SWAPS_TOKEN_OBJECT,
 ]
 
 export const MOCK_TRADE_RESPONSE_1 = [

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -2,6 +2,7 @@ import log from 'loglevel'
 import BigNumber from 'bignumber.js'
 import abi from 'human-standard-token-abi'
 import { isValidAddress } from 'ethereumjs-util'
+import { ETH_SWAPS_TOKEN_OBJECT } from '../../helpers/constants/swaps'
 import { calcTokenValue, calcTokenAmount } from '../../helpers/utils/token-util'
 import { constructTxParams, toPrecisionWithoutTrailingZeros } from '../../helpers/utils/util'
 import { decimalToHex, getValueFromWeiHex } from '../../helpers/utils/conversions.util'
@@ -214,7 +215,10 @@ export async function fetchTradesInfo ({
 export async function fetchTokens () {
   const tokenUrl = getBaseApi('tokens')
   const tokens = await fetchWithCache(tokenUrl, { method: 'GET' }, { cacheRefreshTime: CACHE_REFRESH_ONE_HOUR })
-  const filteredTokens = tokens.filter((token) => validateData(TOKEN_VALIDATORS, token, tokenUrl))
+  const filteredTokens = tokens.filter((token) => {
+    return validateData(TOKEN_VALIDATORS, token, tokenUrl) && (token.address !== ETH_SWAPS_TOKEN_OBJECT.address)
+  })
+  filteredTokens.push(ETH_SWAPS_TOKEN_OBJECT)
   return filteredTokens
 }
 


### PR DESCRIPTION
The swaps '/tokens' api returns a list of token objects. These object always have the following properties: `symbol`, `decimals`, `address`. They sometimes have an `iconUrl`. The list include an object for the "ETH" token, that only includes symbol, decimals and address.

We have a local constant `ETH_SWAPS_TOKEN_OBJECT` that includes a local iconUrl for the "ETH" token. This PR causes us to explicitly replace the ETH token object returned by the api with our local one. This will ensure the iconUrl is always available on the eth token object.