### PR TITLE
Fix PropType error for Chip component

### DIFF
--- a/ui/app/components/ui/chip/chip.js
+++ b/ui/app/components/ui/chip/chip.js
@@ -55,7 +55,7 @@ Chip.propTypes = {
   label: PropTypes.string,
   children: PropTypes.node,
   labelProps: PropTypes.shape({
-    ...omit(Typography.propTypes, ['className']),
+    ...omit(Typography.propTypes, ['children', 'className']),
   }),
   leftIcon: PropTypes.node,
   rightIcon: PropTypes.node,


### PR DESCRIPTION
The Chip component was emitting a PropType error because it was missing the `labelProps.children` prop. It was never supposed to be given that prop - it was a mistake in the PropType declaration. The PropTypes have been fixed to prevent this warning.