### PR TITLE
Detect tokens on custom Mainnet RPC endpoints

### DIFF
--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -2,7 +2,7 @@ import Web3 from 'web3'
 import contracts from '@metamask/contract-metadata'
 import { warn } from 'loglevel'
 import SINGLE_CALL_BALANCES_ABI from 'single-call-balance-checker-abi'
-import { MAINNET } from './network/enums'
+import { MAINNET_CHAIN_ID } from './network/enums'
 
 // By default, poll every 3 minutes
 const DEFAULT_INTERVAL = 180 * 1000
@@ -38,7 +38,7 @@ export default class DetectTokensController {
     if (!this.isActive) {
       return
     }
-    if (this._network.store.getState().provider.type !== MAINNET) {
+    if (this._network.store.getState().provider.chainId !== MAINNET_CHAIN_ID) {
       return
     }
 


### PR DESCRIPTION
Our automatic token detection was hard-coded to only work on our built-in Infura Mainnet endpoint. It now works with custom Mainnet RPC endpoints as well.

Relates to #6992

Manual testing steps:  
  - Add a custom RPC endpoint for Mainnet (e.g. https://cloudflare-eth.com/ )
  - Import an account with a non-zero amount of tokens on Mainnet
  - Wait for those tokens to show up automatically