### PR TITLE
Add MAX_SAFE_CHAIN_ID and refactor chain ID validation

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -845,6 +845,9 @@
   "invalidBlockExplorerURL": {
     "message": "Invalid Block Explorer URL"
   },
+  "invalidChainIdTooBig": {
+    "message": "Invalid chain ID. The chain ID is too big."
+  },
   "invalidCustomNetworkAlertContent1": {
     "message": "The chain ID for custom network '$1' has to be re-entered.",
     "description": "$1 is the name/identifier of the network."

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -160,6 +160,10 @@ export default class NetworkController extends EventEmitter {
   }
 
   setRpcTarget(rpcUrl, chainId, ticker = 'ETH', nickname = '', rpcPrefs) {
+    assert.ok(
+      isPrefixedFormattedHexString(chainId),
+      `Invalid chainId "${chainId}".`,
+    )
     this.setProviderConfig({
       type: NETWORK_TYPE_RPC,
       rpcUrl,
@@ -171,14 +175,14 @@ export default class NetworkController extends EventEmitter {
   }
 
   async setProviderType(type, rpcUrl = '', ticker = 'ETH', nickname = '') {
-    assert.notEqual(
+    assert.notStrictEqual(
       type,
       NETWORK_TYPE_RPC,
       `NetworkController - cannot call "setProviderType" with type "${NETWORK_TYPE_RPC}". Use "setRpcTarget"`,
     )
-    assert(
+    assert.ok(
       INFURA_PROVIDER_TYPES.includes(type),
-      `NetworkController - Unknown rpc type "${type}"`,
+      `Unknown Infura provider type "${type}".`,
     )
     const { chainId } = NETWORK_TYPE_TO_ID_MAP[type]
     this.setProviderConfig({ type, rpcUrl, chainId, ticker, nickname })

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -18,7 +18,10 @@ import {
   MAINNET_CHAIN_ID,
   RINKEBY_CHAIN_ID,
 } from '../../../../shared/constants/network'
-import { isSafeChainId } from '../../../../shared/modules/utils'
+import {
+  isPrefixedFormattedHexString,
+  isSafeChainId,
+} from '../../../../shared/modules/utils'
 import createMetamaskMiddleware from './createMetamaskMiddleware'
 import createInfuraClient from './createInfuraClient'
 import createJsonRpcClient from './createJsonRpcClient'
@@ -163,11 +166,11 @@ export default class NetworkController extends EventEmitter {
   setRpcTarget(rpcUrl, chainId, ticker = 'ETH', nickname = '', rpcPrefs) {
     assert.ok(
       isPrefixedFormattedHexString(chainId),
-      `Invalid hexadecimal chain ID "${chainId}".`,
+      `Invalid chain ID "${chainId}": invalid hex string.`,
     )
     assert.ok(
       isSafeChainId(parseInt(chainId, 16)),
-      `Chain ID "${chainId}" too big.`,
+      `Invalid chain ID "${chainId}": numerical value greater than max safe value.`,
     )
     this.setProviderConfig({
       type: NETWORK_TYPE_RPC,

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -18,6 +18,7 @@ import {
   MAINNET_CHAIN_ID,
   RINKEBY_CHAIN_ID,
 } from '../../../../shared/constants/network'
+import { isSafeChainId } from '../../../../shared/modules/utils'
 import createMetamaskMiddleware from './createMetamaskMiddleware'
 import createInfuraClient from './createInfuraClient'
 import createJsonRpcClient from './createJsonRpcClient'
@@ -162,7 +163,11 @@ export default class NetworkController extends EventEmitter {
   setRpcTarget(rpcUrl, chainId, ticker = 'ETH', nickname = '', rpcPrefs) {
     assert.ok(
       isPrefixedFormattedHexString(chainId),
-      `Invalid chainId "${chainId}".`,
+      `Invalid hexadecimal chain ID "${chainId}".`,
+    )
+    assert.ok(
+      isSafeChainId(parseInt(chainId, 16)),
+      `Chain ID "${chainId}" too big.`,
     )
     this.setProviderConfig({
       type: NETWORK_TYPE_RPC,

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -5,9 +5,9 @@ import { normalize as normalizeAddress } from 'eth-sig-util'
 import { isValidAddress } from 'ethereumjs-util'
 import ethers from 'ethers'
 import log from 'loglevel'
-import { isPrefixedFormattedHexString } from '../lib/util'
 import { LISTED_CONTRACT_ADDRESSES } from '../../../shared/constants/tokens'
 import { NETWORK_TYPE_TO_ID_MAP } from '../../../shared/constants/network'
+import { isPrefixedFormattedHexString } from '../../../shared/modules/utils'
 
 export default class PreferencesController {
   /**

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -148,21 +148,6 @@ function checkForError() {
 }
 
 /**
- * Checks whether the given value is a 0x-prefixed, non-zero, non-zero-padded,
- * hexadecimal string.
- *
- * @param {any} value - The value to check.
- * @returns {boolean} True if the value is a correctly formatted hex string,
- * false otherwise.
- */
-function isPrefixedFormattedHexString(value) {
-  if (typeof value !== 'string') {
-    return false
-  }
-  return /^0x[1-9a-f]+[0-9a-f]*$/iu.test(value)
-}
-
-/**
  * Prefixes a hex string with '0x' or '-0x' and returns it. Idempotent.
  *
  * @param {string} str - The string to prefix.
@@ -202,7 +187,6 @@ export {
   hexToBn,
   BnMultiplyByFraction,
   checkForError,
-  isPrefixedFormattedHexString,
   addHexPrefix,
   bnToHex,
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2402,13 +2402,6 @@ export default class MetamaskController extends EventEmitter {
     nickname,
     rpcPrefs,
   ) {
-    await this.preferencesController.updateRpc({
-      rpcUrl,
-      chainId,
-      ticker,
-      nickname,
-      rpcPrefs,
-    })
     this.networkController.setRpcTarget(
       rpcUrl,
       chainId,
@@ -2416,6 +2409,13 @@ export default class MetamaskController extends EventEmitter {
       nickname,
       rpcPrefs,
     )
+    await this.preferencesController.updateRpc({
+      rpcUrl,
+      chainId,
+      ticker,
+      nickname,
+      rpcPrefs,
+    })
     return rpcUrl
   }
 

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -18,7 +18,7 @@ export const GOERLI_CHAIN_ID = '0x5'
 export const KOVAN_CHAIN_ID = '0x2a'
 
 /**
- * The largest possible chain ID our codebase can handle.
+ * The largest possible chain ID we can handle.
  * TODO: Add link to document explaining why.
  */
 export const MAX_SAFE_CHAIN_ID = 4503599627370476

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -19,7 +19,7 @@ export const KOVAN_CHAIN_ID = '0x2a'
 
 /**
  * The largest possible chain ID we can handle.
- * TODO: Add link to document explaining why.
+ * Explanation: https://gist.github.com/rekmarks/a47bd5f2525936c4b8eee31a16345553
  */
 export const MAX_SAFE_CHAIN_ID = 4503599627370476
 

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -17,6 +17,12 @@ export const RINKEBY_CHAIN_ID = '0x4'
 export const GOERLI_CHAIN_ID = '0x5'
 export const KOVAN_CHAIN_ID = '0x2a'
 
+/**
+ * The largest possible chain ID our codebase can handle.
+ * TODO: Add link to document explaining why.
+ */
+export const MAX_SAFE_CHAIN_ID = 4503599627370476
+
 export const ROPSTEN_DISPLAY_NAME = 'Ropsten'
 export const RINKEBY_DISPLAY_NAME = 'Rinkeby'
 export const KOVAN_DISPLAY_NAME = 'Kovan'

--- a/shared/modules/README.md
+++ b/shared/modules/README.md
@@ -1,3 +1,0 @@
-### Shared Modules
-
-This folder is reserved for modules that can be used globally within both the background and ui applications.

--- a/shared/modules/utils.js
+++ b/shared/modules/utils.js
@@ -9,5 +9,22 @@ import { MAX_SAFE_CHAIN_ID } from '../constants/network'
  * @returns {boolean} Whether the given chain ID is safe.
  */
 export function isSafeChainId(chainId) {
-  return Number.isSafeInteger(chainId) && chainId > 0 && chainId <= MAX_SAFE_CHAIN_ID
+  return (
+    Number.isSafeInteger(chainId) && chainId > 0 && chainId <= MAX_SAFE_CHAIN_ID
+  )
+}
+
+/**
+ * Checks whether the given value is a 0x-prefixed, non-zero, non-zero-padded,
+ * hexadecimal string.
+ *
+ * @param {any} value - The value to check.
+ * @returns {boolean} True if the value is a correctly formatted hex string,
+ * false otherwise.
+ */
+export function isPrefixedFormattedHexString(value) {
+  if (typeof value !== 'string') {
+    return false
+  }
+  return /^0x[1-9a-f]+[0-9a-f]*$/iu.test(value)
 }

--- a/shared/modules/utils.js
+++ b/shared/modules/utils.js
@@ -1,0 +1,13 @@
+import { MAX_SAFE_CHAIN_ID } from '../constants/network'
+
+/**
+ * Checks whether the given number primitive chain ID is safe.
+ * Because some cryptographic libraries we use expect the chain ID to be a
+ * number primitive, it must not exceed a certain size.
+ *
+ * @param {number} chainId - The chain ID to check for safety.
+ * @returns {boolean} Whether the given chain ID is safe.
+ */
+export function isSafeChainId(chainId) {
+  return Number.isSafeInteger(chainId) && chainId > 0 && chainId <= MAX_SAFE_CHAIN_ID
+}

--- a/test/unit/app/util-test.js
+++ b/test/unit/app/util-test.js
@@ -2,8 +2,8 @@ import { strict as assert } from 'assert'
 import {
   getEnvironmentType,
   sufficientBalance,
-  isPrefixedFormattedHexString,
 } from '../../../app/scripts/lib/util'
+import { isPrefixedFormattedHexString } from '../../../shared/modules/utils'
 
 import {
   ENVIRONMENT_TYPE_POPUP,

--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -11,10 +11,8 @@ import {
 } from '../../../helpers/constants/routes'
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../shared/constants/app'
 import { NETWORK_TYPE_RPC } from '../../../../../shared/constants/network'
-import {
-  getEnvironmentType,
-  isPrefixedFormattedHexString,
-} from '../../../../../app/scripts/lib/util'
+import { isPrefixedFormattedHexString } from '../../../../../shared/modules/utils'
+import { getEnvironmentType } from '../../../../../app/scripts/lib/util'
 
 import { Dropdown, DropdownMenuItem } from './components/dropdown'
 import NetworkDropdownIcon from './components/network-dropdown-icon'

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import validUrl from 'valid-url'
-import BigNumber from 'bignumber.js'
 import log from 'loglevel'
 import TextField from '../../../../components/ui/text-field'
 import Button from '../../../../components/ui/button'
 import Tooltip from '../../../../components/ui/tooltip'
+import { isSafeChainId } from '../../../../../../shared/modules/utils'
 import { isPrefixedFormattedHexString } from '../../../../../../app/scripts/lib/util'
 import { jsonRpcRequest } from '../../../../helpers/utils/util'
 
@@ -126,7 +126,7 @@ export default class NetworkForm extends PureComponent {
     if (!chainId || typeof chainId !== 'string' || !chainId.startsWith('0x')) {
       return chainId
     }
-    return new BigNumber(chainId, 16).toString(10)
+    return parseInt(chainId, 16).toString(10)
   }
 
   onSubmit = async () => {
@@ -155,7 +155,7 @@ export default class NetworkForm extends PureComponent {
       // Ensure chainId is a 0x-prefixed, lowercase hex string
       let chainId = formChainId
       if (!chainId.startsWith('0x')) {
-        chainId = `0x${new BigNumber(chainId, 10).toString(16)}`
+        chainId = `0x${parseInt(chainId, 10).toString(16)}`
       }
 
       if (!(await this.validateChainIdOnSubmit(formChainId, chainId, rpcUrl))) {
@@ -308,8 +308,10 @@ export default class NetworkForm extends PureComponent {
   validateChainIdOnChange = (chainIdArg = '') => {
     const chainId = chainIdArg.trim()
     let errorMessage = ''
+    let radix = 10
 
     if (chainId.startsWith('0x')) {
+      radix = 16
       if (!/^0x[0-9a-f]+$/iu.test(chainId)) {
         errorMessage = this.context.t('invalidHexNumber')
       } else if (!isPrefixedFormattedHexString(chainId)) {
@@ -319,6 +321,8 @@ export default class NetworkForm extends PureComponent {
       errorMessage = this.context.t('invalidNumber')
     } else if (chainId.startsWith('0')) {
       errorMessage = this.context.t('invalidNumberLeadingZeros')
+    } else if (!isSafeChainId(parseInt(chainId, radix))) {
+      errorMessage = this.context.t('invalidChainIdTooBig')
     }
 
     this.setErrorTo('chainId', errorMessage)
@@ -356,7 +360,7 @@ export default class NetworkForm extends PureComponent {
       // in an error message in the form.
       if (!formChainId.startsWith('0x')) {
         try {
-          endpointChainId = new BigNumber(endpointChainId, 16).toString(10)
+          endpointChainId = parseInt(endpointChainId, 16).toString(10)
         } catch (err) {
           log.warn(
             'Failed to convert endpoint chain ID to decimal',

--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -5,8 +5,10 @@ import log from 'loglevel'
 import TextField from '../../../../components/ui/text-field'
 import Button from '../../../../components/ui/button'
 import Tooltip from '../../../../components/ui/tooltip'
-import { isSafeChainId } from '../../../../../../shared/modules/utils'
-import { isPrefixedFormattedHexString } from '../../../../../../app/scripts/lib/util'
+import {
+  isPrefixedFormattedHexString,
+  isSafeChainId,
+} from '../../../../../../shared/modules/utils'
 import { jsonRpcRequest } from '../../../../helpers/utils/util'
 
 const FORM_STATE_KEYS = [


### PR DESCRIPTION
- Adds the `MAX_SAFE_CHAIN_ID` constant to `shared/constants`
- Adds `shared/modules/utils.js`
  - Add `isSafeChainId` function to this file
  - Move `isPrefixedFormattedHexString` to this file
- Add `isSafeChainId` validation to UI chain ID validation
- Add hex string and `isSafeChainId` validation calls to network controller
  - We were previously only validating in the UI. `setRpcTarget` is called in a number of places, and for the safety of our users, we should ensure they can't switch to networks without valid chain IDs.
  - We're probably safe with just the validation in the UI, but the checks are cheap, so why not?