### PR TITLE
Provide image sizing so there's no jump when opening the swaps token search

### DIFF
--- a/ui/app/pages/add-token/token-search/token-search.component.js
+++ b/ui/app/pages/add-token/token-search/token-search.component.js
@@ -56,7 +56,7 @@ export default class TokenSearch extends Component {
         position="start"
         style={{ marginRight: '12px' }}
       >
-        <img src="images/search.svg" />
+        <img src="images/search.svg" width="17" height="17" />
       </InputAdornment>
     )
   }

--- a/ui/app/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
+++ b/ui/app/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
@@ -10,7 +10,7 @@ const renderAdornment = () => (
     position="start"
     style={{ marginRight: '12px' }}
   >
-    <img src="images/search.svg" />
+    <img src="images/search.svg" width="17" height="17" />
   </InputAdornment>
 )
 


### PR DESCRIPTION
Explanation:

As of right now, the first time you open the swaps "Swap from" dropdown, there's quick/weird jump in the cursor because the search icon hasn't loaded yet.  By providing width and height attributes, that jump no longer happens.  Very small UX improvement but less UI micro-jumps is good.

Manual testing steps:  
  - Open MetaMask
  - Click "Swaps" button
  - Click on the "ETH" dropdown under the "Swap from" heading
  - No visual leap while icon loads!