### PR TITLE
Ensure method of adding contact when contacts exist

### DIFF
--- a/ui/pages/settings/contact-list-tab/contact-list-tab.component.js
+++ b/ui/pages/settings/contact-list-tab/contact-list-tab.component.js
@@ -5,6 +5,7 @@ import {
   CONTACT_ADD_ROUTE,
   CONTACT_VIEW_ROUTE,
 } from '../../../helpers/constants/routes';
+import Button from '../../../components/ui/button';
 import EditContact from './edit-contact';
 import AddContact from './add-contact';
 import ViewContact from './view-contact';
@@ -66,6 +67,25 @@ export default class ContactListTab extends Component {
     );
   }
 
+  renderAddButton() {
+    const { history } = this.props;
+
+    return (
+      <div className="address-book-add-button">
+        <Button
+          className="address-book-add-button__button"
+          type="secondary"
+          rounded
+          onClick={() => {
+            history.push(CONTACT_ADD_ROUTE);
+          }}
+        >
+          {this.context.t('addContact')}
+        </Button>
+      </div>
+    );
+  }
+
   renderContactContent() {
     const {
       viewingContact,
@@ -106,10 +126,13 @@ export default class ContactListTab extends Component {
   }
 
   render() {
+    const { addingContact, addressBook } = this.props;
+
     return (
       <div className="address-book-wrapper">
         {this.renderAddressBookContent()}
         {this.renderContactContent()}
+        {!addingContact && addressBook.length > 0 && this.renderAddButton()}
       </div>
     );
   }

--- a/ui/pages/settings/contact-list-tab/index.scss
+++ b/ui/pages/settings/contact-list-tab/index.scss
@@ -250,23 +250,14 @@
 .address-book-add-button {
   &__button {
     position: absolute;
-    top: 80px;
+    top: 85px;
     right: 16px;
-    height: 56px;
-    width: 56px;
-    border-radius: 18px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: 50%;
-    border-width: 1px;
-    background: $primary-blue;
-    margin-right: 5px;
-    cursor: pointer;
-    box-shadow: 0 2px 16px rgba(0, 0, 0, 0.25);
+    width: auto;
+    border-radius: 100px;
 
     @media screen and (max-width: 576px) {
-      top: 10px;
+      top: 16px;
+      right: 60px;
     }
   }
 }


### PR DESCRIPTION
While doing QA on 9.5 today, I noticed an issue that we missed during https://github.com/MetaMask/metamask-extension/pull/10680 review -- when there are existing contacts, there is no "Add Contact" button, since that button got moved to the main content area when contacts don't exist.  This PR aims to rectify that problem.

<img width="961" alt="Add" src="https://user-images.githubusercontent.com/46655/116740628-e5d6c180-a9ba-11eb-9cc0-44f9bace2786.png">

<img width="449" alt="AddC" src="https://user-images.githubusercontent.com/46655/116740671-f424dd80-a9ba-11eb-9a5b-d6e3d88e1426.png">
