### PR TITLE
Increase default slippage from 2% to 3%, show Advanced Options by default

### DIFF
--- a/ui/app/pages/swaps/build-quote/build-quote.js
+++ b/ui/app/pages/swaps/build-quote/build-quote.js
@@ -512,6 +512,7 @@ export default function BuildQuote({
               setMaxSlippage(newSlippage);
             }}
             maxAllowedSlippage={MAX_ALLOWED_SLIPPAGE}
+            currentSlippage={maxSlippage}
           />
         </div>
       </div>

--- a/ui/app/pages/swaps/index.js
+++ b/ui/app/pages/swaps/index.js
@@ -84,7 +84,7 @@ export default function Swap() {
   const { destinationTokenInfo = {} } = fetchParams?.metaData || {};
 
   const [inputValue, setInputValue] = useState(fetchParams?.value || '');
-  const [maxSlippage, setMaxSlippage] = useState(fetchParams?.slippage || 2);
+  const [maxSlippage, setMaxSlippage] = useState(fetchParams?.slippage || 3);
 
   const routeState = useSelector(getBackgroundSwapRouteState);
   const selectedAccount = useSelector(getSelectedAccount);

--- a/ui/app/pages/swaps/slippage-buttons/index.scss
+++ b/ui/app/pages/swaps/slippage-buttons/index.scss
@@ -7,23 +7,18 @@
   &__header {
     display: flex;
     align-items: center;
-    color: $Blue-500;
     margin-bottom: 0;
     margin-left: auto;
     margin-right: auto;
     cursor: pointer;
     background: unset;
-
-    &--open {
-      margin-bottom: 8px;
-    }
+    margin-bottom: 8px;
   }
 
   &__header-text {
     @include H6;
 
     margin-right: 6px;
-    color: $Blue-500;
     font-weight: 900;
   }
 

--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -12,7 +12,12 @@ export default function SlippageButtons({
   currentSlippage,
 }) {
   const t = useContext(I18nContext);
-  const [customValue, setCustomValue] = useState('');
+  const [customValue, setCustomValue] = useState(() => {
+    if (currentSlippage && currentSlippage !== 2 && currentSlippage !== 3) {
+      return currentSlippage;
+    }
+    return '';
+  });
   const [enteringCustomValue, setEnteringCustomValue] = useState(false);
   const [activeButtonIndex, setActiveButtonIndex] = useState(() => {
     if (currentSlippage === 3) {
@@ -20,7 +25,6 @@ export default function SlippageButtons({
     } else if (currentSlippage === 2) {
       return 0;
     } else if (currentSlippage) {
-      setCustomValue(currentSlippage);
       return 2;
     }
     return 1; // Choose activeButtonIndex = 1 for 3% slippage by default.

--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -6,7 +6,11 @@ import ButtonGroup from '../../../components/ui/button-group';
 import Button from '../../../components/ui/button';
 import InfoTooltip from '../../../components/ui/info-tooltip';
 
-export default function SlippageButtons({ onSelect, maxAllowedSlippage, currentSlippage }) {
+export default function SlippageButtons({
+  onSelect,
+  maxAllowedSlippage,
+  currentSlippage,
+}) {
   const t = useContext(I18nContext);
   const [customValue, setCustomValue] = useState('');
   const [enteringCustomValue, setEnteringCustomValue] = useState(false);
@@ -18,9 +22,8 @@ export default function SlippageButtons({ onSelect, maxAllowedSlippage, currentS
     } else if (currentSlippage) {
       setCustomValue(currentSlippage);
       return 2;
-    } else {
-      return 1;
     }
+    return 1; // Choose activeButtonIndex = 1 for 3% slippage by default.
   });
   const [inputRef, setInputRef] = useState(null);
 
@@ -157,4 +160,5 @@ export default function SlippageButtons({ onSelect, maxAllowedSlippage, currentS
 SlippageButtons.propTypes = {
   onSelect: PropTypes.func.isRequired,
   maxAllowedSlippage: PropTypes.number.isRequired,
+  currentSlippage: PropTypes.number,
 };

--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -8,7 +8,7 @@ import InfoTooltip from '../../../components/ui/info-tooltip';
 
 export default function SlippageButtons({ onSelect, maxAllowedSlippage }) {
   const t = useContext(I18nContext);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const [customValue, setCustomValue] = useState('');
   const [enteringCustomValue, setEnteringCustomValue] = useState(false);
   const [activeButtonIndex, setActiveButtonIndex] = useState(1);
@@ -87,20 +87,20 @@ export default function SlippageButtons({ onSelect, maxAllowedSlippage }) {
                   setCustomValue('');
                   setEnteringCustomValue(false);
                   setActiveButtonIndex(0);
-                  onSelect(1);
+                  onSelect(2);
                 }}
               >
-                1%
+                2%
               </Button>
               <Button
                 onClick={() => {
                   setCustomValue('');
                   setEnteringCustomValue(false);
                   setActiveButtonIndex(1);
-                  onSelect(2);
+                  onSelect(3);
                 }}
               >
-                2%
+                3%
               </Button>
               <Button
                 className={classnames(

--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -8,7 +8,6 @@ import InfoTooltip from '../../../components/ui/info-tooltip';
 
 export default function SlippageButtons({ onSelect, maxAllowedSlippage }) {
   const t = useContext(I18nContext);
-  const [open, setOpen] = useState(true);
   const [customValue, setCustomValue] = useState('');
   const [enteringCustomValue, setEnteringCustomValue] = useState(false);
   const [activeButtonIndex, setActiveButtonIndex] = useState(1);
@@ -44,110 +43,98 @@ export default function SlippageButtons({ onSelect, maxAllowedSlippage }) {
 
   return (
     <div className="slippage-buttons">
-      <button
-        onClick={() => setOpen(!open)}
-        className={classnames('slippage-buttons__header', {
-          'slippage-buttons__header--open': open,
-        })}
-      >
+      <div className="slippage-buttons__header">
         <div className="slippage-buttons__header-text">
           {t('swapsAdvancedOptions')}
         </div>
-        {open ? (
-          <i className="fa fa-angle-up" />
-        ) : (
-          <i className="fa fa-angle-down" />
-        )}
-      </button>
+      </div>
       <div className="slippage-buttons__content">
-        {open && (
-          <div className="slippage-buttons__dropdown-content">
-            <div className="slippage-buttons__buttons-prefix">
-              <div className="slippage-buttons__prefix-text">
-                {t('swapsMaxSlippage')}
-              </div>
-              <InfoTooltip
-                position="top"
-                contentText={t('swapAdvancedSlippageInfo')}
-              />
+        <div className="slippage-buttons__dropdown-content">
+          <div className="slippage-buttons__buttons-prefix">
+            <div className="slippage-buttons__prefix-text">
+              {t('swapsMaxSlippage')}
             </div>
-            <ButtonGroup
-              defaultActiveButtonIndex={
-                activeButtonIndex === 2 && !customValue ? 1 : activeButtonIndex
-              }
-              variant="radiogroup"
-              newActiveButtonIndex={activeButtonIndex}
-              className={classnames(
-                'button-group',
-                'slippage-buttons__button-group',
-              )}
-            >
-              <Button
-                onClick={() => {
-                  setCustomValue('');
-                  setEnteringCustomValue(false);
-                  setActiveButtonIndex(0);
-                  onSelect(2);
-                }}
-              >
-                2%
-              </Button>
-              <Button
-                onClick={() => {
-                  setCustomValue('');
-                  setEnteringCustomValue(false);
-                  setActiveButtonIndex(1);
-                  onSelect(3);
-                }}
-              >
-                3%
-              </Button>
-              <Button
-                className={classnames(
-                  'slippage-buttons__button-group-custom-button',
-                  {
-                    'radio-button--danger': errorText,
-                  },
-                )}
-                onClick={() => {
-                  setActiveButtonIndex(2);
-                  setEnteringCustomValue(true);
-                }}
-              >
-                {enteringCustomValue ? (
-                  <div
-                    className={classnames('slippage-buttons__custom-input', {
-                      'slippage-buttons__custom-input--danger': errorText,
-                    })}
-                  >
-                    <input
-                      onChange={(event) => {
-                        setCustomValue(event.target.value);
-                        onSelect(Number(event.target.value));
-                      }}
-                      type="number"
-                      step="0.1"
-                      ref={setInputRef}
-                      onBlur={() => {
-                        setEnteringCustomValue(false);
-                        if (customValue === '0') {
-                          setCustomValue('');
-                          setActiveButtonIndex(1);
-                        }
-                      }}
-                      value={customValue || ''}
-                    />
-                  </div>
-                ) : (
-                  customValueText
-                )}
-                {(customValue || enteringCustomValue) && (
-                  <div className="slippage-buttons__percentage-suffix">%</div>
-                )}
-              </Button>
-            </ButtonGroup>
+            <InfoTooltip
+              position="top"
+              contentText={t('swapAdvancedSlippageInfo')}
+            />
           </div>
-        )}
+          <ButtonGroup
+            defaultActiveButtonIndex={
+              activeButtonIndex === 2 && !customValue ? 1 : activeButtonIndex
+            }
+            variant="radiogroup"
+            newActiveButtonIndex={activeButtonIndex}
+            className={classnames(
+              'button-group',
+              'slippage-buttons__button-group',
+            )}
+          >
+            <Button
+              onClick={() => {
+                setCustomValue('');
+                setEnteringCustomValue(false);
+                setActiveButtonIndex(0);
+                onSelect(2);
+              }}
+            >
+              2%
+            </Button>
+            <Button
+              onClick={() => {
+                setCustomValue('');
+                setEnteringCustomValue(false);
+                setActiveButtonIndex(1);
+                onSelect(3);
+              }}
+            >
+              3%
+            </Button>
+            <Button
+              className={classnames(
+                'slippage-buttons__button-group-custom-button',
+                {
+                  'radio-button--danger': errorText,
+                },
+              )}
+              onClick={() => {
+                setActiveButtonIndex(2);
+                setEnteringCustomValue(true);
+              }}
+            >
+              {enteringCustomValue ? (
+                <div
+                  className={classnames('slippage-buttons__custom-input', {
+                    'slippage-buttons__custom-input--danger': errorText,
+                  })}
+                >
+                  <input
+                    onChange={(event) => {
+                      setCustomValue(event.target.value);
+                      onSelect(Number(event.target.value));
+                    }}
+                    type="number"
+                    step="0.1"
+                    ref={setInputRef}
+                    onBlur={() => {
+                      setEnteringCustomValue(false);
+                      if (customValue === '0') {
+                        setCustomValue('');
+                        setActiveButtonIndex(1);
+                      }
+                    }}
+                    value={customValue || ''}
+                  />
+                </div>
+              ) : (
+                customValueText
+              )}
+              {(customValue || enteringCustomValue) && (
+                <div className="slippage-buttons__percentage-suffix">%</div>
+              )}
+            </Button>
+          </ButtonGroup>
+        </div>
         {errorText && (
           <div className="slippage-buttons__error-text">{errorText}</div>
         )}

--- a/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/app/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -6,11 +6,22 @@ import ButtonGroup from '../../../components/ui/button-group';
 import Button from '../../../components/ui/button';
 import InfoTooltip from '../../../components/ui/info-tooltip';
 
-export default function SlippageButtons({ onSelect, maxAllowedSlippage }) {
+export default function SlippageButtons({ onSelect, maxAllowedSlippage, currentSlippage }) {
   const t = useContext(I18nContext);
   const [customValue, setCustomValue] = useState('');
   const [enteringCustomValue, setEnteringCustomValue] = useState(false);
-  const [activeButtonIndex, setActiveButtonIndex] = useState(1);
+  const [activeButtonIndex, setActiveButtonIndex] = useState(() => {
+    if (currentSlippage === 3) {
+      return 1;
+    } else if (currentSlippage === 2) {
+      return 0;
+    } else if (currentSlippage) {
+      setCustomValue(currentSlippage);
+      return 2;
+    } else {
+      return 1;
+    }
+  });
   const [inputRef, setInputRef] = useState(null);
 
   let errorText = '';


### PR DESCRIPTION
## Explanation: 
- Increase default slippage from 2% to 3%
- Increase slippage from 1% to 2%
- Always show Advanced Options

## Manual testing steps:  
  - Click on the `Swap` button in the MetaMask extension
  - See the `Swap` page with Advanced Options visible and 3% slippage tolerance selected by default

## Screenshots:
Swap page: Advanced Options visible and 3% slippage tolerance selected by default
![image](https://user-images.githubusercontent.com/80175477/113921524-f8365480-979a-11eb-927d-447e37bd286b.png)

Verifying that the 3% slippage is send to the server:
![image](https://user-images.githubusercontent.com/80175477/113905668-3ece8380-9788-11eb-8178-1e052cf46ad4.png)

Pre-popullating previously set custom value when going back to the Swap page:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/80175477/113932405-69303900-97a8-11eb-873a-3737c6f23bf6.png">

All unit tests are green:
![image](https://user-images.githubusercontent.com/80175477/113905929-86eda600-9788-11eb-8bc1-dbec2d2ee83d.png)

