### PR TITLE
Skip reporting of successive persistence failures

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -268,6 +268,8 @@ function setupController(initState, initLangCode) {
     return versionedData
   }
 
+  let dataPersistenceFailing = false
+
   async function persistData(state) {
     if (!state) {
       throw new Error('MetaMask - updated state is missing')
@@ -278,9 +280,15 @@ function setupController(initState, initLangCode) {
     if (localStore.isSupported) {
       try {
         await localStore.set(state)
+        if (dataPersistenceFailing) {
+          dataPersistenceFailing = false
+        }
       } catch (err) {
         // log error so we dont break the pipeline
-        captureException(err)
+        if (!dataPersistenceFailing) {
+          dataPersistenceFailing = true
+          captureException(err)
+        }
         log.error('error setting state in local store:', err)
       }
     }


### PR DESCRIPTION
Failure to persist state will now only report to Sentry if the last attempt to save state succeeded. This ensures that if anyone is stuck in a state where state can't be saved (e.g. low disk space), we aren't flooded with repeated errors on Sentry.