### PR TITLE
Add jest coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   restoreMocks: true,
   coverageDirectory: 'jest-coverage/',
   coverageThreshold: {
-    'global': {
+    global: {
       branches: 6.3,
       functions: 9.43,
       lines: 8.66,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,14 @@
 module.exports = {
   restoreMocks: true,
   coverageDirectory: 'jest-coverage/',
+  coverageThreshold: {
+    'global': {
+      branches: 6.3,
+      functions: 9.43,
+      lines: 8.66,
+      statements: 8.88,
+    },
+  },
   setupFiles: ['./test/setup.js', './test/env.js'],
   testMatch: ['**/ui/app/pages/swaps/**/?(*.)+(test).js'],
 };


### PR DESCRIPTION
This will add coverage for any tests ran in jest under the `test:coverage:jest` command, which is currently being used in CI. I set the values to the current test coverage in `ui/app/pages/swaps`.