### PR TITLE
Fix `transferFrom` localized message

### DIFF
--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -220,7 +220,7 @@ export function getTransactionCategoryTitle(t, transactionCategory) {
       return t('transfer');
     }
     case TRANSACTION_CATEGORIES.TOKEN_METHOD_TRANSFER_FROM: {
-      return t('transferfrom');
+      return t('transferFrom');
     }
     case TRANSACTION_CATEGORIES.TOKEN_METHOD_APPROVE: {
       return t('approve');


### PR DESCRIPTION
The `transferFrom` localized message has been unused at least since the transaction list redesign was implemented. The `transactionCategory` has been used directly as the localized message key since then. For most of the other categories this was fine, but for `transferFrom` the message differs slightly from the category (the category is `transferfrom`, with a lower-cased 'f').

I am not yet sure how to manually test this. I only discovered this incidentally via the `verify-locales` script.