### PR TITLE
Restore missing locale descriptions

### DIFF
--- a/app/_locales/hn/messages.json
+++ b/app/_locales/hn/messages.json
@@ -19,11 +19,11 @@
   },
   "appDescription": {
     "message": "इथीरियम ब्राउज़र एक्सटेंशन",
-    "description": "आवेदन का विवरण"
+    "description": "The description of the application"
   },
   "appName": {
     "message": "मेटामास्क/MetaMask",
-    "description": "एप्लिकेशन का नाम"
+    "description": "The name of the application"
   },
   "approve": {
     "message": "मंजूर"
@@ -123,11 +123,11 @@
   },
   "fiat": {
     "message": "FIAT एक्सचेंज टाइप",
-    "description": "एक्सचेंज FIAT टाइप"
+    "description": "Exchange type"
   },
   "fileImportFail": {
     "message": "फ़ाइल आयात काम नहीं कर रहा है? यहां क्लिक करें!",
-    "description": "यूजर को अपने खाते को जे.एस.ौ.एन फ़ाइल से आयात करने में मदद करता है"
+    "description": "Helps user import their account from a JSON file"
   },
   "from": {
     "message": "की तरफ से - संदेश"
@@ -146,11 +146,11 @@
   },
   "getEtherFromFaucet": {
     "message": "$1 के लिए एक नल से ईथर प्राप्त करें",
-    "description": "ईथर नल के लिए नेटवर्क नाम प्रदर्शित करता है"
+    "description": "Displays network name for Ether faucet"
   },
   "here": {
     "message": "यहां",
-    "description": "अधिक जानकारी के लिए यहां क्लिक करें- (परेशानी के साथ जाता है टोकनबैलेंस) (troubleTokenBalances)"
+    "description": "as in -click here- for more information (goes with troubleTokenBalances)"
   },
   "hide": {
     "message": "छुपाएं"
@@ -160,7 +160,7 @@
   },
   "import": {
     "message": "आयात",
-    "description": "एक चयनित फ़ाइल से एक खाता आयात करने के लिए बटन "
+    "description": "Button to import an account from a selected file"
   },
   "importAccount": {
     "message": "खाता आयात"
@@ -170,7 +170,7 @@
   },
   "imported": {
     "message": "आयातित",
-    "description": "यह स्थिति दिखाती है कि कोई खाता पूरी तरह से कीरिंग में लोड हो चुका है"
+    "description": "status showing that an account has been fully loaded into the keyring"
   },
   "infoHelp": {
     "message": "जानकारी और सहायता"
@@ -195,7 +195,7 @@
   },
   "jsonFile": {
     "message": "JSON फ़ाइल",
-    "description": "एक खाता आयात करने के लिए प्रारूप"
+    "description": "format for importing an account"
   },
   "kovan": {
     "message": "कोवान टेस्ट नेटवर्क"
@@ -235,7 +235,7 @@
   },
   "needImportFile": {
     "message": "आयात करने के लिए आपको एक फ़ाइल का चयन करना होगा।",
-    "description": "प्रयोक्ता महत्वपूर्ण खाता है और उसे जारी रखने के लिए एक फ़ाइल जोड़ने की आवश्यकता है"
+    "description": "User is important an account and needs to add a file to continue"
   },
   "negativeETH": {
     "message": "ईटीएच की नकारात्मक मात्रा नहीं भेज सकते हैं।."
@@ -248,7 +248,7 @@
   },
   "newAccountNumberName": {
     "message": "नया खाता $1",
-    "description": "खाते का खाता बनाने पर अगले खाते का डिफ़ॉल्ट नाम"
+    "description": "Default name of next account to be created on create account screen"
   },
   "newContract": {
     "message": "नया अनुबंध"
@@ -267,7 +267,7 @@
   },
   "pastePrivateKey": {
     "message": "यहां अपनी निजी कुंजी स्ट्रिंग चिपकाएं:",
-    "description": "किसी निजी कुंजी से किसी खाते को आयात करने के लिए"
+    "description": "For importing an account from a private key"
   },
   "personalAddressDetected": {
     "message": "व्यक्तिगत पता मिला। टोकन अनुबंध का पता इनपुट।"
@@ -277,7 +277,7 @@
   },
   "privateKey": {
     "message": "निजी कुंजी",
-    "description": "खाता आयात करने के लिए उपयोग करने के लिए इस प्रकार की फ़ाइल का चयन करें"
+    "description": "select this type of file to use to import an account"
   },
   "privateKeyWarning": {
     "message": "चेतावनी: कभी भी इस कुंजी का खुलासा न करें। आपकी निजी कुंजी वाले कोई भी आपके खाते में रखी किसी भी संपत्ति को चुरा सकता है।"
@@ -392,7 +392,7 @@
   },
   "troubleTokenBalances": {
     "message": "मुसीबत... आपके टोकन शेष राशि को लोड करने में हमें परेशानी हुई थी। आप उन्हें देख सकते हैं",
-    "description": "टोकन शेष देखने के लिए एक लिंक ... (यहां)"
+    "description": "Followed by a link (here) to view token balances"
   },
   "typePassword": {
     "message": "अपना पासवर्ड टाइप करें"

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -267,7 +267,7 @@
   },
   "connectTo": {
     "message": "Connettiti a $1",
-    "description": "$1 is the name/origin of a site/dapp that the user can connect to metamask"
+    "description": "$1 is the name/origin of a web3 site/application that the user can connect to metamask"
   },
   "connectToAll": {
     "message": "Connettiti a tutti i tuoi $1",
@@ -426,7 +426,7 @@
   },
   "decryptMessageNotice": {
     "message": "$1 vorrebbe leggere questo messaggio per completare l'azione",
-    "description": "$1 is website or dapp name"
+    "description": "$1 is the web3 site name"
   },
   "decryptMetamask": {
     "message": "Decifra messaggio"
@@ -511,7 +511,7 @@
   },
   "encryptionPublicKeyNotice": {
     "message": "$1 vorrebbe la tua chiave di cifratura pubblica. Consentendo, questo sito sarà in grado di comporre messaggi criptati per te.",
-    "description": "$1 is website or dapp name"
+    "description": "$1 is the web3 site name"
   },
   "encryptionPublicKeyRequest": {
     "message": "Richiedi chiave pubblica di cifratura"

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -13,7 +13,7 @@
   },
   "appDescription": {
     "message": "Ethereum Browser Extension",
-    "description": "Ang deskripsyon ng application"
+    "description": "The description of the application"
   },
   "appName": {
     "message": "MetaMask",
@@ -96,11 +96,11 @@
   },
   "fiat": {
     "message": "FIAT",
-    "description": "Type ng exchange"
+    "description": "Exchange type"
   },
   "fileImportFail": {
     "message": "Hindi gumagana ang file import? I-click ito!",
-    "description": "Tinutulungan ang user na i-import ang kanilang account mula sa JSON file"
+    "description": "Helps user import their account from a JSON file"
   },
   "from": {
     "message": "Mula sa"
@@ -113,11 +113,11 @@
   },
   "getEtherFromFaucet": {
     "message": "Kumuha ng Ether mula sa faucet para sa $1",
-    "description": "Ipinapakita ang pangalan ng network para sa Ether faucet"
+    "description": "Displays network name for Ether faucet"
   },
   "here": {
     "message": "i-click ito",
-    "description": "tulad ng -i-click dito- para sa mas maraming impormasyon (kasama ng troubleTokenBalances)"
+    "description": "as in -click here- for more information (goes with troubleTokenBalances)"
   },
   "hide": {
     "message": "Itago"
@@ -127,14 +127,14 @@
   },
   "import": {
     "message": "I-import",
-    "description": "Button para i-import ang account mula sa napiling file"
+    "description": "Button to import an account from a selected file"
   },
   "importAccount": {
     "message": "I-import ang Account"
   },
   "imported": {
     "message": "Na-import na",
-    "description": "status na nagpapakita na ang account ay lubos na na-load sa keyring"
+    "description": "status showing that an account has been fully loaded into the keyring"
   },
   "infoHelp": {
     "message": "Impormasyon at Tulong"
@@ -159,7 +159,7 @@
   },
   "needImportFile": {
     "message": "Dapat kang pumili ng file para i-import.",
-    "description": "Ang user ay nag-iimport ng account at kailangan magdagdag ng file upang tumuloy"
+    "description": "User is important an account and needs to add a file to continue"
   },
   "newAccount": {
     "message": "Bagong Account"
@@ -181,7 +181,7 @@
   },
   "pastePrivateKey": {
     "message": "I-paste dito ang iyong private key string:",
-    "description": "Para sa pag-import ng account mula sa private key"
+    "description": "For importing an account from a private key"
   },
   "privateKeyWarning": {
     "message": "Babala: Huwag sabihin sa kahit na sino ang key na ito. Maaring makuha at manakaw ng sinumang nakakaalam ng iyong private key ang mga assets sa iyong account."
@@ -233,7 +233,7 @@
   },
   "troubleTokenBalances": {
     "message": "Nagkaroon kami ng problema sa paglo-load ng iyong mga balanseng token. Tingnan ito dito ",
-    "description": "Susundan ng link (dito) para tingnan ang token balances"
+    "description": "Followed by a link (here) to view token balances"
   },
   "typePassword": {
     "message": "I-type ang iyong Password"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -134,7 +134,8 @@
     "message": "Блок-эксплорер"
   },
   "blockExplorerView": {
-    "message": "Посмотреть аккаунт на $1"
+    "message": "Посмотреть аккаунт на $1",
+    "description": "$1 replaced by URL for custom block explorer"
   },
   "blockiesIdenticon": {
     "message": "Использовать Blockies Identicon"
@@ -292,7 +293,7 @@
   },
   "decryptMessageNotice": {
     "message": "Для $1 необходимо прочитать это сообщение, чтобы завершить Ваше действие",
-    "description": "$1 is website or dapp name"
+    "description": "$1 is the web3 site name"
   },
   "decryptMetamask": {
     "message": "Расшифровать сообщение"
@@ -353,7 +354,7 @@
   },
   "encryptionPublicKeyNotice": {
     "message": "$1 запрашивает ваш открытый ключ шифрования. По согласованию, этот сайт сможет создавать для Вас зашифрованные сообщения.",
-    "description": "$1 is website or dapp name"
+    "description": "$1 is the web3 site name"
   },
   "encryptionPublicKeyRequest": {
     "message": "Запрос публичного ключа шифрования"

--- a/app/_locales/ta/messages.json
+++ b/app/_locales/ta/messages.json
@@ -25,11 +25,11 @@
   },
   "appDescription": {
     "message": "எதெரியும்  பிரௌசர்  நீட்டிப்பு",
-    "description": "பயன்பாட்டின் விளக்கம்"
+    "description": "The description of the application"
   },
   "appName": {
     "message": "மேடமஸ்க் ",
-    "description": "பயன்பாட்டின் பெயர்"
+    "description": "The name of the application"
   },
   "approve": {
     "message": "ஒப்புதல்"
@@ -168,11 +168,11 @@
   },
   "fiat": {
     "message": "FIAT",
-    "description": "பரிமாற்ற வகை"
+    "description": "Exchange type"
   },
   "fileImportFail": {
     "message": "கோப்பு இறக்குமதி வேலை செய்யவில்லையா? இங்கே கிளிக் செய்யவும்!",
-    "description": "JSON கோப்பில் பயனர் கணக்கை தங்கள் கணக்கை இறக்குமதி செய்ய உதவுகிறது"
+    "description": "Helps user import their account from a JSON file"
   },
   "forgetDevice": {
     "message": "இந்தச் சாதனத்தை அகற்று"
@@ -194,14 +194,14 @@
   },
   "getEtherFromFaucet": {
     "message": "$ 1 க்கு ஒரு குழாய் இருந்து ஈதர் கிடைக்கும்$1",
-    "description": "ஈத்தர் குழாய் ஐந்து பிணைய பெயர் காட்டுகிறது"
+    "description": "Displays network name for Ether faucet"
   },
   "getStarted": {
     "message": "தொடங்குக"
   },
   "here": {
     "message": "இங்கே",
-    "description": "இங்கே-கிளிக் செய்யவும்- மேலும் தகவலுக்கு (troubleTokenBalances செல்கிறது)"
+    "description": "as in -click here- for more information (goes with troubleTokenBalances)"
   },
   "hide": {
     "message": "மறை"
@@ -249,7 +249,7 @@
   },
   "jsonFile": {
     "message": "JSON கோப்பு",
-    "description": "ஒரு கணக்கை இறக்குமதி செய்ய வடிவமைக்கப்பட்டுள்ளது"
+    "description": "format for importing an account"
   },
   "kovan": {
     "message": "கோவன் டெஸ்ட் நெட்வொர்க்"
@@ -298,7 +298,7 @@
   },
   "needImportFile": {
     "message": "இறக்குமதி செய்ய ஒரு கோப்பை நீங்கள் தேர்ந்தெடுக்க வேண்டும்.",
-    "description": "பயனர் ஒரு கணக்கு முக்கியம் மற்றும் தொடர ஒரு கோப்பு சேர்க்க வேண்டும்"
+    "description": "User is important an account and needs to add a file to continue"
   },
   "negativeETH": {
     "message": "ETH எதிர்மறை அளவுகளை அனுப்ப முடியாது."
@@ -311,7 +311,7 @@
   },
   "newAccountNumberName": {
     "message": "கணக்கு $ 1",
-    "description": "கணக்கு கணக்கை உருவாக்குவதற்கு அடுத்த கணக்கின் இயல்புநிலை பெயர் உருவாக்கப்படும்"
+    "description": "Default name of next account to be created on create account screen"
   },
   "newContract": {
     "message": "புதிய ஒப்பந்தம்"
@@ -351,7 +351,7 @@
   },
   "pastePrivateKey": {
     "message": "இங்கே உங்கள் தனிப்பட்ட விசை சரத்தை ஒட்டுக:",
-    "description": "ஒரு தனிப்பட்ட விசை ஒரு கணக்கை இறக்குமதி செய்ய"
+    "description": "For importing an account from a private key"
   },
   "personalAddressDetected": {
     "message": "தனிப்பட்ட முகவரி கண்டறியப்பட்டது. டோக்கன் ஒப்பந்த முகவரியை உள்ளிடவும்."
@@ -361,7 +361,7 @@
   },
   "privateKey": {
     "message": "தனிப்பட்ட விசை",
-    "description": "ஒரு கணக்கை இறக்குமதி செய்ய பயன்படுத்த இந்த வகை கோப்பை தேர்ந்தெடுக்கவும்"
+    "description": "select this type of file to use to import an account"
   },
   "privateKeyWarning": {
     "message": "எச்சரிக்கை: இந்த விசையை எப்போதும் வெளியிட வேண்டாம். உங்கள் தனிப்பட்ட விசைகளைக் கொண்ட எவரும் உங்கள் கணக்கில் உள்ள எந்த சொத்துக்களையும் திருடலாம்."
@@ -509,7 +509,7 @@
   },
   "troubleTokenBalances": {
     "message": "உங்கள் டோக்கன் நிலுவைகளை ஏற்றுவதில் சிக்கல் ஏற்பட்டது. நீங்கள் அவர்களை பார்க்க முடியும்.",
-    "description": "டோக்கன் நிலுவைகளை காண ஒரு இணைப்பு (இங்கே) தொடர்ந்து"
+    "description": "Followed by a link (here) to view token balances"
   },
   "tryAgain": {
     "message": "மீண்டும் முயல்க"


### PR DESCRIPTION
The localized message descriptions from the `en` locale have been restored to all other locales. These descriptions are intended to help translators understand the context for each message, and are not intended to be translated.