### PR TITLE
addEthereumChain bug fixes

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1945,7 +1945,7 @@
     "message": "View in activity"
   },
   "switchEthereumChainConfirmationDescription": {
-    "message": "This will will switch the selected network within MetaMask to a previously added network:"
+    "message": "This will switch the selected network within MetaMask to a previously added network:"
   },
   "switchEthereumChainConfirmationTitle": {
     "message": "Allow this site to switch the network?"

--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -32,7 +32,9 @@ async function addEthereumChainHandler(
   if (!req.params?.[0] || typeof req.params[0] !== 'object') {
     return end(
       ethErrors.rpc.invalidParams({
-        message: `Expected single, object parameter. Received:\n${req.params}`,
+        message: `Expected single, object parameter. Received:\n${JSON.stringify(
+          req.params,
+        )}`,
       }),
     );
   }

--- a/ui/app/pages/confirmation/confirmation.js
+++ b/ui/app/pages/confirmation/confirmation.js
@@ -9,11 +9,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { isEqual } from 'lodash';
 import { produce } from 'immer';
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
-import {
-  ENVIRONMENT_TYPE_FULLSCREEN,
-  ENVIRONMENT_TYPE_POPUP,
-} from '../../../../shared/constants/app';
 import Box from '../../components/ui/box';
 import Chip from '../../components/ui/chip';
 import MetaMaskTemplateRenderer from '../../components/app/metamask-template-renderer';
@@ -138,16 +133,11 @@ export default function ConfirmationPage() {
   }, [pendingConfirmation, t, dispatch]);
 
   useEffect(() => {
-    const environmentType = getEnvironmentType();
     // If the number of pending confirmations reduces to zero when the user
-    // is in the fullscreen or popup UI, return them to the default route.
-    // Otherwise, if the number of pending confirmations reduces to a number
-    // that is less than the currently viewed index, reset the index.
-    if (
-      pendingConfirmations.length === 0 &&
-      (environmentType === ENVIRONMENT_TYPE_FULLSCREEN ||
-        environmentType === ENVIRONMENT_TYPE_POPUP)
-    ) {
+    // return them to the default route. Otherwise, if the number of pending
+    // confirmations reduces to a number that is less than the currently
+    // viewed index, reset the index.
+    if (pendingConfirmations.length === 0) {
       history.push(DEFAULT_ROUTE);
     } else if (pendingConfirmations.length <= currentPendingConfirmation) {
       setCurrentPendingConfirmation(pendingConfirmations.length - 1);

--- a/ui/app/store/actionConstants.js
+++ b/ui/app/store/actionConstants.js
@@ -2,8 +2,6 @@ export const GO_HOME = 'GO_HOME';
 // modal state
 export const MODAL_OPEN = 'UI_MODAL_OPEN';
 export const MODAL_CLOSE = 'UI_MODAL_CLOSE';
-// notification state
-export const CLOSE_NOTIFICATION_WINDOW = 'CLOSE_NOTIFICATION_WINDOW';
 // sidebar state
 export const SIDEBAR_OPEN = 'UI_SIDEBAR_OPEN';
 export const SIDEBAR_CLOSE = 'UI_SIDEBAR_CLOSE';

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1772,21 +1772,13 @@ export function hideModal(payload) {
 }
 
 export function closeCurrentNotificationWindow() {
-  return (dispatch, getState) => {
+  return (_, getState) => {
     if (
       getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION &&
       !hasUnconfirmedTransactions(getState())
     ) {
       global.platform.closeCurrentWindow();
-
-      dispatch(closeNotificationWindow());
     }
-  };
-}
-
-export function closeNotificationWindow() {
-  return {
-    type: actionConstants.CLOSE_NOTIFICATION_WINDOW,
   };
 }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2476,7 +2476,7 @@ export function resolvePendingApproval(id, value) {
     await promisifiedBackground.resolvePendingApproval(id, value);
     // Before closing the current window, check if any additional confirmations
     // are added as a result of this confirmation being accepted
-    const { pendingApprovals } = await promisifiedBackground.getState();
+    const { pendingApprovals } = await forceUpdateMetamaskState(dispatch);
     if (Object.values(pendingApprovals).length === 0) {
       dispatch(closeCurrentNotificationWindow());
     }
@@ -2494,7 +2494,7 @@ export function rejectPendingApproval(id, error) {
     await promisifiedBackground.rejectPendingApproval(id, error);
     // Before closing the current window, check if any additional confirmations
     // are added as a result of this confirmation being rejected
-    const { pendingApprovals } = await promisifiedBackground.getState();
+    const { pendingApprovals } = await forceUpdateMetamaskState(dispatch);
     if (Object.values(pendingApprovals).length === 0) {
       dispatch(closeCurrentNotificationWindow());
     }


### PR DESCRIPTION
Fixes: QA issues four with wallet_addEthereumChain

1. Stringifies the params object when throwing an error.
2. removes a double word typo in the messages file
3. Closes the confirmation window directly instead of dispatching the corresponding action. This addresses an edge case where a user might have a switch network confirmation open while another transaction is queued up by the dapp or another dapp. The switch network confirmation clears all pending confirmations, but the closeNotificationWindow action is still seeing a pending confirmation when checking if it should close. 

The alternative solution to the third bullet is to wait for promisifedBackground.getState instead of using redux's getState... but not sure what kind of impact that'll have on all the other confirmations. 