### PR TITLE
use chain id for enabling ENS IPFS resolution

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -243,7 +243,9 @@ function setupController(initState, initLangCode) {
   });
 
   setupEnsIpfsResolver({
-    getCurrentNetwork: controller.getCurrentNetwork,
+    getCurrentChainId: controller.networkController.getCurrentChainId.bind(
+      controller.networkController,
+    ),
     getIpfsGateway: controller.preferencesController.getIpfsGateway.bind(
       controller.preferencesController,
     ),

--- a/app/scripts/controllers/ens/index.js
+++ b/app/scripts/controllers/ens/index.js
@@ -2,20 +2,22 @@ import punycode from 'punycode/punycode';
 import ethUtil from 'ethereumjs-util';
 import { ObservableStore } from '@metamask/obs-store';
 import log from 'loglevel';
+import { CHAIN_ID_TO_NETWORK_ID_MAP } from '../../../../shared/constants/network';
 import Ens from './ens';
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const ZERO_X_ERROR_ADDRESS = '0x';
 
 export default class EnsController {
-  constructor({ ens, provider, networkStore } = {}) {
+  constructor({ ens, provider, onNetworkDidChange, getCurrentChainId } = {}) {
     const initState = {
       ensResolutionsByAddress: {},
     };
 
     this._ens = ens;
     if (!this._ens) {
-      const network = networkStore.getState();
+      const chainId = getCurrentChainId();
+      const network = CHAIN_ID_TO_NETWORK_ID_MAP[chainId];
       if (Ens.getNetworkEnsSupport(network)) {
         this._ens = new Ens({
           network,
@@ -25,8 +27,10 @@ export default class EnsController {
     }
 
     this.store = new ObservableStore(initState);
-    networkStore.subscribe((network) => {
+    onNetworkDidChange(() => {
       this.store.putState(initState);
+      const chainId = getCurrentChainId();
+      const network = CHAIN_ID_TO_NETWORK_ID_MAP[chainId];
       if (Ens.getNetworkEnsSupport(network)) {
         this._ens = new Ens({
           network,

--- a/app/scripts/lib/ens-ipfs/setup.js
+++ b/app/scripts/lib/ens-ipfs/setup.js
@@ -8,7 +8,7 @@ const supportedTopLevelDomains = ['eth'];
 
 export default function setupEnsIpfsResolver({
   provider,
-  getCurrentNetwork,
+  getCurrentChainId,
   getIpfsGateway,
 }) {
   // install listener
@@ -30,7 +30,7 @@ export default function setupEnsIpfsResolver({
     const { tabId, url } = details;
     // ignore requests that are not associated with tabs
     // only attempt ENS resolution on mainnet
-    if (tabId === -1 || getCurrentNetwork() !== '1') {
+    if (tabId === -1 || getCurrentChainId() !== '0x1') {
       return;
     }
     // parse ens name

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -178,7 +178,13 @@ export default class MetamaskController extends EventEmitter {
 
     this.ensController = new EnsController({
       provider: this.provider,
-      networkStore: this.networkController.networkStore,
+      getCurrentChainId: this.networkController.getCurrentChainId.bind(
+        this.networkController,
+      ),
+      onNetworkDidChange: this.networkController.on.bind(
+        this.networkController,
+        NETWORK_EVENTS.NETWORK_DID_CHANGE,
+      ),
     });
 
     this.incomingTransactionsController = new IncomingTransactionsController({

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.container.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.container.js
@@ -1,16 +1,18 @@
 import { connect } from 'react-redux';
+import { CHAIN_ID_TO_NETWORK_ID_MAP } from '../../../../../../shared/constants/network';
 import {
-  getCurrentNetwork,
   getSendTo,
   getSendToNickname,
   getAddressBookEntry,
+  getCurrentChainId,
 } from '../../../../selectors';
 import EnsInput from './ens-input.component';
 
 export default connect((state) => {
   const selectedAddress = getSendTo(state);
+  const chainId = getCurrentChainId(state);
   return {
-    network: getCurrentNetwork(state),
+    network: CHAIN_ID_TO_NETWORK_ID_MAP[chainId],
     selectedAddress,
     selectedName: getSendToNickname(state),
     contact: getAddressBookEntry(state, selectedAddress),


### PR DESCRIPTION
Progresses: #8668 
use chainId instead of network for enabling ENS IPFS resolution

<details>
<summary>screenshot</summary>
<img src="https://user-images.githubusercontent.com/4448075/108890972-ce064a00-75d3-11eb-9902-f8b41e0f4893.png" />



</details>