### PR TITLE
Improve constructTxParams param name and deduplicate constructTxParams function

### DIFF
--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -390,9 +390,10 @@ export function addHexPrefixToObjectValues (obj) {
  * @param {string} from - A hex address of the tx sender address
  * @param {string} gas - A hex representation of the gas value for the transaction
  * @param {string} gasPrice - A hex representation of the gas price for the transaction
+ * @param {string} value - A hex number containing the value to be sent with the transaction
  * @returns {object} An object ready for submission to the blockchain, with all values appropriately hex prefixed
  */
-export function constructTxParams ({ sendToken, data, to, amount, from, gas, gasPrice }) {
+export function constructTxParams ({ sendToken, data, to, value, from, gas, gasPrice }) {
   const txParams = {
     data,
     from,
@@ -402,7 +403,7 @@ export function constructTxParams ({ sendToken, data, to, amount, from, gas, gas
   }
 
   if (!sendToken) {
-    txParams.value = amount
+    txParams.value = value
     txParams.to = to
   }
   return addHexPrefixToObjectValues(txParams)

--- a/ui/app/helpers/utils/util.test.js
+++ b/ui/app/helpers/utils/util.test.js
@@ -409,4 +409,69 @@ describe('util', function () {
       )
     })
   })
+
+  describe('constructTxParams()', function () {
+    it('should return a new txParams object with data if there data is given', function () {
+      assert.deepEqual(
+        util.constructTxParams({
+          data: 'someData',
+          sendToken: undefined,
+          to: 'mockTo',
+          amount: 'mockAmount',
+          from: 'mockFrom',
+          gas: 'mockGas',
+          gasPrice: 'mockGasPrice',
+        }),
+        {
+          data: '0xsomeData',
+          to: '0xmockTo',
+          value: '0xmockAmount',
+          from: '0xmockFrom',
+          gas: '0xmockGas',
+          gasPrice: '0xmockGasPrice',
+        },
+      )
+    })
+
+    it('should return a new txParams object with value and to properties if there is no sendToken', function () {
+      assert.deepEqual(
+        util.constructTxParams({
+          sendToken: undefined,
+          to: 'mockTo',
+          amount: 'mockAmount',
+          from: 'mockFrom',
+          gas: 'mockGas',
+          gasPrice: 'mockGasPrice',
+        }),
+        {
+          data: undefined,
+          to: '0xmockTo',
+          value: '0xmockAmount',
+          from: '0xmockFrom',
+          gas: '0xmockGas',
+          gasPrice: '0xmockGasPrice',
+        },
+      )
+    })
+
+    it('should return a new txParams object without a to property and a 0 value if there is a sendToken', function () {
+      assert.deepEqual(
+        util.constructTxParams({
+          sendToken: { address: '0x0' },
+          to: 'mockTo',
+          amount: 'mockAmount',
+          from: 'mockFrom',
+          gas: 'mockGas',
+          gasPrice: 'mockGasPrice',
+        }),
+        {
+          data: undefined,
+          value: '0x0',
+          from: '0xmockFrom',
+          gas: '0xmockGas',
+          gasPrice: '0xmockGasPrice',
+        },
+      )
+    })
+  })
 })

--- a/ui/app/pages/send/send-footer/send-footer.container.js
+++ b/ui/app/pages/send/send-footer/send-footer.container.js
@@ -27,10 +27,12 @@ import {
   getDefaultActiveButtonIndex,
 } from '../../../selectors'
 import { getMostRecentOverviewPage } from '../../../ducks/history/history'
+import {
+  constructTxParams,
+} from '../../../helpers/utils/util'
 import SendFooter from './send-footer.component'
 import {
   addressIsNew,
-  constructTxParams,
   constructUpdatedTx,
 } from './send-footer.utils'
 
