### PR TITLE
Fix PropType error on Awaiting Swap page

### DIFF
--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -41,7 +41,6 @@ import ViewOnEtherScanLink from './view-on-ether-scan-link'
 export default function AwaitingSwap ({
   swapComplete,
   errorKey,
-  symbol,
   txHash,
   networkId,
   tokensReceived,
@@ -189,7 +188,7 @@ export default function AwaitingSwap ({
     headerText = t('swapProcessing')
     statusImage = <PulseLoader />
     submitText = t('swapsViewInActivity')
-    descriptionText = t('swapOnceTransactionHasProcess', [<span key="swapOnceTransactionHasProcess-1" className="awaiting-swap__amount-and-symbol">{symbol}</span>])
+    descriptionText = t('swapOnceTransactionHasProcess', [<span key="swapOnceTransactionHasProcess-1" className="awaiting-swap__amount-and-symbol">{destinationTokenInfo.symbol}</span>])
     content = (
       <>
         <div
@@ -214,8 +213,8 @@ export default function AwaitingSwap ({
   } else if (!errorKey && swapComplete) {
     headerText = t('swapTransactionComplete')
     statusImage = <SwapSuccessIcon />
-    submitText = t('swapViewToken', [symbol])
-    descriptionText = t('swapTokenAvailable', [<span key="swapTokenAvailable-2" className="awaiting-swap__amount-and-symbol">{`${tokensReceived || ''} ${symbol}`}</span>])
+    submitText = t('swapViewToken', [destinationTokenInfo.symbol])
+    descriptionText = t('swapTokenAvailable', [<span key="swapTokenAvailable-2" className="awaiting-swap__amount-and-symbol">{`${tokensReceived || ''} ${destinationTokenInfo.symbol}`}</span>])
     content = blockExplorerUrl && (
       <ViewOnEtherScanLink
         txHash={txHash}
@@ -273,7 +272,6 @@ export default function AwaitingSwap ({
 
 AwaitingSwap.propTypes = {
   swapComplete: PropTypes.bool,
-  symbol: PropTypes.string.isRequired,
   networkId: PropTypes.string.isRequired,
   txHash: PropTypes.string,
   tokensReceived: PropTypes.string,

--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.stories.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.stories.js
@@ -23,7 +23,6 @@ export const swapNotComplete = () => (
         ERROR_FETCHING_QUOTES,
         QUOTES_NOT_AVAILABLE_ERROR,
       ], '')}
-      symbol="ABC"
       estimatedTime="2 minutes"
       networkId="1"
       txHash="0xnotATx"
@@ -45,7 +44,6 @@ export const swapComplete = () => (
         ERROR_FETCHING_QUOTES,
         QUOTES_NOT_AVAILABLE_ERROR,
       ], '')}
-      symbol="ABC"
       estimatedTime={null}
       tokensReceived={320.68}
       networkId="1"
@@ -66,7 +64,6 @@ export const swapError = () => (
         ERROR_FETCHING_QUOTES,
         QUOTES_NOT_AVAILABLE_ERROR,
       ], '')}
-      symbol="ABC"
       estimatedTime={null}
       networkId="1"
       txHash="0xnotATx"

--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -298,7 +298,6 @@ export default function Swap () {
                     <AwaitingSwap
                       swapComplete={false}
                       errorKey={swapsErrorKey}
-                      symbol={destinationTokenInfo?.symbol}
                       txHash={tradeTxData?.hash}
                       networkId={networkId}
                       rpcPrefs={rpcPrefs}
@@ -345,7 +344,6 @@ export default function Swap () {
                 return swapsEnabled === false ? (
                   <AwaitingSwap
                     errorKey={OFFLINE_FOR_MAINTENANCE}
-                    symbol=""
                     networkId={networkId}
                     rpcPrefs={rpcPrefs}
                   />
@@ -360,7 +358,6 @@ export default function Swap () {
                   ? (
                     <AwaitingSwap
                       swapComplete={tradeConfirmed}
-                      symbol={destinationTokenInfo?.symbol}
                       networkId={networkId}
                       txHash={tradeTxData?.hash}
                       tokensReceived={tokensReceived}


### PR DESCRIPTION
A PropType error was shown in the console when on the Awaiting Swap page in certain error scenarios. The `symbol` property was sometimes not set if `destinationTokenInfo` was missing.

The `symbol` prop has been removed, as the `AwaitingSwap` component already selected the `fetchParams`, and the `destinationTokenInfo` object within. The prop was effectively a duplicate.