### PR TITLE
Allow speeding up of all submitted txs from the activity log.

### DIFF
--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
@@ -115,7 +115,7 @@ describe('TransactionActivityLog Component', function () {
     )
   })
 
-  it('should only render inline retry and cancel buttons for newer pending transactions and submitted txs', function () {
+  it('should not render inline retry and cancel buttons for newer pending transactions but does for submitted transactions', function () {
     const activities = [
       {
         eventKey: 'transactionCreated',

--- a/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
+++ b/ui/app/components/app/transaction-activity-log/tests/transaction-activity-log.component.test.js
@@ -58,7 +58,7 @@ describe('TransactionActivityLog Component', function () {
     assert.ok(wrapper.hasClass('test-class'))
   })
 
-  it('should render inline retry and cancel buttons for earliest pending transaction', function () {
+  it('should render inline retry and cancel buttons for earliest pending transaction and submitted transactions', function () {
     const activities = [
       {
         eventKey: 'transactionCreated',
@@ -111,11 +111,11 @@ describe('TransactionActivityLog Component', function () {
     assert.ok(wrapper.hasClass('test-class'))
     assert.equal(
       wrapper.find('.transaction-activity-log__action-link').length,
-      2,
+      3,
     )
   })
 
-  it('should not render inline retry and cancel buttons for newer pending transactions', function () {
+  it('should only render inline retry and cancel buttons for newer pending transactions and submitted txs', function () {
     const activities = [
       {
         eventKey: 'transactionCreated',
@@ -168,7 +168,7 @@ describe('TransactionActivityLog Component', function () {
     assert.ok(wrapper.hasClass('test-class'))
     assert.equal(
       wrapper.find('.transaction-activity-log__action-link').length,
-      0,
+      1,
     )
   })
 })

--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -8,7 +8,10 @@ import {
 import { formatDate } from '../../../helpers/utils/util'
 import { getEtherscanNetworkPrefix } from '../../../../lib/etherscan-prefix-for-network'
 import TransactionActivityLogIcon from './transaction-activity-log-icon'
-import { CONFIRMED_STATUS } from './transaction-activity-log.constants'
+import {
+  CONFIRMED_STATUS,
+  TRANSACTION_SUBMITTED_EVENT,
+} from './transaction-activity-log.constants'
 
 export default class TransactionActivityLog extends PureComponent {
   static contextTypes = {
@@ -39,7 +42,7 @@ export default class TransactionActivityLog extends PureComponent {
     global.platform.openTab({ url: etherscanUrl })
   }
 
-  renderInlineRetry(index) {
+  renderInlineRetry(activity, index) {
     const { t } = this.context
     const {
       inlineRetryIndex,
@@ -48,10 +51,12 @@ export default class TransactionActivityLog extends PureComponent {
       isEarliestNonce,
     } = this.props
     const { status } = primaryTransaction
+    const { eventKey } = activity
 
-    return isEarliestNonce &&
+    return (isEarliestNonce &&
       status !== CONFIRMED_STATUS &&
-      index === inlineRetryIndex ? (
+      index === inlineRetryIndex) ||
+      eventKey === TRANSACTION_SUBMITTED_EVENT ? (
       <div className="transaction-activity-log__action-link" onClick={onRetry}>
         {t('speedUpTransaction')}
       </div>
@@ -115,7 +120,7 @@ export default class TransactionActivityLog extends PureComponent {
           >
             {activityText}
           </div>
-          {this.renderInlineRetry(index)}
+          {this.renderInlineRetry(activity, index)}
           {this.renderInlineCancel(index)}
         </div>
       </div>


### PR DESCRIPTION
Closes #9927

Although the root cause is a larger issue (#9053) with our grouping txs with nonces/speedups/cancels/failures(both from the node and on-chain).
This PR allows all submitted transactions to be sped up through the use of the inline speedup in the activity log.

I do not know if this is the appropriate way we should handle this, and could lead to more user errors than solutions with their state of the tx queue.

Manual testing steps: 

1. Ensure the  `Customize transaction nonce` setting is on in `Settings > Advanced`
2. On a testnet (Rinkeby) send a tx with a gas price of `0.1`.
3. Proceed to send another tx with same nonce as the first tx, the gas price can be the same but not >1. Note: it might be beneficial to change up some of the params to keep track of the txs.
4. Since the tx are grouped be nonce, the 2nd tx will be `primaryTransaction` and the tx we show. But as pointed out in #9927 clicking speed up will speed up the 1st tx.