### PR TITLE
Re-add handler for addEthereumChain

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/index.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/index.js
@@ -1,10 +1,10 @@
-// import addEthereumChain from './add-ethereum-chain';
+import addEthereumChain from './add-ethereum-chain';
 import getProviderState from './get-provider-state';
 import logWeb3ShimUsage from './log-web3-shim-usage';
 import watchAsset from './watch-asset';
 
 const handlers = [
-  // addEthereumChain,
+  addEthereumChain,
   getProviderState,
   logWeb3ShimUsage,
   watchAsset,


### PR DESCRIPTION
uncomments out the code that makes the method active.

~this can't be merged until #10484 is merged and a decision is made on permissioning.~ 