### PR TITLE
Fix 10725 - Make 'forget device' work again

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1306,6 +1306,10 @@ export default class MetamaskController extends EventEmitter {
    */
   async forgetDevice(deviceName) {
     const keyring = await this.getKeyringForDevice(deviceName);
+    const accounts = await keyring.getAccounts();
+    await Promise.all(
+      accounts.map((account) => this.removeAccount(account.toLowerCase())),
+    );
     keyring.forgetDevice();
     return true;
   }


### PR DESCRIPTION
Fixes: #10725

Explanation:  

The call to `keyring.forgetDevice` wasn't sufficient in remove accounts from the keyringController and other important keyring properties.  Shout out to @brad-decker for the help!