### PR TITLE
Ensure swaps detail height doesn't create jump in vertical height

### DIFF
--- a/ui/app/pages/swaps/build-quote/index.scss
+++ b/ui/app/pages/swaps/build-quote/index.scss
@@ -79,6 +79,7 @@
     margin-top: 4px;
     display: flex;
     flex-flow: column;
+    height: 18px;
 
     &--error {
       div:first-of-type {


### PR DESCRIPTION
The short message detail message only shows up in the "Swap from" when ETH is the from but we should the height isn't explicitly set, so using the arrow button adjusts height when ETH isn't selected.


https://user-images.githubusercontent.com/46655/111017457-51b48a80-8379-11eb-853f-8d69f7963056.mp4

