### PR TITLE
Position the 3-dot menu in the same spot on asset screen and home screen

### DIFF
--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -37,7 +37,7 @@
     font-size: $font-size-paragraph;
     color: $Black-100;
     background-color: inherit;
-    padding: 2px 8px;
+    padding: 2px 0 2px 8px;
   }
 
   &__icon {


### PR DESCRIPTION
Last week I implemented a standard height on the home screen header and the asset header.  To further improve uniformity, we should ensure the 3-dot menu doesn't jump.

Before:

https://user-images.githubusercontent.com/46655/111016762-3f385200-8375-11eb-898a-8abf5ea36198.mp4

After:


https://user-images.githubusercontent.com/46655/111016800-668f1f00-8375-11eb-8df9-5aee84388b8f.mp4

