### PR TITLE
Use strict assertion mode everywhere

### DIFF
--- a/app/scripts/account-import-strategies/account-import-strategies.test.js
+++ b/app/scripts/account-import-strategies/account-import-strategies.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { stripHexPrefix } from 'ethereumjs-util';
 import accountImporter from '.';
 

--- a/app/scripts/controllers/cached-balances.test.js
+++ b/app/scripts/controllers/cached-balances.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { KOVAN_CHAIN_ID } from '../../../shared/constants/network';
 import CachedBalancesController from './cached-balances';

--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { ObservableStore } from '@metamask/obs-store';
 import contracts from '@metamask/contract-metadata';

--- a/app/scripts/controllers/ens/index.test.js
+++ b/app/scripts/controllers/ens/index.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import EnsController from '.';
 

--- a/app/scripts/controllers/incoming-transactions.test.js
+++ b/app/scripts/controllers/incoming-transactions.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
 import nock from 'nock';

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import EventEmitter from 'events';
 import { ComposedStore, ObservableStore } from '@metamask/obs-store';
 import { JsonRpcEngine } from 'json-rpc-engine';

--- a/app/scripts/controllers/network/pending-middleware.test.js
+++ b/app/scripts/controllers/network/pending-middleware.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { txMetaStub } from '../../../../test/stub/tx-meta-stub';
 import {
   createPendingNonceMiddleware,

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import {
   MAINNET_CHAIN_ID,

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 
 import { ethers } from 'ethers';
@@ -645,7 +645,7 @@ describe('SwapsController', function () {
           topAggId,
           resultQuotes,
         ] = await swapsController._findTopQuoteAndCalculateSavings(testInput);
-        assert.equal(topAggId, [TEST_AGG_ID_2]);
+        assert.equal(topAggId, TEST_AGG_ID_2);
         assert.deepStrictEqual(resultQuotes, expectedResultQuotes);
       });
     });

--- a/app/scripts/controllers/token-rates-controller.test.js
+++ b/app/scripts/controllers/token-rates-controller.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { ObservableStore } from '@metamask/obs-store';
 import TokenRatesController from './token-rates';

--- a/app/scripts/lib/ComposableObservableStore.test.js
+++ b/app/scripts/lib/ComposableObservableStore.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { ObservableStore } from '@metamask/obs-store';
 import ComposableObservableStore from './ComposableObservableStore';
 

