### PR TITLE
Ensure that priceSlippage fiat amounts are always shown in view-quote.js

### DIFF
--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -518,9 +518,11 @@ export default function ViewQuote() {
   let viewQuotePriceDifferenceComponent = null;
   const priceSlippageFromSource = useEthFiatAmount(
     usedQuote?.priceSlippage?.sourceAmountInETH || 0,
+    { showFiat: true },
   );
   const priceSlippageFromDestination = useEthFiatAmount(
     usedQuote?.priceSlippage?.destinationAmountInETH || 0,
+    { showFiat: true },
   );
 
   // We cannot present fiat value if there is a calculation error or no slippage


### PR DESCRIPTION
This PR fixes an issue found by @tmashuang when QAing v9.3.0: "Market Price unavailable" were always showing up on the second screen of the swaps flow while on the bsc network.

This is because `priceSlippageFromSource` and `priceSlippageFromDestination` were always undefined, because `useEthFiatAmount` returns undefined if not on mainnet nor on a testnet while have set the "show fiat in testnet" setting to true.

To ensure the calls to `useEthFiatAmount` from `view-quote.js` behave on other networks the same as they do on mainnet, this PR adds the `overrides.showFiat` parameter to those calls.