### PR TITLE
Exit `sentry:publish` with non-zero code upon failure

### DIFF
--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -5,12 +5,15 @@ const pify = require('pify')
 const exec = pify(childProcess.exec, { multiArgs: true })
 const VERSION = require('../dist/chrome/manifest.json').version // eslint-disable-line import/no-unresolved
 
-start().catch(console.error)
+start().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
 
 async function start() {
   const authWorked = await checkIfAuthWorks()
   if (!authWorked) {
-    console.log(`Sentry auth failed...`)
+    throw new Error(`Sentry auth failed`)
   }
   // check if version exists or not
   const versionAlreadyExists = await checkIfVersionExists()


### PR DESCRIPTION
The `sentry:publish` script now exits with an exit code of `1` upon failure, indicating that something went wrong. Previously it would exit with a code of `0`, indicating to CI that everything worked correctly.

The script will now also exit early if the authentication check fails.