### PR TITLE
Add validation for the `fee` property from the `/trades` API response

### DIFF
--- a/ui/app/pages/swaps/swaps-util-test-constants.js
+++ b/ui/app/pages/swaps/swaps-util-test-constants.js
@@ -101,6 +101,7 @@ export const MOCK_TRADE_RESPONSE_1 = [
     sourceAmount: '10000000000000000',
     destinationAmount: '2248687',
     error: null,
+    fee: 0.875,
     sourceToken: TOKENS[0].address,
     destinationToken: TOKENS[1].address,
     fetchTime: 553,

--- a/ui/app/pages/swaps/swaps.util.js
+++ b/ui/app/pages/swaps/swaps.util.js
@@ -131,6 +131,10 @@ const QUOTE_VALIDATORS = [
     type: 'number|undefined',
     validator: (gasEstimate) => gasEstimate === undefined || gasEstimate > 0,
   },
+  {
+    property: 'fee',
+    type: 'number',
+  },
 ];
 
 const TOKEN_VALIDATORS = [

--- a/ui/app/pages/swaps/swaps.util.test.js
+++ b/ui/app/pages/swaps/swaps.util.test.js
@@ -64,6 +64,7 @@ describe('Swaps Util', function () {
         sourceAmount: '10000000000000000',
         destinationAmount: '2248687',
         error: null,
+        fee: 0.875,
         sourceToken: TOKENS[0].address,
         destinationToken: TOKENS[1].address,
         fetchTime: 553,


### PR DESCRIPTION
Fixes: #9681

## Explanation
Now we are validating that the `fee` property from the `/trades` API response is the `number` type. If the API would return a different type, we would show an error page with: "No quotes available".

## Manual testing steps
  - Click on the `Swap` button inside the MetaMask extension
  - Choose `Swap from` and `Swap to` tokens
  - Click on `Review Swap`, at which time the `/trades` API is called and response validation happens

## Screenshots
Swap page:
![image](https://user-images.githubusercontent.com/80175477/113787560-1dba5400-96f0-11eb-9dff-722a7e2f2849.png)

`fee` validation passed and a user can see the Swap Review page:
![image](https://user-images.githubusercontent.com/80175477/113787872-aafda880-96f0-11eb-8366-8ad9e44ab40e.png)

`fee` property in the `/trades` API response:
![image](https://user-images.githubusercontent.com/80175477/113787668-4e9a8900-96f0-11eb-84f8-b0dfffb12b7c.png)

"No quotes available" page would be displayed if the type validation fails (e.g. when we would expect an object instead of number):
![image](https://user-images.githubusercontent.com/80175477/113787798-8acde980-96f0-11eb-8df2-92a0ad3b174c.png)

All unit are tests green:
![image](https://user-images.githubusercontent.com/80175477/113787596-2ad74300-96f0-11eb-9385-0373a62cea3c.png)

