### PR TITLE
set last provider when switching to a customRPC

### DIFF
--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -40,6 +40,9 @@ function mapDispatchToProps(dispatch) {
     setProviderType: (type) => {
       dispatch(actions.setProviderType(type))
     },
+    setPreviousProvider: (type) => {
+      dispatch(actions.setPreviousProvider(type))
+    },
     setRpcTarget: (target, chainId, ticker, nickname) => {
       dispatch(actions.setRpcTarget(target, chainId, ticker, nickname))
     },
@@ -82,6 +85,7 @@ class NetworkDropdown extends Component {
     setRpcTarget: PropTypes.func.isRequired,
     hideNetworkDropdown: PropTypes.func.isRequired,
     setNetworksTabAddMode: PropTypes.func.isRequired,
+    setPreviousProvider: PropTypes.func.isRequired,
     setSelectedSettingsRpcUrl: PropTypes.func.isRequired,
     frequentRpcListDetail: PropTypes.array.isRequired,
     networkDropdownOpen: PropTypes.bool.isRequired,
@@ -112,6 +116,10 @@ class NetworkDropdown extends Component {
   }
 
   renderCustomRpcList(rpcListDetail, provider) {
+    const {
+      provider: { type: providerType },
+      setPreviousProvider,
+    } = this.props
     const reversedRpcListDetail = rpcListDetail.slice().reverse()
 
     return reversedRpcListDetail.map((entry) => {
@@ -125,6 +133,7 @@ class NetworkDropdown extends Component {
           closeMenu={() => this.props.hideNetworkDropdown()}
           onClick={() => {
             if (isPrefixedFormattedHexString(chainId)) {
+              setPreviousProvider(providerType)
               this.props.setRpcTarget(rpcUrl, chainId, ticker, nickname)
             } else {
               this.props.displayInvalidCustomNetworkAlert(nickname || rpcUrl)


### PR DESCRIPTION
Fixes: a regression in falling back to the last connected provider when attempting to connect to a custom rpc (localhost as an example). Previously the last successfully connected provider would be reconnected. Presently when attempting to connect to a custom RPC the currently connected provider is not set as the 'lastConnectedProvider', which means that the provider the UI falls back to in the case of an error or user exiting the loading screen is not the most recently connected provider. In some cases, such as if the user loads the extension and immediately chooses a custom RPC, the fallback provider is 'ropsten' which is hardcoded in the UI in case there is no `lastConnectedProvider`.

This PR resolves this by adding the call to `setPreviousProvider` to the custom RPC code. All other cases use the `setProviderType` which triggers the correct UI flow of first setting the `lastConnectedProvider` 