### PR TITLE
Ensure that gas for swap tx submitted at same time as approval is in hex

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -606,7 +606,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       customSwapsGas ||
       (usedQuote?.gasEstimate
         ? estimatedGasLimitWithMultiplier
-        : usedQuote?.maxGas)
+        : `0x${decimalToHex(usedQuote?.maxGas || 0)}`)
 
     const usedGasPrice = getUsedSwapsGasPrice(state)
     usedTradeTxParams.gas = maxGasLimit


### PR DESCRIPTION
Users have experienced the following issue with swaps:
- attempt to swap an ERC-20 token that they have not yet approved MetaSwaps to transfer (so 2 transactions will be needed: an approval tx and a swap)
- the approve transaction successfully completes but the swap transaction does not even submit
- then, when attempting the swap again, it completes successfully

To recreate this issue, you can do the following to test swaps on local host:

0. Update the timeout number on line 341 of `app/scripts/controllers/swaps.js` of metamask from 5000 to 15000
1. Run metamask locally, on develoop
2. Get an infura account and copy your accounts infura endpoint
3. Run `ganache-cli --fork YOUR_INFURA_ENDPOINT`
4. copy one of the private keys that are output in the terminal
5. connect to localhost in metamask and import the private key you just copied

The account you have just imported should have 100 eth on the local network. You should be able to make swaps with this account.

6. Swap eth to an ERC-20, the swap should complete successfully
7. Swap your ERC-20 tokens to something else, the approval tx should go through and the swap tx won't even be submitted, like it didn't exist

This PR fixes this issue.

Before this PR, the `addUnapprovedTransaction` call on line 694 of `ducks/swaps/swaps.js` silently fails when an approval is required because in that case `usedTradeTxParams.gas` is set to `maxGas`, which is a decimal number, but it is required to be a hex number. This issue was introduced here: https://github.com/MetaMask/metamask-extension/pull/10043/files#diff-79e282e22d97801a4a8ac7638c098e38eb40e3c46ad24ff4f7db7405dac2faabR606

This PR correctly formats the `usedTradeTxParams.gas` property, and everything works correctly again.

We probably should also update our error handling so that this does not fail silently, but we should do so in another PR as this relates to this issue https://github.com/MetaMask/metamask-extension/issues/9948, which requires a small amount of design work.