### PR TITLE
Swaps support for local testnet

### DIFF
--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -8,6 +8,7 @@ import { ObservableStore } from '@metamask/obs-store';
 import {
   ROPSTEN_NETWORK_ID,
   MAINNET_NETWORK_ID,
+  MAINNET_CHAIN_ID,
 } from '../../../shared/constants/network';
 import { ETH_SWAPS_TOKEN_OBJECT } from '../../../shared/constants/swaps';
 import { createTestProviderTools } from '../../../test/stub/provider';
@@ -75,6 +76,7 @@ const MOCK_FETCH_METADATA = {
     symbol: 'FOO',
     decimals: 18,
   },
+  chainId: MAINNET_CHAIN_ID,
 };
 
 const MOCK_TOKEN_RATES_STORE = new ObservableStore({
@@ -131,6 +133,8 @@ const sandbox = sinon.createSandbox();
 const fetchTradesInfoStub = sandbox.stub();
 const fetchSwapsFeatureLivenessStub = sandbox.stub();
 const fetchSwapsQuoteRefreshTimeStub = sandbox.stub();
+const getCurrentChainIdStub = sandbox.stub();
+getCurrentChainIdStub.returns(MAINNET_CHAIN_ID);
 
 describe('SwapsController', function () {
   let provider;
@@ -145,6 +149,7 @@ describe('SwapsController', function () {
       fetchTradesInfo: fetchTradesInfoStub,
       fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
       fetchSwapsQuoteRefreshTime: fetchSwapsQuoteRefreshTimeStub,
+      getCurrentChainId: getCurrentChainIdStub,
     });
   };
 
@@ -194,6 +199,7 @@ describe('SwapsController', function () {
         tokenRatesStore: MOCK_TOKEN_RATES_STORE,
         fetchTradesInfo: fetchTradesInfoStub,
         fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
+        getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
       const onNetworkDidChange = networkController.on.getCall(0).args[1];
@@ -218,6 +224,7 @@ describe('SwapsController', function () {
         tokenRatesStore: MOCK_TOKEN_RATES_STORE,
         fetchTradesInfo: fetchTradesInfoStub,
         fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
+        getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
       const onNetworkDidChange = networkController.on.getCall(0).args[1];
@@ -242,6 +249,7 @@ describe('SwapsController', function () {
         tokenRatesStore: MOCK_TOKEN_RATES_STORE,
         fetchTradesInfo: fetchTradesInfoStub,
         fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
+        getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
       const onNetworkDidChange = networkController.on.getCall(0).args[1];
@@ -686,7 +694,10 @@ describe('SwapsController', function () {
         });
 
         assert.strictEqual(
-          fetchTradesInfoStub.calledOnceWithExactly(MOCK_FETCH_PARAMS),
+          fetchTradesInfoStub.calledOnceWithExactly(
+            MOCK_FETCH_PARAMS,
+            MOCK_FETCH_METADATA,
+          ),
           true,
         );
       });

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -943,6 +943,8 @@ export default class TransactionController extends EventEmitter {
   }
 
   _trackSwapsMetrics(txMeta, approvalTxMeta) {
+    const chainId = this.getChainId();
+
     if (this._getParticipateInMetrics() && txMeta.swapMetaData) {
       if (txMeta.txReceipt.status === '0x0') {
         this._trackMetaMetricsEvent({
@@ -958,6 +960,7 @@ export default class TransactionController extends EventEmitter {
           txMeta.txParams.from,
           txMeta.destinationTokenDecimals,
           approvalTxMeta,
+          chainId,
         );
 
         const quoteVsExecutionRatio = `${new BigNumber(tokensReceived, 10)

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -943,8 +943,6 @@ export default class TransactionController extends EventEmitter {
   }
 
   _trackSwapsMetrics(txMeta, approvalTxMeta) {
-    const chainId = this.getChainId();
-
     if (this._getParticipateInMetrics() && txMeta.swapMetaData) {
       if (txMeta.txReceipt.status === '0x0') {
         this._trackMetaMetricsEvent({
@@ -960,7 +958,7 @@ export default class TransactionController extends EventEmitter {
           txMeta.txParams.from,
           txMeta.destinationTokenDecimals,
           approvalTxMeta,
-          chainId,
+          txMeta.chainId,
         );
 
         const quoteVsExecutionRatio = `${new BigNumber(tokensReceived, 10)

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -383,6 +383,9 @@ export default class MetamaskController extends EventEmitter {
         this.networkController,
       ),
       tokenRatesStore: this.tokenRatesController.store,
+      getCurrentChainId: this.networkController.getCurrentChainId.bind(
+        this.networkController,
+      ),
     });
 
     // ensure accountTracker updates balances after network change

--- a/shared/constants/swaps.js
+++ b/shared/constants/swaps.js
@@ -1,3 +1,12 @@
+import { MAINNET_CHAIN_ID } from './network';
+
+export const QUOTES_EXPIRED_ERROR = 'quotes-expired';
+export const SWAP_FAILED_ERROR = 'swap-failed-error';
+export const ERROR_FETCHING_QUOTES = 'error-fetching-quotes';
+export const QUOTES_NOT_AVAILABLE_ERROR = 'quotes-not-avilable';
+export const OFFLINE_FOR_MAINTENANCE = 'offline-for-maintenance';
+export const SWAPS_FETCH_ORDER_CONFLICT = 'swaps-fetch-order-conflict';
+
 // An address that the metaswap-api recognizes as ETH, in place of the token address that ERC-20 tokens have
 const ETH_SWAPS_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -9,17 +18,42 @@ export const ETH_SWAPS_TOKEN_OBJECT = {
   iconUrl: 'images/black-eth-logo.svg',
 };
 
-export const QUOTES_EXPIRED_ERROR = 'quotes-expired';
-export const SWAP_FAILED_ERROR = 'swap-failed-error';
-export const ERROR_FETCHING_QUOTES = 'error-fetching-quotes';
-export const QUOTES_NOT_AVAILABLE_ERROR = 'quotes-not-avilable';
-export const OFFLINE_FOR_MAINTENANCE = 'offline-for-maintenance';
-export const SWAPS_FETCH_ORDER_CONFLICT = 'swaps-fetch-order-conflict';
+const TEST_ETH_SWAPS_TOKEN_OBJECT = {
+  symbol: 'TESTETH',
+  name: 'Test Ether',
+  address: ETH_SWAPS_TOKEN_ADDRESS,
+  decimals: 18,
+  iconUrl: 'images/black-eth-logo.svg',
+};
 
 // A gas value for ERC20 approve calls that should be sufficient for all ERC20 approve implementations
 export const DEFAULT_ERC20_APPROVE_GAS = '0x1d4c0';
 
-export const SWAPS_CONTRACT_ADDRESS =
-  '0x881d40237659c251811cec9c364ef91dc08d300c';
+const MAINNET_CONTRACT_ADDRESS = '0x881d40237659c251811cec9c364ef91dc08d300c';
 
-export const METASWAP_API_HOST = 'https://api.metaswap.codefi.network';
+const TESTNET_CONTRACT_ADDRESS = '0x881d40237659c251811cec9c364ef91dc08d300c';
+
+const METASWAP_ETH_API_HOST = 'https://api.metaswap.codefi.network';
+
+const SWAPS_TESTNET_CHAIN_ID = '0x539';
+const SWAPS_TESTNET_HOST = 'https://metaswap-api.airswap-dev.codefi.network';
+
+export const ALLOWED_SWAPS_CHAIN_IDS = {
+  [MAINNET_CHAIN_ID]: true,
+  [SWAPS_TESTNET_CHAIN_ID]: true,
+};
+
+export const METASWAP_CHAINID_API_HOST_MAP = {
+  [MAINNET_CHAIN_ID]: METASWAP_ETH_API_HOST,
+  [SWAPS_TESTNET_CHAIN_ID]: SWAPS_TESTNET_HOST,
+};
+
+export const SWAPS_CHAINID_CONTRACT_ADDRESS_MAP = {
+  [MAINNET_CHAIN_ID]: MAINNET_CONTRACT_ADDRESS,
+  [SWAPS_TESTNET_CHAIN_ID]: TESTNET_CONTRACT_ADDRESS,
+};
+
+export const SWAPS_CHAINID_DEFAULT_TOKEN_MAP = {
+  [MAINNET_CHAIN_ID]: ETH_SWAPS_TOKEN_OBJECT,
+  [SWAPS_TESTNET_CHAIN_ID]: TEST_ETH_SWAPS_TOKEN_OBJECT,
+};

--- a/shared/modules/swaps.utils.js
+++ b/shared/modules/swaps.utils.js
@@ -1,0 +1,33 @@
+import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../constants/swaps';
+
+/**
+ * Checks whether the provided address is strictly equal to the address for
+ * the default swaps token of the provided chain.
+ *
+ * @param {string} address - The string to compare to the default token address
+ * @param {string} chainId - The hex encoded chain ID of the default swaps token to check
+ * @returns {boolean} Whether the address is the provided chain's default token address
+ */
+export function isSwapsDefaultTokenAddress(address, chainId) {
+  if (!address || !chainId) {
+    return false;
+  }
+
+  return address === SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId]?.address;
+}
+
+/**
+ * Checks whether the provided symbol is strictly equal to the symbol for
+ * the default swaps token of the provided chain.
+ *
+ * @param {string} symbol - The string to compare to the default token symbol
+ * @param {string} chainId - The hex encoded chain ID of the default swaps token to check
+ * @returns {boolean} Whether the symbl is the provided chain's default token symbol
+ */
+export function isSwapsDefaultTokenSymbol(symbol, chainId) {
+  if (!symbol || !chainId) {
+    return false;
+  }
+
+  return symbol === SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId]?.symbol;
+}

--- a/ui/app/components/app/transaction-list/transaction-list.component.js
+++ b/ui/app/components/app/transaction-list/transaction-list.component.js
@@ -5,20 +5,24 @@ import {
   nonceSortedCompletedTransactionsSelector,
   nonceSortedPendingTransactionsSelector,
 } from '../../../selectors/transactions';
+import { getCurrentChainId } from '../../../selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import TransactionListItem from '../transaction-list-item';
 import Button from '../../ui/button';
 import { TOKEN_CATEGORY_HASH } from '../../../helpers/constants/transactions';
-import { SWAPS_CONTRACT_ADDRESS } from '../../../../../shared/constants/swaps';
+import { SWAPS_CHAINID_CONTRACT_ADDRESS_MAP } from '../../../../../shared/constants/swaps';
 import { TRANSACTION_TYPES } from '../../../../../shared/constants/transaction';
 
 const PAGE_INCREMENT = 10;
 
-const getTransactionGroupRecipientAddressFilter = (recipientAddress) => {
+const getTransactionGroupRecipientAddressFilter = (
+  recipientAddress,
+  chainId,
+) => {
   return ({ initialTransaction: { txParams } }) => {
     return (
       txParams?.to === recipientAddress ||
-      (txParams?.to === SWAPS_CONTRACT_ADDRESS &&
+      (txParams?.to === SWAPS_CHAINID_CONTRACT_ADDRESS_MAP[chainId] &&
         txParams.data.match(recipientAddress.slice(2)))
     );
   };
@@ -39,12 +43,13 @@ const getFilteredTransactionGroups = (
   transactionGroups,
   hideTokenTransactions,
   tokenAddress,
+  chainId,
 ) => {
   if (hideTokenTransactions) {
     return transactionGroups.filter(tokenTransactionFilter);
   } else if (tokenAddress) {
     return transactionGroups.filter(
-      getTransactionGroupRecipientAddressFilter(tokenAddress),
+      getTransactionGroupRecipientAddressFilter(tokenAddress, chainId),
     );
   }
   return transactionGroups;
@@ -63,6 +68,7 @@ export default function TransactionList({
   const unfilteredCompletedTransactions = useSelector(
     nonceSortedCompletedTransactionsSelector,
   );
+  const chainId = useSelector(getCurrentChainId);
 
   const pendingTransactions = useMemo(
     () =>
@@ -70,8 +76,14 @@ export default function TransactionList({
         unfilteredPendingTransactions,
         hideTokenTransactions,
         tokenAddress,
+        chainId,
       ),
-    [hideTokenTransactions, tokenAddress, unfilteredPendingTransactions],
+    [
+      hideTokenTransactions,
+      tokenAddress,
+      unfilteredPendingTransactions,
+      chainId,
+    ],
   );
   const completedTransactions = useMemo(
     () =>
@@ -79,8 +91,14 @@ export default function TransactionList({
         unfilteredCompletedTransactions,
         hideTokenTransactions,
         tokenAddress,
+        chainId,
       ),
-    [hideTokenTransactions, tokenAddress, unfilteredCompletedTransactions],
+    [
+      hideTokenTransactions,
+      tokenAddress,
+      unfilteredCompletedTransactions,
+      chainId,
+    ],
   );
 
   const viewMore = useCallback(

--- a/ui/app/components/app/transaction-list/transaction-list.component.js
+++ b/ui/app/components/app/transaction-list/transaction-list.component.js
@@ -15,6 +15,13 @@ import { TRANSACTION_TYPES } from '../../../../../shared/constants/transaction';
 
 const PAGE_INCREMENT = 10;
 
+// When we are on a token page, we only want to show transactions that involve that token.
+// In the case of token transfers or approvals, these will be transactions sent to the
+// token contract. In the case of swaps, these will be transactions sent to the swaps contract
+// and which have the token address in the transaction data.
+//
+// getTransactionGroupRecipientAddressFilter is used to determine whether a transaction matches
+// either of those criteria
 const getTransactionGroupRecipientAddressFilter = (
   recipientAddress,
   chainId,

--- a/ui/app/components/app/wallet-overview/eth-overview.js
+++ b/ui/app/components/app/wallet-overview/eth-overview.js
@@ -25,7 +25,8 @@ import {
   getIsMainnet,
   getIsTestnet,
   getCurrentKeyring,
-  getSwapsEthToken,
+  getSwapsDefaultToken,
+  getIsSwapsChain,
 } from '../../../selectors/selectors';
 import SwapIcon from '../../ui/icon/swap-icon.component';
 import BuyIcon from '../../ui/icon/overview-buy-icon.component';
@@ -63,13 +64,14 @@ const EthOverview = ({ className }) => {
   const { balance } = selectedAccount;
   const isMainnetChain = useSelector(getIsMainnet);
   const isTestnetChain = useSelector(getIsTestnet);
+  const isSwapsChain = useSelector(getIsSwapsChain);
   const enteredSwapsEvent = useNewMetricEvent({
     event: 'Swaps Opened',
     properties: { source: 'Main View', active_currency: 'ETH' },
     category: 'swaps',
   });
   const swapsEnabled = useSelector(getSwapsFeatureLiveness);
-  const swapsEthToken = useSelector(getSwapsEthToken);
+  const defaultSwapsToken = useSelector(getSwapsDefaultToken);
 
   return (
     <WalletOverview
@@ -136,12 +138,12 @@ const EthOverview = ({ className }) => {
           {swapsEnabled ? (
             <IconButton
               className="eth-overview__button"
-              disabled={!isMainnetChain}
+              disabled={!isSwapsChain}
               Icon={SwapIcon}
               onClick={() => {
-                if (isMainnetChain) {
+                if (isSwapsChain) {
                   enteredSwapsEvent();
-                  dispatch(setSwapsFromToken(swapsEthToken));
+                  dispatch(setSwapsFromToken(defaultSwapsToken));
                   if (usingHardwareWallet) {
                     global.platform.openExtensionInBrowser(BUILD_QUOTE_ROUTE);
                   } else {
@@ -154,7 +156,7 @@ const EthOverview = ({ className }) => {
                 <Tooltip
                   title={t('onlyAvailableOnMainnet')}
                   position="bottom"
-                  disabled={isMainnetChain}
+                  disabled={isSwapsChain}
                 >
                   {contents}
                 </Tooltip>

--- a/ui/app/components/app/wallet-overview/token-overview.js
+++ b/ui/app/components/app/wallet-overview/token-overview.js
@@ -25,9 +25,8 @@ import {
 import {
   getAssetImages,
   getCurrentKeyring,
-  getCurrentChainId,
+  getIsSwapsChain,
 } from '../../../selectors/selectors';
-import { MAINNET_CHAIN_ID } from '../../../../../shared/constants/network';
 
 import SwapIcon from '../../ui/icon/swap-icon.component';
 import SendIcon from '../../ui/icon/overview-send-icon.component';
@@ -58,7 +57,7 @@ const TokenOverview = ({ className, token }) => {
     balanceToRender,
     token.symbol,
   );
-  const chainId = useSelector(getCurrentChainId);
+  const isSwapsChain = useSelector(getIsSwapsChain);
   const enteredSwapsEvent = useNewMetricEvent({
     event: 'Swaps Opened',
     properties: { source: 'Token View', active_currency: token.symbol },
@@ -100,10 +99,10 @@ const TokenOverview = ({ className, token }) => {
           {swapsEnabled ? (
             <IconButton
               className="token-overview__button"
-              disabled={chainId !== MAINNET_CHAIN_ID}
+              disabled={!isSwapsChain}
               Icon={SwapIcon}
               onClick={() => {
-                if (chainId === MAINNET_CHAIN_ID) {
+                if (isSwapsChain) {
                   enteredSwapsEvent();
                   dispatch(
                     setSwapsFromToken({
@@ -125,7 +124,7 @@ const TokenOverview = ({ className, token }) => {
                 <Tooltip
                   title={t('onlyAvailableOnMainnet')}
                   position="bottom"
-                  disabled={chainId === MAINNET_CHAIN_ID}
+                  disabled={isSwapsChain}
                 >
                   {contents}
                 </Tooltip>

--- a/ui/app/ducks/swaps/swaps.js
+++ b/ui/app/ducks/swaps/swaps.js
@@ -49,7 +49,8 @@ import {
   getSelectedAccount,
   getTokenExchangeRates,
   getUSDConversionRate,
-  getSwapsEthToken,
+  getSwapsDefaultToken,
+  getCurrentChainId,
 } from '../../selectors';
 import {
   ERROR_FETCHING_QUOTES,
@@ -376,9 +377,11 @@ export const fetchQuotesAndSetQuoteState = (
   metaMetricsEvent,
 ) => {
   return async (dispatch, getState) => {
+    const state = getState();
+    const chainId = getCurrentChainId(state);
     let swapsFeatureIsLive = false;
     try {
-      swapsFeatureIsLive = await fetchSwapsFeatureLiveness();
+      swapsFeatureIsLive = await fetchSwapsFeatureLiveness(chainId);
     } catch (error) {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);
     }
@@ -389,13 +392,14 @@ export const fetchQuotesAndSetQuoteState = (
       return;
     }
 
-    const state = getState();
     const fetchParams = getFetchParams(state);
     const selectedAccount = getSelectedAccount(state);
     const balanceError = getBalanceError(state);
+    const swapsDefaultToken = getSwapsDefaultToken(state);
     const fetchParamsFromToken =
-      fetchParams?.metaData?.sourceTokenInfo?.symbol === 'ETH'
-        ? getSwapsEthToken(state)
+      fetchParams?.metaData?.sourceTokenInfo?.symbol ===
+      swapsDefaultToken.symbol
+        ? swapsDefaultToken
         : fetchParams?.metaData?.sourceTokenInfo;
     const selectedFromToken = getFromToken(state) || fetchParamsFromToken || {};
     const selectedToToken =
@@ -420,7 +424,10 @@ export const fetchQuotesAndSetQuoteState = (
     const contractExchangeRates = getTokenExchangeRates(state);
 
     let destinationTokenAddedForSwap = false;
-    if (toTokenSymbol !== 'ETH' && !contractExchangeRates[toTokenAddress]) {
+    if (
+      toTokenSymbol !== swapsDefaultToken.symbol &&
+      !contractExchangeRates[toTokenAddress]
+    ) {
       destinationTokenAddedForSwap = true;
       await dispatch(
         addToken(
@@ -433,7 +440,7 @@ export const fetchQuotesAndSetQuoteState = (
       );
     }
     if (
-      fromTokenSymbol !== 'ETH' &&
+      fromTokenSymbol !== swapsDefaultToken.symbol &&
       !contractExchangeRates[fromTokenAddress] &&
       fromTokenBalance &&
       new BigNumber(fromTokenBalance, 16).gt(0)
@@ -494,6 +501,7 @@ export const fetchQuotesAndSetQuoteState = (
             sourceTokenInfo,
             destinationTokenInfo,
             accountBalance: selectedAccount.balance,
+            chainId,
           },
         ),
       );
@@ -563,9 +571,12 @@ export const fetchQuotesAndSetQuoteState = (
 
 export const signAndSendTransactions = (history, metaMetricsEvent) => {
   return async (dispatch, getState) => {
+    const state = getState();
+    const chainId = getCurrentChainId(state);
+
     let swapsFeatureIsLive = false;
     try {
-      swapsFeatureIsLive = await fetchSwapsFeatureLiveness();
+      swapsFeatureIsLive = await fetchSwapsFeatureLiveness(chainId);
     } catch (error) {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);
     }
@@ -576,7 +587,6 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       return;
     }
 
-    const state = getState();
     const customSwapsGas = getCustomSwapsGas(state);
     const fetchParams = getFetchParams(state);
     const { metaData, value: swapTokenValue, slippage } = fetchParams;

--- a/ui/app/hooks/useCurrentAsset.js
+++ b/ui/app/hooks/useCurrentAsset.js
@@ -1,13 +1,18 @@
 import { useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
 import { getTokens } from '../ducks/metamask/metamask';
+import { getCurrentChainId } from '../selectors';
 import { ASSET_ROUTE } from '../helpers/constants/routes';
-import { ETH_SWAPS_TOKEN_OBJECT } from '../../../shared/constants/swaps';
+import {
+  SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
+  ETH_SWAPS_TOKEN_OBJECT,
+} from '../../../shared/constants/swaps';
 
 /**
  * Returns a token object for the asset that is currently being viewed.
- * Will return the ETH_SWAPS_TOKEN_OBJECT when the user is viewing either
- * the primary, unfiltered, activity list or the ETH asset page.
+ * Will return the default token object for the current chain when the
+ * user is viewing either the primary, unfiltered, activity list or the
+ * default token asset page.
  * @returns {import('./useTokenDisplayValue').Token}
  */
 export function useCurrentAsset() {
@@ -22,6 +27,10 @@ export function useCurrentAsset() {
   const knownTokens = useSelector(getTokens);
   const token =
     tokenAddress && knownTokens.find(({ address }) => address === tokenAddress);
+  const chainId = useSelector(getCurrentChainId);
 
-  return token ?? ETH_SWAPS_TOKEN_OBJECT;
+  return (
+    token ??
+    (SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId] || ETH_SWAPS_TOKEN_OBJECT)
+  );
 }

--- a/ui/app/hooks/useSwappedTokenValue.js
+++ b/ui/app/hooks/useSwappedTokenValue.js
@@ -1,6 +1,8 @@
+import { useSelector } from 'react-redux';
 import { TRANSACTION_TYPES } from '../../../shared/constants/transaction';
-import { ETH_SWAPS_TOKEN_OBJECT } from '../../../shared/constants/swaps';
+import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../../../shared/constants/swaps';
 import { getSwapsTokensReceivedFromTxMeta } from '../pages/swaps/swaps.util';
+import { getCurrentChainId } from '../selectors';
 import { useTokenFiatAmount } from './useTokenFiatAmount';
 
 /**
@@ -14,10 +16,11 @@ import { useTokenFiatAmount } from './useTokenFiatAmount';
 /**
  * A Swap transaction group's primaryTransaction contains details of the swap,
  * including the source (from) and destination (to) token type (ETH, DAI, etc..)
- * When viewing a non ETH asset page, we need to determine if that asset is the
- * token that was received (destination) from the swap. In that circumstance we
- * would want to show the primaryCurrency in the activity list that is most relevant
- * for that token (- 1000 DAI, for example, when swapping DAI for ETH).
+ * When viewing an asset page that is not for the current chain's default token, we
+ * need to determine if that asset is the token that was received (destination) from
+ * the swap. In that circumstance we would want to show the primaryCurrency in the
+ * activity list that is most relevant for that token (- 1000 DAI, for example, when
+ * swapping DAI for ETH).
  * @param {import('../selectors').transactionGroup} transactionGroup - Group of transactions by nonce
  * @param {import('./useTokenDisplayValue').Token} currentAsset - The current asset the user is looking at
  * @returns {SwappedTokenValue}
@@ -27,11 +30,14 @@ export function useSwappedTokenValue(transactionGroup, currentAsset) {
   const { primaryTransaction, initialTransaction } = transactionGroup;
   const { type } = initialTransaction;
   const { from: senderAddress } = initialTransaction.txParams || {};
+  const chainId = useSelector(getCurrentChainId);
 
   const isViewingReceivedTokenFromSwap =
     currentAsset?.symbol === primaryTransaction.destinationTokenSymbol ||
-    (currentAsset.address === ETH_SWAPS_TOKEN_OBJECT.address &&
-      primaryTransaction.destinationTokenSymbol === 'ETH');
+    (currentAsset.address ===
+      SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].address &&
+      primaryTransaction.destinationTokenSymbol ===
+        SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol);
 
   const swapTokenValue =
     type === TRANSACTION_TYPES.SWAP && isViewingReceivedTokenFromSwap
@@ -41,6 +47,8 @@ export function useSwappedTokenValue(transactionGroup, currentAsset) {
           address,
           senderAddress,
           decimals,
+          null,
+          chainId,
         )
       : type === TRANSACTION_TYPES.SWAP && primaryTransaction.swapTokenValue;
 

--- a/ui/app/hooks/useSwappedTokenValue.js
+++ b/ui/app/hooks/useSwappedTokenValue.js
@@ -1,6 +1,9 @@
 import { useSelector } from 'react-redux';
 import { TRANSACTION_TYPES } from '../../../shared/constants/transaction';
-import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../../../shared/constants/swaps';
+import {
+  isSwapsDefaultTokenAddress,
+  isSwapsDefaultTokenSymbol,
+} from '../../../shared/modules/swaps.utils';
 import { getSwapsTokensReceivedFromTxMeta } from '../pages/swaps/swaps.util';
 import { getCurrentChainId } from '../selectors';
 import { useTokenFiatAmount } from './useTokenFiatAmount';
@@ -34,10 +37,11 @@ export function useSwappedTokenValue(transactionGroup, currentAsset) {
 
   const isViewingReceivedTokenFromSwap =
     currentAsset?.symbol === primaryTransaction.destinationTokenSymbol ||
-    (currentAsset.address ===
-      SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].address &&
-      primaryTransaction.destinationTokenSymbol ===
-        SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol);
+    (isSwapsDefaultTokenAddress(currentAsset.address, chainId) &&
+      isSwapsDefaultTokenSymbol(
+        primaryTransaction.destinationTokenSymbol,
+        chainId,
+      ));
 
   const swapTokenValue =
     type === TRANSACTION_TYPES.SWAP && isViewingReceivedTokenFromSwap

--- a/ui/app/hooks/useTokensToSearch.js
+++ b/ui/app/hooks/useTokensToSearch.js
@@ -13,7 +13,7 @@ import {
   getCurrentChainId,
 } from '../selectors';
 import { getSwapsTokens } from '../ducks/swaps/swaps';
-import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../../../shared/constants/swaps';
+import { isSwapsDefaultTokenSymbol } from '../../../shared/modules/swaps.utils';
 import { useEqualityCheck } from './useEqualityCheck';
 
 const tokenList = shuffle(
@@ -36,7 +36,7 @@ export function getRenderableTokenData(
 
   const formattedFiat =
     getTokenFiatAmount(
-      symbol === SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId]
+      isSwapsDefaultTokenSymbol(symbol, chainId)
         ? 1
         : contractExchangeRates[address],
       conversionRate,
@@ -47,7 +47,7 @@ export function getRenderableTokenData(
     ) || '';
   const rawFiat =
     getTokenFiatAmount(
-      symbol === SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol
+      isSwapsDefaultTokenSymbol(symbol, chainId)
         ? 1
         : contractExchangeRates[address],
       conversionRate,
@@ -128,8 +128,7 @@ export function useTokensToSearch({ usersTokens = [], topTokens = {} }) {
         chainId,
       );
       if (
-        renderableDataToken.symbol ===
-          SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol ||
+        isSwapsDefaultTokenSymbol(renderableDataToken.symbol, chainId) ||
         (usersTokensAddressMap[token.address] &&
           Number(renderableDataToken.balance ?? 0) !== 0)
       ) {

--- a/ui/app/hooks/useTransactionDisplayData.test.js
+++ b/ui/app/hooks/useTransactionDisplayData.test.js
@@ -10,11 +10,13 @@ import {
   getShouldShowFiat,
   getNativeCurrency,
   getCurrentCurrency,
+  getCurrentChainId,
 } from '../selectors';
 import { getTokens } from '../ducks/metamask/metamask';
 import { getMessage } from '../helpers/utils/i18n-helper';
 import messages from '../../../app/_locales/en/messages.json';
 import { ASSET_ROUTE, DEFAULT_ROUTE } from '../helpers/constants/routes';
+import { MAINNET_CHAIN_ID } from '../../../shared/constants/network';
 import {
   TRANSACTION_TYPES,
   TRANSACTION_GROUP_CATEGORIES,
@@ -164,6 +166,8 @@ describe('useTransactionDisplayData', function () {
         return 'ETH';
       } else if (selector === getCurrentCurrency) {
         return 'ETH';
+      } else if (selector === getCurrentChainId) {
+        return MAINNET_CHAIN_ID;
       }
       return null;
     });

--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -26,13 +26,13 @@ import {
 } from '../../../ducks/swaps/swaps';
 import Mascot from '../../../components/ui/mascot';
 import {
-  SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
   QUOTES_EXPIRED_ERROR,
   SWAP_FAILED_ERROR,
   ERROR_FETCHING_QUOTES,
   QUOTES_NOT_AVAILABLE_ERROR,
   OFFLINE_FOR_MAINTENANCE,
 } from '../../../../../shared/constants/swaps';
+import { isSwapsDefaultTokenSymbol } from '../../../../../shared/modules/swaps.utils';
 import PulseLoader from '../../../components/ui/pulse-loader';
 
 import { ASSET_ROUTE, DEFAULT_ROUTE } from '../../../helpers/constants/routes';
@@ -234,8 +234,7 @@ export default function AwaitingSwap({
           } else if (errorKey) {
             await dispatch(navigateBackToBuildQuote(history));
           } else if (
-            destinationTokenInfo?.symbol ===
-            SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol
+            isSwapsDefaultTokenSymbol(destinationTokenInfo?.symbol, chainId)
           ) {
             history.push(DEFAULT_ROUTE);
           } else {

--- a/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/app/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -6,12 +6,14 @@ import { useHistory } from 'react-router-dom';
 import { I18nContext } from '../../../contexts/i18n';
 import { useNewMetricEvent } from '../../../hooks/useMetricEvent';
 import { MetaMetricsContext } from '../../../contexts/metametrics.new';
+
 import {
   getCurrentChainId,
   getCurrentCurrency,
   getRpcPrefsForCurrentProvider,
   getUSDConversionRate,
 } from '../../../selectors';
+
 import {
   getUsedQuote,
   getFetchParams,
@@ -23,14 +25,16 @@ import {
   prepareToLeaveSwaps,
 } from '../../../ducks/swaps/swaps';
 import Mascot from '../../../components/ui/mascot';
-import PulseLoader from '../../../components/ui/pulse-loader';
 import {
+  SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
   QUOTES_EXPIRED_ERROR,
   SWAP_FAILED_ERROR,
   ERROR_FETCHING_QUOTES,
   QUOTES_NOT_AVAILABLE_ERROR,
   OFFLINE_FOR_MAINTENANCE,
 } from '../../../../../shared/constants/swaps';
+import PulseLoader from '../../../components/ui/pulse-loader';
+
 import { ASSET_ROUTE, DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
 import { getRenderableNetworkFeesForQuote } from '../swaps.util';
@@ -73,16 +77,17 @@ export default function AwaitingSwap({
   let feeinUnformattedFiat;
 
   if (usedQuote && swapsGasPrice) {
-    const renderableNetworkFees = getRenderableNetworkFeesForQuote(
-      usedQuote.gasEstimateWithRefund || usedQuote.averageGas,
-      approveTxParams?.gas || '0x0',
-      swapsGasPrice,
+    const renderableNetworkFees = getRenderableNetworkFeesForQuote({
+      tradeGas: usedQuote.gasEstimateWithRefund || usedQuote.averageGas,
+      approveGas: approveTxParams?.gas || '0x0',
+      gasPrice: swapsGasPrice,
       currentCurrency,
-      usdConversionRate,
-      usedQuote?.trade?.value,
-      sourceTokenInfo?.symbol,
-      usedQuote.sourceAmount,
-    );
+      conversionRate: usdConversionRate,
+      tradeValue: usedQuote?.trade?.value,
+      sourceSymbol: sourceTokenInfo?.symbol,
+      sourceAmount: usedQuote.sourceAmount,
+      chainId,
+    });
     feeinUnformattedFiat = renderableNetworkFees.rawNetworkFees;
   }
 
@@ -228,7 +233,10 @@ export default function AwaitingSwap({
             );
           } else if (errorKey) {
             await dispatch(navigateBackToBuildQuote(history));
-          } else if (destinationTokenInfo?.symbol === 'ETH') {
+          } else if (
+            destinationTokenInfo?.symbol ===
+            SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol
+          ) {
             history.push(DEFAULT_ROUTE);
           } else {
             history.push(`${ASSET_ROUTE}/${destinationTokenInfo?.address}`);

--- a/ui/app/pages/swaps/intro-popup/intro-popup.js
+++ b/ui/app/pages/swaps/intro-popup/intro-popup.js
@@ -6,7 +6,7 @@ import { setSwapsFromToken } from '../../../ducks/swaps/swaps';
 import { I18nContext } from '../../../contexts/i18n';
 import { BUILD_QUOTE_ROUTE } from '../../../helpers/constants/routes';
 import { useNewMetricEvent } from '../../../hooks/useMetricEvent';
-import { getSwapsEthToken } from '../../../selectors';
+import { getSwapsDefaultToken } from '../../../selectors';
 import Button from '../../../components/ui/button';
 import Popover from '../../../components/ui/popover';
 
@@ -14,9 +14,14 @@ export default function IntroPopup({ onClose }) {
   const dispatch = useDispatch(useDispatch);
   const history = useHistory();
   const t = useContext(I18nContext);
+
+  const swapsDefaultToken = useSelector(getSwapsDefaultToken);
   const enteredSwapsEvent = useNewMetricEvent({
     event: 'Swaps Opened',
-    properties: { source: 'Intro popup', active_currency: 'ETH' },
+    properties: {
+      source: 'Intro popup',
+      active_currency: swapsDefaultToken.symbol,
+    },
     category: 'swaps',
   });
   const blogPostVisitedEvent = useNewMetricEvent({
@@ -31,7 +36,6 @@ export default function IntroPopup({ onClose }) {
     event: 'Product Overview Dismissed',
     category: 'swaps',
   });
-  const swapsEthToken = useSelector(getSwapsEthToken);
 
   return (
     <div className="intro-popup">
@@ -51,7 +55,7 @@ export default function IntroPopup({ onClose }) {
             onClick={() => {
               onClose();
               enteredSwapsEvent();
-              dispatch(setSwapsFromToken(swapsEthToken));
+              dispatch(setSwapsFromToken(swapsDefaultToken));
               history.push(BUILD_QUOTE_ROUTE);
             }}
           >

--- a/ui/app/pages/swaps/swaps.util.test.js
+++ b/ui/app/pages/swaps/swaps.util.test.js
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import proxyquire from 'proxyquire';
+import { MAINNET_CHAIN_ID } from '../../../../shared/constants/network';
 import {
   TRADES_BASE_PROD_URL,
   TOKENS_BASE_PROD_URL,
@@ -89,42 +90,45 @@ describe('Swaps Util', function () {
       },
     };
     it('should fetch trade info on prod', async function () {
-      const result = await fetchTradesInfo({
-        TOKENS,
-        slippage: '3',
-        sourceToken: TOKENS[0].address,
-        destinationToken: TOKENS[1].address,
-        value: '2000000000000000000',
-        fromAddress: '0xmockAddress',
-        sourceSymbol: TOKENS[0].symbol,
-        sourceDecimals: TOKENS[0].decimals,
-        sourceTokenInfo: { ...TOKENS[0] },
-        destinationTokenInfo: { ...TOKENS[1] },
-      });
+      const result = await fetchTradesInfo(
+        {
+          TOKENS,
+          slippage: '3',
+          sourceToken: TOKENS[0].address,
+          destinationToken: TOKENS[1].address,
+          value: '2000000000000000000',
+          fromAddress: '0xmockAddress',
+          sourceSymbol: TOKENS[0].symbol,
+          sourceDecimals: TOKENS[0].decimals,
+          sourceTokenInfo: { ...TOKENS[0] },
+          destinationTokenInfo: { ...TOKENS[1] },
+        },
+        { chainId: MAINNET_CHAIN_ID },
+      );
       assert.deepStrictEqual(result, expectedResult2);
     });
   });
 
   describe('fetchTokens', function () {
     it('should fetch tokens', async function () {
-      const result = await fetchTokens(true);
+      const result = await fetchTokens(MAINNET_CHAIN_ID);
       assert.deepStrictEqual(result, EXPECTED_TOKENS_RESULT);
     });
 
     it('should fetch tokens on prod', async function () {
-      const result = await fetchTokens(false);
+      const result = await fetchTokens(MAINNET_CHAIN_ID);
       assert.deepStrictEqual(result, EXPECTED_TOKENS_RESULT);
     });
   });
 
   describe('fetchAggregatorMetadata', function () {
     it('should fetch aggregator metadata', async function () {
-      const result = await fetchAggregatorMetadata(true);
+      const result = await fetchAggregatorMetadata(MAINNET_CHAIN_ID);
       assert.deepStrictEqual(result, AGGREGATOR_METADATA);
     });
 
     it('should fetch aggregator metadata on prod', async function () {
-      const result = await fetchAggregatorMetadata(false);
+      const result = await fetchAggregatorMetadata(MAINNET_CHAIN_ID);
       assert.deepStrictEqual(result, AGGREGATOR_METADATA);
     });
   });
@@ -148,12 +152,12 @@ describe('Swaps Util', function () {
       },
     };
     it('should fetch top assets', async function () {
-      const result = await fetchTopAssets(true);
+      const result = await fetchTopAssets(MAINNET_CHAIN_ID);
       assert.deepStrictEqual(result, expectedResult);
     });
 
     it('should fetch top assets on prod', async function () {
-      const result = await fetchTopAssets(false);
+      const result = await fetchTopAssets(MAINNET_CHAIN_ID);
       assert.deepStrictEqual(result, expectedResult);
     });
   });

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -36,7 +36,8 @@ import {
   getSelectedAccount,
   getCurrentCurrency,
   getTokenExchangeRates,
-  getSwapsEthToken,
+  getSwapsDefaultToken,
+  getCurrentChainId,
 } from '../../../selectors';
 import { toPrecisionWithoutTrailingZeros } from '../../../helpers/utils/util';
 import { getTokens } from '../../../ducks/metamask/metamask';
@@ -125,7 +126,8 @@ export default function ViewQuote() {
   const usedQuote = selectedQuote || topQuote;
   const tradeValue = usedQuote?.trade?.value ?? '0x0';
   const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime);
-  const swapsEthToken = useSelector(getSwapsEthToken);
+  const defaultSwapsToken = useSelector(getSwapsDefaultToken);
+  const chainId = useSelector(getCurrentChainId);
 
   const { isBestQuote } = usedQuote;
 
@@ -151,8 +153,8 @@ export default function ViewQuote() {
 
   const { tokensWithBalances } = useTokenTracker(swapsTokens, true);
   const balanceToken =
-    fetchParamsSourceToken === swapsEthToken.address
-      ? swapsEthToken
+    fetchParamsSourceToken === defaultSwapsToken.address
+      ? defaultSwapsToken
       : tokensWithBalances.find(
           ({ address }) => address === fetchParamsSourceToken,
         );
@@ -183,6 +185,7 @@ export default function ViewQuote() {
       currentCurrency,
       approveGas,
       memoizedTokenConversionRates,
+      chainId,
     );
   }, [
     quotes,
@@ -191,6 +194,7 @@ export default function ViewQuote() {
     currentCurrency,
     approveGas,
     memoizedTokenConversionRates,
+    chainId,
   ]);
 
   const renderableDataForUsedQuote = renderablePopoverData.find(
@@ -209,31 +213,33 @@ export default function ViewQuote() {
     sourceTokenIconUrl,
   } = renderableDataForUsedQuote;
 
-  const { feeInFiat, feeInEth } = getRenderableNetworkFeesForQuote(
-    usedGasLimit,
+  const { feeInFiat, feeInEth } = getRenderableNetworkFeesForQuote({
+    tradeGas: usedGasLimit,
     approveGas,
     gasPrice,
     currentCurrency,
     conversionRate,
     tradeValue,
-    sourceTokenSymbol,
-    usedQuote.sourceAmount,
-  );
+    sourceSymbol: sourceTokenSymbol,
+    sourceAmount: usedQuote.sourceAmount,
+    chainId,
+  });
 
   const {
     feeInFiat: maxFeeInFiat,
     feeInEth: maxFeeInEth,
     nonGasFee,
-  } = getRenderableNetworkFeesForQuote(
-    maxGasLimit,
+  } = getRenderableNetworkFeesForQuote({
+    tradeGas: maxGasLimit,
     approveGas,
     gasPrice,
     currentCurrency,
     conversionRate,
     tradeValue,
-    sourceTokenSymbol,
-    usedQuote.sourceAmount,
-  );
+    sourceSymbol: sourceTokenSymbol,
+    sourceAmount: usedQuote.sourceAmount,
+    chainId,
+  });
 
   const tokenCost = new BigNumber(usedQuote.sourceAmount);
   const ethCost = new BigNumber(usedQuote.trade.value || 0, 10).plus(
@@ -481,9 +487,9 @@ export default function ViewQuote() {
         <span key="swapApproveNeedMoreTokens-1" className="view-quote__bold">
           {tokenBalanceNeeded || ethBalanceNeeded}
         </span>,
-        tokenBalanceNeeded && !(sourceTokenSymbol === 'ETH')
+        tokenBalanceNeeded && !(sourceTokenSymbol === defaultSwapsToken.symbol)
           ? sourceTokenSymbol
-          : 'ETH',
+          : defaultSwapsToken.symbol,
       ]);
 
   // Price difference warning
@@ -643,7 +649,7 @@ export default function ViewQuote() {
               setSelectQuotePopoverShown(true);
             }}
             tokenConversionRate={
-              destinationTokenSymbol === 'ETH'
+              destinationTokenSymbol === defaultSwapsToken.symbol
                 ? 1
                 : memoizedTokenConversionRates[destinationToken.address]
             }
@@ -655,7 +661,7 @@ export default function ViewQuote() {
           setSubmitClicked(true);
           if (!balanceError) {
             dispatch(signAndSendTransactions(history, metaMetricsEvent));
-          } else if (destinationToken.symbol === 'ETH') {
+          } else if (destinationToken.symbol === defaultSwapsToken.symbol) {
             history.push(DEFAULT_ROUTE);
           } else {
             history.push(`${ASSET_ROUTE}/${destinationToken.address}`);

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -15,7 +15,10 @@ import {
   getValueFromWeiHex,
   hexToDecimal,
 } from '../helpers/utils/conversions.util';
-import { ETH_SWAPS_TOKEN_OBJECT } from '../../../shared/constants/swaps';
+import {
+  SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
+  ALLOWED_SWAPS_CHAIN_IDS,
+} from '../../../shared/constants/swaps';
 
 /**
  * One of the only remaining valid uses of selecting the network subkey of the
@@ -431,22 +434,26 @@ export function getWeb3ShimUsageStateForOrigin(state, origin) {
  * minimal token units (according to its decimals).
  * `string` is the token balance in a readable format, ready for rendering.
  *
- * Swaps treats ETH as a token, and we use the ETH_SWAPS_TOKEN_OBJECT constant
- * to set the standard properties for the token. The getSwapsEthToken selector
- * extends that object with `balance` and `balance` values of the same type as
- * in regular ERC-20 token objects, per the above description.
+ * Swaps treats the selected chain's currency as a token, and we use the token constants
+ * in the SWAPS_CHAINID_DEFAULT_TOKEN_MAP to set the standard properties for
+ * the token. The getSwapsDefaultToken selector extends that object with
+ * `balance` and `string` values of the same type as in regular ERC-20 token
+ * objects, per the above description.
  *
  * @param {object} state - the redux state object
  * @returns {SwapsEthToken} The token object representation of the currently
  * selected account's ETH balance, as expected by the Swaps API.
  */
 
-export function getSwapsEthToken(state) {
+export function getSwapsDefaultToken(state) {
   const selectedAccount = getSelectedAccount(state);
   const { balance } = selectedAccount;
+  const chainId = getCurrentChainId(state);
+
+  const defaultTokenObject = SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId];
 
   return {
-    ...ETH_SWAPS_TOKEN_OBJECT,
+    ...defaultTokenObject,
     balance: hexToDecimal(balance),
     string: getValueFromWeiHex({
       value: balance,
@@ -454,4 +461,9 @@ export function getSwapsEthToken(state) {
       toDenomination: 'ETH',
     }),
   };
+}
+
+export function getIsSwapsChain(state) {
+  const chainId = getCurrentChainId(state);
+  return ALLOWED_SWAPS_CHAIN_IDS[chainId];
 }


### PR DESCRIPTION
This PR allows swaps to work on local test networks with chainId of `0x539`. It also abstracts swaps logic dependent on chainId in a way that will allow us to add support for future networks simply by editing the `shared/constants/swaps.js` file.

Video demo of swaps working on a local test network:


https://user-images.githubusercontent.com/7499938/111293067-cf9fbc80-862b-11eb-9201-ebea52df0709.mp4

