### PR TITLE
Fix tradeValue assignment and reference in view-quote.js

### DIFF
--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -115,7 +115,7 @@ export default function ViewQuote() {
   const selectedQuote = useSelector(getSelectedQuote)
   const topQuote = useSelector(getTopQuote)
   const usedQuote = selectedQuote || topQuote
-  const { value: tradeValue = '0x0' } = usedQuote?.trade?.value || {}
+  const tradeValue = usedQuote?.trade?.value ?? '0x0'
 
   const fetchParamsSourceToken = fetchParams?.sourceToken
 
@@ -455,7 +455,7 @@ export default function ViewQuote() {
     dispatch(
       showModal({
         name: 'CUSTOMIZE_METASWAP_GAS',
-        value: usedQuote.value,
+        value: tradeValue,
         customGasLimitMessage: approveGas
           ? t('extraApprovalGas', [hexToDecimal(approveGas)])
           : '',


### PR DESCRIPTION
This PR fixes a bug that was introduced in https://github.com/MetaMask/metamask-extension/pull/9599

That PR stopped the use of `tradeTxParams`, and accordingly got `tradeValue` in a new way in view-quote.js (see https://github.com/MetaMask/metamask-extension/pull/9599/files#diff-66bb9868292a4e99fdb3021414460e0f7485f8cab217eed0b1bfca9004d32110L104)

The new code to get `tradeValue` was broken in two places. This PR corrects it