### PR TITLE
Require English descriptions in locale files

### DIFF
--- a/development/lib/locales.js
+++ b/development/lib/locales.js
@@ -37,7 +37,17 @@ function compareLocalesForMissingItems({ base, subject }) {
   return Object.keys(base).filter((key) => !subject[key])
 }
 
+function compareLocalesForMissingDescriptions({ englishLocale, targetLocale }) {
+  return Object.keys(englishLocale).filter(
+    (key) =>
+      targetLocale[key] !== undefined &&
+      englishLocale[key].description !== undefined &&
+      englishLocale[key].description !== targetLocale[key].description,
+  )
+}
+
 module.exports = {
+  compareLocalesForMissingDescriptions,
   compareLocalesForMissingItems,
   getLocale,
   getLocalePath,


### PR DESCRIPTION
The `verify-locale-strings.js` script now validates that the descriptions from the `en` locale are also present in all other locales.

These descriptions are intended to help with translation, and are not meant to be translated. This check will ensure that translators don't accidentally translate these. It also ensures they're present alongside each translated message, which might be helpful for understanding context.