### PR TITLE
Fixing alignment issue with bottom notification

### DIFF
--- a/ui/components/app/whats-new-popup/index.scss
+++ b/ui/components/app/whats-new-popup/index.scss
@@ -2,14 +2,12 @@
   &__notifications {
     display: flex;
     flex-direction: column;
-    align-items: center;
   }
 
   &__notification,
   &__first-notification {
     display: flex;
     flex-direction: column;
-    align-items: left;
     margin: 0 24px 24px 24px;
     border-bottom: 1px solid $Grey-100;
   }


### PR DESCRIPTION
`align-items: left;` is invalid, and `align-items: center;` on the notification container was producing an undesired result, the notifications will align appropriately to the left without it. 

**Before**
<img width="283" alt="Screen Shot 2021-05-03 at 2 03 19 PM" src="https://user-images.githubusercontent.com/8732757/116933918-12881480-ac19-11eb-8f82-438d1f5604a0.png">

**After**
<img width="295" alt="Screen Shot 2021-05-03 at 2 04 55 PM" src="https://user-images.githubusercontent.com/8732757/116933945-1d42a980-ac19-11eb-932c-e1f71ca7d034.png">

