### PR TITLE
update @metamask/etherscan-link to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@metamask/controllers": "^6.2.1",
     "@metamask/eth-ledger-bridge-keyring": "^0.3.0",
     "@metamask/eth-token-tracker": "^3.0.1",
-    "@metamask/etherscan-link": "^1.5.0",
+    "@metamask/etherscan-link": "^2.0.0",
     "@metamask/inpage-provider": "^8.0.4",
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,10 +2303,10 @@
     human-standard-token-abi "^1.0.2"
     safe-event-emitter "^1.0.1"
 
-"@metamask/etherscan-link@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-1.5.0.tgz#c6940ea934b3a7dcf04e459d9ea3c630b69f6b5f"
-  integrity sha512-vPCkZJwZ5p933n20Zh+cC3umJv05un2CRZ8y+14KgMq3I4eOwllqmqxoYf9tn3BLGM8QXm/Nie+aBjmoe/T9ag==
+"@metamask/etherscan-link@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/etherscan-link/-/etherscan-link-2.0.0.tgz#89035736515a39532ba1142d87b9a8c2b4f920f1"
+  integrity sha512-/YS32hS2UTTxs0KyUmAgaDj1w4dzAvOrT+p4TJtpICeH3E/k51r2FO0Or7WJJI/mpzTqNKgcH5yyS2oCtupGiA==
 
 "@metamask/forwarder@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Update etherscan-link to [2.0.0](https://github.com/MetaMask/etherscan-link/releases/tag/v2.0.0)

Note that the breaking changes were just those that came with [setting minimum node version support](https://github.com/MetaMask/etherscan-link/pull/38), and don't affect our implementation