### PR TITLE
Allow 11 characters in symbol for RPC

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -793,6 +793,11 @@ export default class PreferencesController {
     if (typeof symbol !== 'string') {
       throw ethErrors.rpc.invalidParams(`Invalid symbol: not a string.`);
     }
+    if (!(symbol.length > 0)) {
+      throw ethErrors.rpc.invalidParams(
+        `Invalid symbol "${symbol}": shorter than a character.`,
+      );
+    }
     if (!(symbol.length < 7)) {
       throw ethErrors.rpc.invalidParams(
         `Invalid symbol "${symbol}": longer than 6 characters.`,

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -798,9 +798,9 @@ export default class PreferencesController {
         `Invalid symbol "${symbol}": shorter than a character.`,
       );
     }
-    if (!(symbol.length < 7)) {
+    if (!(symbol.length < 12)) {
       throw ethErrors.rpc.invalidParams(
-        `Invalid symbol "${symbol}": longer than 6 characters.`,
+        `Invalid symbol "${symbol}": longer than 11 characters.`,
       );
     }
     const numDecimals = parseInt(decimals, 10);

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -539,6 +539,14 @@ describe('preferences controller', function () {
           decimals: 0,
         }),
       );
+      assert.doesNotThrow(() =>
+        validate({
+          address: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07',
+          symbol: 'ABCDEFGHIJK',
+          decimals: 0,
+        }),
+      );
+
       assert.throws(
         () => validate({ symbol: 'ABC', decimals: 0 }),
         'missing address should fail',
@@ -563,10 +571,19 @@ describe('preferences controller', function () {
         () =>
           validate({
             address: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07',
-            symbol: 'ABCDEFGHI',
+            symbol: 'ABCDEFGHIJKLM',
             decimals: 0,
           }),
-        'invalid symbol should fail',
+        'long symbol should fail',
+      );
+      assert.throws(
+        () =>
+          validate({
+            address: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07',
+            symbol: '',
+            decimals: 0,
+          }),
+        'empty symbol should fail',
       );
       assert.throws(
         () =>


### PR DESCRIPTION
To match the symbol length requirements in the UI, the RPC symbol length checks have been updated to allow 11 character symbols and disallow the empty string as a symbol.  