### PR TITLE
Improve detection of task process exit

### DIFF
--- a/development/build/task.js
+++ b/development/build/task.js
@@ -83,7 +83,7 @@ function runInChildProcess(task) {
     );
     // await end of process
     await new Promise((resolve, reject) => {
-      childProcess.once('close', (errCode) => {
+      childProcess.once('exit', (errCode) => {
         if (errCode !== 0) {
           reject(
             new Error(


### PR DESCRIPTION
Our build script waits for the `close` event to determine whether the task has exited. The `exit` event is a better representation of this, because if a stream is shared between multiple processes, the process may exit without the `close` event being emitted.

We aren't sharing streams between processes, so this edge case doesn't apply to us. This just seemed like a more suitable event to listen to, since we care about the process exiting not the stream ending.

See this description of the `close` event from [the Node.js documentation](https://nodejs.org/docs/latest-v14.x/api/child_process.html#child_process_event_exit):
>The `'close'` event is emitted when the stdio streams of a child process have been closed. This is distinct from the `'exit'` event, since multiple processes might share the same stdio streams.

And see this description of the `exit` event:
>The `'exit'` event is emitted after the child process ends.