### PR TITLE
Display decimal chain ID in network form

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -737,7 +737,7 @@
   "optionalBlockExplorerUrl": {
     "message": "ኤክስፕሎረር URL አግድ (አማራጭ)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "ምልክት (አማራጭ)"
   },
   "orderOneHere": {

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -733,7 +733,7 @@
   "optionalBlockExplorerUrl": {
     "message": "العنوان الإلكتروني لمستكشف البلوكات (اختياري)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "الرمز (اختياري)"
   },
   "orderOneHere": {

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -736,7 +736,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Блокиране на Explorer URL (по избор)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Символ (по избор)"
   },
   "orderOneHere": {

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -740,7 +740,7 @@
   "optionalBlockExplorerUrl": {
     "message": "এক্সপ্লোরার URL ব্লক করুন (ঐচ্ছিক)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "প্রতীক (ঐচ্ছিক)"
   },
   "orderOneHere": {

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -724,7 +724,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Bloqueja l'URL d'Explorer (opcional)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Símbol (opcional)"
   },
   "orderOneHere": {

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -724,7 +724,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blok-stifinder-URL (valgfrit)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbol (valgfrit)"
   },
   "orderOneHere": {

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -737,7 +737,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Διεύθυνση URL Εξερευνητή Μπλοκ (προαιρετικό)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Σύμβολο (προαιρετικό)"
   },
   "orderOneHere": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -875,7 +875,7 @@
     "message": "Invalid IPFS Gateway: The value must be a valid URL"
   },
   "invalidNumber": {
-    "message": "Invalid number. Enter a decimal or hexadecimal number."
+    "message": "Invalid number. Enter a decimal or '0x'-prefixed hexadecimal number."
   },
   "invalidNumberLeadingZeros": {
     "message": "Invalid number. Remove any leading zeros."
@@ -1037,7 +1037,7 @@
     "message": "Network Name"
   },
   "networkSettingsChainIdDescription": {
-    "message": "The chain ID is used for signing transactions. It must match the chain ID returned by the network. Enter a decimal or hexadecimal number starting with '0x'."
+    "message": "The chain ID is used for signing transactions. It must match the chain ID returned by the network. You can enter a decimal or '0x'-prefixed hexadecimal number, but we will display the number in decimal."
   },
   "networkSettingsDescription": {
     "message": "Add and edit custom RPC networks"
@@ -1156,8 +1156,8 @@
   "optionalBlockExplorerUrl": {
     "message": "Block Explorer URL (optional)"
   },
-  "optionalSymbol": {
-    "message": "Symbol (optional)"
+  "optionalCurrencySymbol": {
+    "message": "Currency Symbol (optional)"
   },
   "orderOneHere": {
     "message": "Order a Trezor or Ledger and keep your funds in cold storage"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -580,7 +580,7 @@
   "ofTextNofM": {
     "message": "de"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Símbolo (opcional)"
   },
   "orderOneHere": {

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -725,7 +725,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Bloquear la URL de Explorer (opcional)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Símbolo (opcional)"
   },
   "orderOneHere": {

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -730,7 +730,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokeeri Exploreri URL (valikuline)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Sümbol (valikuline)"
   },
   "orderOneHere": {

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -740,7 +740,7 @@
   "optionalBlockExplorerUrl": {
     "message": "بلاک کردن مرورگر URL (انتخابی)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "سمبول (انتخابی)"
   },
   "orderOneHere": {

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -737,7 +737,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Estä Explorerin URL-osoite (valinnainen)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symboli (valinnainen)"
   },
   "orderOneHere": {

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -671,7 +671,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Block Explorer URL (opsyonal)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbolo (opsyonal)"
   },
   "orderOneHere": {

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -722,7 +722,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Bloquer l'URL de l'explorateur (facultatif)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbole (facultatif)"
   },
   "orderOneHere": {

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -737,7 +737,7 @@
   "optionalBlockExplorerUrl": {
     "message": "חסום כתובת URL של אקספלורר (אופציונלי)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "סמל (אופציונלי)"
   },
   "orderOneHere": {

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -737,7 +737,7 @@
   "optionalBlockExplorerUrl": {
     "message": "एक्सप्लोरर यूआरएल ब्लॉक (वैकल्पिक)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "सिम्बल (वैकल्पिक)"
   },
   "orderOneHere": {

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -733,7 +733,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokiraj Explorerov URL (neobavezno)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbol (neobavezno)"
   },
   "orderOneHere": {

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -733,7 +733,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Explorer URL letiltása (nem kötelező)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Szimbólum (opcionális)"
   },
   "orderOneHere": {

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -721,7 +721,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokir URL Penjelajah (opsional)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbol (opsional)"
   },
   "orderOneHere": {

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1056,7 +1056,7 @@
   "optionalBlockExplorerUrl": {
     "message": "URL del Block Explorer (opzionale)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbolo (opzionale)"
   },
   "orderOneHere": {

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -740,7 +740,7 @@
   "optionalBlockExplorerUrl": {
     "message": "ಅನ್ವೇಷಕ URL ಅನ್ನು ನಿರ್ಬಂಧಿಸಿ (ಐಚ್ಛಿಕ)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "ಚಿಹ್ನೆ (ಐಚ್ಛಿಕ)"
   },
   "orderOneHere": {

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -734,7 +734,7 @@
   "optionalBlockExplorerUrl": {
     "message": "익스플로러 URL 차단 (선택 사항)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbol (선택)"
   },
   "orderOneHere": {

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -740,7 +740,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokuoti naršyklės URL (pasirinktinai)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbolis (nebūtinas)"
   },
   "orderOneHere": {

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -736,7 +736,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Bloķēt Explorer URL (pēc izvēles)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbols (neobligāti)"
   },
   "orderOneHere": {

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -714,7 +714,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Sekat URL Explorer (pilihan)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbol (pilihan)"
   },
   "orderOneHere": {

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -727,7 +727,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokker Explorer URL (valgfritt)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbol (valgfritt)"
   },
   "orderOneHere": {

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -734,7 +734,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Adres URL przeglądarki łańcucha bloków (opcjonalnie)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbol (opcjonalnie)"
   },
   "orderOneHere": {

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -728,7 +728,7 @@
   "optionalBlockExplorerUrl": {
     "message": "URL exploradora de blocos (opcional)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Símbolo (opcional)"
   },
   "orderOneHere": {

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -727,7 +727,7 @@
   "optionalBlockExplorerUrl": {
     "message": "URL explorator bloc (opțional)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbol (opțional)"
   },
   "orderOneHere": {

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -769,7 +769,7 @@
   "optionalBlockExplorerUrl": {
     "message": "URL блок-эксплорера  (необязательно)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Символ  (необязательно)"
   },
   "orderOneHere": {

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -709,7 +709,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokovať URL Explorera (voliteľné)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbol (voliteľné)"
   },
   "orderOneHere": {

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -725,7 +725,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokiraj URL Explorerja (poljubno)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbol (nezahtevano)"
   },
   "orderOneHere": {

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -731,7 +731,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Blokirajte URL Explorer-a (opciono)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Simbol (opciono)"
   },
   "orderOneHere": {

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -724,7 +724,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Block Explorer URL (valfritt)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbol (frivillig)"
   },
   "orderOneHere": {

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -718,7 +718,7 @@
   "optionalBlockExplorerUrl": {
     "message": "URL ya Block Explorer URL (hiari)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Ishara (hiari)"
   },
   "orderOneHere": {

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -740,7 +740,7 @@
   "optionalBlockExplorerUrl": {
     "message": "Блокувати Explorer URL (не обов'язково)"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Символ (не обов'язково)"
   },
   "orderOneHere": {

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -722,7 +722,7 @@
   "optionalBlockExplorerUrl": {
     "message": "屏蔽管理器 URL（选填）"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "符号（选填）"
   },
   "orderOneHere": {

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -731,7 +731,7 @@
   "optionalBlockExplorerUrl": {
     "message": "區塊鏈瀏覽器 URL（非必要）"
   },
-  "optionalSymbol": {
+  "optionalCurrencySymbol": {
     "message": "Symbol (可選)"
   },
   "orderOneHere": {

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -274,7 +274,7 @@ export default class NetworkForm extends PureComponent {
     })
   }
 
-  validateChainId = (chainIdArg = '') => {
+  validateChainIdOnChange = (chainIdArg = '') => {
     const chainId = chainIdArg.trim()
     let errorMessage = ''
 
@@ -429,7 +429,7 @@ export default class NetworkForm extends PureComponent {
         {this.renderFormTextField(
           'chainId',
           'chainId',
-          this.setStateWithValue('chainId', this.validateChainId),
+          this.setStateWithValue('chainId', this.validateChainIdOnChange),
           chainId,
           null,
           viewOnly ? null : t('networkSettingsChainIdDescription'),

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -294,7 +294,7 @@ export default class NetworkForm extends PureComponent {
    * Validates the chain ID by checking it against the `eth_chainId` return
    * value from the given RPC URL.
    * Assumes that all strings are non-empty and correctly formatted.
-   * 
+   *
    * @param {string} formChainId - Non-empty, hex or decimal number string from
    * the form.
    * @param {string} parsedChainId - The parsed, hex string chain ID.

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -147,7 +147,7 @@ export default class NetworkForm extends PureComponent {
       chainId = `0x${new BigNumber(chainId, 10).toString(16)}`
     }
 
-    if (!(await this.validateChainIdOnSubmit(chainId, rpcUrl))) {
+    if (!(await this.validateChainIdOnSubmit(chainId, rpcUrl, stateChainId))) {
       return
     }
 
@@ -289,7 +289,7 @@ export default class NetworkForm extends PureComponent {
     this.setErrorTo('chainId', errorMessage)
   }
 
-  validateChainIdOnSubmit = async (chainId, rpcUrl) => {
+  validateChainIdOnSubmit = async (chainId, rpcUrl, enteredChainId = '') => {
     const { t } = this.context
     let errorMessage
     let endpointChainId
@@ -305,6 +305,17 @@ export default class NetworkForm extends PureComponent {
     if (providerError || typeof endpointChainId !== 'string') {
       errorMessage = t('failedToFetchChainId')
     } else if (chainId !== endpointChainId) {
+      if (enteredChainId && !enteredChainId.startsWith('0x')) {
+        try {
+          endpointChainId = new BigNumber(endpointChainId, 16).toString(10)
+        } catch (err) {
+          log.error(
+            'Failed to convert endpoint chain ID to decimal',
+            endpointChainId,
+          )
+        }
+      }
+
       errorMessage = t('endpointReturnedDifferentChainId', [
         endpointChainId.length <= 12
           ? endpointChainId

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -35,7 +35,7 @@ export default class NetworkForm extends PureComponent {
 
   state = {
     rpcUrl: this.props.rpcUrl,
-    chainId: this.props.chainId,
+    chainId: this.getDisplayChainIdFromProps(),
     ticker: this.props.ticker,
     networkName: this.props.networkName,
     blockExplorerUrl: this.props.blockExplorerUrl,
@@ -49,7 +49,6 @@ export default class NetworkForm extends PureComponent {
     } = prevProps
     const {
       rpcUrl,
-      chainId,
       ticker,
       networkName,
       networksTabIsInAddMode,
@@ -68,7 +67,7 @@ export default class NetworkForm extends PureComponent {
     } else if (prevRpcUrl !== rpcUrl) {
       this.setState({
         rpcUrl,
-        chainId,
+        chainId: this.getDisplayChainIdFromProps(),
         ticker,
         networkName,
         blockExplorerUrl,
@@ -94,22 +93,35 @@ export default class NetworkForm extends PureComponent {
   }
 
   resetForm() {
-    const {
-      rpcUrl,
-      chainId,
-      ticker,
-      networkName,
-      blockExplorerUrl,
-    } = this.props
+    const { rpcUrl, ticker, networkName, blockExplorerUrl } = this.props
 
     this.setState({
       rpcUrl,
-      chainId,
+      chainId: this.getDisplayChainIdFromProps(),
       ticker,
       networkName,
       blockExplorerUrl,
       errors: {},
     })
+  }
+
+  /**
+   * Should be called the chainId is set from the props value.
+   * Ensures that the chainId is always displayed in decimal, even though
+   * it's stored in hexadecimal.
+   * @returns {string} The props chainId in decimal.
+   */
+  getDisplayChainIdFromProps() {
+    const { chainId: propsChainId } = this.props
+
+    if (
+      !propsChainId ||
+      typeof propsChainId !== 'string' ||
+      !propsChainId.startsWith('0x')
+    ) {
+      return propsChainId
+    }
+    return new BigNumber(propsChainId, 16).toString(10)
   }
 
   onSubmit = async () => {
@@ -153,6 +165,10 @@ export default class NetworkForm extends PureComponent {
 
     if (networksTabIsInAddMode) {
       onClear()
+    } else {
+      this.setState({
+        chainId: this.getDisplayChainIdFromProps()
+      })
     }
   }
 
@@ -178,13 +194,7 @@ export default class NetworkForm extends PureComponent {
   }
 
   stateIsUnchanged() {
-    const {
-      rpcUrl,
-      chainId,
-      ticker,
-      networkName,
-      blockExplorerUrl,
-    } = this.props
+    const { rpcUrl, ticker, networkName, blockExplorerUrl } = this.props
 
     const {
       rpcUrl: stateRpcUrl,
@@ -196,7 +206,7 @@ export default class NetworkForm extends PureComponent {
 
     return (
       stateRpcUrl === rpcUrl &&
-      stateChainId === chainId &&
+      stateChainId === this.getDisplayChainIdFromProps() &&
       stateTicker === ticker &&
       stateNetworkName === networkName &&
       stateBlockExplorerUrl === blockExplorerUrl
@@ -404,7 +414,7 @@ export default class NetworkForm extends PureComponent {
           'network-ticker',
           this.setStateWithValue('ticker'),
           ticker,
-          'optionalSymbol',
+          'optionalCurrencySymbol',
         )}
         {this.renderFormTextField(
           'blockExplorerUrl',

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -167,7 +167,7 @@ export default class NetworkForm extends PureComponent {
       onClear()
     } else {
       this.setState({
-        chainId: this.getDisplayChainIdFromProps()
+        chainId: this.getDisplayChainIdFromProps(),
       })
     }
   }
@@ -407,7 +407,7 @@ export default class NetworkForm extends PureComponent {
           this.setStateWithValue('chainId', this.validateChainId),
           chainId,
           null,
-          t('networkSettingsChainIdDescription'),
+          viewOnly ? null : t('networkSettingsChainIdDescription'),
         )}
         {this.renderFormTextField(
           'symbol',

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -327,7 +327,7 @@ export default class NetworkForm extends PureComponent {
         try {
           endpointChainId = new BigNumber(endpointChainId, 16).toString(10)
         } catch (err) {
-          log.error(
+          log.warn(
             'Failed to convert endpoint chain ID to decimal',
             endpointChainId,
           )

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -319,6 +319,10 @@ export default class NetworkForm extends PureComponent {
     if (providerError || typeof endpointChainId !== 'string') {
       errorMessage = t('failedToFetchChainId')
     } else if (parsedChainId !== endpointChainId) {
+      // Here, we are in an error state. The endpoint should always return a
+      // hexadecimal string. If the user entered a decimal string, we attempt
+      // to convert the endpoint's return value to decimal before rendering it
+      // in an error message in the form.
       if (!formChainId.startsWith('0x')) {
         try {
           endpointChainId = new BigNumber(endpointChainId, 16).toString(10)

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -106,9 +106,12 @@ export default class NetworkForm extends PureComponent {
   }
 
   /**
-   * Should be called the chainId is set from the props value.
    * Ensures that the chainId is always displayed in decimal, even though
    * it's stored in hexadecimal.
+   *
+   * Should be called to get the chainId whenever props are used to set the
+   * component's state.
+   *
    * @returns {string} The props chainId in decimal.
    */
   getDisplayChainIdFromProps() {


### PR DESCRIPTION
We've received multiple reports from customer support that users are confused by the format of the chain ID in the network form. The form accepts decimal or hexadecimal values. We have to store the value in hex, and previously we'd always display it in hex, even though most non-technical users enter it in decimal.

This PR ensures that we always display the network form chain ID in decimal whenever we can. The chain ID field tooltip is updated to state that it will always be displayed in decimal.

In addition, we also update the `symbol` field to be labeled `Currency Symbol` instead of just `Symbol`.