### PR TITLE
Prevent memory leak from selected account copy tooltip

### DIFF
--- a/ui/app/components/app/selected-account/selected-account.component.js
+++ b/ui/app/components/app/selected-account/selected-account.component.js
@@ -18,6 +18,17 @@ class SelectedAccount extends Component {
     selectedIdentity: PropTypes.object.isRequired,
   }
 
+  componentDidMount () {
+    this.copyTimeout = null
+  }
+
+  componentWillUnmount () {
+    if (this.copyTimeout) {
+      clearTimeout(this.copyTimeout)
+      this.copyTimeout = null
+    }
+  }
+
   render () {
     const { t } = this.context
     const { selectedIdentity } = this.props
@@ -34,7 +45,7 @@ class SelectedAccount extends Component {
             className="selected-account__clickable"
             onClick={() => {
               this.setState({ copied: true })
-              setTimeout(() => this.setState({ copied: false }), 3000)
+              this.copyTimeout = setTimeout(() => this.setState({ copied: false }), 3000)
               copyToClipboard(checksummedAddress)
             }}
           >


### PR DESCRIPTION
Explanation:  

I noticed that after clicking the account button to copy the address, and quickly clicking the "send button", I saw a warning about setting state on an unmounted component and leading to memory leak.  This prevents said warning.

Manual testing steps:  
  - Open Firefox
  - Click the "Account 1" button at the top of the home screen to copy the wallet address
  - Quickly navigate away (i.e. the "Send" button)
  - No warning.