### PR TITLE
Make JSDoc formatting more consistent

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -139,7 +139,7 @@ initialize().catch(log.error)
 
 /**
  * Initializes the MetaMask controller, and sets up all platform configuration.
- * @returns {Promise} - Setup complete.
+ * @returns {Promise} Setup complete.
  */
 async function initialize() {
   const initState = await loadStateFromPersistence()
@@ -155,7 +155,7 @@ async function initialize() {
 /**
  * Loads any stored data, prioritizing the latest storage strategy.
  * Migrates that data schema in case it was last loaded on an older version.
- * @returns {Promise<MetaMaskState>} - Last data emitted from previous instance of MetaMask.
+ * @returns {Promise<MetaMaskState>} Last data emitted from previous instance of MetaMask.
  */
 async function loadStateFromPersistence() {
   // migrations
@@ -215,7 +215,7 @@ async function loadStateFromPersistence() {
  *
  * @param {Object} initState - The initial state to start the controller with, matches the state that is emitted from the controller.
  * @param {string} initLangCode - The region code for the language preferred by the current user.
- * @returns {Promise} - After setup is complete.
+ * @returns {Promise} After setup is complete.
  */
 function setupController(initState, initLangCode) {
   //
@@ -267,7 +267,7 @@ function setupController(initState, initLangCode) {
   /**
    * Assigns the given state to the versioned object (with metadata), and returns that.
    * @param {Object} state - The state object as emitted by the MetaMaskController.
-   * @returns {VersionedData} - The state object wrapped in an object that includes a metadata key.
+   * @returns {VersionedData} The state object wrapped in an object that includes a metadata key.
    */
   function versionifyData(state) {
     versionedData.data = state

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -120,7 +120,7 @@ function logStreamDisconnectWarning(remoteLabel, err) {
 /**
  * Determines if the provider should be injected
  *
- * @returns {boolean} {@code true} - if the provider should be injected
+ * @returns {boolean} {@code true} Whether the provider should be injected
  */
 function shouldInjectProvider() {
   return (
@@ -134,7 +134,7 @@ function shouldInjectProvider() {
 /**
  * Checks the doctype of the current document if it exists
  *
- * @returns {boolean} {@code true} - if the doctype is html or if none exists
+ * @returns {boolean} {@code true} if the doctype is html or if none exists
  */
 function doctypeCheck() {
   const { doctype } = window.document
@@ -151,7 +151,7 @@ function doctypeCheck() {
  * that we should not inject the provider into. This check is indifferent of
  * query parameters in the location.
  *
- * @returns {boolean} - whether or not the extension of the current document is prohibited
+ * @returns {boolean} whether or not the extension of the current document is prohibited
  */
 function suffixCheck() {
   const prohibitedTypes = [/\.xml$/u, /\.pdf$/u]
@@ -167,7 +167,7 @@ function suffixCheck() {
 /**
  * Checks the documentElement of the current document
  *
- * @returns {boolean} {@code true} - if the documentElement is an html node or if none exists
+ * @returns {boolean} {@code true} if the documentElement is an html node or if none exists
  */
 function documentElementCheck() {
   const documentElement = document.documentElement.nodeName
@@ -180,7 +180,7 @@ function documentElementCheck() {
 /**
  * Checks if the current domain is blocked
  *
- * @returns {boolean} {@code true} - if the current domain is blocked
+ * @returns {boolean} {@code true} if the current domain is blocked
  */
 function blockedDomainCheck() {
   const blockedDomains = [

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -4,7 +4,7 @@ import ObservableStore from 'obs-store'
 export default class AppStateController extends EventEmitter {
   /**
    * @constructor
-   * @param opts
+   * @param {Object} opts
    */
   constructor(opts = {}) {
     const {

--- a/app/scripts/controllers/cached-balances.js
+++ b/app/scripts/controllers/cached-balances.js
@@ -15,7 +15,7 @@ export default class CachedBalancesController {
   /**
    * Creates a new controller instance
    *
-   * @param {CachedBalancesOptions} [opts] Controller configuration parameters
+   * @param {CachedBalancesOptions} [opts] - Controller configuration parameters
    */
   constructor(opts = {}) {
     const { accountTracker, getNetwork } = opts

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -486,8 +486,8 @@ export class PermissionsController {
    * Should only be called after confirming that the permissions exist, to
    * avoid sending unnecessary notifications.
    *
-   * @param {Object} domains { origin: [permissions] } - The map of domain
-   * origins to permissions to remove.
+   * @param {Object} domains - The map of domain origins to permissions to remove.
+   *                           e.g. { origin: [permissions] }
    */
   removePermissionsFor(domains) {
     Object.entries(domains).forEach(([origin, perms]) => {
@@ -703,7 +703,7 @@ export class PermissionsController {
    * A convenience method for retrieving a login object
    * or creating a new one if needed.
    *
-   * @param {string} origin = The origin string representing the domain.
+   * @param {string} origin - The origin string representing the domain.
    */
   _initializePermissions(restoredState) {
     // these permission requests are almost certainly stale

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -13,18 +13,18 @@ export default class PreferencesController {
    *
    * @typedef {Object} PreferencesController
    * @param {Object} opts - Overrides the defaults for the initial state of this.store
-   * @property {object} store The stored object containing a users preferences, stored in local storage
-   * @property {array} store.frequentRpcList A list of custom rpcs to provide the user
-   * @property {array} store.tokens The tokens the user wants display in their token lists
-   * @property {object} store.accountTokens The tokens stored per account and then per network type
-   * @property {object} store.assetImages Contains assets objects related to assets added
+   * @property {Object} store The stored object containing a users preferences, stored in local storage
+   * @property {Array} store.frequentRpcList A list of custom rpcs to provide the user
+   * @property {Array} store.tokens The tokens the user wants display in their token lists
+   * @property {Object} store.accountTokens The tokens stored per account and then per network type
+   * @property {Object} store.assetImages Contains assets objects related to assets added
    * @property {boolean} store.useBlockie The users preference for blockie identicons within the UI
    * @property {boolean} store.useNonceField The users preference for nonce field within the UI
-   * @property {object} store.featureFlags A key-boolean map, where keys refer to features and booleans to whether the
+   * @property {Object} store.featureFlags A key-boolean map, where keys refer to features and booleans to whether the
    * user wishes to see that feature.
    *
    * Feature flags can be set by the global function `setPreference(feature, enabled)`, and so should not expose any sensitive behavior.
-   * @property {object} store.knownMethodData Contains all data methods known by the user
+   * @property {Object} store.knownMethodData Contains all data methods known by the user
    * @property {string} store.currentLocale The preferred language locale key
    * @property {string} store.selectedAddress A hex string that matches the currently selected address in the app
    *
@@ -124,7 +124,7 @@ export default class PreferencesController {
    * Setter for the `participateInMetaMetrics` property
    *
    * @param {boolean} bool - Whether or not the user wants to participate in MetaMetrics
-   * @returns {string|null} - the string of the new metametrics id, or null if not set
+   * @returns {string|null} the string of the new metametrics id, or null if not set
    *
    */
   setParticipateInMetaMetrics(bool) {
@@ -195,10 +195,10 @@ export default class PreferencesController {
   /**
    * RPC engine middleware for requesting new asset added
    *
-   * @param req
-   * @param res
-   * @param {Function} - next
-   * @param {Function} - end
+   * @param {any} req
+   * @param {any} res
+   * @param {Function} next
+   * @param {Function} end
    */
   async requestWatchAsset(req, res, next, end) {
     if (
@@ -271,7 +271,7 @@ export default class PreferencesController {
    * Removes an address from state
    *
    * @param {string} address - A hex address
-   * @returns {string} - the address that was removed
+   * @returns {string} the address that was removed
    */
   removeAddress(address) {
     const { identities } = this.store.getState()
@@ -319,7 +319,7 @@ export default class PreferencesController {
    * Removes any unknown identities, and returns the resulting selected address.
    *
    * @param {Array<string>} addresses - known to the vault.
-   * @returns {Promise<string>} - selectedAddress the selected address.
+   * @returns {Promise<string>} selectedAddress the selected address.
    */
   syncAddresses(addresses) {
     if (!Array.isArray(addresses) || addresses.length === 0) {
@@ -369,7 +369,7 @@ export default class PreferencesController {
    * Setter for the `selectedAddress` property
    *
    * @param {string} _address - A new hex address for an account
-   * @returns {Promise<void>} - Promise resolves with tokens
+   * @returns {Promise<void>} Promise resolves with tokens
    *
    */
   setSelectedAddress(_address) {
@@ -390,7 +390,7 @@ export default class PreferencesController {
   /**
    * Getter for the `selectedAddress` property
    *
-   * @returns {string} - The hex address for the currently selected account
+   * @returns {string} The hex address for the currently selected account
    *
    */
   getSelectedAddress() {
@@ -414,8 +414,8 @@ export default class PreferencesController {
    *
    * @param {string} rawAddress - Hex address of the token contract. May or may not be a checksum address.
    * @param {string} symbol - The symbol of the token
-   * @param {number} decimals  - The number of decimals the token uses.
-   * @returns {Promise<array>} - Promises the new array of AddedToken objects.
+   * @param {number} decimals - The number of decimals the token uses.
+   * @returns {Promise<array>} Promises the new array of AddedToken objects.
    *
    */
   async addToken(rawAddress, symbol, decimals, image) {
@@ -442,7 +442,7 @@ export default class PreferencesController {
    * Removes a specified token from the tokens array.
    *
    * @param {string} rawAddress - Hex address of the token contract to remove.
-   * @returns {Promise<array>} - The new array of AddedToken objects
+   * @returns {Promise<array>} The new array of AddedToken objects
    *
    */
   removeToken(rawAddress) {
@@ -457,7 +457,7 @@ export default class PreferencesController {
   /**
    * A getter for the `tokens` property
    *
-   * @returns {array} - The current array of AddedToken objects
+   * @returns {Array} The current array of AddedToken objects
    *
    */
   getTokens() {
@@ -596,7 +596,7 @@ export default class PreferencesController {
    * Removes custom RPC url from state.
    *
    * @param {string} url - The RPC url to remove from frequentRpcList.
-   * @returns {Promise<array>} - Promise resolving to updated frequentRpcList.
+   * @returns {Promise<array>} Promise resolving to updated frequentRpcList.
    *
    */
   removeFromFrequentRpcList(url) {
@@ -614,7 +614,7 @@ export default class PreferencesController {
   /**
    * Getter for the `frequentRpcListDetail` property.
    *
-   * @returns {array<array>} - An array of rpc urls.
+   * @returns {array<array>} An array of rpc urls.
    *
    */
   getFrequentRpcListDetail() {
@@ -626,7 +626,7 @@ export default class PreferencesController {
    *
    * @param {string} feature - A key that corresponds to a UI feature.
    * @param {boolean} activated - Indicates whether or not the UI feature should be displayed
-   * @returns {Promise<object>} - Promises a new object; the updated featureFlags object.
+   * @returns {Promise<object>} Promises a new object; the updated featureFlags object.
    *
    */
   setFeatureFlag(feature, activated) {
@@ -646,7 +646,7 @@ export default class PreferencesController {
    * found in the settings page.
    * @param {string} preference - The preference to enable or disable.
    * @param {boolean} value - Indicates whether or not the preference should be enabled or disabled.
-   * @returns {Promise<object>} - Promises a new object; the updated preferences object.
+   * @returns {Promise<object>} Promises a new object; the updated preferences object.
    */
   setPreference(preference, value) {
     const currentPreferences = this.getPreferences()
@@ -661,7 +661,7 @@ export default class PreferencesController {
 
   /**
    * A getter for the `preferences` property
-   * @returns {Object} - A key-boolean map of user-selected preferences.
+   * @returns {Object} A key-boolean map of user-selected preferences.
    */
   getPreferences() {
     return this.store.getState().preferences
@@ -678,7 +678,7 @@ export default class PreferencesController {
 
   /**
    * A getter for the `ipfsGateway` property
-   * @returns {string} - The current IPFS gateway domain
+   * @returns {string} The current IPFS gateway domain
    */
   getIpfsGateway() {
     return this.store.getState().ipfsGateway
@@ -687,7 +687,7 @@ export default class PreferencesController {
   /**
    * A setter for the `ipfsGateway` property
    * @param {string} domain - The new IPFS gateway domain
-   * @returns {Promise<string>} - A promise of the update IPFS gateway domain
+   * @returns {Promise<string>} A promise of the update IPFS gateway domain
    */
   setIpfsGateway(domain) {
     this.store.updateState({ ipfsGateway: domain })
@@ -713,7 +713,7 @@ export default class PreferencesController {
   /**
    * Updates `accountTokens` and `tokens` of current account and network according to it.
    *
-   * @param {array} tokens - Array of tokens to be updated.
+   * @param {Array} tokens - Array of tokens to be updated.
    *
    */
   _updateAccountTokens(tokens, assetImages) {
@@ -740,8 +740,8 @@ export default class PreferencesController {
   /**
    * A getter for `tokens` and `accountTokens` related states.
    *
-   * @param {string} [selectedAddress] A new hex address for an account
-   * @returns {Object.<array, object, string, string>} - States to interact with tokens in `accountTokens`
+   * @param {string} [selectedAddress] - A new hex address for an account
+   * @returns {Object.<array, object, string, string>} States to interact with tokens in `accountTokens`
    *
    */
   _getTokenRelatedStates(selectedAddress) {
@@ -764,11 +764,11 @@ export default class PreferencesController {
   /**
    * Handle the suggestion of an ERC20 asset through `watchAsset`
    * *
-   * @param {Promise} promise - Promise according to addition of ERC20 token
+   * @param {Object} tokenMetadata - Token metadata
    *
    */
-  async _handleWatchAssetERC20(options) {
-    const { address, symbol, decimals, image } = options
+  async _handleWatchAssetERC20(tokenMetadata) {
+    const { address, symbol, decimals, image } = tokenMetadata
     const rawAddress = address
     try {
       this._validateERC20AssetParams({ rawAddress, symbol, decimals })

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -48,16 +48,16 @@ const MAX_MEMSTORE_TX_LIST_SIZE = 100 // Number of transactions (by unique nonce
       calculating nonces
 
   @class
-  @param {Object} - opts
-  @param {Object}  opts.initState - initial transaction list default is an empty array
-  @param {Object}  opts.networkStore - an observable store for network number
-  @param {Object}  opts.blockTracker - An instance of eth-blocktracker
-  @param {Object}  opts.provider - A network provider.
-  @param {Function}  opts.signTransaction - function the signs an ethereumjs-tx
-  @param {Object}  opts.getPermittedAccounts - get accounts that an origin has permissions for
-  @param {Function}  opts.signTransaction - ethTx signer that returns a rawTx
-  @param {number}  [opts.txHistoryLimit] - number *optional* for limiting how many transactions are in state
-  @param {Object}  opts.preferencesStore
+  @param {Object} opts
+  @param {Object} opts.initState - initial transaction list default is an empty array
+  @param {Object} opts.networkStore - an observable store for network number
+  @param {Object} opts.blockTracker - An instance of eth-blocktracker
+  @param {Object} opts.provider - A network provider.
+  @param {Function} opts.signTransaction - function the signs an ethereumjs-tx
+  @param {Object} opts.getPermittedAccounts - get accounts that an origin has permissions for
+  @param {Function} opts.signTransaction - ethTx signer that returns a rawTx
+  @param {number} [opts.txHistoryLimit] - number *optional* for limiting how many transactions are in state
+  @param {Object} opts.preferencesStore
 */
 
 export default class TransactionController extends EventEmitter {
@@ -163,7 +163,7 @@ export default class TransactionController extends EventEmitter {
   /**
    * Add a new unapproved transaction to the pipeline
    *
-   * @returns {Promise<string>} - the hash of the transaction after being submitted to the network
+   * @returns {Promise<string>} the hash of the transaction after being submitted to the network
    * @param {Object} txParams - txParams for the transaction
    * @param {Object} opts - with the key origin to put the origin on the txMeta
    */
@@ -295,7 +295,7 @@ export default class TransactionController extends EventEmitter {
   /**
    * Adds the tx gas defaults: gas && gasPrice
    * @param {Object} txMeta - the txMeta object
-   * @returns {Promise<object>} - resolves with txMeta
+   * @returns {Promise<object>} resolves with txMeta
    */
   async addTxGasDefaults(txMeta, getCodeResponse) {
     const defaultGasPrice = await this._getDefaultGasPrice(txMeta)
@@ -539,7 +539,7 @@ export default class TransactionController extends EventEmitter {
   /**
     adds the chain id and signs the transaction and set the status to signed
     @param {number} txId - the tx's Id
-    @returns {string} - rawTx
+    @returns {string} rawTx
   */
   async signTransaction(txId) {
     const txMeta = this.txStateManager.getTx(txId)
@@ -681,22 +681,22 @@ export default class TransactionController extends EventEmitter {
   //
   /** maps methods for convenience*/
   _mapMethods() {
-    /** @returns {Object} - the state in transaction controller */
+    /** @returns {Object} the state in transaction controller */
     this.getState = () => this.memStore.getState()
 
-    /** @returns {string|number} - the network number stored in networkStore */
+    /** @returns {string|number} the network number stored in networkStore */
     this.getNetwork = () => this.networkStore.getState()
 
-    /** @returns {string} - the user selected address */
+    /** @returns {string} the user selected address */
     this.getSelectedAddress = () =>
       this.preferencesStore.getState().selectedAddress
 
-    /** @returns {array} - transactions whos status is unapproved */
+    /** @returns {Array} transactions whos status is unapproved */
     this.getUnapprovedTxCount = () =>
       Object.keys(this.txStateManager.getUnapprovedTxList()).length
 
     /**
-      @returns {number} - number of transactions that have the status submitted
+      @returns {number} number of transactions that have the status submitted
       @param {string} account - hex prefixed account
     */
     this.getPendingTxCount = (account) =>

--- a/app/scripts/controllers/transactions/lib/tx-state-history-helpers.js
+++ b/app/scripts/controllers/transactions/lib/tx-state-history-helpers.js
@@ -3,8 +3,8 @@ import { cloneDeep } from 'lodash'
 
 /**
   converts non-initial history entries into diffs
-  @param {array} longHistory
-  @returns {array}
+  @param {Array} longHistory
+  @returns {Array}
 */
 export function migrateFromSnapshotsToDiffs(longHistory) {
   return (
@@ -29,7 +29,7 @@ export function migrateFromSnapshotsToDiffs(longHistory) {
   @param {Object} previousState - the previous state of the object
   @param {Object} newState - the update object
   @param {string} [note] - a optional note for the state change
-  @returns {array}
+  @returns {Array}
 */
 export function generateHistoryEntry(previousState, newState, note) {
   const entry = jsonDiffer.compare(previousState, newState)

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -12,9 +12,9 @@ import { TRANSACTION_STATUSES } from '../../../../shared/constants/transaction'
 <br>
 @param {Object} config - non optional configuration object consists of:
     @param {Object} config.provider - A network provider.
-    @param {Object} config.nonceTracker see nonce tracker
-    @param {function} config.getPendingTransactions a function for getting an array of transactions,
-    @param {function} config.publishTransaction a async function for publishing raw transactions,
+    @param {Object} config.nonceTracker - see nonce tracker
+    @param {Function} config.getPendingTransactions - a function for getting an array of transactions,
+    @param {Function} config.publishTransaction - a async function for publishing raw transactions,
 
 @class
 */

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -53,7 +53,7 @@ export default class TxGasUtil {
   /**
     Estimates the tx's gas usage
     @param {Object} txMeta - the txMeta object
-    @returns {string} - the estimated gas limit as a hex string
+    @returns {string} the estimated gas limit as a hex string
   */
   async estimateTxGas(txMeta) {
     const { txParams } = txMeta
@@ -67,7 +67,7 @@ export default class TxGasUtil {
 
     @param {string} initialGasLimitHex - the initial gas limit to add the buffer too
     @param {string} blockGasLimitHex - the block gas limit
-    @returns {string} - the buffered gas limit as a hex string
+    @returns {string} the buffered gas limit as a hex string
   */
   addGasBuffer(initialGasLimitHex, blockGasLimitHex, multiplier = 1.5) {
     const initialGasLimitBn = hexToBn(initialGasLimitHex)

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -20,10 +20,10 @@ import { getFinalStates, normalizeTxParams } from './lib/util'
  * storing the transaction. It also has some convenience methods for finding
  * subsets of transactions.
  * @param {Object} opts
- * @param {Object} [opts.initState={ transactions: [] }] initial transactions list with the key transaction {array}
- * @param {number} [opts.txHistoryLimit] limit for how many finished
+ * @param {Object} [opts.initState={ transactions: [] }] - initial transactions list with the key transaction {Array}
+ * @param {number} [opts.txHistoryLimit] - limit for how many finished
  *  transactions can hang around in state
- * @param {function} opts.getNetwork return network number
+ * @param {Function} opts.getNetwork - return network number
  * @class
  */
 export default class TransactionStateManager extends EventEmitter {
@@ -37,7 +37,7 @@ export default class TransactionStateManager extends EventEmitter {
 
   /**
    * @param {Object} opts - the object to use when overwriting defaults
-   * @returns {txMeta} - the default txMeta object
+   * @returns {txMeta} the default txMeta object
    */
   generateTxMeta(opts) {
     const netId = this.getNetwork()
@@ -59,7 +59,7 @@ export default class TransactionStateManager extends EventEmitter {
    *
    * The list is iterated backwards as new transactions are pushed onto it.
    *
-   * @param {number} [limit] a limit for the number of transactions to return
+   * @param {number} [limit] - a limit for the number of transactions to return
    * @returns {Object[]} The {@code txMeta}s, filtered to the current network
    */
   getTxList(limit) {
@@ -91,14 +91,14 @@ export default class TransactionStateManager extends EventEmitter {
   }
 
   /**
-   * @returns {array} - of all the txMetas in store
+   * @returns {Array} of all the txMetas in store
    */
   getFullTxList() {
     return this.store.getState().transactions
   }
 
   /**
-   * @returns {array} - the tx list with unapproved status
+   * @returns {Array} the tx list with unapproved status
    */
   getUnapprovedTxList() {
     const txList = this.getTxsByMetaData(
@@ -112,8 +112,8 @@ export default class TransactionStateManager extends EventEmitter {
   }
 
   /**
-   * @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
-   * @returns {array} - the tx list with approved status if no address is provide
+   * @param {string} [address] - hex prefixed address to sort the txMetas for [optional]
+   * @returns {Array} the tx list with approved status if no address is provide
    *  returns all txMetas with approved statuses for the current network
    */
   getApprovedTransactions(address) {
@@ -125,8 +125,8 @@ export default class TransactionStateManager extends EventEmitter {
   }
 
   /**
-   * @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
-   * @returns {array} - the tx list submitted status if no address is provide
+   * @param {string} [address] - hex prefixed address to sort the txMetas for [optional]
+   * @returns {Array} the tx list submitted status if no address is provide
    *  returns all txMetas with submitted statuses for the current network
    */
   getPendingTransactions(address) {
@@ -138,8 +138,8 @@ export default class TransactionStateManager extends EventEmitter {
   }
 
   /**
-    @param [address] {string} - hex prefixed address to sort the txMetas for [optional]
-    @returns {array} - the tx list whose status is confirmed if no address is provide
+    @param {string} [address] - hex prefixed address to sort the txMetas for [optional]
+    @returns {Array} the tx list whose status is confirmed if no address is provide
     returns all txMetas who's status is confirmed for the current network
   */
   getConfirmedTransactions(address) {
@@ -157,7 +157,7 @@ export default class TransactionStateManager extends EventEmitter {
    * it will also add the key `history` to the txMeta with the snap shot of
    * the original object
    * @param {Object} txMeta
-   * @returns {Object} - the txMeta
+   * @returns {Object} the txMeta
    */
   addTx(txMeta) {
     // normalize and validate txParams if present
@@ -207,7 +207,7 @@ export default class TransactionStateManager extends EventEmitter {
 
   /**
    * @param {number} txId
-   * @returns {Object} - the txMeta who matches the given id if none found
+   * @returns {Object} the txMeta who matches the given id if none found
    * for the network returns undefined
    */
   getTx(txId) {
@@ -307,8 +307,8 @@ export default class TransactionStateManager extends EventEmitter {
   }<br></code>
   optionally the values of the keys can be functions for situations like where
   you want all but one status.
-  @param [initialList=this.getTxList()]
-  @returns {array} - array of txMeta with all
+  @param {Array} [initialList=this.getTxList()]
+  @returns {Array} array of txMeta with all
   options matching
   */
   /*
@@ -335,10 +335,10 @@ export default class TransactionStateManager extends EventEmitter {
 
   /**
    * @param {string} key - the key to check
-   * @param value - the value your looking for can also be a function that returns a bool
-   * @param [txList=this.getTxList()] {array} - the list to search. default is the txList
+   * @param {any} value - the value your looking for can also be a function that returns a bool
+   * @param {Array} [txList=this.getTxList()] - the list to search. default is the txList
    *  from txStateManager#getTxList
-   * @returns {array} - a list of txMetas who matches the search params
+   * @returns {Array} a list of txMetas who matches the search params
    */
   getTxsByMetaData(key, value, txList = this.getTxList()) {
     const filter = typeof value === 'function' ? value : (v) => v === value
@@ -355,7 +355,7 @@ export default class TransactionStateManager extends EventEmitter {
 
   /**
    * @param {number} txId - the txMeta Id
-   * @returns {string} - the status of the tx.
+   * @returns {string} the status of the tx.
    */
   getTxStatus(txId) {
     const txMeta = this.getTx(txId)
@@ -505,7 +505,7 @@ export default class TransactionStateManager extends EventEmitter {
 
   /**
    * Saves the new/updated txList. Intended only for internal use
-   * @param {array} transactions - the list of transactions to save
+   * @param {Array} transactions - the list of transactions to save
    */
   _saveTxList(transactions) {
     this.store.updateState({ transactions })

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -37,7 +37,7 @@ export default class ComposableObservableStore extends ObservableStore {
    * Merges all child store state into a single object rather than
    * returning an object keyed by child store class name
    *
-   * @returns {Object} - Object containing merged child store state
+   * @returns {Object} Object containing merged child store state
    */
   getFlatState() {
     let flatState = {}

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -96,7 +96,7 @@ export default class AccountTracker {
    * Once this AccountTracker's accounts are up to date with those referenced by the passed addresses, each
    * of these accounts are given an updated balance via EthQuery.
    *
-   * @param {array} address - The array of hex addresses for accounts with which this AccountTracker's accounts should be
+   * @param {Array} address - The array of hex addresses for accounts with which this AccountTracker's accounts should be
    * in sync
    *
    */
@@ -126,7 +126,7 @@ export default class AccountTracker {
    * Adds new addresses to track the balances of
    * given a balance as long this._currentBlockNumber is defined.
    *
-   * @param {array} addresses - An array of hex addresses of new accounts to track
+   * @param {Array} addresses - An array of hex addresses of new accounts to track
    *
    */
   addAccounts(addresses) {
@@ -147,7 +147,7 @@ export default class AccountTracker {
   /**
    * Removes accounts from being tracked
    *
-   * @param {array} an - array of hex addresses to stop tracking
+   * @param {Array} an - array of hex addresses to stop tracking
    *
    */
   removeAccount(addresses) {
@@ -199,7 +199,7 @@ export default class AccountTracker {
    * balanceChecker is deployed on main eth (test)nets and requires a single call
    * for all other networks, calls this._updateAccount for each account in this.store
    *
-   * @returns {Promise} - after all account balances updated
+   * @returns {Promise} after all account balances updated
    *
    */
   async _updateAccounts() {
@@ -246,7 +246,7 @@ export default class AccountTracker {
    *
    * @private
    * @param {string} address - A hex address of a the account to be updated
-   * @returns {Promise} - after the account balance is updated
+   * @returns {Promise} after the account balance is updated
    *
    */
   async _updateAccount(address) {

--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -2,9 +2,9 @@
  * Gives the caller a url at which the user can acquire eth, depending on the network they are in
  *
  * @param {Object} opts - Options required to determine the correct url
- * @param {string} opts.network The network for which to return a url
- * @param {string} opts.address The address the bought ETH should be sent to.  Only relevant if network === '1'.
- * @returns {string|undefined} - The url at which the user can access ETH, while in the given network. If the passed
+ * @param {string} opts.network - The network for which to return a url
+ * @param {string} opts.address - The address the bought ETH should be sent to.  Only relevant if network === '1'.
+ * @returns {string|undefined} The url at which the user can access ETH, while in the given network. If the passed
  * network does not match any of the specified cases, or if no network is given, returns undefined.
  *
  */

--- a/app/scripts/lib/cleanErrorStack.js
+++ b/app/scripts/lib/cleanErrorStack.js
@@ -1,7 +1,7 @@
 /**
  * Returns error without stack trace for better UI display
  * @param {Error} err - error
- * @returns {Error} - Error with clean stack trace.
+ * @returns {Error} Error with clean stack trace.
  */
 export default function cleanErrorStack(err) {
   let { name } = err

--- a/app/scripts/lib/decrypt-message-manager.js
+++ b/app/scripts/lib/decrypt-message-manager.js
@@ -34,7 +34,7 @@ export default class DecryptMessageManager extends EventEmitter {
    * @property {Object} memStore The observable store where DecryptMessage are saved.
    * @property {Object} memStore.unapprovedDecryptMsgs A collection of all DecryptMessages in the 'unapproved' state
    * @property {number} memStore.unapprovedDecryptMsgCount The count of all DecryptMessages in this.memStore.unapprovedDecryptMsgs
-   * @property {array} messages Holds all messages that have been created by this DecryptMessageManager
+   * @property {Array} messages Holds all messages that have been created by this DecryptMessageManager
    *
    */
   constructor() {
@@ -77,8 +77,8 @@ export default class DecryptMessageManager extends EventEmitter {
    * the new DecryptMessage to this.messages, and to save the unapproved DecryptMessages from that list to
    * this.memStore.
    *
-   * @param {Object} msgParams The params for the eth_decrypt call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
+   * @param {Object} msgParams - The params for the eth_decrypt call to be made after the message is approved.
+   * @param {Object} [req] - The original request object possibly containing the origin
    * @returns {Promise<Buffer>} The raw decrypted message contents
    *
    */
@@ -122,8 +122,8 @@ export default class DecryptMessageManager extends EventEmitter {
    * the new DecryptMessage to this.messages, and to save the unapproved DecryptMessages from that list to
    * this.memStore.
    *
-   * @param {Object} msgParams The params for the eth_decryptMsg call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
+   * @param {Object} msgParams - The params for the eth_decryptMsg call to be made after the message is approved.
+   * @param {Object} [req] - The original request object possibly containing the origin
    * @returns {number} The id of the newly created DecryptMessage.
    *
    */
@@ -290,7 +290,7 @@ export default class DecryptMessageManager extends EventEmitter {
    * unapprovedDecryptMsgs index to storage via this._saveMsgList
    *
    * @private
-   * @param {msg} DecryptMessage A DecryptMessage that will replace an existing DecryptMessage (with the same
+   * @param {DecryptMessage} msg - A DecryptMessage that will replace an existing DecryptMessage (with the same
    * id) in this.messages
    *
    */

--- a/app/scripts/lib/encryption-public-key-manager.js
+++ b/app/scripts/lib/encryption-public-key-manager.js
@@ -30,7 +30,7 @@ export default class EncryptionPublicKeyManager extends EventEmitter {
    * @property {Object} memStore The observable store where EncryptionPublicKey are saved with persistance.
    * @property {Object} memStore.unapprovedEncryptionPublicKeyMsgs A collection of all EncryptionPublicKeys in the 'unapproved' state
    * @property {number} memStore.unapprovedEncryptionPublicKeyMsgCount The count of all EncryptionPublicKeys in this.memStore.unapprobedMsgs
-   * @property {array} messages Holds all messages that have been created by this EncryptionPublicKeyManager
+   * @property {Array} messages Holds all messages that have been created by this EncryptionPublicKeyManager
    *
    */
   constructor() {
@@ -73,8 +73,8 @@ export default class EncryptionPublicKeyManager extends EventEmitter {
    * the new EncryptionPublicKey to this.messages, and to save the unapproved EncryptionPublicKeys from that list to
    * this.memStore.
    *
-   * @param {Object} address The param for the eth_getEncryptionPublicKey call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
+   * @param {Object} address - The param for the eth_getEncryptionPublicKey call to be made after the message is approved.
+   * @param {Object} [req] - The original request object possibly containing the origin
    * @returns {Promise<Buffer>} The raw public key contents
    *
    */
@@ -115,8 +115,8 @@ export default class EncryptionPublicKeyManager extends EventEmitter {
    * the new EncryptionPublicKey to this.messages, and to save the unapproved EncryptionPublicKeys from that list to
    * this.memStore.
    *
-   * @param {Object} address The param for the eth_getEncryptionPublicKey call to be made after the message is approved.
-   * @param {Object} _req (optional) The original request object possibly containing the origin
+   * @param {Object} address - The param for the eth_getEncryptionPublicKey call to be made after the message is approved.
+   * @param {Object} [req] - The original request object possibly containing the origin
    * @returns {number} The id of the newly created EncryptionPublicKey.
    *
    */
@@ -275,7 +275,7 @@ export default class EncryptionPublicKeyManager extends EventEmitter {
    * unapprovedEncryptionPublicKeyMsgs index to storage via this._saveMsgList
    *
    * @private
-   * @param {msg} EncryptionPublicKey A EncryptionPublicKey that will replace an existing EncryptionPublicKey (with the same
+   * @param {EncryptionPublicKey} msg - A EncryptionPublicKey that will replace an existing EncryptionPublicKey (with the same
    * id) in this.messages
    *
    */

--- a/app/scripts/lib/ens-ipfs/resolver.js
+++ b/app/scripts/lib/ens-ipfs/resolver.js
@@ -70,7 +70,7 @@ function hexValueIsEmpty(value) {
 
 /**
  * Returns the registry address for the given chain ID
- * @param {number} chainId the chain ID
+ * @param {number} chainId - the chain ID
  * @returns {string|null} the registry address if known, null otherwise
  */
 function getRegistryForChainId(chainId) {

--- a/app/scripts/lib/extractEthjsErrorMessage.js
+++ b/app/scripts/lib/extractEthjsErrorMessage.js
@@ -6,7 +6,7 @@ const errorLabelPrefix = 'Error: '
  * is returned unchanged.
  *
  * @param {string} errorMessage - The error message to parse
- * @returns {string} - Returns an error message, either the same as was passed, or the ending message portion of an isEthjsRpcError
+ * @returns {string} Returns an error message, either the same as was passed, or the ending message portion of an isEthjsRpcError
  *
  * @example
  * // returns 'Transaction Failed: replacement transaction underpriced'

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -19,7 +19,7 @@ allLocales.forEach((locale) => {
  * Returns a preferred language code, based on settings within the user's browser. If we have no translations for the
  * users preferred locales, 'en' is returned.
  *
- * @returns {Promise<string>} - Promises a locale code, either one from the user's preferred list that we have a translation for, or 'en'
+ * @returns {Promise<string>} Promises a locale code, either one from the user's preferred list that we have a translation for, or 'en'
  *
  */
 export default async function getFirstPreferredLangCode() {

--- a/app/scripts/lib/getObjStructure.js
+++ b/app/scripts/lib/getObjStructure.js
@@ -17,7 +17,7 @@ import { cloneDeep } from 'lodash'
  * type.
  *
  * @param {Object} obj - The object for which a 'structure' will be returned. Usually a plain object and not a class.
- * @returns {Object} - The "mapped" version of a deep clone of the passed object, with each non-object property value
+ * @returns {Object} The "mapped" version of a deep clone of the passed object, with each non-object property value
  * replaced with the javascript type of that value.
  *
  */
@@ -34,7 +34,7 @@ export default function getObjStructure(obj) {
  *
  * @param {Object} target - The object to modify
  * @param {Function} visit - The modifier to apply to each non-object property value
- * @returns {Object} - The modified object
+ * @returns {Object} The modified object
  */
 function deepMap(target = {}, visit) {
   Object.entries(target).forEach(([key, value]) => {

--- a/app/scripts/lib/local-store.js
+++ b/app/scripts/lib/local-store.js
@@ -45,7 +45,7 @@ export default class ExtensionStore {
   /**
    * Returns all of the keys currently saved
    * @private
-   * @returns {Object} - the key-value map from local storage
+   * @returns {Object} the key-value map from local storage
    */
   _get() {
     const { local } = extension.storage

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -28,11 +28,10 @@ export default class MessageManager extends EventEmitter {
    * Controller in charge of managing - storing, adding, removing, updating - Messages.
    *
    * @typedef {Object} MessageManager
-   * @param {Object} opts @deprecated
    * @property {Object} memStore The observable store where Messages are saved.
    * @property {Object} memStore.unapprovedMsgs A collection of all Messages in the 'unapproved' state
    * @property {number} memStore.unapprovedMsgCount The count of all Messages in this.memStore.unapprovedMsgs
-   * @property {array} messages Holds all messages that have been created by this MessageManager
+   * @property {Array} messages Holds all messages that have been created by this MessageManager
    *
    */
   constructor() {
@@ -47,7 +46,7 @@ export default class MessageManager extends EventEmitter {
   /**
    * A getter for the number of 'unapproved' Messages in this.messages
    *
-   * @returns {number} - The number of 'unapproved' Messages in this.messages
+   * @returns {number} The number of 'unapproved' Messages in this.messages
    *
    */
   get unapprovedMsgCount() {
@@ -57,7 +56,7 @@ export default class MessageManager extends EventEmitter {
   /**
    * A getter for the 'unapproved' Messages in this.messages
    *
-   * @returns {Object} - An index of Message ids to Messages, for all 'unapproved' Messages in this.messages
+   * @returns {Object} An index of Message ids to Messages, for all 'unapproved' Messages in this.messages
    *
    */
   getUnapprovedMsgs() {
@@ -74,8 +73,8 @@ export default class MessageManager extends EventEmitter {
    * new Message to this.messages, and to save the unapproved Messages from that list to this.memStore.
    *
    * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {promise} - after signature has been
+   * @param {Object} [req] - The original request object possibly containing the origin
+   * @returns {promise} after signature has been
    *
    */
   addUnapprovedMessageAsync(msgParams, req) {
@@ -110,8 +109,8 @@ export default class MessageManager extends EventEmitter {
    * new Message to this.messages, and to save the unapproved Messages from that list to this.memStore.
    *
    * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object where the origin may be specified
-   * @returns {number} - The id of the newly created message.
+   * @param {Object} [req] - The original request object where the origin may be specified
+   * @returns {number} The id of the newly created message.
    *
    */
   addUnapprovedMessage(msgParams, req) {
@@ -153,7 +152,7 @@ export default class MessageManager extends EventEmitter {
    * Returns a specified Message.
    *
    * @param {number} msgId - The id of the Message to get
-   * @returns {Message|undefined} - The Message with the id that matches the passed msgId, or undefined if no Message has that id.
+   * @returns {Message|undefined} The Message with the id that matches the passed msgId, or undefined if no Message has that id.
    *
    */
   getMsg(msgId) {
@@ -166,7 +165,7 @@ export default class MessageManager extends EventEmitter {
    *
    * @param {Object} msgParams - The msgParams to be used when eth_sign is called, plus data added by MetaMask.
    * @param {Object} msgParams.metamaskId Added to msgParams for tracking and identification within MetaMask.
-   * @returns {Promise<object>} - Promises the msgParams object with metamaskId removed.
+   * @returns {Promise<object>} Promises the msgParams object with metamaskId removed.
    *
    */
   approveMessage(msgParams) {
@@ -203,7 +202,7 @@ export default class MessageManager extends EventEmitter {
    * Removes the metamaskId property from passed msgParams and returns a promise which resolves the updated msgParams
    *
    * @param {Object} msgParams - The msgParams to modify
-   * @returns {Promise<object>} - Promises the msgParams with the metamaskId property removed
+   * @returns {Promise<object>} Promises the msgParams with the metamaskId property removed
    *
    */
   prepMsgForSigning(msgParams) {
@@ -281,7 +280,7 @@ export default class MessageManager extends EventEmitter {
  * A helper function that converts raw buffer data to a hex, or just returns the data if it is already formatted as a hex.
  *
  * @param {any} data - The buffer data to convert to a hex
- * @returns {string} - A hex string conversion of the buffer data
+ * @returns {string} A hex string conversion of the buffer data
  *
  */
 function normalizeMsgData(data) {

--- a/app/scripts/lib/migrator/index.js
+++ b/app/scripts/lib/migrator/index.js
@@ -1,13 +1,13 @@
 import EventEmitter from 'events'
 
 /**
- * @typedef {object} Migration
+ * @typedef {Object} Migration
  * @property {number} version - The migration version
  * @property {Function} migrate - Returns a promise of the migrated data
  */
 
 /**
- * @typedef {object} MigratorOptions
+ * @typedef {Object} MigratorOptions
  * @property {Array<Migration>} [migrations] - The list of migrations to apply
  * @property {number} [defaultVersion] - The version to use in the initial state
  */

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -79,7 +79,7 @@ export default class NotificationManager {
    * Given an array of windows, returns the 'popup' that has been opened by MetaMask, or null if no such window exists.
    *
    * @private
-   * @param {array} windows - An array of objects containing data about the open MetaMask extension windows.
+   * @param {Array} windows - An array of objects containing data about the open MetaMask extension windows.
    *
    */
   _getPopupIn(windows) {

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -33,11 +33,10 @@ export default class PersonalMessageManager extends EventEmitter {
    * Controller in charge of managing - storing, adding, removing, updating - PersonalMessage.
    *
    * @typedef {Object} PersonalMessageManager
-   * @param {Object} opts @deprecated
    * @property {Object} memStore The observable store where PersonalMessage are saved.
    * @property {Object} memStore.unapprovedPersonalMsgs A collection of all PersonalMessages in the 'unapproved' state
    * @property {number} memStore.unapprovedPersonalMsgCount The count of all PersonalMessages in this.memStore.unapprobedMsgs
-   * @property {array} messages Holds all messages that have been created by this PersonalMessageManager
+   * @property {Array} messages Holds all messages that have been created by this PersonalMessageManager
    *
    */
   constructor() {
@@ -52,7 +51,7 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * A getter for the number of 'unapproved' PersonalMessages in this.messages
    *
-   * @returns {number} - The number of 'unapproved' PersonalMessages in this.messages
+   * @returns {number} The number of 'unapproved' PersonalMessages in this.messages
    *
    */
   get unapprovedPersonalMsgCount() {
@@ -62,7 +61,7 @@ export default class PersonalMessageManager extends EventEmitter {
   /**
    * A getter for the 'unapproved' PersonalMessages in this.messages
    *
-   * @returns {Object} - An index of PersonalMessage ids to PersonalMessages, for all 'unapproved' PersonalMessages in
+   * @returns {Object} An index of PersonalMessage ids to PersonalMessages, for all 'unapproved' PersonalMessages in
    * this.messages
    *
    */
@@ -81,8 +80,8 @@ export default class PersonalMessageManager extends EventEmitter {
    * this.memStore.
    *
    * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {promise} - When the message has been signed or rejected
+   * @param {Object} [req] - The original request object possibly containing the origin
+   * @returns {promise} When the message has been signed or rejected
    *
    */
   addUnapprovedMessageAsync(msgParams, req) {
@@ -123,8 +122,8 @@ export default class PersonalMessageManager extends EventEmitter {
    * this.memStore.
    *
    * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {number} - The id of the newly created PersonalMessage.
+   * @param {Object} [req] - The original request object possibly containing the origin
+   * @returns {number} The id of the newly created PersonalMessage.
    *
    */
   addUnapprovedMessage(msgParams, req) {
@@ -171,7 +170,7 @@ export default class PersonalMessageManager extends EventEmitter {
    * Returns a specified PersonalMessage.
    *
    * @param {number} msgId - The id of the PersonalMessage to get
-   * @returns {PersonalMessage|undefined} - The PersonalMessage with the id that matches the passed msgId, or undefined
+   * @returns {PersonalMessage|undefined} The PersonalMessage with the id that matches the passed msgId, or undefined
    * if no PersonalMessage has that id.
    *
    */
@@ -185,7 +184,7 @@ export default class PersonalMessageManager extends EventEmitter {
    *
    * @param {Object} msgParams - The msgParams to be used when eth_sign is called, plus data added by MetaMask.
    * @param {Object} msgParams.metamaskId Added to msgParams for tracking and identification within MetaMask.
-   * @returns {Promise<object>} - Promises the msgParams object with metamaskId removed.
+   * @returns {Promise<object>} Promises the msgParams object with metamaskId removed.
    *
    */
   approveMessage(msgParams) {
@@ -222,7 +221,7 @@ export default class PersonalMessageManager extends EventEmitter {
    * Removes the metamaskId property from passed msgParams and returns a promise which resolves the updated msgParams
    *
    * @param {Object} msgParams - The msgParams to modify
-   * @returns {Promise<object>} - Promises the msgParams with the metamaskId property removed
+   * @returns {Promise<object>} Promises the msgParams with the metamaskId property removed
    *
    */
   prepMsgForSigning(msgParams) {
@@ -307,7 +306,7 @@ export default class PersonalMessageManager extends EventEmitter {
    * A helper function that converts raw buffer data to a hex, or just returns the data if it is already formatted as a hex.
    *
    * @param {any} data - The buffer data to convert to a hex
-   * @returns {string} - A hex string conversion of the buffer data
+   * @returns {string} A hex string conversion of the buffer data
    *
    */
   normalizeMsgData(data) {

--- a/app/scripts/lib/seed-phrase-verifier.js
+++ b/app/scripts/lib/seed-phrase-verifier.js
@@ -10,9 +10,9 @@ const seedPhraseVerifier = {
    * - The created accounts in the primary keyring are always the same.
    * - The keyring always creates the accounts in the same sequence.
    *
-   * @param {array} createdAccounts - The accounts to restore
+   * @param {Array} createdAccounts - The accounts to restore
    * @param {string} seedWords - The seed words to verify
-   * @returns {Promise<void>} - Promises undefined
+   * @returns {Promise<void>} Promises undefined
    *
    */
   async verifyAccounts(createdAccounts, seedWords) {

--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -4,7 +4,7 @@ import pump from 'pump'
 /**
  * Sets up stream multiplexing for the given stream
  * @param {any} connectionStream - the stream to mux
- * @returns {stream.Stream} - the multiplexed stream
+ * @returns {stream.Stream} the multiplexed stream
  */
 export function setupMultiplex(connectionStream) {
   const mux = new ObjectMultiplex()

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -44,7 +44,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * A getter for the number of 'unapproved' TypedMessages in this.messages
    *
-   * @returns {number} - The number of 'unapproved' TypedMessages in this.messages
+   * @returns {number} The number of 'unapproved' TypedMessages in this.messages
    *
    */
   get unapprovedTypedMessagesCount() {
@@ -54,7 +54,7 @@ export default class TypedMessageManager extends EventEmitter {
   /**
    * A getter for the 'unapproved' TypedMessages in this.messages
    *
-   * @returns {Object} - An index of TypedMessage ids to TypedMessages, for all 'unapproved' TypedMessages in
+   * @returns {Object} An index of TypedMessage ids to TypedMessages, for all 'unapproved' TypedMessages in
    * this.messages
    *
    */
@@ -73,8 +73,8 @@ export default class TypedMessageManager extends EventEmitter {
    * this.memStore. Before any of this is done, msgParams are validated
    *
    * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {promise} - When the message has been signed or rejected
+   * @param {Object} [req] - The original request object possibly containing the origin
+   * @returns {promise} When the message has been signed or rejected
    *
    */
   addUnapprovedMessageAsync(msgParams, req, version) {
@@ -113,8 +113,8 @@ export default class TypedMessageManager extends EventEmitter {
    * this.memStore. Before any of this is done, msgParams are validated
    *
    * @param {Object} msgParams - The params for the eth_sign call to be made after the message is approved.
-   * @param {Object} req (optional) The original request object possibly containing the origin
-   * @returns {number} - The id of the newly created TypedMessage.
+   * @param {Object} [req] - The original request object possibly containing the origin
+   * @returns {number} The id of the newly created TypedMessage.
    *
    */
   addUnapprovedMessage(msgParams, req, version) {
@@ -224,7 +224,7 @@ export default class TypedMessageManager extends EventEmitter {
    * Returns a specified TypedMessage.
    *
    * @param {number} msgId - The id of the TypedMessage to get
-   * @returns {TypedMessage|undefined} - The TypedMessage with the id that matches the passed msgId, or undefined
+   * @returns {TypedMessage|undefined} The TypedMessage with the id that matches the passed msgId, or undefined
    * if no TypedMessage has that id.
    *
    */
@@ -238,7 +238,7 @@ export default class TypedMessageManager extends EventEmitter {
    *
    * @param {Object} msgParams - The msgParams to be used when eth_sign is called, plus data added by MetaMask.
    * @param {Object} msgParams.metamaskId Added to msgParams for tracking and identification within MetaMask.
-   * @returns {Promise<object>} - Promises the msgParams object with metamaskId removed.
+   * @returns {Promise<object>} Promises the msgParams object with metamaskId removed.
    *
    */
   approveMessage(msgParams) {
@@ -275,7 +275,7 @@ export default class TypedMessageManager extends EventEmitter {
    * Removes the metamaskId property from passed msgParams and returns a promise which resolves the updated msgParams
    *
    * @param {Object} msgParams - The msgParams to modify
-   * @returns {Promise<object>} - Promises the msgParams with the metamaskId property removed
+   * @returns {Promise<object>} Promises the msgParams with the metamaskId property removed
    *
    */
   prepMsgForSigning(msgParams) {

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -50,7 +50,7 @@ const getEnvironmentType = (url = window.location.href) =>
 /**
  * Returns the platform (browser) where the extension is running.
  *
- * @returns {string} - the platform ENUM
+ * @returns {string} the platform ENUM
  *
  */
 const getPlatform = (_) => {
@@ -74,11 +74,11 @@ const getPlatform = (_) => {
  * Checks whether a given balance of ETH, represented as a hex string, is sufficient to pay a value plus a gas fee
  *
  * @param {Object} txParams - Contains data about a transaction
- * @param {string} txParams.gas The gas for a transaction
- * @param {string} txParams.gasPrice The price per gas for the transaction
- * @param {string} txParams.value The value of ETH to send
+ * @param {string} txParams.gas - The gas for a transaction
+ * @param {string} txParams.gasPrice - The price per gas for the transaction
+ * @param {string} txParams.value - The value of ETH to send
  * @param {string} hexBalance - A balance of ETH represented as a hex string
- * @returns {boolean} - Whether the balance is greater than or equal to the value plus the value of gas times gasPrice
+ * @returns {boolean} Whether the balance is greater than or equal to the value plus the value of gas times gasPrice
  *
  */
 function sufficientBalance(txParams, hexBalance) {
@@ -107,7 +107,7 @@ function sufficientBalance(txParams, hexBalance) {
  * Converts a hex string to a BN object
  *
  * @param {string} inputHex - A number represented as a hex string
- * @returns {Object} - A BN object
+ * @returns {Object} A BN object
  *
  */
 function hexToBn(inputHex) {
@@ -120,7 +120,7 @@ function hexToBn(inputHex) {
  * @param {BN} targetBN - The number to multiply by a fraction
  * @param {number|string} numerator - The numerator of the fraction multiplier
  * @param {number|string} denominator - The denominator of the fraction multiplier
- * @returns {BN} - The product of the multiplication
+ * @returns {BN} The product of the multiplication
  *
  */
 function BnMultiplyByFraction(targetBN, numerator, denominator) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -498,7 +498,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * The metamask-state of the various controllers, made available to the UI
    *
-   * @returns {Object} - status
+   * @returns {Object} status
    */
   getState() {
     const { vault } = this.keyringController.store.getState()
@@ -515,7 +515,7 @@ export default class MetamaskController extends EventEmitter {
    * These functions are the interface for the UI.
    * The API object can be transmitted over a stream with dnode.
    *
-   * @returns {Object} - Object containing API functions.
+   * @returns {Object} Object containing API functions.
    */
   getApi() {
     const {
@@ -842,9 +842,8 @@ export default class MetamaskController extends EventEmitter {
    * A keychain, or keyring, controls many accounts with a single backup and signing strategy.
    * For example, a mnemonic phrase can generate many accounts, and is a keyring.
    *
-   * @param  {string} password
-   *
-   * @returns {Object} - vault
+   * @param {string} password
+   * @returns {Object} vault
    */
   async createNewVaultAndKeychain(password) {
     const releaseLock = await this.createVaultMutex.acquire()
@@ -867,8 +866,8 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Create a new Vault and restore an existent keyring.
-   * @param  {} password
-   * @param  {} seed
+   * @param {string} password
+   * @param {string} seed
    */
   async createNewVaultAndRestore(password, seed) {
     const releaseLock = await this.createVaultMutex.acquire()
@@ -962,7 +961,7 @@ export default class MetamaskController extends EventEmitter {
   /**
    * Collects all the information that we want to share
    * with the mobile client for syncing purposes
-   * @returns {Promise<Object>} - Parts of the state that we want to syncx
+   * @returns {Promise<Object>} Parts of the state that we want to syncx
    */
   async fetchInfoToSync() {
     // Preferences
@@ -1053,7 +1052,7 @@ export default class MetamaskController extends EventEmitter {
    * is up to date with known accounts once the vault is decrypted.
    *
    * @param {string} password - The user's password
-   * @returns {Promise<object>} - The keyringController update.
+   * @returns {Promise<object>} The keyringController update.
    */
   async submitPassword(password) {
     await this.keyringController.submitPassword(password)
@@ -1261,7 +1260,7 @@ export default class MetamaskController extends EventEmitter {
    *
    * Called when the first account is created and on unlocking the vault.
    *
-   * @returns {Promise<string>} - Seed phrase to be confirmed by the user.
+   * @returns {Promise<string>} Seed phrase to be confirmed by the user.
    */
   async verifySeedPhrase() {
     const primaryKeyring = this.keyringController.getKeyringsByType(
@@ -1293,7 +1292,7 @@ export default class MetamaskController extends EventEmitter {
    * Mostly used in development environments, when networks are restarted with
    * the same network ID.
    *
-   * @returns {Promise<string>} - The current selected address.
+   * @returns {Promise<string>} The current selected address.
    */
   async resetAccount() {
     const selectedAddress = this.preferencesController.getSelectedAddress()
@@ -1327,9 +1326,9 @@ export default class MetamaskController extends EventEmitter {
    * These are defined in app/scripts/account-import-strategies
    * Each strategy represents a different way of serializing an Ethereum key pair.
    *
-   * @param  {string} strategy - A unique identifier for an account import strategy.
-   * @param  {any} args - The data required by that strategy to import an account.
-   * @param  {Function} cb - A callback function called with a state update on success.
+   * @param {string} strategy - A unique identifier for an account import strategy.
+   * @param {any} args - The data required by that strategy to import an account.
+   * @param {Function} cb - A callback function called with a state update on success.
    */
   async importAccountWithStrategy(strategy, args) {
     const privateKey = await accountImporter.importAccount(strategy, args)
@@ -1369,7 +1368,7 @@ export default class MetamaskController extends EventEmitter {
    * information.
    *
    * @param {Object} msgParams - The params passed to eth_sign.
-   * @param {Function} cb = The callback function called with the signature.
+   * @param {Function} cb - The callback function called with the signature.
    */
   newUnsignedMessage(msgParams, req) {
     const promise = this.messageManager.addUnapprovedMessageAsync(
@@ -1384,8 +1383,8 @@ export default class MetamaskController extends EventEmitter {
   /**
    * Signifies user intent to complete an eth_sign method.
    *
-   * @param  {Object} msgParams - The params passed to eth_call.
-   * @returns {Promise<Object>} - Full state update.
+   * @param {Object} msgParams - The params passed to eth_call.
+   * @returns {Promise<Object>} Full state update.
    */
   signMessage(msgParams) {
     log.info('MetaMaskController - signMessage')
@@ -1449,7 +1448,7 @@ export default class MetamaskController extends EventEmitter {
    * Triggers signing, and the callback function from newUnsignedPersonalMessage.
    *
    * @param {Object} msgParams - The params of the message to sign & return to the Dapp.
-   * @returns {Promise<Object>} - A full state update.
+   * @returns {Promise<Object>} A full state update.
    */
   signPersonalMessage(msgParams) {
     log.info('MetaMaskController - signPersonalMessage')
@@ -1507,7 +1506,7 @@ export default class MetamaskController extends EventEmitter {
    * Only decrypt message and don't touch transaction state
    *
    * @param {Object} msgParams - The params of the message to decrypt.
-   * @returns {Promise<Object>} - A full state update.
+   * @returns {Promise<Object>} A full state update.
    */
   async decryptMessageInline(msgParams) {
     log.info('MetaMaskController - decryptMessageInline')
@@ -1533,7 +1532,7 @@ export default class MetamaskController extends EventEmitter {
    * Triggers decrypt, and the callback function from newUnsignedDecryptMessage.
    *
    * @param {Object} msgParams - The params of the message to decrypt & return to the Dapp.
-   * @returns {Promise<Object>} - A full state update.
+   * @returns {Promise<Object>} A full state update.
    */
   async decryptMessage(msgParams) {
     log.info('MetaMaskController - decryptMessage')
@@ -1600,7 +1599,7 @@ export default class MetamaskController extends EventEmitter {
    * Triggers receiving, and the callback function from newUnsignedEncryptionPublicKey.
    *
    * @param {Object} msgParams - The params of the message to receive & return to the Dapp.
-   * @returns {Promise<Object>} - A full state update.
+   * @returns {Promise<Object>} A full state update.
    */
   async encryptionPublicKey(msgParams) {
     log.info('MetaMaskController - encryptionPublicKey')
@@ -1664,8 +1663,8 @@ export default class MetamaskController extends EventEmitter {
    * The method for a user approving a call to eth_signTypedData, per EIP 712.
    * Triggers the callback in newUnsignedTypedMessage.
    *
-   * @param  {Object} msgParams - The params passed to eth_signTypedData.
-   * @returns {Object|undefined} - Full state update.
+   * @param {Object} msgParams - The params passed to eth_signTypedData.
+   * @returns {Object} Full state update.
    */
   async signTypedMessage(msgParams) {
     log.info('MetaMaskController - eth_signTypedData')
@@ -1720,7 +1719,7 @@ export default class MetamaskController extends EventEmitter {
    * transaction.
    * @param {number} originalTxId - the id of the txMeta that you want to attempt to cancel
    * @param {string} [customGasPrice] - the hex value to use for the cancel transaction
-   * @returns {Object} - MetaMask state
+   * @returns {Object} MetaMask state
    */
   async createCancelTransaction(originalTxId, customGasPrice) {
     await this.txController.createCancelTransaction(
@@ -2022,7 +2021,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} origin - The connection's origin string.
    * @param {Object} options - Data associated with the connection
    * @param {Object} options.engine - The connection's JSON Rpc Engine
-   * @returns {string} - The connection's id (so that it can be deleted later)
+   * @returns {string} The connection's id (so that it can be deleted later)
    */
   addConnection(origin, { engine }) {
     if (origin === 'metamask') {
@@ -2265,7 +2264,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} chainId - The chainId of the selected network.
    * @param {string} ticker - The ticker symbol of the selected network.
    * @param {string} nickname - Optional nickname of the selected network.
-   * @returns {Promise<String>} - The RPC Target URL confirmed.
+   * @returns {Promise<String>} The RPC Target URL confirmed.
    */
   async updateAndSetCustomRpc(
     rpcUrl,
@@ -2297,7 +2296,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {string} chainId - The chainId of the selected network.
    * @param {string} ticker - The ticker symbol of the selected network.
    * @param {string} nickname - Optional nickname of the selected network.
-   * @returns {Promise<String>} - The RPC Target URL confirmed.
+   * @returns {Promise<String>} The RPC Target URL confirmed.
    */
   async setCustomRpc(
     rpcUrl,
@@ -2510,15 +2509,6 @@ export default class MetamaskController extends EventEmitter {
     this.detectTokensController.isOpen = open
   }
   /* eslint-enable accessor-pairs */
-
-  /**
-   * Creates RPC engine middleware for processing eth_signTypedData requests
-   *
-   * @param {Object} req - request object
-   * @param {Object} res - response object
-   * @param {Function} - next
-   * @param {Function} - end
-   */
 
   /**
    * Adds a domain to the PhishingController safelist

--- a/shared/modules/metametrics.js
+++ b/shared/modules/metametrics.js
@@ -157,7 +157,7 @@ export const segmentLegacy =
  *
  * @param {string} metamaskVersion - The current version of the MetaMask extension.
  * @param {() => MetaMetricsRequiredState} getDynamicState - A function returning required fields
- * @returns {(payload: MetaMetricsEventPayload) => Promise<void>} - function to track an event
+ * @returns {(payload: MetaMetricsEventPayload) => Promise<void>} function to track an event
  */
 export function getTrackMetaMetricsEvent(metamaskVersion, getDynamicState) {
   const version =

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -37,7 +37,7 @@ class ChromeDriver {
   /**
    * Returns the extension ID for the given extension name
    * @param {string} extensionName - the extension name
-   * @returns {Promise<string|undefined>} - the extension ID
+   * @returns {Promise<string|undefined>} the extension ID
    */
   async getExtensionIdByName(extensionName) {
     await this._driver.get('chrome://extensions')

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -79,7 +79,7 @@ class FirefoxDriver {
   /**
    * Installs the extension at the given path
    * @param {string} addonPath - the path to the unpacked extension or XPI
-   * @returns {Promise<string>} - the extension ID
+   * @returns {Promise<string>} the extension ID
    */
   async installExtension(addonPath) {
     const cmd = new Command(GeckoDriverCommand.INSTALL_ADDON)
@@ -91,7 +91,7 @@ class FirefoxDriver {
 
   /**
    * Returns the Internal UUID for the given extension
-   * @returns {Promise<string>} - the Internal UUID for the given extension
+   * @returns {Promise<string>} the Internal UUID for the given extension
    */
   async getInternalId() {
     await this._driver.get('about:debugging#addons')

--- a/test/unit/app/controllers/permissions/helpers.js
+++ b/test/unit/app/controllers/permissions/helpers.js
@@ -45,7 +45,7 @@ export function getRequestUserApprovalHelper(permController) {
  *
  * This function must be called on the permissions controller for each request.
  *
- * @param {PermissionsController} - A permissions controller.
+ * @param {PermissionsController} permController - A permissions controller.
  * @returns {Promise<void>} A Promise that resolves once a pending approval
  * has been set.
  */

--- a/ui/app/contexts/metametrics.js
+++ b/ui/app/contexts/metametrics.js
@@ -72,7 +72,7 @@ export function MetaMetricsProvider({ children }) {
   /**
    * track a metametrics event
    *
-   * @param {import('../../../shared/modules/metametrics').MetaMetricsEventPayload} - payload for event
+   * @param {import('../../../shared/modules/metametrics').MetaMetricsEventPayload} payload - payload for event
    * @returns undefined
    */
   const trackEvent = useMemo(() => {

--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -87,7 +87,7 @@ export function MetaMetricsProvider({ children }) {
   /**
    * track a metametrics event
    *
-   * @param {import('../../../shared/modules/metametrics').MetaMetricsEventPayload} - payload for event
+   * @param {import('../../../shared/modules/metametrics').MetaMetricsEventPayload} payload - payload for event
    * @returns undefined
    */
   const trackEvent = useMemo(() => {

--- a/ui/app/helpers/utils/conversion-util.js
+++ b/ui/app/helpers/utils/conversion-util.js
@@ -5,15 +5,15 @@
  * currency. It should return a single value.
  *
  * @param {(number | string | BN)} value - The value to convert.
- * @param {Object} [options] Options to specify details of the conversion
- * @param {string} [options.fromCurrency = 'ETH' | 'USD'] The currency of the passed value
- * @param {string} [options.toCurrency = 'ETH' | 'USD'] The desired currency of the result
- * @param {string} [options.fromNumericBase = 'hex' | 'dec' | 'BN'] The numeric basic of the passed value.
- * @param {string} [options.toNumericBase = 'hex' | 'dec' | 'BN'] The desired numeric basic of the result.
- * @param {string} [options.fromDenomination = 'WEI'] The denomination of the passed value
- * @param {string} [options.numberOfDecimals] The desired number of decimals in the result
- * @param {string} [options.roundDown] The desired number of decimals to round down to
- * @param {number} [options.conversionRate] The rate to use to make the fromCurrency -> toCurrency conversion
+ * @param {Object} [options] - Options to specify details of the conversion
+ * @param {string} [options.fromCurrency = 'ETH' | 'USD'] - The currency of the passed value
+ * @param {string} [options.toCurrency = 'ETH' | 'USD'] - The desired currency of the result
+ * @param {string} [options.fromNumericBase = 'hex' | 'dec' | 'BN'] - The numeric basic of the passed value.
+ * @param {string} [options.toNumericBase = 'hex' | 'dec' | 'BN'] - The desired numeric basic of the result.
+ * @param {string} [options.fromDenomination = 'WEI'] - The denomination of the passed value
+ * @param {string} [options.numberOfDecimals] - The desired number of decimals in the result
+ * @param {string} [options.roundDown] - The desired number of decimals to round down to
+ * @param {number} [options.conversionRate] - The rate to use to make the fromCurrency -> toCurrency conversion
  * @returns {(number | string | BN)}
  *
  * The utility passes value along with the options as a single object to the `converter` function.

--- a/ui/app/helpers/utils/i18n-helper.js
+++ b/ui/app/helpers/utils/i18n-helper.js
@@ -14,7 +14,7 @@ const missingSubstitutionErrors = {}
  * @param {Object} localeMessages - The map of messages for the current locale
  * @param {string} key - The message key
  * @param {string[]} substitutions - A list of message substitution replacements
- * @returns {null|string} - The localized message
+ * @returns {null|string} The localized message
  */
 export const getMessage = (localeCode, localeMessages, key, substitutions) => {
   if (!localeMessages) {

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -101,7 +101,7 @@ export async function getMethodDataAsync(fourBytePrefix) {
  * Returns four-byte method signature from data
  *
  * @param {string} data - The hex data (@code txParams.data) of a transaction
- * @returns {string} - The four-byte method signature
+ * @returns {string} The four-byte method signature
  */
 export function getFourBytePrefix(data = '') {
   const prefixedData = addHexPrefix(data)
@@ -113,7 +113,7 @@ export function getFourBytePrefix(data = '') {
  * Given an transaction category, returns a boolean which indicates whether the transaction is calling an erc20 token method
  *
  * @param {string} transactionCategory - The category of transaction being evaluated
- * @returns {boolean} - whether the transaction is calling an erc20 token method
+ * @returns {boolean} whether the transaction is calling an erc20 token method
  */
 export function isTokenMethodAction(transactionCategory) {
   return [

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -300,7 +300,7 @@ export function exportAsFile(filename, data, type = 'text/csv') {
  * Safely checksumms a potentially-null address
  *
  * @param {string} [address] - address to checksum
- * @returns {string} - checksummed address
+ * @returns {string} checksummed address
  *
  */
 export function checksumAddress(address) {
@@ -378,7 +378,7 @@ export function isExtensionUrl(urlLike) {
  * lowercased version of the addresses.
  *
  * @param {string} address - The hex address to check
- * @param {array} list - The array of objects to check
+ * @param {Array} list - The array of objects to check
  * @returns {boolean} Whether or not the address is in the list
  */
 export function checkExistingAddresses(address, list = []) {
@@ -428,7 +428,7 @@ export function addHexPrefixToObjectValues(obj) {
  * @param {string} from - A hex address of the tx sender address
  * @param {string} gas - A hex representation of the gas value for the transaction
  * @param {string} gasPrice - A hex representation of the gas price for the transaction
- * @returns {object} An object ready for submission to the blockchain, with all values appropriately hex prefixed
+ * @returns {Object} An object ready for submission to the blockchain, with all values appropriately hex prefixed
  */
 export function constructTxParams({
   sendToken,

--- a/ui/app/hooks/useCopyToClipboard.js
+++ b/ui/app/hooks/useCopyToClipboard.js
@@ -5,7 +5,7 @@ import { useTimeout } from './useTimeout'
 /**
  * useCopyToClipboard
  *
- * @param {number}  [delay=3000]   - delay in ms
+ * @param {number} [delay=3000] - delay in ms
  *
  * @return {[boolean, Function]}
  */

--- a/ui/app/hooks/useEqualityCheck.js
+++ b/ui/app/hooks/useEqualityCheck.js
@@ -10,7 +10,7 @@ import { isEqual } from 'lodash'
  * infrequently changes it's value. By default, uses isEqual from
  * lodash. This is typically only useful with objects and arrays.
  *
- * @param {T}                 value      - any value to check equality of
+ * @param {T} value - any value to check equality of
  * @param {(T, T) => boolean} equalityFn - A function to determine equality
  * @returns {T}
  */

--- a/ui/app/hooks/useEthFiatAmount.js
+++ b/ui/app/hooks/useEthFiatAmount.js
@@ -12,7 +12,7 @@ import { formatCurrency } from '../helpers/utils/confirm-tx.util'
  * Get an Eth amount converted to fiat and formatted for display
  *
  * @param {string} [tokenAmount] - The eth amount to convert
- * @param {object} [overrides] - A configuration object that allows the called to explicitly
+ * @param {Object} [overrides] - A configuration object that allows the called to explicitly
  *                              ensure fiat is shown even if the property is not set in state.
  * @param {boolean} [overrides.showFiat] - If truthy, ensures the fiat value is shown even if the showFiat value from state is falsey
  * @param {boolean} hideCurrencySymbol Indicates whether the returned formatted amount should include the trailing currency symbol

--- a/ui/app/hooks/useMethodData.js
+++ b/ui/app/hooks/useMethodData.js
@@ -13,7 +13,7 @@ import { getKnownMethodData } from '../selectors/selectors'
  * if the data is in the store and returning it directly. While using this hook
  * in multiple places in a tree for the same data will create extra event ticks and
  * hit the action more frequently, it should only ever result in a single store update
- * @param {string} data the transaction data to find method data for
+ * @param {string} data - the transaction data to find method data for
  * @return {Object} contract method data
  */
 export function useMethodData(data) {

--- a/ui/app/hooks/useMetricEvent.js
+++ b/ui/app/hooks/useMetricEvent.js
@@ -17,11 +17,11 @@ export function useMetricEvent(config = {}, overrides = {}) {
  * track a metametrics event using segment
  * e.g metricsEvent({ event: 'Unlocked MetaMask', category: 'Navigation' })
  *
- * @param {object}  config - configuration object for the event to track
+ * @param {Object}  config - configuration object for the event to track
  * @param {string}  config.event - event name to track
  * @param {string}  config.category - category to associate event to
  * @param {boolean} [config.isOptIn] - happened during opt in/out workflow
- * @param {object}  [config.properties] - object of custom values to track, snake_case
+ * @param {Object}  [config.properties] - object of custom values to track, snake_case
  * @param {number}  [config.revenue] - amount of currency that event creates in revenue for MetaMask
  * @param {string}  [config.currency] - ISO 4127 format currency for events with revenue, defaults to US dollars
  * @param {number}  [config.value] - Abstract "value" that this event has for MetaMask.

--- a/ui/app/hooks/useTimeout.js
+++ b/ui/app/hooks/useTimeout.js
@@ -3,9 +3,9 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 /**
  * useTimeout
  *
- * @param {Function}  cb   - callback function inside setTimeout
- * @param {number}  delay   - delay in ms
- * @param {boolean}  [immediate]   - determines whether the timeout is invoked immediately
+ * @param {Function} cb - callback function inside setTimeout
+ * @param {number} delay - delay in ms
+ * @param {boolean} [immediate] - determines whether the timeout is invoked immediately
  *
  * @return {Function|undefined}
  */

--- a/ui/app/hooks/useTokenData.js
+++ b/ui/app/hooks/useTokenData.js
@@ -5,7 +5,7 @@ import { getTokenData } from '../helpers/utils/transactions.util'
  * useTokenData
  * Given the data string from txParams return a decoded object of the details of the
  * transaction data.
- * @param {string}  [transactionData]    - Raw data string from token transaction
+ * @param {string} [transactionData]     - Raw data string from token transaction
  * @param {boolean} [isTokenTransaction] - Due to the nature of hooks, it isn't possible
  *                                         to conditionally call this hook. This flag will
  *                                         force this hook to return null if it set as false

--- a/ui/app/hooks/useTokenFiatAmount.js
+++ b/ui/app/hooks/useTokenFiatAmount.js
@@ -14,7 +14,7 @@ import { getTokenFiatAmount } from '../helpers/utils/token-util'
  * @param {string} [tokenAddress] - The token address
  * @param {string} [tokenAmount] - The token balance
  * @param {string} [tokenSymbol] - The token symbol
- * @param {object} [overrides] - A configuration object that allows the caller to explicitly pass an exchange rate or
+ * @param {Object} [overrides] - A configuration object that allows the caller to explicitly pass an exchange rate or
  *                              ensure fiat is shown even if the property is not set in state.
  * @param {number} [overrides.exchangeRate] -  An exhchange rate to use instead of the one selected from state
  * @param {boolean} [overrides.showFiat] - If truthy, ensures the fiat value is shown even if the showFiat value from state is falsey

--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -48,7 +48,7 @@ import { useCurrentAsset } from './useCurrentAsset'
  * state access required to take a transactionGroup and derive from it a shape
  * of data that can power all views related to a transaction. Presently the main
  * case is for shared logic between transaction-list-item and transaction-detail-view
- * @param {Object} transactionGroup group of transactions
+ * @param {Object} transactionGroup - group of transactions
  * @return {TransactionDisplayData}
  */
 export function useTransactionDisplayData(transactionGroup) {


### PR DESCRIPTION
A few inconsistencies in JSDoc formatting have been fixed throughout the project. Many issues remain; these were just the few things that were easy to fix with a regular expression.

The changes include:

* Using lower-case for primitive types, but capitalizing non-primitive  types
* Separating the parameter identifier and the description with a dash
* Omitting a dash between the return type and the return description
* Ensuring the parameter type is first and the identifier is second (in a few places it was backwards)
* Using square brackets to denote when a parameter is optional, rather than putting "(optional)" in the parameter description
* Including a type and identifier with every parameter
* Fixing inconsistent spacing, except where it's used for alignment
* Remove incorrectly formatted `@deprecated` tags that reference non-existent properties
* Remove lone comment block without accompanying function

Additionally, one parameter was renamed for clarity.