### PR TITLE
json-rpc-engine@6.1.0

### DIFF
--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -1,5 +1,4 @@
-import mergeMiddleware from 'json-rpc-engine/src/mergeMiddleware'
-import createScaffoldMiddleware from 'json-rpc-engine/src/createScaffoldMiddleware'
+import { createScaffoldMiddleware, mergeMiddleware } from 'json-rpc-engine'
 import createBlockReRefMiddleware from 'eth-json-rpc-middleware/block-ref'
 import createRetryOnEmptyMiddleware from 'eth-json-rpc-middleware/retryOnEmpty'
 import createBlockCacheMiddleware from 'eth-json-rpc-middleware/block-cache'

--- a/app/scripts/controllers/network/createJsonRpcClient.js
+++ b/app/scripts/controllers/network/createJsonRpcClient.js
@@ -1,5 +1,4 @@
-import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware'
-import mergeMiddleware from 'json-rpc-engine/src/mergeMiddleware'
+import { createAsyncMiddleware, mergeMiddleware } from 'json-rpc-engine'
 import createFetchMiddleware from 'eth-json-rpc-middleware/fetch'
 import createBlockRefRewriteMiddleware from 'eth-json-rpc-middleware/block-ref-rewrite'
 import createBlockCacheMiddleware from 'eth-json-rpc-middleware/block-cache'

--- a/app/scripts/controllers/network/createMetamaskMiddleware.js
+++ b/app/scripts/controllers/network/createMetamaskMiddleware.js
@@ -1,5 +1,4 @@
-import mergeMiddleware from 'json-rpc-engine/src/mergeMiddleware'
-import createScaffoldMiddleware from 'json-rpc-engine/src/createScaffoldMiddleware'
+import { createScaffoldMiddleware, mergeMiddleware } from 'json-rpc-engine'
 import createWalletSubprovider from 'eth-json-rpc-middleware/wallet'
 import {
   createPendingNonceMiddleware,

--- a/app/scripts/controllers/network/middleware/pending.js
+++ b/app/scripts/controllers/network/middleware/pending.js
@@ -1,4 +1,4 @@
-import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware'
+import { createAsyncMiddleware } from 'json-rpc-engine'
 import { formatTxMetaForRpcResult } from '../util'
 
 export function createPendingNonceMiddleware({ getPendingNonce }) {

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -2,7 +2,7 @@ import assert from 'assert'
 import EventEmitter from 'events'
 import ObservableStore from 'obs-store'
 import ComposedStore from 'obs-store/lib/composed'
-import JsonRpcEngine from 'json-rpc-engine'
+import { JsonRpcEngine } from 'json-rpc-engine'
 import providerFromEngine from 'eth-json-rpc-middleware/providerFromEngine'
 import log from 'loglevel'
 import {

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -1,6 +1,5 @@
 import nanoid from 'nanoid'
-import JsonRpcEngine from 'json-rpc-engine'
-import asMiddleware from 'json-rpc-engine/src/asMiddleware'
+import { JsonRpcEngine } from 'json-rpc-engine'
 import ObservableStore from 'obs-store'
 import log from 'loglevel'
 import { CapabilitiesController as RpcCap } from 'rpc-cap'
@@ -109,7 +108,7 @@ export class PermissionsController {
       }),
     )
 
-    return asMiddleware(engine)
+    return engine.asMiddleware()
   }
 
   /**

--- a/app/scripts/controllers/permissions/permissionsMethodMiddleware.js
+++ b/app/scripts/controllers/permissions/permissionsMethodMiddleware.js
@@ -1,4 +1,4 @@
-import createAsyncMiddleware from 'json-rpc-engine/src/createAsyncMiddleware'
+import { createAsyncMiddleware } from 'json-rpc-engine'
 import { ethErrors } from 'eth-json-rpc-errors'
 
 /**

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -7,7 +7,7 @@ const Box = process.env.IN_TEST
 /* eslint-enable import/order */
 
 import log from 'loglevel'
