### PR TITLE
@metamask/test-dapp@4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@babel/register": "^7.5.5",
     "@metamask/eslint-config": "^4.1.0",
     "@metamask/forwarder": "^1.1.0",
-    "@metamask/test-dapp": "^3.2.0",
+    "@metamask/test-dapp": "4.0.0",
     "@sentry/cli": "^1.58.0",
     "@storybook/addon-actions": "^5.3.14",
     "@storybook/addon-backgrounds": "^5.3.14",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@babel/register": "^7.5.5",
     "@metamask/eslint-config": "^4.1.0",
     "@metamask/forwarder": "^1.1.0",
-    "@metamask/test-dapp": "4.0.0",
+    "@metamask/test-dapp": "^4.0.1",
     "@sentry/cli": "^1.58.0",
     "@storybook/addon-actions": "^5.3.14",
     "@storybook/addon-backgrounds": "^5.3.14",

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -102,7 +102,7 @@ describe('MetaMask', function () {
     })
 
     it('creates a sign typed data signature request', async function () {
-      await driver.clickElement(By.id('signTypedData'), 10000)
+      await driver.clickElement(By.id('signTypedDataV4'), 10000)
       await driver.delay(largeDelayMs)
 
       await driver.delay(regularDelayMs)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,10 +2331,10 @@
     gl-mat4 "1.1.4"
     gl-vec3 "1.0.3"
 
-"@metamask/test-dapp@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-3.2.0.tgz#b0fb8b75519585b38fec8ecd527fa54257e6411d"
-  integrity sha512-FLhImScxbkI+SuhF7o9D3J2yxYUBTHrg+erlHqBA8lYZelSWDPczgGuIO8XzLIpj+p5a6BT6hM+0IFWmOP14mA==
+"@metamask/test-dapp@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-4.0.0.tgz#dc9c5c089435da65c4ba708f141177b842fa444c"
+  integrity sha512-03nNWoCqRIILtSeMvXrsb96ko3tpA1chgP3+k2LEb21gAGvuPsfxaALMpNPkDPXwqKlqyzU59x2ksQMDAJsPhg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,10 +2331,10 @@
     gl-mat4 "1.1.4"
     gl-vec3 "1.0.3"
 
-"@metamask/test-dapp@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-4.0.0.tgz#dc9c5c089435da65c4ba708f141177b842fa444c"
-  integrity sha512-03nNWoCqRIILtSeMvXrsb96ko3tpA1chgP3+k2LEb21gAGvuPsfxaALMpNPkDPXwqKlqyzU59x2ksQMDAJsPhg==
+"@metamask/test-dapp@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-4.0.1.tgz#fbc66069687f0502ebb4c6ac0fa7c9862ea6563c"
+  integrity sha512-FN2Rz7ctY7Blx3iK6AmZmZEU+TkvEcpYvvebUmqZyOrmjh/DsYKVxfRicVAbyK9mDkeJ18Gx8r7swwFFR4rSgA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
- `@metamask/test-dapp@4.0.1`
- Use `eth_signTypedData_v4` in e2e tests
  - The element IDs in the test dapp have changed. Previously we were using `v3`. If it works, it works 🤷 