### PR TITLE
Remove `file-loader` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,6 @@
     "eslint-plugin-react-hooks": "^4.0.4",
     "fancy-log": "^1.3.3",
     "fast-glob": "^3.2.2",
-    "file-loader": "^1.1.11",
     "fs-extra": "^8.1.0",
     "ganache-cli": "^6.12.1",
     "ganache-core": "^2.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11121,14 +11121,6 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
-  integrity sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==
-  dependencies:
-    loader-utils "^1.0.2"
-    schema-utils "^0.4.5"
-
 file-loader@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"


### PR DESCRIPTION
This dependency has not been used since #8249.