### PR TITLE
Fix library bundle visualizations

### DIFF
--- a/development/source-map-explorer.sh
+++ b/development/source-map-explorer.sh
@@ -5,6 +5,7 @@ mkdir -p build-artifacts/source-map-explorer
 npx source-map-explorer dist/chrome/inpage.js --html build-artifacts/source-map-explorer/inpage.html
 npx source-map-explorer dist/chrome/contentscript.js --html build-artifacts/source-map-explorer/contentscript.html
 npx source-map-explorer dist/chrome/background.js --html build-artifacts/source-map-explorer/background.html
+npx source-map-explorer dist/chrome/bg-libs.js --html build-artifacts/source-map-explorer/bg-libs.html
 npx source-map-explorer dist/chrome/ui.js --html build-artifacts/source-map-explorer/ui.html
-npx source-map-explorer dist/chrome/libs.js --html build-artifacts/source-map-explorer/libs.html
+npx source-map-explorer dist/chrome/ui-libs.js --html build-artifacts/source-map-explorer/ui-libs.html
 npx source-map-explorer dist/chrome/phishing-detect.js --html build-artifacts/source-map-explorer/phishing-detect.html


### PR DESCRIPTION
The bundle visualizations for the library bundles has been fixed. Previously it was trying to generate a visualization for the non-
existent 'libs.js' module. Now it correctly generates a visualization for the 'ui-libs.js` and 'bg-libs.js' modules.