### PR TITLE
@metamask/controllers@4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@formatjs/intl-relativetimeformat": "^5.2.6",
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@material-ui/core": "^4.11.0",
-    "@metamask/controllers": "^4.0.0",
+    "@metamask/controllers": "^4.0.2",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,10 +1833,10 @@
     web3 "^0.20.7"
     web3-provider-engine "^16.0.1"
 
-"@metamask/controllers@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-4.0.0.tgz#fa00c7e068c19ac1e7cfb3342ea4210dd499e229"
-  integrity sha512-7Y8bOpkYGtqj/dqKBo9HsALQ2xRQoFBYjiRgmy8xS0ocUihWZkdiFD4jkOs9U1shKNGPg2y8UU/NnwyJEtkIPQ==
+"@metamask/controllers@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-4.0.2.tgz#ec7efa2bea7f323bb3dc458b8a29d1a284f2849e"
+  integrity sha512-SoEgVgRlguazOJF/pHCE+DFk+9Wb0z/cSsfyFrUSLUiQ0hZOx+fuuxf5bbNvnUNdXgMqai8WP11f9IBXPBad3w==
   dependencies:
     await-semaphore "^0.1.3"
     eth-contract-metadata "^1.11.0"
@@ -1847,7 +1847,7 @@
     eth-phishing-detect "^1.1.13"
     eth-query "^2.1.2"
     eth-rpc-errors "^4.0.0"
-    eth-sig-util "3.0.0"
+    eth-sig-util "^3.0.0"
     ethereumjs-util "^6.1.0"
     ethereumjs-wallet "0.6.0"
     ethjs-query "^0.3.8"
@@ -9915,18 +9915,6 @@ eth-rpc-errors@^4.0.0:
   integrity sha512-BCx0QBS6eVM+KWleeChtYOUIKBbnUvM9amzMlenvJfMK4KA7gBA1zRpQsLf8e98VziuHcnqdCIX7YVw3DbbKkw==
   dependencies:
     fast-safe-stringify "^2.0.6"
-
-eth-sig-util@3.0.0, eth-sig-util@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-3.0.0.tgz#75133b3d7c20a5731af0690c385e184ab942b97e"
-  integrity sha512-4eFkMOhpGbTxBQ3AMzVf0haUX2uTur7DpWiHzWyTURa28BVJJtOkcb9Ok5TV0YvEPG61DODPW7ZUATbJTslioQ==
-  dependencies:
-    buffer "^5.2.1"
-    elliptic "^6.4.0"
-    ethereumjs-abi "0.6.5"
-    ethereumjs-util "^5.1.1"
-    tweetnacl "^1.0.0"
-    tweetnacl-util "^0.15.0"
 
 eth-sig-util@^1.4.0, eth-sig-util@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
- `@metamask/controllers@4.0.2`
  - Guess who didn't export the controller they added in `4.0.0`?
    - And who accidentally pinned `eth-sig-util` in `4.0.1`? 😑 