### PR TITLE
Reset swaps routeState in navigateBackToBuildQuote

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -329,8 +329,8 @@ export {
 export const navigateBackToBuildQuote = (history) => {
   return async (dispatch) => {
     // TODO: Ensure any fetch in progress is cancelled
+    await dispatch(setBackgroundSwapRouteState(''))
     dispatch(navigatedBackToBuildQuote())
-
     history.push(BUILD_QUOTE_ROUTE)
   }
 }


### PR DESCRIPTION
This PR fixes the back button on the swaps loading quotes page.

#9994 removed a call to `resetSwapsPostFetchState` from the `navigateBackToBuildQuote` method. This was done to stop clearing some state that was needed on first render of the build quote component, and then subsequently cleared anyway in a useEffect call in the build quote screen.

Due to some unnecessary complexity and messy inter-dependencies within our routing logic, removing the `resetSwapsPostFetchState` call removed one piece of state clearing that was needed before the `history.push(BUILD_QUOTE_ROUTE)` call within `navigateBackToBuildQuote`: resetting `routeState` from `'loading'` to `''`. If that was not reset, the component passed to the render property of the `FeatureToggledRoute` for the `BUILD_QUOTE_ROUTE` in `pages/swaps/index.js` would redirect to the `LOADING_QUOTES_ROUTE` (See lines 276-289 of `pages/swaps/index.js`)

This PR ensures the resetting of the route state is done before the history.push call in `navigateBackToBuildQuote`. This fixes the back button on the loading quotes screen, while maintaining the fix to the issue that was fixed in #9994
