### PR TITLE
Fix setGasPrice dispatch function parameters

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/basic-tab-content/tests/basic-tab-content-component.test.js
@@ -32,7 +32,8 @@ const mockGasPriceButtonGroupProps = {
       gasEstimateType: GAS_ESTIMATE_TYPES.AVERAGE,
     },
   ],
-  handleGasPriceSelection: (newPrice) => console.log('NewPrice: ', newPrice),
+  handleGasPriceSelection: ({ gasPrice }) =>
+    console.log('NewPrice: ', gasPrice),
   noButtonActiveByDefault: true,
   showCheck: true,
 }

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -321,7 +321,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     },
     gasPriceButtonGroupProps: {
       ...gasPriceButtonGroupProps,
-      handleGasPriceSelection: otherDispatchProps.updateCustomGasPrice,
+      handleGasPriceSelection: ({ gasPrice }) =>
+        otherDispatchProps.updateCustomGasPrice(gasPrice),
     },
     cancelAndClose: () => {
       dispatchCancelAndClose()

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -274,7 +274,7 @@ describe('gas-modal-page-container container', function () {
       let result
       tests.forEach(({ mockState, mockOwnProps, expectedResult }) => {
         result = mapStateToProps(mockState, mockOwnProps)
-        assert.deepEqual(result, expectedResult)
+        assert.deepStrictEqual(result, expectedResult)
       })
     })
   })
