### PR TITLE
Prevent button background color from displaying

### DIFF
--- a/ui/app/pages/swaps/dropdown-search-list/index.scss
+++ b/ui/app/pages/swaps/dropdown-search-list/index.scss
@@ -1,6 +1,7 @@
 .dropdown-search-list {
   flex-flow: column;
   border: none;
+  background: unset;
 
   &__search-list-open {
     margin: 24px;


### PR DESCRIPTION
Explanation:  

Prevents button background colors from bleeding through in the from/to widgets

Manual testing steps:  
  - Open the swap screen
  - Button background should be invisible


<img width="579" alt="Background" src="https://user-images.githubusercontent.com/46655/97194222-e8d8c700-1777-11eb-8f2b-698e1a19aa6d.png">
