### PR TITLE
Fix TokenList component name

### DIFF
--- a/ui/app/pages/add-token/token-list/token-list.component.js
+++ b/ui/app/pages/add-token/token-list/token-list.component.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import { checkExistingAddresses } from '../../../helpers/utils/util'
 import TokenListPlaceholder from './token-list-placeholder'
 
-export default class InfoBox extends Component {
+export default class TokenList extends Component {
   static contextTypes = {
     t: PropTypes.func,
   }


### PR DESCRIPTION
The TokenList component on the `add-token` page had the name `InfoBox`, which doesn't seem applicable. It has been renamed to `TokenList`, to match the module filename and the component name we use elsewhere.