### PR TITLE
prevent environment key from leaking into all builds

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -325,7 +325,8 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
     // inflating event volume.
     const SEGMENT_PROD_WRITE_KEY = opts.testing ? undefined : process.env.SEGMENT_PROD_WRITE_KEY
     const SEGMENT_DEV_WRITE_KEY = opts.testing ? undefined : conf.SEGMENT_WRITE_KEY
-    const SEGMENT_LEGACY_WRITE_KEY = opts.testing ? undefined : conf.SEGMENT_LEGACY_WRITE_KEY
+    const SEGMENT_PROD_LEGACY_WRITE_KEY = opts.testing ? undefined : process.env.SEGMENT_PROD_LEGACY_WRITE_KEY
+    const SEGMENT_DEV_LEGACY_WRITE_KEY = opts.testing ? undefined : conf.SEGMENT_LEGACY_WRITE_KEY
 
     // Inject variables into bundle
     bundler.transform(envify({
@@ -345,7 +346,7 @@ function createScriptTasks ({ browserPlatforms, livereload }) {
           : conf.INFURA_PROJECT_ID
       ),
       SEGMENT_WRITE_KEY: environment === 'production' ? SEGMENT_PROD_WRITE_KEY : SEGMENT_DEV_WRITE_KEY,
-      SEGMENT_LEGACY_WRITE_KEY: environment === 'production' ? process.env.SEGMENT_LEGACY_WRITE_KEY : SEGMENT_LEGACY_WRITE_KEY,
+      SEGMENT_LEGACY_WRITE_KEY: environment === 'production' ? SEGMENT_PROD_LEGACY_WRITE_KEY : SEGMENT_DEV_LEGACY_WRITE_KEY,
     }), {
       global: true,
     })


### PR DESCRIPTION
Fixes: all builds in circleci would include the segment write key, resulting in test data in our segment instance.

Explanation: The logic for setting the real key based on the environment was flawed, and the safest way of dealing with this is having a separate key/env name for production environments, even if it's the same underlying value.

Manual testing steps:  
  - Unzip a build without this change and a build that is on this pr
  - Examine the UI build output for our segment legacy write key (see brad for key, or login to segment)
  - It should exist in any previous build, and not exist in builds on this PR

**NOTE**
@Gudahtt, we should probably make this change immediately after the final release of 8.1.3, or include this in the release. Either way I will not update the environment variables in CircleCI until this PR is included in a release to avoid missing the key assignment. 