### PR TITLE
Fix Polish locale spelling

### DIFF
--- a/app/_locales/index.json
+++ b/app/_locales/index.json
@@ -36,7 +36,7 @@
   { "code": "nl", "name": "Nederlands" },
   { "code": "no", "name": "Norwegian" },
   { "code": "ph", "name": "Pilipino" },
-  { "code": "pl", "name": "Polskie" },
+  { "code": "pl", "name": "Polski" },
   { "code": "pt", "name": "Português" },
   { "code": "pt_BR", "name": "Português (Brazillian)" },
   { "code": "pt_PT", "name": "Português (European)" },


### PR DESCRIPTION
Fixes: #

Explanation:  Correction of the spelling

Manual testing steps:  
  - check language selection drop down and Polskie -> Polski
