### PR TITLE
Remove unused `react-test-renderer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,6 @@
     "randomcolor": "^0.5.4",
     "rc": "^1.2.8",
     "react-devtools": "^4.10.1",
-    "react-test-renderer": "^16.12.0",
     "read-installed": "^4.0.3",
     "redux-mock-store": "^1.5.4",
     "remote-redux-devtools": "^0.5.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21338,7 +21338,7 @@ react-syntax-highlighter@^13.5.0:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.12.0:
+react-test-renderer@^16.0.0-0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.12.0.tgz#11417ffda579306d4e841a794d32140f3da1b43f"
   integrity sha512-Vj/teSqt2oayaWxkbhQ6gKis+t5JrknXfPVo+aIJ8QwYAqMPH77uptOdrlphyxl8eQI/rtkOYg86i/UWkpFu0w==


### PR DESCRIPTION
This package seems to have always been unused. I suspect it was added years ago by mistake.