### PR TITLE
Fix error when `fetchParams` is null

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -111,7 +111,7 @@ export default class SwapsController {
   pollForNewQuotes () {
     this.pollingTimeout = setTimeout(() => {
       const { swapsState } = this.store.getState()
-      this.fetchAndSetQuotes(swapsState.fetchParams, swapsState.fetchParams.metaData, true)
+      this.fetchAndSetQuotes(swapsState.fetchParams, swapsState.fetchParams?.metaData, true)
     }, QUOTE_POLLING_INTERVAL)
   }
 


### PR DESCRIPTION
If the swaps state is cleared in between the initial quote fetch and the subsequent poll fetch, a `TypeError` will be thrown due to
`fetchParams` being set to `null`. This is of no functional consequence, as `fetchParams` _should_ be `null` in this case, and and no further action should be taken.

The optional chaining operator is now used to ensure the call no longer throws.