### PR TITLE
Replace uses of `hasOwnProperty.call` with simpler alternatives

### DIFF
--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -13,7 +13,9 @@ export default class ComposableObservableStore extends ObservableStore {
    */
   constructor(initState, config) {
     super(initState);
-    this.updateStructure(config);
+    if (config) {
+      this.updateStructure(config);
+    }
   }
 
   /**
@@ -24,12 +26,10 @@ export default class ComposableObservableStore extends ObservableStore {
   updateStructure(config) {
     this.config = config;
     this.removeAllListeners();
-    for (const key in config) {
-      if (Object.prototype.hasOwnProperty.call(config, key)) {
-        config[key].subscribe((state) => {
-          this.updateState({ [key]: state });
-        });
-      }
+    for (const key of Object.keys(this.config)) {
+      config[key].subscribe((state) => {
+        this.updateState({ [key]: state });
+      });
     }
   }
 
@@ -40,15 +40,16 @@ export default class ComposableObservableStore extends ObservableStore {
    * @returns {Object} Object containing merged child store state
    */
   getFlatState() {
+    if (!this.config) {
+      return {};
+    }
     let flatState = {};
-    for (const key in this.config) {
-      if (Object.prototype.hasOwnProperty.call(this.config, key)) {
-        const controller = this.config[key];
-        const state = controller.getState
-          ? controller.getState()
-          : controller.state;
-        flatState = { ...flatState, ...state };
-      }
+    for (const key of Object.keys(this.config)) {
+      const controller = this.config[key];
+      const state = controller.getState
+        ? controller.getState()
+        : controller.state;
+      flatState = { ...flatState, ...state };
     }
     return flatState;
   }

--- a/app/scripts/lib/ComposableObservableStore.test.js
+++ b/app/scripts/lib/ComposableObservableStore.test.js
@@ -32,4 +32,9 @@ describe('ComposableObservableStore', function () {
     });
     assert.deepEqual(store.getFlatState(), { foo: 'foo', bar: 'bar' });
   });
+
+  it('should return empty flattened state when not configured', function () {
+    const store = new ComposableObservableStore();
+    assert.deepEqual(store.getFlatState(), {});
+  });
 });

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -40,9 +40,7 @@ export default async function getFirstPreferredLangCode() {
 
   const firstPreferredLangCode = userPreferredLocaleCodes
     .map((code) => code.toLowerCase().replace('_', '-'))
-    .find((code) =>
-      Object.prototype.hasOwnProperty.call(existingLocaleCodes, code),
-    );
+    .find((code) => existingLocaleCodes[code] !== undefined);
 
   return existingLocaleCodes[firstPreferredLangCode] || 'en';
 }


### PR DESCRIPTION
Three uses of `hasOwnProperty.call` have been replaced with simpler alternatives. I did this because I found this convention confusing.

The `ComposableObservableStore` changes required adding a check for whether the `config` is defined, because the old syntax would allow iterating over `undefined` as if it was an empty object. Functionally it should be identical. A new test was added to highlight this functionality.