### PR TITLE
Log web3 usage for functions and nested properties only

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -35,18 +35,18 @@ const recordedWeb3Usage = {}
  * @param {LogWeb3UsageOptions} options
  */
 function logWeb3UsageHandler(req, res, _next, end, { origin, sendMetrics }) {
-  const { action, name } = req.params[0]
+  const { action, path } = req.params[0]
 
   if (!recordedWeb3Usage[origin]) {
     recordedWeb3Usage[origin] = {}
   }
-  if (!recordedWeb3Usage[origin][name]) {
-    recordedWeb3Usage[origin][name] = true
+  if (!recordedWeb3Usage[origin][path]) {
+    recordedWeb3Usage[origin][path] = true
 
     sendMetrics({
-      event: `Website Accessed window.web3`,
+      event: `Website Used window.web3`,
       category: 'inpage_provider',
-      properties: { action, web3Property: name },
+      properties: { action, web3Path: path },
       eventContext: {
         referrer: {
           url: origin,

--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -44,6 +44,7 @@ function logWeb3UsageHandler(req, res, _next, end, { origin, sendMetrics }) {
     recordedWeb3Usage[origin][path] = true
 
     sendMetrics({
+      matomo: true,
       event: `Website Used window.web3`,
       category: 'inpage_provider',
       properties: { action, web3Path: path },

--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -53,7 +53,7 @@ export default function setupWeb3(log) {
           const path = `web3.${topKey}.${key}`
 
           if (web3Entitites[path]) {
-            if (web3Entitites[path].type === 'function') {
+            if (web3Entitites[path] === 'function') {
               applyTrapKeys.set(key, path)
             } else {
               getTrapKeys.set(key, path)

--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -115,10 +115,15 @@ export default function setupWeb3(log) {
     'isConnected',
     'setProvider',
     'reset',
+    'sha3',
     'toHex',
+    'toAscii',
     'fromAscii',
+    'toDecimal',
     'fromDecimal',
+    'fromWei',
     'toWei',
+    'toBigNumber',
     'isAddress',
   ]
 

--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -111,7 +111,7 @@ export default function setupWeb3(log) {
     })
   }
 
-  const unEnumerableFunctionKeys = [
+  const topLevelFunctions = [
     'isConnected',
     'setProvider',
     'reset',
@@ -127,8 +127,8 @@ export default function setupWeb3(log) {
     'isAddress',
   ]
 
-  // apply-trap un-enumerable top-level functions
-  unEnumerableFunctionKeys.forEach((key) => {
+  // apply-trap top-level functions
+  topLevelFunctions.forEach((key) => {
     // This type check is probably redundant, but we've been burned before.
     if (typeof web3[key] === 'function') {
       web3[key] = new Proxy(web3[key], {

--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -34,6 +34,7 @@ export default function setupWeb3(log) {
 
   // Setup logging of nested property usage
   if (shouldLogUsage) {
+    // web3 namespaces with common and uncommon dapp actions
     const includedTopKeys = [
       'eth',
       'db',
@@ -44,6 +45,8 @@ export default function setupWeb3(log) {
       'version',
     ]
 
+    // For each top-level property, create appropriate Proxy traps for all of
+    // their properties
     includedTopKeys.forEach((topKey) => {
       const applyTrapKeys = new Map()
       const getTrapKeys = new Map()
@@ -60,7 +63,7 @@ export default function setupWeb3(log) {
         }
       })
 
-      // Create apply traps for namespace functions
+      // Create apply traps for function properties
       for (const [key, path] of applyTrapKeys) {
         web3[topKey][key] = new Proxy(web3[topKey][key], {
           apply: (...params) => {
@@ -80,7 +83,7 @@ export default function setupWeb3(log) {
         })
       }
 
-      // Create get trap for entire namespace
+      // Create get trap for non-function properties
       web3[topKey] = new Proxy(web3[topKey], {
         get: (web3Prop, key, ...params) => {
           const name = stringifyKey(key)

--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -3,6 +3,7 @@
 // TODO:deprecate:2020
 // Delete this file
 
+import web3Entitites from './web3-entities.json'
 import 'web3/dist/web3.min'
 
 const shouldLogUsage = ![
@@ -31,8 +32,84 @@ export default function setupWeb3(log) {
     value: web3.eth,
   })
 
+  // Setup logging of nested property usage
+  if (shouldLogUsage) {
+    const includedTopKeys = new Set([
+      'eth',
+      'db',
+      'shh',
+      'net',
+      'personal',
+      'bzz',
+      'version',
+    ])
+
+    Object.keys(web3).forEach((rawTopKey) => {
+      const topKey = stringifyKey(rawTopKey)
+      if (includedTopKeys.has(topKey)) {
+        const applyTrapKeys = new Map()
+        const getTrapKeys = new Map()
+
+        Object.keys(web3[topKey]).forEach((rawKey) => {
+          const key = stringifyKey(rawKey)
+          const path = `web3.${topKey}.${key}`
+
+          if (web3Entitites[path]) {
+            if (web3Entitites[path].type === 'function') {
+              applyTrapKeys.set(key, path)
+            } else {
+              getTrapKeys.set(key, path)
+            }
+          }
+        })
+
+        // Create apply traps for namespace functions
+        for (const [key, path] of applyTrapKeys) {
+          web3[topKey][key] = new Proxy(web3[topKey][key], {
+            apply: (...params) => {
+              window.ethereum.request({
+                method: 'metamask_logInjectedWeb3Usage',
+                params: [
+                  {
+                    action: 'apply',
+                    path,
+                  },
+                ],
+              })
+
+              // Call function normally
+              return Reflect.apply(...params)
+            },
+          })
+        }
+
+        // Create get trap for entire namespace
+        web3[topKey] = new Proxy(web3[topKey], {
+          get: (web3Prop, key, ...params) => {
+            const name = stringifyKey(key)
+
+            if (getTrapKeys.has(name)) {
+              window.ethereum.request({
+                method: 'metamask_logInjectedWeb3Usage',
+                params: [
+                  {
+                    action: 'get',
+                    path: getTrapKeys.get(name),
+                  },
+                ],
+              })
+            }
+
+            // return value normally
+            return Reflect.get(web3Prop, key, ...params)
+          },
+        })
+      }
+    })
+  }
+
   const web3Proxy = new Proxy(web3, {
-    get: (_web3, key) => {
+    get: (...params) => {
       // get the time of use
       lastTimeUsed = Date.now()
 
@@ -44,28 +121,8 @@ export default function setupWeb3(log) {
         hasBeenWarned = true
       }
 
-      if (shouldLogUsage) {
-        const name = stringifyKey(key)
-        window.ethereum.request({
-          method: 'metamask_logInjectedWeb3Usage',
-          params: [{ action: 'get', name }],
-        })
-      }
-
       // return value normally
-      return _web3[key]
-    },
-    set: (_web3, key, value) => {
-      const name = stringifyKey(key)
-      if (shouldLogUsage) {
-        window.ethereum.request({
-          method: 'metamask_logInjectedWeb3Usage',
-          params: [{ action: 'set', name }],
-        })
-      }
-
-      // set value normally
-      _web3[key] = value
+      return Reflect.get(...params)
     },
   })
 

--- a/app/scripts/lib/setupWeb3.js
+++ b/app/scripts/lib/setupWeb3.js
@@ -44,14 +44,12 @@ export default function setupWeb3(log) {
       'version',
     ])
 
-    Object.keys(web3).forEach((rawTopKey) => {
-      const topKey = stringifyKey(rawTopKey)
+    Object.keys(web3).forEach((topKey) => {
       if (includedTopKeys.has(topKey)) {
         const applyTrapKeys = new Map()
         const getTrapKeys = new Map()
 
-        Object.keys(web3[topKey]).forEach((rawKey) => {
-          const key = stringifyKey(rawKey)
+        Object.keys(web3[topKey]).forEach((key) => {
           const path = `web3.${topKey}.${key}`
 
           if (web3Entitites[path]) {

--- a/app/scripts/lib/web3-entities.json
+++ b/app/scripts/lib/web3-entities.json
@@ -1,596 +1,101 @@
 {
-  "web3.bzz.blockNetworkRead": {
-    "path": "web3.bzz.blockNetworkRead",
-    "type": "function",
-    "prop": "blockNetworkRead",
-    "parent": "bzz"
-  },
-  "web3.bzz.download": {
-    "path": "web3.bzz.download",
-    "type": "function",
-    "prop": "download",
-    "parent": "bzz"
-  },
-  "web3.bzz.get": {
-    "path": "web3.bzz.get",
-    "type": "function",
-    "prop": "get",
-    "parent": "bzz"
-  },
-  "web3.bzz.getHive": {
-    "path": "web3.bzz.getHive",
-    "type": "function",
-    "prop": "getHive",
-    "parent": "bzz"
-  },
-  "web3.bzz.getInfo": {
-    "path": "web3.bzz.getInfo",
-    "type": "function",
-    "prop": "getInfo",
-    "parent": "bzz"
-  },
-  "web3.bzz.hive": {
-    "path": "web3.bzz.hive",
-    "type": "TRAP",
-    "prop": "hive",
-    "parent": "bzz"
-  },
-  "web3.bzz.info": {
-    "path": "web3.bzz.info",
-    "type": "TRAP",
-    "prop": "info",
-    "parent": "bzz"
-  },
-  "web3.bzz.modify": {
-    "path": "web3.bzz.modify",
-    "type": "function",
-    "prop": "modify",
-    "parent": "bzz"
-  },
-  "web3.bzz.put": {
-    "path": "web3.bzz.put",
-    "type": "function",
-    "prop": "put",
-    "parent": "bzz"
-  },
-  "web3.bzz.retrieve": {
-    "path": "web3.bzz.retrieve",
-    "type": "function",
-    "prop": "retrieve",
-    "parent": "bzz"
-  },
-  "web3.bzz.store": {
-    "path": "web3.bzz.store",
-    "type": "function",
-    "prop": "store",
-    "parent": "bzz"
-  },
-  "web3.bzz.swapEnabled": {
-    "path": "web3.bzz.swapEnabled",
-    "type": "function",
-    "prop": "swapEnabled",
-    "parent": "bzz"
-  },
-  "web3.bzz.syncEnabled": {
-    "path": "web3.bzz.syncEnabled",
-    "type": "function",
-    "prop": "syncEnabled",
-    "parent": "bzz"
-  },
-  "web3.bzz.upload": {
-    "path": "web3.bzz.upload",
-    "type": "function",
-    "prop": "upload",
-    "parent": "bzz"
-  },
-  "web3.db.getHex": {
-    "path": "web3.db.getHex",
-    "type": "function",
-    "prop": "getHex",
-    "parent": "db"
-  },
-  "web3.db.getString": {
-    "path": "web3.db.getString",
-    "type": "function",
-    "prop": "getString",
-    "parent": "db"
-  },
-  "web3.db.putHex": {
-    "path": "web3.db.putHex",
-    "type": "function",
-    "prop": "putHex",
-    "parent": "db"
-  },
-  "web3.db.putString": {
-    "path": "web3.db.putString",
-    "type": "function",
-    "prop": "putString",
-    "parent": "db"
-  },
-  "web3.eth.accounts": {
-    "path": "web3.eth.accounts",
-    "type": "object",
-    "prop": "accounts",
-    "parent": "eth"
-  },
-  "web3.eth.blockNumber": {
-    "path": "web3.eth.blockNumber",
-    "type": "TRAP",
-    "prop": "blockNumber",
-    "parent": "eth"
-  },
-  "web3.eth.call": {
-    "path": "web3.eth.call",
-    "type": "function",
-    "prop": "call",
-    "parent": "eth"
-  },
-  "web3.eth.coinbase": {
-    "path": "web3.eth.coinbase",
-    "type": "object",
-    "prop": "coinbase",
-    "parent": "eth"
-  },
-  "web3.eth.compile": {
-    "path": "web3.eth.compile",
-    "type": "object",
-    "prop": "compile",
-    "parent": "eth"
-  },
-  "web3.eth.estimateGas": {
-    "path": "web3.eth.estimateGas",
-    "type": "function",
-    "prop": "estimateGas",
-    "parent": "eth"
-  },
-  "web3.eth.gasPrice": {
-    "path": "web3.eth.gasPrice",
-    "type": "TRAP",
-    "prop": "gasPrice",
-    "parent": "eth"
-  },
-  "web3.eth.getAccounts": {
-    "path": "web3.eth.getAccounts",
-    "type": "function",
-    "prop": "getAccounts",
-    "parent": "eth"
-  },
-  "web3.eth.getBalance": {
-    "path": "web3.eth.getBalance",
-    "type": "function",
-    "prop": "getBalance",
-    "parent": "eth"
-  },
-  "web3.eth.getBlock": {
-    "path": "web3.eth.getBlock",
-    "type": "function",
-    "prop": "getBlock",
-    "parent": "eth"
-  },
-  "web3.eth.getBlockNumber": {
-    "path": "web3.eth.getBlockNumber",
-    "type": "function",
-    "prop": "getBlockNumber",
-    "parent": "eth"
-  },
-  "web3.eth.getBlockTransactionCount": {
-    "path": "web3.eth.getBlockTransactionCount",
-    "type": "function",
-    "prop": "getBlockTransactionCount",
-    "parent": "eth"
-  },
-  "web3.eth.getBlockUncleCount": {
-    "path": "web3.eth.getBlockUncleCount",
-    "type": "function",
-    "prop": "getBlockUncleCount",
-    "parent": "eth"
-  },
-  "web3.eth.getCode": {
-    "path": "web3.eth.getCode",
-    "type": "function",
-    "prop": "getCode",
-    "parent": "eth"
-  },
-  "web3.eth.getCoinbase": {
-    "path": "web3.eth.getCoinbase",
-    "type": "function",
-    "prop": "getCoinbase",
-    "parent": "eth"
-  },
-  "web3.eth.getCompilers": {
-    "path": "web3.eth.getCompilers",
-    "type": "function",
-    "prop": "getCompilers",
-    "parent": "eth"
-  },
-  "web3.eth.getGasPrice": {
-    "path": "web3.eth.getGasPrice",
-    "type": "function",
-    "prop": "getGasPrice",
-    "parent": "eth"
-  },
-  "web3.eth.getHashrate": {
-    "path": "web3.eth.getHashrate",
-    "type": "function",
-    "prop": "getHashrate",
-    "parent": "eth"
-  },
-  "web3.eth.getMining": {
-    "path": "web3.eth.getMining",
-    "type": "function",
-    "prop": "getMining",
-    "parent": "eth"
-  },
-  "web3.eth.getProtocolVersion": {
-    "path": "web3.eth.getProtocolVersion",
-    "type": "function",
-    "prop": "getProtocolVersion",
-    "parent": "eth"
-  },
-  "web3.eth.getStorageAt": {
-    "path": "web3.eth.getStorageAt",
-    "type": "function",
-    "prop": "getStorageAt",
-    "parent": "eth"
-  },
-  "web3.eth.getSyncing": {
-    "path": "web3.eth.getSyncing",
-    "type": "function",
-    "prop": "getSyncing",
-    "parent": "eth"
-  },
-  "web3.eth.getTransaction": {
-    "path": "web3.eth.getTransaction",
-    "type": "function",
-    "prop": "getTransaction",
-    "parent": "eth"
-  },
-  "web3.eth.getTransactionCount": {
-    "path": "web3.eth.getTransactionCount",
-    "type": "function",
-    "prop": "getTransactionCount",
-    "parent": "eth"
-  },
-  "web3.eth.getTransactionFromBlock": {
-    "path": "web3.eth.getTransactionFromBlock",
-    "type": "function",
-    "prop": "getTransactionFromBlock",
-    "parent": "eth"
-  },
-  "web3.eth.getTransactionReceipt": {
-    "path": "web3.eth.getTransactionReceipt",
-    "type": "function",
-    "prop": "getTransactionReceipt",
-    "parent": "eth"
-  },
-  "web3.eth.getUncle": {
-    "path": "web3.eth.getUncle",
-    "type": "function",
-    "prop": "getUncle",
-    "parent": "eth"
-  },
-  "web3.eth.getWork": {
-    "path": "web3.eth.getWork",
-    "type": "function",
-    "prop": "getWork",
-    "parent": "eth"
-  },
-  "web3.eth.hashrate": {
-    "path": "web3.eth.hashrate",
-    "type": "TRAP",
-    "prop": "hashrate",
-    "parent": "eth"
-  },
-  "web3.eth.iban": {
-    "path": "web3.eth.iban",
-    "type": "function",
-    "prop": "iban",
-    "parent": "eth"
-  },
-  "web3.eth.mining": {
-    "path": "web3.eth.mining",
-    "type": "TRAP",
-    "prop": "mining",
-    "parent": "eth"
-  },
-  "web3.eth.protocolVersion": {
-    "path": "web3.eth.protocolVersion",
-    "type": "TRAP",
-    "prop": "protocolVersion",
-    "parent": "eth"
-  },
-  "web3.eth.sendIBANTransaction": {
-    "path": "web3.eth.sendIBANTransaction",
-    "type": "function",
-    "prop": "sendIBANTransaction",
-    "parent": "eth"
-  },
-  "web3.eth.sendRawTransaction": {
-    "path": "web3.eth.sendRawTransaction",
-    "type": "function",
-    "prop": "sendRawTransaction",
-    "parent": "eth"
-  },
-  "web3.eth.sendTransaction": {
-    "path": "web3.eth.sendTransaction",
-    "type": "function",
-    "prop": "sendTransaction",
-    "parent": "eth"
-  },
-  "web3.eth.sign": {
-    "path": "web3.eth.sign",
-    "type": "function",
-    "prop": "sign",
-    "parent": "eth"
-  },
-  "web3.eth.signTransaction": {
-    "path": "web3.eth.signTransaction",
-    "type": "function",
-    "prop": "signTransaction",
-    "parent": "eth"
-  },
-  "web3.eth.submitWork": {
-    "path": "web3.eth.submitWork",
-    "type": "function",
-    "prop": "submitWork",
-    "parent": "eth"
-  },
-  "web3.eth.syncing": {
-    "path": "web3.eth.syncing",
-    "type": "TRAP",
-    "prop": "syncing",
-    "parent": "eth"
-  },
-  "web3.net.getListening": {
-    "path": "web3.net.getListening",
-    "type": "function",
-    "prop": "getListening",
-    "parent": "net"
-  },
-  "web3.net.getPeerCount": {
-    "path": "web3.net.getPeerCount",
-    "type": "function",
-    "prop": "getPeerCount",
-    "parent": "net"
-  },
-  "web3.net.listening": {
-    "path": "web3.net.listening",
-    "type": "TRAP",
-    "prop": "listening",
-    "parent": "net"
-  },
-  "web3.net.peerCount": {
-    "path": "web3.net.peerCount",
-    "type": "TRAP",
-    "prop": "peerCount",
-    "parent": "net"
-  },
-  "web3.personal.ecRecover": {
-    "path": "web3.personal.ecRecover",
-    "type": "function",
-    "prop": "ecRecover",
-    "parent": "personal"
-  },
-  "web3.personal.getListAccounts": {
-    "path": "web3.personal.getListAccounts",
-    "type": "function",
-    "prop": "getListAccounts",
-    "parent": "personal"
-  },
-  "web3.personal.importRawKey": {
-    "path": "web3.personal.importRawKey",
-    "type": "function",
-    "prop": "importRawKey",
-    "parent": "personal"
-  },
-  "web3.personal.listAccounts": {
-    "path": "web3.personal.listAccounts",
-    "type": "TRAP",
-    "prop": "listAccounts",
-    "parent": "personal"
-  },
-  "web3.personal.lockAccount": {
-    "path": "web3.personal.lockAccount",
-    "type": "function",
-    "prop": "lockAccount",
-    "parent": "personal"
-  },
-  "web3.personal.newAccount": {
-    "path": "web3.personal.newAccount",
-    "type": "function",
-    "prop": "newAccount",
-    "parent": "personal"
-  },
-  "web3.personal.sendTransaction": {
-    "path": "web3.personal.sendTransaction",
-    "type": "function",
-    "prop": "sendTransaction",
-    "parent": "personal"
-  },
-  "web3.personal.sign": {
-    "path": "web3.personal.sign",
-    "type": "function",
-    "prop": "sign",
-    "parent": "personal"
-  },
-  "web3.personal.unlockAccount": {
-    "path": "web3.personal.unlockAccount",
-    "type": "function",
-    "prop": "unlockAccount",
-    "parent": "personal"
-  },
-  "web3.providers.HttpProvider": {
-    "path": "web3.providers.HttpProvider",
-    "type": "function",
-    "prop": "HttpProvider",
-    "parent": "providers"
-  },
-  "web3.providers.IpcProvider": {
-    "path": "web3.providers.IpcProvider",
-    "type": "function",
-    "prop": "IpcProvider",
-    "parent": "providers"
-  },
-  "web3.shh.addPrivateKey": {
-    "path": "web3.shh.addPrivateKey",
-    "type": "function",
-    "prop": "addPrivateKey",
-    "parent": "shh"
-  },
-  "web3.shh.addSymKey": {
-    "path": "web3.shh.addSymKey",
-    "type": "function",
-    "prop": "addSymKey",
-    "parent": "shh"
-  },
-  "web3.shh.deleteKeyPair": {
-    "path": "web3.shh.deleteKeyPair",
-    "type": "function",
-    "prop": "deleteKeyPair",
-    "parent": "shh"
-  },
-  "web3.shh.deleteSymKey": {
-    "path": "web3.shh.deleteSymKey",
-    "type": "function",
-    "prop": "deleteSymKey",
-    "parent": "shh"
-  },
-  "web3.shh.generateSymKeyFromPassword": {
-    "path": "web3.shh.generateSymKeyFromPassword",
-    "type": "function",
-    "prop": "generateSymKeyFromPassword",
-    "parent": "shh"
-  },
-  "web3.shh.getPrivateKey": {
-    "path": "web3.shh.getPrivateKey",
-    "type": "function",
-    "prop": "getPrivateKey",
-    "parent": "shh"
-  },
-  "web3.shh.getPublicKey": {
-    "path": "web3.shh.getPublicKey",
-    "type": "function",
-    "prop": "getPublicKey",
-    "parent": "shh"
-  },
-  "web3.shh.getSymKey": {
-    "path": "web3.shh.getSymKey",
-    "type": "function",
-    "prop": "getSymKey",
-    "parent": "shh"
-  },
-  "web3.shh.hasKeyPair": {
-    "path": "web3.shh.hasKeyPair",
-    "type": "function",
-    "prop": "hasKeyPair",
-    "parent": "shh"
-  },
-  "web3.shh.hasSymKey": {
-    "path": "web3.shh.hasSymKey",
-    "type": "function",
-    "prop": "hasSymKey",
-    "parent": "shh"
-  },
-  "web3.shh.info": {
-    "path": "web3.shh.info",
-    "type": "function",
-    "prop": "info",
-    "parent": "shh"
-  },
-  "web3.shh.markTrustedPeer": {
-    "path": "web3.shh.markTrustedPeer",
-    "type": "function",
-    "prop": "markTrustedPeer",
-    "parent": "shh"
-  },
-  "web3.shh.newKeyPair": {
-    "path": "web3.shh.newKeyPair",
-    "type": "function",
-    "prop": "newKeyPair",
-    "parent": "shh"
-  },
-  "web3.shh.newSymKey": {
-    "path": "web3.shh.newSymKey",
-    "type": "function",
-    "prop": "newSymKey",
-    "parent": "shh"
-  },
-  "web3.shh.post": {
-    "path": "web3.shh.post",
-    "type": "function",
-    "prop": "post",
-    "parent": "shh"
-  },
-  "web3.shh.setMaxMessageSize": {
-    "path": "web3.shh.setMaxMessageSize",
-    "type": "function",
-    "prop": "setMaxMessageSize",
-    "parent": "shh"
-  },
-  "web3.shh.setMinPoW": {
-    "path": "web3.shh.setMinPoW",
-    "type": "function",
-    "prop": "setMinPoW",
-    "parent": "shh"
-  },
-  "web3.shh.version": {
-    "path": "web3.shh.version",
-    "type": "function",
-    "prop": "version",
-    "parent": "shh"
-  },
-  "web3.version.api": {
-    "path": "web3.version.api",
-    "type": "string",
-    "prop": "api",
-    "parent": "version"
-  },
-  "web3.version.ethereum": {
-    "path": "web3.version.ethereum",
-    "type": "TRAP",
-    "prop": "ethereum",
-    "parent": "version"
-  },
-  "web3.version.getEthereum": {
-    "path": "web3.version.getEthereum",
-    "type": "function",
-    "prop": "getEthereum",
-    "parent": "version"
-  },
-  "web3.version.getNetwork": {
-    "path": "web3.version.getNetwork",
-    "type": "function",
-    "prop": "getNetwork",
-    "parent": "version"
-  },
-  "web3.version.getNode": {
-    "path": "web3.version.getNode",
-    "type": "function",
-    "prop": "getNode",
-    "parent": "version"
-  },
-  "web3.version.getWhisper": {
-    "path": "web3.version.getWhisper",
-    "type": "function",
-    "prop": "getWhisper",
-    "parent": "version"
-  },
-  "web3.version.network": {
-    "path": "web3.version.network",
-    "type": "string",
-    "prop": "network",
-    "parent": "version"
-  },
-  "web3.version.node": {
-    "path": "web3.version.node",
-    "type": "TRAP",
-    "prop": "node",
-    "parent": "version"
-  },
-  "web3.version.whisper": {
-    "path": "web3.version.whisper",
-    "type": "TRAP",
-    "prop": "whisper",
-    "parent": "version"
-  }
+  "web3.bzz.blockNetworkRead": "function",
+  "web3.bzz.download": "function",
+  "web3.bzz.get": "function",
+  "web3.bzz.getHive": "function",
+  "web3.bzz.getInfo": "function",
+  "web3.bzz.hive": "TRAP",
+  "web3.bzz.info": "TRAP",
+  "web3.bzz.modify": "function",
+  "web3.bzz.put": "function",
+  "web3.bzz.retrieve": "function",
+  "web3.bzz.store": "function",
+  "web3.bzz.swapEnabled": "function",
+  "web3.bzz.syncEnabled": "function",
+  "web3.bzz.upload": "function",
+  "web3.db.getHex": "function",
+  "web3.db.getString": "function",
+  "web3.db.putHex": "function",
+  "web3.db.putString": "function",
+  "web3.eth.accounts": "object",
+  "web3.eth.blockNumber": "TRAP",
+  "web3.eth.call": "function",
+  "web3.eth.coinbase": "object",
+  "web3.eth.compile": "object",
+  "web3.eth.estimateGas": "function",
+  "web3.eth.gasPrice": "TRAP",
+  "web3.eth.getAccounts": "function",
+  "web3.eth.getBalance": "function",
+  "web3.eth.getBlock": "function",
+  "web3.eth.getBlockNumber": "function",
+  "web3.eth.getBlockTransactionCount": "function",
+  "web3.eth.getBlockUncleCount": "function",
+  "web3.eth.getCode": "function",
+  "web3.eth.getCoinbase": "function",
+  "web3.eth.getCompilers": "function",
+  "web3.eth.getGasPrice": "function",
+  "web3.eth.getHashrate": "function",
+  "web3.eth.getMining": "function",
+  "web3.eth.getProtocolVersion": "function",
+  "web3.eth.getStorageAt": "function",
+  "web3.eth.getSyncing": "function",
+  "web3.eth.getTransaction": "function",
+  "web3.eth.getTransactionCount": "function",
+  "web3.eth.getTransactionFromBlock": "function",
+  "web3.eth.getTransactionReceipt": "function",
+  "web3.eth.getUncle": "function",
+  "web3.eth.getWork": "function",
+  "web3.eth.hashrate": "TRAP",
+  "web3.eth.iban": "function",
+  "web3.eth.mining": "TRAP",
+  "web3.eth.protocolVersion": "TRAP",
+  "web3.eth.sendIBANTransaction": "function",
+  "web3.eth.sendRawTransaction": "function",
+  "web3.eth.sendTransaction": "function",
+  "web3.eth.sign": "function",
+  "web3.eth.signTransaction": "function",
+  "web3.eth.submitWork": "function",
+  "web3.eth.syncing": "TRAP",
+  "web3.net.getListening": "function",
+  "web3.net.getPeerCount": "function",
+  "web3.net.listening": "TRAP",
+  "web3.net.peerCount": "TRAP",
+  "web3.personal.ecRecover": "function",
+  "web3.personal.getListAccounts": "function",
+  "web3.personal.importRawKey": "function",
+  "web3.personal.listAccounts": "TRAP",
+  "web3.personal.lockAccount": "function",
+  "web3.personal.newAccount": "function",
+  "web3.personal.sendTransaction": "function",
+  "web3.personal.sign": "function",
+  "web3.personal.unlockAccount": "function",
+  "web3.providers.HttpProvider": "function",
+  "web3.providers.IpcProvider": "function",
+  "web3.shh.addPrivateKey": "function",
+  "web3.shh.addSymKey": "function",
+  "web3.shh.deleteKeyPair": "function",
+  "web3.shh.deleteSymKey": "function",
+  "web3.shh.generateSymKeyFromPassword": "function",
+  "web3.shh.getPrivateKey": "function",
+  "web3.shh.getPublicKey": "function",
+  "web3.shh.getSymKey": "function",
+  "web3.shh.hasKeyPair": "function",
+  "web3.shh.hasSymKey": "function",
+  "web3.shh.info": "function",
+  "web3.shh.markTrustedPeer": "function",
+  "web3.shh.newKeyPair": "function",
+  "web3.shh.newSymKey": "function",
+  "web3.shh.post": "function",
+  "web3.shh.setMaxMessageSize": "function",
+  "web3.shh.setMinPoW": "function",
+  "web3.shh.version": "function",
+  "web3.version.api": "string",
+  "web3.version.ethereum": "TRAP",
+  "web3.version.getEthereum": "function",
+  "web3.version.getNetwork": "function",
+  "web3.version.getNode": "function",
+  "web3.version.getWhisper": "function",
+  "web3.version.network": "string",
+  "web3.version.node": "TRAP",
+  "web3.version.whisper": "TRAP"
 }

--- a/app/scripts/lib/web3-entities.json
+++ b/app/scripts/lib/web3-entities.json
@@ -1,0 +1,596 @@
+{
+  "web3.bzz.blockNetworkRead": {
+    "path": "web3.bzz.blockNetworkRead",
+    "type": "function",
+    "prop": "blockNetworkRead",
+    "parent": "bzz"
+  },
+  "web3.bzz.download": {
+    "path": "web3.bzz.download",
+    "type": "function",
+    "prop": "download",
+    "parent": "bzz"
+  },
+  "web3.bzz.get": {
+    "path": "web3.bzz.get",
+    "type": "function",
+    "prop": "get",
+    "parent": "bzz"
+  },
+  "web3.bzz.getHive": {
+    "path": "web3.bzz.getHive",
+    "type": "function",
+    "prop": "getHive",
+    "parent": "bzz"
+  },
+  "web3.bzz.getInfo": {
+    "path": "web3.bzz.getInfo",
+    "type": "function",
+    "prop": "getInfo",
+    "parent": "bzz"
+  },
+  "web3.bzz.hive": {
+    "path": "web3.bzz.hive",
+    "type": "TRAP",
+    "prop": "hive",
+    "parent": "bzz"
+  },
+  "web3.bzz.info": {
+    "path": "web3.bzz.info",
+    "type": "TRAP",
+    "prop": "info",
+    "parent": "bzz"
+  },
+  "web3.bzz.modify": {
+    "path": "web3.bzz.modify",
+    "type": "function",
+    "prop": "modify",
+    "parent": "bzz"
+  },
+  "web3.bzz.put": {
+    "path": "web3.bzz.put",
+    "type": "function",
+    "prop": "put",
+    "parent": "bzz"
+  },
+  "web3.bzz.retrieve": {
+    "path": "web3.bzz.retrieve",
+    "type": "function",
+    "prop": "retrieve",
+    "parent": "bzz"
+  },
+  "web3.bzz.store": {
+    "path": "web3.bzz.store",
+    "type": "function",
+    "prop": "store",
+    "parent": "bzz"
+  },
+  "web3.bzz.swapEnabled": {
+    "path": "web3.bzz.swapEnabled",
+    "type": "function",
+    "prop": "swapEnabled",
+    "parent": "bzz"
+  },
+  "web3.bzz.syncEnabled": {
+    "path": "web3.bzz.syncEnabled",
+    "type": "function",
+    "prop": "syncEnabled",
+    "parent": "bzz"
+  },
+  "web3.bzz.upload": {
+    "path": "web3.bzz.upload",
+    "type": "function",
+    "prop": "upload",
+    "parent": "bzz"
+  },
+  "web3.db.getHex": {
+    "path": "web3.db.getHex",
+    "type": "function",
+    "prop": "getHex",
+    "parent": "db"
+  },
+  "web3.db.getString": {
+    "path": "web3.db.getString",
+    "type": "function",
+    "prop": "getString",
+    "parent": "db"
+  },
+  "web3.db.putHex": {
+    "path": "web3.db.putHex",
+    "type": "function",
+    "prop": "putHex",
+    "parent": "db"
+  },
+  "web3.db.putString": {
+    "path": "web3.db.putString",
+    "type": "function",
+    "prop": "putString",
+    "parent": "db"
+  },
+  "web3.eth.accounts": {
+    "path": "web3.eth.accounts",
+    "type": "object",
+    "prop": "accounts",
+    "parent": "eth"
+  },
+  "web3.eth.blockNumber": {
+    "path": "web3.eth.blockNumber",
+    "type": "TRAP",
+    "prop": "blockNumber",
+    "parent": "eth"
+  },
+  "web3.eth.call": {
+    "path": "web3.eth.call",
+    "type": "function",
+    "prop": "call",
+    "parent": "eth"
+  },
+  "web3.eth.coinbase": {
+    "path": "web3.eth.coinbase",
+    "type": "object",
+    "prop": "coinbase",
+    "parent": "eth"
+  },
+  "web3.eth.compile": {
+    "path": "web3.eth.compile",
+    "type": "object",
+    "prop": "compile",
+    "parent": "eth"
+  },
+  "web3.eth.estimateGas": {
+    "path": "web3.eth.estimateGas",
+    "type": "function",
+    "prop": "estimateGas",
+    "parent": "eth"
+  },
+  "web3.eth.gasPrice": {
+    "path": "web3.eth.gasPrice",
+    "type": "TRAP",
+    "prop": "gasPrice",
+    "parent": "eth"
+  },
+  "web3.eth.getAccounts": {
+    "path": "web3.eth.getAccounts",
+    "type": "function",
+    "prop": "getAccounts",
+    "parent": "eth"
+  },
+  "web3.eth.getBalance": {
+    "path": "web3.eth.getBalance",
+    "type": "function",
+    "prop": "getBalance",
+    "parent": "eth"
+  },
+  "web3.eth.getBlock": {
+    "path": "web3.eth.getBlock",
+    "type": "function",
+    "prop": "getBlock",
+    "parent": "eth"
+  },
+  "web3.eth.getBlockNumber": {
+    "path": "web3.eth.getBlockNumber",
+    "type": "function",
+    "prop": "getBlockNumber",
+    "parent": "eth"
+  },
+  "web3.eth.getBlockTransactionCount": {
+    "path": "web3.eth.getBlockTransactionCount",
+    "type": "function",
+    "prop": "getBlockTransactionCount",
+    "parent": "eth"
+  },
+  "web3.eth.getBlockUncleCount": {
+    "path": "web3.eth.getBlockUncleCount",
+    "type": "function",
+    "prop": "getBlockUncleCount",
+    "parent": "eth"
+  },
+  "web3.eth.getCode": {
+    "path": "web3.eth.getCode",
+    "type": "function",
+    "prop": "getCode",
+    "parent": "eth"
+  },
+  "web3.eth.getCoinbase": {
+    "path": "web3.eth.getCoinbase",
+    "type": "function",
+    "prop": "getCoinbase",
+    "parent": "eth"
+  },
+  "web3.eth.getCompilers": {
+    "path": "web3.eth.getCompilers",
+    "type": "function",
+    "prop": "getCompilers",
+    "parent": "eth"
+  },
+  "web3.eth.getGasPrice": {
+    "path": "web3.eth.getGasPrice",
+    "type": "function",
+    "prop": "getGasPrice",
+    "parent": "eth"
+  },
+  "web3.eth.getHashrate": {
+    "path": "web3.eth.getHashrate",
+    "type": "function",
+    "prop": "getHashrate",
+    "parent": "eth"
+  },
+  "web3.eth.getMining": {
+    "path": "web3.eth.getMining",
+    "type": "function",
+    "prop": "getMining",
+    "parent": "eth"
+  },
+  "web3.eth.getProtocolVersion": {
+    "path": "web3.eth.getProtocolVersion",
+    "type": "function",
+    "prop": "getProtocolVersion",
+    "parent": "eth"
+  },
+  "web3.eth.getStorageAt": {
+    "path": "web3.eth.getStorageAt",
+    "type": "function",
+    "prop": "getStorageAt",
+    "parent": "eth"
+  },
+  "web3.eth.getSyncing": {
+    "path": "web3.eth.getSyncing",
+    "type": "function",
+    "prop": "getSyncing",
+    "parent": "eth"
+  },
+  "web3.eth.getTransaction": {
+    "path": "web3.eth.getTransaction",
+    "type": "function",
+    "prop": "getTransaction",
+    "parent": "eth"
+  },
+  "web3.eth.getTransactionCount": {
+    "path": "web3.eth.getTransactionCount",
+    "type": "function",
+    "prop": "getTransactionCount",
+    "parent": "eth"
+  },
+  "web3.eth.getTransactionFromBlock": {
+    "path": "web3.eth.getTransactionFromBlock",
+    "type": "function",
+    "prop": "getTransactionFromBlock",
+    "parent": "eth"
+  },
+  "web3.eth.getTransactionReceipt": {
+    "path": "web3.eth.getTransactionReceipt",
+    "type": "function",
+    "prop": "getTransactionReceipt",
+    "parent": "eth"
+  },
+  "web3.eth.getUncle": {
+    "path": "web3.eth.getUncle",
+    "type": "function",
+    "prop": "getUncle",
+    "parent": "eth"
+  },
+  "web3.eth.getWork": {
+    "path": "web3.eth.getWork",
+    "type": "function",
+    "prop": "getWork",
+    "parent": "eth"
+  },
+  "web3.eth.hashrate": {
+    "path": "web3.eth.hashrate",
+    "type": "TRAP",
+    "prop": "hashrate",
+    "parent": "eth"
+  },
+  "web3.eth.iban": {
+    "path": "web3.eth.iban",
+    "type": "function",
+    "prop": "iban",
+    "parent": "eth"
+  },
+  "web3.eth.mining": {
+    "path": "web3.eth.mining",
+    "type": "TRAP",
+    "prop": "mining",
+    "parent": "eth"
+  },
+  "web3.eth.protocolVersion": {
+    "path": "web3.eth.protocolVersion",
+    "type": "TRAP",
+    "prop": "protocolVersion",
+    "parent": "eth"
+  },
+  "web3.eth.sendIBANTransaction": {
+    "path": "web3.eth.sendIBANTransaction",
+    "type": "function",
+    "prop": "sendIBANTransaction",
+    "parent": "eth"
+  },
+  "web3.eth.sendRawTransaction": {
+    "path": "web3.eth.sendRawTransaction",
+    "type": "function",
+    "prop": "sendRawTransaction",
+    "parent": "eth"
+  },
+  "web3.eth.sendTransaction": {
+    "path": "web3.eth.sendTransaction",
+    "type": "function",
+    "prop": "sendTransaction",
+    "parent": "eth"
+  },
+  "web3.eth.sign": {
+    "path": "web3.eth.sign",
+    "type": "function",
+    "prop": "sign",
+    "parent": "eth"
+  },
+  "web3.eth.signTransaction": {
+    "path": "web3.eth.signTransaction",
+    "type": "function",
+    "prop": "signTransaction",
+    "parent": "eth"
+  },
+  "web3.eth.submitWork": {
+    "path": "web3.eth.submitWork",
+    "type": "function",
+    "prop": "submitWork",
+    "parent": "eth"
+  },
+  "web3.eth.syncing": {
+    "path": "web3.eth.syncing",
+    "type": "TRAP",
+    "prop": "syncing",
+    "parent": "eth"
+  },
+  "web3.net.getListening": {
+    "path": "web3.net.getListening",
+    "type": "function",
+    "prop": "getListening",
+    "parent": "net"
+  },
+  "web3.net.getPeerCount": {
+    "path": "web3.net.getPeerCount",
+    "type": "function",
+    "prop": "getPeerCount",
+    "parent": "net"
+  },
+  "web3.net.listening": {
+    "path": "web3.net.listening",
+    "type": "TRAP",
+    "prop": "listening",
+    "parent": "net"
+  },
+  "web3.net.peerCount": {
+    "path": "web3.net.peerCount",
+    "type": "TRAP",
+    "prop": "peerCount",
+    "parent": "net"
+  },
+  "web3.personal.ecRecover": {
+    "path": "web3.personal.ecRecover",
+    "type": "function",
+    "prop": "ecRecover",
+    "parent": "personal"
+  },
+  "web3.personal.getListAccounts": {
+    "path": "web3.personal.getListAccounts",
+    "type": "function",
+    "prop": "getListAccounts",
+    "parent": "personal"
+  },
+  "web3.personal.importRawKey": {
+    "path": "web3.personal.importRawKey",
+    "type": "function",
+    "prop": "importRawKey",
+    "parent": "personal"
+  },
+  "web3.personal.listAccounts": {
+    "path": "web3.personal.listAccounts",
+    "type": "TRAP",
+    "prop": "listAccounts",
+    "parent": "personal"
+  },
+  "web3.personal.lockAccount": {
+    "path": "web3.personal.lockAccount",
+    "type": "function",
+    "prop": "lockAccount",
+    "parent": "personal"
+  },
+  "web3.personal.newAccount": {
+    "path": "web3.personal.newAccount",
+    "type": "function",
+    "prop": "newAccount",
+    "parent": "personal"
+  },
+  "web3.personal.sendTransaction": {
+    "path": "web3.personal.sendTransaction",
+    "type": "function",
+    "prop": "sendTransaction",
+    "parent": "personal"
+  },
+  "web3.personal.sign": {
+    "path": "web3.personal.sign",
+    "type": "function",
+    "prop": "sign",
+    "parent": "personal"
+  },
+  "web3.personal.unlockAccount": {
+    "path": "web3.personal.unlockAccount",
+    "type": "function",
+    "prop": "unlockAccount",
+    "parent": "personal"
+  },
+  "web3.providers.HttpProvider": {
+    "path": "web3.providers.HttpProvider",
+    "type": "function",
+    "prop": "HttpProvider",
+    "parent": "providers"
+  },
+  "web3.providers.IpcProvider": {
+    "path": "web3.providers.IpcProvider",
+    "type": "function",
+    "prop": "IpcProvider",
+    "parent": "providers"
+  },
+  "web3.shh.addPrivateKey": {
+    "path": "web3.shh.addPrivateKey",
+    "type": "function",
+    "prop": "addPrivateKey",
+    "parent": "shh"
+  },
+  "web3.shh.addSymKey": {
+    "path": "web3.shh.addSymKey",
+    "type": "function",
+    "prop": "addSymKey",
+    "parent": "shh"
+  },
+  "web3.shh.deleteKeyPair": {
+    "path": "web3.shh.deleteKeyPair",
+    "type": "function",
+    "prop": "deleteKeyPair",
+    "parent": "shh"
+  },
+  "web3.shh.deleteSymKey": {
+    "path": "web3.shh.deleteSymKey",
+    "type": "function",
+    "prop": "deleteSymKey",
+    "parent": "shh"
+  },
+  "web3.shh.generateSymKeyFromPassword": {
+    "path": "web3.shh.generateSymKeyFromPassword",
+    "type": "function",
+    "prop": "generateSymKeyFromPassword",
+    "parent": "shh"
+  },
+  "web3.shh.getPrivateKey": {
+    "path": "web3.shh.getPrivateKey",
+    "type": "function",
+    "prop": "getPrivateKey",
+    "parent": "shh"
+  },
+  "web3.shh.getPublicKey": {
+    "path": "web3.shh.getPublicKey",
+    "type": "function",
+    "prop": "getPublicKey",
+    "parent": "shh"
+  },
+  "web3.shh.getSymKey": {
+    "path": "web3.shh.getSymKey",
+    "type": "function",
+    "prop": "getSymKey",
+    "parent": "shh"
+  },
+  "web3.shh.hasKeyPair": {
+    "path": "web3.shh.hasKeyPair",
+    "type": "function",
+    "prop": "hasKeyPair",
+    "parent": "shh"
+  },
+  "web3.shh.hasSymKey": {
+    "path": "web3.shh.hasSymKey",
+    "type": "function",
+    "prop": "hasSymKey",
+    "parent": "shh"
+  },
+  "web3.shh.info": {
+    "path": "web3.shh.info",
+    "type": "function",
+    "prop": "info",
+    "parent": "shh"
+  },
+  "web3.shh.markTrustedPeer": {
+    "path": "web3.shh.markTrustedPeer",
+    "type": "function",
+    "prop": "markTrustedPeer",
+    "parent": "shh"
+  },
+  "web3.shh.newKeyPair": {
+    "path": "web3.shh.newKeyPair",
+    "type": "function",
+    "prop": "newKeyPair",
+    "parent": "shh"
+  },
+  "web3.shh.newSymKey": {
+    "path": "web3.shh.newSymKey",
+    "type": "function",
+    "prop": "newSymKey",
+    "parent": "shh"
+  },
+  "web3.shh.post": {
+    "path": "web3.shh.post",
+    "type": "function",
+    "prop": "post",
+    "parent": "shh"
+  },
+  "web3.shh.setMaxMessageSize": {
+    "path": "web3.shh.setMaxMessageSize",
+    "type": "function",
+    "prop": "setMaxMessageSize",
+    "parent": "shh"
+  },
+  "web3.shh.setMinPoW": {
+    "path": "web3.shh.setMinPoW",
+    "type": "function",
+    "prop": "setMinPoW",
+    "parent": "shh"
+  },
+  "web3.shh.version": {
+    "path": "web3.shh.version",
+    "type": "function",
+    "prop": "version",
+    "parent": "shh"
+  },
+  "web3.version.api": {
+    "path": "web3.version.api",
+    "type": "string",
+    "prop": "api",
+    "parent": "version"
+  },
+  "web3.version.ethereum": {
+    "path": "web3.version.ethereum",
+    "type": "TRAP",
+    "prop": "ethereum",
+    "parent": "version"
+  },
+  "web3.version.getEthereum": {
+    "path": "web3.version.getEthereum",
+    "type": "function",
+    "prop": "getEthereum",
+    "parent": "version"
+  },
+  "web3.version.getNetwork": {
+    "path": "web3.version.getNetwork",
+    "type": "function",
+    "prop": "getNetwork",
+    "parent": "version"
+  },
+  "web3.version.getNode": {
+    "path": "web3.version.getNode",
+    "type": "function",
+    "prop": "getNode",
+    "parent": "version"
+  },
+  "web3.version.getWhisper": {
+    "path": "web3.version.getWhisper",
+    "type": "function",
+    "prop": "getWhisper",
+    "parent": "version"
+  },
+  "web3.version.network": {
+    "path": "web3.version.network",
+    "type": "string",
+    "prop": "network",
+    "parent": "version"
+  },
+  "web3.version.node": {
+    "path": "web3.version.node",
+    "type": "TRAP",
+    "prop": "node",
+    "parent": "version"
+  },
+  "web3.version.whisper": {
+    "path": "web3.version.whisper",
+    "type": "TRAP",
+    "prop": "whisper",
+    "parent": "version"
+  }
+}


### PR DESCRIPTION
This PR updates our `window.web3` usage logging to log the use of nested properties only. This more granular logging will give us a better idea of which sites are meaningfully using `window.web3`, as opposed to e.g. inspecting it our fingerprinting users via `web3.eth.accounts`.

The segment event name is changed, and the existing metrics (that logged `get` and `set` operations on the top-level keys) have been removed.

The implementation relies on a JSON file with information about nested `web3` properties. This file was produced by examining the nested properties of the injected `window.web3` object. Some of those nested properties have `get` traps that call functions, which complicates the matter. In essence, I identified which properties are of type `function`, and which are something else.

For `function` properties, we proxy the function itself and use an `apply` trap to detect when it's called. For other properties, we log their "usage" in a `get` trap whenever they're accessed.

The JSON file has been manually pruned to remove e.g. `web3.currentProvider` keys. It was originally generated using this snippet:

```javascript
function enumerateKeysAndTypes() {
  const entries = []
  Object.keys(window.web3).forEach(topKey => {
    Object.keys(window.web3[topKey]).forEach(key => {
      const path = `web3.${topKey}.${key}`
      let type
      try {
        type = typeof window.web3[topKey][key]
      }
      catch (err) {
        type = 'TRAP'
      }
      console.log(key, type)
      entries.push({ path, type })
    })
  })

  entries.sort((a, b) => {
    return a.path.localeCompare(b.path)
  })

  console.log(JSON.stringify(entries, null, 2))
}
```