### PR TITLE
Add categories to each changelog release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1442,8 +1442,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug that would sometimes display transactions as failed that could be successfully mined.
 
 ## [3.10.2] - 2017-09-19
-
-rollback to 3.10.0 due to bug
+### Uncategorized
+- rollback to 3.10.0 due to bug
 
 ## [3.10.1] - 2017-09-18
 ### Uncategorized
@@ -1737,7 +1737,6 @@ rollback to 3.10.0 due to bug
 ## [3.2.2] - 2017-02-09
 ### Uncategorized
 - Revert eth.sign behavior to the previous one with a big warning. We will be gradually implementing the new behavior over the coming time. https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
-
 - Improve test coverage of eth.sign behavior, including a code example of verifying a signature.
 
 ## [3.2.1] - 2017-02-09
@@ -1876,14 +1875,12 @@ rollback to 3.10.0 due to bug
 ## [2.13.0] - 2016-09-18
 ### Uncategorized
 - Add Parity compatibility, fixing Geth dependency issues.
-- Add a link to the transaction in history that goes to https://metamask.github.io/eth-tx-viz
-  too help visualize transactions and to where they are going.
+- Add a link to the transaction in history that goes to https://metamask.github.io/eth-tx-viz to help visualize transactions and to where they are going.
 - Show "Buy Ether" button and warning on tx confirmation when sender balance is insufficient
 
 ## [2.12.1] - 2016-09-14
 ### Uncategorized
-- Fixed bug where if you send a transaction from within MetaMask extension the
-  popup notification opens up.
+- Fixed bug where if you send a transaction from within MetaMask extension the popup notification opens up.
 - Fixed bug where some tx errors would block subsequent txs until the plugin was refreshed.
 
 ## [2.12.0] - 2016-09-14
@@ -2173,12 +2170,12 @@ rollback to 3.10.0 due to bug
 - Fixed some styling issues.
 
 ## [1.0.0] - 2016-03-25
-
-Made seed word restoring BIP44 compatible.
+### Uncategorized
+- Made seed word restoring BIP44 compatible.
 
 ## [0.14.0] - 2016-03-16
