### PR TITLE
Fragment system for events

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -823,6 +823,10 @@ export default class MetamaskController extends EventEmitter {
         metaMetricsController.trackEvent,
         metaMetricsController,
       ),
+      trackMetaMetricsEventFragment: nodeify(
+        metaMetricsController.trackEventFragment,
+        metaMetricsController,
+      ),
       trackMetaMetricsPage: nodeify(
         metaMetricsController.trackPage,
         metaMetricsController,

--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -77,6 +77,8 @@
  * @property {boolean} [matomoEvent] - is this event a holdover from matomo
  *  that needs further migration? when true, sends the data to a special
  *  segment source that marks the event data as not conforming to our schema
+ * @property {boolean} [includeFragment] - if true pulls event properties and
+ *  sensitiveProperties in the store and includes them in the event payload
  */
 
 /**


### PR DESCRIPTION
Depends on: #9857 

### Rationale
Certain events happen across many different screens, such as onboarding. Where the previous metrics expected many events and then used dashboards to coalesce the data, the new schema has one event with many properties indicating the route the user took. For example, instead of "clicked import from seed phrase" the new schema has a field, `imported_from_seek` in properties. With the current segment implementation, we'd have to keep track of this transitional state somewhere (or tap into existing state).

### Implementation
Adds a new 'fragments' key in the MetaMetrics controller's state. This fragment object allows storing event property payloads in state. It also exposes a new `trackEventFragment` method to the UI that will allow storing both `properties` and `sensitiveProperties` across many views. These values will persist until they are included in a `trackEvent` call by supplying the option `includeFragment: true`. 

### Possible gotchas
The current implementation relies on `event` and `category` to derive the key for storage of partials. Because the data is never cleared until it is included in an event, this could lead to pollution of payloads. A more explicit alternative could be:

```js
trackEventFragment('onboarding', { imported_from_seed: true })
/*... later...*/
trackEvent(
  {
    event: 'Onboarding Complete',
    category: 'Onboarding',
    properties: { opted_in: true }
  },
  { includeFragment: 'onboarding' }
)
```

It still suffers from the same issues but the generation of the key is firmly in the hands of the consumers of the API. 

Open to opinions and feedback as always!