--- a/app/scripts/lib/buy-eth-url.test.js
+++ b/app/scripts/lib/buy-eth-url.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import {
   KOVAN_CHAIN_ID,
   MAINNET_CHAIN_ID,

--- a/app/scripts/lib/cleanErrorStack.test.js
+++ b/app/scripts/lib/cleanErrorStack.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import cleanErrorStack from './cleanErrorStack';
 
 describe('Clean Error Stack', function () {
@@ -14,7 +14,7 @@ describe('Clean Error Stack', function () {
   });
 
   it('tests error with message', function () {
-    assert.equal(cleanErrorStack(testError), 'Error: Test Message');
+    assert.equal(cleanErrorStack(testError).toString(), 'Error: Test Message');
   });
 
   it('tests error with undefined name', function () {
@@ -29,6 +29,6 @@ describe('Clean Error Stack', function () {
   });
 
   it('tests error with blank message', function () {
-    assert.equal(cleanErrorStack(blankMsgError), 'Error');
+    assert.equal(cleanErrorStack(blankMsgError).toString(), 'Error');
   });
 });

--- a/app/scripts/lib/createMetaRPCHandler.test.js
+++ b/app/scripts/lib/createMetaRPCHandler.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { obj as createThoughStream } from 'through2';
 import createMetaRPCHandler from './createMetaRPCHandler';
 

--- a/app/scripts/lib/message-manager.test.js
+++ b/app/scripts/lib/message-manager.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import MessageManager from './message-manager';
 

--- a/app/scripts/lib/metaRPCClientFactory.test.js
+++ b/app/scripts/lib/metaRPCClientFactory.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { obj as createThoughStream } from 'through2';
 import metaRPCClientFactory from './metaRPCClientFactory';
 

--- a/app/scripts/lib/migrator/index.test.js
+++ b/app/scripts/lib/migrator/index.test.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { cloneDeep } from 'lodash';
 import liveMigrations from '../../migrations';
 import data from '../../first-time-state';

--- a/app/scripts/lib/nodeify.test.js
+++ b/app/scripts/lib/nodeify.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import nodeify from './nodeify';
 
 describe('nodeify', function () {

--- a/app/scripts/lib/personal-message-manager.test.js
+++ b/app/scripts/lib/personal-message-manager.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import PersonalMessageManager from './personal-message-manager';
 

--- a/app/scripts/lib/seed-phrase-verifier.test.js
+++ b/app/scripts/lib/seed-phrase-verifier.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { cloneDeep } from 'lodash';
 import KeyringController from 'eth-keyring-controller';
 import firstTimeState from '../first-time-state';

--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { ObservableStore } from '@metamask/obs-store';
 import { ethErrors } from 'eth-rpc-errors';
 import { typedSignatureHash, TYPED_MESSAGE_SCHEMA } from 'eth-sig-util';

--- a/app/scripts/lib/typed-message-manager.test.js
+++ b/app/scripts/lib/typed-message-manager.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import TypedMessageManager from './typed-message-manager';

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import extension from 'extensionizer';
 import { stripHexPrefix } from 'ethereumjs-util';
 import BN from 'bn.js';

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { cloneDeep } from 'lodash';
 import nock from 'nock';
@@ -493,8 +493,8 @@ describe('MetaMaskController', function () {
         );
       } catch (e) {
         assert.equal(
-          e,
-          'Error: MetamaskController:getKeyringForDevice - Unknown device',
+          e.message,
+          'MetamaskController:getKeyringForDevice - Unknown device',
         );
       }
     });
@@ -535,8 +535,8 @@ describe('MetaMaskController', function () {
         );
       } catch (e) {
         assert.equal(
-          e,
-          'Error: MetamaskController:getKeyringForDevice - Unknown device',
+          e.message,
+          'MetamaskController:getKeyringForDevice - Unknown device',
         );
       }
     });
@@ -554,8 +554,8 @@ describe('MetaMaskController', function () {
         await metamaskController.forgetDevice('Some random device name');
       } catch (e) {
         assert.equal(
-          e,
-          'Error: MetamaskController:getKeyringForDevice - Unknown device',
+          e.message,
+          'MetamaskController:getKeyringForDevice - Unknown device',
         );
       }
     });

--- a/app/scripts/migrations/021.test.js
+++ b/app/scripts/migrations/021.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import wallet2 from '../../../test/lib/migrations/002.json';
 import migration21 from './021';
 

--- a/app/scripts/migrations/022.test.js
+++ b/app/scripts/migrations/022.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import migration22 from './022';
 

--- a/app/scripts/migrations/023.test.js
+++ b/app/scripts/migrations/023.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import migration23 from './023';
 

--- a/app/scripts/migrations/024.test.js
+++ b/app/scripts/migrations/024.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import data from '../first-time-state';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import migration24 from './024';

--- a/app/scripts/migrations/025.test.js
+++ b/app/scripts/migrations/025.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import data from '../first-time-state';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import migration25 from './025';

--- a/app/scripts/migrations/026.test.js
+++ b/app/scripts/migrations/026.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import firstTimeState from '../first-time-state';
 import migration26 from './026';
 

--- a/app/scripts/migrations/027.test.js
+++ b/app/scripts/migrations/027.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import firstTimeState from '../first-time-state';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import migration27 from './027';

--- a/app/scripts/migrations/028.test.js
+++ b/app/scripts/migrations/028.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import firstTimeState from '../first-time-state';
 import migration28 from './028';
 

