### PR TITLE
Don't use concatenized token value for ETH in asset list item

### DIFF
--- a/ui/app/components/app/asset-list-item/asset-list-item.js
+++ b/ui/app/components/app/asset-list-item/asset-list-item.js
@@ -96,7 +96,7 @@ const AssetListItem = ({
         <button
           className="asset-list-item__token-button"
           onClick={onClick}
-          title={`${primary} ${tokenSymbol || ''}`}
+          title={`${primary} ${tokenSymbol}`}
         >
           <h2>
             <span className="asset-list-item__token-value">{primary}</span>

--- a/ui/app/components/app/asset-list/asset-list.js
+++ b/ui/app/components/app/asset-list/asset-list.js
@@ -47,10 +47,13 @@ const AssetList = ({ onClickAsset }) => {
     numberOfDecimals: secondaryNumberOfDecimals,
   } = useUserPreferencedCurrency(SECONDARY, { ethNumberOfDecimals: 4 })
 
-  const [, primaryCurrencyProperties] = useCurrencyDisplay(selectedAccountBalance, {
-    numberOfDecimals: primaryNumberOfDecimals,
-    currency: primaryCurrency,
-  })
+  const [, primaryCurrencyProperties] = useCurrencyDisplay(
+    selectedAccountBalance,
+    {
+      numberOfDecimals: primaryNumberOfDecimals,
+      currency: primaryCurrency,
+    },
+  )
 
   const [secondaryCurrencyDisplay] = useCurrencyDisplay(
     selectedAccountBalance,

--- a/ui/app/components/app/asset-list/asset-list.js
+++ b/ui/app/components/app/asset-list/asset-list.js
@@ -47,7 +47,7 @@ const AssetList = ({ onClickAsset }) => {
     numberOfDecimals: secondaryNumberOfDecimals,
   } = useUserPreferencedCurrency(SECONDARY, { ethNumberOfDecimals: 4 })
 
-  const [primaryCurrencyDisplay] = useCurrencyDisplay(selectedAccountBalance, {
+  const [, primaryCurrencyProperties] = useCurrencyDisplay(selectedAccountBalance, {
     numberOfDecimals: primaryNumberOfDecimals,
     currency: primaryCurrency,
   })
@@ -65,7 +65,8 @@ const AssetList = ({ onClickAsset }) => {
       <AssetListItem
         onClick={() => onClickAsset(nativeCurrency)}
         data-testid="wallet-balance"
-        primary={primaryCurrencyDisplay}
+        primary={primaryCurrencyProperties.value}
+        tokenSymbol={primaryCurrencyProperties.suffix}
         secondary={showFiat ? secondaryCurrencyDisplay : undefined}
       />
       <TokenList


### PR DESCRIPTION
Fixes:

The first item in the asset list, always $ETH, has its `primary` passed in as `# ETH` instead of just `#` with ETH as the symbol.  We should ensure that ETH values and symbol is passed in regardless of token type.

