### PR TITLE
Fix inflated gas estimates

### DIFF
--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -1,6 +1,7 @@
 import EthQuery from 'ethjs-query'
 import log from 'loglevel'
 import ethUtil from 'ethereumjs-util'
+import { cloneDeep } from 'lodash'
 import { hexToBn, BnMultiplyByFraction, bnToHex } from '../../lib/util'
 
 /**
@@ -56,7 +57,13 @@ export default class TxGasUtil {
     @returns {string} the estimated gas limit as a hex string
   */
   async estimateTxGas(txMeta) {
-    const { txParams } = txMeta
+    const txParams = cloneDeep(txMeta.txParams)
+
+    // `eth_estimateGas` can fail if the user has insufficient balance for the
+    // value being sent, or for the gas cost. We don't want to check their
+    // balance here, we just want the gas estimate. The gas price is removed
+    // to skip those balance checks. We check balance elsewhere.
+    delete txParams.gasPrice
 
     // estimate tx gas requirements
     return await this.query.estimateGas(txParams)


### PR DESCRIPTION
If a `gasPrice` was specified in a transaction sent via a dapp, we would include it in our `eth_estimateGas` call, causing it to fail if the user had insufficient balance (for either the transaction amount or the gas fee). This resulted in the fallback gas estimate being used; the block gas limit. The block gas limit is quite a bit larger than most transactions need, so this resulted in wildly inflated gas costs being shown on our confirmation screen.

The `gasPrice` has been removed from the `txParams` object we pass to `eth_estimateGas`, so now it won't perform any balance checks anymore. This ensures that we'll get a valid gas estimate, as long as geth is able to simulate the contract execution properly.

Fixes #9967

Manual testing steps:  
Follow the reproduction steps listed in #9967, and observe that the initial value set for gas limit is not absurdly high (it was `79500` when I tested it).