### PR TITLE
Fix mobile sync filtering of ERC20 tokens

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -26,6 +26,7 @@ import {
 } from '@metamask/controllers';
 import { getBackgroundMetaMetricState } from '../../ui/app/selectors';
 import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
+import { MAINNET_CHAIN_ID } from '../../shared/constants/network';
 import ComposableObservableStore from './lib/ComposableObservableStore';
 import AccountTracker from './lib/account-tracker';
 import createLoggerMiddleware from './lib/createLoggerMiddleware';
@@ -1074,10 +1075,10 @@ export default class MetamaskController extends EventEmitter {
     Object.keys(accountTokens).forEach((address) => {
       const checksummedAddress = ethUtil.toChecksumAddress(address);
       filteredAccountTokens[checksummedAddress] = {};
-      Object.keys(accountTokens[address]).forEach((networkType) => {
-        filteredAccountTokens[checksummedAddress][networkType] =
-          networkType === 'mainnet'
-            ? accountTokens[address][networkType].filter(
+      Object.keys(accountTokens[address]).forEach((chainId) => {
+        filteredAccountTokens[checksummedAddress][chainId] =
+          chainId === MAINNET_CHAIN_ID
+            ? accountTokens[address][chainId].filter(
                 ({ address: tokenAddress }) => {
                   const checksumAddress = ethUtil.toChecksumAddress(
                     tokenAddress,
@@ -1087,7 +1088,7 @@ export default class MetamaskController extends EventEmitter {
                     : true;
                 },
               )
-            : accountTokens[address][networkType];
+            : accountTokens[address][chainId];
       });
     });
 


### PR DESCRIPTION
In #10510 we changed how tokens are stored, keying them by `chainId` rather than network type. However we didn't update our mobile sync function to account for this, which ended up breaking the filtering logic used to prepare the data that is synced.

Specifically, custom tokens added by users are filtered out to just those that are confirmed to be ERC20 tokens in our built-in list of tokens. This filters out unrecognized tokens and NFTs.

The filtering logic has been restored to the pre-#10510 behaviour. The tokens remain keyed by `chainId` though, which is different from pre-v9.1.0