### PR TITLE
Workaround to fix lag/freeze on external monitors

### DIFF
--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -14,6 +14,47 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
   align-items: center;
 }
 
+// Fix for UI lag on external monitor: https://github.com/MetaMask/metamask-extension/issues/10173
+.app::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  background-color: $Grey-000;
+  -webkit-animation-name: emptySpinningDiv;
+  animation-name: emptySpinningDiv;
+  -webkit-animation-duration: 2s;
+  animation-duration: 2s;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+}
+
+@-webkit-keyframes emptySpinningDiv {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes emptySpinningDiv {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+
 // Main container
 .main-container {
   z-index: $main-container-z-index;

--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -23,10 +23,7 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
   width: 1px;
   height: 1px;
   background-color: $Grey-000;
-  animation-name: emptySpinningDiv;
-  animation-duration: 2s;
-  animation-iteration-count: infinite;
-  animation-timing-function: linear;
+  animation: emptySpinningDiv 1s infinite linear;
 }
 
 @keyframes emptySpinningDiv {

--- a/ui/app/css/itcss/components/newui-sections.scss
+++ b/ui/app/css/itcss/components/newui-sections.scss
@@ -23,34 +23,17 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
   width: 1px;
   height: 1px;
   background-color: $Grey-000;
-  -webkit-animation-name: emptySpinningDiv;
   animation-name: emptySpinningDiv;
-  -webkit-animation-duration: 2s;
   animation-duration: 2s;
-  -webkit-animation-iteration-count: infinite;
   animation-iteration-count: infinite;
-  -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
-}
-
-@-webkit-keyframes emptySpinningDiv {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  to {
-    -webkit-transform: rotate(1turn);
-    transform: rotate(1turn);
-  }
 }
 
 @keyframes emptySpinningDiv {
   0% {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   to {
-    -webkit-transform: rotate(1turn);
     transform: rotate(1turn);
   }
 }


### PR DESCRIPTION
Fixes: #10173 

Explanation:  
Add a bit of CSS that renders a visually invisible rotating 1px element that forces the UI to update on each tick

Manual testing steps:  
  - Move Chrome window to an external monitor
  - Open Metamask popup and type in any input (password or a send amount)
  - See the UI updating after each keystroke


Here's a comparison before the fix: (UI only refreshes after a mouse move)
![before-fix](https://user-images.githubusercontent.com/1911427/112537521-07191200-8d6c-11eb-85c3-3b983d234897.gif)

After the fix: (UI updates on each keystroke)
![after-fix](https://user-images.githubusercontent.com/1911427/112537567-14ce9780-8d6c-11eb-853f-1cb8cea2a485.gif)
