### PR TITLE
Increase minimum Firefox version to v68

### DIFF
--- a/app/manifest/firefox.json
+++ b/app/manifest/firefox.json
@@ -2,7 +2,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "56.0"
+      "strict_min_version": "68.0"
     }
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,7 @@ module.exports = function (api) {
         '@babel/preset-env',
         {
           targets: {
-            browsers: ['chrome >= 63', 'firefox >= 56.2'],
+            browsers: ['chrome >= 63', 'firefox >= 68'],
           },
         },
       ],


### PR DESCRIPTION
Firefox v68 is the _previous_ Extended Support Release. We are increasing this because our current minimum version doesn't support async iterators, so some of our dependencies cause the extension to crash.

Our metrics show that usage of Firefox versions older than this is quite low (under 0.7% of Firefox users in the past month). These older versions are also _very behind_ on security updates. Using the Extended Support Release also makes it easier for us to test the minimum version, and ensure our extension remains compatible with it.

Relates to #6805