### PR TITLE
Prevent network menu highlighting

### DIFF
--- a/ui/app/components/app/network-display/index.scss
+++ b/ui/app/components/app/network-display/index.scss
@@ -6,6 +6,7 @@
   border-radius: 4px;
   min-height: 25px;
   cursor: pointer;
+  user-select: none;
 
   &--disabled {
     cursor: not-allowed;


### PR DESCRIPTION
Micro-optimization that prevents network dropdown labels from being highlighted when clicked:

<img width="305" alt="NetworkDropdown" src="https://user-images.githubusercontent.com/46655/111017281-0d74ba80-8378-11eb-9297-222029c67271.png">
