### PR TITLE
Send accounts with isUnlocked provider notification

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -469,7 +469,7 @@ export class PermissionsController {
     if (this._isUnlocked()) {
       this._notifyDomain(origin, {
         method: NOTIFICATION_NAMES.accountsChanged,
-        result: newAccounts,
+        params: newAccounts,
       })
       this.permissionsLog.updateAccountsHistory(origin, newAccounts)
     }
@@ -513,7 +513,7 @@ export class PermissionsController {
     // extension lock state
     this._notifyAllDomains({
       method: NOTIFICATION_NAMES.accountsChanged,
-      result: [],
+      params: [],
     })
   }
 

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -464,7 +464,7 @@ export const getters = deepFreeze({
     removedAccounts: () => {
       return {
         method: NOTIFICATION_NAMES.accountsChanged,
-        result: [],
+        params: [],
       }
     },
 
@@ -477,7 +477,7 @@ export const getters = deepFreeze({
     newAccounts: (accounts) => {
       return {
         method: NOTIFICATION_NAMES.accountsChanged,
-        result: accounts,
+        params: accounts,
       }
     },
   },


### PR DESCRIPTION
This PR sends the accounts with the `isUnlocked` notification on extension unlock. To enable this, the `notifyAllConnections` methods on the main controller is refactored such that, when passed a function, it will for each connection call that function with the connection's `origin,` and use the return value as the notification payload.

Corresponding provider PR: https://github.com/MetaMask/inpage-provider/pull/121