### PR TITLE
Fix 10609 - Prevent overflow of confirmation page hostname

### DIFF
--- a/ui/app/pages/confirmation/confirmation.scss
+++ b/ui/app/pages/confirmation/confirmation.scss
@@ -21,6 +21,7 @@
   &__content {
     grid-area: content;
     padding: 16px 16px 0;
+    min-width: 0;
 
     & > :last-child {
       margin-bottom: 16px;
@@ -58,5 +59,13 @@
 
   &__navigation &__navigation-button:last-child {
     margin-left: 8px;
+  }
+
+  .chip {
+    max-width: 100%;
+
+    &__label {
+      word-break: break-all;
+    }
   }
 }


### PR DESCRIPTION
Fixes: #10609

Explanation:  Presently a long hostname on the confirmation screen can take make the window stretch beyond its width.  I've updated the design to keep screen width integrity and wrap the hostname so the user can always see that full text.

<img width="603" alt="Wrappers" src="https://user-images.githubusercontent.com/46655/116158241-ec5ff300-a6b3-11eb-8490-608060335437.png">

Shout out to @brad-decker for the CSS wizardry ideas.