### PR TITLE
Ignore unit tests when verifying localized messages

### DIFF
--- a/development/verify-locale-strings.js
+++ b/development/verify-locale-strings.js
@@ -173,10 +173,13 @@ async function verifyEnglishLocale() {
   const globsToStrictSearch = [
     'ui/app/components/app/metamask-translation/*.js',
   ];
+  const testGlob = '**/*.test.js';
   const javascriptFiles = await glob(['ui/**/*.js', 'shared/**/*.js'], {
-    ignore: globsToStrictSearch,
+    ignore: [...globsToStrictSearch, testGlob],
   });
-  const javascriptFilesToStrictSearch = await glob(globsToStrictSearch);
+  const javascriptFilesToStrictSearch = await glob(globsToStrictSearch, {
+    ignore: [testGlob],
+  });
 
   const strictSearchRegex = /\bt\(\s*'(\w+)'\s*\)|\btranslationKey:\s*'(\w+)'/gu;
   // match "t(`...`)" because constructing message keys from template strings


### PR DESCRIPTION
The `verify-locale-strings` script now ignores unit tests. This ensures the use of a string literal in a unit test won't mistakenly make this script believe that a message is used in the extension.

This came up recently in #10396, where the deletion of unit tests for dead code triggered an unused message lint failure. This was then fixed in #10395.