### PR TITLE
Standard reference to ETH_SWAPS_TOKEN_ADDRESS via ETH_SWAPS_TOKEN_OBJECT.address

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -8,7 +8,7 @@ import { calcTokenAmount } from '../../../ui/app/helpers/utils/token-util';
 import { calcGasTotal } from '../../../ui/app/pages/send/send.utils';
 import { conversionUtil } from '../../../ui/app/helpers/utils/conversion-util';
 import {
-  ETH_SWAPS_TOKEN_ADDRESS,
+  ETH_SWAPS_TOKEN_OBJECT,
   DEFAULT_ERC20_APPROVE_GAS,
   QUOTES_EXPIRED_ERROR,
   QUOTES_NOT_AVAILABLE_ERROR,
@@ -191,7 +191,7 @@ export default class SwapsController {
 
     let approvalRequired = false;
     if (
-      fetchParams.sourceToken !== ETH_SWAPS_TOKEN_ADDRESS &&
+      fetchParams.sourceToken !== ETH_SWAPS_TOKEN_OBJECT.address &&
       Object.values(newQuotes).length
     ) {
       const allowance = await this._getERC20Allowance(
@@ -552,7 +552,7 @@ export default class SwapsController {
       // If the swap is from ETH, subtract the sourceAmount from the total cost.
       // Otherwise, the total fee is simply trade.value plus gas fees.
       const ethFee =
-        sourceToken === ETH_SWAPS_TOKEN_ADDRESS
+        sourceToken === ETH_SWAPS_TOKEN_OBJECT.address
           ? conversionUtil(
               totalWeiCost.minus(sourceAmount, 10), // sourceAmount is in wei
               {
@@ -589,7 +589,9 @@ export default class SwapsController {
       );
 
       const conversionRateForCalculations =
-        destinationToken === ETH_SWAPS_TOKEN_ADDRESS ? 1 : tokenConversionRate;
+        destinationToken === ETH_SWAPS_TOKEN_OBJECT.address
+          ? 1
+          : tokenConversionRate;
 
       const overallValueOfQuoteForSorting =
         conversionRateForCalculations === undefined
@@ -616,7 +618,7 @@ export default class SwapsController {
     });
 
     const isBest =
-      newQuotes[topAggId].destinationToken === ETH_SWAPS_TOKEN_ADDRESS ||
+      newQuotes[topAggId].destinationToken === ETH_SWAPS_TOKEN_OBJECT.address ||
       Boolean(tokenConversionRates[newQuotes[topAggId]?.destinationToken]);
 
     let savings = null;

--- a/test/unit/app/controllers/swaps-test.js
+++ b/test/unit/app/controllers/swaps-test.js
@@ -9,7 +9,7 @@ import {
   ROPSTEN_NETWORK_ID,
   MAINNET_NETWORK_ID,
 } from '../../../../shared/constants/network';
-import { ETH_SWAPS_TOKEN_ADDRESS } from '../../../../ui/app/helpers/constants/swaps';
+import { ETH_SWAPS_TOKEN_OBJECT } from '../../../../ui/app/helpers/constants/swaps';
 import { createTestProviderTools } from '../../../stub/provider';
 import SwapsController, {
   utils,
@@ -471,7 +471,7 @@ describe('SwapsController', function () {
           getTopQuoteAndSavingsMockQuotes(),
           (quote) => ({
             ...quote,
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
           }),
@@ -480,42 +480,42 @@ describe('SwapsController', function () {
         const expectedResultQuotes = {
           [TEST_AGG_ID_1]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_1],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '2.0195',
           },
           [TEST_AGG_ID_2]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_2],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.9996',
           },
           [TEST_AGG_ID_3]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_3],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.9698',
           },
           [TEST_AGG_ID_4]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_4],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.94',
           },
           [TEST_AGG_ID_5]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_5],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.9102',
           },
           [TEST_AGG_ID_6]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_6],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.8705',
@@ -535,7 +535,7 @@ describe('SwapsController', function () {
           getTopQuoteAndSavingsMockQuotes(),
           (quote) => ({
             ...quote,
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
           }),
@@ -546,7 +546,7 @@ describe('SwapsController', function () {
         const expectedResultQuotes = {
           [TEST_AGG_ID_1]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_1],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8b553ece48ec0000' },
             overallValueOfQuote: '1.9795',
@@ -554,7 +554,7 @@ describe('SwapsController', function () {
           },
           [TEST_AGG_ID_2]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_2],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.9996',
@@ -569,28 +569,28 @@ describe('SwapsController', function () {
           },
           [TEST_AGG_ID_3]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_3],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.9698',
           },
           [TEST_AGG_ID_4]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_4],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.94',
           },
           [TEST_AGG_ID_5]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_5],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.9102',
           },
           [TEST_AGG_ID_6]: {
             ...baseExpectedResultQuotes[TEST_AGG_ID_6],
-            sourceToken: ETH_SWAPS_TOKEN_ADDRESS,
+            sourceToken: ETH_SWAPS_TOKEN_OBJECT.address,
             destinationToken: '0x1111111111111111111111111111111111111111',
             trade: { value: '0x8ac7230489e80000' },
             overallValueOfQuote: '1.8705',

--- a/ui/app/helpers/constants/swaps.js
+++ b/ui/app/helpers/constants/swaps.js
@@ -1,6 +1,5 @@
 // An address that the metaswap-api recognizes as ETH, in place of the token address that ERC-20 tokens have
-export const ETH_SWAPS_TOKEN_ADDRESS =
-  '0x0000000000000000000000000000000000000000';
+const ETH_SWAPS_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 export const ETH_SWAPS_TOKEN_OBJECT = {
   symbol: 'ETH',

--- a/ui/app/hooks/useSwappedTokenValue.js
+++ b/ui/app/hooks/useSwappedTokenValue.js
@@ -1,5 +1,5 @@
 import { TRANSACTION_CATEGORIES } from '../../../shared/constants/transaction';
-import { ETH_SWAPS_TOKEN_ADDRESS } from '../helpers/constants/swaps';
+import { ETH_SWAPS_TOKEN_OBJECT } from '../helpers/constants/swaps';
 import { getSwapsTokensReceivedFromTxMeta } from '../pages/swaps/swaps.util';
 import { useTokenFiatAmount } from './useTokenFiatAmount';
 
@@ -30,7 +30,7 @@ export function useSwappedTokenValue(transactionGroup, currentAsset) {
 
   const isViewingReceivedTokenFromSwap =
     currentAsset?.symbol === primaryTransaction.destinationTokenSymbol ||
-    (currentAsset.address === ETH_SWAPS_TOKEN_ADDRESS &&
+    (currentAsset.address === ETH_SWAPS_TOKEN_OBJECT.address &&
       primaryTransaction.destinationTokenSymbol === 'ETH');
 
   const swapTokenValue =


### PR DESCRIPTION
Currently, there are two ways to check whether an swaps token address is the ETH address. In some places we directly check against the `ETH_SWAPS_TOKEN_ADDRESS`, and in other places we check against `ETH_SWAPS_TOKEN_OBJECT.address`. This PR standardizes this to check against `ETH_SWAPS_TOKEN_OBJECT.address` in all places.