### PR TITLE
Remove `babel-loader`

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,6 @@
     "@testing-library/react-hooks": "^3.2.1",
     "@types/react": "^16.9.53",
     "addons-linter": "1.14.0",
-    "babel-loader": "^8.0.6",
     "babelify": "^10.0.0",
     "brfs": "^2.0.2",
     "browserify": "^16.5.1",


### PR DESCRIPTION
This dependency was added to get Storybook working, but since then it has been made a direct dependency of Storybook. We no longer use it directly, and we don't need it in our dependencies.