### PR TITLE
Replace incoming with external transactions

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1608,12 +1608,6 @@
   "showHexDataDescription": {
     "message": "Select this to show the hex data field on the send screen"
   },
-  "showIncomingTransactions": {
-    "message": "Show Incoming Transactions"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Select this to use Etherscan to show incoming transactions in the transactions list"
-  },
   "showPermissions": {
     "message": "Show permissions"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -700,6 +700,9 @@
   "externalExtension": {
     "message": "External Extension"
   },
+  "externalSend": {
+    "message": "External Send"
+  },
   "extraApprovalGas": {
     "message": "+$1 approval gas",
     "description": "Expresses an additional gas amount the user will have to pay, on top of some other displayed amount. $1 is a decimal amount of gas"
@@ -1586,6 +1589,12 @@
   },
   "showAdvancedGasInlineDescription": {
     "message": "Select this to show gas price and limit controls directly on the send and confirm screens."
+  },
+  "showExternalTransactions": {
+    "message": "Show External Transactions"
+  },
+  "showExternalTransactionsDescription": {
+    "message": "Select this to use Etherscan to show external transactions (incoming and originated from external wallets) in the transactions list"
   },
   "showFiatConversionInTestnets": {
     "message": "Show Conversion on Testnets"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1437,12 +1437,6 @@
   "showHexDataDescription": {
     "message": "Seleccionar esto para mostrar el campo de los datos en formato hex en la pantalla de mandar"
   },
-  "showIncomingTransactions": {
-    "message": "Mostrar transacciones entrantes"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Seleccione esto para usar Etherscan para mostrar las transacciones entrantes en la lista de transacciones"
-  },
   "showPermissions": {
     "message": "Mostrar permisos"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1437,12 +1437,6 @@
   "showHexDataDescription": {
     "message": "Selecciona esto para mostrar el campo de datos hexadecimales en la pantalla de envío"
   },
-  "showIncomingTransactions": {
-    "message": "Mostrar transacciones entrantes"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Seleccione esto para usar Etherscan para mostrar las transacciones entrantes en la lista de transacciones"
-  },
   "showPermissions": {
     "message": "Mostrar permisos"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1428,12 +1428,6 @@
   "showHexDataDescription": {
     "message": "भेजने की स्क्रीन पर हेक्स डेटा फ़ील्ड दिखाने के लिए इसका चयन करें"
   },
-  "showIncomingTransactions": {
-    "message": "आने वाले लेनदेन दिखाएँ"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "लेनदेन सूची में आने वाले लेनदेन को दिखाने के लिए Etherscan का उपयोग करने के लिए इसका चयन करें"
-  },
   "showPermissions": {
     "message": "अनुमतियाँ दिखाएँ"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1428,12 +1428,6 @@
   "showHexDataDescription": {
     "message": "Pilih ini untuk menampilkan bidang data hex di layar kirim"
   },
-  "showIncomingTransactions": {
-    "message": "Menampilkan Transaksi yang Masuk"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Pilih ini untuk menggunakan Etherscan untuk menampilkan transaksi yang masuk di daftar transaksi"
-  },
   "showPermissions": {
     "message": "Tampilkan Izin"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1443,12 +1443,6 @@
   "showHexDataDescription": {
     "message": "Seleziona per mostrare il campo dei dati hex nella schermata di invio"
   },
-  "showIncomingTransactions": {
-    "message": "Mostra Transazioni in Ingresso"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Usa Etherscan per visualizzare le transazioni in ingresso nella lista delle transazioni"
-  },
   "showPermissions": {
     "message": "Mostra permessi"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1437,12 +1437,6 @@
   "showHexDataDescription": {
     "message": "オンにすると、送金画面に16進データフィールドを表示します"
   },
-  "showIncomingTransactions": {
-    "message": "着信したトランザクションの表示"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "オンにすると、Etherscanを使用して、着信トランザクションをトランザクションリストに表示します"
-  },
   "showPermissions": {
     "message": "権限の表示"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1428,12 +1428,6 @@
   "showHexDataDescription": {
     "message": "이 항목을 선택하면 보내기 화면에 16진수 데이터 필드가 표시됩니다."
   },
-  "showIncomingTransactions": {
-    "message": "수신 거래 표시"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "이 항목을 선택하면 Etherscan을 사용하여 거래 목록에 수신 거래를 표시합니다."
-  },
   "showPermissions": {
     "message": "권한 표시"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1428,12 +1428,6 @@
   "showHexDataDescription": {
     "message": "Выберите эту опцию, чтобы отобразить поле шестнадцатеричных данных на экране отправки"
   },
-  "showIncomingTransactions": {
-    "message": "Показать входящие транзакции"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Выберите это, чтобы использовать Etherscan для отображения входящих транзакций в списке транзакций"
-  },
   "showPermissions": {
     "message": "Показать разрешения"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1425,12 +1425,6 @@
   "showHexDataDescription": {
     "message": "Piliin ito para ipakita ang field ng hex data sa screen ng pagpapadala"
   },
-  "showIncomingTransactions": {
-    "message": "Ipakita ang Mga Papasok na Transaksyon"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Piliin ito para gamitin ang Etherscan sa pagpapakita ng mga papasok na transaksyon sa listahan ng mga transaksyon"
-  },
   "showPermissions": {
     "message": "Ipakita ang mga pahintulot"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1428,12 +1428,6 @@
   "showHexDataDescription": {
     "message": "Chọn tùy chọn này để hiển thị trường dữ liệu thập lục phân trên màn hình gửi"
   },
-  "showIncomingTransactions": {
-    "message": "Hiển thị các giao dịch đến"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "Chọn tùy chọn này nếu bạn muốn dùng Etherscan để hiển thị các giao dịch đến trong danh sách giao dịch"
-  },
   "showPermissions": {
     "message": "Hiển thị quyền"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1437,12 +1437,6 @@
   "showHexDataDescription": {
     "message": "请选择该选项，在发送页面显示十六进制数据字域"
   },
-  "showIncomingTransactions": {
-    "message": "显示收到的交易"
-  },
-  "showIncomingTransactionsDescription": {
-    "message": "选择该选项可使用 Etherscan（以太坊浏览器）（以太坊浏览器）在交易列表中显示收到的交易。"
-  },
   "showPermissions": {
     "message": "显示权限"
   },

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -49,7 +49,7 @@ export default class PreferencesController {
       // for convenient testing of pre-release features, and should never
       // perform sensitive operations.
       featureFlags: {
-        showIncomingTransactions: true,
+        showExternalTransactions: true,
       },
       knownMethodData: {},
       firstTimeFlowType: null,

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -31,7 +31,7 @@ export const SENTRY_STATE = {
     featureFlags: true,
     firstTimeFlowType: true,
     forgottenPassword: true,
-    incomingTxLastFetchedBlockByChainId: true,
+    externalTxLastFetchedBlockByChainId: true,
     ipfsGateway: true,
     isAccountMenuOpen: true,
     isInitialized: true,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -41,7 +41,7 @@ import CachedBalancesController from './controllers/cached-balances';
 import AlertController from './controllers/alert';
 import OnboardingController from './controllers/onboarding';
 import ThreeBoxController from './controllers/threebox';
-import IncomingTransactionsController from './controllers/incoming-transactions';
+import ExternalTransactionsController from './controllers/external-transactions';
 import MessageManager from './lib/message-manager';
 import DecryptMessageManager from './lib/decrypt-message-manager';
 import EncryptionPublicKeyManager from './lib/encryption-public-key-manager';
@@ -186,7 +186,7 @@ export default class MetamaskController extends EventEmitter {
       ),
     });
 
-    this.incomingTransactionsController = new IncomingTransactionsController({
+    this.externalTransactionsController = new ExternalTransactionsController({
       blockTracker: this.blockTracker,
       onNetworkDidChange: this.networkController.on.bind(
         this.networkController,
@@ -196,7 +196,7 @@ export default class MetamaskController extends EventEmitter {
         this.networkController,
       ),
       preferencesController: this.preferencesController,
-      initState: initState.IncomingTransactionsController,
+      initState: initState.ExternalTransactionsController,
     });
 
     // account tracker watches balances, nonces, and any code at their address
@@ -212,11 +212,11 @@ export default class MetamaskController extends EventEmitter {
     this.on('controllerConnectionChanged', (activeControllerConnections) => {
       if (activeControllerConnections > 0) {
         this.accountTracker.start();
-        this.incomingTransactionsController.start();
+        this.externalTransactionsController.start();
         this.tokenRatesController.start();
       } else {
         this.accountTracker.stop();
-        this.incomingTransactionsController.stop();
+        this.externalTransactionsController.stop();
         this.tokenRatesController.stop();
       }
     });
@@ -423,7 +423,7 @@ export default class MetamaskController extends EventEmitter {
       CachedBalancesController: this.cachedBalancesController.store,
       AlertController: this.alertController.store,
       OnboardingController: this.onboardingController.store,
-      IncomingTransactionsController: this.incomingTransactionsController.store,
+      ExternalTransactionsController: this.externalTransactionsController.store,
       PermissionsController: this.permissionsController.permissions,
       PermissionsMetadata: this.permissionsController.store,
       ThreeBoxController: this.threeBoxController.store,
@@ -448,7 +448,7 @@ export default class MetamaskController extends EventEmitter {
       CurrencyController: this.currencyRateController,
       AlertController: this.alertController.store,
       OnboardingController: this.onboardingController.store,
-      IncomingTransactionsController: this.incomingTransactionsController.store,
+      ExternalTransactionsController: this.externalTransactionsController.store,
       PermissionsController: this.permissionsController.permissions,
       PermissionsMetadata: this.permissionsController.store,
       ThreeBoxController: this.threeBoxController.store,

--- a/app/scripts/migrations/058.js
+++ b/app/scripts/migrations/058.js
@@ -31,7 +31,7 @@ function transformState(state) {
       .incomingTxLastFetchedBlockByChainId;
   }
 
-  if (state?.PreferencesController) {
+  if (state?.PreferencesController?.featureFlags) {
     state.PreferencesController.featureFlags.showExternalTransactions =
       state.PreferencesController.featureFlags?.showIncomingTransactions;
     delete state.PreferencesController.featureFlags.showIncomingTransactions;

--- a/app/scripts/migrations/058.js
+++ b/app/scripts/migrations/058.js
@@ -1,0 +1,40 @@
+import { cloneDeep } from 'lodash';
+
+const version = 58;
+
+/**
+ * replace IncomingTransactionsController with ExternalTransactionsController
+ * replace showIncomingTransactions with showExternalTransactions
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    versionedData.data = transformState(state);
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  if (state?.IncomingTransactionsController) {
+    state.ExternalTransactionsController = state.IncomingTransactionsController;
+    state.ExternalTransactionsController.externalTransactions =
+      state.IncomingTransactionsController.incomingTransactions;
+    state.ExternalTransactionsController.externalTxLastFetchedBlockByChainId =
+      state.IncomingTransactionsController.incomingTxLastFetchedBlockByChainId;
+
+    delete state.IncomingTransactionsController;
+    delete state.ExternalTransactionsController.incomingTransactions;
+    delete state.ExternalTransactionsController
+      .incomingTxLastFetchedBlockByChainId;
+  }
+
+  if (state?.PreferencesController) {
+    state.PreferencesController.featureFlags.showExternalTransactions =
+      state.PreferencesController.featureFlags?.showIncomingTransactions;
+    delete state.PreferencesController.featureFlags.showIncomingTransactions;
+  }
+  return state;
+}

--- a/app/scripts/migrations/058.test.js
+++ b/app/scripts/migrations/058.test.js
@@ -36,7 +36,7 @@ describe('migration #58', function () {
               },
             },
           },
-          incomingTxLastFetchedBlocksByNetwork: {
+          incomingTxLastFetchedBlockByChainId: {
             [MAINNET_CHAIN_ID]: 1,
             [ROPSTEN_CHAIN_ID]: 2,
             [RINKEBY_CHAIN_ID]: 3,

--- a/app/scripts/migrations/058.test.js
+++ b/app/scripts/migrations/058.test.js
@@ -1,0 +1,99 @@
+import { strict as assert } from 'assert';
+import {
+  GOERLI_CHAIN_ID,
+  KOVAN_CHAIN_ID,
+  MAINNET_CHAIN_ID,
+  RINKEBY_CHAIN_ID,
+  ROPSTEN_CHAIN_ID,
+} from '../../../shared/constants/network';
+import migration58 from './058';
+
+describe('migration #58', function () {
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      meta: {
+        version: 57,
+      },
+      data: {},
+    };
+
+    const newStorage = await migration58.migrate(oldStorage);
+    assert.deepEqual(newStorage.meta, {
+      version: 58,
+    });
+  });
+
+  it('should replace IncomingTransactionsController with ExternalTransactionsController, and carry over old values', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        IncomingTransactionsController: {
+          incomingTransactions: {
+            test: {
+              transactionCategory: 'incoming',
+              txParams: {
+                foo: 'bar',
+              },
+            },
+          },
+          incomingTxLastFetchedBlocksByNetwork: {
+            [MAINNET_CHAIN_ID]: 1,
+            [ROPSTEN_CHAIN_ID]: 2,
+            [RINKEBY_CHAIN_ID]: 3,
+            [GOERLI_CHAIN_ID]: 4,
+            [KOVAN_CHAIN_ID]: 5,
+          },
+        },
+        foo: 'bar',
+      },
+    };
+
+    const newStorage = await migration58.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      ExternalTransactionsController: {
+        externalTransactions:
+          oldStorage.data.IncomingTransactionsController.incomingTransactions,
+        externalTxLastFetchedBlockByChainId: {
+          [MAINNET_CHAIN_ID]: 1,
+          [ROPSTEN_CHAIN_ID]: 2,
+          [RINKEBY_CHAIN_ID]: 3,
+          [GOERLI_CHAIN_ID]: 4,
+          [KOVAN_CHAIN_ID]: 5,
+        },
+      },
+      foo: 'bar',
+    });
+  });
+
+  it('should do nothing if state is empty', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {},
+    };
+
+    const newStorage = await migration58.migrate(oldStorage);
+    assert.deepEqual(oldStorage.data, newStorage.data);
+  });
+
+  it('should replace showIncomingTransactions with showExternalTransactions', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          featureFlags: {
+            showIncomingTransactions: true,
+          },
+        },
+      },
+    };
+
+    const newStorage = await migration58.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      PreferencesController: {
+        featureFlags: {
+          showExternalTransactions: true,
+        },
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -62,6 +62,7 @@ const migrations = [
   require('./055').default,
   require('./056').default,
   require('./057').default,
+  require('./058').default,
 ];
 
 export default migrations;

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -9,6 +9,7 @@
  * @property {'approve'} TOKEN_METHOD_APPROVE - A token transaction requesting an
  *  allowance of the token to spend on behalf of the user
  * @property {'incoming'} INCOMING - An incoming (deposit) transaction
+ * @property {'sent'} SENT - A transaction sent from external source (other than MetaMask)
  * @property {'sentEther'} SENT_ETHER - A transaction sending ether to a recipient
  * @property {'contractInteraction'} CONTRACT_INTERACTION - A transaction that is
  *  interacting with a smart contract's methods that we have not treated as a special
@@ -46,6 +47,7 @@ export const TRANSACTION_TYPES = {
   TOKEN_METHOD_TRANSFER_FROM: 'transferfrom',
   TOKEN_METHOD_APPROVE: 'approve',
   INCOMING: 'incoming',
+  SENT: 'sent',
   SENT_ETHER: 'sentEther',
   CONTRACT_INTERACTION: 'contractInteraction',
   DEPLOY_CONTRACT: 'contractDeployment',

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -9,7 +9,7 @@
   },
   "metamask": {
     "featureFlags": {
-      "showIncomingTransactions": true
+      "showExternalTransactions": true
     },
     "network": "4",
     "provider": {
@@ -26,7 +26,7 @@
       }
     },
     "cachedBalances": {},
-    "incomingTransactions": {},
+    "externalTransactions": {},
     "unapprovedTxs": {
       "8393540981007587": {
         "id": 8393540981007587,

--- a/test/e2e/fixtures/address-entry/state.json
+++ b/test/e2e/fixtures/address-entry/state.json
@@ -28,9 +28,9 @@
       "currentCurrency": "usd",
       "nativeCurrency": "ETH"
     },
-    "IncomingTransactionsController": {
-      "incomingTransactions": {},
-      "incomingTxLastFetchedBlocksByNetwork": {
+    "ExternalTransactionsController": {
+      "externalTransactions": {},
+      "externalTxLastFetchedBlocksByNetwork": {
         "goerli": null,
         "kovan": null,
         "mainnet": null,
@@ -97,7 +97,7 @@
       "completedOnboarding": true,
       "currentLocale": "en",
       "featureFlags": {
-        "showIncomingTransactions": true,
+        "showExternalTransactions": true,
         "transactionTime": false
       },
       "firstTimeFlowType": "create",

--- a/test/e2e/fixtures/connected-state/state.json
+++ b/test/e2e/fixtures/connected-state/state.json
@@ -18,9 +18,9 @@
       "currentCurrency": "usd",
       "nativeCurrency": "ETH"
     },
-    "IncomingTransactionsController": {
-      "incomingTransactions": {},
-      "incomingTxLastFetchedBlocksByNetwork": {
+    "ExternalTransactionsController": {
+      "externalTransactions": {},
+      "externalTxLastFetchedBlocksByNetwork": {
         "goerli": null,
         "kovan": null,
         "mainnet": null,
@@ -103,7 +103,7 @@
       "useNonceField": false,
       "usePhishDetect": true,
       "featureFlags": {
-        "showIncomingTransactions": true,
+        "showExternalTransactions": true,
         "transactionTime": false
       },
       "knownMethodData": {},

--- a/test/e2e/fixtures/imported-account/state.json
+++ b/test/e2e/fixtures/imported-account/state.json
@@ -15,9 +15,9 @@
       "currentCurrency": "usd",
       "nativeCurrency": "ETH"
     },
-    "IncomingTransactionsController": {
-      "incomingTransactions": {},
-      "incomingTxLastFetchedBlocksByNetwork": {
+    "ExternalTransactionsController": {
+      "externalTransactions": {},
+      "externalTxLastFetchedBlocksByNetwork": {
         "goerli": null,
         "kovan": null,
         "mainnet": null,
@@ -84,7 +84,7 @@
       "completedOnboarding": true,
       "currentLocale": "en",
       "featureFlags": {
-        "showIncomingTransactions": true,
+        "showExternalTransactions": true,
         "transactionTime": false
       },
       "firstTimeFlowType": "create",

--- a/test/e2e/fixtures/localization/state.json
+++ b/test/e2e/fixtures/localization/state.json
@@ -15,9 +15,9 @@
       "currentCurrency": "php",
       "nativeCurrency": "ETH"
     },
-    "IncomingTransactionsController": {
-      "incomingTransactions": {},
-      "incomingTxLastFetchedBlocksByNetwork": {
+    "ExternalTransactionsController": {
+      "externalTransactions": {},
+      "externalTxLastFetchedBlocksByNetwork": {
         "goerli": null,
         "kovan": null,
         "mainnet": null,
@@ -84,7 +84,7 @@
       "completedOnboarding": true,
       "currentLocale": "en",
       "featureFlags": {
-        "showIncomingTransactions": true,
+        "showExternalTransactions": true,
         "transactionTime": false
       },
       "firstTimeFlowType": "create",

--- a/test/e2e/fixtures/metrics-enabled/state.json
+++ b/test/e2e/fixtures/metrics-enabled/state.json
@@ -18,9 +18,9 @@
       "currentCurrency": "usd",
       "nativeCurrency": "ETH"
     },
-    "IncomingTransactionsController": {
-      "incomingTransactions": {},
-      "incomingTxLastFetchedBlocksByNetwork": {
+    "ExternalTransactionsController": {
+      "externalTransactions": {},
+      "externalTxLastFetchedBlocksByNetwork": {
         "goerli": null,
         "kovan": null,
         "mainnet": null,
@@ -103,7 +103,7 @@
       "useNonceField": false,
       "usePhishDetect": true,
       "featureFlags": {
-        "showIncomingTransactions": true,
+        "showExternalTransactions": true,
         "transactionTime": false
       },
       "knownMethodData": {},

--- a/test/e2e/fixtures/send-edit/state.json
+++ b/test/e2e/fixtures/send-edit/state.json
@@ -15,9 +15,9 @@
       "currentCurrency": "usd",
       "nativeCurrency": "ETH"
     },
-    "IncomingTransactionsController": {
-      "incomingTransactions": {},
-      "incomingTxLastFetchedBlocksByNetwork": {
+    "ExternalTransactionsController": {
+      "externalTransactions": {},
+      "externalTxLastFetchedBlocksByNetwork": {
         "goerli": null,
         "kovan": null,
         "mainnet": null,
@@ -84,7 +84,7 @@
       "completedOnboarding": true,
       "currentLocale": "en",
       "featureFlags": {
-        "showIncomingTransactions": true,
+        "showExternalTransactions": true,
         "transactionTime": false
       },
       "firstTimeFlowType": "create",

--- a/test/e2e/fixtures/threebox-enabled/state.json
+++ b/test/e2e/fixtures/threebox-enabled/state.json
@@ -18,9 +18,9 @@
       "nativeCurrency": "ETH",
       "usdConversionRate": 2072.49
     },
-    "IncomingTransactionsController": {
-      "incomingTransactions": {},
-      "incomingTxLastFetchedBlockByChainId": {
+    "ExternalTransactionsController": {
+      "externalTransactions": {},
+      "externalTxLastFetchedBlockByChainId": {
         "0x5": null,
         "0x2a": null,
         "0x1": null,
@@ -76,7 +76,7 @@
       "useNonceField": false,
       "usePhishDetect": true,
       "featureFlags": {
-        "showIncomingTransactions": true,
+        "showExternalTransactions": true,
         "transactionTime": false
       },
       "knownMethodData": {},

--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -210,6 +210,10 @@ export function useTransactionDisplayData(transactionGroup) {
     category = TRANSACTION_GROUP_CATEGORIES.SEND;
     title = t('send');
     subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
+  } else if (type === TRANSACTION_TYPES.SENT) {
+    category = TRANSACTION_GROUP_CATEGORIES.SEND;
+    title = t('externalSend');
+    subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
   }
 
   const primaryCurrencyPreferences = useUserPreferencedCurrency(PRIMARY);

--- a/ui/app/pages/settings/security-tab/security-tab.component.js
+++ b/ui/app/pages/settings/security-tab/security-tab.component.js
@@ -15,8 +15,8 @@ export default class SecurityTab extends PureComponent {
     history: PropTypes.object,
     participateInMetaMetrics: PropTypes.bool.isRequired,
     setParticipateInMetaMetrics: PropTypes.func.isRequired,
-    showIncomingTransactions: PropTypes.bool.isRequired,
-    setShowIncomingTransactionsFeatureFlag: PropTypes.func.isRequired,
+    showExternalTransactions: PropTypes.bool.isRequired,
+    setShowExternalTransactionsFeatureFlag: PropTypes.func.isRequired,
     setUsePhishDetect: PropTypes.func.isRequired,
     usePhishDetect: PropTypes.bool.isRequired,
   };
@@ -84,27 +84,27 @@ export default class SecurityTab extends PureComponent {
     );
   }
 
-  renderIncomingTransactionsOptIn() {
+  renderExternalTransactionsOptIn() {
     const { t } = this.context;
     const {
-      showIncomingTransactions,
-      setShowIncomingTransactionsFeatureFlag,
+      showExternalTransactions,
+      setShowExternalTransactionsFeatureFlag,
     } = this.props;
 
     return (
       <div className="settings-page__content-row">
         <div className="settings-page__content-item">
-          <span>{t('showIncomingTransactions')}</span>
+          <span>{t('showExternalTransactions')}</span>
           <div className="settings-page__content-description">
-            {t('showIncomingTransactionsDescription')}
+            {t('showExternalTransactionsDescription')}
           </div>
         </div>
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
             <ToggleButton
-              value={showIncomingTransactions}
+              value={showExternalTransactions}
               onToggle={(value) =>
-                setShowIncomingTransactionsFeatureFlag(!value)
+                setShowExternalTransactionsFeatureFlag(!value)
               }
               offLabel={t('off')}
               onLabel={t('on')}
@@ -148,7 +148,7 @@ export default class SecurityTab extends PureComponent {
       <div className="settings-page__body">
         {warning && <div className="settings-tab__error">{warning}</div>}
         {this.renderSeedWords()}
-        {this.renderIncomingTransactionsOptIn()}
+        {this.renderExternalTransactionsOptIn()}
         {this.renderPhishingDetectionToggle()}
         {this.renderMetaMetricsOptIn()}
       </div>

--- a/ui/app/pages/settings/security-tab/security-tab.container.js
+++ b/ui/app/pages/settings/security-tab/security-tab.container.js
@@ -14,14 +14,14 @@ const mapStateToProps = (state) => {
     metamask,
   } = state;
   const {
-    featureFlags: { showIncomingTransactions } = {},
+    featureFlags: { showExternalTransactions } = {},
     participateInMetaMetrics,
     usePhishDetect,
   } = metamask;
 
   return {
     warning,
-    showIncomingTransactions,
+    showExternalTransactions,
     participateInMetaMetrics,
     usePhishDetect,
   };
@@ -31,8 +31,8 @@ const mapDispatchToProps = (dispatch) => {
   return {
     setParticipateInMetaMetrics: (val) =>
       dispatch(setParticipateInMetaMetrics(val)),
-    setShowIncomingTransactionsFeatureFlag: (shouldShow) =>
-      dispatch(setFeatureFlag('showIncomingTransactions', shouldShow)),
+    setShowExternalTransactionsFeatureFlag: (shouldShow) =>
+      dispatch(setFeatureFlag('showExternalTransactions', shouldShow)),
     setUsePhishDetect: (val) => dispatch(setUsePhishDetect(val)),
   };
 };

--- a/ui/app/pages/settings/security-tab/security-tab.container.test.js
+++ b/ui/app/pages/settings/security-tab/security-tab.container.test.js
@@ -11,8 +11,8 @@ describe('Security Tab', () => {
     showClearApprovalModal: sinon.spy(),
     setParticipateInMetaMetrics: sinon.spy(),
     displayWarning: sinon.spy(),
-    showIncomingTransactions: false,
-    setShowIncomingTransactionsFeatureFlag: sinon.spy(),
+    showExternalTransactions: false,
+    setShowExternalTransactionsFeatureFlag: sinon.spy(),
     history: {
       push: sinon.spy(),
     },
@@ -40,11 +40,11 @@ describe('Security Tab', () => {
     expect(props.history.push.getCall(0).args[0]).toStrictEqual('/seed');
   });
 
-  it('toggles incoming txs', () => {
-    const incomingTxs = wrapper.find({ type: 'checkbox' }).at(0);
-    incomingTxs.simulate('click');
+  it('toggles external txs', () => {
+    const externalTxs = wrapper.find({ type: 'checkbox' }).at(0);
+    externalTxs.simulate('click');
     expect(
-      props.setShowIncomingTransactionsFeatureFlag.calledOnce,
+      props.setShowExternalTransactionsFeatureFlag.calledOnce,
     ).toStrictEqual(true);
   });
 

--- a/ui/app/selectors/transactions.test.js
+++ b/ui/app/selectors/transactions.test.js
@@ -115,13 +115,14 @@ describe('Transaction Selectors', () => {
             chainId: MAINNET_CHAIN_ID,
           },
           featureFlags: {
-            showIncomingTransactions: false,
+            showExternalTransactions: false,
           },
           selectedAddress: '0xAddress',
           currentNetworkTxList: [
             {
               id: 0,
               time: 0,
+              hash: '0',
               txParams: {
                 from: '0xAddress',
                 to: '0xRecipient',
@@ -130,6 +131,7 @@ describe('Transaction Selectors', () => {
             {
               id: 1,
               time: 1,
+              hash: '1',
               txParams: {
                 from: '0xAddress',
                 to: '0xRecipient',
@@ -155,6 +157,7 @@ describe('Transaction Selectors', () => {
       const tx1 = {
         id: 0,
         time: 0,
+        hash: '0',
         txParams: {
           from: '0xAddress',
           to: '0xRecipient',
@@ -165,6 +168,7 @@ describe('Transaction Selectors', () => {
       const tx2 = {
         id: 1,
         time: 1,
+        hash: '1',
         txParams: {
           from: '0xAddress',
           to: '0xRecipient',
@@ -180,7 +184,7 @@ describe('Transaction Selectors', () => {
           },
           selectedAddress: '0xAddress',
           featureFlags: {
-            showIncomingTransactions: false,
+            showExternalTransactions: false,
           },
           currentNetworkTxList: [tx1, tx2],
         },
@@ -215,6 +219,7 @@ describe('Transaction Selectors', () => {
     const submittedTx = {
       id: 0,
       time: 0,
+      hash: '0',
       txParams: {
         from: '0xAddress',
         to: '0xRecipient',
@@ -226,6 +231,7 @@ describe('Transaction Selectors', () => {
     const unapprovedTx = {
       id: 1,
       time: 1,
+      hash: '1',
       txParams: {
         from: '0xAddress',
         to: '0xRecipient',
@@ -237,6 +243,7 @@ describe('Transaction Selectors', () => {
     const approvedTx = {
       id: 2,
       time: 2,
+      hash: '2',
       txParams: {
         from: '0xAddress',
         to: '0xRecipient',
@@ -248,6 +255,7 @@ describe('Transaction Selectors', () => {
     const confirmedTx = {
       id: 3,
       time: 3,
+      hash: '3',
       txParams: {
         from: '0xAddress',
         to: '0xRecipient',
@@ -264,7 +272,7 @@ describe('Transaction Selectors', () => {
         },
         selectedAddress: '0xAddress',
         featureFlags: {
-          showIncomingTransactions: false,
+          showExternalTransactions: false,
         },
         currentNetworkTxList: [
           submittedTx,


### PR DESCRIPTION
Fixes: #505 #7452

Explanation:  

1.  `IncomingTransactionsController` has been replaced with `ExternalTransactionsController`
2.  `showIncomingTransactions` feature flag has been changed to `showExternalTransactions`
3. `ExternalTransactionsController` now does not filter out outgoing transactions
4.  New transactions type `SENT` has been added, wich is described as "External Send" transaction
5.  `_normalizeTxFromEtherscan` sets the new transaction type `SENT` when address of the sender is the same as the one passed as the parameter

<img width="359" alt="Screenshot 2021-04-20 at 12 51 58" src="https://user-images.githubusercontent.com/5708018/115512474-53c80e00-a282-11eb-97ca-9334dfd870e1.png">

Manual testing steps:  
  - Import account using private key
  - Use the same private key to import it to other instance of MM or any other wallet
  - Send transaction using 2nd wallet
  - Wait for the block request in 1st MM instance
  - Check if "External Send" transaction will show up