### PR TITLE
Robustify waiting logic in e2e test

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -763,7 +763,7 @@ describe('MetaMask', function () {
 
   describe('Add a custom token from a dapp', function () {
     it('creates a new token', async function () {
-      let windowHandles = await driver.getAllWindowHandles()
+      const windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
       const dapp = windowHandles[1]
       await driver.delay(regularDelayMs * 2)
@@ -772,7 +772,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs * 2)
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create Token')]`))
-      await waitUntilXWindowHandles(3)
+      await driver.waitUntilXWindowHandles(3)
 
       const popup = windowHandles[2]
       await driver.switchToWindow(popup)

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -772,9 +772,11 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs * 2)
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create Token')]`))
-      await driver.delay(largeDelayMs)
+      await driver.wait(async () => {
+        windowHandles = await driver.getAllWindowHandles()
+        return windowHandles.length > 2
+      }, 10000)
 
-      windowHandles = await driver.getAllWindowHandles()
       const popup = windowHandles[2]
       await driver.switchToWindow(popup)
       await driver.delay(regularDelayMs)

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -772,10 +772,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs * 2)
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create Token')]`))
-      await driver.wait(async () => {
-        windowHandles = await driver.getAllWindowHandles()
-        return windowHandles.length > 2
-      }, 10000)
+      await waitUntilXWindowHandles(3)
 
       const popup = windowHandles[2]
       await driver.switchToWindow(popup)

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -763,7 +763,7 @@ describe('MetaMask', function () {
 
   describe('Add a custom token from a dapp', function () {
     it('creates a new token', async function () {
-      const windowHandles = await driver.getAllWindowHandles()
+      let windowHandles = await driver.getAllWindowHandles()
       const extension = windowHandles[0]
       const dapp = windowHandles[1]
       await driver.delay(regularDelayMs * 2)
@@ -772,7 +772,7 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs * 2)
 
       await driver.clickElement(By.xpath(`//button[contains(text(), 'Create Token')]`))
-      await driver.waitUntilXWindowHandles(3)
+      windowHandles = await driver.waitUntilXWindowHandles(3)
 
       const popup = windowHandles[2]
       await driver.switchToWindow(popup)

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -124,10 +124,11 @@ class Driver {
 
   async waitUntilXWindowHandles (x, delayStep = 1000, timeout = 5000) {
     let timeElapsed = 0
+    let windowHandles = []
     while (timeElapsed <= timeout) {
-      const windowHandles = await this.driver.getAllWindowHandles()
+      windowHandles = await this.driver.getAllWindowHandles()
       if (windowHandles.length === x) {
-        return
+        return windowHandles
       }
       await this.delay(delayStep)
       timeElapsed += delayStep


### PR DESCRIPTION
Purpose: Ensures e2e tests work with: https://github.com/MetaMask/test-dapp/pull/76

Explanation: Replaces a flaky `await driver.delay` with a `await driver.wait` that will always work

Manual testing steps:  n/a