### PR TITLE
Fix #10081 - Use fetchWithCache to retrieve and store basic gas estimates

### DIFF
--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -2,10 +2,18 @@ import assert from 'assert'
 import sinon from 'sinon'
 import proxyquire from 'proxyquire'
 
-const fakeStorage = {}
+const mockGasPriceApiResponse = {
+  SafeGasPrice: 10,
+  ProposeGasPrice: 20,
+  FastGasPrice: 30,
+}
 
 const GasDuck = proxyquire('./gas.duck.js', {
-  '../../../lib/storage-helpers': fakeStorage,
+  // We have fetch-with-cache tests, so we can reasonably
+  // return a specific mock response
+  '../../helpers/utils/fetch-with-cache': {
+    default: () => Promise.resolve(mockGasPriceApiResponse),
+  },
 })
 
 const {
@@ -14,44 +22,11 @@ const {
   setBasicGasEstimateData,
   setCustomGasPrice,
   setCustomGasLimit,
-  resetCustomGasState,
   fetchBasicGasEstimates,
 } = GasDuck
 const GasReducer = GasDuck.default
 
 describe('Gas Duck', function () {
-  let tempFetch
-  let tempDateNow
-  const mockGasPriceApiResponse = {
-    SafeGasPrice: 10,
-    ProposeGasPrice: 20,
-    FastGasPrice: 30,
-  }
-  const fakeFetch = () =>
-    new Promise((resolve) => {
-      const dataToResolve = mockGasPriceApiResponse
-      resolve({
-        json: () => Promise.resolve(dataToResolve),
-      })
-    })
-
-  beforeEach(function () {
-    tempFetch = window.fetch
-    tempDateNow = global.Date.now
-
-    fakeStorage.getStorageItem = sinon.stub()
-    fakeStorage.setStorageItem = sinon.spy()
-    window.fetch = sinon.stub().callsFake(fakeFetch)
-    global.Date.now = () => 2000000
-  })
-
-  afterEach(function () {
-    sinon.restore()
-
-    window.fetch = tempFetch
-    global.Date.now = tempDateNow
-  })
-
   const mockState = {
     mockProp: 123,
   }
@@ -66,18 +41,14 @@ describe('Gas Duck', function () {
       safeLow: null,
     },
     basicEstimateIsLoading: true,
-    basicPriceEstimatesLastRetrieved: 0,
   }
   const BASIC_GAS_ESTIMATE_LOADING_FINISHED =
     'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_FINISHED'
   const BASIC_GAS_ESTIMATE_LOADING_STARTED =
     'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_STARTED'
-  const RESET_CUSTOM_GAS_STATE = 'metamask/gas/RESET_CUSTOM_GAS_STATE'
   const SET_BASIC_GAS_ESTIMATE_DATA = 'metamask/gas/SET_BASIC_GAS_ESTIMATE_DATA'
   const SET_CUSTOM_GAS_LIMIT = 'metamask/gas/SET_CUSTOM_GAS_LIMIT'
   const SET_CUSTOM_GAS_PRICE = 'metamask/gas/SET_CUSTOM_GAS_PRICE'
-  const SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED =
-    'metamask/gas/SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED'
 
   describe('GasReducer()', function () {
     it('should initialize state', function () {
@@ -137,13 +108,6 @@ describe('Gas Duck', function () {
         { customData: { limit: 9876 }, ...mockState },
       )
     })
-
-    it('should return the initial state in response to a RESET_CUSTOM_GAS_STATE action', function () {
-      assert.deepStrictEqual(
-        GasReducer(mockState, { type: RESET_CUSTOM_GAS_STATE }),
-        initState,
-      )
-    })
   })
 
   describe('basicGasEstimatesLoadingStarted', function () {
@@ -167,21 +131,13 @@ describe('Gas Duck', function () {
       const mockDistpatch = sinon.spy()
 
       await fetchBasicGasEstimates()(mockDistpatch, () => ({
-        gas: { ...initState, basicPriceAEstimatesLastRetrieved: 1000000 },
+        gas: { ...initState },
       }))
       assert.deepStrictEqual(mockDistpatch.getCall(0).args, [
         { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
       ])
-      assert.ok(
-        window.fetch
-          .getCall(0)
-          .args[0].startsWith('https://api.metaswap.codefi.network/gasPrices'),
-        'should fetch metaswap /gasPrices',
-      )
+
       assert.deepStrictEqual(mockDistpatch.getCall(1).args, [
-        { type: SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED, value: 2000000 },
-      ])
-      assert.deepStrictEqual(mockDistpatch.getCall(2).args, [
         {
           type: SET_BASIC_GAS_ESTIMATE_DATA,
           value: {
@@ -191,76 +147,7 @@ describe('Gas Duck', function () {
           },
         },
       ])
-      assert.deepStrictEqual(mockDistpatch.getCall(3).args, [
-        { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
-      ])
-    })
-
-    it('should fetch recently retrieved estimates from storage', async function () {
-      const mockDistpatch = sinon.spy()
-      fakeStorage.getStorageItem
-        .withArgs('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED')
-        .returns(2000000 - 1) // one second ago from "now"
-      fakeStorage.getStorageItem.withArgs('BASIC_PRICE_ESTIMATES').returns({
-        average: 25,
-        fast: 35,
-        safeLow: 15,
-      })
-
-      await fetchBasicGasEstimates()(mockDistpatch, () => ({
-        gas: { ...initState },
-      }))
-      assert.deepStrictEqual(mockDistpatch.getCall(0).args, [
-        { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
-      ])
-      assert.ok(window.fetch.notCalled)
-      assert.deepStrictEqual(mockDistpatch.getCall(1).args, [
-        {
-          type: SET_BASIC_GAS_ESTIMATE_DATA,
-          value: {
-            average: 25,
-            fast: 35,
-            safeLow: 15,
-          },
-        },
-      ])
       assert.deepStrictEqual(mockDistpatch.getCall(2).args, [
-        { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
-      ])
-    })
-
-    it('should fallback to network if retrieving estimates from storage fails', async function () {
-      const mockDistpatch = sinon.spy()
-      fakeStorage.getStorageItem
-        .withArgs('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED')
-        .returns(2000000 - 1) // one second ago from "now"
-
-      await fetchBasicGasEstimates()(mockDistpatch, () => ({
-        gas: { ...initState },
-      }))
-      assert.deepStrictEqual(mockDistpatch.getCall(0).args, [
-        { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
-      ])
-      assert.ok(
-        window.fetch
-          .getCall(0)
-          .args[0].startsWith('https://api.metaswap.codefi.network/gasPrices'),
-        'should fetch metaswap /gasPrices',
-      )
-      assert.deepStrictEqual(mockDistpatch.getCall(1).args, [
-        { type: SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED, value: 2000000 },
-      ])
-      assert.deepStrictEqual(mockDistpatch.getCall(2).args, [
-        {
-          type: SET_BASIC_GAS_ESTIMATE_DATA,
-          value: {
-            safeLow: 10,
-            average: 20,
-            fast: 30,
-          },
-        },
-      ])
-      assert.deepStrictEqual(mockDistpatch.getCall(3).args, [
         { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
       ])
     })
@@ -289,14 +176,6 @@ describe('Gas Duck', function () {
       assert.deepStrictEqual(setCustomGasLimit('mockCustomGasLimit'), {
         type: SET_CUSTOM_GAS_LIMIT,
         value: 'mockCustomGasLimit',
-      })
-    })
-  })
-
-  describe('resetCustomGasState', function () {
-    it('should create the correct action', function () {
-      assert.deepStrictEqual(resetCustomGasState(), {
-        type: RESET_CUSTOM_GAS_STATE,
       })
     })
   })

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash'
 import BigNumber from 'bignumber.js'
-import { getStorageItem, setStorageItem } from '../../../lib/storage-helpers'
 
+import fetchWithCache from '../../helpers/utils/fetch-with-cache'
 import { decGWEIToHexWEI } from '../../helpers/utils/conversions.util'
 
 // Actions
@@ -9,13 +9,10 @@ const BASIC_GAS_ESTIMATE_LOADING_FINISHED =
   'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_FINISHED'
 const BASIC_GAS_ESTIMATE_LOADING_STARTED =
   'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_STARTED'
-const RESET_CUSTOM_GAS_STATE = 'metamask/gas/RESET_CUSTOM_GAS_STATE'
 const RESET_CUSTOM_DATA = 'metamask/gas/RESET_CUSTOM_DATA'
 const SET_BASIC_GAS_ESTIMATE_DATA = 'metamask/gas/SET_BASIC_GAS_ESTIMATE_DATA'
 const SET_CUSTOM_GAS_LIMIT = 'metamask/gas/SET_CUSTOM_GAS_LIMIT'
 const SET_CUSTOM_GAS_PRICE = 'metamask/gas/SET_CUSTOM_GAS_PRICE'
-const SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED =
-  'metamask/gas/SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED'
 
 const initState = {
   customData: {
@@ -28,7 +25,6 @@ const initState = {
     fast: null,
   },
   basicEstimateIsLoading: true,
-  basicPriceEstimatesLastRetrieved: 0,
 }
 
 // Reducer
@@ -65,18 +61,11 @@ export default function reducer(state = initState, action) {
           limit: action.value,
         },
       }
-    case SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED:
-      return {
-        ...state,
-        basicPriceEstimatesLastRetrieved: action.value,
-      }
     case RESET_CUSTOM_DATA:
       return {
         ...state,
         customData: cloneDeep(initState.customData),
       }
-    case RESET_CUSTOM_GAS_STATE:
-      return cloneDeep(initState)
     default:
       return state
   }
@@ -96,36 +85,27 @@ export function basicGasEstimatesLoadingFinished() {
 }
 
 async function basicGasPriceQuery() {
-  const url = `https://api.metaswap.codefi.network/gasPrices`
-  return await window.fetch(url, {
-    headers: {},
-    referrer: 'https://api.metaswap.codefi.network/gasPrices',
+  const url = 'https://api.metaswap.codefi.network/gasPrices'
+  const fetchOptions = {
+    referrer: url,
     referrerPolicy: 'no-referrer-when-downgrade',
-    body: null,
     method: 'GET',
     mode: 'cors',
-  })
+  }
+  const expirationOptions = { cacheRefreshTime: 75000 }
+
+  const responseJson = await fetchWithCache(
+    url,
+    fetchOptions,
+    expirationOptions,
+  )
+  return responseJson
 }
 
 export function fetchBasicGasEstimates() {
-  return async (dispatch, getState) => {
-    const { basicPriceEstimatesLastRetrieved } = getState().gas
-    const timeLastRetrieved =
-      basicPriceEstimatesLastRetrieved ||
-      (await getStorageItem('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED')) ||
-      0
-
+  return async (dispatch) => {
     dispatch(basicGasEstimatesLoadingStarted())
-
-    let basicEstimates
-    if (Date.now() - timeLastRetrieved > 75000) {
-      basicEstimates = await fetchExternalBasicGasEstimates(dispatch)
-    } else {
-      const cachedBasicEstimates = await getStorageItem('BASIC_PRICE_ESTIMATES')
-      basicEstimates =
-        cachedBasicEstimates || (await fetchExternalBasicGasEstimates(dispatch))
-    }
-
+    const basicEstimates = await fetchExternalBasicGasEstimates(dispatch)
     dispatch(setBasicGasEstimateData(basicEstimates))
     dispatch(basicGasEstimatesLoadingFinished())
 
@@ -133,16 +113,28 @@ export function fetchBasicGasEstimates() {
   }
 }
 
-async function fetchExternalBasicGasEstimates(dispatch) {
-  const response = await basicGasPriceQuery()
+async function fetchExternalBasicGasEstimates() {
+  const {
+    SafeGasPrice,
+    ProposeGasPrice,
+    FastGasPrice,
+  } = await basicGasPriceQuery()
 
-  const { SafeGasPrice, ProposeGasPrice, FastGasPrice } = await response.json()
+  console.log(
+    'await basicGasPriceQuery returns: ',
+    SafeGasPrice,
+    ProposeGasPrice,
+    FastGasPrice,
+  )
 
   const [safeLow, average, fast] = [
     SafeGasPrice,
     ProposeGasPrice,
     FastGasPrice,
-  ].map((price) => new BigNumber(price, 10).toNumber())
+  ].map((price) => {
+    console.log('Price is: ', price)
+    return new BigNumber(price, 10).toNumber()
+  })
 
   const basicEstimates = {
     safeLow,
@@ -150,20 +142,13 @@ async function fetchExternalBasicGasEstimates(dispatch) {
     fast,
   }
 
-  const timeRetrieved = Date.now()
-  await Promise.all([
-    setStorageItem('BASIC_PRICE_ESTIMATES', basicEstimates),
-    setStorageItem('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED', timeRetrieved),
-  ])
-  dispatch(setBasicPriceEstimatesLastRetrieved(timeRetrieved))
-
   return basicEstimates
 }
 
 export function setCustomGasPriceForRetry(newPrice) {
   return async (dispatch) => {
     if (newPrice === '0x0') {
-      const { fast } = await getStorageItem('BASIC_PRICE_ESTIMATES')
+      const { fast } = await fetchExternalBasicGasEstimates()
       dispatch(setCustomGasPrice(decGWEIToHexWEI(fast)))
     } else {
       dispatch(setCustomGasPrice(newPrice))
@@ -190,17 +175,6 @@ export function setCustomGasLimit(newLimit) {
     type: SET_CUSTOM_GAS_LIMIT,
     value: newLimit,
   }
-}
-
-export function setBasicPriceEstimatesLastRetrieved(retrievalTime) {
-  return {
-    type: SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED,
-    value: retrievalTime,
-  }
-}
-
-export function resetCustomGasState() {
-  return { type: RESET_CUSTOM_GAS_STATE }
 }
 
 export function resetCustomData() {


### PR DESCRIPTION
Fixes: #10081

Explanation:  It appears we're currently fetching basic gas estimates and storing the result along with last fetched time, and then doing expiration validation, when `fetchWithCache` can do all of this for us.

Currently a WIP.  Fighting with `proxyquire` to ensure storage can be stub'd in `ui/app/helpers/utils/fetch-with-cache.js`