### PR TITLE
Add changelog entries under release candidate header

### DIFF
--- a/development/auto-changelog.js
+++ b/development/auto-changelog.js
@@ -84,7 +84,7 @@ async function main() {
     : currentDevelopBranchHeader;
 
   const releaseHeaderIndex = changelogLines.findIndex((line) =>
-    line.match(new RegExp(currentReleaseHeaderPattern, 'um')),
+    line.match(new RegExp(currentReleaseHeaderPattern, 'u')),
   );
   if (releaseHeaderIndex === -1) {
     throw new Error(

--- a/development/auto-changelog.js
+++ b/development/auto-changelog.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 const fs = require('fs').promises;
+const assert = require('assert').strict;
 const path = require('path');
+const { version } = require('../app/manifest/_base.json');
 const runCommand = require('./lib/runCommand');
 
 const URL = 'https://github.com/MetaMask/metamask-extension';
@@ -18,6 +20,7 @@ async function main() {
     '--tags',
     mostRecentTagCommitHash,
   ]);
+  assert.equal(mostRecentTag[0], 'v', 'Most recent tag should start with v');
 
   const commitsSinceLastRelease = await runCommand('git', [
     'rev-list',
@@ -67,11 +70,28 @@ async function main() {
   const changelogFilename = path.resolve(__dirname, '..', 'CHANGELOG.md');
   const changelog = await fs.readFile(changelogFilename, { encoding: 'utf8' });
   const changelogLines = changelog.split('\n');
-  const releaseHeaderIndex = changelogLines.findIndex(
-    (line) => line === '## Current Develop Branch',
+
+  // remove the "v" prefix
+  const mostRecentVersion = mostRecentTag.slice(1);
+
+  const isReleaseCandidate = mostRecentVersion !== version;
+  const versionHeader = `## ${version}`;
+  const currentDevelopBranchHeader = '## Current Develop Branch';
+  const currentReleaseHeaderPattern = isReleaseCandidate
+    ? // This ensures this doesn't match on a version with a suffix
+      // e.g. v9.0.0 should not match on the header v9.0.0-beta.0
+      `${versionHeader}$|${versionHeader}\\s`
+    : currentDevelopBranchHeader;
+
+  const releaseHeaderIndex = changelogLines.findIndex((line) =>
+    line.match(new RegExp(currentReleaseHeaderPattern, 'um')),
   );
   if (releaseHeaderIndex === -1) {
-    throw new Error('Failed to find release header');
+    throw new Error(
+      `Failed to find release header '${
+        isReleaseCandidate ? versionHeader : currentDevelopBranchHeader
+      }'`,
+    );
   }
   changelogLines.splice(releaseHeaderIndex + 1, 0, ...changelogEntries);
   const updatedChangelog = changelogLines.join('\n');


### PR DESCRIPTION
Instead of always placing new changelog entries under the "Current Develop Branch" header, the changelog script now places them under the header for the current release if that release has not yet been tagged.

This eliminates one manual step from the release process.

Relates to #10752

Manual testing steps :

For development changelog updates:
- Run `yarn update-changelog`
- See that it places changelog entries under 'Current Develop Branch'
 
For RC changelog updates:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Add a new release header to the changelog for the new version
- Run `yarn update-changelog`
- See that it places changelog entries under the new release header
 
For updates without a release header:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Run `yarn update-changelog`
- See that it throws an error because it cannot find the release header
 
For testing that it doesn't confuse v10.0.0 and v10.0.0-prefix:
- Bump the `version` in `app/manifest/_base.json` to v10.0.0, to simulate an RC-like environment
- Add a header to the changelog for v10.0.0-beta.0
- Run `yarn update-changelog`
- See that it throws an error because it cannot find the release header, showing that it doesn't confuse v10.0.0 for v10.0.0-beta.0