### PR TITLE
Migrate check for GITHUB_TOKEN

### DIFF
--- a/.circleci/scripts/release-commit-version-bump.sh
+++ b/.circleci/scripts/release-commit-version-bump.sh
@@ -16,6 +16,16 @@ then
     exit 1
 fi
 
+if [[ -z "${GITHUB_TOKEN:-}" ]]
+then
+    printf '%s\n' 'GITHUB_TOKEN environment variable must be set'
+    exit 1
+elif [[ -z "${GITHUB_TOKEN_USER:-}" ]]
+then
+    printf '%s\n' 'GITHUB_TOKEN_USER environment variable must be set'
+    exit 1
+fi
+
 printf '%s\n' 'Commit the manifest version and changelog if the manifest has changed'
 
 if git diff --quiet app/manifest/_base.json;

--- a/.circleci/scripts/release-create-release-pr.sh
+++ b/.circleci/scripts/release-create-release-pr.sh
@@ -16,12 +16,6 @@ then
     exit 1
 fi
 
-if [[ -z "${GITHUB_TOKEN:-}" ]]
-then
-    printf '%s\n' 'GITHUB_TOKEN environment variable must be set'
-    exit 1
-fi
-
 function install_github_cli ()
 {
     printf '%s\n' 'Installing hub CLI'


### PR DESCRIPTION
The check for the GITHUB_TOKEN environment variable was being done in the wrong release script. It has been migrated to the relevant script.

A second check for the username has also been added, as it is also required.