### PR TITLE
Fix hardware account selection

### DIFF
--- a/ui/app/pages/create-account/connect-hardware/account-list.js
+++ b/ui/app/pages/create-account/connect-hardware/account-list.js
@@ -90,7 +90,7 @@ class AccountList extends Component {
                 name="selectedAccount"
                 id={`address-${idx}`}
                 value={account.index}
-                onChange={(e) => this.props.onAccountChange(e.target.value)}
+                onClick={(e) => this.props.onAccountChange(e.target.value)}
                 checked={
                   this.props.selectedAccount === account.index.toString()
                 }


### PR DESCRIPTION
Fixes #9244

When trying to connect a Trezor account on a fresh install of MetaMask, the radio buttons on the account selection page would not respond to being clicked.

When debugging this, it looks like the `onChange` event was never triggered. A radio `<input>` element should trigger `onChange` whenever the selection state change, but seemingly this wouldn't happen if the change in selection state was undone during the same render cycle. If I paused at a breakpoint during the render, I could see the checkbox get selected then unselected again without triggering `onChange`.

The simplest fix was to use `onClick` instead of `onChange`. This seems more appropriate anyway because we're treating the radio button as a controlled component here, so the state of the underlying element isn't really of any concern.