### PR TITLE
Hide zero balance tokens at useTokenTracker layer

### DIFF
--- a/ui/app/components/app/token-list/token-list.js
+++ b/ui/app/components/app/token-list/token-list.js
@@ -10,10 +10,7 @@ import {
   getAssetImages,
   getShouldHideZeroBalanceTokens,
 } from '../../../selectors';
-import {
-  getTokens,
-  getTokensWithBalance,
-} from '../../../ducks/metamask/metamask';
+import { getTokens } from '../../../ducks/metamask/metamask';
 
 export default function TokenList({ onTokenClick }) {
   const t = useI18nContext();
@@ -25,13 +22,11 @@ export default function TokenList({ onTokenClick }) {
   // from the background so it has a new reference with each background update,
   // even if the tokens haven't changed
   const tokens = useSelector(getTokens, isEqual);
-  const tokensWithBalance = useSelector(getTokensWithBalance, isEqual);
-
   const { loading, tokensWithBalances } = useTokenTracker(
-    shouldHideZeroBalanceTokens ? tokensWithBalance : tokens,
+    tokens,
     true,
+    shouldHideZeroBalanceTokens,
   );
-
   if (loading) {
     return (
       <div

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -386,6 +386,3 @@ export const getUnconnectedAccountAlertShown = (state) =>
   state.metamask.unconnectedAccountAlertShownOrigins;
 
 export const getTokens = (state) => state.metamask.tokens;
-
-export const getTokensWithBalance = (state) =>
-  state.metamask.tokens.filter((token) => Number(token.balance) > 0);

--- a/ui/app/hooks/useTokenTracker.js
+++ b/ui/app/hooks/useTokenTracker.js
@@ -4,21 +4,30 @@ import { useSelector } from 'react-redux';
 import { getCurrentNetwork, getSelectedAddress } from '../selectors';
 import { useEqualityCheck } from './useEqualityCheck';
 
-export function useTokenTracker(tokens, includeFailedTokens = false) {
+export function useTokenTracker(
+  tokens,
+  includeFailedTokens = false,
+  hideZeroBalanceTokens = false,
+) {
   const network = useSelector(getCurrentNetwork);
   const userAddress = useSelector(getSelectedAddress);
-
   const [loading, setLoading] = useState(() => tokens?.length >= 0);
   const [tokensWithBalances, setTokensWithBalances] = useState([]);
   const [error, setError] = useState(null);
   const tokenTracker = useRef(null);
   const memoizedTokens = useEqualityCheck(tokens);
 
-  const updateBalances = useCallback((tokenWithBalances) => {
-    setTokensWithBalances(tokenWithBalances);
-    setLoading(false);
-    setError(null);
-  }, []);
+  const updateBalances = useCallback(
+    (tokenWithBalances) => {
+      const matchingTokens = hideZeroBalanceTokens
+        ? tokenWithBalances.filter((token) => Number(token.balance) > 0)
+        : tokenWithBalances;
+      setTokensWithBalances(matchingTokens);
+      setLoading(false);
+      setError(null);
+    },
+    [hideZeroBalanceTokens],
+  );
 
   const showError = useCallback((err) => {
     setError(err);


### PR DESCRIPTION
Fixes:  Issue with current release candidate where too many tokens were being hidden when zero balance preference is on

Explanation:  The data structure I used originally was incomplete of balance at the time it was used.  This implements balance checking every time we get an update from the TokenTracker


https://user-images.githubusercontent.com/46655/110823479-c394b300-8257-11eb-9234-1103428372ac.mp4

