### PR TITLE
Prevent React prop warning for maxSlippage

### DIFF
--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -305,7 +305,7 @@ export default function Swap() {
                     ethBalance={ethBalance}
                     setMaxSlippage={setMaxSlippage}
                     selectedAccountAddress={selectedAccountAddress}
-                    maxSlippage={maxSlippage}
+                    maxSlippage={Number(maxSlippage)}
                   />
                 )
               }}


### PR DESCRIPTION
Explanation:  

I saw a React warning when changing the maxSlippage manually via `custom` option.  This PR fixes said problem.