### PR TITLE
Ensure custom slippage is a number

### DIFF
--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -299,7 +299,7 @@ export default function Swap() {
                     ethBalance={ethBalance}
                     setMaxSlippage={setMaxSlippage}
                     selectedAccountAddress={selectedAccountAddress}
-                    maxSlippage={Number(maxSlippage)}
+                    maxSlippage={maxSlippage}
                   />
                 )
               }}

--- a/ui/app/pages/swaps/select-quote-popover/select-quote-popover-constants.js
+++ b/ui/app/pages/swaps/select-quote-popover/select-quote-popover-constants.js
@@ -10,7 +10,7 @@ export const QUOTE_DATA_ROWS_PROPTYPES_SHAPE = PropTypes.shape({
   networkFees: PropTypes.string.isRequired,
   quoteSource: PropTypes.string.isRequired,
   rawNetworkFees: PropTypes.string.isRequired,
-  slippage: PropTypes.string.isRequired,
+  slippage: PropTypes.number.isRequired,
   sourceTokenDecimals: PropTypes.number.isRequired,
   sourceTokenSymbol: PropTypes.string.isRequired,
   sourceTokenValue: PropTypes.string.isRequired,

--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -116,7 +116,7 @@ export default function SlippageButtons({ onSelect }) {
                     <input
                       onChange={(event) => {
                         setCustomValue(event.target.value)
-                        onSelect(event.target.value)
+                        onSelect(Number(event.target.value))
                       }}
                       type="number"
                       step="0.1"


### PR DESCRIPTION
This fixes a PropType error when using non-custom slippage, and it fixes a type inconsistency when custom slippage is used.

Previously, `slippage` was being converted explicitly to a `Number` as it was passed into `BuildQuote`, but not as it was passed into `AwaitingSwap`. Also the PropType was set as `string`, despite the fact that it's a number in most cases, and is used for math.

The PropType has been changed to `number`, and the selective casting to `Number` has been removed. Instead, the `maxSlippage` value is cast to a `Number` as it's being selected, so that the type is always consistent.