### PR TITLE
use token custom icons where possible

### DIFF
--- a/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
+++ b/ui/app/pages/send/send-content/send-asset-row/send-asset-row.component.js
@@ -16,6 +16,7 @@ export default class SendAssetRow extends Component {
       }),
     ).isRequired,
     accounts: PropTypes.object.isRequired,
+    assetImages: PropTypes.object,
     selectedAddress: PropTypes.string.isRequired,
     sendTokenAddress: PropTypes.string,
     setSendToken: PropTypes.func.isRequired,
@@ -155,6 +156,7 @@ export default class SendAssetRow extends Component {
   renderAsset(token, insideDropdown = false) {
     const { address, symbol } = token;
     const { t } = this.context;
+    const { assetImages } = this.props;
 
     return (
       <div
@@ -163,7 +165,11 @@ export default class SendAssetRow extends Component {
         onClick={() => this.selectToken(token)}
       >
         <div className="send-v2__asset-dropdown__asset-icon">
-          <Identicon address={address} diameter={36} />
+          <Identicon
+            address={address}
+            diameter={36}
+            image={assetImages[address]}
+          />
         </div>
         <div className="send-v2__asset-dropdown__asset-data">
           <div className="send-v2__asset-dropdown__symbol">{symbol}</div>

--- a/ui/app/pages/send/send-content/send-asset-row/send-asset-row.container.js
+++ b/ui/app/pages/send/send-content/send-asset-row/send-asset-row.container.js
@@ -4,6 +4,7 @@ import {
   getNativeCurrency,
   getNativeCurrencyImage,
   getSendTokenAddress,
+  getAssetImages,
 } from '../../../../selectors';
 import { updateSendToken } from '../../../../store/actions';
 import SendAssetRow from './send-asset-row.component';
@@ -16,6 +17,7 @@ function mapStateToProps(state) {
     accounts: getMetaMaskAccounts(state),
     nativeCurrency: getNativeCurrency(state),
     nativeCurrencyImage: getNativeCurrencyImage(state),
+    assetImages: getAssetImages(state),
   };
 }
 


### PR DESCRIPTION
Fixes: #8252

Explanation:  Adds custom icon for a token to the send token flow in the asset-dropdown

Manual testing steps:  
  - Add a custom token via the methods outlined in [EIP-747](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-747.md)
  - Attempt to send some of this token
  - Confirm that the custom icon that was supplied when first importing the token is visible beside token name(rather than generic identicon).
  
  Here is a method that can be called in the browser console to initialize the addition of a token with a custom icon into MetaMask:
  
  `ethereum.request({
  method: 'wallet_watchAsset',
  params: {
    type: 'ERC20',
    options: {
      address: '0xb60e8dd61c5d32be8058bb8eb970870f07233155',
      symbol: 'FOO',
      decimals: 18,
      image: 'https://w7.pngwing.com/pngs/1018/815/png-transparent-luminiferous-aether-symbol-diethyl-ether-symbol-miscellaneous-purple-chemical-element.png',
    },
  },
})
  .then((success) => {
    if (success) {
      console.log('FOO successfully added to wallet!')
    } else {
      throw new Error('Something went wrong.')
    }
  })
  .catch(console.error)`