### PR TITLE
Setting balance to 0x0 when the original value is undefined

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -286,7 +286,8 @@ export default class AccountTracker {
         return;
       }
       addresses.forEach((address, index) => {
-        const balance = bnToHex(result[index]);
+        const balance =
+          result[index] === undefined ? '0x0' : bnToHex(result[index]);
         accounts[address] = { address, balance };
       });
       this.store.updateState({ accounts });

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -286,8 +286,7 @@ export default class AccountTracker {
         return;
       }
       addresses.forEach((address, index) => {
-        const balance =
-          result[index] === undefined ? '0x0' : bnToHex(result[index]);
+        const balance = result[index] ? bnToHex(result[index]) : '0x0';
         accounts[address] = { address, balance };
       });
       this.store.updateState({ accounts });


### PR DESCRIPTION
Fixes: #10553 

Explanation:  

Issue: `TypeError: Cannot read property 'toString' of undefined` error is thrown if the balance value returned for any of the accounts is undefined. 
Sentry logged around 294K events from `https://costone.flare.network/ext/bc/C/rpc` network alone for the past 4 months(seems to start by the end of November 2020) and 2.4 K from Infura from starting around the same time.

Fix: The balance value for each account is checked for undefined, if true it will be set to `0x0` otherwise it will be passed to bnToHex() to convert the BigNumber to Hex.
