### PR TITLE
Fix French "block explorer" translations

### DIFF
--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -525,7 +525,7 @@
     "message": "Pas de réseau ETH, régler en minuscules"
   },
   "invalidBlockExplorerURL": {
-    "message": "URL Block Explorer invalide"
+    "message": "URL de l'explorateur de blocs invalide"
   },
   "invalidIpfsGateway": {
     "message": "IPFS Gateway Invalide: la valeur doit être une URL valide"
@@ -696,7 +696,7 @@
     "message": "Activé"
   },
   "optionalBlockExplorerUrl": {
-    "message": "Bloquer l'URL de l'explorateur (facultatif)"
+    "message": "URL de l'explorateur de blocs (facultatif)"
   },
   "optionalCurrencySymbol": {
     "message": "Symbole (facultatif)"


### PR DESCRIPTION
Fixes #9465 

Per the aforementioned issue, fixes French translations of "Block Explorer URL". Google Translate confirms that the user's suggestion is valid.