### PR TITLE
Fix 10010 - Fetch swap quote refresh time from API

### DIFF
--- a/ui/app/pages/swaps/countdown-timer/countdown-timer.js
+++ b/ui/app/pages/swaps/countdown-timer/countdown-timer.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useContext, useRef } from 'react'
+import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { Duration } from 'luxon'
 import { I18nContext } from '../../../contexts/i18n'
 import InfoTooltip from '../../../components/ui/info-tooltip'
-
-const TIMER_BASE = 60000
+import { getSwapsQuoteRefreshTime } from '../../../ducks/swaps/swaps'
 
 // Return the mm:ss start time of the countdown timer.
 // If time has elapsed between `timeStarted` the time current time,
@@ -31,7 +31,7 @@ function timeBelowWarningTime(timer, warningTime) {
 export default function CountdownTimer({
   timeStarted,
   timeOnly,
-  timerBase = TIMER_BASE,
+  timerBase,
   warningTime,
   labelKey,
   infoTooltipLabelKey,
@@ -40,9 +40,12 @@ export default function CountdownTimer({
   const intervalRef = useRef()
   const initialTimeStartedRef = useRef()
 
+  const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime)
+  const timerStart = Number(timerBase) || swapsQuoteRefreshTime
+
   const [currentTime, setCurrentTime] = useState(() => Date.now())
   const [timer, setTimer] = useState(() =>
-    getNewTimer(currentTime, timeStarted, timerBase),
+    getNewTimer(currentTime, timeStarted, timerStart),
   )
 
   useEffect(() => {
@@ -67,14 +70,14 @@ export default function CountdownTimer({
       initialTimeStartedRef.current = timeStarted
       const newCurrentTime = Date.now()
       setCurrentTime(newCurrentTime)
-      setTimer(getNewTimer(newCurrentTime, timeStarted, timerBase))
+      setTimer(getNewTimer(newCurrentTime, timeStarted, timerStart))
 
       clearInterval(intervalRef.current)
       intervalRef.current = setInterval(() => {
         setTimer(decreaseTimerByOne)
       }, 1000)
     }
-  }, [timeStarted, timer, timerBase])
+  }, [timeStarted, timer, timerStart])
 
   const formattedTimer = Duration.fromMillis(timer).toFormat('m:ss')
   let time

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -24,20 +24,24 @@ const TOKEN_TRANSFER_LOG_TOPIC_HASH =
 
 const CACHE_REFRESH_ONE_HOUR = 3600000
 
+const METASWAP_API_HOST = 'https://api.metaswap.codefi.network'
+
 const getBaseApi = function (type) {
   switch (type) {
     case 'trade':
-      return `https://api.metaswap.codefi.network/trades?`
+      return `${METASWAP_API_HOST}/trades?`
     case 'tokens':
-      return `https://api.metaswap.codefi.network/tokens`
+      return `${METASWAP_API_HOST}/tokens`
     case 'topAssets':
-      return `https://api.metaswap.codefi.network/topAssets`
+      return `${METASWAP_API_HOST}/topAssets`
     case 'featureFlag':
-      return `https://api.metaswap.codefi.network/featureFlag`
+      return `${METASWAP_API_HOST}/featureFlag`
     case 'aggregatorMetadata':
-      return `https://api.metaswap.codefi.network/aggregatorMetadata`
+      return `${METASWAP_API_HOST}/aggregatorMetadata`
     case 'gasPrices':
-      return `https://api.metaswap.codefi.network/gasPrices`
+      return `${METASWAP_API_HOST}/gasPrices`
+    case 'refreshTime':
+      return `${METASWAP_API_HOST}/quoteRefreshRate`
     default:
       throw new Error('getBaseApi requires an api call type')
   }
@@ -321,6 +325,17 @@ export async function fetchSwapsFeatureLiveness() {
     { cacheRefreshTime: 600000 },
   )
   return status?.active
+}
+
+export async function fetchSwapsQuoteRefreshTime() {
+  const response = await fetchWithCache(
+    getBaseApi('refreshTime'),
+    { method: 'GET' },
+    { cacheRefreshTime: 600000 },
+  )
+
+  // We presently use milliseconds in the UI
+  return response?.seconds * 1000
 }
 
 export async function fetchTokenPrice(address) {

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -27,6 +27,7 @@ import {
   signAndSendTransactions,
   getBackgroundSwapRouteState,
   swapsQuoteSelected,
+  getSwapsQuoteRefreshTime,
 } from '../../../ducks/swaps/swaps'
 import {
   conversionRateSelector,
@@ -114,6 +115,7 @@ export default function ViewQuote() {
   const topQuote = useSelector(getTopQuote)
   const usedQuote = selectedQuote || topQuote
   const tradeValue = usedQuote?.trade?.value ?? '0x0'
+  const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime)
 
   const { isBestQuote } = usedQuote
 
@@ -267,14 +269,23 @@ export default function ViewQuote() {
   useEffect(() => {
     const currentTime = Date.now()
     const timeSinceLastFetched = currentTime - quotesLastFetched
-    if (timeSinceLastFetched > 60000 && !dispatchedSafeRefetch) {
+    if (
+      timeSinceLastFetched > swapsQuoteRefreshTime &&
+      !dispatchedSafeRefetch
+    ) {
       setDispatchedSafeRefetch(true)
       dispatch(safeRefetchQuotes())
-    } else if (timeSinceLastFetched > 60000) {
+    } else if (timeSinceLastFetched > swapsQuoteRefreshTime) {
       dispatch(setSwapsErrorKey(QUOTES_EXPIRED_ERROR))
       history.push(SWAPS_ERROR_ROUTE)
     }
-  }, [quotesLastFetched, dispatchedSafeRefetch, dispatch, history])
+  }, [
+    quotesLastFetched,
+    dispatchedSafeRefetch,
+    dispatch,
+    history,
+    swapsQuoteRefreshTime,
+  ])
 
   useEffect(() => {
     if (!originalApproveAmount && approveAmount) {


### PR DESCRIPTION
Fixes: #10010

The MetaSwap team has implemented a new endpoint which tells us how often quotes should refresh.  We were hardcoding 60 seconds as the refresh value, but moving that value to the MetaSwap API would prevent the MetaMask team from needing to create and deploy a new release in each browser to adjust that value.

As to why I've gone this route to accomplish this functionality, I like this strategy because we aren't pinging MetaSwap until we absolutely need to (i.e. when we're fetching quotes to display).  We also benefit from `fetchWithCache` caching that value, so that we aren't pinging MetaSwap each time.  @cloudonshore had mentioned this value wouldn't often change, so a fetch with cache only when we need that value should make us performant.