### PR TITLE
Remove date from changelog release header

### DIFF
--- a/.circleci/scripts/release-bump-changelog-version.sh
+++ b/.circleci/scripts/release-bump-changelog-version.sh
@@ -21,13 +21,12 @@ version="${CIRCLE_BRANCH/Version-v/}"
 if ! grep --quiet --fixed-strings "$version" CHANGELOG.md
 then
     printf '%s\n' 'Adding this release to CHANGELOG.md'
-    date_str="$(date '+%a %b %d %Y')"
     cp CHANGELOG.md{,.bak}
 
 update_headers=$(cat <<END
 /## Current Develop Branch/ {
     print "## Current Develop Branch\n";
-    print "## ${version} ${date_str}";
+    print "## ${version}";
     next;
 }
 {


### PR DESCRIPTION
New changelog release headers now omit the date. These headers are added automatically when a new release branch is created, and that rarely ends up being the actual date of the release, so these dates have all been inaccurate anyway.

The date will be re-added to the changelog later as part of a new script, after a release has been published.