### PR TITLE
add new typography component

### DIFF
--- a/ui/app/components/ui/typography/index.js
+++ b/ui/app/components/ui/typography/index.js
@@ -1,0 +1,1 @@
+export { default } from './typography'

--- a/ui/app/components/ui/typography/typography.js
+++ b/ui/app/components/ui/typography/typography.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import classnames from 'classnames'
+import PropTypes from 'prop-types'
+import { COLORS, TYPOGRAPHY } from '../../../helpers/constants/design-system'
+
+const { H6, H7, H8, H9 } = TYPOGRAPHY
+
+export default function Typography({
+  variant = TYPOGRAPHY.Paragraph,
+  className,
+  color = COLORS.BLACK,
+  tag,
+  children,
+  spacing = 1,
+  fontWeight = 'normal',
+  align,
+}) {
+  const computedClassName = classnames(
+    'typography',
+    className,
+    `typography--${variant}`,
+    `typography--align-${align}`,
+    `typography--spacing-${spacing}`,
+    `typography--color-${color}`,
+    `typography--weight-${fontWeight}`,
+  )
+
+  let Tag = tag ?? variant
+
+  if (Tag === TYPOGRAPHY.Paragraph) {
+    Tag = 'p'
+  } else if ([H7, H8, H9].includes(Tag)) {
+    Tag = H6
+  }
+
+  return <Tag className={computedClassName}>{children}</Tag>
+}
+
+Typography.propTypes = {
+  variant: PropTypes.oneOf(Object.values(TYPOGRAPHY)),
+  children: PropTypes.node.isRequired,
+  color: PropTypes.oneOf(Object.values(COLORS)),
+  className: PropTypes.string,
+  align: PropTypes.oneOf(['center', 'right']),
+  spacing: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8]),
+  fontWeight: PropTypes.oneOf(['bold', 'normal']),
+  tag: PropTypes.oneOf([
+    'p',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'span',
+    'div',
+  ]),
+}

--- a/ui/app/components/ui/typography/typography.scss
+++ b/ui/app/components/ui/typography/typography.scss
@@ -1,0 +1,38 @@
+@use "design-system";
+@use "sass:map";
+
+.typography {
+  @include design-system.Paragraph;
+
+  @each $variant in map.keys(design-system.$typography-variants) {
+    &--#{$variant} {
+      @include design-system.typography($variant);
+    }
+  }
+
+  @each $variant, $color in design-system.$color-map {
+    &--color-#{$variant} {
+      color: $color;
+    }
+  }
+
+  @each $variant, $weight in design-system.$typography-font-weights {
+    &--weight-#{$variant} {
+      font-weight: $weight;
+    }
+  }
+
+  &--align-center {
+    text-align: center;
+  }
+
+  &--align-right {
+    text-align: right;
+  }
+
+  @for $i from 1 through 8 {
+    &--spacing-#{$i} {
+      margin: #{$i * 4}px auto;
+    }
+  }
+}

--- a/ui/app/components/ui/typography/typography.stories.js
+++ b/ui/app/components/ui/typography/typography.stories.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { number, select, text } from '@storybook/addon-knobs'
+import { COLORS, TYPOGRAPHY } from '../../../helpers/constants/design-system'
+import Typography from '.'
+
+export default {
+  title: 'Typography',
+}
+
+const fontWeightOptions = {
+  bold: 'bold',
+  normal: 'normal',
+}
+
+const alignOptions = {
+  left: undefined,
+  center: 'center',
+  right: 'right',
+}
+
+export const list = () => (
+  <div style={{ width: '80%', flexDirection: 'column' }}>
+    {Object.values(TYPOGRAPHY).map((variant) => (
+      <div key={variant} style={{ width: '100%' }}>
+        <Typography
+          variant={variant}
+          color={select('color', COLORS, COLORS.BLACK)}
+          spacing={number('spacing', 1, { range: true, min: 1, max: 8 })}
+          align={select('align', alignOptions, undefined)}
+          fontWeight={select('font weight', fontWeightOptions, 'normal')}
+        >
+          {variant}
+        </Typography>
+      </div>
+    ))}
+  </div>
+)
+
+export const TheQuickOrangeFox = () => (
+  <div style={{ width: '80%', flexDirection: 'column' }}>
+    <div style={{ width: '100%' }}>
+      <Typography
+        color={select('color', COLORS, COLORS.BLACK)}
+        variant={select('variant', TYPOGRAPHY, TYPOGRAPHY.Paragraph)}
+        spacing={number('spacing', 1, { range: true, min: 1, max: 8 })}
+        align={select('align', alignOptions, undefined)}
+        fontWeight={select('font weight', fontWeightOptions, 'normal')}
+      >
+        {text('content', 'The quick orange fox jumped over the lazy dog.')}
+      </Typography>
+    </div>
+  </div>
+)

--- a/ui/app/components/ui/ui-components.scss
+++ b/ui/app/components/ui/ui-components.scss
@@ -37,5 +37,6 @@
 @import 'toggle-button/index';
 @import 'token-balance/index';
 @import 'tooltip/index';
+@import 'typography/typography';
 @import 'unit-input/index';
 @import 'url-icon/index';


### PR DESCRIPTION
Requires: ~#10193~

Adds a new `Typography` UI component that will allow quickly styling text per the design system without adding additional class names and scss.

Example: where you might have previously needed to do something like this:
```jsx
  <div className="my-component">
    <header className="my-component__header">
      <h1>Text</h1>
      <h4>Text</h4>
    </header>
  </div>
```
```scss
.my-component {
  &__header {
    h1 {
     @include H1;

     color: $ui-4;
    }
    h4 {
     @include H4;
   
     color: $ui-2;
    }
  }
}
```

You can now do:
```jsx
  <div className="my-component">
    <header>
      <Typography variant={TYPOGRAPHY.H1} color={COLORS.UI4}>Text</Typography>
      <Typography variant={TYPOGRAPHY.H4} color={COLORS.UI2}>Text</Typography>
    </header>
  </div>
```

The lack of an example scss file for the second one is on purpose... you don't need it!

To an extent, this PR also will do some alignment and positioning for you, behind the `spacing` and `align` props. Eventually, I hope to improve the `Typography` component to hit 90% of the UI use cases without needing to apply a className or custom scss.

Storybook:
![storybook](https://user-images.githubusercontent.com/4448075/104773595-ec5a6980-573a-11eb-9931-fbb00e8d5000.gif)
