### PR TITLE
Fix #10081 - Use fetchWithCache to retrieve and store basic gas estim…

### DIFF
--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -5,23 +5,18 @@ import {
   decGWEIToHexWEI,
   getValueFromWeiHex,
 } from '../../helpers/utils/conversions.util';
-import getFetchWithTimeout from '../../../../shared/modules/fetch-with-timeout';
 import { getIsMainnet, getCurrentChainId } from '../../selectors';
-
-const fetchWithTimeout = getFetchWithTimeout(30000);
+import fetchWithCache from '../../helpers/utils/fetch-with-cache';
 
 // Actions
 const BASIC_GAS_ESTIMATE_LOADING_FINISHED =
   'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_FINISHED';
 const BASIC_GAS_ESTIMATE_LOADING_STARTED =
   'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_STARTED';
-const RESET_CUSTOM_GAS_STATE = 'metamask/gas/RESET_CUSTOM_GAS_STATE';
 const RESET_CUSTOM_DATA = 'metamask/gas/RESET_CUSTOM_DATA';
 const SET_BASIC_GAS_ESTIMATE_DATA = 'metamask/gas/SET_BASIC_GAS_ESTIMATE_DATA';
 const SET_CUSTOM_GAS_LIMIT = 'metamask/gas/SET_CUSTOM_GAS_LIMIT';
 const SET_CUSTOM_GAS_PRICE = 'metamask/gas/SET_CUSTOM_GAS_PRICE';
-const SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED =
-  'metamask/gas/SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED';
 
 const initState = {
   customData: {
@@ -34,7 +29,6 @@ const initState = {
     fast: null,
   },
   basicEstimateIsLoading: true,
-  basicPriceEstimatesLastRetrieved: 0,
 };
 
 // Reducer
@@ -71,18 +65,11 @@ export default function reducer(state = initState, action) {
           limit: action.value,
         },
       };
-    case SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED:
-      return {
-        ...state,
-        basicPriceEstimatesLastRetrieved: action.value,
-      };
     case RESET_CUSTOM_DATA:
       return {
         ...state,
         customData: cloneDeep(initState.customData),
       };
-    case RESET_CUSTOM_GAS_STATE:
-      return cloneDeep(initState);
     default:
       return state;
   }
@@ -103,40 +90,27 @@ export function basicGasEstimatesLoadingFinished() {
 
 async function basicGasPriceQuery() {
   const url = `https://api.metaswap.codefi.network/gasPrices`;
-  return await fetchWithTimeout(url, {
-    headers: {},
-    referrer: 'https://api.metaswap.codefi.network/gasPrices',
-    referrerPolicy: 'no-referrer-when-downgrade',
-    body: null,
-    method: 'GET',
-    mode: 'cors',
-  });
+  return await fetchWithCache(
+    url,
+    {
+      referrer: url,
+      referrerPolicy: 'no-referrer-when-downgrade',
+      method: 'GET',
+      mode: 'cors',
+    },
+    { cacheRefreshTime: 75000 },
+  );
 }
 
 export function fetchBasicGasEstimates() {
   return async (dispatch, getState) => {
     const isMainnet = getIsMainnet(getState());
-    const { basicPriceEstimatesLastRetrieved } = getState().gas;
-
-    const timeLastRetrieved =
-      basicPriceEstimatesLastRetrieved ||
-      (await getStorageItem('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED')) ||
-      0;
 
     dispatch(basicGasEstimatesLoadingStarted());
 
     let basicEstimates;
     if (isMainnet || process.env.IN_TEST) {
-      if (Date.now() - timeLastRetrieved > 75000) {
-        basicEstimates = await fetchExternalBasicGasEstimates(dispatch);
-      } else {
-        const cachedBasicEstimates = await getStorageItem(
-          'BASIC_PRICE_ESTIMATES',
-        );
-        basicEstimates =
-          cachedBasicEstimates ||
-          (await fetchExternalBasicGasEstimates(dispatch));
-      }
+      basicEstimates = await fetchExternalBasicGasEstimates();
     } else {
       basicEstimates = await fetchEthGasPriceEstimates(getState());
     }
@@ -148,10 +122,12 @@ export function fetchBasicGasEstimates() {
   };
 }
 
-async function fetchExternalBasicGasEstimates(dispatch) {
-  const response = await basicGasPriceQuery();
-
-  const { SafeGasPrice, ProposeGasPrice, FastGasPrice } = await response.json();
+async function fetchExternalBasicGasEstimates() {
+  const {
+    SafeGasPrice,
+    ProposeGasPrice,
+    FastGasPrice,
+  } = await basicGasPriceQuery();
 
   const [safeLow, average, fast] = [
     SafeGasPrice,
@@ -165,12 +141,6 @@ async function fetchExternalBasicGasEstimates(dispatch) {
     fast,
   };
 
-  const timeRetrieved = Date.now();
-  await Promise.all([
-    setStorageItem('BASIC_PRICE_ESTIMATES', basicEstimates),
-    setStorageItem('BASIC_PRICE_ESTIMATES_LAST_RETRIEVED', timeRetrieved),
-  ]);
-  dispatch(setBasicPriceEstimatesLastRetrieved(timeRetrieved));
   return basicEstimates;
 }
 
@@ -209,7 +179,7 @@ async function fetchEthGasPriceEstimates(state) {
 export function setCustomGasPriceForRetry(newPrice) {
   return async (dispatch) => {
     if (newPrice === '0x0') {
-      const { fast } = await getStorageItem('BASIC_PRICE_ESTIMATES');
+      const { fast } = await fetchExternalBasicGasEstimates();
       dispatch(setCustomGasPrice(decGWEIToHexWEI(fast)));
     } else {
       dispatch(setCustomGasPrice(newPrice));
@@ -236,17 +206,6 @@ export function setCustomGasLimit(newLimit) {
     type: SET_CUSTOM_GAS_LIMIT,
     value: newLimit,
   };
-}
-
-export function setBasicPriceEstimatesLastRetrieved(retrievalTime) {
-  return {
-    type: SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED,
-    value: retrievalTime,
-  };
-}
-
-export function resetCustomGasState() {
-  return { type: RESET_CUSTOM_GAS_STATE };
 }
 
 export function resetCustomData() {


### PR DESCRIPTION
Fixes: #10081

Explanation:  

Supercedes https://github.com/MetaMask/metamask-extension/pull/10098 to avoid huge rebase.

It appears we're currently fetching basic gas estimates and storing the result along with last fetched time, and then doing expiration validation, when fetchWithCache can do all of this for us.
