### PR TITLE
Disable the swaps submit button after the first time it is clicked

### DIFF
--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -83,6 +83,7 @@ export default function ViewQuote() {
   const metaMetricsEvent = useContext(MetaMetricsContext)
 
   const [dispatchedSafeRefetch, setDispatchedSafeRefetch] = useState(false)
+  const [submitClicked, setSubmitClicked] = useState(false)
   const [selectQuotePopoverShown, setSelectQuotePopoverShown] = useState(false)
   const [warningHidden, setWarningHidden] = useState(false)
   const [originalApproveAmount, setOriginalApproveAmount] = useState(null)
@@ -570,6 +571,7 @@ export default function ViewQuote() {
       </div>
       <SwapsFooter
         onSubmit={() => {
+          setSubmitClicked(true)
           if (!balanceError) {
             dispatch(signAndSendTransactions(history, metaMetricsEvent))
           } else if (destinationToken.symbol === 'ETH') {
@@ -580,7 +582,12 @@ export default function ViewQuote() {
         }}
         submitText={t('swap')}
         onCancel={async () => await dispatch(navigateBackToBuildQuote(history))}
-        disabled={balanceError || gasPrice === null || gasPrice === undefined}
+        disabled={
+          submitClicked ||
+          balanceError ||
+          gasPrice === null ||
+          gasPrice === undefined
+        }
         className={isShowingWarning && 'view-quote__thin-swaps-footer'}
         showTopBorder
       />


### PR DESCRIPTION
This PR prevents an accidental submission of two swaps that could be caused by clicking the submit button a second time before the user is rerouted to the awaiting swaps screen.