### PR TITLE
Ensure that the approval fee in the swaps custom gas modal is in network specific currency

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -143,10 +143,6 @@
   "amount": {
     "message": "Amount"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Amount:"
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -126,10 +126,6 @@
   "amount": {
     "message": "Cantidad"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Cantidad:"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -126,10 +126,6 @@
   "amount": {
     "message": "Monto"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Monto:"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -120,10 +120,6 @@
   "amount": {
     "message": "राशि"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "राशि:"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -120,10 +120,6 @@
   "amount": {
     "message": "Jumlah"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Jumlah:"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -126,10 +126,6 @@
   "amount": {
     "message": "Importo"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Importo:"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -126,10 +126,6 @@
   "amount": {
     "message": "金額"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "金額:"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -120,10 +120,6 @@
   "amount": {
     "message": "금액"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "금액:"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -120,10 +120,6 @@
   "amount": {
     "message": "Сумма"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Сумма:"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -120,10 +120,6 @@
   "amount": {
     "message": "Halaga"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Halaga:"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -120,10 +120,6 @@
   "amount": {
     "message": "Số tiền"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "Số tiền:"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -126,10 +126,6 @@
   "amount": {
     "message": "数额"
   },
-  "amountInEth": {
-    "message": "$1 ETH",
-    "description": "Displays an eth amount to the user. $1 is a decimal number"
-  },
   "amountWithColon": {
     "message": "数额："
   },

--- a/ui/app/pages/swaps/view-quote/view-quote.js
+++ b/ui/app/pages/swaps/view-quote/view-quote.js
@@ -470,7 +470,7 @@ export default function ViewQuote() {
         extraInfoRow: extraInfoRowLabel
           ? {
               label: extraInfoRowLabel,
-              value: t('amountInEth', [extraNetworkFeeTotalInEth]),
+              value: `${extraNetworkFeeTotalInEth} ${nativeCurrencySymbol}`,
             }
           : null,
         initialGasPrice: gasPrice,


### PR DESCRIPTION
Addresses an issue found by @tmashuang while QAing v9.3.0

The `extraInfoRow.value` property passed from view-quote.js to the custom gas modal was using the `amountInEth` translation, meaning that the approve fee shown in the modal always had "ETH" as the currency symbol instead of the current networks symbol (e.g. BNB). This PR corrects that.

After:

![Screenshot from 2021-03-29 21-25-10](https://user-images.githubusercontent.com/7499938/112913896-4a111780-90d5-11eb-9855-e95481dd30ce.png)
