### PR TITLE
build - catch build pipeline errors properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,9 @@ jobs:
   prep-build:
     docker:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    resource_class: medium+
     environment:
-      NODE_OPTIONS: --max_old_space_size=1024
+      NODE_OPTIONS: --max_old_space_size=2048
     steps:
       - checkout
       - attach_workspace:
@@ -143,8 +144,9 @@ jobs:
   prep-build-test:
     docker:
       - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    resource_class: medium+
     environment:
-      NODE_OPTIONS: --max_old_space_size=1024
+      NODE_OPTIONS: --max_old_space_size=2048
     steps:
       - checkout
       - attach_workspace:

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -207,7 +207,7 @@ function createScriptTasks({ browserPlatforms, livereload }) {
         // Initialize Source Maps
         buffer(),
         // loads map from browserify file
-        buildPipeline.push(sourcemaps.init({ loadMaps: true })),
+        sourcemaps.init({ loadMaps: true }),
       ]
 
       // Minification

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -199,37 +199,42 @@ function createScriptTasks({ browserPlatforms, livereload }) {
         // output build logs to terminal
         bundler.on('log', log)
       }
-      
+
       // process bundles
-      await pump(...[
-        bundler.bundle(),
-        // convert bundle stream to gulp vinyl stream
-        source(opts.filename),
+      await pump(
+        ...[
+          bundler.bundle(),
+          // convert bundle stream to gulp vinyl stream
+          source(opts.filename),
           // buffer file contents (?)
-        buffer(),
-        // Initialize Source Maps
-        // loads map from browserify file
-        sourcemaps.init({
-          loadMaps: true
-        }),
-        // Minification
-        !opts.devMode && terser({
-          mangle: {
-            reserved: ['MetamaskInpageProvider'],
-          },
-          sourceMap: {
-            content: true,
-          },
-        }),
-        // Finalize Source Maps
-        opts.devMode ? 
-          // Use inline source maps for development due to Chrome DevTools bug
-          // https://bugs.chromium.org/p/chromium/issues/detail?id=931675
-          sourcemaps.write() : 
-          sourcemaps.write('../sourcemaps'),
+          buffer(),
+          // Initialize Source Maps
+          // loads map from browserify file
+          sourcemaps.init({
+            loadMaps: true,
+          }),
+          // Minification
+          !opts.devMode &&
+            terser({
+              mangle: {
+                reserved: ['MetamaskInpageProvider'],
+              },
+              sourceMap: {
+                content: true,
+              },
+            }),
+          // Finalize Source Maps
+          opts.devMode
+            ? // Use inline source maps for development due to Chrome DevTools bug
+              // https://bugs.chromium.org/p/chromium/issues/detail?id=931675
+              sourcemaps.write()
+            : sourcemaps.write('../sourcemaps'),
           // write completed bundles
-        ...browserPlatforms.map(platform => gulp.dest(`./dist/${platform}`))
-      ].filter(Boolean))
+          ...browserPlatforms.map((platform) =>
+            gulp.dest(`./dist/${platform}`),
+          ),
+        ].filter(Boolean),
+      )
     }
   }
 
@@ -380,10 +385,6 @@ function createScriptTasks({ browserPlatforms, livereload }) {
 
     return bundler
   }
-}
-
-function beep() {
-  process.stdout.write('\x07')
 }
 
 function getEnvironment({ devMode, test }) {

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -426,7 +426,7 @@ function beep() {
   process.stdout.write('\x07')
 }
 
-function gracefulError (err) {
+function gracefulError(err) {
   console.warn(err)
   beep()
 }

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -241,7 +241,15 @@ function createScriptTasks({ browserPlatforms, livereload }) {
       })
 
       // process bundles
-      await pump(buildPipeline)
+      if (opts.devMode) {
+        try {
+          await pump(buildPipeline)
+        } catch (err) {
+          gracefulError(err)
+        }
+      } else {
+        await pump(buildPipeline)
+      }
     }
   }
 
@@ -412,4 +420,13 @@ function getEnvironment({ devMode, test }) {
     return 'pull-request'
   }
   return 'other'
+}
+
+function beep() {
+  process.stdout.write('\x07')
+}
+
+function gracefulError (err) {
+  console.warn(err)
+  beep()
 }

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const gulp = require('gulp')
 const watch = require('gulp-watch')
+const pify = require('pify')
+const pump = pify(require('pump'))
 const source = require('vinyl-source-stream')
 const buffer = require('vinyl-buffer')
 const log = require('fancy-log')
@@ -11,8 +13,6 @@ const envify = require('envify/custom')
 const sourcemaps = require('gulp-sourcemaps')
 const sesify = require('sesify')
 const terser = require('gulp-terser-js')
-const pify = require('pify')
-const endOfStream = pify(require('end-of-stream'))
 const { makeStringTransform } = require('browserify-transform-tools')
 
 const conf = require('rc')('metamask', {
@@ -199,61 +199,37 @@ function createScriptTasks({ browserPlatforms, livereload }) {
         // output build logs to terminal
         bundler.on('log', log)
       }
-
-      let buildStream = bundler.bundle()
-
-      // handle errors
-      buildStream.on('error', (err) => {
-        beep()
-        if (opts.devMode) {
-          console.warn(err.stack)
-        } else {
-          throw err
-        }
-      })
-
+      
       // process bundles
-      buildStream = buildStream
+      await pump(...[
+        bundler.bundle(),
         // convert bundle stream to gulp vinyl stream
-        .pipe(source(opts.filename))
-        // buffer file contents (?)
-        .pipe(buffer())
-
-      // Initialize Source Maps
-      buildStream = buildStream
+        source(opts.filename),
+          // buffer file contents (?)
+        buffer(),
+        // Initialize Source Maps
         // loads map from browserify file
-        .pipe(sourcemaps.init({ loadMaps: true }))
-
-      // Minification
-      if (!opts.devMode) {
-        buildStream = buildStream.pipe(
-          terser({
-            mangle: {
-              reserved: ['MetamaskInpageProvider'],
-            },
-            sourceMap: {
-              content: true,
-            },
-          }),
-        )
-      }
-
-      // Finalize Source Maps
-      if (opts.devMode) {
-        // Use inline source maps for development due to Chrome DevTools bug
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=931675
-        buildStream = buildStream.pipe(sourcemaps.write())
-      } else {
-        buildStream = buildStream.pipe(sourcemaps.write('../sourcemaps'))
-      }
-
-      // write completed bundles
-      browserPlatforms.forEach((platform) => {
-        const dest = `./dist/${platform}`
-        buildStream = buildStream.pipe(gulp.dest(dest))
-      })
-
-      await endOfStream(buildStream)
+        sourcemaps.init({
+          loadMaps: true
+        }),
+        // Minification
+        !opts.devMode && terser({
+          mangle: {
+            reserved: ['MetamaskInpageProvider'],
+          },
+          sourceMap: {
+            content: true,
+          },
+        }),
+        // Finalize Source Maps
+        opts.devMode ? 
+          // Use inline source maps for development due to Chrome DevTools bug
+          // https://bugs.chromium.org/p/chromium/issues/detail?id=931675
+          sourcemaps.write() : 
+          sourcemaps.write('../sourcemaps'),
+          // write completed bundles
+        ...browserPlatforms.map(platform => gulp.dest(`./dist/${platform}`))
+      ].filter(Boolean))
     }
   }
 


### PR DESCRIPTION
Uses `pump` because it knows how to handle errors. need to handle errors for every stream you create, errors don't propagate through streams