### PR TITLE
Remove unused `confirmTransaction` state

### DIFF
--- a/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/tests/gas-modal-page-container-container.test.js
@@ -19,10 +19,6 @@ const gasActionSpies = {
   resetCustomData: sinon.spy(),
 };
 
-const confirmTransactionActionSpies = {
-  updateGasAndCalculate: sinon.spy(),
-};
-
 const sendActionSpies = {
   hideGasButtonGroup: sinon.spy(),
 };
@@ -48,7 +44,6 @@ proxyquire('../gas-modal-page-container.container.js', {
   },
   '../../../../store/actions': actionSpies,
   '../../../../ducks/gas/gas.duck': gasActionSpies,
-  '../../../../ducks/confirm-transaction/confirm-transaction.duck': confirmTransactionActionSpies,
   '../../../../ducks/send/send.duck': sendActionSpies,
 });
 

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -1,4 +1,3 @@
-import { addHexPrefix } from '../../../../app/scripts/lib/util';
 import {
   conversionRateSelector,
   currentCurrencySelector,
@@ -24,32 +23,19 @@ import { conversionUtil } from '../../helpers/utils/conversion-util';
 const createActionType = (action) => `metamask/confirm-transaction/${action}`;
 
 const UPDATE_TX_DATA = createActionType('UPDATE_TX_DATA');
-const CLEAR_TX_DATA = createActionType('CLEAR_TX_DATA');
 const UPDATE_TOKEN_DATA = createActionType('UPDATE_TOKEN_DATA');
-const CLEAR_TOKEN_DATA = createActionType('CLEAR_TOKEN_DATA');
-const UPDATE_METHOD_DATA = createActionType('UPDATE_METHOD_DATA');
-const CLEAR_METHOD_DATA = createActionType('CLEAR_METHOD_DATA');
 const CLEAR_CONFIRM_TRANSACTION = createActionType('CLEAR_CONFIRM_TRANSACTION');
 const UPDATE_TRANSACTION_AMOUNTS = createActionType(
   'UPDATE_TRANSACTION_AMOUNTS',
 );
 const UPDATE_TRANSACTION_FEES = createActionType('UPDATE_TRANSACTION_FEES');
 const UPDATE_TRANSACTION_TOTALS = createActionType('UPDATE_TRANSACTION_TOTALS');
-const UPDATE_TOKEN_PROPS = createActionType('UPDATE_TOKEN_PROPS');
 const UPDATE_NONCE = createActionType('UPDATE_NONCE');
-const UPDATE_TO_SMART_CONTRACT = createActionType('UPDATE_TO_SMART_CONTRACT');
-const FETCH_DATA_START = createActionType('FETCH_DATA_START');
-const FETCH_DATA_END = createActionType('FETCH_DATA_END');
 
 // Initial state
 const initState = {
   txData: {},
   tokenData: {},
-  methodData: {},
-  tokenProps: {
-    tokenDecimals: '',
-    tokenSymbol: '',
-  },
   fiatTransactionAmount: '',
   fiatTransactionFee: '',
   fiatTransactionTotal: '',
@@ -60,8 +46,6 @@ const initState = {
   hexTransactionFee: '',
   hexTransactionTotal: '',
   nonce: '',
-  toSmartContract: false,
-  fetchingData: false,
 };
 
 // Reducer
@@ -74,34 +58,12 @@ export default function reducer(state = initState, action = {}) {
           ...action.payload,
         },
       };
-    case CLEAR_TX_DATA:
-      return {
-        ...state,
-        txData: {},
-      };
     case UPDATE_TOKEN_DATA:
       return {
         ...state,
         tokenData: {
           ...action.payload,
         },
-      };
-    case CLEAR_TOKEN_DATA:
-      return {
-        ...state,
-        tokenData: {},
-      };
-    case UPDATE_METHOD_DATA:
-      return {
-        ...state,
-        methodData: {
-          ...action.payload,
-        },
-      };
-    case CLEAR_METHOD_DATA:
-      return {
-        ...state,
-        methodData: {},
       };
     case UPDATE_TRANSACTION_AMOUNTS: {
       const {
@@ -146,36 +108,10 @@ export default function reducer(state = initState, action = {}) {
         hexTransactionTotal: hexTransactionTotal || state.hexTransactionTotal,
       };
     }
-    case UPDATE_TOKEN_PROPS: {
-      const { tokenSymbol = '', tokenDecimals = '' } = action.payload;
-      return {
-        ...state,
-        tokenProps: {
-          ...state.tokenProps,
-          tokenSymbol,
-          tokenDecimals,
-        },
-      };
-    }
     case UPDATE_NONCE:
       return {
         ...state,
         nonce: action.payload,
-      };
-    case UPDATE_TO_SMART_CONTRACT:
-      return {
-        ...state,
-        toSmartContract: action.payload,
-      };
-    case FETCH_DATA_START:
-      return {
-        ...state,
-        fetchingData: true,
-      };
-    case FETCH_DATA_END:
-      return {
-        ...state,
-        fetchingData: false,
       };
     case CLEAR_CONFIRM_TRANSACTION:
       return initState;
@@ -192,35 +128,10 @@ export function updateTxData(txData) {
   };
 }
 
-export function clearTxData() {
-  return {
-    type: CLEAR_TX_DATA,
-  };
-}
-
 export function updateTokenData(tokenData) {
   return {
     type: UPDATE_TOKEN_DATA,
     payload: tokenData,
-  };
-}
-
-export function clearTokenData() {
-  return {
-    type: CLEAR_TOKEN_DATA,
-  };
-}
-
-export function updateMethodData(methodData) {
-  return {
-    type: UPDATE_METHOD_DATA,
-    payload: methodData,
-  };
-}
-
-export function clearMethodData() {
-  return {
-    type: CLEAR_METHOD_DATA,
   };
 }
 
@@ -245,48 +156,10 @@ export function updateTransactionTotals(totals) {
   };
 }
 
