### PR TITLE
Rename provider streams, notify provider of stream failures

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -16,16 +16,13 @@ const inpageContent = fs.readFileSync(
 const inpageSuffix = `//# sourceURL=${extension.runtime.getURL('inpage.js')}\n`
 const inpageBundle = inpageContent + inpageSuffix
 
-// Eventually this streaming injection could be replaced with:
-// https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.exportFunction
-//
-// But for now that is only Firefox
-// If we create a FireFox-only code path using that API,
-// MetaMask will be much faster loading and performant on Firefox.
+const CONTENT_SCRIPT = 'metamask-contentscript'
+const INPAGE = 'metamask-inpage'
+const PROVIDER = 'metamask-provider'
 
 if (shouldInjectProvider()) {
   injectScript(inpageBundle)
-  start()
+  setupStreams()
 }
 
 /**
@@ -47,15 +44,6 @@ function injectScript(content) {
 }
 
 /**
- * Sets up the stream communication and submits site metadata
- *
- */
-async function start() {
-  await setupStreams()
-  await domIsReady()
-}
-
-/**
  * Sets up two-way communication streams between the
  * browser extension and local per-page browser context.
  *
@@ -63,10 +51,10 @@ async function start() {
 async function setupStreams() {
   // the transport-specific streams for communication between inpage and background
   const pageStream = new LocalMessageDuplexStream({
-    name: 'contentscript',
-    target: 'inpage',
+    name: CONTENT_SCRIPT,
+    target: INPAGE,
   })
-  const extensionPort = extension.runtime.connect({ name: 'contentscript' })
+  const extensionPort = extension.runtime.connect({ name: CONTENT_SCRIPT })
   const extensionStream = new PortStream(extensionPort)
 
   // create and connect channel muxers
@@ -79,25 +67,26 @@ async function setupStreams() {
   pump(pageMux, pageStream, pageMux, (err) =>
     logStreamDisconnectWarning('MetaMask Inpage Multiplex', err),
   )
-  pump(extensionMux, extensionStream, extensionMux, (err) =>
-    logStreamDisconnectWarning('MetaMask Background Multiplex', err),
-  )
+  pump(extensionMux, extensionStream, extensionMux, (err) => {
+    logStreamDisconnectWarning('MetaMask Background Multiplex', err)
+    notifyInpageOfStreamFailure()
+  })
 
   // forward communication across inpage-background for these channels only
-  forwardTrafficBetweenMuxers('provider', pageMux, extensionMux)
+  forwardTrafficBetweenMuxes(PROVIDER, pageMux, extensionMux)
 
   // connect "phishing" channel to warning system
   const phishingStream = extensionMux.createStream('phishing')
   phishingStream.once('data', redirectToPhishingWarning)
 }
 
-function forwardTrafficBetweenMuxers(channelName, muxA, muxB) {
+function forwardTrafficBetweenMuxes(channelName, muxA, muxB) {
   const channelA = muxA.createStream(channelName)
   const channelB = muxB.createStream(channelName)
-  pump(channelA, channelB, channelA, (err) =>
-    logStreamDisconnectWarning(
+  pump(channelA, channelB, channelA, (error) =>
+    console.debug(
       `MetaMask muxed traffic for channel "${channelName}" failed.`,
-      err,
+      error,
     ),
   )
 }
@@ -106,14 +95,35 @@ function forwardTrafficBetweenMuxers(channelName, muxA, muxB) {
  * Error handler for page to extension stream disconnections
  *
  * @param {string} remoteLabel - Remote stream name
- * @param {Error} err - Stream connection error
+ * @param {Error} error - Stream connection error
  */
-function logStreamDisconnectWarning(remoteLabel, err) {
-  let warningMsg = `MetamaskContentscript - lost connection to ${remoteLabel}`
-  if (err) {
-    warningMsg += `\n${err.stack}`
-  }
-  console.warn(warningMsg)
+function logStreamDisconnectWarning(remoteLabel, error) {
+  console.debug(
+    `MetaMask Contentscript: Lost connection to "${remoteLabel}".`,
+    error,
+  )
+}
+
+/**
+ * This function must ONLY be called in pump destruction/close callbacks.
+ * Notifies the inpage context that streams have failed, via window.postMessage.
+ * Relies on obj-multiplex and post-message-stream implementation details.
+ */
+function notifyInpageOfStreamFailure() {
+  window.postMessage(
+    {
+      target: INPAGE, // the post-message-stream "target"
+      data: {
+        // this object gets passed to obj-multiplex
+        name: PROVIDER, // the obj-multiplex channel name
+        data: {
+          jsonrpc: '2.0',
+          method: 'METAMASK_STREAM_FAILURE',
+        },
+      },
+    },
+    window.location.origin,
+  )
 }
 
 /**
@@ -219,18 +229,4 @@ function redirectToPhishingWarning() {
     hostname: window.location.hostname,
     href: window.location.href,
   })}`
-}
-
-/**
- * Returns a promise that resolves when the DOM is loaded (does not wait for images to load)
- */
-async function domIsReady() {
-  // already loaded
-  if (['interactive', 'complete'].includes(document.readyState)) {
-    return undefined
-  }
-  // wait for load
-  return new Promise((resolve) =>
-    window.addEventListener('DOMContentLoaded', resolve, { once: true }),
-  )
 }

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -45,8 +45,8 @@ log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
 // setup background connection
 const metamaskStream = new LocalMessageDuplexStream({
-  name: 'inpage',
-  target: 'contentscript',
+  name: 'metamask-inpage',
+  target: 'metamask-contentscript',
 })
 
 initializeProvider({

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1813,7 +1813,7 @@ export default class MetamaskController extends EventEmitter {
     const mux = setupMultiplex(connectionStream)
 
     // messages between inpage and background
-    this.setupProviderConnection(mux.createStream('provider'), sender)
+    this.setupProviderConnection(mux.createStream('metamask-provider'), sender)
   }
 
   /**

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -1022,7 +1022,7 @@ describe('MetaMaskController', function () {
       }
       streamTest.write(
         {
-          name: 'provider',
+          name: 'metamask-provider',
           data: message,
         },
         null,
@@ -1061,7 +1061,7 @@ describe('MetaMaskController', function () {
       }
       streamTest.write(
         {
-          name: 'provider',
+          name: 'metamask-provider',
           data: message,
         },
         null,


### PR DESCRIPTION
This PR renames the streams we use to connect to the `inpage-provider`, and ensures that the provider is notified when the streams connecting the content script to the MetaMask background fails.

Currently, the provider streams have very generic names. Although it is unlikely that this would cause problems in production, we could encounter naming collisions with other extensions that use our stream packages in production. In any event, it doesn't cost us anything to rename the streams. IIRC, the last time I suggested we do this, @Gudahtt mentioned that it could be breaking for e.g. sites that bring our provider to get around the Firefox CSP issue where injection fails, but we are shipping so many breaking changes that those folks will have to upgrade anyway.

Now, for the second change, if the extension background process is restarted, all pages will have to be reloaded in order for the provider to establish its connection to the new background process. Historically, three warnings about MetaMask stream failures have appeared in the page console when this happens. In these cases, the provider should emit the `disconnect` event. However, this never happened in practice, because it was the content script streams that failed, and the provider was never notified of this. We improve upon this state of affairs by informing the provider that the connection to the background is lost, so that it can emit the `disconnect` event, and the user can reload the page.

Corresponding `inpage-provider` PR: https://github.com/MetaMask/inpage-provider/pull/120