### PR TITLE
Remove unused parameter in styles build script

### DIFF
--- a/development/build/styles.js
+++ b/development/build/styles.js
@@ -50,7 +50,7 @@ function createStyleTasks ({ livereload }) {
           livereload.changed(event.path)
         })
       }
-      await buildScss(devMode)
+      await buildScss()
     }
 
     async function buildScss () {


### PR DESCRIPTION
The `devMode` parameter being passed to the `buildScss` function was not being used. The `buildScss` function was declared _inside_ the function in which it is invoked, so the `devMode` variable is already in scope - it doesn't need to be passed in.