### PR TITLE
Fix 10562 - Hide the suggested token pane when not on Mainnet or test network

### DIFF
--- a/ui/app/pages/add-token/add-token.component.js
+++ b/ui/app/pages/add-token/add-token.component.js
@@ -28,6 +28,7 @@ class AddToken extends Component {
     clearPendingTokens: PropTypes.func,
     tokens: PropTypes.array,
     identities: PropTypes.object,
+    showSearchTab: PropTypes.bool.isRequired,
     mostRecentOverviewPage: PropTypes.string.isRequired,
   };
 
@@ -315,14 +316,23 @@ class AddToken extends Component {
   }
 
   renderTabs() {
-    return (
-      <Tabs>
-        <Tab name={this.context.t('search')}>{this.renderSearchToken()}</Tab>
-        <Tab name={this.context.t('customToken')}>
-          {this.renderCustomTokenForm()}
-        </Tab>
-      </Tabs>
+    const { showSearchTab } = this.props;
+    const tabs = [];
+
+    if (showSearchTab) {
+      tabs.push(
+        <Tab name={this.context.t('search')} key="search-tab">
+          {this.renderSearchToken()}
+        </Tab>,
+      );
+    }
+    tabs.push(
+      <Tab name={this.context.t('customToken')} key="custom-tab">
+        {this.renderCustomTokenForm()}
+      </Tab>,
     );
+
+    return <Tabs>{tabs}</Tabs>;
   }
 
   render() {

--- a/ui/app/pages/add-token/add-token.container.js
+++ b/ui/app/pages/add-token/add-token.container.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 
 import { setPendingTokens, clearPendingTokens } from '../../store/actions';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
+import { getIsMainOrTestNet } from '../../selectors/selectors';
 import AddToken from './add-token.component';
 
 const mapStateToProps = (state) => {
@@ -13,6 +14,7 @@ const mapStateToProps = (state) => {
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     tokens,
     pendingTokens,
+    showSearchTab: getIsMainOrTestNet(state),
   };
 };
 

--- a/ui/app/pages/add-token/add-token.container.js
+++ b/ui/app/pages/add-token/add-token.container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 
 import { setPendingTokens, clearPendingTokens } from '../../store/actions';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
-import { getIsMainOrTestNet } from '../../selectors/selectors';
+import { getIsMainnet } from '../../selectors/selectors';
 import AddToken from './add-token.component';
 
 const mapStateToProps = (state) => {
@@ -14,7 +14,7 @@ const mapStateToProps = (state) => {
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     tokens,
     pendingTokens,
-    showSearchTab: getIsMainOrTestNet(state),
+    showSearchTab: getIsMainnet(state) || process.env.IN_TEST === 'true',
   };
 };
 

--- a/ui/app/pages/add-token/add-token.test.js
+++ b/ui/app/pages/add-token/add-token.test.js
@@ -26,6 +26,7 @@ describe('Add Token', function () {
     tokens: [],
     identities: {},
     mostRecentOverviewPage: '/',
+    showSearchTab: true,
   };
 
   describe('Add Token', function () {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -340,6 +340,10 @@ export function getIsTestnet(state) {
   return TEST_CHAINS.includes(chainId);
 }
 
+export function getIsMainOrTestNet(state) {
+  return getIsMainnet(state) || getIsTestnet(state);
+}
+
 export function getPreferences({ metamask }) {
   return metamask.preferences;
 }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -4,7 +4,6 @@ import { addHexPrefix } from '../../../app/scripts/lib/util';
 import {
   MAINNET_CHAIN_ID,
   TEST_CHAINS,
-  LOCALHOST_CHAIN_ID,
   NETWORK_TYPE_RPC,
 } from '../../../shared/constants/network';
 import {
@@ -339,14 +338,6 @@ export function getIsMainnet(state) {
 export function getIsTestnet(state) {
   const chainId = getCurrentChainId(state);
   return TEST_CHAINS.includes(chainId);
-}
-
-export function getIsMainOrTestNet(state) {
-  return (
-    getIsMainnet(state) ||
-    getIsTestnet(state) ||
-    getCurrentChainId(state) === LOCALHOST_CHAIN_ID
-  );
 }
 
 export function getPreferences({ metamask }) {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -4,6 +4,7 @@ import { addHexPrefix } from '../../../app/scripts/lib/util';
 import {
   MAINNET_CHAIN_ID,
   TEST_CHAINS,
+  LOCALHOST_CHAIN_ID,
   NETWORK_TYPE_RPC,
 } from '../../../shared/constants/network';
 import {
@@ -341,7 +342,11 @@ export function getIsTestnet(state) {
 }
 
 export function getIsMainOrTestNet(state) {
-  return getIsMainnet(state) || getIsTestnet(state);
+  return (
+    getIsMainnet(state) ||
+    getIsTestnet(state) ||
+    getCurrentChainId(state) === LOCALHOST_CHAIN_ID
+  );
 }
 
 export function getPreferences({ metamask }) {


### PR DESCRIPTION
Fixes: #10562

Explanation:  

When a user clicks "Add Token", we don't want to show the token search pane if the user isn't on Ethereum Main Net or a known test network.

Manual testing steps:  
  - Set the network to Ethereum main net
  - Click "Add token -- you will see the search tab and it will be functional
  - Set the network to a custom network
  - Click "Add token -- you will *not* see the search tab


https://user-images.githubusercontent.com/46655/112218037-3d7e5200-8bf1-11eb-978c-cbb51f7f7f51.mp4

