### PR TITLE
Fix intermittent metrics e2e test failure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -197,6 +197,7 @@ module.exports = {
         'stylelint.config.js',
         'development/**/*.js',
         'test/e2e/**/*.js',
+        'test/lib/wait-until-called.js',
         'test/env.js',
         'test/setup.js',
       ],

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -27,7 +27,7 @@ async function withFixtures(options, testSuite) {
   const ganacheServer = new Ganache()
   let dappServer
   let segmentServer
-  let segmentSpy
+  let segmentStub
 
   let webDriver
   try {
@@ -52,10 +52,10 @@ async function withFixtures(options, testSuite) {
       })
     }
     if (mockSegment) {
-      segmentSpy = sinon.spy()
+      segmentStub = sinon.stub()
       segmentServer = createSegmentServer((_request, response, events) => {
         for (const event of events) {
-          segmentSpy(event)
+          segmentStub(event)
         }
         response.statusCode = 200
         response.end()
@@ -67,7 +67,7 @@ async function withFixtures(options, testSuite) {
 
     await testSuite({
       driver,
-      segmentSpy,
+      segmentStub,
     })
 
     if (process.env.SELENIUM_BROWSER === 'chrome') {


### PR DESCRIPTION
The metrics e2e test would fail if the segment events still weren't dispatched when the page loaded. The Segment events are sent on a set interval, so it isn't abnormal for them to lag behind the page load itself. The `waitUntilCalled` utility has been used to wait until all required events have been dispatched.

The `wait-until-called` module was converted to an ES5 module, so that it could be used from an e2e test. The optional `callCount` parameter has also been added, to allow waiting for more than one call.

The `segmentSpy` had to be converted to a `segmentStub`, to allow the `waitUntilCalled` utility to be used.