### PR TITLE
Add HTML coverage report to MetaMask bot comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,6 +399,9 @@ jobs:
           path: builds
           destination: builds
       - store_artifacts:
+          path: coverage
+          destination: coverage
+      - store_artifacts:
           path: test-artifacts
           destination: test-artifacts
       # important: generate sesify viz AFTER uploading builds as artifacts

--- a/development/metamaskbot-build-announce.js
+++ b/development/metamaskbot-build-announce.js
@@ -55,6 +55,9 @@ async function start() {
     })
     .join(', ')
 
+  const coverageUrl = `${BUILD_LINK_BASE}/coverage/index.html`
+  const coverageLink = `<a href="${coverageUrl}">Report</a>`
+
   // links to bundle browser builds
   const depVizUrl = `${BUILD_LINK_BASE}/build-artifacts/deps-viz/background/index.html`
   const depVizLink = `<a href="${depVizUrl}">background</a>`
@@ -65,6 +68,7 @@ async function start() {
   const contentRows = [
     `builds: ${buildLinks}`,
     `bundle viz: ${bundleLinks}`,
+    `code coverage: ${coverageLink}`,
     `dep viz: ${depVizLink}`,
     `<a href="${allArtifactsUrl}">all artifacts</a>`,
   ]


### PR DESCRIPTION
The HTML code coverage report generated by `nyc` is now included in the MetaMask bot comment. It has been saved as an artifact on CircleCI.