### PR TITLE
Fix metaMaskFee proptypes error

### DIFF
--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -368,7 +368,7 @@ export default function ViewQuote() {
     bestQuoteReviewedEvent,
   ])
 
-  const metaMaskFee = usedQuote.fee
+  const metaMaskFee = String(usedQuote.fee)
 
   const onFeeCardTokenApprovalClick = () => {
     editSpendLimitOpened()


### PR DESCRIPTION
Explanation:  

I'm seeing a swaps propType error due to `metaMaskFee`.  This might be reverted in https://github.com/MetaMask/metamask-extension/pull/9904 but since it's a `develop` error now, I wanted to fix it.

@danjm Feel free to just close this if it's unwanted.