### PR TITLE
Remove invalid `matomo` metric event option

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-usage.js
@@ -44,7 +44,6 @@ function logWeb3UsageHandler(req, res, _next, end, { origin, sendMetrics }) {
     recordedWeb3Usage[origin][path] = true
 
     sendMetrics({
-      matomo: true,
       event: `Website Used window.web3`,
       category: 'inpage_provider',
       properties: { action, web3Path: path },


### PR DESCRIPTION
The `matomo` option passed to the send metrics function is invalid. The intent was to set the `matomoEvent` option, but instead of rectifying that, we've decide to keep sending this event to the production Segment project for now. The invalid option has been removed.