### PR TITLE
Add token verification message to swaps build quote screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2086,7 +2086,8 @@
     "message": "Username"
   },
   "verifyThisTokenOn": {
-    "message": "Verify this token on $1"
+    "message": "Verify this token on $1",
+    "description": "Points the user to etherscan as a place they can verify information about a token. $1 is replaced with the translation for \"etherscan\""
   },
   "viewAccount": {
     "message": "View Account"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -629,6 +629,9 @@
   "ethereumPublicAddress": {
     "message": "Ethereum Public Address"
   },
+  "etherscan": {
+    "message": "Etherscan"
+  },
   "etherscanView": {
     "message": "View account on Etherscan"
   },
@@ -1848,6 +1851,9 @@
   "swapUsingBestQuote": {
     "message": "Using the best quote"
   },
+  "swapVerifyTokenExplanation": {
+    "message": "Multiple tokens can use the same name and symbol. Check Etherscan to verify this is the token you're looking for."
+  },
   "swapViewToken": {
     "message": "View $1"
   },
@@ -2078,6 +2084,9 @@
   },
   "userName": {
     "message": "Username"
+  },
+  "verifyThisTokenOn": {
+    "message": "Verify this token on $1"
   },
   "viewAccount": {
     "message": "View Account"

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -13,6 +13,7 @@ import DropdownInputPair from '../dropdown-input-pair'
 import DropdownSearchList from '../dropdown-search-list'
 import SlippageButtons from '../slippage-buttons'
 import { getTokens } from '../../../ducks/metamask/metamask'
+import InfoTooltip from '../../../components/ui/info-tooltip'
 
 import {
   fetchQuotesAndSetQuoteState,
@@ -366,6 +367,31 @@ export default function BuildQuote({
             defaultToAll
           />
         </div>
+        {selectedToToken?.address &&
+          selectedToToken?.address !== ETH_SWAPS_TOKEN_OBJECT.address && (
+            <div className="build-quote__token-message">
+              <span>
+                {t('verifyThisTokenOn', [
+                  <span
+                    className="build-quote__token-etherscan-link"
+                    key="build-quote-etherscan-link"
+                    onClick={() => {
+                      const etherscanUrl = `https://etherscan.io/token/${selectedToToken.address}`
+
+                      global.platform.openTab({ url: etherscanUrl })
+                    }}
+                  >
+                    {t('etherscan')}
+                  </span>,
+                ])}
+              </span>
+              <InfoTooltip
+                position="top"
+                contentText={t('swapVerifyTokenExplanation')}
+                containerClassName="build-quote__token-tooltip-container"
+              />
+            </div>
+          )}
         <div className="build-quote__slippage-buttons-container">
           <SlippageButtons
             onSelect={(newSlippage) => {

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -370,21 +370,19 @@ export default function BuildQuote({
         {selectedToToken?.address &&
           selectedToToken?.address !== ETH_SWAPS_TOKEN_OBJECT.address && (
             <div className="build-quote__token-message">
-              <span>
-                {t('verifyThisTokenOn', [
-                  <a
-                    className="build-quote__token-etherscan-link"
-                    key="build-quote-etherscan-link"
-                    onClick={() => {
-                      const etherscanUrl = `https://etherscan.io/token/${selectedToToken.address}`
+              {t('verifyThisTokenOn', [
+                <a
+                  className="build-quote__token-etherscan-link"
+                  key="build-quote-etherscan-link"
+                  onClick={() => {
+                    const etherscanUrl = `https://etherscan.io/token/${selectedToToken.address}`
 
-                      global.platform.openTab({ url: etherscanUrl })
-                    }}
-                  >
-                    {t('etherscan')}
-                  </a>,
-                ])}
-              </span>
+                    global.platform.openTab({ url: etherscanUrl })
+                  }}
+                >
+                  {t('etherscan')}
+                </a>,
+              ])}
               <InfoTooltip
                 position="top"
                 contentText={t('swapVerifyTokenExplanation')}

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -374,11 +374,9 @@ export default function BuildQuote({
                 <a
                   className="build-quote__token-etherscan-link"
                   key="build-quote-etherscan-link"
-                  onClick={() => {
-                    const etherscanUrl = `https://etherscan.io/token/${selectedToToken.address}`
-
-                    global.platform.openTab({ url: etherscanUrl })
-                  }}
+                  href={`https://etherscan.io/token/${selectedToToken.address}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   {t('etherscan')}
                 </a>,

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -372,7 +372,7 @@ export default function BuildQuote({
             <div className="build-quote__token-message">
               <span>
                 {t('verifyThisTokenOn', [
-                  <span
+                  <a
                     className="build-quote__token-etherscan-link"
                     key="build-quote-etherscan-link"
                     onClick={() => {
@@ -382,7 +382,7 @@ export default function BuildQuote({
                     }}
                   >
                     {t('etherscan')}
-                  </span>,
+                  </a>,
                 ])}
               </span>
               <InfoTooltip

--- a/ui/app/pages/swaps/build-quote/index.scss
+++ b/ui/app/pages/swaps/build-quote/index.scss
@@ -116,6 +116,27 @@
     }
   }
 
+  &__token-message {
+    @include H7;
+
+    width: 100%;
+    color: $Grey-500;
+    margin-top: 4px;
+    display: flex;
+    align-items: center;
+  }
+
+  &__token-etherscan-link {
+    color: $Blue-500;
+    cursor: pointer;
+    margin-right: 4px;
+  }
+
+  &__token-tooltip-container {
+    // Needed to override the style property added by the react-tippy library
+    display: flex !important;
+  }
+
   /* Prevents the swaps "Swap to" field from overflowing */
   .dropdown-input-pair__to .dropdown-search-list {
     width: 100%;


### PR DESCRIPTION
Fixes part of https://github.com/MetaMask/metamask-extension/issues/9873

The user will now see a message below the token 'to' field that links them to etherscan where they can verify that the token they selected is the one they indeed wish to swap.

![build-quote-token-message](https://user-images.githubusercontent.com/7499938/99305474-68652d80-282e-11eb-8713-90d7e8dce803.gif)


