### PR TITLE
Use string literals for transaction category localized messages

### DIFF
--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -205,3 +205,53 @@ export function getBlockExplorerUrlForTx(networkId, hash, rpcPrefs = {}) {
   const prefix = getEtherscanNetworkPrefix(networkId);
   return `https://${prefix}etherscan.io/tx/${hash}`;
 }
+
+/**
+ * Returns a title for the given transaction category.
+ *
+ * This will throw an error if the transaction category is unrecognized and no default is provided.
+ * @param {function} t - The translation function
+ * @param {TRANSACTION_CATEGORIES[keyof TRANSACTION_CATEGORIES]} transactionCategory - The transaction category constant
+ * @param {string} [defaultTitle] - The default title to return if the transaction cateogory is not recognized.
+ * @returns {string} The transaction category title
+ */
+export function getTransactionCategoryTitle(
+  t,
+  transactionCategory,
+  defaultTitle,
+) {
+  switch (transactionCategory) {
+    case TRANSACTION_CATEGORIES.TOKEN_METHOD_TRANSFER: {
+      return t('transfer');
+    }
+    case TRANSACTION_CATEGORIES.TOKEN_METHOD_TRANSFER_FROM: {
+      return t('transferfrom');
+    }
+    case TRANSACTION_CATEGORIES.TOKEN_METHOD_APPROVE: {
+      return t('approve');
+    }
+    case TRANSACTION_CATEGORIES.SENT_ETHER: {
+      return t('sentEther');
+    }
+    case TRANSACTION_CATEGORIES.CONTRACT_INTERACTION: {
+      return t('contractInteraction');
+    }
+    case TRANSACTION_CATEGORIES.DEPLOY_CONTRACT: {
+      return t('contractDeployment');
+    }
+    case TRANSACTION_CATEGORIES.SWAP: {
+      return t('swap');
+    }
+    case TRANSACTION_CATEGORIES.SWAP_APPROVAL: {
+      return t('swapApproval');
+    }
+    default: {
+      if (defaultTitle) {
+        return defaultTitle;
+      }
+      throw new Error(
+        `Unrecognized transaction category: ${transactionCategory}`,
+      );
+    }
+  }
+}

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -212,14 +212,9 @@ export function getBlockExplorerUrlForTx(networkId, hash, rpcPrefs = {}) {
  * This will throw an error if the transaction category is unrecognized and no default is provided.
  * @param {function} t - The translation function
  * @param {TRANSACTION_CATEGORIES[keyof TRANSACTION_CATEGORIES]} transactionCategory - The transaction category constant
- * @param {string} [defaultTitle] - The default title to return if the transaction cateogory is not recognized.
  * @returns {string} The transaction category title
  */
-export function getTransactionCategoryTitle(
-  t,
-  transactionCategory,
-  defaultTitle,
-) {
+export function getTransactionCategoryTitle(t, transactionCategory) {
   switch (transactionCategory) {
     case TRANSACTION_CATEGORIES.TOKEN_METHOD_TRANSFER: {
       return t('transfer');
@@ -246,9 +241,6 @@ export function getTransactionCategoryTitle(
       return t('swapApproval');
     }
     default: {
-      if (defaultTitle) {
-        return defaultTitle;
-      }
       throw new Error(
         `Unrecognized transaction category: ${transactionCategory}`,
       );

--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -1,6 +1,9 @@
 import { useSelector } from 'react-redux';
 import { getKnownMethodData } from '../selectors/selectors';
-import { getStatusKey } from '../helpers/utils/transactions.util';
+import {
+  getStatusKey,
+  getTransactionCategoryTitle,
+} from '../helpers/utils/transactions.util';
 import { camelCaseToCapitalize } from '../helpers/utils/common.util';
 import { PRIMARY, SECONDARY } from '../helpers/constants/common';
 import { getTokenAddressParam } from '../helpers/utils/token-util';
@@ -186,9 +189,13 @@ export function useTransactionDisplayData(transactionGroup) {
     transactionCategory === TRANSACTION_CATEGORIES.CONTRACT_INTERACTION
   ) {
     category = TRANSACTION_GROUP_CATEGORIES.INTERACTION;
+    const transactionCategoryTitle = getTransactionCategoryTitle(
+      t,
+      transactionCategory,
+    );
     title =
       (methodData?.name && camelCaseToCapitalize(methodData.name)) ||
-      t(transactionCategory);
+      transactionCategoryTitle;
     subtitle = origin;
     subtitleContainsOrigin = true;
   } else if (transactionCategory === TRANSACTION_CATEGORIES.INCOMING) {

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -22,6 +22,7 @@ import {
   TRANSACTION_CATEGORIES,
   TRANSACTION_STATUSES,
 } from '../../../../shared/constants/transaction';
+import { getTransactionCategoryTitle } from '../../helpers/utils/transactions.util';
 
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
@@ -689,11 +690,11 @@ export default class ConfirmTransactionBase extends Component {
 
     let functionType = getMethodName(name);
     if (!functionType) {
-      if (transactionCategory) {
-        functionType = t(transactionCategory) || transactionCategory;
-      } else {
-        functionType = t('contractInteraction');
-      }
+      functionType = getTransactionCategoryTitle(
+        t,
+        transactionCategory,
+        transactionCategory || t('contractInteraction'),
+      );
     }
 
     return (

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -690,11 +690,11 @@ export default class ConfirmTransactionBase extends Component {
 
     let functionType = getMethodName(name);
     if (!functionType) {
-      functionType = getTransactionCategoryTitle(
-        t,
-        transactionCategory,
-        transactionCategory || t('contractInteraction'),
-      );
+      if (transactionCategory) {
+        functionType = getTransactionCategoryTitle(t, transactionCategory);
+      } else {
+        functionType = t('contractInteraction');
+      }
     }
 
     return (


### PR DESCRIPTION
We now use string literals for all transaction category localized messages. This makes it easier to verify that we have translations for each of them, and that we aren't leaving any unused translations around.