### PR TITLE
Fix 9435 - Allow speeding up of underpriced transactions

### DIFF
--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -234,7 +234,7 @@ export const nonceSortedTransactionsSelector = createSelector(
         const { primaryTransaction: { time: primaryTxTime = 0 } = {} } = nonceProps
 
         const previousPrimaryIsNetworkFailure = nonceProps.primaryTransaction.status === FAILED_STATUS && nonceProps.primaryTransaction?.txReceipt?.status !== '0x0';
-        const currentTransactionIsOnChainFailure = transaction.txReceipt?.status === '0x0'
+        const currentTransactionIsOnChainFailure = transaction?.txReceipt?.status === '0x0'
         
         if (status === CONFIRMED_STATUS || currentTransactionIsOnChainFailure || previousPrimaryIsNetworkFailure || (txTime > primaryTxTime && status in PRIORITY_STATUS_HASH)) {
           nonceProps.primaryTransaction = transaction

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -236,7 +236,7 @@ export const nonceSortedTransactionsSelector = createSelector(
         const previousPrimaryIsNetworkFailure = nonceProps.primaryTransaction.status === FAILED_STATUS && nonceProps.primaryTransaction?.txReceipt?.status !== '0x0';
         const currentTransactionIsOnChainFailure = transaction.txReceipt?.status === '0x0'
         
-        if (status === CONFIRMED_STATUS || currentTransactionIsOnChainFailure || previousPrimaryIsNetworkFailure || txTime > primaryTxTime) {
+        if (status === CONFIRMED_STATUS || currentTransactionIsOnChainFailure || previousPrimaryIsNetworkFailure || (txTime > primaryTxTime && status in PRIORITY_STATUS_HASH)) {
           nonceProps.primaryTransaction = transaction
           console.warn("Reassigning primary transaction! New: ", transaction, "; Old: ", nonceProps.primaryTransaction)
         }

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -232,19 +232,12 @@ export const nonceSortedTransactionsSelector = createSelector(
         insertTransactionByTime(nonceProps.transactions, transaction)
 
         const { primaryTransaction: { time: primaryTxTime = 0 } = {} } = nonceProps
-        if (status in PRIORITY_STATUS_HASH) {
-          if (status === CONFIRMED_STATUS || txTime > primaryTxTime) {
-            nonceProps.primaryTransaction = transaction
-          }
-        }
+        const transactionConfirmedOrNewer = status === CONFIRMED_STATUS || txTime > primaryTxTime
+        const previousPrimaryIsFailed = nonceProps.primaryTransaction?.status === FAILED_STATUS || nonceProps.primaryTransaction?.txReceipt?.status === '0x0'
 
-        // If the primary transaction is failed or this transaction newer, assign as primary
-        if (
-          (nonceProps.primaryTransaction.status === FAILED_STATUS && nonceProps.primaryTransaction?.txReceipt?.status === '0x0' && transaction.status !== FAILED_STATUS) ||
-          txTime > primaryTxTime
-          ) {
-          console.warn("Reassigning primary transaction!", transaction)
+        if ((status in PRIORITY_STATUS_HASH || previousPrimaryIsFailed) && transactionConfirmedOrNewer) {
           nonceProps.primaryTransaction = transaction
+          console.warn("Reassigning primary transaction! New: ", transaction, "; Old: ", nonceProps.primaryTransaction)
         }
         else {
           console.info("*Not* reassigning primary transaction", transaction)

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -207,9 +207,6 @@ export const nonceSortedTransactionsSelector = createSelector(
     const orderedNonces = []
     const nonceToTransactionsMap = {}
 
-    console.log("----------------------------")
-    console.log("Transactions: ", transactions)
-
     transactions.forEach((transaction) => {
       const { txParams: { nonce } = {}, status, type, time: txTime, transactionCategory } = transaction
 
@@ -233,15 +230,11 @@ export const nonceSortedTransactionsSelector = createSelector(
 
         const { primaryTransaction: { time: primaryTxTime = 0 } = {} } = nonceProps
 
-        const previousPrimaryIsNetworkFailure = nonceProps.primaryTransaction.status === FAILED_STATUS && nonceProps.primaryTransaction?.txReceipt?.status !== '0x0';
+        const previousPrimaryIsNetworkFailure = nonceProps.primaryTransaction.status === FAILED_STATUS && nonceProps.primaryTransaction?.txReceipt?.status !== '0x0'
         const currentTransactionIsOnChainFailure = transaction?.txReceipt?.status === '0x0'
-        
+
         if (status === CONFIRMED_STATUS || currentTransactionIsOnChainFailure || previousPrimaryIsNetworkFailure || (txTime > primaryTxTime && status in PRIORITY_STATUS_HASH)) {
           nonceProps.primaryTransaction = transaction
-          console.warn("Reassigning primary transaction! New: ", transaction, "; Old: ", nonceProps.primaryTransaction)
-        }
-        else {
-          console.info("*Not* reassigning primary transaction", transaction)
         }
 
         const { initialTransaction: { time: initialTxTime = 0 } = {} } = nonceProps
@@ -260,10 +253,10 @@ export const nonceSortedTransactionsSelector = createSelector(
           nonceProps.hasCancelled = true
         }
       } else {
-        
+
         /*
         if (transaction.status === FAILED_STATUS && Boolean(transaction?.err?.message)) {
-          
+
         }
         */
 

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -207,9 +207,6 @@ export const nonceSortedTransactionsSelector = createSelector(
     const orderedNonces = []
     const nonceToTransactionsMap = {}
 
-    console.log("------------------------")
-    console.log('nonceSortedTransactionsSelector start; transactions', transactions);
-
     transactions.forEach((transaction) => {
       const { txParams: { nonce } = {}, status, type, time: txTime, transactionCategory } = transaction
 
@@ -233,7 +230,7 @@ export const nonceSortedTransactionsSelector = createSelector(
 
         if (status in PRIORITY_STATUS_HASH) {
           // Accommodates for no primary transaction due to failure
-          const primaryTxTime = nonceProps?.primaryTransaction?.time ?? 0;
+          const primaryTxTime = nonceProps?.primaryTransaction?.time ?? 0
 
           if (status === CONFIRMED_STATUS || txTime > primaryTxTime) {
             nonceProps.primaryTransaction = transaction
@@ -256,19 +253,9 @@ export const nonceSortedTransactionsSelector = createSelector(
           nonceProps.hasCancelled = true
         }
       } else {
-        /*
-          Error:
-          {
-            message: "Error: [ethjs-rpc] rpc error with payload {\"id\":428016472614,\"jsonrpc\":\"2.0\",\"params\":[\"0xf8650a843b9aca00843b9aca00940bd88c9c99be119dbbcd493699bfbffab0904d6980802ca0f511cd1297503b5a670e9459a174eceb4a2b7786df212821873eb2302727a49ba05ac22d6732af3e21539a2cbb738f53ccac2477de1e5a2d2a389f46b88693432f\"],\"method\":\"eth_sendRawTransaction\"} [object Object]",
-​​​            rpc: {
-              code: -32000
-              message: "exceeds block gas limit"
-            }
-          }
-        */
         let primaryTransaction = transaction
-        if(transaction.status === FAILED_STATUS && Boolean(transaction?.err?.message)) {
-          primaryTransaction = null;
+        if (transaction.status === FAILED_STATUS && Boolean(transaction?.err?.message)) {
+          primaryTransaction = null
         }
 
         nonceToTransactionsMap[nonce] = {
@@ -286,11 +273,7 @@ export const nonceSortedTransactionsSelector = createSelector(
 
     const orderedTransactionGroups = orderedNonces.map((nonce) => nonceToTransactionsMap[nonce])
     mergeNonNonceTransactionGroups(orderedTransactionGroups, incomingTransactionGroups)
-    const returnValue = unapprovedTransactionGroups.concat(orderedTransactionGroups)
-
-    console.log('nonceSortedTransactionsSelector end; returnValue', returnValue);
-    
-    return returnValue;
+    return unapprovedTransactionGroups.concat(orderedTransactionGroups)
   },
 )
 

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -232,10 +232,11 @@ export const nonceSortedTransactionsSelector = createSelector(
         insertTransactionByTime(nonceProps.transactions, transaction)
 
         const { primaryTransaction: { time: primaryTxTime = 0 } = {} } = nonceProps
-        const transactionConfirmedOrNewer = status === CONFIRMED_STATUS || txTime > primaryTxTime
-        const previousPrimaryIsFailed = nonceProps.primaryTransaction?.status === FAILED_STATUS || nonceProps.primaryTransaction?.txReceipt?.status === '0x0'
 
-        if ((status in PRIORITY_STATUS_HASH || previousPrimaryIsFailed) && transactionConfirmedOrNewer) {
+        const previousPrimaryIsNetworkFailure = nonceProps.primaryTransaction.status === FAILED_STATUS && nonceProps.primaryTransaction?.txReceipt?.status !== '0x0';
+        const currentTransactionIsOnChainFailure = transaction.txReceipt?.status === '0x0'
+        
+        if (status === CONFIRMED_STATUS || currentTransactionIsOnChainFailure || previousPrimaryIsNetworkFailure || txTime > primaryTxTime) {
           nonceProps.primaryTransaction = transaction
           console.warn("Reassigning primary transaction! New: ", transaction, "; Old: ", nonceProps.primaryTransaction)
         }

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect'
 import {
   SUBMITTED_STATUS,
   CONFIRMED_STATUS,
+  FAILED_STATUS,
   PRIORITY_STATUS_HASH,
   PENDING_STATUS_HASH,
 } from '../helpers/constants/transactions'
@@ -206,6 +207,9 @@ export const nonceSortedTransactionsSelector = createSelector(
     const orderedNonces = []
     const nonceToTransactionsMap = {}
 
+    console.log("------------------------")
+    console.log('nonceSortedTransactionsSelector start; transactions', transactions);
+
     transactions.forEach((transaction) => {
       const { txParams: { nonce } = {}, status, type, time: txTime, transactionCategory } = transaction
 
@@ -228,7 +232,8 @@ export const nonceSortedTransactionsSelector = createSelector(
         insertTransactionByTime(nonceProps.transactions, transaction)
 
         if (status in PRIORITY_STATUS_HASH) {
-          const { primaryTransaction: { time: primaryTxTime = 0 } = {} } = nonceProps
+          // Accommodates for no primary transaction due to failure
+          const primaryTxTime = nonceProps?.primaryTransaction?.time ?? 0;
 
           if (status === CONFIRMED_STATUS || txTime > primaryTxTime) {
             nonceProps.primaryTransaction = transaction
@@ -251,11 +256,26 @@ export const nonceSortedTransactionsSelector = createSelector(
           nonceProps.hasCancelled = true
         }
       } else {
+        /*
+          Error:
+          {
+            message: "Error: [ethjs-rpc] rpc error with payload {\"id\":428016472614,\"jsonrpc\":\"2.0\",\"params\":[\"0xf8650a843b9aca00843b9aca00940bd88c9c99be119dbbcd493699bfbffab0904d6980802ca0f511cd1297503b5a670e9459a174eceb4a2b7786df212821873eb2302727a49ba05ac22d6732af3e21539a2cbb738f53ccac2477de1e5a2d2a389f46b88693432f\"],\"method\":\"eth_sendRawTransaction\"} [object Object]",
+​​​            rpc: {
+              code: -32000
+              message: "exceeds block gas limit"
+            }
+          }
+        */
+        let primaryTransaction = transaction
+        if(transaction.status === FAILED_STATUS && Boolean(transaction?.err?.message)) {
+          primaryTransaction = null;
+        }
+
         nonceToTransactionsMap[nonce] = {
           nonce,
           transactions: [transaction],
           initialTransaction: transaction,
-          primaryTransaction: transaction,
+          primaryTransaction,
           hasRetried: transaction.type === TRANSACTION_TYPE_RETRY,
           hasCancelled: transaction.type === TRANSACTION_TYPE_CANCEL,
         }
@@ -266,7 +286,11 @@ export const nonceSortedTransactionsSelector = createSelector(
 
     const orderedTransactionGroups = orderedNonces.map((nonce) => nonceToTransactionsMap[nonce])
     mergeNonNonceTransactionGroups(orderedTransactionGroups, incomingTransactionGroups)
-    return unapprovedTransactionGroups.concat(orderedTransactionGroups)
+    const returnValue = unapprovedTransactionGroups.concat(orderedTransactionGroups)
+
+    console.log('nonceSortedTransactionsSelector end; returnValue', returnValue);
+    
+    return returnValue;
   },
 )
 

--- a/ui/app/selectors/transactions.js
+++ b/ui/app/selectors/transactions.js
@@ -253,13 +253,6 @@ export const nonceSortedTransactionsSelector = createSelector(
           nonceProps.hasCancelled = true
         }
       } else {
-
-        /*
-        if (transaction.status === FAILED_STATUS && Boolean(transaction?.err?.message)) {
-
-        }
-        */
-
         nonceToTransactionsMap[nonce] = {
           nonce,
           transactions: [transaction],


### PR DESCRIPTION
Fixes #9435

This patch shows the "Pending" status transaction instead of a FAILED transaction that prevents any further transactions.

One remaining problem is possibly our speed up mechanism:

First, if the price is set very low, we only allow bumping up by an increment of 1, and that's not going to help very much:

<img width="729" alt="SpeedUp" src="https://user-images.githubusercontent.com/46655/96933954-04e21d00-1487-11eb-8a29-5329fb6d5bee.png">

Second, pressing "Yes, let's try" doesn't do anything
