### PR TITLE
Fix accessor-pairs issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,7 +89,6 @@ module.exports = {
     'node/no-process-env': 'off',
 
     // TODO: re-enable these rules
-    'accessor-pairs': 'off',
     'node/no-sync': 'off',
     'node/no-unpublished-import': 'off',
     'node/no-unpublished-require': 'off',

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -86,6 +86,7 @@ export default class DetectTokensController {
     this.interval = DEFAULT_INTERVAL
   }
 
+  /* eslint-disable accessor-pairs */
   /**
    * @type {Number}
    */
@@ -162,4 +163,5 @@ export default class DetectTokensController {
   get isActive () {
     return this.isOpen && this.isUnlocked
   }
+  /* eslint-enable accessor-pairs */
 }

--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -46,6 +46,7 @@ export default class TokenRatesController {
     this.store.putState({ contractExchangeRates })
   }
 
+  /* eslint-disable accessor-pairs */
   /**
    * @type {Object}
    */
@@ -68,6 +69,7 @@ export default class TokenRatesController {
     this._tokens = tokens
     this.updateExchangeRates()
   }
+  /* eslint-enable accessor-pairs */
 
   start (interval = DEFAULT_INTERVAL) {
     this._handle && clearInterval(this._handle)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2163,6 +2163,7 @@ export default class MetamaskController extends EventEmitter {
   }
 
   // TODO: Replace isClientOpen methods with `controllerConnectionChanged` events.
+  /* eslint-disable accessor-pairs */
   /**
    * A method for recording whether the MetaMask user interface is open or not.
    * @private
@@ -2172,6 +2173,7 @@ export default class MetamaskController extends EventEmitter {
     this._isClientOpen = open
     this.detectTokensController.isOpen = open
   }
+  /* eslint-enable accessor-pairs */
 
   /**
   * Creates RPC engine middleware for processing eth_signTypedData requests


### PR DESCRIPTION
Refs #9663

See [`accessor-pairs`][1] for more information.

This change enables `accessor-pairs` and fixes the issues raised by the rule.

  [1]:https://eslint.org/docs/rules/accessor-pairs