### PR TITLE
Don't render faucet row in deposit modal for custom chains

### DIFF
--- a/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
+++ b/ui/app/components/app/modals/deposit-ether-modal/deposit-ether-modal.component.js
@@ -155,14 +155,15 @@ export default class DepositEtherModal extends Component {
               buttonLabel: this.context.t('viewAccount'),
               onButtonClick: () => this.goToAccountDetailsModal(),
             })}
-            {this.renderRow({
-              logo: <i className="fa fa-tint fa-2x" />,
-              title: this.context.t('testFaucet'),
-              text: this.context.t('getEtherFromFaucet', [networkName]),
-              buttonLabel: this.context.t('getEther'),
-              onButtonClick: () => toFaucet(chainId),
-              hide: !isTestnet,
-            })}
+            {networkName &&
+              this.renderRow({
+                logo: <i className="fa fa-tint fa-2x" />,
+                title: this.context.t('testFaucet'),
+                text: this.context.t('getEtherFromFaucet', [networkName]),
+                buttonLabel: this.context.t('getEther'),
+                onButtonClick: () => toFaucet(chainId),
+                hide: !isTestnet,
+              })}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#10038

Follow reproduction steps laid out in issue, no longer rendering faucet links for custom chains