### PR TITLE
Only update store for quote refresh time if it has changed

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -121,9 +121,11 @@ export default class SwapsController {
     }
 
     const { swapsState } = this.store.getState()
-    this.store.updateState({
-      swapsState: { ...swapsState, swapsQuoteRefreshTime },
-    })
+    if (swapsState.swapsQuoteRefreshTime !== swapsQuoteRefreshTime) {
+      this.store.updateState({
+        swapsState: { ...swapsState, swapsQuoteRefreshTime },
+      })
+    }
   }
 
   // Once quotes are fetched, we poll for new ones to keep the quotes up to date. Market and aggregator contract conditions can change fast enough


### PR DESCRIPTION
Explanation:  

Small improvement.  We get a fresh "quote refresh" time when we make a swap request, and if the value doesn't change from what we currently have in state, we don't need to call `updateState`.