### PR TITLE
fix METAMASK-GH2B

### DIFF
--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -127,7 +127,8 @@ export function MetaMetricsProvider({ children }) {
         location.pathname.startsWith('/initialize')) ||
       participateInMetaMetrics
     ) {
-      // Events that happen during initialization before the user opts into MetaMetrics will be anonymous
+      // Events that happen during initialization before the user opts into
+      // MetaMetrics will be anonymous
       const idTrait = metaMetricsId ? 'userId' : 'anonymousId'
       const idValue = metaMetricsId ?? METAMETRICS_ANONYMOUS_ID
       const match = matchPath(location.pathname, {
@@ -135,19 +136,15 @@ export function MetaMetricsProvider({ children }) {
         exact: true,
         strict: true,
       })
-      // Start by checking for a missing match route. If this falls through to the else if, then we know we
-      // have a matched route for tracking.
+      // Start by checking for a missing match route. If this falls through to
+      // the else if, then we know we have a matched route for tracking.
       if (!match) {
-        // We have more specific pages for each type of transaction confirmation
-        // The user lands on /confirm-transaction first, then is redirected based on
-        // the contents of state.
-        if (location.pathname !== '/confirm-transaction') {
-          // Otherwise we are legitimately missing a matching route
-          captureMessage(`Segment page tracking found unmatched route`, {
+        captureMessage(`Segment page tracking found unmatched route`, {
+          extra: {
             previousMatch,
             currentPath: location.pathname,
-          })
-        }
+          },
+        })
       } else if (
         previousMatch.current !== match.path &&
         !(
@@ -156,9 +153,11 @@ export function MetaMetricsProvider({ children }) {
           previousMatch.current === undefined
         )
       ) {
-        // When a notification window is open by a Dapp we do not want to track the initial home route load that can
-        // sometimes happen. To handle this we keep track of the previousMatch, and we skip the event track in the event
-        // that we are dealing with the initial load of the homepage
+        // When a notification window is open by a Dapp we do not want to track
+        // the initial home route load that can sometimes happen. To handle
+        // this we keep track of the previousMatch, and we skip the event track
+        // in the event that we are dealing with the initial load of the
+        // homepage
         const { path, params } = match
         const name = PATH_NAME_MAP[path]
         segment.page({

--- a/ui/app/helpers/constants/routes.js
+++ b/ui/app/helpers/constants/routes.js
@@ -99,6 +99,8 @@ const PATH_NAME_MAP = {
   [`${CONNECT_ROUTE}/:id${CONNECT_CONFIRM_PERMISSIONS_ROUTE}`]: 'Grant Connected Site Permissions Confirmation Page',
   [CONNECTED_ROUTE]: 'Sites Connected To This Account Page',
   [CONNECTED_ACCOUNTS_ROUTE]: 'Accounts Connected To This Site Page',
+  [`${CONFIRM_TRANSACTION_ROUTE}/:id`]: 'Confirmation Root Page',
+  [CONFIRM_TRANSACTION_ROUTE]: 'Confirmation Root Page',
   [`${CONFIRM_TRANSACTION_ROUTE}/:id${CONFIRM_TOKEN_METHOD_PATH}`]: 'Confirm Token Method Transaction Page',
   [`${CONFIRM_TRANSACTION_ROUTE}/:id${CONFIRM_SEND_ETHER_PATH}`]: 'Confirm Send Ether Transaction Page',
   [`${CONFIRM_TRANSACTION_ROUTE}/:id${CONFIRM_SEND_TOKEN_PATH}`]: 'Confirm Send Token Transaction Page',


### PR DESCRIPTION
Fixes: METAMASK-GH2B

Explanation: Frequent issues related to missing route tracks due to a route not matching. In the implementation of page tracking, I skipped the root '/confirmation' route. The root confirmation route has no UI representation and redirects the user to the more specific confirmation routes based on type. This has been prone to err so far. 

My investigation looked at a handful of error instances, and I noticed that these weren't single confirmation flows. Each of them involves clicking something (like the next button on multiple confirmation screens or an unapproved tx in full screen). I was able to reproduce the error in fullscreen mode by clicking on an unapproved signature request. I could also reproduce by stacking multiple confirmation screens in the correct order (but I did not confirm what that order is) inconsistently. 

This complexity of implementation and the resulting error is accidental; there was no requirement to *not track this route*. I tried to prevent noise in the signal, but these pages might hold a value that we do not yet know of. Most certainly, it isn't worth adding additional noise to our error reports.

I noticed that in fullscreen mode, the confirmation-route also gets triggered with the id of the original window that triggered the approval (`confirm-transaction/00000` for example), so I added that path as well as the base to the PATH_NAME_MAP, which is used to compute the `PATHS_TO_CHECK` constant. 

Additionally, I realized I made a mistake in implementing the extra data attributes to attach to this error. This has been resolved so that future instances of this error will hopefully signal actual issues with our routing and will be easier to debug. 
