### PR TITLE
Migrate unreleased changes in changelog

### DIFF
--- a/development/lib/changelog/changelog.js
+++ b/development/lib/changelog/changelog.js
@@ -234,6 +234,36 @@ class Changelog {
   }
 
   /**
+   * Migrate all unreleased changes to a release section.
+   *
+   * Changes are migrated in their existing categories, and placed above any
+   * pre-existing changes in that category.
+   *
+   * @param {Version} version - The release version to migrate unreleased
+   *   changes to.
+   */
+  migrateUnreleasedChangesToRelease(version) {
+    const releaseChanges = this._changes[version];
+    if (!releaseChanges) {
+      throw new Error(`Specified release version does not exist: '${version}'`);
+    }
+
+    const unreleasedChanges = this._changes[unreleased];
+
+    for (const category of Object.keys(unreleasedChanges)) {
+      if (releaseChanges[category]) {
+        releaseChanges[category] = [
+          ...unreleasedChanges[category],
+          ...releaseChanges[category],
+        ];
+      } else {
+        releaseChanges[category] = unreleasedChanges[category];
+      }
+    }
+    this._changes[unreleased] = {};
+  }
+
+  /**
    * Gets the metadata for all releases.
    * @returns {Array<ReleaseMetadata>} The metadata for each release.
    */

--- a/development/lib/changelog/updateChangelog.js
+++ b/development/lib/changelog/updateChangelog.js
@@ -127,7 +127,11 @@ async function updateChangelog({
     ({ prNumber }) => !loggedPrNumbers.includes(prNumber),
   );
 
-  if (newCommits.length === 0) {
+  const hasUnreleasedChanges = changelog.getUnreleasedChanges().length !== 0;
+  if (
+    newCommits.length === 0 &&
+    (!isReleaseCandidate || hasUnreleasedChanges)
+  ) {
     return undefined;
   }
 
@@ -139,6 +143,10 @@ async function updateChangelog({
       .find((release) => release.version === currentVersion)
   ) {
     changelog.addRelease({ currentVersion });
+  }
+
+  if (isReleaseCandidate && hasUnreleasedChanges) {
+    changelog.migrateUnreleasedChangesToRelease(currentVersion);
   }
 
   const newChangeEntries = newCommits.map(({ prNumber, description }) => {


### PR DESCRIPTION
When updating the changelog for a release candidate, any unreleased changes are now migrated to the release header.

Generally we don't make a habit of adding changes to the changelog prior to creating a release candidate, but if any are there we certainly don't want them duplicated.

Relates to #10752

Manual testing steps:  

- Run `yarn update-changelog` to add unreleased changes
- See that changes have been added to the "Unreleased" header
- Run `yarn update-changelog --rc`
- See that it has migrated everything to the v9.3.0 header.
  - Note that any commits without a PR number in the description are duplicated. This is a pre-existing issue, as our duplication detection relies upon the PR number. This will be prevented in the future by mandating GitHub Squash & Merge as the only allowed strategy, which will ensure that a PR number is present in the commit message.