### PR TITLE
Validate sendToken address when component updates

### DIFF
--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -154,6 +154,7 @@ export default class SendTransactionScreen extends Component {
 
     if (sendTokenAddress && prevTokenAddress !== sendTokenAddress) {
       this.updateSendToken()
+      this.validate(sendTokenAddress)
       updateGas = true
     }
 

--- a/ui/app/pages/send/tests/send-component.test.js
+++ b/ui/app/pages/send/tests/send-component.test.js
@@ -138,7 +138,7 @@ describe('Send Component', function () {
           balance: '',
         },
       })
-      assert(utilsMethodStubs.doesAmountErrorRequireUpdate.calledOnce)
+      assert(utilsMethodStubs.doesAmountErrorRequireUpdate.calledTwice)
       assert.deepEqual(
         utilsMethodStubs.doesAmountErrorRequireUpdate.getCall(0).args[0],
         {


### PR DESCRIPTION
On a reproduction of trying to get the `Known contract address` error message it seems that if an token address is set as the recipient along with asset ETH selected then changing the asset to a token address, the error message won't show.

This will validate the sendtoken address on prop change to properly update the warning message.

Manual testing steps:  

1. On the home screen, Click Send button.
2. Add a token contract to recipient address. i.e. `0x0F5D2fB29fb7d3CFeE444a200298f468908cC942 (MANA)`
3. On the Screen, the Asset should be ETH. Change to any Token. 
4. The warning `Known contract address` should not show.

Additional feedback: 
Is the `Known contract address` error sufficient description? Maybe it should be clearer, like `Warning: sending token to token address`?