### PR TITLE
Can't click address list item when you first time import a hw wallet

### DIFF
--- a/ui/app/pages/create-account/connect-hardware/account-list.js
+++ b/ui/app/pages/create-account/connect-hardware/account-list.js
@@ -17,6 +17,12 @@ class AccountList extends Component {
       },
     ]
   }
+  
+  UNSAFE_componentWillMount = () => {
+    if (!this.props.selectedAccount && this.props.accounts.length > 0) {
+      this.props.onAccountChange('0');
+    }
+  }
 
     goToNextPage = () => {
       // If we have < 5 accounts, it's restricted by BIP-44

--- a/ui/app/pages/create-account/connect-hardware/account-list.js
+++ b/ui/app/pages/create-account/connect-hardware/account-list.js
@@ -17,10 +17,10 @@ class AccountList extends Component {
       },
     ]
   }
-  
+
   UNSAFE_componentWillMount = () => {
     if (!this.props.selectedAccount && this.props.accounts.length > 0) {
-      this.props.onAccountChange('0');
+      this.props.onAccountChange('0')
     }
   }
 


### PR DESCRIPTION
Fixes: #6343 

Explanation:  Sometimes in page `account-list.js`. `this.props.selectedAccount = undefine`, but it need to have a value like '0','1'..., so I think the below code will work fine.
```
  UNSAFE_componentWillMount = () => {
    if (!this.props.selectedAccount && this.props.accounts.length > 0) {
      this.props.onAccountChange('0');
    }
  }
```
I have read the CLA Document and I hereby sign the CLA
