### PR TITLE
Remove default to 18 decimals in quotesToRenderableData method

### DIFF
--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -467,11 +467,11 @@ export function quotesToRenderableData(
     } = quote
     const sourceValue = calcTokenAmount(
       sourceAmount,
-      sourceTokenInfo.decimals || 18,
+      sourceTokenInfo.decimals,
     ).toString(10)
     const destinationValue = calcTokenAmount(
       destinationAmount,
-      destinationTokenInfo.decimals || 18,
+      destinationTokenInfo.decimals,
     ).toPrecision(8)
 
     const {
@@ -501,14 +501,11 @@ export function quotesToRenderableData(
       destinationTokenInfo.symbol === 'ETH'
         ? calcTokenAmount(
             destinationAmount,
-            destinationTokenInfo.decimals || 18,
+            destinationTokenInfo.decimals,
           ).minus(rawEthFee, 10)
         : new BigNumber(tokenConversionRate || 0, 10)
             .times(
-              calcTokenAmount(
-                destinationAmount,
-                destinationTokenInfo.decimals || 18,
-              ),
+              calcTokenAmount(destinationAmount, destinationTokenInfo.decimals),
               10,
             )
             .minus(rawEthFee, 10)


### PR DESCRIPTION
Fixes an issue where tokens with `0` decimals would show incorrect amounts on the view token screen.

The default to 18 decimals was unnecessary, as we validate `/tokens` api responses in `swaps.util.js` to verify that decimals are defined and either a number or a string of decimal digits between 0 and 36. If the decimals were somehow undefined by the time quotesToRenderableData in `view-quote.js`, then it would be better that a user hit an error than be shown an incorrect default.

A future improvement will be to add data validation to the  `quotesToRenderableData` method