### PR TITLE
Reject eth_getEncryptionPublicKey for ledger hw wallets

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1643,6 +1643,13 @@ export default class MetamaskController extends EventEmitter {
    * Passed back to the requesting Dapp.
    */
   async newRequestEncryptionPublicKey(msgParams, req) {
+    const address = msgParams
+    const keyring = await this.keyringController.getKeyringForAccount(address)
+    if (keyring.type === 'Ledger Hardware') {
+      return new Promise((_, reject) => {
+        reject(new Error('Ledger does not support eth_getEncryptionPublicKey.'))
+      })
+    }
     const promise = this.encryptionPublicKeyManager.addUnapprovedMessageAsync(
       msgParams,
       req,


### PR DESCRIPTION
Fixes #10111

Determine if the msgParams/address for the newRequestEncryptionPublicKey is a ledger keyring via getKeyringForAccount and return a promise rejection.

Manual testing steps:  
- Connect a Ledger HW wallet
- Attempt to get an encryption key for Ledger.
- Should reject with the error message `Ledger does not support eth_getEncryptionPublicKey.`