### PR TITLE
Anchor the Need Help text to the bottom of the expanded page

### DIFF
--- a/ui/components/ui/tabs/index.scss
+++ b/ui/components/ui/tabs/index.scss
@@ -1,6 +1,7 @@
 @import 'tab/index';
 
 .tabs {
+  flex-grow: 1;
   // Just for Firefox — https://github.com/MetaMask/metamask-extension/issues/8700
   -moz-transform: translateZ(0);
 


### PR DESCRIPTION
Fixes an issue found by @tmashuang during QA.

<img width="985" alt="Bottom" src="https://user-images.githubusercontent.com/46655/116590655-a2f5ea80-a8e3-11eb-8f4d-b2e6d273cc6e.png">
