### PR TITLE
Fix lint error

### DIFF
--- a/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.component.js
+++ b/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.component.js
@@ -11,11 +11,10 @@ export default class FirstTimeFlowSwitch extends PureComponent {
   static propTypes = {
     completedOnboarding: PropTypes.bool,
     isInitialized: PropTypes.bool,
-    isUnlocked: PropTypes.bool,
   }
 
   render() {
-    const { completedOnboarding, isInitialized, isUnlocked } = this.props
+    const { completedOnboarding, isInitialized } = this.props
 
     if (completedOnboarding) {
       return <Redirect to={{ pathname: DEFAULT_ROUTE }} />

--- a/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.container.js
+++ b/ui/app/pages/first-time-flow/first-time-flow-switch/first-time-flow-switch.container.js
@@ -2,12 +2,11 @@ import { connect } from 'react-redux'
 import FirstTimeFlowSwitch from './first-time-flow-switch.component'
 
 const mapStateToProps = ({ metamask }) => {
-  const { completedOnboarding, isInitialized, isUnlocked } = metamask
+  const { completedOnboarding, isInitialized } = metamask
 
   return {
     completedOnboarding,
     isInitialized,
-    isUnlocked,
   }
 }
 


### PR DESCRIPTION
A lint error was accidentally introduced recently when two PRs changed the same area of code (#9793 and #9795). They didn't conflict, and the lint passed for both, but when combined they left an unused variable.