### PR TITLE
Update readme to node 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To learn how to contribute to the MetaMask project itself, visit our [Internal D
 
 ## Building locally
 
-- Install [Node.js](https://nodejs.org) version 10
+- Install [Node.js](https://nodejs.org) version 14
     - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn](https://yarnpkg.com/en/docs/install)
 - Install dependencies: `yarn`


### PR DESCRIPTION
Follows on from the work done to upgrade Node to version 14 https://github.com/MetaMask/metamask-extension/pull/9514