### PR TITLE
Show send text upon hover in main asset list

### DIFF
--- a/ui/app/components/app/asset-list-item/asset-list-item.scss
+++ b/ui/app/components/app/asset-list-item/asset-list-item.scss
@@ -57,7 +57,8 @@
       display: flex;
     }
 
-    & &__send-token-button {
+    &:hover &__send-token-button,
+    &:focus-within &__send-token-button {
       display: inline-block;
     }
 


### PR DESCRIPTION
Explanation:  

@rachelcope had mentioned that the original intent of the send buttons in the asset list was to appear on hover

Manual testing steps:  
  - Open metamask in full screen mode
  - See no 'send' buttons
  - Hover over an item, see send button.