### PR TITLE
Update `@metamask/controllers` to v5.1.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -105,6 +105,7 @@ export default class MetamaskController extends EventEmitter {
 
     this.approvalController = new ApprovalController({
       showApprovalRequest: opts.showUserConfirmation,
+      defaultApprovalType: 'NO_TYPE',
     })
 
     this.networkController = new NetworkController(initState.NetworkController)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.19.0",
-    "@metamask/controllers": "^4.2.0",
+    "@metamask/controllers": "^5.1.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^1.4.0",

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -71,6 +71,7 @@ export function getPermControllerOpts() {
   return {
     approvals: new ApprovalController({
       showApprovalRequest: noop,
+      defaultApprovalType: 'NO_TYPE',
     }),
     getKeyringAccounts: async () => [...keyringAccounts],
     getUnlockPromise: () => Promise.resolve(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,13 +2047,13 @@
     web3 "^0.20.7"
     web3-provider-engine "^16.0.1"
 
-"@metamask/controllers@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-4.2.0.tgz#ee304fa26aa1d291e21e7969dffee0977b149cbf"
-  integrity sha512-NPpBFP6x2YPEdJhjP5jC9E/WHJ+FJNWH7wf8he5/dfeY0J9hlXgkRv6vrvYI3wo6YvcgPy3IF1EOA0rR4jNbeg==
+"@metamask/controllers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-5.1.0.tgz#02c1957295bcb6db1655a716d165665d170e7f34"
+  integrity sha512-4piqkIrpphe+9nEy68WH+yBw9wsXZyCMVeBZeRtliVHAJFXUdz+KZDUi/R1Y+568JBzqAvsOtOzbUIU4btD3Fw==
   dependencies:
+    "@metamask/contract-metadata" "^1.19.0"
     await-semaphore "^0.1.3"
-    eth-contract-metadata "^1.11.0"
     eth-ens-namehash "^2.0.8"
     eth-json-rpc-infura "^5.1.0"
     eth-keyring-controller "^6.1.0"
@@ -2063,14 +2063,13 @@
     eth-rpc-errors "^4.0.0"
     eth-sig-util "^3.0.0"
     ethereumjs-util "^6.1.0"
-    ethereumjs-wallet "0.6.0"
+    ethereumjs-wallet "^0.6.4"
     ethjs-query "^0.3.8"
     human-standard-collectible-abi "^1.0.2"
     human-standard-token-abi "^2.0.0"
     isomorphic-fetch "^3.0.0"
     jsonschema "^1.2.4"
     nanoid "^3.1.12"
-    percentile "^1.2.1"
     single-call-balance-checker-abi "^1.0.0"
     uuid "^3.3.2"
     web3 "^0.20.7"
@@ -10244,7 +10243,7 @@ ethereumjs-wallet@0.6.0:
     utf8 "^2.1.1"
     uuid "^2.0.1"
 
-ethereumjs-wallet@0.6.5, ethereumjs-wallet@^0.6.0:
+ethereumjs-wallet@0.6.5, ethereumjs-wallet@^0.6.0, ethereumjs-wallet@^0.6.4:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz#685e9091645cee230ad125c007658833991ed474"
   integrity sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==


### PR DESCRIPTION
This update comes with a breaking change to the Approval controller. It now requires a `defaultApprovalType` parameter.

I don't think we have any use for a default approval type, but I've added a "NO_TYPE" one for now because it's a strict requirement. We should consider making this parameter optional in the future, for cases like this where it's not needed.

This update will hopefully address some caching issues we've been seeing with our phishing configuration. See here for more details: https://github.com/MetaMask/controllers/pull/297