@@ -316,7 +316,7 @@ describe('gas-modal-page-container container', function () {
         mapDispatchToPropsObject.updateCustomGasPrice('ffff')
         assert(dispatchSpy.calledOnce)
         assert(gasActionSpies.setCustomGasPrice.calledOnce)
-        assert.equal(
+        assert.strictEqual(
           gasActionSpies.setCustomGasPrice.getCall(0).args[0],
           '0xffff',
         )
@@ -326,7 +326,7 @@ describe('gas-modal-page-container container', function () {
         mapDispatchToPropsObject.updateCustomGasPrice('0xffff')
         assert(dispatchSpy.calledOnce)
         assert(gasActionSpies.setCustomGasPrice.calledOnce)
-        assert.equal(
+        assert.strictEqual(
           gasActionSpies.setCustomGasPrice.getCall(0).args[0],
           '0xffff',
         )
@@ -338,7 +338,7 @@ describe('gas-modal-page-container container', function () {
         mapDispatchToPropsObject.updateCustomGasLimit('0x10')
         assert(dispatchSpy.calledOnce)
         assert(gasActionSpies.setCustomGasLimit.calledOnce)
-        assert.equal(
+        assert.strictEqual(
           gasActionSpies.setCustomGasLimit.getCall(0).args[0],
           '0x10',
         )
@@ -351,19 +351,19 @@ describe('gas-modal-page-container container', function () {
         assert(dispatchSpy.calledTwice)
         assert(actionSpies.setGasPrice.calledOnce)
         assert(actionSpies.setGasLimit.calledOnce)
-        assert.equal(actionSpies.setGasLimit.getCall(0).args[0], 'ffff')
-        assert.equal(actionSpies.setGasPrice.getCall(0).args[0], 'aaaa')
+        assert.strictEqual(actionSpies.setGasLimit.getCall(0).args[0], 'ffff')
+        assert.strictEqual(actionSpies.setGasPrice.getCall(0).args[0], 'aaaa')
       })
     })
 
     describe('updateConfirmTxGasAndCalculate()', function () {
       it('should dispatch a updateGasAndCalculate action with the correct props', function () {
         mapDispatchToPropsObject.updateConfirmTxGasAndCalculate('ffff', 'aaaa')
-        assert.equal(dispatchSpy.callCount, 3)
+        assert.strictEqual(dispatchSpy.callCount, 3)
         assert(actionSpies.setGasPrice.calledOnce)
         assert(actionSpies.setGasLimit.calledOnce)
-        assert.equal(actionSpies.setGasLimit.getCall(0).args[0], 'ffff')
-        assert.equal(actionSpies.setGasPrice.getCall(0).args[0], 'aaaa')
+        assert.strictEqual(actionSpies.setGasLimit.getCall(0).args[0], 'ffff')
+        assert.strictEqual(actionSpies.setGasPrice.getCall(0).args[0], 'aaaa')
       })
     })
   })
@@ -410,37 +410,45 @@ describe('gas-modal-page-container container', function () {
     it('should return the expected props when isConfirm is true', function () {
       const result = mergeProps(stateProps, dispatchProps, ownProps)
 
-      assert.equal(result.isConfirm, true)
-      assert.equal(result.someOtherStateProp, 'baz')
-      assert.equal(
+      assert.strictEqual(result.isConfirm, true)
+      assert.strictEqual(result.someOtherStateProp, 'baz')
+      assert.strictEqual(
         result.gasPriceButtonGroupProps.someGasPriceButtonGroupProp,
         'foo',
       )
-      assert.equal(
+      assert.strictEqual(
         result.gasPriceButtonGroupProps.anotherGasPriceButtonGroupProp,
         'bar',
       )
-      assert.equal(result.someOwnProp, 123)
+      assert.strictEqual(result.someOwnProp, 123)
 
-      assert.equal(dispatchProps.updateConfirmTxGasAndCalculate.callCount, 0)
-      assert.equal(dispatchProps.setGasData.callCount, 0)
-      assert.equal(dispatchProps.hideGasButtonGroup.callCount, 0)
-      assert.equal(dispatchProps.hideModal.callCount, 0)
+      assert.strictEqual(
+        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
+        0,
+      )
+      assert.strictEqual(dispatchProps.setGasData.callCount, 0)
+      assert.strictEqual(dispatchProps.hideGasButtonGroup.callCount, 0)
+      assert.strictEqual(dispatchProps.hideModal.callCount, 0)
 
       result.onSubmit()
 
-      assert.equal(dispatchProps.updateConfirmTxGasAndCalculate.callCount, 1)
-      assert.equal(dispatchProps.setGasData.callCount, 0)
-      assert.equal(dispatchProps.hideGasButtonGroup.callCount, 0)
-      assert.equal(dispatchProps.hideModal.callCount, 1)
+      assert.strictEqual(
+        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
+        1,
+      )
+      assert.strictEqual(dispatchProps.setGasData.callCount, 0)
+      assert.strictEqual(dispatchProps.hideGasButtonGroup.callCount, 0)
+      assert.strictEqual(dispatchProps.hideModal.callCount, 1)
 
-      assert.equal(dispatchProps.updateCustomGasPrice.callCount, 0)
-      result.gasPriceButtonGroupProps.handleGasPriceSelection()
-      assert.equal(dispatchProps.updateCustomGasPrice.callCount, 1)
+      assert.strictEqual(dispatchProps.updateCustomGasPrice.callCount, 0)
+      result.gasPriceButtonGroupProps.handleGasPriceSelection({
+        gasPrice: '0x0',
+      })
+      assert.strictEqual(dispatchProps.updateCustomGasPrice.callCount, 1)
 
-      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 0)
+      assert.strictEqual(dispatchProps.someOtherDispatchProp.callCount, 0)
       result.someOtherDispatchProp()
-      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 1)
+      assert.strictEqual(dispatchProps.someOtherDispatchProp.callCount, 1)
     })
 
     it('should return the expected props when isConfirm is false', function () {
@@ -450,41 +458,49 @@ describe('gas-modal-page-container container', function () {
         ownProps,
       )
 
-      assert.equal(result.isConfirm, false)
-      assert.equal(result.someOtherStateProp, 'baz')
-      assert.equal(
+      assert.strictEqual(result.isConfirm, false)
+      assert.strictEqual(result.someOtherStateProp, 'baz')
+      assert.strictEqual(
         result.gasPriceButtonGroupProps.someGasPriceButtonGroupProp,
         'foo',
       )
-      assert.equal(
+      assert.strictEqual(
         result.gasPriceButtonGroupProps.anotherGasPriceButtonGroupProp,
         'bar',
       )
-      assert.equal(result.someOwnProp, 123)
+      assert.strictEqual(result.someOwnProp, 123)
 
-      assert.equal(dispatchProps.updateConfirmTxGasAndCalculate.callCount, 0)
-      assert.equal(dispatchProps.setGasData.callCount, 0)
-      assert.equal(dispatchProps.hideGasButtonGroup.callCount, 0)
-      assert.equal(dispatchProps.cancelAndClose.callCount, 0)
+      assert.strictEqual(
+        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
+        0,
+      )
+      assert.strictEqual(dispatchProps.setGasData.callCount, 0)
+      assert.strictEqual(dispatchProps.hideGasButtonGroup.callCount, 0)
+      assert.strictEqual(dispatchProps.cancelAndClose.callCount, 0)
 
       result.onSubmit('mockNewLimit', 'mockNewPrice')
 
-      assert.equal(dispatchProps.updateConfirmTxGasAndCalculate.callCount, 0)
-      assert.equal(dispatchProps.setGasData.callCount, 1)
-      assert.deepEqual(dispatchProps.setGasData.getCall(0).args, [
+      assert.strictEqual(
+        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
+        0,
+      )
+      assert.strictEqual(dispatchProps.setGasData.callCount, 1)
+      assert.deepStrictEqual(dispatchProps.setGasData.getCall(0).args, [
         'mockNewLimit',
         'mockNewPrice',
       ])
-      assert.equal(dispatchProps.hideGasButtonGroup.callCount, 1)
-      assert.equal(dispatchProps.cancelAndClose.callCount, 1)
+      assert.strictEqual(dispatchProps.hideGasButtonGroup.callCount, 1)
+      assert.strictEqual(dispatchProps.cancelAndClose.callCount, 1)
 
-      assert.equal(dispatchProps.updateCustomGasPrice.callCount, 0)
-      result.gasPriceButtonGroupProps.handleGasPriceSelection()
-      assert.equal(dispatchProps.updateCustomGasPrice.callCount, 1)
+      assert.strictEqual(dispatchProps.updateCustomGasPrice.callCount, 0)
+      result.gasPriceButtonGroupProps.handleGasPriceSelection({
+        gasPrice: '0x0',
+      })
+      assert.strictEqual(dispatchProps.updateCustomGasPrice.callCount, 1)
 
-      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 0)
+      assert.strictEqual(dispatchProps.someOtherDispatchProp.callCount, 0)
       result.someOtherDispatchProp()
-      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 1)
+      assert.strictEqual(dispatchProps.someOtherDispatchProp.callCount, 1)
     })
 
     it('should dispatch the expected actions from obSubmit when isConfirm is false and isSpeedUp is true', function () {
@@ -496,13 +512,16 @@ describe('gas-modal-page-container container', function () {
 
       result.onSubmit()
 
-      assert.equal(dispatchProps.updateConfirmTxGasAndCalculate.callCount, 0)
-      assert.equal(dispatchProps.setGasData.callCount, 0)
-      assert.equal(dispatchProps.hideGasButtonGroup.callCount, 0)
-      assert.equal(dispatchProps.cancelAndClose.callCount, 1)
+      assert.strictEqual(
+        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
+        0,
+      )
+      assert.strictEqual(dispatchProps.setGasData.callCount, 0)
+      assert.strictEqual(dispatchProps.hideGasButtonGroup.callCount, 0)
+      assert.strictEqual(dispatchProps.cancelAndClose.callCount, 1)
 
-      assert.equal(dispatchProps.createSpeedUpTransaction.callCount, 1)
-      assert.equal(dispatchProps.hideSidebar.callCount, 1)
+      assert.strictEqual(dispatchProps.createSpeedUpTransaction.callCount, 1)
+      assert.strictEqual(dispatchProps.hideSidebar.callCount, 1)
     })
   })
 })

--- a/ui/app/components/app/gas-customization/gas-price-button-group/gas-price-button-group.component.js
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/gas-price-button-group.component.js
@@ -94,10 +94,10 @@ export default class GasPriceButtonGroup extends Component {
     return (
       <Button
         onClick={() =>
-          handleGasPriceSelection(
-            priceInHexWei,
-            renderableGasInfo.gasEstimateType,
-          )
+          handleGasPriceSelection({
+            gasPrice: priceInHexWei,
+            gasEstimateType: renderableGasInfo.gasEstimateType,
+          })
         }
         key={`gas-price-button-${index}`}
       >

--- a/ui/app/components/app/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/tests/gas-price-button-group-component.test.js
@@ -73,13 +73,13 @@ describe('GasPriceButtonGroup Component', function () {
         defaultActiveButtonIndex,
         noButtonActiveByDefault,
       } = wrapper.props()
-      assert.equal(className, 'gas-price-button-group')
-      assert.equal(defaultActiveButtonIndex, 2)
-      assert.equal(noButtonActiveByDefault, true)
+      assert.strictEqual(className, 'gas-price-button-group')
+      assert.strictEqual(defaultActiveButtonIndex, 2)
+      assert.strictEqual(noButtonActiveByDefault, true)
     })
 
     function renderButtonArgsTest(i, mockPropsAndFlags) {
-      assert.deepEqual(
+      assert.deepStrictEqual(
         GasPriceButtonGroup.prototype.renderButton.getCall(i).args,
         [
           { ...mockGasPriceButtonGroupProps.gasButtonInfo[i] },
@@ -90,7 +90,10 @@ describe('GasPriceButtonGroup Component', function () {
     }
 
     it('should call this.renderButton 3 times, with the correct args', function () {
-      assert.equal(GasPriceButtonGroup.prototype.renderButton.callCount, 3)
+      assert.strictEqual(
+        GasPriceButtonGroup.prototype.renderButton.callCount,
+        3,
+      )
       renderButtonArgsTest(0, mockButtonPropsAndFlags)
       renderButtonArgsTest(1, mockButtonPropsAndFlags)
       renderButtonArgsTest(2, mockButtonPropsAndFlags)
@@ -100,7 +103,7 @@ describe('GasPriceButtonGroup Component', function () {
       wrapper.setProps({ buttonDataLoading: true })
       assert(wrapper.is('div'))
       assert(wrapper.hasClass('gas-price-button-group__loading-container'))
-      assert.equal(wrapper.text(), 'loading')
+      assert.strictEqual(wrapper.text(), 'loading')
     })
   })
 
@@ -119,30 +122,34 @@ describe('GasPriceButtonGroup Component', function () {
     })
 
     it('should render a button', function () {
-      assert.equal(wrappedRenderButtonResult.type(), 'button')
+      assert.strictEqual(wrappedRenderButtonResult.type(), 'button')
     })
 
     it('should call the correct method when clicked', function () {
-      assert.equal(
+      assert.strictEqual(
         mockGasPriceButtonGroupProps.handleGasPriceSelection.callCount,
         0,
       )
       wrappedRenderButtonResult.props().onClick()
-      assert.equal(
+      assert.strictEqual(
         mockGasPriceButtonGroupProps.handleGasPriceSelection.callCount,
         1,
       )
-      assert.deepEqual(
+      assert.deepStrictEqual(
         mockGasPriceButtonGroupProps.handleGasPriceSelection.getCall(0).args,
         [
-          mockGasPriceButtonGroupProps.gasButtonInfo[0].priceInHexWei,
-          mockGasPriceButtonGroupProps.gasButtonInfo[0].gasEstimateType,
+          {
+            gasPrice:
+              mockGasPriceButtonGroupProps.gasButtonInfo[0].priceInHexWei,
+            gasEstimateType:
+              mockGasPriceButtonGroupProps.gasButtonInfo[0].gasEstimateType,
+          },
         ],
       )
     })
 
     it('should call this.renderButtonContent with the correct args', function () {
-      assert.equal(
+      assert.strictEqual(
         GasPriceButtonGroup.prototype.renderButtonContent.callCount,
         1,
       )
@@ -153,7 +160,7 @@ describe('GasPriceButtonGroup Component', function () {
         gasEstimateType,
       } = mockGasPriceButtonGroupProps.gasButtonInfo[0]
       const { showCheck, className } = mockGasPriceButtonGroupProps
-      assert.deepEqual(
+      assert.deepStrictEqual(
         GasPriceButtonGroup.prototype.renderButtonContent.getCall(0).args,
         [
           {
@@ -184,11 +191,11 @@ describe('GasPriceButtonGroup Component', function () {
       const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult.childAt(0).children().length,
         1,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult.find('.someClass__label').text(),
         'slow',
       )
@@ -206,11 +213,11 @@ describe('GasPriceButtonGroup Component', function () {
       const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult.childAt(0).children().length,
         1,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult
           .find('.someClass__primary-currency')
           .text(),
@@ -230,11 +237,11 @@ describe('GasPriceButtonGroup Component', function () {
       const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult.childAt(0).children().length,
         1,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult
           .find('.someClass__secondary-currency')
           .text(),
@@ -254,11 +261,11 @@ describe('GasPriceButtonGroup Component', function () {
       const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult.childAt(0).children().length,
         1,
       )
-      assert.equal(
+      assert.strictEqual(
         wrappedRenderButtonContentResult
           .find('.someClass__time-estimate')
           .text(),
@@ -277,7 +284,10 @@ describe('GasPriceButtonGroup Component', function () {
       const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       )
-      assert.equal(wrappedRenderButtonContentResult.find('.fa-check').length, 1)
+      assert.strictEqual(
+        wrappedRenderButtonContentResult.find('.fa-check').length,
+        1,
+      )
     })
 
     it('should render all elements if all args passed', function () {
@@ -296,7 +306,7 @@ describe('GasPriceButtonGroup Component', function () {
       const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       )
-      assert.equal(wrappedRenderButtonContentResult.children().length, 5)
+      assert.strictEqual(wrappedRenderButtonContentResult.children().length, 5)
     })
 
     it('should render no elements if all args passed', function () {
@@ -307,7 +317,7 @@ describe('GasPriceButtonGroup Component', function () {
       const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       )
-      assert.equal(wrappedRenderButtonContentResult.children().length, 0)
+      assert.strictEqual(wrappedRenderButtonContentResult.children().length, 0)
     })
   })
 })

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -101,7 +101,7 @@ export default class SendGasRow extends Component {
           className="gas-price-button-group--small"
           showCheck={false}
           {...gasPriceButtonGroupProps}
-          handleGasPriceSelection={async (...args) => {
+          handleGasPriceSelection={async (opts) => {
             metricsEvent({
               eventOpts: {
                 category: 'Transactions',
@@ -109,7 +109,7 @@ export default class SendGasRow extends Component {
                 name: 'Changed Gas Button',
               },
             })
-            await gasPriceButtonGroupProps.handleGasPriceSelection(...args)
+            await gasPriceButtonGroupProps.handleGasPriceSelection(opts)
             if (maxModeOn) {
               this.setMaxAmount()
             }
@@ -134,7 +134,7 @@ export default class SendGasRow extends Component {
       <div>
         <AdvancedGasInputs
           updateCustomGasPrice={(newGasPrice) =>
-            setGasPrice(newGasPrice, gasLimit)
+            setGasPrice({ gasPrice: newGasPrice, gasLimit })
           }
           updateCustomGasLimit={(newGasLimit) =>
             setGasLimit(newGasLimit, gasPrice)

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
@@ -89,11 +89,11 @@ function mapDispatchToProps(dispatch) {
   return {
     showCustomizeGasModal: () =>
       dispatch(showModal({ name: 'CUSTOMIZE_GAS', hideBasic: true })),
-    setGasPrice: (newPrice, gasLimit) => {
-      dispatch(setGasPrice(newPrice))
-      dispatch(setCustomGasPrice(newPrice))
+    setGasPrice: ({ gasPrice, gasLimit }) => {
+      dispatch(setGasPrice(gasPrice))
+      dispatch(setCustomGasPrice(gasPrice))
       if (gasLimit) {
-        dispatch(setGasTotal(calcGasTotal(gasLimit, newPrice)))
+        dispatch(setGasTotal(calcGasTotal(gasLimit, gasPrice)))
       }
     },
     setGasLimit: (newLimit, gasPrice) => {

--- a/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
+++ b/ui/app/pages/send/send-content/send-gas-row/tests/send-gas-row-container.test.js
@@ -58,7 +58,7 @@ describe('send-gas-row container', function () {
       it('should dispatch an action', function () {
         mapDispatchToPropsObject.showCustomizeGasModal()
         assert(dispatchSpy.calledOnce)
-        assert.deepEqual(actionSpies.showModal.getCall(0).args[0], {
+        assert.deepStrictEqual(actionSpies.showModal.getCall(0).args[0], {
           name: 'CUSTOMIZE_GAS',
           hideBasic: true,
         })
@@ -67,16 +67,22 @@ describe('send-gas-row container', function () {
 
     describe('setGasPrice()', function () {
       it('should dispatch an action', function () {
-        mapDispatchToPropsObject.setGasPrice('mockNewPrice', 'mockLimit')
+        mapDispatchToPropsObject.setGasPrice({
+          gasPrice: 'mockNewPrice',
+          gasLimit: 'mockLimit',
+        })
         assert(dispatchSpy.calledThrice)
         assert(actionSpies.setGasPrice.calledOnce)
-        assert.equal(actionSpies.setGasPrice.getCall(0).args[0], 'mockNewPrice')
-        assert.equal(
+        assert.strictEqual(
+          actionSpies.setGasPrice.getCall(0).args[0],
+          'mockNewPrice',
+        )
+        assert.strictEqual(
           gasDuckSpies.setCustomGasPrice.getCall(0).args[0],
           'mockNewPrice',
         )
         assert(actionSpies.setGasTotal.calledOnce)
-        assert.equal(
+        assert.strictEqual(
           actionSpies.setGasTotal.getCall(0).args[0],
           'mockLimitmockNewPrice',
         )
@@ -88,13 +94,16 @@ describe('send-gas-row container', function () {
         mapDispatchToPropsObject.setGasLimit('mockNewLimit', 'mockPrice')
         assert(dispatchSpy.calledThrice)
         assert(actionSpies.setGasLimit.calledOnce)
-        assert.equal(actionSpies.setGasLimit.getCall(0).args[0], 'mockNewLimit')
-        assert.equal(
+        assert.strictEqual(
+          actionSpies.setGasLimit.getCall(0).args[0],
+          'mockNewLimit',
+        )
+        assert.strictEqual(
           gasDuckSpies.setCustomGasLimit.getCall(0).args[0],
           'mockNewLimit',
         )
         assert(actionSpies.setGasTotal.calledOnce)
-        assert.equal(
+        assert.strictEqual(
           actionSpies.setGasTotal.getCall(0).args[0],
           'mockNewLimitmockPrice',
         )
@@ -134,24 +143,24 @@ describe('send-gas-row container', function () {
       const ownProps = { someOwnProp: 123 }
       const result = mergeProps(stateProps, dispatchProps, ownProps)
 
-      assert.equal(result.someOtherStateProp, 'baz')
-      assert.equal(
+      assert.strictEqual(result.someOtherStateProp, 'baz')
+      assert.strictEqual(
         result.gasPriceButtonGroupProps.someGasPriceButtonGroupProp,
         'foo',
       )
-      assert.equal(
+      assert.strictEqual(
         result.gasPriceButtonGroupProps.anotherGasPriceButtonGroupProp,
         'bar',
       )
-      assert.equal(result.someOwnProp, 123)
+      assert.strictEqual(result.someOwnProp, 123)
 
-      assert.equal(dispatchProps.setGasPrice.callCount, 0)
+      assert.strictEqual(dispatchProps.setGasPrice.callCount, 0)
       result.gasPriceButtonGroupProps.handleGasPriceSelection()
-      assert.equal(dispatchProps.setGasPrice.callCount, 1)
+      assert.strictEqual(dispatchProps.setGasPrice.callCount, 1)
 
-      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 0)
+      assert.strictEqual(dispatchProps.someOtherDispatchProp.callCount, 0)
       result.someOtherDispatchProp()
-      assert.equal(dispatchProps.someOtherDispatchProp.callCount, 1)
+      assert.strictEqual(dispatchProps.someOtherDispatchProp.callCount, 1)
     })
   })
 })

--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
@@ -61,9 +61,9 @@ export default class GasModalPageContainer extends Component {
       <BasicTabContent
         gasPriceButtonGroupProps={{
           ...gasPriceButtonGroupProps,
-          handleGasPriceSelection: (gasPriceInHexWei, gasEstimateType) => {
+          handleGasPriceSelection: ({ gasPrice, gasEstimateType }) => {
             this.setGasSpeedType(gasEstimateType)
-            this.props.setSwapsCustomizationModalPrice(gasPriceInHexWei)
+            this.props.setSwapsCustomizationModalPrice(gasPrice)
           },
         }}
       />


### PR DESCRIPTION
This fixes a bug introduced in #9599. In that PR, the `gas-price-button-group` prop `handleGasPriceSelection` was overwritten in the swaps gas customization modal in order to take the gas estimate type (a string constant) as its second parameter (context: https://github.com/MetaMask/metamask-extension/pull/9599#discussion_r510516228). At the time, we missed that `handleGasPriceSelection` normally takes as its second parameter a hexadecimal string gas limit. BigNumber errors result.

This PR enables `handleGasPriceSelection` to be used in both contexts by means of named parameters. Note that most of the diff is changing `assert.equal` and `assert.deepEqual` to their `strict` equivalents in unit tests.