### PR TITLE
Removing unused prop from TransactionActivityLog

### DIFF
--- a/ui/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -14,7 +14,6 @@ import { CONFIRMED_STATUS } from './transaction-activity-log.constants';
 export default class TransactionActivityLog extends PureComponent {
   static contextTypes = {
     t: PropTypes.func,
-    metricEvent: PropTypes.func,
   };
 
   static propTypes = {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11008

The `metricEvent` prop wasn't actually being used anywhere