### PR TITLE
Make hiring link a link on text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetaMask Browser Extension
 
-Hey! We are hiring JavaScript Engineers! Apply here: https://boards.greenhouse.io/consensys/jobs/2572388
+Hey! We are hiring JavaScript Engineers! [Apply here](https://boards.greenhouse.io/consensys/jobs/2572388)!
 ---
 
 You can find the latest version of MetaMask on [our official website](https://metamask.io/). For help using MetaMask, visit our [User Support Site](https://metamask.zendesk.com/hc/en-us).


### PR DESCRIPTION
To avoid repelling the neurotic JS developer.