### PR TITLE
Include error string from ledger errors

### DIFF
--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -125,7 +125,7 @@ class ConnectHardwareForm extends Component {
         }
       })
       .catch((e) => {
-        const errorMessage = e.message || e
+        const errorMessage = typeof e === 'string' ? e : e.message
         if (errorMessage === 'Window blocked') {
           this.setState({ browserSupported: false, error: null })
         } else if (errorMessage.includes(U2F_ERROR)) {

--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -33,6 +33,10 @@ class ConnectHardwareForm extends Component {
     this.setState({ accounts: newAccounts })
   }
 
+  componentDidMount() {
+    this.checkIfUnlocked()
+  }
+
   async checkIfUnlocked() {
     for (const device of ['trezor', 'ledger']) {
       const unlocked = await this.props.checkHardwareStatus(

--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -33,10 +33,6 @@ class ConnectHardwareForm extends Component {
     this.setState({ accounts: newAccounts })
   }
 
-  componentDidMount() {
-    this.checkIfUnlocked()
-  }
-
   async checkIfUnlocked() {
     for (const device of ['trezor', 'ledger']) {
       const unlocked = await this.props.checkHardwareStatus(
@@ -129,7 +125,7 @@ class ConnectHardwareForm extends Component {
         }
       })
       .catch((e) => {
-        const errorMessage = e.message
+        const errorMessage = e.message || e
         if (errorMessage === 'Window blocked') {
           this.setState({ browserSupported: false, error: null })
         } else if (errorMessage.includes(U2F_ERROR)) {
@@ -210,6 +206,7 @@ class ConnectHardwareForm extends Component {
             // eslint-disable-next-line react/jsx-key
             <a
               href="https://metamask.zendesk.com/hc/en-us/articles/360020394612-How-to-connect-a-Trezor-or-Ledger-Hardware-Wallet"
+              key="hardware-connection-guide"
               target="_blank"
               rel="noopener noreferrer"
               className="hw-connect__link"


### PR DESCRIPTION
<del>Also remove the componentMount to check hardware status. This would constantly check the status of the hardware wallet upon mounting, even after the wallet is unplugged.</del>

Manual testing steps on Win10/Firefox

1. Do not plug in ledger
2. Select Ledger and attempt to connect even though one is not connected.
2.1 Win10 users will need to cancel/close(x) the Windows Security window for usb.
3. After some time, the error `TypeError: t is undefined` will log to the console, and the error message won't render, https://github.com/MetaMask/metamask-extension/blob/60d3d980bea5354be994eedb520ad65ffea2f178/ui%2Fapp%2Fpages%2Fcreate-account%2Fconnect-hardware%2Findex.js#L200-L220