### PR TITLE
Fix encypt/decrypt tx queueing

### DIFF
--- a/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.container.js
+++ b/ui/app/pages/confirm-decrypt-message/confirm-decrypt-message.container.js
@@ -10,6 +10,7 @@ import {
 } from '../../store/actions';
 import {
   getTargetAccountWithSendEtherInfo,
+  unconfirmedTransactionsListSelector,
   conversionRateSelector,
 } from '../../selectors';
 import { clearConfirmTransaction } from '../../ducks/confirm-transaction/confirm-transaction.duck';
@@ -18,11 +19,12 @@ import ConfirmDecryptMessage from './confirm-decrypt-message.component';
 
 function mapStateToProps(state) {
   const {
-    confirmTransaction,
     metamask: { domainMetadata = {} },
   } = state;
 
-  const { txData = {} } = confirmTransaction;
+  const unconfirmedTransactions = unconfirmedTransactionsListSelector(state);
+
+  const txData = unconfirmedTransactions[0];
 
   const {
     msgParams: { from },

--- a/ui/app/pages/confirm-encryption-public-key/confirm-encryption-public-key.container.js
+++ b/ui/app/pages/confirm-encryption-public-key/confirm-encryption-public-key.container.js
@@ -10,6 +10,7 @@ import {
 
 import {
   conversionRateSelector,
+  unconfirmedTransactionsListSelector,
   getTargetAccountWithSendEtherInfo,
 } from '../../selectors';
 
@@ -19,11 +20,12 @@ import ConfirmEncryptionPublicKey from './confirm-encryption-public-key.componen
 
 function mapStateToProps(state) {
   const {
-    confirmTransaction,
     metamask: { domainMetadata = {} },
   } = state;
 
-  const { txData = {} } = confirmTransaction;
+  const unconfirmedTransactions = unconfirmedTransactionsListSelector(state);
+
+  const txData = unconfirmedTransactions[0];
 
   const { msgParams: from } = txData;
 


### PR DESCRIPTION
Fixes #10231

Use unconfirmedTransactionsListSelector in the encypt/decrypt components to render the appropriate data to the component at the appropriate time(?).
I am still unsure how sometimes the state.confirmTransaction can we left empty sometimes on rendering the component, possibly the issue with the ConfirmTransaction componentDidUpdate constantly hitting this section.
https://github.com/MetaMask/metamask-extension/blob/97d268c8eea6aac630ae47b3c993cae1c4847f19/ui%2Fapp%2Fpages%2Fconfirm-transaction%2Fconfirm-transaction.component.js#L94-L101

For now this seems to be an intermediate fix.

Manual testing steps:  
  I've tried queueing other types of transactions in the middle and around these requests and there doesn't seem to be an issue with the order, but if anyone else can confirm much appreciated.
  -  Request 2 encrypt requests. Confirm/Approve both shouldn't be an issue. 
  The requests can be from two different origins (edge-case check).
  - Request 2 decrypt requests. Confirm/Decrypt both shouldn't be an issue. The requests can be from two different origins, and it should return the request decrypted string to the appropriate origin.