### PR TITLE
Swaps keyboard dropdown

### DIFF
--- a/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
+++ b/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
@@ -26,19 +26,18 @@ export default function DropdownSearchList ({
   hideItemIf,
   listContainerClassName,
 }) {
+  const t = useContext(I18nContext)
+  const [isOpen, setIsOpen] = useState(false)
+  const [selectedItem, setSelectedItem] = useState(startingItem)
   const close = () => {
     setIsOpen(false)
     onClose && onClose()
   }
-
-  const t = useContext(I18nContext)
-  const [isOpen, setIsOpen] = useState(false)
-  const [selectedItem, setSelectedItem] = useState(startingItem)
   const onClickItem = useCallback((item) => {
     onSelect && onSelect(item)
     setSelectedItem(item)
-    close();
-  }, [onClose, onSelect])
+    close()
+  }, [onSelect])
 
   const onClickSelector = useCallback(() => {
     if (!isOpen) {
@@ -65,7 +64,7 @@ export default function DropdownSearchList ({
     <button
       className={classnames('dropdown-search-list', className)}
       onClick={onClickSelector}
-      onKeyUp={e => e.key === 'Escape' && close()}
+      onKeyUp={(e) => e.key === 'Escape' && close()}
     >
       {!isOpen && (
         <div

--- a/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
+++ b/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
@@ -26,14 +26,19 @@ export default function DropdownSearchList ({
   hideItemIf,
   listContainerClassName,
 }) {
+
+  function close() {
+    setIsOpen(false)
+    onClose && onClose()
+  }
+
   const t = useContext(I18nContext)
   const [isOpen, setIsOpen] = useState(false)
   const [selectedItem, setSelectedItem] = useState(startingItem)
   const onClickItem = useCallback((item) => {
     onSelect && onSelect(item)
     setSelectedItem(item)
-    setIsOpen(false)
-    onClose && onClose()
+    close();
   }, [onClose, onSelect])
 
   const onClickSelector = useCallback(() => {
@@ -58,9 +63,10 @@ export default function DropdownSearchList ({
   }, [externallySelectedItem, selectedItem, prevExternallySelectedItem])
 
   return (
-    <div
+    <button
       className={classnames('dropdown-search-list', className)}
       onClick={onClickSelector}
+      onKeyUp={e => e.key === 'Escape' && close()}
     >
       {!isOpen && (
         <div
@@ -124,7 +130,7 @@ export default function DropdownSearchList ({
           />
         </>
       )}
-    </div>
+    </button>
   )
 }
 

--- a/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
+++ b/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
@@ -29,15 +29,16 @@ export default function DropdownSearchList ({
   const t = useContext(I18nContext)
   const [isOpen, setIsOpen] = useState(false)
   const [selectedItem, setSelectedItem] = useState(startingItem)
-  const close = () => {
+  const close = useCallback(() => {
     setIsOpen(false)
     onClose && onClose()
-  }
+  }, [onClose])
+
   const onClickItem = useCallback((item) => {
     onSelect && onSelect(item)
     setSelectedItem(item)
     close()
-  }, [onSelect])
+  }, [onSelect, close])
 
   const onClickSelector = useCallback(() => {
     if (!isOpen) {

--- a/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
+++ b/ui/app/pages/swaps/dropdown-search-list/dropdown-search-list.js
@@ -26,8 +26,7 @@ export default function DropdownSearchList ({
   hideItemIf,
   listContainerClassName,
 }) {
-
-  function close() {
+  const close = () => {
     setIsOpen(false)
     onClose && onClose()
   }

--- a/ui/app/pages/swaps/dropdown-search-list/index.scss
+++ b/ui/app/pages/swaps/dropdown-search-list/index.scss
@@ -1,6 +1,8 @@
 .dropdown-search-list {
   flex-flow: column;
   border: none;
+  background: unset;
+  padding: 0;
 
   &__search-list-open {
     margin: 24px;

--- a/ui/app/pages/swaps/searchable-item-list/index.scss
+++ b/ui/app/pages/swaps/searchable-item-list/index.scss
@@ -66,7 +66,8 @@
       border-bottom: 1px solid $Grey-100;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $Grey-000;
     }
 

--- a/ui/app/pages/swaps/searchable-item-list/item-list/item-list.component.js
+++ b/ui/app/pages/swaps/searchable-item-list/item-list/item-list.component.js
@@ -34,6 +34,7 @@ export default function ItemList ({
                   return null
                 }
 
+                const onClick = () => onClickItem && onClickItem(result)
                 const {
                   iconUrl,
                   identiconAddress,
@@ -52,8 +53,8 @@ export default function ItemList ({
                       'searchable-item-list__item--selected': selected,
                       'searchable-item-list__item--disabled': disabled,
                     })}
-                    onClick={() => onClickItem && onClickItem(result)}
-                    onKeyUp={e => e.key === "Enter" && onClickItem && onClickItem(result)}
+                    onClick={onClick}
+                    onKeyUp={e => e.key === "Enter" && onClick()}
                     key={`searchable-item-list-item-${i}`}
                   >
                     {(iconUrl || primaryLabel) && (<UrlIcon url={iconUrl} name={primaryLabel} />)}

--- a/ui/app/pages/swaps/searchable-item-list/item-list/item-list.component.js
+++ b/ui/app/pages/swaps/searchable-item-list/item-list/item-list.component.js
@@ -47,11 +47,13 @@ export default function ItemList ({
                 } = result
                 return (
                   <div
+                    tabIndex="0"
                     className={classnames('searchable-item-list__item', {
                       'searchable-item-list__item--selected': selected,
                       'searchable-item-list__item--disabled': disabled,
                     })}
                     onClick={() => onClickItem && onClickItem(result)}
+                    onKeyUp={e => e.key === "Enter" && onClickItem && onClickItem(result)}
                     key={`searchable-item-list-item-${i}`}
                   >
                     {(iconUrl || primaryLabel) && (<UrlIcon url={iconUrl} name={primaryLabel} />)}

--- a/ui/app/pages/swaps/searchable-item-list/item-list/item-list.component.js
+++ b/ui/app/pages/swaps/searchable-item-list/item-list/item-list.component.js
@@ -54,7 +54,7 @@ export default function ItemList ({
                       'searchable-item-list__item--disabled': disabled,
                     })}
                     onClick={onClick}
-                    onKeyUp={e => e.key === "Enter" && onClick()}
+                    onKeyUp={(e) => e.key === 'Enter' && onClick()}
                     key={`searchable-item-list-item-${i}`}
                   >
                     {(iconUrl || primaryLabel) && (<UrlIcon url={iconUrl} name={primaryLabel} />)}


### PR DESCRIPTION
Explanation:  

At present the dropdowns used in swaps are not accessible via keyboard.  This PR makes it so that:
- Users can tab to the dropdown, press Enter, and then press tab to get from item to item, then press Enter to select one
- Pressing Escape closes the dropdown

Manual testing steps:  
  - Open each dropdown via Enter key, press Tab to move from item to item
  - Press Enter to select items
  - Open each dropdown via Enter key, press Escape to close the dropdown

Would be good for @danjm to review as I'd like to ensure everything looks good on Linux.

![Keyboard](https://user-images.githubusercontent.com/46655/97046387-e8a0b780-153c-11eb-95fd-5a2e3cf4ce89.gif)
