### PR TITLE
Update changelog headers and fix dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Current Develop Branch
 
-## 9.2.1 Thu Mar 25 2021
+## [9.2.1] - 2021-03-26
 - [#10692](https://github.com/MetaMask/metamask-extension/pull/10692): Prevent UI crash when a 'wallet_requestPermissions" confirmation is queued behind a "wallet_addEthereumChain" confirmation
 - [#10712](https://github.com/MetaMask/metamask-extension/pull/10712): Fix infinite spinner when request for token symbol fails while attempting an approve transaction
 
-## 9.2.0 Tue Mar 09 2021
+## [9.2.0] - 2021-03-15
 - [#10546](https://github.com/MetaMask/metamask-extension/pull/10546): Add a warning when sending a token to its own contract address
 - [#10563](https://github.com/MetaMask/metamask-extension/pull/10563): Update references to MetaMask support
 - [#10126](https://github.com/MetaMask/metamask-extension/pull/10126): Update Italian translation
@@ -19,11 +19,11 @@
 - [#10505](https://github.com/MetaMask/metamask-extension/pull/10505): Add support for multiple Ledger & Trezor hardware accounts
 - [#10587](https://github.com/MetaMask/metamask-extension/pull/10587): Show correct block explorer for custom RPC endpoints for built-in networks
 
-## 9.1.1 Wed Mar 03 2021
+## [9.1.1] - 2021-03-03
 - [#10560](https://github.com/MetaMask/metamask-extension/pull/10560): Fix ENS resolution related crashes when switching networks on send screen
 - [#10561](https://github.com/MetaMask/metamask-extension/pull/10561): Fix crash when speeding up an attempt to cancel a transaction on custom networks
 
-## 9.1.0 Mon Mar 01 2021
+## [9.1.0] - 2021-02-01
 - [#10265](https://github.com/MetaMask/metamask-extension/pull/10265): Update Japanese translations.
 - [#9388](https://github.com/MetaMask/metamask-extension/pull/9388): Update Chinese(Simplified) translations.
 - [#10270](https://github.com/MetaMask/metamask-extension/pull/10270): Update Vietnamese translations.
@@ -58,7 +58,7 @@
 - [#9187](https://github.com/MetaMask/metamask-extension/pull/9187): Warn users when an ENS name contains 'confusable' characters
 - [#10507](https://github.com/MetaMask/metamask-extension/pull/10507): Fixes ENS IPFS resolution on custom networks with the chainID of 1.
 
-## 9.0.5 Mon Feb 08 2021
+## [9.0.5] - 2021-02-09
 - [#10278](https://github.com/MetaMask/metamask-extension/pull/10278): Allow editing transaction amount after clicking max
 - [#10214](https://github.com/MetaMask/metamask-extension/pull/10214): Standardize size, shape and color of network color indicators
 - [#10298](https://github.com/MetaMask/metamask-extension/pull/10298): Use network primary currency instead of always defaulting to ETH in the confirm approve screen
@@ -73,7 +73,7 @@
 - [#10326](https://github.com/MetaMask/metamask-extension/pull/10326): Throw error when attempting to get an encryption key via eth_getEncryptionPublicKey when connected to Ledger HW
 - [#10386](https://github.com/MetaMask/metamask-extension/pull/10386): Make action buttons on message components in swaps flow accessible
 
-## 9.0.4 Fri Jan 22 2021
+## [9.0.4] - 2021-01-27
 - [#10285](https://github.com/MetaMask/metamask-extension/pull/10285): Update @metamask/contract-metadata from v1.21.0 to 1.22.0
 - [#10264](https://github.com/MetaMask/metamask-extension/pull/10264): Update `hi` localized messages
 - [#10174](https://github.com/MetaMask/metamask-extension/pull/10174): Move fox to bottom of 'About' page
@@ -87,24 +87,24 @@
 - [#10166](https://github.com/MetaMask/metamask-extension/pull/10166): Fix back button on swaps loading page
 - [#9947](https://github.com/MetaMask/metamask-extension/pull/9947): Do not publish swaps transaction if the estimateGas call made when adding the transaction fails.
 
-## 9.0.3 Fri Jan 22 2021
+## [9.0.3] - 2021-01-22
 - [#10243](https://github.com/MetaMask/metamask-extension/pull/10243): Fix site metadata handling
 - [#10252](https://github.com/MetaMask/metamask-extension/pull/10252): Fix decrypt message confirmation UI crash
 
-## 9.0.2 Wed Jan 20 2021
+## [9.0.2] - 2021-01-20
 
 - [#10191](https://github.com/MetaMask/metamask-extension/pull/10191): zh_TW: 乙太 -> 以太 (#10191)
 - [#10207](https://github.com/MetaMask/metamask-extension/pull/10207): zh_TW: Translate buy, assets, activity (#10207)
 - [#10219](https://github.com/MetaMask/metamask-extension/pull/10219): Restore provider 'data' event (#10219)
 
-## 9.0.1 Wed Jan 13 2021
+## [9.0.1] - 2021-01-13
 
 - [#10169](https://github.com/MetaMask/metamask-extension/pull/10169): Improved detection of contract methods with array parameters
 - [#10178](https://github.com/MetaMask/metamask-extension/pull/10178): Only warn of injected web3 usage once per page
 - [#10179](https://github.com/MetaMask/metamask-extension/pull/10179): Restore support for @metamask/inpage provider@"< 8.0.0"
 - [#10180](https://github.com/MetaMask/metamask-extension/pull/10180): Fix UI crash when domain metadata is missing on public encryption key confirmation page
 
-## 9.0.0 Fri Jan 8 2021
+## [9.0.0] - 2021-01-12
 
 - [#9156](https://github.com/MetaMask/metamask-extension/pull/9156): Remove window.web3 injection
 - [#10039](https://github.com/MetaMask/metamask-extension/pull/10039): Add web3 shim usage notification
@@ -126,11 +126,11 @@
 - [#9772](https://github.com/MetaMask/metamask-extension/pull/9772): Improve zh_CN translation
 - [#10170](https://github.com/MetaMask/metamask-extension/pull/10170): Fix bug where swaps button was disabled on Mainnet if the user hadn't switched networks in a long time
 
-## 8.1.11 Thu Jan 07 2021
+## [8.1.11] - 2021-01-07
 
 - [#10155](https://github.com/MetaMask/metamask-extension/pull/10155): Disable swaps when the current network's chainId does not match the mainnet chain ID, instead of disabling based on network ID
 
-## 8.1.10 Fri Dec 18 2020
+## [8.1.10] - 2021-01-04
 
 - [#10084](https://github.com/MetaMask/metamask-extension/pull/10084): Set last provider when switching to a customRPC
 - [#10096](https://github.com/MetaMask/metamask-extension/pull/10096): Update `@metamask/controllers` to v5.1.0
@@ -138,7 +138,7 @@
 - [#10104](https://github.com/MetaMask/metamask-extension/pull/10104): Bump @metamask/contract-metadata from 1.19.0 to 1.20.0
 - [#10110](https://github.com/MetaMask/metamask-extension/pull/10110): Fix frozen loading screen on Firefox when strict Enhanced Tracking Protection is enabled
 
-## 8.1.9 Tue Dec 15 2020
+## [8.1.9] - 2020-12-15
 
 - [#10034](https://github.com/MetaMask/metamask-extension/pull/10034): Fix contentscript injection failure on Firefox 56
 - [#10045](https://github.com/MetaMask/metamask-extension/pull/10045): Fix token validation in Send flow
@@ -148,18 +148,18 @@
 - [#10069](https://github.com/MetaMask/metamask-extension/pull/10069): Fetch swap quote refresh time from API
 - [#10040](https://github.com/MetaMask/metamask-extension/pull/10040): Disable console in contentscript to reduce noise
 
-## 8.1.8 Wed Dec 09 2020
+## [8.1.8] - 2020-12-09
 
 - [#9992](https://github.com/MetaMask/metamask-extension/pull/9992): Improve transaction params validation
 - [#9991](https://github.com/MetaMask/metamask-extension/pull/9991): Don't allow more than 15% slippage
 - [#9994](https://github.com/MetaMask/metamask-extension/pull/9994): Prevent unwanted 'no quotes available' message when going back to build quote screen while having insufficient funds
 - [#9999](https://github.com/MetaMask/metamask-extension/pull/9999): Fix missing contacts upon restart
 
-## 8.1.7 Tue Dec 08 2020
+## [8.1.7] - 2020-12-09
 
 - Revert SES lockdown
 
-## 8.1.6 Wed Dec 02 2020
+## [8.1.6] - 2020-12-04
 
 - [#9916](https://github.com/MetaMask/metamask-extension/pull/9916): Fix QR code scans interpretting payment requests as token addresses
 - [#9847](https://github.com/MetaMask/metamask-extension/pull/9847): Add alt text for images in list items
@@ -171,7 +171,7 @@
 - [#9984](https://github.com/MetaMask/metamask-extension/pull/9984): Show correct gas estimates when users don't have sufficient balance for contract transaction
 - [#9993](https://github.com/MetaMask/metamask-extension/pull/9993): Add 48x48 MetaMask icon for use by browsers
 
-## 8.1.5 Wed Nov 18 2020
+## [8.1.5] - 2020-11-19
 
 - [#9871](https://github.com/MetaMask/metamask-extension/pull/9871): Show send text upon hover in main asset list
 - [#9855](https://github.com/MetaMask/metamask-extension/pull/9855): Make edit icon and account name in account details modal focusable
@@ -186,7 +186,7 @@
 - [#9911](https://github.com/MetaMask/metamask-extension/pull/9911): Fix display of Ledger connection error
 - [#9918](https://github.com/MetaMask/metamask-extension/pull/9918): Fix missing icon in asset page dropdown and in advanced gas modal button group
 
-## 8.1.4 Tue Nov 10 2020
+## [8.1.4] - 2020-11-16
 
 - [#9687](https://github.com/MetaMask/metamask-extension/pull/9687): Allow speeding up of underpriced transactions
 - [#9694](https://github.com/MetaMask/metamask-extension/pull/9694): normalize UI component font styles
@@ -221,7 +221,7 @@
 - [#9871](https://github.com/MetaMask/metamask-extension/pull/9871): Show send text upon hover in main asset list
 - [#9880](https://github.com/MetaMask/metamask-extension/pull/9880): Properly detect U2F errors in hardware wallet
 
-## 8.1.3 Mon Oct 26 2020
+## [8.1.3] - 2020-10-29
 
 - [#9642](https://github.com/MetaMask/metamask-extension/pull/9642) Prevent excessive overflow from swap dropdowns
 - [#9658](https://github.com/MetaMask/metamask-extension/pull/9658): Fix sorting Quote Source column of quote sort list
@@ -240,7 +240,7 @@
 - [#9743](https://github.com/MetaMask/metamask-extension/pull/9743): Fix "+-" prefix on swap token amount
 - [#9715](https://github.com/MetaMask/metamask-extension/pull/9715): Focus on wallet address in buy workflow
 
-## 8.1.2 Mon Oct 19 2020
+## [8.1.2] - 2020-10-20
 
 - [#9608](https://github.com/MetaMask/metamask-extension/pull/9608): Ensure QR code scanner works
 - [#9624](https://github.com/MetaMask/metamask-extension/pull/9624): Help users avoid insufficient gas prices in swaps
@@ -249,7 +249,7 @@
 - [#9630](https://github.com/MetaMask/metamask-extension/pull/9630): Fix UI crash when trying to render estimated time remaining of non-submitted transaction
 - [#9633](https://github.com/MetaMask/metamask-extension/pull/9633): Update View Quote page to better represent the MetaMask fee
 
-## 8.1.1 Tue Oct 13 2020
+## [8.1.1] - 2020-10-15
 
 - [#9586](https://github.com/MetaMask/metamask-extension/pull/9586): Prevent build quote crash when swapping from non-tracked token with balance (#9586)
 - [#9592](https://github.com/MetaMask/metamask-extension/pull/9592): Remove commitment to maintain a public metrics dashboard (#9592)
@@ -262,7 +262,7 @@
 - [#9602](https://github.com/MetaMask/metamask-extension/pull/9602): Prevent swap button from being focused when disabled (#9602)
 - [#9609](https://github.com/MetaMask/metamask-extension/pull/9609): Ensure swaps customize gas modal values are set correctly (#9609)
 
-## 8.1.0 Tue Oct 13 2020
+## [8.1.0] - 2020-10-13
 
 - [#9565](https://github.com/MetaMask/metamask-extension/pull/9565): Ensure address book entries are shared between networks with the same chain ID
 - [#9552](https://github.com/MetaMask/metamask-extension/pull/9552): Fix `eth_signTypedData_v4` chain ID validation for non-default networks
@@ -295,25 +295,25 @@
 - [#9152](https://github.com/MetaMask/metamask-extension/pull/9152): Fix vertical align of the network name in network dropdown button
 - [#9073](https://github.com/MetaMask/metamask-extension/pull/9073): Use new Euclid font throughout MetaMask
 
-## 8.0.10 Wed Sep 16 2020
+## [8.0.10] - 2020-09-16
 
 - [#9423](https://github.com/MetaMask/metamask-extension/pull/9423): Update default phishing list
 - [#9416](https://github.com/MetaMask/metamask-extension/pull/9416): Fix fetching a new phishing list on Firefox
 
-## 8.0.9 Wed Aug 19 2020
+## [8.0.9] - 2020-08-19
 
 - [#9228](https://github.com/MetaMask/metamask-extension/pull/9228): Move transaction confirmation footer buttons to scrollable area
 - [#9256](https://github.com/MetaMask/metamask-extension/pull/9256): Handle non-String web3 property access
 - [#9266](https://github.com/MetaMask/metamask-extension/pull/9266): Use @metamask/controllers@2.0.5
 - [#9189](https://github.com/MetaMask/metamask-extension/pull/9189): Hide ETH Gas Station estimates on non-main network
 
-## 8.0.8 Fri Aug 14 2020
+## [8.0.8] - 2020-08-14
 
 - [#9211](https://github.com/MetaMask/metamask-extension/pull/9211): Fix Etherscan redirect on notification click
 - [#9237](https://github.com/MetaMask/metamask-extension/pull/9237): Reduce volume of web3 usage metrics
 - [#9227](https://github.com/MetaMask/metamask-extension/pull/9227): Permit all-caps addresses
 
-## 8.0.7 Fri Aug 07 2020
+## [8.0.7] - 2020-08-10
 
 - [#9065](https://github.com/MetaMask/metamask-extension/pull/9065): Change title of "Reveal Seed Words" page to "Reveal Seed Phrase"
 - [#8974](https://github.com/MetaMask/metamask-extension/pull/8974): Add tooltip to copy button for contacts and seed phrase
@@ -326,7 +326,7 @@
 - [#9152](https://github.com/MetaMask/metamask-extension/pull/9152): Fix network name alignment
 - [#9144](https://github.com/MetaMask/metamask-extension/pull/9144): Add web3 usage metrics and prepare for web3 removal
 
-## 8.0.6 Wed Jul 22 2020
+## [8.0.6] - 2020-07-23
 
 - [#9030](https://github.com/MetaMask/metamask-extension/pull/9030): Hide "delete" button when editing contact of wallet account
 - [#9031](https://github.com/MetaMask/metamask-extension/pull/9031): Fix crash upon removing contact
@@ -336,7 +336,7 @@
 - [#9051](https://github.com/MetaMask/metamask-extension/pull/9051): Use content-hash@2.5.2
 - [#9056](https://github.com/MetaMask/metamask-extension/pull/9056): Display at least one significant digit of small non-zero token balances
 
-## 8.0.5 Thu Jul 16 2020
+## [8.0.5] - 2020-07-17
 
 - [#8942](https://github.com/MetaMask/metamask-extension/pull/8942): Fix display of incoming transactions (#8942)
 - [#8998](https://github.com/MetaMask/metamask-extension/pull/8998): Fix `web3_clientVersion` method (#8998)
@@ -349,19 +349,19 @@
 - [#9025](https://github.com/MetaMask/metamask-extension/pull/9025): Catch gas estimate errors (#9025)
 - [#9026](https://github.com/MetaMask/metamask-extension/pull/9026): Clear transactions on createNewVaultAndRestore (#9026)
 
-## 8.0.4 Tue Jul 07 2020
+## [8.0.4] - 2020-07-08
 
 - [#8934](https://github.com/MetaMask/metamask-extension/pull/8934): Fix transaction activity on custom networks
 - [#8936](https://github.com/MetaMask/metamask-extension/pull/8936): Fix account tracker optimization
 
-## 8.0.3 Mon Jul 06 2020
+## [8.0.3] - 2020-07-06
 
 - [#8921](https://github.com/MetaMask/metamask-extension/pull/8921): Restore missing 'data' provider event, and fix 'notification' event
 - [#8923](https://github.com/MetaMask/metamask-extension/pull/8923): Normalize the 'from' parameter for `eth_sendTransaction`
 - [#8924](https://github.com/MetaMask/metamask-extension/pull/8924): Fix handling of multiple `eth_requestAccount` messages from the same domain
 - [#8917](https://github.com/MetaMask/metamask-extension/pull/8917): Update Italian translations
 
-## 8.0.2 Fri Jul 03 2020
+## [8.0.2] - 2020-07-03
 
 - [#8907](https://github.com/MetaMask/metamask-extension/pull/8907): Tolerate missing or falsey substitutions
 - [#8908](https://github.com/MetaMask/metamask-extension/pull/8908): Fix activity log inline buttons
@@ -369,7 +369,7 @@
 - [#8910](https://github.com/MetaMask/metamask-extension/pull/8910): Handle suggested token resolved elsewhere
 - [#8913](https://github.com/MetaMask/metamask-extension/pull/8913): Fix Kovan chain ID constant
 
-## 8.0.1 Thu Jul 02 2020
+## [8.0.1] - 2020-07-02
 
 - [#8874](https://github.com/MetaMask/metamask-extension/pull/8874): Fx overflow behaviour of add token list
 - [#8885](https://github.com/MetaMask/metamask-extension/pull/8885): Show `origin` in connect flow rather than site name
@@ -382,7 +382,7 @@
 - [#8896](https://github.com/MetaMask/metamask-extension/pull/8896): Include relative time polyfill locale data
 - [#8898](https://github.com/MetaMask/metamask-extension/pull/8898): Replace percentage opacity value
 
-## 8.0.0 Mon Jun 23 2020
+## [8.0.0] - 2020-07-01
 
 - [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Add permission system
 - [#7261](https://github.com/MetaMask/metamask-extension/pull/7261): Search accounts by name
@@ -474,7 +474,7 @@
 - [#8850](https://github.com/MetaMask/metamask-extension/pull/8850): Stop upper-casing exported private key
 - [#8631](https://github.com/MetaMask/metamask-extension/pull/8631): Include imported accounts in mobile sync
 
-## 7.7.9 Tue Apr 28 2020
+## [7.7.9] - 2020-05-04
 
 - [#8446](https://github.com/MetaMask/metamask-extension/pull/8446): Fix popup not opening
 - [#8449](https://github.com/MetaMask/metamask-extension/pull/8449): Skip adding history entry for empty txMeta diffs
@@ -492,28 +492,28 @@
 - [#8476](https://github.com/MetaMask/metamask-extension/pull/8476): Update eth-contract-metadata
 - [#8509](https://github.com/MetaMask/metamask-extension/pull/8509): Fix Tohen Typo
 
-## 7.7.8 Wed Mar 11 2020
+## [7.7.8] - 2020-03-13
 
 - [#8176](https://github.com/MetaMask/metamask-extension/pull/8176): Handle and set gas estimation when max mode is clicked
 - [#8178](https://github.com/MetaMask/metamask-extension/pull/8178): Use specified gas limit when speeding up a transaction
 
-## 7.7.7 Wed Mar 04 2020
+## [7.7.7] - 2020-03-04
 
 - [#8162](https://github.com/MetaMask/metamask-extension/pull/8162): Remove invalid Ledger accounts
 - [#8163](https://github.com/MetaMask/metamask-extension/pull/8163): Fix account index check
 
-## 7.7.6 Mon Mar 02 2020
+## [7.7.6] - 2020-03-03
 
 - [#8154](https://github.com/MetaMask/metamask-extension/pull/8154): Prevent signing from incorrect Ledger account
 
-## 7.7.5 Fri Feb 14 2020
+## [7.7.5] - 2020-02-18
 
 - [#8053](https://github.com/MetaMask/metamask-extension/pull/8053): Inline the source text not the binary encoding for inpage script
 - [#8049](https://github.com/MetaMask/metamask-extension/pull/8049): Add warning to watchAsset API when editing a known token
 - [#8051](https://github.com/MetaMask/metamask-extension/pull/8051): Update Wyre ETH purchase url
 - [#8059](https://github.com/MetaMask/metamask-extension/pull/8059): Attempt ENS resolution on any valid domain name
 
-## 7.7.4 Wed Jan 29 2020
+## [7.7.4] - 2020-01-31
 
 - [#7918](https://github.com/MetaMask/metamask-extension/pull/7918): Update data on Approve screen after updating custom spend limit
 - [#7919](https://github.com/MetaMask/metamask-extension/pull/7919): Allow editing max spend limit
@@ -521,18 +521,18 @@
 - [#7944](https://github.com/MetaMask/metamask-extension/pull/7944): Only resolve ENS on mainnet
 - [#7954](https://github.com/MetaMask/metamask-extension/pull/7954): Update ENS registry addresses
 
-## 7.7.3 Fri Jan 24 2020
+## [7.7.3] - 2020-01-27
 
 - [#7894](https://github.com/MetaMask/metamask-extension/pull/7894): Update GABA dependency version
 - [#7901](https://github.com/MetaMask/metamask-extension/pull/7901): Use eth-contract-metadata@1.12.1
 - [#7910](https://github.com/MetaMask/metamask-extension/pull/7910): Fixing broken JSON import help link
 
-## 7.7.2 Fri Jan 10 2020
+## [7.7.2] - 2020-01-13
 
 - [#7753](https://github.com/MetaMask/metamask-extension/pull/7753): Fix gas estimate for tokens
 - [#7473](https://github.com/MetaMask/metamask-extension/pull/7473): Fix transaction order on transaction confirmation screen
 
-## 7.7.1 Wed Dec 04 2019
+## [7.7.1] - 2019-12-09
 
 - [#7488](https://github.com/MetaMask/metamask-extension/pull/7488): Fix text overlap when expanding transaction
 - [#7491](https://github.com/MetaMask/metamask-extension/pull/7491): Update gas when asset is changed on send screen
@@ -547,7 +547,7 @@
 - [#7628](https://github.com/MetaMask/metamask-extension/pull/7628): Fix typo that resulted in degrated account menu performance
 - [#7558](https://github.com/MetaMask/metamask-extension/pull/7558): Use localized messages for NotificationModal buttons
 
-## 7.7.0 Thu Nov 28 2019 [WITHDRAWN]
+## [7.7.0] - 2019-12-03 [WITHDRAWN]
 
 - [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Connect distinct accounts per site
 - [#7480](https://github.com/MetaMask/metamask-extension/pull/7480): Fixed link on root README.md
@@ -561,19 +561,19 @@
 - [#7558](https://github.com/MetaMask/metamask-extension/pull/7558): Use localized messages for NotificationModal buttons
 - [#7488](https://github.com/MetaMask/metamask-extension/pull/7488): Fix text overlap when expanding transaction
 
-## 7.6.1 Tue Nov 19 2019
+## [7.6.1] - 2019-11-19
 
 - [#7475](https://github.com/MetaMask/metamask-extension/pull/7475): Add 'Remind Me Later' to the Maker notification
 - [#7436](https://github.com/MetaMask/metamask-extension/pull/7436): Add additional rpcUrl verification
 - [#7468](https://github.com/MetaMask/metamask-extension/pull/7468): Show transaction fee units on approve screen
 
-## 7.6.0 Mon Nov 18 2019
+## [7.6.0] - 2019-11-18
 
 - [#7450](https://github.com/MetaMask/metamask-extension/pull/7450): Add migration notification for users with non-zero Sai
 - [#7461](https://github.com/MetaMask/metamask-extension/pull/7461): Import styles for showing multiple notifications
 - [#7451](https://github.com/MetaMask/metamask-extension/pull/7451): Add button disabled when password is empty
 
-## 7.5.3 Fri Nov 15 2019
+## [7.5.3] - 2019-11-15
 
 - [#7412](https://github.com/MetaMask/metamask-extension/pull/7412): lock eth-contract-metadata (#7412)
 - [#7416](https://github.com/MetaMask/metamask-extension/pull/7416): Add eslint import plugin to help detect unresolved paths
@@ -588,17 +588,17 @@
 - [#7439](https://github.com/MetaMask/metamask-extension/pull/7439): Add metricsEvent to contextTypes (#7439)
 - [#7419](https://github.com/MetaMask/metamask-extension/pull/7419): Added webRequest.RequestFilter to filter main_frame .eth requests (#7419)
 
-## 7.5.2 Thu Nov 14 2019
+## [7.5.2] - 2019-11-14
 
 - [#7414](https://github.com/MetaMask/metamask-extension/pull/7414): Ensure SignatureRequestOriginal 'beforeunload' handler is bound
 
-## 7.5.1 Tuesday Nov 13 2019
+## [7.5.1] - 2019-11-13
 
 - [#7402](https://github.com/MetaMask/metamask-extension/pull/7402): Fix regression for signed types data screens
 - [#7390](https://github.com/MetaMask/metamask-extension/pull/7390): Update json-rpc-engine
 - [#7401](https://github.com/MetaMask/metamask-extension/pull/7401): Reject connection request on window close
 
-## 7.5.0 Mon Nov 04 2019
+## [7.5.0] - 2019-11-12
 
 - [#7328](https://github.com/MetaMask/metamask-extension/pull/7328): ignore known transactions on first broadcast and continue with normal flow
 - [#7327](https://github.com/MetaMask/metamask-extension/pull/7327): eth_getTransactionByHash will now check metamask's local history for pending transactions
@@ -617,7 +617,7 @@
 - [#7357](https://github.com/MetaMask/metamask-extension/pull/7357): Update to gaba@1.8.0
 - [#7335](https://github.com/MetaMask/metamask-extension/pull/7335): Add onbeforeunload and have it call onCancel
 
-## 7.4.0 Tue Oct 29 2019
+## [7.4.0] - 2019-11-04
 
 - [#7186](https://github.com/MetaMask/metamask-extension/pull/7186): Use `AdvancedGasInputs` in `AdvancedTabContent`
 - [#7304](https://github.com/MetaMask/metamask-extension/pull/7304): Move signTypedData signing out to keyrings
@@ -631,11 +631,11 @@
 - [#7325](https://github.com/MetaMask/metamask-extension/pull/7325): Update eth-json-rpc-filters to fix memory leak
 - [#7334](https://github.com/MetaMask/metamask-extension/pull/7334): Add web3 deprecation warning
 
-## 7.3.1 Mon Oct 21 2019
+## [7.3.1] - 2019-10-22
 
 - [#7298](https://github.com/MetaMask/metamask-extension/pull/7298): Turn off full screen vs popup a/b test
 
-## 7.3.0 Fri Sep 27 2019
+## [7.3.0] - 2019-10-21
 
 - [#6972](https://github.com/MetaMask/metamask-extension/pull/6972): 3box integration
 - [#7168](https://github.com/MetaMask/metamask-extension/pull/7168): Add fixes for German translations
@@ -655,21 +655,21 @@
 - [#7285](https://github.com/MetaMask/metamask-extension/pull/7285): Lessen the length of ENS validation to 3
 - [#7287](https://github.com/MetaMask/metamask-extension/pull/7287): Fix phishing detect script
 
-## 7.2.3 Fri Oct 04 2019
+## [7.2.3] - 2019-10-08
 
 - [#7252](https://github.com/MetaMask/metamask-extension/pull/7252): Fix gas limit when sending tx without data to a contract
 - [#7260](https://github.com/MetaMask/metamask-extension/pull/7260): Do not transate on seed phrases
 - [#7252](https://github.com/MetaMask/metamask-extension/pull/7252): Ensure correct tx category when sending to contracts without tx data
 
-## 7.2.2 Tue Sep 24 2019
+## [7.2.2] - 2019-09-25
 
 - [#7213](https://github.com/MetaMask/metamask-extension/pull/7213): Update minimum Firefox verison to 56.0
 
-## 7.2.1 Tue Sep 17 2019
+## [7.2.1] - 2019-09-17
 
 - [#7180](https://github.com/MetaMask/metamask-extension/pull/7180): Add `appName` message to each locale
 
-## 7.2.0 Mon Sep 8, 2019
+## [7.2.0] - 2019-09-17
 
 - [#7099](https://github.com/MetaMask/metamask-extension/pull/7099): Update localization from Transifex Brave
 - [#7137](https://github.com/MetaMask/metamask-extension/pull/7137): Fix validation of empty block explorer url's in custom network form
@@ -682,7 +682,7 @@
 - [#7161](https://github.com/MetaMask/metamask-extension/pull/7161): Replace `undefined` selectedAddress with `null`
 - [#7171](https://github.com/MetaMask/metamask-extension/pull/7171): Fix recipient field of approve screen
 
-## 7.1.1 Tue Aug 27 2019
+## [7.1.1] - 2019-09-03
 
 - [#7059](https://github.com/MetaMask/metamask-extension/pull/7059): Remove blockscale, replace with ethgasstation
 - [#7037](https://github.com/MetaMask/metamask-extension/pull/7037): Remove Babel 6 from internal dependencies
@@ -694,7 +694,7 @@
 - [#6878](https://github.com/MetaMask/metamask-extension/pull/6878): Persian translation
 - [#7012](https://github.com/MetaMask/metamask-extension/pull/7012): Added missed phrases to RU locale
 
-## 7.1.0 Fri Aug 16 2019
+## [7.1.0] - 2019-08-26
 
 - [#7035](https://github.com/MetaMask/metamask-extension/pull/7035): Filter non-ERC-20 assets during mobile sync (#7035)
 - [#7021](https://github.com/MetaMask/metamask-extension/pull/7021): Using translated string for end of flow messaging (#7021)
@@ -708,11 +708,11 @@
 - [#7046](https://github.com/MetaMask/metamask-extension/pull/7046): Update Italian translation (#7046)
 - [#7047](https://github.com/MetaMask/metamask-extension/pull/7047): Add warning about reload on network change
 
-## 7.0.1 Thu Aug 08 2019
+## [7.0.1] - 2019-08-08
 
 - [#6975](https://github.com/MetaMask/metamask-extension/pull/6975): Ensure seed phrase backup notification only shows up for new users
 
-## 7.0.0 Fri Aug 02 2019
+## [7.0.0] - 2019-08-07
 
 - [#6828](https://github.com/MetaMask/metamask-extension/pull/6828): Capitalized speed up label to match rest of UI
 - [#6874](https://github.com/MetaMask/metamask-extension/pull/6928): Allows skipping of seed phrase challenge during onboarding, and completing it at a later time
@@ -722,11 +722,11 @@
 - [#6928](https://github.com/MetaMask/metamask-extension/pull/6928): Disable Copy Tx ID and block explorer link for transactions without hash
 - [#6967](https://github.com/MetaMask/metamask-extension/pull/6967): Fix mobile sync
 
-## 6.7.3 Thu Jul 18 2019
+## [6.7.3] - 2019-07-19
 
 - [#6888](https://github.com/MetaMask/metamask-extension/pull/6888): Fix bug with resubmitting unsigned transactions.
 
-## 6.7.2 Mon Jul 01 2019
+## [6.7.2] - 2019-07-03
 
 - [#6713](https://github.com/MetaMask/metamask-extension/pull/6713): \* Normalize and Validate txParams in TransactionStateManager.addTx too
 - [#6759](https://github.com/MetaMask/metamask-extension/pull/6759): Update to Node.js v10
@@ -741,11 +741,11 @@
 - [#6648](https://github.com/MetaMask/metamask-extension/pull/6648): Add loading view to notification.html
 - [#6731](https://github.com/MetaMask/metamask-extension/pull/6731): Add brave as a platform type for MetaMask
 
-## 6.7.1 Fri Jun 28 2019
+## [6.7.1] - 2019-07-28
 
 - [#6764](https://github.com/MetaMask/metamask-extension/pull/6764): Fix display of token amount on confirm transaction screen
 
-## 6.7.0 Tue Jun 18 2019
+## [6.7.0] - 2019-07-26
 
 - [#6623](https://github.com/MetaMask/metamask-extension/pull/6623): Improve contract method data fetching (#6623)
 - [#6551](https://github.com/MetaMask/metamask-extension/pull/6551): Adds 4byte registry fallback to getMethodData() (#6435)
@@ -756,39 +756,39 @@
 - [#6700](https://github.com/MetaMask/metamask-extension/pull/6700): Fix styles on 'import account' page, update help link
 - [#6775](https://github.com/MetaMask/metamask-extension/pull/6775): Started adding visual documentation of MetaMask plugin components with the account menu component first
 
-## 6.6.2 Fri Jun 07 2019
+## [6.6.2] - 2019-07-17
 
 - [#6690](https://github.com/MetaMask/metamask-extension/pull/6690): Update dependencies, re-enable npm audit CI job
 - [#6700](https://github.com/MetaMask/metamask-extension/pull/6700): Fix styles on 'import account' page, update help link
 
-## 6.6.1 Thu Jun 06 2019
+## [6.6.1] - 2019-06-06
 
 - [#6691](https://github.com/MetaMask/metamask-extension/pull/6691): Revert "Improve ENS Address Input" to fix bugs on input field on non-main networks.
 
-## 6.6.0 Mon Jun 03 2019
+## [6.6.0] - 2019-06-04
 
 - [#6659](https://github.com/MetaMask/metamask-extension/pull/6659): Enable Ledger hardware wallet support on Firefox
 - [#6671](https://github.com/MetaMask/metamask-extension/pull/6671): bugfix: reject enable promise on user rejection
 - [#6625](https://github.com/MetaMask/metamask-extension/pull/6625): Ensures that transactions cannot be confirmed if gas limit is below 21000.
 - [#6633](https://github.com/MetaMask/metamask-extension/pull/6633): Fix grammatical error in i18n endOfFlowMessage6
 
-## 6.5.3 Thu May 16 2019
+## [6.5.3] - 2019-05-16
 
 - [#6619](https://github.com/MetaMask/metamask-extension/pull/6619): bugfix: show extension window if locked regardless of approval
 - [#6388](https://github.com/MetaMask/metamask-extension/pull/6388): Transactions/pending - check nonce against the network and mark as dropped if not included in a block
 - [#6606](https://github.com/MetaMask/metamask-extension/pull/6606): Improve ENS Address Input
 - [#6615](https://github.com/MetaMask/metamask-extension/pull/6615): Adds e2e test for removing imported accounts.
 
-## 6.5.2 Wed May 15 2019
+## [6.5.2] - 2019-05-15
 
 - [#6613](https://github.com/MetaMask/metamask-extension/pull/6613): Hardware Wallet Fix
 
-## 6.5.1 Tue May 14 2019
+## [6.5.1] - 2019-05-14
 
 - Fix bug where approve method would show a warning. #6602
 - [#6593](https://github.com/MetaMask/metamask-extension/pull/6593): Fix wording of autoLogoutTimeLimitDescription
 
-## 6.5.0 Fri May 10 2019
+## [6.5.0] - 2019-05-13
 
 - [#6568](https://github.com/MetaMask/metamask-extension/pull/6568): feature: integrate gaba/PhishingController
 - [#6490](https://github.com/MetaMask/metamask-extension/pull/6490): Redesign custom RPC form
@@ -799,11 +799,11 @@
 - [#6502](https://github.com/MetaMask/metamask-extension/pull/6502): Add subheader to all settings subviews
 - [#6501](https://github.com/MetaMask/metamask-extension/pull/6501): Improve confirm screen loading performance by fixing home screen rendering bug
 
-## 6.4.1 Fri Apr 26 2019
+## [6.4.1] - 2019-04-26
 
 - [#6521](https://github.com/MetaMask/metamask-extension/pull/6521): Revert "Adds 4byte registry fallback to getMethodData()" to fix stalling bug.
 
-## 6.4.0 Wed Apr 17 2019
+## [6.4.0] - 2019-04-18
 
 - [#6445](https://github.com/MetaMask/metamask-extension/pull/6445): \* Move send to pages/
 - [#6470](https://github.com/MetaMask/metamask-extension/pull/6470): update publishing.md with dev diagram
@@ -829,19 +829,19 @@
 - [#6389](https://github.com/MetaMask/metamask-extension/pull/6389): Fix display of gas chart on Ethereum networks
 - [#6382](https://github.com/MetaMask/metamask-extension/pull/6382): Remove NoticeController
 
-## 6.3.2 Mon Apr 8 2019
+## [6.3.2] - 2019-04-08
 
 - [#6389](https://github.com/MetaMask/metamask-extension/pull/6389): Fix display of gas chart on ethereum networks
 - [#6395](https://github.com/MetaMask/metamask-extension/pull/6395): Fixes for signing methods for ledger and trezor devices
 - [#6397](https://github.com/MetaMask/metamask-extension/pull/6397): Fix Wyre link
 
-## 6.3.1 Fri Mar 26 2019
+## [6.3.1] - 2019-03-29
 
 - [#6353](https://github.com/MetaMask/metamask-extension/pull/6353): Open restore vault in full screen when clicked from popup
 - [#6372](https://github.com/MetaMask/metamask-extension/pull/6372): Prevents duplicates of account addresses from showing in send screen "To" dropdown
 - [#6374](https://github.com/MetaMask/metamask-extension/pull/6374): Ensures users are placed on correct confirm screens even when registry service fails
 
-## 6.3.0 Mon Mar 25 2019
+## [6.3.0] - 2019-03-26
 
 - [#6300](https://github.com/MetaMask/metamask-extension/pull/6300): Gas chart hidden on custom networks
 - [#6301](https://github.com/MetaMask/metamask-extension/pull/6301): Fix gas fee in the submitted step of the transaction details activity log
@@ -856,23 +856,23 @@
 - [#6341](https://github.com/MetaMask/metamask-extension/pull/6341): Disable transaction "Cancel" button when balance is insufficient
 - [#6347](https://github.com/MetaMask/metamask-extension/pull/6347): Enable privacy mode by default for first time users
 
-## 6.2.2 Tue Mar 12 2019
+## [6.2.2] - 2019-03-12
 
 - [#6271](https://github.com/MetaMask/metamask-extension/pull/6271): Centre all notification popups
 - [#6268](https://github.com/MetaMask/metamask-extension/pull/6268): Improve Korean translations
 - [#6279](https://github.com/MetaMask/metamask-extension/pull/6279): Nonmultiple notifications for batch txs
 - [#6280](https://github.com/MetaMask/metamask-extension/pull/6280): No longer check network when validating checksum addresses
 
-## 6.2.1 Wed Mar 06 2019
+## [6.2.1] - 2019-03-11
 
-## 6.2.0 Tue Mar 05 2019
+## [6.2.0] - 2019-03-05
 
 - [#6192](https://github.com/MetaMask/metamask-extension/pull/6192): Improves design and UX of onboarding flow
 - [#6195](https://github.com/MetaMask/metamask-extension/pull/6195): Fixes gas estimation when sending to contracts
 - [#6223](https://github.com/MetaMask/metamask-extension/pull/6223): Fixes display of notification windows when metamask is active in a tab
 - [#6171](https://github.com/MetaMask/metamask-extension/pull/6171): Adds MetaMetrics usage analytics system
 
-## 6.1.0 Tue Feb 19 2019
+## [6.1.0] - 2019-02-20
 
 - [#6182](https://github.com/MetaMask/metamask-extension/pull/6182): Change "Token Address" to "Token Contract Address"
 - [#6177](https://github.com/MetaMask/metamask-extension/pull/6177): Fixes #6176
@@ -881,14 +881,14 @@
 - [#6147](https://github.com/MetaMask/metamask-extension/pull/6147): Add button to force edit token symbol when adding custom token
 - [#6124](https://github.com/MetaMask/metamask-extension/pull/6124): recent-blocks - dont listen for block when on infura providers -[#5973] (https://github.com/MetaMask/metamask-extension/pull/5973): Fix incorrectly showing checksums on non-ETH blockchains (issue 5838)
 
-## 6.0.1 Tue Feb 12 2019
+## [6.0.1] - 2019-02-12
 
 - [#6139](https://github.com/MetaMask/metamask-extension/pull/6139) Fix advanced gas controls on the confirm screen
 - [#6134](https://github.com/MetaMask/metamask-extension/pull/6134) Trim whitespace from seed phrase during import
 - [#6119](https://github.com/MetaMask/metamask-extension/pull/6119) Update Italian translation
 - [#6125](https://github.com/MetaMask/metamask-extension/pull/6125) Improved Traditional Chinese translation
 
-## 6.0.0 Thu Feb 07 2019
+## [6.0.0] - 2019-02-11
 
 - [#6082](https://github.com/MetaMask/metamask-extension/pull/6082): Migrate all users to the new UI
 - [#6114](https://github.com/MetaMask/metamask-extension/pull/6114): Add setting for inputting gas price with a text field for advanced users.
@@ -899,22 +899,22 @@
 - [#6120](https://github.com/MetaMask/metamask-extension/pull/6120): Add class to sign footer button
 - [#6116](https://github.com/MetaMask/metamask-extension/pull/6116): Fix locale codes contains underscore never being preferred
 
-## 5.3.5 Mon Feb 4 2019
+## [5.3.5] - 2019-02-04
 
 - [#6084](https://github.com/MetaMask/metamask-extension/pull/6087): Privacy mode fixes
 
-## 5.3.4 Thu Jan 31 2019
+## [5.3.4] - 2019-01-31
 
 - [#6079](https://github.com/MetaMask/metamask-extension/pull/6079): fix - migration 30
 
-## 5.3.3 Wed Jan 30 2019
+## [5.3.3] - 2019-01-30
 
 - [#6006](https://github.com/MetaMask/metamask-extension/pull/6006): Update privacy notice
 - [#6072](https://github.com/MetaMask/metamask-extension/pull/6072): Improved Spanish translations
 - [#5854](https://github.com/MetaMask/metamask-extension/pull/5854): Add visual indicator when displaying a cached balance.
 - [#6044](https://github.com/MetaMask/metamask-extension/pull/6044): Fix bug that interferred with using multiple custom networks.
 
-## 5.3.2 Mon Jan 28 2019
+## [5.3.2] - 2019-01-28
 
 - [#6021](https://github.com/MetaMask/metamask-extension/pull/6021): Order shapeshift transactions by time within the transactions list
 - [#6052](https://github.com/MetaMask/metamask-extension/pull/6052): Add and use cached method signatures to reduce provider requests
@@ -923,7 +923,7 @@
 - [#6029](https://github.com/MetaMask/metamask-extension/pull/6029): Fix grammar error in Current Conversion
 - [#6024](https://github.com/MetaMask/metamask-extension/pull/6024): Disable account dropdown on signing screens
 
-## 5.3.1 Wed Jan 16 2019
+## [5.3.1] - 2019-01-16
 
 - [#5966](https://github.com/MetaMask/metamask-extension/pull/5966): Update Slovenian translation
 - [#6005](https://github.com/MetaMask/metamask-extension/pull/6005): Set auto conversion off for token/eth conversion
@@ -936,7 +936,7 @@
 - [#5992](https://github.com/MetaMask/metamask-extension/pull/5992): Add scrolling button to account list
 - [#5989](https://github.com/MetaMask/metamask-extension/pull/5989): fix typo in phishing.html title
 
-## 5.3.0 Wed Jan 02 2019
+## [5.3.0] - 2019-01-02
 
 - [#5978](https://github.com/MetaMask/metamask-extension/pull/5978): Fix etherscan links on notifications
 - [#5980](https://github.com/MetaMask/metamask-extension/pull/5980): Fix drizzle tests
@@ -945,31 +945,31 @@
 - [#5924](https://github.com/MetaMask/metamask-extension/pull/5924): transactions - throw an error if a transaction is generated while the network is loading
 - [#5893](https://github.com/MetaMask/metamask-extension/pull/5893): Add loading network screen
 
-## 5.2.2 Wed Dec 12 2018
+## [5.2.2] - 2018-12-13
 
 - [#5925](https://github.com/MetaMask/metamask-extension/pull/5925): Fix speed up button not showing for transactions with the lowest nonce
 - [#5923](https://github.com/MetaMask/metamask-extension/pull/5923): Update the Phishing Warning notice text to not use inline URLs
 - [#5919](https://github.com/MetaMask/metamask-extension/pull/5919): Fix some styling and translations in the gas customization modal
 
-## 5.2.1 Wed Dec 12 2018
+## [5.2.1] - 2018-12-12
 
 - [#5917] bugfix: Ensures that advanced tab gas limit reflects tx gas limit
 
-## 5.2.0 Mon Dec 11 2018
+## [5.2.0] - 2018-12-11
 
 - [#5704] Implements new gas customization features for sending, confirming and speeding up transactions
 - [#5886] Groups transactions - speed up, cancel and original - by nonce in the transaction history list
 - [#5892] bugfix: eliminates infinite spinner issues caused by switching quickly from a loading network that ultimately fails to resolve
 - [$5902] bugfix: provider crashes caused caching issues in `json-rpc-engine`. Fixed in (https://github.com/MetaMask/json-rpc-engine/commit/6de511afbd03ccef4550ea43ff4010b7d7a84039)
 
-## 5.1.0 Mon Dec 03 2018
+## [5.1.0] - 2018-12-03
 
 - [#5860](https://github.com/MetaMask/metamask-extension/pull/5860): Fixed an infinite spinner bug.
 - [#5875](https://github.com/MetaMask/metamask-extension/pull/5875): Update phishing warning copy
 - [#5863](https://github.com/MetaMask/metamask-extension/pull/5863): bugfix: normalize contract addresss when fetching exchange rates
 - [#5843](https://github.com/MetaMask/metamask-extension/pull/5843): Use selector for state.metamask.accounts in all cases.
 
-## 5.0.4 Thu Nov 29 2018
+## [5.0.4] - 2018-11-29
 
 - [#5878](https://github.com/MetaMask/metamask-extension/pull/5878): Formats 32-length byte strings passed to personal_sign as hex, rather than UTF8.
 - [#5840](https://github.com/MetaMask/metamask-extension/pull/5840): transactions/tx-gas-utils - add the acctual response for eth_getCode for NO_CONTRACT_ERROR's && add a debug object to simulationFailed
@@ -992,30 +992,30 @@
 - [#5334](https://github.com/MetaMask/metamask-extension/pull/5334): Default to the new UI for first time users
 - [#5791](https://github.com/MetaMask/metamask-extension/pull/5791): Bump eth-ledger-bridge-keyring
 
-## 5.0.3 Mon Nov 19 2018
+## [5.0.3] - 2018-11-20
 
 - [#5547](https://github.com/MetaMask/metamask-extension/pull/5547): Bundle some ui dependencies separately to limit the build size of ui.js
 - Resubmit approved transactions on new block, to fix bug where an error can stick transactions in this state.
 - Fixed a bug that could cause an error when sending the max number of tokens.
 
-## 5.0.2 Friday November 9 2018
+## [5.0.2] - 2018-11-10
 
 - Fixed bug that caused accounts to update slowly to sites. #5717
 - Fixed bug that could lead to some sites crashing. #5709
 
-## 5.0.1 Wednesday November 7 2018
+## [5.0.1] - 2018-11-07
 
 - Fixed bug in privacy mode that made it not work correctly on Firefox.
 
-## 5.0.0 Tuesday November 6 2018
+## [5.0.0] - 2018-11-06
 
 - Implements EIP 1102 as a user-activated "Privacy Mode".
 
-## 4.17.1 Saturday November 3 2018
+## [4.17.1] - 2018-11-03
 
 - Revert chain ID lookup change which introduced a bug which caused problems when connecting to mainnet via Infura's RESTful API.
 
-## 4.17.0 Thursday November 1 2018
+## [4.17.0] - 2018-11-01
 
 - Fix bug where data lookups like balances would get stale data (stopped block-tracker bug)
 - Transaction Details now show entry for onchain failure
@@ -1027,7 +1027,7 @@
 - Attempt chain ID lookup via `eth_chainId` before `net_version`
 - Fix account display width for large currency values
 
-## 4.16.0 Wednesday October 17 2018
+## [4.16.0] - 2018-10-17
 
 - Feature: Add toggle for primary currency (eth/fiat)
 - Feature: add tooltip for view etherscan tx
@@ -1039,34 +1039,34 @@
 - Bug Fix: Fix document extension check when injecting web3
 - Bug Fix: Fix some support links
 
-## 4.15.0 Thursday October 11 2018
+## [4.15.0] - 2018-10-11
 
 - A rollback release, equivalent to `v4.11.1` to be deployed in the case that `v4.14.0` is found to have bugs.
 
-## 4.14.0 Thursday October 11 2018
+## [4.14.0] - 2018-10-11
 
 - Update transaction statuses when switching networks.
 - [#5470](https://github.com/MetaMask/metamask-extension/pull/5470) 100% coverage in French locale, fixed the procedure to verify proposed locale.
 - Added rudimentary support for the subscription API to support web3 1.0 and Truffle's Drizzle.
 - [#5502](https://github.com/MetaMask/metamask-extension/pull/5502) Update Italian translation.
 
-## 4.13.0
+## [4.13.0] - 2018-10-04
 
 - A rollback release, equivalent to `v4.11.1` to be deployed in the case that `v4.12.0` is found to have bugs.
 
-## 4.12.0 Thursday September 27 2018
+## [4.12.0] - 2018-09-27
 
 - Reintroduces changes from 4.10.0
 
-## 4.11.1 Tuesday September 25 2018
+## [4.11.1] - 2018-09-25
 
 - Adds Ledger support.
 
-## 4.11.0 Monday September 24 2018
+## [4.11.0] - 2018-09-24
 
 - Identical to 4.9.3. A rollback version to give time to fix bugs in the 4.10.x branch.
 
-## 4.10.0 Mon Sep 17 2018
+## [4.10.0] - 2018-09-18
 
 - [#4803](https://github.com/MetaMask/metamask-extension/pull/4803): Implement EIP-712: Sign typed data, but continue to support v1.
 - [#4898](https://github.com/MetaMask/metamask-extension/pull/4898): Restore multiple consecutive accounts with balances.
@@ -1080,17 +1080,17 @@
 - [#5189](https://github.com/MetaMask/metamask-extension/pull/5189): Fix bug where Ropsten loading message is shown when connecting to Kovan.
 - [#5256](https://github.com/MetaMask/metamask-extension/pull/5256): Add mock EIP-1102 support
 
-## 4.9.3 Wed Aug 15 2018
+## [4.9.3] - 2018-08-16
 
 - [#4897](https://github.com/MetaMask/metamask-extension/pull/4897): QR code scan for recipient addresses.
 - [#4961](https://github.com/MetaMask/metamask-extension/pull/4961): Add a download seed phrase link.
 - [#5060](https://github.com/MetaMask/metamask-extension/pull/5060): Fix bug where gas was not updating properly.
 
-## 4.9.2 Mon Aug 09 2018
+## [4.9.2] - 2018-08-10
 
 - [#5020](https://github.com/MetaMask/metamask-extension/pull/5020): Fix bug in migration #28 ( moving tokens to specific accounts )
 
-## 4.9.1 Mon Aug 09 2018
+## [4.9.1] - 2018-08-09
 
 - [#4884](https://github.com/MetaMask/metamask-extension/pull/4884): Allow to have tokens per account and network.
 - [#4989](https://github.com/MetaMask/metamask-extension/pull/4989): Continue to use original signedTypedData.
@@ -1098,7 +1098,7 @@
 - [#5000](https://github.com/MetaMask/metamask-extension/pull/5000): Show error while allowing confirmation of tx where simulation fails.
 - [#4995](https://github.com/MetaMask/metamask-extension/pull/4995): Shows retry button on dApp initialized transactions.
 
-## 4.9.0 Mon Aug 07 2018
+## [4.9.0] - 2018-08-07
 
 - [#4926](https://github.com/MetaMask/metamask-extension/pull/4926): Show retry button on the latest tx of the earliest nonce.
 - [#4888](https://github.com/MetaMask/metamask-extension/pull/4888): Suggest using the new user interface.
@@ -1114,7 +1114,7 @@
 - [#4855](https://github.com/MetaMask/metamask-extension/pull/4855): network.js: convert rpc protocol to lower case.
 - [#4898](https://github.com/MetaMask/metamask-extension/pull/4898): Restore multiple consecutive accounts with balances.
 
-## 4.8.0 Thur Jun 14 2018
+## [4.8.0] - 2018-06-18
 
 - [#4513](https://github.com/MetaMask/metamask-extension/pull/4513): Attempting to import an empty private key will now show a clear error.
 - [#4570](https://github.com/MetaMask/metamask-extension/pull/4570): Fix bug where metamask data would stop being written to disk after prolonged use.
@@ -1124,30 +1124,30 @@
 - [#4566](https://github.com/MetaMask/metamask-extension/pull/4566): Add phishing notice.
 - [#4591](https://github.com/MetaMask/metamask-extension/pull/4591): Allow Copying Token Addresses and link to Token on Etherscan.
 
-## 4.7.4 Tue Jun 05 2018
+## [4.7.4] - 2018-06-05
 
 - Add diagnostic reporting for users with multiple HD keyrings
 - Throw explicit error when selected account is unset
 
-## 4.7.3 Mon Jun 04 2018
+## [4.7.3] - 2018-06-04
 
 - Hide token now uses new modal
 - Indicate the current selected account on the popup account view
 - Reduce height of notice container in onboarding
 - Fixes issue where old nicknames were kept around causing errors
 
-## 4.7.2 Sun Jun 03 2018
+## [4.7.2] - 2018-06-03
 
 - Fix bug preventing users from logging in. Internally accounts and identities were out of sync.
 - Fix support links to point to new support system (Zendesk)
 - Fix bug in migration #26 ( moving account nicknames to preferences )
 - Clears account nicknames on restore from seedPhrase
 
-## 4.7.1 Fri Jun 01 2018
+## [4.7.1] - 2018-06-01
 
 - Fix bug where errors were not returned to Dapps.
 
-## 4.7.0 Wed May 30 2018
+## [4.7.0] - 2018-05-30
 
 - Fix Brave support
 - Adds error messages when passwords don't match in onboarding flow.
@@ -1162,7 +1162,7 @@
 - Styling improvements to labels in first time flow and signature request headers.
 - Allow other extensions to make access our ethereum provider API ([#3997](https://github.com/MetaMask/metamask-extension/pull/3997))
 
-## 4.6.1 Mon Apr 30 2018
+## [4.6.1] - 2018-04-30
 
 - Fix bug where sending a transaction resulted in an infinite spinner
 - Allow transactions with a 0 gwei gas price
@@ -1170,7 +1170,7 @@
 - Fix ShapeShift forms (new + old ui)
 - Fix sourcemaps
 
-## 4.6.0 Thu Apr 26 2018
+## [4.6.0] - 2018-04-26
 
 - Correctly format currency conversion for locally selected preferred currency.
 - Improved performance of 3D fox logo.
@@ -1180,7 +1180,7 @@
 - Allow transactions with a 0 gwei gas price
 - Made provider RPC errors contain useful messages
 
-## 4.5.5 Fri Apr 06 2018
+## [4.5.5] - 2018-04-06
 
 - Graceful handling of unknown keys in txParams
 - Fixes buggy handling of historical transactions with unknown keys in txParams
@@ -1188,35 +1188,35 @@
 - Fix Download State Logs button [#3791](https://github.com/MetaMask/metamask-extension/issues/3791)
 - Enhanced migration error handling + reporting
 
-## 4.5.4 (aborted) Thu Apr 05 2018
+## [4.5.4] - 2018-04-05 [WITHDRAWN]
 
 - Graceful handling of unknown keys in txParams
 - Fix link for 'Learn More' in the Add Token Screen to open to a new tab.
 - Fix Download State Logs button [#3791](https://github.com/MetaMask/metamask-extension/issues/3791)
 - Fix migration error reporting
 
-## 4.5.3 Wed Apr 04 2018
+## [4.5.3] - 2018-04-04
 
 - Fix bug where checksum address are messing with balance issue [#3843](https://github.com/MetaMask/metamask-extension/issues/3843)
 - new ui: fix the confirm transaction screen
 
-## 4.5.2 Wed Apr 04 2018
+## [4.5.2] - 2018-04-04
 
 - Fix overly strict validation where transactions were rejected with hex encoded "chainId"
 
-## 4.5.1 Tue Apr 03 2018
+## [4.5.1] - 2018-04-03
 
 - Fix default network (should be mainnet not Rinkeby)
 - Fix Sentry automated error reporting endpoint
 
-## 4.5.0 Mon Apr 02 2018
+## [4.5.0] - 2018-04-02
 
 - (beta ui) Internationalization: Select your preferred language in the settings screen
 - Internationalization: various locale improvements
 - Fix bug where the "Reset account" feature would not clear the network cache.
 - Increase maximum gas limit, to allow very gas heavy transactions, since block gas limits have been stable.
 
-## 4.4.0 Mon Mar 26 2018
+## [4.4.0] - 2018-03-27
 
 - Internationalization: Taiwanese, Thai, Slovenian
 - Fixes bug where MetaMask would not open once its storage grew too large.
@@ -1227,7 +1227,7 @@
 - Popup extension in new-ui uses new on-boarding designs
 - Buy ether step of new-ui on-boarding uses new buy ether modal designs
 
-## 4.3.0 Wed Mar 21 2018
+## [4.3.0] - 2018-03-21
 
 - (beta) Add internationalization support! Includes translations for 13 (!!) new languages: French, Spanish, Italian, German, Dutch, Portuguese, Japanese, Korean, Vietnamese, Mandarin, Hindi, Tagalog, and Russian! Select "Try Beta" in the menu to take them for a spin. Read more about the community effort [here](https://medium.com/gitcoin/metamask-internationalizes-via-gitcoin-bf1390c0301c)
 - No longer uses nonces specified by the dapp
@@ -1243,7 +1243,7 @@
 - Hide network dropdown before account is initialized
 - Fix bug that could prevent MetaMask from saving the latest vault.
 
-## 4.2.0 Tue Mar 06 2018
+## [4.2.0] - 2018-03-06
 
 - Replace "Loose" wording to "Imported".
 - Replace "Unlock" wording with "Log In".
@@ -1253,17 +1253,17 @@
 - NewUI shapeshift form can select all coins (not just BTC)
 - Add most of Microsoft Edge support.
 
-## 4.1.3 2018-2-28
+## [4.1.3] - 2018-03-02
 
 - Ensure MetaMask's inpage provider is named MetamaskInpageProvider to keep some sites from breaking.
 - Add retry transaction button back into classic ui.
 - Add network dropdown styles to support long custom RPC urls
 
-## 4.1.2 2018-2-28
+## [4.1.2] - 2018-02-28
 
 - Actually includes all the fixes mentioned in 4.1.1 (sorry)
 
-## 4.1.1 2018-2-28
+## [4.1.1] - 2018-02-28
 
 - Fix "Add Token" screen referencing missing token logo urls
 - Prevent user from switching network during signature request
@@ -1271,50 +1271,50 @@
 - Fix cancel button on "Buy Eth" screen
 - Improve new-ui onboarding flow style
 
-## 4.1.0 2018-2-27
+## [4.1.0] - 2018-02-27
 
 - Report failed txs to Sentry with more specific message
 - Fix internal feature flags being sometimes undefined
 - Standardized license to MIT
 
-## 4.0.0 2018-2-22
+## [4.0.0] - 2018-02-22
 
 - Introduce new MetaMask user interface.
 
-## 3.14.2 2018-2-15
+## [3.14.2] - 2018-02-27
 
 - Fix bug where log subscriptions would break when switching network.
 - Fix bug where storage values were cached across blocks.
 - Add MetaMask light client [testing container](https://github.com/MetaMask/mesh-testing)
 
-## 3.14.1 2018-2-1
+## [3.14.1] - 2018-02-01
 
 - Further fix scrolling for Firefox.
 
-## 3.14.0 2018-2-1
+## [3.14.0] - 2018-02-01
 
 - Removed unneeded data from storage
 - Add a "reset account" feature to Settings
 - Add warning for importing some kinds of files.
 - Scrollable Setting view for Firefox.
 
-## 3.13.8 2018-1-29
+## [3.13.8] - 2018-01-29
 
 - Fix provider for Kovan network.
 - Bump limit for EventEmitter listeners before warning.
 - Display Error when empty string is entered as a token address.
 
-## 3.13.7 2018-1-22
+## [3.13.7] - 2018-01-22
 
 - Add ability to bypass gas estimation loading indicator.
 - Forward failed transactions to Sentry error reporting service
 - Re-add changes from 3.13.5
 
-## 3.13.6 2017-1-18
+## [3.13.6] - 2017-01-18
 
 - Roll back changes to 3.13.4 to fix some issues with the new Infura REST provider.
 
-## 3.13.5 2018-1-16
+## [3.13.5] - 2018-01-16
 
 - Estimating gas limit for simple ether sends now faster & cheaper, by avoiding VM usage on recipients with no code.
 - Add an extra px to address for Firefox clipping.
@@ -1323,7 +1323,7 @@
 - Fix bug that prevented eth_signTypedData from signing bytes.
 - Further improve gas price estimation.
 
-## 3.13.4 2018-1-9
+## [3.13.4] - 2018-01-09
 
 - Remove recipient field if application initializes a tx with an empty string, or 0x, and tx data. Throw an error with the same condition, but without tx data.
 - Improve gas price suggestion to be closer to the lowest that will be accepted.
@@ -1333,95 +1333,95 @@
 - Fix rounding error when specifying an ether amount that has too much precision.
 - Fix bug where incorrectly inputting seed phrase would prevent any future attempts from succeeding.
 
-## 3.13.3 2017-12-14
+## [3.13.3] - 2017-12-14
 
 - Show tokens that are held that have no balance.
 - Reduce load on Infura by using a new block polling endpoint.
 
-## 3.13.2 2017-12-9
+## [3.13.2] - 2017-12-09
 
 - Reduce new block polling interval to 8000 ms, to ease server load.
 
-## 3.13.1 2017-12-7
+## [3.13.1] - 2017-12-07
 
 - Allow Dapps to specify a transaction nonce, allowing dapps to propose resubmit and force-cancel transactions.
 
-## 3.13.0 2017-12-7
+## [3.13.0] - 2017-12-07
 
 - Allow resubmitting transactions that are taking long to complete.
 
-## 3.12.1 2017-11-29
+## [3.12.1] - 2017-11-29
 
 - Fix bug where a user could be shown two different seed phrases.
 - Detect when multiple web3 extensions are active, and provide useful error.
 - Adds notice about seed phrase backup.
 
-## 3.12.0 2017-10-25
+## [3.12.0] - 2017-10-26
 
 - Add support for alternative ENS TLDs (Ethereum Name Service Top-Level Domains).
 - Lower minimum gas price to 0.1 GWEI.
 - Remove web3 injection message from production (thanks to @ChainsawBaby)
 - Add additional debugging info to our state logs, specifically OS version and browser version.
 
-## 3.11.2 2017-10-21
+## [3.11.2] - 2017-10-21
 
 - Fix bug where reject button would sometimes not work.
 - Fixed bug where sometimes MetaMask's connection to a page would be unreliable.
 
-## 3.11.1 2017-10-20
+## [3.11.1] - 2017-10-20
 
 - Fix bug where log filters were not populated correctly
 - Fix bug where web3 API was sometimes injected after the page loaded.
 - Fix bug where first account was sometimes not selected correctly after creating or restoring a vault.
 - Fix bug where imported accounts could not use new eth_signTypedData method.
 
-## 3.11.0 2017-10-11
+## [3.11.0] - 2017-10-11
 
 - Add support for new eth_signTypedData method per EIP 712.
 - Fix bug where some transactions would be shown as pending forever, even after successfully mined.
 - Fix bug where a transaction might be shown as pending forever if another tx with the same nonce was mined.
 - Fix link to support article on token addresses.
 
-## 3.10.9 2017-10-5
+## [3.10.9] - 2017-10-05
 
 - Only rebrodcast transactions for a day not a days worth of blocks
 - Remove Slack link from info page, since it is a big phishing target.
 - Stop computing balance based on pending transactions, to avoid edge case where users are unable to send transactions.
 
-## 3.10.8 2017-9-28
+## [3.10.8] - 2017-09-30
 
 - Fixed usage of new currency fetching API.
 
-## 3.10.7 2017-9-28
+## [3.10.7] - 2017-09-29
 
 - Fixed bug where sometimes the current account was not correctly set and exposed to web apps.
 - Added AUD, HKD, SGD, IDR, PHP to currency conversion list
 
-## 3.10.6 2017-9-27
+## [3.10.6] - 2017-09-27
 
 - Fix bug where newly created accounts were not selected.
 - Fix bug where selected account was not persisted between lockings.
 
-## 3.10.5 2017-9-27
+## [3.10.5] - 2017-09-27
 
 - Fix block gas limit estimation.
 
-## 3.10.4 2017-9-27
+## [3.10.4] - 2017-09-27
 
 - Fix bug that could mis-render token balances when very small. (Not actually included in 3.9.9)
 - Fix memory leak warning.
 - Fix bug where new event filters would not include historical events.
 
-## 3.10.3 2017-9-21
+## [3.10.3] - 2017-09-21
 
 - Fix bug where metamask-dapp connections are lost on rpc error
 - Fix bug that would sometimes display transactions as failed that could be successfully mined.
 
-## 3.10.2 2017-9-18
+## [3.10.2] - 2017-09-19
 
 rollback to 3.10.0 due to bug
 
-## 3.10.1 2017-9-18
+## [3.10.1] - 2017-09-18
 
 - Add ability to export private keys as a file.
 - Add ability to export seed words as a file.
@@ -1433,7 +1433,7 @@ rollback to 3.10.0 due to bug
 - Warn users when a dapp proposes a high gas limit (90% of blockGasLimit or higher
 - Sort currencies by currency name (thanks to strelok1: https://github.com/strelok1).
 
-## 3.10.0 2017-9-11
+## [3.10.0] - 2017-09-11
 
 - Readded loose keyring label back into the account list.
 - Remove cryptonator from chrome permissions.
@@ -1441,11 +1441,11 @@ rollback to 3.10.0 due to bug
 - Add validation preventing users from inputting their own addresses as token tracking addresses.
 - Added button to reject all transactions (thanks to davidp94! https://github.com/davidp94)
 
-## 3.9.13 2017-9-8
+## [3.9.13] - 2017-09-08
 
 - Changed the way we initialize the inpage provider to fix a bug affecting some developers.
 
-## 3.9.12 2017-9-6
+## [3.9.12] - 2017-09-06
 
 - Fix bug that prevented Web3 1.0 compatibility
 - Make eth_sign deprecation warning less noisy
@@ -1457,59 +1457,59 @@ rollback to 3.10.0 due to bug
 - Update Support center link to new one with HTTPS.
 - Make web3 deprecation notice more useful by linking to a descriptive article.
 
-## 3.9.11 2017-8-24
+## [3.9.11] - 2017-08-24
 
 - Fix nonce calculation bug that would sometimes generate very wrong nonces.
 - Give up resubmitting a transaction after 3500 blocks.
 
-## 3.9.10 2017-8-23
+## [3.9.10] - 2017-08-23
 
 - Improve nonce calculation, to prevent bug where people are unable to send transactions reliably.
 - Remove link to eth-tx-viz from identicons in tx history.
 
-## 3.9.9 2017-8-18
+## [3.9.9] - 2017-08-18
 
 - Fix bug where some transaction submission errors would show an empty screen.
 - Fix bug that could mis-render token balances when very small.
 - Fix formatting of eth_sign "Sign Message" view.
 - Add deprecation warning to eth_sign "Sign Message" view.
 
-## 3.9.8 2017-8-16
+## [3.9.8] - 2017-08-16
 
 - Reenable token list.
 - Remove default tokens.
 
-## 3.9.7 2017-8-15
+## [3.9.7] - 2017-08-15
 
 - hotfix - disable token list
 - Added a deprecation warning for web3 https://github.com/ethereum/mist/releases/tag/v0.9.0
 
-## 3.9.6 2017-8-09
+## [3.9.6] - 2017-08-10
 
 - Replace account screen with an account drop-down menu.
 - Replace account buttons with a new account-specific drop-down menu.
 
-## 3.9.5 2017-8-04
+## [3.9.5] - 2017-08-04
 
 - Improved phishing detection configuration update rate
 
-## 3.9.4 2017-8-03
+## [3.9.4] - 2017-08-04
 
 - Fixed bug that prevented transactions from being rejected.
 
-## 3.9.3 2017-8-03
+## [3.9.3] - 2017-08-03
 
 - Add support for EGO ujo token
 - Continuously update blacklist for known phishing sites in background.
 - Automatically detect suspicious URLs too similar to common phishing targets, and blacklist them.
 
-## 3.9.2 2017-7-26
+## [3.9.2] - 2017-07-26
 
 - Fix bugs that could sometimes result in failed transactions after switching networks.
 - Include stack traces in txMeta's to better understand the life cycle of transactions
 - Enhance blacklister functionality to include levenshtein logic. (credit to @sogoiii and @409H for their help!)
 
-## 3.9.1 2017-7-19
+## [3.9.1] - 2017-07-19
 
 - No longer automatically request 1 ropsten ether for the first account in a new vault.
 - Now redirects from known malicious sites faster.
@@ -1518,37 +1518,37 @@ rollback to 3.10.0 due to bug
 - Fixed bug in nonce tracker where an incorrect nonce would be calculated.
 - Lowered minimum gas price to 1 Gwei.
 
-## 3.9.0 2017-7-12
+## [3.9.0] - 2017-07-12
 
 - Now detects and blocks known phishing sites.
 
-## 3.8.6 2017-7-11
+## [3.8.6] - 2017-07-11
 
 - Make transaction resubmission more resilient.
 - No longer validate nonce client-side in retry loop.
 - Fix bug where insufficient balance error was sometimes shown on successful transactions.
 
-## 3.8.5 2017-7-7
+## [3.8.5] - 2017-07-08
 
 - Fix transaction resubmit logic to fail slightly less eagerly.
 
-## 3.8.4 2017-7-7
+## [3.8.4] - 2017-07-07
 
 - Improve transaction resubmit logic to fail more eagerly when a user would expect it to.
 
-## 3.8.3 2017-7-6
+## [3.8.3] - 2017-07-06
 
 - Re-enable default token list.
 - Add origin header to dapp-bound requests to allow providers to throttle sites.
 - Fix bug that could sometimes resubmit a transaction that had been stalled due to low balance after balance was restored.
 
-## 3.8.2 2017-7-3
+## [3.8.2] - 2017-07-03
 
 - No longer show network loading indication on config screen, to allow selecting custom RPCs.
 - Visually indicate that network spinner is a menu.
 - Indicate what network is being searched for when disconnected.
 
-## 3.8.1 2017-6-30
+## [3.8.1] - 2017-06-30
 
 - Temporarily disabled loading popular tokens by default to improve performance.
 - Remove SEND token button until a better token sending form can be built, due to some precision issues.
@@ -1556,7 +1556,7 @@ rollback to 3.10.0 due to bug
 - Cache token symbol and precisions to reduce network load.
 - Transpile some newer JavaScript, restores compatibility with some older browsers.
 
-## 3.8.0 2017-6-28
+## [3.8.0] - 2017-06-28
 
 - No longer stop rebroadcasting transactions
 - Add list of popular tokens held to the account detail view.
@@ -1571,7 +1571,7 @@ rollback to 3.10.0 due to bug
 - Allow Dapps to specify gas price as hex string.
 - Add button for copying state logs to clipboard.
 
-## 3.7.8 2017-6-12
+## [3.7.8] - 2017-06-12
 
 - Add an `ethereum:` prefix to the QR code address
 - The default network on installation is now MainNet
@@ -1579,30 +1579,30 @@ rollback to 3.10.0 due to bug
 - Update gasLimit params with every new block seen.
 - Fix ENS resolver symbol UI.
 
-## 3.7.7 2017-6-8
+## [3.7.7] - 2017-06-08
 
 - Fix bug where metamask would show old data after computer being asleep or disconnected from the internet.
 
-## 3.7.6 2017-6-5
+## [3.7.6] - 2017-06-05
 
 - Fix bug that prevented publishing contracts.
 
-## 3.7.5 2017-6-5
+## [3.7.5] - 2017-06-05
 
 - Prevent users from sending to the `0x0` address.
 - Provide useful errors when entering bad characters in ENS name.
 - Add ability to copy addresses from transaction confirmation view.
 
-## 3.7.4 2017-6-2
+## [3.7.4] - 2017-06-02
 
 - Fix bug with inflight cache that caused some block lookups to return bad values (affected OasisDex).
 - Fixed bug with gas limit calculation that would sometimes create unsubmittable gas limits.
 
-## 3.7.3 2017-6-1
+## [3.7.3] - 2017-06-01
 
 - Rebuilt to fix cache clearing bug.
 
-## 3.7.2 2017-5-31
+## [3.7.2] - 2017-05-31
 
 - Now when switching networks sites that use web3 will reload
 - Now when switching networks the extension does not restart
@@ -1615,7 +1615,7 @@ rollback to 3.10.0 due to bug
 - Some contracts will now display logos instead of jazzicons.
 - Some contracts will now have names displayed in the confirmation view.
 
-## 3.7.0 2017-5-23
+## [3.7.0] - 2017-05-23
 
 - Add Transaction Number (nonce) to transaction list.
 - Label the pending tx icon with a tooltip.
@@ -1623,7 +1623,7 @@ rollback to 3.10.0 due to bug
 - Continually resubmit pending txs for a period of time to ensure successful broadcast.
 - ENS names will no longer resolve to their owner if no resolver is set. Resolvers must be explicitly set and configured.
 
-## 3.6.5 2017-5-17
+## [3.6.5] - 2017-05-17
 
 - Fix bug where edited gas parameters would not take effect.
 - Trim currency list.
@@ -1632,15 +1632,15 @@ rollback to 3.10.0 due to bug
 - Fix event filter bug introduced by newer versions of Geth.
 - Fix bug where decimals in gas inputs could result in strange values.
 
-## 3.6.4 2017-5-8
+## [3.6.4] - 2017-05-09
 
 - Fix main-net ENS resolution.
 
-## 3.6.3 2017-5-8
+## [3.6.3] - 2017-05-09
 
 - Fix bug that could stop newer versions of Geth from working with MetaMask.
 
-## 3.6.2 2017-5-8
+## [3.6.2] - 2017-05-08
 
 - Input gas price in Gwei.
 - Enforce Safe Gas Minimum recommended by EthGasStation.
@@ -1648,39 +1648,39 @@ rollback to 3.10.0 due to bug
 - Reduce UI size by removing internal web3.
 - Fix bug where gas parameters would not properly update on adjustment.
 
-## 3.6.1 2017-4-30
+## [3.6.1] - 2017-05-07
 
 - Made fox less nosy.
 - Fix bug where error was reported in debugger console when Chrome opened a new window.
 
-## 3.6.0 2017-4-26
+## [3.6.0] - 2017-04-27
 
 - Add Rinkeby Test Network to our network list.
 
-## 3.5.4 2017-4-25
+## [3.5.4] - 2017-04-25
 
 - Fix occasional nonce tracking issue.
 - Fix bug where some events would not be emitted by web3.
 - Fix bug where an error would be thrown when composing signatures for networks with large ID values.
 
-## 3.5.3 2017-4-24
+## [3.5.3] - 2017-04-24
 
 - Popup new transactions in Firefox.
 - Fix transition issue from account detail screen.
 - Revise buy screen for more modularity.
 - Fixed some other small bugs.
 
-## 3.5.2 2017-3-28
+## [3.5.2] - 2017-03-28
 
 - Fix bug where gas estimate totals were sometimes wrong.
 - Add link to Kovan Test Faucet instructions on buy view.
 - Inject web3 into loaded iFrames.
 
-## 3.5.1 2017-3-27
+## [3.5.1] - 2017-03-27
 
 - Fix edge case where users were unable to enable the notice button if notices were short enough to not require a scrollbar.
 
-## 3.5.0 2017-3-27
+## [3.5.0] - 2017-03-27
 
 - Add better error messages for when a transaction fails on approval
 - Allow sending to ENS names in send form on Ropsten.
@@ -1695,7 +1695,7 @@ rollback to 3.10.0 due to bug
 - Add Kovan as an option on our network list.
 - Fixed bug where transactions on other networks would disappear when submitting a transaction on another network.
 
-## 3.4.0 2017-3-8
+## [3.4.0] - 2017-03-08
 
 - Add two most recently used custom RPCs to network dropdown menu.
 - Add personal_sign method support.
@@ -1703,53 +1703,49 @@ rollback to 3.10.0 due to bug
 - Add ability to customize gas and gasPrice on the transaction approval screen.
 - Increase default gas buffer to 1.5x estimated gas value.
 
-## 3.3.0 2017-2-20
+## [3.3.0] - 2017-02-20
 
 - net_version has been made synchronous.
 - Test suite for migrations expanded.
 - Network now changeable from lock screen.
 - Improve test coverage of eth.sign behavior, including a code example of verifying a signature.
 
-## 3.2.2 2017-2-8
+## [3.2.2] - 2017-02-09
 
 - Revert eth.sign behavior to the previous one with a big warning. We will be gradually implementing the new behavior over the coming time. https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
 
 - Improve test coverage of eth.sign behavior, including a code example of verifying a signature.
 
-## 3.2.2 2017-2-8
-
-- Revert eth.sign behavior to the previous one with a big warning. We will be gradually implementing the new behavior over the coming time. https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
-
-## 3.2.1 2017-2-8
+## [3.2.1] - 2017-02-09
 
 - Revert back to old style message signing.
 - Fixed some build errors that were causing a variety of bugs.
 
-## 3.2.0 2017-2-8
+## [3.2.0] - 2017-02-08
 
 - Add ability to import accounts in JSON file format (used by Mist, Geth, MyEtherWallet, and more!)
 - Fix unapproved messages not being included in extension badge.
 - Fix rendering bug where the Confirm transaction view would let you approve transactions when the account has insufficient balance.
 
-## 3.1.2 2017-1-24
+## [3.1.2] - 2017-01-24
 
 - Fix "New Account" default keychain
 
-## 3.1.1 2017-1-20
+## [3.1.1] - 2017-01-20
 
 - Fix HD wallet seed export
 
-## 3.1.0 2017-1-18
+## [3.1.0] - 2017-01-18
 
 - Add ability to import accounts by private key.
 - Fixed bug that returned the wrong transaction hashes on private networks that had not implemented EIP 155 replay protection (like TestRPC).
 
-## 3.0.1 2017-1-17
+## [3.0.1] - 2017-01-17
 
 - Fixed bug that prevented eth.sign from working.
 - Fix the displaying of transactions that have been submitted to the network in Transaction History
 
-## 3.0.0 2017-1-16
+## [3.0.0] - 2017-01-16
 
 - Fix seed word account generation (https://medium.com/metamask/metamask-3-migration-guide-914b79533cdd#.t4i1qmmsz).
 - Fix Bug where you see an empty transaction flash by on the confirm transaction view.
@@ -1764,33 +1760,33 @@ rollback to 3.10.0 due to bug
 - Implement replay attack protections allowed by EIP 155.
 - Fix bug where sometimes loading account data would fail by querying a future block.
 
-## 2.14.1 2016-12-20
+## [2.14.1] - 2016-12-20
 
 - Update Coinbase info. and increase the buy amount to $15
 - Fixed ropsten transaction links
 - Temporarily disable extension reload detection causing infinite reload bug.
 - Implemented basic checking for valid RPC URIs.
 
-## 2.14.0 2016-12-16
+## [2.14.0] - 2016-12-16
 
 - Removed Morden testnet provider from provider menu.
 - Add support for notices.
 - Fix broken reload detection.
 - Fix transaction forever cached-as-pending bug.
 
-## 2.13.11 2016-11-23
+## [2.13.11] - 2016-11-23
 
 - Add support for synchronous RPC method "eth_uninstallFilter".
 - Forgotten password prompts now send users directly to seed word restoration.
 
-## 2.13.10 2016-11-22
+## [2.13.10] - 2016-11-22
 
 - Improve gas calculation logic.
 - Default to Dapp-specified gas limits for transactions.
 - Ropsten networks now properly point to the faucet when attempting to buy ether.
 - Ropsten transactions now link to etherscan correctly.
 
-## 2.13.9 2016-11-21
+## [2.13.9] - 2016-11-21
 
 - Add support for the new, default Ropsten Test Network.
 - Fix bug that would cause MetaMask to occasionally lose its StreamProvider connection and drop requests.
@@ -1798,19 +1794,19 @@ rollback to 3.10.0 due to bug
 - Point ropsten faucet button to actual faucet.
 - Phase out ethereumjs-util from our encryptor module.
 
-## 2.13.8 2016-11-16
+## [2.13.8] - 2016-11-16
 
 - Show a warning when a transaction fails during simulation.
 - Fix bug where 20% of gas estimate was not being added properly.
 - Render error messages in confirmation screen more gracefully.
 
-## 2.13.7 2016-11-8
+## [2.13.7] - 2016-11-08
 
 - Fix bug where gas estimate would sometimes be very high.
 - Increased our gas estimate from 100k gas to 20% of estimate.
 - Fix GitHub link on info page to point at current repository.
 
-## 2.13.6 2016-10-26
+## [2.13.6] - 2016-10-26
 
 - Add a check for improper Transaction data.
 - Inject up to date version of web3.js
@@ -1819,18 +1815,18 @@ rollback to 3.10.0 due to bug
 - Fix bug where connecting to a local morden node would make two providers appear selected.
 - Fix bug that was sometimes preventing transactions from being sent.
 
-## 2.13.5 2016-10-18
+## [2.13.5] - 2016-10-18
 
 - Increase default max gas to `100000` over the RPC's `estimateGas` response.
 - Fix bug where slow-loading dapps would sometimes trigger infinite reload loops.
 
-## 2.13.4 2016-10-17
+## [2.13.4] - 2016-10-17
 
 - Add custom transaction fee field to send form.
 - Fix bug where web3 was being injected into XML files.
 - Fix bug where changing network would not reload current Dapps.
 
-## 2.13.3 2016-10-4
+## [2.13.3] - 2016-10-05
 
 - Fix bug where log queries were filtered out.
 - Decreased vault confirmation button font size to help some Linux users who could not see it.
@@ -1841,42 +1837,42 @@ rollback to 3.10.0 due to bug
 - Updated Terms of Service and Usage.
 - Prompt users to re-agree to the Terms of Service when they are updated.
 
-## 2.13.2 2016-10-4
+## [2.13.2] - 2016-10-04
 
 - Fix bug where chosen FIAT exchange rate does no persist when switching networks
 - Fix additional parameters that made MetaMask sometimes receive errors from Parity.
 - Fix bug where invalid transactions would still open the MetaMask popup.
 - Removed hex prefix from private key export, to increase compatibility with Geth, MyEtherWallet, and Jaxx.
 
-## 2.13.1 2016-09-23
+## [2.13.1] - 2016-09-23
 
 - Fix a bug with estimating gas on Parity
 - Show loading indication when selecting ShapeShift as purchasing method.
 
-## 2.13.0 2016-09-18
+## [2.13.0] - 2016-09-18
 
 - Add Parity compatibility, fixing Geth dependency issues.
 - Add a link to the transaction in history that goes to https://metamask.github.io/eth-tx-viz
   too help visualize transactions and to where they are going.
 - Show "Buy Ether" button and warning on tx confirmation when sender balance is insufficient
 
-## 2.12.1 2016-09-14
+## [2.12.1] - 2016-09-14
 
 - Fixed bug where if you send a transaction from within MetaMask extension the
   popup notification opens up.
 - Fixed bug where some tx errors would block subsequent txs until the plugin was refreshed.
 
-## 2.12.0 2016-09-14
+## [2.12.0] - 2016-09-14
 
 - Add a QR button to the Account detail screen
 - Fixed bug where opening MetaMask could close a non-metamask popup.
 - Fixed memory leak that caused occasional crashes.
 
-## 2.11.1 2016-09-12
+## [2.11.1] - 2016-09-13
 
 - Fix bug that prevented caches from being cleared in Opera.
 
-## 2.11.0 2016-09-12
+## [2.11.0] - 2016-09-12
 
 - Fix bug where pending transactions from Test net (or other networks) show up In Main net.
 - Add fiat conversion values to more views.
@@ -1887,29 +1883,29 @@ rollback to 3.10.0 due to bug
 - Now showing loading indication during vault unlocking, to clarify behavior for users who are experiencing slow unlocks.
 - Now only initially creates one wallet when restoring a vault, to reduce some users' confusion.
 
-## 2.10.2 2016-09-02
+## [2.10.2] - 2016-09-02
 
 - Fix bug where notification popup would not display.
 
-## 2.10.1 2016-09-02
+## [2.10.1] - 2016-09-02
 
 - Fix bug where provider menu did not allow switching to custom network from a custom network.
 - Sending a transaction from within MetaMask no longer triggers a popup.
 - The ability to build without livereload features (such as for production) can be enabled with the gulp --disableLiveReload flag.
 - Fix Ethereum JSON RPC Filters bug.
 
-## 2.10.0 2016-08-29
+## [2.10.0] - 2016-08-29
 
 - Changed transaction approval from notifications system to popup system.
 - Add a back button to locked screen to allow restoring vault from seed words when password is forgotten.
 - Forms now retain their values even when closing the popup and reopening it.
 - Fixed a spelling error in provider menu.
 
-## 2.9.2 2016-08-24
+## [2.9.2] - 2016-08-24
 
 - Fixed shortcut bug from preventing installation.
 
-## 2.9.1 2016-08-24
+## [2.9.1] - 2016-08-24
 
 - Added static image as fallback for when WebGL isn't supported.
 - Transaction history now has a hard limit.
@@ -1919,14 +1915,14 @@ rollback to 3.10.0 due to bug
 - Prevent API calls in tests.
 - Fixed bug where sign message confirmation would sometimes render blank.
 
-## 2.9.0 2016-08-22
+## [2.9.0] - 2016-08-22
 
 - Added ShapeShift to the transaction history
 - Added affiliate key to Shapeshift requests
 - Added feature to reflect current conversion rates of current vault balance.
 - Modify balance display logic.
 
-## 2.8.0 2016-08-15
+## [2.8.0] - 2016-08-15
 
 - Integrate ShapeShift
 - Add a form for Coinbase to specify amount to buy
@@ -1934,35 +1930,35 @@ rollback to 3.10.0 due to bug
 - Make dapp-metamask connection more reliable
 - Remove Ethereum Classic from provider menu.
 
-## 2.7.3 2016-07-29
+## [2.7.3] - 2016-07-29
 
 - Fix bug where changing an account would not update in a live Dapp.
 
-## 2.7.2 2016-07-29
+## [2.7.2] - 2016-07-29
 
 - Add Ethereum Classic to provider menu
 - Fix bug where host store would fail to receive updates.
 
-## 2.7.1 2016-07-27
+## [2.7.1] - 2016-07-27
 
 - Fix bug where web3 would sometimes not be injected in time for the application.
 - Fixed bug where sometimes when opening the plugin, it would not fully open until closing and re-opening.
 - Got most functionality working within Firefox (still working on review process before it can be available).
 - Fixed menu dropdown bug introduced in Chrome 52.
 
-## 2.7.0 2016-07-21
+## [2.7.0] - 2016-07-21
 
 - Added a Warning screen about storing ETH
 - Add buy Button!
 - MetaMask now throws descriptive errors when apps try to use synchronous web3 methods.
 - Removed firefox-specific line in manifest.
 
-## 2.6.2 2016-07-20
+## [2.6.2] - 2016-07-20
 
 - Fixed bug that would prevent the plugin from reopening on the first try after receiving a new transaction while locked.
 - Fixed bug that would render 0 ETH as a non-exact amount.
 
-## 2.6.1 2016-07-13
+## [2.6.1] - 2016-07-13
 
 - Fix tool tips on Eth balance to show the 6 decimals
 - Fix rendering of recipient SVG in tx approval notification.
@@ -1971,7 +1967,7 @@ rollback to 3.10.0 due to bug
 - Fixed bug where some lowercase or uppercase addresses were not being recognized as valid.
 - Fixed bug where gas cost was misestimated on the tx confirmation view.
 
-## 2.6.0 2016-07-11
+## [2.6.0] - 2016-07-11
 
 - Fix formatting of ETH balance
 - Fix formatting of account details.
@@ -1983,7 +1979,7 @@ rollback to 3.10.0 due to bug
 - Abbreviate ether balances on transaction details to maintain formatting.
 - General code cleanup.
 
-## 2.5.0 2016-06-29
+## [2.5.0] - 2016-06-29
 
 - Implement new account design.
 - Added a network indicator mark in dropdown menu
@@ -1992,7 +1988,7 @@ rollback to 3.10.0 due to bug
 - Unify wording for transaction approve/reject options on notifications and the extension.
 - Fix bug where confirmation view would be shown twice.
 
-## 2.4.5 2016-06-29
+## [2.4.5] - 2016-06-29
 
 - Fixed bug where MetaMask interfered with PDF loading.
 - Moved switch account icon into menu bar.
@@ -2004,23 +2000,23 @@ rollback to 3.10.0 due to bug
 - Fix out-of-place positioning of pending transaction badges on wallet list.
 - Change network status icons to reflect current design.
 
-## 2.4.4 2016-06-23
+## [2.4.4] - 2016-06-23
 
 - Update web3-stream-provider for batch payload bug fix
 
-## 2.4.3 2016-06-23
+## [2.4.3] - 2016-06-23
 
 - Remove redundant network option buttons from settings page
 - Switch out font family Transat for Montserrat
 
-## 2.4.2 2016-06-22
+## [2.4.2] - 2016-06-22
 
 - Change out export icon for key.
 - Unify copy to clipboard icon
 - Fixed eth.sign behavior.
 - Fix behavior of batched outbound transactions.
 
-## 2.4.0 2016-06-20
+## [2.4.0] - 2016-06-20
 
 - Clean up UI.
 - Remove nonfunctional QR code button.
@@ -2029,26 +2025,26 @@ rollback to 3.10.0 due to bug
 - Fixed bug when signing messages under 64 hex characters long.
 - Add disclaimer view with placeholder text for first time users.
 
-## 2.3.1 2016-06-09
+## [2.3.1] - 2016-06-09
 
 - Style up the info page
 - Cache identicon images to optimize for long lists of transactions.
 - Fix out of gas errors
 
-## 2.3.0 2016-06-06
+## [2.3.0] - 2016-06-06
 
 - Show network status in title bar
 - Added seed word recovery to config screen.
 - Clicking network status indicator now reveals a provider menu.
 
-## 2.2.0 2016-06-02
+## [2.2.0] - 2016-06-02
 
 - Redesigned init, vault create, vault restore and seed confirmation screens.
 - Added pending transactions to transaction list on account screen.
 - Clicking a pending transaction takes you back to the transaction approval screen.
 - Update provider-engine to fix intermittent out of gas errors.
 
-## 2.1.0 2016-05-26
+## [2.1.0] - 2016-05-26
 
 - Added copy address button to account list.
 - Fixed back button on confirm transaction screen.
@@ -2056,7 +2052,7 @@ rollback to 3.10.0 due to bug
 - Fixed bug where error warning was sometimes not cleared on view transition.
 - Updated eth-lightwallet to fix a critical security issue.
 
-## 2.0.0 2016-05-23
+## [2.0.0] - 2016-05-23
 
 - UI Overhaul per Vlad Todirut's designs.
 - Replaced identicons with jazzicons.
@@ -2066,27 +2062,27 @@ rollback to 3.10.0 due to bug
 - Added ability to generate new accounts.
 - Added ability to locally nickname accounts.
 
-## 1.8.4 2016-05-13
+## [1.8.4] - 2016-05-13
 
 - Point rpc servers to https endpoints.
 
-## 1.8.3 2016-05-12
+## [1.8.3] - 2016-05-12
 
 - Bumped web3 to 0.6.0
 - Really fixed `eth_syncing` method response.
 
-## 1.8.2 2016-05-11
+## [1.8.2] - 2016-05-11
 
 - Fixed bug where send view would not load correctly the first time it was visited per account.
 - Migrated all users to new scalable backend.
 - Fixed `eth_syncing` method response.
 
-## 1.8.1 2016-05-10
+## [1.8.1] - 2016-05-10
 
 - Initial usage of scalable blockchain backend.
 - Made official providers more easily configurable for us internally.
 
-## 1.8.0 2016-05-10
+## [1.8.0] - 2016-05-10
 
 - Add support for calls to `eth.sign`.
 - Moved account exporting within subview of the account detail view.
@@ -2097,7 +2093,7 @@ rollback to 3.10.0 due to bug
 - Changing provider now reloads current Dapps
 - Improved appearance of transaction list in account detail view.
 
-## 1.7.0 2016-04-29
+## [1.7.0] - 2016-04-29
 
 - Account detail view is now the primary view.
 - The account detail view now has a "Change acct" button which shows the account list.
@@ -2111,7 +2107,7 @@ rollback to 3.10.0 due to bug
 - Fixed transaction links to etherscan blockchain explorer.
 - Fixed some UI transitions that had weird behavior.
 
-## 1.6.0 2016-04-22
+## [1.6.0] - 2016-04-22
 
 - Pending transactions are now persisted to localStorage and resume even after browser is closed.
 - Completed transactions are now persisted and can be displayed via UI.
@@ -2123,7 +2119,7 @@ rollback to 3.10.0 due to bug
 - Improve config view styling.
 - Users have been migrated from old test-net RPC to a newer test-net RPC.
 
-## 1.5.1 2016-04-15
+## [1.5.1] - 2016-04-15
 
 - Corrected text above account list. Selected account is visible to all sites, not just the current domain.
 - Merged the UI codebase into the main plugin codebase for simpler maintenance.
@@ -2131,13 +2127,13 @@ rollback to 3.10.0 due to bug
 - Fix some inpage synchronous methods
 - Change account rendering to show four decimals and a leading zero.
 
-## 1.5.0 2016-04-13
+## [1.5.0] - 2016-04-13
 
 - Added ability to send ether.
 - Fixed bugs related to using Javascript numbers, which lacked appropriate precision.
 - Replaced Etherscan main-net provider with our own production RPC.
 
-## 1.4.0 2016-04-08
+## [1.4.0] - 2016-04-08
 
 - Removed extra entropy text field for simplified vault creation.
 - Now supports exporting an account's private key.
@@ -2146,20 +2142,16 @@ rollback to 3.10.0 due to bug
 - Fix popup's web3 stream provider
 - Temporarily deactivated fauceting indication because it would activate when restoring an empty account.
 
-## 1.3.2 2016-04-04
+## [1.3.2] - 2016-04-04
 
 - When unlocking, first account is auto-selected.
 - When creating a first vault on the test-net, the first account is auto-funded.
 - Fixed some styling issues.
 
-## 1.0.1-1.3.1
-
-Many changes not logged. Hopefully beginning to log consistently now!
-
-## 1.0.0
+## [1.0.0] - 2016-03-25
 
 Made seed word restoring BIP44 compatible.
 
-## 0.14.0
+## [0.14.0] - 2016-03-16
 
 Added the ability to restore accounts from seed words.

--- a/development/auto-changelog.js
+++ b/development/auto-changelog.js
@@ -94,7 +94,7 @@ async function main() {
 
     // Add release header if not found
     const firstReleaseHeaderIndex = changelogLines.findIndex((line) =>
-      line.match(/## \d+\.\d+\.\d+/u),
+      line.match(/## \[\d+\.\d+\.\d+\]/u),
     );
     changelogLines.splice(firstReleaseHeaderIndex, 0, versionHeader, '');
     releaseHeaderIndex = firstReleaseHeaderIndex;

--- a/development/auto-changelog.js
+++ b/development/auto-changelog.js
@@ -2,6 +2,7 @@
 const fs = require('fs').promises;
 const assert = require('assert').strict;
 const path = require('path');
+const { escapeRegExp } = require('lodash');
 const { version } = require('../app/manifest/_base.json');
 const runCommand = require('./lib/runCommand');
 
@@ -72,12 +73,13 @@ async function main() {
   const mostRecentVersion = mostRecentTag.slice(1);
 
   const isReleaseCandidate = mostRecentVersion !== version;
-  const versionHeader = `## ${version}`;
+  const versionHeader = `## [${version}]`;
+  const escapedVersionHeader = escapeRegExp(versionHeader);
   const currentDevelopBranchHeader = '## Current Develop Branch';
   const currentReleaseHeaderPattern = isReleaseCandidate
     ? // This ensures this doesn't match on a version with a suffix
       // e.g. v9.0.0 should not match on the header v9.0.0-beta.0
-      `${versionHeader}$|${versionHeader}\\s`
+      `${escapedVersionHeader}$|${escapedVersionHeader}\\s`
     : currentDevelopBranchHeader;
 
   let releaseHeaderIndex = changelogLines.findIndex((line) =>


### PR DESCRIPTION
The changelog release header format has been updated to match the ["keep a changelog" ](https://keepachangelog.com/en/1.0.0/) format. Each header is now the bracketed version number followed by a dash, then the release date in ISO-8601 format.

The release dates in each header were also updated to match the date of the corresponding [GitHub Release](https://github.com/MetaMask/metamask-extension/releases). Many of these dates were incorrect because they were set on the day we created the release candidate, rather than on the day of release.

Any changelog release entries without a corresponding GitHub release was left with the date already specified.

The three oldest release headers were missing dates. For the first two, I used the date of the version bump commit. For the third, I removed it since no changes were listed anyway, and it represented a range of releases rather than a single one.

The `auto-changelog.js` script has been updated to account for this new format as well.

Manual testing steps: 

For RC changelog updates with existing release header:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Add a new release header to the changelog for the new version
- Run `yarn update-changelog`
- See that it places changelog entries under the new release header
 
For updates without a release header:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Run `yarn update-changelog`
- See that it places changelog entries under the newly added release header