### PR TITLE
Add `--rc` flag to changelog script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           command: .circleci/scripts/release-bump-manifest-version.sh
       - run:
           name: Update changelog
-          command: yarn update-changelog
+          command: yarn update-changelog --rc
       - run:
           name: Commit changes
           command: .circleci/scripts/release-commit-version-bump.sh

--- a/development/auto-changelog.js
+++ b/development/auto-changelog.js
@@ -9,6 +9,17 @@ const runCommand = require('./lib/runCommand');
 const URL = 'https://github.com/MetaMask/metamask-extension';
 
 async function main() {
+  const args = process.argv.slice(2);
+  let isReleaseCandidate = false;
+
+  for (const arg of args) {
+    if (arg === '---rc') {
+      isReleaseCandidate = true;
+    } else {
+      throw new Error(`Unrecognized argument: ${arg}`);
+    }
+  }
+
   await runCommand('git', ['fetch', '--tags']);
 
   const [mostRecentTagCommitHash] = await runCommand('git', [
@@ -100,10 +111,6 @@ async function main() {
     return;
   }
 
-  // remove the "v" prefix
-  const mostRecentVersion = mostRecentTag.slice(1);
-
-  const isReleaseCandidate = mostRecentVersion !== version;
   const versionHeader = `## [${version}]`;
   const escapedVersionHeader = escapeRegExp(versionHeader);
   const currentDevelopBranchHeader = '## [Unreleased]';

--- a/development/auto-changelog.js
+++ b/development/auto-changelog.js
@@ -13,7 +13,7 @@ async function main() {
   let isReleaseCandidate = false;
 
   for (const arg of args) {
-    if (arg === '---rc') {
+    if (arg === '--rc') {
       isReleaseCandidate = true;
     } else {
       throw new Error(`Unrecognized argument: ${arg}`);


### PR DESCRIPTION
The changelog script now accepts an `--rc` flag to tell it whether to add new changes to `Unreleased` or to the header for the current version.

Previously this was inferred from whether the current version matched the most recent tag. However this method only works for the first update. Using a flag simplifies this logic, and makes it possible to manually re-run this for further updates to a release candidate.

Relates to #10752

Manual testing steps: 

To update the changelog with unreleased changes: 
  - Run `yarn update-changelog`
  - See that it puts changes under the "Unreleased" header
 
To update the changelog for a release candidate:
- Run `yarn update-changelog --rc`
- See that it puts changes under the header for the current release candidate