### PR TITLE
Consolidate notification UI openers

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -225,10 +225,7 @@ function setupController(initState, initLangCode) {
   const controller = new MetamaskController({
     infuraProjectId: process.env.INFURA_PROJECT_ID,
     // User confirmation callbacks:
-    showUnconfirmedMessage: triggerUi,
-    showUnapprovedTx: triggerUi,
-    showPermissionRequest: triggerUi,
-    showUnlockRequest: triggerUi,
+    showUserConfirmation: triggerUi,
     openPopup,
     // initial state
     initState,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -150,7 +150,7 @@ export default class MetamaskController extends EventEmitter {
       isUnlocked: this.isUnlocked.bind(this),
       initState: initState.AppStateController,
       onInactiveTimeout: () => this.setLocked(),
-      showUnlockRequest: opts.showUnlockRequest,
+      showUnlockRequest: opts.showUserConfirmation,
       preferencesStore: this.preferencesController.store,
     })
 
@@ -247,7 +247,7 @@ export default class MetamaskController extends EventEmitter {
         notifyDomain: this.notifyConnections.bind(this),
         notifyAllDomains: this.notifyAllConnections.bind(this),
         preferences: this.preferencesController.store,
-        showPermissionRequest: opts.showPermissionRequest,
+        showPermissionRequest: opts.showUserConfirmation,
       },
       initState.PermissionsController,
       initState.PermissionsMetadata,
@@ -302,7 +302,7 @@ export default class MetamaskController extends EventEmitter {
       getParticipateInMetrics: () =>
         this.preferencesController.getParticipateInMetaMetrics(),
     })
-    this.txController.on('newUnapprovedTx', () => opts.showUnapprovedTx())
+    this.txController.on('newUnapprovedTx', () => opts.showUserConfirmation())
 
     this.txController.on(`tx:status-update`, async (txId, status) => {
       if (
@@ -1376,7 +1376,7 @@ export default class MetamaskController extends EventEmitter {
       req,
     )
     this.sendUpdate()
-    this.opts.showUnconfirmedMessage()
+    this.opts.showUserConfirmation()
     return promise
   }
 
@@ -1439,7 +1439,7 @@ export default class MetamaskController extends EventEmitter {
       req,
     )
     this.sendUpdate()
-    this.opts.showUnconfirmedMessage()
+    this.opts.showUserConfirmation()
     return promise
   }
 
@@ -1498,7 +1498,7 @@ export default class MetamaskController extends EventEmitter {
       req,
     )
     this.sendUpdate()
-    this.opts.showUnconfirmedMessage()
+    this.opts.showUserConfirmation()
     return promise
   }
 
@@ -1590,7 +1590,7 @@ export default class MetamaskController extends EventEmitter {
       req,
     )
     this.sendUpdate()
-    this.opts.showUnconfirmedMessage()
+    this.opts.showUserConfirmation()
     return promise
   }
 
@@ -1655,7 +1655,7 @@ export default class MetamaskController extends EventEmitter {
       version,
     )
     this.sendUpdate()
-    this.opts.showUnconfirmedMessage()
+    this.opts.showUserConfirmation()
     return promise
   }
 

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -97,8 +97,7 @@ describe('MetaMaskController', function () {
       .reply(200, '{"JPY":12415.9}')
 
     metamaskController = new MetaMaskController({
-      showUnapprovedTx: noop,
-      showUnconfirmedMessage: noop,
+      showUserConfirmation: noop,
       encryptor: {
         encrypt(_, object) {
           this.object = object

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -44,7 +44,7 @@ describe('Actions', function () {
       platform: { getVersion: () => 'foo' },
       provider,
       keyringController: new KeyringController({}),
-      showUnconfirmedMessage: noop,
+      showUserConfirmation: noop,
       encryptor: {
         encrypt(_, object) {
           this.object = object

--- a/test/unit/ui/app/actions.spec.js
+++ b/test/unit/ui/app/actions.spec.js
@@ -44,7 +44,6 @@ describe('Actions', function () {
       platform: { getVersion: () => 'foo' },
       provider,
       keyringController: new KeyringController({}),
-      showUnapprovedTx: noop,
       showUnconfirmedMessage: noop,
       encryptor: {
         encrypt(_, object) {


### PR DESCRIPTION
We were passing the `triggerUi` function from `background.js` to `MetaMaskController` under a variety of different names. This consolidates all of them under the name `showUserConfirmation`.

In a follow-up PR to this and #9401, I will move the `wallet_watchAsset` implementation to the approval controller / RPC method middleware, which will allow us to get rid of the `openPopup` param currently passed to `MetaMaskController`.