### PR TITLE
eth-json-rpc-middleware@8.0.0

### DIFF
--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -1,10 +1,13 @@
 import { createScaffoldMiddleware, mergeMiddleware } from 'json-rpc-engine';
-import createBlockRefMiddleware from 'eth-json-rpc-middleware/block-ref';
-import createRetryOnEmptyMiddleware from 'eth-json-rpc-middleware/retryOnEmpty';
-import createBlockCacheMiddleware from 'eth-json-rpc-middleware/block-cache';
-import createInflightCacheMiddleware from 'eth-json-rpc-middleware/inflight-cache';
-import createBlockTrackerInspectorMiddleware from 'eth-json-rpc-middleware/block-tracker-inspector';
-import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddleware';
+import {
+  createBlockRefMiddleware,
+  createRetryOnEmptyMiddleware,
+  createBlockCacheMiddleware,
+  createInflightCacheMiddleware,
+  createBlockTrackerInspectorMiddleware,
+  providerFromMiddleware,
+} from 'eth-json-rpc-middleware';
+
 import createInfuraMiddleware from 'eth-json-rpc-infura';
 import { PollingBlockTracker } from 'eth-block-tracker';
 

--- a/app/scripts/controllers/network/createJsonRpcClient.js
+++ b/app/scripts/controllers/network/createJsonRpcClient.js
@@ -1,10 +1,12 @@
 import { createAsyncMiddleware, mergeMiddleware } from 'json-rpc-engine';
-import createFetchMiddleware from 'eth-json-rpc-middleware/fetch';
-import createBlockRefRewriteMiddleware from 'eth-json-rpc-middleware/block-ref-rewrite';
-import createBlockCacheMiddleware from 'eth-json-rpc-middleware/block-cache';
-import createInflightMiddleware from 'eth-json-rpc-middleware/inflight-cache';
-import createBlockTrackerInspectorMiddleware from 'eth-json-rpc-middleware/block-tracker-inspector';
-import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddleware';
+import {
+  createFetchMiddleware,
+  createBlockRefRewriteMiddleware,
+  createBlockCacheMiddleware,
+  createInflightCacheMiddleware,
+  createBlockTrackerInspectorMiddleware,
+  providerFromMiddleware,
+} from 'eth-json-rpc-middleware';
 import { PollingBlockTracker } from 'eth-block-tracker';
 import { SECOND } from '../../../../shared/constants/time';
 
@@ -27,7 +29,7 @@ export default function createJsonRpcClient({ rpcUrl, chainId }) {
     createChainIdMiddleware(chainId),
     createBlockRefRewriteMiddleware({ blockTracker }),
     createBlockCacheMiddleware({ blockTracker }),
-    createInflightMiddleware(),
+    createInflightCacheMiddleware(),
     createBlockTrackerInspectorMiddleware({ blockTracker }),
     fetchMiddleware,
   ]);

--- a/app/scripts/controllers/network/createMetamaskMiddleware.js
+++ b/app/scripts/controllers/network/createMetamaskMiddleware.js
@@ -1,5 +1,5 @@
 import { createScaffoldMiddleware, mergeMiddleware } from 'json-rpc-engine';
