### PR TITLE
Remove all uses of createAsyncMiddleware

### DIFF
--- a/app/scripts/controllers/network/createJsonRpcClient.js
+++ b/app/scripts/controllers/network/createJsonRpcClient.js
@@ -1,4 +1,4 @@
-import { createAsyncMiddleware, mergeMiddleware } from 'json-rpc-engine';
+import { mergeMiddleware } from 'json-rpc-engine';
 import createFetchMiddleware from 'eth-json-rpc-middleware/fetch';
 import createBlockRefRewriteMiddleware from 'eth-json-rpc-middleware/block-ref-rewrite';
 import createBlockCacheMiddleware from 'eth-json-rpc-middleware/block-cache';
@@ -49,10 +49,10 @@ function createChainIdMiddleware(chainId) {
  * Adds a delay to `eth_estimateGas` calls.
  */
 function createEstimateGasDelayTestMiddleware() {
-  return createAsyncMiddleware(async (req, _, next) => {
+  return async (req, _, next) => {
     if (req.method === 'eth_estimateGas') {
       await new Promise((resolve) => setTimeout(resolve, 2000));
     }
     return next();
-  });
+  };
 }

--- a/app/scripts/controllers/network/middleware/pending.js
+++ b/app/scripts/controllers/network/middleware/pending.js
@@ -1,35 +1,32 @@
-import { createAsyncMiddleware } from 'json-rpc-engine';
 import { formatTxMetaForRpcResult } from '../util';
 
 export function createPendingNonceMiddleware({ getPendingNonce }) {
-  return createAsyncMiddleware(async (req, res, next) => {
+  return async (req, res, next, end) => {
     const { method, params } = req;
     if (method !== 'eth_getTransactionCount') {
-      next();
-      return;
+      return next();
     }
     const [param, blockRef] = params;
     if (blockRef !== 'pending') {
-      next();
-      return;
+      return next();
     }
     res.result = await getPendingNonce(param);
-  });
+    return end();
+  };
 }
 
 export function createPendingTxMiddleware({ getPendingTransactionByHash }) {
-  return createAsyncMiddleware(async (req, res, next) => {
+  return (req, res, next, end) => {
     const { method, params } = req;
     if (method !== 'eth_getTransactionByHash') {
-      next();
-      return;
+      return next();
     }
     const [hash] = params;
     const txMeta = getPendingTransactionByHash(hash);
     if (!txMeta) {
-      next();
-      return;
+      return next();
     }
     res.result = formatTxMetaForRpcResult(txMeta);
-  });
+    return end();
+  };
 }


### PR DESCRIPTION
After I lost hours to a bug in a `createAsyncMiddleware` middleware — due to an unsafe pattern that it forces the consumer to use — I realized that `createAsyncMiddleware` is superfluous. Free your mind; delete `createAsyncMiddleware`.