### PR TITLE
Fix token validation in Send flow

### DIFF
--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -156,7 +156,7 @@ export default class SendTransactionScreen extends Component {
 
     if (sendTokenAddress && prevTokenAddress !== sendTokenAddress) {
       this.updateSendToken()
-      this.validate(sendTokenAddress)
+      this.validate(this.state.query)
       updateGas = true
     }
 


### PR DESCRIPTION
Additional validation was added in #9907 to ensure that the "Known contract address" warning was shown when sending tokens to another token address after switching assets on the Send screen. Unfortunately this change had the unintended side-effect of preventing _all_ token sends after switching assets, so long as the recipient was not an internal address.

The problem is that the `validate` function expects to be passed the address of the token send recipient in the case where a token is selected. Instead the token address was being passed to the validate function.

The `query` state is now used, which should always contain the recipient address. This is the same state used in the only other place the `validate` function is called.

Fixes: #10044

Manual testing steps:  

To test that the validation doesn't incorrectly flag a non-contract-address as a contract address:
1. Click 'Send' on the Home screen
2. Enter some external address (one that is _not_ a contract address)
3. Select a token in the "Asset" dropdown
4. You should not see the "Known contract address" warning

To test that the validation still works when the recipient really is a known token address:
1. On the home screen, Click Send button.
2. Add a token contract to recipient address. i.e. `0x0F5D2fB29fb7d3CFeE444a200298f468908cC942 (MANA)`
3. On the Screen, the Asset should be ETH. Change to any token. 
4. The warning `Known contract address` should show.