### PR TITLE
Prevent malformed next nonce warning

### DIFF
--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -141,7 +141,7 @@ export default class ConfirmTransactionBase extends Component {
       nextNonce !== prevNextNonce ||
       customNonceValue !== prevCustomNonceValue
     ) {
-      if (customNonceValue > nextNonce) {
+      if (nextNonce !== null && customNonceValue > nextNonce) {
         this.setState({
           submitWarning: this.context.t('nextNonceWarning', [nextNonce]),
         })


### PR DESCRIPTION
The "Next nonce" warning warns users when the custom nonce they set is higher than our suggested nonce. This warning was mistakenly being shown even when we didn't have a suggested nonce yet.

Fixes #9989