### PR TITLE
Fix: ETH 'token' now only appears once in the swaps to and from dropdowns

### DIFF
--- a/ui/app/pages/swaps/swaps-util-test-constants.js
+++ b/ui/app/pages/swaps/swaps-util-test-constants.js
@@ -9,7 +9,7 @@ export const AGGREGATOR_METADATA_BASE_PROD_URL =
 export const TOP_ASSET_BASE_PROD_URL =
   'https://api.metaswap.codefi.network/topAssets';
 
-export const TOKENS = [
+const BASE_TOKENS = [
   {
     erc20: true,
     symbol: 'META',
@@ -82,8 +82,11 @@ export const TOKENS = [
     decimals: 8,
     address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
   },
-  ETH_SWAPS_TOKEN_OBJECT,
 ];
+
+export const TOKENS = [...BASE_TOKENS, ETH_SWAPS_TOKEN_OBJECT];
+
+export const EXPECTED_TOKENS_RESULT = [ETH_SWAPS_TOKEN_OBJECT, ...BASE_TOKENS];
 
 export const MOCK_TRADE_RESPONSE_1 = [
   {

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -279,13 +279,18 @@ export async function fetchTokens() {
     { method: 'GET' },
     { cacheRefreshTime: CACHE_REFRESH_ONE_HOUR },
   );
-  const filteredTokens = tokens.filter((token) => {
-    return (
-      validateData(TOKEN_VALIDATORS, token, tokenUrl) &&
-      token.address !== ETH_SWAPS_TOKEN_OBJECT.address
-    );
-  });
-  filteredTokens.push(ETH_SWAPS_TOKEN_OBJECT);
+  const filteredTokens = [
+    ETH_SWAPS_TOKEN_OBJECT,
+    ...tokens.filter((token) => {
+      return (
+        validateData(TOKEN_VALIDATORS, token, tokenUrl) &&
+        !(
+          token.symbol === ETH_SWAPS_TOKEN_OBJECT.symbol ||
+          token.address === ETH_SWAPS_TOKEN_OBJECT.address
+        )
+      );
+    }),
+  ];
   return filteredTokens;
 }
 

--- a/ui/app/pages/swaps/swaps.util.test.js
+++ b/ui/app/pages/swaps/swaps.util.test.js
@@ -6,6 +6,7 @@ import {
   AGGREGATOR_METADATA_BASE_PROD_URL,
   TOP_ASSET_BASE_PROD_URL,
   TOKENS,
+  EXPECTED_TOKENS_RESULT,
   MOCK_TRADE_RESPONSE_2,
   AGGREGATOR_METADATA,
   TOP_ASSETS,
@@ -107,12 +108,12 @@ describe('Swaps Util', function () {
   describe('fetchTokens', function () {
     it('should fetch tokens', async function () {
       const result = await fetchTokens(true);
-      assert.deepStrictEqual(result, TOKENS);
+      assert.deepStrictEqual(result, EXPECTED_TOKENS_RESULT);
     });
 
     it('should fetch tokens on prod', async function () {
       const result = await fetchTokens(false);
-      assert.deepStrictEqual(result, TOKENS);
+      assert.deepStrictEqual(result, EXPECTED_TOKENS_RESULT);
     });
   });
 


### PR DESCRIPTION
Previous to this PR users could see the ETH "token" three times in the "Swap from" and "Swap To" dropdowns of the the first screen of the swaps flow. This PR corrects this issue.

Before:
<img src="https://user-images.githubusercontent.com/7499938/111129959-a282d980-8559-11eb-95cf-b07cf669cf07.png" width="200" />

After:
<img src="https://user-images.githubusercontent.com/7499938/111134465-9b11ff00-855e-11eb-895a-5462a3b49888.png" width="200" />
<img src="https://user-images.githubusercontent.com/7499938/111134467-9baa9580-855e-11eb-90f7-01770cc6b67d.png" width="200" />

