### PR TITLE
Update allow-scripts config

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,6 @@
       "optipng-bin": true,
       "gifsicle": true,
       "jpegtran-bin": true,
-      "scrypt": true,
       "chromedriver": true,
       "geckodriver": true,
       "@sentry/cli": true,
@@ -324,7 +323,8 @@
       "gc-stats": false,
       "github:assemblyscript/assemblyscript": false,
       "tiny-secp256k1": false,
-      "@lavamoat/preinstall-always-fail": false
+      "@lavamoat/preinstall-always-fail": false,
+      "fsevents": false
     }
   }
 }


### PR DESCRIPTION
After merging #10358, `yarn install && yarn allow-scripts auto && yarn allow-scripts` on `develop` updated the `allow-scripts` config in package.json. This includes those updates.