### PR TITLE
Fix crash when adding new changelog release header

### DIFF
--- a/development/lib/changelog/updateChangelog.js
+++ b/development/lib/changelog/updateChangelog.js
@@ -142,7 +142,7 @@ async function updateChangelog({
       .getReleases()
       .find((release) => release.version === currentVersion)
   ) {
-    changelog.addRelease({ currentVersion });
+    changelog.addRelease({ version: currentVersion });
   }
 
   if (isReleaseCandidate && hasUnreleasedChanges) {


### PR DESCRIPTION
The `auto-changelog.js` script crashes when trying to add a new release header. This bug was introduced in #10847. The cause was a simple misnamed parameter.

Manual testing steps: 
- Bump the `version` in `app/manifest/_base.json`, to simulate an RC-like environment
- Run `yarn update-changelog --rc`

Previously this is where it would crash. On this branch, it should successfully add the new release header and update the changelog.