### PR TITLE
Improve stability of contract deposit e2e test

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -676,7 +676,7 @@ describe('MetaMask', function () {
       await driver.switchToWindow(extension)
       await driver.delay(largeDelayMs * 2)
 
-      await driver.findElements(By.css('.transaction-list-item'))
+      await driver.findElements(By.css('.transaction-list-item--unconfirmed'))
       const txListValue = await driver.findClickableElement(By.css('.transaction-list-item__primary-currency'))
       await driver.wait(until.elementTextMatches(txListValue, /-4\s*ETH/u), 10000)
       await txListValue.click()


### PR DESCRIPTION
The e2e test for the contract deposit action was unnecessarily reliant upon timing. After initiating a deposit, it would grab the first
transaction in the transaction list and assume it was the deposit that it had just initiated. If it looked prior to the unapproved transaction being added to the list, it would grab the wrong transaction.

It now looks specifically for _unconfirmed_ transactions, meaning it will block until the deposit transaction is rendered.

This was discovered in testing a test-dapp PR: https://github.com/MetaMask/test-dapp/pull/76