### PR TITLE
Use consistent font size for modal top right Close links

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/index.scss
@@ -35,6 +35,7 @@
 
       color: #4eade7;
       position: absolute;
+      font-size: 0.75rem;
       top: 4px;
       right: 16px;
       cursor: pointer;

--- a/ui/app/pages/send/send.scss
+++ b/ui/app/pages/send/send.scss
@@ -21,6 +21,7 @@
       position: absolute;
       right: 1rem;
       width: min-content;
+      font-size: 0.75rem;
     }
   }
 


### PR DESCRIPTION
Both the Swaps gas price modal and Send screen have a "Cancel"/"Close" button in the top right, which are larger than the "Close" button of the Swaps modal.  We should be consistent with our sizing.