### PR TITLE
Fixing migration script generation paths

### DIFF
--- a/development/generate-migration.sh
+++ b/development/generate-migration.sh
@@ -8,8 +8,8 @@ g-migration() {
   touch app/scripts/migrations/"$vnum".js
   cp app/scripts/migrations/template.js app/scripts/migrations/"$vnum".js
 
-  touch test/unit/migrations/"$vnum".js
-  cp test/unit/migrations/template-test.js test/unit/migrations/"$vnum"-test.js
+  touch app/scripts/migrations/"$vnum".test.js
+  cp app/scripts/migrations/template.test.js app/scripts/migrations/"$vnum".test.js
 }
 
 g-migration "$1"


### PR DESCRIPTION
Testing paths were updated via: https://github.com/MetaMask/metamask-extension/pull/10655

`development/generate-migration.sh` was not updated to use the new paths and formatting to generate the migration scripts.

Manual testing steps:  
  - yarn generate:migration n (where the last migration id + 1)
  - Ensure migration file and test file are correctly created