-export function updateTokenProps(tokenProps) {
-  return {
-    type: UPDATE_TOKEN_PROPS,
-    payload: tokenProps,
-  };
-}
-
 export function updateNonce(nonce) {
   return {
     type: UPDATE_NONCE,
     payload: nonce,
-  };
-}
-
-export function updateToSmartContract(toSmartContract) {
-  return {
-    type: UPDATE_TO_SMART_CONTRACT,
-    payload: toSmartContract,
-  };
-}
-
-export function setFetchingData(isFetching) {
-  return {
-    type: isFetching ? FETCH_DATA_START : FETCH_DATA_END,
-  };
-}
-
-export function updateGasAndCalculate({ gasLimit, gasPrice }) {
-  return (dispatch, getState) => {
-    const {
-      confirmTransaction: { txData },
-    } = getState();
-    const newTxData = {
-      ...txData,
-      txParams: {
-        ...txData.txParams,
-        gas: addHexPrefix(gasLimit),
-        gasPrice: addHexPrefix(gasPrice),
-      },
-    };
-
-    dispatch(updateTxDataAndCalculate(newTxData));
   };
 }
 

--- a/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/app/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -2,21 +2,13 @@ import assert from 'assert';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import sinon from 'sinon';
-import {
-  TRANSACTION_CATEGORIES,
-  TRANSACTION_STATUSES,
-} from '../../../../shared/constants/transaction';
+import { TRANSACTION_STATUSES } from '../../../../shared/constants/transaction';
 
 import ConfirmTransactionReducer, * as actions from './confirm-transaction.duck';
 
 const initialState = {
   txData: {},
   tokenData: {},
-  methodData: {},
-  tokenProps: {
-    tokenDecimals: '',
-    tokenSymbol: '',
-  },
   fiatTransactionAmount: '',
   fiatTransactionFee: '',
   fiatTransactionTotal: '',
@@ -27,28 +19,17 @@ const initialState = {
   hexTransactionFee: '',
   hexTransactionTotal: '',
   nonce: '',
-  toSmartContract: false,
-  fetchingData: false,
 };
 
 const UPDATE_TX_DATA = 'metamask/confirm-transaction/UPDATE_TX_DATA';
-const CLEAR_TX_DATA = 'metamask/confirm-transaction/CLEAR_TX_DATA';
 const UPDATE_TOKEN_DATA = 'metamask/confirm-transaction/UPDATE_TOKEN_DATA';
-const CLEAR_TOKEN_DATA = 'metamask/confirm-transaction/CLEAR_TOKEN_DATA';
-const UPDATE_METHOD_DATA = 'metamask/confirm-transaction/UPDATE_METHOD_DATA';
-const CLEAR_METHOD_DATA = 'metamask/confirm-transaction/CLEAR_METHOD_DATA';
 const UPDATE_TRANSACTION_AMOUNTS =
   'metamask/confirm-transaction/UPDATE_TRANSACTION_AMOUNTS';
 const UPDATE_TRANSACTION_FEES =
   'metamask/confirm-transaction/UPDATE_TRANSACTION_FEES';
 const UPDATE_TRANSACTION_TOTALS =
   'metamask/confirm-transaction/UPDATE_TRANSACTION_TOTALS';
-const UPDATE_TOKEN_PROPS = 'metamask/confirm-transaction/UPDATE_TOKEN_PROPS';
 const UPDATE_NONCE = 'metamask/confirm-transaction/UPDATE_NONCE';
-const UPDATE_TO_SMART_CONTRACT =
-  'metamask/confirm-transaction/UPDATE_TO_SMART_CONTRACT';
-const FETCH_DATA_START = 'metamask/confirm-transaction/FETCH_DATA_START';
-const FETCH_DATA_END = 'metamask/confirm-transaction/FETCH_DATA_END';
 const CLEAR_CONFIRM_TRANSACTION =
   'metamask/confirm-transaction/CLEAR_CONFIRM_TRANSACTION';
 
@@ -61,13 +42,6 @@ describe('Confirm Transaction Duck', function () {
       tokenData: {
         name: 'abcToken',
       },
-      methodData: {
-        name: TRANSACTION_CATEGORIES.TOKEN_METHOD_APPROVE,
-      },
-      tokenProps: {
-        tokenDecimals: '3',
-        tokenSymbol: 'ABC',
-      },
       fiatTransactionAmount: '469.26',
       fiatTransactionFee: '0.01',
       fiatTransactionTotal: '1.000021',
@@ -78,8 +52,6 @@ describe('Confirm Transaction Duck', function () {
       hexTransactionFee: '0x1319718a5000',
       hexTransactionTotal: '',
       nonce: '0x0',
-      toSmartContract: false,
-      fetchingData: false,
     };
 
     it('should initialize state', function () {
@@ -117,18 +89,6 @@ describe('Confirm Transaction Duck', function () {
       );
     });
 
-    it('should clear txData when receiving a CLEAR_TX_DATA action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(mockState, {
-          type: CLEAR_TX_DATA,
-        }),
-        {
-          ...mockState,
-          txData: {},
-        },
-      );
-    });
-
     it('should set tokenData when receiving a UPDATE_TOKEN_DATA action', function () {
       assert.deepStrictEqual(
         ConfirmTransactionReducer(mockState, {
@@ -143,48 +103,6 @@ describe('Confirm Transaction Duck', function () {
             ...mockState.tokenData,
             name: 'defToken',
           },
-        },
-      );
-    });
-
-    it('should clear tokenData when receiving a CLEAR_TOKEN_DATA action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(mockState, {
-          type: CLEAR_TOKEN_DATA,
-        }),
-        {
-          ...mockState,
-          tokenData: {},
-        },
-      );
-    });
-
-    it('should set methodData when receiving a UPDATE_METHOD_DATA action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(mockState, {
-          type: UPDATE_METHOD_DATA,
-          payload: {
-            name: 'transferFrom',
-          },
-        }),
-        {
-          ...mockState,
-          methodData: {
-            ...mockState.methodData,
-            name: 'transferFrom',
-          },
-        },
-      );
-    });
-
-    it('should clear methodData when receiving a CLEAR_METHOD_DATA action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(mockState, {
-          type: CLEAR_METHOD_DATA,
-        }),
-        {
-          ...mockState,
-          methodData: {},
         },
       );
     });
