### PR TITLE
send user to activity tab after transaction complete

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -1117,16 +1117,10 @@ describe('MetaMask', function () {
     });
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.wait(async () => {
-        const confirmedTxes = await driver.findElements(
-          '.transaction-list__completed-transactions .transaction-list-item',
-        );
-        return confirmedTxes.length === 1;
-      }, 10000);
-
       await driver.waitForSelector(
         {
-          css: '.transaction-list-item__primary-currency',
+          css:
+            '.transaction-list__completed-transactions .transaction-list-item__primary-currency',
           text: '-1 TST',
         },
         { timeout: 10000 },
@@ -1219,15 +1213,9 @@ describe('MetaMask', function () {
     });
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.wait(async () => {
-        const confirmedTxes = await driver.findElements(
-          '.transaction-list__completed-transactions .transaction-list-item',
-        );
-        return confirmedTxes.length === 2;
-      }, 10000);
-
       await driver.waitForSelector({
-        css: '.transaction-list-item__primary-currency',
+        css:
+          '.transaction-list__completed-transactions .transaction-list-item__primary-currency',
         text: '-1.5 TST',
       });
 
@@ -1235,10 +1223,22 @@ describe('MetaMask', function () {
         css: '.list-item__heading',
         text: 'Send TST',
       });
+    });
+
+    it('checks balance', async function () {
+      await driver.clickElement({
+        text: 'Assets',
+        tag: 'button',
+      });
 
       await driver.waitForSelector({
-        css: '.token-overview__primary-balance',
+        css: '.asset-list-item__token-button',
         text: '7.5 TST',
+      });
+
+      await driver.clickElement({
+        text: 'Activity',
+        tag: 'button',
       });
     });
   });
