### PR TITLE
Fix malformed PropType declaraton

### DIFF
--- a/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
+++ b/ui/app/pages/first-time-flow/end-of-flow/end-of-flow.component.js
@@ -15,7 +15,7 @@ export default class EndOfFlowScreen extends PureComponent {
   static propTypes = {
     history: PropTypes.object,
     completionMetaMetricsName: PropTypes.string,
-    setCompletedOnboarding: PropTypes.function,
+    setCompletedOnboarding: PropTypes.func,
     onboardingInitiator: PropTypes.exact({
       location: PropTypes.string,
       tabId: PropTypes.number,


### PR DESCRIPTION
`PropTypes.function` was used accidentally instead of `PropType.func`