### PR TITLE
Update `@reduxjs/toolkit` from v1.3.2 to v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@metamask/logo": "^2.5.0",
     "@metamask/obs-store": "^5.0.0",
     "@popperjs/core": "^2.4.0",
-    "@reduxjs/toolkit": "^1.3.2",
+    "@reduxjs/toolkit": "^1.5.0",
     "@sentry/browser": "^5.26.0",
     "@sentry/integrations": "^5.26.0",
     "@zxing/library": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,12 +2245,12 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@reduxjs/toolkit@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.3.2.tgz#cbd062f0b806eb4611afeb2b30240e5186d6dd27"
-  integrity sha512-IRI9Nx6Ys/u4NDqPvUC0+e8MH+e1VME9vn30xAmd+MBqDsClc0Dhrlv4Scw2qltRy/mrINarU6BqJp4/dcyyFg==
+"@reduxjs/toolkit@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.5.0.tgz#1025c1ccb224d1fc06d8d98a61f6717d57e6d477"
+  integrity sha512-E/FUraRx+8guw9Hlg/Ja8jI/hwCrmIKed8Annt9YsZw3BQp+F24t5I5b2OWR6pkEHY4hn1BgP08FrTZFRKsdaQ==
   dependencies:
-    immer "^6.0.1"
+    immer "^8.0.0"
     redux "^4.0.0"
     redux-thunk "^2.3.0"
     reselect "^4.0.0"
@@ -13364,10 +13364,10 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
-immer@^6.0.1:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.3.tgz#94d5051cd724668160a900d66d85ec02816f29bd"
-  integrity sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ==
+immer@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
The changes made between v1.3.2 and v1.5.0 of `@reduxjs/toolkit` don't appear to affect us at all. They mostly consist of feature additions and bug fixes for edge cases we haven't encountered.[1]

The one change that is technically breaking is that v8 of `immer` now freezes state objects in production rather than just in development. That would only be breaking if we were mutating Redux state though, which we aren't doing in the few Redux slices in which we use `@reduxjs/toolkit`. Even if we were, we would have noticed that it broke in development already.

[1]: https://github.com/reduxjs/redux-toolkit/releases