### PR TITLE
Fix `yarn build styles:dev`

### DIFF
--- a/development/build/styles.js
+++ b/development/build/styles.js
@@ -54,22 +54,25 @@ function createStyleTasks ({ livereload }) {
     }
 
     async function buildScss () {
-      await pump(...[
-        // pre-process
-        gulp.src(src),
-        devMode && sourcemaps.init(),
-        sass().on('error', sass.logError),
-        devMode && sourcemaps.write(),
-        autoprefixer(),
-        // standard
-        gulp.dest(dest),
-        // right-to-left
-        rtlcss(),
-        rename({ suffix: '-rtl' }),
-        devMode && sourcemaps.write(),
-        gulp.dest(dest),
-      ].filter(Boolean))
+      await Promise.all([
+        buildScssPipeline(src, dest, devMode, false),
+        buildScssPipeline(src, dest, devMode, true),
+      ])
     }
   }
 
+}
+
+async function buildScssPipeline (src, dest, devMode, rtl) {
+  await pump(...[
+    // pre-process
+    gulp.src(src),
+    devMode && sourcemaps.init(),
+    sass().on('error', sass.logError),
+    autoprefixer(),
+    rtl && rtlcss(),
+    rtl && rename({ suffix: '-rtl' }),
+    devMode && sourcemaps.write(),
+    gulp.dest(dest),
+  ].filter(Boolean))
 }


### PR DESCRIPTION
The `styles:dev` step of the development build was broken in #9568 when the `lockdown()` function from SES was introduced. One of the effects of `lockdown()` is preventing the use of `RegExp.lastMatch`, which is relied upon by `postcss` for parsing inline sourcemaps.

This problem has been worked around by re-arranging the build pipeline for styles.

Firstly, the `autoprefixer` stage was moved _before_ sourcemaps were generated. Its placement _after_ sourcemaps was a mistake in the first place - it should have always been before they were written, so that the sourcemaps could keep track of the changes made by `autoprefixer`.

Second, the `-rtl` sourcemap generation was moved to a separate build pipeline. The `rtl` stage also uses `postcss`, and it must come after the sourcemaps are written for the non-RTL styles, so splitting it into a separate build was the only way to avoid passing in inline sourcemaps. This does make the build slightly slower, but it also decreases the size of the RTL sourcemaps dramatically.