### PR TITLE
Move add contact button in fullscreen/expanded view lower.

### DIFF
--- a/ui/app/pages/settings/contact-list-tab/index.scss
+++ b/ui/app/pages/settings/contact-list-tab/index.scss
@@ -220,11 +220,6 @@
 
 .address-book-add-button {
   &__button {
-
-    @media screen and (max-width: 576px) {
-      top: 10px;
-    }
-
     position: absolute;
     top: 80px;
     right: 16px;
@@ -240,6 +235,10 @@
     margin-right: 5px;
     cursor: pointer;
     box-shadow: 0 2px 16px rgba(0, 0, 0, 0.25);
+
+    @media screen and (max-width: 576px) {
+      top: 10px;
+    }
   }
 }
 

--- a/ui/app/pages/settings/contact-list-tab/index.scss
+++ b/ui/app/pages/settings/contact-list-tab/index.scss
@@ -220,8 +220,13 @@
 
 .address-book-add-button {
   &__button {
+
+    @media screen and (max-width: 576px) {
+      top: 10px;
+    }
+
     position: absolute;
-    top: 10px;
+    top: 80px;
     right: 16px;
     height: 56px;
     width: 56px;


### PR DESCRIPTION
Fixes #9868

Move the add contact button that is overlapping (x)/close setting icon lower, on the same line as Contacts in fullscreen/expanded view. This should only move the button in the fullscreen/expanded view, and it should not change the button position in the extension/popup view, which overlaps the close(x) icon as well.

<details>
  <summary>Before</summary>
  <img src="https://user-images.githubusercontent.com/5479136/99068952-b3bcd900-25ad-11eb-8b22-9c7b1edfd336.png">
</details>

<details>
  <summary>After</summary>
  <img src="https://user-images.githubusercontent.com/13376180/99117493-a94d1000-25aa-11eb-85ca-b7a43eaf57d6.png">
</details>