### PR TITLE
Fix 10036 - Prevent odd localStorage migration error in Firefox

### DIFF
--- a/app/scripts/migrations/050.js
+++ b/app/scripts/migrations/050.js
@@ -24,7 +24,7 @@ export default {
     versionedData.meta.version = version;
 
     LEGACY_LOCAL_STORAGE_KEYS.forEach((key) =>
-      window.localStorage.removeItem(key),
+      window.localStorage?.removeItem(key),
     );
 
     return versionedData;


### PR DESCRIPTION
Fixes: #10036

Explanation:  

This is a weird one -- the only hint I can find is:  https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Privacy/Storage_access_policy, though it cites the error having been removed in Firefox 70, yet we're seeing the error happen in up to Firefox 84.

That said, we've only seen this happen 16 times in Firefox since January 2021, and it's for a "cleanup" migration with no other side effect than old cached data in a structure we're no longer using.

I think a `window.localStorage` check here would suffice.