### PR TITLE
Fix lint errors

### DIFF
--- a/shared/modules/metametrics.js
+++ b/shared/modules/metametrics.js
@@ -68,7 +68,10 @@ export const segment = process.env.SEGMENT_WRITE_KEY
   : segmentNoop
 
 export const segmentLegacy = process.env.SEGMENT_LEGACY_WRITE_KEY
-  ? new Analytics(process.env.SEGMENT_LEGACY_WRITE_KEY, { flushAt, flushInterval })
+  ? new Analytics(process.env.SEGMENT_LEGACY_WRITE_KEY, {
+      flushAt,
+      flushInterval,
+    })
   : segmentNoop
 
 /**
@@ -256,7 +259,6 @@ export function getTrackMetaMetricsEvent(metamaskVersion, getDynamicState) {
       } else {
         segment.track(trackOptions, callback)
       }
-
     })
   }
 }

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -207,6 +207,7 @@ export function getOrderedConnectedAccountsForActiveTab(state) {
   } = state
 
   const permissionsHistoryByAccount =
+    // eslint-disable-next-line camelcase
     permissionsHistory[activeTab.origin]?.eth_accounts?.accounts
   const orderedAccounts = getMetaMaskAccountsOrdered(state)
   const connectedAccounts = getPermittedAccountsForCurrentTab(state)


### PR DESCRIPTION
There were a few lint errors introduced in #9768 due to the recently merged prettier PR. They have now been fixed.

Additionally, one line using the property `eth_accounts` was intermittently failing for me locally. I've been seeing this lint failure off-and-on for a few days now - I'm not sure why I haven't seen it on CI. Either way though, it's now ignored.