### PR TITLE
Migration 51: ensure chainId is set in state for default/infura providers

### DIFF
--- a/app/scripts/migrations/051.js
+++ b/app/scripts/migrations/051.js
@@ -1,0 +1,29 @@
+import { cloneDeep } from 'lodash'
+import { NETWORK_TYPE_TO_ID_MAP } from '../controllers/network/enums'
+
+const version = 51
+
+/**
+ * Set the chainId in the Network Controller provider data for all infura networks
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData)
+    versionedData.meta.version = version
+    const state = versionedData.data
+    versionedData.data = transformState(state)
+    return versionedData
+  },
+}
+
+function transformState(state) {
+  const type = state?.NetworkController?.provider?.type
+
+  if (NETWORK_TYPE_TO_ID_MAP[type]) {
+    state.NetworkController.provider.chainId =
+      NETWORK_TYPE_TO_ID_MAP[type]?.chainId
+  }
+
+  return state
+}

--- a/app/scripts/migrations/051.js
+++ b/app/scripts/migrations/051.js
@@ -19,11 +19,10 @@ export default {
 
 function transformState(state) {
   const { chainId, type } = state?.NetworkController?.provider || {}
+  const enumChainId = NETWORK_TYPE_TO_ID_MAP[type]?.chainId
 
-  if (!chainId && NETWORK_TYPE_TO_ID_MAP[type]) {
-    state.NetworkController.provider.chainId =
-      NETWORK_TYPE_TO_ID_MAP[type].chainId
+  if (enumChainId && chainId !== enumChainId) {
+    state.NetworkController.provider.chainId = enumChainId
   }
-
   return state
 }

--- a/app/scripts/migrations/051.js
+++ b/app/scripts/migrations/051.js
@@ -18,11 +18,11 @@ export default {
 }
 
 function transformState(state) {
-  const type = state?.NetworkController?.provider?.type
+  const { chainId, type } = state?.NetworkController?.provider || {}
 
-  if (NETWORK_TYPE_TO_ID_MAP[type]) {
+  if (!chainId && NETWORK_TYPE_TO_ID_MAP[type]) {
     state.NetworkController.provider.chainId =
-      NETWORK_TYPE_TO_ID_MAP[type]?.chainId
+      NETWORK_TYPE_TO_ID_MAP[type].chainId
   }
 
   return state

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -55,6 +55,7 @@ const migrations = [
   require('./048').default,
   require('./049').default,
   require('./050').default,
+  require('./051').default,
 ]
 
 export default migrations

--- a/test/unit/migrations/051-test.js
+++ b/test/unit/migrations/051-test.js
@@ -22,7 +22,7 @@ describe('migration #51', function () {
 
   describe('setting chainId', function () {
     INFURA_PROVIDER_TYPES.forEach(function (type) {
-      it(`should correctly set the chainId for the Infura network: ${type}, if no chainId is set`, async function () {
+      it(`should correctly set the chainId for the Infura network "${type}", if no chainId is set`, async function () {
         const oldStorage = {
           meta: {},
           data: {
@@ -32,6 +32,37 @@ describe('migration #51', function () {
               },
               provider: {
                 type,
+              },
+            },
+            foo: 'bar',
+          },
+        }
+        const newStorage = await migration51.migrate(oldStorage)
+        assert.deepEqual(newStorage.data, {
+          NetworkController: {
+            settings: {
+              fizz: 'buzz',
+            },
+            provider: {
+              type,
+              chainId: NETWORK_TYPE_TO_ID_MAP[type].chainId,
+            },
+          },
+          foo: 'bar',
+        })
+      })
+
+      it(`should correctly set the chainId for the Infura network "${type}", if an incorrect chainId is set`, async function () {
+        const oldStorage = {
+          meta: {},
+          data: {
+            NetworkController: {
+              settings: {
+                fizz: 'buzz',
+              },
+              provider: {
+                type,
+                chainId: 'foo',
               },
             },
             foo: 'bar',

--- a/test/unit/migrations/051-test.js
+++ b/test/unit/migrations/051-test.js
@@ -22,7 +22,7 @@ describe('migration #51', function () {
 
   describe('setting chainId', function () {
     INFURA_PROVIDER_TYPES.forEach(function (type) {
-      it(`should correctly set the chainId for the Infura network: ${type}`, async function () {
+      it(`should correctly set the chainId for the Infura network: ${type}, if no chainId is set`, async function () {
         const oldStorage = {
           meta: {},
           data: {

--- a/test/unit/migrations/051-test.js
+++ b/test/unit/migrations/051-test.js
@@ -1,0 +1,93 @@
+import { strict as assert } from 'assert'
+import migration51 from '../../../app/scripts/migrations/051'
+import {
+  INFURA_PROVIDER_TYPES,
+  NETWORK_TYPE_TO_ID_MAP,
+} from '../../../app/scripts/controllers/network/enums'
+
+describe('migration #51', function () {
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      meta: {
+        version: 50,
+      },
+      data: {},
+    }
+
+    const newStorage = await migration51.migrate(oldStorage)
+    assert.deepEqual(newStorage.meta, {
+      version: 51,
+    })
+  })
+
+  describe('setting chainId', function () {
+    INFURA_PROVIDER_TYPES.forEach(function (type) {
+      it(`should correctly set the chainId for the Infura network: ${type}`, async function () {
+        const oldStorage = {
+          meta: {},
+          data: {
+            NetworkController: {
+              settings: {
+                fizz: 'buzz',
+              },
+              provider: {
+                type,
+              },
+            },
+            foo: 'bar',
+          },
+        }
+        const newStorage = await migration51.migrate(oldStorage)
+        assert.deepEqual(newStorage.data, {
+          NetworkController: {
+            settings: {
+              fizz: 'buzz',
+            },
+            provider: {
+              type,
+              chainId: NETWORK_TYPE_TO_ID_MAP[type].chainId,
+            },
+          },
+          foo: 'bar',
+        })
+      })
+    })
+
+    it('should not set the chainId for a non-Infura network that does not have chainId set', async function () {
+      const oldStorage = {
+        meta: {},
+        data: {
+          NetworkController: {
+            settings: {
+              fizz: 'buzz',
+            },
+            provider: {
+              type: 'foo',
+            },
+          },
+        },
+      }
+      const newStorage = await migration51.migrate(oldStorage)
+      assert.deepEqual(newStorage.data, oldStorage.data)
+    })
+
+    it('should not set the chainId for a non-Infura network that does have chainId set', async function () {
+      const oldStorage = {
+        meta: {},
+        data: {
+          NetworkController: {
+            settings: {
+              fizz: 'buzz',
+            },
+            provider: {
+              type: 'foo',
+              chainId: '0x999',
+            },
+          },
+        },
+      }
+      const newStorage = await migration51.migrate(oldStorage)
+      assert.deepEqual(newStorage.data, oldStorage.data)
+    })
+  })
+})


### PR DESCRIPTION
Currently, some users are experiencing a disabled swaps buttom on the home screen, in v8.1.11

This can be recreated by:

- building v8.1.4 (or any other version <v8.1.8) locally (you'll notice swaps button is enabled)
- checking out the commit for v8.1.11 and building that locally (now swaps button is disabled)

This is because `chainId` wasn't set to a default in the network controller provider state until #9999 shipped in v8.1.8. However, it will get set whenever a user switches network. Users that first installed metamask prior to v8.1.8 but have not switched networks away from mainnet since installation will not have a `chainId` in their network controller provider state. With the changes in #10155, this will cause swaps to be disabled as their chainId in state will not match the hard-coded mainnet chainId

This PR fixes that issue by ensure that the provider data in state is updated to include the correct chainId for all default / infura networks (i.e. those for which we have hard coded chainIds).

This will also prevent similar errors from happening if/when we add any future code changes that rely on comparison of chainId in state to hard coded chainIds

Note: the hard coded chainIds can be found in `controllers/network/enums.js`

