### PR TITLE
Add release header when updating changelog

### DIFF
--- a/development/auto-changelog.js
+++ b/development/auto-changelog.js
@@ -80,15 +80,22 @@ async function main() {
       `${versionHeader}$|${versionHeader}\\s`
     : currentDevelopBranchHeader;
 
-  const releaseHeaderIndex = changelogLines.findIndex((line) =>
+  let releaseHeaderIndex = changelogLines.findIndex((line) =>
     line.match(new RegExp(currentReleaseHeaderPattern, 'u')),
   );
   if (releaseHeaderIndex === -1) {
-    throw new Error(
-      `Failed to find release header '${
-        isReleaseCandidate ? versionHeader : currentDevelopBranchHeader
-      }'`,
+    if (!isReleaseCandidate) {
+      throw new Error(
+        `Failed to find release header '${currentDevelopBranchHeader}'`,
+      );
+    }
+
+    // Add release header if not found
+    const firstReleaseHeaderIndex = changelogLines.findIndex((line) =>
+      line.match(/## \d+\.\d+\.\d+/u),
     );
+    changelogLines.splice(firstReleaseHeaderIndex, 0, versionHeader, '');
+    releaseHeaderIndex = firstReleaseHeaderIndex;
   }
 
   const prNumbersWithChangelogEntries = [];


### PR DESCRIPTION
The changelog update script now adds a release header if it doesn't find one already that matches the current release candidate version.

Relates to #10752

Manual testing steps:  

For development changelog updates:
- Run `yarn update-changelog`
- See that it places changelog entries under 'Current Develop Branch'
 
For RC changelog updates with existing release header:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Add a new release header to the changelog for the new version
- Run `yarn update-changelog`
- See that it places changelog entries under the new release header
 
For updates without a release header:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Run `yarn update-changelog`
- See that it places changelog entries under the newly added release header