### PR TITLE
Fix #10173 - Prevent lag in external monitors when using Mac + Chrome

### DIFF
--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -158,4 +158,12 @@ export default class AppStateController extends EventEmitter {
       timeoutMinutes * 60 * 1000,
     );
   }
+
+  /**
+   * Sets the current browser and OS environment
+   * @returns {void}
+   */
+  setBrowserEnvironment(os, browser) {
+    this.store.updateState({ browserEnvironment: { os, browser } })
+  }
 }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -23,6 +23,7 @@ export default class AppStateController extends EventEmitter {
       timeoutMinutes: 0,
       connectedStatusPopoverHasBeenShown: true,
       defaultHomeActiveTabName: null,
+      browserEnvironment: {},
       ...initState,
     });
     this.timer = null;
@@ -164,6 +165,6 @@ export default class AppStateController extends EventEmitter {
    * @returns {void}
    */
   setBrowserEnvironment(os, browser) {
-    this.store.updateState({ browserEnvironment: { os, browser } })
+    this.store.updateState({ browserEnvironment: { os, browser } });
   }
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -476,6 +476,17 @@ export default class MetamaskController extends EventEmitter {
       this.submitPassword(password);
     }
 
+    // Lazily update the store with the current extension environment
+    this.extension.runtime.getPlatformInfo(({ os }) => {
+      this.appStateController.setBrowserEnvironment(
+        os,
+        // This method is presently only supported by Firefox
+        this.extension.runtime.getBrowserInfo === undefined
+        ? 'chrome'
+        : 'firefox',
+      );
+    });
+
     // TODO:LegacyProvider: Delete
     this.publicConfigStore = this.createPublicConfigStore();
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -482,8 +482,8 @@ export default class MetamaskController extends EventEmitter {
         os,
         // This method is presently only supported by Firefox
         this.extension.runtime.getBrowserInfo === undefined
-        ? 'chrome'
-        : 'firefox',
+          ? 'chrome'
+          : 'firefox',
       );
     });
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -52,6 +52,7 @@ const ExtensionizerMock = {
     onInstalled: {
       addListener: () => undefined,
     },
+    getPlatformInfo: async () => 'mac',
   },
 };
 

--- a/ui/css/itcss/components/newui-sections.scss
+++ b/ui/css/itcss/components/newui-sections.scss
@@ -14,6 +14,47 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
   align-items: center;
 }
 
