### PR TITLE
Replace use of 'destinationAmountInEth' property with 'destinationAmountInETH'

### DIFF
--- a/ui/app/pages/swaps/view-quote/tests/view-quote-price-difference.test.js
+++ b/ui/app/pages/swaps/view-quote/tests/view-quote-price-difference.test.js
@@ -51,7 +51,7 @@ describe('View Price Quote Difference', function () {
         calculationError: '',
         bucket: 'low',
         sourceAmountInETH: 1,
-        destinationAmountInEth: 0.9921849150875727,
+        destinationAmountInETH: 0.9921849150875727,
       },
       slippage: 2,
       sourceTokenInfo: {

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -510,7 +510,7 @@ export default function ViewQuote() {
     usedQuote?.priceSlippage?.sourceAmountInETH || 0,
   );
   const priceSlippageFromDestination = useEthFiatAmount(
-    usedQuote?.priceSlippage?.destinationAmountInEth || 0,
+    usedQuote?.priceSlippage?.destinationAmountInETH || 0,
   );
 
   // We cannot present fiat value if there is a calculation error or no slippage


### PR DESCRIPTION
Currently the swaps `/trades` api returns objects that include the following property:
```
"priceSlippage": {
  "ratio": 0,
  "calculationError": "No trade data to calculate price slippage",
  "bucket": "high",
  "sourceAmountInETH": 0,
  "destinationAmountInEth": 0,
  "destinationAmountInETH": 0
}
```

The `destinationAmountInEth` and `destinationAmountInETH` are always identical. We want to update the api to only include `destinationAmountInETH`. This PR makes that possible.