### PR TITLE
Prevent props error in swaps gas modal

### DIFF
--- a/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
+++ b/ui/app/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.component.js
@@ -35,7 +35,7 @@ export default class GasModalPageContainer extends Component {
     disableSave: PropTypes.bool,
     customGasLimitMessage: PropTypes.string,
     customTotalSupplement: PropTypes.string,
-    usdConversionRate: PropTypes.string,
+    usdConversionRate: PropTypes.number,
     customGasPrice: PropTypes.string,
     customGasLimit: PropTypes.string,
     setSwapsCustomizationModalPrice: PropTypes.func,


### PR DESCRIPTION
Saw this pop up when I was testing something else:

<img width="925" alt="PropsErr" src="https://user-images.githubusercontent.com/46655/101193713-9b773180-3622-11eb-97d9-03fc4a88c17c.png">

We store this rate as a number so it's just a case of having the wrong type.