### PR TITLE
Make the login screen's Restore and Import links accessible

### DIFF
--- a/ui/app/pages/unlock-page/index.scss
+++ b/ui/app/pages/unlock-page/index.scss
@@ -40,6 +40,9 @@
 
   &__link {
     cursor: pointer;
+    background-color: unset;
+    color: unset;
+    font-size: unset;
 
     &--import {
       color: $ecstasy;

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -170,13 +170,13 @@ export default class UnlockPage extends Component {
           <div className="unlock-page__links">
             <button
               className="unlock-page__link"
-              onClick={onRestore}
+              onClick={() => onRestore()}
             >
               { t('restoreFromSeed') }
             </button>
             <button
               className="unlock-page__link unlock-page__link--import"
-              onClick={onImport}
+              onClick={() => onImport()}
             >
               { t('importUsingSeed') }
             </button>

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -168,17 +168,14 @@ export default class UnlockPage extends Component {
           </form>
           {this.renderSubmitButton()}
           <div className="unlock-page__links">
-            <button
-              className="unlock-page__link"
-              onClick={() => onRestore()}
-            >
-              { t('restoreFromSeed') }
+            <button className="unlock-page__link" onClick={() => onRestore()}>
+              {t('restoreFromSeed')}
             </button>
             <button
               className="unlock-page__link unlock-page__link--import"
               onClick={() => onImport()}
             >
-              { t('importUsingSeed') }
+              {t('importUsingSeed')}
             </button>
           </div>
         </div>

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -168,15 +168,18 @@ export default class UnlockPage extends Component {
           </form>
           {this.renderSubmitButton()}
           <div className="unlock-page__links">
-            <div className="unlock-page__link" onClick={() => onRestore()}>
-              {t('restoreFromSeed')}
-            </div>
-            <div
-              className="unlock-page__link unlock-page__link--import"
-              onClick={() => onImport()}
+            <button
+              className="unlock-page__link"
+              onClick={onRestore}
             >
-              {t('importUsingSeed')}
-            </div>
+              { t('restoreFromSeed') }
+            </button>
+            <button
+              className="unlock-page__link unlock-page__link--import"
+              onClick={onImport}
+            >
+              { t('importUsingSeed') }
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Explanation:  Allows users to tab to these two highly important links; at present, the only option is to click

Manual testing steps:  
  - Go to the login screen
  - Tab to both links
  - Click on each to go to the appropriate screen

<img width="365" alt="Buttons" src="https://user-images.githubusercontent.com/46655/97482023-9c31ef00-1923-11eb-90b6-9cbe50796cd6.png">
