### PR TITLE
Do not publish swaps transaction if the estimateGas call made when adding the tx fails.

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -716,6 +716,21 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       addUnapprovedTransaction(usedTradeTxParams, 'metamask'),
     )
     dispatch(setTradeTxId(tradeTxMeta.id))
+
+    // The simulationFails property is added during the transaction controllers
+    // addUnapprovedTransaction call if the estimateGas call fails. In cases
+    // when no approval is required, this indicates that the swap will likely
+    // fail. There was an earlier estimateGas call made by the swaps controller,
+    // but it is possible that external conditions have change since then, and
+    // a previously succeeding estimate gas call could now fail. By checking for
+    // the `simulationFails` property here, we can reduce the number of swap
+    // transactions that get published to the blockchain only to fail and thereby
+    // waste the user's funds on gas.
+    if (!approveTxParams && tradeTxMeta.simulationFails) {
+      await dispatch(setSwapsErrorKey(SWAP_FAILED_ERROR))
+      history.push(SWAPS_ERROR_ROUTE)
+      return
+    }
     const finalTradeTxMeta = await dispatch(
       updateTransaction(
         {


### PR DESCRIPTION
This PR is explained by the inline comment that is added within the code change.

For now, the swaps that are failed due to the changes in this PR will have the same error screen as all other failures. That will be improved upon with https://github.com/MetaMask/metamask-extension/issues/9948