### PR TITLE
eth-block-tracker@5.0.1

### DIFF
--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -6,7 +6,7 @@ import createInflightMiddleware from 'eth-json-rpc-middleware/inflight-cache';
 import createBlockTrackerInspectorMiddleware from 'eth-json-rpc-middleware/block-tracker-inspector';
 import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddleware';
 import createInfuraMiddleware from 'eth-json-rpc-infura';
-import BlockTracker from 'eth-block-tracker';
+import { PollingBlockTracker } from 'eth-block-tracker';
 
 import { NETWORK_TYPE_TO_ID_MAP } from '../../../../shared/constants/network';
 
@@ -18,7 +18,7 @@ export default function createInfuraClient({ network, projectId }) {
     source: 'metamask',
   });
   const infuraProvider = providerFromMiddleware(infuraMiddleware);
-  const blockTracker = new BlockTracker({ provider: infuraProvider });
+  const blockTracker = new PollingBlockTracker({ provider: infuraProvider });
 
   const networkMiddleware = mergeMiddleware([
     createNetworkAndChainIdMiddleware({ network }),

--- a/app/scripts/controllers/network/createJsonRpcClient.js
+++ b/app/scripts/controllers/network/createJsonRpcClient.js
@@ -5,7 +5,7 @@ import createBlockCacheMiddleware from 'eth-json-rpc-middleware/block-cache';
 import createInflightMiddleware from 'eth-json-rpc-middleware/inflight-cache';
 import createBlockTrackerInspectorMiddleware from 'eth-json-rpc-middleware/block-tracker-inspector';
 import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddleware';
-import BlockTracker from 'eth-block-tracker';
+import { PollingBlockTracker } from 'eth-block-tracker';
 
 const inTest = process.env.IN_TEST === 'true';
 const blockTrackerOpts = inTest ? { pollingInterval: 1000 } : {};
@@ -16,7 +16,7 @@ const getTestMiddlewares = () => {
 export default function createJsonRpcClient({ rpcUrl, chainId }) {
   const fetchMiddleware = createFetchMiddleware({ rpcUrl });
   const blockProvider = providerFromMiddleware(fetchMiddleware);
-  const blockTracker = new BlockTracker({
+  const blockTracker = new PollingBlockTracker({
     ...blockTrackerOpts,
     provider: blockProvider,
   });

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "debounce-stream": "^2.0.0",
     "deep-freeze-strict": "1.1.1",
     "end-of-stream": "^1.4.4",
-    "eth-block-tracker": "^4.4.2",
+    "eth-block-tracker": "^5.0.1",
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-filters": "^4.2.1",
     "eth-json-rpc-infura": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9617,6 +9617,15 @@ eth-block-tracker@^4.4.2:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
+eth-block-tracker@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eth-block-tracker/-/eth-block-tracker-5.0.1.tgz#c5ad39902bd0454223b601ec0874f9fcc9f30eed"
+  integrity sha512-NVs+JDSux0FdmOrl3A2YDcQFkkYf9/qW9irvPmtC7bhMoPAe6oBlaqqe/m9Ixh5rkKqAox4mEyWGpsFmf/IsNw==
+  dependencies:
+    "@metamask/safe-event-emitter" "^2.0.0"
+    json-rpc-random-id "^1.0.1"
+    pify "^3.0.0"
+
 eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz#229ac46eca86d52e0c991e7cb2aef83ff0f68bcf"


### PR DESCRIPTION
New major version of `eth-block-tracker`. Exports changed, and our uses have been updated.