### PR TITLE
Fix LavaMoat config check

### DIFF
--- a/.circleci/scripts/validate-allow-scripts.sh
+++ b/.circleci/scripts/validate-allow-scripts.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 yarn allow-scripts auto
 
-if git diff-index --quiet HEAD
+if git diff --exit-code --quiet
 then
   echo "allow-scripts configuration is up-to-date"
 else

--- a/.circleci/scripts/validate-lavamoat-policy.sh
+++ b/.circleci/scripts/validate-lavamoat-policy.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 yarn lavamoat:auto
 
-if git diff-index --quiet HEAD
+if git diff --exit-code --quiet
 then
   echo "LavaMoat policy is up-to-date"
 else


### PR DESCRIPTION
The CI script to ensure no LavaMoat policy changes are required has been failing despite there being no changes. It turns out that the command used to check for changes (`git diff-index`) was failing despite the lack of changes because the file was written again by `yarn lavamoat:auto` but git hadn't gotten around to updating its index since the write occurred, so [it was considering it as changed until it verified it wasn't](https://stackoverflow.com/questions/34807971/why-does-git-diff-index-head-result-change-for-touched-files-after-git-diff-or-g
).

The command has been replaced by `git diff --exit-code --quiet`, whichshould do exactly the same thing except that it forces git to update its internal cache to verify whether changes are present.