### PR TITLE
fix contract exchange rate race condition 

### DIFF
--- a/app/scripts/controllers/token-rates.js
+++ b/app/scripts/controllers/token-rates.js
@@ -19,10 +19,13 @@ export default class TokenRatesController {
    *
    * @param {Object} [config] - Options to configure controller
    */
-  constructor({ currency, preferences } = {}) {
+  constructor({ preferences, getNativeCurrency } = {}) {
     this.store = new ObservableStore();
-    this.currency = currency;
-    this.preferences = preferences;
+    this.getNativeCurrency = getNativeCurrency;
+    this.tokens = preferences.getState().tokens;
+    preferences.subscribe(({ tokens = [] }) => {
+      this.tokens = tokens;
+    });
   }
 
   /**
@@ -30,9 +33,7 @@ export default class TokenRatesController {
    */
   async updateExchangeRates() {
     const contractExchangeRates = {};
-    const nativeCurrency = this.currency
-      ? this.currency.state.nativeCurrency.toLowerCase()
-      : 'eth';
+    const nativeCurrency = this.getNativeCurrency().toLowerCase();
     const pairs = this._tokens.map((token) => token.address).join(',');
     const query = `contract_addresses=${pairs}&vs_currencies=${nativeCurrency}`;
     if (this._tokens.length > 0) {
@@ -60,21 +61,6 @@ export default class TokenRatesController {
   }
 
   /* eslint-disable accessor-pairs */
-  /**
-   * @type {Object}
-   */
-  set preferences(preferences) {
-    this._preferences && this._preferences.unsubscribe();
-    if (!preferences) {
-      return;
-    }
-    this._preferences = preferences;
-    this.tokens = preferences.getState().tokens;
-    preferences.subscribe(({ tokens = [] }) => {
-      this.tokens = tokens;
-    });
-  }
-
   /**
    * @type {Array}
    */

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -169,8 +169,11 @@ export default class MetamaskController extends EventEmitter {
 
     // token exchange rate tracker
     this.tokenRatesController = new TokenRatesController({
-      currency: this.currencyRateController,
       preferences: this.preferencesController.store,
+      getNativeCurrency: () => {
+        const { ticker } = this.networkController.getProviderConfig();
+        return ticker ?? 'ETH';
+      },
     });
 
     this.ensController = new EnsController({

--- a/test/unit/app/controllers/token-rates-controller.js
+++ b/test/unit/app/controllers/token-rates-controller.js
@@ -4,10 +4,19 @@ import { ObservableStore } from '@metamask/obs-store';
 import TokenRatesController from '../../../../app/scripts/controllers/token-rates';
 
 describe('TokenRatesController', function () {
+  let nativeCurrency;
+  let getNativeCurrency;
+  beforeEach(function () {
+    nativeCurrency = 'ETH';
+    getNativeCurrency = () => nativeCurrency;
+  });
   it('should listen for preferences store updates', function () {
     const preferences = new ObservableStore({ tokens: [] });
     preferences.putState({ tokens: ['foo'] });
-    const controller = new TokenRatesController({ preferences });
+    const controller = new TokenRatesController({
+      preferences,
+      getNativeCurrency,
+    });
     assert.deepEqual(controller._tokens, ['foo']);
   });
 
@@ -15,7 +24,10 @@ describe('TokenRatesController', function () {
     const stub = sinon.stub(global, 'setInterval');
     const preferences = new ObservableStore({ tokens: [] });
     preferences.putState({ tokens: ['foo'] });
-    const controller = new TokenRatesController({ preferences });
+    const controller = new TokenRatesController({
+      preferences,
+      getNativeCurrency,
+    });
     controller.start(1337);
 
     assert.strictEqual(stub.getCall(0).args[1], 1337);


### PR DESCRIPTION
Fixes: #10189 

Token fiat amounts would become out of sync with one another because contract exchange rates are fetched when tokens are added, not when the network switches. As a result, token exchange rates would get updated on network switch as a result of the token list changing -- but the token rates controller's event was happening prior to the currency rate controller's native currency key being updated. 

To fix this I simplified the code a bit, breaking apart the dependency of token-rates-controller to currency-rate-controller. The only thing that token rates needed from currency rates was the native currency. Because currency rates controller also has a dependency on the network's native currency I decided to tie token rates controller to the network instead.

I also removed the 'preferences' setter in the controller because it confused me. in no place are we setting preferences on the controller except the constructor. 