### PR TITLE
Cache dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,14 +128,17 @@ jobs:
     executor: node-browsers
     steps:
       - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run:
           name: Install deps
           command: |
             .circleci/scripts/deps-install.sh
-      - run:
-          name: Collect yarn install HAR logs
-          command: |
-            .circleci/scripts/collect-har-artifact.sh
+      - save_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules/
+            - build-artifacts/yarn-install-har/
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/scripts/collect-har-artifact.sh
+++ b/.circleci/scripts/collect-har-artifact.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -x
-
-mkdir -p build-artifacts/yarn-install-har
-mv ./*.har build-artifacts/yarn-install-har/

--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -7,6 +7,14 @@ set -e
 
 yarn --frozen-lockfile --ignore-scripts --har
 
+# Move HAR file into directory with consistent name so that we can cache it
+mkdir -p build-artifacts/yarn-install-har
+har_files=(./*.har)
+if [[ -f "${har_files[0]}" ]]
+then
+  mv ./*.har build-artifacts/yarn-install-har/
+fi
+
 # run each in subshell so directory change does not persist
 # scripts can be any of:
 #   preinstall


### PR DESCRIPTION
Dependencies are now cached between builds, using a checksum of the `yarn.lock` file as the cache key. The `node_modules` directory and the `.har` file from the install are cached and restored, so that we ensure the record of the install is always preserved alongside the dependencies.

The consolidation of the `collect-har-artifact` script was to make it easier to cache the `.har` file along with the dependencies.