-
-Added the ability to restore accounts from seed words.
+### Uncategorized
+- Added the ability to restore accounts from seed words.
 
 [Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v9.3.0...HEAD
 [9.3.0]: https://github.com/MetaMask/metamask-extension/compare/v9.2.1...v9.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,50 @@
 # Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ## [9.3.0] - 2021-04-02
-- [#10777](https://github.com/MetaMask/metamask-extension/pull/10777): Display BNB token image for default currency on BSC network home screen
+### Added
 - [#10721](https://github.com/MetaMask/metamask-extension/pull/10721): Swaps support for the Binance network
 - [#10658](https://github.com/MetaMask/metamask-extension/pull/10658): Swaps support for forked Mainnet on localhost
+
+### Fixed
+- [#10777](https://github.com/MetaMask/metamask-extension/pull/10777): Display BNB token image for default currency on BSC network home screen
 - [#10650](https://github.com/MetaMask/metamask-extension/pull/10650): Fix: ETH now only appears once in the swaps "to" and "from" dropdowns.
 
 ## [9.2.1] - 2021-03-26
+### Fixed
 - [#10692](https://github.com/MetaMask/metamask-extension/pull/10692): Prevent UI crash when a 'wallet_requestPermissions" confirmation is queued behind a "wallet_addEthereumChain" confirmation
 - [#10712](https://github.com/MetaMask/metamask-extension/pull/10712): Fix infinite spinner when request for token symbol fails while attempting an approve transaction
+- [#10486](https://github.com/MetaMask/metamask-extension/pull/10486): Add setting to hide zero balance tokens
 
 ## [9.2.0] - 2021-03-15
+### Added
 - [#10546](https://github.com/MetaMask/metamask-extension/pull/10546): Add a warning when sending a token to its own contract address
+- [#10582](https://github.com/MetaMask/metamask-extension/pull/10582): Adding warnings for excessive custom gas input
+- [#10505](https://github.com/MetaMask/metamask-extension/pull/10505): Add support for multiple Ledger & Trezor hardware accounts
+
+### Changed
 - [#10563](https://github.com/MetaMask/metamask-extension/pull/10563): Update references to MetaMask support
 - [#10126](https://github.com/MetaMask/metamask-extension/pull/10126): Update Italian translation
+
+### Fixed
 - [#10591](https://github.com/MetaMask/metamask-extension/pull/10591): Fix mobile sync of ERC20 tokens
-- [#10582](https://github.com/MetaMask/metamask-extension/pull/10582): Adding warnings for excessive custom gas input
 - [#10601](https://github.com/MetaMask/metamask-extension/pull/10601): Fix activity title text truncation
 - [#10598](https://github.com/MetaMask/metamask-extension/pull/10598): Remove 'Ethereum' from custom RPC endpoint warning
 - [#10606](https://github.com/MetaMask/metamask-extension/pull/10606): Show loading screen while fetching token data for approve screen
-- [#10486](https://github.com/MetaMask/metamask-extension/pull/10486): Add setting to hide zero balance tokens
-- [#10505](https://github.com/MetaMask/metamask-extension/pull/10505): Add support for multiple Ledger & Trezor hardware accounts
 - [#10587](https://github.com/MetaMask/metamask-extension/pull/10587): Show correct block explorer for custom RPC endpoints for built-in networks
 
 ## [9.1.1] - 2021-03-03
+### Fixed
 - [#10560](https://github.com/MetaMask/metamask-extension/pull/10560): Fix ENS resolution related crashes when switching networks on send screen
 - [#10561](https://github.com/MetaMask/metamask-extension/pull/10561): Fix crash when speeding up an attempt to cancel a transaction on custom networks
 
 ## [9.1.0] - 2021-02-01
+### Uncategorized
 - [#10265](https://github.com/MetaMask/metamask-extension/pull/10265): Update Japanese translations.
 - [#9388](https://github.com/MetaMask/metamask-extension/pull/9388): Update Chinese(Simplified) translations.
 - [#10270](https://github.com/MetaMask/metamask-extension/pull/10270): Update Vietnamese translations.
@@ -65,6 +80,7 @@
 - [#10507](https://github.com/MetaMask/metamask-extension/pull/10507): Fixes ENS IPFS resolution on custom networks with the chainID of 1.
 
 ## [9.0.5] - 2021-02-09
+### Uncategorized
 - [#10278](https://github.com/MetaMask/metamask-extension/pull/10278): Allow editing transaction amount after clicking max
 - [#10214](https://github.com/MetaMask/metamask-extension/pull/10214): Standardize size, shape and color of network color indicators
 - [#10298](https://github.com/MetaMask/metamask-extension/pull/10298): Use network primary currency instead of always defaulting to ETH in the confirm approve screen
@@ -80,6 +96,7 @@
 - [#10386](https://github.com/MetaMask/metamask-extension/pull/10386): Make action buttons on message components in swaps flow accessible
 
 ## [9.0.4] - 2021-01-27
+### Uncategorized
 - [#10285](https://github.com/MetaMask/metamask-extension/pull/10285): Update @metamask/contract-metadata from v1.21.0 to 1.22.0
 - [#10264](https://github.com/MetaMask/metamask-extension/pull/10264): Update `hi` localized messages
 - [#10174](https://github.com/MetaMask/metamask-extension/pull/10174): Move fox to bottom of 'About' page
@@ -94,24 +111,25 @@
 - [#9947](https://github.com/MetaMask/metamask-extension/pull/9947): Do not publish swaps transaction if the estimateGas call made when adding the transaction fails.
 
 ## [9.0.3] - 2021-01-22
+### Uncategorized
 - [#10243](https://github.com/MetaMask/metamask-extension/pull/10243): Fix site metadata handling
 - [#10252](https://github.com/MetaMask/metamask-extension/pull/10252): Fix decrypt message confirmation UI crash
 
 ## [9.0.2] - 2021-01-20
-
+### Uncategorized
 - [#10191](https://github.com/MetaMask/metamask-extension/pull/10191): zh_TW: 乙太 -> 以太 (#10191)
 - [#10207](https://github.com/MetaMask/metamask-extension/pull/10207): zh_TW: Translate buy, assets, activity (#10207)
 - [#10219](https://github.com/MetaMask/metamask-extension/pull/10219): Restore provider 'data' event (#10219)
 
 ## [9.0.1] - 2021-01-13
-
+### Uncategorized
 - [#10169](https://github.com/MetaMask/metamask-extension/pull/10169): Improved detection of contract methods with array parameters
 - [#10178](https://github.com/MetaMask/metamask-extension/pull/10178): Only warn of injected web3 usage once per page
 - [#10179](https://github.com/MetaMask/metamask-extension/pull/10179): Restore support for @metamask/inpage provider@"< 8.0.0"
 - [#10180](https://github.com/MetaMask/metamask-extension/pull/10180): Fix UI crash when domain metadata is missing on public encryption key confirmation page
 
 ## [9.0.0] - 2021-01-12
-
+### Uncategorized
 - [#9156](https://github.com/MetaMask/metamask-extension/pull/9156): Remove window.web3 injection
 - [#10039](https://github.com/MetaMask/metamask-extension/pull/10039): Add web3 shim usage notification
 - [#8640](https://github.com/MetaMask/metamask-extension/pull/8640): Implement breaking window.ethereum API changes
@@ -133,11 +151,11 @@
 - [#10170](https://github.com/MetaMask/metamask-extension/pull/10170): Fix bug where swaps button was disabled on Mainnet if the user hadn't switched networks in a long time
 
 ## [8.1.11] - 2021-01-07
-
+### Uncategorized
 - [#10155](https://github.com/MetaMask/metamask-extension/pull/10155): Disable swaps when the current network's chainId does not match the mainnet chain ID, instead of disabling based on network ID
 
 ## [8.1.10] - 2021-01-04
-
+### Uncategorized
 - [#10084](https://github.com/MetaMask/metamask-extension/pull/10084): Set last provider when switching to a customRPC
 - [#10096](https://github.com/MetaMask/metamask-extension/pull/10096): Update `@metamask/controllers` to v5.1.0
 - [#10103](https://github.com/MetaMask/metamask-extension/pull/10103): Prevent stuck loading screen in some situations
@@ -145,7 +163,7 @@
 - [#10110](https://github.com/MetaMask/metamask-extension/pull/10110): Fix frozen loading screen on Firefox when strict Enhanced Tracking Protection is enabled
 
 ## [8.1.9] - 2020-12-15
-
+### Uncategorized
 - [#10034](https://github.com/MetaMask/metamask-extension/pull/10034): Fix contentscript injection failure on Firefox 56
 - [#10045](https://github.com/MetaMask/metamask-extension/pull/10045): Fix token validation in Send flow
 - [#10048](https://github.com/MetaMask/metamask-extension/pull/10048): Display boolean values when signing typed data
@@ -155,18 +173,18 @@
 - [#10040](https://github.com/MetaMask/metamask-extension/pull/10040): Disable console in contentscript to reduce noise
 
 ## [8.1.8] - 2020-12-09
-
+### Uncategorized
 - [#9992](https://github.com/MetaMask/metamask-extension/pull/9992): Improve transaction params validation
 - [#9991](https://github.com/MetaMask/metamask-extension/pull/9991): Don't allow more than 15% slippage
 - [#9994](https://github.com/MetaMask/metamask-extension/pull/9994): Prevent unwanted 'no quotes available' message when going back to build quote screen while having insufficient funds
 - [#9999](https://github.com/MetaMask/metamask-extension/pull/9999): Fix missing contacts upon restart
 
 ## [8.1.7] - 2020-12-09
-
+### Uncategorized
 - Revert SES lockdown
 
 ## [8.1.6] - 2020-12-04
-
+### Uncategorized
 - [#9916](https://github.com/MetaMask/metamask-extension/pull/9916): Fix QR code scans interpretting payment requests as token addresses
 - [#9847](https://github.com/MetaMask/metamask-extension/pull/9847): Add alt text for images in list items
 - [#9960](https://github.com/MetaMask/metamask-extension/pull/9960): Ensure watchAsset returns errors for invalid token symbols
@@ -178,7 +196,7 @@
 - [#9993](https://github.com/MetaMask/metamask-extension/pull/9993): Add 48x48 MetaMask icon for use by browsers
 
 ## [8.1.5] - 2020-11-19
-
+### Uncategorized
 - [#9871](https://github.com/MetaMask/metamask-extension/pull/9871): Show send text upon hover in main asset list
 - [#9855](https://github.com/MetaMask/metamask-extension/pull/9855): Make edit icon and account name in account details modal focusable
 - [#9853](https://github.com/MetaMask/metamask-extension/pull/9853): Provide alternative text for images where appropriate
@@ -193,7 +211,7 @@
 - [#9918](https://github.com/MetaMask/metamask-extension/pull/9918): Fix missing icon in asset page dropdown and in advanced gas modal button group
 
 ## [8.1.4] - 2020-11-16
-
+### Uncategorized
 - [#9687](https://github.com/MetaMask/metamask-extension/pull/9687): Allow speeding up of underpriced transactions
 - [#9694](https://github.com/MetaMask/metamask-extension/pull/9694): normalize UI component font styles
 - [#9695](https://github.com/MetaMask/metamask-extension/pull/9695): normalize app component font styles
@@ -228,7 +246,7 @@
 - [#9880](https://github.com/MetaMask/metamask-extension/pull/9880): Properly detect U2F errors in hardware wallet
 
 ## [8.1.3] - 2020-10-29
-
+### Uncategorized
 - [#9642](https://github.com/MetaMask/metamask-extension/pull/9642) Prevent excessive overflow from swap dropdowns
 - [#9658](https://github.com/MetaMask/metamask-extension/pull/9658): Fix sorting Quote Source column of quote sort list
 - [#9667](https://github.com/MetaMask/metamask-extension/pull/9667): Fix adding contact with QR code
@@ -247,7 +265,7 @@
 - [#9715](https://github.com/MetaMask/metamask-extension/pull/9715): Focus on wallet address in buy workflow
 
 ## [8.1.2] - 2020-10-20
-
+### Uncategorized
 - [#9608](https://github.com/MetaMask/metamask-extension/pull/9608): Ensure QR code scanner works
 - [#9624](https://github.com/MetaMask/metamask-extension/pull/9624): Help users avoid insufficient gas prices in swaps
 - [#9614](https://github.com/MetaMask/metamask-extension/pull/9614): Update swaps network fee tooltip
@@ -256,7 +274,7 @@
 - [#9633](https://github.com/MetaMask/metamask-extension/pull/9633): Update View Quote page to better represent the MetaMask fee
 
 ## [8.1.1] - 2020-10-15
-
+### Uncategorized
 - [#9586](https://github.com/MetaMask/metamask-extension/pull/9586): Prevent build quote crash when swapping from non-tracked token with balance (#9586)
 - [#9592](https://github.com/MetaMask/metamask-extension/pull/9592): Remove commitment to maintain a public metrics dashboard (#9592)
 - [#9596](https://github.com/MetaMask/metamask-extension/pull/9596): Fix TypeError when `signTypedData` throws (#9596)
@@ -269,7 +287,7 @@
 - [#9609](https://github.com/MetaMask/metamask-extension/pull/9609): Ensure swaps customize gas modal values are set correctly (#9609)
 
 ## [8.1.0] - 2020-10-13
-
+### Uncategorized
 - [#9565](https://github.com/MetaMask/metamask-extension/pull/9565): Ensure address book entries are shared between networks with the same chain ID
 - [#9552](https://github.com/MetaMask/metamask-extension/pull/9552): Fix `eth_signTypedData_v4` chain ID validation for non-default networks
 - [#9551](https://github.com/MetaMask/metamask-extension/pull/9551): Allow the "Localhost 8545" network to be edited, and require a chain ID to be specified for it
@@ -302,25 +320,25 @@
 - [#9073](https://github.com/MetaMask/metamask-extension/pull/9073): Use new Euclid font throughout MetaMask
 
 ## [8.0.10] - 2020-09-16
-
+### Uncategorized
 - [#9423](https://github.com/MetaMask/metamask-extension/pull/9423): Update default phishing list
 - [#9416](https://github.com/MetaMask/metamask-extension/pull/9416): Fix fetching a new phishing list on Firefox
 
 ## [8.0.9] - 2020-08-19
-
+### Uncategorized
 - [#9228](https://github.com/MetaMask/metamask-extension/pull/9228): Move transaction confirmation footer buttons to scrollable area
 - [#9256](https://github.com/MetaMask/metamask-extension/pull/9256): Handle non-String web3 property access
 - [#9266](https://github.com/MetaMask/metamask-extension/pull/9266): Use @metamask/controllers@2.0.5
 - [#9189](https://github.com/MetaMask/metamask-extension/pull/9189): Hide ETH Gas Station estimates on non-main network
 
 ## [8.0.8] - 2020-08-14
-
+### Uncategorized
 - [#9211](https://github.com/MetaMask/metamask-extension/pull/9211): Fix Etherscan redirect on notification click
 - [#9237](https://github.com/MetaMask/metamask-extension/pull/9237): Reduce volume of web3 usage metrics
 - [#9227](https://github.com/MetaMask/metamask-extension/pull/9227): Permit all-caps addresses
 
 ## [8.0.7] - 2020-08-10
-
+### Uncategorized
 - [#9065](https://github.com/MetaMask/metamask-extension/pull/9065): Change title of "Reveal Seed Words" page to "Reveal Seed Phrase"
 - [#8974](https://github.com/MetaMask/metamask-extension/pull/8974): Add tooltip to copy button for contacts and seed phrase
 - [#9063](https://github.com/MetaMask/metamask-extension/pull/9063): Fix broken UI upon failed password validation
@@ -333,7 +351,7 @@
 - [#9144](https://github.com/MetaMask/metamask-extension/pull/9144): Add web3 usage metrics and prepare for web3 removal
 
 ## [8.0.6] - 2020-07-23
-
+### Uncategorized
 - [#9030](https://github.com/MetaMask/metamask-extension/pull/9030): Hide "delete" button when editing contact of wallet account
 - [#9031](https://github.com/MetaMask/metamask-extension/pull/9031): Fix crash upon removing contact
 - [#9032](https://github.com/MetaMask/metamask-extension/pull/9032): Do not show spend limit for approvals
@@ -343,7 +361,7 @@
 - [#9056](https://github.com/MetaMask/metamask-extension/pull/9056): Display at least one significant digit of small non-zero token balances
 
 ## [8.0.5] - 2020-07-17
-
+### Uncategorized
 - [#8942](https://github.com/MetaMask/metamask-extension/pull/8942): Fix display of incoming transactions (#8942)
 - [#8998](https://github.com/MetaMask/metamask-extension/pull/8998): Fix `web3_clientVersion` method (#8998)
 - [#9003](https://github.com/MetaMask/metamask-extension/pull/9003): @metamask/inpage-provider@6.0.1 (#9003)
@@ -356,19 +374,19 @@
 - [#9026](https://github.com/MetaMask/metamask-extension/pull/9026): Clear transactions on createNewVaultAndRestore (#9026)
 
 ## [8.0.4] - 2020-07-08
-
+### Uncategorized
 - [#8934](https://github.com/MetaMask/metamask-extension/pull/8934): Fix transaction activity on custom networks
 - [#8936](https://github.com/MetaMask/metamask-extension/pull/8936): Fix account tracker optimization
 
 ## [8.0.3] - 2020-07-06
-
+### Uncategorized
 - [#8921](https://github.com/MetaMask/metamask-extension/pull/8921): Restore missing 'data' provider event, and fix 'notification' event
 - [#8923](https://github.com/MetaMask/metamask-extension/pull/8923): Normalize the 'from' parameter for `eth_sendTransaction`
 - [#8924](https://github.com/MetaMask/metamask-extension/pull/8924): Fix handling of multiple `eth_requestAccount` messages from the same domain
 - [#8917](https://github.com/MetaMask/metamask-extension/pull/8917): Update Italian translations
 
 ## [8.0.2] - 2020-07-03
-
+### Uncategorized
 - [#8907](https://github.com/MetaMask/metamask-extension/pull/8907): Tolerate missing or falsey substitutions
 - [#8908](https://github.com/MetaMask/metamask-extension/pull/8908): Fix activity log inline buttons
 - [#8909](https://github.com/MetaMask/metamask-extension/pull/8909): Prevent confirming blank suggested token
@@ -376,7 +394,7 @@
 - [#8913](https://github.com/MetaMask/metamask-extension/pull/8913): Fix Kovan chain ID constant
 
 ## [8.0.1] - 2020-07-02
-
+### Uncategorized
 - [#8874](https://github.com/MetaMask/metamask-extension/pull/8874): Fx overflow behaviour of add token list
 - [#8885](https://github.com/MetaMask/metamask-extension/pull/8885): Show `origin` in connect flow rather than site name
 - [#8883](https://github.com/MetaMask/metamask-extension/pull/8883): Allow setting a custom nonce of zero
@@ -389,7 +407,7 @@
 - [#8898](https://github.com/MetaMask/metamask-extension/pull/8898): Replace percentage opacity value
 
 ## [8.0.0] - 2020-07-01
-
+### Uncategorized
 - [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Add permission system
 - [#7261](https://github.com/MetaMask/metamask-extension/pull/7261): Search accounts by name
 - [#7483](https://github.com/MetaMask/metamask-extension/pull/7483): Buffer 3 blocks before dropping a transaction
@@ -481,7 +499,7 @@
 - [#8631](https://github.com/MetaMask/metamask-extension/pull/8631): Include imported accounts in mobile sync
 
 ## [7.7.9] - 2020-05-04
-
+### Uncategorized
 - [#8446](https://github.com/MetaMask/metamask-extension/pull/8446): Fix popup not opening
 - [#8449](https://github.com/MetaMask/metamask-extension/pull/8449): Skip adding history entry for empty txMeta diffs
 - [#8447](https://github.com/MetaMask/metamask-extension/pull/8447): Delete Dai/Sai migration notification
@@ -499,28 +517,28 @@
 - [#8509](https://github.com/MetaMask/metamask-extension/pull/8509): Fix Tohen Typo
 
 ## [7.7.8] - 2020-03-13
-
+### Uncategorized
 - [#8176](https://github.com/MetaMask/metamask-extension/pull/8176): Handle and set gas estimation when max mode is clicked
 - [#8178](https://github.com/MetaMask/metamask-extension/pull/8178): Use specified gas limit when speeding up a transaction
 
 ## [7.7.7] - 2020-03-04
-
+### Uncategorized
 - [#8162](https://github.com/MetaMask/metamask-extension/pull/8162): Remove invalid Ledger accounts
 - [#8163](https://github.com/MetaMask/metamask-extension/pull/8163): Fix account index check
 
 ## [7.7.6] - 2020-03-03
-
+### Uncategorized
 - [#8154](https://github.com/MetaMask/metamask-extension/pull/8154): Prevent signing from incorrect Ledger account
 
 ## [7.7.5] - 2020-02-18
-
+### Uncategorized
 - [#8053](https://github.com/MetaMask/metamask-extension/pull/8053): Inline the source text not the binary encoding for inpage script
 - [#8049](https://github.com/MetaMask/metamask-extension/pull/8049): Add warning to watchAsset API when editing a known token
 - [#8051](https://github.com/MetaMask/metamask-extension/pull/8051): Update Wyre ETH purchase url
 - [#8059](https://github.com/MetaMask/metamask-extension/pull/8059): Attempt ENS resolution on any valid domain name
 
 ## [7.7.4] - 2020-01-31
-
+### Uncategorized
 - [#7918](https://github.com/MetaMask/metamask-extension/pull/7918): Update data on Approve screen after updating custom spend limit
 - [#7919](https://github.com/MetaMask/metamask-extension/pull/7919): Allow editing max spend limit
 - [#7920](https://github.com/MetaMask/metamask-extension/pull/7920): Validate custom spend limit
@@ -528,18 +546,18 @@
 - [#7954](https://github.com/MetaMask/metamask-extension/pull/7954): Update ENS registry addresses
 
 ## [7.7.3] - 2020-01-27
-
+### Uncategorized
 - [#7894](https://github.com/MetaMask/metamask-extension/pull/7894): Update GABA dependency version
 - [#7901](https://github.com/MetaMask/metamask-extension/pull/7901): Use eth-contract-metadata@1.12.1
 - [#7910](https://github.com/MetaMask/metamask-extension/pull/7910): Fixing broken JSON import help link
 
 ## [7.7.2] - 2020-01-13
-
+### Uncategorized
 - [#7753](https://github.com/MetaMask/metamask-extension/pull/7753): Fix gas estimate for tokens
 - [#7473](https://github.com/MetaMask/metamask-extension/pull/7473): Fix transaction order on transaction confirmation screen
 
 ## [7.7.1] - 2019-12-09
-
+### Uncategorized
 - [#7488](https://github.com/MetaMask/metamask-extension/pull/7488): Fix text overlap when expanding transaction
 - [#7491](https://github.com/MetaMask/metamask-extension/pull/7491): Update gas when asset is changed on send screen
 - [#7500](https://github.com/MetaMask/metamask-extension/pull/7500): Remove unused onClick prop from Dropdown component
@@ -554,7 +572,7 @@
 - [#7558](https://github.com/MetaMask/metamask-extension/pull/7558): Use localized messages for NotificationModal buttons
 
 ## [7.7.0] - 2019-12-03 [WITHDRAWN]
-
+### Uncategorized
 - [#7004](https://github.com/MetaMask/metamask-extension/pull/7004): Connect distinct accounts per site
 - [#7480](https://github.com/MetaMask/metamask-extension/pull/7480): Fixed link on root README.md
 - [#7482](https://github.com/MetaMask/metamask-extension/pull/7482): Update Wyre ETH purchase url
@@ -568,19 +586,19 @@
 - [#7488](https://github.com/MetaMask/metamask-extension/pull/7488): Fix text overlap when expanding transaction
 
 ## [7.6.1] - 2019-11-19
-
+### Uncategorized
 - [#7475](https://github.com/MetaMask/metamask-extension/pull/7475): Add 'Remind Me Later' to the Maker notification
 - [#7436](https://github.com/MetaMask/metamask-extension/pull/7436): Add additional rpcUrl verification
 - [#7468](https://github.com/MetaMask/metamask-extension/pull/7468): Show transaction fee units on approve screen
 
 ## [7.6.0] - 2019-11-18
-
+### Uncategorized
 - [#7450](https://github.com/MetaMask/metamask-extension/pull/7450): Add migration notification for users with non-zero Sai
 - [#7461](https://github.com/MetaMask/metamask-extension/pull/7461): Import styles for showing multiple notifications
 - [#7451](https://github.com/MetaMask/metamask-extension/pull/7451): Add button disabled when password is empty
 
 ## [7.5.3] - 2019-11-15
-
+### Uncategorized
 - [#7412](https://github.com/MetaMask/metamask-extension/pull/7412): lock eth-contract-metadata (#7412)
 - [#7416](https://github.com/MetaMask/metamask-extension/pull/7416): Add eslint import plugin to help detect unresolved paths
 - [#7414](https://github.com/MetaMask/metamask-extension/pull/7414): Ensure SignatureRequestOriginal 'beforeunload' handler is bound (#7414)
@@ -595,17 +613,17 @@
 - [#7419](https://github.com/MetaMask/metamask-extension/pull/7419): Added webRequest.RequestFilter to filter main_frame .eth requests (#7419)
 
 ## [7.5.2] - 2019-11-14
-
+### Uncategorized
 - [#7414](https://github.com/MetaMask/metamask-extension/pull/7414): Ensure SignatureRequestOriginal 'beforeunload' handler is bound
 
 ## [7.5.1] - 2019-11-13
-
+### Uncategorized
 - [#7402](https://github.com/MetaMask/metamask-extension/pull/7402): Fix regression for signed types data screens
 - [#7390](https://github.com/MetaMask/metamask-extension/pull/7390): Update json-rpc-engine
 - [#7401](https://github.com/MetaMask/metamask-extension/pull/7401): Reject connection request on window close
 
 ## [7.5.0] - 2019-11-12
-
+### Uncategorized
 - [#7328](https://github.com/MetaMask/metamask-extension/pull/7328): ignore known transactions on first broadcast and continue with normal flow
 - [#7327](https://github.com/MetaMask/metamask-extension/pull/7327): eth_getTransactionByHash will now check metamask's local history for pending transactions
 - [#7333](https://github.com/MetaMask/metamask-extension/pull/7333): Cleanup beforeunload handler after transaction is resolved
@@ -624,7 +642,7 @@
 - [#7335](https://github.com/MetaMask/metamask-extension/pull/7335): Add onbeforeunload and have it call onCancel
 
 ## [7.4.0] - 2019-11-04
-
+### Uncategorized
 - [#7186](https://github.com/MetaMask/metamask-extension/pull/7186): Use `AdvancedGasInputs` in `AdvancedTabContent`
 - [#7304](https://github.com/MetaMask/metamask-extension/pull/7304): Move signTypedData signing out to keyrings
 - [#7306](https://github.com/MetaMask/metamask-extension/pull/7306): correct the zh-TW translation
@@ -638,11 +656,11 @@
 - [#7334](https://github.com/MetaMask/metamask-extension/pull/7334): Add web3 deprecation warning
 
 ## [7.3.1] - 2019-10-22
-
+### Uncategorized
 - [#7298](https://github.com/MetaMask/metamask-extension/pull/7298): Turn off full screen vs popup a/b test
 
 ## [7.3.0] - 2019-10-21
-
+### Uncategorized
 - [#6972](https://github.com/MetaMask/metamask-extension/pull/6972): 3box integration
 - [#7168](https://github.com/MetaMask/metamask-extension/pull/7168): Add fixes for German translations
 - [#7170](https://github.com/MetaMask/metamask-extension/pull/7170): Remove the disk store
@@ -662,21 +680,21 @@
 - [#7287](https://github.com/MetaMask/metamask-extension/pull/7287): Fix phishing detect script
 
 ## [7.2.3] - 2019-10-08
-
+### Uncategorized
 - [#7252](https://github.com/MetaMask/metamask-extension/pull/7252): Fix gas limit when sending tx without data to a contract
 - [#7260](https://github.com/MetaMask/metamask-extension/pull/7260): Do not transate on seed phrases
 - [#7252](https://github.com/MetaMask/metamask-extension/pull/7252): Ensure correct tx category when sending to contracts without tx data
 
 ## [7.2.2] - 2019-09-25
-
+### Uncategorized
 - [#7213](https://github.com/MetaMask/metamask-extension/pull/7213): Update minimum Firefox verison to 56.0
 
 ## [7.2.1] - 2019-09-17
-
+### Uncategorized
 - [#7180](https://github.com/MetaMask/metamask-extension/pull/7180): Add `appName` message to each locale
 
 ## [7.2.0] - 2019-09-17
-
+### Uncategorized
 - [#7099](https://github.com/MetaMask/metamask-extension/pull/7099): Update localization from Transifex Brave
 - [#7137](https://github.com/MetaMask/metamask-extension/pull/7137): Fix validation of empty block explorer url's in custom network form
 - [#7128](https://github.com/MetaMask/metamask-extension/pull/7128): Support for eth_signTypedData_v4
@@ -689,7 +707,7 @@
 - [#7171](https://github.com/MetaMask/metamask-extension/pull/7171): Fix recipient field of approve screen
 
 ## [7.1.1] - 2019-09-03
-
+### Uncategorized
 - [#7059](https://github.com/MetaMask/metamask-extension/pull/7059): Remove blockscale, replace with ethgasstation
 - [#7037](https://github.com/MetaMask/metamask-extension/pull/7037): Remove Babel 6 from internal dependencies
 - [#7093](https://github.com/MetaMask/metamask-extension/pull/7093): Allow dismissing privacy mode notification from popup
@@ -701,7 +719,7 @@
 - [#7012](https://github.com/MetaMask/metamask-extension/pull/7012): Added missed phrases to RU locale
 
 ## [7.1.0] - 2019-08-26
-
+### Uncategorized
 - [#7035](https://github.com/MetaMask/metamask-extension/pull/7035): Filter non-ERC-20 assets during mobile sync (#7035)
 - [#7021](https://github.com/MetaMask/metamask-extension/pull/7021): Using translated string for end of flow messaging (#7021)
 - [#7018](https://github.com/MetaMask/metamask-extension/pull/7018): Rename Contacts List settings tab to Contacts (#7018)
@@ -715,11 +733,11 @@
 - [#7047](https://github.com/MetaMask/metamask-extension/pull/7047): Add warning about reload on network change
 
 ## [7.0.1] - 2019-08-08
-
+### Uncategorized
 - [#6975](https://github.com/MetaMask/metamask-extension/pull/6975): Ensure seed phrase backup notification only shows up for new users
 
 ## [7.0.0] - 2019-08-07
-
+### Uncategorized
 - [#6828](https://github.com/MetaMask/metamask-extension/pull/6828): Capitalized speed up label to match rest of UI
 - [#6874](https://github.com/MetaMask/metamask-extension/pull/6928): Allows skipping of seed phrase challenge during onboarding, and completing it at a later time
 - [#6900](https://github.com/MetaMask/metamask-extension/pull/6900): Prevent opening of asset dropdown if no tokens in account
@@ -729,11 +747,11 @@
 - [#6967](https://github.com/MetaMask/metamask-extension/pull/6967): Fix mobile sync
 
 ## [6.7.3] - 2019-07-19
-
+### Uncategorized
 - [#6888](https://github.com/MetaMask/metamask-extension/pull/6888): Fix bug with resubmitting unsigned transactions.
 
 ## [6.7.2] - 2019-07-03
-
+### Uncategorized
 - [#6713](https://github.com/MetaMask/metamask-extension/pull/6713): \* Normalize and Validate txParams in TransactionStateManager.addTx too
 - [#6759](https://github.com/MetaMask/metamask-extension/pull/6759): Update to Node.js v10
 - [#6694](https://github.com/MetaMask/metamask-extension/pull/6694): Fixes #6694
@@ -748,11 +766,11 @@
 - [#6731](https://github.com/MetaMask/metamask-extension/pull/6731): Add brave as a platform type for MetaMask
 
 ## [6.7.1] - 2019-07-28
-
+### Uncategorized
 - [#6764](https://github.com/MetaMask/metamask-extension/pull/6764): Fix display of token amount on confirm transaction screen
 
 ## [6.7.0] - 2019-07-26
-
+### Uncategorized
 - [#6623](https://github.com/MetaMask/metamask-extension/pull/6623): Improve contract method data fetching (#6623)
 - [#6551](https://github.com/MetaMask/metamask-extension/pull/6551): Adds 4byte registry fallback to getMethodData() (#6435)
 - [#6718](https://github.com/MetaMask/metamask-extension/pull/6718): Add delete to custom RPC form
@@ -763,39 +781,39 @@
 - [#6775](https://github.com/MetaMask/metamask-extension/pull/6775): Started adding visual documentation of MetaMask plugin components with the account menu component first
 
 ## [6.6.2] - 2019-07-17
-
+### Uncategorized
 - [#6690](https://github.com/MetaMask/metamask-extension/pull/6690): Update dependencies, re-enable npm audit CI job
 - [#6700](https://github.com/MetaMask/metamask-extension/pull/6700): Fix styles on 'import account' page, update help link
 
 ## [6.6.1] - 2019-06-06
-
+### Uncategorized
 - [#6691](https://github.com/MetaMask/metamask-extension/pull/6691): Revert "Improve ENS Address Input" to fix bugs on input field on non-main networks.
 
 ## [6.6.0] - 2019-06-04
-
+### Uncategorized
 - [#6659](https://github.com/MetaMask/metamask-extension/pull/6659): Enable Ledger hardware wallet support on Firefox
 - [#6671](https://github.com/MetaMask/metamask-extension/pull/6671): bugfix: reject enable promise on user rejection
 - [#6625](https://github.com/MetaMask/metamask-extension/pull/6625): Ensures that transactions cannot be confirmed if gas limit is below 21000.
 - [#6633](https://github.com/MetaMask/metamask-extension/pull/6633): Fix grammatical error in i18n endOfFlowMessage6
 
 ## [6.5.3] - 2019-05-16
-
+### Uncategorized
 - [#6619](https://github.com/MetaMask/metamask-extension/pull/6619): bugfix: show extension window if locked regardless of approval
 - [#6388](https://github.com/MetaMask/metamask-extension/pull/6388): Transactions/pending - check nonce against the network and mark as dropped if not included in a block
 - [#6606](https://github.com/MetaMask/metamask-extension/pull/6606): Improve ENS Address Input
 - [#6615](https://github.com/MetaMask/metamask-extension/pull/6615): Adds e2e test for removing imported accounts.
 
 ## [6.5.2] - 2019-05-15
-
+### Uncategorized
 - [#6613](https://github.com/MetaMask/metamask-extension/pull/6613): Hardware Wallet Fix
 
 ## [6.5.1] - 2019-05-14
-
+### Uncategorized
 - Fix bug where approve method would show a warning. #6602
 - [#6593](https://github.com/MetaMask/metamask-extension/pull/6593): Fix wording of autoLogoutTimeLimitDescription
 
 ## [6.5.0] - 2019-05-13
-
+### Uncategorized
 - [#6568](https://github.com/MetaMask/metamask-extension/pull/6568): feature: integrate gaba/PhishingController
 - [#6490](https://github.com/MetaMask/metamask-extension/pull/6490): Redesign custom RPC form
 - [#6558](https://github.com/MetaMask/metamask-extension/pull/6558): Adds auto logout with customizable time frame
@@ -806,11 +824,11 @@
 - [#6501](https://github.com/MetaMask/metamask-extension/pull/6501): Improve confirm screen loading performance by fixing home screen rendering bug
 
 ## [6.4.1] - 2019-04-26
-
+### Uncategorized
 - [#6521](https://github.com/MetaMask/metamask-extension/pull/6521): Revert "Adds 4byte registry fallback to getMethodData()" to fix stalling bug.
 
 ## [6.4.0] - 2019-04-18
-
+### Uncategorized
 - [#6445](https://github.com/MetaMask/metamask-extension/pull/6445): \* Move send to pages/
 - [#6470](https://github.com/MetaMask/metamask-extension/pull/6470): update publishing.md with dev diagram
 - [#6403](https://github.com/MetaMask/metamask-extension/pull/6403): Update to eth-method-registry@1.2.0
@@ -836,19 +854,19 @@
 - [#6382](https://github.com/MetaMask/metamask-extension/pull/6382): Remove NoticeController
 
 ## [6.3.2] - 2019-04-08
-
+### Uncategorized
 - [#6389](https://github.com/MetaMask/metamask-extension/pull/6389): Fix display of gas chart on ethereum networks
 - [#6395](https://github.com/MetaMask/metamask-extension/pull/6395): Fixes for signing methods for ledger and trezor devices
 - [#6397](https://github.com/MetaMask/metamask-extension/pull/6397): Fix Wyre link
 
 ## [6.3.1] - 2019-03-29
-
+### Uncategorized
 - [#6353](https://github.com/MetaMask/metamask-extension/pull/6353): Open restore vault in full screen when clicked from popup
 - [#6372](https://github.com/MetaMask/metamask-extension/pull/6372): Prevents duplicates of account addresses from showing in send screen "To" dropdown
 - [#6374](https://github.com/MetaMask/metamask-extension/pull/6374): Ensures users are placed on correct confirm screens even when registry service fails
 
 ## [6.3.0] - 2019-03-26
-
+### Uncategorized
 - [#6300](https://github.com/MetaMask/metamask-extension/pull/6300): Gas chart hidden on custom networks
 - [#6301](https://github.com/MetaMask/metamask-extension/pull/6301): Fix gas fee in the submitted step of the transaction details activity log
 - [#6302](https://github.com/MetaMask/metamask-extension/pull/6302): Replaces the coinbase link in the deposit modal with one for wyre
@@ -863,7 +881,7 @@
 - [#6347](https://github.com/MetaMask/metamask-extension/pull/6347): Enable privacy mode by default for first time users
 
 ## [6.2.2] - 2019-03-12
-
+### Uncategorized
 - [#6271](https://github.com/MetaMask/metamask-extension/pull/6271): Centre all notification popups
 - [#6268](https://github.com/MetaMask/metamask-extension/pull/6268): Improve Korean translations
 - [#6279](https://github.com/MetaMask/metamask-extension/pull/6279): Nonmultiple notifications for batch txs
@@ -872,14 +890,14 @@
 ## [6.2.1] - 2019-03-11
 
 ## [6.2.0] - 2019-03-05
-
+### Uncategorized
 - [#6192](https://github.com/MetaMask/metamask-extension/pull/6192): Improves design and UX of onboarding flow
 - [#6195](https://github.com/MetaMask/metamask-extension/pull/6195): Fixes gas estimation when sending to contracts
 - [#6223](https://github.com/MetaMask/metamask-extension/pull/6223): Fixes display of notification windows when metamask is active in a tab
 - [#6171](https://github.com/MetaMask/metamask-extension/pull/6171): Adds MetaMetrics usage analytics system
 
 ## [6.1.0] - 2019-02-20
-
+### Uncategorized
 - [#6182](https://github.com/MetaMask/metamask-extension/pull/6182): Change "Token Address" to "Token Contract Address"
 - [#6177](https://github.com/MetaMask/metamask-extension/pull/6177): Fixes #6176
 - [#6146](https://github.com/MetaMask/metamask-extension/pull/6146): \* Add Copy Tx ID button to transaction-list-item-details
@@ -888,14 +906,14 @@
 - [#6124](https://github.com/MetaMask/metamask-extension/pull/6124): recent-blocks - dont listen for block when on infura providers -[#5973] (https://github.com/MetaMask/metamask-extension/pull/5973): Fix incorrectly showing checksums on non-ETH blockchains (issue 5838)
 
 ## [6.0.1] - 2019-02-12
-
+### Uncategorized
 - [#6139](https://github.com/MetaMask/metamask-extension/pull/6139) Fix advanced gas controls on the confirm screen
 - [#6134](https://github.com/MetaMask/metamask-extension/pull/6134) Trim whitespace from seed phrase during import
 - [#6119](https://github.com/MetaMask/metamask-extension/pull/6119) Update Italian translation
 - [#6125](https://github.com/MetaMask/metamask-extension/pull/6125) Improved Traditional Chinese translation
 
 ## [6.0.0] - 2019-02-11
-
+### Uncategorized
 - [#6082](https://github.com/MetaMask/metamask-extension/pull/6082): Migrate all users to the new UI
 - [#6114](https://github.com/MetaMask/metamask-extension/pull/6114): Add setting for inputting gas price with a text field for advanced users.
 - [#6091](https://github.com/MetaMask/metamask-extension/pull/6091): Add Swap feature to CurrencyInput
@@ -906,22 +924,22 @@
 - [#6116](https://github.com/MetaMask/metamask-extension/pull/6116): Fix locale codes contains underscore never being preferred
 
 ## [5.3.5] - 2019-02-04
-
+### Uncategorized
 - [#6084](https://github.com/MetaMask/metamask-extension/pull/6087): Privacy mode fixes
 
 ## [5.3.4] - 2019-01-31
-
+### Uncategorized
 - [#6079](https://github.com/MetaMask/metamask-extension/pull/6079): fix - migration 30
 
 ## [5.3.3] - 2019-01-30
-
+### Uncategorized
 - [#6006](https://github.com/MetaMask/metamask-extension/pull/6006): Update privacy notice
 - [#6072](https://github.com/MetaMask/metamask-extension/pull/6072): Improved Spanish translations
 - [#5854](https://github.com/MetaMask/metamask-extension/pull/5854): Add visual indicator when displaying a cached balance.
 - [#6044](https://github.com/MetaMask/metamask-extension/pull/6044): Fix bug that interferred with using multiple custom networks.
 
 ## [5.3.2] - 2019-01-28
-
+### Uncategorized
 - [#6021](https://github.com/MetaMask/metamask-extension/pull/6021): Order shapeshift transactions by time within the transactions list
 - [#6052](https://github.com/MetaMask/metamask-extension/pull/6052): Add and use cached method signatures to reduce provider requests
 - [#6048](https://github.com/MetaMask/metamask-extension/pull/6048): Refactor BalanceComponent to jsx
@@ -930,7 +948,7 @@
 - [#6024](https://github.com/MetaMask/metamask-extension/pull/6024): Disable account dropdown on signing screens
 
 ## [5.3.1] - 2019-01-16
-
+### Uncategorized
 - [#5966](https://github.com/MetaMask/metamask-extension/pull/5966): Update Slovenian translation
 - [#6005](https://github.com/MetaMask/metamask-extension/pull/6005): Set auto conversion off for token/eth conversion
 - [#6008](https://github.com/MetaMask/metamask-extension/pull/6008): Fix confirm screen for sending ether tx with hex data
@@ -943,7 +961,7 @@
 - [#5989](https://github.com/MetaMask/metamask-extension/pull/5989): fix typo in phishing.html title
 
 ## [5.3.0] - 2019-01-02
-
+### Uncategorized
 - [#5978](https://github.com/MetaMask/metamask-extension/pull/5978): Fix etherscan links on notifications
 - [#5980](https://github.com/MetaMask/metamask-extension/pull/5980): Fix drizzle tests
 - [#5922](https://github.com/MetaMask/metamask-extension/pull/5922): Prevent users from changing the From field in the send screen
@@ -952,31 +970,31 @@
 - [#5893](https://github.com/MetaMask/metamask-extension/pull/5893): Add loading network screen
 
 ## [5.2.2] - 2018-12-13
-
+### Uncategorized
 - [#5925](https://github.com/MetaMask/metamask-extension/pull/5925): Fix speed up button not showing for transactions with the lowest nonce
 - [#5923](https://github.com/MetaMask/metamask-extension/pull/5923): Update the Phishing Warning notice text to not use inline URLs
 - [#5919](https://github.com/MetaMask/metamask-extension/pull/5919): Fix some styling and translations in the gas customization modal
 
 ## [5.2.1] - 2018-12-12
-
+### Uncategorized
 - [#5917] bugfix: Ensures that advanced tab gas limit reflects tx gas limit
 
 ## [5.2.0] - 2018-12-11
-
+### Uncategorized
 - [#5704] Implements new gas customization features for sending, confirming and speeding up transactions
 - [#5886] Groups transactions - speed up, cancel and original - by nonce in the transaction history list
 - [#5892] bugfix: eliminates infinite spinner issues caused by switching quickly from a loading network that ultimately fails to resolve
 - [$5902] bugfix: provider crashes caused caching issues in `json-rpc-engine`. Fixed in (https://github.com/MetaMask/json-rpc-engine/commit/6de511afbd03ccef4550ea43ff4010b7d7a84039)
 
 ## [5.1.0] - 2018-12-03
-
+### Uncategorized
 - [#5860](https://github.com/MetaMask/metamask-extension/pull/5860): Fixed an infinite spinner bug.
 - [#5875](https://github.com/MetaMask/metamask-extension/pull/5875): Update phishing warning copy
 - [#5863](https://github.com/MetaMask/metamask-extension/pull/5863): bugfix: normalize contract addresss when fetching exchange rates
 - [#5843](https://github.com/MetaMask/metamask-extension/pull/5843): Use selector for state.metamask.accounts in all cases.
 
 ## [5.0.4] - 2018-11-29
-
+### Uncategorized
 - [#5878](https://github.com/MetaMask/metamask-extension/pull/5878): Formats 32-length byte strings passed to personal_sign as hex, rather than UTF8.
 - [#5840](https://github.com/MetaMask/metamask-extension/pull/5840): transactions/tx-gas-utils - add the acctual response for eth_getCode for NO_CONTRACT_ERROR's && add a debug object to simulationFailed
 - [#5848](https://github.com/MetaMask/metamask-extension/pull/5848): Soften accusatory language on phishing warning
@@ -999,30 +1017,30 @@
 - [#5791](https://github.com/MetaMask/metamask-extension/pull/5791): Bump eth-ledger-bridge-keyring
 
 ## [5.0.3] - 2018-11-20
-
+### Uncategorized
 - [#5547](https://github.com/MetaMask/metamask-extension/pull/5547): Bundle some ui dependencies separately to limit the build size of ui.js
 - Resubmit approved transactions on new block, to fix bug where an error can stick transactions in this state.
 - Fixed a bug that could cause an error when sending the max number of tokens.
 
 ## [5.0.2] - 2018-11-10
-
+### Uncategorized
 - Fixed bug that caused accounts to update slowly to sites. #5717
 - Fixed bug that could lead to some sites crashing. #5709
 
 ## [5.0.1] - 2018-11-07
-
+### Uncategorized
 - Fixed bug in privacy mode that made it not work correctly on Firefox.
 
 ## [5.0.0] - 2018-11-06
-
+### Uncategorized
 - Implements EIP 1102 as a user-activated "Privacy Mode".
 
 ## [4.17.1] - 2018-11-03
-
+### Uncategorized
 - Revert chain ID lookup change which introduced a bug which caused problems when connecting to mainnet via Infura's RESTful API.
 
 ## [4.17.0] - 2018-11-01
-
+### Uncategorized
 - Fix bug where data lookups like balances would get stale data (stopped block-tracker bug)
 - Transaction Details now show entry for onchain failure
 - [#5559](https://github.com/MetaMask/metamask-extension/pull/5559) Localize language names in translation select list
@@ -1034,7 +1052,7 @@
 - Fix account display width for large currency values
 
 ## [4.16.0] - 2018-10-17
-
+### Uncategorized
 - Feature: Add toggle for primary currency (eth/fiat)
 - Feature: add tooltip for view etherscan tx
 - Feature: add Polish translations
@@ -1046,34 +1064,34 @@
 - Bug Fix: Fix some support links
 
 ## [4.15.0] - 2018-10-11
-
+### Uncategorized
 - A rollback release, equivalent to `v4.11.1` to be deployed in the case that `v4.14.0` is found to have bugs.
 
 ## [4.14.0] - 2018-10-11
-
+### Uncategorized
 - Update transaction statuses when switching networks.
 - [#5470](https://github.com/MetaMask/metamask-extension/pull/5470) 100% coverage in French locale, fixed the procedure to verify proposed locale.
 - Added rudimentary support for the subscription API to support web3 1.0 and Truffle's Drizzle.
 - [#5502](https://github.com/MetaMask/metamask-extension/pull/5502) Update Italian translation.
 
 ## [4.13.0] - 2018-10-04
-
+### Uncategorized
 - A rollback release, equivalent to `v4.11.1` to be deployed in the case that `v4.12.0` is found to have bugs.
 
 ## [4.12.0] - 2018-09-27
-
+### Uncategorized
 - Reintroduces changes from 4.10.0
 
 ## [4.11.1] - 2018-09-25
-
+### Uncategorized
 - Adds Ledger support.
 
 ## [4.11.0] - 2018-09-24
-
+### Uncategorized
 - Identical to 4.9.3. A rollback version to give time to fix bugs in the 4.10.x branch.
 
 ## [4.10.0] - 2018-09-18
-
+### Uncategorized
 - [#4803](https://github.com/MetaMask/metamask-extension/pull/4803): Implement EIP-712: Sign typed data, but continue to support v1.
 - [#4898](https://github.com/MetaMask/metamask-extension/pull/4898): Restore multiple consecutive accounts with balances.
 - [#4279](https://github.com/MetaMask/metamask-extension/pull/4279): New BlockTracker and Json-Rpc-Engine based Provider.
@@ -1087,17 +1105,17 @@
 - [#5256](https://github.com/MetaMask/metamask-extension/pull/5256): Add mock EIP-1102 support
 
 ## [4.9.3] - 2018-08-16
-
+### Uncategorized
 - [#4897](https://github.com/MetaMask/metamask-extension/pull/4897): QR code scan for recipient addresses.
 - [#4961](https://github.com/MetaMask/metamask-extension/pull/4961): Add a download seed phrase link.
 - [#5060](https://github.com/MetaMask/metamask-extension/pull/5060): Fix bug where gas was not updating properly.
 
 ## [4.9.2] - 2018-08-10
-
+### Uncategorized
 - [#5020](https://github.com/MetaMask/metamask-extension/pull/5020): Fix bug in migration #28 ( moving tokens to specific accounts )
 
 ## [4.9.1] - 2018-08-09
-
+### Uncategorized
 - [#4884](https://github.com/MetaMask/metamask-extension/pull/4884): Allow to have tokens per account and network.
 - [#4989](https://github.com/MetaMask/metamask-extension/pull/4989): Continue to use original signedTypedData.
 - [#5010](https://github.com/MetaMask/metamask-extension/pull/5010): Fix ENS resolution issues.
@@ -1105,7 +1123,7 @@
 - [#4995](https://github.com/MetaMask/metamask-extension/pull/4995): Shows retry button on dApp initialized transactions.
 
 ## [4.9.0] - 2018-08-07
-
+### Uncategorized
 - [#4926](https://github.com/MetaMask/metamask-extension/pull/4926): Show retry button on the latest tx of the earliest nonce.
 - [#4888](https://github.com/MetaMask/metamask-extension/pull/4888): Suggest using the new user interface.
 - [#4947](https://github.com/MetaMask/metamask-extension/pull/4947): Prevent sending multiple transasctions on multiple confirm clicks.
@@ -1121,7 +1139,7 @@
 - [#4898](https://github.com/MetaMask/metamask-extension/pull/4898): Restore multiple consecutive accounts with balances.
 
 ## [4.8.0] - 2018-06-18
-
+### Uncategorized
 - [#4513](https://github.com/MetaMask/metamask-extension/pull/4513): Attempting to import an empty private key will now show a clear error.
 - [#4570](https://github.com/MetaMask/metamask-extension/pull/4570): Fix bug where metamask data would stop being written to disk after prolonged use.
 - [#4523](https://github.com/MetaMask/metamask-extension/pull/4523): Fix bug where account reset did not work with custom RPC providers.
@@ -1131,30 +1149,30 @@
 - [#4591](https://github.com/MetaMask/metamask-extension/pull/4591): Allow Copying Token Addresses and link to Token on Etherscan.
 
 ## [4.7.4] - 2018-06-05
-
+### Uncategorized
 - Add diagnostic reporting for users with multiple HD keyrings
 - Throw explicit error when selected account is unset
 
 ## [4.7.3] - 2018-06-04
-
+### Uncategorized
 - Hide token now uses new modal
 - Indicate the current selected account on the popup account view
 - Reduce height of notice container in onboarding
 - Fixes issue where old nicknames were kept around causing errors
 
 ## [4.7.2] - 2018-06-03
-
+### Uncategorized
 - Fix bug preventing users from logging in. Internally accounts and identities were out of sync.
 - Fix support links to point to new support system (Zendesk)
 - Fix bug in migration #26 ( moving account nicknames to preferences )
 - Clears account nicknames on restore from seedPhrase
 
 ## [4.7.1] - 2018-06-01
-
+### Uncategorized
 - Fix bug where errors were not returned to Dapps.
 
 ## [4.7.0] - 2018-05-30
-
+### Uncategorized
 - Fix Brave support
 - Adds error messages when passwords don't match in onboarding flow.
 - Adds modal notification if a retry in the process of being confirmed is dropped.
@@ -1169,7 +1187,7 @@
 - Allow other extensions to make access our ethereum provider API ([#3997](https://github.com/MetaMask/metamask-extension/pull/3997))
 
 ## [4.6.1] - 2018-04-30
-
+### Uncategorized
 - Fix bug where sending a transaction resulted in an infinite spinner
 - Allow transactions with a 0 gwei gas price
 - Handle encoding errors in ERC20 symbol + digits
@@ -1177,7 +1195,7 @@
 - Fix sourcemaps
 
 ## [4.6.0] - 2018-04-26
-
+### Uncategorized
 - Correctly format currency conversion for locally selected preferred currency.
 - Improved performance of 3D fox logo.
 - Fetch token prices based on contract address, not symbol
@@ -1187,7 +1205,7 @@
 - Made provider RPC errors contain useful messages
 
 ## [4.5.5] - 2018-04-06
-
+### Uncategorized
 - Graceful handling of unknown keys in txParams
 - Fixes buggy handling of historical transactions with unknown keys in txParams
 - Fix link for 'Learn More' in the Add Token Screen to open to a new tab.
@@ -1195,35 +1213,35 @@
 - Enhanced migration error handling + reporting
 
 ## [4.5.4] - 2018-04-05 [WITHDRAWN]
-
+### Uncategorized
 - Graceful handling of unknown keys in txParams
 - Fix link for 'Learn More' in the Add Token Screen to open to a new tab.
 - Fix Download State Logs button [#3791](https://github.com/MetaMask/metamask-extension/issues/3791)
 - Fix migration error reporting
 
 ## [4.5.3] - 2018-04-04
-
+### Uncategorized
 - Fix bug where checksum address are messing with balance issue [#3843](https://github.com/MetaMask/metamask-extension/issues/3843)
 - new ui: fix the confirm transaction screen
 
 ## [4.5.2] - 2018-04-04
-
+### Uncategorized
 - Fix overly strict validation where transactions were rejected with hex encoded "chainId"
 
 ## [4.5.1] - 2018-04-03
-
+### Uncategorized
 - Fix default network (should be mainnet not Rinkeby)
 - Fix Sentry automated error reporting endpoint
 
 ## [4.5.0] - 2018-04-02
-
+### Uncategorized
 - (beta ui) Internationalization: Select your preferred language in the settings screen
 - Internationalization: various locale improvements
 - Fix bug where the "Reset account" feature would not clear the network cache.
 - Increase maximum gas limit, to allow very gas heavy transactions, since block gas limits have been stable.
 
 ## [4.4.0] - 2018-03-27
-
+### Uncategorized
 - Internationalization: Taiwanese, Thai, Slovenian
 - Fixes bug where MetaMask would not open once its storage grew too large.
 - Updates design of new-ui Add Token screen
@@ -1234,7 +1252,7 @@
 - Buy ether step of new-ui on-boarding uses new buy ether modal designs
 
 ## [4.3.0] - 2018-03-21
-
+### Uncategorized
 - (beta) Add internationalization support! Includes translations for 13 (!!) new languages: French, Spanish, Italian, German, Dutch, Portuguese, Japanese, Korean, Vietnamese, Mandarin, Hindi, Tagalog, and Russian! Select "Try Beta" in the menu to take them for a spin. Read more about the community effort [here](https://medium.com/gitcoin/metamask-internationalizes-via-gitcoin-bf1390c0301c)
 - No longer uses nonces specified by the dapp
 - Will now throw an error if the `to` field in txParams is not valid.
@@ -1250,7 +1268,7 @@
 - Fix bug that could prevent MetaMask from saving the latest vault.
 
 ## [4.2.0] - 2018-03-06
-
+### Uncategorized
 - Replace "Loose" wording to "Imported".
 - Replace "Unlock" wording with "Log In".
 - Add Imported Account disclaimer.
@@ -1260,17 +1278,17 @@
 - Add most of Microsoft Edge support.
 
 ## [4.1.3] - 2018-03-02
-
+### Uncategorized
 - Ensure MetaMask's inpage provider is named MetamaskInpageProvider to keep some sites from breaking.
 - Add retry transaction button back into classic ui.
 - Add network dropdown styles to support long custom RPC urls
 
 ## [4.1.2] - 2018-02-28
-
+### Uncategorized
 - Actually includes all the fixes mentioned in 4.1.1 (sorry)
 
 ## [4.1.1] - 2018-02-28
-
+### Uncategorized
 - Fix "Add Token" screen referencing missing token logo urls
 - Prevent user from switching network during signature request
 - Fix misleading language "Contract Published" -> "Contract Deployment"
@@ -1278,50 +1296,50 @@
 - Improve new-ui onboarding flow style
 
 ## [4.1.0] - 2018-02-27
-
+### Uncategorized
 - Report failed txs to Sentry with more specific message
 - Fix internal feature flags being sometimes undefined
 - Standardized license to MIT
 
 ## [4.0.0] - 2018-02-22
-
+### Uncategorized
 - Introduce new MetaMask user interface.
 
 ## [3.14.2] - 2018-02-27
-
+### Uncategorized
 - Fix bug where log subscriptions would break when switching network.
 - Fix bug where storage values were cached across blocks.
 - Add MetaMask light client [testing container](https://github.com/MetaMask/mesh-testing)
 
 ## [3.14.1] - 2018-02-01
-
+### Uncategorized
 - Further fix scrolling for Firefox.
 
 ## [3.14.0] - 2018-02-01
-
+### Uncategorized
 - Removed unneeded data from storage
 - Add a "reset account" feature to Settings
 - Add warning for importing some kinds of files.
 - Scrollable Setting view for Firefox.
 
 ## [3.13.8] - 2018-01-29
-
+### Uncategorized
 - Fix provider for Kovan network.
 - Bump limit for EventEmitter listeners before warning.
 - Display Error when empty string is entered as a token address.
 
 ## [3.13.7] - 2018-01-22
-
+### Uncategorized
 - Add ability to bypass gas estimation loading indicator.
 - Forward failed transactions to Sentry error reporting service
 - Re-add changes from 3.13.5
 
 ## [3.13.6] - 2017-01-18
-
+### Uncategorized
 - Roll back changes to 3.13.4 to fix some issues with the new Infura REST provider.
 
 ## [3.13.5] - 2018-01-16
-
+### Uncategorized
 - Estimating gas limit for simple ether sends now faster & cheaper, by avoiding VM usage on recipients with no code.
 - Add an extra px to address for Firefox clipping.
 - Fix Firefox scrollbar.
@@ -1330,7 +1348,7 @@
 - Further improve gas price estimation.
 
 ## [3.13.4] - 2018-01-09
-
+### Uncategorized
 - Remove recipient field if application initializes a tx with an empty string, or 0x, and tx data. Throw an error with the same condition, but without tx data.
 - Improve gas price suggestion to be closer to the lowest that will be accepted.
 - Throw an error if a application tries to submit a tx whose value is a decimal, and inform that it should be in wei.
@@ -1340,86 +1358,86 @@
 - Fix bug where incorrectly inputting seed phrase would prevent any future attempts from succeeding.
 
 ## [3.13.3] - 2017-12-14
-
+### Uncategorized
 - Show tokens that are held that have no balance.
 - Reduce load on Infura by using a new block polling endpoint.
 
 ## [3.13.2] - 2017-12-09
-
+### Uncategorized
 - Reduce new block polling interval to 8000 ms, to ease server load.
 
 ## [3.13.1] - 2017-12-07
-
+### Uncategorized
 - Allow Dapps to specify a transaction nonce, allowing dapps to propose resubmit and force-cancel transactions.
 
 ## [3.13.0] - 2017-12-07
-
+### Uncategorized
 - Allow resubmitting transactions that are taking long to complete.
 
 ## [3.12.1] - 2017-11-29
-
+### Uncategorized
 - Fix bug where a user could be shown two different seed phrases.
 - Detect when multiple web3 extensions are active, and provide useful error.
 - Adds notice about seed phrase backup.
 
 ## [3.12.0] - 2017-10-26
-
+### Uncategorized
 - Add support for alternative ENS TLDs (Ethereum Name Service Top-Level Domains).
 - Lower minimum gas price to 0.1 GWEI.
 - Remove web3 injection message from production (thanks to @ChainsawBaby)
 - Add additional debugging info to our state logs, specifically OS version and browser version.
 
 ## [3.11.2] - 2017-10-21
-
+### Uncategorized
 - Fix bug where reject button would sometimes not work.
 - Fixed bug where sometimes MetaMask's connection to a page would be unreliable.
 
 ## [3.11.1] - 2017-10-20
-
+### Uncategorized
 - Fix bug where log filters were not populated correctly
 - Fix bug where web3 API was sometimes injected after the page loaded.
 - Fix bug where first account was sometimes not selected correctly after creating or restoring a vault.
 - Fix bug where imported accounts could not use new eth_signTypedData method.
 
 ## [3.11.0] - 2017-10-11
-
+### Uncategorized
 - Add support for new eth_signTypedData method per EIP 712.
 - Fix bug where some transactions would be shown as pending forever, even after successfully mined.
 - Fix bug where a transaction might be shown as pending forever if another tx with the same nonce was mined.
 - Fix link to support article on token addresses.
 
 ## [3.10.9] - 2017-10-05
-
+### Uncategorized
 - Only rebrodcast transactions for a day not a days worth of blocks
 - Remove Slack link from info page, since it is a big phishing target.
 - Stop computing balance based on pending transactions, to avoid edge case where users are unable to send transactions.
 
 ## [3.10.8] - 2017-09-30
-
+### Uncategorized
 - Fixed usage of new currency fetching API.
 
 ## [3.10.7] - 2017-09-29
-
+### Uncategorized
 - Fixed bug where sometimes the current account was not correctly set and exposed to web apps.
 - Added AUD, HKD, SGD, IDR, PHP to currency conversion list
 
 ## [3.10.6] - 2017-09-27
-
+### Uncategorized
 - Fix bug where newly created accounts were not selected.
 - Fix bug where selected account was not persisted between lockings.
 
 ## [3.10.5] - 2017-09-27
-
+### Uncategorized
 - Fix block gas limit estimation.
 
 ## [3.10.4] - 2017-09-27
-
+### Uncategorized
 - Fix bug that could mis-render token balances when very small. (Not actually included in 3.9.9)
 - Fix memory leak warning.
 - Fix bug where new event filters would not include historical events.
 
 ## [3.10.3] - 2017-09-21
-
+### Uncategorized
 - Fix bug where metamask-dapp connections are lost on rpc error
 - Fix bug that would sometimes display transactions as failed that could be successfully mined.
 
@@ -1428,7 +1446,7 @@
 rollback to 3.10.0 due to bug
 
 ## [3.10.1] - 2017-09-18
-
+### Uncategorized
 - Add ability to export private keys as a file.
 - Add ability to export seed words as a file.
 - Changed state logs to a file download than a clipboard copy.
@@ -1440,7 +1458,7 @@ rollback to 3.10.0 due to bug
 - Sort currencies by currency name (thanks to strelok1: https://github.com/strelok1).
 
 ## [3.10.0] - 2017-09-11
-
+### Uncategorized
 - Readded loose keyring label back into the account list.
 - Remove cryptonator from chrome permissions.
 - Add info on token contract addresses.
@@ -1448,11 +1466,11 @@ rollback to 3.10.0 due to bug
 - Added button to reject all transactions (thanks to davidp94! https://github.com/davidp94)
 
 ## [3.9.13] - 2017-09-08
-
+### Uncategorized
 - Changed the way we initialize the inpage provider to fix a bug affecting some developers.
 
 ## [3.9.12] - 2017-09-06
-
+### Uncategorized
 - Fix bug that prevented Web3 1.0 compatibility
 - Make eth_sign deprecation warning less noisy
 - Add useful link to eth_sign deprecation warning.
@@ -1464,59 +1482,59 @@ rollback to 3.10.0 due to bug
 - Make web3 deprecation notice more useful by linking to a descriptive article.
 
 ## [3.9.11] - 2017-08-24
-
+### Uncategorized
 - Fix nonce calculation bug that would sometimes generate very wrong nonces.
 - Give up resubmitting a transaction after 3500 blocks.
 
 ## [3.9.10] - 2017-08-23
-
+### Uncategorized
 - Improve nonce calculation, to prevent bug where people are unable to send transactions reliably.
 - Remove link to eth-tx-viz from identicons in tx history.
 
 ## [3.9.9] - 2017-08-18
-
+### Uncategorized
 - Fix bug where some transaction submission errors would show an empty screen.
 - Fix bug that could mis-render token balances when very small.
 - Fix formatting of eth_sign "Sign Message" view.
 - Add deprecation warning to eth_sign "Sign Message" view.
 
 ## [3.9.8] - 2017-08-16
-
+### Uncategorized
 - Reenable token list.
 - Remove default tokens.
 
 ## [3.9.7] - 2017-08-15
-
+### Uncategorized
 - hotfix - disable token list
 - Added a deprecation warning for web3 https://github.com/ethereum/mist/releases/tag/v0.9.0
 
 ## [3.9.6] - 2017-08-10
-
+### Uncategorized
 - Replace account screen with an account drop-down menu.
 - Replace account buttons with a new account-specific drop-down menu.
 
 ## [3.9.5] - 2017-08-04
-
+### Uncategorized
 - Improved phishing detection configuration update rate
 
 ## [3.9.4] - 2017-08-04
-
+### Uncategorized
 - Fixed bug that prevented transactions from being rejected.
 
 ## [3.9.3] - 2017-08-03
-
+### Uncategorized
 - Add support for EGO ujo token
 - Continuously update blacklist for known phishing sites in background.
 - Automatically detect suspicious URLs too similar to common phishing targets, and blacklist them.
 
 ## [3.9.2] - 2017-07-26
-
+### Uncategorized
 - Fix bugs that could sometimes result in failed transactions after switching networks.
 - Include stack traces in txMeta's to better understand the life cycle of transactions
 - Enhance blacklister functionality to include levenshtein logic. (credit to @sogoiii and @409H for their help!)
 
 ## [3.9.1] - 2017-07-19
-
+### Uncategorized
 - No longer automatically request 1 ropsten ether for the first account in a new vault.
 - Now redirects from known malicious sites faster.
 - Added a link to our new support page to the help screen.
@@ -1525,37 +1543,37 @@ rollback to 3.10.0 due to bug
 - Lowered minimum gas price to 1 Gwei.
 
 ## [3.9.0] - 2017-07-12
-
+### Uncategorized
 - Now detects and blocks known phishing sites.
 
 ## [3.8.6] - 2017-07-11
-
+### Uncategorized
 - Make transaction resubmission more resilient.
 - No longer validate nonce client-side in retry loop.
 - Fix bug where insufficient balance error was sometimes shown on successful transactions.
 
 ## [3.8.5] - 2017-07-08
-
+### Uncategorized
 - Fix transaction resubmit logic to fail slightly less eagerly.
 
 ## [3.8.4] - 2017-07-07
-
+### Uncategorized
 - Improve transaction resubmit logic to fail more eagerly when a user would expect it to.
 
 ## [3.8.3] - 2017-07-06
-
+### Uncategorized
 - Re-enable default token list.
 - Add origin header to dapp-bound requests to allow providers to throttle sites.
 - Fix bug that could sometimes resubmit a transaction that had been stalled due to low balance after balance was restored.
 
 ## [3.8.2] - 2017-07-03
-
+### Uncategorized
 - No longer show network loading indication on config screen, to allow selecting custom RPCs.
 - Visually indicate that network spinner is a menu.
 - Indicate what network is being searched for when disconnected.
 
 ## [3.8.1] - 2017-06-30
-
+### Uncategorized
 - Temporarily disabled loading popular tokens by default to improve performance.
 - Remove SEND token button until a better token sending form can be built, due to some precision issues.
 - Fix precision bug in token balances.
@@ -1563,7 +1581,7 @@ rollback to 3.10.0 due to bug
 - Transpile some newer JavaScript, restores compatibility with some older browsers.
 
 ## [3.8.0] - 2017-06-28
-
+### Uncategorized
 - No longer stop rebroadcasting transactions
 - Add list of popular tokens held to the account detail view.
 - Add ability to add Tokens to token list.
@@ -1578,7 +1596,7 @@ rollback to 3.10.0 due to bug
 - Add button for copying state logs to clipboard.
 
 ## [3.7.8] - 2017-06-12
-
+### Uncategorized
 - Add an `ethereum:` prefix to the QR code address
 - The default network on installation is now MainNet
 - Fix currency API URL from cryptonator.
@@ -1586,30 +1604,30 @@ rollback to 3.10.0 due to bug
 - Fix ENS resolver symbol UI.
 
 ## [3.7.7] - 2017-06-08
-
+### Uncategorized
 - Fix bug where metamask would show old data after computer being asleep or disconnected from the internet.
 
 ## [3.7.6] - 2017-06-05
-
+### Uncategorized
 - Fix bug that prevented publishing contracts.
 
 ## [3.7.5] - 2017-06-05
-
+### Uncategorized
 - Prevent users from sending to the `0x0` address.
 - Provide useful errors when entering bad characters in ENS name.
 - Add ability to copy addresses from transaction confirmation view.
 
 ## [3.7.4] - 2017-06-02
-
+### Uncategorized
 - Fix bug with inflight cache that caused some block lookups to return bad values (affected OasisDex).
 - Fixed bug with gas limit calculation that would sometimes create unsubmittable gas limits.
 
 ## [3.7.3] - 2017-06-01
-
+### Uncategorized
 - Rebuilt to fix cache clearing bug.
 
 ## [3.7.2] - 2017-05-31
-
+### Uncategorized
 - Now when switching networks sites that use web3 will reload
 - Now when switching networks the extension does not restart
 - Cleanup decimal bugs in our gas inputs.
@@ -1622,7 +1640,7 @@ rollback to 3.10.0 due to bug
 - Some contracts will now have names displayed in the confirmation view.
 
 ## [3.7.0] - 2017-05-23
-
+### Uncategorized
 - Add Transaction Number (nonce) to transaction list.
 - Label the pending tx icon with a tooltip.
 - Fix bug where website filters would pile up and not deallocate when leaving a site.
@@ -1630,7 +1648,7 @@ rollback to 3.10.0 due to bug
 - ENS names will no longer resolve to their owner if no resolver is set. Resolvers must be explicitly set and configured.
 
 ## [3.6.5] - 2017-05-17
-
+### Uncategorized
 - Fix bug where edited gas parameters would not take effect.
 - Trim currency list.
 - Enable decimals in our gas prices.
@@ -1639,15 +1657,15 @@ rollback to 3.10.0 due to bug
 - Fix bug where decimals in gas inputs could result in strange values.
 
 ## [3.6.4] - 2017-05-09
-
+### Uncategorized
 - Fix main-net ENS resolution.
 
 ## [3.6.3] - 2017-05-09
-
+### Uncategorized
 - Fix bug that could stop newer versions of Geth from working with MetaMask.
 
 ## [3.6.2] - 2017-05-08
-
+### Uncategorized
 - Input gas price in Gwei.
 - Enforce Safe Gas Minimum recommended by EthGasStation.
 - Fix bug where block-tracker could stop polling for new blocks.
@@ -1655,39 +1673,39 @@ rollback to 3.10.0 due to bug
 - Fix bug where gas parameters would not properly update on adjustment.
 
 ## [3.6.1] - 2017-05-07
-
+### Uncategorized
 - Made fox less nosy.
 - Fix bug where error was reported in debugger console when Chrome opened a new window.
 
 ## [3.6.0] - 2017-04-27
-
+### Uncategorized
 - Add Rinkeby Test Network to our network list.
 
 ## [3.5.4] - 2017-04-25
-
+### Uncategorized
 - Fix occasional nonce tracking issue.
 - Fix bug where some events would not be emitted by web3.
 - Fix bug where an error would be thrown when composing signatures for networks with large ID values.
 
 ## [3.5.3] - 2017-04-24
-
+### Uncategorized
 - Popup new transactions in Firefox.
 - Fix transition issue from account detail screen.
 - Revise buy screen for more modularity.
 - Fixed some other small bugs.
 
 ## [3.5.2] - 2017-03-28
-
+### Uncategorized
 - Fix bug where gas estimate totals were sometimes wrong.
 - Add link to Kovan Test Faucet instructions on buy view.
 - Inject web3 into loaded iFrames.
 
 ## [3.5.1] - 2017-03-27
-
+### Uncategorized
 - Fix edge case where users were unable to enable the notice button if notices were short enough to not require a scrollbar.
 
 ## [3.5.0] - 2017-03-27
-
+### Uncategorized
 - Add better error messages for when a transaction fails on approval
 - Allow sending to ENS names in send form on Ropsten.
 - Added an address book functionality that remembers the last 15 unique addresses sent to.
@@ -1702,7 +1720,7 @@ rollback to 3.10.0 due to bug
 - Fixed bug where transactions on other networks would disappear when submitting a transaction on another network.
 
 ## [3.4.0] - 2017-03-08
-
+### Uncategorized
 - Add two most recently used custom RPCs to network dropdown menu.
 - Add personal_sign method support.
 - Add personal_ecRecover method support.
@@ -1710,49 +1728,49 @@ rollback to 3.10.0 due to bug
 - Increase default gas buffer to 1.5x estimated gas value.
 
 ## [3.3.0] - 2017-02-20
-
+### Uncategorized
 - net_version has been made synchronous.
 - Test suite for migrations expanded.
 - Network now changeable from lock screen.
 - Improve test coverage of eth.sign behavior, including a code example of verifying a signature.
 
 ## [3.2.2] - 2017-02-09
-
+### Uncategorized
 - Revert eth.sign behavior to the previous one with a big warning. We will be gradually implementing the new behavior over the coming time. https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign
 
 - Improve test coverage of eth.sign behavior, including a code example of verifying a signature.
 
 ## [3.2.1] - 2017-02-09
-
+### Uncategorized
 - Revert back to old style message signing.
 - Fixed some build errors that were causing a variety of bugs.
 
 ## [3.2.0] - 2017-02-08
-
+### Uncategorized
 - Add ability to import accounts in JSON file format (used by Mist, Geth, MyEtherWallet, and more!)
 - Fix unapproved messages not being included in extension badge.
 - Fix rendering bug where the Confirm transaction view would let you approve transactions when the account has insufficient balance.
 
 ## [3.1.2] - 2017-01-24
-
+### Uncategorized
 - Fix "New Account" default keychain
 
 ## [3.1.1] - 2017-01-20
-
+### Uncategorized
 - Fix HD wallet seed export
 
 ## [3.1.0] - 2017-01-18
-
+### Uncategorized
 - Add ability to import accounts by private key.
 - Fixed bug that returned the wrong transaction hashes on private networks that had not implemented EIP 155 replay protection (like TestRPC).
 
 ## [3.0.1] - 2017-01-17
-
+### Uncategorized
 - Fixed bug that prevented eth.sign from working.
 - Fix the displaying of transactions that have been submitted to the network in Transaction History
 
 ## [3.0.0] - 2017-01-16
-
+### Uncategorized
 - Fix seed word account generation (https://medium.com/metamask/metamask-3-migration-guide-914b79533cdd#.t4i1qmmsz).
 - Fix Bug where you see an empty transaction flash by on the confirm transaction view.
 - Create visible difference in transaction history between an approved but not yet included in a block transaction and a transaction who has been confirmed.
@@ -1767,33 +1785,33 @@ rollback to 3.10.0 due to bug
 - Fix bug where sometimes loading account data would fail by querying a future block.
 
 ## [2.14.1] - 2016-12-20
-
+### Uncategorized
 - Update Coinbase info. and increase the buy amount to $15
 - Fixed ropsten transaction links
 - Temporarily disable extension reload detection causing infinite reload bug.
 - Implemented basic checking for valid RPC URIs.
 
 ## [2.14.0] - 2016-12-16
-
+### Uncategorized
 - Removed Morden testnet provider from provider menu.
 - Add support for notices.
 - Fix broken reload detection.
 - Fix transaction forever cached-as-pending bug.
 
 ## [2.13.11] - 2016-11-23
-
+### Uncategorized
 - Add support for synchronous RPC method "eth_uninstallFilter".
 - Forgotten password prompts now send users directly to seed word restoration.
 
 ## [2.13.10] - 2016-11-22
-
+### Uncategorized
 - Improve gas calculation logic.
 - Default to Dapp-specified gas limits for transactions.
 - Ropsten networks now properly point to the faucet when attempting to buy ether.
 - Ropsten transactions now link to etherscan correctly.
 
 ## [2.13.9] - 2016-11-21
-
+### Uncategorized
 - Add support for the new, default Ropsten Test Network.
 - Fix bug that would cause MetaMask to occasionally lose its StreamProvider connection and drop requests.
 - Fix bug that would cause the Custom RPC menu item to not appear when Localhost 8545 was selected.
@@ -1801,19 +1819,19 @@ rollback to 3.10.0 due to bug
 - Phase out ethereumjs-util from our encryptor module.
 
 ## [2.13.8] - 2016-11-16
-
+### Uncategorized
 - Show a warning when a transaction fails during simulation.
 - Fix bug where 20% of gas estimate was not being added properly.
 - Render error messages in confirmation screen more gracefully.
 
 ## [2.13.7] - 2016-11-08
-
+### Uncategorized
 - Fix bug where gas estimate would sometimes be very high.
 - Increased our gas estimate from 100k gas to 20% of estimate.
 - Fix GitHub link on info page to point at current repository.
 
 ## [2.13.6] - 2016-10-26
-
+### Uncategorized
 - Add a check for improper Transaction data.
 - Inject up to date version of web3.js
 - Now nicknaming new accounts "Account #" instead of "Wallet #" for clarity.
@@ -1822,18 +1840,18 @@ rollback to 3.10.0 due to bug
 - Fix bug that was sometimes preventing transactions from being sent.
 
 ## [2.13.5] - 2016-10-18
-
+### Uncategorized
 - Increase default max gas to `100000` over the RPC's `estimateGas` response.
 - Fix bug where slow-loading dapps would sometimes trigger infinite reload loops.
 
 ## [2.13.4] - 2016-10-17
-
+### Uncategorized
 - Add custom transaction fee field to send form.
 - Fix bug where web3 was being injected into XML files.
 - Fix bug where changing network would not reload current Dapps.
 
 ## [2.13.3] - 2016-10-05
-
+### Uncategorized
 - Fix bug where log queries were filtered out.
 - Decreased vault confirmation button font size to help some Linux users who could not see it.
 - Made popup a little taller because it would sometimes cut off buttons.
@@ -1844,42 +1862,42 @@ rollback to 3.10.0 due to bug
 - Prompt users to re-agree to the Terms of Service when they are updated.
 
 ## [2.13.2] - 2016-10-04
-
+### Uncategorized
 - Fix bug where chosen FIAT exchange rate does no persist when switching networks
 - Fix additional parameters that made MetaMask sometimes receive errors from Parity.
 - Fix bug where invalid transactions would still open the MetaMask popup.
 - Removed hex prefix from private key export, to increase compatibility with Geth, MyEtherWallet, and Jaxx.
 
 ## [2.13.1] - 2016-09-23
-
+### Uncategorized
 - Fix a bug with estimating gas on Parity
 - Show loading indication when selecting ShapeShift as purchasing method.
 
 ## [2.13.0] - 2016-09-18
-
+### Uncategorized
 - Add Parity compatibility, fixing Geth dependency issues.
 - Add a link to the transaction in history that goes to https://metamask.github.io/eth-tx-viz
   too help visualize transactions and to where they are going.
 - Show "Buy Ether" button and warning on tx confirmation when sender balance is insufficient
 
 ## [2.12.1] - 2016-09-14
-
+### Uncategorized
 - Fixed bug where if you send a transaction from within MetaMask extension the
   popup notification opens up.
 - Fixed bug where some tx errors would block subsequent txs until the plugin was refreshed.
 
 ## [2.12.0] - 2016-09-14
-
+### Uncategorized
 - Add a QR button to the Account detail screen
 - Fixed bug where opening MetaMask could close a non-metamask popup.
 - Fixed memory leak that caused occasional crashes.
 
 ## [2.11.1] - 2016-09-13
-
+### Uncategorized
 - Fix bug that prevented caches from being cleared in Opera.
 
 ## [2.11.0] - 2016-09-12
-
+### Uncategorized
 - Fix bug where pending transactions from Test net (or other networks) show up In Main net.
 - Add fiat conversion values to more views.
 - On fresh install, open a new tab with the MetaMask Introduction video. Does not open on update.
@@ -1890,29 +1908,29 @@ rollback to 3.10.0 due to bug
 - Now only initially creates one wallet when restoring a vault, to reduce some users' confusion.
 
 ## [2.10.2] - 2016-09-02
-
+### Uncategorized
 - Fix bug where notification popup would not display.
 
 ## [2.10.1] - 2016-09-02
-
+### Uncategorized
 - Fix bug where provider menu did not allow switching to custom network from a custom network.
 - Sending a transaction from within MetaMask no longer triggers a popup.
 - The ability to build without livereload features (such as for production) can be enabled with the gulp --disableLiveReload flag.
 - Fix Ethereum JSON RPC Filters bug.
 
 ## [2.10.0] - 2016-08-29
-
+### Uncategorized
 - Changed transaction approval from notifications system to popup system.
 - Add a back button to locked screen to allow restoring vault from seed words when password is forgotten.
 - Forms now retain their values even when closing the popup and reopening it.
 - Fixed a spelling error in provider menu.
 
 ## [2.9.2] - 2016-08-24
-
+### Uncategorized
 - Fixed shortcut bug from preventing installation.
 
 ## [2.9.1] - 2016-08-24
-
+### Uncategorized
 - Added static image as fallback for when WebGL isn't supported.
 - Transaction history now has a hard limit.
 - Added info link on account screen that visits Etherscan.
@@ -1922,14 +1940,14 @@ rollback to 3.10.0 due to bug
 - Fixed bug where sign message confirmation would sometimes render blank.
 
 ## [2.9.0] - 2016-08-22
-
+### Uncategorized
 - Added ShapeShift to the transaction history
 - Added affiliate key to Shapeshift requests
 - Added feature to reflect current conversion rates of current vault balance.
 - Modify balance display logic.
 
 ## [2.8.0] - 2016-08-15
-
+### Uncategorized
 - Integrate ShapeShift
 - Add a form for Coinbase to specify amount to buy
 - Fix various typos.
@@ -1937,35 +1955,35 @@ rollback to 3.10.0 due to bug
 - Remove Ethereum Classic from provider menu.
 
 ## [2.7.3] - 2016-07-29
-
+### Uncategorized
 - Fix bug where changing an account would not update in a live Dapp.
 
 ## [2.7.2] - 2016-07-29
-
+### Uncategorized
 - Add Ethereum Classic to provider menu
 - Fix bug where host store would fail to receive updates.
 
 ## [2.7.1] - 2016-07-27
-
+### Uncategorized
 - Fix bug where web3 would sometimes not be injected in time for the application.
 - Fixed bug where sometimes when opening the plugin, it would not fully open until closing and re-opening.
 - Got most functionality working within Firefox (still working on review process before it can be available).
 - Fixed menu dropdown bug introduced in Chrome 52.
 
 ## [2.7.0] - 2016-07-21
-
+### Uncategorized
 - Added a Warning screen about storing ETH
 - Add buy Button!
 - MetaMask now throws descriptive errors when apps try to use synchronous web3 methods.
 - Removed firefox-specific line in manifest.
 
 ## [2.6.2] - 2016-07-20
-
+### Uncategorized
 - Fixed bug that would prevent the plugin from reopening on the first try after receiving a new transaction while locked.
 - Fixed bug that would render 0 ETH as a non-exact amount.
 
 ## [2.6.1] - 2016-07-13
-
+### Uncategorized
 - Fix tool tips on Eth balance to show the 6 decimals
 - Fix rendering of recipient SVG in tx approval notification.
 - New vaults now generate only one wallet instead of three.
@@ -1974,7 +1992,7 @@ rollback to 3.10.0 due to bug
 - Fixed bug where gas cost was misestimated on the tx confirmation view.
 
 ## [2.6.0] - 2016-07-11
-
+### Uncategorized
 - Fix formatting of ETH balance
 - Fix formatting of account details.
 - Use web3 minified dist for faster inject times
@@ -1986,7 +2004,7 @@ rollback to 3.10.0 due to bug
 - General code cleanup.
 
 ## [2.5.0] - 2016-06-29
-
+### Uncategorized
 - Implement new account design.
 - Added a network indicator mark in dropdown menu
 - Added network name next to network indicator
@@ -1995,7 +2013,7 @@ rollback to 3.10.0 due to bug
 - Fix bug where confirmation view would be shown twice.
 
 ## [2.4.5] - 2016-06-29
-
+### Uncategorized
 - Fixed bug where MetaMask interfered with PDF loading.
 - Moved switch account icon into menu bar.
 - Changed status shapes to be a yellow warning sign for failure and ellipsis for pending transactions.
@@ -2007,23 +2025,23 @@ rollback to 3.10.0 due to bug
 - Change network status icons to reflect current design.
 
 ## [2.4.4] - 2016-06-23
-
+### Uncategorized
 - Update web3-stream-provider for batch payload bug fix
 
 ## [2.4.3] - 2016-06-23
-
+### Uncategorized
 - Remove redundant network option buttons from settings page
 - Switch out font family Transat for Montserrat
 
 ## [2.4.2] - 2016-06-22
-
+### Uncategorized
 - Change out export icon for key.
 - Unify copy to clipboard icon
 - Fixed eth.sign behavior.
 - Fix behavior of batched outbound transactions.
 
 ## [2.4.0] - 2016-06-20
-
+### Uncategorized
 - Clean up UI.
 - Remove nonfunctional QR code button.
 - Make network loading indicator clickable to select accessible network.
@@ -2032,26 +2050,26 @@ rollback to 3.10.0 due to bug
 - Add disclaimer view with placeholder text for first time users.
 
 ## [2.3.1] - 2016-06-09
-
+### Uncategorized
 - Style up the info page
 - Cache identicon images to optimize for long lists of transactions.
 - Fix out of gas errors
 
 ## [2.3.0] - 2016-06-06
-
+### Uncategorized
 - Show network status in title bar
 - Added seed word recovery to config screen.
 - Clicking network status indicator now reveals a provider menu.
 
 ## [2.2.0] - 2016-06-02
-
+### Uncategorized
 - Redesigned init, vault create, vault restore and seed confirmation screens.
 - Added pending transactions to transaction list on account screen.
 - Clicking a pending transaction takes you back to the transaction approval screen.
 - Update provider-engine to fix intermittent out of gas errors.
 
 ## [2.1.0] - 2016-05-26
-
+### Uncategorized
 - Added copy address button to account list.
 - Fixed back button on confirm transaction screen.
 - Add indication of pending transactions to account list screen.
@@ -2059,7 +2077,7 @@ rollback to 3.10.0 due to bug
 - Updated eth-lightwallet to fix a critical security issue.
 
 ## [2.0.0] - 2016-05-23
-
+### Uncategorized
 - UI Overhaul per Vlad Todirut's designs.
 - Replaced identicons with jazzicons.
 - Fixed glitchy transitions.
@@ -2069,27 +2087,27 @@ rollback to 3.10.0 due to bug
 - Added ability to locally nickname accounts.
 
 ## [1.8.4] - 2016-05-13
-
+### Uncategorized
 - Point rpc servers to https endpoints.
 
 ## [1.8.3] - 2016-05-12
-
+### Uncategorized
 - Bumped web3 to 0.6.0
 - Really fixed `eth_syncing` method response.
 
 ## [1.8.2] - 2016-05-11
-
+### Uncategorized
 - Fixed bug where send view would not load correctly the first time it was visited per account.
 - Migrated all users to new scalable backend.
 - Fixed `eth_syncing` method response.
 
 ## [1.8.1] - 2016-05-10
-
+### Uncategorized
 - Initial usage of scalable blockchain backend.
 - Made official providers more easily configurable for us internally.
 
 ## [1.8.0] - 2016-05-10
-
+### Uncategorized
 - Add support for calls to `eth.sign`.
 - Moved account exporting within subview of the account detail view.
 - Added buttons to the account export process.
@@ -2100,7 +2118,7 @@ rollback to 3.10.0 due to bug
 - Improved appearance of transaction list in account detail view.
 
 ## [1.7.0] - 2016-04-29
-
+### Uncategorized
 - Account detail view is now the primary view.
 - The account detail view now has a "Change acct" button which shows the account list.
 - Clicking accounts in the account list now both selects that account and displays that account's detail view.
@@ -2114,7 +2132,7 @@ rollback to 3.10.0 due to bug
 - Fixed some UI transitions that had weird behavior.
 
 ## [1.6.0] - 2016-04-22
-
+### Uncategorized
 - Pending transactions are now persisted to localStorage and resume even after browser is closed.
 - Completed transactions are now persisted and can be displayed via UI.
 - Added transaction list to account detail view.
@@ -2126,7 +2144,7 @@ rollback to 3.10.0 due to bug
 - Users have been migrated from old test-net RPC to a newer test-net RPC.
 
 ## [1.5.1] - 2016-04-15
-
+### Uncategorized
 - Corrected text above account list. Selected account is visible to all sites, not just the current domain.
 - Merged the UI codebase into the main plugin codebase for simpler maintenance.
 - Fix Ether display rounding error. Now rendering to four decimal points.
@@ -2134,13 +2152,13 @@ rollback to 3.10.0 due to bug
 - Change account rendering to show four decimals and a leading zero.
 
 ## [1.5.0] - 2016-04-13
-
+### Uncategorized
 - Added ability to send ether.
 - Fixed bugs related to using Javascript numbers, which lacked appropriate precision.
 - Replaced Etherscan main-net provider with our own production RPC.
 
 ## [1.4.0] - 2016-04-08
-
+### Uncategorized
 - Removed extra entropy text field for simplified vault creation.
 - Now supports exporting an account's private key.
 - Unified button and input styles across the app.
@@ -2149,7 +2167,7 @@ rollback to 3.10.0 due to bug
 - Temporarily deactivated fauceting indication because it would activate when restoring an empty account.
 
 ## [1.3.2] - 2016-04-04
-
+### Uncategorized
 - When unlocking, first account is auto-selected.
 - When creating a first vault on the test-net, the first account is auto-funded.
 - Fixed some styling issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#10692](https://github.com/MetaMask/metamask-extension/pull/10692): Prevent UI crash when a 'wallet_requestPermissions" confirmation is queued behind a "wallet_addEthereumChain" confirmation
 - [#10712](https://github.com/MetaMask/metamask-extension/pull/10712): Fix infinite spinner when request for token symbol fails while attempting an approve transaction
-- [#10486](https://github.com/MetaMask/metamask-extension/pull/10486): Add setting to hide zero balance tokens
 
 ## [9.2.0] - 2021-03-15
 ### Added
 - [#10546](https://github.com/MetaMask/metamask-extension/pull/10546): Add a warning when sending a token to its own contract address
 - [#10582](https://github.com/MetaMask/metamask-extension/pull/10582): Adding warnings for excessive custom gas input
 - [#10505](https://github.com/MetaMask/metamask-extension/pull/10505): Add support for multiple Ledger & Trezor hardware accounts
+- [#10486](https://github.com/MetaMask/metamask-extension/pull/10486): Add setting to hide zero balance tokens
 
 ### Changed
 - [#10563](https://github.com/MetaMask/metamask-extension/pull/10563): Update references to MetaMask support


### PR DESCRIPTION
Each changelog release now has category headers. The standard ["keep a changelog"](https://keepachangelog.com/en/1.0.0/) categories are used, along with the addition of "Uncategorized" for any changes that have not yet been categorized.

The changelog script has been updated to add this "Uncategorized" header if it isn't already present, and to place any new commits under this header.

The changelog has been updated to property categorize each change in recent releases, and to place changes in older releases under the header "Uncategorized".

Relates to #10752

Manual testing steps:  

For development changelog updates:
- Run `yarn update-changelog`
- See that it places changelog entries under 'Unreleased`, under the "Uncategorized" header

For RC changelog updates with existing release header:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Add a new release header to the changelog for the new version
- Run `yarn update-changelog`
- See that it places changelog entries under the new release header under the "Uncategorized" category
 
For updates without a release header:
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Run `yarn update-changelog`
- See that it places changelog entries under the newly added release header under the "Uncategorized" category