### PR TITLE
Improve safety of source map explorer script

### DIFF
--- a/development/source-map-explorer.sh
+++ b/development/source-map-explorer.sh
@@ -1,11 +1,15 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -x
+set -e
+set -u
+set -o pipefail
 
 mkdir -p build-artifacts/source-map-explorer
-npx source-map-explorer dist/chrome/inpage.js --html build-artifacts/source-map-explorer/inpage.html
-npx source-map-explorer dist/chrome/contentscript.js --html build-artifacts/source-map-explorer/contentscript.html
-npx source-map-explorer dist/chrome/background.js --html build-artifacts/source-map-explorer/background.html
-npx source-map-explorer dist/chrome/bg-libs.js --html build-artifacts/source-map-explorer/bg-libs.html
-npx source-map-explorer dist/chrome/ui.js --html build-artifacts/source-map-explorer/ui.html
-npx source-map-explorer dist/chrome/ui-libs.js --html build-artifacts/source-map-explorer/ui-libs.html
-npx source-map-explorer dist/chrome/phishing-detect.js --html build-artifacts/source-map-explorer/phishing-detect.html
+yarn source-map-explorer dist/chrome/inpage.js --html build-artifacts/source-map-explorer/inpage.html
+yarn source-map-explorer dist/chrome/contentscript.js --html build-artifacts/source-map-explorer/contentscript.html
+yarn source-map-explorer dist/chrome/background.js --html build-artifacts/source-map-explorer/background.html
+yarn source-map-explorer dist/chrome/bg-libs.js --html build-artifacts/source-map-explorer/bg-libs.html
+yarn source-map-explorer dist/chrome/ui.js --html build-artifacts/source-map-explorer/ui.html
+yarn source-map-explorer dist/chrome/ui-libs.js --html build-artifacts/source-map-explorer/ui-libs.html
+yarn source-map-explorer dist/chrome/phishing-detect.js --html build-artifacts/source-map-explorer/phishing-detect.html


### PR DESCRIPTION
The source map explorer script will now use `yarn` instead of `npx` to create the visualizations, to ensure that it's using the exact version of `source-map-explorer` that we have in our dependencies.

The standard set of Bash flags have been set as well, and the standard Bash shebang we use. This ensures the script will fail if an error is encountered.