### PR TITLE
use one segment instance

### DIFF
--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -11,7 +11,6 @@ import MetaMetricsController from './metametrics';
 import { NETWORK_EVENTS } from './network';
 
 const segment = createSegmentMock(2, 10000);
-const segmentLegacy = createSegmentMock(2, 10000);
 
 const VERSION = '0.0.1-test';
 const NETWORK = 'Mainnet';
@@ -91,7 +90,6 @@ function getMetaMetricsController({
 } = {}) {
   return new MetaMetricsController({
     segment,
-    segmentLegacy,
     getNetworkIdentifier: networkController.getNetworkIdentifier.bind(
       networkController,
     ),
@@ -286,7 +284,7 @@ describe('MetaMetricsController', function () {
     });
 
     it('should track a legacy event', function () {
-      const mock = sinon.mock(segmentLegacy);
+      const mock = sinon.mock(segment);
       const metaMetricsController = getMetaMetricsController();
       mock
         .expects('track')
@@ -297,6 +295,7 @@ describe('MetaMetricsController', function () {
           context: DEFAULT_TEST_CONTEXT,
           properties: {
             test: 1,
+            legacy_event: true,
             ...DEFAULT_EVENT_PROPERTIES,
           },
         });
@@ -544,7 +543,6 @@ describe('MetaMetricsController', function () {
   afterEach(function () {
     // flush the queues manually after each test
     segment.flush();
-    segmentLegacy.flush();
     sinon.restore();
   });
 });

--- a/app/scripts/lib/segment.js
+++ b/app/scripts/lib/segment.js
@@ -4,7 +4,6 @@ const isDevOrTestEnvironment = Boolean(
   process.env.METAMASK_DEBUG || process.env.IN_TEST,
 );
 const SEGMENT_WRITE_KEY = process.env.SEGMENT_WRITE_KEY ?? null;
-const SEGMENT_LEGACY_WRITE_KEY = process.env.SEGMENT_LEGACY_WRITE_KEY ?? null;
 const SEGMENT_HOST = process.env.SEGMENT_HOST ?? null;
 
 // flushAt controls how many events are sent to segment at once. Segment will
@@ -86,15 +85,6 @@ export const segment =
   !SEGMENT_WRITE_KEY || (isDevOrTestEnvironment && !SEGMENT_HOST)
     ? createSegmentMock(SEGMENT_FLUSH_AT, SEGMENT_FLUSH_INTERVAL)
     : new Analytics(SEGMENT_WRITE_KEY, {
-        host: SEGMENT_HOST,
-        flushAt: SEGMENT_FLUSH_AT,
-        flushInterval: SEGMENT_FLUSH_INTERVAL,
-      });
-
-export const segmentLegacy =
-  !SEGMENT_LEGACY_WRITE_KEY || (isDevOrTestEnvironment && !SEGMENT_HOST)
-    ? createSegmentMock(SEGMENT_FLUSH_AT, SEGMENT_FLUSH_INTERVAL)
-    : new Analytics(SEGMENT_LEGACY_WRITE_KEY, {
         host: SEGMENT_HOST,
         flushAt: SEGMENT_FLUSH_AT,
         flushInterval: SEGMENT_FLUSH_INTERVAL,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -58,7 +58,7 @@ import nodeify from './lib/nodeify';
 import accountImporter from './account-import-strategies';
 import seedPhraseVerifier from './lib/seed-phrase-verifier';
 import MetaMetricsController from './controllers/metametrics';
-import { segment, segmentLegacy } from './lib/segment';
+import { segment } from './lib/segment';
 import createMetaRPCHandler from './lib/createMetaRPCHandler';
 
 export const METAMASK_CONTROLLER_EVENTS = {
@@ -128,7 +128,6 @@ export default class MetamaskController extends EventEmitter {
 
     this.metaMetricsController = new MetaMetricsController({
       segment,
-      segmentLegacy,
       preferencesStore: this.preferencesController.store,
       onNetworkDidChange: this.networkController.on.bind(
         this.networkController,


### PR DESCRIPTION
Fixes: no longer splitting analytics into two mixpanels to separate old analytics schema from new, work in progress one. Instead, we will segment in mixpanel to keep visualizations separate. 