### PR TITLE
Add Truncated Definition List

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2086,6 +2086,9 @@
   "viewAccount": {
     "message": "View Account"
   },
+  "viewAllDetails": {
+    "message": "View all details"
+  },
   "viewContact": {
     "message": "View Contact"
   },

--- a/ui/app/components/ui/popover/popover.component.js
+++ b/ui/app/components/ui/popover/popover.component.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
+import { omit } from 'lodash'
 import { useI18nContext } from '../../../hooks/useI18nContext'
 
 const Popover = ({
@@ -79,7 +80,14 @@ Popover.propTypes = {
 }
 
 export default class PopoverPortal extends PureComponent {
-  static propTypes = Popover.propTypes
+  static propTypes = {
+    ...Popover.propTypes,
+    open: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    open: true,
+  }
 
   rootNode = document.getElementById('popover-content')
 
@@ -102,7 +110,10 @@ export default class PopoverPortal extends PureComponent {
   }
 
   render() {
-    const children = <Popover {...this.props} />
+    if (this.props.open === false) {
+      return null
+    }
+    const children = <Popover {...omit(this.props, 'open')} />
     return this.rootNode
       ? ReactDOM.createPortal(children, this.instanceNode)
       : children

--- a/ui/app/components/ui/popover/popover.component.js
+++ b/ui/app/components/ui/popover/popover.component.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
-import { omit } from 'lodash'
 import { useI18nContext } from '../../../hooks/useI18nContext'
 
 const Popover = ({
@@ -80,14 +79,7 @@ Popover.propTypes = {
 }
 
 export default class PopoverPortal extends PureComponent {
-  static propTypes = {
-    ...Popover.propTypes,
-    open: PropTypes.bool,
-  }
-
-  static defaultProps = {
-    open: true,
-  }
+  static propTypes = Popover.propTypes
 
   rootNode = document.getElementById('popover-content')
 
@@ -110,10 +102,7 @@ export default class PopoverPortal extends PureComponent {
   }
 
   render() {
-    if (this.props.open === false) {
-      return null
-    }
-    const children = <Popover {...omit(this.props, 'open')} />
+    const children = <Popover {...this.props} />
     return this.rootNode
       ? ReactDOM.createPortal(children, this.instanceNode)
       : children

--- a/ui/app/components/ui/truncated-definition-list/index.js
+++ b/ui/app/components/ui/truncated-definition-list/index.js
@@ -1,0 +1,1 @@
+export { default } from './truncated-definition-list'

--- a/ui/app/components/ui/truncated-definition-list/truncated-definition-list.js
+++ b/ui/app/components/ui/truncated-definition-list/truncated-definition-list.js
@@ -6,6 +6,7 @@ import Box from '../box'
 import Button from '../button'
 import DefinitionList from '../definition-list/definition-list'
 import Popover from '../popover'
+import { useI18nContext } from '../../../hooks/useI18nContext'
 
 export default function TruncatedDefinitionList({
   dictionary,
@@ -14,9 +15,10 @@ export default function TruncatedDefinitionList({
   title,
 }) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+  const t = useI18nContext()
 
   return (
-    <div className="truncated-definition-list">
+    <>
       <Box
         margin={6}
         padding={4}
@@ -33,36 +35,38 @@ export default function TruncatedDefinitionList({
           type="link"
           onClick={() => setIsPopoverOpen(true)}
         >
-          View all details
+          {t('viewAllDetails')}
         </Button>
       </Box>
-      <Popover
-        title={title}
-        open={isPopoverOpen}
-        onClose={() => setIsPopoverOpen(false)}
-        footer={
-          <>
-            <div />
-            <Button
-              type="primary"
-              style={{ width: '50%' }}
-              rounded
-              onClick={() => setIsPopoverOpen(false)}
-            >
-              Close
-            </Button>
-          </>
-        }
-      >
-        <Box padding={6} paddingTop={0}>
-          <DefinitionList
-            gap={SIZES.MD}
-            tooltips={tooltips}
-            dictionary={dictionary}
-          />
-        </Box>
-      </Popover>
-    </div>
+      {isPopoverOpen && (
+        <Popover
+          title={title}
+          open={isPopoverOpen}
+          onClose={() => setIsPopoverOpen(false)}
+          footer={
+            <>
+              <div />
+              <Button
+                type="primary"
+                style={{ width: '50%' }}
+                rounded
+                onClick={() => setIsPopoverOpen(false)}
+              >
+                Close
+              </Button>
+            </>
+          }
+        >
+          <Box padding={6} paddingTop={0}>
+            <DefinitionList
+              gap={SIZES.MD}
+              tooltips={tooltips}
+              dictionary={dictionary}
+            />
+          </Box>
+        </Popover>
+      )}
+    </>
   )
 }
 

--- a/ui/app/components/ui/truncated-definition-list/truncated-definition-list.js
+++ b/ui/app/components/ui/truncated-definition-list/truncated-definition-list.js
@@ -16,12 +16,12 @@ export default function TruncatedDefinitionList({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
   return (
-    <>
+    <div className="truncated-definition-list">
       <Box
         margin={6}
         padding={4}
         paddingBottom={3}
-        borderRadius="lg"
+        borderRadius={SIZES.LG}
         borderColor={COLORS.UI2}
       >
         <DefinitionList
@@ -29,7 +29,7 @@ export default function TruncatedDefinitionList({
           tooltips={tooltips}
         />
         <Button
-          className="approval-page__view-all-details"
+          className="truncated-definition-list__view-more"
           type="link"
           onClick={() => setIsPopoverOpen(true)}
         >
@@ -62,7 +62,7 @@ export default function TruncatedDefinitionList({
           />
         </Box>
       </Popover>
-    </>
+    </div>
   )
 }
 

--- a/ui/app/components/ui/truncated-definition-list/truncated-definition-list.js
+++ b/ui/app/components/ui/truncated-definition-list/truncated-definition-list.js
@@ -1,0 +1,74 @@
+import { pick } from 'lodash'
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { COLORS, SIZES } from '../../../helpers/constants/design-system'
+import Box from '../box'
+import Button from '../button'
+import DefinitionList from '../definition-list/definition-list'
+import Popover from '../popover'
+
+export default function TruncatedDefinitionList({
+  dictionary,
+  tooltips,
+  prefaceKeys,
+  title,
+}) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+
+  return (
+    <>
+      <Box
+        margin={6}
+        padding={4}
+        paddingBottom={3}
+        borderRadius="lg"
+        borderColor={COLORS.UI2}
+      >
+        <DefinitionList
+          dictionary={pick(dictionary, prefaceKeys)}
+          tooltips={tooltips}
+        />
+        <Button
+          className="approval-page__view-all-details"
+          type="link"
+          onClick={() => setIsPopoverOpen(true)}
+        >
+          View all details
+        </Button>
+      </Box>
+      <Popover
+        title={title}
+        open={isPopoverOpen}
+        onClose={() => setIsPopoverOpen(false)}
+        footer={
+          <>
+            <div />
+            <Button
+              type="primary"
+              style={{ width: '50%' }}
+              rounded
+              onClick={() => setIsPopoverOpen(false)}
+            >
+              Close
+            </Button>
+          </>
+        }
+      >
+        <Box padding={6} paddingTop={0}>
+          <DefinitionList
+            gap={SIZES.MD}
+            tooltips={tooltips}
+            dictionary={dictionary}
+          />
+        </Box>
+      </Popover>
+    </>
+  )
+}
+
+TruncatedDefinitionList.propTypes = {
+  dictionary: DefinitionList.propTypes.dictionary,
+  tooltips: DefinitionList.propTypes.dictionary,
+  title: PropTypes.string,
+  prefaceKeys: PropTypes.arrayOf(PropTypes.string),
+}

--- a/ui/app/components/ui/truncated-definition-list/truncated-definition-list.scss
+++ b/ui/app/components/ui/truncated-definition-list/truncated-definition-list.scss
@@ -1,4 +1,4 @@
-.truncated-defintiion-list {
+.truncated-definition-list {
   &__view-more {
     @include H6;
 

--- a/ui/app/components/ui/truncated-definition-list/truncated-definition-list.scss
+++ b/ui/app/components/ui/truncated-definition-list/truncated-definition-list.scss
@@ -1,0 +1,9 @@
+.truncated-defintiion-list {
+  &__view-more {
+    @include H6;
+
+    display: inline-block;
+    padding: 0;
+    width: auto;
+  }
+}

--- a/ui/app/components/ui/truncated-definition-list/truncated-definition-list.stories.js
+++ b/ui/app/components/ui/truncated-definition-list/truncated-definition-list.stories.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { object, text } from '@storybook/addon-knobs'
+
+import TruncatedDefinitionList from './truncated-definition-list'
+
+export default {
+  title: 'Truncated Definition List',
+}
+
+const basic = {
+  term:
+    'a word or phrase used to describe a thing or to express a concept, especially in a particular kind of language or branch of study.',
+  definition:
+    'a statement of the exact meaning of a word, especially in a dictionary.',
+  dl: 'HTML tag denoting a definition list',
+  dt: 'HTML tag denoting a definition list term',
+  dd: 'HTML tag denoting a definition list definition',
+}
+
+const advanced = {
+  'Network Name': 'Ethereum Mainnet',
+  'Chain ID': '1',
+  Ticker: 'ETH',
+}
+
+const tooltips = {
+  'Network Name': 'The name that is associated with this network',
+  'Chain ID': 'The numeric value representing the ID of this network',
+  Ticker: 'The currency symbol of the primary currency for this network',
+}
+
+export const truncatedDefinitionList = () => (
+  <TruncatedDefinitionList
+    dictionary={object('dictionary', basic)}
+    title={text('title', 'Basic definitions')}
+    prefaceKeys={object('prefaceKeys', ['term', 'definition'])}
+  />
+)
+
+export const withTooltips = () => (
+  <TruncatedDefinitionList
+    dictionary={object('dictionary', advanced)}
+    title={text('title', 'Network Details')}
+    tooltips={object('tooltips', tooltips)}
+    prefaceKeys={object('prefaceKeys', ['Chain ID'])}
+  />
+)

--- a/ui/app/components/ui/ui-components.scss
+++ b/ui/app/components/ui/ui-components.scss
@@ -42,6 +42,7 @@
 @import 'toggle-button/index';
 @import 'token-balance/index';
 @import 'tooltip/index';
+@import 'truncated-definition-list/truncated-definition-list';
 @import 'typography/typography';
 @import 'unit-input/index';
 @import 'url-icon/index';


### PR DESCRIPTION
Requires: ~#10289~, ~#10291~ 

### Rationale
The new custom network UI calls for a definition list that has a few important keys visible, with others viewable in a popover summoned by clicking a "View all details" button. This "Truncated Definition List" component makes this functionality reusable, by supplying an array of keys that should be viewable on the main screen. 

#### Quasi-related changes
~Popovers are normally rendered conditionally, instead of passing an 'open' prop to them to allow the main component to handle whether the contents / overlay should be rendered or not. I revised this but left it such that open is the default. This will preserve the behavior of Popover everywhere else in the app.~

#### Examples

<details>
<summary>use prefaceKeys to control which terms to display</summary>
<img src="https://user-images.githubusercontent.com/4448075/106167932-58819800-6153-11eb-943e-f7e292abdb0d.png" />
</details>

<details>
<summary>All terms displayed in popover</summary>
<img src="https://user-images.githubusercontent.com/4448075/106168061-7a7b1a80-6153-11eb-84b0-1c6bdc7e46d3.png" />

</details>