### PR TITLE
Use getTokenTrackerLink for asset view etherscan link in token-asset.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@metamask/controllers": "^4.2.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^3.0.1",
-    "@metamask/etherscan-link": "^1.2.0",
+    "@metamask/etherscan-link": "^1.3.0",
     "@metamask/inpage-provider": "^6.1.0",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^2.5.0",

--- a/ui/app/pages/asset/components/token-asset.js
+++ b/ui/app/pages/asset/components/token-asset.js
@@ -2,10 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
+import { getTokenTrackerLink } from '@metamask/etherscan-link'
 
 import TransactionList from '../../../components/app/transaction-list'
 import { TokenOverview } from '../../../components/app/wallet-overview'
-import { getSelectedIdentity } from '../../../selectors/selectors'
+import {
+  getCurrentNetworkId,
+  getSelectedIdentity,
+} from '../../../selectors/selectors'
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes'
 import { showModal } from '../../../store/actions'
 
@@ -14,6 +18,7 @@ import TokenOptions from './token-options'
 
 export default function TokenAsset({ token }) {
   const dispatch = useDispatch()
+  const network = useSelector(getCurrentNetworkId)
   const selectedIdentity = useSelector(getSelectedIdentity)
   const selectedAccountName = selectedIdentity.name
   const selectedAddress = selectedIdentity.address
@@ -31,7 +36,11 @@ export default function TokenAsset({ token }) {
               dispatch(showModal({ name: 'HIDE_TOKEN_CONFIRMATION', token }))
             }
             onViewEtherscan={() => {
-              const url = `https://etherscan.io/token/${token.address}?a=${selectedAddress}`
+              const url = getTokenTrackerLink(
+                token.address,
+                network,
+                selectedAddress,
+              )
               global.platform.openTab({ url })
             }}
             tokenSymbol={token.symbol}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,10 +1891,10 @@
     human-standard-token-abi "^1.0.2"
     safe-event-emitter "^1.0.1"
 
-"@metamask/etherscan-link@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-1.2.0.tgz#677aa49774bd41a1f0fe783a9c04e13075ad73d2"
-  integrity sha512-zSrOowUdEmr2u3HrlrO/dn1Wc6REXvs0bV1m9/JJmzLw1fXpJQ6qn2sPeu/KtZF0Im9iPt4a01nGjFuhzot54w==
+"@metamask/etherscan-link@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-1.3.0.tgz#ce5b9e0083f51386f8f462110b4094cf6243022c"
+  integrity sha512-2BLaSJLqOIq5CasneVqortc7sPMjgXDTdPv4dSjseF+RUtv/HPTSXZPhV2dFkGd/n+eCQoevPRVOFsVvuRnFeA==
 
 "@metamask/forwarder@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Improves on the solution in https://github.com/MetaMask/metamask-extension/pull/9909 by using the solution from https://github.com/MetaMask/etherscan-link/pull/23 that was fixed in https://github.com/MetaMask/etherscan-link/pull/24

Blocked by https://github.com/MetaMask/etherscan-link/pull/24 and will need to update yarn.lock whenthat is merged and version bumped