### PR TITLE
Fix signature confirmation PropType error

### DIFF
--- a/ui/app/components/app/signature-request-original/signature-request-original.container.js
+++ b/ui/app/components/app/signature-request-original/signature-request-original.container.js
@@ -44,8 +44,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     txData,
   } = ownProps
 
-  const { allAccounts } = stateProps
-  delete stateProps.allAccounts
+  const { allAccounts, ...otherStateProps } = stateProps
 
   const {
     type,
@@ -69,7 +68,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
 
   return {
     ...ownProps,
-    ...stateProps,
+    ...otherStateProps,
     ...dispatchProps,
     fromAccount,
     txData,


### PR DESCRIPTION
Upon the first render, the "original" signature request confirmation page would trigger a PropType error. This was caused by unexpected mutation of the state props. The container has been updated to avoid mutating the props, and now the PropType warning is no longer present.