### PR TITLE
Deobfuscate error messages

### DIFF
--- a/app/scripts/runLockdown.js
+++ b/app/scripts/runLockdown.js
@@ -1,6 +1,7 @@
 // Freezes all intrinsics
 // eslint-disable-next-line no-undef,import/unambiguous
 lockdown({
+  consoleTaming: 'unsafe',
   errorTaming: 'unsafe',
   mathTaming: 'unsafe',
   dateTaming: 'unsafe',


### PR DESCRIPTION
The SES lockdown added in #9729 had the effect of obfuscating our error messages. Any messages printed to the console would have the error message replaced with the string "Error #" followed by a number. The stack was also updated to point at `lockdown.cjs`, though the original stack was preserved beneath the top stack frame.

Marking the `console` API as untamed seems to have fixed both issues. The original error message is now printed to the console, along with the original stack.