### PR TITLE
ci - cache deps before patch-package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,13 +135,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
+          key: dependency-cache-v1-{{ checksum "yarn.lock" }}
       - run:
           name: Install deps
           command: |
             .circleci/scripts/deps-install.sh
       - save_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
+          key: dependency-cache-v1-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
             - build-artifacts/yarn-install-har/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,10 @@ jobs:
           paths:
             - node_modules/
             - build-artifacts/yarn-install-har/
+      - run:
+          name: Postinstall
+          command: |
+            yarn setup:postinstall
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/scripts/deps-install.sh
+++ b/.circleci/scripts/deps-install.sh
@@ -5,7 +5,7 @@ set -x
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-yarn setup-ci
+yarn install --frozen-lockfile --har
 
 # Move HAR file into directory with consistent name so that we can cache it
 mkdir -p build-artifacts/yarn-install-har

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "setup": "yarn install && yarn patch-package && yarn allow-scripts",
-    "setup-ci": "yarn install --frozen-lockfile --har && yarn patch-package && yarn allow-scripts",
+    "setup": "yarn install && yarn setup:postinstall",
+    "setup:postinstall": "yarn patch-package && yarn allow-scripts",
     "start": "node development/build/index.js dev",
     "start:lavamoat": "yarn build dev",
     "dist": "yarn build prod",


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/10734

we are accidentally caching the patched package and then patching them again