### PR TITLE
refactor incoming tx controller

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -70,21 +70,7 @@ if (inTest || process.env.METAMASK_DEBUG) {
 initialize().catch(log.error);
 
 /**
- * An object representing a transaction, in whatever state it is in.
- * @typedef TransactionMeta
- *
- * @property {number} id - An internally unique tx identifier.
- * @property {number} time - Time the tx was first suggested, in unix epoch time (ms).
- * @property {string} status - The current transaction status (unapproved, signed, submitted, dropped, failed, rejected), as defined in `tx-state-manager.js`.
- * @property {string} metamaskNetworkId - The transaction's network ID, used for EIP-155 compliance.
- * @property {boolean} loadingDefaults - TODO: Document
- * @property {Object} txParams - The tx params as passed to the network provider.
- * @property {Object[]} history - A history of mutations to this TransactionMeta object.
- * @property {string} origin - A string representing the interface that suggested the transaction.
- * @property {Object} nonceDetails - A metadata object containing information used to derive the suggested nonce, useful for debugging nonce issues.
- * @property {string} rawTx - A hex string of the final signed transaction, ready to submit to the network.
- * @property {string} hash - A hex string of the transaction hash, used to identify the transaction on the network.
- * @property {number} submittedTime - The time the transaction was submitted to the network, in Unix epoch time (ms).
+ * @typedef {import('../../shared/constants/transaction').TransactionMeta} TransactionMeta
  */
 
 /**

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -31,7 +31,7 @@ export const SENTRY_STATE = {
     featureFlags: true,
     firstTimeFlowType: true,
     forgottenPassword: true,
-    incomingTxLastFetchedBlocksByNetwork: true,
+    incomingTxLastFetchedBlockByChainId: true,
     ipfsGateway: true,
     isAccountMenuOpen: true,
     isInitialized: true,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -189,7 +189,13 @@ export default class MetamaskController extends EventEmitter {
 
     this.incomingTransactionsController = new IncomingTransactionsController({
       blockTracker: this.blockTracker,
-      networkController: this.networkController,
+      onNetworkDidChange: this.networkController.on.bind(
+        this.networkController,
+        NETWORK_EVENTS.NETWORK_DID_CHANGE,
+      ),
+      getCurrentChainId: this.networkController.getCurrentChainId.bind(
+        this.networkController,
+      ),
       preferencesController: this.preferencesController,
       initState: initState.IncomingTransactionsController,
     });

--- a/app/scripts/migrations/055.js
+++ b/app/scripts/migrations/055.js
@@ -1,0 +1,32 @@
+import { cloneDeep, mapKeys } from 'lodash';
+import { NETWORK_TYPE_TO_ID_MAP } from '../../../shared/constants/network';
+
+const version = 55;
+
+/**
+ * replace 'incomingTxLastFetchedBlocksByNetwork' with 'incomingTxLastFetchedBlockByChainId'
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    versionedData.data = transformState(state);
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  if (
+    state?.IncomingTransactionsController?.incomingTxLastFetchedBlocksByNetwork
+  ) {
+    state.IncomingTransactionsController.incomingTxLastFetchedBlockByChainId = mapKeys(
+      state.IncomingTransactionsController.incomingTxLastFetchedBlocksByNetwork,
+      (_, key) => NETWORK_TYPE_TO_ID_MAP[key].chainId,
+    );
+    delete state.IncomingTransactionsController
+      .incomingTxLastFetchedBlocksByNetwork;
+  }
+  return state;
+}

--- a/app/scripts/migrations/055.test.js
+++ b/app/scripts/migrations/055.test.js
@@ -1,0 +1,96 @@
+import { strict as assert } from 'assert';
+import {
+  GOERLI,
+  GOERLI_CHAIN_ID,
+  KOVAN,
+  KOVAN_CHAIN_ID,
+  MAINNET,
+  MAINNET_CHAIN_ID,
+  RINKEBY,
+  RINKEBY_CHAIN_ID,
+  ROPSTEN,
+  ROPSTEN_CHAIN_ID,
+} from '../../../shared/constants/network';
+import migration55 from './055';
+
+describe('migration #55', function () {
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      meta: {
+        version: 54,
+      },
+      data: {},
+    };
+
+    const newStorage = await migration55.migrate(oldStorage);
+    assert.deepEqual(newStorage.meta, {
+      version: 55,
+    });
+  });
+
+  it('should replace incomingTxLastFetchedBlocksByNetwork with incomingTxLastFetchedBlockByChainId, and carry over old values', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        IncomingTransactionsController: {
+          incomingTransactions: {
+            test: {
+              transactionCategory: 'incoming',
+              txParams: {
+                foo: 'bar',
+              },
+            },
+          },
+          incomingTxLastFetchedBlocksByNetwork: {
+            [MAINNET]: 1,
+            [ROPSTEN]: 2,
+            [RINKEBY]: 3,
+            [GOERLI]: 4,
+            [KOVAN]: 5,
+          },
+        },
+        foo: 'bar',
+      },
+    };
+
+    const newStorage = await migration55.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      IncomingTransactionsController: {
+        incomingTransactions:
+          oldStorage.data.IncomingTransactionsController.incomingTransactions,
+        incomingTxLastFetchedBlockByChainId: {
+          [MAINNET_CHAIN_ID]: 1,
+          [ROPSTEN_CHAIN_ID]: 2,
+          [RINKEBY_CHAIN_ID]: 3,
+          [GOERLI_CHAIN_ID]: 4,
+          [KOVAN_CHAIN_ID]: 5,
+        },
+      },
+      foo: 'bar',
+    });
+  });
+
+  it('should do nothing if incomingTxLastFetchedBlocksByNetwork key is not populated', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        IncomingTransactionsController: {
+          foo: 'baz',
+        },
+        foo: 'bar',
+      },
+    };
+
+    const newStorage = await migration55.migrate(oldStorage);
+    assert.deepEqual(oldStorage.data, newStorage.data);
+  });
+  it('should do nothing if state is empty', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {},
+    };
+
+    const newStorage = await migration55.migrate(oldStorage);
+    assert.deepEqual(oldStorage.data, newStorage.data);
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -59,6 +59,7 @@ const migrations = [
   require('./052').default,
   require('./053').default,
   require('./054').default,
+  require('./055').default,
 ];
 
 export default migrations;

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -31,6 +31,12 @@
  */
 
 /**
+ * This type will work anywhere you expect a string that can be one of the
+ * above transaction types.
+ * @typedef {TransactionTypes[keyof TransactionTypes]} TransactionTypeString
+ */
+
+/**
  * @type {TransactionTypes}
  */
 export const TRANSACTION_TYPES = {
@@ -63,6 +69,12 @@ export const TRANSACTION_TYPES = {
  * @property {'dropped'} DROPPED - The transaction was dropped due to a tx with same
  *  nonce being accepted
  * @property {'confirmed'} CONFIRMED - The transaction was confirmed by the network
+ */
+
+/**
+ * This type will work anywhere you expect a string that can be one of the
+ * above transaction statuses.
+ * @typedef {TransactionStatuses[keyof TransactionStatuses]} TransactionStatusString
  */
 
 /**
@@ -132,3 +144,45 @@ export const TRANSACTION_GROUP_CATEGORIES = {
   SIGNATURE_REQUEST: 'signature-request',
   SWAP: 'swap',
 };
+
+/**
+ * @typedef {Object} TxParams
+ * @property {string} from - The address the transaction is sent from
+ * @property {string} to - The address the transaction is sent to
+ * @property {string} value - The amount of wei, in hexadecimal, to send
+ * @property {number} nonce - The transaction count for the current account/network
+ * @property {string} gasPrice - The amount of gwei, in hexadecimal, per unit of gas
+ * @property {string} gas - The max amount of gwei, in hexadecimal, the user is willing to pay
+ * @property {string} [data] - Hexadecimal encoded string representing calls to the EVM's ABI
+ */
+/**
+ * An object representing a transaction, in whatever state it is in.
+ * @typedef {Object} TransactionMeta
+ *
+ * @property {string} [blockNumber] - The block number this transaction was
+ *  included in. Currently only present on incoming transactions!
+ * @property {number} id - An internally unique tx identifier.
+ * @property {number} time - Time the transaction was first suggested, in unix
+ *  epoch time (ms).
+ * @property {TransactionTypeString} type - The type of transaction this txMeta
+ *  represents.
+ * @property {TransactionStatusString} status - The current status of the
+ *  transaction.
+ * @property {string} metamaskNetworkId - The transaction's network ID, used
+ *  for EIP-155 compliance.
+ * @property {boolean} loadingDefaults - TODO: Document
+ * @property {TxParams} txParams - The transaction params as passed to the
+ *  network provider.
+ * @property {Object[]} history - A history of mutations to this
+ *  TransactionMeta object.
+ * @property {string} origin - A string representing the interface that
+ *  suggested the transaction.
+ * @property {Object} nonceDetails - A metadata object containing information
+ *  used to derive the suggested nonce, useful for debugging nonce issues.
+ * @property {string} rawTx - A hex string of the final signed transaction,
+ *  ready to submit to the network.
+ * @property {string} hash - A hex string of the transaction hash, used to
+ *  identify the transaction on the network.
+ * @property {number} submittedTime - The time the transaction was submitted to
+ *  the network, in Unix epoch time (ms).
+ */


### PR DESCRIPTION
### Rationale
As a means of more deeply understanding what the incoming transaction controller does I set out to document its methods with types and descriptions. In so doing I found a number of cases where I felt like the readability of the controller could be improved. This **should** be a non-functional refactor. Please take care in reading the changes to the *test* file to see if I have altered the desired outcomes in any functional way.

~This will require a migration as I renamed `incomingTxLastFetchedBlocksByNetwork` to `incomingTxLastFetchedBlockByChainId`. Although the value is an object storing values that are blocks, each `chainId` only has one block. Although I've changed it from `network` to `chainId`, this shouldn't result in functional changes except where user's are using custom networks with `chainIds` that match default chains.~

Migration now included, and the case above doesn't exist because we were mapping chainId to provider type before, so custom network with chainId `0x1` would have had its last fetched block stored in the `mainnet` key