### PR TITLE
Add support for rpcUrl with basic auth when retrieving chainId on net…

### DIFF
--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -475,7 +475,9 @@ export async function jsonRpcRequest(rpcUrl, rpcMethod, rpcParams = []) {
   if (authMatches && authMatches[2] && authMatches[3]) {
     // eslint-disable-next-line no-unused-vars
     const [_, protocol, username, password, remainderUrl] = authMatches
-    const encodedAuth = btoa(`${username}:${password}`)
+    const encodedAuth = Buffer.from(`${username}:${password}`).toString(
+      'base64',
+    )
     headers.Authorization = `Basic ${encodedAuth}`
     fetchUrl = `${protocol}://${remainderUrl}`
   }

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -465,20 +465,26 @@ export function constructTxParams({
  * or throws an error in case of failure.
  */
 export async function jsonRpcRequest(rpcUrl, rpcMethod, rpcParams = []) {
-  const jsonRpcResponse = await window
-    .fetch(rpcUrl, {
-      method: 'POST',
-      body: JSON.stringify({
-        id: Date.now().toString(),
-        jsonrpc: '2.0',
-        method: rpcMethod,
-        params: rpcParams,
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      cache: 'default',
-    })
+  const headers = {
+    'Content-Type': 'application/json'
+  };
+  let matches = rpcUrl.match('(http[s]?):\/\/(.+):(.+)@(.+)');
+  if (matches && matches[2] && matches[3]) {
+    const encoded = Buffer.from(`${matches[1]}:${matches[2]}`).toString('base64');
+    headers['Authorization'] = `Basic ${encoded}`;
+    rpcUrl = `${matches[1]}://${matches[4]}`;
+  }
+  const jsonRpcResponse = await window.fetch(rpcUrl, {
+    method: 'POST',
+    body: JSON.stringify({
+      id: Date.now().toString(),
+      jsonrpc: '2.0',
+      method: rpcMethod,
+      params: rpcParams,
+    }),
+    headers,
+    cache: 'default',
+  })
     .then((httpResponse) => httpResponse.json())
 
   if (

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -470,16 +470,15 @@ export async function jsonRpcRequest(rpcUrl, rpcMethod, rpcParams = []) {
     'Content-Type': 'application/json',
   }
   // Convert basic auth URL component to Authorization header
-  const authMatches = rpcUrl.match('(http[s]?)://(.+):(.+)@(.+)')
-  // Confirm that we have matches, and a username and password
-  if (authMatches && authMatches[2] && authMatches[3]) {
+  const { origin, pathname, username, password } = new URL(rpcUrl)
+  // URLs containing username and password needs special processing
+  if (username && password) {
     // eslint-disable-next-line no-unused-vars
-    const [_, protocol, username, password, remainderUrl] = authMatches
     const encodedAuth = Buffer.from(`${username}:${password}`).toString(
       'base64',
     )
     headers.Authorization = `Basic ${encodedAuth}`
-    fetchUrl = `${protocol}://${remainderUrl}`
+    fetchUrl = `${origin}${pathname}`
   }
   const jsonRpcResponse = await window
     .fetch(fetchUrl, {

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -469,21 +469,16 @@ export async function jsonRpcRequest(rpcUrl, rpcMethod, rpcParams = []) {
   const headers = {
     'Content-Type': 'application/json',
   }
-
   // Convert basic auth URL component to Authorization header
   const authMatches = rpcUrl.match('(http[s]?)://(.+):(.+)@(.+)')
   // Confirm that we have matches, and a username and password
   if (authMatches && authMatches[2] && authMatches[3]) {
     // eslint-disable-next-line no-unused-vars
     const [_, protocol, username, password, remainderUrl] = authMatches
-
-    const encodedAuth = Buffer.from(`${username}:${password}`).toString(
-      'base64',
-    )
+    const encodedAuth = btoa(`${username}:${password}`)
     headers.Authorization = `Basic ${encodedAuth}`
     fetchUrl = `${protocol}://${remainderUrl}`
   }
-
   const jsonRpcResponse = await window
     .fetch(fetchUrl, {
       method: 'POST',

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -473,7 +473,6 @@ export async function jsonRpcRequest(rpcUrl, rpcMethod, rpcParams = []) {
   const { origin, pathname, username, password } = new URL(rpcUrl)
   // URLs containing username and password needs special processing
   if (username && password) {
-    // eslint-disable-next-line no-unused-vars
     const encodedAuth = Buffer.from(`${username}:${password}`).toString(
       'base64',
     )

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -470,14 +470,14 @@ export async function jsonRpcRequest(rpcUrl, rpcMethod, rpcParams = []) {
     'Content-Type': 'application/json',
   }
   // Convert basic auth URL component to Authorization header
-  const { origin, pathname, username, password } = new URL(rpcUrl)
+  const { origin, pathname, username, password, search } = new URL(rpcUrl)
   // URLs containing username and password needs special processing
   if (username && password) {
     const encodedAuth = Buffer.from(`${username}:${password}`).toString(
       'base64',
     )
     headers.Authorization = `Basic ${encodedAuth}`
-    fetchUrl = `${origin}${pathname}`
+    fetchUrl = `${origin}${pathname}${search}`
   }
   const jsonRpcResponse = await window
     .fetch(fetchUrl, {


### PR DESCRIPTION
…work creation

Fixes: #9791

Explanation:  This new function to retrieve chainId on network creation does not take into account that `rpcUrl` may contain basic auth: `https://<username>:<password>@permissioned.network`. Fix adds checking for the basic auth in the URL and adds basic auth to the header and adjust the rpcUrl passed to `window.fetch()`

Manual testing steps:  
  - Create a new network
  - in the RPC field, provide the url of the form `https://<username>:<password>@permissioned.network` (exact value dependent on the permissioned network)
  - provide the permissioned network's chainId
  - click "Save"
  - Error: `Could not fetch chain ID. Is your RPC URL correct?`