### PR TITLE
Removing unnecessary params from withFixtures function call.

### DIFF
--- a/test/e2e/tests/address-book.spec.js
+++ b/test/e2e/tests/address-book.spec.js
@@ -91,7 +91,6 @@ describe('Address Book', function () {
   it('Sends to an address book entry', async function () {
     await withFixtures(
       {
-        dapp: true,
         fixtures: 'address-entry',
         ganacheOptions,
         title: this.test.title,

--- a/test/e2e/tests/send-edit.spec.js
+++ b/test/e2e/tests/send-edit.spec.js
@@ -20,7 +20,6 @@ describe('Editing Confirm Transaction', function () {
     };
     await withFixtures(
       {
-        dapp: true,
         fixtures: 'send-edit',
         ganacheOptions,
         title: this.test.title,


### PR DESCRIPTION
Removing the `dapp=true` parameter from `withFixtures` function call on the tests that are not using the Dapp.