### PR TITLE
Handling gas price fetch failure 

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -678,6 +678,9 @@
   "estimatedProcessingTimes": {
     "message": "Estimated Processing Times"
   },
+  "ethGasPriceFetchWarning": {
+    "message": "Backup gas price is provided as the main gas estimation service is unavailable right now."
+  },
   "eth_accounts": {
     "message": "View the addresses of your permitted accounts (required)",
     "description": "The description for the `eth_accounts` permission"
@@ -773,6 +776,9 @@
   },
   "gasPriceExtremelyLow": {
     "message": "Gas Price Extremely Low"
+  },
+  "gasPriceFetchFailed": {
+    "message": "Gas price estimation failed due to network error."
   },
   "gasPriceInfoTooltipContent": {
     "message": "Gas price specifies the amount of Ether you are willing to pay for each unit of gas."

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -22,6 +22,7 @@ export default class ConfirmPageContainerContent extends Component {
     titleComponent: PropTypes.node,
     warning: PropTypes.string,
     origin: PropTypes.string.isRequired,
+    ethGasPriceWarning: PropTypes.string,
     // Footer
     onCancelAll: PropTypes.func,
     onCancel: PropTypes.func,
@@ -81,11 +82,15 @@ export default class ConfirmPageContainerContent extends Component {
       unapprovedTxCount,
       rejectNText,
       origin,
+      ethGasPriceWarning,
     } = this.props;
 
     return (
       <div className="confirm-page-container-content">
         {warning && <ConfirmPageContainerWarning warning={warning} />}
+        {ethGasPriceWarning && (
+          <ConfirmPageContainerWarning warning={ethGasPriceWarning} />
+        )}
         <ConfirmPageContainerSummary
           className={classnames({
             'confirm-page-container-summary--border':

--- a/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-warning/index.scss
@@ -1,7 +1,6 @@
 .confirm-page-container-warning {
   background-color: #fffcdb;
   display: flex;
-  justify-content: center;
   align-items: center;
   border-bottom: 1px solid $geyser;
   padding: 12px 24px;

--- a/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/app/components/app/confirm-page-container/confirm-page-container.component.js
@@ -43,6 +43,7 @@ export default class ConfirmPageContainer extends Component {
     warning: PropTypes.string,
     unapprovedTxCount: PropTypes.number,
     origin: PropTypes.string.isRequired,
+    ethGasPriceWarning: PropTypes.string,
     // Navigation
     totalTx: PropTypes.number,
     positionOfCurrentTx: PropTypes.number,
@@ -103,6 +104,7 @@ export default class ConfirmPageContainer extends Component {
       hideSenderToRecipient,
       showAccountInHeader,
       origin,
+      ethGasPriceWarning,
     } = this.props;
     const renderAssetImage = contentComponent || !identiconAddress;
 
@@ -162,6 +164,7 @@ export default class ConfirmPageContainer extends Component {
             unapprovedTxCount={unapprovedTxCount}
             rejectNText={this.context.t('rejectTxsN', [unapprovedTxCount])}
             origin={origin}
+            ethGasPriceWarning={ethGasPriceWarning}
           />
         )}
         {contentComponent && (

--- a/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/app/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -123,19 +123,25 @@ export default class GasModalPageContainer extends Component {
       infoRowProps: { newTotalFiat, newTotalEth, sendAmount, transactionFee },
     } = this.props;
 
-    let tabsToRender = [
-      {
-        name: this.context.t('basic'),
-        content: this.renderBasicTabContent(gasPriceButtonGroupProps),
-      },
-      {
-        name: this.context.t('advanced'),
-        content: this.renderAdvancedTabContent(),
-      },
-    ];
-
+    let tabsToRender;
     if (hideBasic) {
-      tabsToRender = tabsToRender.slice(1);
+      tabsToRender = [
+        {
+          name: this.context.t('advanced'),
+          content: this.renderAdvancedTabContent(),
+        },
+      ];
+    } else {
+      tabsToRender = [
+        {
+          name: this.context.t('basic'),
+          content: this.renderBasicTabContent(gasPriceButtonGroupProps),
+        },
+        {
+          name: this.context.t('advanced'),
+          content: this.renderAdvancedTabContent(),
+        },
+      ];
     }
 
     return (

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -50,6 +50,7 @@ describe('Gas Duck', () => {
       safeLow: null,
     },
     basicEstimateIsLoading: true,
+    isEthGasPriceFetched: false,
   };
 
   const providerState = {

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -3,8 +3,7 @@ import sinon from 'sinon';
 import BN from 'bn.js';
 
 import GasReducer, {
-  basicGasEstimatesLoadingStarted,
-  basicGasEstimatesLoadingFinished,
+  setBasicEstimateStatus,
   setBasicGasEstimateData,
   setCustomGasPrice,
   setCustomGasLimit,
@@ -49,8 +48,8 @@ describe('Gas Duck', () => {
       fast: null,
       safeLow: null,
     },
-    basicEstimateIsLoading: true,
-    isEthGasPriceFetched: false,
+    basicEstimateStatus: 'LOADING',
+    estimateSource: '',
   };
 
   const providerState = {
@@ -62,14 +61,12 @@ describe('Gas Duck', () => {
     type: 'mainnet',
   };
 
-  const BASIC_GAS_ESTIMATE_LOADING_FINISHED =
-    'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_FINISHED';
-  const BASIC_GAS_ESTIMATE_LOADING_STARTED =
-    'metamask/gas/BASIC_GAS_ESTIMATE_LOADING_STARTED';
+  const BASIC_GAS_ESTIMATE_STATUS = 'metamask/gas/BASIC_GAS_ESTIMATE_STATUS';
   const SET_BASIC_GAS_ESTIMATE_DATA =
     'metamask/gas/SET_BASIC_GAS_ESTIMATE_DATA';
   const SET_CUSTOM_GAS_LIMIT = 'metamask/gas/SET_CUSTOM_GAS_LIMIT';
   const SET_CUSTOM_GAS_PRICE = 'metamask/gas/SET_CUSTOM_GAS_PRICE';
+  const SET_ESTIMATE_SOURCE = 'metamask/gas/SET_ESTIMATE_SOURCE';
 
   describe('GasReducer()', () => {
     it('should initialize state', () => {
@@ -85,16 +82,13 @@ describe('Gas Duck', () => {
       ).toStrictEqual(mockState);
     });
 
-    it('should set basicEstimateIsLoading to true when receiving a BASIC_GAS_ESTIMATE_LOADING_STARTED action', () => {
+    it('should set basicEstimateStatus to LOADING when receiving a BASIC_GAS_ESTIMATE_STATUS action with value LOADING', () => {
       expect(
-        GasReducer(mockState, { type: BASIC_GAS_ESTIMATE_LOADING_STARTED }),
-      ).toStrictEqual({ basicEstimateIsLoading: true, ...mockState });
-    });
-
-    it('should set basicEstimateIsLoading to false when receiving a BASIC_GAS_ESTIMATE_LOADING_FINISHED action', () => {
-      expect(
-        GasReducer(mockState, { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED }),
-      ).toStrictEqual({ basicEstimateIsLoading: false, ...mockState });
+        GasReducer(mockState, {
+          type: BASIC_GAS_ESTIMATE_STATUS,
+          value: 'LOADING',
+        }),
+      ).toStrictEqual({ basicEstimateStatus: 'LOADING', ...mockState });
     });
 
     it('should set basicEstimates when receiving a SET_BASIC_GAS_ESTIMATE_DATA action', () => {
@@ -128,18 +122,17 @@ describe('Gas Duck', () => {
     });
   });
 
-  describe('basicGasEstimatesLoadingStarted', () => {
-    it('should create the correct action', () => {
-      expect(basicGasEstimatesLoadingStarted()).toStrictEqual({
-        type: BASIC_GAS_ESTIMATE_LOADING_STARTED,
-      });
-    });
+  it('should set estimateSource to Metaswaps when receiving a SET_ESTIMATE_SOURCE action with value Metaswaps', () => {
+    expect(
+      GasReducer(mockState, { type: SET_ESTIMATE_SOURCE, value: 'Metaswaps' }),
+    ).toStrictEqual({ estimateSource: 'Metaswaps', ...mockState });
   });
 
-  describe('basicGasEstimatesLoadingFinished', () => {
+  describe('basicEstimateStatus', () => {
     it('should create the correct action', () => {
-      expect(basicGasEstimatesLoadingFinished()).toStrictEqual({
-        type: BASIC_GAS_ESTIMATE_LOADING_FINISHED,
+      expect(setBasicEstimateStatus('LOADING')).toStrictEqual({
+        type: BASIC_GAS_ESTIMATE_STATUS,
+        value: 'LOADING',
       });
     });
   });
@@ -159,7 +152,7 @@ describe('Gas Duck', () => {
       }));
 
       expect(mockDistpatch.getCall(0).args).toStrictEqual([
-        { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
+        { type: 'metamask/gas/BASIC_GAS_ESTIMATE_STATUS', value: 'LOADING' },
       ]);
 
       expect(
@@ -168,8 +161,12 @@ describe('Gas Duck', () => {
           .args[0].startsWith('https://api.metaswap.codefi.network/gasPrices'),
       ).toStrictEqual(true);
 
-      expect(mockDistpatch.getCall(3).args).toStrictEqual([
-        { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
+      expect(mockDistpatch.getCall(2).args).toStrictEqual([
+        { type: 'metamask/gas/SET_ESTIMATE_SOURCE', value: 'MetaSwaps' },
+      ]);
+
+      expect(mockDistpatch.getCall(4).args).toStrictEqual([
+        { type: 'metamask/gas/BASIC_GAS_ESTIMATE_STATUS', value: 'READY' },
       ]);
     });
 
@@ -191,7 +188,10 @@ describe('Gas Duck', () => {
         metamask: { provider: { ...providerStateForTestNetwork } },
       }));
       expect(mockDistpatch.getCall(0).args).toStrictEqual([
-        { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
+        { type: 'metamask/gas/BASIC_GAS_ESTIMATE_STATUS', value: 'LOADING' },
+      ]);
+      expect(mockDistpatch.getCall(1).args).toStrictEqual([
+        { type: 'metamask/gas/SET_ESTIMATE_SOURCE', value: 'eth_gasprice' },
       ]);
       expect(mockDistpatch.getCall(2).args).toStrictEqual([
         {
@@ -202,7 +202,7 @@ describe('Gas Duck', () => {
         },
       ]);
       expect(mockDistpatch.getCall(3).args).toStrictEqual([
-        { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
+        { type: 'metamask/gas/BASIC_GAS_ESTIMATE_STATUS', value: 'READY' },
       ]);
     });
   });

--- a/ui/app/ducks/gas/gas-duck.test.js
+++ b/ui/app/ducks/gas/gas-duck.test.js
@@ -168,7 +168,7 @@ describe('Gas Duck', () => {
           .args[0].startsWith('https://api.metaswap.codefi.network/gasPrices'),
       ).toStrictEqual(true);
 
-      expect(mockDistpatch.getCall(2).args).toStrictEqual([
+      expect(mockDistpatch.getCall(3).args).toStrictEqual([
         { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
       ]);
     });
@@ -193,7 +193,7 @@ describe('Gas Duck', () => {
       expect(mockDistpatch.getCall(0).args).toStrictEqual([
         { type: BASIC_GAS_ESTIMATE_LOADING_STARTED },
       ]);
-      expect(mockDistpatch.getCall(1).args).toStrictEqual([
+      expect(mockDistpatch.getCall(2).args).toStrictEqual([
         {
           type: SET_BASIC_GAS_ESTIMATE_DATA,
           value: {
@@ -201,7 +201,7 @@ describe('Gas Duck', () => {
           },
         },
       ]);
-      expect(mockDistpatch.getCall(2).args).toStrictEqual([
+      expect(mockDistpatch.getCall(3).args).toStrictEqual([
         { type: BASIC_GAS_ESTIMATE_LOADING_FINISHED },
       ]);
     });

--- a/ui/app/helpers/constants/error-keys.js
+++ b/ui/app/helpers/constants/error-keys.js
@@ -2,3 +2,6 @@ export const INSUFFICIENT_FUNDS_ERROR_KEY = 'insufficientFunds';
 export const GAS_LIMIT_TOO_LOW_ERROR_KEY = 'gasLimitTooLow';
 export const TRANSACTION_ERROR_KEY = 'transactionError';
 export const TRANSACTION_NO_CONTRACT_ERROR_KEY = 'transactionErrorNoContract';
+export const ETH_GAS_PRICE_FETCH_WARNING_KEY = 'ethGasPriceFetchWarning';
+export const GAS_PRICE_FETCH_FAILURE_ERROR_KEY = 'gasPriceFetchFailed';
+export const GAS_PRICE_EXCESSIVE_ERROR_KEY = 'gasPriceExcessive';

--- a/ui/app/pages/confirm-approve/confirm-approve.js
+++ b/ui/app/pages/confirm-approve/confirm-approve.js
@@ -24,6 +24,8 @@ import {
   getUseNonceField,
   getCustomNonceValue,
   getNextSuggestedNonce,
+  getNoGasPriceFetched,
+  getIsEthGasPriceFetched,
 } from '../../selectors';
 import { currentNetworkTxListSelector } from '../../selectors/transactions';
 import Loading from '../../components/ui/loading-screen';
@@ -116,6 +118,8 @@ export default function ConfirmApprove() {
   const customData = customPermissionAmount
     ? getCustomTxParamsData(data, { customPermissionAmount, decimals })
     : null;
+  const isEthGasPrice = useSelector(getIsEthGasPriceFetched);
+  const noGasPrice = useSelector(getNoGasPriceFetched);
 
   return tokenSymbol === undefined ? (
     <Loading />
@@ -136,7 +140,13 @@ export default function ConfirmApprove() {
           tokenSymbol={tokenSymbol}
           tokenBalance={tokenBalance}
           showCustomizeGasModal={() =>
-            dispatch(showModal({ name: 'CUSTOMIZE_GAS', txData }))
+            dispatch(
+              showModal({
+                name: 'CUSTOMIZE_GAS',
+                txData,
+                hideBasic: isEthGasPrice || noGasPrice,
+              }),
+            )
           }
           showEditApprovalPermissionModal={({
             /* eslint-disable no-shadow */

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -745,7 +745,6 @@ export default class ConfirmTransactionBase extends Component {
         functionType = t('contractInteraction');
       }
     }
-    console.log(errorKey);
     return (
       <ConfirmPageContainer
         fromName={fromName}

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -95,6 +95,8 @@ export default class ConfirmTransactionBase extends Component {
     showAccountInHeader: PropTypes.bool,
     mostRecentOverviewPage: PropTypes.string.isRequired,
     isMainnet: PropTypes.bool,
+    isEthGasPrice: PropTypes.bool,
+    noGasPrice: PropTypes.bool,
   };
 
   state = {
@@ -243,9 +245,12 @@ export default class ConfirmTransactionBase extends Component {
       nextNonce,
       getNextNonce,
       isMainnet,
+      isEthGasPrice,
+      noGasPrice,
     } = this.props;
 
     const notMainnetOrTest = !(isMainnet || process.env.IN_TEST);
+    const gasPriceFetchFailure = isEthGasPrice || noGasPrice;
 
     return (
       <div className="confirm-page-container-content__details">
@@ -253,18 +258,26 @@ export default class ConfirmTransactionBase extends Component {
           <ConfirmDetailRow
             label="Gas Fee"
             value={hexTransactionFee}
-            headerText={notMainnetOrTest ? '' : 'Edit'}
+            headerText={notMainnetOrTest || gasPriceFetchFailure ? '' : 'Edit'}
             headerTextClassName={
-              notMainnetOrTest ? '' : 'confirm-detail-row__header-text--edit'
+              notMainnetOrTest || gasPriceFetchFailure
+                ? ''
+                : 'confirm-detail-row__header-text--edit'
             }
-            onHeaderClick={notMainnetOrTest ? null : () => this.handleEditGas()}
+            onHeaderClick={
+              notMainnetOrTest || gasPriceFetchFailure
+                ? null
+                : () => this.handleEditGas()
+            }
             secondaryText={
               hideFiatConversion
                 ? this.context.t('noConversionRateAvailable')
                 : ''
             }
           />
-          {advancedInlineGasShown || notMainnetOrTest ? (
+          {advancedInlineGasShown ||
+          notMainnetOrTest ||
+          gasPriceFetchFailure ? (
             <AdvancedGasInputs
               updateCustomGasPrice={(newGasPrice) =>
                 updateGasAndCalculate({ ...customGas, gasPrice: newGasPrice })

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -211,14 +211,13 @@ export const mapDispatchToProps = (dispatch) => {
     showTransactionConfirmedModal: ({ onSubmit }) => {
       return dispatch(showModal({ name: 'TRANSACTION_CONFIRMED', onSubmit }));
     },
-    showCustomizeGasModal: ({ txData, onSubmit, validate, hideBasic }) => {
+    showCustomizeGasModal: ({ txData, onSubmit, validate }) => {
       return dispatch(
         showModal({
           name: 'CUSTOMIZE_GAS',
           txData,
           onSubmit,
           validate,
-          hideBasic,
         }),
       );
     },
@@ -289,14 +288,7 @@ const getValidateEditGas = ({ balance, conversionRate, txData }) => {
 };
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const {
-    balance,
-    conversionRate,
-    txData,
-    unapprovedTxs,
-    isEthGasPrice,
-    noGasPrice,
-  } = stateProps;
+  const { balance, conversionRate, txData, unapprovedTxs } = stateProps;
 
   const {
     cancelAllTransactions: dispatchCancelAllTransactions,
@@ -320,7 +312,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         txData,
         onSubmit: (customGas) => dispatchUpdateGasAndCalculate(customGas),
         validate: validateEditGas,
-        hideBasic: isEthGasPrice || noGasPrice,
       }),
     cancelAllTransactions: () =>
       dispatchCancelAllTransactions(valuesFor(unapprovedTxs)),

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -37,6 +37,8 @@ import {
   getUseNonceField,
   getPreferences,
   transactionFeeSelector,
+  getNoGasPriceFetched,
+  getIsEthGasPriceFetched,
 } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { transactionMatchesNetwork } from '../../../../shared/modules/transaction.utils';
@@ -150,6 +152,8 @@ const mapStateToProps = (state, ownProps) => {
     };
   }
   customNonceValue = getCustomNonceValue(state);
+  const isEthGasPrice = getIsEthGasPriceFetched(state);
+  const noGasPrice = getNoGasPriceFetched(state);
 
   return {
     balance,
@@ -189,6 +193,8 @@ const mapStateToProps = (state, ownProps) => {
     nextNonce,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     isMainnet,
+    isEthGasPrice,
+    noGasPrice,
   };
 };
 
@@ -205,9 +211,15 @@ export const mapDispatchToProps = (dispatch) => {
     showTransactionConfirmedModal: ({ onSubmit }) => {
       return dispatch(showModal({ name: 'TRANSACTION_CONFIRMED', onSubmit }));
     },
-    showCustomizeGasModal: ({ txData, onSubmit, validate }) => {
+    showCustomizeGasModal: ({ txData, onSubmit, validate, hideBasic }) => {
       return dispatch(
-        showModal({ name: 'CUSTOMIZE_GAS', txData, onSubmit, validate }),
+        showModal({
+          name: 'CUSTOMIZE_GAS',
+          txData,
+          onSubmit,
+          validate,
+          hideBasic,
+        }),
       );
     },
     updateGasAndCalculate: (updatedTx) => {
@@ -277,7 +289,15 @@ const getValidateEditGas = ({ balance, conversionRate, txData }) => {
 };
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { balance, conversionRate, txData, unapprovedTxs } = stateProps;
+  const {
+    balance,
+    conversionRate,
+    txData,
+    unapprovedTxs,
+    isEthGasPrice,
+    noGasPrice,
+  } = stateProps;
+
   const {
     cancelAllTransactions: dispatchCancelAllTransactions,
     showCustomizeGasModal: dispatchShowCustomizeGasModal,
@@ -300,6 +320,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         txData,
         onSubmit: (customGas) => dispatchUpdateGasAndCalculate(customGas),
         validate: validateEditGas,
+        hideBasic: isEthGasPrice || noGasPrice,
       }),
     cancelAllTransactions: () =>
       dispatchCancelAllTransactions(valuesFor(unapprovedTxs)),

--- a/ui/app/pages/send/send-content/send-content.component.js
+++ b/ui/app/pages/send/send-content/send-content.component.js
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import PageContainerContent from '../../../components/ui/page-container/page-container-content.component';
 import Dialog from '../../../components/ui/dialog';
+import {
+  ETH_GAS_PRICE_FETCH_WARNING_KEY,
+  GAS_PRICE_FETCH_FAILURE_ERROR_KEY,
+  GAS_PRICE_EXCESSIVE_ERROR_KEY,
+} from '../../../helpers/constants/error-keys';
 import SendAmountRow from './send-amount-row';
 import SendGasRow from './send-gas-row';
 import SendHexDataRow from './send-hex-data-row';
@@ -21,16 +26,30 @@ export default class SendContent extends Component {
     warning: PropTypes.string,
     error: PropTypes.string,
     gasIsExcessive: PropTypes.bool.isRequired,
+    isEthGasPrice: PropTypes.bool,
+    noGasPrice: PropTypes.bool,
   };
 
   updateGas = (updateData) => this.props.updateGas(updateData);
 
   render() {
-    const { warning, error, gasIsExcessive } = this.props;
+    const {
+      warning,
+      error,
+      gasIsExcessive,
+      isEthGasPrice,
+      noGasPrice,
+    } = this.props;
+
+    let gasError;
+    if (gasIsExcessive) gasError = GAS_PRICE_EXCESSIVE_ERROR_KEY;
+    else if (noGasPrice) gasError = GAS_PRICE_FETCH_FAILURE_ERROR_KEY;
+
     return (
       <PageContainerContent>
         <div className="send-v2__form">
-          {gasIsExcessive && this.renderError(true)}
+          {gasError && this.renderError(gasError)}
+          {isEthGasPrice && this.renderWarning(ETH_GAS_PRICE_FETCH_WARNING_KEY)}
           {error && this.renderError()}
           {warning && this.renderWarning()}
           {this.maybeRenderAddContact()}
@@ -68,24 +87,22 @@ export default class SendContent extends Component {
     );
   }
 
-  renderWarning() {
+  renderWarning(gasWarning = '') {
     const { t } = this.context;
     const { warning } = this.props;
-
     return (
       <Dialog type="warning" className="send__error-dialog">
-        {t(warning)}
+        {gasWarning === '' ? t(warning) : t(gasWarning)}
       </Dialog>
     );
   }
 
-  renderError(gasError = false) {
+  renderError(gasError = '') {
     const { t } = this.context;
     const { error } = this.props;
-
     return (
       <Dialog type="error" className="send__error-dialog">
-        {gasError ? t('gasPriceExcessive') : t(error)}
+        {gasError === '' ? t(error) : t(gasError)}
       </Dialog>
     );
   }

--- a/ui/app/pages/send/send-content/send-content.container.js
+++ b/ui/app/pages/send/send-content/send-content.container.js
@@ -3,6 +3,8 @@ import {
   getSendTo,
   accountsWithSendEtherInfoSelector,
   getAddressBookEntry,
+  getIsEthGasPriceFetched,
+  getNoGasPriceFetched,
 } from '../../../selectors';
 
 import * as actions from '../../../store/actions';
@@ -19,6 +21,8 @@ function mapStateToProps(state) {
     ),
     contact: getAddressBookEntry(state, to),
     to,
+    isEthGasPrice: getIsEthGasPriceFetched(state),
+    noGasPrice: getNoGasPriceFetched(state),
   };
 }
 

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -26,6 +26,8 @@ export default class SendGasRow extends Component {
     gasLimit: PropTypes.string,
     insufficientBalance: PropTypes.bool,
     isMainnet: PropTypes.bool,
+    isEthGasPriceFetched: PropTypes.bool,
+    noGasPriceFetched: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -92,6 +94,8 @@ export default class SendGasRow extends Component {
       gasLimit,
       insufficientBalance,
       isMainnet,
+      isEthGasPriceFetched,
+      noGasPriceFetched,
     } = this.props;
     const { metricsEvent } = this.context;
 
@@ -148,7 +152,12 @@ export default class SendGasRow extends Component {
       </div>
     );
     // Tests should behave in same way as mainnet, but are using Localhost
-    if (advancedInlineGasShown || (!isMainnet && !process.env.IN_TEST)) {
+    if (
+      advancedInlineGasShown ||
+      (!isMainnet && !process.env.IN_TEST) ||
+      isEthGasPriceFetched ||
+      noGasPriceFetched
+    ) {
       return advancedGasInputs;
     } else if (gasButtonGroupShown) {
       return gasPriceButtonGroup;

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -26,8 +26,8 @@ export default class SendGasRow extends Component {
     gasLimit: PropTypes.string,
     insufficientBalance: PropTypes.bool,
     isMainnet: PropTypes.bool,
-    isEthGasPriceFetched: PropTypes.bool,
-    noGasPriceFetched: PropTypes.bool,
+    isEthGasPrice: PropTypes.bool,
+    noGasPrice: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -37,9 +37,17 @@ export default class SendGasRow extends Component {
 
   renderAdvancedOptionsButton() {
     const { metricsEvent } = this.context;
-    const { showCustomizeGasModal, isMainnet } = this.props;
+    const {
+      showCustomizeGasModal,
+      isMainnet,
+      isEthGasPrice,
+      noGasPrice,
+    } = this.props;
     // Tests should behave in same way as mainnet, but are using Localhost
     if (!isMainnet && !process.env.IN_TEST) {
+      return null;
+    }
+    if (isEthGasPrice || noGasPrice) {
       return null;
     }
     return (
@@ -94,10 +102,11 @@ export default class SendGasRow extends Component {
       gasLimit,
       insufficientBalance,
       isMainnet,
-      isEthGasPriceFetched,
-      noGasPriceFetched,
+      isEthGasPrice,
+      noGasPrice,
     } = this.props;
     const { metricsEvent } = this.context;
+    const gasPriceFetchFailure = isEthGasPrice || noGasPrice;
 
     const gasPriceButtonGroup = (
       <div>
@@ -155,8 +164,7 @@ export default class SendGasRow extends Component {
     if (
       advancedInlineGasShown ||
       (!isMainnet && !process.env.IN_TEST) ||
-      isEthGasPriceFetched ||
-      noGasPriceFetched
+      gasPriceFetchFailure
     ) {
       return advancedGasInputs;
     } else if (gasButtonGroupShown) {

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
@@ -66,6 +66,8 @@ function mapStateToProps(state) {
     balance,
     conversionRate,
   });
+  const isEthGasPrice = getIsEthGasPriceFetched(state);
+  const noGasPrice = getNoGasPriceFetched(state);
 
   return {
     balance: getSendFromBalance(state),
@@ -87,8 +89,8 @@ function mapStateToProps(state) {
     sendToken: getSendToken(state),
     tokenBalance: getTokenBalance(state),
     isMainnet: getIsMainnet(state),
-    isEthGasPriceFetched: getIsEthGasPriceFetched(state),
-    noGasPriceFetched: getNoGasPriceFetched(state),
+    isEthGasPrice,
+    noGasPrice,
   };
 }
 

--- a/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/app/pages/send/send-content/send-gas-row/send-gas-row.container.js
@@ -18,6 +18,8 @@ import {
   getRenderableEstimateDataForSmallButtonsFromGWEI,
   getDefaultActiveButtonIndex,
   getIsMainnet,
+  getIsEthGasPriceFetched,
+  getNoGasPriceFetched,
 } from '../../../../selectors';
 import { isBalanceSufficient, calcGasTotal } from '../../send.utils';
 import { calcMaxAmount } from '../send-amount-row/amount-max-button/amount-max-button.utils';
@@ -85,6 +87,8 @@ function mapStateToProps(state) {
     sendToken: getSendToken(state),
     tokenBalance: getTokenBalance(state),
     isMainnet: getIsMainnet(state),
+    isEthGasPriceFetched: getIsEthGasPriceFetched(state),
+    noGasPriceFetched: getNoGasPriceFetched(state),
   };
 }
 

--- a/ui/app/pages/send/send-footer/send-footer.component.js
+++ b/ui/app/pages/send/send-footer/send-footer.component.js
@@ -27,6 +27,7 @@ export default class SendFooter extends Component {
     gasEstimateType: PropTypes.string,
     gasIsLoading: PropTypes.bool,
     mostRecentOverviewPage: PropTypes.string.isRequired,
+    noGasPrice: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -109,6 +110,7 @@ export default class SendFooter extends Component {
       to,
       gasLimit,
       gasIsLoading,
+      noGasPrice,
     } = this.props;
     const missingTokenBalance = sendToken && !tokenBalance;
     const gasLimitTooLow = gasLimit < 5208; // 5208 is hex value of 21000, minimum gas limit
@@ -118,7 +120,8 @@ export default class SendFooter extends Component {
       missingTokenBalance ||
       !(data || to) ||
       gasLimitTooLow ||
-      gasIsLoading;
+      gasIsLoading ||
+      noGasPrice;
     return shouldBeDisabled;
   }
 

--- a/ui/app/pages/send/send-footer/send-footer.component.test.js
+++ b/ui/app/pages/send/send-footer/send-footer.component.test.js
@@ -49,6 +49,7 @@ describe('SendFooter Component', () => {
         update={propsMethodSpies.update}
         sendErrors={{}}
         mostRecentOverviewPage="mostRecentOverviewPage"
+        noGasPrice={false}
       />,
       { context: { t: (str) => str, metricsEvent: () => ({}) } },
     );

--- a/ui/app/pages/send/send-footer/send-footer.container.js
+++ b/ui/app/pages/send/send-footer/send-footer.container.js
@@ -24,6 +24,7 @@ import {
   getGasIsLoading,
   getRenderableEstimateDataForSmallButtonsFromGWEI,
   getDefaultActiveButtonIndex,
+  getNoGasPriceFetched,
 } from '../../../selectors';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import { addHexPrefix } from '../../../../../app/scripts/lib/util';
@@ -67,6 +68,7 @@ function mapStateToProps(state) {
     gasEstimateType,
     gasIsLoading: getGasIsLoading(state),
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
+    noGasPrice: getNoGasPriceFetched(state),
   };
 }
 

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -369,8 +369,5 @@ export function getIsEthGasPriceFetched(state) {
 
 export function getNoGasPriceFetched(state) {
   const gasState = state.gas;
-  return Boolean(
-    gasState.estimateSource === 'eth_gasprice' &&
-      gasState.basicEstimateStatus === 'FAILED',
-  );
+  return Boolean(gasState.basicEstimateStatus === 'FAILED');
 }

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -31,8 +31,10 @@ export function getBasicGasEstimateLoadingStatus(state) {
 }
 
 export function getAveragePriceEstimateInHexWEI(state) {
-  const averagePriceEstimate = state.gas.basicEstimates.average;
-  return getGasPriceInHexWei(averagePriceEstimate || '0x0');
+  const averagePriceEstimate = state.gas.basicEstimates
+    ? state.gas.basicEstimates.average
+    : '0x0';
+  return getGasPriceInHexWei(averagePriceEstimate);
 }
 
 export function getFastPriceEstimateInHexWEI(state) {
@@ -51,6 +53,10 @@ export function getDefaultActiveButtonIndex(
 }
 
 export function getSafeLowEstimate(state) {
+  if (getNoGasPriceFetched(state)) {
+    return false;
+  }
+
   const {
     gas: {
       basicEstimates: { safeLow },
@@ -61,6 +67,9 @@ export function getSafeLowEstimate(state) {
 }
 
 export function getFastPriceEstimate(state) {
+  if (getNoGasPriceFetched(state)) {
+    return false;
+  }
   const {
     gas: {
       basicEstimates: { fast },
@@ -287,6 +296,9 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
   if (getBasicGasEstimateLoadingStatus(state)) {
     return [];
   }
+  if (getNoGasPriceFetched(state)) {
+    return [];
+  }
 
   const { showFiatInTestnets } = getPreferences(state);
   const isMainnet = getIsMainnet(state);
@@ -354,4 +366,12 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
       priceInHexWei: getGasPriceInHexWei(fast, true),
     },
   ];
+}
+
+export function getIsEthGasPriceFetched(state) {
+  return state.gas.isEthGasPriceFetched;
+}
+
+export function getNoGasPriceFetched(state) {
+  return !state.gas.basicEstimates;
 }

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -271,6 +271,11 @@ export function getRenderableBasicEstimateData(state, gasLimit) {
     return [];
   }
 
+  if (getNoGasPriceFetched(state) || getIsEthGasPriceFetched(state)) {
+    console.log('gas fetch failed');
+    return [];
+  }
+
   const { showFiatInTestnets } = getPreferences(state);
   const isMainnet = getIsMainnet(state);
   const showFiat = isMainnet || Boolean(showFiatInTestnets);
@@ -296,7 +301,7 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
   if (getBasicGasEstimateLoadingStatus(state)) {
     return [];
   }
-  if (getNoGasPriceFetched(state)) {
+  if (getNoGasPriceFetched(state) || getIsEthGasPriceFetched(state)) {
     return [];
   }
 

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -272,7 +272,6 @@ export function getRenderableBasicEstimateData(state, gasLimit) {
   }
 
   if (getNoGasPriceFetched(state) || getIsEthGasPriceFetched(state)) {
-    console.log('gas fetch failed');
     return [];
   }
 

--- a/ui/app/selectors/custom-gas.js
+++ b/ui/app/selectors/custom-gas.js
@@ -27,7 +27,7 @@ export function getCustomGasPrice(state) {
 }
 
 export function getBasicGasEstimateLoadingStatus(state) {
-  return state.gas.basicEstimateIsLoading;
+  return state.gas.basicEstimateStatus === 'LOADING';
 }
 
 export function getAveragePriceEstimateInHexWEI(state) {
@@ -53,10 +53,6 @@ export function getDefaultActiveButtonIndex(
 }
 
 export function getSafeLowEstimate(state) {
-  if (getNoGasPriceFetched(state)) {
-    return false;
-  }
-
   const {
     gas: {
       basicEstimates: { safeLow },
@@ -67,9 +63,6 @@ export function getSafeLowEstimate(state) {
 }
 
 export function getFastPriceEstimate(state) {
-  if (getNoGasPriceFetched(state)) {
-    return false;
-  }
   const {
     gas: {
       basicEstimates: { fast },
@@ -271,10 +264,6 @@ export function getRenderableBasicEstimateData(state, gasLimit) {
     return [];
   }
 
-  if (getNoGasPriceFetched(state) || getIsEthGasPriceFetched(state)) {
-    return [];
-  }
-
   const { showFiatInTestnets } = getPreferences(state);
   const isMainnet = getIsMainnet(state);
   const showFiat = isMainnet || Boolean(showFiatInTestnets);
@@ -298,9 +287,6 @@ export function getRenderableBasicEstimateData(state, gasLimit) {
 
 export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
   if (getBasicGasEstimateLoadingStatus(state)) {
-    return [];
-  }
-  if (getNoGasPriceFetched(state) || getIsEthGasPriceFetched(state)) {
     return [];
   }
 
@@ -373,9 +359,18 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
 }
 
 export function getIsEthGasPriceFetched(state) {
-  return state.gas.isEthGasPriceFetched;
+  const gasState = state.gas;
+  return Boolean(
+    gasState.estimateSource === 'eth_gasprice' &&
+      gasState.basicEstimateStatus === 'READY' &&
+      getIsMainnet(state),
+  );
 }
 
 export function getNoGasPriceFetched(state) {
-  return !state.gas.basicEstimates;
+  const gasState = state.gas;
+  return Boolean(
+    gasState.estimateSource === 'eth_gasprice' &&
+      gasState.basicEstimateStatus === 'FAILED',
+  );
 }


### PR DESCRIPTION
Fixes: #10556 

Explanation:  Currently when the gas estimate service is unavailable, the gas row send and confirm page will go into infinite loading loop.

**Changes introduced:**
- Advanced gas input will be displayed in case the main service fails, eth_gasprice will be fetched and the submission buttons will be active.
- In cases where both main service eth_gasprice and main service fails, Advanced gas input will be displayed, gasPrice displayed will be 0 and the primary button `next` button in the send flow or `confirm` button in the confirmation flow will be disabled.

Manual testing steps:  

**Gas estimation service failing and eth_gasprice fetched:**

You can mimmic the gas price fetch failure by replacing `basicGasPriceQuery` call in `fetchExternalBasicGasEstimates` by `Promise.reject()`

**_Send Page:_**
<img width="355" alt="Screen Shot 2021-04-22 at 4 37 27 PM" src="https://user-images.githubusercontent.com/43930900/115785743-db4e7380-a38d-11eb-886f-af0fb2b70e35.png">


**_Confirmation page:_** 

https://user-images.githubusercontent.com/43930900/115785726-d7baec80-a38d-11eb-8d47-66a295280082.mov


**Both the gas estimation services failed:**

You can mimmic the gas price fetch failure by replacing `global.eth.gasPrice()` call in `fetchEthGasPriceEstimates` by `Promise.reject()`;

**_Send Page:_**
<img width="357" alt="Screen Shot 2021-04-22 at 4 19 15 PM" src="https://user-images.githubusercontent.com/43930900/115785736-d984b000-a38d-11eb-82b8-d2c6191f6577.png">


**_Confirmation page:_**

https://user-images.githubusercontent.com/43930900/115785732-d8ec1980-a38d-11eb-9655-a8ff5c194b11.mov



