### PR TITLE
Removing double click bug from delete custom network modal

### DIFF
--- a/ui/app/components/app/dropdowns/network-dropdown.js
+++ b/ui/app/components/app/dropdowns/network-dropdown.js
@@ -25,6 +25,7 @@ const notToggleElementClassnames = [
   'network-indicator',
   'network-caret',
   'network-component',
+  'modal-container__footer-button',
 ];
 
 const DROP_DOWN_MENU_ITEM_STYLE = {


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#10626

Manual testing steps:  
  - Add a custom network
  - Open menu dropdown, click 'x' next to that custom network
  - Confirm that clicking "Cancel" in the modal dismisses the modal
  - Open menu dropdown again, clicking 'x' next to the custom network
  - Confirm that clicking "Delete" removes the custom network from the dropdown