### PR TITLE
Fix gas_fees properties collected for swaps analytics events

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -155,7 +155,7 @@ export default class MetamaskController extends EventEmitter {
     })
 
     this.currencyRateController = new CurrencyRateController(
-      undefined,
+      { includeUSDRate: true },
       initState.CurrencyController,
     )
 

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -77,6 +77,7 @@ describe('gas-modal-page-container container', function () {
           },
           currentCurrency: 'abc',
           conversionRate: 50,
+          usdConversionRate: 123,
           preferences: {
             showFiatInTestnets: false,
           },

--- a/ui/app/helpers/utils/conversions.util.js
+++ b/ui/app/helpers/utils/conversions.util.js
@@ -182,13 +182,17 @@ export function addHexes(aHexWEI, bHexWEI) {
   })
 }
 
-export function sumHexWEIsToRenderableFiat(
+export function sumHexWEIs(hexWEIs) {
+  return hexWEIs.filter((n) => n).reduce(addHexes)
+}
+
+export function sumHexWEIsToUnformattedFiat(
   hexWEIs,
   convertedCurrency,
   conversionRate,
 ) {
-  const hexWEIsSum = hexWEIs.filter((n) => n).reduce(addHexes)
-  const ethTotal = decEthToConvertedCurrency(
+  const hexWEIsSum = sumHexWEIs(hexWEIs)
+  const convertedTotal = decEthToConvertedCurrency(
     getValueFromWeiHex({
       value: hexWEIsSum,
       toCurrency: 'ETH',
@@ -197,5 +201,18 @@ export function sumHexWEIsToRenderableFiat(
     convertedCurrency,
     conversionRate,
   )
-  return formatCurrency(ethTotal, convertedCurrency)
+  return convertedTotal
+}
+
+export function sumHexWEIsToRenderableFiat(
+  hexWEIs,
+  convertedCurrency,
+  conversionRate,
+) {
+  const convertedTotal = sumHexWEIsToUnformattedFiat(
+    hexWEIs,
+    convertedCurrency,
+    conversionRate,
+  )
+  return formatCurrency(convertedTotal, convertedCurrency)
 }

--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router-dom'
 import { I18nContext } from '../../../contexts/i18n'
 import { useNewMetricEvent } from '../../../hooks/useMetricEvent'
 import { MetaMetricsContext } from '../../../contexts/metametrics.new'
-import { getCurrentCurrency, conversionRateSelector } from '../../../selectors'
+import { getCurrentCurrency, getUSDConversionRate } from '../../../selectors'
 import {
   getUsedQuote,
   getFetchParams,
@@ -69,14 +69,14 @@ export default function AwaitingSwap({
   const approveTxParams = useSelector(getApproveTxParams)
   const swapsGasPrice = useSelector(getUsedSwapsGasPrice)
   const currentCurrency = useSelector(getCurrentCurrency)
-  const conversionRate = useSelector(conversionRateSelector)
+  const usdConversionRate = useSelector(getUSDConversionRate)
 
   const [timeRemainingExpired, setTimeRemainingExpired] = useState(false)
   const [trackedQuotesExpiredEvent, setTrackedQuotesExpiredEvent] = useState(
     false,
   )
 
-  let feeinFiat
+  let feeinUnformattedFiat
 
   if (usedQuote && swapsGasPrice) {
     const renderableNetworkFees = getRenderableNetworkFeesForQuote(
@@ -84,12 +84,12 @@ export default function AwaitingSwap({
       approveTxParams?.gas || '0x0',
       swapsGasPrice,
       currentCurrency,
-      conversionRate,
+      usdConversionRate,
       usedQuote?.trade?.value,
       sourceTokenInfo?.symbol,
       usedQuote.sourceAmount,
     )
-    feeinFiat = renderableNetworkFees.feeinFiat?.slice(1)
+    feeinUnformattedFiat = renderableNetworkFees.rawNetworkFees
   }
 
   const quotesExpiredEvent = useNewMetricEvent({
@@ -101,7 +101,7 @@ export default function AwaitingSwap({
       request_type: fetchParams?.balanceError ? 'Quote' : 'Order',
       slippage: fetchParams?.slippage,
       custom_slippage: fetchParams?.slippage === 2,
-      gas_fees: feeinFiat,
+      gas_fees: feeinUnformattedFiat,
     },
     category: 'swaps',
   })

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import PageContainer from '../../../components/ui/page-container'
 import { Tabs, Tab } from '../../../components/ui/tabs'
 import { calcGasTotal } from '../../send/send.utils'
-import { sumHexWEIsToRenderableFiat } from '../../../helpers/utils/conversions.util'
+import { sumHexWEIsToUnformattedFiat } from '../../../helpers/utils/conversions.util'
 import AdvancedGasInputs from '../../../components/app/gas-customization/advanced-gas-inputs'
 import BasicTabContent from '../../../components/app/gas-customization/gas-modal-page-container/basic-tab-content'
 import { GAS_ESTIMATE_TYPES } from '../../../helpers/constants/common'
@@ -35,8 +35,7 @@ export default class GasModalPageContainer extends Component {
     disableSave: PropTypes.bool,
     customGasLimitMessage: PropTypes.string,
     customTotalSupplement: PropTypes.string,
-    value: PropTypes.string,
-    conversionRate: PropTypes.string,
+    usdConversionRate: PropTypes.string,
     customGasPrice: PropTypes.string,
     customGasLimit: PropTypes.string,
     setSwapsCustomizationModalPrice: PropTypes.func,
@@ -246,14 +245,10 @@ export default class GasModalPageContainer extends Component {
               category: 'swaps',
               properties: {
                 speed_set: this.state.gasSpeedType,
-                gas_fees: sumHexWEIsToRenderableFiat(
-                  [
-                    this.props.value,
-                    newSwapGasTotal,
-                    this.props.customTotalSupplement,
-                  ],
+                gas_fees: sumHexWEIsToUnformattedFiat(
+                  [newSwapGasTotal, this.props.customTotalSupplement],
                   'usd',
-                  this.props.conversionRate,
+                  this.props.usdConversionRate,
                 )?.slice(1),
               },
             })

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
@@ -6,6 +6,7 @@ import {
   getCurrentEthBalance,
   getDefaultActiveButtonIndex,
   getRenderableGasButtonData,
+  getUSDConversionRate,
 } from '../../../selectors'
 
 import {
@@ -118,8 +119,7 @@ const mapStateToProps = (state) => {
     insufficientBalance,
     customGasLimitMessage,
     customTotalSupplement,
-    conversionRate,
-    value,
+    usdConversionRate: getUSDConversionRate(state),
     disableSave: insufficientBalance,
   }
 }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -359,3 +359,7 @@ export function getOriginOfCurrentTab(state) {
 export function getIpfsGateway(state) {
   return state.metamask.ipfsGateway
 }
+
+export function getUSDConversionRate(state) {
+  return state.metamask.usdConversionRate
+}


### PR DESCRIPTION
This is in response to a comment on another PR.

A few fixes are included here. The most important is that the `gas_fees` property on analytics events should be denominated in USD. This will allow all gas fees data to be easily comparible. This requires https://github.com/MetaMask/controllers/pull/292

Additional fixes are commented on in the diff