### PR TITLE
Disable console in contentscript

### DIFF
--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -38,6 +38,7 @@
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "js": [
+        "disable-console.js",
         "globalthis.js",
         "lockdown.js",
         "runLockdown.js",

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -223,7 +223,6 @@ function blockedDomainCheck() {
  * Redirects the current page to a phishing information page
  */
 function redirectToPhishingWarning() {
-  console.log('MetaMask - routing to Phishing Warning component')
   const extensionURL = extension.runtime.getURL('phishing.html')
   window.location.href = `${extensionURL}#${querystring.stringify({
     hostname: window.location.hostname,

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -38,8 +38,8 @@ function injectScript(content) {
     scriptTag.textContent = content
     container.insertBefore(scriptTag, container.children[0])
     container.removeChild(scriptTag)
-  } catch (e) {
-    console.error('MetaMask provider injection failed.', e)
+  } catch (error) {
+    console.error('MetaMask: Provider injection failed.', error)
   }
 }
 
@@ -85,7 +85,7 @@ function forwardTrafficBetweenMuxes(channelName, muxA, muxB) {
   const channelB = muxB.createStream(channelName)
   pump(channelA, channelB, channelA, (error) =>
     console.debug(
-      `MetaMask muxed traffic for channel "${channelName}" failed.`,
+      `MetaMask: Muxed traffic for channel "${channelName}" failed.`,
       error,
     ),
   )
@@ -99,7 +99,7 @@ function forwardTrafficBetweenMuxes(channelName, muxA, muxB) {
  */
 function logStreamDisconnectWarning(remoteLabel, error) {
   console.debug(
-    `MetaMask Contentscript: Lost connection to "${remoteLabel}".`,
+    `MetaMask: Content script lost connection to "${remoteLabel}".`,
     error,
   )
 }
@@ -223,6 +223,7 @@ function blockedDomainCheck() {
  * Redirects the current page to a phishing information page
  */
 function redirectToPhishingWarning() {
+  console.debug('MetaMask: Routing to Phishing Warning component.')
   const extensionURL = extension.runtime.getURL('phishing.html')
   window.location.href = `${extensionURL}#${querystring.stringify({
     hostname: window.location.hostname,

--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -1,4 +1,7 @@
 // disable console.log in contentscript to prevent SES/lockdown logging to external page
+// eslint-disable-next-line import/unambiguous
 if (typeof window.console !== undefined) {
+  // eslint-disable-next-line no-empty-function
   console.log = () => {}
+
 }

--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -3,5 +3,4 @@
 if (typeof window.console !== undefined) {
   // eslint-disable-next-line no-empty-function
   console.log = () => {}
-
 }

--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -1,0 +1,4 @@
+// disable console.log in contentscript to prevent SES/lockdown logging to external page
+if (typeof window.console !== undefined) {
+  console.log = () => {}
+}

--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -1,7 +1,7 @@
 // Disable console.log in contentscript to prevent SES/lockdown logging to external page
 // eslint-disable-next-line import/unambiguous
 if (
-  !(typeof process !== 'undefined' && process.env?.METAMASK_DEBUG) &&
+  !(typeof process !== 'undefined' && process.env.METAMASK_DEBUG) &&
   typeof console !== undefined
 ) {
   console.log = () => undefined

--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -1,6 +1,10 @@
-// disable console.log in contentscript to prevent SES/lockdown logging to external page
+// Disable console.log in contentscript to prevent SES/lockdown logging to external page
 // eslint-disable-next-line import/unambiguous
-if (typeof window.console !== undefined) {
-  // eslint-disable-next-line no-empty-function
-  console.log = () => {}
+if (
+  typeof process !== 'undefined' &&
+  !process.env.METAMASK_DEBUG &&
+  typeof console !== undefined
+) {
+  console.log = () => undefined
+  console.info = () => undefined
 }

--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -1,8 +1,7 @@
 // Disable console.log in contentscript to prevent SES/lockdown logging to external page
 // eslint-disable-next-line import/unambiguous
 if (
-  typeof process !== 'undefined' &&
-  !process.env.METAMASK_DEBUG &&
+  !(typeof process !== 'undefined' && process.env?.METAMASK_DEBUG) &&
   typeof console !== undefined
 ) {
   console.log = () => undefined

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -115,11 +115,18 @@ function createScriptTasks({ browserPlatforms, livereload }) {
         }),
       )
     })
+
     // inpage must be built before contentscript
     // because inpage bundle result is included inside contentscript
     const contentscriptSubtask = createTask(
       `${taskPrefix}:contentscript`,
       createTaskForBuildJsExtensionContentscript({ devMode, testing }),
+    )
+
+    // this can run whenever
+    const disableConsoleSubtask = createTask(
+      `${taskPrefix}:disable-console`,
+      createTaskForBuildJsExtensionDisableConsole({ devMode }),
     )
 
     // task for initiating livereload
@@ -142,6 +149,7 @@ function createScriptTasks({ browserPlatforms, livereload }) {
     const allSubtasks = [
       ...standardSubtasks,
       contentscriptSubtask,
+      disableConsoleSubtask,
     ].map((subtask) => runInChildProcess(subtask))
     // const allSubtasks = [...standardSubtasks, contentscriptSubtask].map(subtask => (subtask))
     // make a parent task that runs each task in a child thread
@@ -162,6 +170,16 @@ function createScriptTasks({ browserPlatforms, livereload }) {
         : externalDependenciesMap[filename],
       devMode,
       testing,
+    })
+  }
+
+  function createTaskForBuildJsExtensionDisableConsole({ devMode }) {
+    const filename = 'disable-console'
+    return bundleTask({
+      label: filename,
+      filename: `${filename}.js`,
+      filepath: `./app/scripts/${filename}.js`,
+      devMode,
     })
   }
 

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -49,6 +49,11 @@ const copyTargets = [
     dest: `globalthis.js`,
   },
   {
+    src: `./app/scripts/`,
+    pattern: `disable-console.js`,
+    dest: ``,
+  },
+  {
     src: `./node_modules/ses/dist/lockdown.cjs`,
     dest: `lockdown.js`,
   },

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -49,11 +49,6 @@ const copyTargets = [
     dest: `globalthis.js`,
   },
   {
-    src: `./app/scripts/`,
-    pattern: `disable-console.js`,
-    dest: ``,
-  },
-  {
     src: `./node_modules/ses/dist/lockdown.cjs`,
     dest: `lockdown.js`,
   },


### PR DESCRIPTION
Logging in the content scripts surfaces to the external page console. SES/lockdown's logging of removals was appearing in the web console on every web page. This fix renders `console` useless inside of content scripts to avoid this.