### PR TITLE
Fixes related to swaps custom gas limit

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -23,6 +23,8 @@ import {
   updateTransaction,
   resetBackgroundSwapsState,
   setSwapsLiveness,
+  setSelectedQuoteAggId,
+  setSwapsTxGasLimit,
 } from '../../store/actions'
 import {
   AWAITING_SWAP_ROUTE,
@@ -344,6 +346,14 @@ export const prepareToLeaveSwaps = () => {
   return async (dispatch) => {
     dispatch(clearSwapsState())
     await dispatch(resetBackgroundSwapsState())
+  }
+}
+
+export const swapsQuoteSelected = (aggId) => {
+  return (dispatch) => {
+    dispatch(swapCustomGasModalLimitEdited(null))
+    dispatch(setSelectedQuoteAggId(aggId))
+    dispatch(setSwapsTxGasLimit(''))
   }
 }
 

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -95,6 +95,8 @@ const slice = createSlice({
       state.approveTxId = null
       state.balanceError = false
       state.fetchingQuotes = false
+      state.customGas.limit = null
+      state.customGas.price = null
     },
     retriedGetQuotes: (state) => {
       state.approveTxId = null
@@ -121,6 +123,10 @@ const slice = createSlice({
     },
     setToToken: (state, action) => {
       state.toToken = action.payload
+    },
+    swapCustomGasModalClosed: (state) => {
+      state.customGas.price = null
+      state.customGas.limit = null
     },
     swapCustomGasModalPriceEdited: (state, action) => {
       state.customGas.price = action.payload
@@ -299,6 +305,7 @@ const {
   swapCustomGasModalPriceEdited,
   swapCustomGasModalLimitEdited,
   retrievedFallbackSwapsGasPrice,
+  swapCustomGasModalClosed,
 } = actions
 
 export {
@@ -312,6 +319,7 @@ export {
   setToToken as setSwapToToken,
   swapCustomGasModalPriceEdited,
   swapCustomGasModalLimitEdited,
+  swapCustomGasModalClosed,
 }
 
 export const navigateBackToBuildQuote = (history) => {

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -445,7 +445,7 @@ export default function ViewQuote() {
           : null,
         initialGasPrice: gasPrice,
         initialGasLimit: maxGasLimit,
-        minimumGasLimit: parseInt(nonCustomMaxGasLimit, 16),
+        minimumGasLimit: new BigNumber(nonCustomMaxGasLimit, 16).toString(10),
       }),
     )
 

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -443,7 +443,7 @@ export default function ViewQuote() {
           : null,
         initialGasPrice: gasPrice,
         initialGasLimit: maxGasLimit,
-        minimumGasLimit: new BigNumber(nonCustomMaxGasLimit, 16).toString(10),
+        minimumGasLimit: new BigNumber(nonCustomMaxGasLimit, 16).toNumber(),
       }),
     )
 

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -26,7 +26,7 @@ import {
   navigateBackToBuildQuote,
   signAndSendTransactions,
   getBackgroundSwapRouteState,
-  swapCustomGasModalLimitEdited,
+  swapsQuoteSelected,
 } from '../../../ducks/swaps/swaps'
 import {
   conversionRateSelector,
@@ -39,8 +39,6 @@ import { getTokens } from '../../../ducks/metamask/metamask'
 import {
   safeRefetchQuotes,
   setCustomApproveTxData,
-  setSwapsTxGasLimit,
-  setSelectedQuoteAggId,
   setSwapsErrorKey,
   showModal,
 } from '../../../store/actions'
@@ -471,11 +469,7 @@ export default function ViewQuote() {
           <SelectQuotePopover
             quoteDataRows={renderablePopoverData}
             onClose={() => setSelectQuotePopoverShown(false)}
-            onSubmit={(aggId) => {
-              dispatch(setSelectedQuoteAggId(aggId))
-              dispatch(swapCustomGasModalLimitEdited(null))
-              dispatch(setSwapsTxGasLimit(''))
-            }}
+            onSubmit={(aggId) => dispatch(swapsQuoteSelected(aggId))}
             swapToSymbol={destinationTokenSymbol}
             initialAggId={usedQuote.aggregator}
             onQuoteDetailsIsOpened={quoteDetailsOpened}

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -11,7 +11,6 @@ import { useNewMetricEvent } from '../../../hooks/useMetricEvent'
 import { useSwapsEthToken } from '../../../hooks/useSwapsEthToken'
 import { MetaMetricsContext } from '../../../contexts/metametrics.new'
 import FeeCard from '../fee-card'
-import { setCustomGasLimit } from '../../../ducks/gas/gas.duck'
 import {
   getQuotes,
   getSelectedQuote,
@@ -27,6 +26,7 @@ import {
   navigateBackToBuildQuote,
   signAndSendTransactions,
   getBackgroundSwapRouteState,
+  swapCustomGasModalLimitEdited,
 } from '../../../ducks/swaps/swaps'
 import {
   conversionRateSelector,
@@ -445,7 +445,7 @@ export default function ViewQuote() {
           : null,
         initialGasPrice: gasPrice,
         initialGasLimit: maxGasLimit,
-        minimumGasLimit: nonCustomMaxGasLimit,
+        minimumGasLimit: parseInt(nonCustomMaxGasLimit, 16),
       }),
     )
 
@@ -473,7 +473,7 @@ export default function ViewQuote() {
             onClose={() => setSelectQuotePopoverShown(false)}
             onSubmit={(aggId) => {
               dispatch(setSelectedQuoteAggId(aggId))
-              dispatch(setCustomGasLimit(null))
+              dispatch(swapCustomGasModalLimitEdited(null))
               dispatch(setSwapsTxGasLimit(''))
             }}
             swapToSymbol={destinationTokenSymbol}


### PR DESCRIPTION
This PR fixes the following issues:
- in the swaps custom gas modal, if the gas limit value was set below the minimum gas limit, the error message would show a minimum amount in hex
- if a custom gas limit or price was set in the modal, and then it was closed without saving, and then opened again, the previously set but not saved price and/or limit would be set in the modal again
- if a custom gas limit was set and saved, and then the user either selected a different quote or went "Back" to the build quotes screen and then returned to the view quote screen, and then opened the modal again, the previously set gas limit would be set

Demo video of everything working correctly: https://streamable.com/ujqxbz

