### PR TITLE
Show confirmation when deleting a network from the network dropdown

### DIFF
--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -42,9 +42,6 @@ function mapDispatchToProps (dispatch) {
     setRpcTarget: (target, chainId, ticker, nickname) => {
       dispatch(actions.setRpcTarget(target, chainId, ticker, nickname))
     },
-    delRpcTarget: (target) => {
-      dispatch(actions.delRpcTarget(target))
-    },
     hideNetworkDropdown: () => dispatch(actions.hideNetworkDropdown()),
     setNetworksTabAddMode: (isInAddMode) => {
       dispatch(actions.setNetworksTabAddMode(isInAddMode))
@@ -54,6 +51,13 @@ function mapDispatchToProps (dispatch) {
     },
     displayInvalidCustomNetworkAlert: (networkName) => {
       dispatch(displayInvalidCustomNetworkAlert(networkName))
+    },
+    showConfirmDeleteNetworkModal: ({ target, onConfirm }) => {
+      return dispatch(actions.showModal({
+        name: 'CONFIRM_DELETE_NETWORK',
+        target,
+        onConfirm,
+      }))
     },
   }
 }
@@ -79,8 +83,8 @@ class NetworkDropdown extends Component {
     frequentRpcListDetail: PropTypes.array.isRequired,
     networkDropdownOpen: PropTypes.bool.isRequired,
     history: PropTypes.object.isRequired,
-    delRpcTarget: PropTypes.func.isRequired,
     displayInvalidCustomNetworkAlert: PropTypes.func.isRequired,
+    showConfirmDeleteNetworkModal: PropTypes.func.isRequired,
   }
 
   handleClick (newProviderType) {
@@ -151,7 +155,10 @@ class NetworkDropdown extends Component {
                   className="fa fa-times delete"
                   onClick={(e) => {
                     e.stopPropagation()
-                    this.props.delRpcTarget(rpcUrl)
+                    this.props.showConfirmDeleteNetworkModal({
+                      target: rpcUrl,
+                      onConfirm: () => undefined,
+                    })
                   }}
                 />
               )


### PR DESCRIPTION
This PR shows a confirmation when the user deletes a network via the network dropdown. Previously, no confirmation was shown, and the network was immediately deleted if the user clicked the "X" icon. This was flagged as undesirable during design review.

The modal used is the same as when a network is deleted in network settings.

Ideally, the dropdown wouldn't close when clicking in the modal, but implementing that behavior seems like too much of a pain given the implementation of the modal used. We can revisit that once we replace the modal with one of the [new alerts](https://github.com/MetaMask/metamask-extension/blob/088d4c3/ui/app/components/app/alerts/alerts.js).

Manual testing steps:  
  - Add a custom RPC network
  - Try deleting it via the network dropdown

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/25517051/97660753-bb1da780-1a2f-11eb-80eb-40ee26c2252b.png" width=351px/>
</details>