### PR TITLE
Fix logWeb3ShimUsage metrics

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-shim-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-shim-usage.js
@@ -40,16 +40,18 @@ function logWeb3ShimUsageHandler(
   if (getWeb3ShimUsageState(origin) === undefined) {
     setWeb3ShimUsageRecorded(origin)
 
-    sendMetrics({
-      event: `Website Accessed window.web3 Shim`,
-      category: 'inpage_provider',
-      eventContext: {
+    sendMetrics(
+      {
+        event: `Website Accessed window.web3 Shim`,
+        category: 'inpage_provider',
         referrer: {
           url: origin,
         },
       },
-      excludeMetaMetricsId: true,
-    })
+      {
+        excludeMetaMetricsId: true,
+      },
+    )
   }
 
   res.result = true


### PR DESCRIPTION
The `sendMetrics` call in the `metamask_logWeb3ShimUsage` handler was... not correctly formatted. It should now be fixed. I couldn't find any usage of the `referrer` property, but according to the following type definition, it should be fine now: https://github.com/MetaMask/metamask-extension/blob/develop/shared/constants/metametrics.js/#L17-L22