### PR TITLE
Use CircleCI executors to simplify CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,19 @@
 version: 2.1
 
+executors:
+  node-browsers:
+    docker:
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+  node-browsers-medium-plus:
+    docker:
+      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    resource_class: medium+
+    environment:
+      NODE_OPTIONS: --max_old_space_size=2048
+  shellcheck:
+    docker:
+      - image: koalaman/shellcheck-alpine@sha256:35882cba254810c7de458528011e935ba2c4f3ebcb224275dfa7ebfa930ef294
+
 workflows:
   test_and_release:
     jobs:
@@ -98,8 +112,7 @@ workflows:
 
 jobs:
   create_release_pull_request:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -112,8 +125,7 @@ jobs:
             .circleci/scripts/release-create-release-pr
 
   prep-deps:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - run:
@@ -131,11 +143,7 @@ jobs:
           - build-artifacts
 
   prep-build:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
-    resource_class: medium+
-    environment:
-      NODE_OPTIONS: --max_old_space_size=2048
+    executor: node-browsers-medium-plus
     steps:
       - checkout
       - attach_workspace:
@@ -153,11 +161,7 @@ jobs:
             - builds
 
   prep-build-test:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
-    resource_class: medium+
-    environment:
-      NODE_OPTIONS: --max_old_space_size=2048
+    executor: node-browsers-medium-plus
     steps:
       - checkout
       - attach_workspace:
@@ -174,11 +178,7 @@ jobs:
             - dist-test
 
   prep-build-test-metrics:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
-    resource_class: medium+
-    environment:
-      NODE_OPTIONS: --max_old_space_size=2048
+    executor: node-browsers-medium-plus
     steps:
       - checkout
       - attach_workspace:
@@ -195,8 +195,7 @@ jobs:
             - dist-test-metrics
 
   prep-build-storybook:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -210,8 +209,7 @@ jobs:
             - .out
 
   test-lint:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -224,8 +222,7 @@ jobs:
           command: yarn verify-locales --quiet
 
   test-lint-shellcheck:
-    docker:
-      - image: koalaman/shellcheck-alpine@sha256:35882cba254810c7de458528011e935ba2c4f3ebcb224275dfa7ebfa930ef294
+    executor: shellcheck
     steps:
       - checkout
       - run: apk add --no-cache bash jq yarn
@@ -234,8 +231,7 @@ jobs:
           command: ./development/shellcheck.sh
 
   test-lint-lockfile:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -245,8 +241,7 @@ jobs:
           command: yarn lint:lockfile
 
   test-deps:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -256,8 +251,7 @@ jobs:
           command: .circleci/scripts/yarn-audit
 
   test-e2e-chrome:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -278,8 +272,7 @@ jobs:
           destination: test-artifacts
 
   test-e2e-chrome-metrics:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -300,8 +293,7 @@ jobs:
           destination: test-artifacts
 
   test-e2e-firefox:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - run:
@@ -325,8 +317,7 @@ jobs:
           destination: test-artifacts
 
   test-e2e-firefox-metrics:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - run:
@@ -350,8 +341,7 @@ jobs:
           destination: test-artifacts
 
   benchmark:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -371,8 +361,7 @@ jobs:
             - test-artifacts
 
   job-publish-prerelease:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -403,8 +392,7 @@ jobs:
           command: ./development/metamaskbot-build-announce.js
 
   job-publish-release:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -421,8 +409,7 @@ jobs:
           command: .circleci/scripts/release-create-master-pr
 
   job-publish-storybook:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -437,8 +424,7 @@ jobs:
             yarn storybook:deploy
 
   test-unit:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -452,8 +438,7 @@ jobs:
             - .nyc_output
             - coverage
   test-unit-global:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -463,8 +448,7 @@ jobs:
           command: yarn test:unit:global
 
   validate-source-maps:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -474,8 +458,7 @@ jobs:
           command: yarn validate-source-maps
 
   test-mozilla-lint:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:
@@ -485,16 +468,14 @@ jobs:
           command: NODE_OPTIONS=--max_old_space_size=3072 yarn mozilla-lint
 
   all-tests-pass:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - run:
           name: All Tests Passed
           command: echo 'weew - everything passed!'
 
   coveralls-upload:
-    docker:
-      - image: circleci/node@sha256:e16740707de2ebed45c05d507f33ef204902349c7356d720610b5ec6a35d3d88
+    executor: node-browsers
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
The CI config has been updated to use CircleCI executors. This allows us to define the container environments used in one place, and reuse these environment definitions between jobs.

This should result in no functional changes.