### PR TITLE
Remove unused TransactionController option

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -293,7 +293,6 @@ export default class MetamaskController extends EventEmitter {
       ),
       preferencesStore: this.preferencesController.store,
       txHistoryLimit: 40,
-      getNetwork: this.networkController.getNetworkState.bind(this),
       signTransaction: this.keyringController.signTransaction.bind(
         this.keyringController,
       ),


### PR DESCRIPTION
The function `getNetwork` was being passed into the TransactionController constructor, but no such option was used in the controller itself.