### PR TITLE
ci/benchmark - increase executor size to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
           destination: test-artifacts
 
   benchmark:
-    executor: node-browsers
+    executor: node-browsers-medium-plus
     steps:
       - checkout
       - run:


### PR DESCRIPTION
it failed on me randomly :crying_cat_face: 

executor resource class will increase until morale improves :pirate_flag: 