### PR TITLE
Move `externally_connectable` from base to Chrome manifest

### DIFF
--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -41,10 +41,6 @@
   ],
   "default_locale": "en",
   "description": "__MSG_appDescription__",
-  "externally_connectable": {
-    "matches": ["https://metamask.io/*"],
-    "ids": ["*"]
-  },
   "icons": {
     "16": "images/icon-16.png",
     "19": "images/icon-19.png",

--- a/app/manifest/chrome.json
+++ b/app/manifest/chrome.json
@@ -1,3 +1,7 @@
 {
+  "externally_connectable": {
+    "matches": ["https://metamask.io/*"],
+    "ids": ["*"]
+  },
   "minimum_chrome_version": "58"
 }


### PR DESCRIPTION
The `externally_connectable` property of the extension manifest is not recognized by Firefox. It has been moved from the base manifest to the Chrome manifest, so that we no longer get a warning about this property on Firefox.

We would like to eventually remove it from the Chrome manifest as well, but we'll wait until we can batch it with other permission changes so that it doesn't unnecessarily re-prompt the user (see #9804)