### PR TITLE
Fixing activity title text truncation

### DIFF
--- a/ui/app/components/ui/list-item/list-item.component.js
+++ b/ui/app/components/ui/list-item/list-item.component.js
@@ -17,7 +17,7 @@ export default function ListItem({
   const primaryClassName = classnames('list-item', className);
 
   return (
-    <div
+    <button
       className={primaryClassName}
       onClick={onClick}
       data-testid={dataTestId}
@@ -27,9 +27,7 @@ export default function ListItem({
         {React.isValidElement(title) ? (
           title
         ) : (
-          <button onClick={onClick}>
-            <h2 className="list-item__title">{title}</h2>
-          </button>
+          <h2 className="list-item__title">{title}</h2>
         )}
         {titleIcon && (
           <div className="list-item__heading-wrap">{titleIcon}</div>
@@ -41,7 +39,7 @@ export default function ListItem({
       {rightContent && (
         <div className="list-item__right-content">{rightContent}</div>
       )}
-    </div>
+    </button>
   );
 }
 


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#9997

<img width="356" alt="Screen Shot 2021-03-07 at 11 31 21 PM" src="https://user-images.githubusercontent.com/8732757/110284751-75558a80-7f9f-11eb-98f8-8c2415a5c5eb.png">

Manual testing steps:  
  - Access an account with activity
  - Via another transaction (or the inspector tool), create a long activity title
  - Ensure that the title text truncates appropriately
  - Edit balance amount title so it truncates
  - Ensure that there is no overlap when both titles are truncated