### PR TITLE
Fix contentscript injection failure on Firefox 56

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -195,6 +195,7 @@ module.exports = {
         'babel.config.js',
         'nyc.config.js',
         'stylelint.config.js',
+        'app/scripts/runLockdown.js',
         'development/**/*.js',
         'test/e2e/**/*.js',
         'test/lib/wait-until-called.js',

--- a/app/scripts/runLockdown.js
+++ b/app/scripts/runLockdown.js
@@ -1,8 +1,19 @@
 // Freezes all intrinsics
-// eslint-disable-next-line no-undef,import/unambiguous
-lockdown({
-  consoleTaming: 'unsafe',
-  errorTaming: 'unsafe',
-  mathTaming: 'unsafe',
-  dateTaming: 'unsafe',
-})
+try {
+  // eslint-disable-next-line no-undef,import/unambiguous
+  lockdown({
+    consoleTaming: 'unsafe',
+    errorTaming: 'unsafe',
+    mathTaming: 'unsafe',
+    dateTaming: 'unsafe',
+  })
+} catch (error) {
+  // If the `lockdown` call throws an exception, it interferes with the
+  // contentscript injection on some versions of Firefox. The error is
+  // caught and logged here so that the contentscript still gets injected.
+  // This affects Firefox v56 and Waterfox Classic
+  console.error('Lockdown failed:', error)
+  if (window.sentry && window.sentry.captureException) {
+    window.sentry.captureException(error)
+  }
+}


### PR DESCRIPTION
On Firefox 56 and Waterfox Classic, our `runLockdown.js` script throws an error. This is fine on the HTML pages, as the next script tags still get run without issue (though they don't benefit from the SES lockdown sadly). But in the `contentscript`, an exception thrown here appears to halt the execution of subsequent scripts.

To prevent the `contentscript` from crashing completely, lockdown errors are now caught and logged. They are also logged to Sentry on the pages where Sentry is setup.