### PR TITLE
Fix SES lockdown on older browsers

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -10,6 +10,7 @@
   <body>
     <div id="app-content"></div>
     <div id="popover-content"></div>
+    <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
     <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
     <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>

--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -2,6 +2,7 @@
   "author": "https://metamask.io",
   "background": {
     "scripts": [
+      "globalthis.js",
       "initSentry.js",
       "lockdown.cjs",
       "runLockdown.js",
@@ -36,7 +37,12 @@
   "content_scripts": [
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "js": ["lockdown.cjs", "runLockdown.js", "contentscript.js"],
+      "js": [
+        "globalthis.js",
+        "lockdown.cjs",
+        "runLockdown.js",
+        "contentscript.js"
+      ],
       "run_at": "document_start",
       "all_frames": true
     },

--- a/app/notification.html
+++ b/app/notification.html
@@ -33,6 +33,7 @@
       <img id="loading__spinner" src="./images/spinner.gif" alt="" />
     </div>
     <div id="popover-content"></div>
+    <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
     <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
     <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>

--- a/app/phishing.html
+++ b/app/phishing.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Ethereum Phishing Detection - MetaMask</title>
+    <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
     <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./phishing-detect.js"></script>

--- a/app/popup.html
+++ b/app/popup.html
@@ -10,6 +10,7 @@
   <body style="width:357px; height:600px;">
     <div id="app-content"></div>
     <div id="popover-content"></div>
+    <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
     <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
     <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -45,6 +45,10 @@ const copyTargets = [
     dest: ``,
   },
   {
+    src: `./node_modules/globalthis/dist/browser.js`,
+    dest: `globalthis.js`,
+  },
+  {
     src: `./node_modules/ses/dist/`,
     pattern: `lockdown.cjs`,
     dest: ``,

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "extensionizer": "^1.0.1",
     "fast-json-patch": "^2.0.4",
     "fuse.js": "^3.2.0",
+    "globalthis": "^1.0.1",
     "human-standard-token-abi": "^2.0.0",
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^2.1.1",


### PR DESCRIPTION
On [older browsers that don't support `globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#Browser_compatibility), the SES lockdown throws an error. The `globalthis` shim has been added to all pages, to the background process, and to the `contentscript`. This should prevent the error on older browsers.

Manual testing steps:  
  - Load each page
  - See whether the error `globalThis is not defined` is in the dev console

Four of our pages use the lockdown script, so are affected by this: `home.html`, `notification.html`, `phishing.html`, and `popup.html`. The `contentscript` environment and the background process are also affected.