### PR TITLE
Remove unused state from Redux `gas` slice

### DIFF
--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -14,8 +14,6 @@ const {
   setBasicGasEstimateData,
   setCustomGasPrice,
   setCustomGasLimit,
-  setCustomGasTotal,
-  setCustomGasErrors,
   resetCustomGasState,
   fetchBasicGasEstimates,
 } = GasDuck
@@ -68,7 +66,6 @@ describe('Gas Duck', function () {
       safeLow: null,
     },
     basicEstimateIsLoading: true,
-    errors: {},
     basicPriceEstimatesLastRetrieved: 0,
   }
   const BASIC_GAS_ESTIMATE_LOADING_FINISHED =
@@ -77,10 +74,8 @@ describe('Gas Duck', function () {
     'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_STARTED'
   const RESET_CUSTOM_GAS_STATE = 'metamask/gas/RESET_CUSTOM_GAS_STATE'
   const SET_BASIC_GAS_ESTIMATE_DATA = 'metamask/gas/SET_BASIC_GAS_ESTIMATE_DATA'
-  const SET_CUSTOM_GAS_ERRORS = 'metamask/gas/SET_CUSTOM_GAS_ERRORS'
   const SET_CUSTOM_GAS_LIMIT = 'metamask/gas/SET_CUSTOM_GAS_LIMIT'
   const SET_CUSTOM_GAS_PRICE = 'metamask/gas/SET_CUSTOM_GAS_PRICE'
-  const SET_CUSTOM_GAS_TOTAL = 'metamask/gas/SET_CUSTOM_GAS_TOTAL'
   const SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED =
     'metamask/gas/SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED'
 
@@ -140,26 +135,6 @@ describe('Gas Duck', function () {
           value: 9876,
         }),
         { customData: { limit: 9876 }, ...mockState },
-      )
-    })
-
-    it('should set customData.total when receiving a SET_CUSTOM_GAS_TOTAL action', function () {
-      assert.deepStrictEqual(
-        GasReducer(mockState, {
-          type: SET_CUSTOM_GAS_TOTAL,
-          value: 10000,
-        }),
-        { customData: { total: 10000 }, ...mockState },
-      )
-    })
-
-    it('should set errors when receiving a SET_CUSTOM_GAS_ERRORS action', function () {
-      assert.deepStrictEqual(
-        GasReducer(mockState, {
-          type: SET_CUSTOM_GAS_ERRORS,
-          value: { someError: 'error_error' },
-        }),
-        { errors: { someError: 'error_error' }, ...mockState },
       )
     })
 
@@ -314,24 +289,6 @@ describe('Gas Duck', function () {
       assert.deepStrictEqual(setCustomGasLimit('mockCustomGasLimit'), {
         type: SET_CUSTOM_GAS_LIMIT,
         value: 'mockCustomGasLimit',
-      })
-    })
-  })
-
-  describe('setCustomGasTotal', function () {
-    it('should create the correct action', function () {
-      assert.deepStrictEqual(setCustomGasTotal('mockCustomGasTotal'), {
-        type: SET_CUSTOM_GAS_TOTAL,
-        value: 'mockCustomGasTotal',
-      })
-    })
-  })
-
-  describe('setCustomGasErrors', function () {
-    it('should create the correct action', function () {
-      assert.deepStrictEqual(setCustomGasErrors('mockErrorObject'), {
-        type: SET_CUSTOM_GAS_ERRORS,
-        value: 'mockErrorObject',
       })
     })
   })

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -12,10 +12,8 @@ const BASIC_GAS_ESTIMATE_LOADING_STARTED =
 const RESET_CUSTOM_GAS_STATE = 'metamask/gas/RESET_CUSTOM_GAS_STATE'
 const RESET_CUSTOM_DATA = 'metamask/gas/RESET_CUSTOM_DATA'
 const SET_BASIC_GAS_ESTIMATE_DATA = 'metamask/gas/SET_BASIC_GAS_ESTIMATE_DATA'
