### PR TITLE
Fix fetching of swap quotes when initial network was testnet

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -18,6 +18,7 @@ import {
   fetchTradesInfo as defaultFetchTradesInfo,
   fetchSwapsFeatureLiveness as defaultFetchSwapsFeatureLiveness,
 } from '../../../ui/app/pages/swaps/swaps.util'
+import { MAINNET_CHAIN_ID } from './network/enums'
 
 const METASWAP_ADDRESS = '0x881d40237659c251811cec9c364ef91dc08d300c'
 
@@ -91,7 +92,8 @@ export default class SwapsController {
 
     this.indexOfNewestCallInFlight = 0
 
-    this.ethersProvider = new ethers.providers.Web3Provider(provider)
+    // The chain ID is hard-coded as Mainnet because swaps is only used on Mainnet
+    this.ethersProvider = new ethers.providers.Web3Provider(provider, parseInt(MAINNET_CHAIN_ID, 16))
 
     this._setupSwapsLivenessFetching()
   }

--- a/test/stub/provider.js
+++ b/test/stub/provider.js
@@ -31,6 +31,9 @@ export function createTestProviderTools (opts = {}) {
   // handle block tracker methods
   engine.push(providerAsMiddleware(GanacheCore.provider({
     mnemonic: getTestSeed(),
+    network_id: opts.networkId,
+    _chainId: opts.chainId,
+    _chainIdRpc: opts.chainId,
   })))
   // wrap in standard provider interface
   const provider = providerFromEngine(engine)

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -119,7 +119,7 @@ describe('SwapsController', function () {
       // by default, all accounts are external accounts (not contracts)
       eth_getCode: '0x',
     }
-    provider = createTestProviderTools({ scaffold: providerResultStub })
+    provider = createTestProviderTools({ scaffold: providerResultStub, networkId: 1, chainId: 1 })
       .provider
   })
 


### PR DESCRIPTION
If the initial network when the extension is started is something other than Mainnet, the swaps controller will never successfully retrieve swap quotes. This is because the `ethers` provider used by the swaps controller doesn't allow network changes by default - it assumes that the network remains the same as when the provider was initialized.

This was fixed by hard-coding Mainnet as the initial chain ID for this `ethers` provider used by the swaps controller.

Some adjustments needed to be made to the `provider` stub to allow setting `1` as the network ID and chain ID in unit tests.

Manual testing steps:  
  - Change the current network to Ropsten
  - Restart the extension (e.g. on Chrome, navigate to chrome://extensions/ and click the "reload" circular arrow button on the MetaMask extension).
  - Unlock the extension, and observe that the current network is Ropsten
  - Switch to Mainnet
  - Navigate to swaps and attempt to get quotes
  - Before this change, the attempt would always fail. After this change, it should succeed.