### PR TITLE
Revert "Show a 'send eth' button on home screen in full screen mode"

### DIFF
--- a/ui/app/components/app/asset-list/asset-list.js
+++ b/ui/app/components/app/asset-list/asset-list.js
@@ -13,13 +13,11 @@ import {
   getCurrentAccountWithSendEtherInfo,
   getNativeCurrency,
   getShouldShowFiat,
-  getSelectedAddress,
 } from '../../../selectors'
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay'
 
 const AssetList = ({ onClickAsset }) => {
   const history = useHistory()
-  const selectedAddress = useSelector((state) => getSelectedAddress(state))
   const selectedAccountBalance = useSelector(
     (state) => getCurrentAccountWithSendEtherInfo(state).balance,
   )
@@ -71,7 +69,6 @@ const AssetList = ({ onClickAsset }) => {
         onClick={() => onClickAsset(nativeCurrency)}
         data-testid="wallet-balance"
         primary={primaryCurrencyProperties.value}
-        tokenAddress={selectedAddress}
         tokenSymbol={primaryCurrencyProperties.suffix}
         secondary={showFiat ? secondaryCurrencyDisplay : undefined}
       />


### PR DESCRIPTION
Reverts MetaMask/metamask-extension#9845

Unfortunately this patch has introduced a bug where the incorrect icon displays next to ETH.