### PR TITLE
no more node:console

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["node:console"]
+}


### PR DESCRIPTION
Make vscode stop auto importing `node:console` when autocompleting 'console'.