### PR TITLE
Correct use of useTokenTracker in viewQuote to ensure token data is not disrupted by faulty token in user account

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1841,6 +1841,10 @@
     "message": "Your $1 has been added to your account.",
     "description": "This message is shown after a swap is successful and communicates the exact amount of tokens the user has received for a swap. The $1 is a decimal number of tokens followed by the token symbol."
   },
+  "swapTokenBalanceUnavailable": {
+    "message": "The balance of $1 is unavailable",
+    "description": "This message communicates to the user that their balance of a given token is currently unavailable. $1 will be replaced by a token symbol"
+  },
   "swapTokenToToken": {
     "message": "Swap $1 to $2",
     "description": "Used in the transaction display list to describe a swap. $1 and $2 are the symbols of tokens in involved in a swap."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1842,7 +1842,7 @@
     "description": "This message is shown after a swap is successful and communicates the exact amount of tokens the user has received for a swap. The $1 is a decimal number of tokens followed by the token symbol."
   },
   "swapTokenBalanceUnavailable": {
-    "message": "The balance of $1 is unavailable",
+    "message": "We were unable to retrieve your $1 balance",
     "description": "This message communicates to the user that their balance of a given token is currently unavailable. $1 will be replaced by a token symbol"
   },
   "swapTokenToToken": {

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -164,6 +164,8 @@ export default function ViewQuote() {
       selectedFromToken.balance || '0x0',
       selectedFromToken.decimals,
     ).toFixed(9);
+  const tokenBalanceUnavailable =
+    tokensWithBalances && balanceToken === undefined;
 
   const approveData = getTokenData(approveTxParams?.data);
   const approveValue = approveData && getTokenValueParam(approveData);
@@ -473,14 +475,16 @@ export default function ViewQuote() {
     </span>
   );
 
-  const actionableInsufficientMessage = t('swapApproveNeedMoreTokens', [
-    <span key="swapApproveNeedMoreTokens-1" className="view-quote__bold">
-      {tokenBalanceNeeded || ethBalanceNeeded}
-    </span>,
-    tokenBalanceNeeded && !(sourceTokenSymbol === 'ETH')
-      ? sourceTokenSymbol
-      : 'ETH',
-  ]);
+  const actionableBalanceErrorMessage = tokenBalanceUnavailable
+    ? t('swapTokenBalanceUnavailable', [sourceTokenSymbol])
+    : t('swapApproveNeedMoreTokens', [
+        <span key="swapApproveNeedMoreTokens-1" className="view-quote__bold">
+          {tokenBalanceNeeded || ethBalanceNeeded}
+        </span>,
+        tokenBalanceNeeded && !(sourceTokenSymbol === 'ETH')
+          ? sourceTokenSymbol
+          : 'ETH',
+      ]);
 
   // Price difference warning
   const priceSlippageBucket = usedQuote?.priceSlippage?.bucket;
@@ -528,6 +532,7 @@ export default function ViewQuote() {
   }
 
   const shouldShowPriceDifferenceWarning =
+    !tokenBalanceUnavailable &&
     !showInsufficientWarning &&
     usedQuote &&
     (priceDifferenceRiskyBuckets.includes(priceSlippageBucket) ||
@@ -580,9 +585,9 @@ export default function ViewQuote() {
           })}
         >
           {viewQuotePriceDifferenceComponent}
-          {showInsufficientWarning && (
+          {(showInsufficientWarning || tokenBalanceUnavailable) && (
             <ActionableMessage
-              message={actionableInsufficientMessage}
+              message={actionableBalanceErrorMessage}
               onClose={() => setWarningHidden(true)}
             />
           )}
@@ -661,6 +666,7 @@ export default function ViewQuote() {
         disabled={
           submitClicked ||
           balanceError ||
+          tokenBalanceUnavailable ||
           disableSubmissionDueToPriceWarning ||
           gasPrice === null ||
           gasPrice === undefined

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -148,7 +148,7 @@ export default function ViewQuote() {
 
   const gasTotalInWeiHex = calcGasTotal(maxGasLimit, gasPrice);
 
-  const { tokensWithBalances } = useTokenTracker(swapsTokens);
+  const { tokensWithBalances } = useTokenTracker(swapsTokens, true);
   const swapsEthToken = useSwapsEthToken();
   const balanceToken =
     fetchParamsSourceToken === swapsEthToken.address


### PR DESCRIPTION
**This PR fixes the following bug which exists on develop and prod:**

1. Get exactly 5 UNI in your account
2. Use MetaMask's "Add token" feature to add a token that always returns an error when the `eth-token-tracker` tries to call either the `symbol`, `balance` or `balanceOf` method on the token contract. For example, add `0x7a250d5630b4cf539739df2c5dacb4c659f2488d` and use a symbol name like "Test"
3. Then send most of your ETH out of your account. Leave $1-$10 USD of eth in your account
4. Then go to the home screen, select the UNI token, clicked the "Swap" button once on that token's asset screen
5. Once on the swap build quote screen, click the "Max" button, so that you are swapping away all 5 of your UNI.
6. Select ETH and the token to swap to, and request quotes
**7. You will arrive at the view quote screen and see a message that says "You need 5 more UNI to complete this swap", even though you have exactly 5 UNI in your account. Instead you should see a "You need ## more ETH to complete this swap"**

**Cause of this bug:**

The `useTokenTracker` hook is how we get all balance information for users tokens. The `useTokenTracker` hook gets it balances via the `eth-token-tracker` library. That library receives data on all of a users tokens, and attempts to fetch balance data for all of them within a `Promise.all` call. If an error is thrown when attempting to fetch the balance data for any single token, it ultimately causes the `useTokenTracker` to return an empty array of token balances, even if balances for token other than the erroneous one would have succeeded.

If the user arrived at the view quote screen, and the above happened AND they had insufficient ETH for the token swap, then they see an error that says they have insufficient tokens. The `useTokenTracker` has no data on the token, so the view-quote screen logic evaluates the users balance of the token to be 0. Meanwhile, because the the user has insufficient ETH, the `swaps.state.balanceError` property is set to true. This causes the logic that sets `insufficientTokens` to evaluate to true, and `tokenBalanceNeeded` to evaluate to the amount of tokens being sent.

**Solution:**

This PR solves the issue in two ways, each of which would work on their own, but together they handle possible erroneous cases that could arise in the future as well.

First, the second parameter passed to `useTokenTracker` in view-quote is set to true. This is the `includeFailedTokens` parameter. It ensures that balances for all tokens that can be successfully retrieved are returned, even if attempting to get the balance of one or more tokens encounters and error. (This functionality was added in https://github.com/MetaMask/metamask-extension/pull/9896). This alone prevents the bug as described above as it ensures that the token balance reflects the user's actual token balance and is not incorrectly defaulted to `0`. As a result, the user will now correctly see an eth balance error (instead of a token balance error).

Second, if for whatever reason the `useTokenTracker` fails to get the balance for the currently selected token, we should not assume the balance is `0` and then show the user an error message that suggests that. Instead we should tell the user that we were unable to get information on their token balance, while also disabling submission of swaps in this case. A `tokenBalanceUnavailable` variable and associated error message has been added to handle this case.


