### PR TITLE
Fix broken LoadingScreen PropType declaration

### DIFF
--- a/ui/app/components/ui/loading-screen/loading-screen.component.js
+++ b/ui/app/components/ui/loading-screen/loading-screen.component.js
@@ -9,7 +9,7 @@ class LoadingScreen extends Component {
   }
 
   static propTypes = {
-    loadingMessage: PropTypes.oneOf([PropTypes.string, PropTypes.element]),
+    loadingMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     showLoadingSpinner: PropTypes.bool,
     header: PropTypes.element,
   }


### PR DESCRIPTION
`PropTypes.oneOf` was used accidentally instead of `PropTypes.oneOfType`. `oneOf` expects literal values, not types.