+// Fix for UI lag on external monitor: https://github.com/MetaMask/metamask-extension/issues/10173
+.app::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  background-color: $Grey-000;
+  -webkit-animation-name: emptySpinningDiv;
+  animation-name: emptySpinningDiv;
+  -webkit-animation-duration: 2s;
+  animation-duration: 2s;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+}
+
+@-webkit-keyframes emptySpinningDiv {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes emptySpinningDiv {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+
 // Main container
 .main-container {
   z-index: $main-container-z-index;

--- a/ui/css/itcss/components/newui-sections.scss
+++ b/ui/css/itcss/components/newui-sections.scss
@@ -23,10 +23,7 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
   width: 1px;
   height: 1px;
   background-color: $Grey-000;
-  animation-name: emptySpinningDiv;
-  animation-duration: 2s;
-  animation-iteration-count: infinite;
-  animation-timing-function: linear;
+  animation: emptySpinningDiv 1s infinite linear;
 }
 
 @keyframes emptySpinningDiv {

--- a/ui/css/itcss/components/newui-sections.scss
+++ b/ui/css/itcss/components/newui-sections.scss
@@ -23,34 +23,17 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
   width: 1px;
   height: 1px;
   background-color: $Grey-000;
-  -webkit-animation-name: emptySpinningDiv;
   animation-name: emptySpinningDiv;
-  -webkit-animation-duration: 2s;
   animation-duration: 2s;
-  -webkit-animation-iteration-count: infinite;
   animation-iteration-count: infinite;
-  -webkit-animation-timing-function: linear;
   animation-timing-function: linear;
-}
-
-@-webkit-keyframes emptySpinningDiv {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  to {
-    -webkit-transform: rotate(1turn);
-    transform: rotate(1turn);
-  }
 }
 
 @keyframes emptySpinningDiv {
   0% {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   to {
-    -webkit-transform: rotate(1turn);
     transform: rotate(1turn);
   }
 }

--- a/ui/css/itcss/components/newui-sections.scss
+++ b/ui/css/itcss/components/newui-sections.scss
@@ -15,7 +15,7 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
 }
 
 // Fix for UI lag on external monitor: https://github.com/MetaMask/metamask-extension/issues/10173
-.app::after {
+.app.os-mac.browser-chrome::after {
   content: "";
   position: fixed;
   top: 0;
@@ -27,12 +27,8 @@ $sub-mid-size-breakpoint-range: "screen and (min-width: #{$break-large}) and (ma
 }
 
 @keyframes emptySpinningDiv {
-  0% {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(1turn);
-  }
+  0% { transform: rotate(0deg); }
+  to { transform: rotate(1turn); }
 }
 
 // Main container

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -90,6 +90,7 @@ export default class Routes extends Component {
     autoLockTimeLimit: PropTypes.number,
     pageChanged: PropTypes.func.isRequired,
     prepareToLeaveSwaps: PropTypes.func,
+    browserEnvironment: PropTypes.object,
   };
 
   static contextTypes = {
@@ -275,6 +276,7 @@ export default class Routes extends Component {
       submittedPendingTransactions,
       isMouseUser,
       prepareToLeaveSwaps,
+      browserEnvironment,
     } = this.props;
     const loadMessage =
       loadingMessage || isNetworkLoading
@@ -296,9 +298,12 @@ export default class Routes extends Component {
         ({ id }) => id === sidebarTransaction.id,
       );
 
+    const { os, browser } = browserEnvironment;
     return (
       <div
-        className={classnames('app', { 'mouse-user-styles': isMouseUser })}
+        className={classnames('app', `os-${os}`, `browser-${browser}`, { 
+          'mouse-user-styles': isMouseUser,
+        })}
         dir={textDirection}
         onClick={() => setMouseUserState(true)}
         onKeyDown={(e) => {

--- a/ui/pages/routes/routes.component.js
+++ b/ui/pages/routes/routes.component.js
@@ -301,7 +301,9 @@ export default class Routes extends Component {
     const { os, browser } = browserEnvironment;
     return (
       <div
-        className={classnames('app', `os-${os}`, `browser-${browser}`, { 
+        className={classnames('app', {
+          [`os-${os}`]: os,
+          [`browser-${browser}`]: browser,
           'mouse-user-styles': isMouseUser,
         })}
         dir={textDirection}

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -29,6 +29,8 @@ function mapStateToProps(state) {
   } = appState;
   const { autoLockTimeLimit = 0 } = getPreferences(state);
 
+  console.log("Routes state: ", state);
+
   return {
     sidebar,
     alertOpen,
@@ -45,6 +47,7 @@ function mapStateToProps(state) {
     isMouseUser: state.appState.isMouseUser,
     providerId: getNetworkIdentifier(state),
     autoLockTimeLimit,
+    browserEnvironment: state.appState.browserEnvironment,
   };
 }
 

--- a/ui/pages/routes/routes.container.js
+++ b/ui/pages/routes/routes.container.js
@@ -29,8 +29,6 @@ function mapStateToProps(state) {
   } = appState;
   const { autoLockTimeLimit = 0 } = getPreferences(state);
 
-  console.log("Routes state: ", state);
-
   return {
     sidebar,
     alertOpen,
@@ -47,7 +45,7 @@ function mapStateToProps(state) {
     isMouseUser: state.appState.isMouseUser,
     providerId: getNetworkIdentifier(state),
     autoLockTimeLimit,
-    browserEnvironment: state.appState.browserEnvironment,
+    browserEnvironment: state.metamask.browserEnvironment,
   };
 }
 


### PR DESCRIPTION
Fixes: #10173

Explanation:  Add a bit of CSS that renders a visually invisible rotating 1px element that forces the UI to update on each tick

Manual testing steps:  
  - Move Chrome window to an external monitor
  - Open Metamask popup and type in any input (password or a send amount)
  - See the UI updating after each keystroke
