### PR TITLE
Rename `lockdown.cjs` to `lockdown.js`

### DIFF
--- a/app/home.html
+++ b/app/home.html
@@ -12,7 +12,7 @@
     <div id="popover-content"></div>
     <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
     <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
-    <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
+    <script src="./lockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui-libs.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui.js" type="text/javascript" charset="utf-8"></script>

--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -4,7 +4,7 @@
     "scripts": [
       "globalthis.js",
       "initSentry.js",
-      "lockdown.cjs",
+      "lockdown.js",
       "runLockdown.js",
       "bg-libs.js",
       "background.js"
@@ -39,7 +39,7 @@
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "js": [
         "globalthis.js",
-        "lockdown.cjs",
+        "lockdown.js",
         "runLockdown.js",
         "contentscript.js"
       ],

--- a/app/notification.html
+++ b/app/notification.html
@@ -35,7 +35,7 @@
     <div id="popover-content"></div>
     <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
     <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
-    <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
+    <script src="./lockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui-libs.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui.js" type="text/javascript" charset="utf-8"></script>

--- a/app/phishing.html
+++ b/app/phishing.html
@@ -3,7 +3,7 @@
   <head>
     <title>Ethereum Phishing Detection - MetaMask</title>
     <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
-    <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
+    <script src="./lockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./phishing-detect.js"></script>
     <link rel="stylesheet" type="text/css" href="./index.css" title="ltr">

--- a/app/popup.html
+++ b/app/popup.html
@@ -12,7 +12,7 @@
     <div id="popover-content"></div>
     <script src="./globalthis.js" type="text/javascript" charset="utf-8"></script>
     <script src="./initSentry.js" type="text/javascript" charset="utf-8"></script>
-    <script src="./lockdown.cjs" type="text/javascript" charset="utf-8"></script>
+    <script src="./lockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./runLockdown.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui-libs.js" type="text/javascript" charset="utf-8"></script>
     <script src="./ui.js" type="text/javascript" charset="utf-8"></script>

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -49,9 +49,8 @@ const copyTargets = [
     dest: `globalthis.js`,
   },
   {
-    src: `./node_modules/ses/dist/`,
-    pattern: `lockdown.cjs`,
-    dest: ``,
+    src: `./node_modules/ses/dist/lockdown.cjs`,
+    dest: `lockdown.js`,
   },
   {
     src: `./app/scripts/`,


### PR DESCRIPTION
When you load an extension `.zip` file in Firefox, it fails to load scripts with the `.cjs` file extension. However, it works if you load
the extension via the `manifest.json` file instead.

After renaming the `lockdown.cjs` file to `lockdown.js`, it works in Firefox in all cases, regardless whether it's loaded by manifest or by `.zip`.

Fixes #10023