### PR TITLE
Refactor home notification

### DIFF
--- a/ui/app/components/app/home-notification/home-notification.component.js
+++ b/ui/app/components/app/home-notification/home-notification.component.js
@@ -43,7 +43,7 @@ const HomeNotification = ({
           <Button
             type="secondary"
             className="home-notification__ignore-button"
-            onClick={() => onIgnore()}
+            onClick={onIgnore}
           >
             {ignoreText}
           </Button>

--- a/ui/app/components/app/home-notification/home-notification.component.js
+++ b/ui/app/components/app/home-notification/home-notification.component.js
@@ -34,7 +34,7 @@ const HomeNotification = ({
           <Button
             type="primary"
             className="home-notification__accept-button"
-            onClick={() => onAccept()}
+            onClick={onAccept}
           >
             {acceptText}
           </Button>

--- a/ui/app/components/app/home-notification/home-notification.component.js
+++ b/ui/app/components/app/home-notification/home-notification.component.js
@@ -1,101 +1,66 @@
-import React, { PureComponent } from 'react'
+import React from 'react'
 import classnames from 'classnames'
-import { Tooltip as ReactTippy } from 'react-tippy'
 import PropTypes from 'prop-types'
 import Button from '../../ui/button'
+import Tooltip from '../../ui/tooltip'
 
-export default class HomeNotification extends PureComponent {
-  static contextTypes = {
-    metricsEvent: PropTypes.func,
-  }
-
-  static defaultProps = {
-    onAccept: null,
-    ignoreText: null,
-    onIgnore: null,
-    infoText: null,
-  }
-
-  static propTypes = {
-    acceptText: PropTypes.node.isRequired,
-    onAccept: PropTypes.func,
-    ignoreText: PropTypes.node,
-    onIgnore: PropTypes.func,
-    descriptionText: PropTypes.node.isRequired,
-    infoText: PropTypes.node,
-    classNames: PropTypes.array,
-  }
-
-  handleAccept = () => {
-    this.props.onAccept()
-  }
-
-  handleIgnore = () => {
-    this.props.onIgnore()
-  }
-
-  render() {
-    const {
-      descriptionText,
-      acceptText,
-      onAccept,
-      ignoreText,
-      onIgnore,
-      infoText,
-      classNames = [],
-    } = this.props
-
-    return (
-      <div className={classnames('home-notification', ...classNames)}>
-        <div className="home-notification__header">
-          <div className="home-notification__header-container">
-            <img
-              className="home-notification__icon"
-              alt=""
-              src="images/icons/connect.svg"
-            />
-            <div className="home-notification__text">{descriptionText}</div>
-          </div>
-          {infoText ? (
-            <ReactTippy
-              style={{
-                display: 'flex',
-              }}
-              html={
-                <p className="home-notification-tooltip__content">{infoText}</p>
-              }
-              offset={-36}
-              distance={36}
-              animation="none"
-              position="top"
-              arrow
-              theme="tippy-tooltip-home"
-            >
-              <img alt="" src="images/icons/info.svg" />
-            </ReactTippy>
-          ) : null}
+const HomeNotification = ({
+  acceptText,
+  classNames = [],
+  descriptionText,
+  ignoreText,
+  infoText,
+  onAccept,
+  onIgnore,
+}) => {
+  return (
+    <div className={classnames('home-notification', ...classNames)}>
+      <div className="home-notification__content">
+        <div className="home-notification__content-container">
+          <div className="home-notification__text">{descriptionText}</div>
         </div>
-        <div className="home-notification__buttons">
-          {onAccept && acceptText ? (
-            <Button
-              type="primary"
-              className="home-notification__accept-button"
-              onClick={this.handleAccept}
-            >
-              {acceptText}
-            </Button>
-          ) : null}
-          {onIgnore && ignoreText ? (
-            <Button
-              type="secondary"
-              className="home-notification__ignore-button"
-              onClick={this.handleIgnore}
-            >
-              {ignoreText}
-            </Button>
-          ) : null}
-        </div>
+        {infoText ? (
+          <Tooltip
+            position="top"
+            title={infoText}
+            wrapperClassName="home-notification__tooltip-wrapper"
+          >
+            <i className="fa fa-info-circle" />
+          </Tooltip>
+        ) : null}
       </div>
-    )
-  }
+      <div className="home-notification__buttons">
+        {onAccept && acceptText ? (
+          <Button
+            type="primary"
+            className="home-notification__accept-button"
+            onClick={() => onAccept()}
+          >
+            {acceptText}
+          </Button>
+        ) : null}
+        {onIgnore && ignoreText ? (
+          <Button
+            type="secondary"
+            className="home-notification__ignore-button"
+            onClick={() => onIgnore()}
+          >
+            {ignoreText}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
 }
+
+HomeNotification.propTypes = {
+  acceptText: PropTypes.node,
+  classNames: PropTypes.array,
+  descriptionText: PropTypes.node.isRequired,
+  ignoreText: PropTypes.node,
+  infoText: PropTypes.node,
+  onAccept: PropTypes.func,
+  onIgnore: PropTypes.func,
+}
+
+export default HomeNotification

--- a/ui/app/components/app/home-notification/index.scss
+++ b/ui/app/components/app/home-notification/index.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-flow: column;
   justify-content: space-between;
-
   background: rgba(36, 41, 46, 0.9);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
   border-radius: 8px;

--- a/ui/app/components/app/home-notification/index.scss
+++ b/ui/app/components/app/home-notification/index.scss
@@ -1,14 +1,8 @@
-.tippy-tooltip {
-  // This looks weird, but its repeating the class name
-  // using interpolation for higher specificity.
-  &#{&}-home-theme {
-    background: rgba(36, 41, 46, 0.9);
-    color: $white;
-    border-radius: 8px;
-  }
-}
-
 .home-notification {
+  display: flex;
+  flex-flow: column;
+  justify-content: space-between;
+
   background: rgba(36, 41, 46, 0.9);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
   border-radius: 8px;
@@ -19,31 +13,20 @@
     min-width: 472px;
   }
 
-  display: flex;
-  flex-flow: column;
-  justify-content: space-between;
-
-  &__header-container {
+  &__content-container {
     display: flex;
   }
 
-  &__header {
+  &__content {
     display: flex;
     align-items: center;
     justify-content: space-between;
-  }
-
-  &__icon {
-    height: 16px;
-    align-self: center;
   }
 
   &__text {
     @include H7;
 
     color: $white;
-    margin-left: 10px;
-    margin-right: 8px;
   }
 
   .fa-info-circle {
@@ -102,23 +85,14 @@
   &__buttons {
     display: flex;
     width: 100%;
-    margin-top: 10px;
-    justify-content: flex-start;
+    padding-top: 10px;
+    align-items: center;
+    justify-content: space-between;
     flex-direction: row-reverse;
   }
-}
 
-.home-notification-tooltip {
-  &__tooltip-container {
+  &__tooltip-wrapper {
     display: flex;
-  }
-
-  &__content {
-    @include H7;
-
-    color: $white;
-    text-align: left;
-    display: inline-block;
-    width: 200px;
+    margin-left: 10px;
   }
 }


### PR DESCRIPTION
The `HomeNotification` refactor pulled from #10039, with some additional changes. In sum:

- Refactor `HomeNotification` to a functional component
- Remove the "connect" svg icon
  - This was just meaningless filler.
- Use our own `Tooltip` component instead of `react-tippy` directly
- Update button spacing
- Various style fixes

Here's what the existing notifications look like with the updates:
<img src="https://user-images.githubusercontent.com/25517051/101819826-9d396d00-3ada-11eb-93f5-d67190383786.png" width=350px>
<img src="https://user-images.githubusercontent.com/25517051/101819837-a0345d80-3ada-11eb-8313-33d6b224f7f4.png" width=350px>