### PR TITLE
Allow TextField to receive min and max attributes

### DIFF
--- a/ui/app/components/ui/text-field/text-field.component.js
+++ b/ui/app/components/ui/text-field/text-field.component.js
@@ -88,6 +88,8 @@ const getMaterialThemeInputProps = ({
   dir,
   classes: { materialLabel, materialFocused, materialError, materialUnderline },
   startAdornment,
+  min,
+  max,
 }) => ({
   InputLabelProps: {
     classes: {
@@ -103,6 +105,8 @@ const getMaterialThemeInputProps = ({
     },
     inputProps: {
       dir,
+      min,
+      max,
     },
   },
 });
@@ -116,6 +120,8 @@ const getMaterialWhitePaddedThemeInputProps = ({
     materialWhitePaddedUnderline,
   },
   startAdornment,
+  min,
+  max,
 }) => ({
   InputProps: {
     startAdornment,
@@ -127,6 +133,8 @@ const getMaterialWhitePaddedThemeInputProps = ({
     },
     inputProps: {
       dir,
+      min,
+      max,
     },
   },
 });
@@ -145,6 +153,8 @@ const getBorderedThemeInputProps = ({
   },
   largeLabel,
   startAdornment,
+  min,
+  max,
 }) => ({
   InputLabelProps: {
     shrink: true,
@@ -165,6 +175,8 @@ const getBorderedThemeInputProps = ({
     },
     inputProps: {
       dir,
+      min,
+      max,
     },
   },
 });
@@ -182,6 +194,8 @@ const TextField = ({
   startAdornment,
   largeLabel,
   dir,
+  min,
+  max,
   ...textFieldProps
 }) => {
   const inputProps = themeToInputProps[theme]({
@@ -189,6 +203,8 @@ const TextField = ({
     startAdornment,
     largeLabel,
     dir,
+    min,
+    max,
   });
 
   return (
@@ -214,6 +230,8 @@ TextField.propTypes = {
   theme: PropTypes.oneOf(['bordered', 'material', 'material-white-padded']),
   startAdornment: PropTypes.element,
   largeLabel: PropTypes.bool,
+  min: PropTypes.number,
+  max: PropTypes.number,
 };
 
 export default withStyles(styles)(TextField);

--- a/ui/app/pages/add-token/add-token.component.js
+++ b/ui/app/pages/add-token/add-token.component.js
@@ -13,6 +13,9 @@ import TokenSearch from './token-search';
 
 const emptyAddr = '0x0000000000000000000000000000000000000000';
 
+const MIN_DECIMAL_VALUE = 0;
+const MAX_DECIMAL_VALUE = 36;
+
 class AddToken extends Component {
   static contextTypes = {
     t: PropTypes.func,
@@ -211,8 +214,8 @@ class AddToken extends Component {
     const validDecimals =
       customDecimals !== null &&
       customDecimals !== '' &&
-      customDecimals >= 0 &&
-      customDecimals <= 36;
+      customDecimals >= MIN_DECIMAL_VALUE &&
+      customDecimals <= MAX_DECIMAL_VALUE;
     let customDecimalsError = null;
 
     if (!validDecimals) {
@@ -282,6 +285,8 @@ class AddToken extends Component {
           fullWidth
           margin="normal"
           disabled={autoFilled}
+          min={MIN_DECIMAL_VALUE}
+          max={MAX_DECIMAL_VALUE}
         />
       </div>
     );


### PR DESCRIPTION
When an `input` has a `type` of `number`, up and down arrows appear for the users to click.  Since we have known `min` and `max` values for token precision, we should use them.