### PR TITLE
Removing gray background from contact address input

### DIFF
--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -66,7 +66,6 @@ export default class AddContact extends PureComponent {
   renderInput() {
     return (
       <EnsInput
-        className="send__to-row"
         scanQrCode={(_) => {
           this.props.scanQrCode();
         }}


### PR DESCRIPTION
The classname `.send__to-row` contains necessary rules for the `EnsInput` component as it is used in the send flow, but it is not needed for its use in the Add Contact view. 

**Before**
<img width="423" alt="Screen Shot 2021-05-02 at 11 21 15 PM" src="https://user-images.githubusercontent.com/8732757/116846538-51788480-ab9d-11eb-9490-c054cb58e56c.png">

**After**
<img width="423" alt="Screen Shot 2021-05-02 at 11 22 07 PM" src="https://user-images.githubusercontent.com/8732757/116846554-5a695600-ab9d-11eb-9a12-ad276797c9da.png">

