### PR TITLE
Ensure that swap approve tx and swap tx always have the same gas price

### DIFF
--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -288,7 +288,7 @@ export const getApproveTxParams = (state) => {
   }
   const data = getSwapsState(state)?.customApproveTxData || approvalNeeded.data;
 
-  const gasPrice = getCustomSwapsGasPrice(state) || approvalNeeded.gasPrice;
+  const gasPrice = getUsedSwapsGasPrice(state);
   return { ...approvalNeeded, gasPrice, data };
 };
 


### PR DESCRIPTION
This PR fixes a bug whereby the approve tx and swap tx created within our swaps feature could each have a different gas price. This would happen in the case when there is no custom gas price set, and the call to the swaps `/gasPrices` api fails. In such a case, both would get their gas price from the `eth_gasPrice` method, but at different times (swap tx at the time quotes are requested, and approve tx at the time the swap is submitted).

This PR fixes that by having both gas prices set by calling the same selector `getUsedSwapsGasPrice`