@@ -1368,13 +1368,6 @@ describe('MetaMask', function () {
     });
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.wait(async () => {
-        const confirmedTxes = await driver.findElements(
-          '.transaction-list__completed-transactions .transaction-list-item',
-        );
-        return confirmedTxes.length === 3;
-      }, 10000);
-
       await driver.waitForSelector({
         // Select only the heading of the first entry in the transaction list.
         css:
@@ -1427,13 +1420,6 @@ describe('MetaMask', function () {
     });
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.wait(async () => {
-        const confirmedTxes = await driver.findElements(
-          '.transaction-list__completed-transactions .transaction-list-item',
-        );
-        return confirmedTxes.length === 4;
-      }, 10000);
-
       await driver.waitForSelector({
         // Select the heading of the first transaction list item in the
         // completed transaction list with text matching Send TST
@@ -1443,7 +1429,8 @@ describe('MetaMask', function () {
       });
 
       await driver.waitForSelector({
-        css: '.transaction-list-item__primary-currency',
+        css:
+          '.transaction-list__completed-transactions .transaction-list-item:first-child .transaction-list-item__primary-currency',
         text: '-1.5 TST',
       });
     });
@@ -1509,13 +1496,6 @@ describe('MetaMask', function () {
     });
 
     it('finds the transaction in the transactions list', async function () {
-      await driver.wait(async () => {
-        const confirmedTxes = await driver.findElements(
-          '.transaction-list__completed-transactions .transaction-list-item',
-        );
-        return confirmedTxes.length === 5;
-      }, 10000);
-
       await driver.waitForSelector({
         css:
           '.transaction-list__completed-transactions .transaction-list-item:first-child .list-item__heading',
@@ -1526,6 +1506,10 @@ describe('MetaMask', function () {
 
   describe('Hide token', function () {
     it('hides the token when clicked', async function () {
+      await driver.clickElement({ text: 'Assets', tag: 'button' });
+
+      await driver.clickElement({ text: 'TST', tag: 'span' });
+
       await driver.clickElement('[data-testid="asset-options__button"]');
 
       await driver.clickElement('[data-testid="asset-options__hide"]');

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -7,7 +7,10 @@ import ConfirmPageContainer, {
   ConfirmDetailRow,
 } from '../../components/app/confirm-page-container';
 import { isBalanceSufficient } from '../send/send.utils';
-import { CONFIRM_TRANSACTION_ROUTE } from '../../helpers/constants/routes';
+import {
+  CONFIRM_TRANSACTION_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../helpers/constants/routes';
 import {
   INSUFFICIENT_FUNDS_ERROR_KEY,
   TRANSACTION_ERROR_KEY,
@@ -100,6 +103,7 @@ export default class ConfirmTransactionBase extends Component {
     isMainnet: PropTypes.bool,
     isEthGasPrice: PropTypes.bool,
     noGasPrice: PropTypes.bool,
+    setDefaultHomeActiveTabName: PropTypes.func,
   };
 
   state = {
@@ -115,12 +119,12 @@ export default class ConfirmTransactionBase extends Component {
       showTransactionConfirmedModal,
       history,
       clearConfirmTransaction,
-      mostRecentOverviewPage,
       nextNonce,
       customNonceValue,
       toAddress,
       tryReverseResolveAddress,
       isEthGasPrice,
+      setDefaultHomeActiveTabName,
     } = this.props;
     const {
       customNonceValue: prevCustomNonceValue,
@@ -151,7 +155,9 @@ export default class ConfirmTransactionBase extends Component {
       showTransactionConfirmedModal({
         onSubmit: () => {
           clearConfirmTransaction();
-          history.push(mostRecentOverviewPage);
+          setDefaultHomeActiveTabName('Activity').then(() => {
+            history.push(DEFAULT_ROUTE);
+          });
         },
       });
     }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -14,6 +14,7 @@ import {
   updateTransaction,
   getNextNonce,
   tryReverseResolveAddress,
+  setDefaultHomeActiveTabName,
 } from '../../store/actions';
 import {
   INSUFFICIENT_FUNDS_ERROR_KEY,
@@ -238,6 +239,8 @@ export const mapDispatchToProps = (dispatch) => {
       dispatch(updateAndApproveTx(customNonceMerge(txData))),
     setMetaMetricsSendCount: (val) => dispatch(setMetaMetricsSendCount(val)),
     getNextNonce: () => dispatch(getNextNonce()),
+    setDefaultHomeActiveTabName: (tabName) =>
+      dispatch(setDefaultHomeActiveTabName(tabName)),
   };
 };
 

--- a/ui/pages/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirm-transaction/confirm-transaction.component.js
@@ -23,6 +23,7 @@ import {
   SIGNATURE_REQUEST_PATH,
   DECRYPT_MESSAGE_REQUEST_PATH,
   ENCRYPTION_PUBLIC_KEY_REQUEST_PATH,
+  DEFAULT_ROUTE,
 } from '../../helpers/constants/routes';
 import ConfTx from './conf-tx';
 
@@ -45,6 +46,7 @@ export default class ConfirmTransaction extends Component {
     paramsTransactionId: PropTypes.string,
     getTokenParams: PropTypes.func,
     isTokenMethodAction: PropTypes.bool,
+    setDefaultHomeActiveTabName: PropTypes.func,
   };
 
   componentDidMount() {
@@ -89,6 +91,7 @@ export default class ConfirmTransaction extends Component {
       history,
       mostRecentOverviewPage,
       totalUnapprovedCount,
+      setDefaultHomeActiveTabName,
     } = this.props;
 
     if (
@@ -104,7 +107,9 @@ export default class ConfirmTransaction extends Component {
       !transactionId &&
       !totalUnapprovedCount
     ) {
-      history.replace(mostRecentOverviewPage);
+      setDefaultHomeActiveTabName('Activity').then(() => {
+        history.replace(DEFAULT_ROUTE);
+      });
     } else if (
       prevProps.transactionId &&
       transactionId &&

--- a/ui/pages/confirm-transaction/confirm-transaction.container.js
+++ b/ui/pages/confirm-transaction/confirm-transaction.container.js
@@ -8,7 +8,11 @@ import {
 import { isTokenMethodAction } from '../../helpers/utils/transactions.util';
 import { fetchBasicGasEstimates } from '../../ducks/gas/gas.duck';
 
-import { getContractMethodData, getTokenParams } from '../../store/actions';
+import {
+  getContractMethodData,
+  getTokenParams,
+  setDefaultHomeActiveTabName,
+} from '../../store/actions';
 import { unconfirmedTransactionsListSelector } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import ConfirmTransaction from './confirm-transaction.component';
@@ -51,6 +55,8 @@ const mapDispatchToProps = (dispatch) => {
     fetchBasicGasEstimates: () => dispatch(fetchBasicGasEstimates()),
     getContractMethodData: (data) => dispatch(getContractMethodData(data)),
     getTokenParams: (tokenAddress) => dispatch(getTokenParams(tokenAddress)),
+    setDefaultHomeActiveTabName: (tabName) =>
+      dispatch(setDefaultHomeActiveTabName(tabName)),
   };
 };
 

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2047,8 +2047,9 @@ export function updatePreferences(value) {
 }
 
 export function setDefaultHomeActiveTabName(value) {
-  return async () => {
+  return async (dispatch) => {
     await promisifiedBackground.setDefaultHomeActiveTabName(value);
+    await forceUpdateMetamaskState(dispatch);
   };
 }
 


### PR DESCRIPTION
Fixes: #10340

Explanation:  Directs user to activity tab upon completing a transaction. Updates e2e tests accordingly. 

Manual testing steps:  
  - Initialize a send transaction for eth or token
  - After completing confirmation flow confirm that 'Activity' tab is selected
 