### PR TITLE
resolve issue with missing template error

### DIFF
--- a/ui/app/helpers/constants/routes.js
+++ b/ui/app/helpers/constants/routes.js
@@ -104,6 +104,8 @@ const PATH_NAME_MAP = {
   [CONNECTED_ACCOUNTS_ROUTE]: 'Accounts Connected To This Site Page',
   [`${CONFIRM_TRANSACTION_ROUTE}/:id`]: 'Confirmation Root Page',
   [CONFIRM_TRANSACTION_ROUTE]: 'Confirmation Root Page',
+  // TODO: rename when this is the only confirmation page
+  [CONFIRMATION_V_NEXT_ROUTE]: 'New Confirmation Page',
   [`${CONFIRM_TRANSACTION_ROUTE}/:id${CONFIRM_TOKEN_METHOD_PATH}`]: 'Confirm Token Method Transaction Page',
   [`${CONFIRM_TRANSACTION_ROUTE}/:id${CONFIRM_SEND_ETHER_PATH}`]: 'Confirm Send Ether Transaction Page',
   [`${CONFIRM_TRANSACTION_ROUTE}/:id${CONFIRM_SEND_TOKEN_PATH}`]: 'Confirm Send Token Transaction Page',

--- a/ui/app/pages/confirmation/confirmation.js
+++ b/ui/app/pages/confirmation/confirmation.js
@@ -17,7 +17,7 @@ import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import { stripHttpsScheme } from '../../helpers/utils/util';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { useOriginMetadata } from '../../hooks/useOriginMetadata';
-import { getUnapprovedConfirmations } from '../../selectors';
+import { getUnapprovedTemplatedConfirmations } from '../../selectors';
 import NetworkDisplay from '../../components/app/network-display/network-display';
 import { COLORS, SIZES } from '../../helpers/constants/design-system';
 import Callout from '../../components/ui/callout';
@@ -115,7 +115,10 @@ export default function ConfirmationPage() {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const history = useHistory();
-  const pendingConfirmations = useSelector(getUnapprovedConfirmations, isEqual);
+  const pendingConfirmations = useSelector(
+    getUnapprovedTemplatedConfirmations,
+    isEqual,
+  );
   const [currentPendingConfirmation, setCurrentPendingConfirmation] = useState(
     0,
   );

--- a/ui/app/pages/confirmation/templates/index.js
+++ b/ui/app/pages/confirmation/templates/index.js
@@ -12,7 +12,9 @@ const APPROVAL_TEMPLATES = {
   [MESSAGE_TYPE.SWITCH_ETHEREUM_CHAIN]: switchEthereumChain,
 };
 
-export const SUPPORTED_MESSAGE_TYPES = Object.keys(APPROVAL_TEMPLATES);
+export const TEMPLATED_CONFIRMATION_MESSAGE_TYPES = Object.keys(
+  APPROVAL_TEMPLATES,
+);
 
 const ALLOWED_TEMPLATE_KEYS = [
   'content',

--- a/ui/app/pages/confirmation/templates/index.js
+++ b/ui/app/pages/confirmation/templates/index.js
@@ -12,6 +12,8 @@ const APPROVAL_TEMPLATES = {
   [MESSAGE_TYPE.SWITCH_ETHEREUM_CHAIN]: switchEthereumChain,
 };
 
+export const SUPPORTED_MESSAGE_TYPES = Object.keys(APPROVAL_TEMPLATES);
+
 const ALLOWED_TEMPLATE_KEYS = [
   'content',
   'approvalText',

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -73,7 +73,7 @@ export default class Home extends PureComponent {
     setWeb3ShimUsageAlertDismissed: PropTypes.func.isRequired,
     originOfCurrentTab: PropTypes.string,
     disableWeb3ShimUsageAlert: PropTypes.func.isRequired,
-    pendingApprovals: PropTypes.arrayOf(PropTypes.object).isRequired,
+    pendingConfirmations: PropTypes.arrayOf(PropTypes.object).isRequired,
   };
 
   state = {
@@ -91,7 +91,7 @@ export default class Home extends PureComponent {
       haveSwapsQuotes,
       showAwaitingSwapScreen,
       swapsFetchParams,
-      pendingApprovals,
+      pendingConfirmations,
     } = this.props;
 
     this.setState({ mounted: true });
@@ -109,7 +109,7 @@ export default class Home extends PureComponent {
       history.push(CONFIRM_TRANSACTION_ROUTE);
     } else if (Object.keys(suggestedTokens).length > 0) {
       history.push(CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE);
-    } else if (pendingApprovals.length > 0) {
+    } else if (pendingConfirmations.length > 0) {
       history.push(CONFIRMATION_V_NEXT_ROUTE);
     }
   }

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -58,7 +58,7 @@ const mapStateToProps = (state) => {
   const { forgottenPassword, threeBoxLastUpdated } = appState;
   const totalUnapprovedCount = getTotalUnapprovedCount(state);
   const swapsEnabled = getSwapsFeatureLiveness(state);
-  const pendingApprovals = getUnapprovedTemplatedConfirmations(state);
+  const pendingConfirmations = getUnapprovedTemplatedConfirmations(state);
 
   const envType = getEnvironmentType();
   const isPopup = envType === ENVIRONMENT_TYPE_POPUP;
@@ -103,7 +103,7 @@ const mapStateToProps = (state) => {
     isMainnet: getIsMainnet(state),
     originOfCurrentTab,
     shouldShowWeb3ShimUsageNotification,
-    pendingApprovals,
+    pendingConfirmations,
   };
 };
 

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -8,6 +8,7 @@ import {
   getIsMainnet,
   getOriginOfCurrentTab,
   getTotalUnapprovedCount,
+  getUnapprovedTemplatedConfirmations,
   getWeb3ShimUsageStateForOrigin,
   unconfirmedTransactionsCountSelector,
 } from '../../selectors';
@@ -38,7 +39,6 @@ import {
   ALERT_TYPES,
   WEB3_SHIM_USAGE_ALERT_STATES,
 } from '../../../../shared/constants/alerts';
-import { SUPPORTED_MESSAGE_TYPES } from '../confirmation/templates';
 import Home from './home.component';
 
 const mapStateToProps = (state) => {
@@ -53,12 +53,12 @@ const mapStateToProps = (state) => {
     connectedStatusPopoverHasBeenShown,
     defaultHomeActiveTabName,
     swapsState,
-    pendingApprovals = {},
   } = metamask;
   const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
   const totalUnapprovedCount = getTotalUnapprovedCount(state);
   const swapsEnabled = getSwapsFeatureLiveness(state);
+  const pendingApprovals = getUnapprovedTemplatedConfirmations(state);
 
   const envType = getEnvironmentType();
   const isPopup = envType === ENVIRONMENT_TYPE_POPUP;
@@ -103,9 +103,7 @@ const mapStateToProps = (state) => {
     isMainnet: getIsMainnet(state),
     originOfCurrentTab,
     shouldShowWeb3ShimUsageNotification,
-    pendingApprovals: Object.values(pendingApprovals).filter((approval) =>
-      SUPPORTED_MESSAGE_TYPES.includes(approval.type),
-    ),
+    pendingApprovals,
   };
 };
 

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -38,6 +38,7 @@ import {
   ALERT_TYPES,
   WEB3_SHIM_USAGE_ALERT_STATES,
 } from '../../../../shared/constants/alerts';
+import { SUPPORTED_MESSAGE_TYPES } from '../confirmation/templates';
 import Home from './home.component';
 
 const mapStateToProps = (state) => {
@@ -102,7 +103,9 @@ const mapStateToProps = (state) => {
     isMainnet: getIsMainnet(state),
     originOfCurrentTab,
     shouldShowWeb3ShimUsageNotification,
-    pendingApprovals: Object.values(pendingApprovals),
+    pendingApprovals: Object.values(pendingApprovals).filter((approval) =>
+      SUPPORTED_MESSAGE_TYPES.includes(approval.type),
+    ),
   };
 };
 

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -19,6 +19,7 @@ import {
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
   ALLOWED_SWAPS_CHAIN_IDS,
 } from '../../../shared/constants/swaps';
+import { TEMPLATED_CONFIRMATION_MESSAGE_TYPES } from '../pages/confirmation/templates';
 
 /**
  * One of the only remaining valid uses of selecting the network subkey of the
@@ -323,6 +324,13 @@ function getUnapprovedTxCount(state) {
 export function getUnapprovedConfirmations(state) {
   const { pendingApprovals } = state.metamask;
   return Object.values(pendingApprovals);
+}
+
+export function getUnapprovedTemplatedConfirmations(state) {
+  const unapprovedConfirmations = getUnapprovedConfirmations(state);
+  return unapprovedConfirmations.filter((approval) =>
+    TEMPLATED_CONFIRMATION_MESSAGE_TYPES.includes(approval.type),
+  );
 }
 
 function getSuggestedTokenCount(state) {


### PR DESCRIPTION
Fixes: [METAMASK-GSGN](https://sentry.io/organizations/metamask/issues/2262591771/?environment=production&project=273505&query=wallet_requestPermissions&statsPeriod=14d)

Possible cause?
```js
    this.setState({ mounted: true });
    if (isNotification && totalUnapprovedCount === 0) {
      global.platform.closeCurrentWindow();
    } else if (!isNotification && showAwaitingSwapScreen) {
      history.push(AWAITING_SWAP_ROUTE);
    } else if (!isNotification && haveSwapsQuotes) {
      history.push(VIEW_QUOTE_ROUTE);
    } else if (!isNotification && swapsFetchParams) {
      history.push(BUILD_QUOTE_ROUTE);
    } else if (firstPermissionsRequestId) { // <------ If this is undefined, which is an approval
      history.push(`${CONNECT_ROUTE}/${firstPermissionsRequestId}`);
    } else if (unconfirmedTransactionsCount > 0) {
      history.push(CONFIRM_TRANSACTION_ROUTE);
    } else if (Object.keys(suggestedTokens).length > 0) {
      history.push(CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE);
    } else if (pendingApprovals.length > 0) { // <------- Then this would be true
      history.push(CONFIRMATION_V_NEXT_ROUTE);
    }
```

Why would firstPermissionsRequestId be undefined when there is pending approval of this type? Not sure. This change just makes it so that the only approvals that will be caught on the last block of the else/if are ones that have templates. This might mean for that user that they don't get routed to the notification at all -- perhaps not a real solution but one that doesn't cause an error.

