### PR TITLE
Converting ListItem container from button to div

### DIFF
--- a/ui/app/components/ui/list-item/list-item.component.js
+++ b/ui/app/components/ui/list-item/list-item.component.js
@@ -17,10 +17,17 @@ export default function ListItem({
   const primaryClassName = classnames('list-item', className);
 
   return (
-    <button
+    <div
       className={primaryClassName}
       onClick={onClick}
       data-testid={dataTestId}
+      role="button"
+      tabIndex={0}
+      onKeyPress={(event) => {
+        if (event.key === 'Enter') {
+          onClick();
+        }
+      }}
     >
       {icon && <div className="list-item__icon">{icon}</div>}
       <div className="list-item__heading">
@@ -39,7 +46,7 @@ export default function ListItem({
       {rightContent && (
         <div className="list-item__right-content">{rightContent}</div>
       )}
-    </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#10610

Explanation:  Converts the outer container of the ListItem component from `button` -> `div`. This prevents nested buttons, the div has also been made keyboard accessible.

Manual testing steps:  
  - Open MetaMask, navigate to activity view
  - Ensure no related react errors in the page console
  - Ensure that activity entries can be tabbed through and can interact with the `Enter` key