### PR TITLE
fix: confirm page header should show address in fullscreen

### DIFF
--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/confirm-page-container-header.component.js
@@ -25,7 +25,7 @@ export default function ConfirmPageContainerHeader({
     windowType !== ENVIRONMENT_TYPE_POPUP;
 
   if (!showEdit && isFullScreen) {
-    return null;
+    return children;
   }
   return (
     <div className="confirm-page-container-header">

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-header/tests/confirm-page-container-header.component.test.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-header/tests/confirm-page-container-header.component.test.js
@@ -1,0 +1,63 @@
+import assert from 'assert';
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { Provider } from 'react-redux';
+import ConfirmPageContainerHeader from '../confirm-page-container-header.component';
+import configureStore from '../../../../../store/store';
+import testData from '../../../../../../../.storybook/test-data';
+
+const util = require('../../../../../../../app/scripts/lib/util');
+
+describe('Confirm Detail Row Component', function () {
+  describe('render', function () {
+    it('should render a div with a confirm-page-container-header class', function () {
+      const stub = sinon
+        .stub(util, 'getEnvironmentType')
+        .callsFake(() => 'popup');
+      const wrapper = shallow(
+        <Provider store={configureStore(testData)}>
+          <ConfirmPageContainerHeader
+            showEdit={false}
+            onEdit={() => {
+              // noop
+            }}
+            showAccountInHeader={false}
+            accountAddress="0xmockAccountAddress"
+          />
+        </Provider>,
+      );
+      assert.strictEqual(
+        wrapper.html().includes('confirm-page-container-header'),
+        true,
+      );
+      stub.restore();
+    });
+
+    it('should only render children when fullscreen and showEdit is false', function () {
+      const stub = sinon
+        .stub(util, 'getEnvironmentType')
+        .callsFake(() => 'fullscreen');
+      const wrapper = shallow(
+        <Provider store={configureStore(testData)}>
+          <ConfirmPageContainerHeader
+            showEdit={false}
+            onEdit={() => {
+              // noop
+            }}
+            showAccountInHeader={false}
+            accountAddress="0xmockAccountAddress"
+          >
+            <div className="nested-test-class" />
+          </ConfirmPageContainerHeader>
+        </Provider>,
+      );
+      assert.strictEqual(wrapper.html().includes('nested-test-class'), true);
+      assert.strictEqual(
+        wrapper.html().includes('confirm-page-container-header'),
+        false,
+      );
+      stub.restore();
+    });
+  });
+});


### PR DESCRIPTION
Fixes: #9920

Explanation:  
This PR fixes a regression in logic where it was previously using a `renderTop` function to decide on rendering the page headers, and always rendering children. This PR brings back that functionality of always rendering the children, instead of returning null in some cases.

Manual testing steps:  
1. Use the metamask test-dapp to create a token
1. Use metamask in fullscreen
1. Send a token to any address
1. Confirm page is missing the sender to recipient addresses 
  
  
![image](https://user-images.githubusercontent.com/364566/108138661-4b313c80-7073-11eb-8917-1a40133ae948.png)
