### PR TITLE
Remove border radius from transfer button

### DIFF
--- a/ui/app/pages/send/send.scss
+++ b/ui/app/pages/send/send.scss
@@ -55,6 +55,7 @@
 
         padding: 1rem;
         border-bottom: 1px solid $alto;
+        border-radius: 0;
         align-items: center;
         justify-content: flex-start;
       }


### PR DESCRIPTION
I didn't notice this when I switched to a button:

Before:

<img width="467" alt="transfer-before" src="https://user-images.githubusercontent.com/46655/97740852-d7f9bf80-1aaf-11eb-929f-d5efae0d0c40.png">


After:

<img width="440" alt="NoRadius" src="https://user-images.githubusercontent.com/46655/97740837-d4663880-1aaf-11eb-8b04-5a6154ec937b.png">
