### PR TITLE
Update jsconfig excludes array

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,3 +1,14 @@
 {
-  "exclude": ["node:console"]
+  "exclude": [
+    "*.log",
+    "builds",
+    "coverage",
+    "dist",
+    "docs",
+    "lavamoat",
+    "node:console",
+    "node_modules",
+    "patches",
+    "test-artifacts"
+  ]
 }


### PR DESCRIPTION
I and other have experienced degraded performance in VS Code recently. In particular, I've constantly received notifications that I need to exclude files for the benefit of VS Code's native JavaScript and TypeScript extension. 

VS Code's [documentation](https://code.visualstudio.com/Docs/languages/javascript) has this to say on the matter:

> If not all JavaScript files in your workspace should be considered part of a single JavaScript project. `jsconfig.json` files let you exclude some files from showing up in IntelliSense.

This PR adds a bunch of directories and one glob to the `excludes` array of our `jsconfig.json`, in the hope of improving or restoring VS Code / IntelliSense performance for the extension repository.