### PR TITLE
Hide basic tab in advanced gas modal when on testnets

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -26,6 +26,7 @@ import {
   getNextSuggestedNonce,
   getNoGasPriceFetched,
   getIsEthGasPriceFetched,
+  getIsMainnet,
 } from '../../selectors';
 import { currentNetworkTxListSelector } from '../../selectors/transactions';
 import Loading from '../../components/ui/loading-screen';
@@ -120,7 +121,9 @@ export default function ConfirmApprove() {
     : null;
   const isEthGasPrice = useSelector(getIsEthGasPriceFetched);
   const noGasPrice = useSelector(getNoGasPriceFetched);
-
+  const isMainnet = useSelector(getIsMainnet);
+  const hideBasic =
+    isEthGasPrice || noGasPrice || !(isMainnet || process.env.IN_TEST);
   return tokenSymbol === undefined ? (
     <Loading />
   ) : (
@@ -144,7 +147,7 @@ export default function ConfirmApprove() {
               showModal({
                 name: 'CUSTOMIZE_GAS',
                 txData,
-                hideBasic: isEthGasPrice || noGasPrice,
+                hideBasic,
               }),
             )
           }


### PR DESCRIPTION
Fixes: #10980 

The only location the custom gas modal is accessed in test-net is in `confirm-approve`. This PR checks if the network is not Mainnet or test environment (for e2e test).