### PR TITLE
Cancel transaction when swaps submission is failed because the simulation fails

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -706,7 +706,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     // transactions that get published to the blockchain only to fail and thereby
     // waste the user's funds on gas.
     if (!approveTxParams && tradeTxMeta.simulationFails) {
-      await dispatch(cancelTx(tradeTxMeta, true))
+      await dispatch(cancelTx(tradeTxMeta, false))
       await dispatch(setSwapsErrorKey(SWAP_FAILED_ERROR))
       history.push(SWAPS_ERROR_ROUTE)
       return

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -23,6 +23,7 @@ import {
   setSwapsLiveness,
   setSelectedQuoteAggId,
   setSwapsTxGasLimit,
+  cancelTx,
 } from '../../store/actions'
 import {
   AWAITING_SWAP_ROUTE,
@@ -705,6 +706,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     // transactions that get published to the blockchain only to fail and thereby
     // waste the user's funds on gas.
     if (!approveTxParams && tradeTxMeta.simulationFails) {
+      await dispatch(cancelTx(tradeTxMeta, true))
       await dispatch(setSwapsErrorKey(SWAP_FAILED_ERROR))
       history.push(SWAPS_ERROR_ROUTE)
       return

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1048,9 +1048,9 @@ export function cancelTypedMsg(msgData) {
   }
 }
 
-export function cancelTx(txData) {
+export function cancelTx(txData, dontShowLoadingIndicator) {
   return (dispatch) => {
-    dispatch(showLoadingIndication())
+    !dontShowLoadingIndicator && dispatch(showLoadingIndication())
     return new Promise((resolve, reject) => {
       background.cancelTransaction(txData.id, (error) => {
         if (error) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1048,9 +1048,9 @@ export function cancelTypedMsg(msgData) {
   }
 }
 
-export function cancelTx(txData, dontShowLoadingIndicator) {
+export function cancelTx(txData, _showLoadingIndication = true) {
   return (dispatch) => {
-    !dontShowLoadingIndicator && dispatch(showLoadingIndication())
+    _showLoadingIndication && dispatch(showLoadingIndication())
     return new Promise((resolve, reject) => {
       background.cancelTransaction(txData.id, (error) => {
         if (error) {


### PR DESCRIPTION
This PR fixes a bug with the code added here https://github.com/MetaMask/metamask-extension/pull/9947/files#diff-79e282e22d97801a4a8ac7638c098e38eb40e3c46ad24ff4f7db7405dac2faabR719

That code prevents a swap transaction for which the gas estimation fails from being signed and published to the blockchain. However, there is a bug in the code: the swaps transaction is not cancelled. This leaves an unapproved transaction in state, which the user would see after exiting swaps and attempting to return to the home page. The user could then still submit the swap, which is what we are trying to prevent.

The solution is to cancel the swap in addition to taking the user to the error screen. 