### PR TITLE
Remove `multihashes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "lodash": "^4.17.19",
     "loglevel": "^1.4.1",
     "luxon": "^1.24.1",
-    "multihashes": "^0.4.12",
     "nanoid": "^2.1.6",
     "nonce-tracker": "^1.0.0",
     "obj-multiplex": "^1.0.0",


### PR DESCRIPTION
This dependency was used in our IPFS ENS resolver, but it has not been used directly since #6402.