--- a/app/scripts/migrations/029.test.js
+++ b/app/scripts/migrations/029.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import migration29 from './029';
 

--- a/app/scripts/migrations/030.test.js
+++ b/app/scripts/migrations/030.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migrationTemplate from './030';
 
 const storage = {

--- a/app/scripts/migrations/031.test.js
+++ b/app/scripts/migrations/031.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration31 from './031';
 
 describe('migration #31', function () {

--- a/app/scripts/migrations/033.test.js
+++ b/app/scripts/migrations/033.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration33 from './033';
 
 describe('Migration to delete notice controller', function () {

--- a/app/scripts/migrations/034.test.js
+++ b/app/scripts/migrations/034.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration34 from './034';
 
 describe('migration #34', function () {

--- a/app/scripts/migrations/035.test.js
+++ b/app/scripts/migrations/035.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration35 from './035';
 
 describe('migration #35', function () {

--- a/app/scripts/migrations/036.test.js
+++ b/app/scripts/migrations/036.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration36 from './036';
 
 describe('migration #36', function () {

--- a/app/scripts/migrations/037.test.js
+++ b/app/scripts/migrations/037.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration37 from './037';
 
 describe('migration #37', function () {

--- a/app/scripts/migrations/039.test.js
+++ b/app/scripts/migrations/039.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration39 from './039';
 
 describe('migration #39', function () {

--- a/app/scripts/migrations/040.test.js
+++ b/app/scripts/migrations/040.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration40 from './040';
 
 describe('migration #40', function () {

--- a/app/scripts/migrations/041.test.js
+++ b/app/scripts/migrations/041.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration41 from './041';
 
 describe('migration #41', function () {

--- a/app/scripts/migrations/042.test.js
+++ b/app/scripts/migrations/042.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration42 from './042';
 
 describe('migration #42', function () {

--- a/app/scripts/migrations/045.test.js
+++ b/app/scripts/migrations/045.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration45 from './045';
 
 describe('migration #45', function () {

--- a/app/scripts/migrations/049.test.js
+++ b/app/scripts/migrations/049.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration49 from './049';
 
 describe('migration #49', function () {

--- a/app/scripts/migrations/052.test.js
+++ b/app/scripts/migrations/052.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import {
   GOERLI,
   GOERLI_CHAIN_ID,

--- a/app/scripts/migrations/056.test.js
+++ b/app/scripts/migrations/056.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migration56 from './056';
 
 const BAD_TOKEN_DATA = { symbol: null, decimals: null };

--- a/app/scripts/migrations/migrations.test.js
+++ b/app/scripts/migrations/migrations.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import wallet1 from '../../../test/lib/migrations/001.json';
 import vault4 from '../../../test/lib/migrations/004.json';
 import migration2 from './002';
@@ -52,7 +52,7 @@ describe('wallet1 is migrated successfully', function () {
         const fourthData = fourthResult.data;
         assert.equal(
           fourthData.config.provider.rpcTarget,
-          null,
+          undefined,
           'old rpcTarget should not exist.',
         );
         assert.equal(
@@ -65,15 +65,15 @@ describe('wallet1 is migrated successfully', function () {
       })
       .then((fifthResult) => {
         const fifthData = fifthResult.data;
-        assert.equal(fifthData.vault, null, 'old vault should not exist');
+        assert.equal(fifthData.vault, undefined, 'old vault should not exist');
         assert.equal(
           fifthData.walletNicknames,
-          null,
+          undefined,
           'old walletNicknames should not exist',
         );
         assert.equal(
           fifthData.config.selectedAccount,
-          null,
+          undefined,
           'old config.selectedAccount should not exist',
         );
         assert.equal(
@@ -102,7 +102,7 @@ describe('wallet1 is migrated successfully', function () {
       .then((sixthResult) => {
         assert.equal(
           sixthResult.data.KeyringController.selectedAccount,
-          null,
+          undefined,
           'old selectedAccount should not exist',
         );
         assert.equal(
@@ -117,12 +117,12 @@ describe('wallet1 is migrated successfully', function () {
       .then((seventhResult) => {
         assert.equal(
           seventhResult.data.transactions,
-          null,
+          undefined,
           'old transactions should not exist',
         );
         assert.equal(
           seventhResult.data.gasMultiplier,
-          null,
+          undefined,
           'old gasMultiplier should not exist',
         );
         assert.equal(
@@ -142,7 +142,7 @@ describe('wallet1 is migrated successfully', function () {
       .then((eighthResult) => {
         assert.equal(
           eighthResult.data.noticesList,
-          null,
+          undefined,
           'old noticesList should not exist',
         );
         assert.equal(
@@ -157,22 +157,22 @@ describe('wallet1 is migrated successfully', function () {
       .then((ninthResult) => {
         assert.equal(
           ninthResult.data.currentFiat,
-          null,
+          undefined,
           'old currentFiat should not exist',
         );
         assert.equal(
           ninthResult.data.fiatCurrency,
-          null,
+          undefined,
           'old fiatCurrency should not exist',
         );
         assert.equal(
           ninthResult.data.conversionRate,
-          null,
+          undefined,
           'old conversionRate should not exist',
         );
         assert.equal(
           ninthResult.data.conversionDate,
-          null,
+          undefined,
           'old conversionDate should not exist',
         );
 
@@ -198,7 +198,7 @@ describe('wallet1 is migrated successfully', function () {
       .then((tenthResult) => {
         assert.equal(
           tenthResult.data.shapeShiftTxList,
-          null,
+          undefined,
           'old shapeShiftTxList should not exist',
         );
         assert.equal(
@@ -211,12 +211,12 @@ describe('wallet1 is migrated successfully', function () {
       .then((eleventhResult) => {
         assert.equal(
           eleventhResult.data.isDisclaimerConfirmed,
-          null,
+          undefined,
           'isDisclaimerConfirmed should not exist',
         );
         assert.equal(
           eleventhResult.data.TOSHash,
-          null,
+          undefined,
           'TOSHash should not exist',
         );
 

--- a/app/scripts/migrations/template.test.js
+++ b/app/scripts/migrations/template.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import migrationTemplate from './template';
 
 const storage = {

--- a/shared/modules/fetch-with-timeout.test.js
+++ b/shared/modules/fetch-with-timeout.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import nock from 'nock';
 
 import getFetchWithTimeout from './fetch-with-timeout';

--- a/shared/modules/tests/transaction.utils.test.js
+++ b/shared/modules/tests/transaction.utils.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import {
   MAINNET_CHAIN_ID,
   MAINNET_NETWORK_ID,

--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { strict: assert } = require('assert');
 
 const enLocaleMessages = require('../../app/_locales/en/messages.json');
 const { tinyDelayMs, regularDelayMs, largeDelayMs } = require('./helpers');

--- a/test/unit-global/balance-formatter.test.js
+++ b/test/unit-global/balance-formatter.test.js
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import currencyFormatter from 'currency-formatter';
 import availableCurrencies from '../../ui/helpers/constants/available-conversions.json';
 

--- a/test/unit-global/frozenPromise.test.js
+++ b/test/unit-global/frozenPromise.test.js
@@ -2,7 +2,7 @@
 import './globalPatch';
 import 'ses/lockdown';
 import '../../app/scripts/runLockdown';
-import assert from 'assert'; /* eslint-disable-line import/first,import/order */
+import { strict as assert } from 'assert'; /* eslint-disable-line import/first,import/order */
 
 describe('Promise global is immutable', function () {
   it('throws when reassinging promise (syntax 1)', function () {


### PR DESCRIPTION
The `assert` module has two modes: "Legacy" and "strict". When using strict mode, the "strict" version of each assertion method is implied. Whereas in legacy mode, by default it will use the deprecated, "loose" version of each assertion.

We now use strict mode everywhere. A few tests required updates where they were asserting the wrong thing, and it was passing beforehand due to the loose matching.