### PR TITLE
Provide reminder to hardware wallet users to have their device ready to confirm transactions

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -813,9 +813,15 @@
   "hardwareWalletConnected": {
     "message": "Hardware wallet connected"
   },
+  "hardwareWalletLedgerConnectReminder": {
+    "message": "Please ensure that your Ledger device is connected, unlocked, and the Ethereum app is open before confirming."
+  },
   "hardwareWalletLegacyDescription": {
     "message": "(legacy)",
     "description": "Text representing the MEW path"
+  },
+  "hardwareWalletTrezorConnectReminder": {
+    "message": "Please ensure that your Trezor device is connected and unlocked before confirming."
   },
   "hardwareWallets": {
     "message": "Connect a hardware wallet"

--- a/ui/app/components/app/confirm-page-container/confirm-detail-row/index.scss
+++ b/ui/app/components/app/confirm-page-container/confirm-detail-row/index.scss
@@ -47,6 +47,10 @@
     }
   }
 
+  &__info {
+    font-size: 80%;
+  }
+
   .advanced-gas-inputs__gas-edit-rows {
     margin-bottom: 16px;
   }

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -6,6 +6,7 @@ import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import ConfirmPageContainer, {
   ConfirmDetailRow,
 } from '../../components/app/confirm-page-container';
+import Callout from '../../components/ui/callout';
 import { isBalanceSufficient } from '../send/send.utils';
 import { CONFIRM_TRANSACTION_ROUTE } from '../../helpers/constants/routes';
 import {
@@ -23,6 +24,7 @@ import {
   TRANSACTION_STATUSES,
 } from '../../../../shared/constants/transaction';
 import { getTransactionTypeTitle } from '../../helpers/utils/transactions.util';
+import { SEVERITIES } from '../../helpers/constants/design-system';
 
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
@@ -95,6 +97,8 @@ export default class ConfirmTransactionBase extends Component {
     showAccountInHeader: PropTypes.bool,
     mostRecentOverviewPage: PropTypes.string.isRequired,
     isMainnet: PropTypes.bool,
+    isLedgerHardwareDevice: PropTypes.bool,
+    isTrezorHardwareDevice: PropTypes.bool,
   };
 
   state = {
@@ -243,7 +247,11 @@ export default class ConfirmTransactionBase extends Component {
       nextNonce,
       getNextNonce,
       isMainnet,
+      isLedgerHardwareDevice,
+      isTrezorHardwareDevice,
     } = this.props;
+
+    console.log('This props: ', this.props);
 
     const notMainnetOrTest = !(isMainnet || process.env.IN_TEST);
 
@@ -328,6 +336,18 @@ export default class ConfirmTransactionBase extends Component {
             </div>
           </div>
         ) : null}
+        {(isLedgerHardwareDevice || isTrezorHardwareDevice) && (
+          <div className="confirm-detail-row confirm-detail-row__info">
+            <Callout severity={SEVERITIES.INFO} />
+            <>
+              {this.context.t(
+                isLedgerHardwareDevice
+                  ? 'hardwareWalletLedgerConnectReminder'
+                  : 'hardwareWalletTrezorConnectReminder',
+              )}
+            </>
+          </div>
+        )}
       </div>
     );
   }

--- a/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/app/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -37,6 +37,8 @@ import {
   getUseNonceField,
   getPreferences,
   transactionFeeSelector,
+  getIsLedgerHardwareDevice,
+  getIsTrezorHardwareDevice,
 } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { transactionMatchesNetwork } from '../../../../shared/modules/transaction.utils';
@@ -188,6 +190,8 @@ const mapStateToProps = (state, ownProps) => {
     nextNonce,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     isMainnet,
+    isLedgerHardwareDevice: getIsLedgerHardwareDevice(state),
+    isTrezorHardwareDevice: getIsTrezorHardwareDevice(state),
   };
 };
 

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -27,6 +27,9 @@ import { TEMPLATED_CONFIRMATION_MESSAGE_TYPES } from '../pages/confirmation/temp
 
 import { getNativeCurrency } from './send';
 
+const TREZOR_HARDWARE_KEY = 'Trezor Hardware';
+const LEDGER_HARDWARE_KEY = 'Ledger Hardware';
+
 /**
  * One of the only remaining valid uses of selecting the network subkey of the
  * metamask state tree is to determine if the network is currently 'loading'.
@@ -83,14 +86,28 @@ export function getAccountType(state) {
   const type = currentKeyring && currentKeyring.type;
 
   switch (type) {
-    case 'Trezor Hardware':
-    case 'Ledger Hardware':
+    case TREZOR_HARDWARE_KEY:
+    case LEDGER_HARDWARE_KEY:
       return 'hardware';
     case 'Simple Key Pair':
       return 'imported';
     default:
       return 'default';
   }
+}
+
+export function getIsLedgerHardwareDevice(state) {
+  const currentKeyring = getCurrentKeyring(state);
+  const type = currentKeyring && currentKeyring.type;
+
+  return type === LEDGER_HARDWARE_KEY;
+}
+
+export function getIsTrezorHardwareDevice(state) {
+  const currentKeyring = getCurrentKeyring(state);
+  const type = currentKeyring && currentKeyring.type;
+
+  return type === TREZOR_HARDWARE_KEY;
 }
 
 /**


### PR DESCRIPTION
Explanation:  

One of the top reasons users have problems with their hardware wallets is not having the device ready when they confirm a transaction.  This PR aims to remind users they must have their hardware wallets ready before confirmation.

<img width="426" alt="Reminder" src="https://user-images.githubusercontent.com/46655/113445210-0fe89400-93bb-11eb-8693-e4c7b3f685b2.png">
