### PR TITLE
add hamburger menu to eth page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -176,6 +176,9 @@
   "asset": {
     "message": "Asset"
   },
+  "assetOptions": {
+    "message": "Asset options"
+  },
   "assets": {
     "message": "Assets"
   },
@@ -2131,9 +2134,6 @@
   },
   "tokenContractAddress": {
     "message": "Token Contract Address"
-  },
-  "tokenOptions": {
-    "message": "Token options"
   },
   "tokenSymbol": {
     "message": "Token Symbol"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1864,9 +1864,6 @@
   "tokenContractAddress": {
     "message": "Dirección del contrato de token"
   },
-  "tokenOptions": {
-    "message": "Opciones del Token"
-  },
   "tokenSymbol": {
     "message": "Símbolo del token"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1864,9 +1864,6 @@
   "tokenContractAddress": {
     "message": "Dirección de contrato del token"
   },
-  "tokenOptions": {
-    "message": "Opciones del Token"
-  },
   "tokenSymbol": {
     "message": "Símbolo del token"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1828,9 +1828,6 @@
   "tokenContractAddress": {
     "message": "टोकन अनुबंध पता"
   },
-  "tokenOptions": {
-    "message": "टोकन के विकल्प"
-  },
   "tokenSymbol": {
     "message": "टोकन का प्रतीक"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1828,9 +1828,6 @@
   "tokenContractAddress": {
     "message": "Alamat Kontrak Token"
   },
-  "tokenOptions": {
-    "message": "Opsi token"
-  },
   "tokenSymbol": {
     "message": "Simbol Token"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1887,9 +1887,6 @@
   "tokenContractAddress": {
     "message": "Indirizzo Contratto Token"
   },
-  "tokenOptions": {
-    "message": "Opzioni token"
-  },
   "tokenSymbol": {
     "message": "Simbolo Token"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1864,9 +1864,6 @@
   "tokenContractAddress": {
     "message": "トークンコントラクトのアドレス"
   },
-  "tokenOptions": {
-    "message": "トークンのオプション"
-  },
   "tokenSymbol": {
     "message": "トークンシンボル"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1828,9 +1828,6 @@
   "tokenContractAddress": {
     "message": "토큰 계약 주소"
   },
-  "tokenOptions": {
-    "message": "토큰 옵션"
-  },
   "tokenSymbol": {
     "message": "토큰 기호"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1828,9 +1828,6 @@
   "tokenContractAddress": {
     "message": "Адрес контракта токена"
   },
-  "tokenOptions": {
-    "message": "Опции токена"
-  },
   "tokenSymbol": {
     "message": "Символ токена"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1825,9 +1825,6 @@
   "tokenContractAddress": {
     "message": "Address ng Kontrata ng Token"
   },
-  "tokenOptions": {
-    "message": "Mga opsyon ng token"
-  },
   "tokenSymbol": {
     "message": "Simbolo ng Token"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1828,9 +1828,6 @@
   "tokenContractAddress": {
     "message": "Địa chỉ hợp đồng token"
   },
-  "tokenOptions": {
-    "message": "Tùy chọn token"
-  },
   "tokenSymbol": {
     "message": "Ký hiệu token"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1864,9 +1864,6 @@
   "tokenContractAddress": {
     "message": "代币合约地址"
   },
-  "tokenOptions": {
-    "message": "代币选项"
-  },
   "tokenSymbol": {
     "message": "代币符号"
   },

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -1508,9 +1508,9 @@ describe('MetaMask', function () {
 
   describe('Hide token', function () {
     it('hides the token when clicked', async function () {
-      await driver.clickElement('[data-testid="token-options__button"]');
+      await driver.clickElement('[data-testid="asset-options__button"]');
 
-      await driver.clickElement('[data-testid="token-options__hide"]');
+      await driver.clickElement('[data-testid="asset-options__hide"]');
 
       // wait for confirm hide modal to be visible
       const confirmHideModal = await driver.findVisibleElement('span .modal');

--- a/ui/app/pages/asset/asset.scss
+++ b/ui/app/pages/asset/asset.scss
@@ -32,7 +32,7 @@
   }
 }
 
-.token-options {
+.asset-options {
   &__button {
     font-size: $font-size-paragraph;
     color: $Black-100;

--- a/ui/app/pages/asset/components/asset-options.js
+++ b/ui/app/pages/asset/components/asset-options.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { I18nContext } from '../../../contexts/i18n';
 import { Menu, MenuItem } from '../../../components/ui/menu';
 
-const TokenOptions = ({
+const AssetOptions = ({
   onRemove,
   onViewEtherscan,
   onViewAccountDetails,
@@ -12,40 +12,40 @@ const TokenOptions = ({
   isNativeAsset,
 }) => {
   const t = useContext(I18nContext);
-  const [tokenOptionsButtonElement, setTokenOptionsButtonElement] = useState(
+  const [assetOptionsButtonElement, setAssetOptionsButtonElement] = useState(
     null,
   );
-  const [tokenOptionsOpen, setTokenOptionsOpen] = useState(false);
+  const [assetOptionsOpen, setAssetOptionsOpen] = useState(false);
 
   return (
     <>
       <button
-        className="fas fa-ellipsis-v token-options__button"
-        data-testid="token-options__button"
-        onClick={() => setTokenOptionsOpen(true)}
-        ref={setTokenOptionsButtonElement}
-        title={t('tokenOptions')}
+        className="fas fa-ellipsis-v asset-options__button"
+        data-testid="asset-options__button"
+        onClick={() => setAssetOptionsOpen(true)}
+        ref={setAssetOptionsButtonElement}
+        title={t('assetOptions')}
       />
-      {tokenOptionsOpen ? (
+      {assetOptionsOpen ? (
         <Menu
-          anchorElement={tokenOptionsButtonElement}
-          onHide={() => setTokenOptionsOpen(false)}
+          anchorElement={assetOptionsButtonElement}
+          onHide={() => setAssetOptionsOpen(false)}
         >
           <MenuItem
             iconClassName="fas fa-qrcode"
-            data-testid="token-options__account-details"
+            data-testid="asset-options__account-details"
             onClick={() => {
-              setTokenOptionsOpen(false);
+              setAssetOptionsOpen(false);
               onViewAccountDetails();
             }}
           >
             {t('accountDetails')}
           </MenuItem>
           <MenuItem
-            iconClassName="fas fa-external-link-alt token-options__icon"
-            data-testid="token-options__etherscan"
+            iconClassName="fas fa-external-link-alt asset-options__icon"
+            data-testid="asset-options__etherscan"
             onClick={() => {
-              setTokenOptionsOpen(false);
+              setAssetOptionsOpen(false);
               onViewEtherscan();
             }}
           >
@@ -53,10 +53,10 @@ const TokenOptions = ({
           </MenuItem>
           {isNativeAsset ? null : (
             <MenuItem
-              iconClassName="fas fa-trash-alt token-options__icon"
-              data-testid="token-options__hide"
+              iconClassName="fas fa-trash-alt asset-options__icon"
+              data-testid="asset-options__hide"
               onClick={() => {
-                setTokenOptionsOpen(false);
+                setAssetOptionsOpen(false);
                 onRemove();
               }}
             >
@@ -69,7 +69,7 @@ const TokenOptions = ({
   );
 };
 
-TokenOptions.propTypes = {
+AssetOptions.propTypes = {
   isNativeAsset: PropTypes.bool,
   onRemove: PropTypes.func.isRequired,
   onViewEtherscan: PropTypes.func.isRequired,
@@ -77,4 +77,4 @@ TokenOptions.propTypes = {
   tokenSymbol: PropTypes.string,
 };
 
-export default TokenOptions;
+export default AssetOptions;

--- a/ui/app/pages/asset/components/native-asset.js
+++ b/ui/app/pages/asset/components/native-asset.js
@@ -8,12 +8,13 @@ import {
   getSelectedIdentity,
   getCurrentChainId,
   getRpcPrefsForCurrentProvider,
+  getSelectedAddress,
 } from '../../../selectors/selectors';
 import { showModal } from '../../../store/actions';
 import getAccountLink from '../../../../lib/account-link';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import AssetNavigation from './asset-navigation';
-import TokenOptions from './token-options';
+import AssetOptions from './asset-options';
 
 export default function NativeAsset({ nativeCurrency }) {
   const selectedAccountName = useSelector(
@@ -23,8 +24,7 @@ export default function NativeAsset({ nativeCurrency }) {
 
   const chainId = useSelector(getCurrentChainId);
   const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
-  const selectedIdentity = useSelector(getSelectedIdentity);
-  const { address } = selectedIdentity;
+  const address = useSelector(getSelectedAddress);
   const history = useHistory();
 
   return (
@@ -34,7 +34,7 @@ export default function NativeAsset({ nativeCurrency }) {
         assetName={nativeCurrency}
         onBack={() => history.push(DEFAULT_ROUTE)}
         optionsButton={
-          <TokenOptions
+          <AssetOptions
             isNativeAsset
             onViewEtherscan={() => {
               global.platform.openTab({

--- a/ui/app/pages/asset/components/native-asset.js
+++ b/ui/app/pages/asset/components/native-asset.js
@@ -1,19 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-
 import TransactionList from '../../../components/app/transaction-list';
 import { EthOverview } from '../../../components/app/wallet-overview';
-import { getSelectedIdentity } from '../../../selectors/selectors';
+import {
+  getSelectedIdentity,
+  getCurrentChainId,
+  getRpcPrefsForCurrentProvider,
+} from '../../../selectors/selectors';
+import { showModal } from '../../../store/actions';
+import getAccountLink from '../../../../lib/account-link';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-
 import AssetNavigation from './asset-navigation';
+import TokenOptions from './token-options';
 
 export default function NativeAsset({ nativeCurrency }) {
   const selectedAccountName = useSelector(
     (state) => getSelectedIdentity(state).name,
   );
+  const dispatch = useDispatch();
+
+  const chainId = useSelector(getCurrentChainId);
+  const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
+  const selectedIdentity = useSelector(getSelectedIdentity);
+  const { address } = selectedIdentity;
   const history = useHistory();
 
   return (
@@ -22,6 +33,19 @@ export default function NativeAsset({ nativeCurrency }) {
         accountName={selectedAccountName}
         assetName={nativeCurrency}
         onBack={() => history.push(DEFAULT_ROUTE)}
+        optionsButton={
+          <TokenOptions
+            isNativeAsset
+            onViewEtherscan={() => {
+              global.platform.openTab({
+                url: getAccountLink(address, chainId, rpcPrefs),
+              });
+            }}
+            onViewAccountDetails={() => {
+              dispatch(showModal({ name: 'ACCOUNT_DETAILS' }));
+            }}
+          />
+        }
       />
       <EthOverview className="asset__overview" />
       <TransactionList hideTokenTransactions />

--- a/ui/app/pages/asset/components/token-asset.js
+++ b/ui/app/pages/asset/components/token-asset.js
@@ -14,7 +14,7 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { showModal } from '../../../store/actions';
 
 import AssetNavigation from './asset-navigation';
-import TokenOptions from './token-options';
+import AssetOptions from './asset-options';
 
 export default function TokenAsset({ token }) {
   const dispatch = useDispatch();
@@ -31,7 +31,7 @@ export default function TokenAsset({ token }) {
         assetName={token.symbol}
         onBack={() => history.push(DEFAULT_ROUTE)}
         optionsButton={
-          <TokenOptions
+          <AssetOptions
             onRemove={() =>
               dispatch(showModal({ name: 'HIDE_TOKEN_CONFIRMATION', token }))
             }

--- a/ui/app/pages/asset/components/token-options.js
+++ b/ui/app/pages/asset/components/token-options.js
@@ -9,6 +9,7 @@ const TokenOptions = ({
   onViewEtherscan,
   onViewAccountDetails,
   tokenSymbol,
+  isNativeAsset,
 }) => {
   const t = useContext(I18nContext);
   const [tokenOptionsButtonElement, setTokenOptionsButtonElement] = useState(
@@ -50,16 +51,18 @@ const TokenOptions = ({
           >
             {t('viewOnEtherscan')}
           </MenuItem>
-          <MenuItem
-            iconClassName="fas fa-trash-alt token-options__icon"
-            data-testid="token-options__hide"
-            onClick={() => {
-              setTokenOptionsOpen(false);
-              onRemove();
-            }}
-          >
-            {t('hideTokenSymbol', [tokenSymbol])}
-          </MenuItem>
+          {isNativeAsset ? null : (
+            <MenuItem
+              iconClassName="fas fa-trash-alt token-options__icon"
+              data-testid="token-options__hide"
+              onClick={() => {
+                setTokenOptionsOpen(false);
+                onRemove();
+              }}
+            >
+              {t('hideTokenSymbol', [tokenSymbol])}
+            </MenuItem>
+          )}
         </Menu>
       ) : null}
     </>
@@ -67,10 +70,11 @@ const TokenOptions = ({
 };
 
 TokenOptions.propTypes = {
+  isNativeAsset: PropTypes.bool,
   onRemove: PropTypes.func.isRequired,
   onViewEtherscan: PropTypes.func.isRequired,
   onViewAccountDetails: PropTypes.func.isRequired,
-  tokenSymbol: PropTypes.string.isRequired,
+  tokenSymbol: PropTypes.string,
 };
 
 export default TokenOptions;


### PR DESCRIPTION
(Completes) Fixes: #10148

Explanation:  Adds the hamburger menu that currently exists for non-native asset token pages to the native asset (eth) page fork navigating to account details and Etherscan.

Manual testing steps:  
  - Navigate to native asset (eth) page
  - Confirm that there is a hamburger menu available in top right hand corner
  - Confirm that links in menu work as expected.
