### PR TITLE
Remove missing messages from verify locales script

### DIFF
--- a/development/lib/locales.js
+++ b/development/lib/locales.js
@@ -1,0 +1,44 @@
+const path = require('path')
+const fs = require('fs')
+const { promisify } = require('util')
+
+const log = require('loglevel')
+
+const readFile = promisify(fs.readFile)
+
+function getLocalePath(code) {
+  return path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'app',
+    '_locales',
+    code,
+    'messages.json',
+  )
+}
+
+async function getLocale(code) {
+  try {
+    const localeFilePath = getLocalePath(code)
+    const fileContents = await readFile(localeFilePath, 'utf8')
+    return JSON.parse(fileContents)
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      log.error('Locale file not found')
+    } else {
+      log.error(`Error opening your locale ("${code}") file: `, e)
+    }
+    process.exit(1)
+  }
+}
+
+function compareLocalesForMissingItems({ base, subject }) {
+  return Object.keys(base).filter((key) => !subject[key])
+}
+
+module.exports = {
+  compareLocalesForMissingItems,
+  getLocale,
+  getLocalePath,
+}

--- a/development/missing-locale-strings.js
+++ b/development/missing-locale-strings.js
@@ -1,0 +1,78 @@
+// //////////////////////////////////////////////////////////////////////////////
+//
+// Reports on missing localized strings
+//
+// usage:
+//
+//     node app/scripts/missing-locale-strings.js [<locale>] [--verbose]
+//
+// This script will report on any missing localized strings. It will compare the
+// chosen locale (or all locales, if none is chosen) with the `en` locale, and
+// report the coverage percentage.
+//
+// The optional '--verbose' argument will print the key for each localized string
+// to the console.
+//
+// //////////////////////////////////////////////////////////////////////////////
+
+const log = require('loglevel')
+const localeIndex = require('../app/_locales/index.json')
+const { compareLocalesForMissingItems, getLocale } = require('./lib/locales')
+
+log.setDefaultLevel('info')
+
+let verbose = false
+let specifiedLocale
+for (const arg of process.argv.slice(2)) {
+  if (arg === '--verbose') {
+    verbose = true
+  } else {
+    specifiedLocale = arg
+  }
+}
+
+main().catch((error) => {
+  log.error(error)
+  process.exit(1)
+})
+
+async function main() {
+  if (specifiedLocale === 'en') {
+    throw new Error(
+      `Can't compare 'en' locale to itself to find missing messages`,
+    )
+  } else if (specifiedLocale) {
+    await reportMissingMessages(specifiedLocale)
+  } else {
+    const localeCodes = localeIndex
+      .filter((localeMeta) => localeMeta.code !== 'en')
+      .map((localeMeta) => localeMeta.code)
+
+    for (const code of localeCodes) {
+      await reportMissingMessages(code)
+    }
+  }
+}
+
+async function reportMissingMessages(code) {
+  const englishLocale = await getLocale('en')
+  const targetLocale = await getLocale(code)
+
+  const missingItems = compareLocalesForMissingItems({
+    base: englishLocale,
+    subject: targetLocale,
+  })
+
+  const englishEntryCount = Object.keys(englishLocale).length
+  const coveragePercent =
+    (100 * (englishEntryCount - missingItems.length)) / englishEntryCount
+
+  log.info(`**${code}**: ${coveragePercent.toFixed(2)}% coverage`)
+  if (missingItems.length && verbose) {
+    console.log(`**${code}**: ${missingItems.length} missing messages`)
+    log.info('Extra items that should not be localized:')
+    missingItems.forEach(function (key) {
+      log.info(`  - [ ] ${key}`)
+    })
+  }
+}

--- a/development/verify-locale-strings.js
+++ b/development/verify-locale-strings.js
@@ -10,13 +10,12 @@
 // the English locale against string literals found under `ui/`, and it will check
 // other locales by comparing them to the English locale.
 //
-// A report will be printed to the console detailing any unused locales, and also
-// any missing messages in the non-English locales.
+// A report will be printed to the console detailing any unused messages.
 //
