### PR TITLE
Temporarily disable sesify viz step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,9 +309,11 @@ jobs:
           path: test-artifacts
           destination: test-artifacts
       # important: generate sesify viz AFTER uploading builds as artifacts
-      - run:
-          name: build:sesify-viz
-          command: ./.circleci/scripts/create-sesify-viz
+      # Temporarily disabled until we can update to a version of `sesify` with
+      # this fix included: https://github.com/LavaMoat/LavaMoat/pull/121
+      # - run:
+      #     name: build:sesify-viz
+      #     command: ./.circleci/scripts/create-sesify-viz
       - store_artifacts:
           path: build-artifacts
           destination: build-artifacts


### PR DESCRIPTION
The sesify viz step of the build was broken in #9838 when `eth-rpc-errors@4` was introduced to the project. `eth-rpc-errors@4`
uses inline sourcemaps without including the full source in the sourcemap, which breaks `sesify`.

`sesify` [has been fixed](https://github.com/LavaMoat/LavaMoat/pull/121) (under its new name, `lavamoat-browserify`), but it has been disabled temporarily until this fix is included in a new release, and until we can update to use it.