### PR TITLE
Reduce swaps liveness fetching interval in controller to once every 6 hours

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -634,14 +634,14 @@ export default class SwapsController {
 
   /**
    * Sets up the fetching of the swaps feature liveness flag from our API.
-   * Performs an initial fetch when called, then fetches on a 10-minute
+   * Performs an initial fetch when called, then fetches on a six-hour interval
    * interval.
    *
    * If the browser goes offline, the interval is cleared and swaps are disabled
    * until the value can be fetched again.
    */
   _setupSwapsLivenessFetching() {
-    const TEN_MINUTES_MS = 10 * 60 * 1000
+    const SIX_HOURS = 6 * 60 * 60 * 1000
     let intervalId = null
 
     const fetchAndSetupInterval = () => {
@@ -650,7 +650,7 @@ export default class SwapsController {
         // initial call to this function.
         intervalId = setInterval(
           this._fetchAndSetSwapsLiveness.bind(this),
-          TEN_MINUTES_MS,
+          SIX_HOURS,
         )
         this._fetchAndSetSwapsLiveness()
       }

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -29,7 +29,7 @@ const MAX_GAS_LIMIT = 2500000
 const POLL_COUNT_LIMIT = 3
 
 // Represents the interval time for which we check for swaps feature liveliness
-const SWAPS_LIVELINESS_CHECK_INTERVAL = 6 * 60 * 60 * 1000 // 6 hours
+export const SWAPS_LIVELINESS_CHECK_INTERVAL = 6 * 60 * 60 * 1000 // 6 hours
 
 function calculateGasEstimateWithRefund(
   maxGas = MAX_GAS_LIMIT,

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -28,6 +28,9 @@ const MAX_GAS_LIMIT = 2500000
 // 3 seems to be an appropriate balance of giving users the time they need when MetaMask is not left idle, and turning polling off when it is.
 const POLL_COUNT_LIMIT = 3
 
+// Represents the interval time for which we check for swaps feature liveliness
+const SWAPS_LIVELINESS_CHECK_INTERVAL = 6 * 60 * 60 * 1000 // 6 hours
+
 function calculateGasEstimateWithRefund(
   maxGas = MAX_GAS_LIMIT,
   estimatedRefund = 0,
@@ -634,14 +637,13 @@ export default class SwapsController {
 
   /**
    * Sets up the fetching of the swaps feature liveness flag from our API.
-   * Performs an initial fetch when called, then fetches on a six-hour interval
+   * Performs an initial fetch when called, then fetches on a fixed
    * interval.
    *
    * If the browser goes offline, the interval is cleared and swaps are disabled
    * until the value can be fetched again.
    */
   _setupSwapsLivenessFetching() {
-    const SIX_HOURS = 6 * 60 * 60 * 1000
     let intervalId = null
 
     const fetchAndSetupInterval = () => {
@@ -650,7 +652,7 @@ export default class SwapsController {
         // initial call to this function.
         intervalId = setInterval(
           this._fetchAndSetSwapsLiveness.bind(this),
-          SIX_HOURS,
+          SWAPS_LIVELINESS_CHECK_INTERVAL,
         )
         this._fetchAndSetSwapsLiveness()
       }

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -29,7 +29,7 @@ const MAX_GAS_LIMIT = 2500000
 const POLL_COUNT_LIMIT = 3
 
 // Represents the interval time for which we check for swaps feature liveliness
-export const SWAPS_LIVELINESS_CHECK_INTERVAL = 6 * 60 * 60 * 1000 // 6 hours
+export const SWAPS_LIVENESS_CHECK_INTERVAL = 6 * 60 * 60 * 1000 // 6 hours
 
 function calculateGasEstimateWithRefund(
   maxGas = MAX_GAS_LIMIT,
@@ -652,7 +652,7 @@ export default class SwapsController {
         // initial call to this function.
         intervalId = setInterval(
           this._fetchAndSetSwapsLiveness.bind(this),
-          SWAPS_LIVELINESS_CHECK_INTERVAL,
+          SWAPS_LIVENESS_CHECK_INTERVAL,
         )
         this._fetchAndSetSwapsLiveness()
       }

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -13,6 +13,7 @@ import { ETH_SWAPS_TOKEN_ADDRESS } from '../../../../ui/app/helpers/constants/sw
 import { createTestProviderTools } from '../../../stub/provider'
 import SwapsController, {
   utils,
+  SWAPS_LIVELINESS_CHECK_INTERVAL,
 } from '../../../../app/scripts/controllers/swaps'
 
 const MOCK_FETCH_PARAMS = {
@@ -868,7 +869,7 @@ describe('SwapsController', function () {
 
     describe('_setupSwapsLivenessFetching ', function () {
       let clock
-      const EXPECTED_TIME = 6 * 60 * 60 * 1000
+      const EXPECTED_TIME = SWAPS_LIVELINESS_CHECK_INTERVAL
 
       const getLivenessState = () => {
         return swapsController.store.getState().swapsState.swapsFeatureIsLive

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -868,7 +868,7 @@ describe('SwapsController', function () {
 
     describe('_setupSwapsLivenessFetching ', function () {
       let clock
-      const EXPECTED_TIME = 600000
+      const EXPECTED_TIME = 6 * 60 * 60 * 1000
 
       const getLivenessState = () => {
         return swapsController.store.getState().swapsState.swapsFeatureIsLive

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -13,7 +13,7 @@ import { ETH_SWAPS_TOKEN_ADDRESS } from '../../../../ui/app/helpers/constants/sw
 import { createTestProviderTools } from '../../../stub/provider'
 import SwapsController, {
   utils,
-  SWAPS_LIVELINESS_CHECK_INTERVAL,
+  SWAPS_LIVENESS_CHECK_INTERVAL,
 } from '../../../../app/scripts/controllers/swaps'
 
 const MOCK_FETCH_PARAMS = {
@@ -869,7 +869,7 @@ describe('SwapsController', function () {
 
     describe('_setupSwapsLivenessFetching ', function () {
       let clock
-      const EXPECTED_TIME = SWAPS_LIVELINESS_CHECK_INTERVAL
+      const EXPECTED_TIME = SWAPS_LIVENESS_CHECK_INTERVAL
 
       const getLivenessState = () => {
         return swapsController.store.getState().swapsState.swapsFeatureIsLive


### PR DESCRIPTION
Turning off the swaps `/featureFlag` api will happen very rarely now that swaps is very stable. Currently, we make a request to fetch it after various actions in the UI, and also on a 10 minute interval in the background. This background polling is causing a huge load on the server.

By reducing the polling time we reduce that load, while still providing some of the desired affect of the polling. If a user leaves there metamask running but without touching swaps for 6+ hours, that local liveness state can be updated. So, for instance, if we turn off the feature flag while the user is sleeping or over the course of their work day, it can update.

Meanwhile, the fetch on start of the app is maintained. So if we turn the feature flag back on and the user really wants to urgently regain access to swaps, they can close and open their browser.