### PR TITLE
Change selector of the selected account name to check for visibility.

### DIFF
--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -109,7 +109,9 @@ describe('Metamask Import UI', function () {
         await driver.clickElement({ text: 'Create', tag: 'button' });
 
         // should show the correct account name
-        const accountName = await driver.findElement('.selected-account__name');
+        const accountName = await driver.findVisibleElement(
+          '.selected-account__name',
+        );
         assert.equal(await accountName.getText(), '2nd account');
 
         // Switch back to original account


### PR DESCRIPTION
After creating a new account, their seems to be a loading screen after confirming new account creation, momentarily/initially setting the account name to `Account {index}`. This behavior is affecting the automated tests that's assuming that the account name is immediately populated with no wait time. The fix is to wait for the element to be visible, which I assume take into account the change in opacity from the loading screen. An alternative would be to set a delay before the account name assertion.