### PR TITLE
Track whether seed phrase has been backed up

### DIFF
--- a/app/scripts/controllers/onboarding.js
+++ b/app/scripts/controllers/onboarding.js
@@ -27,7 +27,7 @@ export default class OnboardingController {
       onboardingTabs: {},
     }
     const initState = {
-      seedPhraseBackedUp: true,
+      seedPhraseBackedUp: null,
       ...opts.initState,
       ...initialTransientState,
     }

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -64,7 +64,7 @@ const mapStateToProps = (state) => {
     swapsEnabled,
     unconfirmedTransactionsCount: unconfirmedTransactionsCountSelector(state),
     shouldShowSeedPhraseReminder:
-      !seedPhraseBackedUp &&
+      seedPhraseBackedUp === false &&
       (parseInt(accountBalance, 16) > 0 || tokens.length > 0),
     isPopup,
     isNotification,


### PR DESCRIPTION
The `seedPhraseBackedUp` now tracks whether or not the seed phrase has been backed up. Previously this defaulted to `true`, which left no way to distinguish whether it had been backed up or not during onboarding.

The default is now `null`, and the UI logic has been updated to account for this, so that "existing users" (i.e. users that have a backup that is years old) aren't mistakenly considered to have not backed up their seed phrase. This value is already set explicitly to `true` or `false` during onboarding, in both the create and import flow.

This change was made primarily to make it easier to fix the onboarding library integration, which will be done in a subsequent PR.