### PR TITLE
add MetaMaskTranslation component

### DIFF
--- a/development/verify-locale-strings.js
+++ b/development/verify-locale-strings.js
@@ -22,9 +22,9 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const fs = require('fs');
-const path = require('path');
 const { promisify } = require('util');
 const log = require('loglevel');
+const glob = require('fast-glob');
 const matchAll = require('string.prototype.matchall').getPolyfill();
 const localeIndex = require('../app/_locales/index.json');
 const {
@@ -34,7 +34,6 @@ const {
   getLocalePath,
 } = require('./lib/locales');
 
-const readdir = promisify(fs.readdir);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
@@ -168,15 +167,19 @@ async function verifyLocale(code) {
 
 async function verifyEnglishLocale() {
   const englishLocale = await getLocale('en');
-  const uiJSFiles = await findJavascriptFiles(
-    path.resolve(__dirname, '..', 'ui'),
-  );
-  const sharedJSFiles = await findJavascriptFiles(
-    path.resolve(__dirname, '..', 'shared'),
-  );
+  // As time allows we'll switch to only performing the strict search.
+  // In the meantime we'll use glob to specify which paths can be strict searched
+  // and gradually phase out the key based search
+  const globsToStrictSearch = [
+    'ui/app/components/app/metamask-translation/*.js',
+    'ui/app/pages/confirmation/templates/*.js',
+  ];
+  const javascriptFiles = await glob(['ui/**/*.js', 'shared/**/*.js'], {
+    ignore: globsToStrictSearch,
+  });
+  const javascriptFilesToStrictSearch = await glob(globsToStrictSearch);
 
-  const javascriptFiles = sharedJSFiles.concat(uiJSFiles);
-
+  const strictSearchRegex = /\bt\('(\w+)'\)|\bt\('(\W+)'\)|\btranslationKey:\s'(\w+)'|\btranslationKey:\s'(\W+)'/gu;
   // match "t(`...`)" because constructing message keys from template strings
   // prevents this script from finding the messages, and then inappropriately
   // deletes them
@@ -189,6 +192,19 @@ async function verifyEnglishLocale() {
   for await (const fileContents of getFileContents(javascriptFiles)) {
     for (const match of matchAll.call(fileContents, keyRegex)) {
       usedMessages.add(match[1] || match[2]);
+    }
+    const templateMatches = fileContents.match(templateStringRegex);
+    if (templateMatches) {
+      // concat doesn't work here for some reason
+      templateMatches.forEach((match) => templateUsage.push(match));
+    }
+  }
+
+  for await (const fileContents of getFileContents(
+    javascriptFilesToStrictSearch,
+  )) {
+    for (const match of matchAll.call(fileContents, strictSearchRegex)) {
+      usedMessages.add(match[1] || match[2] || match[3] || match[4]);
     }
 
     const templateMatches = fileContents.match(templateStringRegex);
@@ -235,21 +251,6 @@ async function verifyEnglishLocale() {
   }
 
   return true; // failed === true
-}
-
-async function findJavascriptFiles(rootDir) {
-  const javascriptFiles = [];
-  const contents = await readdir(rootDir, { withFileTypes: true });
-  for (const file of contents) {
-    if (file.isDirectory()) {
-      javascriptFiles.push(
-        ...(await findJavascriptFiles(path.join(rootDir, file.name))),
-      );
-    } else if (file.isFile() && file.name.endsWith('.js')) {
-      javascriptFiles.push(path.join(rootDir, file.name));
-    }
-  }
-  return javascriptFiles;
 }
 
 async function* getFileContents(filenames) {

--- a/development/verify-locale-strings.js
+++ b/development/verify-locale-strings.js
@@ -172,14 +172,13 @@ async function verifyEnglishLocale() {
   // and gradually phase out the key based search
   const globsToStrictSearch = [
     'ui/app/components/app/metamask-translation/*.js',
-    'ui/app/pages/confirmation/templates/*.js',
   ];
   const javascriptFiles = await glob(['ui/**/*.js', 'shared/**/*.js'], {
     ignore: globsToStrictSearch,
   });
   const javascriptFilesToStrictSearch = await glob(globsToStrictSearch);
 
-  const strictSearchRegex = /\bt\('(\w+)'\)|\bt\('(\W+)'\)|\btranslationKey:\s'(\w+)'|\btranslationKey:\s'(\W+)'/gu;
+  const strictSearchRegex = /\bt\(\s*'(\w+)'\s*\)|\btranslationKey:\s*'(\w+)'/gu;
   // match "t(`...`)" because constructing message keys from template strings
   // prevents this script from finding the messages, and then inappropriately
   // deletes them
@@ -195,7 +194,6 @@ async function verifyEnglishLocale() {
     }
     const templateMatches = fileContents.match(templateStringRegex);
     if (templateMatches) {
-      // concat doesn't work here for some reason
       templateMatches.forEach((match) => templateUsage.push(match));
     }
   }
@@ -209,7 +207,6 @@ async function verifyEnglishLocale() {
 
     const templateMatches = fileContents.match(templateStringRegex);
     if (templateMatches) {
-      // concat doesn't work here for some reason
       templateMatches.forEach((match) => templateUsage.push(match));
     }
   }

--- a/ui/app/components/app/metamask-template-renderer/metamask-template-renderer.js
+++ b/ui/app/components/app/metamask-template-renderer/metamask-template-renderer.js
@@ -77,7 +77,7 @@ const MetaMaskTemplateRenderer = ({ sections }) => {
   );
 };
 
-const SectionShape = {
+export const SectionShape = {
   props: PropTypes.object,
   element: PropTypes.oneOf(Object.keys(safeComponentList)).isRequired,
   key: PropTypes.string,

--- a/ui/app/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/app/components/app/metamask-template-renderer/safe-component-list.js
@@ -5,8 +5,10 @@ import TruncatedDefinitionList from '../../ui/truncated-definition-list';
 import Popover from '../../ui/popover';
 import Typography from '../../ui/typography';
 import Box from '../../ui/box';
+import MetaMaskTranslation from '../metamask-translation';
 
 export const safeComponentList = {
+  MetaMaskTranslation,
   b: 'b',
   p: 'p',
   div: 'div',

--- a/ui/app/components/app/metamask-translation/index.js
+++ b/ui/app/components/app/metamask-translation/index.js
@@ -1,0 +1,1 @@
+export { default } from './metamask-translation';

--- a/ui/app/components/app/metamask-translation/metamask-translation.js
+++ b/ui/app/components/app/metamask-translation/metamask-translation.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import MetaMaskTemplateRenderer, {
+  SectionShape,
+} from '../metamask-template-renderer/metamask-template-renderer';
+
+/**
+ * MetaMaskTranslation is a simple helper Component for adding full translation
+ * support to the template system. We do pass the translation function to the
+ * template getValues function, but passing it react components as variables
+ * would require react to be in scope, and breaks the object pattern paradigm.
+ *
+ * This component gets around that by converting variables that are templates
+ * themselves into tiny React trees. This component does additional validation
+ * to make sure that the tree has a single root node, with maximum two leaves.
+ * Each subnode can have a maximum of one child that must be a string.
+ *
+ * This enforces a maximum recursion depth of 2, preventing translation strings
+ * from being performance hogs. We could further limit this, and also attenuate
+ * the safeComponentList for what kind of components we allow these special
+ * trees to contain.
+ */
+export default function MetaMaskTranslation({ translationKey, variables }) {
+  const t = useI18nContext();
+
+  return t(
+    translationKey,
+    variables?.map((variable) => {
+      if (
+        typeof variable === 'object' &&
+        !Array.isArray(variable) &&
+        variable.element
+      ) {
+        if (!variable.key) {
+          throw new Error(
+            `When using MetaMask Template Language in a MetaMaskTranslation variable, you must provide a key for the section regardless of syntax.
+            Section with element '${variable.element}' for translationKey: '${translationKey}' has no key property`,
+          );
+        }
+        if (
+          variable.children &&
+          Array.isArray(variable.children) &&
+          variable.children.length > 2
+        ) {
+          throw new Error(
+            'MetaMaskTranslation only renders templates with a single section and maximum two children',
+          );
+        } else if (
+          (variable.children?.[0]?.children !== undefined &&
+            typeof variable.children[0].children !== 'string') ||
+          (variable.children?.[1]?.children !== undefined &&
+            typeof variable.children[1].children !== 'string')
+        ) {
+          throw new Error(
+            'MetaMaskTranslation does not allow for component trees of non trivial depth',
+          );
+        }
+        return (
+          <MetaMaskTemplateRenderer
+            key={`${translationKey}-${variable.key}`}
+            sections={variable}
+          />
+        );
+      }
+      return variable;
+    }),
+  );
+}
+
+MetaMaskTranslation.propTypes = {
+  translationKey: PropTypes.string.isRequired,
+  variables: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.shape(SectionShape),
+    ]),
+  ),
+};

--- a/ui/app/components/app/metamask-translation/metamask-translation.js
+++ b/ui/app/components/app/metamask-translation/metamask-translation.js
@@ -9,7 +9,7 @@ import MetaMaskTemplateRenderer, {
  * MetaMaskTranslation is a simple helper Component for adding full translation
  * support to the template system. We do pass the translation function to the
  * template getValues function, but passing it react components as variables
- * would require react to be in scope, and breaks the object pattern paradigm.
+ * would require React to be in scope, and breaks the object pattern paradigm.
  *
  * This component gets around that by converting variables that are templates
  * themselves into tiny React trees. This component does additional validation

--- a/ui/app/components/app/metamask-translation/metamask-translation.js
+++ b/ui/app/components/app/metamask-translation/metamask-translation.js
@@ -8,7 +8,7 @@ import MetaMaskTemplateRenderer, {
 /**
  * MetaMaskTranslation is a simple helper Component for adding full translation
  * support to the template system. We do pass the translation function to the
- * template getValues function, but passing it react components as variables
+ * template getValues function, but passing it React components as variables
  * would require React to be in scope, and breaks the object pattern paradigm.
  *
  * This component gets around that by converting variables that are templates

--- a/ui/app/components/app/metamask-translation/metamask-translation.stories.js
+++ b/ui/app/components/app/metamask-translation/metamask-translation.stories.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { select, object } from '@storybook/addon-knobs';
+import { groupBy } from 'lodash';
+import en from '../../../../../app/_locales/en/messages.json';
+import MetaMaskTranslation from './metamask-translation';
+
+export default {
+  title: 'MetaMaskTranslation',
+};
+
+const { keysWithSubstitution, keysWithoutSubstitution } = groupBy(
+  Object.keys(en),
+  (key) => {
+    if (en[key].message.includes('$1')) {
+      return 'keysWithSubstitution';
+    }
+    return 'keysWithoutSubstitution';
+  },
+);
+
+export const withoutSubstitutions = () => (
+  <MetaMaskTranslation
+    translationKey={select(
+      'translationKey',
+      keysWithoutSubstitution,
+      keysWithoutSubstitution[0],
+    )}
+  />
+);
+
+export const withSubstitutions = () => (
+  <MetaMaskTranslation
+    translationKey={select(
+      'translationKey',
+      keysWithSubstitution,
+      keysWithSubstitution[0],
+    )}
+    variables={object('variables', [])}
+  />
+);
+
+export const withTemplate = () => (
+  <MetaMaskTranslation
+    translationKey={select(
+      'translationKey',
+      keysWithSubstitution,
+      keysWithSubstitution[0],
+    )}
+    variables={[
+      {
+        element: 'span',
+        key: 'link',
+        children: {
+          element: 'MetaMaskTranslation',
+          props: {
+            translationKey: select(
+              'innerTranslationKey',
+              keysWithoutSubstitution,
+              keysWithoutSubstitution[0],
+            ),
+          },
+        },
+      },
+    ]}
+  />
+);


### PR DESCRIPTION
### Rationale
The template methods of the future `addEthereumChain` confirmation UI are passed in the `t` function for i18n strings. The problem lies in special cases where `t` requires JSX replacements, such as embedding a link in a string of text. To do this in normal situations you'd simply call:

```js
content: t('yourKey', [<a>t('linkKey')</a>])
```

This could be done in the current setup, however, the result would require React to be in scope with the template files which I was trying to avoid. It'd also end up embedding the resulting string with jsx into the template object which seems like it could be prone to memory leaks.

This solution adds a new MetaMaskTranslation component that can render the MetaMask template objects. Additional checks are performed to ensure a maximum depth.

```js
content: {
  element: 'MetaMaskTranslation',
  key: 'thekey',
  props: {
    translationKey: 'yourKey',
    variables: [{
      element: 'a',
      key: 'link',
      children: {
        element: 'MetaMaskTranslation',
        props: {
          translationKey: 'linkKey',
        }
      }
   }]
  }
}
```

To provide a path forward for requiring `t` to only be called with string literals, I have proposed some changes to the verify-locale script that would check for either `t('$1')` or `translationKey: '$1'` when determining if keys had been used. It also provides a mechanism for gradually switching verify-locales over to use the more strict search. 