### PR TITLE
Avoid rendering Approve screen before token data has been retrieved.

### DIFF
--- a/ui/app/pages/confirm-approve/confirm-approve.js
+++ b/ui/app/pages/confirm-approve/confirm-approve.js
@@ -19,6 +19,7 @@ import {
   getNativeCurrency,
 } from '../../selectors';
 import { currentNetworkTxListSelector } from '../../selectors/transactions';
+import Loading from '../../components/ui/loading-screen';
 import { getCustomTxParamsData } from './confirm-approve.util';
 import ConfirmApproveContent from './confirm-approve-content';
 
@@ -87,7 +88,7 @@ export default function ConfirmApprove() {
     ? getCustomTxParamsData(data, { customPermissionAmount, decimals })
     : null;
 
-  return (
+  return tokenSymbol ? (
     <ConfirmTransactionBase
       toAddress={toAddress}
       identiconAddress={tokenAddress}
@@ -141,5 +142,7 @@ export default function ConfirmApprove() {
       hideSenderToRecipient
       customTxParamsData={customData}
     />
+  ) : (
+    <Loading />
   );
 }


### PR DESCRIPTION

Fixes: #10088 

Explanation:  

**Issue:** The `approve screen` gets rendered before the token Data was retrieved, resulting in errors in the console and white screen flashing before the original page renders.
**Fix:** The fix is to check for the `tokenSymbol` value before rendering the `<ConfirmTransactionBase/>` from `confirm-approve.container.js`, which in turn calls `<ConfirmApproveContent/>`. The check is using `tokenSymbol` as it is the only token data that is being used in the first rendering of `<ConfirmApproveContent/>`

Manual testing steps:  
-  Go to [test-dapp](https://metamask.github.io/test-dapp/)
-  Click on `Create token`, and approve the deploy transaction (ideally on a testnet)
-  Wait for the transaction to be confirmed
-  Click `Approve tokens`
-  The notification window should pop up, the Approve confirmation screen renders with proper values on the first call and there is no error in the console.