### PR TITLE
Move ganache server from setup file to individual test suites

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,3 @@
-import Ganache from 'ganache-core';
 import nock from 'nock';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -30,13 +29,6 @@ process.on('exit', () => {
 });
 
 Enzyme.configure({ adapter: new Adapter() });
-
-// ganache server
-const server = Ganache.server();
-server.listen(8545);
-
-server.on('error', console.error);
-server.on('clientError', console.error);
 
 log.setDefaultLevel(5);
 global.log = log;

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -11,6 +11,10 @@ import createTxMeta from '../../../lib/createTxMeta';
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import { TRANSACTION_STATUSES } from '../../../../shared/constants/transaction';
 
+const Ganache = require('../../../e2e/ganache');
+
+const ganacheServer = new Ganache();
+
 const threeBoxSpies = {
   init: sinon.stub(),
   getThreeBoxSyncingState: sinon.stub().returns(true),
@@ -90,6 +94,10 @@ describe('MetaMaskController', function () {
   const sandbox = sinon.createSandbox();
   const noop = () => undefined;
 
+  before(async function () {
+    await ganacheServer.start();
+  });
+
   beforeEach(function () {
     nock('https://min-api.cryptocompare.com')
       .persist()
@@ -131,6 +139,10 @@ describe('MetaMaskController', function () {
   afterEach(function () {
     nock.cleanAll();
     sandbox.restore();
+  });
+
+  after(async function () {
+    await ganacheServer.quit();
   });
 
   describe('#getAccounts', function () {


### PR DESCRIPTION
Jest setup files run on each individual test file/suite. This moves the Ganache out of the test setup files and into the tests that Ganache is used. <strike>One issue is at the end of the unit test output. there is an error from Ganache that I am unfamiliar with how to handle.

<details>
<summary>Error output screenshot</summary>
<img src='https://user-images.githubusercontent.com/13376180/97048177-dd468f80-152e-11eb-9020-135f82a42d7b.png'>
</details>
</strike> Strikethough no longer valid now that #10331 has been merged.