### PR TITLE
Fix 9906 - Prevent unwanted 'no quotes available' message when going back to build quote screen while having insufficient funds

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -325,7 +325,6 @@ export {
 export const navigateBackToBuildQuote = (history) => {
   return async (dispatch) => {
     // TODO: Ensure any fetch in progress is cancelled
-    await dispatch(resetSwapsPostFetchState())
     dispatch(navigatedBackToBuildQuote())
 
     history.push(BUILD_QUOTE_ROUTE)


### PR DESCRIPTION
Supercedes https://github.com/MetaMask/metamask-extension/pull/9958

Fixes: #9906

Explanation:  

This bug took me in a million places but in the end, I found that this call to `resetSwapsPostFetchState` appears to do absolutely nothing with regard to changing the state, but what it does do is redirect the user back to the "build quote" screen, thus negating the need for `history.push(BUILD_QUOTE_ROUTE)` and causing our timing conflict.

Manual testing steps:  
  - Create a swap where you have an insufficient balance.
  - When swap view comes up, click "Back" in the footer
  - Change nothing, click "Swap" again
  - Before this PR, the swap would show "No quotes available" error; with this PR applied, the swap view should display again.