### PR TITLE
Restore `metamask-extension-provider@2.0.0` compatibility

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1872,6 +1872,7 @@ export default class MetamaskController extends EventEmitter {
     // TODO:LegacyProvider: Delete
     // legacy streams
     this.setupPublicConfig(mux.createStream('publicConfig'))
+    this.setupProviderConnection(mux.createStream('provider'), sender)
   }
 
   /**


### PR DESCRIPTION
Restore compatibility with `metamask-extension-provider@2.0.0`, which uses a legacy (<v8) inpage provider.

This was tested with the [`extension-test-dapp`](https://github.com/MetaMask/test-dapp/compare/extension-test-dapp) branch of the test dapp, which can be installed as an extension in Chrome.

Manual testing steps:
 - Build the extension on this branch, install it in Chrome, and proceed through onboarding
 - Checkout the `extension-test-dapp` branch of the `test-dapp`, run `yarn`, then update `node_modules/metamask-extension-provider/config.json` to set the `CHROME_ID` to match the id of the test extension build installed in the first step.
 - Proceed to the `index.html` page of the test dapp
 - Test any dapp interactions