### PR TITLE
Track a new schema event when adding a token

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -2,10 +2,10 @@ import { strict as assert } from 'assert'
 import ObservableStore from 'obs-store'
 import { normalize as normalizeAddress } from 'eth-sig-util'
 import { isValidAddress, sha3, bufferToHex } from 'ethereumjs-util'
-import contractMap from 'eth-contract-metadata'
 import ethers from 'ethers'
 import log from 'loglevel'
 import { isPrefixedFormattedHexString } from '../lib/util'
+import { LISTED_CONTRACT_ADDRESSES } from '../../../shared/constants/tokens'
 import { addInternalMethodPrefix } from './permissions'
 import { NETWORK_TYPE_TO_ID_MAP } from './network/enums'
 
@@ -181,7 +181,7 @@ export default class PreferencesController {
       symbol,
       decimals,
       image,
-      unlisted: contractMap[address] === undefined,
+      unlisted: !LISTED_CONTRACT_ADDRESSES.includes(address.toLowerCase()),
     }
     suggested[address] = newEntry
     this.store.updateState({ suggestedTokens: suggested })

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -2,6 +2,7 @@ import { strict as assert } from 'assert'
 import ObservableStore from 'obs-store'
 import { normalize as normalizeAddress } from 'eth-sig-util'
 import { isValidAddress, sha3, bufferToHex } from 'ethereumjs-util'
+import contractMap from 'eth-contract-metadata'
 import ethers from 'ethers'
 import log from 'loglevel'
 import { isPrefixedFormattedHexString } from '../lib/util'
@@ -175,7 +176,13 @@ export default class PreferencesController {
     const suggested = this.getSuggestedTokens()
     const { rawAddress, symbol, decimals, image } = tokenOpts
     const address = normalizeAddress(rawAddress)
-    const newEntry = { address, symbol, decimals, image }
+    const newEntry = {
+      address,
+      symbol,
+      decimals,
+      image,
+      unlisted: contractMap[address] === undefined,
+    }
     suggested[address] = newEntry
     this.store.updateState({ suggestedTokens: suggested })
   }

--- a/shared/constants/tokens.js
+++ b/shared/constants/tokens.js
@@ -1,0 +1,10 @@
+import contractMap from 'eth-contract-metadata'
+
+/**
+ * A normalized list of addresses exported as part of the contractMap in
+ * eth-contract-metadata. Used primarily to validate if manually entered
+ * contract addresses do not match one of our listed tokens
+ */
+export const LISTED_CONTRACT_ADDRESSES = Object.keys(
+  contractMap,
+).map((address) => address.toLowerCase())

