### PR TITLE
rule out empty string for symbol

### DIFF
--- a/ui/app/pages/confirm-approve/confirm-approve.js
+++ b/ui/app/pages/confirm-approve/confirm-approve.js
@@ -88,7 +88,9 @@ export default function ConfirmApprove() {
     ? getCustomTxParamsData(data, { customPermissionAmount, decimals })
     : null;
 
-  return tokenSymbol ? (
+  return tokenSymbol === undefined ? (
+    <Loading />
+  ) : (
     <ConfirmTransactionBase
       toAddress={toAddress}
       identiconAddress={tokenAddress}
@@ -142,7 +144,5 @@ export default function ConfirmApprove() {
       hideSenderToRecipient
       customTxParamsData={customData}
     />
-  ) : (
-    <Loading />
   );
 }


### PR DESCRIPTION
Fixes: #10705 

It's possible for the token symbol to be an empty string on some tokens, this change simply makes it so that the approve confirmation loads when there is an empty string. Credit to @danjm for pointing out the fix and @tmashuang for identifying easy reproduction steps.