### PR TITLE
make migration more safe

### DIFF
--- a/app/scripts/migrations/055.js
+++ b/app/scripts/migrations/055.js
@@ -17,14 +17,25 @@ export default {
   },
 };
 
+const UNKNOWN_CHAIN_ID_KEY = 'UNKNOWN';
+
 function transformState(state) {
   if (
     state?.IncomingTransactionsController?.incomingTxLastFetchedBlocksByNetwork
   ) {
     state.IncomingTransactionsController.incomingTxLastFetchedBlockByChainId = mapKeys(
       state.IncomingTransactionsController.incomingTxLastFetchedBlocksByNetwork,
-      (_, key) => NETWORK_TYPE_TO_ID_MAP[key].chainId,
+      // using optional chaining in case user's state has fetched blocks for
+      // RPC network types (which don't map to a single chainId). This should
+      // not be possible, but it's safer
+      (_, key) => NETWORK_TYPE_TO_ID_MAP[key]?.chainId ?? UNKNOWN_CHAIN_ID_KEY,
     );
+    // Now that mainnet and test net last fetched blocks are keyed by their
+    // respective chainIds, we can safely delete anything we had for custom
+    // networks. Any custom network that shares a chainId with one of the
+    // aforementioned networks will use the value stored by chainId.
+    delete state.IncomingTransactionsController
+      .incomingTxLastFetchedBlockByChainId[UNKNOWN_CHAIN_ID_KEY];
     delete state.IncomingTransactionsController
       .incomingTxLastFetchedBlocksByNetwork;
   }


### PR DESCRIPTION
@rekmarks experienced an issue with the migration added in #10639 that resulted in an unusable extension. He resolved it by adding optional chaining but wound up with a strange state where there was an undefined key with a block number on it. I'm not sure why that would be the case, but this change should make the migration stable even under those circumstances. 