### PR TITLE
Allow 0% slippage, show a warning for 0 < slippage <= 1, disable "Review Swap" button for negative slippage

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1979,7 +1979,7 @@
     "message": "Below are all the quotes gathered from multiple liquidity sources."
   },
   "swapSlippageTooLow": {
-    "message": "Slippage must be greater than zero"
+    "message": "Slippage must be greater or equal to zero"
   },
   "swapSource": {
     "message": "Liquidity source"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1981,9 +1981,6 @@
   "swapSlippageNegative": {
     "message": "Slippage must be greater or equal to zero"
   },
-  "swapSlippageTooLow": {
-    "message": "Slippage must be greater than zero"
-  },
   "swapSource": {
     "message": "Liquidity source"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1978,6 +1978,9 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Below are all the quotes gathered from multiple liquidity sources."
   },
+  "swapSlippageTooLow": {
+    "message": "Slippage must be greater than zero"
+  },
   "swapSlippageNegative": {
     "message": "Slippage must be greater or equal to zero"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1978,7 +1978,7 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Below are all the quotes gathered from multiple liquidity sources."
   },
-  "swapSlippageTooLow": {
+  "swapSlippageNegative": {
     "message": "Slippage must be greater or equal to zero"
   },
   "swapSource": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1978,11 +1978,11 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Below are all the quotes gathered from multiple liquidity sources."
   },
-  "swapSlippageTooLow": {
-    "message": "Slippage must be greater than zero"
-  },
   "swapSlippageNegative": {
     "message": "Slippage must be greater or equal to zero"
+  },
+  "swapSlippageTooLow": {
+    "message": "Slippage must be greater than zero"
   },
   "swapSource": {
     "message": "Liquidity source"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1690,9 +1690,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "A continuación se muestran todas las cotizaciones recopiladas de múltiples fuentes de liquidez."
   },
-  "swapSlippageTooLow": {
-    "message": "El deslizamiento debe ser mayor que cero"
-  },
   "swapSource": {
     "message": "Fuente de liquidez"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1690,9 +1690,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "A continuación se muestran todas las cotizaciones recopiladas de múltiples fuentes de liquidez."
   },
-  "swapSlippageTooLow": {
-    "message": "El deslizamiento debe ser mayor que cero"
-  },
   "swapSource": {
     "message": "Fuente de liquidez"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1660,9 +1660,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "नीचे दिए गए सभी उद्धरण कई चलनिधि स्रोतों से एकत्र किए गए हैं।"
   },
-  "swapSlippageTooLow": {
-    "message": "स्लिपेज शून्य से अधिक होना चाहिए"
-  },
   "swapSource": {
     "message": "चलनिधि का स्रोत"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1660,9 +1660,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Di bawah ini adalah semua kuota yang dikumpulkan dari beberapa sumber likuiditas."
   },
-  "swapSlippageTooLow": {
-    "message": "Slippage harus lebih besar dari nol"
-  },
   "swapSource": {
     "message": "Sumber likuiditas"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1702,9 +1702,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Sotto trovi tutte le quotazioni raccolte da multiple sorgenti di liquidità."
   },
-  "swapSlippageTooLow": {
-    "message": "Lo slippage deve essere maggiore di zero"
-  },
   "swapSource": {
     "message": "Sorgente di liquidità"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1690,9 +1690,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "以下は複数の流動性ソースから収集したすべての見積です。"
   },
-  "swapSlippageTooLow": {
-    "message": "スリッページは 0 より多くする必要があります。"
-  },
   "swapSource": {
     "message": "流動性ソース"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1660,9 +1660,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "다음은 여러 유동성 소스에서 수집한 전체 견적입니다."
   },
-  "swapSlippageTooLow": {
-    "message": "슬리패지는 0보다 커야 합니다."
-  },
   "swapSource": {
     "message": "유동성 소스"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1660,9 +1660,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Ниже приведены все котировки, собранные из нескольких источников ликвидности."
   },
-  "swapSlippageTooLow": {
-    "message": "Проскальзывание должно быть больше нуля"
-  },
   "swapSource": {
     "message": "Источник ликвидности"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1657,9 +1657,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Makikita sa ibaba ang lahat ng quote na nakuha mula sa maraming pinagkukunan ng liquidity."
   },
-  "swapSlippageTooLow": {
-    "message": "Dapat ay mas malaki sa zero ang slippage"
-  },
   "swapSource": {
     "message": "Pinagkunan ng liquidity"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1660,9 +1660,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "Dưới đây là tất cả các báo giá thu thập từ nhiều nguồn thanh khoản."
   },
-  "swapSlippageTooLow": {
-    "message": "Mức trượt giá phải lớn hơn 0"
-  },
   "swapSource": {
     "message": "Nguồn thanh khoản"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1690,9 +1690,6 @@
   "swapSelectQuotePopoverDescription": {
     "message": "以下是从多个流动资金来源收集到的所有报价。"
   },
-  "swapSlippageTooLow": {
-    "message": "滑点必须大于零"
-  },
   "swapSource": {
     "message": "流动资金来源"
   },

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -533,7 +533,7 @@ export default function BuildQuote({
           !isFeatureFlagLoaded ||
           !Number(inputValue) ||
           !selectedToToken?.address ||
-          Number(maxSlippage) === 0 ||
+          Number(maxSlippage) < 0 ||
           Number(maxSlippage) > MAX_ALLOWED_SLIPPAGE ||
           (toTokenIsNotDefault && occurances < 2 && !verificationClicked)
         }

--- a/ui/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -13,8 +13,12 @@ export default function SlippageButtons({
 }) {
   const t = useContext(I18nContext);
   const [customValue, setCustomValue] = useState(() => {
-    if (currentSlippage && currentSlippage !== 2 && currentSlippage !== 3) {
-      return currentSlippage;
+    if (
+      typeof currentSlippage === 'number' &&
+      currentSlippage !== 2 &&
+      currentSlippage !== 3
+    ) {
+      return currentSlippage.toString();
     }
     return '';
   });
@@ -24,7 +28,7 @@ export default function SlippageButtons({
       return 1;
     } else if (currentSlippage === 2) {
       return 0;
-    } else if (currentSlippage) {
+    } else if (typeof currentSlippage === 'number') {
       return 2;
     }
     return 1; // Choose activeButtonIndex = 1 for 3% slippage by default.
@@ -33,9 +37,12 @@ export default function SlippageButtons({
 
   let errorText = '';
   if (customValue) {
-    if (Number(customValue) <= 0) {
+    // customValue is a string, e.g. '0'
+    if (Number(customValue) < 0) {
       errorText = t('swapSlippageTooLow');
-    } else if (Number(customValue) < 0.5) {
+    } else if (Number(customValue) > 0 && Number(customValue) <= 1) {
+      // We will not show this warning for 0% slippage, because we will only
+      // return non-slippage quotes from off-chain makers.
       errorText = t('swapLowSlippageError');
     } else if (
       Number(customValue) >= 5 &&
@@ -136,10 +143,6 @@ export default function SlippageButtons({
                     ref={setInputRef}
                     onBlur={() => {
                       setEnteringCustomValue(false);
-                      if (customValue === '0') {
-                        setCustomValue('');
-                        setActiveButtonIndex(1);
-                      }
                     }}
                     value={customValue || ''}
                   />

--- a/ui/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -39,7 +39,8 @@ export default function SlippageButtons({
   if (customValue) {
     // customValue is a string, e.g. '0'
     if (Number(customValue) < 0) {
-      errorText = t('swapSlippageTooLow');
+      // TODO: Remove 'swapSlippageTooLow' once `swapSlippageNegative` is translated everywhere.
+      errorText = t('swapSlippageNegative') || t('swapSlippageTooLow');
     } else if (Number(customValue) > 0 && Number(customValue) <= 1) {
       // We will not show this warning for 0% slippage, because we will only
       // return non-slippage quotes from off-chain makers.

--- a/ui/pages/swaps/slippage-buttons/slippage-buttons.js
+++ b/ui/pages/swaps/slippage-buttons/slippage-buttons.js
@@ -39,8 +39,7 @@ export default function SlippageButtons({
   if (customValue) {
     // customValue is a string, e.g. '0'
     if (Number(customValue) < 0) {
-      // TODO: Remove 'swapSlippageTooLow' once `swapSlippageNegative` is translated everywhere.
-      errorText = t('swapSlippageNegative') || t('swapSlippageTooLow');
+      errorText = t('swapSlippageNegative');
     } else if (Number(customValue) > 0 && Number(customValue) <= 1) {
       // We will not show this warning for 0% slippage, because we will only
       // return non-slippage quotes from off-chain makers.


### PR DESCRIPTION
## Explanation
This PR:
- Enables 0% slippage
- Shows no warning messages for 0% slippage
- Updates a message if custom slippage is negative. Previously: `Slippage must be greater than zero`, now: `Slippage must be greater or equal to zero`
- Shows a warning for low slippage: 0 < slippage <= 1 (previously 0 < slippage < 0.5)
- Prefills 0% custom slippage when a user is coming back to the build quote page
- Fixes a bug that allowed to click on the "Review Swap" button with negative slippage

## Manual testing steps
Test case: "Review Swap button enabled for 0% slippage with no warning message"
- Get on the Swaps page
- Choose tokens From and To
- Enter 0 into custom slippage
- Review Swap button is enabled

Test case: "Review Swap button enabled for 0.5% slippage with a warning message"
- Get on the Swaps page
- Choose tokens From and To
- Enter 0.5 into custom slippage
- Review Swap button is enabled and the `Transaction may fail, max slippage too low.` message is displayed

Test case: "Review Swap button disabled for negative slippage"
- Get on the Swaps page
- Choose tokens From and To
- Enter -1 into custom slippage
- Review Swap button is disabled and the `Slippage must be greater or equal to zero` message is displayed

Test case: "0% slippage is prefilled when coming back to the main Swaps page"
- Get on the Swaps page
- Choose tokens From and To
- Enter 0 into custom slippage
- Click on the "Review Swap" button
- Click on the "Back" button on a new page
- 0% is prefilled

## Screenshots
Review Swap button enabled for 0% slippage and no warning message:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/80175477/116165540-f46a6380-a6b0-11eb-839f-4b9a6b6471d6.png">

Review Swap button enabled for 0.5% slippage with a warning message:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/80175477/116165549-fc2a0800-a6b0-11eb-8814-8800a7631e32.png">

Review Swap button disabled for negative slippage:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/80175477/116165572-051ad980-a6b1-11eb-852e-2e7ac9684988.png">