### PR TITLE
Fix #10447 - Prevent navigation from jumping vertically when clicking into token

### DIFF
--- a/ui/app/components/app/menu-bar/index.scss
+++ b/ui/app/components/app/menu-bar/index.scss
@@ -4,6 +4,7 @@
   column-gap: 5px;
   padding: 0 8px;
   border-bottom: 1px solid $Grey-100;
+  height: 64px;
 
   .menu-bar__account-options {
     background: none;

--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -13,7 +13,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px;
-  height: 54px;
+  height: 64px;
 }
 
 .asset-breadcrumb {


### PR DESCRIPTION
Fixes: #10447

Explanation:  The heading space between the main screen and individual token screens "jumps" when clicking back and forth, which is unsightly.  Hooray for preventing it.

![NoJump](https://user-images.githubusercontent.com/46655/108298288-53b47080-7162-11eb-82bd-c1bc9a5c5472.gif)
