### PR TITLE
Porting MetaMask for Safari 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ notes.txt
 .nyc_output
 
 .metamaskrc
+
+safari/

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ yarn dist
 
 - [How to add custom build to Chrome](./docs/add-to-chrome.md)
 - [How to add custom build to Firefox](./docs/add-to-firefox.md)
+- [How to build for Safari](./docs/build-for-safari.md)
 - [How to add a new translation to MetaMask](./docs/translating-guide.md)
 - [Publishing Guide](./docs/publishing.md)
 - [How to use the TREZOR emulator](./docs/trezor-emulator.md)

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -123,7 +123,8 @@ initialize().catch(log.error);
  */
 async function initialize() {
   const initState = await loadStateFromPersistence();
-  const initLangCode = await getFirstPreferredLangCode();
+  // const initLangCode = await getFirstPreferredLangCode();
+  const initLangCode = 'en';
   await setupController(initState, initLangCode);
   log.debug('MetaMask initialization complete.');
 }
@@ -283,7 +284,7 @@ function setupController(initState, initLangCode) {
   // connect to other contexts
   //
   extension.runtime.onConnect.addListener(connectRemote);
-  extension.runtime.onConnectExternal.addListener(connectExternal);
+  // extension.runtime.onConnectExternal.addListener(connectExternal);
 
   const metamaskInternalProcessHash = {
     [ENVIRONMENT_TYPE_POPUP]: true,

--- a/app/scripts/disable-console.js
+++ b/app/scripts/disable-console.js
@@ -1,13 +1,13 @@
 // Disable console.log in contentscript to prevent SES/lockdown logging to external page
 // eslint-disable-next-line import/unambiguous
-if (
-  !(typeof process !== 'undefined' && process.env.METAMASK_DEBUG) &&
-  typeof console !== undefined
-) {
-  console.log = noop;
-  console.info = noop;
-}
+// if (
+//   !(typeof process !== 'undefined' && process.env.METAMASK_DEBUG) &&
+//   typeof console !== undefined
+// ) {
+//   console.log = noop;
+//   console.info = noop;
+// }
 
-function noop() {
-  return undefined;
-}
+// function noop() {
+//   return undefined;
+// }

--- a/app/scripts/runLockdown.js
+++ b/app/scripts/runLockdown.js
@@ -1,13 +1,13 @@
 // Freezes all intrinsics
 try {
   // eslint-disable-next-line no-undef,import/unambiguous
-  lockdown({
-    consoleTaming: 'unsafe',
-    errorTaming: 'unsafe',
-    mathTaming: 'unsafe',
-    dateTaming: 'unsafe',
-    overrideTaming: 'severe',
-  });
+  // lockdown({
+  //   consoleTaming: 'unsafe',
+  //   errorTaming: 'unsafe',
+  //   mathTaming: 'unsafe',
+  //   dateTaming: 'unsafe',
+  //   overrideTaming: 'severe',
+  // });
 } catch (error) {
   // If the `lockdown` call throws an exception, it interferes with the
   // contentscript injection on some versions of Firefox. The error is

--- a/docs/build-for-safari.md
+++ b/docs/build-for-safari.md
@@ -1,0 +1,65 @@
+## Safari 14 Extension
+
+The Safari extension can be achieved from the Chrome-targeting build now, with very little changes.
+First of all, before beginning, make sure you have Safari 14 and Xcode 12 installed.
+
+### Building the extension for Chrome
+
+```
+$ nvm use 14
+$ yarn setup && yarn dist
+
+...
+
+build completed. task timeline:
+█ clean 0.0s
+█████████████████████████████████████████ prod 54.8s
+███▋ styles:prod 3.5s
+  ▐██████████████████████████▋ scripts:deps:background 35.7s
+  ▐██████████████▍ scripts:deps:ui 18.9s
+  ▐██████████████████████████▋ scripts:core:prod:background 35.6s
+  ▐████████████████████████████████████▎ scripts:core:prod:ui 48.8s
+  ▐██████▊ scripts:core:prod:phishing-detect 8.5s
+  ▐█████ scripts:core:prod:initSentry 6.1s
+  ▐█████▋ scripts:core:prod:contentscript 6.9s
+  ▐██▊ scripts:core:prod:disable-console 3.0s
+  ▐███████████████████████████ static:prod 36.2s
+  ▐▋ manifest:prod 0.0s
+                                      ███ zip 2.5s
+✨  Done in 57.40s.
+```
+
+### Bootstrapping the Xcode project
+
+This step is necessary if you want to build the extension for yourself or distribute in the Apple Safari Extensions store. The generated project contains no specific patches, so the resulting output in `safari/` will be ignored by Git.
+
+```
+$ yarn safari-extension-convert
+```
+
+It runs `xcrun safari-web-extension-converter` internally, a tool provided by Apple in Xcode 12+.
+
+Upon completion, we get the following warning that can be ignored:
+```
+Warning: The following keys in your manifest.json are not supported by your current version of Safari. If these are critical to your extension, you should review your code to see if you need to make changes to support Safari:
+	notifications
+	persistent
+	externally_connectable
+```
+
+### Building the extension
+
+```
+$ open ./safari/MetaMask/MetaMask.xcodeproj
+```
+
+Will launch an Xcode instance. Just press "Start" button there.
+
+Safari will be opened, yet extension will not appear at first sight. You need to do the following steps first:
+
+* Safari -> preferences -> enable development menu
+* Safari -> develop menu -> click allow unsigned extension (need to do this every time Safari is restarted)
+* Safari -> preferences -> extensions tab -> click the extension
+* Open a web site, click the icon near the address bar, and allow the access
+
+These steps are for local non-signed builds. Do not trust any externally built extension that is not signed.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "verify-locales:fix": "node ./development/verify-locale-strings.js --fix",
     "mozilla-lint": "addons-linter dist/firefox",
     "watch": "mocha --watch --require test/env.js --require test/setup.js --reporter min --recursive \"test/unit/**/*.js\" \"ui/app/**/*.test.js\" \"shared/**/*.test.js\"",
+    "safari-extension-convert": "echo yes | xcrun safari-web-extension-converter --swift --no-open --bundle-identifier io.metamask.MetaMask --project-location ./safari/ ./dist/chrome",
     "devtools:react": "react-devtools",
     "devtools:redux": "remotedev --hostname=localhost --port=8000",
     "start:dev": "concurrently -k -n build,react,redux yarn:start yarn:devtools:react yarn:devtools:redux",


### PR DESCRIPTION
**Updates:** #8879

**Explanation:**  

This PR should ignite interest in the _official_ support and builds of the extension for Safari 14.

The extension works fine, except (obviously) HW devices are unsupported, also some styles are not rendering pixel-perfectly. 
