### PR TITLE
Fixing ENS input entry in send flow

### DIFF
--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -83,6 +83,9 @@ export function isValidAddress(address) {
     return false;
   }
   const prefixed = addHexPrefix(address);
+  if (!isHex(prefixed)) {
+    return false;
+  }
   return (
     (isAllOneCase(prefixed.slice(2)) && ethUtil.isValidAddress(prefixed)) ||
     ethUtil.isValidChecksumAddress(prefixed)

--- a/ui/app/pages/send/send-content/add-recipient/add-recipient.js
+++ b/ui/app/pages/send/send-content/add-recipient/add-recipient.js
@@ -22,7 +22,7 @@ export function getToErrorObject(to, sendTokenAddress, chainId) {
   let toError = null;
   if (!to) {
     toError = REQUIRED_ERROR;
-  } else if (!isValidAddress(to)) {
+  } else if (!isValidAddress(to) && !isValidDomainName(to)) {
     toError = isDefaultMetaMaskChain(chainId)
       ? INVALID_RECIPIENT_ADDRESS_ERROR
       : INVALID_RECIPIENT_ADDRESS_NOT_ETH_NETWORK_ERROR;

--- a/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/app/pages/send/send-content/add-recipient/ens-input.component.js
@@ -314,7 +314,7 @@ export default class EnsInput extends Component {
     }
 
     if (ensFailure) {
-      return <i className="fa fa-warning fa-lg warning'" />;
+      return <i className="fa fa-warning fa-lg warning" />;
     }
 
     if (ensResolution && ensResolution !== ZERO_ADDRESS) {


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#10691

Explanation:  
With recent updates to `isValidAddress` as provided by `ethereumjs-util`, it is not accepting of invalid hex strings.
This adds an `isHex` validation check to our shared utility for `isValidAddress` to address the regression. With regards to MetaMask/metamask-extension#10691, we additionally check domain validity so as to not throw an invalid recipient error.

Manual testing steps:  
Steps for MetaMask/metamask-extension#10691 are defined in the issue. A general regression test should be performed with sending to ENS and hex addresses.

With fix:
<img width="443" alt="Screen Shot 2021-04-24 at 8 24 08 PM" src="https://user-images.githubusercontent.com/8732757/115979670-0c6ca680-a53c-11eb-837d-8f76ad207688.png">
<img width="436" alt="Screen Shot 2021-04-24 at 8 22 21 PM" src="https://user-images.githubusercontent.com/8732757/115979671-0d9dd380-a53c-11eb-994c-1555009b29ba.png">
<img width="455" alt="Screen Shot 2021-04-24 at 8 21 47 PM" src="https://user-images.githubusercontent.com/8732757/115979672-0d9dd380-a53c-11eb-8c67-02289d20e133.png">
<img width="453" alt="Screen Shot 2021-04-24 at 8 21 35 PM" src="https://user-images.githubusercontent.com/8732757/115979673-0e366a00-a53c-11eb-8c96-356b57820d2a.png">
<img width="464" alt="Screen Shot 2021-04-24 at 8 21 29 PM" src="https://user-images.githubusercontent.com/8732757/115979674-0ecf0080-a53c-11eb-8a9c-b04c09befbec.png">

