### PR TITLE
Accommodate for 0 sources verifying swap token

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1899,6 +1899,9 @@
     "message": "Always confirm the token address on $1.",
     "description": "Points the user to Etherscan as a place they can verify information about a token. $1 is replaced with the translation for \"Etherscan\" followed by an info icon that shows more info on hover."
   },
+  "swapTokenVerificationNoSource": {
+    "message": "This token has not been verified."
+  },
   "swapTokenVerificationOnlyOneSource": {
     "message": "Only verified on 1 source."
   },

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -113,7 +113,7 @@ export default function BuildQuote({
   const toTokenIsNotEth =
     selectedToToken?.address &&
     selectedToToken?.address !== ETH_SWAPS_TOKEN_OBJECT.address;
-
+  const occurances = Number(selectedToToken.occurances);
   const {
     address: fromTokenAddress,
     symbol: fromTokenSymbol,
@@ -376,12 +376,14 @@ export default function BuildQuote({
           />
         </div>
         {toTokenIsNotEth &&
-          (selectedToToken.occurances === 1 ? (
+          (occurances < 2 ? (
             <ActionableMessage
               message={
                 <div className="build-quote__token-verification-warning-message">
                   <div className="build-quote__bold">
-                    {t('swapTokenVerificationOnlyOneSource')}
+                    {occurances === 1
+                      ? t('swapTokenVerificationOnlyOneSource')
+                      : t('swapTokenVerificationNoSource')}
                   </div>
                   <div>
                     {t('verifyThisTokenOn', [
@@ -416,9 +418,7 @@ export default function BuildQuote({
                 className="build-quote__bold"
                 key="token-verification-bold-text"
               >
-                {t('swapTokenVerificationSources', [
-                  selectedToToken.occurances,
-                ])}
+                {t('swapTokenVerificationSources', [occurances])}
               </span>
               {t('swapTokenVerificationMessage', [
                 <a
@@ -465,9 +465,7 @@ export default function BuildQuote({
           !selectedToToken?.address ||
           Number(maxSlippage) === 0 ||
           Number(maxSlippage) > MAX_ALLOWED_SLIPPAGE ||
-          (toTokenIsNotEth &&
-            selectedToToken.occurances === 1 &&
-            !verificationClicked)
+          (toTokenIsNotEth && occurances < 2 && !verificationClicked)
         }
         hideCancel
         showTermsOfService

--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -113,7 +113,7 @@ export default function BuildQuote({
   const toTokenIsNotEth =
     selectedToToken?.address &&
     selectedToToken?.address !== ETH_SWAPS_TOKEN_OBJECT.address;
-  const occurances = Number(selectedToToken.occurances);
+  const occurances = Number(selectedToToken?.occurances || 0);
   const {
     address: fromTokenAddress,
     symbol: fromTokenSymbol,


### PR DESCRIPTION
Fixes this issue:

<img width="311" alt="imagen" src="https://user-images.githubusercontent.com/46655/109197379-82ce7180-7762-11eb-998a-3ba654f0d4c8.png">

<img width="489" alt="NotVerified" src="https://user-images.githubusercontent.com/46655/109197686-ec4e8000-7762-11eb-9a07-55de2d759e2a.png">

I've provided a custom message for this rare case.