### PR TITLE
Remove unnecessary assertion in e2e metrics test

### DIFF
--- a/test/e2e/metrics.spec.js
+++ b/test/e2e/metrics.spec.js
@@ -35,10 +35,6 @@ describe('Segment metrics', function () {
         await driver.findElement(By.css('[data-testid="eth-overview-send"]'))
 
         assert.ok(segmentSpy.called, 'Segment should receive metrics')
-        assert.ok(
-          segmentSpy.callCount >= 3,
-          'At least 3 segment events should be sent',
-        )
 
         const firstSegmentEvent = segmentSpy.getCall(0).args[0]
         assert.equal(firstSegmentEvent.name, 'Home')


### PR DESCRIPTION
The assertion ensuring that there were at least 3 metrics received didn't end up being useful. If this assertion fails, it doesn't explain what segment events _were_ received.

By removing this assertion and letting the later assertions catch this case, we at least learn which of the three expected events were present.