### PR TITLE
Add documentation and improve validation for swaps quotes and some of its properties

### DIFF
--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -35,13 +35,18 @@ const getBaseApi = function (type) {
 
 const validHex = (string) => Boolean(string?.match(/^0x[a-f0-9]+$/u))
 const truthyString = (string) => Boolean(string?.length)
+const stringIsValidDecimalNumber = (string) => !isNaN(string) && string.match(/^[.0-9]+$/u) && !isNaN(parseFloat(string))
 const truthyDigitString = (string) => truthyString(string) && Boolean(string.match(/^\d+$/u))
 
 const QUOTE_VALIDATORS = [
   {
     property: 'trade',
     type: 'object',
-    validator: (trade) => trade && validHex(trade.data) && isValidAddress(trade.to) && isValidAddress(trade.from) && truthyString(trade.value),
+    validator: (trade) => trade &&
+      validHex(trade.data) &&
+      isValidAddress(trade.to) &&
+      isValidAddress(trade.from) &&
+      stringIsValidDecimalNumber(trade.value),
   },
   {
     property: 'approvalNeeded',
@@ -59,12 +64,12 @@ const QUOTE_VALIDATORS = [
   {
     property: 'sourceAmount',
     type: 'string',
-    validator: truthyDigitString,
+    validator: stringIsValidDecimalNumber,
   },
   {
     property: 'destinationAmount',
     type: 'string',
-    validator: truthyDigitString,
+    validator: stringIsValidDecimalNumber,
   },
   {
     property: 'sourceToken',

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -297,8 +297,8 @@ export function getRenderableGasFeesForQuote (tradeGas, approveGas, gasPrice, cu
 export function quotesToRenderableData (quotes, gasPrice, conversionRate, currentCurrency, approveGas, tokenConversionRates) {
   return Object.values(quotes).map((quote) => {
     const {
-      destinationAmount = 0,
-      sourceAmount = 0,
+      destinationAmount = '0',
+      sourceAmount = '0',
       sourceTokenInfo,
       destinationTokenInfo,
       slippage,

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -156,6 +156,57 @@ function validateData (validators, object, urlUsed) {
   })
 }
 
+/**
+ * Defines the shape for the quote.trade properties that are used in swaps. This object resembles a valid transaction object
+ * that can be published to the blockchain, except that it does not include a gasPrice.
+ * @typedef {Object} SwapsQuoteTrade
+ * @property {string} data - A hex string containing the data to include in the transaction
+ * @property {string} to - A hex address of the tx recipient address
+ * @property {string} from - A hex address of the tx sender address
+ * @property {string} gas - A hex representation of the gas value for the transaction
+ * @property {string} value - A hex representation of the value to be sent with the transaction
+ */
+
+ /**
+  * Defines the shape for objects that contain metadata about swaps tokens.
+  * @typedef {Object} SwapsTokenInfoObject
+  * @property {string} address - A hex string containing the contract address of the token
+  * @property {string} symbol - A string of letters that identifies the token
+  * @property {string} decimals - The token's decimals. Determines the maximum exponent of ten into which the token can be divided
+  * @property {string} iconUrl - A url at which an icon representing the token is hosted
+  */
+
+/**
+ * Defines the shape for the SwapsQuote objects used in swaps
+ * @typedef {Object} SwapsQuote
+ * @property {string} data - A hex string containing the data to include in the transaction
+ * @property {string} to - A hex address of the tx recipient address
+ * @property {string} from - A hex address of the tx sender address
+ * @property {string} gas - A hex representation of the gas value for the transaction
+ * @property {string} gasPrice - A hex representation of the gas price for the transaction
+ * @property {SwapsQuoteTrade} trade - txParams, except for gas price, of the swap transaction that would execute this quote
+ * @property {SwapsQuoteTrade} approvalNeeded - txParams, except for gas price, of the transaction that would approve the
+ * swaps contract to transfer the current accounts tokens
+ * @property {string} sourceAmount - A decimal number, denominated in WEI, representing the amount of tokens that will be sent
+ * @property {string} destinationAmount -  A decimal number, denominated in WEI, representing the approximate amount of tokens that will be received
+ * @property {string} error - An error message describing why a trade is not possible for the aggregator
+ * @property {string} sourceToken - A hex string containing the contract address of the token to be sent
+ * @property {string} destinationToken - A hex string containing the contract address of the token to be received
+ * @property {number} maxGas - An estimate of the maximum gas that will have to be spent for this quote
+ * @property {number} averageGas - An estimate of the amount of gas that will be likely to be spent for this quote
+ * @property {number} estimatedRefund - An estimate of the amount of gas from the estimated gas limit that will be refunded to the user
+ * @property {number} fetchTime - The amount of time it took to retrieve this quote, in milliseconds
+ * @property {string} aggregator - A unique identifier of the aggregator that was the source of this quote
+ * @property {string} aggType - A label that described the aggregator that was the source of this quote
+ * @property {number} fee - The fee, as a percentage, that metamask will collect if this swap is completed
+ * @property {number} slippage - The maximum amount of slippage that the user can expect for this quote
+ * @property {SwapsTokenInfoObject} sourceTokenInfo - metadata about the token to be sent
+ * @property {SwapsTokenInfoObject} destinationTokenInfo - metadata about the token to be received
+ * @property {string} gasEstimate - An estimated amount of gas, in hex WEI, for the swap transaction. As determined by eth_estimateGas
+ * @property {string} gasEstimateWithRefund - gasEstimate subtract estimatedRefund
+ * @property {boolean} isBestQuote - indicates whether the quote has the best value for the user
+ */
+
 export async function fetchTradesInfo ({
   slippage,
   sourceToken,

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -223,7 +223,7 @@ export default function ViewQuote () {
   )
 
   const tokenCost = (new BigNumber(usedQuote.sourceAmount))
-  const ethCost = (new BigNumber(usedQuote.trade.value || 0, 10))
+  const ethCost = (new BigNumber(usedQuote.trade.value || '0x0', 16))
     .plus((new BigNumber(gasTotalInWeiHex, 16)))
 
   const insufficientTokens = (


### PR DESCRIPTION
This PR does the following:

- improves the validation of `quote.trade.value`, `quote.sourceAmount` and `quote.destinationAmount` as returned by the metaswap-api `/trades` endpoint
- adds documentation for the objects returned by the the `/trades` endpoint
- corrects the type of the default values of `destinationAmount` and `sourceAmount` in quotesToRenderableData
- corrects the base parameter used when creating a BigNumber from `quote.trade.value` in view-quote.js (note that this previously did not cause any error/bug because if the first parameter to BigNumber is `0x` prefixed, then it will treat it as a hex, even if the second parameter is not 16)