### PR TITLE
Use nativeCurrency in the confirm approve screen

### DIFF
--- a/ui/app/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/app/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -24,6 +24,7 @@ export default class ConfirmApproveContent extends Component {
     data: PropTypes.string,
     toAddress: PropTypes.string,
     currentCurrency: PropTypes.string,
+    nativeCurrency: PropTypes.string,
     fiatTransactionTotal: PropTypes.string,
     ethTransactionTotal: PropTypes.string,
   }
@@ -75,6 +76,7 @@ export default class ConfirmApproveContent extends Component {
     const { t } = this.context
     const {
       currentCurrency,
+      nativeCurrency,
       ethTransactionTotal,
       fiatTransactionTotal,
     } = this.props
@@ -88,7 +90,7 @@ export default class ConfirmApproveContent extends Component {
             {formatCurrency(fiatTransactionTotal, currentCurrency)}
           </div>
           <div className="confirm-approve-content__transaction-details-content__secondary-fee">
-            {`${ethTransactionTotal} ETH`}
+            {`${ethTransactionTotal} ${nativeCurrency}`}
           </div>
         </div>
       </div>

--- a/ui/app/pages/confirm-approve/confirm-approve.js
+++ b/ui/app/pages/confirm-approve/confirm-approve.js
@@ -14,11 +14,10 @@ import { getTokens } from '../../ducks/metamask/metamask'
 import {
   transactionFeeSelector,
   txDataSelector,
-} from '../../selectors/confirm-transaction'
-import {
   getCurrentCurrency,
   getDomainMetadata,
-} from '../../selectors/selectors'
+  getNativeCurrency,
+} from '../../selectors'
 import { currentNetworkTxListSelector } from '../../selectors/transactions'
 import { getCustomTxParamsData } from './confirm-approve.util'
 import ConfirmApproveContent from './confirm-approve-content'
@@ -32,6 +31,7 @@ export default function ConfirmApprove() {
   } = useSelector(txDataSelector)
 
   const currentCurrency = useSelector(getCurrentCurrency)
+  const nativeCurrency = useSelector(getNativeCurrency)
   const currentNetworkTxList = useSelector(currentNetworkTxListSelector)
   const domainMetadata = useSelector(getDomainMetadata)
   const tokens = useSelector(getTokens)
@@ -133,6 +133,7 @@ export default function ConfirmApprove() {
           data={customData || data}
           toAddress={toAddress}
           currentCurrency={currentCurrency}
+          nativeCurrency={nativeCurrency}
           ethTransactionTotal={ethTransactionTotal}
           fiatTransactionTotal={fiatTransactionTotal}
         />


### PR DESCRIPTION
Gets nativeCurrency from state and uses in place of the previously hardcoded ETH value in the confirm approve component.

<details>
<summary>After</summary>
<img src='https://user-images.githubusercontent.com/13376180/106047705-ccab3580-6098-11eb-8ef9-91d8fcc0ef4b.png'>
</details>