### PR TITLE
Fixes css override of token option menu icons.

### DIFF
--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -41,8 +41,6 @@
   }
 
   &__icon {
-    @include Paragraph;
-
     font-weight: 900;
   }
 }


### PR DESCRIPTION
Fixes: Display of the icons in the Token Menu Options

The `@include Paragraph` was added in one of the typography PRs but I believe it was intended for the token options text, not the icon. I believe the Paragraph only applies to text like everywhere else in the UI and this should be safe to remove from the icon to display the font-family from Font Awesome.

If the Paragraph was intended for the text then that can be a separate PR, but I believe it looks fine as is.

<details>
<summary>Before</summary>
<img src='https://user-images.githubusercontent.com/13376180/107699956-a4603100-6c6b-11eb-8565-121bd068c301.png'>
</details>

<details>
<summary>After</summary>
<img src='https://user-images.githubusercontent.com/13376180/107699546-17b57300-6c6b-11eb-86e0-d40442f1890d.png'>
</details>
