### PR TITLE
Track web3 usage as legacy event

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -44,7 +44,7 @@ function logWeb3UsageHandler(req, res, _next, end, { origin, sendMetrics }) {
     recordedWeb3Usage[origin][path] = true
 
     sendMetrics({
-      matomo: true,
+      matomoEvent: true,
       event: `Website Used window.web3`,
       category: 'inpage_provider',
       properties: { action, web3Path: path },


### PR DESCRIPTION
The web3 usage event was mistakenly tracked as a "new" event instead of as a legacy event. This was due to a mistake when setting the `matomoEvent` flag (`matomo` was set instead, which was ignored).