### PR TITLE
validate addresses in qr codes

### DIFF
--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import ethUtil from 'ethereumjs-util'
 import { debounce } from 'lodash'
 import {
   getAmountErrorObject,
@@ -16,6 +17,7 @@ import AddRecipient from './send-content/add-recipient'
 import SendContent from './send-content'
 import SendFooter from './send-footer'
 import EnsInput from './send-content/add-recipient/ens-input'
+import { INVALID_RECIPIENT_ADDRESS_ERROR } from './send.constants'
 
 export default class SendTransactionScreen extends Component {
   static propTypes = {
@@ -161,12 +163,18 @@ export default class SendTransactionScreen extends Component {
     if (qrCodeData) {
       if (qrCodeData.type === 'address') {
         scannedAddress = qrCodeData.values.address.toLowerCase()
-        const currentAddress = prevTo?.toLowerCase()
-        if (currentAddress !== scannedAddress) {
-          updateSendTo(scannedAddress)
-          updateGas = true
-          // Clean up QR code data after handling
+        if (ethUtil.isValidAddress(scannedAddress)) {
+          const currentAddress = prevTo?.toLowerCase()
+          if (currentAddress !== scannedAddress) {
+            updateSendTo(scannedAddress)
+            updateGas = true
+            // Clean up QR code data after handling
+            qrCodeDetected(null)
+          }
+        } else {
+          scannedAddress = null
           qrCodeDetected(null)
+          this.setState({ toError: INVALID_RECIPIENT_ADDRESS_ERROR })
         }
       }
     }


### PR DESCRIPTION
Fixes: #9889 

Explanation:  We didn't do any validation of the to address, and this would incorrectly interpret ERC-20 token send encoded uris as being sent to the token address. This PR just checks the validity of the address.

<details>
<summary>Valid QR code (ethereum:xxxx) </summary>

<img src="https://user-images.githubusercontent.com/4448075/99682666-1a764280-2a45-11eb-8fbd-64328a40020c.png" width="50%"/>


</details>

<details>
<summary>Invalid QR code (ethereum:xxxx/transfer?address=xxxx&uint256=1) vis a vis <a href="https://eips.ethereum.org/EIPS/eip-681" target="_blank"> eip-681</a></summary>

<img src="https://user-images.githubusercontent.com/4448075/99683238-bc962a80-2a45-11eb-9d2e-59b2025791b5.png" width="50%" />

</details>

Manual testing steps:  
  - Open extension
  - Click send
  - Click the QR code scanner button in ENS input field
  - Scan the valid QR code example
  - See that an address is populated.
  - Repeat steps above with the invalid QR code
  - See an error message. 