### PR TITLE
Ci storybook rel img

### DIFF
--- a/ui/app/components/ui/box/box.stories.js
+++ b/ui/app/components/ui/box/box.stories.js
@@ -25,7 +25,7 @@ export const box = () => {
     'children',
   )
   for (let $i = 0; $i < number('items', 1, {}, 'children'); $i++) {
-    items.push(<img width={size} height={size} src="/images/eth_logo.svg" />)
+    items.push(<img width={size} height={size} src="./images/eth_logo.svg" />)
   }
   return (
     <Box


### PR DESCRIPTION
fixes an issue with an image not resolving when storybook is hosted via ci build artifacts
intended to be merged after https://github.com/MetaMask/metamask-extension/pull/10360