### PR TITLE
Fix 9906 - Prevent unwanted 'no quotes available' message when going back to build quote screen while having insufficient funds

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -93,7 +93,6 @@ const slice = createSlice({
     clearSwapsState: () => initialState,
     navigatedBackToBuildQuote: (state) => {
       state.approveTxId = null
-      state.balanceError = false
       state.fetchingQuotes = false
       state.customGas.limit = null
       state.customGas.price = null

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -575,7 +575,7 @@ export default function ViewQuote() {
           }
         }}
         submitText={t('swap')}
-        onCancel={async () => await dispatch(navigateBackToBuildQuote(history))}
+        onCancel={async () => dispatch(navigateBackToBuildQuote(history))}
         disabled={balanceError || gasPrice === null || gasPrice === undefined}
         showTermsOfService
         showTopBorder


### PR DESCRIPTION
Fixes: #9906

Explanation:  As I detailed in #9906's comments, there's a timing conflict between going back to the build screen and the balanceError being reset.  See comments for details.

Manual testing steps:  
  - Create a swap where you have an insufficient balance.
  - When swap view comes up, click "Back" in the footer
  - *Change nothing*, click "Swap" again
  - Before this PR, the swap would show "No quotes available" error; with this PR applied, the swap view should display again.