### PR TITLE
Update the CLA Signature bot to v3.0.2 (#10947)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Signature Bot"
-        uses: MetaMask/cla-signature-bot@v3.0.1
+        uses: MetaMask/cla-signature-bot@v3.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This update includes support for PRs with >100 commits.

Develop: https://github.com/MetaMask/metamask-extension/pull/10947