### PR TITLE
Remove unnecessary `externally_connectable` manifest entry

### DIFF
--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -41,10 +41,6 @@
   ],
   "default_locale": "en",
   "description": "__MSG_appDescription__",
-  "externally_connectable": {
-    "matches": ["https://metamask.io/*"],
-    "ids": ["*"]
-  },
   "icons": {
     "16": "images/icon-16.png",
     "19": "images/icon-19.png",


### PR DESCRIPTION
The `externally_connectable` property allows websites to directly connect to the extension, or it allows us to prevent other extensions and Chrome apps from connecting to the extension. It is not supported by Firefox.

We don't currently rely upon anything from the `metamask.io` domain communicating with the extension, so this is not useful. The current `externally_connectable` entry also allows all communication from other extensions and app, which is the default behavior, so that is not useful either.

Removing this should have no impact upon Chrome, and it should remove a long-standing warning on the Add-ons page on Firefox.