### PR TITLE
fix misuse of getCurrentNetwork

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -22,7 +22,7 @@ async function addEthereumChainHandler(
   end,
   {
     addCustomRpc,
-    getCurrentNetwork,
+    getCurrentChainId,
     findCustomRpcBy,
     updateRpcTarget,
     requestUserApproval,
@@ -122,8 +122,8 @@ async function addEthereumChainHandler(
   const existingNetwork = findCustomRpcBy({ chainId: _chainId });
 
   if (existingNetwork !== null) {
-    const currentNetwork = getCurrentNetwork();
-    if (currentNetwork.chainId === _chainId) {
+    const currentChainId = getCurrentChainId();
+    if (currentChainId === _chainId) {
       res.result = null;
       return end();
     }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2111,7 +2111,9 @@ export default class MetamaskController extends EventEmitter {
           this.alertController,
         ),
         findCustomRpcBy: this.findCustomRpcBy.bind(this),
-        getCurrentNetwork: this.getCurrentNetwork.bind(this),
+        getCurrentChainId: this.networkController.getCurrentChainId.bind(
+          this.networkController,
+        ),
         requestUserApproval: this.approvalController.addAndShowApprovalRequest.bind(
           this.approvalController,
         ),


### PR DESCRIPTION
progresses https://github.com/MetaMask/metamask-extension/issues/8668

Explanation:  
- we were using getCurrentNetwork instead of getCurrentChainId for determining if the chainId matches the chainId submitted to wallet_addEthereumChain