### PR TITLE
Fix eth-method-registry import

### DIFF
--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -1,4 +1,4 @@
-import MethodRegistry from 'eth-method-registry'
+import { MethodRegistry } from 'eth-method-registry'
 import abi from 'human-standard-token-abi'
 import { ethers } from 'ethers'
 import log from 'loglevel'


### PR DESCRIPTION
[`eth-method-registry@2.0.0`](https://github.com/MetaMask/eth-method-registry/blob/main/src/index.ts) switched from default to named export, but this was missed during review and not captured by our e2e tests.