### PR TITLE
Update custom RPC network dropdown icons

### DIFF
--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -106,7 +106,7 @@ class NetworkDropdown extends Component {
 
     return reversedRpcListDetail.map((entry) => {
       const { rpcUrl, chainId, ticker = 'ETH', nickname = '' } = entry
-      const currentRpcTarget = (
+      const isCurrentRpcTarget = (
         provider.type === 'rpc' && rpcUrl === provider.rpcUrl
       )
 
@@ -128,15 +128,15 @@ class NetworkDropdown extends Component {
           }}
         >
           {
-            currentRpcTarget
+            isCurrentRpcTarget
               ? <i className="fa fa-check" />
               : <div className="network-check__transparent">✓</div>
           }
-          <i className="fa fa-question-circle fa-med menu-icon-circle" />
+          <NetworkDropdownIcon backgroundColor="#d6d9dc" isSelected={isCurrentRpcTarget} />
           <span
             className="network-name-item"
             style={{
-              color: currentRpcTarget
+              color: isCurrentRpcTarget
                 ? '#ffffff'
                 : '#9b9b9b',
             }}
@@ -144,7 +144,7 @@ class NetworkDropdown extends Component {
             {nickname || rpcUrl}
           </span>
           {
-            currentRpcTarget
+            isCurrentRpcTarget
               ? null
               : (
                 <i

--- a/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
+++ b/ui/app/components/app/dropdowns/tests/network-dropdown.test.js
@@ -91,7 +91,7 @@ describe('Network Dropdown', function () {
     })
 
     it('checks background color for sixth NetworkDropdownIcon', function () {
-      assert.equal(wrapper.find(NetworkDropdownIcon).at(5).prop('innerBorder'), '1px solid #9b9b9b')
+      assert.equal(wrapper.find(NetworkDropdownIcon).at(5).prop('backgroundColor'), '#d6d9dc') // "Custom network grey"
     })
 
     it('checks dropdown for frequestRPCList from state', function () {


### PR DESCRIPTION
This updates the network dropdown icons for custom RPC networks to something less unsightly. Item from design review.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/25517051/97660741-b2c56c80-1a2f-11eb-9cb4-c9e1c47fe624.png" width=351px/>
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/25517051/97659582-8eb45c00-1a2c-11eb-8bee-587542e63bd6.png" width=351px/>
</details>