### PR TITLE
fix: remove unused `metamask.rpcUrl` from redux state + fix tests to reflect that

### DIFF
--- a/.storybook/test-data.js
+++ b/.storybook/test-data.js
@@ -5,7 +5,6 @@ const state = {
     isInitialized: true,
     isUnlocked: true,
     featureFlags: { sendHexData: true },
-    rpcUrl: 'https://rawtestrpc.metamask.io/',
     identities: {
       '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825': {
         address: '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825',

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -7,7 +7,6 @@ export default function reduceMetamask(state = {}, action) {
     isInitialized: false,
     isUnlocked: false,
     isAccountMenuOpen: false,
-    rpcUrl: 'https://rawtestrpc.metamask.io/',
     identities: {},
     unapprovedTxs: {},
     frequentRpcList: [],

--- a/ui/app/selectors/send-selectors-test-data.js
+++ b/ui/app/selectors/send-selectors-test-data.js
@@ -5,7 +5,6 @@ const state = {
     isInitialized: true,
     isUnlocked: true,
     featureFlags: { sendHexData: true },
-    rpcUrl: 'https://rawtestrpc.metamask.io/',
     identities: {
       '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825': {
         address: '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825',

--- a/ui/app/store/actionConstants.test.js
+++ b/ui/app/store/actionConstants.test.js
@@ -8,8 +8,10 @@ describe('Redux actionConstants', function () {
   describe('SET_RPC_TARGET', function () {
     const initialState = {
       metamask: {
-        rpcUrl: 'foo',
         frequentRpcList: [],
+        provider: {
+          rpcUrl: 'bar',
+        },
       },
       appState: {
         currentView: {


### PR DESCRIPTION

Explanation:  
`metamask.rpcUrl` is unused