### PR TITLE
Set NODE_OPTIONS=--max_old_space_size=1024 for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,8 @@ jobs:
   prep-build:
     docker:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    environment:
+      NODE_OPTIONS: --max_old_space_size=1024
     steps:
       - checkout
       - attach_workspace:
@@ -141,6 +143,8 @@ jobs:
   prep-build-test:
     docker:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    environment:
+      NODE_OPTIONS: --max_old_space_size=1024
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
This reduces the footprint of each Node process in an attempt to try and lower the failure rate for builds. This is for builds alone (the `prep-build` and `prep-build-test` jobs) as those spawn multiple processes to build stages in parallel.

From this one source:<sup>[\[1\]][1]</sup>

> Expected behavior with `--max-old-space-size` within container constraints
>
> By default, Node.js (up to 11.x) uses a maximum heap size of 700MB and 1400MB on 32-bit and 64-bit platforms, respectively.

  [1]:https://developer.ibm.com/languages/node-js/articles/nodejs-memory-management-in-container-environments/
