### PR TITLE
Remove unnecessary optional chain operator

### DIFF
--- a/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
+++ b/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.component.js
@@ -195,7 +195,7 @@ export default class ConfirmDecryptMessage extends Component {
             {originMetadata?.icon ? (
               <img
                 className="request-decrypt-message__visual-identicon"
-                src={originMetadata?.icon}
+                src={originMetadata.icon}
                 alt=""
               />
             ) : (


### PR DESCRIPTION
This operator is being used under a condition that guarantees that the property is present, so the optional chain operator is useless.