### PR TITLE
Update Version v9.1.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Current Develop Branch
 
 ## 9.1.1 Wed Mar 03 2021
+- [#10560](https://github.com/MetaMask/metamask-extension/pull/10560): Fix ENS resolution related crashes when switching networks on send screen
+- [#10561](https://github.com/MetaMask/metamask-extension/pull/10561): Fix crash when speeding up an attempt to cancel a transaction on custom networks
 
 ## 9.1.0 Mon Mar 01 2021
 - [#10265](https://github.com/MetaMask/metamask-extension/pull/10265): Update Japanese translations.


### PR DESCRIPTION
## 9.1.1 Wed Mar 03 2021
- [#10560](https://github.com/MetaMask/metamask-extension/pull/10560): Fix ENS resolution related crashes when switching networks on send screen
- [#10561](https://github.com/MetaMask/metamask-extension/pull/10561): Fix crash when speeding up an attempt to cancel a transaction on custom networks