### PR TITLE
add version to page events

### DIFF
--- a/ui/app/contexts/metametrics.new.js
+++ b/ui/app/contexts/metametrics.new.js
@@ -83,6 +83,12 @@ export function MetaMetricsProvider({ children }) {
   const context = useSegmentContext()
   const network = useSelector(getMetricsNetworkIdentifier)
   const chainId = useSelector(getCurrentChainId)
+  // Temporary until the background controller refactor merges:
+  const baseVersion = global.platform.getVersion()
+  const version =
+    process.env.METAMASK_ENVIRONMENT === 'production'
+      ? baseVersion
+      : `${baseVersion}-${process.env.METAMASK_ENVIRONMENT}`
 
   /**
    * track a metametrics event
@@ -171,13 +177,17 @@ export function MetaMetricsProvider({ children }) {
             network,
             environment_type: environmentType,
           },
-          context,
+          context: {
+            ...context,
+            version,
+          },
         })
       }
       previousMatch.current = match?.path
     }
   }, [
     location,
+    version,
     locale,
     context,
     network,


### PR DESCRIPTION
Fixes: missing app key in the context of page events

Explanation: page events have not had an app key since 8.1.2, the setting of this context value was moved to the shared implementation but the page was only implemented in the frontend -- resulting in the loss of this context key.