-import JsonRpcEngine from 'json-rpc-engine'
+import { JsonRpcEngine } from 'json-rpc-engine'
 import providerFromEngine from 'eth-json-rpc-middleware/providerFromEngine'
 import Migrator from '../lib/migrator'
 import migrations from '../migrations'

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4,7 +4,7 @@ import pump from 'pump'
 import Dnode from 'dnode'
 import ObservableStore from 'obs-store'
 import asStream from 'obs-store/lib/asStream'
-import RpcEngine from 'json-rpc-engine'
+import { JsonRpcEngine } from 'json-rpc-engine'
 import { debounce } from 'lodash'
 import createEngineStream from 'json-rpc-middleware-stream/engineStream'
 import createFilterMiddleware from 'eth-json-rpc-filters'
@@ -1935,7 +1935,7 @@ export default class MetamaskController extends EventEmitter {
     isInternal = false,
   }) {
     // setup json rpc engine stack
-    const engine = new RpcEngine()
+    const engine = new JsonRpcEngine()
     const { provider, blockTracker } = this
 
     // create filter polyfill middleware

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
     "human-standard-token-abi": "^2.0.0",
-    "json-rpc-engine": "^5.3.0",
+    "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^2.1.1",
     "jsonschema": "^1.2.4",
     "lodash": "^4.17.19",

--- a/test/stub/provider.js
+++ b/test/stub/provider.js
@@ -1,4 +1,4 @@
-import JsonRpcEngine from 'json-rpc-engine'
+import { JsonRpcEngine } from 'json-rpc-engine'
 import scaffoldMiddleware from 'eth-json-rpc-middleware/scaffold'
 import providerAsMiddleware from 'eth-json-rpc-middleware/providerAsMiddleware'
 import GanacheCore from 'ganache-core'

--- a/test/unit/app/controllers/permissions/permissions-controller-test.js
+++ b/test/unit/app/controllers/permissions/permissions-controller-test.js
@@ -1290,12 +1290,6 @@ describe('permissions controller', function () {
       }, 'should not throw')
 
       assert.equal(typeof middleware, 'function', 'should return function')
-
-      assert.equal(
-        middleware.name,
-        'engineAsMiddleware',
-        'function name should be "engineAsMiddleware"',
-      )
     })
 
     it('should create a middleware with extensionId', function () {
@@ -1310,12 +1304,6 @@ describe('permissions controller', function () {
       }, 'should not throw')
 
       assert.equal(typeof middleware, 'function', 'should return function')
-
-      assert.equal(
-        middleware.name,
-        'engineAsMiddleware',
-        'function name should be "engineAsMiddleware"',
-      )
 
       const metadataStore = permController.store.getState()[METADATA_STORE_KEY]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,6 +1932,11 @@
     gl-mat4 "1.1.4"
     gl-vec3 "1.0.3"
 
+"@metamask/safe-event-emitter@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
+  integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
+
 "@metamask/test-dapp@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/test-dapp/-/test-dapp-4.0.1.tgz#fbc66069687f0502ebb4c6ac0fa7c9862ea6563c"
@@ -9916,6 +9921,13 @@ eth-rpc-errors@^4.0.0:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
+eth-rpc-errors@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.2.tgz#11bc164e25237a679061ac05b7da7537b673d3b7"
+  integrity sha512-n+Re6Gu8XGyfFy1it0AwbD1x0MUzspQs0D5UiPs1fFPCr6WAwZM+vbIhXheBFrpgosqN9bs5PqlB4Q61U/QytQ==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 eth-sig-util@^1.4.0, eth-sig-util@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-1.4.2.tgz#8d958202c7edbaae839707fba6f09ff327606210"
@@ -15250,6 +15262,14 @@ json-rpc-engine@^5.2.0, json-rpc-engine@^5.3.0:
   dependencies:
     eth-rpc-errors "^3.0.0"
     safe-event-emitter "^1.0.1"
+
+json-rpc-engine@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz#bf5ff7d029e1c1bf20cb6c0e9f348dcd8be5a393"
+  integrity sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==
+  dependencies:
+    "@metamask/safe-event-emitter" "^2.0.0"
+    eth-rpc-errors "^4.0.2"
 
 json-rpc-error@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- `json-rpc-engine@6.1.0`
  - A major version bump, but not breaking for our purposes, except the exports.