### PR TITLE
add fsevents entry from allow-scripts for mac os x

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,7 +317,8 @@
       "gc-stats": false,
       "github:assemblyscript/assemblyscript": false,
       "tiny-secp256k1": false,
-      "@lavamoat/preinstall-always-fail": false
+      "@lavamoat/preinstall-always-fail": false,
+      "fsevents": false
     }
   }
 }


### PR DESCRIPTION
Adds the `fsevents` entry into `lavamoat.allowScripts` which is required for a mac, but should not impact other OSes. 