### PR TITLE
Remove redundant babelify

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -334,14 +334,6 @@ function createScriptTasks({ browserPlatforms, livereload }) {
 
     let bundler = browserify(browserifyOpts)
       .transform('babelify')
-      // Transpile any dependencies using the object spread/rest operator
-      // because it is incompatible with `esprima`, which is used by `envify`
-      // See https://github.com/jquery/esprima/issues/1927
-      .transform('babelify', {
-        only: ['./**/node_modules/libp2p'],
-        global: true,
-        plugins: ['@babel/plugin-proposal-object-rest-spread'],
-      })
       .transform('brfs')
 
     if (opts.buildLib) {


### PR DESCRIPTION
Since we've replaced `envify` with `loose-envify`, the spread operator incompatibility is fixed.