@@ -246,25 +164,6 @@ describe('Confirm Transaction Duck', function () {
       );
     });
 
-    it('should update tokenProps when receiving an UPDATE_TOKEN_PROPS action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(mockState, {
-          type: UPDATE_TOKEN_PROPS,
-          payload: {
-            tokenSymbol: 'DEF',
-            tokenDecimals: '1',
-          },
-        }),
-        {
-          ...mockState,
-          tokenProps: {
-            tokenSymbol: 'DEF',
-            tokenDecimals: '1',
-          },
-        },
-      );
-    });
-
     it('should update nonce when receiving an UPDATE_NONCE action', function () {
       assert.deepStrictEqual(
         ConfirmTransactionReducer(mockState, {
@@ -275,41 +174,6 @@ describe('Confirm Transaction Duck', function () {
           ...mockState,
           nonce: '0x1',
         },
-      );
-    });
-
-    it('should update nonce when receiving an UPDATE_TO_SMART_CONTRACT action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(mockState, {
-          type: UPDATE_TO_SMART_CONTRACT,
-          payload: true,
-        }),
-        {
-          ...mockState,
-          toSmartContract: true,
-        },
-      );
-    });
-
-    it('should set fetchingData to true when receiving a FETCH_DATA_START action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(mockState, {
-          type: FETCH_DATA_START,
-        }),
-        {
-          ...mockState,
-          fetchingData: true,
-        },
-      );
-    });
-
-    it('should set fetchingData to false when receiving a FETCH_DATA_END action', function () {
-      assert.deepStrictEqual(
-        ConfirmTransactionReducer(
-          { fetchingData: true },
-          { type: FETCH_DATA_END },
-        ),
-        { fetchingData: false },
       );
     });
 
@@ -334,14 +198,6 @@ describe('Confirm Transaction Duck', function () {
       assert.deepStrictEqual(actions.updateTxData(txData), expectedAction);
     });
 
