### PR TITLE
Increase Chrome minimum version

### DIFF
--- a/app/manifest/chrome.json
+++ b/app/manifest/chrome.json
@@ -3,5 +3,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "58"
+  "minimum_chrome_version": "63"
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,7 @@ module.exports = function (api) {
         '@babel/preset-env',
         {
           targets: {
-            browsers: ['chrome >= 58', 'firefox >= 56.2'],
+            browsers: ['chrome >= 63', 'firefox >= 56.2'],
           },
         },
       ],


### PR DESCRIPTION
The Chrome minimum version has been increased from v58 to v63. We found that we had very few users on versions below v63, and v62 is incompatible with our SES lockdown dependency.

This also makes us compatible with Object rest/spread syntax, so we might not have to transpile that anymore. I'll revisit that separately.