### PR TITLE
Fix _getPermittedAccounts type safety

### DIFF
--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -297,7 +297,7 @@ export class PermissionsController {
     this.validatePermittedAccounts([account]);
 
     const oldPermittedAccounts = this._getPermittedAccounts(origin);
-    if (!oldPermittedAccounts) {
+    if (oldPermittedAccounts.length === 0) {
       throw new Error(`Origin does not have 'eth_accounts' permission`);
     } else if (oldPermittedAccounts.includes(account)) {
       throw new Error('Account is already permitted for origin');
@@ -335,7 +335,7 @@ export class PermissionsController {
     this.validatePermittedAccounts([account]);
 
     const oldPermittedAccounts = this._getPermittedAccounts(origin);
-    if (!oldPermittedAccounts) {
+    if (oldPermittedAccounts.length === 0) {
       throw new Error(`Origin does not have 'eth_accounts' permission`);
     } else if (!oldPermittedAccounts.includes(account)) {
       throw new Error('Account is not permitted for origin');
@@ -612,7 +612,7 @@ export class PermissionsController {
    * Get current set of permitted accounts for the given origin
    *
    * @param {string} origin - The origin to obtain permitted accounts for
-   * @returns {Array<string>|null} The list of permitted accounts
+   * @returns {Array<string>} The list of permitted accounts
    */
   _getPermittedAccounts(origin) {
     const permittedAccounts = this.permissions
@@ -620,7 +620,7 @@ export class PermissionsController {
       ?.caveats?.find((caveat) => caveat.name === CAVEAT_NAMES.exposedAccounts)
       ?.value;
 
-    return permittedAccounts || null;
+    return permittedAccounts || [];
   }
 
   /**


### PR DESCRIPTION
`PermissionsController._getPermittedAccounts` could return an array or `null`, but it was used in `removeAllAccountPermissions` as though it could only return an array.

I don't believe it _would_ ever return anything other than an array as things stand, but it's not type safe, and we should fix it. Things with `getAccounts` in the name tend to only return arrays in our codebase, so I made `_getPermittedAccounts` only return arrays, and updated calls expecting `null` to expect an empty array instead.