### PR TITLE
Focus on wallet address in buy workflow

### DIFF
--- a/ui/app/components/ui/qr-code/qr-code.js
+++ b/ui/app/components/ui/qr-code/qr-code.js
@@ -59,6 +59,7 @@ function QrCodeView (props) {
       />
       <ReadOnlyInput
         wrapperClass="ellip-address-wrapper"
+        autoFocus
         value={checksumAddress(data)}
       />
     </div>

--- a/ui/app/components/ui/readonly-input/readonly-input.js
+++ b/ui/app/components/ui/readonly-input/readonly-input.js
@@ -9,6 +9,7 @@ export default function ReadOnlyInput (props) {
     value,
     textarea,
     onClick,
+    autoFocus = false,
   } = props
 
   const InputType = textarea ? 'textarea' : 'input'
@@ -21,6 +22,7 @@ export default function ReadOnlyInput (props) {
         readOnly
         onFocus={(event) => event.target.select()}
         onClick={onClick}
+        autoFocus={autoFocus}
       />
     </div>
   )
@@ -32,4 +34,5 @@ ReadOnlyInput.propTypes = {
   value: PropTypes.string,
   textarea: PropTypes.bool,
   onClick: PropTypes.func,
+  autoFocus: PropTypes.bool,
 }


### PR DESCRIPTION
Explanation:  

Quality of life improvement in buy workflow

<img width="406" alt="Copy" src="https://user-images.githubusercontent.com/46655/97193528-1a04c780-1777-11eb-8560-52cecb6a10c7.png">


Manual testing steps:  
  - Open "buy" button
  - Direct deposit Ether
  - Input should be focused and address highlighted.