### PR TITLE
handle undefined network

### DIFF
--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -72,10 +72,19 @@ export default class EnsInput extends Component {
     }
 
     if (prevProps.network !== network) {
-      const provider = global.ethereumProvider;
-      this.ens = new ENS({ provider, network });
-      if (!newProvidedValue) {
-        newValue = input;
+      if (getNetworkEnsSupport(network)) {
+        const provider = global.ethereumProvider;
+        this.ens = new ENS({ provider, network });
+        this.checkName = debounce(this.lookupEnsName, 200);
+        if (!newProvidedValue) {
+          newValue = input;
+        }
+      } else {
+        // ens is null on mount on a network that does not have ens support
+        // this is intended to prevent accidental lookup of domains across
+        // networks
+        this.ens = null;
+        this.checkName = null;
       }
     }
 


### PR DESCRIPTION
Fixes: when switching networks the chainId is temporarily undefined, resulting in trying to construct a new instance of ENS without a network. This fix will prevent constructing ENS when the network isn't supported yet for ENS lookup. It will set this.ens to null when switching to an unsupported network. 

Fixes #10559