### PR TITLE
Remove `regenerator-runtime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,6 @@
     "react-test-renderer": "^16.12.0",
     "read-installed": "^4.0.3",
     "redux-mock-store": "^1.5.4",
-    "regenerator-runtime": "^0.13.3",
     "remote-redux-devtools": "^0.5.16",
     "remotedev-server": "^0.3.1",
     "resolve-url-loader": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21898,7 +21898,7 @@ regenerator-runtime@^0.12.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
-regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==


### PR DESCRIPTION
This package was added as a devDependency to address a peerDependency warning when installing Storybook v5.3.14. We're now using Storybook v6, which doesn't list this as a peerDependency.