### PR TITLE
show failed token balance updates

### DIFF
--- a/ui/app/components/app/token-cell/token-cell.js
+++ b/ui/app/components/app/token-cell/token-cell.js
@@ -10,7 +10,7 @@ import { useTokenFiatAmount } from '../../../hooks/useTokenFiatAmount'
 export default function TokenCell({
   address,
   decimals,
-  outdatedBalance,
+  balanceError,
   symbol,
   string,
   image,
@@ -21,13 +21,14 @@ export default function TokenCell({
 
   const formattedFiat = useTokenFiatAmount(address, string, symbol)
 
-  const warning = outdatedBalance ? (
+  const warning = balanceError ? (
     <span>
       {t('troubleTokenBalances')}
       <a
         href={`https://ethplorer.io/address/${userAddress}`}
         rel="noopener noreferrer"
         target="_blank"
+        onClick={(event) => event.stopPropagation()}
         style={{ color: '#F7861C' }}
       >
         {t('here')}
@@ -38,7 +39,7 @@ export default function TokenCell({
   return (
     <AssetListItem
       className={classnames('token-cell', {
-        'token-cell--outdated': outdatedBalance,
+        'token-cell--outdated': Boolean(balanceError),
       })}
       iconClassName="token-cell__icon"
       onClick={onClick.bind(null, address)}
@@ -55,7 +56,7 @@ export default function TokenCell({
 
 TokenCell.propTypes = {
   address: PropTypes.string,
-  outdatedBalance: PropTypes.bool,
+  balanceError: PropTypes.object,
   symbol: PropTypes.string,
   decimals: PropTypes.number,
   string: PropTypes.string,
@@ -64,5 +65,5 @@ TokenCell.propTypes = {
 }
 
 TokenCell.defaultProps = {
-  outdatedBalance: false,
+  balanceError: null,
 }

--- a/ui/app/components/app/token-list/token-list.js
+++ b/ui/app/components/app/token-list/token-list.js
@@ -16,7 +16,7 @@ export default function TokenList({ onTokenClick }) {
   // from the background so it has a new reference with each background update,
   // even if the tokens haven't changed
   const tokens = useSelector(getTokens, isEqual)
-  const { loading, error, tokensWithBalances } = useTokenTracker(tokens)
+  const { loading, tokensWithBalances } = useTokenTracker(tokens, true)
 
   if (loading) {
     return (
@@ -38,14 +38,7 @@ export default function TokenList({ onTokenClick }) {
     <div>
       {tokensWithBalances.map((tokenData, index) => {
         tokenData.image = assetImages[tokenData.address]
-        return (
-          <TokenCell
-            key={index}
-            {...tokenData}
-            outdatedBalance={Boolean(error)}
-            onClick={onTokenClick}
-          />
-        )
+        return <TokenCell key={index} {...tokenData} onClick={onTokenClick} />
       })}
     </div>
   )

--- a/ui/app/hooks/useTokenTracker.js
+++ b/ui/app/hooks/useTokenTracker.js
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import { getCurrentNetwork, getSelectedAddress } from '../selectors'
 import { useEqualityCheck } from './useEqualityCheck'
 
-export function useTokenTracker(tokens) {
+export function useTokenTracker(tokens, includeFailedTokens = false) {
   const network = useSelector(getCurrentNetwork)
   const userAddress = useSelector(getSelectedAddress)
 
@@ -42,6 +42,7 @@ export function useTokenTracker(tokens) {
         userAddress: address,
         provider: global.ethereumProvider,
         tokens: tokenList,
+        includeFailedTokens,
         pollingInterval: 8000,
       })
 
@@ -49,7 +50,7 @@ export function useTokenTracker(tokens) {
       tokenTracker.current.on('error', showError)
       tokenTracker.current.updateBalances()
     },
-    [updateBalances, showError, teardownTracker],
+    [updateBalances, includeFailedTokens, showError, teardownTracker],
   )
 
   // Effect to remove the tracker when the component is removed from DOM


### PR DESCRIPTION
Fixes: #9057 

~requires the future release of eth-token-tracker after https://github.com/MetaMask/eth-token-tracker/pull/53 lands.~

steps to test:
1. clone eth-token-tracker and checkout allow-updating-failed-tokens branch.
2. run `yarn install`
3. run `yarn build`
4. run `yarn link`
5. switch to metamask-extension repo
6. run `yarn link @metamask/eth-token-tracker`
7. run `yarn start`
8. load the assets screen and follow the steps in #9057

<details>
<summary>Before (no tokens show up due to error) </summary>
<img src="https://user-images.githubusercontent.com/4448075/99457340-7085a180-28f0-11eb-9542-f0d0c7a4ab2c.png" alt="Before: No tokens show up due to error in SNX" />



</details>

<details>
<summary>After (all tokens show up, error on SNX) </summary>
<img src="https://user-images.githubusercontent.com/4448075/99457090-0836c000-28f0-11eb-9c72-a5dd1358ceaf.png" alt="After: All tokens show up, error shown only on SNX" />

</details>