### PR TITLE
Ensure that the correct default currency symbols are used for fees on the view quote screen

### DIFF
--- a/ui/app/helpers/utils/formatters.js
+++ b/ui/app/helpers/utils/formatters.js
@@ -1,3 +1,4 @@
-export function formatETHFee(ethFee) {
-  return `${ethFee} ETH`;
+// TODO: Rename to reflect that this function is used for more cases than ETH, and update all uses.
+export function formatETHFee(ethFee, currencySymbol = 'ETH') {
+  return `${ethFee} ${currencySymbol}`;
 }

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -427,6 +427,7 @@ export function getRenderableNetworkFeesForQuote({
   sourceSymbol,
   sourceAmount,
   chainId,
+  nativeCurrencySymbol,
 }) {
   const totalGasLimitForCalculation = new BigNumber(tradeGas || '0x0', 16)
     .plus(approveGas || '0x0', 16)
@@ -456,11 +457,15 @@ export function getRenderableNetworkFeesForQuote({
     numberOfDecimals: 2,
   });
   const formattedNetworkFee = formatCurrency(rawNetworkFees, currentCurrency);
+
+  const chainCurrencySymbolToUse =
+    nativeCurrencySymbol || SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol;
+
   return {
     rawNetworkFees,
     rawEthFee: ethFee,
     feeInFiat: formattedNetworkFee,
-    feeInEth: `${ethFee} ${SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol}`,
+    feeInEth: `${ethFee} ${chainCurrencySymbolToUse}`,
     nonGasFee,
   };
 }

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -38,6 +38,7 @@ import {
   getTokenExchangeRates,
   getSwapsDefaultToken,
   getCurrentChainId,
+  getNativeCurrency,
 } from '../../../selectors';
 import { toPrecisionWithoutTrailingZeros } from '../../../helpers/utils/util';
 import { getTokens } from '../../../ducks/metamask/metamask';
@@ -128,6 +129,7 @@ export default function ViewQuote() {
   const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken);
   const chainId = useSelector(getCurrentChainId);
+  const nativeCurrencySymbol = useSelector(getNativeCurrency);
 
   const { isBestQuote } = usedQuote;
 
@@ -223,6 +225,7 @@ export default function ViewQuote() {
     sourceSymbol: sourceTokenSymbol,
     sourceAmount: usedQuote.sourceAmount,
     chainId,
+    nativeCurrencySymbol,
   });
 
   const {
@@ -239,6 +242,7 @@ export default function ViewQuote() {
     sourceSymbol: sourceTokenSymbol,
     sourceAmount: usedQuote.sourceAmount,
     chainId,
+    nativeCurrencySymbol,
   });
 
   const tokenCost = new BigNumber(usedQuote.sourceAmount);

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -134,13 +134,18 @@ export function basicPriceEstimateToETHTotal(
   });
 }
 
-export function getRenderableEthFee(estimate, gasLimit, numberOfDecimals = 9) {
+export function getRenderableEthFee(
+  estimate,
+  gasLimit,
+  numberOfDecimals = 9,
+  nativeCurrency = 'ETH',
+) {
   const value = conversionUtil(estimate, {
     fromNumericBase: 'dec',
     toNumericBase: 'hex',
   });
   const fee = basicPriceEstimateToETHTotal(value, gasLimit, numberOfDecimals);
-  return formatETHFee(fee);
+  return formatETHFee(fee, nativeCurrency);
 }
 
 export function getRenderableConvertedCurrencyFee(
@@ -186,12 +191,18 @@ export function getRenderableGasButtonData(
   showFiat,
   conversionRate,
   currentCurrency,
+  nativeCurrency,
 ) {
   const { safeLow, average, fast } = estimates;
 
   const slowEstimateData = {
     gasEstimateType: GAS_ESTIMATE_TYPES.SLOW,
-    feeInPrimaryCurrency: getRenderableEthFee(safeLow, gasLimit),
+    feeInPrimaryCurrency: getRenderableEthFee(
+      safeLow,
+      gasLimit,
+      9,
+      nativeCurrency,
+    ),
     feeInSecondaryCurrency: showFiat
       ? getRenderableConvertedCurrencyFee(
           safeLow,
@@ -204,7 +215,12 @@ export function getRenderableGasButtonData(
   };
   const averageEstimateData = {
     gasEstimateType: GAS_ESTIMATE_TYPES.AVERAGE,
-    feeInPrimaryCurrency: getRenderableEthFee(average, gasLimit),
+    feeInPrimaryCurrency: getRenderableEthFee(
+      average,
+      gasLimit,
+      9,
+      nativeCurrency,
+    ),
     feeInSecondaryCurrency: showFiat
       ? getRenderableConvertedCurrencyFee(
           average,
@@ -217,7 +233,12 @@ export function getRenderableGasButtonData(
   };
   const fastEstimateData = {
     gasEstimateType: GAS_ESTIMATE_TYPES.FAST,
-    feeInPrimaryCurrency: getRenderableEthFee(fast, gasLimit),
+    feeInPrimaryCurrency: getRenderableEthFee(
+      fast,
+      gasLimit,
+      9,
+      nativeCurrency,
+    ),
     feeInSecondaryCurrency: showFiat
       ? getRenderableConvertedCurrencyFee(
           fast,
@@ -295,7 +316,6 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
         safeLow,
         gasLimit,
         NUMBER_OF_DECIMALS_SM_BTNS,
-        true,
       ),
       priceInHexWei: getGasPriceInHexWei(safeLow, true),
     },
@@ -313,7 +333,6 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
         average,
         gasLimit,
         NUMBER_OF_DECIMALS_SM_BTNS,
-        true,
       ),
       priceInHexWei: getGasPriceInHexWei(average, true),
     },
@@ -331,7 +350,6 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
         fast,
         gasLimit,
         NUMBER_OF_DECIMALS_SM_BTNS,
-        true,
       ),
       priceInHexWei: getGasPriceInHexWei(fast, true),
     },


### PR DESCRIPTION
This PR fixes an issues found by @tmashuang while reviewing v9.3.0

It ensures that fees on the view quote screen - in both the fees card and in the gas modal - use the correct currency symbol. On mainnet this will be ETH. On custom networks, this will be the currency symbol set by the user, or if no currency symbol has been set, it will be the symbol of the default token for that network.

Demo video is here: https://www.veed.io/download/a2f4f25e-f0b6-4658-8909-4f48730f1890