-const SET_CUSTOM_GAS_ERRORS = 'metamask/gas/SET_CUSTOM_GAS_ERRORS'
 const SET_CUSTOM_GAS_LIMIT = 'metamask/gas/SET_CUSTOM_GAS_LIMIT'
 const SET_CUSTOM_GAS_PRICE = 'metamask/gas/SET_CUSTOM_GAS_PRICE'
-const SET_CUSTOM_GAS_TOTAL = 'metamask/gas/SET_CUSTOM_GAS_TOTAL'
 const SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED =
   'metamask/gas/SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED'
 
@@ -31,7 +29,6 @@ const initState = {
   },
   basicEstimateIsLoading: true,
   basicPriceEstimatesLastRetrieved: 0,
-  errors: {},
 }
 
 // Reducer
@@ -66,22 +63,6 @@ export default function reducer(state = initState, action) {
         customData: {
           ...state.customData,
           limit: action.value,
-        },
-      }
-    case SET_CUSTOM_GAS_TOTAL:
-      return {
-        ...state,
-        customData: {
-          ...state.customData,
-          total: action.value,
-        },
-      }
-    case SET_CUSTOM_GAS_ERRORS:
-      return {
-        ...state,
-        errors: {
-          ...state.errors,
-          ...action.value,
         },
       }
     case SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED:
@@ -208,20 +189,6 @@ export function setCustomGasLimit(newLimit) {
   return {
     type: SET_CUSTOM_GAS_LIMIT,
     value: newLimit,
-  }
-}
-
-export function setCustomGasTotal(newTotal) {
-  return {
-    type: SET_CUSTOM_GAS_TOTAL,
-    value: newTotal,
-  }
-}
-
-export function setCustomGasErrors(newErrors) {
-  return {
-    type: SET_CUSTOM_GAS_ERRORS,
-    value: newErrors,
   }
 }
 

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -13,20 +13,12 @@ import { getCurrentCurrency, getIsMainnet, getPreferences } from '.'
 
 const NUMBER_OF_DECIMALS_SM_BTNS = 5
 
-export function getCustomGasErrors(state) {
-  return state.gas.errors
-}
-
 export function getCustomGasLimit(state) {
   return state.gas.customData.limit
 }
 
 export function getCustomGasPrice(state) {
   return state.gas.customData.price
-}
-
-export function getCustomGasTotal(state) {
-  return state.gas.customData.total
 }
 
 export function getBasicGasEstimateLoadingStatus(state) {

--- a/ui/app/selectors/tests/custom-gas.test.js
+++ b/ui/app/selectors/tests/custom-gas.test.js
@@ -2,10 +2,8 @@ import assert from 'assert'
 import proxyquire from 'proxyquire'
 
 const {
-  getCustomGasErrors,
   getCustomGasLimit,
   getCustomGasPrice,
-  getCustomGasTotal,
   getRenderableBasicEstimateData,
   getRenderableEstimateDataForSmallButtonsFromGWEI,
 } = proxyquire('../custom-gas', {})
@@ -22,20 +20,6 @@ describe('custom-gas selectors', function () {
     it('should return gas.customData.limit', function () {
       const mockState = { gas: { customData: { limit: 'mockLimit' } } }
       assert.strictEqual(getCustomGasLimit(mockState), 'mockLimit')
-    })
-  })
-
-  describe('getCustomGasTotal()', function () {
-    it('should return gas.customData.total', function () {
-      const mockState = { gas: { customData: { total: 'mockTotal' } } }
-      assert.strictEqual(getCustomGasTotal(mockState), 'mockTotal')
-    })
-  })
-
-  describe('getCustomGasErrors()', function () {
-    it('should return gas.errors', function () {
-      const mockState = { gas: { errors: 'mockErrors' } }
-      assert.strictEqual(getCustomGasErrors(mockState), 'mockErrors')
     })
   })
 


### PR DESCRIPTION
The `errors` and `total` state has been removed from the `gas` slice, along with related functions. It appears to have been unused for a long time, though I'm not exactly sure as of when.