### PR TITLE
Fix color indicator size

### DIFF
--- a/ui/app/components/ui/color-indicator/color-indicator.js
+++ b/ui/app/components/ui/color-indicator/color-indicator.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { COLORS, SIZES } from '../../../helpers/constants/design-system';
 
 export default function ColorIndicator({
-  size = 'small',
+  size = SIZES.SM,
   type = 'outlined',
   color = COLORS.UI4,
   borderColor,


### PR DESCRIPTION
Fixes the size of color indicator icon.

<details>
<summary>Before</summary>
<img src='https://user-images.githubusercontent.com/13376180/107684273-7113a700-6c57-11eb-914b-45c8d27a16e9.png'>
</details>

<details>
<summary>After</summary>
<img src='https://user-images.githubusercontent.com/13376180/107684348-87216780-6c57-11eb-9ccb-6122e9d7873a.png'>
</details>
