### PR TITLE
Override font-weight from Paragraph and set to 900

### DIFF
--- a/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
+++ b/ui/app/components/app/gas-customization/gas-price-button-group/index.scss
@@ -247,6 +247,7 @@
 
       display: flex;
       color: $primary-blue;
+      font-weight: 900;
     }
   }
 }

--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -42,6 +42,7 @@
 
   &__icon {
     @include Paragraph;
+
     font-weight: 900;
   }
 }

--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -42,5 +42,6 @@
 
   &__icon {
     @include Paragraph;
+    font-weight: 900;
   }
 }


### PR DESCRIPTION
Fixes: Missing icon next to `View on Etherscan` on an individual token

<details>
  <summary>Before</summary>
  <img src="https://user-images.githubusercontent.com/13376180/99712698-46e78a00-2a58-11eb-9cd4-5d4c148949ff.png">
</details>

<details>
  <summary>After</summary>
  <img src="https://user-images.githubusercontent.com/13376180/99712612-29b2bb80-2a58-11eb-8dce-a9157156145d.png">
</details>

Addition: Fixes: #9762

<details>
  <summary>Before</summary>
  <img src="https://user-images.githubusercontent.com/46655/97648994-32e5d500-1a24-11eb-89b3-830c4f9b8fbe.png">
</details>


<details>
  <summary>After</summary>
  <img src="https://user-images.githubusercontent.com/13376180/99717930-ec9df780-2a5e-11eb-83c5-6bbab654d5c5.png">
</details>
