### PR TITLE
fix metametrics option tracking

### DIFF
--- a/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/ui/app/pages/first-time-flow/metametrics-opt-in/metametrics-opt-in.component.js
@@ -105,7 +105,10 @@ export default class MetaMetricsOptIn extends Component {
                 await setParticipateInMetaMetrics(false)
 
                 try {
-                  if (participateInMetaMetrics === true) {
+                  if (
+                    participateInMetaMetrics === null ||
+                    participateInMetaMetrics === true
+                  ) {
                     await metricsEvent({
                       eventOpts: {
                         category: 'Onboarding',
@@ -128,7 +131,10 @@ export default class MetaMetricsOptIn extends Component {
                 )
                 try {
                   const metrics = []
-                  if (participateInMetaMetrics === false) {
+                  if (
+                    participateInMetaMetrics === null ||
+                    participateInMetaMetrics === false
+                  ) {
                     metrics.push(
                       metricsEvent({
                         eventOpts: {


### PR DESCRIPTION
in https://github.com/MetaMask/metamask-extension/pull/9222, which aimed at removing negated conditions, we accidentally introduced a change in how we filtered events from firing on the metrics opt-in page.

Previously, we checked if the previous value for `participateInMetaMetrics` was not equal to what we were tracking. e.g: if the user was opting in, we made sure the previous `participateInMetaMetrics` **was not true.** The change made it such that it would only track an event if the previous `participateInMetaMetrics` was strictly the inverse of the user's intention. e.g: if the user was opting in, we made sure the previous `participateInMetaMetrics` **was false**.

The problem here is that all new users default this value to `null`, which would have been fine in the previous version but not find in the new version. 

This issue landed in 8.1.0 on Oct 13, and subsequently, 8.1.3 which migrated us off of matomo landed on oct 28. Due to chrome review times and what not, there probably wasn't a huge gap between when the bug was rolled out to most of our chrome users and when matomo was removed for most of our chrome users. 