### PR TITLE
Remove `SET_CURRENT_FIAT` action

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2517,7 +2517,7 @@ export default class MetamaskController extends EventEmitter {
       };
       this.currencyRateController.update(currencyState);
       this.currencyRateController.configure(currencyState);
-      cb(null, this.currencyRateController.state);
+      cb(null);
       return;
     } catch (err) {
       cb(err);

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -93,13 +93,6 @@ export default function reduceMetamask(state = {}, action) {
       return Object.assign(metamaskState, { identities });
     }
 
-    case actionConstants.SET_CURRENT_FIAT:
-      return Object.assign(metamaskState, {
-        currentCurrency: action.value.currentCurrency,
-        conversionRate: action.value.conversionRate,
-        conversionDate: action.value.conversionDate,
-      });
-
     case actionConstants.UPDATE_TOKENS:
       return {
         ...metamaskState,

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -74,26 +74,6 @@ describe('MetaMask Reducers', () => {
     });
   });
 
-  it('sets current fiat', () => {
-    const value = {
-      currentCurrency: 'yen',
-      conversionRate: 3.14,
-      conversionDate: new Date(2018, 9),
-    };
-
-    const state = reduceMetamask(
-      {},
-      {
-        type: actionConstants.SET_CURRENT_FIAT,
-        value,
-      },
-    );
-
-    expect(state.currentCurrency).toStrictEqual(value.currentCurrency);
-    expect(state.conversionRate).toStrictEqual(value.conversionRate);
-    expect(state.conversionDate).toStrictEqual(value.conversionDate);
-  });
-
   it('updates tokens', () => {
     const newTokens = {
       address: '0x617b3f8050a0bd94b6b1da02b4384ee5b4df13f4',

--- a/ui/store/actionConstants.js
+++ b/ui/store/actionConstants.js
@@ -29,7 +29,6 @@ export const HIDE_WARNING = 'HIDE_WARNING';
 export const SHOW_ACCOUNT_DETAIL = 'SHOW_ACCOUNT_DETAIL';
 export const SHOW_ACCOUNTS_PAGE = 'SHOW_ACCOUNTS_PAGE';
 export const SHOW_CONF_TX_PAGE = 'SHOW_CONF_TX_PAGE';
-export const SET_CURRENT_FIAT = 'SET_CURRENT_FIAT';
 // account detail screen
 export const SHOW_SEND_TOKEN_PAGE = 'SHOW_SEND_TOKEN_PAGE';
 export const SHOW_PRIVATE_KEY = 'SHOW_PRIVATE_KEY';

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -470,25 +470,16 @@ export function setCurrentCurrency(currencyCode) {
   return async (dispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setCurrentCurrency`);
-    let data;
     try {
-      data = await promisifiedBackground.setCurrentCurrency(currencyCode);
+      await promisifiedBackground.setCurrentCurrency(currencyCode);
+      await forceUpdateMetamaskState(dispatch);
     } catch (error) {
-      log.error(error.stack);
+      log.error(error);
       dispatch(displayWarning(error.message));
       return;
     } finally {
       dispatch(hideLoadingIndication());
     }
-
-    dispatch({
-      type: actionConstants.SET_CURRENT_FIAT,
-      value: {
-        currentCurrency: data.currentCurrency,
-        conversionRate: data.conversionRate,
-        conversionDate: data.conversionDate,
-      },
-    });
   };
 }
 

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -618,28 +618,18 @@ describe('Actions', () => {
 
     it('calls setCurrentCurrency', async () => {
       const store = mockStore();
-      const setCurrentCurrency = background.setCurrentCurrency.callsFake(
-        (_, cb) =>
-          cb(null, {
-            currentCurrency: 'currency',
-            conversionRate: 100,
-            conversionDate: 1611839083653,
-          }),
-      );
-
+      background.setCurrentCurrency.callsFake((_, cb) => cb());
       actions._setBackgroundConnection(background);
 
       await store.dispatch(actions.setCurrentCurrency('jpy'));
-      expect(setCurrentCurrency.callCount).toStrictEqual(1);
+      expect(background.setCurrentCurrency.callCount).toStrictEqual(1);
     });
 
     it('throws if setCurrentCurrency throws', async () => {
       const store = mockStore();
-
       background.setCurrentCurrency.callsFake((_, cb) =>
         cb(new Error('error')),
       );
-
       actions._setBackgroundConnection(background);
 
       const expectedActions = [


### PR DESCRIPTION
The `SET_CURRENT_FIAT` action has been removed. It has been replaced by a call to `forceUpdateMetamaskState`. The only purpose of this action was to eagerly update the current fiat currency settings before the next state update. Forcing a state update instead is simpler and safer.

The `setCurrentCurrency` function in the background has been updated to no longer return the state, now that it's no longer needed.