### PR TITLE
Never disable network form save button if props chain ID is invalid

### DIFF
--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -198,7 +198,13 @@ export default class NetworkForm extends PureComponent {
   }
 
   stateIsUnchanged() {
-    const { rpcUrl, ticker, networkName, blockExplorerUrl } = this.props
+    const {
+      rpcUrl,
+      chainId: propsChainId,
+      ticker,
+      networkName,
+      blockExplorerUrl,
+    } = this.props
 
     const {
       rpcUrl: stateRpcUrl,
@@ -208,9 +214,17 @@ export default class NetworkForm extends PureComponent {
       blockExplorerUrl: stateBlockExplorerUrl,
     } = this.state
 
+    // These added conditions are in case the saved chainId is invalid, which
+    // was possible in versions <8.1 of the extension.
+    // Basically, we always want to be able to overwrite an invalid chain ID.
+    const chainIdIsUnchanged =
+      typeof propsChainId === 'string' &&
+      propsChainId.toLowerCase().startsWith('0x') &&
+      stateChainId === this.getDisplayChainIdFromProps()
+
     return (
       stateRpcUrl === rpcUrl &&
-      stateChainId === this.getDisplayChainIdFromProps() &&
+      chainIdIsUnchanged &&
       stateTicker === ticker &&
       stateNetworkName === networkName &&
       stateBlockExplorerUrl === blockExplorerUrl


### PR DESCRIPTION
We received reports of users trying to update the chain ID for custom networks but the save button being disabled. This could happen if they had correctly stored the chain ID in decimal prior to version 8.1 of the extension.

In that case, we'd flag the network as invalid, and prompt the user to change it. However, if they re-entered the same decimal value, the form would disable the save button, since it compared the entered chain ID value against persisted chain ID value.

This PR avoids this problem by never flagging the form state as "unchanged" if the persisted chain ID is invalid.