### PR TITLE
Adding default properties to NetworkForm

### DIFF
--- a/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/app/pages/settings/networks-tab/network-form/network-form.component.js
@@ -43,6 +43,14 @@ export default class NetworkForm extends PureComponent {
     isFullScreen: PropTypes.bool,
   };
 
+  static defaultProps = {
+    rpcUrl: '',
+    chainId: '',
+    ticker: '',
+    networkName: '',
+    blockExplorerUrl: '',
+  };
+
   state = {
     rpcUrl: this.props.rpcUrl,
     chainId: this.getDisplayChainId(this.props.chainId),


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#10681

In `NetworkForm`, the initial is state is given default values of component properties. When navigating to the "Add a network form" from the network dropdown specifically, those initial properties are `undefined`. In the case of adding a network, those fields should default to `''`. This simply adds a defaultProps block ensuring that the values are `prop || ''` as they should not be `undefined` when set as the initial value of a text input field.

Manual testing steps:  
Defined in issue

**Reviewer's manual testing note** - a simple regression test for adding and managing custom networks should be performed from both the network dropdown and the settings tab.