### PR TITLE
Use late-bound noop function when disabling console

### DIFF
--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -4,6 +4,10 @@ if (
   !(typeof process !== 'undefined' && process.env.METAMASK_DEBUG) &&
   typeof console !== undefined
 ) {
-  console.log = () => undefined
-  console.info = () => undefined
+  console.log = noop
+  console.info = noop
+}
+
+function noop() {
+  return undefined
 }


### PR DESCRIPTION
The `disable-console` script introduced in #10040 used an arrow-function no-op function to replace `console.log` and `console.info`. This replacement function was early-bound to the `this` context of the `disable-console` script, because that's how arrow functions work.

This violates an assumption baked into Sentry, which also replaces the `console` functions. It wraps them in a function it uses to track console logs as breadcrumbs. This wrapper function blows up for some reason if the "original" `console` function is early-bound to a `this` value of `undefined`.

This resulted in various UI freezes. One example is during onboarding, when using Firefox with Enhanced Tracking Protection set in "strict" mode. After submitting a password in the 'Create wallet' flow, the Sentry `console` wrapper would throw and leave the user stuck on the loading screen.

By replacing the no-op arrow function with a no-op function declaration, the problem has been resolved.

Relates to #10097