-import createWalletSubprovider from 'eth-json-rpc-middleware/wallet';
+import { createWalletMiddleware } from 'eth-json-rpc-middleware';
 import {
   createPendingNonceMiddleware,
   createPendingTxMiddleware,
@@ -21,11 +21,10 @@ export default function createMetamaskMiddleware({
 }) {
   const metamaskMiddleware = mergeMiddleware([
     createScaffoldMiddleware({
-      // staticSubprovider
       eth_syncing: false,
       web3_clientVersion: `MetaMask/v${version}`,
     }),
-    createWalletSubprovider({
+    createWalletMiddleware({
       getAccounts,
       processTransaction,
       processEthSignMessage,

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import EventEmitter from 'events';
 import { ComposedStore, ObservableStore } from '@metamask/obs-store';
 import { JsonRpcEngine } from 'json-rpc-engine';
-import providerFromEngine from 'eth-json-rpc-middleware/providerFromEngine';
+import { providerFromEngine } from 'eth-json-rpc-middleware';
 import log from 'loglevel';
 import {
   createSwappableProxy,

--- a/app/scripts/controllers/threebox.js
+++ b/app/scripts/controllers/threebox.js
@@ -8,7 +8,7 @@ const Box = process.env.IN_TEST
 
 import log from 'loglevel';
 import { JsonRpcEngine } from 'json-rpc-engine';
-import providerFromEngine from 'eth-json-rpc-middleware/providerFromEngine';
+import { providerFromEngine } from 'eth-json-rpc-middleware';
 import Migrator from '../lib/migrator';
 import migrations from '../migrations';
 import createOriginMiddleware from '../lib/createOriginMiddleware';

--- a/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
+++ b/app/scripts/lib/rpc-method-middleware/createMethodMiddleware.js
@@ -1,3 +1,5 @@
+import { ethErrors } from 'eth-rpc-errors';
+import { UNSUPPORTED_RPC_METHODS } from '../../../../shared/constants/network';
 import handlers from './handlers';
 
 const handlerMap = handlers.reduce((map, handler) => {
@@ -26,6 +28,11 @@ const handlerMap = handlers.reduce((map, handler) => {
  */
 export default function createMethodMiddleware(opts) {
   return function methodMiddleware(req, res, next, end) {
+    // Reject unsupported methods.
+    if (UNSUPPORTED_RPC_METHODS.has(req.method)) {
+      return end(ethErrors.rpc.methodNotSupported());
+    }
+
     if (handlerMap.has(req.method)) {
       return handlerMap.get(req.method)(req, res, next, end, opts);
     }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7,7 +7,7 @@ import { debounce } from 'lodash';
 import createEngineStream from 'json-rpc-middleware-stream/engineStream';
 import createFilterMiddleware from 'eth-json-rpc-filters';
 import createSubscriptionManager from 'eth-json-rpc-filters/subscriptionManager';
-import providerAsMiddleware from 'eth-json-rpc-middleware/providerAsMiddleware';
+import { providerAsMiddleware } from 'eth-json-rpc-middleware';
 import KeyringController from 'eth-keyring-controller';
 import { Mutex } from 'await-semaphore';
 import { stripHexPrefix } from 'ethereumjs-util';

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-filters": "^4.2.1",
     "eth-json-rpc-infura": "^5.1.0",
-    "eth-json-rpc-middleware": "^7.0.1",
+    "eth-json-rpc-middleware": "^8.0.0",
     "eth-keyring-controller": "^6.2.0",
     "eth-method-registry": "^2.0.0",
     "eth-query": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-filters": "^4.2.1",
     "eth-json-rpc-infura": "^5.1.0",
-    "eth-json-rpc-middleware": "^6.0.0",
+    "eth-json-rpc-middleware": "^7.0.1",
     "eth-keyring-controller": "^6.2.0",
     "eth-method-registry": "^2.0.0",
     "eth-query": "^2.1.2",

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -161,3 +161,13 @@ export const CHAIN_ID_TO_GAS_LIMIT_BUFFER_MAP = {
   [OPTIMISM_CHAIN_ID]: 1,
   [OPTIMISM_TESTNET_CHAIN_ID]: 1,
 };
+
+/**
+ * Ethereum JSON-RPC methods that are known to exist but that we intentionally
+ * do not support.
+ */
+export const UNSUPPORTED_RPC_METHODS = new Set([
+  // This is implemented later in our middleware stack – specifically, in
+  // eth-json-rpc-middleware – but our UI does not support it.
+  'eth_signTransaction',
+]);

--- a/test/e2e/tests/provider-api.spec.js
+++ b/test/e2e/tests/provider-api.spec.js
@@ -1,17 +1,22 @@
 const { strict: assert } = require('assert');
+const { errorCodes } = require('eth-rpc-errors');
+const {
+  UNSUPPORTED_RPC_METHODS,
+} = require('../../../shared/constants/network');
 const { withFixtures } = require('../helpers');
 
 describe('MetaMask', function () {
+  const ganacheOptions = {
+    accounts: [
+      {
+        secretKey:
+          '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
+        balance: 25000000000000000000,
+      },
+    ],
+  };
+
   it('provider should inform dapp when switching networks', async function () {
-    const ganacheOptions = {
-      accounts: [
-        {
-          secretKey:
-            '0x7C9529A67102755B7E6102D6D950AC5D5863C98713805CEC576B945B15B71EAC',
-          balance: 25000000000000000000,
-        },
-      ],
-    };
     await withFixtures(
       {
         dapp: true,
@@ -59,6 +64,47 @@ describe('MetaMask', function () {
           await accountsDiv.getText(),
           '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
         );
+      },
+    );
+  });
+
+  it('should reject unsupported methods', async function () {
+    await withFixtures(
+      {
+        dapp: true,
+        fixtures: 'connected-state',
+        ganacheOptions,
+        title: this.test.title,
+      },
+      async ({ driver }) => {
+        await driver.navigate();
+        await driver.fill('#password', 'correct horse battery staple');
+        await driver.press('#password', driver.Key.ENTER);
+
+        await driver.openNewPage('http://127.0.0.1:8080/');
+        for (const unsupportedMethod of UNSUPPORTED_RPC_METHODS.values()) {
+          assert.equal(
+            await driver.executeScript(`
+              try {
+                await window.ethereum.request({ method: '${unsupportedMethod}' });
+                console.error('The unsupported method "${unsupportedMethod}" was not rejected.');
+                return false;
+              } catch (error) {
+                if (error.code === ${errorCodes.rpc.methodNotSupported}) {
+                  return true;
+                }
+
+                console.error(
+                  'The unsupported method "${unsupportedMethod}" was rejected with an unexpected error.',
+                  error,
+                );
+                return false;
+              }
+            `),
+            true,
+            `The unsupported method "${unsupportedMethod}" should be rejected by the provider.`,
+          );
+        }
       },
     );
   });

--- a/test/e2e/tests/provider-api.spec.js
+++ b/test/e2e/tests/provider-api.spec.js
@@ -69,6 +69,7 @@ describe('MetaMask', function () {
     await withFixtures(
       {
         dapp: true,
+        failOnConsoleError: false,
         fixtures: 'connected-state',
         ganacheOptions,
         title: this.test.title,

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -29,6 +29,10 @@ function wrapElementWithAPI(element, driver) {
   return element;
 }
 
+/**
+ * For Selenium WebDriver API documentation, see:
+ * https://www.selenium.dev/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
+ */
 class Driver {
   /**
    * @param {!ThenableWebDriver} driver - A {@code WebDriver} instance
@@ -47,6 +51,10 @@ class Driver {
       BACK_SPACE: '\uE003',
       ENTER: '\uE007',
     };
+  }
+
+  async executeAsyncScript(script, ...args) {
+    return this.driver.executeAsyncScript(script, args);
   }
 
   async executeScript(script, ...args) {

--- a/test/stub/provider.js
+++ b/test/stub/provider.js
@@ -1,6 +1,5 @@
-import { JsonRpcEngine } from 'json-rpc-engine';
-import scaffoldMiddleware from 'eth-json-rpc-middleware/scaffold';
-import providerAsMiddleware from 'eth-json-rpc-middleware/providerAsMiddleware';
+import { JsonRpcEngine, createScaffoldMiddleware } from 'json-rpc-engine';
+import { providerAsMiddleware } from 'eth-json-rpc-middleware';
 import GanacheCore from 'ganache-core';
 
 export function getTestSeed() {
@@ -45,7 +44,7 @@ export function providerFromEngine(engine) {
 export function createTestProviderTools(opts = {}) {
   const engine = createEngineForTestData();
   // handle provided hooks
-  engine.push(scaffoldMiddleware(opts.scaffold || {}));
+  engine.push(createScaffoldMiddleware(opts.scaffold || {}));
   // handle block tracker methods
   engine.push(
     providerAsMiddleware(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12325,6 +12325,21 @@ eth-json-rpc-middleware@^6.0.0:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
+eth-json-rpc-middleware@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-7.0.1.tgz#3b9d7f61ea8d86b112add1558432a51efa413f56"
+  integrity sha512-Z0Fg5spBzayjfLf7aTTaSZnzUhXE6wLWOWgdtX01LMigbttjSUbJxp23Z2jw5CavCnG8yEz9yQNHFQV2p2o/hQ==
+  dependencies:
+    "@metamask/safe-event-emitter" "^2.0.0"
+    btoa "^1.2.1"
+    clone "^2.1.1"
+    eth-rpc-errors "^4.0.3"
+    eth-sig-util "^1.4.2"
+    json-rpc-engine "^6.1.0"
+    json-stable-stringify "^1.0.1"
+    node-fetch "^2.6.1"
+    pify "^3.0.0"
+
 eth-keyring-controller@^6.1.0, eth-keyring-controller@^6.2.0, eth-keyring-controller@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-6.2.1.tgz#61901071fc74059ed37cb5ae93870fdcae6e3781"
@@ -12402,6 +12417,13 @@ eth-rpc-errors@^4.0.0, eth-rpc-errors@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.2.tgz#11bc164e25237a679061ac05b7da7537b673d3b7"
   integrity sha512-n+Re6Gu8XGyfFy1it0AwbD1x0MUzspQs0D5UiPs1fFPCr6WAwZM+vbIhXheBFrpgosqN9bs5PqlB4Q61U/QytQ==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
+eth-rpc-errors@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz#6ddb6190a4bf360afda82790bb7d9d5e724f423a"
+  integrity sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==
   dependencies:
     fast-safe-stringify "^2.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12325,10 +12325,10 @@ eth-json-rpc-middleware@^6.0.0:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-json-rpc-middleware@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-7.0.1.tgz#3b9d7f61ea8d86b112add1558432a51efa413f56"
-  integrity sha512-Z0Fg5spBzayjfLf7aTTaSZnzUhXE6wLWOWgdtX01LMigbttjSUbJxp23Z2jw5CavCnG8yEz9yQNHFQV2p2o/hQ==
+eth-json-rpc-middleware@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-8.0.0.tgz#d2a50a5fceca996ddc9d6775d53cf7e341500a88"
+  integrity sha512-G0693ZsEXzERrvE6mb2fevDvSE2gs1ClqFnh/r6/RUYq3y1uzK/5klRsfQvQPCGM9q2FEBKxWYdbIjMZAXWcDQ==
   dependencies:
     "@metamask/safe-event-emitter" "^2.0.0"
     btoa "^1.2.1"


### PR DESCRIPTION
We're bumping from `^6` to `^8`. All imports are now named, and they have been updated. This is a breaking change, in that support for `eth_signTransaction` is added in `^8.0.0`. We do not support this method in our UI, so our middleware stack has been instrumented to reject.

In addition, there are some non-breaking behavioral changes in this version that reviewers should be aware of, see the [7.0.0 release](https://github.com/MetaMask/eth-json-rpc-middleware/releases).