### PR TITLE
Improve contributor documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,49 @@ To learn how to contribute to the MetaMask project itself, visit our [Internal D
     - Replace the `INFURA_PROJECT_ID` value with your own personal [Infura Project ID](https://infura.io/docs).
     - If debugging MetaMetrics, you'll need to add a value for `SEGMENT_WRITE_KEY` [Segment write key](https://segment.com/docs/connections/find-writekey/).
 - Build the project to the `./dist/` folder with `yarn dist`.
-- Optionally, to start a development build (e.g. with logging and file watching) run `yarn start` instead.
-    - To start the [React DevTools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io)
-      alongside the app, use `yarn start:dev`.
-      - React DevTools will open in a separate window; no browser extension is required
-      - Redux DevTools will need to be installed as a browser extension. Open the Redux Remote Devtools to access Redux state logs. This can be done by either right clicking within the web browser to bring up the context menu, expanding the Redux DevTools panel and clicking Open Remote DevTools OR clicking the Redux DevTools extension icon and clicking Open Remote DevTools.
-        - You will also need to check the "Use custom (local) server" checkbox in the Remote DevTools Settings, using the default server configuration (host `localhost`, port `8000`, secure connection checkbox unchecked)
 
 Uncompressed builds can be found in `/dist`, compressed builds can be found in `/builds` once they're built.
 
 ## Contributing
 
-### Running Tests
+### Development builds
 
-Run tests with `yarn test`.
+To start a development build (e.g. with logging and file watching) run `yarn start`.
 
-You can also test with a continuously watching process, via `yarn watch`.
+To start the [React DevTools](https://github.com/facebook/react-devtools) and [Redux DevTools Extension](http://extension.remotedev.io)
+  alongside the app, use `yarn start:dev`.
+  - React DevTools will open in a separate window; no browser extension is required
+  - Redux DevTools will need to be installed as a browser extension. Open the Redux Remote Devtools to access Redux state logs. This can be done by either right clicking within the web browser to bring up the context menu, expanding the Redux DevTools panel and clicking Open Remote DevTools OR clicking the Redux DevTools extension icon and clicking Open Remote DevTools.
+    - You will also need to check the "Use custom (local) server" checkbox in the Remote DevTools Settings, using the default server configuration (host `localhost`, port `8000`, secure connection checkbox unchecked)
 
-You can run the linter by itself with `yarn lint`.
+### Running Unit Tests and Linting
+
+Run unit tests and the linter with `yarn test`.
+
+To run just unit tests, run `yarn test:unit`. To run unit tests continuously with a file watcher, run `yarn watch`.
+
+You can run the linter by itself with `yarn lint`, and you can automatically fix some lint problems with `yarn lint:fix`. You can also run these two commands just on your local changes to save time with `yarn lint:changed` and `yarn lint:changed:fix` respectively.
+
+### Running E2E Tests
+
+Our e2e test suite can be run on either Firefox or Chrome. In either case, start by creating a test build by running `yarn build:test`.
+
+Firefox e2e tests can be run with `yarn test:e2e:firefox`.
+
+Chrome e2e tests can be run with `yarn test:e2e:chrome`, but they will only work if you have Chrome v79 installed. Update the `chromedriver` package to a version matching your local Chrome installation to run e2e tests on newer Chrome versions.
+
+### Changing dependencies
+
+Whenever you change dependencies (adding, removing, or updating, either in `package.json` or `yarn.lock`), there are various files that must be kept up-to-date.
+
+* `yarn.lock`:
+  * Run `yarn setup` again after your changes to ensure `yarn.lock` has been properly updated.
+* The `allow-scripts` configuration in `package.json`
+  * Run `yarn allow-scripts auto` to update the `allow-scripts` configuration automatically. This config determines whether the package's install/postinstall scripts are allowed to run. Review each new package to determine whether the install script needs to run or not, testing if necessary.
+  * Unfortunately, `yarn allow-scripts auto` will behave inconsistently on different platforms. macOS and Windows users may see extraneous changes relating to optional dependencies.
+* The LavaMoat auto-generated policy in `lavamoat/node/policy.json`
+  * Run `yarn lavamoat:auto` to re-generate this policy file. Review the changes to determine whether the access granted to each package seems appropriate.
+  * Unfortunately, `yarn lavamoat:auto` will behave inconsistently on different platforms. macOS and Windows users may see extraneous changes relating to optional dependencies.
 
 ## Architecture
 


### PR DESCRIPTION
The contributor documentation in the README has been improved in various ways:

* There is now a dedicated section for development builds under 'Contributing', rather than this being under 'Building locally'
* Additional unit test and linting commands have been documented
* Instructions for running e2e tests have been added
* Instructions on how to handle dependency changes have been added, to accommodate recent changes relating to `allow-scripts` and `LavaMoat`.