### PR TITLE
drop the fox in about

### DIFF
--- a/ui/app/pages/settings/info-tab/index.scss
+++ b/ui/app/pages/settings/info-tab/index.scss
@@ -6,7 +6,10 @@
 
   &__logo {
     max-height: 100%;
-    max-width: 100%;
+    max-width: 50%;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   &__item {

--- a/ui/app/pages/settings/info-tab/info-tab.component.js
+++ b/ui/app/pages/settings/info-tab/info-tab.component.js
@@ -110,11 +110,7 @@ export default class InfoTab extends PureComponent {
           {this.renderInfoLinks()}
         </div>
         <div className="info-tab__logo-wrapper">
-          <img
-            src="images/info-logo.png"
-            className="info-tab__logo"
-            alt=""
-          />
+          <img src="images/info-logo.png" className="info-tab__logo" alt="" />
         </div>
       </div>
     )

--- a/ui/app/pages/settings/info-tab/info-tab.component.js
+++ b/ui/app/pages/settings/info-tab/info-tab.component.js
@@ -95,13 +95,6 @@ export default class InfoTab extends PureComponent {
       <div className="settings-page__body">
         <div className="settings-page__content-row">
           <div className="settings-page__content-item settings-page__content-item--without-height">
-            <div className="info-tab__logo-wrapper">
-              <img
-                src="images/info-logo.png"
-                className="info-tab__logo"
-                alt=""
-              />
-            </div>
             <div className="info-tab__item">
               <div className="info-tab__version-header">
                 {t('metamaskVersion')}
@@ -115,6 +108,13 @@ export default class InfoTab extends PureComponent {
             </div>
           </div>
           {this.renderInfoLinks()}
+        </div>
+        <div className="info-tab__logo-wrapper">
+          <img
+            src="images/info-logo.png"
+            className="info-tab__logo"
+            alt=""
+          />
         </div>
       </div>
     )


### PR DESCRIPTION
Fixes #6443 

Dropped the Fox element in the About Page and also centered it.