### PR TITLE
Log when attempt to fetch quotes fails

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -402,8 +402,11 @@ export const fetchQuotesAndSetQuoteState = (history, inputValue, maxSlippage, me
     } catch (e) {
       // A newer swap request is running, so simply bail and let the newer request respond
       if (e.message === SWAPS_FETCH_ORDER_CONFLICT) {
+        log.debug(`Swap fetch order conflict detected; ignoring older request`)
         return
       }
+      // TODO: Check for any errors we should expect to occur in production, and report others to Sentry
+      log.error(`Error fetching quotes: `, e)
       dispatch(setSwapsErrorKey(ERROR_FETCHING_QUOTES))
     }
 


### PR DESCRIPTION
If the attempt to fetch quotes fails, an error message is now logged to the console explaining why it failed. This makes it dramatically easier to understand what's happening when quotes fail.

At some point later on we should also look specifically for errors we expect to occur, and report to Sentry in unexpected cases. I've added a TODO comment about this.

Manual testing steps:  
  - Navigate to the "Build Quote" page and select a "To" and "From" token
  - Open Dev Tools and block the swaps API
  - Submit the quote
  - The "Awaiting Swaps" loading page should be shown, followed by an error page that explains that an error was encountered. The console should explain why it failed.