### PR TITLE
Fix 10517 - Prevent tokens without addresses from being added to token list

### DIFF
--- a/app/scripts/migrations/056.js
+++ b/app/scripts/migrations/056.js
@@ -21,32 +21,6 @@ export default {
       );
     }
 
-    if (Array.isArray(PreferencesController.hiddenTokens)) {
-      PreferencesController.hiddenTokens = PreferencesController.hiddenTokens.filter(
-        Boolean,
-      );
-    }
-
-    if (
-      PreferencesController.accountHiddenTokens &&
-      typeof PreferencesController.accountHiddenTokens === 'object'
-    ) {
-      Object.keys(PreferencesController.accountHiddenTokens).forEach(
-        (address) => {
-          const chains = Object.keys(
-            PreferencesController.accountHiddenTokens[address],
-          );
-          chains.forEach((chain) => {
-            PreferencesController.accountHiddenTokens[address][
-              chain
-            ] = PreferencesController.accountHiddenTokens[address][
-              chain
-            ].filter(Boolean);
-          });
-        },
-      );
-    }
-
     if (
       PreferencesController.accountTokens &&
       typeof PreferencesController.accountTokens === 'object'

--- a/app/scripts/migrations/056.js
+++ b/app/scripts/migrations/056.js
@@ -1,0 +1,77 @@
+import { cloneDeep } from 'lodash';
+
+const version = 56;
+
+/**
+ * Remove tokens that don't have an address due to
+ * lack of previous addToken validation.  Also removes
+ * an unwanted, undefined image property
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+
+    const { PreferencesController } = versionedData.data;
+
+    if (Array.isArray(PreferencesController.tokens)) {
+      PreferencesController.tokens = PreferencesController.tokens.filter(
+        ({ address }) => address,
+      );
+    }
+
+    if (Array.isArray(PreferencesController.hiddenTokens)) {
+      PreferencesController.hiddenTokens = PreferencesController.hiddenTokens.filter(
+        Boolean,
+      );
+    }
+
+    if (
+      PreferencesController.accountHiddenTokens &&
+      typeof PreferencesController.accountHiddenTokens === 'object'
+    ) {
+      Object.keys(PreferencesController.accountHiddenTokens).forEach(
+        (address) => {
+          const chains = Object.keys(
+            PreferencesController.accountHiddenTokens[address],
+          );
+          chains.forEach((chain) => {
+            PreferencesController.accountHiddenTokens[address][
+              chain
+            ] = PreferencesController.accountHiddenTokens[address][
+              chain
+            ].filter(Boolean);
+          });
+        },
+      );
+    }
+
+    if (
+      PreferencesController.accountTokens &&
+      typeof PreferencesController.accountTokens === 'object'
+    ) {
+      Object.keys(PreferencesController.accountTokens).forEach((account) => {
+        const chains = Object.keys(
+          PreferencesController.accountTokens[account],
+        );
+        chains.forEach((chain) => {
+          PreferencesController.accountTokens[account][
+            chain
+          ] = PreferencesController.accountTokens[account][chain].filter(
+            ({ address }) => address,
+          );
+        });
+      });
+    }
+
+    if (
+      PreferencesController.assetImages &&
+      'undefined' in PreferencesController.assetImages
+    ) {
+      delete PreferencesController.assetImages.undefined;
+    }
+
+    return versionedData;
+  },
+};

--- a/app/scripts/migrations/056.test.js
+++ b/app/scripts/migrations/056.test.js
@@ -1,0 +1,237 @@
+import assert from 'assert';
+import migration56 from './056';
+
+const BAD_TOKEN_DATA = { symbol: null, decimals: null };
+const TOKEN2 = { symbol: 'TXT', address: '0x11', decimals: 18 };
+const TOKEN3 = { symbol: 'TVT', address: '0x12', decimals: 18 };
+
+describe('migration #56', function () {
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      meta: {
+        version: 55,
+      },
+      data: {
+        PreferencesController: {
+          tokens: [],
+          hiddenTokens: [],
+          accountTokens: {},
+          accountHiddenTokens: {},
+          assetImages: {},
+        },
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+    assert.deepStrictEqual(newStorage.meta, {
+      version: 56,
+    });
+  });
+
+  it(`should filter out tokens without a valid address property`, async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [BAD_TOKEN_DATA, TOKEN2, BAD_TOKEN_DATA, TOKEN3],
+          hiddenTokens: [],
+          accountTokens: {},
+          accountHiddenTokens: {},
+          assetImages: {},
+        },
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+    assert.deepStrictEqual(newStorage.data.PreferencesController.tokens, [
+      TOKEN2,
+      TOKEN3,
+    ]);
+  });
+  it(`should not filter any tokens when all token information is valid`, async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [TOKEN2, TOKEN3],
+          hiddenTokens: [],
+          accountTokens: {},
+          accountHiddenTokens: {},
+          assetImages: {},
+        },
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+    assert.deepStrictEqual(newStorage.data.PreferencesController.tokens, [
+      TOKEN2,
+      TOKEN3,
+    ]);
+  });
+
+  it(`should filter out hiddenTokens without a valid address property`, async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [],
+          hiddenTokens: [undefined, TOKEN2.address, TOKEN3.address],
+          accountTokens: {},
+          accountHiddenTokens: {},
+          assetImages: {},
+        },
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+    assert.deepStrictEqual(newStorage.data.PreferencesController.hiddenTokens, [
+      TOKEN2.address,
+      TOKEN3.address,
+    ]);
+  });
+
+  it(`should filter out accountTokens without a valid address property`, async function () {
+    const originalAccountTokens = {
+      '0x1111111111111111111111111': {
+        '0x1': [
+          {
+            address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+            decimals: 18,
+            symbol: 'LINK',
+          },
+          BAD_TOKEN_DATA,
+        ],
+        '0x3': [],
+        '0x4': [BAD_TOKEN_DATA, BAD_TOKEN_DATA],
+      },
+    };
+
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [],
+          hiddenTokens: [],
+          accountTokens: originalAccountTokens,
+          accountHiddenTokens: {},
+          assetImages: {},
+        },
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+
+    const desiredResult = { ...originalAccountTokens };
+    // The last item in the array was bad and should be removed
+    desiredResult['0x1111111111111111111111111']['0x1'].pop();
+    // All items in 0x4 were bad
+    desiredResult['0x1111111111111111111111111']['0x4'] = [];
+
+    assert.deepStrictEqual(
+      newStorage.data.PreferencesController.accountTokens,
+      desiredResult,
+    );
+  });
+
+  it(`should filter out accountHiddenTokens without a valid address property`, async function () {
+    const originalAccountHiddenTokens = {
+      '0x1111111111111111111111111': {
+        '0x1': [TOKEN2.address, undefined],
+        '0x3': [],
+        '0x4': [undefined],
+      },
+    };
+
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [],
+          hiddenTokens: [],
+          accountTokens: {},
+          accountHiddenTokens: originalAccountHiddenTokens,
+          assetImages: {},
+        },
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+
+    const desiredResult = { ...originalAccountHiddenTokens };
+    // The last item in the array was bad and should be removed
+    desiredResult['0x1111111111111111111111111']['0x1'].pop();
+    // All items in 0x4 were bad
+    desiredResult['0x1111111111111111111111111']['0x4'] = [];
+
+    assert.deepStrictEqual(
+      newStorage.data.PreferencesController.accountHiddenTokens,
+      desiredResult,
+    );
+  });
+
+  it(`should remove a bad assetImages key`, async function () {
+    const desiredAssetImages = {
+      '0x514910771af9ca656af840dff83e8264ecf986ca':
+        'images/contract/chainlink.svg',
+    };
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [],
+          hiddenTokens: [],
+          accountTokens: {},
+          accountHiddenTokens: {},
+          assetImages: { ...desiredAssetImages, undefined: null },
+        },
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+    assert.deepStrictEqual(
+      newStorage.data.PreferencesController.assetImages,
+      desiredAssetImages,
+    );
+  });
+
+  it(`token data with no problems should preserve all data`, async function () {
+    const perfectData = {
+      tokens: [TOKEN2, TOKEN3],
+      hiddenTokens: [TOKEN2.address, TOKEN3.address],
+      accountTokens: {
+        '0x1111111111111111111111111': {
+          '0x1': [],
+          '0x3': [],
+        },
+        '0x1111111111111111111111112': {
+          '0x1': [TOKEN2, TOKEN3],
+          '0x3': [],
+        },
+      },
+      accountHiddenTokens: {
+        '0x1111111111111111111111111': {
+          '0x1': [],
+        },
+        '0x1111111111111111111111112': {},
+        '0x1111111111111111111111113': {
+          '0x1': [TOKEN2.address, TOKEN3.address],
+          '0x38': [],
+        },
+      },
+      assetImages: {
+        '0x514910771af9ca656af840dff83e8264ecf986ca':
+          'images/contract/chainlink.svg',
+      },
+    };
+
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: perfectData,
+      },
+    };
+
+    const newStorage = await migration56.migrate(oldStorage);
+    assert.deepStrictEqual(newStorage.data.PreferencesController, perfectData);
+  });
+});

--- a/app/scripts/migrations/056.test.js
+++ b/app/scripts/migrations/056.test.js
@@ -14,9 +14,7 @@ describe('migration #56', function () {
       data: {
         PreferencesController: {
           tokens: [],
-          hiddenTokens: [],
           accountTokens: {},
-          accountHiddenTokens: {},
           assetImages: {},
         },
       },
@@ -34,9 +32,7 @@ describe('migration #56', function () {
       data: {
         PreferencesController: {
           tokens: [BAD_TOKEN_DATA, TOKEN2, BAD_TOKEN_DATA, TOKEN3],
-          hiddenTokens: [],
           accountTokens: {},
-          accountHiddenTokens: {},
           assetImages: {},
         },
       },
@@ -48,15 +44,14 @@ describe('migration #56', function () {
       TOKEN3,
     ]);
   });
+
   it(`should not filter any tokens when all token information is valid`, async function () {
     const oldStorage = {
       meta: {},
       data: {
         PreferencesController: {
           tokens: [TOKEN2, TOKEN3],
-          hiddenTokens: [],
           accountTokens: {},
-          accountHiddenTokens: {},
           assetImages: {},
         },
       },
@@ -69,38 +64,15 @@ describe('migration #56', function () {
     ]);
   });
 
-  it(`should filter out hiddenTokens without a valid address property`, async function () {
-    const oldStorage = {
-      meta: {},
-      data: {
-        PreferencesController: {
-          tokens: [],
-          hiddenTokens: [undefined, TOKEN2.address, TOKEN3.address],
-          accountTokens: {},
-          accountHiddenTokens: {},
-          assetImages: {},
-        },
-      },
-    };
-
-    const newStorage = await migration56.migrate(oldStorage);
-    assert.deepStrictEqual(newStorage.data.PreferencesController.hiddenTokens, [
-      TOKEN2.address,
-      TOKEN3.address,
-    ]);
-  });
-
   it(`should filter out accountTokens without a valid address property`, async function () {
     const originalAccountTokens = {
       '0x1111111111111111111111111': {
-        '0x1': [
-          {
-            address: '0x514910771af9ca656af840dff83e8264ecf986ca',
-            decimals: 18,
-            symbol: 'LINK',
-          },
-          BAD_TOKEN_DATA,
-        ],
+        '0x1': [TOKEN2, TOKEN3, BAD_TOKEN_DATA],
+        '0x3': [],
+        '0x4': [BAD_TOKEN_DATA, BAD_TOKEN_DATA],
+      },
+      '0x1111111111111111111111112': {
+        '0x1': [TOKEN2],
         '0x3': [],
         '0x4': [BAD_TOKEN_DATA, BAD_TOKEN_DATA],
       },
@@ -111,9 +83,7 @@ describe('migration #56', function () {
       data: {
         PreferencesController: {
           tokens: [],
-          hiddenTokens: [],
           accountTokens: originalAccountTokens,
-          accountHiddenTokens: {},
           assetImages: {},
         },
       },
@@ -126,45 +96,10 @@ describe('migration #56', function () {
     desiredResult['0x1111111111111111111111111']['0x1'].pop();
     // All items in 0x4 were bad
     desiredResult['0x1111111111111111111111111']['0x4'] = [];
+    desiredResult['0x1111111111111111111111112']['0x4'] = [];
 
     assert.deepStrictEqual(
       newStorage.data.PreferencesController.accountTokens,
-      desiredResult,
-    );
-  });
-
-  it(`should filter out accountHiddenTokens without a valid address property`, async function () {
-    const originalAccountHiddenTokens = {
-      '0x1111111111111111111111111': {
-        '0x1': [TOKEN2.address, undefined],
-        '0x3': [],
-        '0x4': [undefined],
-      },
-    };
-
-    const oldStorage = {
-      meta: {},
-      data: {
-        PreferencesController: {
-          tokens: [],
-          hiddenTokens: [],
-          accountTokens: {},
-          accountHiddenTokens: originalAccountHiddenTokens,
-          assetImages: {},
-        },
-      },
-    };
-
-    const newStorage = await migration56.migrate(oldStorage);
-
-    const desiredResult = { ...originalAccountHiddenTokens };
-    // The last item in the array was bad and should be removed
-    desiredResult['0x1111111111111111111111111']['0x1'].pop();
-    // All items in 0x4 were bad
-    desiredResult['0x1111111111111111111111111']['0x4'] = [];
-
-    assert.deepStrictEqual(
-      newStorage.data.PreferencesController.accountHiddenTokens,
       desiredResult,
     );
   });
@@ -179,9 +114,7 @@ describe('migration #56', function () {
       data: {
         PreferencesController: {
           tokens: [],
-          hiddenTokens: [],
           accountTokens: {},
-          accountHiddenTokens: {},
           assetImages: { ...desiredAssetImages, undefined: null },
         },
       },
@@ -197,30 +130,15 @@ describe('migration #56', function () {
   it(`token data with no problems should preserve all data`, async function () {
     const perfectData = {
       tokens: [TOKEN2, TOKEN3],
-      hiddenTokens: [TOKEN2.address, TOKEN3.address],
       accountTokens: {
         '0x1111111111111111111111111': {
           '0x1': [],
-          '0x3': [],
+          '0x3': [TOKEN2],
         },
         '0x1111111111111111111111112': {
           '0x1': [TOKEN2, TOKEN3],
           '0x3': [],
         },
-      },
-      accountHiddenTokens: {
-        '0x1111111111111111111111111': {
-          '0x1': [],
-        },
-        '0x1111111111111111111111112': {},
-        '0x1111111111111111111111113': {
-          '0x1': [TOKEN2.address, TOKEN3.address],
-          '0x38': [],
-        },
-      },
-      assetImages: {
-        '0x514910771af9ca656af840dff83e8264ecf986ca':
-          'images/contract/chainlink.svg',
       },
     };
 

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -60,6 +60,7 @@ const migrations = [
   require('./053').default,
   require('./054').default,
   require('./055').default,
+  require('./056').default,
 ];
 
 export default migrations;

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -425,6 +425,7 @@ export const fetchQuotesAndSetQuoteState = (
 
     let destinationTokenAddedForSwap = false;
     if (
+      toTokenAddress &&
       toTokenSymbol !== swapsDefaultToken.symbol &&
       !contractExchangeRates[toTokenAddress]
     ) {
@@ -440,6 +441,7 @@ export const fetchQuotesAndSetQuoteState = (
       );
     }
     if (
+      fromTokenAddress &&
       fromTokenSymbol !== swapsDefaultToken.symbol &&
       !contractExchangeRates[fromTokenAddress] &&
       fromTokenBalance &&

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -1389,7 +1389,12 @@ export function addToken(
   dontShowLoadingIndicator,
 ) {
   return (dispatch) => {
-    !dontShowLoadingIndicator && dispatch(showLoadingIndication());
+    if (!address) {
+      throw new Error('MetaMask - Cannot add token without address');
+    }
+    if (!dontShowLoadingIndicator) {
+      dispatch(showLoadingIndication());
+    }
     return new Promise((resolve, reject) => {
       background.addToken(address, symbol, decimals, image, (err, tokens) => {
         dispatch(hideLoadingIndication());

--- a/ui/app/store/actions.test.js
+++ b/ui/app/store/actions.test.js
@@ -1177,7 +1177,13 @@ describe('Actions', function () {
 
       actions._setBackgroundConnection(background.getApi());
 
-      await store.dispatch(actions.addToken());
+      await store.dispatch(
+        actions.addToken({
+          address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+          symbol: 'LINK',
+          decimals: 18,
+        }),
+      );
       assert(addTokenStub.calledOnce);
     });
 
@@ -1209,7 +1215,13 @@ describe('Actions', function () {
         },
       ];
 
-      await store.dispatch(actions.addToken());
+      await store.dispatch(
+        actions.addToken({
+          address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+          symbol: 'LINK',
+          decimals: 18,
+        }),
+      );
 
       assert.deepStrictEqual(store.getActions(), expectedActions);
     });
@@ -1234,7 +1246,13 @@ describe('Actions', function () {
       ];
 
       try {
-        await store.dispatch(actions.addToken());
+        await store.dispatch(
+          actions.addToken({
+            address: '_',
+            symbol: '',
+            decimals: 0,
+          }),
+        );
         assert.fail('Should have thrown error');
       } catch (_) {
         assert.deepEqual(store.getActions(), expectedActions);


### PR DESCRIPTION
Fixes: #10517

Explanation:  

ToDo:
* [x] Add migration
* [x] Throw error in `addToken` to prevent this from happening again
* [x] Explore `ui/app/ducks/swaps/swaps.js` to see if this is truly the place it's happening, and if `selectedFromToken` and `selectedToToken` are the true culprits.