### PR TITLE
Shorten unit input max-width and overflow/ellipsis it.

### DIFF
--- a/ui/app/components/ui/unit-input/index.scss
+++ b/ui/app/components/ui/unit-input/index.scss
@@ -39,7 +39,9 @@
 
     color: #4d4d4d;
     border: none;
-    max-width: 22ch;
+    max-width: 15ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
     height: 16px;
 
     &__disabled {


### PR DESCRIPTION
Fixes long input amount in send screen by shortening the max-width, add the hidden overflow, and ellipsis the overflow.

<details>
  <summary>Before Extension View</summary>
  <img src="https://user-images.githubusercontent.com/13376180/97949389-596b7f00-1d48-11eb-8928-3ea622b9db4e.png">
</details>

<details>
  <summary>After Extension View</summary>
  <img src="https://user-images.githubusercontent.com/13376180/97949425-730cc680-1d48-11eb-98ae-dbe72f9d033f.png">
</details>


<details>
  <summary>Before FullScreen View</summary>
  <img src="https://user-images.githubusercontent.com/13376180/97949447-8029b580-1d48-11eb-8866-32254fabc0fd.png">
</details>

<details>
  <summary>After Fullscreen View</summary>
  <img src="https://user-images.githubusercontent.com/13376180/97949452-828c0f80-1d48-11eb-8cab-d648e1f9d19e.png">
</details>
