### PR TITLE
call callback func in segmentNoop.track

### DIFF
--- a/shared/modules/metametrics.js
+++ b/shared/modules/metametrics.js
@@ -12,8 +12,10 @@ const flushAt = 1
 export const METAMETRICS_ANONYMOUS_ID = '0x0000000000000000'
 
 const segmentNoop = {
-  track () {
-    // noop
+  track (_, callback = () => undefined) {
+    // Need to call the callback so that environments without a segment id still
+    // resolve the promise from trackMetaMetricsEvent
+    return callback()
   },
   page () {
     // noop


### PR DESCRIPTION
The noop segment object, that is used when a build isn't provided a segment write key, doesn't accept or call a callback function. In the `trackMetaMetricsEvent` function we rely on that callback to resolve the promise. This is breaking E2E tests anywhere that we wait for that promise to resolve. This currently only affects #9646, but would also cause unresolved promises for all of the MetaSwaps events. 