### PR TITLE
Add SES lockdown and Sentry to all pages

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -10,6 +10,9 @@
   <body>
     <div id="app-content"></div>
     <div id="popover-content"></div>
+    <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
+    <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui-libs.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui.js" type="text/javascript" charset="utf-8"></script>
   </body>

--- a/app/notification.html
+++ b/app/notification.html
@@ -33,6 +33,9 @@
       <img id="loading__spinner" src="./images/spinner.gif" alt="" />
     </div>
     <div id="popover-content"></div>
+    <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
+    <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui-libs.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui.js" type="text/javascript" charset="utf-8"></script>
   </body>


### PR DESCRIPTION
When the SES lockdown was added in #9729, the lockdown and the Sentry initialization were migrated from the main bundle into separate modules, which were run as separate `<script>` tags. These extra tags were accidentally omitted for `home.html` and `notification.html`. As a result Sentry was not initialized on these pages, so any errors thrown on them would not be collected. They also do not benefit from the SES lockdown.

The SES lockdown and Sentry initialization modules have been added to both pages where they were missing.