### PR TITLE
Fix getting the site metadata from the request origin params.

### DIFF
--- a/app/scripts/controllers/permissions/permissionsMethodMiddleware.js
+++ b/app/scripts/controllers/permissions/permissionsMethodMiddleware.js
@@ -74,8 +74,8 @@ export default function createPermissionsMethodMiddleware({
       // custom method for getting metadata from the requesting domain,
       // sent automatically by the inpage provider when it's initialized
       case 'metamask_sendDomainMetadata': {
-        if (typeof req.domainMetadata?.name === 'string') {
-          addDomainMetadata(req.origin, req.domainMetadata)
+        if (typeof req.params?.name === 'string') {
+          addDomainMetadata(req.origin, req.params)
         }
         res.result = true
         return

--- a/test/unit/app/controllers/permissions/mocks.js
+++ b/test/unit/app/controllers/permissions/mocks.js
@@ -600,7 +600,7 @@ export const getters = deepFreeze({
       return {
         origin,
         method: 'metamask_sendDomainMetadata',
-        domainMetadata: {
+        params: {
           ...args,
           name,
         },


### PR DESCRIPTION
Regressed from inpage-provider ts migration the request. The property domainMetadata is now set as a params key for the request.

https://github.com/MetaMask/inpage-provider/blob/v7.0.0/src/siteMetadata.js#L19-L25
vs
https://github.com/MetaMask/inpage-provider/blob/main/src/siteMetadata.ts#L19-L27

Fixes getting the site metadata to populate the domainMetadata in state that is used for populating the decrypt message component which has been broken since the updated of the inpage-provider package.