### PR TITLE
Show a 'send eth' button on home screen in full screen mode

### DIFF
--- a/ui/app/components/app/asset-list/asset-list.js
+++ b/ui/app/components/app/asset-list/asset-list.js
@@ -13,11 +13,13 @@ import {
   getCurrentAccountWithSendEtherInfo,
   getNativeCurrency,
   getShouldShowFiat,
+  getSelectedAddress,
 } from '../../../selectors'
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay'
 
 const AssetList = ({ onClickAsset }) => {
   const history = useHistory()
+  const selectedAddress = useSelector((state) => getSelectedAddress(state))
   const selectedAccountBalance = useSelector(
     (state) => getCurrentAccountWithSendEtherInfo(state).balance,
   )
@@ -69,6 +71,7 @@ const AssetList = ({ onClickAsset }) => {
         onClick={() => onClickAsset(nativeCurrency)}
         data-testid="wallet-balance"
         primary={primaryCurrencyProperties.value}
+        tokenAddress={selectedAddress}
         tokenSymbol={primaryCurrencyProperties.suffix}
         secondary={showFiat ? secondaryCurrencyDisplay : undefined}
       />


### PR DESCRIPTION
Explanation:  

Presently there's no "Send ETH" button because we aren't passing a token address for the first item.

Manual testing steps:  
  - Open MM in full screen mode
  - See the new button
  - Click it, ensure sending works

<img width="1071" alt="SendEth" src="https://user-images.githubusercontent.com/46655/98715243-7e1ab480-234f-11eb-937c-5a5a42a6ac31.png">
