### PR TITLE
Warn on duplicate web3 and do not inject

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -61,12 +61,12 @@ initProvider({
 // Setup web3
 
 if (typeof window.web3 !== 'undefined') {
-  throw new Error(`MetaMask detected another web3.
+  log.warn(`MetaMask detected another web3.
      MetaMask will not work reliably with another web3 extension.
      This usually happens if you have two MetaMasks installed,
      or MetaMask and another web3 extension. Please remove one
      and try again.`)
+} else {
+  // proxy web3, assign to window, and set up site auto reload
+  setupWeb3(log)
 }
-
-// proxy web3, assign to window, and set up site auto reload
-setupWeb3(log)

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -60,13 +60,13 @@ initProvider({
 // TODO:deprecate:2020
 // Setup web3
 
-if (typeof window.web3 !== 'undefined') {
+if (typeof window.web3 === 'undefined') {
+  // proxy web3, assign to window, and set up site auto reload
+  setupWeb3(log)
+} else {
   log.warn(`MetaMask detected another web3.
      MetaMask will not work reliably with another web3 extension.
      This usually happens if you have two MetaMasks installed,
      or MetaMask and another web3 extension. Please remove one
      and try again.`)
-} else {
-  // proxy web3, assign to window, and set up site auto reload
-  setupWeb3(log)
 }


### PR DESCRIPTION
Replaces #9084.
Fixes issue where a browser with two web3 wallets would cause unrelated websites to crash.