### PR TITLE
Wrong Currency Symbol when using Custom Network

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -337,7 +337,6 @@ export default class MetamaskController extends EventEmitter {
       );
     });
     const { ticker } = this.networkController.getProviderConfig();
-    // this.currencyRateController.update({ nativeCurrency: ticker ?? 'ETH' });
     this.currencyRateController.configure({ nativeCurrency: ticker ?? 'ETH' });
     this.networkController.lookupNetwork();
     this.messageManager = new MessageManager();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -336,17 +336,9 @@ export default class MetamaskController extends EventEmitter {
         },
       );
     });
-
-    // const { ticker } = this.networkController.getProviderConfig();
+    const { ticker } = this.networkController.getProviderConfig();
     // this.currencyRateController.update({ nativeCurrency: ticker ?? 'ETH' });
-    this.setCurrentCurrency(
-      this.currencyRateController.state.currentCurrency,
-      (error) => {
-        if (error) {
-          throw error;
-        }
-      },
-    );
+    this.currencyRateController.configure({ nativeCurrency: ticker ?? 'ETH' });
     this.networkController.lookupNetwork();
     this.messageManager = new MessageManager();
     this.personalMessageManager = new PersonalMessageManager();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -337,7 +337,7 @@ export default class MetamaskController extends EventEmitter {
       );
     });
 
-    const { ticker } = this.networkController.getProviderConfig();
+    // const { ticker } = this.networkController.getProviderConfig();
     // this.currencyRateController.update({ nativeCurrency: ticker ?? 'ETH' });
     this.setCurrentCurrency(
       this.currencyRateController.state.currentCurrency,
@@ -2478,7 +2478,6 @@ export default class MetamaskController extends EventEmitter {
    * @param {Function} cb - A callback function returning currency info.
    */
   setCurrentCurrency(currencyCode, cb) {
-    console.log('in setCurrentCurrency')
     const { ticker } = this.networkController.getProviderConfig();
     try {
       const currencyState = {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -338,8 +338,15 @@ export default class MetamaskController extends EventEmitter {
     });
 
     const { ticker } = this.networkController.getProviderConfig();
-    this.currencyRateController.update({ nativeCurrency: ticker ?? 'ETH' });
-
+    // this.currencyRateController.update({ nativeCurrency: ticker ?? 'ETH' });
+    this.setCurrentCurrency(
+      this.currencyRateController.state.currentCurrency,
+      (error) => {
+        if (error) {
+          throw error;
+        }
+      },
+    );
     this.networkController.lookupNetwork();
     this.messageManager = new MessageManager();
     this.personalMessageManager = new PersonalMessageManager();
@@ -2471,6 +2478,7 @@ export default class MetamaskController extends EventEmitter {
    * @param {Function} cb - A callback function returning currency info.
    */
   setCurrentCurrency(currencyCode, cb) {
+    console.log('in setCurrentCurrency')
     const { ticker } = this.networkController.getProviderConfig();
     try {
       const currencyState = {


### PR DESCRIPTION
Fixes: #10389 

Explanation:  The currency symbol shown for the native currency in the Homepage was ETH irrespective of the currency symbol defined for the current network selected. This was because the `update()` performed on the `state` of `CurrencyRatecontroller` for nativeCurrency was not getting reflected. If we call `configure()` on `CurrencyRateController`, it is appropriately updating the currency symbol by called `updateExchangeRate()`.


Manual testing steps:  
  - Add a custom network with currency symbol is not ETH.
  - Either close and reopen the chrome or Disable and enable MetaMask via the button in the extensions page
  - Now the Home Page shows the correct currency symbol as per the current network settings.