### PR TITLE
Restore support for @metamask/inpage provider@"< 8.0.0"

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -68,7 +68,6 @@ async function setupStreams() {
   // so we can handle the channels individually
   const pageMux = new ObjectMultiplex()
   pageMux.setMaxListeners(25)
-  pageMux.ignoreStream(LEGACY_PUBLIC_CONFIG) // TODO:LegacyProvider: Delete
   const extensionMux = new ObjectMultiplex()
   extensionMux.setMaxListeners(25)
   extensionMux.ignoreStream(LEGACY_PUBLIC_CONFIG) // TODO:LegacyProvider: Delete

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -23,6 +23,7 @@ const PROVIDER = 'metamask-provider'
 // TODO:LegacyProvider: Delete
 const LEGACY_CONTENT_SCRIPT = 'contentscript'
 const LEGACY_INPAGE = 'inpage'
+const LEGACY_PROVIDER = 'provider'
 const LEGACY_PUBLIC_CONFIG ='publicConfig'
 
 if (shouldInjectProvider()) {
@@ -107,7 +108,7 @@ async function setupStreams() {
   })
 
   forwardNamedTrafficBetweenMuxes(
-    'provider',
+    LEGACY_PROVIDER,
     PROVIDER,
     legacyPageMux,
     legacyExtensionMux,

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -20,11 +20,13 @@ const CONTENT_SCRIPT = 'metamask-contentscript'
 const INPAGE = 'metamask-inpage'
 const PROVIDER = 'metamask-provider'
 
+// TODO:LegacyProvider: Delete
 const LEGACY_CONTENT_SCRIPT = 'contentscript'
 const LEGACY_INPAGE = 'inpage'
+const LEGACY_PUBLIC_CONFIG ='publicConfig'
 
 if (shouldInjectProvider()) {
-  injectScript(inpageBundle)
+  // injectScript(inpageBundle)
   setupStreams()
 }
 
@@ -64,8 +66,10 @@ async function setupStreams() {
   // so we can handle the channels individually
   const pageMux = new ObjectMultiplex()
   pageMux.setMaxListeners(25)
+  pageMux.ignoreStream(LEGACY_PUBLIC_CONFIG) // TODO:LegacyProvider: Delete
   const extensionMux = new ObjectMultiplex()
   extensionMux.setMaxListeners(25)
+  extensionMux.ignoreStream(LEGACY_PUBLIC_CONFIG) // TODO:LegacyProvider: Delete
 
   pump(pageMux, pageStream, pageMux, (err) =>
     logStreamDisconnectWarning('MetaMask Inpage Multiplex', err),
@@ -82,6 +86,7 @@ async function setupStreams() {
   const phishingStream = extensionMux.createStream('phishing')
   phishingStream.once('data', redirectToPhishingWarning)
 
+  // TODO:LegacyProvider: Delete
   // handle legacy provider
   const legacyPageStream = new LocalMessageDuplexStream({
     name: LEGACY_CONTENT_SCRIPT,
@@ -107,7 +112,7 @@ async function setupStreams() {
     legacyPageMux,
     legacyExtensionMux,
   )
-  forwardTrafficBetweenMuxes('publicConfig', legacyPageMux, legacyExtensionMux)
+  forwardTrafficBetweenMuxes(LEGACY_PUBLIC_CONFIG, legacyPageMux, legacyExtensionMux)
 }
 
 function forwardTrafficBetweenMuxes(channelName, muxA, muxB) {
@@ -121,6 +126,7 @@ function forwardTrafficBetweenMuxes(channelName, muxA, muxB) {
   )
 }
 
+// TODO:LegacyProvider: Delete
 function forwardNamedTrafficBetweenMuxes(
   channelAName,
   channelBName,

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -28,7 +28,7 @@ const LEGACY_PROVIDER = 'provider'
 const LEGACY_PUBLIC_CONFIG = 'publicConfig'
 
 if (shouldInjectProvider()) {
-  // injectScript(inpageBundle)
+  injectScript(inpageBundle)
   setupStreams()
 }
 

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -101,7 +101,12 @@ async function setupStreams() {
     notifyInpageOfStreamFailure()
   })
 
-  forwardTrafficBetweenMuxes(PROVIDER, legacyPageMux, legacyExtensionMux)
+  forwardNamedTrafficBetweenMuxes(
+    'provider',
+    PROVIDER,
+    legacyPageMux,
+    legacyExtensionMux,
+  )
   forwardTrafficBetweenMuxes('publicConfig', legacyPageMux, legacyExtensionMux)
 }
 
@@ -111,6 +116,22 @@ function forwardTrafficBetweenMuxes(channelName, muxA, muxB) {
   pump(channelA, channelB, channelA, (error) =>
     console.debug(
       `MetaMask: Muxed traffic for channel "${channelName}" failed.`,
+      error,
+    ),
+  )
+}
+
+function forwardNamedTrafficBetweenMuxes(
+  channelAName,
+  channelBName,
+  muxA,
+  muxB,
+) {
+  const channelA = muxA.createStream(channelAName)
+  const channelB = muxB.createStream(channelBName)
+  pump(channelA, channelB, channelA, (error) =>
+    console.debug(
+      `MetaMask: Muxed traffic between channels "${channelAName}" and "${channelBName}" failed.`,
       error,
     ),
   )

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -415,6 +415,9 @@ export default class MetamaskController extends EventEmitter {
     ) {
       this.submitPassword(password)
     }
+
+    // TODO:LegacyProvider: Delete
+    this.publicConfigStore = this.createPublicConfigStore()
   }
 
   /**
@@ -462,6 +465,7 @@ export default class MetamaskController extends EventEmitter {
   }
 
   /**
+   * TODO:LegacyProvider: Delete
    * Constructor helper: initialize a public config store.
    * This store is used to make some config info available to Dapps synchronously.
    */
@@ -473,11 +477,6 @@ export default class MetamaskController extends EventEmitter {
     // setup memStore subscription hooks
     this.on('update', updatePublicConfigStore)
     updatePublicConfigStore(this.getState())
-
-    publicConfigStore.destroy = () => {
-      this.removeEventListener &&
-        this.removeEventListener('update', updatePublicConfigStore)
-    }
 
     function updatePublicConfigStore(memState) {
       const chainId = networkController.getCurrentChainId()
@@ -1870,6 +1869,7 @@ export default class MetamaskController extends EventEmitter {
     // messages between inpage and background
     this.setupProviderConnection(mux.createStream('metamask-provider'), sender)
 
+    // TODO:LegacyProvider: Delete
     // legacy streams
     this.setupPublicConfig(mux.createStream('publicConfig'))
   }
@@ -2058,6 +2058,7 @@ export default class MetamaskController extends EventEmitter {
   }
 
   /**
+   * TODO:LegacyProvider: Delete
    * A method for providing our public config info over a stream.
    * This includes info we like to be synchronous if possible, like
    * the current selected account, and network ID.
@@ -2068,11 +2069,9 @@ export default class MetamaskController extends EventEmitter {
    * @param {*} outStream - The stream to provide public config over.
    */
   setupPublicConfig(outStream) {
-    const configStore = this.createPublicConfigStore()
-    const configStream = storeAsStream(configStore)
+    const configStream = storeAsStream(this.publicConfigStore)
 
     pump(configStream, outStream, (err) => {
-      configStore.destroy()
       configStream.destroy()
       if (err) {
         log.error(err)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1,6 +1,8 @@
 import EventEmitter from 'events'
 import pump from 'pump'
 import Dnode from 'dnode'
+import { ObservableStore } from '@metamask/obs-store'
+import { storeAsStream } from '@metamask/obs-store/dist/asStream'
 import { JsonRpcEngine } from 'json-rpc-engine'
 import { debounce } from 'lodash'
 import createEngineStream from 'json-rpc-middleware-stream/engineStream'
@@ -457,6 +459,42 @@ export default class MetamaskController extends EventEmitter {
       providerOpts,
     )
     return providerProxy
+  }
+
+  /**
+   * Constructor helper: initialize a public config store.
+   * This store is used to make some config info available to Dapps synchronously.
+   */
+  createPublicConfigStore() {
+    // subset of state for metamask inpage provider
+    const publicConfigStore = new ObservableStore()
+    const { networkController } = this
+
+    // setup memStore subscription hooks
+    this.on('update', updatePublicConfigStore)
+    updatePublicConfigStore(this.getState())
+
+    publicConfigStore.destroy = () => {
+      this.removeEventListener &&
+        this.removeEventListener('update', updatePublicConfigStore)
+    }
+
+    function updatePublicConfigStore(memState) {
+      const chainId = networkController.getCurrentChainId()
+      if (memState.network !== 'loading') {
+        publicConfigStore.putState(selectPublicState(chainId, memState))
+      }
+    }
+
+    function selectPublicState(chainId, { isUnlocked, network }) {
+      return {
+        isUnlocked,
+        chainId,
+        networkVersion: network,
+      }
+    }
+
+    return publicConfigStore
   }
 
   /**
@@ -1831,6 +1869,9 @@ export default class MetamaskController extends EventEmitter {
 
     // messages between inpage and background
     this.setupProviderConnection(mux.createStream('metamask-provider'), sender)
+
+    // legacy streams
+    this.setupPublicConfig(mux.createStream('publicConfig'))
   }
 
   /**
@@ -2014,6 +2055,29 @@ export default class MetamaskController extends EventEmitter {
     // forward to metamask primary provider
     engine.push(providerAsMiddleware(provider))
     return engine
+  }
+
+  /**
+   * A method for providing our public config info over a stream.
+   * This includes info we like to be synchronous if possible, like
+   * the current selected account, and network ID.
+   *
+   * Since synchronous methods have been deprecated in web3,
+   * this is a good candidate for deprecation.
+   *
+   * @param {*} outStream - The stream to provide public config over.
+   */
+  setupPublicConfig(outStream) {
+    const configStore = this.createPublicConfigStore()
+    const configStream = storeAsStream(configStore)
+
+    pump(configStream, outStream, (err) => {
+      configStore.destroy()
+      configStream.destroy()
+      if (err) {
+        log.error(err)
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
This PR restores support for `@metamask/inpage-provider@" 8.0.0"`, for consumers who bring their own version of this package. The plan is to keep this support in production for about a month after communicating its removal to those consumers.