### PR TITLE
Replacing "Seed Phrase" with "Secret Recovery Phrase" 

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -557,7 +557,7 @@
     "message": "Dismiss"
   },
   "dismissReminderDescriptionField": {
-    "message": "Turn this on to dismiss the recovery phrase backup reminder message. We highly recommend that you back up your seed phrase to avoid loss of funds"
+    "message": "Turn this on to dismiss the recovery phrase backup reminder message. We highly recommend that you back up your Secret Recovery Phrase to avoid loss of funds"
   },
   "dismissReminderField": {
     "message": "Dismiss recovery phrase backup reminder"
@@ -603,7 +603,7 @@
     "message": "Request encryption public key"
   },
   "endOfFlowMessage1": {
-    "message": "You passed the test - keep your seedphrase safe, it's your responsibility!"
+    "message": "You passed the test - keep your Secret Recovery Phrase safe, it's your responsibility!"
   },
   "endOfFlowMessage10": {
     "message": "All Done"
@@ -618,17 +618,17 @@
     "message": "Never share the phrase with anyone."
   },
   "endOfFlowMessage5": {
-    "message": "Be careful of phishing! MetaMask will never spontaneously ask for your seed phrase."
+    "message": "Be careful of phishing! MetaMask will never spontaneously ask for your Secret Recovery Phrase."
   },
   "endOfFlowMessage6": {
-    "message": "If you need to back up your seed phrase again, you can find it in Settings -> Security."
+    "message": "If you need to back up your Secret Recovery Phrase again, you can find it in Settings -> Security."
   },
   "endOfFlowMessage7": {
     "message": "If you ever have questions or see something fishy, contact our support $1.",
     "description": "$1 is a clickable link with text defined by the 'here' key. The link will open to a form where users can file support tickets."
   },
   "endOfFlowMessage8": {
-    "message": "MetaMask cannot recover your seedphrase."
+    "message": "MetaMask cannot recover your Secret Recovery Phrase."
   },
   "endOfFlowMessage9": {
     "message": "Learn more."
@@ -878,13 +878,13 @@
     "message": "Import Account"
   },
   "importAccountLinkText": {
-    "message": "import using seed phrase"
+    "message": "import using Secret Recovery Phrase"
   },
   "importAccountMsg": {
-    "message": " Imported accounts will not be associated with your originally created MetaMask account seedphrase. Learn more about imported accounts "
+    "message": " Imported accounts will not be associated with your originally created MetaMask account Secret Recovery Phrase. Learn more about imported accounts "
   },
   "importAccountSeedPhrase": {
-    "message": "Import an account with seed phrase"
+    "message": "Import an account with Secret Recovery Phrase"
   },
   "importAccountText": {
     "message": "or $1",
@@ -894,7 +894,7 @@
     "message": "Import wallet"
   },
   "importYourExisting": {
-    "message": "Import your existing wallet using a seed phrase"
+    "message": "Import your existing wallet using a Secret Recovery Phrase"
   },
   "imported": {
     "message": "Imported",
@@ -964,7 +964,7 @@
     "message": "Invalid RPC URL"
   },
   "invalidSeedPhrase": {
-    "message": "Invalid seed phrase"
+    "message": "Invalid Secret Recovery Phrase"
   },
   "ipfsGateway": {
     "message": "IPFS Gateway"
@@ -1215,7 +1215,7 @@
     "message": "No address has been set for this name."
   },
   "noAlreadyHaveSeed": {
-    "message": "No, I already have a seed phrase"
+    "message": "No, I already have a Secret Recovery Phrase"
   },
   "noConversionRateAvailable": {
     "message": "No Conversion Rate Available"
@@ -1434,7 +1434,7 @@
     "message": "Remove account"
   },
   "removeAccountDescription": {
-    "message": "This account will be removed from your wallet. Please make sure you have the original seed phrase or private key for this imported account before continuing. You can import or create accounts again from the account drop-down. "
+    "message": "This account will be removed from your wallet. Please make sure you have the original Secret Recovery Phrase or private key for this imported account before continuing. You can import or create accounts again from the account drop-down. "
   },
   "requestsAwaitingAcknowledgement": {
     "message": "requests waiting to be acknowledged"
@@ -1449,13 +1449,13 @@
     "message": "Reset Account"
   },
   "resetAccountDescription": {
-    "message": "Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your seed phrase."
+    "message": "Resetting your account will clear your transaction history. This will not change the balances in your accounts or require you to re-enter your Secret Recovery Phrase."
   },
   "restore": {
     "message": "Restore"
   },
   "restoreAccountWithSeed": {
-    "message": "Restore your Account with Seed Phrase"
+    "message": "Restore your Account with Secret Recovery Phrase"
   },
   "restoreWalletPreferences": {
     "message": "A backup of your data from $1 has been found. Would you like to restore your wallet preferences?",
@@ -1468,13 +1468,13 @@
     "message": "A token here reuses a symbol from another token you watch, this can be confusing or deceptive."
   },
   "revealSeedWords": {
-    "message": "Reveal Seed Phrase"
+    "message": "Reveal Secret Recovery Phrase"
   },
   "revealSeedWordsDescription": {
-    "message": "If you ever change browsers or move computers, you will need this seed phrase to access your accounts. Save them somewhere safe and secret."
+    "message": "If you ever change browsers or move computers, you will need this Secret Recovery Phrase to access your accounts. Save them somewhere safe and secret."
   },
   "revealSeedWordsTitle": {
-    "message": "Seed Phrase"
+    "message": "Secret Recovery Phrase"
   },
   "revealSeedWordsWarning": {
     "message": "These words can be used to steal all your accounts."
@@ -1534,7 +1534,7 @@
     "message": "Security & Privacy"
   },
   "securitySettingsDescription": {
-    "message": "Privacy settings and wallet seed phrase"
+    "message": "Privacy settings and wallet Secret Recovery Phrase"
   },
   "seedPhraseIntroSidebarBulletFour": {
     "message": "Write down and store in multiple secret places."
@@ -1576,10 +1576,10 @@
     "message": "Separate each word with a single space"
   },
   "seedPhrasePlaceholderPaste": {
-    "message": "Paste seed phrase from clipboard"
+    "message": "Paste Secret Recovery Phrase from clipboard"
   },
   "seedPhraseReq": {
-    "message": "Seed phrases contain 12, 15, 18, 21, or 24 words"
+    "message": "Secret Recovery Phrases contain 12, 15, 18, 21, or 24 words"
   },
   "selectAHigherGasFee": {
     "message": "Select a higher gas fee to accelerate the processing of your transaction.*"
@@ -1671,7 +1671,7 @@
     "message": "Show Private Keys"
   },
   "showSeedPhrase": {
-    "message": "Show seed phrase"
+    "message": "Show Secret Recovery Phrase"
   },
   "sigRequest": {
     "message": "Signature Request"
@@ -2134,7 +2134,7 @@
     "message": "Test Faucet"
   },
   "thisWillCreate": {
-    "message": "This will create a new wallet and seed phrase"
+    "message": "This will create a new wallet and Secret Recovery Phrase"
   },
   "tips": {
     "message": "Tips"
@@ -2318,10 +2318,10 @@
     "message": "our hardware wallet connection guide"
   },
   "walletSeed": {
-    "message": "Seed phrase"
+    "message": "Secret Recovery Phrase"
   },
   "walletSeedRestore": {
-    "message": "Wallet Seed"
+    "message": "Wallet Secret Recovery Phrase"
   },
   "web3ShimUsageNotification": {
     "message": "We noticed that the current website tried to use the removed window.web3 API. If the site appears to be broken, please click $1 for more information.",
@@ -2361,7 +2361,7 @@
     "message": "You are signing"
   },
   "yourPrivateSeedPhrase": {
-    "message": "Your private seed phrase"
+    "message": "Your private Secret Recovery Phrase"
   },
   "zeroGasPriceOnSpeedUpError": {
     "message": "Zero gas price on speed up"

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -83,12 +83,12 @@ describe('MetaMask', function () {
 
     let seedPhrase;
 
-    it('renders the seed phrase intro screen', async function () {
+    it('renders the Secret Recovery Phrase intro screen', async function () {
       await driver.clickElement('.seed-phrase-intro__left button');
       await driver.delay(regularDelayMs);
     });
 
-    it('reveals the seed phrase', async function () {
+    it('reveals the Secret Recovery Phrase', async function () {
       const byRevealButton =
         '.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button';
       await driver.findElement(byRevealButton);
@@ -116,7 +116,7 @@ describe('MetaMask', function () {
       await driver.delay(tinyDelayMs);
     }
 
-    it('can retype the seed phrase', async function () {
+    it('can retype the Secret Recovery Phrase', async function () {
       const words = seedPhrase.split(' ');
 
       for (const word of words) {
@@ -218,7 +218,7 @@ describe('MetaMask', function () {
     });
   });
 
-  describe('Import seed phrase', function () {
+  describe('Import Secret Recovery Phrase', function () {
     it('logs out of the vault', async function () {
       await driver.clickElement('.account-menu__icon');
       await driver.delay(regularDelayMs);
@@ -231,11 +231,14 @@ describe('MetaMask', function () {
       await driver.delay(regularDelayMs);
     });
 
-    it('imports seed phrase', async function () {
+    it('imports Secret Recovery Phrase', async function () {
       const restoreSeedLink = await driver.findClickableElement(
         '.unlock-page__link--import',
       );
-      assert.equal(await restoreSeedLink.getText(), 'import using seed phrase');
+      assert.equal(
+        await restoreSeedLink.getText(),
+        'import using Secret Recovery Phrase',
+      );
       await restoreSeedLink.click();
       await driver.delay(regularDelayMs);
 

--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -3,7 +3,7 @@ const { withFixtures, regularDelayMs } = require('../helpers');
 const enLocaleMessages = require('../../../app/_locales/en/messages.json');
 
 describe('Metamask Import UI', function () {
-  it('Importing wallet using seed phrase', async function () {
+  it('Importing wallet using Secret Recovery Phrase', async function () {
     const ganacheOptions = {
       accounts: [
         {
@@ -40,9 +40,9 @@ describe('Metamask Import UI', function () {
         // clicks the "No thanks" option on the metametrics opt-in screen
         await driver.clickElement('.btn-default');
 
-        // Import seed phrase
+        // Import Secret Recovery Phrase
         await driver.fill(
-          'input[placeholder="Paste seed phrase from clipboard"]',
+          'input[placeholder="Paste Secret Recovery Phrase from clipboard"]',
           testSeedPhrase,
         );
 

--- a/test/e2e/tests/incremental-security.spec.js
+++ b/test/e2e/tests/incremental-security.spec.js
@@ -17,7 +17,7 @@ describe('Incremental Security', function () {
       },
     ],
   };
-  it('Back up seed phrase from backup reminder', async function () {
+  it('Back up Secret Recovery Phrase from backup reminder', async function () {
     await withFixtures(
       {
         dapp: true,
@@ -56,10 +56,10 @@ describe('Incremental Security', function () {
         await driver.clickElement('.first-time-flow__checkbox');
         await driver.clickElement('.first-time-flow__form button');
 
-        // renders the seed phrase intro screen'
+        // renders the Secret Recovery Phrase intro screen'
         await driver.clickElement('.seed-phrase-intro__left button');
 
-        // skips the seed phrase challenge
+        // skips the Secret Recovery Phrase challenge
         await driver.clickElement({
           text: enLocaleMessages.remindMeLater.message,
           tag: 'button',
@@ -118,7 +118,7 @@ describe('Incremental Security', function () {
         let balance = await currencyDisplay.getText();
         assert.strictEqual(balance, '1');
 
-        // backs up the seed phrase
+        // backs up the Secret Recovery Phrase
         // should show a backup reminder
         const backupReminder = await driver.findElements({
           xpath:
@@ -129,7 +129,7 @@ describe('Incremental Security', function () {
         // should take the user to the seedphrase backup screen
         await driver.clickElement('.home-notification__accept-button');
 
-        // reveals the seed phrase
+        // reveals the Secret Recovery Phrase
         await driver.clickElement(
           '.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button',
         );
@@ -153,7 +153,7 @@ describe('Incremental Security', function () {
           await driver.delay(tinyDelayMs);
         }
 
-        // can retype the seed phrase
+        // can retype the Secret Recovery Phrase
         const words = seedPhrase.split(' ');
 
         for (const word of words) {

--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -42,10 +42,10 @@ describe('Metamask Responsive UI', function () {
         await driver.clickElement('.first-time-flow__checkbox');
         await driver.clickElement('.first-time-flow__form button');
 
-        // renders the seed phrase intro screen
+        // renders the Secret Recovery Phrase intro screen
         await driver.clickElement('.seed-phrase-intro__left button');
 
-        // reveals the seed phrase
+        // reveals the Secret Recovery Phrase
         await driver.clickElement(
           '.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button',
         );
@@ -67,7 +67,7 @@ describe('Metamask Responsive UI', function () {
           await driver.delay(tinyDelayMs);
         }
 
-        // can retype the seed phrase
+        // can retype the Secret Recovery Phrase
         const words = seedPhrase.split(' ');
         for (const word of words) {
           await clickWordAndWait(word);
@@ -106,13 +106,13 @@ describe('Metamask Responsive UI', function () {
       async ({ driver }) => {
         await driver.navigate();
 
-        // Import seed phrase
+        // Import Secret Recovery Phrase
         const restoreSeedLink = await driver.findClickableElement(
           '.unlock-page__link--import',
         );
         assert.equal(
           await restoreSeedLink.getText(),
-          'import using seed phrase',
+          'import using Secret Recovery Phrase',
         );
         await restoreSeedLink.click();
 

--- a/ui/helpers/constants/routes.js
+++ b/ui/helpers/constants/routes.js
@@ -81,7 +81,7 @@ const PATH_NAME_MAP = {
   [`${CONTACT_EDIT_ROUTE}/:address`]: 'Edit Contact Settings Page',
   [CONTACT_ADD_ROUTE]: 'Add Contact Settings Page',
   [`${CONTACT_VIEW_ROUTE}/:address`]: 'View Contact Settings Page',
-  [REVEAL_SEED_ROUTE]: 'Reveal Seed Page',
+  [REVEAL_SEED_ROUTE]: 'Reveal Secret Recovery Phrase Page',
   [MOBILE_SYNC_ROUTE]: 'Sync With Mobile Page',
   [RESTORE_VAULT_ROUTE]: 'Restore Vault Page',
   [ADD_TOKEN_ROUTE]: 'Add Token Page',
@@ -113,16 +113,17 @@ const PATH_NAME_MAP = {
   [INITIALIZE_UNLOCK_ROUTE]: 'Initialization Unlock page',
   [INITIALIZE_CREATE_PASSWORD_ROUTE]: 'Initialization Create Password Page',
   [INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE]:
-    'Initialization Import Account With Seed Phrase Page',
+    'Initialization Import Account With Secret Recovery Phrase Page',
   [INITIALIZE_SELECT_ACTION_ROUTE]:
     'Initialization Choose Restore or New Account Page',
-  [INITIALIZE_SEED_PHRASE_ROUTE]: 'Initialization Seed Phrase Page',
+  [INITIALIZE_SEED_PHRASE_ROUTE]: 'Initialization Secret Recovery Phrase Page',
   [INITIALIZE_BACKUP_SEED_PHRASE_ROUTE]:
-    'Initialization Backup Seed Phrase Page',
-  [INITIALIZE_SEED_PHRASE_INTRO_ROUTE]: 'Initialization Seed Phrase Intro Page',
+    'Initialization Backup Secret Recovery Phrase Page',
+  [INITIALIZE_SEED_PHRASE_INTRO_ROUTE]:
+    'Initialization Secret Recovery Phrase Intro Page',
   [INITIALIZE_END_OF_FLOW_ROUTE]: 'End of Initialization Page',
   [INITIALIZE_CONFIRM_SEED_PHRASE_ROUTE]:
-    'Initialization Confirm Seed Phrase Page',
+    'Initialization Confirm Secret Recovery Phrase Page',
   [INITIALIZE_METAMETRICS_OPT_IN_ROUTE]: 'MetaMetrics Opt In Page',
   [BUILD_QUOTE_ROUTE]: 'Swaps Build Quote Page',
   [VIEW_QUOTE_ROUTE]: 'Swaps View Quotes Page',

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.test.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.test.js
@@ -23,7 +23,7 @@ describe('ImportWithSeedPhrase Component', () => {
   });
 
   describe('parseSeedPhrase', () => {
-    it('should handle a regular seed phrase', () => {
+    it('should handle a regular Secret Recovery Phrase', () => {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       });
@@ -33,7 +33,7 @@ describe('ImportWithSeedPhrase Component', () => {
       expect(parseSeedPhrase('foo bar baz')).toStrictEqual('foo bar baz');
     });
 
-    it('should handle a mixed-case seed phrase', () => {
+    it('should handle a mixed-case Secret Recovery Phrase', () => {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       });
@@ -43,7 +43,7 @@ describe('ImportWithSeedPhrase Component', () => {
       expect(parseSeedPhrase('FOO bAr baZ')).toStrictEqual('foo bar baz');
     });
 
-    it('should handle an upper-case seed phrase', () => {
+    it('should handle an upper-case Secret Recovery Phrase', () => {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       });
@@ -53,7 +53,7 @@ describe('ImportWithSeedPhrase Component', () => {
       expect(parseSeedPhrase('FOO BAR BAZ')).toStrictEqual('foo bar baz');
     });
 
-    it('should trim extraneous whitespace from the given seed phrase', () => {
+    it('should trim extraneous whitespace from the given Secret Recovery Phrase', () => {
       const root = shallowRender({
         onSubmit: sinon.spy(),
       });

--- a/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.test.js
+++ b/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 import RevealSeedPhrase from './reveal-seed-phrase.container';
 
-describe('Reveal Seed Phrase', () => {
+describe('Reveal Secret Recovery Phrase', () => {
   let wrapper;
 
   const TEST_SEED =
@@ -27,7 +27,7 @@ describe('Reveal Seed Phrase', () => {
     });
   });
 
-  it('seed phrase', () => {
+  it('secret recovery phrase', () => {
     const seedPhrase = wrapper.find(
       '.reveal-seed-phrase__secret-words--hidden',
     );

--- a/ui/pages/unlock-page/unlock-page.component.test.js
+++ b/ui/pages/unlock-page/unlock-page.component.test.js
@@ -23,7 +23,7 @@ describe('Unlock Page Component', () => {
       configureMockStore()({ metamask: { currentLocale: 'en' } }),
     );
 
-    fireEvent.click(getByText('import using seed phrase'));
+    fireEvent.click(getByText('import using Secret Recovery Phrase'));
     expect(props.onRestore.calledOnce).toStrictEqual(true);
   });
 });


### PR DESCRIPTION
Fixes: #10992 

Explanation: Updated references to "seed phrase" with "Secret Recovery Phrase" in the `messages` in en/message.json, in PATH_NAME_MAP and tests.
