### PR TITLE
Update `@metamask/inpage-provider` from v8.0.3 to v8.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^1.4.0",
-    "@metamask/inpage-provider": "^8.0.3",
+    "@metamask/inpage-provider": "^8.0.4",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^2.5.0",
     "@metamask/obs-store": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,10 +2108,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/forwarder/-/forwarder-1.1.0.tgz#13829d8244bbf19ea658c0b20d21a77b67de0bdd"
   integrity sha512-Hggj4y0QIjDzKGTXzarhEPIQyFSB2bi2y6YLJNwaT4JmP30UB5Cj6gqoY0M4pj3QT57fzp0BUuGp7F/AUe28tw==
 
-"@metamask/inpage-provider@^8.0.3":
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-8.0.3.tgz#65f636233a13a00e1f199a421bdfa8099ed28ea4"
-  integrity sha512-pj9tGNoS1edohuRJzxOuILRqRrQTdgu5mJwMwa9wuOZIMQLFZtr3g2T6vayPBwoNkE1FzLhs/osUqaVQDRfDvQ==
+"@metamask/inpage-provider@^8.0.4":
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@metamask/inpage-provider/-/inpage-provider-8.0.4.tgz#6534fbdba4445a3aff639e32db66bb0ab5f0cd79"
+  integrity sha512-jdI0gVWW/0wQvKZe6shXl70cU+vIb8GpAimKFU4udc/HKtgp8tLd21ezq74RaMP/lHR+qq0coOQ2KnOnl8iNNg==
   dependencies:
     "@metamask/object-multiplex" "^1.1.0"
     "@metamask/safe-event-emitter" "^2.0.0"


### PR DESCRIPTION
Fixes #10356

There was a bug in the inpage provider that would mistakenly report usage of our injected `web3` instance when the `web3.currentProvider` property was accessed. This was fixed in v8.0.4 of `@metamask/inpage-provider`.

Manual testing steps:  
  - Access the `currentProvider` property of our injected web3 shim multiple times
  - See that an error is not shown in the console, and that a warning is not shown in the MetaMask extension popup UI