### PR TITLE
Fix 9874 - Improve gas maximum estimation 

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -39,7 +39,6 @@ import { calcGasTotal } from '../../pages/send/send.utils'
 import {
   decimalToHex,
   getValueFromWeiHex,
-  hexMax,
   decGWEIToHexWEI,
   hexToDecimal,
   hexWEIToDecGWEI,
@@ -593,20 +592,13 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     const usedQuote = getUsedQuote(state)
     const usedTradeTxParams = usedQuote.trade
 
-    const estimatedGasLimit = new BigNumber(
-      usedQuote?.gasEstimate || `0x${decimalToHex(0)}`,
-      16,
-    )
+    const estimatedGasLimit = new BigNumber(usedQuote?.gasEstimate || `0x0`, 16)
     const estimatedGasLimitWithMultiplier = estimatedGasLimit
       .times(usedQuote?.gasMultiplier, 10)
       .round(0)
       .toString(16)
     const maxGasLimit =
-      customSwapsGas ||
-      hexMax(
-        `0x${decimalToHex(usedQuote?.maxGas || 0)}`,
-        estimatedGasLimitWithMultiplier,
-      )
+      customSwapsGas || estimatedGasLimitWithMultiplier || usedQuote?.maxGas
 
     const usedGasPrice = getUsedSwapsGasPrice(state)
     usedTradeTxParams.gas = maxGasLimit

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -594,11 +594,11 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     const usedTradeTxParams = usedQuote.trade
 
     const estimatedGasLimit = new BigNumber(
-      usedQuote?.gasEstimate || decimalToHex(usedQuote?.averageGas || 0),
+      usedQuote?.gasEstimate || `0x${decimalToHex(0)}`,
       16,
     )
     const estimatedGasLimitWithMultiplier = estimatedGasLimit
-      .times(1.4, 10)
+      .times(usedQuote?.gasMultiplier, 10)
       .round(0)
       .toString(16)
     const maxGasLimit =

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -66,6 +66,8 @@ const GAS_PRICES_LOADING_STATES = {
   COMPLETED: 'COMPLETED',
 }
 
+export const FALLBACK_GAS_MULTIPLIER = 1.5
+
 const initialState = {
   aggregatorMetadata: null,
   approveTxId: null,
@@ -594,7 +596,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
 
     const estimatedGasLimit = new BigNumber(usedQuote?.gasEstimate || `0x0`, 16)
     const estimatedGasLimitWithMultiplier = estimatedGasLimit
-      .times(usedQuote?.gasMultiplier, 10)
+      .times(usedQuote?.gasMultiplier || FALLBACK_GAS_MULTIPLIER, 10)
       .round(0)
       .toString(16)
     const maxGasLimit =

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -598,7 +598,10 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       .round(0)
       .toString(16)
     const maxGasLimit =
-      customSwapsGas || estimatedGasLimitWithMultiplier || usedQuote?.maxGas
+      customSwapsGas ||
+      (usedQuote?.gasEstimate
+        ? estimatedGasLimitWithMultiplier
+        : usedQuote?.maxGas)
 
     const usedGasPrice = getUsedSwapsGasPrice(state)
     usedTradeTxParams.gas = maxGasLimit

--- a/ui/app/helpers/utils/conversions.util.js
+++ b/ui/app/helpers/utils/conversions.util.js
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js'
 import { ETH, GWEI, WEI } from '../constants/common'
 import { addHexPrefix } from '../../../../app/scripts/lib/util'
 import {
@@ -161,16 +160,6 @@ export function hexWEIToDecETH(hexWEI) {
     fromDenomination: 'WEI',
     toDenomination: 'ETH',
   })
-}
-
-export function hexMax(...hexNumbers) {
-  let max = hexNumbers[0]
-  hexNumbers.slice(1).forEach((hexNumber) => {
-    if (new BigNumber(hexNumber, 16).gt(max, 16)) {
-      max = hexNumber
-    }
-  })
-  return max
 }
 
 export function addHexes(aHexWEI, bHexWEI) {

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -112,6 +112,10 @@ const QUOTE_VALIDATORS = [
     property: 'maxGas',
     type: 'number',
   },
+  {
+    property: 'gasEstimate',
+    type: 'number|undefined',
+  }
 ]
 
 const TOKEN_VALIDATORS = [

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -115,7 +115,7 @@ const QUOTE_VALIDATORS = [
   {
     property: 'gasEstimate',
     type: 'number|undefined',
-  }
+  },
 ]
 
 const TOKEN_VALIDATORS = [

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -115,6 +115,7 @@ const QUOTE_VALIDATORS = [
   {
     property: 'gasEstimate',
     type: 'number|undefined',
+    validator: (gasEstimate) => gasEstimate === undefined || gasEstimate > 0,
   },
 ]
 

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -12,6 +12,7 @@ import { useSwapsEthToken } from '../../../hooks/useSwapsEthToken'
 import { MetaMetricsContext } from '../../../contexts/metametrics.new'
 import FeeCard from '../fee-card'
 import {
+  FALLBACK_GAS_MULTIPLIER,
   getQuotes,
   getSelectedQuote,
   getApproveTxParams,
@@ -125,7 +126,7 @@ export default function ViewQuote() {
   const gasLimitForMax = usedQuote?.gasEstimate || `0x0`
 
   const usedGasLimitWithMultiplier = new BigNumber(gasLimitForMax, 16)
-    .times(usedQuote?.gasMultiplier, 10)
+    .times(usedQuote?.gasMultiplier || FALLBACK_GAS_MULTIPLIER, 10)
     .round(0)
     .toString(16)
 

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -122,7 +122,7 @@ export default function ViewQuote() {
     usedQuote?.gasEstimateWithRefund ||
     `0x${decimalToHex(usedQuote?.averageGas || 0)}`
 
-  const gasLimitForMax = usedQuote?.gasEstimate || `0x${decimalToHex(0)}`
+  const gasLimitForMax = usedQuote?.gasEstimate || `0x0`
 
   const usedGasLimitWithMultiplier = new BigNumber(gasLimitForMax, 16)
     .times(usedQuote?.gasMultiplier, 10)

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -57,7 +57,6 @@ import {
 } from '../../../helpers/utils/token-util'
 import {
   decimalToHex,
-  hexMax,
   hexToDecimal,
   getValueFromWeiHex,
 } from '../../../helpers/utils/conversions.util'
@@ -123,18 +122,16 @@ export default function ViewQuote() {
     usedQuote?.gasEstimateWithRefund ||
     `0x${decimalToHex(usedQuote?.averageGas || 0)}`
 
-  const gasLimitForMax =
-    usedQuote?.gasEstimate || `0x${decimalToHex(usedQuote?.averageGas || 0)}`
+  const gasLimitForMax = usedQuote?.gasEstimate || `0x${decimalToHex(0)}`
 
   const usedGasLimitWithMultiplier = new BigNumber(gasLimitForMax, 16)
-    .times(1.4, 10)
+    .times(usedQuote?.gasMultiplier, 10)
     .round(0)
     .toString(16)
 
-  const nonCustomMaxGasLimit = hexMax(
-    `0x${decimalToHex(usedQuote?.maxGas || 0)}`,
-    usedGasLimitWithMultiplier,
-  )
+  const nonCustomMaxGasLimit = usedQuote?.gasEstimate
+    ? usedGasLimitWithMultiplier
+    : `0x${decimalToHex(usedQuote?.maxGas || 0)}`
   const maxGasLimit = customMaxGas || nonCustomMaxGasLimit
 
   const gasTotalInWeiHex = calcGasTotal(maxGasLimit, gasPrice)


### PR DESCRIPTION
Fixes: #9874

This is important as some of our gas estimates are high, possibly preventing some users from completing swaps
