### PR TITLE
add view account-details menu item to token-options menu

### DIFF
--- a/ui/app/pages/asset/components/token-asset.js
+++ b/ui/app/pages/asset/components/token-asset.js
@@ -43,6 +43,9 @@ export default function TokenAsset({ token }) {
               );
               global.platform.openTab({ url });
             }}
+            onViewAccountDetails={() => {
+              dispatch(showModal({ name: 'ACCOUNT_DETAILS' }));
+            }}
             tokenSymbol={token.symbol}
           />
         }

--- a/ui/app/pages/asset/components/token-options.js
+++ b/ui/app/pages/asset/components/token-options.js
@@ -69,6 +69,7 @@ const TokenOptions = ({
 TokenOptions.propTypes = {
   onRemove: PropTypes.func.isRequired,
   onViewEtherscan: PropTypes.func.isRequired,
+  onViewAccountDetails: PropTypes.func.isRequired,
   tokenSymbol: PropTypes.string.isRequired,
 };
 

--- a/ui/app/pages/asset/components/token-options.js
+++ b/ui/app/pages/asset/components/token-options.js
@@ -4,7 +4,12 @@ import PropTypes from 'prop-types';
 import { I18nContext } from '../../../contexts/i18n';
 import { Menu, MenuItem } from '../../../components/ui/menu';
 
-const TokenOptions = ({ onRemove, onViewEtherscan, tokenSymbol }) => {
+const TokenOptions = ({
+  onRemove,
+  onViewEtherscan,
+  onViewAccountDetails,
+  tokenSymbol,
+}) => {
   const t = useContext(I18nContext);
   const [tokenOptionsButtonElement, setTokenOptionsButtonElement] = useState(
     null,
@@ -25,6 +30,16 @@ const TokenOptions = ({ onRemove, onViewEtherscan, tokenSymbol }) => {
           anchorElement={tokenOptionsButtonElement}
           onHide={() => setTokenOptionsOpen(false)}
         >
+          <MenuItem
+            iconClassName="fas fa-qrcode"
+            data-testid="token-options__account-details"
+            onClick={() => {
+              setTokenOptionsOpen(false);
+              onViewAccountDetails();
+            }}
+          >
+            {t('accountDetails')}
+          </MenuItem>
           <MenuItem
             iconClassName="fas fa-external-link-alt token-options__icon"
             data-testid="token-options__etherscan"


### PR DESCRIPTION
(partially) Fixes: #10148

Explanation:  Adds the Account Details menu item/link to the hamburger menu on token pages

Manual testing steps:  
  - Navigate to a token page (other than Eth)
  - Click the hamburger/meatball menu in the top right hand corner
  - Confirm that there is an Account Details menu item available and that when clicked it pops the correct modal.