### PR TITLE
Prevent React warning for custom slippage

### DIFF
--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -113,7 +113,7 @@ export default function SlippageButtons ({
                             setActiveButtonIndex(1)
                           }
                         }}
-                        value={customValue}
+                        value={customValue || ''}
                       />
                     </div>
                   )

--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -74,7 +74,7 @@ export default function SlippageButtons ({
               </Button>
               <Button
                 onClick={() => {
-                  setCustomValue(undefined)
+                  setCustomValue('')
                   setEnteringCustomValue(false)
                   setActiveButtonIndex(1)
                   onSelect(2)
@@ -108,8 +108,8 @@ export default function SlippageButtons ({
                         ref={setInputRef}
                         onBlur={() => {
                           setEnteringCustomValue(false)
-                          if (customValue === '' || customValue === '0') {
-                            setCustomValue(null)
+                          if (customValue === '0') {
+                            setCustomValue('')
                             setActiveButtonIndex(1)
                           }
                         }}


### PR DESCRIPTION
Explanation:  

Fixes an issue I somehow triggered by clicking in the custom slippage box quickly:

```
Warning: `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
    in input (created by SlippageButtons)
    in div (created by SlippageButtons)
    in button (created by ButtonGroup)
    in div (created by ButtonGroup)
    in ButtonGroup (created by SlippageButtons)
    in div (created by SlippageButtons)
    in div (created by SlippageButtons)
    in div (created by SlippageButtons)
    in SlippageButtons (created by BuildQuote)
    in div (created by BuildQuote)
    in div (created by BuildQuote)
    in div (created by BuildQuote)
    in BuildQuote (created by Context.Consumer)
    in Route (created by FeatureToggledRoute)
    in FeatureToggledRoute (created by Swap)
    in Switch (created by Swap)
    in div (created by Swap)
    in div (created by Swap)
    in div (created by Swap)
    in Swap (created by Context.Consumer)
    in Route (created by Authenticated)
    in Authenticated (created by ConnectFunction)
    in ConnectFunction (created by Routes)
    in Switch (created by Routes)
    in div (created by Routes)
    in div (created by Routes)
    in Routes (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in withRouter(Connect(Routes)) (created by Index)
    in LegacyI18nProvider (created by Index)
    in I18nProvider (created by Index)
    in LegacyMetaMetricsProvider (created by Index)
    in MetaMetricsProvider (created by Index)
    in LegacyMetaMetricsProvider (created by Index)
    in MetaMetricsProvider (created by Index)
    in Router (created by HashRouter)
    in HashRouter (created by Index)
    in Provider (created by Index)
    in Index backend.js:32
    n backend.js:32
    React 12
    unstable_runWithPriority scheduler.development.js:697
    React 26
    startApp index.js:136
    launchMetamaskUi index.js:34
    apply index.js:123
    handle index.js:99
    handle dnode.js:140
    write dnode.js:128
    ondata _stream_readable.js:612
    emitOne events.js:106
    emit events.js:184
    addChunk _stream_readable.js:284
    readableAddChunk _stream_readable.js:271
    push _stream_readable.js:238
    _write index.js:68
    doWrite _stream_writable.js:406
    writeOrBuffer _stream_writable.js:395
    write _stream_writable.js:322
    ondata _stream_readable.js:619
    emitOne events.js:106
    emit events.js:184
    addChunk _stream_readable.js:291
    readableAddChunk _stream_readable.js:278
    push _stream_readable.js:245
    _onMessage index.js:38
```

Manual testing steps:  
  - Click in the custom slippage component, see no warnings.