--- a/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -9,6 +9,7 @@ import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../../app/scripts/lib/enums
 export default class ConfirmAddSuggestedToken extends Component {
   static contextTypes = {
     t: PropTypes.func,
+    trackEvent: PropTypes.func,
   }
 
   static propTypes = {
@@ -139,6 +140,23 @@ export default class ConfirmAddSuggestedToken extends Component {
               onClick={() => {
                 addToken(pendingToken)
                   .then(() => removeSuggestedTokens())
+                  .then(() => {
+                    this.context.trackEvent({
+                      event: 'Token Added',
+                      category: 'Wallet',
+                      excludeMetaMetricsId: true,
+                      properties: {
+                        token_symbol: pendingToken.symbol,
+                        token_contract_address: pendingToken.address,
+                        token_decimal_precision: pendingToken.decimals,
+                        custom: pendingToken.isCustom,
+                      },
+                    })
+                    this.context.trackEvent({
+                      event: 'Token Added',
+                      category: 'Wallet',
+                    })
+                  })
                   .then(() => history.push(mostRecentOverviewPage))
               }}
             >

--- a/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/app/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -144,17 +144,13 @@ export default class ConfirmAddSuggestedToken extends Component {
                     this.context.trackEvent({
                       event: 'Token Added',
                       category: 'Wallet',
-                      excludeMetaMetricsId: true,
-                      properties: {
+                      sensitiveProperties: {
                         token_symbol: pendingToken.symbol,
                         token_contract_address: pendingToken.address,
                         token_decimal_precision: pendingToken.decimals,
-                        custom: pendingToken.isCustom,
+                        unlisted: pendingToken.unlisted,
+                        source: 'dapp',
                       },
-                    })
-                    this.context.trackEvent({
-                      event: 'Token Added',
-                      category: 'Wallet',
                     })
                   })
                   .then(() => history.push(mostRecentOverviewPage))

--- a/ui/app/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/app/pages/confirm-add-token/confirm-add-token.component.js
@@ -105,7 +105,7 @@ export default class ConfirmAddToken extends Component {
               onClick={() => {
                 addTokens(pendingTokens).then(() => {
                   const pendingTokenValues = Object.values(pendingTokens)
-                  pendingTokenValues?.forEach((pendingToken) => {
+                  pendingTokenValues.forEach((pendingToken) => {
                     this.context.trackEvent({
                       event: 'Token Added',
                       category: 'Wallet',

--- a/ui/app/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/app/pages/confirm-add-token/confirm-add-token.component.js
@@ -8,6 +8,7 @@ import TokenBalance from '../../components/ui/token-balance'
 export default class ConfirmAddToken extends Component {
   static contextTypes = {
     t: PropTypes.func,
+    trackEvent: PropTypes.func,
   }
 
   static propTypes = {
@@ -103,10 +104,27 @@ export default class ConfirmAddToken extends Component {
               className="page-container__footer-button"
               onClick={() => {
                 addTokens(pendingTokens).then(() => {
+                  const pendingTokenValues = Object.values(pendingTokens)
+                  console.log(pendingTokenValues)
+                  pendingTokenValues?.forEach((pendingToken) => {
+                    this.context.trackEvent({
+                      event: 'Token Added',
+                      category: 'Wallet',
+                      excludeMetaMetricsId: true,
+                      properties: {
+                        token_symbol: pendingToken.symbol,
+                        token_contract_address: pendingToken.address,
+                        token_decimal_precision: pendingToken.decimals,
+                        custom: pendingToken.isCustom,
+                      },
+                    })
+                    this.context.trackEvent({
+                      event: 'Token Added',
+                      category: 'Wallet',
+                    })
+                  })
                   clearPendingTokens()
-                  const firstTokenAddress = Object.values(
-                    pendingTokens,
-                  )?.[0].address?.toLowerCase()
+                  const firstTokenAddress = pendingTokenValues?.[0].address?.toLowerCase()
                   if (firstTokenAddress) {
                     history.push(`${ASSET_ROUTE}/${firstTokenAddress}`)
                   } else {

--- a/ui/app/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/app/pages/confirm-add-token/confirm-add-token.component.js
@@ -109,17 +109,13 @@ export default class ConfirmAddToken extends Component {
                     this.context.trackEvent({
                       event: 'Token Added',
                       category: 'Wallet',
-                      excludeMetaMetricsId: true,
-                      properties: {
+                      sensitiveProperties: {
                         token_symbol: pendingToken.symbol,
                         token_contract_address: pendingToken.address,
                         token_decimal_precision: pendingToken.decimals,
-                        custom: pendingToken.isCustom,
+                        unlisted: pendingToken.unlisted,
+                        source: pendingToken.isCustom ? 'custom' : 'list',
                       },
-                    })
-                    this.context.trackEvent({
-                      event: 'Token Added',
-                      category: 'Wallet',
                     })
                   })
                   clearPendingTokens()

--- a/ui/app/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/app/pages/confirm-add-token/confirm-add-token.component.js
@@ -105,7 +105,6 @@ export default class ConfirmAddToken extends Component {
               onClick={() => {
                 addTokens(pendingTokens).then(() => {
                   const pendingTokenValues = Object.values(pendingTokens)
-                  console.log(pendingTokenValues)
                   pendingTokenValues?.forEach((pendingToken) => {
                     this.context.trackEvent({
                       event: 'Token Added',

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -26,6 +26,10 @@ import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-accoun
 import { getUnconnectedAccountAlertEnabledness } from '../ducks/metamask/metamask'
 import * as actionConstants from './actionConstants'
 
+const LISTED_CONTRACT_ADDRESSES = Object.keys(contractMap).map((address) =>
+  address.toLowerCase(),
+)
+
 let background = null
 let promisifiedBackground = null
 export function _setBackgroundConnection(backgroundConnection) {
@@ -2221,7 +2225,9 @@ export function setPendingTokens(pendingTokens) {
       : selectedTokens
 
   Object.keys(tokens).forEach((tokenAddress) => {
-    tokens[tokenAddress].unlisted = contractMap[tokenAddress] === undefined
+    tokens[tokenAddress].unlisted = !LISTED_CONTRACT_ADDRESSES.includes(
+      tokenAddress.toLowerCase(),
+    )
   })
 
   return {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2,6 +2,7 @@ import abi from 'human-standard-token-abi'
 import pify from 'pify'
 import log from 'loglevel'
 import { capitalize } from 'lodash'
+import contractMap from 'eth-contract-metadata'
 import getBuyEthUrl from '../../../app/scripts/lib/buy-eth-url'
 import { checksumAddress } from '../helpers/utils/util'
 import { calcTokenBalance, estimateGasForSend } from '../pages/send/send.utils'
@@ -2210,8 +2211,18 @@ export function setPendingTokens(pendingTokens) {
   const { address, symbol, decimals } = customToken
   const tokens =
     address && symbol && decimals
-      ? { ...selectedTokens, [address]: { ...customToken, isCustom: true } }
+      ? {
+          ...selectedTokens,
+          [address]: {
+            ...customToken,
+            isCustom: true,
+          },
+        }
       : selectedTokens
+
+  Object.keys(tokens).forEach((tokenAddress) => {
+    tokens[tokenAddress].unlisted = contractMap[tokenAddress] === undefined
+  })
 
   return {
     type: actionConstants.SET_PENDING_TOKENS,

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2,7 +2,6 @@ import abi from 'human-standard-token-abi'
 import pify from 'pify'
 import log from 'loglevel'
 import { capitalize } from 'lodash'
-import contractMap from 'eth-contract-metadata'
 import getBuyEthUrl from '../../../app/scripts/lib/buy-eth-url'
 import { checksumAddress } from '../helpers/utils/util'
 import { calcTokenBalance, estimateGasForSend } from '../pages/send/send.utils'
@@ -24,11 +23,8 @@ import {
 } from '../selectors'
 import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-account'
 import { getUnconnectedAccountAlertEnabledness } from '../ducks/metamask/metamask'
+import { LISTED_CONTRACT_ADDRESSES } from '../../../shared/constants/tokens'
 import * as actionConstants from './actionConstants'
-
-const LISTED_CONTRACT_ADDRESSES = Object.keys(contractMap).map((address) =>
-  address.toLowerCase(),
-)
 
 let background = null
 let promisifiedBackground = null


### PR DESCRIPTION
Explanation:
The new schema has an event for 'Token Added', the intent of which is to surface popular tokens that are being added in spikes. This would help to inform support of the potential influx of issues as well as swaps for adding support for new token pairs.

