### PR TITLE
Remove unreachable branches from first time flow switch

### DIFF
--- a/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.component.js
+++ b/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.component.js
@@ -6,7 +6,6 @@ import {
   LOCK_ROUTE,
   INITIALIZE_WELCOME_ROUTE,
   INITIALIZE_UNLOCK_ROUTE,
-  INITIALIZE_METAMETRICS_OPT_IN_ROUTE,
 } from '../../../helpers/constants/routes'
 
 export default class FirstTimeFlowSwitch extends PureComponent {
@@ -14,16 +13,10 @@ export default class FirstTimeFlowSwitch extends PureComponent {
     completedOnboarding: PropTypes.bool,
     isInitialized: PropTypes.bool,
     isUnlocked: PropTypes.bool,
-    optInMetaMetrics: PropTypes.bool,
   }
 
   render() {
-    const {
-      completedOnboarding,
-      isInitialized,
-      isUnlocked,
-      optInMetaMetrics,
-    } = this.props
+    const { completedOnboarding, isInitialized, isUnlocked } = this.props
 
     if (completedOnboarding) {
       return <Redirect to={{ pathname: DEFAULT_ROUTE }} />
@@ -37,14 +30,6 @@ export default class FirstTimeFlowSwitch extends PureComponent {
       return <Redirect to={{ pathname: INITIALIZE_WELCOME_ROUTE }} />
     }
 
-    if (!isUnlocked) {
-      return <Redirect to={{ pathname: INITIALIZE_UNLOCK_ROUTE }} />
-    }
-
-    if (optInMetaMetrics === null) {
-      return <Redirect to={{ pathname: INITIALIZE_WELCOME_ROUTE }} />
-    }
-
-    return <Redirect to={{ pathname: INITIALIZE_METAMETRICS_OPT_IN_ROUTE }} />
+    return <Redirect to={{ pathname: INITIALIZE_UNLOCK_ROUTE }} />
   }
 }

--- a/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.container.js
+++ b/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.container.js
@@ -2,18 +2,12 @@ import { connect } from 'react-redux'
 import FirstTimeFlowSwitch from './first-time-flow-switch.component'
 
 const mapStateToProps = ({ metamask }) => {
-  const {
-    completedOnboarding,
-    isInitialized,
-    isUnlocked,
-    participateInMetaMetrics: optInMetaMetrics,
-  } = metamask
+  const { completedOnboarding, isInitialized, isUnlocked } = metamask
 
   return {
     completedOnboarding,
     isInitialized,
     isUnlocked,
-    optInMetaMetrics,
   }
 }
 


### PR DESCRIPTION
The conditions `isUnlocked` and `!isUnlocked` did account for all cases, so any branches after that were unreachable.