### PR TITLE
Fetch eth_gasprice in send flow on non-Mainnet networks

### DIFF
--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -58,6 +58,16 @@ describe('Gas Duck', function () {
     basicEstimateIsLoading: true,
     basicPriceEstimatesLastRetrieved: 0,
   };
+
+  const providerState = {
+    chainId: "0x1",
+    nickname: "",
+    rpcPrefs: {},
+    rpcUrl: "",
+    ticker: "ETH",
+    type: "mainnet",
+  }
+
   const BASIC_GAS_ESTIMATE_LOADING_FINISHED =
     'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_FINISHED';
   const BASIC_GAS_ESTIMATE_LOADING_STARTED =
@@ -165,6 +175,7 @@ describe('Gas Duck', function () {
 
       await fetchBasicGasEstimates()(mockDistpatch, () => ({
         gas: { ...initState, basicPriceAEstimatesLastRetrieved: 1000000 },
+        metamask: { provider: { ...providerState } },
       }));
       assert.deepStrictEqual(mockDistpatch.getCall(0).args, [
         { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
@@ -209,6 +220,7 @@ describe('Gas Duck', function () {
 
       await fetchBasicGasEstimates()(mockDistpatch, () => ({
         gas: { ...initState },
+        metamask: { provider: { ...providerState } },
       }));
       assert.deepStrictEqual(mockDistpatch.getCall(0).args, [
         { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
@@ -244,6 +256,7 @@ describe('Gas Duck', function () {
 
       await fetchBasicGasEstimates()(mockDistpatch, () => ({
         gas: { ...initState },
+        metamask: { provider: { ...providerState } },
       }));
       assert.deepStrictEqual(mockDistpatch.getCall(0).args, [
         { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -60,13 +60,13 @@ describe('Gas Duck', function () {
   };
 
   const providerState = {
-    chainId: "0x1",
-    nickname: "",
+    chainId: '0x1',
+    nickname: '',
     rpcPrefs: {},
-    rpcUrl: "",
-    ticker: "ETH",
-    type: "mainnet",
-  }
+    rpcUrl: '',
+    ticker: 'ETH',
+    type: 'mainnet',
+  };
 
   const BASIC_GAS_ESTIMATE_LOADING_FINISHED =
     'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_FINISHED';

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import nock from 'nock';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
+import BN from 'bn.js';
 
 const fakeStorage = {};
 
@@ -196,6 +197,42 @@ describe('Gas Duck', function () {
             average: 20,
             fast: 30,
             safeLow: 10,
+          },
+        },
+      ]);
+      assert.deepStrictEqual(mockDistpatch.getCall(3).args, [
+        { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
+      ]);
+    });
+
+    it('should call fetch with the expected params for test network', async function () {
+      global.eth = { gasPrice: sinon.fake.returns(new BN(48199313, 10)) };
+
+      const mockDistpatch = sinon.spy();
+      const providerStateForTestNetwrok = {
+        chainId: '0x5',
+        nickname: '',
+        rpcPrefs: {},
+        rpcUrl: '',
+        ticker: 'ETH',
+        type: 'goerli',
+      };
+
+      await fetchBasicGasEstimates()(mockDistpatch, () => ({
+        gas: { ...initState, basicPriceAEstimatesLastRetrieved: 1000000 },
+        metamask: { provider: { ...providerStateForTestNetwrok } },
+      }));
+      assert.deepStrictEqual(mockDistpatch.getCall(0).args, [
+        { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
+      ]);
+      assert.deepStrictEqual(mockDistpatch.getCall(1).args, [
+        { type: SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED, value: 2000000 },
+      ]);
+      assert.deepStrictEqual(mockDistpatch.getCall(2).args, [
+        {
+          type: SET_BASIC_GAS_ESTIMATE_DATA,
+          value: {
+            average: 0.0482,
           },
         },
       ]);

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -226,9 +226,6 @@ describe('Gas Duck', function () {
         { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
       ]);
       assert.deepStrictEqual(mockDistpatch.getCall(1).args, [
-        { type: SET_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED, value: 2000000 },
-      ]);
-      assert.deepStrictEqual(mockDistpatch.getCall(2).args, [
         {
           type: SET_BASIC_GAS_ESTIMATE_DATA,
           value: {
@@ -236,7 +233,7 @@ describe('Gas Duck', function () {
           },
         },
       ]);
-      assert.deepStrictEqual(mockDistpatch.getCall(3).args, [
+      assert.deepStrictEqual(mockDistpatch.getCall(2).args, [
         { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
       ]);
     });

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -188,7 +188,7 @@ async function fetchEthGasPriceEstimates(dispatch) {
   });
 
   const basicEstimates = {
-    average: averageGasPriceInDecGWEI,
+    average: Number(averageGasPriceInDecGWEI),
   };
   const timeRetrieved = Date.now();
 

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -176,14 +176,11 @@ async function fetchExternalBasicGasEstimates(dispatch) {
 
 async function fetchEthGasPriceEstimates(state) {
   const chainId = getCurrentChainId(state);
-  let timeLastRetrieved, cachedBasicEstimates;
-  await Promise.all([
+  let [cachedTimeLastRetrieved, cachedBasicEstimates] = await Promise.all([
     getStorageItem(`${chainId}_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED`),
     getStorageItem(`${chainId}_BASIC_PRICE_ESTIMATES`),
-  ]).then((values) => {
-    timeLastRetrieved = values[0] ? values[0] : 0;
-    cachedBasicEstimates = values[1];
-  });
+  ]);
+  const timeLastRetrieved = cachedTimeLastRetrieved ? cachedTimeLastRetrieved || 0;
   if (cachedBasicEstimates && Date.now() - timeLastRetrieved < 75000) {
     return cachedBasicEstimates;
   }

--- a/ui/app/ducks/gas/gas.duck.js
+++ b/ui/app/ducks/gas/gas.duck.js
@@ -176,11 +176,11 @@ async function fetchExternalBasicGasEstimates(dispatch) {
 
 async function fetchEthGasPriceEstimates(state) {
   const chainId = getCurrentChainId(state);
-  let [cachedTimeLastRetrieved, cachedBasicEstimates] = await Promise.all([
+  const [cachedTimeLastRetrieved, cachedBasicEstimates] = await Promise.all([
     getStorageItem(`${chainId}_BASIC_PRICE_ESTIMATES_LAST_RETRIEVED`),
     getStorageItem(`${chainId}_BASIC_PRICE_ESTIMATES`),
   ]);
-  const timeLastRetrieved = cachedTimeLastRetrieved ? cachedTimeLastRetrieved || 0;
+  const timeLastRetrieved = cachedTimeLastRetrieved || 0;
   if (cachedBasicEstimates && Date.now() - timeLastRetrieved < 75000) {
     return cachedBasicEstimates;
   }

--- a/ui/app/pages/send/send.component.js
+++ b/ui/app/pages/send/send.component.js
@@ -147,6 +147,7 @@ export default class SendTransactionScreen extends Component {
           address,
         });
         updateToNicknameIfNecessary(to, toNickname, addressBook);
+        this.props.fetchBasicGasEstimates();
         updateGas = true;
       }
     }


### PR DESCRIPTION
**Fixes:** #10003 

**Explanation:**

The issue was that the `gasPrice` fetched for the test networks while performing `send` is the same as the Mainnet. 

The fix will check for the network type and, if it is a test network then the gasprice will be fetched using `gasPrice()` from `ethjs` which in turn uses `ethjs-query`. 
If user switches the network from `Send Eth` page, the gas values will be updated for the new network. 

**Manual testing steps:**  

https://user-images.githubusercontent.com/43930900/107836541-8c6fd680-6d6b-11eb-9cb6-cd1bb85f8e4f.mov



https://user-images.githubusercontent.com/43930900/107838014-ce038000-6d71-11eb-8079-9c9979dffa38.mov


