### PR TITLE
Add Definition List component

### DIFF
--- a/ui/app/components/ui/box/box.js
+++ b/ui/app/components/ui/box/box.js
@@ -13,7 +13,7 @@ import {
 
 const ValidSize = PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 const ArrayOfValidSizes = PropTypes.arrayOf(ValidSize)
-const MultipleSizes = PropTypes.oneOf([ValidSize, ArrayOfValidSizes])
+const MultipleSizes = PropTypes.oneOfType([ValidSize, ArrayOfValidSizes])
 
 function generateSizeClasses(baseClass, type, main, top, right, bottom, left) {
   const arr = Array.isArray(main) ? main : []

--- a/ui/app/components/ui/definition-list/definition-list.js
+++ b/ui/app/components/ui/definition-list/definition-list.js
@@ -6,6 +6,7 @@ import {
   COLORS,
   SIZES,
   TYPOGRAPHY,
+  FONT_WEIGHT,
 } from '../../../helpers/constants/design-system'
 import Tooltip from '../tooltip'
 
@@ -27,10 +28,10 @@ export default function DefinitionList({
   return (
     <dl className="definition-list">
       {Object.entries(dictionary).map(([term, definition]) => (
-        <>
+        <React.Fragment key={`definition-for-${term}`}>
           <Typography
             variant={TYPOGRAPHY.H6}
-            fontWeight="bold"
+            fontWeight={FONT_WEIGHT.BOLD}
             {...termTypography}
             boxProps={{
               marginTop: 0,
@@ -63,7 +64,7 @@ export default function DefinitionList({
           >
             {definition}
           </Typography>
-        </>
+        </React.Fragment>
       ))}
     </dl>
   )
@@ -73,6 +74,10 @@ DefinitionList.propTypes = {
   gapSize: PropTypes.oneOf(Object.values(SIZES)),
   dictionary: PropTypes.objectOf(PropTypes.string),
   tooltips: PropTypes.objectOf(PropTypes.string),
-  termTypography: omit(Typography.propTypes, ['tag', 'className']),
-  definitionTypography: omit(Typography.propTypes, ['tag', 'className']),
+  termTypography: PropTypes.shape({
+    ...omit(Typography.propTypes, ['tag', 'className']),
+  }),
+  definitionTypography: PropTypes.shape({
+    ...omit(Typography.propTypes, ['tag', 'className']),
+  }),
 }

--- a/ui/app/components/ui/definition-list/definition-list.js
+++ b/ui/app/components/ui/definition-list/definition-list.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { omit } from 'lodash'
+import Typography from '../typography'
+import {
+  COLORS,
+  SIZES,
+  TYPOGRAPHY,
+} from '../../../helpers/constants/design-system'
+import Tooltip from '../tooltip'
+
+const MARGIN_MAP = {
+  [SIZES.XS]: 0,
+  [SIZES.SM]: 2,
+  [SIZES.MD]: 4,
+  [SIZES.LG]: 6,
+  [SIZES.XL]: 8,
+}
+
+export default function DefinitionList({
+  dictionary,
+  termTypography = {},
+  definitionTypography = {},
+  tooltips = {},
+  gapSize = SIZES.SM,
+}) {
+  return (
+    <dl className="definition-list">
+      {Object.entries(dictionary).map(([term, definition]) => (
+        <>
+          <Typography
+            variant={TYPOGRAPHY.H6}
+            fontWeight="bold"
+            {...termTypography}
+            boxProps={{
+              marginTop: 0,
+              marginBottom: 1,
+            }}
+            className="definition-list__term"
+            tag="dt"
+          >
+            {term}
+            {tooltips[term] && (
+              <Tooltip
+                title={tooltips[term]}
+                position="top"
+                containerClassName="definition-list__tooltip-wrapper"
+              >
+                <i className="fas fa-info-circle" />
+              </Tooltip>
+            )}
+          </Typography>
+          <Typography
+            variant={TYPOGRAPHY.H6}
+            color={COLORS.UI4}
+            {...definitionTypography}
+            boxProps={{
+              marginTop: 0,
+              marginBottom: MARGIN_MAP[gapSize],
+            }}
+            className="definition-list__definition"
+            tag="dd"
+          >
+            {definition}
+          </Typography>
+        </>
+      ))}
+    </dl>
+  )
+}
+
+DefinitionList.propTypes = {
+  gapSize: PropTypes.oneOf(Object.values(SIZES)),
+  dictionary: PropTypes.objectOf(PropTypes.string),
+  tooltips: PropTypes.objectOf(PropTypes.string),
+  termTypography: omit(Typography.propTypes, ['tag', 'className']),
+  definitionTypography: omit(Typography.propTypes, ['tag', 'className']),
+}

--- a/ui/app/components/ui/definition-list/definition-list.js
+++ b/ui/app/components/ui/definition-list/definition-list.js
@@ -75,9 +75,9 @@ DefinitionList.propTypes = {
   dictionary: PropTypes.objectOf(PropTypes.string),
   tooltips: PropTypes.objectOf(PropTypes.string),
   termTypography: PropTypes.shape({
-    ...omit(Typography.propTypes, ['tag', 'className']),
+    ...omit(Typography.propTypes, ['tag', 'className', 'boxProps']),
   }),
   definitionTypography: PropTypes.shape({
-    ...omit(Typography.propTypes, ['tag', 'className']),
+    ...omit(Typography.propTypes, ['tag', 'className', 'boxProps']),
   }),
 }

--- a/ui/app/components/ui/definition-list/definition-list.scss
+++ b/ui/app/components/ui/definition-list/definition-list.scss
@@ -1,0 +1,19 @@
+.definition-list {
+  $self: &;
+
+  &__term {
+    display: flex;
+    align-items: center;
+
+    & i {
+      color: $ui-3;
+      margin-left: 6px;
+      font-size: $font-size-h8;
+    }
+
+    & #{$self}__tooltip-wrapper {
+      display: flex !important;
+      align-items: center;
+    }
+  }
+}

--- a/ui/app/components/ui/definition-list/definition-list.stories.js
+++ b/ui/app/components/ui/definition-list/definition-list.stories.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { object, select } from '@storybook/addon-knobs'
+import {
+  COLORS,
+  SIZES,
+  TYPOGRAPHY,
+} from '../../../helpers/constants/design-system'
+import DefinitionList from './definition-list'
+
+export default {
+  title: 'Definition List',
+}
+
+const basic = {
+  term:
+    'a word or phrase used to describe a thing or to express a concept, especially in a particular kind of language or branch of study.',
+  definition:
+    'a statement of the exact meaning of a word, especially in a dictionary.',
+  dl: 'HTML tag denoting a definition list',
+  dt: 'HTML tag denoting a definition list term',
+  dd: 'HTML tag denoting a definition list definition',
+}
+
+const advanced = {
+  'Network Name': 'Ethereum Mainnet',
+  'Chain ID': '1',
+  Ticker: 'ETH',
+}
+
+const tooltips = {
+  'Network Name': 'The name that is associated with this network',
+  'Chain ID': 'The numeric value representing the ID of this network',
+  Ticker: 'The currency symbol of the primary currency for this network',
+}
+
+export const definitionList = () => (
+  <DefinitionList
+    dictionary={object('dictionary', basic)}
+    gapSize={select('gapSize', SIZES, SIZES.SM)}
+  />
+)
+
+export const withTooltips = () => (
+  <DefinitionList
+    dictionary={object('dictionary', advanced)}
+    tooltips={object('tooltips', tooltips)}
+    gapSize={select('gapSize', SIZES, SIZES.SM)}
+  />
+)
+
+export const withTypographyControl = () => (
+  <DefinitionList
+    dictionary={object('dictionary', advanced)}
+    tooltips={object('tooltips', tooltips)}
+    gapSize={select('gapSize', SIZES, SIZES.SM)}
+    termTypography={{
+      variant: select('term typography variant', TYPOGRAPHY, TYPOGRAPHY.H6),
+      color: select('term typography color', COLORS, COLORS.BLACK),
+    }}
+    definitionTypography={{
+      variant: select(
+        'definition typography variant',
+        TYPOGRAPHY,
+        TYPOGRAPHY.H6,
+      ),
+      color: select('definition typography color', COLORS, COLORS.BLACK),
+    }}
+  />
+)

--- a/ui/app/components/ui/definition-list/definition-list.stories.js
+++ b/ui/app/components/ui/definition-list/definition-list.stories.js
@@ -54,16 +54,16 @@ export const withTypographyControl = () => (
     tooltips={object('tooltips', tooltips)}
     gapSize={select('gapSize', SIZES, SIZES.SM)}
     termTypography={{
-      variant: select('term typography variant', TYPOGRAPHY, TYPOGRAPHY.H6),
-      color: select('term typography color', COLORS, COLORS.BLACK),
+      variant: select('termTypography.variant', TYPOGRAPHY, TYPOGRAPHY.H6),
+      color: select('termTypography.color', COLORS, COLORS.BLACK),
     }}
     definitionTypography={{
       variant: select(
-        'definition typography variant',
+        'definitionTypography.variant',
         TYPOGRAPHY,
         TYPOGRAPHY.H6,
       ),
-      color: select('definition typography color', COLORS, COLORS.BLACK),
+      color: select('definitionTypography.color', COLORS, COLORS.BLACK),
     }}
   />
 )

--- a/ui/app/components/ui/definition-list/index.js
+++ b/ui/app/components/ui/definition-list/index.js
@@ -1,0 +1,1 @@
+export { default } from './definition-list'

--- a/ui/app/components/ui/typography/typography.js
+++ b/ui/app/components/ui/typography/typography.js
@@ -69,5 +69,7 @@ Typography.propTypes = {
     'h6',
     'span',
     'div',
+    'dt',
+    'dd',
   ]),
 }

--- a/ui/app/components/ui/ui-components.scss
+++ b/ui/app/components/ui/ui-components.scss
@@ -13,6 +13,7 @@
 @import 'color-indicator/color-indicator';
 @import 'currency-display/index';
 @import 'currency-input/index';
+@import 'definition-list/definition-list';
 @import 'dialog/dialog';
 @import 'dropdown/dropdown';
 @import 'editable-label/index';


### PR DESCRIPTION
*Requires*: ~#10289~
### Rationale
Using a `<dl>` for terms and definitions is good, semantic markup. We have a new component introduced in the `add-ethereum-chain` UI that has terms in bold and definitions or values in normal text below the bolded term. This component allows passing a simple dictionary object and gets a formatted `<dl>` out of it. Also allows for passing tooltips as an object for the use case where the "terms" are the "keys" and the "definitions" are "values". Examples of each below

<details>
<summary>Term with Definition</summary>

<img src="https://user-images.githubusercontent.com/4448075/106036158-8fe03e00-609a-11eb-8377-68773bc1fd19.png" />

</details>

<details>
<summary>Key with Value</summary>
<img src="https://user-images.githubusercontent.com/4448075/106036414-f1a0a800-609a-11eb-969c-c65a38f286ea.png" />


</details>

You can also control the typography for the two different types (definition, term)

<details>
<summary>Typography controls</summary>

<img src="https://user-images.githubusercontent.com/4448075/106036621-33315300-609b-11eb-8ef5-21031026d9bc.png" />

</details>

You can also expand the space between entries via `gapSize` prop

<details>
<summary>gapSize control</summary>

<img src="https://user-images.githubusercontent.com/4448075/106036769-5b20b680-609b-11eb-91de-a2f1a5c2052b.png" />

</details>


### Additional notes
This also cleans up some prop-type warnings from my previous work :( 