### PR TITLE
Remove unused AppHeader props

### DIFF
--- a/ui/app/components/app/app-header/app-header.container.js
+++ b/ui/app/components/app/app-header/app-header.container.js
@@ -8,18 +8,10 @@ import AppHeader from './app-header.component';
 const mapStateToProps = (state) => {
   const { appState, metamask } = state;
   const { networkDropdownOpen } = appState;
-  const {
-    network,
-    provider,
-    selectedAddress,
-    isUnlocked,
-    isAccountMenuOpen,
-  } = metamask;
+  const { selectedAddress, isUnlocked, isAccountMenuOpen } = metamask;
 
   return {
     networkDropdownOpen,
-    network,
-    provider,
     selectedAddress,
     isUnlocked,
     isAccountMenuOpen,


### PR DESCRIPTION
These two props were being passed into the AppHeader component by the AppHeader container despite them being unused.