### PR TITLE
Prevent jump when hovering over asset list items

### DIFF
--- a/ui/app/components/app/asset-list-item/asset-list-item.scss
+++ b/ui/app/components/app/asset-list-item/asset-list-item.scss
@@ -46,6 +46,8 @@
     display: none;
     text-transform: uppercase;
     width: fit-content;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   @media (min-width: 576px) {


### PR DESCRIPTION
Frustratingly I didn't see the initial jump that occurs with https://github.com/MetaMask/metamask-extension/pull/9871 ; this prevents the jump when hovering over asset list items.