### PR TITLE
Update Firefox version used on CI for e2e tests

### DIFF
--- a/.circleci/scripts/firefox-install
+++ b/.circleci/scripts/firefox-install
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-FIREFOX_VERSION='70.0'
+FIREFOX_VERSION='83.0'
 FIREFOX_BINARY="firefox-${FIREFOX_VERSION}.tar.bz2"
 FIREFOX_BINARY_URL="https://ftp.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/${FIREFOX_BINARY}"
 FIREFOX_PATH='/opt/firefox'


### PR DESCRIPTION
The Firefox version has been updated to the latest stable version: v83. This was required to replicate production Firefox errors we saw recently (#10023)