### PR TITLE
Add eth-contract-metadata to Dependabot auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,5 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@metamask/*"
+      - dependency-name: "eth-contract-metadata"
     versioning-strategy: "lockfile-only"


### PR DESCRIPTION
This change adds `eth-contract-metadata` to the list of packages that Dependabot will autoupdate.