### PR TITLE
@metamask/etherscan-link@1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@metamask/controllers": "^4.2.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^3.0.1",
-    "@metamask/etherscan-link": "^1.3.0",
+    "@metamask/etherscan-link": "^1.4.0",
     "@metamask/inpage-provider": "^6.1.0",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,10 +2100,10 @@
     human-standard-token-abi "^1.0.2"
     safe-event-emitter "^1.0.1"
 
-"@metamask/etherscan-link@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-1.3.0.tgz#ce5b9e0083f51386f8f462110b4094cf6243022c"
-  integrity sha512-2BLaSJLqOIq5CasneVqortc7sPMjgXDTdPv4dSjseF+RUtv/HPTSXZPhV2dFkGd/n+eCQoevPRVOFsVvuRnFeA==
+"@metamask/etherscan-link@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-1.4.0.tgz#4631e9beec17de26b35b3ccd643ede2bae8ed811"
+  integrity sha512-4Bi72Y8/FQZbfTARyv+oWKGuECzdQ37cQKt88Eu5JPDrHAcRDZt4Bt7bWC9phUBrphAr1qbCKh9S90X9hW0pZg==
 
 "@metamask/forwarder@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
- `@metamask/etherscan-link@1.4.0`
  - Now with Goerli support!