### PR TITLE
Revert "Add custom hd path option (#9367)"

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1425,7 +1425,7 @@
     "message": "Select Locale"
   },
   "selectPathHelp": {
-    "message": "If you don't see your existing Ledger accounts below, try a different HD path."
+    "message": "If you don't see your existing Ledger accounts below, try switching paths to \"Legacy (MEW / MyCrypto)\""
   },
   "selectType": {
     "message": "Select Type"

--- a/ui/app/pages/create-account/connect-hardware/account-list.js
+++ b/ui/app/pages/create-account/connect-hardware/account-list.js
@@ -5,13 +5,6 @@ import getAccountLink from '../../../../lib/account-link'
 import Button from '../../../components/ui/button'
 
 class AccountList extends Component {
-  state = {
-    showCustomInput: false,
-    customPathSelected: false,
-  }
-
-  inputRef = React.createRef()
-
   getHdPaths() {
     return [
       {
@@ -21,10 +14,6 @@ class AccountList extends Component {
       {
         label: `Legacy (MEW / MyCrypto)`,
         value: `m/44'/60'/0'`,
-      },
-      {
-        label: `Custom`,
-        value: `custom`,
       },
     ]
   }
@@ -43,7 +32,6 @@ class AccountList extends Component {
   }
 
   renderHdPathSelector() {
-    const { showCustomInput } = this.state
     const { onPathChange, selectedPath } = this.props
 
     const options = this.getHdPaths()
@@ -58,41 +46,19 @@ class AccountList extends Component {
             className="hw-connect__hdPath__select"
             name="hd-path-select"
             clearable={false}
-            value={showCustomInput ? 'custom' : selectedPath}
+            value={selectedPath}
             options={options}
             onChange={(opt) => {
-              if (opt.value === 'custom') {
-                this.setState({ showCustomInput: true })
-              } else {
-                this.setState({ showCustomInput: false })
-                onPathChange(opt.value)
-              }
+              onPathChange(opt.value)
             }}
           />
         </div>
-        {showCustomInput && this.renderCustomInput()}
       </div>
     )
   }
 
   capitalizeDevice(device) {
     return device.slice(0, 1).toUpperCase() + device.slice(1)
-  }
-
-  renderCustomInput() {
-    const hdPaths = this.getHdPaths()
-    return (
-      <input
-        className="hw-connect__custom-input"
-        type="text"
-        defaultValue={hdPaths[0].value}
-        onChange={() => {
-          this.setState({ customPathSelected: false })
-        }}
-        ref={this.inputRef}
-        autoFocus
-      />
-    )
   }
 
   renderHeader() {
@@ -177,9 +143,6 @@ class AccountList extends Component {
   }
 
   renderButtons() {
-    const { showCustomInput, customPathSelected } = this.state
-    const { onPathChange } = this.props
-    const showSelectButton = showCustomInput && !customPathSelected
     const disabled = this.props.selectedAccount === null
     const buttonProps = {}
     if (disabled) {
@@ -196,29 +159,15 @@ class AccountList extends Component {
         >
           {this.context.t('cancel')}
         </Button>
-        {showSelectButton ? (
-          <Button
-            type="primary"
-            large
-            className="new-external-account-form__button unlock"
-            onClick={() => {
-              onPathChange(this.inputRef.current.value)
-              this.setState({ customPathSelected: true })
-            }}
-          >
-            {this.context.t('selectHdPath')}
-          </Button>
-        ) : (
-          <Button
-            type="primary"
-            large
-            className="new-external-account-form__button unlock"
-            disabled={disabled}
-            onClick={this.props.onUnlockAccount.bind(this, this.props.device)}
-          >
-            {this.context.t('unlock')}
-          </Button>
-        )}
+        <Button
+          type="primary"
+          large
+          className="new-external-account-form__button unlock"
+          disabled={disabled}
+          onClick={this.props.onUnlockAccount.bind(this, this.props.device)}
+        >
+          {this.context.t('unlock')}
+        </Button>
       </div>
     )
   }
@@ -234,12 +183,11 @@ class AccountList extends Component {
   }
 
   render() {
-    const { showCustomInput, customPathSelected } = this.state
     return (
       <div className="new-external-account-form account-list">
         {this.renderHeader()}
-        {(!showCustomInput || customPathSelected) && this.renderAccounts()}
-        {(!showCustomInput || customPathSelected) && this.renderPagination()}
+        {this.renderAccounts()}
+        {this.renderPagination()}
         {this.renderButtons()}
         {this.renderForgetDevice()}
       </div>

--- a/ui/app/pages/create-account/connect-hardware/index.scss
+++ b/ui/app/pages/create-account/connect-hardware/index.scss
@@ -196,17 +196,6 @@
     margin: 0 auto 20px;
     display: flex;
   }
-
-  &__custom-input {
-    height: 54px;
-    width: 335px;
-    border: 1px solid $geyser;
-    border-radius: 4px;
-    background-color: $white;
-    color: $scorpion;
-    font-size: 16px;
-    padding: 0 20px;
-  }
 }
 
 .hw-account-list {


### PR DESCRIPTION
This reverts commit f30d261e692c668969e0a357cfd2b5f881b26095.

The custom HD path option introduced in #9367 was found to be unsafe to use, because the displayed list of accounts would differ depending on which application was open on the Ledger device. Essentially Ledger was accepting invalid inputs, and returning junk responses.

This was too dangerous to ship, as it could leave users with an account that they can't reliably recover. If we don't know how the derivation is happening, then allowing this import puts our users at risk of losing funds.

We can re-introduce this functionality after adding validation to ensure that we only allow inputs that are handled correctly by Ledger.