### PR TITLE
Implement local perf render monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
     "start": "yarn build dev",
+    "start:perf": "PERF=1 yarn build dev",
     "dist": "yarn build prod",
     "build": "node development/build/index.js",
     "start:test": "yarn build testDev",
@@ -90,6 +91,7 @@
     "@reduxjs/toolkit": "^1.5.0",
     "@sentry/browser": "^5.26.0",
     "@sentry/integrations": "^5.26.0",
+    "@welldone-software/why-did-you-render": "^6.0.5",
     "@zxing/library": "^0.8.0",
     "abortcontroller-polyfill": "^1.4.0",
     "analytics-node": "^3.4.0-beta.3",

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,3 +1,4 @@
+import './wdry';
 import copyToClipboard from 'copy-to-clipboard';
 import log from 'loglevel';
 import { clone } from 'lodash';

--- a/ui/wdry.js
+++ b/ui/wdry.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const whyDidYouRender = require('@welldone-software/why-did-you-render');
+
+whyDidYouRender(React, { trackAllPureComponents: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3426,6 +3426,13 @@
     text-table "^0.2.0"
     webpack-log "^1.1.2"
 
+"@welldone-software/why-did-you-render@^6.0.5":
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/@welldone-software/why-did-you-render/-/why-did-you-render-6.0.5.tgz#a8df3509ed612770bb21b5fa0ad61634acc61f38"
+  integrity sha512-8fWib+bKoAmnJHZPU8/qpEXKG8piB3oaoKj78fXNAdYd3x8ryde1pC7D5tKff5Mart2iOJUvYNxxcYlbtT9tow==
+  dependencies:
+    lodash "^4"
+
 "@wry/equality@^0.1.2":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
@@ -16199,7 +16206,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@4.17.20, lodash@=3.10.1, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.2, lodash@~4.17.4:
+lodash@4.17.20, lodash@=3.10.1, lodash@^4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.2, lodash@~4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
I was recently reading https://nosleepjavascript.com/react-performance/ and the `useCallback` section jumped out at me.  That lead me to WDYR and I noticed that we seem to have many renders due to `onChange` and similar event handlers.  I think this library could help us to improve performance in the UI.

<img width="857" alt="onclick" src="https://user-images.githubusercontent.com/46655/108015642-49fe0200-6fd6-11eb-823d-d433eb3cccc8.png">
