### PR TITLE
add locale to page events

### DIFF
--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -168,6 +168,7 @@ export function MetaMetricsProvider({ children }) {
             // We do not want to send addresses or accounts in any events
             // Some routes include these as params.
             params: omit(params, ['account', 'address']),
+            locale: locale.replace('_', '-'),
             network,
             environment_type: environmentType,
           },
@@ -176,7 +177,14 @@ export function MetaMetricsProvider({ children }) {
       }
       previousMatch.current = match?.path
     }
-  }, [location, context, network, metaMetricsId, participateInMetaMetrics])
+  }, [
+    location,
+    locale,
+    context,
+    network,
+    metaMetricsId,
+    participateInMetaMetrics,
+  ])
 
   return (
     <MetaMetricsContext.Provider value={trackEvent}>


### PR DESCRIPTION
We moved locale to properties in #9769 but I forgot to do the same for page events.
