### PR TITLE
Move initial e2e navigation into individual tests

### DIFF
--- a/test/e2e/address-book.spec.js
+++ b/test/e2e/address-book.spec.js
@@ -29,6 +29,7 @@ describe('MetaMask', function () {
     })
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -13,6 +13,7 @@ const ALL_PAGES = Object.values(PAGES)
 async function measurePage(pageName) {
   let metrics
   await withFixtures({ fixtures: 'imported-account' }, async ({ driver }) => {
+    await driver.navigate()
     const passwordField = await driver.findElement(By.css('#password'))
     await passwordField.sendKeys('correct horse battery staple')
     await passwordField.sendKeys(Key.ENTER)

--- a/test/e2e/ethereum-on.spec.js
+++ b/test/e2e/ethereum-on.spec.js
@@ -28,6 +28,7 @@ describe('MetaMask', function () {
     })
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/from-import-ui.spec.js
+++ b/test/e2e/from-import-ui.spec.js
@@ -35,6 +35,7 @@ describe('Using MetaMask with an existing account', function () {
     })
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/incremental-security.spec.js
+++ b/test/e2e/incremental-security.spec.js
@@ -33,6 +33,7 @@ describe('MetaMask', function () {
     })
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/metamask-responsive-ui.spec.js
+++ b/test/e2e/metamask-responsive-ui.spec.js
@@ -22,6 +22,7 @@ describe('MetaMask', function () {
     await ganacheServer.start()
     const result = await buildWebDriver({ responsive: true })
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -23,6 +23,7 @@ describe('MetaMask', function () {
     await ganacheServer.start()
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/metrics.spec.js
+++ b/test/e2e/metrics.spec.js
@@ -27,6 +27,7 @@ describe('Segment metrics', function () {
         mockSegment: true,
       },
       async ({ driver, segmentSpy }) => {
+        await driver.navigate()
         const passwordField = await driver.findElement(By.css('#password'))
         await passwordField.sendKeys('correct horse battery staple')
         await passwordField.sendKeys(Key.ENTER)

--- a/test/e2e/permissions.spec.js
+++ b/test/e2e/permissions.spec.js
@@ -28,6 +28,7 @@ describe('MetaMask', function () {
     })
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/send-edit.spec.js
+++ b/test/e2e/send-edit.spec.js
@@ -30,6 +30,7 @@ describe('Using MetaMask with an existing account', function () {
     })
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/signature-request.spec.js
+++ b/test/e2e/signature-request.spec.js
@@ -28,6 +28,7 @@ describe('MetaMask', function () {
     publicAddress = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1'
     const result = await buildWebDriver()
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {

--- a/test/e2e/tests/localization.spec.js
+++ b/test/e2e/tests/localization.spec.js
@@ -16,6 +16,7 @@ describe('Localization', function () {
     await withFixtures(
       { fixtures: 'localization', ganacheOptions, title: this.test.title },
       async ({ driver }) => {
+        await driver.navigate()
         const passwordField = await driver.findElement(By.css('#password'))
         await passwordField.sendKeys('correct horse battery staple')
         await passwordField.sendKeys(Key.ENTER)

--- a/test/e2e/tests/personal-sign.spec.js
+++ b/test/e2e/tests/personal-sign.spec.js
@@ -21,6 +21,7 @@ describe('Personal sign', function () {
         title: this.test.title,
       },
       async ({ driver }) => {
+        await driver.navigate()
         const passwordField = await driver.findElement(By.css('#password'))
         await passwordField.sendKeys('correct horse battery staple')
         await passwordField.sendKeys(Key.ENTER)

--- a/test/e2e/tests/simple-send.spec.js
+++ b/test/e2e/tests/simple-send.spec.js
@@ -15,6 +15,7 @@ describe('Simple send', function () {
     await withFixtures(
       { fixtures: 'imported-account', ganacheOptions, title: this.test.title },
       async ({ driver }) => {
+        await driver.navigate()
         const passwordField = await driver.findElement(By.css('#password'))
         await passwordField.sendKeys('correct horse battery staple')
         await passwordField.sendKeys(Key.ENTER)

--- a/test/e2e/threebox.spec.js
+++ b/test/e2e/threebox.spec.js
@@ -31,6 +31,7 @@ describe('MetaMask', function () {
     })
     const result = await buildWebDriver({ port: await getPort() })
     driver = result.driver
+    await driver.navigate()
   })
 
   afterEach(async function () {
@@ -189,6 +190,7 @@ describe('MetaMask', function () {
     before(async function () {
       const result = await buildWebDriver({ port: await getPort() })
       driver2 = result.driver
+      await driver2.navigate()
     })
 
     after(async function () {

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -15,9 +15,6 @@ async function buildWebDriver({ responsive, port } = {}) {
   } = await buildBrowserWebDriver(browser, { extensionPath, responsive, port })
   await setupFetchMocking(seleniumDriver)
   const driver = new Driver(seleniumDriver, browser, extensionUrl)
-  await driver.navigate()
-
-  await driver.delay(1000)
 
   return {
     driver,


### PR DESCRIPTION
The e2e test driver used to perform the initial navigation automatically within the `buildWebDriver` function, so that that step wouldn't need to be repeated at the beginning of each test. However this prevented you from doing any setup in the test before the first navigation.

The navigation has now been moved into each individual test. It should be functionally equivalent, except now it's possible to control exactly when the first navigation occurs.

A 1 second delay was also removed, as it didn't seem to be necessary when testing this. It was initially added as an attempted fix to an intermittent failure. It did not fix that failure.