### PR TITLE
Display boolean values when signing typed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Current Develop Branch
+- [#10048](https://github.com/MetaMask/metamask-extension/pull/10048): Display boolean values when signing typed data
 
 ## 8.1.8 Wed Dec 09 2020
 - [#9992](https://github.com/MetaMask/metamask-extension/pull/9992): Improve transaction params validation

--- a/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -29,7 +29,7 @@ export default class SignatureRequestMessage extends PureComponent {
               this.renderNode(value)
             ) : (
               <span className="signature-request-message--node-value">
-                {value.toString()}
+                {`${value}`}
               </span>
             )}
           </div>

--- a/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -29,7 +29,7 @@ export default class SignatureRequestMessage extends PureComponent {
               this.renderNode(value)
             ) : (
               <span className="signature-request-message--node-value">
-                {value}
+                {value.toString()}
               </span>
             )}
           </div>


### PR DESCRIPTION
Fixes: #4639.

Explanation:  The confirmation popup when signing typed data was not correctly displaying boolean fields. This is because booleans have special meaning in JSX and don't render their string representation ([source](https://react-cn.github.io/react/tips/false-in-jsx.html)). The fix is simple, just `toString()` the values being displayed.

Manual testing steps:  
  - Load sample code included below :point_down:. 

  - Check to see that the values are correctly displayed (especially noting the `bool` value which is displayed now)
    ![image](https://user-images.githubusercontent.com/4210206/101836687-2635c000-3b3e-11eb-85db-d2dbdca13168.png)

  - Profit :euro: 

<details><summary><code>index.html</code></summary>

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <title>Sign Typed Data Test</title>
    <script src="./index.js"></script>
  </head>
  <body>
    <button id="sign">eth_signTypedData</button>
  </body>
</html>
```

</details>
<details><summary><code>index.js</code></summary>

```js
import { ethers, BigNumber } from "ethers";

async function main() {
  await window.ethereum.enable();

  const provider = new ethers.providers.Web3Provider(window.ethereum);
  const signer = provider.getSigner();
  const account = await signer.getAddress();

  document.querySelector("#sign").addEventListener("click", async () => {
    const signature = await provider.send("eth_signTypedData_v4", [
      account.toLowerCase(),
      JSON.stringify({
        types: {
          EIP712Domain: [
            { name: "name", type: "string" },
          ],
          Data: [
            { name: "bytes2", type: "bytes2" },
            { name: "uint32", type: "uint32" },
            { name: "bool", type: "bool" },
            { name: "bytes", type: "bytes" },
            { name: "string", type: "string" },
            { name: "nested", type: "Inner[]" },
          ],
          Inner: [
            { name: "int8", type: "int8" },
            { name: "uint128", type: "uint128" },
            { name: "address", type: "address" },
          ],
        },
        primaryType: "Data",
        domain: { name: "Test" },
        message: {
          bytes2: "0x1337",
          uint32: "0xbadc0de",
          bool: true,
          bytes: "0x010203040506070809",
          string: "Hello MetaMask!",
          nested: [{
            int8: -42,
            uint128: BigNumber.from("12384761928764192812341324214").toHexString(),
            address: account,
          }],
        },
      })
    ]);

    console.log(signature);
  });
}

main()
  .then(() => console.log("done"))
  .catch((err) => console.error(err));
```

</details>