### PR TITLE
Use `.zip` for Firefox e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,10 +168,14 @@ jobs:
       - run:
           name: Move test build to 'dist-test' to avoid conflict with production build
           command: mv ./dist ./dist-test
+      - run:
+          name: Move test zips to 'builds-test' to avoid conflict with production build
+          command: mv ./builds ./builds-test
       - persist_to_workspace:
           root: .
           paths:
             - dist-test
+            - builds-test
 
   prep-build-test-metrics:
     docker:
@@ -189,10 +193,14 @@ jobs:
       - run:
           name: Move test build to 'dist-test-metrics' to avoid conflict with production build
           command: mv ./dist ./dist-test-metrics
+      - run:
+          name: Move test zips to 'builds-test' to avoid conflict with production build
+          command: mv ./builds ./builds-test-metrics
       - persist_to_workspace:
           root: .
           paths:
             - dist-test-metrics
+            - builds-test-metrics
 
   prep-build-storybook:
     docker:
@@ -266,6 +274,9 @@ jobs:
           name: Move test build to dist
           command: mv ./dist-test ./dist
       - run:
+          name: Move test zips to builds
+          command: mv ./builds-test ./builds
+      - run:
           name: test:e2e:chrome
           command: |
             if .circleci/scripts/test-run-e2e
@@ -287,6 +298,9 @@ jobs:
       - run:
           name: Move test build to dist
           command: mv ./dist-test-metrics ./dist
+      - run:
+          name: Move test zips to builds
+          command: mv ./builds-test-metrics ./builds
       - run:
           name: test:e2e:chrome:metrics
           command: |
@@ -313,6 +327,9 @@ jobs:
           name: Move test build to dist
           command: mv ./dist-test ./dist
       - run:
+          name: Move test zips to builds
+          command: mv ./builds-test ./builds
+      - run:
           name: test:e2e:firefox
           command: |
             if .circleci/scripts/test-run-e2e
@@ -338,6 +355,9 @@ jobs:
           name: Move test build to dist
           command: mv ./dist-test-metrics ./dist
       - run:
+          name: Move test zips to builds
+          command: mv ./builds-test-metrics ./builds
+      - run:
           name: test:e2e:firefox:metrics
           command: |
             if .circleci/scripts/test-run-e2e
@@ -359,6 +379,9 @@ jobs:
       - run:
           name: Move test build to dist
           command: mv ./dist-test ./dist
+      - run:
+          name: Move test zips to builds
+          command: mv ./builds-test ./builds
       - run:
           name: Run page load benchmark
           command: yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -79,6 +79,7 @@ function defineAllTasks() {
       clean,
       styleTasks.prod,
       composeParallel(scriptTasks.test, staticTasks.prod, manifestTasks.test),
+      zip,
     ),
   )
 

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -5,8 +5,8 @@ const chrome = require('selenium-webdriver/chrome')
  * A wrapper around a {@code WebDriver} instance exposing Chrome-specific functionality
  */
 class ChromeDriver {
-  static async build({ extensionPath, responsive, port }) {
-    const args = [`load-extension=${extensionPath}`]
+  static async build({ responsive, port }) {
+    const args = [`load-extension=dist/chrome`]
     if (responsive) {
       args.push('--auto-open-devtools-for-tabs')
     }

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -6,13 +6,12 @@ const FirefoxDriver = require('./firefox')
 
 async function buildWebDriver({ responsive, port } = {}) {
   const browser = process.env.SELENIUM_BROWSER
-  const extensionPath = `dist/${browser}`
 
   const {
     driver: seleniumDriver,
     extensionId,
     extensionUrl,
-  } = await buildBrowserWebDriver(browser, { extensionPath, responsive, port })
+  } = await buildBrowserWebDriver(browser, { responsive, port })
   await setupFetchMocking(seleniumDriver)
   const driver = new Driver(seleniumDriver, browser, extensionUrl)
 


### PR DESCRIPTION
The Firefox e2e tests now use the `.zip` file for testing the extension. We've found this to produce more similar results to production, compared to the old method of loading the unzipped directory.

Passing in a `.zip` file to the Chrome driver didn't seem to work. I didn't investigate this further to see if it was possible, but I'm not
sure it makes a difference on Chrome anyway. 