### PR TITLE
Use better value for average savings analytics

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -23,7 +23,7 @@ import {
 import { AWAITING_SWAP_ROUTE, BUILD_QUOTE_ROUTE, LOADING_QUOTES_ROUTE, SWAPS_ERROR_ROUTE, SWAPS_MAINTENANCE_ROUTE } from '../../helpers/constants/routes'
 import { fetchSwapsFeatureLiveness } from '../../pages/swaps/swaps.util'
 import { calcGasTotal } from '../../pages/send/send.utils'
-import { decimalToHex, getValueFromWeiHex, hexMax, decGWEIToHexWEI, hexToDecimal, decEthToConvertedCurrency, hexWEIToDecGWEI } from '../../helpers/utils/conversions.util'
+import { decimalToHex, getValueFromWeiHex, hexMax, decGWEIToHexWEI, hexToDecimal, hexWEIToDecGWEI } from '../../helpers/utils/conversions.util'
 import { calcTokenAmount } from '../../helpers/utils/token-util'
 import {
   getFastPriceEstimateInHexWEI,
@@ -462,13 +462,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       conversionRate,
       numberOfDecimals: 6,
     })
-    const averageSavings = usedQuote.isBestQuote
-      ? decEthToConvertedCurrency(
-        usedQuote.savings?.total,
-        'usd',
-        conversionRate,
-      )
-      : null
+
     const swapMetaData = {
       token_from: sourceTokenInfo.symbol,
       token_from_amount: String(swapTokenValue),
@@ -484,7 +478,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       estimated_gas: estimatedGasLimit.toString(10),
       suggested_gas_price: hexWEIToDecGWEI(usedGasPrice),
       used_gas_price: hexWEIToDecGWEI(fastGasEstimate),
-      average_savings: averageSavings,
+      average_savings: usedQuote.savings?.performance,
     }
 
     const metaMetricsConfig = {


### PR DESCRIPTION
https://github.com/MetaMask/metamask-extension/pull/9611 implemented a savings calculation, but it had an error. https://github.com/MetaMask/metamask-extension/pull/9675 will fix that calculation, but will be shipped after v8.1.3

Right now the savings calculation does not affect users in any way. But we do use the `savings.total` property for analytics. This is the property that is incorrect. However, the `savings.performance` property does actually measure what we wanted to track in analytics: the difference between overall value of the best quote and the median overall quote value.

This PR updates the place at which we are using `savings` data to user `performance` instead of `total`. This will greatly improve the usefulness of our savings metrics, which can help inform future work.

This is a hotfix that can be reverted after https://github.com/MetaMask/metamask-extension/pull/9675 lands.