### PR TITLE
[Fixed] Hide links to etherscan when no block explorer is specified for a custom network

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -196,7 +196,7 @@ export default class ExtensionPlatform {
     const nonce = parseInt(txMeta.txParams.nonce, 16);
 
     const title = 'Confirmed transaction';
-    const message = `Transaction ${nonce} confirmed! View on Etherscan`;
+    const message = `Transaction ${nonce} confirmed! ${!url.length? 'View on Etherscan' : ''}`;
     this._showNotification(title, message, url);
   }
 

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -196,7 +196,9 @@ export default class ExtensionPlatform {
     const nonce = parseInt(txMeta.txParams.nonce, 16);
 
     const title = 'Confirmed transaction';
-    const message = `Transaction ${nonce} confirmed! ${!url.length? 'View on Etherscan' : ''}`;
+    const message = `Transaction ${nonce} confirmed! ${
+      url.length ? 'View on Etherscan' : ''
+    }`;
     this._showNotification(title, message, url);
   }
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@metamask/controllers": "^5.1.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.2.6",
     "@metamask/eth-token-tracker": "^3.0.1",
-    "@metamask/etherscan-link": "^1.4.0",
+    "@metamask/etherscan-link": "^1.4.1",
     "@metamask/inpage-provider": "^8.0.4",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,10 +2098,10 @@
     human-standard-token-abi "^1.0.2"
     safe-event-emitter "^1.0.1"
 
-"@metamask/etherscan-link@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-1.4.0.tgz#4631e9beec17de26b35b3ccd643ede2bae8ed811"
-  integrity sha512-4Bi72Y8/FQZbfTARyv+oWKGuECzdQ37cQKt88Eu5JPDrHAcRDZt4Bt7bWC9phUBrphAr1qbCKh9S90X9hW0pZg==
+"@metamask/etherscan-link@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-1.4.1.tgz#44377c5c9be2c02ef26aff5da74bd839e50c09f9"
+  integrity sha512-hs8Qi62+6BZN9J7dknnoJR4DStEP6PzWEwRt+ScEVM4CuBVo08mqY0HXRny52A6FjBQrSnBgA5gvMbBOMqDavg==
 
 "@metamask/forwarder@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Fixes: #5631

Explanation: 
Once this PR is merged, [etherscan-link PR](https://github.com/MetaMask/etherscan-link/pull/29), I'll update the latest version of etherscan-link in the package.json and these changes will be valid.

In these PR, if there is a custom network implemented we set the `url` to an empty string so it doesn't render an invalid etherscan url. We then also conditionally render the `View on Etherscan` text if the url is empty.

Manual testing steps:  
  - Load a custom network
  - Send a transaction
  - There will be no url link to go to, thus removing the invalid etherscan url if a custom network is used