### PR TITLE
Excluding sourcemaps comment in production builds

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -254,7 +254,9 @@ function createScriptTasks({ browserPlatforms, livereload }) {
         // note: sourcemaps call arity is important
         buildPipeline.push(sourcemaps.write());
       } else {
-        buildPipeline.push(sourcemaps.write('../sourcemaps'));
+        buildPipeline.push(
+          sourcemaps.write('../sourcemaps', { addComment: false }),
+        );
       }
 
       // write completed bundles


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#7077

Manual testing steps:  
  - Build production MetaMask with `yarn dist`
  - Load the extension in to the browser
  - Navigate to a site such as `https://www.cryptokitties.co/`
  - Open Dev Tools > Console
  - Ensure sourcemap console warnings are not present
  
**Before:**
<img width="430" alt="Screen Shot 2021-03-22 at 2 34 31 PM" src="https://user-images.githubusercontent.com/8732757/112062019-8fa17380-8b1c-11eb-8581-c69397e1687b.png">

**After:**
<img width="366" alt="Screen Shot 2021-03-22 at 2 38 46 PM" src="https://user-images.githubusercontent.com/8732757/112062070-9f20bc80-8b1c-11eb-898d-8678ce0462a2.png">

