### PR TITLE
Add trezor HD path for ledger wallets

### DIFF
--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -15,9 +15,11 @@ const U2F_ERROR = 'U2F';
 
 const LEDGER_LIVE_PATH = `m/44'/60'/0'/0/0`;
 const MEW_PATH = `m/44'/60'/0'`;
+const BIP44_PATH = `m/44'/60'/0'/0`;
 const HD_PATHS = [
   { name: 'Ledger Live', value: LEDGER_LIVE_PATH },
   { name: 'Legacy (MEW / MyCrypto)', value: MEW_PATH },
+  { name: `BIP44 Standard (e.g. Trezor)`, value: BIP44_PATH },
 ];
 
 class ConnectHardwareForm extends Component {


### PR DESCRIPTION
Fixes: #10531

Explanation:

Allows Trezor users to access their accounts from a Ledger

Manual testing steps:

    Load Trezor from mnemonic.
    Load Ledger from mnemonic.
    Connect to Trezor in Metamask and note the first 10 accounts.
    Connect to Ledger in Metamask using Trezor from dropdown for HD path.

User should be able to access all accounts they had on Trezor from their ledger.

_This is a re-post of PR #10532 by @bgits_