### PR TITLE
fix: manually connect accountsChanged

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -126,7 +126,12 @@ export class PermissionsController {
    */
   async requestAccountsPermissionWithId(origin) {
     const id = nanoid();
-    this._requestPermissions({ origin }, { eth_accounts: {} }, id);
+    this._requestPermissions({ origin }, { eth_accounts: {} }, id).then(
+      async () => {
+        const permittedAccounts = await this.getAccounts(origin);
+        this.notifyAccountsChanged(origin, permittedAccounts);
+      },
+    );
     return id;
   }
 


### PR DESCRIPTION
Fixes: #9933

Explanation:  
This adds notifying of `accountChanged` when manually connecting to a site.

Manual testing steps:  
  - using example code in issue or I made a repo here: https://github.com/shanejonas/test-dapp-manual-accounts-changed
  - navigate to test app
  - remove all connected accounts from metamask
  - click `...` button
  - click connected sites
  - click "Manually Connect to current site"
  - see that it does fire a change event