### PR TITLE
Reduce wait during incoming transaction unit tests

### DIFF
--- a/test/unit/app/controllers/incoming-transactions-test.js
+++ b/test/unit/app/controllers/incoming-transactions-test.js
@@ -25,6 +25,7 @@ const IncomingTransactionsController = proxyquire(
 
 const FAKE_CHAIN_ID = '0x1338'
 const MOCK_SELECTED_ADDRESS = '0x0101'
+const SET_STATE_TIMEOUT = 10
 
 function getEmptyInitState() {
   return {
@@ -297,7 +298,14 @@ describe('IncomingTransactionsController', function () {
         },
       )
       // reply with a valid request for any supported network, so that this test has every opportunity to fail
-      for (const network of [GOERLI, KOVAN, MAINNET, RINKEBY, ROPSTEN]) {
+      for (const network of [
+        GOERLI,
+        KOVAN,
+        MAINNET,
+        RINKEBY,
+        ROPSTEN,
+        'undefined',
+      ]) {
         nock(
           `https://api${
             network === MAINNET ? '' : `-${network.toLowerCase()}`
@@ -336,7 +344,7 @@ describe('IncomingTransactionsController', function () {
           updateStateCalled,
           putStateCalled,
           new Promise((_, reject) => {
-            setTimeout(() => reject(new Error('TIMEOUT')), 1000)
+            setTimeout(() => reject(new Error('TIMEOUT')), SET_STATE_TIMEOUT)
           }),
         ])
         assert.fail('Update state should not have been called')
@@ -357,7 +365,14 @@ describe('IncomingTransactionsController', function () {
         },
       )
       // reply with a valid request for any supported network, so that this test has every opportunity to fail
-      for (const network of [GOERLI, KOVAN, MAINNET, RINKEBY, ROPSTEN]) {
+      for (const network of [
+        GOERLI,
+        KOVAN,
+        MAINNET,
+        RINKEBY,
+        ROPSTEN,
+        'undefined',
+      ]) {
         nock(
           `https://api${
             network === MAINNET ? '' : `-${network.toLowerCase()}`
@@ -396,7 +411,7 @@ describe('IncomingTransactionsController', function () {
           updateStateCalled,
           putStateCalled,
           new Promise((_, reject) => {
-            setTimeout(() => reject(new Error('TIMEOUT')), 1000)
+            setTimeout(() => reject(new Error('TIMEOUT')), SET_STATE_TIMEOUT)
           }),
         ])
         assert.fail('Update state should not have been called')
@@ -415,7 +430,14 @@ describe('IncomingTransactionsController', function () {
         },
       )
       // reply with a valid request for any supported network, so that this test has every opportunity to fail
-      for (const network of [GOERLI, KOVAN, MAINNET, RINKEBY, ROPSTEN]) {
+      for (const network of [
+        GOERLI,
+        KOVAN,
+        MAINNET,
+        RINKEBY,
+        ROPSTEN,
+        'undefined',
+      ]) {
         nock(
           `https://api${
             network === MAINNET ? '' : `-${network.toLowerCase()}`
@@ -452,7 +474,7 @@ describe('IncomingTransactionsController', function () {
           updateStateCalled,
           putStateCalled,
           new Promise((_, reject) => {
-            setTimeout(() => reject(new Error('TIMEOUT')), 1000)
+            setTimeout(() => reject(new Error('TIMEOUT')), SET_STATE_TIMEOUT)
           }),
         ])
         assert.fail('Update state should not have been called')
@@ -471,7 +493,14 @@ describe('IncomingTransactionsController', function () {
         },
       )
       // reply with a valid request for any supported network, so that this test has every opportunity to fail
-      for (const network of [GOERLI, KOVAN, MAINNET, RINKEBY, ROPSTEN]) {
+      for (const network of [
+        GOERLI,
+        KOVAN,
+        MAINNET,
+        RINKEBY,
+        ROPSTEN,
+        'undefined',
+      ]) {
         nock(
           `https://api${
             network === MAINNET ? '' : `-${network.toLowerCase()}`
@@ -510,7 +539,7 @@ describe('IncomingTransactionsController', function () {
           updateStateCalled,
           putStateCalled,
           new Promise((_, reject) => {
-            setTimeout(() => reject(new Error('TIMEOUT')), 1000)
+            setTimeout(() => reject(new Error('TIMEOUT')), SET_STATE_TIMEOUT)
           }),
         ])
         assert.fail('Update state should not have been called')
@@ -613,7 +642,14 @@ describe('IncomingTransactionsController', function () {
       )
       const NEW_MOCK_SELECTED_ADDRESS = `${MOCK_SELECTED_ADDRESS}9`
       // reply with a valid request for any supported network, so that this test has every opportunity to fail
-      for (const network of [GOERLI, KOVAN, MAINNET, RINKEBY, ROPSTEN]) {
+      for (const network of [
+        GOERLI,
+        KOVAN,
+        MAINNET,
+        RINKEBY,
+        ROPSTEN,
+        'undefined',
+      ]) {
         nock(
           `https://api${
             network === MAINNET ? '' : `-${network.toLowerCase()}`
@@ -659,7 +695,7 @@ describe('IncomingTransactionsController', function () {
           updateStateCalled,
           putStateCalled,
           new Promise((_, reject) => {
-            setTimeout(() => reject(new Error('TIMEOUT')), 1000)
+            setTimeout(() => reject(new Error('TIMEOUT')), SET_STATE_TIMEOUT)
           }),
         ])
         assert.fail('Update state should not have been called')
@@ -760,7 +796,14 @@ describe('IncomingTransactionsController', function () {
         },
       )
       // reply with a valid request for any supported network, so that this test has every opportunity to fail
-      for (const network of [GOERLI, KOVAN, MAINNET, RINKEBY, ROPSTEN]) {
+      for (const network of [
+        GOERLI,
+        KOVAN,
+        MAINNET,
+        RINKEBY,
+        ROPSTEN,
+        'undefined',
+      ]) {
         nock(
           `https://api${
             network === MAINNET ? '' : `-${network.toLowerCase()}`
@@ -804,7 +847,7 @@ describe('IncomingTransactionsController', function () {
           updateStateCalled,
           putStateCalled,
           new Promise((_, reject) => {
-            setTimeout(() => reject(new Error('TIMEOUT')), 1000)
+            setTimeout(() => reject(new Error('TIMEOUT')), SET_STATE_TIMEOUT)
           }),
         ])
         assert.fail('Update state should not have been called')


### PR DESCRIPTION
Some of the unit tests for the incoming transaction controller included a 1 second wait. The wait was to ensure that a state update did not occur, as it happens asynchronously.

The tests work equally well using a `setTimeout` with a zero second wait, because the asynchronous block update is guaranteed to have been queued up by the time this timeout function is called. The timeout has been reduced to `0` to speed up the tests.

Additionally, `undefined` has been added to the list of network names used to construct the fake API responses. This is to ensure that the API returns a valid response, so that the test fails when it should.