### PR TITLE
potential fix for METAMASK-GKCN

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@sentry/integrations": "^5.26.0",
     "@zxing/library": "^0.8.0",
     "abortcontroller-polyfill": "^1.4.0",
-    "analytics-node": "^3.4.0-beta.2",
+    "analytics-node": "^3.4.0-beta.3",
     "await-semaphore": "^0.1.1",
     "bignumber.js": "^4.1.0",
     "bn.js": "^4.11.7",

--- a/shared/modules/metametrics.js
+++ b/shared/modules/metametrics.js
@@ -1,13 +1,23 @@
 import Analytics from 'analytics-node'
 import { omit, pick } from 'lodash'
 
-// flushAt controls how many events are collected in the queue before they
-// are sent to segment. I recommend a queue size of one due to an issue with
-// detecting and flushing events in an extension beforeunload doesn't work in
-// a notification context. Because notification windows are opened and closed
-// in reaction to the very events we want to track, it is problematic to cache
-// at all.
-const flushAt = 1
+// flushAt controls how many events are sent to segment at once. Segment
+// will hold onto a queue of events until it hits this number, then it sends
+// them as a batch. This setting defaults to 20, but that is too high for
+// notification workflows. We also cannot send each event as singular payloads
+// because it seems to bombard segment and potentially cause event loss.
+// I chose 5 here because it is sufficiently high enough to optimize our network
+// requests, while also being low enough to be reasonable.
+const flushAt = process.env.METAMASK_ENVIRONMENT === 'production' ? 5 : 1
+// flushInterval controls how frequently the queue is flushed to segment.
+// This happens regardless of the size of the queue. The default setting is
+// 10,000ms (10 seconds). This default is absurdly high for our typical user
+// flow through confirmations. I have chosen 10 ms here because it works really
+// well with our wrapped track function. The track function returns a promise
+// that is only fulfilled when it has been sent to segment. A 10 ms delay is
+// negligible to the user, but allows us to properly batch events that happen
+// in rapid succession.
+const flushInterval = 10
 
 export const METAMETRICS_ANONYMOUS_ID = '0x0000000000000000'
 
@@ -54,11 +64,11 @@ export function sendCountIsTrackable (sendCount) {
 // E2E, which is handled in the build process by never providing the SEGMENT_WRITE_KEY
 // when process.env.IN_TEST is truthy
 export const segment = process.env.SEGMENT_WRITE_KEY
-  ? new Analytics(process.env.SEGMENT_WRITE_KEY, { flushAt })
+  ? new Analytics(process.env.SEGMENT_WRITE_KEY, { flushAt, flushInterval })
   : segmentNoop
 
 export const segmentLegacy = process.env.SEGMENT_LEGACY_WRITE_KEY
-  ? new Analytics(process.env.SEGMENT_LEGACY_WRITE_KEY, { flushAt })
+  ? new Analytics(process.env.SEGMENT_LEGACY_WRITE_KEY, { flushAt, flushInterval })
   : segmentNoop
 
 /**
@@ -230,10 +240,7 @@ export function getTrackMetaMetricsEvent (
     }
 
     return new Promise((resolve, reject) => {
-      // This is only safe to do because we are no longer batching events through segment.
-      // If flushAt is greater than one the callback won't be triggered until after a number
-      // of events have been queued equal to the flushAt value OR flushInterval passes. The
-      // default flushInterval is ten seconds
+      // This is only safe to do because we have set an extremely low (10ms) flushInterval.
       const callback = (err) => {
         if (err) {
           return reject(err)
@@ -246,6 +253,7 @@ export function getTrackMetaMetricsEvent (
       } else {
         segment.track(trackOptions, callback)
       }
+
     })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3947,13 +3947,13 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-analytics-node@^3.4.0-beta.2:
-  version "3.4.0-beta.2"
-  resolved "https://registry.yarnpkg.com/analytics-node/-/analytics-node-3.4.0-beta.2.tgz#d4921927c2253dcc2fcbf18604dac2ee098a9b52"
-  integrity sha512-wjdCQQk412RBckuqGtyY7tdxaRpG7HLD0iBQrJBc7aUzHFNYyEbz3kepaUmNd5+ZbAGDqfnvKVsFO5DmzI1KNA==
+analytics-node@^3.4.0-beta.3:
+  version "3.4.0-beta.3"
+  resolved "https://registry.yarnpkg.com/analytics-node/-/analytics-node-3.4.0-beta.3.tgz#5eb0694598cff493c64faf5efc1225533a253f13"
+  integrity sha512-NIdpxiwlZ4cKgs9MDlDe89b5bg/pMq2W7XTA+cjzCM66IwW3ujZhVE49vk+zG6Yrxk0s/DXmennJ+cCQIsTKMA==
   dependencies:
     "@segment/loosely-validate-event" "^2.0.0"
-    axios "^0.19.0"
+    axios "^0.19.2"
     axios-retry "^3.0.2"
     lodash.isstring "^4.0.1"
     md5 "^2.2.1"
@@ -4852,7 +4852,7 @@ axios-retry@^3.0.2:
   dependencies:
     is-retry-allowed "^1.1.0"
 
-axios@^0.19.0:
+axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==


### PR DESCRIPTION
Fixes: METAMASK-GKCN

Explanation:  
This error seems to only be triggered when a notification or popup occurs and events are fired off in rapid succession (within ~ 1 millisecond)

<details>
<summary>Evidence?</summary>
<img src="https://user-images.githubusercontent.com/4448075/97741767-4428f300-1ab1-11eb-931b-c74919d28546.png" />
<img src="https://user-images.githubusercontent.com/4448075/97741881-763a5500-1ab1-11eb-97b6-1efa85e124c9.png" />
</details>

To my knowledge, the only thing that has changed is the addition of a segment instance (we maintain two simultaneously, one for the real schema we are moving to and one for the old matomo schema). The result of that change is a higher volume of events moving through segment now. 

So I have two theories on possible threads that lead to this issue. This PR tries to mitigate both of them. 

### First possibility
We set our `flustAt` to `1` to avoid batching altogether. This was done for a noble reason: we didn't want to lose any events that might happen when a user has a queue of events and then closes their window before the batch size is reached. However, given that most of the instances of this error happen when multiple events are fire off together I have a theory that its related to batching or that batching could mitigate whatever issue this might actually be.

It should be noted that I purposefully flooded the legacy instance with 1,000 of every event that would go to it to try and trigger this issue and could not. I feel like if this were the only cause, that it would most certainly have been reproducible. 

To resolve this possible thread I have tweaked our segment settings to:
`flushAt = 5`, previously it was 1 which means we had no batching.
`flushInterval = 10`, the default for this setting was 10,000ms. Decreasing to 10 is a negligible timeout but would be enough ms to catch 100% of the instances of this error that I have checked. I also tested thoroughly with notification flows to ensure that the final event that is typically fired along side the window closing is captured by segment. 

### Second possibility
As this issue emerged only after we added a second instance of Segment, I investigated their repo and found that a release had been made. One of the included PRs was https://github.com/segmentio/analytics-node/pull/255. The details seem to point to issues where the Axios context is polluted across module boundaries, which if true would also mean that it could be polluted across Segment instance boundaries.

To resolve this possible thread I have bumped the version of analytics-node.