### PR TITLE
Fixing incorrectly typed token decimal attribute

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -378,7 +378,7 @@ export default class PreferencesController {
    */
   async addToken(rawAddress, symbol, decimals, image) {
     const address = normalizeAddress(rawAddress);
-    const newEntry = { address, symbol, decimals };
+    const newEntry = { address, symbol, decimals: Number(decimals) };
     const { tokens, hiddenTokens } = this.store.getState();
     const assetImages = this.getAssetImages();
     const updatedHiddenTokens = hiddenTokens.filter(

--- a/app/scripts/migrations/054.js
+++ b/app/scripts/migrations/054.js
@@ -1,0 +1,75 @@
+import { cloneDeep } from 'lodash';
+
+const version = 54;
+
+function isValidDecimals(decimals) {
+  return (
+    typeof decimals === 'number' ||
+    (typeof decimals === 'string' && decimals.match(/^(0x)?\d+$/u))
+  );
+}
+
+/**
+ * Migrates preference tokens with decimals typed as string to number.
+ * It also removes any tokens with corrupted or inconvertible decimal values.
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    const newState = transformState(state);
+    versionedData.data = newState;
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  const newState = state;
+
+  if (!newState.PreferencesController) {
+    return newState;
+  }
+
+  const tokens = newState.PreferencesController.tokens || [];
+  // Filter out any tokens with corrupted decimal values
+  const validTokens = tokens.filter(({ decimals }) =>
+    isValidDecimals(decimals),
+  );
+  for (const token of validTokens) {
+    // In the case of a decimal value type string, convert to a number.
+    if (typeof token.decimals === 'string') {
+      // eslint-disable-next-line radix
+      token.decimals = parseInt(token.decimals);
+    }
+  }
+  newState.PreferencesController.tokens = validTokens;
+
+  const { accountTokens } = newState.PreferencesController;
+  if (accountTokens && typeof accountTokens === 'object') {
+    for (const address of Object.keys(accountTokens)) {
+      const networkTokens = accountTokens[address];
+      if (networkTokens && typeof networkTokens === 'object') {
+        for (const network of Object.keys(networkTokens)) {
+          const tokensOnNetwork = networkTokens[network] || [];
+          // Filter out any tokens with corrupted decimal values
+          const validTokensOnNetwork = tokensOnNetwork.filter(({ decimals }) =>
+            isValidDecimals(decimals),
+          );
+          // In the case of a decimal value type string, convert to a number.
+          for (const token of validTokensOnNetwork) {
+            if (typeof token.decimals === 'string') {
+              // eslint-disable-next-line radix
+              token.decimals = parseInt(token.decimals);
+            }
+          }
+          networkTokens[network] = validTokensOnNetwork;
+        }
+      }
+    }
+  }
+  newState.PreferencesController.accountTokens = accountTokens;
+
+  return newState;
+}

--- a/app/scripts/migrations/054.test.js
+++ b/app/scripts/migrations/054.test.js
@@ -1,0 +1,687 @@
+import { strict as assert } from 'assert';
+import {
+  MAINNET_CHAIN_ID,
+  ROPSTEN_CHAIN_ID,
+} from '../../../shared/constants/network';
+import migration54 from './054';
+
+describe('migration #54', function () {
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      meta: {
+        version: 53,
+      },
+      data: {},
+    };
+
+    const newStorage = await migration54.migrate(oldStorage);
+    assert.deepEqual(newStorage.meta, {
+      version: 54,
+    });
+  });
+
+  it('should retype instance of 0 decimal values to numbers [tokens]', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [
+            {
+              address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+              decimals: '0',
+              symbol: 'CK',
+            },
+            {
+              address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+              decimals: 18,
+              symbol: 'BAT',
+            },
+            {
+              address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+              decimals: 18,
+              symbol: 'LINK',
+            },
+            {
+              address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+              decimals: '0',
+              symbol: 'SOR',
+            },
+          ],
+          accountTokens: [],
+        },
+      },
+    };
+
+    const newStorage = await migration54.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        tokens: [
+          {
+            address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+            decimals: 0,
+            symbol: 'CK',
+          },
+          {
+            address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+            decimals: 18,
+            symbol: 'BAT',
+          },
+          {
+            address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+            decimals: 18,
+            symbol: 'LINK',
+          },
+          {
+            address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+            decimals: 0,
+            symbol: 'SOR',
+          },
+        ],
+        accountTokens: [],
+      },
+    });
+  });
+
+  it('should do nothing if all decimal value typings are correct [tokens]', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          tokens: [
+            {
+              address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+              decimals: 0,
+              symbol: 'CK',
+            },
+            {
+              address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+              decimals: 18,
+              symbol: 'BAT',
+            },
+            {
+              address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+              decimals: 18,
+              symbol: 'LINK',
+            },
+            {
+              address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+              decimals: 0,
+              symbol: 'SOR',
+            },
+          ],
+          accountTokens: [],
+        },
+      },
+    };
+
+    const newStorage = await migration54.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        tokens: [
+          {
+            address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+            decimals: 0,
+            symbol: 'CK',
+          },
+          {
+            address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+            decimals: 18,
+            symbol: 'BAT',
+          },
+          {
+            address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+            decimals: 18,
+            symbol: 'LINK',
+          },
+          {
+            address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+            decimals: 0,
+            symbol: 'SOR',
+          },
+        ],
+        accountTokens: [],
+      },
+    });
+  });
+
+  it('should retype instance of 0 decimal values to numbers [accountTokens]', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          accountTokens: {
+            '0x1111': {
+              [MAINNET_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: '0',
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: '0',
+                  symbol: 'SOR',
+                },
+              ],
+            },
+            '0x1112': {
+              [ROPSTEN_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: '0',
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: '0',
+                  symbol: 'SOR',
+                },
+              ],
+            },
+          },
+          tokens: [],
+        },
+      },
+    };
+
+    const newStorage = await migration54.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        accountTokens: {
+          '0x1111': {
+            [MAINNET_CHAIN_ID]: [
+              {
+                address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                decimals: 0,
+                symbol: 'CK',
+              },
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+              {
+                address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                decimals: 0,
+                symbol: 'SOR',
+              },
+            ],
+          },
+          '0x1112': {
+            [ROPSTEN_CHAIN_ID]: [
+              {
+                address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                decimals: 0,
+                symbol: 'CK',
+              },
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+              {
+                address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                decimals: 0,
+                symbol: 'SOR',
+              },
+            ],
+          },
+        },
+        tokens: [],
+      },
+    });
+  });
+
+  it('should do nothing if all decimal value typings are correct [accountTokens]', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          accountTokens: {
+            '0x1111': {
+              [MAINNET_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: 0,
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: 0,
+                  symbol: 'SOR',
+                },
+              ],
+            },
+            '0x1112': {
+              [ROPSTEN_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: 0,
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: 0,
+                  symbol: 'SOR',
+                },
+              ],
+            },
+          },
+          tokens: [],
+        },
+      },
+    };
+
+    const newStorage = await migration54.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        accountTokens: {
+          '0x1111': {
+            [MAINNET_CHAIN_ID]: [
+              {
+                address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                decimals: 0,
+                symbol: 'CK',
+              },
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+              {
+                address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                decimals: 0,
+                symbol: 'SOR',
+              },
+            ],
+          },
+          '0x1112': {
+            [ROPSTEN_CHAIN_ID]: [
+              {
+                address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                decimals: 0,
+                symbol: 'CK',
+              },
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+              {
+                address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                decimals: 0,
+                symbol: 'SOR',
+              },
+            ],
+          },
+        },
+        tokens: [],
+      },
+    });
+  });
+
+  it('should retype instance of 0 decimal values to numbers [accountTokens and tokens]', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          accountTokens: {
+            '0x1111': {
+              [MAINNET_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: '0',
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: '0',
+                  symbol: 'SOR',
+                },
+              ],
+            },
+            '0x1112': {
+              [ROPSTEN_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: '0',
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: '0',
+                  symbol: 'SOR',
+                },
+              ],
+            },
+          },
+          tokens: [
+            {
+              address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+              decimals: '0',
+              symbol: 'CK',
+            },
+            {
+              address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+              decimals: 18,
+              symbol: 'BAT',
+            },
+            {
+              address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+              decimals: 18,
+              symbol: 'LINK',
+            },
+            {
+              address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+              decimals: '0',
+              symbol: 'SOR',
+            },
+          ],
+        },
+      },
+    };
+
+    const newStorage = await migration54.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        accountTokens: {
+          '0x1111': {
+            [MAINNET_CHAIN_ID]: [
+              {
+                address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                decimals: 0,
+                symbol: 'CK',
+              },
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+              {
+                address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                decimals: 0,
+                symbol: 'SOR',
+              },
+            ],
+          },
+          '0x1112': {
+            [ROPSTEN_CHAIN_ID]: [
+              {
+                address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                decimals: 0,
+                symbol: 'CK',
+              },
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+              {
+                address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                decimals: 0,
+                symbol: 'SOR',
+              },
+            ],
+          },
+        },
+        tokens: [
+          {
+            address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+            decimals: 0,
+            symbol: 'CK',
+          },
+          {
+            address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+            decimals: 18,
+            symbol: 'BAT',
+          },
+          {
+            address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+            decimals: 18,
+            symbol: 'LINK',
+          },
+          {
+            address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+            decimals: 0,
+            symbol: 'SOR',
+          },
+        ],
+      },
+    });
+  });
+
+  it('should retype instance of 0 decimal values to numbers, and remove tokens with corrupted decimal values [accountTokens and tokens]', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          accountTokens: {
+            '0x1111': {
+              [MAINNET_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: '',
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: '0',
+                  symbol: 'SOR',
+                },
+              ],
+            },
+            '0x1112': {
+              [ROPSTEN_CHAIN_ID]: [
+                {
+                  address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                  decimals: '0',
+                  symbol: 'CK',
+                },
+                {
+                  address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                  decimals: 18,
+                  symbol: 'BAT',
+                },
+                {
+                  address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                  decimals: 18,
+                  symbol: 'LINK',
+                },
+                {
+                  address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                  decimals: 'corrupted_decimal?',
+                  symbol: 'SOR',
+                },
+              ],
+            },
+          },
+          tokens: [
+            {
+              address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+              decimals: '0',
+              symbol: 'CK',
+            },
+            {
+              address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+              decimals: 18,
+              symbol: 'BAT',
+            },
+            {
+              address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+              decimals: 18,
+              symbol: 'LINK',
+            },
+            {
+              address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+              decimals: '18xx',
+              symbol: 'SOR',
+            },
+          ],
+        },
+      },
+    };
+
+    const newStorage = await migration54.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        accountTokens: {
+          '0x1111': {
+            [MAINNET_CHAIN_ID]: [
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+              {
+                address: '0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205',
+                decimals: 0,
+                symbol: 'SOR',
+              },
+            ],
+          },
+          '0x1112': {
+            [ROPSTEN_CHAIN_ID]: [
+              {
+                address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+                decimals: 0,
+                symbol: 'CK',
+              },
+              {
+                address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+                decimals: 18,
+                symbol: 'BAT',
+              },
+              {
+                address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+                decimals: 18,
+                symbol: 'LINK',
+              },
+            ],
+          },
+        },
+        tokens: [
+          {
+            address: '0x06012c8cf97bead5deae237070f9587f8e7a266d',
+            decimals: 0,
+            symbol: 'CK',
+          },
+          {
+            address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
+            decimals: 18,
+            symbol: 'BAT',
+          },
+          {
+            address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+            decimals: 18,
+            symbol: 'LINK',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -58,6 +58,7 @@ const migrations = [
   require('./051').default,
   require('./052').default,
   require('./053').default,
+  require('./054').default,
 ];
 
 export default migrations;


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/10665

Essentially if you are to add an NFT, or something with a 0 decimal value that does not allow for override, that gets saved to the state as `"0"` as opposed to 0, so we causing some component issues. Migrations added to back-fix the issue.

Manual testing steps:  
Defined in issue