-// The if the optional '--fix' parameter is given, locales will be automatically
+// The if the optional '--fix' argument is given, locales will be automatically
 // updated to remove any unused messages.
 //
-// The optional '--quiet' parameter reduces the verbosity of the output, printing
+// The optional '--quiet' argument reduces the verbosity of the output, printing
 // just a single summary of results for each locale verified
 //
 // //////////////////////////////////////////////////////////////////////////////
@@ -27,6 +26,11 @@ const { promisify } = require('util')
 const log = require('loglevel')
 const matchAll = require('string.prototype.matchall').getPolyfill()
 const localeIndex = require('../app/_locales/index.json')
+const {
+  compareLocalesForMissingItems,
+  getLocale,
+  getLocalePath,
+} = require('./lib/locales')
 
 const readdir = promisify(fs.readdir)
 const readFile = promisify(fs.readFile)
@@ -63,6 +67,8 @@ async function main() {
         : await verifyLocale(locale)
     if (failed) {
       process.exit(1)
+    } else {
+      console.log('No invalid entries!')
     }
   } else {
     log.info('Verifying all locales:\n')
@@ -72,33 +78,15 @@ async function main() {
       .map((localeMeta) => localeMeta.code)
 
     for (const code of localeCodes) {
-      log.info() // Separate each locale report by a newline when not in '--quiet' mode
       const localeFailed = await verifyLocale(code, fix)
       failed = failed || localeFailed
     }
 
     if (failed) {
       process.exit(1)
-    }
-  }
-}
-
-function getLocalePath(code) {
-  return path.resolve(__dirname, '..', 'app', '_locales', code, 'messages.json')
-}
-
-async function getLocale(code) {
-  try {
-    const localeFilePath = getLocalePath(code)
-    const fileContents = await readFile(localeFilePath, 'utf8')
-    return JSON.parse(fileContents)
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      log.error('Locale file not found')
     } else {
-      log.error(`Error opening your locale ("${code}") file: `, e)
+      console.log('No invalid entries!')
     }
-    process.exit(1)
   }
 }
 
@@ -128,14 +116,6 @@ async function verifyLocale(code) {
     base: targetLocale,
     subject: englishLocale,
   })
-  const missingItems = compareLocalesForMissingItems({
-    base: englishLocale,
-    subject: targetLocale,
-  })
-
-  const englishEntryCount = Object.keys(englishLocale).length
-  const coveragePercent =
-    (100 * (englishEntryCount - missingItems.length)) / englishEntryCount
 
   if (extraItems.length) {
     console.log(`**${code}**: ${extraItems.length} unused messages`)
@@ -143,20 +123,6 @@ async function verifyLocale(code) {
     extraItems.forEach(function (key) {
       log.info(`  - [ ] ${key}`)
     })
-  } else {
-    log.info(`**${code}**: ${extraItems.length} unused messages`)
-  }
-
-  log.info(`${coveragePercent.toFixed(2)}% coverage`)
-  if (missingItems.length) {
-    log.info(`Missing items not present in localized file:`)
-    missingItems.forEach(function (key) {
-      log.info(`  - [ ] ${key}`)
-    })
-  }
-
-  if (!extraItems.length && !missingItems.length) {
-    log.info('Full coverage  : )')
   }
 
   if (extraItems.length > 0) {
@@ -230,7 +196,6 @@ async function verifyEnglishLocale() {
   }
 
   if (!unusedMessages.length && !templateUsage.length) {
-    log.info('Full coverage  : )')
     return false // failed === false
   }
 
@@ -264,8 +229,4 @@ async function* getFileContents(filenames) {
   for (const filename of filenames) {
     yield readFile(filename, 'utf8')
   }
-}
-
-function compareLocalesForMissingItems({ base, subject }) {
-  return Object.keys(base).filter((key) => !subject[key])
 }


### PR DESCRIPTION
The report on missing messages has been removed from the verify locales script. This report was making the console output of this command unreasonably long, and would obscure the reports on any invalid entries.

A new script was written to report on missing localized messages. This can be run with the command `yarn locale-coverage`. This will print a report to the console on the coverage for each locale.