### PR TITLE
add includePaths to sass-loader in storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -28,6 +28,9 @@ module.exports = {
           options: {
             sourceMap: true,
             implementation: require('sass'),
+            sassOptions: {
+              includePaths: ['ui/app/css/'],
+            },
           },
         },
       ],


### PR DESCRIPTION
Fixes:

Not impacted yet, but #10197, #10199 and #10209 add storybook stories that use the design-system. In order to be able to do ```@use "design-system"``` versus ```@use "../../../css/design-system"``` we have to set the `includePaths` in the `sass-loader`