### PR TITLE
Remove context shims from unit tests

### DIFF
--- a/test/lib/render-helpers.js
+++ b/test/lib/render-helpers.js
@@ -1,18 +1,12 @@
 import React, { useMemo } from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { I18nContext, LegacyI18nProvider } from '../../ui/contexts/i18n';
 import { getMessage } from '../../ui/helpers/utils/i18n-helper';
 import * as en from '../../app/_locales/en/messages.json';
-
-export function shallowWithContext(jsxComponent) {
-  return shallow(jsxComponent, {
-    context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) },
-  });
-}
 
 export function mountWithRouter(component, store = {}, pathname = '/') {
   // Instantiate router context

--- a/ui/components/app/account-list-item/account-list-item-component.test.js
+++ b/ui/components/app/account-list-item/account-list-item-component.test.js
@@ -30,7 +30,6 @@ describe('AccountListItem Component', () => {
           handleClick={propsMethodSpies.handleClick}
           icon={<i className="mockIcon" />}
         />,
-        { context: { t: (str) => `${str}_t` } },
       );
     });
 

--- a/ui/components/app/app-header/app-header.test.js
+++ b/ui/components/app/app-header/app-header.test.js
@@ -26,12 +26,7 @@ describe('App Header', () => {
   };
 
   beforeEach(() => {
-    wrapper = shallow(<AppHeader.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-        metricsEvent: () => undefined,
-      },
-    });
+    wrapper = shallow(<AppHeader.WrappedComponent {...props} />);
   });
 
   afterEach(() => {

--- a/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-input-component.test.js
+++ b/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-input-component.test.js
@@ -22,11 +22,7 @@ describe('Advanced Gas Inputs', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers();
 
-    wrapper = mount(<AdvancedTabContent.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    wrapper = mount(<AdvancedTabContent.WrappedComponent {...props} />, {});
   });
 
   afterEach(() => {

--- a/ui/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content-component.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/advanced-tab-content/advanced-tab-content-component.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
-import { shallowWithContext } from '../../../../../../test/lib/render-helpers';
+import { shallow } from 'enzyme';
 import AdvancedTabContent from './advanced-tab-content.component';
 
 describe('AdvancedTabContent Component', () => {
@@ -13,7 +13,7 @@ describe('AdvancedTabContent Component', () => {
     };
     sinon.spy(AdvancedTabContent.prototype, 'renderDataSummary');
 
-    wrapper = shallowWithContext(
+    wrapper = shallow(
       <AdvancedTabContent
         updateCustomGasPrice={propsMethodSpies.updateCustomGasPrice}
         updateCustomGasLimit={propsMethodSpies.updateCustomGasLimit}
@@ -59,7 +59,7 @@ describe('AdvancedTabContent Component', () => {
     let dataSummary;
 
     beforeEach(() => {
-      dataSummary = shallowWithContext(
+      dataSummary = shallow(
         wrapper.instance().renderDataSummary('mockTotalFee'),
       );
     });

--- a/ui/components/app/gas-customization/gas-modal-page-container/basic-tab-content/basic-tab-content-component.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/basic-tab-content/basic-tab-content-component.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { shallow } from 'enzyme';
 import GasPriceButtonGroup from '../../gas-price-button-group';
 import Loading from '../../../../ui/loading-screen';
 import { GAS_ESTIMATE_TYPES } from '../../../../../helpers/constants/common';
-import { shallowWithContext } from '../../../../../../test/lib/render-helpers';
 import BasicTabContent from './basic-tab-content.component';
 
 const mockGasPriceButtonGroupProps = {
@@ -42,7 +42,7 @@ describe('BasicTabContent Component', () => {
     let wrapper;
 
     beforeEach(() => {
-      wrapper = shallowWithContext(
+      wrapper = shallow(
         <BasicTabContent
           gasPriceButtonGroupProps={mockGasPriceButtonGroupProps}
         />,

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-component.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-component.test.js
@@ -125,7 +125,6 @@ describe('GasModalPageContainer Component', () => {
           fetchBasicGasEstimates={propsMethodSpies.fetchBasicGasEstimates}
           fetchGasEstimates={propsMethodSpies.fetchGasEstimates}
         />,
-        { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
       );
       const { tabsComponent } = renderTabsWrapperTester
         .find(PageContainer)

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-component.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-component.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
-import { shallowWithContext } from '../../../../../test/lib/render-helpers';
+import { shallow } from 'enzyme';
 
 import PageContainer from '../../../ui/page-container';
 
@@ -63,7 +63,7 @@ describe('GasModalPageContainer Component', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallowWithContext(
+    wrapper = shallow(
       <GasModalPageContainer
         cancelAndClose={propsMethodSpies.cancelAndClose}
         onSubmit={propsMethodSpies.onSubmit}
@@ -120,7 +120,7 @@ describe('GasModalPageContainer Component', () => {
 
     it('should pass the correct renderTabs property to PageContainer', () => {
       sinon.stub(GP, 'renderTabs').returns('mockTabs');
-      const renderTabsWrapperTester = shallowWithContext(
+      const renderTabsWrapperTester = shallow(
         <GasModalPageContainer
           fetchBasicGasEstimates={propsMethodSpies.fetchBasicGasEstimates}
           fetchGasEstimates={propsMethodSpies.fetchGasEstimates}
@@ -149,7 +149,7 @@ describe('GasModalPageContainer Component', () => {
 
     it('should render a Tabs component with "Basic" and "Advanced" tabs', () => {
       const renderTabsResult = wrapper.instance().renderTabs();
-      const renderedTabs = shallowWithContext(renderTabsResult);
+      const renderedTabs = shallow(renderTabsResult);
       expect(renderedTabs.props().className).toStrictEqual('tabs');
 
       const tabs = renderedTabs.find(Tab);
@@ -188,7 +188,7 @@ describe('GasModalPageContainer Component', () => {
     });
 
     it('should not render the basic tab if hideBasic is true', () => {
-      wrapper = shallowWithContext(
+      wrapper = shallow(
         <GasModalPageContainer
           cancelAndClose={propsMethodSpies.cancelAndClose}
           onSubmit={propsMethodSpies.onSubmit}
@@ -206,7 +206,7 @@ describe('GasModalPageContainer Component', () => {
       );
       const renderTabsResult = wrapper.instance().renderTabs();
 
-      const renderedTabs = shallowWithContext(renderTabsResult);
+      const renderedTabs = shallow(renderTabsResult);
       const tabs = renderedTabs.find(Tab);
       expect(tabs).toHaveLength(1);
       expect(tabs.at(0).props().name).toStrictEqual('advanced');
@@ -228,7 +228,7 @@ describe('GasModalPageContainer Component', () => {
   describe('renderInfoRows', () => {
     it('should render the info rows with the passed data', () => {
       const baseClassName = 'gas-modal-content__info-row';
-      const renderedInfoRowsContainer = shallowWithContext(
+      const renderedInfoRowsContainer = shallow(
         wrapper
           .instance()
           .renderInfoRows(

--- a/ui/components/app/gas-customization/gas-price-button-group/gas-price-button-group-component.test.js
+++ b/ui/components/app/gas-customization/gas-price-button-group/gas-price-button-group-component.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
-import { shallowWithContext } from '../../../../../test/lib/render-helpers';
+import { shallow } from 'enzyme';
 import { GAS_ESTIMATE_TYPES } from '../../../../helpers/constants/common';
 
 import ButtonGroup from '../../../ui/button-group';
@@ -54,7 +54,7 @@ describe('GasPriceButtonGroup Component', () => {
     sinon.spy(GasPriceButtonGroup.prototype, 'renderButton');
     sinon.spy(GasPriceButtonGroup.prototype, 'renderButtonContent');
 
-    wrapper = shallowWithContext(
+    wrapper = shallow(
       <GasPriceButtonGroup {...mockGasPriceButtonGroupProps} />,
     );
   });
@@ -119,7 +119,7 @@ describe('GasPriceButtonGroup Component', () => {
           { ...mockGasPriceButtonGroupProps.gasButtonInfo[0] },
           mockButtonPropsAndFlags,
         );
-      wrappedRenderButtonResult = shallowWithContext(renderButtonResult);
+      wrappedRenderButtonResult = shallow(renderButtonResult);
     });
 
     it('should render a button', () => {
@@ -183,7 +183,7 @@ describe('GasPriceButtonGroup Component', () => {
           className: 'someClass',
         },
       );
-      const wrappedRenderButtonContentResult = shallowWithContext(
+      const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       );
       expect(
@@ -203,7 +203,7 @@ describe('GasPriceButtonGroup Component', () => {
           className: 'someClass',
         },
       );
-      const wrappedRenderButtonContentResult = shallowWithContext(
+      const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       );
       expect(
@@ -225,7 +225,7 @@ describe('GasPriceButtonGroup Component', () => {
           className: 'someClass',
         },
       );
-      const wrappedRenderButtonContentResult = shallowWithContext(
+      const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       );
       expect(
@@ -247,7 +247,7 @@ describe('GasPriceButtonGroup Component', () => {
           className: 'someClass',
         },
       );
-      const wrappedRenderButtonContentResult = shallowWithContext(
+      const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       );
       expect(
@@ -268,7 +268,7 @@ describe('GasPriceButtonGroup Component', () => {
           showCheck: true,
         },
       );
-      const wrappedRenderButtonContentResult = shallowWithContext(
+      const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       );
       expect(wrappedRenderButtonContentResult.find('.fa-check')).toHaveLength(
@@ -289,7 +289,7 @@ describe('GasPriceButtonGroup Component', () => {
           showCheck: true,
         },
       );
-      const wrappedRenderButtonContentResult = shallowWithContext(
+      const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       );
       expect(wrappedRenderButtonContentResult.children()).toHaveLength(5);
@@ -300,7 +300,7 @@ describe('GasPriceButtonGroup Component', () => {
         {},
         {},
       );
-      const wrappedRenderButtonContentResult = shallowWithContext(
+      const wrappedRenderButtonContentResult = shallow(
         renderButtonContentResult,
       );
       expect(wrappedRenderButtonContentResult.children()).toHaveLength(0);

--- a/ui/components/app/modals/account-details-modal/account-details-modal.test.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.test.js
@@ -33,11 +33,7 @@ describe('Account Details Modal', () => {
   };
 
   beforeEach(() => {
-    wrapper = shallow(<AccountDetailsModal.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    wrapper = shallow(<AccountDetailsModal.WrappedComponent {...props} />);
   });
 
   it('sets account label when changing default account label', () => {

--- a/ui/components/app/modals/confirm-delete-network/confirm-delete-network.test.js
+++ b/ui/components/app/modals/confirm-delete-network/confirm-delete-network.test.js
@@ -14,11 +14,7 @@ describe('Confirm Delete Network', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<ConfirmDeleteNetwork.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    wrapper = mount(<ConfirmDeleteNetwork.WrappedComponent {...props} />, {});
   });
 
   afterEach(() => {

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
@@ -32,10 +32,6 @@ describe('Confirm Remove Account', () => {
         <ConfirmRemoveAccount.WrappedComponent {...props} />
       </Provider>,
       {
-        context: {
-          t: (str) => str,
-          store,
-        },
         childContextTypes: {
           t: PropTypes.func,
           store: PropTypes.object,

--- a/ui/components/app/modals/confirm-reset-account/confirm-reset-account.test.js
+++ b/ui/components/app/modals/confirm-reset-account/confirm-reset-account.test.js
@@ -12,11 +12,7 @@ describe('Confirm Reset Account', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<ConfirmResetAccount.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    wrapper = mount(<ConfirmResetAccount.WrappedComponent {...props} />);
   });
 
   afterEach(() => {

--- a/ui/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.test.js
+++ b/ui/components/app/modals/metametrics-opt-in-modal/metametrics-opt-in-modal.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import messages from '../../../../../app/_locales/en/messages.json';
 import MetaMetricsOptIn from './metametrics-opt-in-modal.container';
 
 describe('MetaMetrics Opt In', () => {
@@ -14,12 +13,7 @@ describe('MetaMetrics Opt In', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<MetaMetricsOptIn.WrappedComponent {...props} />, {
-      context: {
-        metricsEvent: () => undefined,
-        t: (key) => messages[key].message,
-      },
-    });
+    wrapper = mount(<MetaMetricsOptIn.WrappedComponent {...props} />);
   });
 
   afterEach(() => {

--- a/ui/components/app/modals/reject-transactions/reject-transactions.test.js
+++ b/ui/components/app/modals/reject-transactions/reject-transactions.test.js
@@ -13,11 +13,7 @@ describe('Reject Transactions Model', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<RejectTransactionsModal.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    wrapper = mount(<RejectTransactionsModal.WrappedComponent {...props} />);
   });
 
   afterEach(() => {

--- a/ui/components/app/modals/transaction-confirmed/transaction-confirmed.test.js
+++ b/ui/components/app/modals/transaction-confirmed/transaction-confirmed.test.js
@@ -9,14 +9,7 @@ describe('Transaction Confirmed', () => {
       onSubmit: sinon.spy(),
       hideModal: sinon.spy(),
     };
-    const wrapper = mount(
-      <TransactionConfirmed.WrappedComponent {...props} />,
-      {
-        context: {
-          t: (str) => str,
-        },
-      },
-    );
+    const wrapper = mount(<TransactionConfirmed.WrappedComponent {...props} />);
     const submit = wrapper.find(
       '.btn-secondary.modal-container__footer-button',
     );

--- a/ui/components/app/selected-account/selected-account-component.test.js
+++ b/ui/components/app/selected-account/selected-account-component.test.js
@@ -11,7 +11,6 @@ describe('SelectedAccount Component', () => {
           address: '0x1b82543566f41a7db9a9a75fc933c340ffb55c9d',
         }}
       />,
-      { context: { t: () => undefined } },
     );
     // Checksummed version of address is displayed
     expect(wrapper.find('.selected-account__address').text()).toStrictEqual(

--- a/ui/components/app/signature-request/signature-request.component.test.js
+++ b/ui/components/app/signature-request/signature-request.component.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { shallowWithContext } from '../../../../test/lib/render-helpers';
+import { shallow } from 'enzyme';
 import SignatureRequest from './signature-request.component';
 
 describe('Signature Request Component', () => {
   describe('render', () => {
     const fromAddress = '0x123456789abcdef';
     it('should render a div with one child', () => {
-      const wrapper = shallowWithContext(
+      const wrapper = shallow(
         <SignatureRequest
           clearConfirmTransaction={() => undefined}
           cancel={() => undefined}

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.component.test.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.component.test.js
@@ -50,7 +50,6 @@ describe('TransactionActivityLog Component', () => {
         onRetry={() => undefined}
         primaryTransactionStatus="confirmed"
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     expect(wrapper.hasClass('transaction-activity-log')).toStrictEqual(true);
@@ -103,7 +102,6 @@ describe('TransactionActivityLog Component', () => {
         primaryTransactionStatus="pending"
         isEarliestNonce
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     expect(wrapper.hasClass('transaction-activity-log')).toStrictEqual(true);
@@ -159,7 +157,6 @@ describe('TransactionActivityLog Component', () => {
         primaryTransactionStatus="pending"
         isEarliestNonce={false}
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     expect(wrapper.hasClass('transaction-activity-log')).toStrictEqual(true);

--- a/ui/components/app/transaction-breakdown/transaction-breakdown-row/transaction-breakdown-row.component.test.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown-row/transaction-breakdown-row.component.test.js
@@ -9,7 +9,6 @@ describe('TransactionBreakdownRow Component', () => {
       <TransactionBreakdownRow title="test" className="test-class">
         Test
       </TransactionBreakdownRow>,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     expect(wrapper.hasClass('transaction-breakdown-row')).toStrictEqual(true);
@@ -26,7 +25,6 @@ describe('TransactionBreakdownRow Component', () => {
       <TransactionBreakdownRow title="test" className="test-class">
         <Button onClick={() => undefined}>Button</Button>
       </TransactionBreakdownRow>,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     expect(wrapper.hasClass('transaction-breakdown-row')).toStrictEqual(true);

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.test.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.test.js
@@ -21,7 +21,6 @@ describe('TransactionBreakdown Component', () => {
 
     const wrapper = shallow(
       <TransactionBreakdown transaction={transaction} className="test-class" />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     expect(wrapper.hasClass('transaction-breakdown')).toStrictEqual(true);

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.test.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.test.js
@@ -40,7 +40,6 @@ describe('TransactionListItemDetails Component', () => {
         senderNickname="sender-nickname"
         recipientNickname="recipient-nickname"
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
     const child = wrapper.childAt(0);
     expect(child.hasClass('transaction-list-item-details')).toStrictEqual(true);
@@ -86,7 +85,6 @@ describe('TransactionListItemDetails Component', () => {
         senderNickname="sender-nickname"
         recipientNickname="recipient-nickname"
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     const child = wrapper.childAt(0);
@@ -127,7 +125,6 @@ describe('TransactionListItemDetails Component', () => {
         senderNickname="sender-nickname"
         recipientNickname="recipient-nickname"
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     const child = wrapper.childAt(0);
@@ -171,7 +168,6 @@ describe('TransactionListItemDetails Component', () => {
         senderNickname="sender-nickname"
         recipientNickname="recipient-nickname"
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
 
     const child = wrapper.childAt(0);

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.test.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.test.js
@@ -3,14 +3,8 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import ImportWithSeedPhrase from './import-with-seed-phrase.component';
 
-function shallowRender(props = {}, context = {}) {
-  return shallow(<ImportWithSeedPhrase {...props} />, {
-    context: {
-      t: (str) => `${str}_t`,
-      metricsEvent: sinon.spy(),
-      ...context,
-    },
-  });
+function shallowRender(props = {}) {
+  return shallow(<ImportWithSeedPhrase {...props} />);
 }
 
 describe('ImportWithSeedPhrase Component', () => {

--- a/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase-component.test.js
+++ b/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase-component.test.js
@@ -3,13 +3,8 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import ConfirmSeedPhrase from './confirm-seed-phrase/confirm-seed-phrase.component';
 
-function shallowRender(props = {}, context = {}) {
-  return shallow(<ConfirmSeedPhrase {...props} />, {
-    context: {
-      t: (str) => `${str}_t`,
-      ...context,
-    },
-  });
+function shallowRender(props = {}) {
+  return shallow(<ConfirmSeedPhrase {...props} />);
 }
 
 describe('ConfirmSeedPhrase Component', () => {

--- a/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.test.js
+++ b/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.test.js
@@ -19,12 +19,7 @@ describe('Reveal Seed Phrase', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<RevealSeedPhrase.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-        metricsEvent: () => undefined,
-      },
-    });
+    wrapper = mount(<RevealSeedPhrase.WrappedComponent {...props} />);
   });
 
   it('seed phrase', () => {

--- a/ui/pages/keychains/reveal-seed.test.js
+++ b/ui/pages/keychains/reveal-seed.test.js
@@ -12,11 +12,7 @@ describe('Reveal Seed Page', () => {
       requestRevealSeedWords: sinon.stub().resolves(),
       mostRecentOverviewPage: '/',
     };
-    const wrapper = mount(<RevealSeedPage.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    const wrapper = mount(<RevealSeedPage.WrappedComponent {...props} />);
 
     wrapper.find('form').simulate('submit');
     expect(props.requestRevealSeedWords.calledOnce).toStrictEqual(true);

--- a/ui/pages/send/send-content/add-recipient/add-recipient.component.test.js
+++ b/ui/pages/send/send-content/add-recipient/add-recipient.component.test.js
@@ -51,7 +51,6 @@ describe('AddRecipient Component', () => {
           },
         ]}
       />,
-      { context: { t: (str) => `${str}_t` } },
     );
     instance = wrapper.instance();
   });

--- a/ui/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.test.js
+++ b/ui/pages/send/send-content/send-amount-row/amount-max-button/amount-max-button.component.test.js
@@ -29,12 +29,6 @@ describe('AmountMaxButton Component', () => {
         setMaxModeTo={propsMethodSpies.setMaxModeTo}
         tokenBalance="mockTokenBalance"
       />,
-      {
-        context: {
-          t: (str) => `${str}_t`,
-          metricsEvent: () => undefined,
-        },
-      },
     );
     instance = wrapper.instance();
   });

--- a/ui/pages/send/send-content/send-amount-row/send-amount-row.component.test.js
+++ b/ui/pages/send/send-content/send-amount-row/send-amount-row.component.test.js
@@ -188,7 +188,6 @@ function shallowRenderSendAmountRow() {
       updateSendAmountError={updateSendAmountError}
       updateGas={() => undefined}
     />,
-    { context: { t: (str) => `${str}_t` } },
   );
   const instance = wrapper.instance();
   const updateAmount = sinon.spy(instance, 'updateAmount');

--- a/ui/pages/send/send-content/send-content.component.test.js
+++ b/ui/pages/send/send-content/send-content.component.test.js
@@ -13,9 +13,7 @@ describe('SendContent Component', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<SendContent showHexData />, {
-      context: { t: (str) => `${str}_t` },
-    });
+    wrapper = shallow(<SendContent showHexData />);
   });
 
   describe('render', () => {

--- a/ui/pages/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.test.js
+++ b/ui/pages/send/send-content/send-gas-row/gas-fee-display/gas-fee-display.component.test.js
@@ -23,7 +23,6 @@ describe('GasFeeDisplay Component', () => {
           showGasButtonGroup={propsMethodSpies.showCustomizeGasModal}
           onReset={propsMethodSpies.onReset}
         />,
-        { context: { t: (str) => `${str}_t` } },
       );
     });
 

--- a/ui/pages/send/send-content/send-gas-row/send-gas-row.component.test.js
+++ b/ui/pages/send/send-content/send-gas-row/send-gas-row.component.test.js
@@ -32,7 +32,6 @@ describe('SendGasRow Component', () => {
             anotherGasPriceButtonGroupProp: 'bar',
           }}
         />,
-        { context: { t: (str) => `${str}_t`, metricsEvent: () => ({}) } },
       );
       wrapper.setProps({ isMainnet: true });
     });

--- a/ui/pages/send/send-content/send-row-wrapper/send-row-error-message/send-row-error-message.component.test.js
+++ b/ui/pages/send/send-content/send-row-wrapper/send-row-error-message/send-row-error-message.component.test.js
@@ -12,7 +12,6 @@ describe('SendRowErrorMessage Component', () => {
           errors={{ error1: 'abc', error2: 'def' }}
           errorType="error3"
         />,
-        { context: { t: (str) => `${str}_t` } },
       );
     });
 

--- a/ui/pages/send/send-footer/send-footer.component.test.js
+++ b/ui/pages/send/send-footer/send-footer.component.test.js
@@ -51,7 +51,6 @@ describe('SendFooter Component', () => {
         mostRecentOverviewPage="mostRecentOverviewPage"
         noGasPrice={false}
       />,
-      { context: { t: (str) => str, metricsEvent: () => ({}) } },
     );
   });
 
@@ -225,7 +224,6 @@ describe('SendFooter Component', () => {
           update={propsMethodSpies.update}
           mostRecentOverviewPage="mostRecentOverviewPage"
         />,
-        { context: { t: (str) => str, metricsEvent: () => ({}) } },
       );
     });
 

--- a/ui/pages/send/send-header/send-header.component.test.js
+++ b/ui/pages/send/send-header/send-header.component.test.js
@@ -26,7 +26,6 @@ describe('SendHeader Component', () => {
         mostRecentOverviewPage="mostRecentOverviewPage"
         titleKey="mockTitleKey"
       />,
-      { context: { t: (str1, str2) => (str2 ? str1 + str2 : str1) } },
     );
   });
 

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -16,11 +16,6 @@ describe('AdvancedTab Component', () => {
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
       />,
-      {
-        context: {
-          t: (s) => `_${s}`,
-        },
-      },
     );
 
     expect(root.find('.settings-page__content-row')).toHaveLength(11);
@@ -38,11 +33,6 @@ describe('AdvancedTab Component', () => {
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
       />,
-      {
-        context: {
-          t: (s) => `_${s}`,
-        },
-      },
     );
 
     const autoTimeout = root.find('.settings-page__content-row').at(7);

--- a/ui/pages/settings/security-tab/security-tab.container.test.js
+++ b/ui/pages/settings/security-tab/security-tab.container.test.js
@@ -24,12 +24,7 @@ describe('Security Tab', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<SecurityTab.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-        metricsEvent: () => undefined,
-      },
-    });
+    wrapper = mount(<SecurityTab.WrappedComponent {...props} />);
   });
 
   it('navigates to reveal seed words page', () => {

--- a/ui/pages/settings/settings-tab/settings-tab.container.test.js
+++ b/ui/pages/settings/settings-tab/settings-tab.container.test.js
@@ -22,11 +22,7 @@ describe('Settings Tab', () => {
     useNativeCurrencyAsPrimaryCurrency: true,
   };
   beforeEach(() => {
-    wrapper = mount(<SettingsTab.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    wrapper = mount(<SettingsTab.WrappedComponent {...props} />);
   });
 
   it('selects currency', async () => {

--- a/ui/pages/unlock-page/unlock-page.container.test.js
+++ b/ui/pages/unlock-page/unlock-page.container.test.js
@@ -18,11 +18,7 @@ describe('Unlock Page', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<UnlockPage.WrappedComponent {...props} />, {
-      context: {
-        t: (str) => str,
-      },
-    });
+    wrapper = mount(<UnlockPage.WrappedComponent {...props} />);
   });
 
   afterAll(() => {


### PR DESCRIPTION
In https://github.com/MetaMask/metamask-extension/pull/10895 we started using our real localization messages, so we should no longer need to shim in our own contexts for localization.