@@ -72,7 +74,7 @@ function mapDispatchToProps (dispatch) {
     clearSend: () => dispatch(clearSend()),
     sign: ({ sendToken, to, amount, from, gas, gasPrice, data }) => {
       const txParams = constructTxParams({
-        amount,
+        value: amount,
         data,
         from,
         gas,

--- a/ui/app/pages/send/send-footer/send-footer.utils.js
+++ b/ui/app/pages/send/send-footer/send-footer.utils.js
@@ -3,23 +3,6 @@ import ethUtil from 'ethereumjs-util'
 import { TOKEN_TRANSFER_FUNCTION_SIGNATURE } from '../send.constants'
 import { addHexPrefixToObjectValues } from '../../../helpers/utils/util'
 
-export function constructTxParams ({ sendToken, data, to, amount, from, gas, gasPrice }) {
-  const txParams = {
-    data,
-    from,
-    value: '0',
-    gas,
-    gasPrice,
-  }
-
-  if (!sendToken) {
-    txParams.value = amount
-    txParams.to = to
-  }
-
-  return addHexPrefixToObjectValues(txParams)
-}
-
 export function constructUpdatedTx ({
   amount,
   data,

--- a/ui/app/pages/send/send-footer/tests/send-footer-container.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-container.test.js
@@ -11,12 +11,14 @@ const actionSpies = {
   signTx: sinon.spy(),
   updateTransaction: sinon.spy(),
 }
-const utilsStubs = {
+const sendFooterUtilsStubs = {
   addressIsNew: sinon.stub().returns(true),
+  constructUpdatedTx: sinon.stub().returns('mockConstructedUpdatedTxParams'),
+}
+const utilsStubs = {
   constructTxParams: sinon.stub().returns({
     value: 'mockAmount',
   }),
-  constructUpdatedTx: sinon.stub().returns('mockConstructedUpdatedTxParams'),
 }
 
 proxyquire('../send-footer.container.js', {
@@ -46,7 +48,8 @@ proxyquire('../send-footer.container.js', {
     getRenderableEstimateDataForSmallButtonsFromGWEI: (s) => ([{ gasEstimateType: `mockGasEstimateType:${s}` }]),
     getDefaultActiveButtonIndex: () => 0,
   },
-  './send-footer.utils': utilsStubs,
+  './send-footer.utils': sendFooterUtilsStubs,
+  '../../../helpers/utils/util': utilsStubs,
 })
 
 describe('send-footer container', function () {

--- a/ui/app/pages/send/send-footer/tests/send-footer-utils.test.js
+++ b/ui/app/pages/send/send-footer/tests/send-footer-utils.test.js
@@ -16,7 +16,6 @@ const sendUtils = proxyquire('../send-footer.utils.js', {
 })
 const {
   addressIsNew,
-  constructTxParams,
   constructUpdatedTx,
 } = sendUtils
 
@@ -42,71 +41,6 @@ describe('send-footer utils', function () {
           { address: '0xghi' },
         ], '0xxyz'),
         true,
-      )
-    })
-  })
-
-  describe('constructTxParams()', function () {
-    it('should return a new txParams object with data if there data is given', function () {
-      assert.deepEqual(
-        constructTxParams({
-          data: 'someData',
-          sendToken: undefined,
-          to: 'mockTo',
-          amount: 'mockAmount',
-          from: 'mockFrom',
-          gas: 'mockGas',
-          gasPrice: 'mockGasPrice',
-        }),
-        {
-          data: '0xsomeData',
-          to: '0xmockTo',
-          value: '0xmockAmount',
-          from: '0xmockFrom',
-          gas: '0xmockGas',
-          gasPrice: '0xmockGasPrice',
-        },
-      )
-    })
-
-    it('should return a new txParams object with value and to properties if there is no sendToken', function () {
-      assert.deepEqual(
-        constructTxParams({
-          sendToken: undefined,
-          to: 'mockTo',
-          amount: 'mockAmount',
-          from: 'mockFrom',
-          gas: 'mockGas',
-          gasPrice: 'mockGasPrice',
-        }),
-        {
-          data: undefined,
-          to: '0xmockTo',
-          value: '0xmockAmount',
-          from: '0xmockFrom',
-          gas: '0xmockGas',
-          gasPrice: '0xmockGasPrice',
-        },
-      )
-    })
-
-    it('should return a new txParams object without a to property and a 0 value if there is a sendToken', function () {
-      assert.deepEqual(
-        constructTxParams({
-          sendToken: { address: '0x0' },
-          to: 'mockTo',
-          amount: 'mockAmount',
-          from: 'mockFrom',
-          gas: 'mockGas',
-          gasPrice: 'mockGasPrice',
-        }),
-        {
-          data: undefined,
-          value: '0x0',
-          from: '0xmockFrom',
-          gas: '0xmockGas',
-          gasPrice: '0xmockGasPrice',
-        },
       )
     })
   })

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -182,7 +182,7 @@ export async function fetchTradesInfo ({
         to: quote.trade.to,
         from: quote.trade.from,
         data: quote.trade.data,
-        amount: decimalToHex(quote.trade.value),
+        value: decimalToHex(quote.trade.value),
         gas: decimalToHex(quote.maxGas),
       })
 


### PR DESCRIPTION
Prior to this PR, `constructTxParams` would accept an `amount` param and return a tx object with a `value` param. This has long been a source of confusion that is corrected with this PR.

This PR also eliminates one of the two identical `constructTxParams` in the code base.