### PR TITLE
 [Fixed] #7921 Message text overflow removed redundant title

### DIFF
--- a/ui/app/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/app/components/app/signature-request/signature-request-message/index.scss
@@ -37,7 +37,7 @@
 
   &--node,
   &--node-leaf {
-    padding-left: 0.8rem;
+    padding-left: 0.3rem;
 
     &-label {
       color: #5b5d67;

--- a/ui/app/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/app/components/app/signature-request/signature-request-message/index.scss
@@ -29,7 +29,6 @@
     overflow: auto;
     padding-left: 12px;
     padding-right: 12px;
-    width: 360px;
 
     @media screen and (min-width: 576px) {
       width: auto;
@@ -55,9 +54,9 @@
     &-value {
       color: black;
       margin-left: 0.5rem;
-      overflow-wrap: break-word;
       white-space: pre-line;
       overflow: hidden;
+      word-wrap: break-word;
     }
   }
 

--- a/ui/app/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/app/components/app/signature-request/signature-request-message/index.scss
@@ -35,20 +35,13 @@
     }
   }
 
-  &__type-title {
-    @include H6;
-
-    margin-left: 12px;
-    margin-top: 6px;
-    margin-bottom: 10px;
-  }
-
   &--node,
   &--node-leaf {
     padding-left: 0.8rem;
 
     &-label {
       color: #5b5d67;
+      margin-left: 0.5rem;
     }
 
     &-value {

--- a/ui/app/components/app/signature-request/signature-request-message/index.scss
+++ b/ui/app/components/app/signature-request/signature-request-message/index.scss
@@ -55,8 +55,8 @@
     &-value {
       color: black;
       margin-left: 0.5rem;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      overflow-wrap: break-word;
+      white-space: pre-line;
       overflow: hidden;
     }
   }

--- a/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -43,9 +43,6 @@ export default class SignatureRequestMessage extends PureComponent {
 
     return (
       <div className="signature-request-message">
-        <div className="signature-request-message__title">
-          {this.context.t('signatureRequest1')}
-        </div>
         <div className="signature-request-message--root">
           <div className="signature-request-message__type-title">
             {this.context.t('signatureRequest1')}

--- a/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
+++ b/ui/app/components/app/signature-request/signature-request-message/signature-request-message.component.js
@@ -43,10 +43,10 @@ export default class SignatureRequestMessage extends PureComponent {
 
     return (
       <div className="signature-request-message">
+        <div className="signature-request-message__title">
+          {this.context.t('signatureRequest1')}
+        </div>
         <div className="signature-request-message--root">
-          <div className="signature-request-message__type-title">
-            {this.context.t('signatureRequest1')}
-          </div>
           {this.renderNode(data)}
         </div>
       </div>


### PR DESCRIPTION
Fixes: #7921

Explanation: 
Message text overflow removed redundant title

Manual testing steps:  
  -  Connect to metaMask test dapp
  -  Press sign button from SignTypedData_4
 
Result:
  -  Text should warp and redundant message title should only show one message 