### PR TITLE
Add MetaMask to list of BIP44 HD path examples

### DIFF
--- a/ui/app/pages/create-account/connect-hardware/index.js
+++ b/ui/app/pages/create-account/connect-hardware/index.js
@@ -21,7 +21,7 @@ const BIP44_PATH = `m/44'/60'/0'/0`;
 const HD_PATHS = [
   { name: 'Ledger Live', value: LEDGER_LIVE_PATH },
   { name: 'Legacy (MEW / MyCrypto)', value: MEW_PATH },
-  { name: `BIP44 Standard (e.g. Trezor)`, value: BIP44_PATH },
+  { name: `BIP44 Standard (e.g. MetaMask, Trezor)`, value: BIP44_PATH },
 ];
 
 class ConnectHardwareForm extends Component {


### PR DESCRIPTION
The "BIP44 Standard" HD path option in the Ledger connect flow listed only Trezor as an example. It seemed appropriate to include MetaMask as well, since we use the same path. This helps users who have imported their MetaMask seed phrase onto a Ledger device to discover this option.

<details>
<summary>Screenshot:</summary>

![bip44-metamask](https://user-images.githubusercontent.com/2459287/112233044-a3cc9a00-8c1c-11eb-9020-f7a98811179d.png)

</details>