### PR TITLE
Remove unnecessary swaps footer space when in dropdown mode

### DIFF
--- a/ui/app/pages/swaps/view-quote/index.scss
+++ b/ui/app/pages/swaps/view-quote/index.scss
@@ -17,7 +17,7 @@
 
     @media screen and (max-width: 576px) {
       overflow-y: auto;
-      max-height: 388px;
+      max-height: 428px;
     }
   }
 


### PR DESCRIPTION
Explanation:  When we moved the TOS link from the view quote screen to the build quote screen, we left behind an artifact of the UI, namely extra space:

## Before
<img width="365" alt="FooterBefore" src="https://user-images.githubusercontent.com/46655/102523318-fcf4c280-405c-11eb-9347-5ecb90e07781.png">

## After
<img width="386" alt="FooterAfter" src="https://user-images.githubusercontent.com/46655/102523339-02eaa380-405d-11eb-971c-56e595021a0e.png">
