### PR TITLE
Group signature transactions

### DIFF
--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -1,3 +1,5 @@
+import { MESSAGE_TYPE } from './app';
+
 /**
  * Transaction Type is a MetaMask construct used internally
  * @typedef {Object} TransactionTypes
@@ -51,6 +53,11 @@ export const TRANSACTION_TYPES = {
   DEPLOY_CONTRACT: 'contractDeployment',
   SWAP: 'swap',
   SWAP_APPROVAL: 'swapApproval',
+  SIGN: MESSAGE_TYPE.ETH_SIGN,
+  SIGN_TYPED_DATA: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA,
+  PERSONAL_SIGN: MESSAGE_TYPE.PERSONAL_SIGN,
+  ETH_DECRYPT: MESSAGE_TYPE.ETH_DECRYPT,
+  ETH_GET_ENCRYPTION_PUBLIC_KEY: MESSAGE_TYPE.ETH_GET_ENCRYPTION_PUBLIC_KEY,
 };
 
 /**

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -145,7 +145,17 @@ export function useTransactionDisplayData(transactionGroup) {
   // 6. Swap
   // 7. Swap Approval
 
-  if (type === null || type === undefined) {
+  const signatureTypes = [
+    null,
+    undefined,
+    TRANSACTION_TYPES.SIGN,
+    TRANSACTION_TYPES.PERSONAL_SIGN,
+    TRANSACTION_TYPES.SIGN_TYPED_DATA,
+    TRANSACTION_TYPES.ETH_DECRYPT,
+    TRANSACTION_TYPES.ETH_GET_ENCRYPTION_PUBLIC_KEY,
+  ];
+
+  if (signatureTypes.includes(type)) {
     category = TRANSACTION_GROUP_CATEGORIES.SIGNATURE_REQUEST;
     title = t('signatureRequest');
     subtitle = origin;


### PR DESCRIPTION
We need to group the explicitly known signing types with `null` and undefined so they are treated properly by the transaction list.