### PR TITLE
Eliminate artificial delay in swaps loading screen after request loading is complete

### DIFF
--- a/ui/app/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
+++ b/ui/app/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
@@ -112,13 +112,9 @@ export default function LoadingSwapsQuotes({
     // This is to give the user a sense of progress. The callback passed to `setTimeout` updates the quoteCount and therefore causes
     // a new logo to be shown, the fox to look at that logo, the logo bar and aggregator name to update.
 
-    // If loading is complete and all logos + aggregator names have been shown, give the user 1.2 seconds to read the
-    // "Finalizing message" and prepare for the screen change
-    if (quoteCount === numberOfQuotes && loadingComplete) {
-      timeoutLength = 1200;
-    } else if (loadingComplete) {
-      // If loading is complete, but the quoteCount is not, we quickly display the remaining logos/names/fox looks. 0.5s each
-      timeoutLength = 500;
+    if (loadingComplete) {
+      // If loading is complete, but the quoteCount is not, we quickly display the remaining logos/names/fox looks. 0.2s each
+      timeoutLength = 200;
     } else {
       // If loading is not complete, we display remaining logos/names/fox looks at random intervals between 0.5s and 2s, to simulate the
       // sort of loading a user would experience in most async scenarios


### PR DESCRIPTION
Previous to this PR, we were adding an artificial delay to the length of time that each logo, name and fox look was shown on the swaps loading screen _after_ the network request that is loading is complete. This was to give the user time to reading names and logos.

It has been decided that it is preferable to move the user to the view-quote screen faster then to give the user extra time to read names. The most important reason for this is that it will increase swaps success rates as the shorter the time between the retrieval of quotes and the submission of swaps, the more likely that the swap will be successful. There have been recent api improvements that reduce the average time for the `/trades` request to respond, which means that the changes added in this PR will have an affect much more often.

This is what the loading screen will look like when the `/trades` request takes only 2-3 seconds.


https://user-images.githubusercontent.com/7499938/108857597-d48dc500-75c5-11eb-8bff-5e44af9488e2.mp4

