### PR TITLE
throw a new wrapped error instead of default one from segment

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -265,7 +265,7 @@ export default class MetaMetricsController {
     return new Promise((resolve, reject) => {
       const callback = (err) => {
         if (err) {
-          return reject(err)
+          return reject(new Error(err.message))
         }
         return resolve()
       }

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -265,7 +265,13 @@ export default class MetaMetricsController {
     return new Promise((resolve, reject) => {
       const callback = (err) => {
         if (err) {
-          return reject(new Error(err.message))
+          // The error that segment gives us has some manipulation done to it
+          // that seemingly breaks with lockdown enabled. Creating a new error
+          // here prevents the system from freezing when the network request to
+          // segment fails for any reason.
+          const safeError = new Error(err.message)
+          safeError.stack = err.stack
+          return reject(safeError)
         }
         return resolve()
       }


### PR DESCRIPTION
@Gudahtt was able to reproduce the firefox freezing using tracking protection in Firefox, or by blocking segment in chrome. The problem, as he discovered, seems to be in something that segment was doing with its error objects. I just changed the metametrics implementation to reject with a new error, using the original error's message and stack trace