### PR TITLE
fix for METAMASK-GKF5

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1893,7 +1893,7 @@ export default class MetamaskController extends EventEmitter {
     }
 
     const metamaskState = await this.getState()
-    const additionalProperties = getBackgroundMetaMetricState(metamaskState)
+    const additionalProperties = getBackgroundMetaMetricState({ metamask: metamaskState })
 
     this.trackMetaMetricsEvent({
       event: name,


### PR DESCRIPTION
Fixes: [METAMASK-GKF5](https://sentry.io/organizations/metamask/issues/1991172730/?environment=production&project=273505&query=is%3Aunresolved+environment%3Aproduction+release%3A8.1.3&statsPeriod=14d)

Explanation: 
When I refactored the `sendBackgroundMetaMetrics` implementation I didn't catch that the previous implementation of the selector didn't take the state object directly, but rather a new object with a `metamask` key

Manual testing steps:  
  - None that I know of, the only place this seems to be called is for on-chain failures