### PR TITLE
Update dependabot to standard settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "06:00"
     allow:
       - dependency-name: "@metamask/*"
-    versioning-strategy: "lockfile-only"
+    target-branch: "develop"
+    versioning-strategy: "increase-if-necessary"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Puts our dependabot in line with new template.  The only consideration is whether we want to remove `"@metamask/*"` -- we may get an avalanche of non-MM repo dependency updates. (i.e. react widgets, etc.)