-    it('should create an action to clear txData', function () {
-      const expectedAction = {
-        type: CLEAR_TX_DATA,
-      };
-
-      assert.deepStrictEqual(actions.clearTxData(), expectedAction);
-    });
-
     it('should create an action to update tokenData', function () {
       const tokenData = { test: 123 };
       const expectedAction = {
@@ -353,35 +209,6 @@ describe('Confirm Transaction Duck', function () {
         actions.updateTokenData(tokenData),
         expectedAction,
       );
-    });
-
-    it('should create an action to clear tokenData', function () {
-      const expectedAction = {
-        type: CLEAR_TOKEN_DATA,
-      };
-
-      assert.deepStrictEqual(actions.clearTokenData(), expectedAction);
-    });
-
-    it('should create an action to update methodData', function () {
-      const methodData = { test: 123 };
-      const expectedAction = {
-        type: UPDATE_METHOD_DATA,
-        payload: methodData,
-      };
-
-      assert.deepStrictEqual(
-        actions.updateMethodData(methodData),
-        expectedAction,
-      );
-    });
-
-    it('should create an action to clear methodData', function () {
-      const expectedAction = {
-        type: CLEAR_METHOD_DATA,
-      };
-
-      assert.deepStrictEqual(actions.clearMethodData(), expectedAction);
     });
 
     it('should create an action to update transaction amounts', function () {
@@ -423,22 +250,6 @@ describe('Confirm Transaction Duck', function () {
       );
     });
 
-    it('should create an action to update tokenProps', function () {
-      const tokenProps = {
-        tokenDecimals: '1',
-        tokenSymbol: 'abc',
-      };
-      const expectedAction = {
-        type: UPDATE_TOKEN_PROPS,
-        payload: tokenProps,
-      };
-
-      assert.deepStrictEqual(
-        actions.updateTokenProps(tokenProps),
-        expectedAction,
-      );
-    });
-
     it('should create an action to update nonce', function () {
       const nonce = '0x1';
       const expectedAction = {
@@ -447,22 +258,6 @@ describe('Confirm Transaction Duck', function () {
       };
 
       assert.deepStrictEqual(actions.updateNonce(nonce), expectedAction);
-    });
-
-    it('should create an action to set fetchingData to true', function () {
-      const expectedAction = {
-        type: FETCH_DATA_START,
-      };
-
-      assert.deepStrictEqual(actions.setFetchingData(true), expectedAction);
-    });
-
-    it('should create an action to set fetchingData to false', function () {
-      const expectedAction = {
-        type: FETCH_DATA_END,
-      };
-
-      assert.deepStrictEqual(actions.setFetchingData(false), expectedAction);
     });
 
     it('should create an action to clear confirmTransaction', function () {
@@ -487,61 +282,6 @@ describe('Confirm Transaction Duck', function () {
 
     afterEach(function () {
       global.eth.getCode.resetHistory();
-    });
-
-    it('updates txData and gas on an existing transaction in confirmTransaction', function () {
-      const mockState = {
-        metamask: {
-          conversionRate: 468.58,
-          currentCurrency: 'usd',
-        },
-        confirmTransaction: {
-          ethTransactionAmount: '1',
-          ethTransactionFee: '0.000021',
-          ethTransactionTotal: '1.000021',
-          fetchingData: false,
-          fiatTransactionAmount: '469.26',
-          fiatTransactionFee: '0.01',
-          fiatTransactionTotal: '469.27',
-          hexGasTotal: '0x1319718a5000',
-          methodData: {},
-          nonce: '',
-          tokenData: {},
-          tokenProps: {
-            tokenDecimals: '',
-            tokenSymbol: '',
-          },
-          txData: {
-            history: [],
-            id: 2603411941761054,
-            loadingDefaults: false,
-            metamaskNetworkId: '3',
-            origin: 'faucet.metamask.io',
-            status: TRANSACTION_STATUSES.UNAPPROVED,
-            time: 1530838113716,
-          },
-        },
-      };
-
-      const middlewares = [thunk];
-      const mockStore = configureMockStore(middlewares);
-      const store = mockStore(mockState);
-      const expectedActions = [
-        'metamask/confirm-transaction/UPDATE_TX_DATA',
-        'metamask/confirm-transaction/UPDATE_TRANSACTION_AMOUNTS',
-        'metamask/confirm-transaction/UPDATE_TRANSACTION_FEES',
-        'metamask/confirm-transaction/UPDATE_TRANSACTION_TOTALS',
-      ];
-
-      store.dispatch(
-        actions.updateGasAndCalculate({ gasLimit: '0x2', gasPrice: '0x25' }),
-      );
-
-      const storeActions = store.getActions();
-      assert.strictEqual(storeActions.length, expectedActions.length);
-      storeActions.forEach((action, index) =>
-        assert.strictEqual(action.type, expectedActions[index]),
-      );
     });
 
     it('updates txData and updates gas values in confirmTransaction', function () {


### PR DESCRIPTION
The `confirmTransaction` Redux slice had a lot of unused state and action creators. They have all been removed.