### PR TITLE
Prevent metaMaskFee prop error in FeeCard

### DIFF
--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -544,7 +544,7 @@ export default function ViewQuote() {
             tokenApprovalTextComponent={tokenApprovalTextComponent}
             tokenApprovalSourceTokenSymbol={sourceTokenSymbol}
             onTokenApprovalClick={onFeeCardTokenApprovalClick}
-            metaMaskFee={metaMaskFee}
+            metaMaskFee={String(metaMaskFee)}
             isBestQuote={isBestQuote}
             numberOfQuotes={Object.values(quotes).length}
             onQuotesClick={() => {


### PR DESCRIPTION
I noticed a prop error when getting a quote.  This was introduced a few days ago:

https://github.com/MetaMask/metamask-extension/commit/da5e5cd8b6c3027c8caf0f5f6de906da54b32037

Simple fix.