### PR TITLE
Adding periodic reminder modal for backing up recovery phrase

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1425,6 +1425,30 @@
   "recipientAddressPlaceholder": {
     "message": "Search, public address (0x), or ENS"
   },
+  "recoveryPhraseReminderBackupStart": {
+    "message": "Start here"
+  },
+  "recoveryPhraseReminderConfirm": {
+    "message": "Got it"
+  },
+  "recoveryPhraseReminderHasBackedUp": {
+    "message": "Always keep your Secret Recovery Phrase in a secure and secret place"
+  },
+  "recoveryPhraseReminderHasNotBackedUp": {
+    "message": "Need to backup your Secret Recovery Phrase again?"
+  },
+  "recoveryPhraseReminderItemOne": {
+    "message": "Never share your Secret Recovery Phrase with anyone"
+  },
+  "recoveryPhraseReminderItemTwo": {
+    "message": "The MetaMask team will never ask for your Secret Recovery Phrase"
+  },
+  "recoveryPhraseReminderSubText": {
+    "message": "Your Secret Recovery Phrase controls all of your accounts."
+  },
+  "recoveryPhraseReminderTitle": {
+    "message": "Protect your funds"
+  },
   "reject": {
     "message": "Reject"
   },

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -1,6 +1,14 @@
 import EventEmitter from 'events';
 import { ObservableStore } from '@metamask/obs-store';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
+import * as time from '../../../shared/constants/time';
+
+// 1 hour
+const REMINDER_CHECK_INTERVAL = time.HOUR;
+// 2 days
+const INITIAL_REMINDER_FREQUENCY = time.DAY * 2;
+// 90 days
+const FOLLOWUP_REMINDER_FREQUENCY = time.DAY * 90;
 
 export default class AppStateController extends EventEmitter {
   /**
@@ -24,9 +32,13 @@ export default class AppStateController extends EventEmitter {
       connectedStatusPopoverHasBeenShown: true,
       defaultHomeActiveTabName: null,
       browserEnvironment: {},
+      recoveryPhraseReminderHasBeenShown: false,
+      recoveryPhraseReminderLastShown: 0,
+      shouldShowRecoveryPhraseReminder: false,
       ...initState,
     });
     this.timer = null;
+    this.interval = REMINDER_CHECK_INTERVAL;
 
     this.isUnlocked = isUnlocked;
     this.waitingForUnlock = [];
@@ -43,6 +55,19 @@ export default class AppStateController extends EventEmitter {
 
     const { preferences } = preferencesStore.getState();
     this._setInactiveTimeout(preferences.autoLockTimeLimit);
+  }
+
+  /* eslint-disable accessor-pairs */
+  /**
+   * @type {number}
+   */
+  set interval(interval) {
+    if (this._handleReminderCheck) {
+      clearInterval(this._handleReminderCheck);
+    }
+    this._handleReminderCheck = setInterval(() => {
+      this._checkShouldShowRecoveryPhraseReminder();
+    }, interval);
   }
 
   /**
@@ -113,6 +138,16 @@ export default class AppStateController extends EventEmitter {
   }
 
   /**
+   * Record that the user has been shown the recovery phrase reminder
+   */
+  setRecoveryPhraseReminderHasBeenShown() {
+    this.store.updateState({
+      recoveryPhraseReminderHasBeenShown: true,
+      shouldShowRecoveryPhraseReminder: false,
+    });
+  }
+
+  /**
    * Sets the last active time to the current time
    * @returns {void}
    */
@@ -132,6 +167,68 @@ export default class AppStateController extends EventEmitter {
     });
 
     this._resetTimer();
+  }
+
+  _checkShouldShowRecoveryPhraseReminder() {
+    const {
+      recoveryPhraseReminderHasBeenShown,
+      recoveryPhraseReminderLastShown,
+    } = this.store.getState();
+    // Capture the current timestamp
+    const currentTime = new Date().getTime();
+
+    // For the first interval run, set recoveryPhraseReminderLastShown to the current time.
+    if (recoveryPhraseReminderLastShown === 0) {
+      this.store.updateState({
+        recoveryPhraseReminderLastShown: currentTime,
+      });
+      return;
+    }
+
+    // Wait 2 days before the first display
+    if (!recoveryPhraseReminderHasBeenShown) {
+      if (
+        currentTime - recoveryPhraseReminderLastShown >=
+        INITIAL_REMINDER_FREQUENCY
+      ) {
+        this._setShouldShowRecoveryPhraseReminder(true);
+        this._setRecoveryPhraseReminderLastShown(currentTime);
+      }
+      return;
+    }
+
+    // For subsequent displays, wait 90 days
+    if (
+      currentTime - recoveryPhraseReminderLastShown >=
+      FOLLOWUP_REMINDER_FREQUENCY
+    ) {
+      this._setShouldShowRecoveryPhraseReminder(true);
+      this._setRecoveryPhraseReminderLastShown(currentTime);
+    }
+  }
+
+  /**
+   * Record the timestamp of the last time the user has seen the recovery phrase reminder
+   * @param {number} lastShown - timestamp when user was last shown the reminder
+   * @returns {void}
+   * @private
+   */
+  _setRecoveryPhraseReminderLastShown(lastShown) {
+    this.store.updateState({
+      recoveryPhraseReminderLastShown: lastShown,
+    });
+  }
+
+  /**
+   * Set whether or not the user should be shown the recovery phrase reminder
+   * @param {boolean} shouldShow - whether or not the reminder should be shown
+   * @returns {void}
+   * @private
+   */
+  _setShouldShowRecoveryPhraseReminder(shouldShow) {
+    this.store.updateState({
+      shouldShowRecoveryPhraseReminder: shouldShow,
+    });
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -783,6 +783,10 @@ export default class MetamaskController extends EventEmitter {
         this.appStateController.setRecoveryPhraseReminderHasBeenShown,
         this.appStateController,
       ),
+      setRecoveryPhraseReminderLastShown: nodeify(
+        this.appStateController.setRecoveryPhraseReminderLastShown,
+        this.appStateController,
+      ),
 
       // EnsController
       tryReverseResolveAddress: nodeify(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -779,6 +779,10 @@ export default class MetamaskController extends EventEmitter {
         this.appStateController.setConnectedStatusPopoverHasBeenShown,
         this.appStateController,
       ),
+      setRecoveryPhraseReminderHasBeenShown: nodeify(
+        this.appStateController.setRecoveryPhraseReminderHasBeenShown,
+        this.appStateController,
+      ),
 
       // EnsController
       tryReverseResolveAddress: nodeify(

--- a/app/scripts/migrations/061.js
+++ b/app/scripts/migrations/061.js
@@ -1,0 +1,33 @@
+import { cloneDeep } from 'lodash';
+
+const version = 61;
+
+/**
+ * Initialize attributes related to recovery seed phrase reminder
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    const newState = transformState(state);
+    versionedData.data = newState;
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  if (state.AppStateController) {
+    state.AppStateController.recoveryPhraseReminderHasBeenShown = false;
+    state.AppStateController.recoveryPhraseReminderLastShown = 0;
+    state.AppStateController.shouldShowRecoveryPhraseReminder = false;
+  } else {
+    state.AppStateController = {
+      recoveryPhraseReminderHasBeenShown: false,
+      recoveryPhraseReminderLastShown: 0,
+      shouldShowRecoveryPhraseReminder: false,
+    };
+  }
+  return state;
+}

--- a/app/scripts/migrations/061.js
+++ b/app/scripts/migrations/061.js
@@ -18,15 +18,14 @@ export default {
 };
 
 function transformState(state) {
+  const currentTime = new Date().getTime();
   if (state.AppStateController) {
     state.AppStateController.recoveryPhraseReminderHasBeenShown = false;
-    state.AppStateController.recoveryPhraseReminderLastShown = 0;
-    state.AppStateController.shouldShowRecoveryPhraseReminder = false;
+    state.AppStateController.recoveryPhraseReminderLastShown = currentTime;
   } else {
     state.AppStateController = {
       recoveryPhraseReminderHasBeenShown: false,
-      recoveryPhraseReminderLastShown: 0,
-      shouldShowRecoveryPhraseReminder: false,
+      recoveryPhraseReminderLastShown: currentTime,
     };
   }
   return state;

--- a/app/scripts/migrations/061.test.js
+++ b/app/scripts/migrations/061.test.js
@@ -1,7 +1,18 @@
 import { strict as assert } from 'assert';
+import sinon from 'sinon';
 import migration61 from './061';
 
 describe('migration #61', function () {
+  let dateStub;
+
+  beforeEach(function () {
+    dateStub = sinon.stub(Date.prototype, 'getTime').returns(1621580400000);
+  });
+
+  afterEach(function () {
+    dateStub.restore();
+  });
+
   it('should update the version metadata', async function () {
     const oldStorage = {
       meta: {
@@ -16,7 +27,7 @@ describe('migration #61', function () {
     });
   });
 
-  it('should set recoveryPhraseReminderHasBeenShown to false, recoveryPhraseReminderLastShown to 0, and shouldShowRecoveryPhraseReminder to false', async function () {
+  it('should set recoveryPhraseReminderHasBeenShown to false and recoveryPhraseReminderLastShown to the current time', async function () {
     const oldStorage = {
       meta: {},
       data: {
@@ -30,8 +41,7 @@ describe('migration #61', function () {
     assert.deepEqual(newStorage.data, {
       AppStateController: {
         recoveryPhraseReminderHasBeenShown: false,
-        recoveryPhraseReminderLastShown: 0,
-        shouldShowRecoveryPhraseReminder: false,
+        recoveryPhraseReminderLastShown: 1621580400000,
         existingProperty: 'foo',
       },
     });
@@ -50,8 +60,7 @@ describe('migration #61', function () {
       existingProperty: 'foo',
       AppStateController: {
         recoveryPhraseReminderHasBeenShown: false,
-        recoveryPhraseReminderLastShown: 0,
-        shouldShowRecoveryPhraseReminder: false,
+        recoveryPhraseReminderLastShown: 1621580400000,
       },
     });
   });

--- a/app/scripts/migrations/061.test.js
+++ b/app/scripts/migrations/061.test.js
@@ -1,0 +1,58 @@
+import { strict as assert } from 'assert';
+import migration61 from './061';
+
+describe('migration #61', function () {
+  it('should update the version metadata', async function () {
+    const oldStorage = {
+      meta: {
+        version: 60,
+      },
+      data: {},
+    };
+
+    const newStorage = await migration61.migrate(oldStorage);
+    assert.deepEqual(newStorage.meta, {
+      version: 61,
+    });
+  });
+
+  it('should set recoveryPhraseReminderHasBeenShown to false, recoveryPhraseReminderLastShown to 0, and shouldShowRecoveryPhraseReminder to false', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        AppStateController: {
+          existingProperty: 'foo',
+        },
+      },
+    };
+
+    const newStorage = await migration61.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      AppStateController: {
+        recoveryPhraseReminderHasBeenShown: false,
+        recoveryPhraseReminderLastShown: 0,
+        shouldShowRecoveryPhraseReminder: false,
+        existingProperty: 'foo',
+      },
+    });
+  });
+
+  it('should initialize AppStateController if it does not exist', async function () {
+    const oldStorage = {
+      meta: {},
+      data: {
+        existingProperty: 'foo',
+      },
+    };
+
+    const newStorage = await migration61.migrate(oldStorage);
+    assert.deepEqual(newStorage.data, {
+      existingProperty: 'foo',
+      AppStateController: {
+        recoveryPhraseReminderHasBeenShown: false,
+        recoveryPhraseReminderLastShown: 0,
+        shouldShowRecoveryPhraseReminder: false,
+      },
+    });
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -65,6 +65,7 @@ const migrations = [
   require('./058').default,
   require('./059').default,
   require('./060').default,
+  require('./061').default,
 ];
 
 export default migrations;

--- a/shared/constants/time.js
+++ b/shared/constants/time.js
@@ -1,0 +1,5 @@
+export const MILLISECOND = 1;
+export const SECOND = MILLISECOND * 1000;
+export const MINUTE = SECOND * 60;
+export const HOUR = MINUTE * 60;
+export const DAY = HOUR * 24;

--- a/ui/components/app/app-components.scss
+++ b/ui/components/app/app-components.scss
@@ -23,6 +23,7 @@
 @import 'permission-page-container/index';
 @import 'permissions-connect-footer/index';
 @import 'permissions-connect-header/index';
+@import 'recovery-phrase-reminder/index';
 @import 'selected-account/index';
 @import 'sidebars/index';
 @import 'signature-request/index';

--- a/ui/components/app/recovery-phrase-reminder/index.js
+++ b/ui/components/app/recovery-phrase-reminder/index.js
@@ -1,0 +1,1 @@
+export { default } from './recovery-phrase-reminder';

--- a/ui/components/app/recovery-phrase-reminder/index.scss
+++ b/ui/components/app/recovery-phrase-reminder/index.scss
@@ -1,0 +1,10 @@
+.recovery-phrase-reminder {
+  &__list {
+    list-style: disc;
+    padding-left: 20px;
+
+    li {
+      margin-bottom: 5px;
+    }
+  }
+}

--- a/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
+++ b/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+// Components
+import Box from '../../ui/box';
+import Button from '../../ui/button';
+import Popover from '../../ui/popover';
+import Typography from '../../ui/typography';
+// Helpers
+import {
+  COLORS,
+  DISPLAY,
+  TEXT_ALIGN,
+  TYPOGRAPHY,
+  BLOCK_SIZES,
+  FONT_WEIGHT,
+  JUSTIFY_CONTENT,
+} from '../../../helpers/constants/design-system';
+import { INITIALIZE_BACKUP_SEED_PHRASE_ROUTE } from '../../../helpers/constants/routes';
+
+export default function RecoveryPhraseReminder({ onConfirm, hasBackedUp }) {
+  const t = useI18nContext();
+  const history = useHistory();
+
+  const handleBackUp = () => {
+    history.push(INITIALIZE_BACKUP_SEED_PHRASE_ROUTE);
+  };
+
+  return (
+    <Popover centerTitle title={t('recoveryPhraseReminderTitle')}>
+      <Box padding={[0, 4, 6, 4]} className="recovery-phrase-reminder">
+        <Typography
+          color={COLORS.BLACK}
+          align={TEXT_ALIGN.CENTER}
+          variant={TYPOGRAPHY.Paragraph}
+          boxProps={{ marginTop: 0, marginBottom: 4 }}
+        >
+          {t('recoveryPhraseReminderSubText')}
+        </Typography>
+        <Box margin={[4, 0, 8, 0]}>
+          <ul className="recovery-phrase-reminder__list">
+            <li>
+              <Typography
+                tag="span"
+                color={COLORS.BLACK}
+                fontWeight={FONT_WEIGHT.BOLD}
+              >
+                {t('recoveryPhraseReminderItemOne')}
+              </Typography>
+            </li>
+            <li>{t('recoveryPhraseReminderItemTwo')}</li>
+            <li>
+              {hasBackedUp ? (
+                t('recoveryPhraseReminderHasBackedUp')
+              ) : (
+                <>
+                  {t('recoveryPhraseReminderHasNotBackedUp')}
+                  <Box display={DISPLAY.INLINE_BLOCK} marginLeft={1}>
+                    <Button
+                      type="link"
+                      onClick={handleBackUp}
+                      style={{
+                        fontSize: 'inherit',
+                        padding: 0,
+                      }}
+                    >
+                      {t('recoveryPhraseReminderBackupStart')}
+                    </Button>
+                  </Box>
+                </>
+              )}
+            </li>
+          </ul>
+        </Box>
+        <Box justifyContent={JUSTIFY_CONTENT.CENTER}>
+          <Box width={BLOCK_SIZES.TWO_FIFTHS}>
+            <Button rounded type="primary" onClick={onConfirm}>
+              {t('recoveryPhraseReminderConfirm')}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Popover>
+  );
+}
+
+RecoveryPhraseReminder.propTypes = {
+  hasBackedUp: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+};

--- a/ui/components/ui/popover/index.scss
+++ b/ui/components/ui/popover/index.scss
@@ -47,6 +47,10 @@
           margin-right: 24px;
         }
       }
+
+      &.center {
+        justify-content: center;
+      }
     }
 
     &__subtitle {

--- a/ui/components/ui/popover/popover.component.js
+++ b/ui/components/ui/popover/popover.component.js
@@ -17,6 +17,7 @@ const Popover = ({
   showArrow,
   CustomBackground,
   popoverRef,
+  centerTitle,
 }) => {
   const t = useI18nContext();
   return (
@@ -32,7 +33,12 @@ const Popover = ({
       >
         {showArrow ? <div className="popover-arrow" /> : null}
         <header className="popover-header">
-          <div className="popover-header__title">
+          <div
+            className={classnames(
+              'popover-header__title',
+              centerTitle ? 'center' : '',
+            )}
+          >
             <h2 title={title}>
               {onBack ? (
                 <button
@@ -43,12 +49,14 @@ const Popover = ({
               ) : null}
               {title}
             </h2>
-            <button
-              className="fas fa-times popover-header__button"
-              title={t('close')}
-              data-testid="popover-close"
-              onClick={onClose}
-            />
+            {onClose ? (
+              <button
+                className="fas fa-times popover-header__button"
+                title={t('close')}
+                data-testid="popover-close"
+                onClick={onClose}
+              />
+            ) : null}
           </div>
           {subtitle ? (
             <p className="popover-header__subtitle">{subtitle}</p>
@@ -76,7 +84,7 @@ Popover.propTypes = {
   footer: PropTypes.node,
   footerClassName: PropTypes.string,
   onBack: PropTypes.func,
-  onClose: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
   CustomBackground: PropTypes.func,
   contentClassName: PropTypes.string,
   className: PropTypes.string,
@@ -84,6 +92,7 @@ Popover.propTypes = {
   popoverRef: PropTypes.shape({
     current: PropTypes.instanceOf(window.Element),
   }),
+  centerTitle: PropTypes.bool,
 };
 
 export default class PopoverPortal extends PureComponent {

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -14,6 +14,7 @@ import ConnectedAccounts from '../connected-accounts';
 import { Tabs, Tab } from '../../components/ui/tabs';
 import { EthOverview } from '../../components/app/wallet-overview';
 import WhatsNewPopup from '../../components/app/whats-new-popup';
+import RecoveryPhraseReminder from '../../components/app/recovery-phrase-reminder';
 
 import {
   ASSET_ROUTE,
@@ -76,6 +77,9 @@ export default class Home extends PureComponent {
     showWhatsNewPopup: PropTypes.bool.isRequired,
     hideWhatsNewPopup: PropTypes.func.isRequired,
     notificationsToShow: PropTypes.bool.isRequired,
+    shouldShowRecoveryPhraseReminder: PropTypes.bool.isRequired,
+    setRecoveryPhraseReminderHasBeenShown: PropTypes.func.isRequired,
+    seedPhraseBackedUp: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -325,6 +329,9 @@ export default class Home extends PureComponent {
       notificationsToShow,
       showWhatsNewPopup,
       hideWhatsNewPopup,
+      shouldShowRecoveryPhraseReminder,
+      setRecoveryPhraseReminderHasBeenShown,
+      seedPhraseBackedUp,
     } = this.props;
 
     if (forgottenPassword) {
@@ -332,6 +339,8 @@ export default class Home extends PureComponent {
     } else if (this.state.closing || this.state.redirecting) {
       return null;
     }
+
+    const showWhatsNew = notificationsToShow && showWhatsNewPopup;
 
     return (
       <div className="main-container">
@@ -342,8 +351,12 @@ export default class Home extends PureComponent {
           exact
         />
         <div className="home__container">
-          {notificationsToShow && showWhatsNewPopup ? (
-            <WhatsNewPopup onClose={hideWhatsNewPopup} />
+          {showWhatsNew ? <WhatsNewPopup onClose={hideWhatsNewPopup} /> : null}
+          {!showWhatsNew && shouldShowRecoveryPhraseReminder ? (
+            <RecoveryPhraseReminder
+              hasBackedUp={seedPhraseBackedUp}
+              onConfirm={setRecoveryPhraseReminderHasBeenShown}
+            />
           ) : null}
           {isPopup && !connectedStatusPopoverHasBeenShown
             ? this.renderPopover()

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -77,8 +77,9 @@ export default class Home extends PureComponent {
     showWhatsNewPopup: PropTypes.bool.isRequired,
     hideWhatsNewPopup: PropTypes.func.isRequired,
     notificationsToShow: PropTypes.bool.isRequired,
-    shouldShowRecoveryPhraseReminder: PropTypes.bool.isRequired,
+    showRecoveryPhraseReminder: PropTypes.bool.isRequired,
     setRecoveryPhraseReminderHasBeenShown: PropTypes.func.isRequired,
+    setRecoveryPhraseReminderLastShown: PropTypes.func.isRequired,
     seedPhraseBackedUp: PropTypes.bool.isRequired,
   };
 
@@ -166,6 +167,15 @@ export default class Home extends PureComponent {
       setupThreeBox();
     }
   }
+
+  onRecoveryPhraseReminderClose = () => {
+    const {
+      setRecoveryPhraseReminderHasBeenShown,
+      setRecoveryPhraseReminderLastShown,
+    } = this.props;
+    setRecoveryPhraseReminderHasBeenShown(true);
+    setRecoveryPhraseReminderLastShown(new Date().getTime());
+  };
 
   renderNotifications() {
     const { t } = this.context;
@@ -329,9 +339,8 @@ export default class Home extends PureComponent {
       notificationsToShow,
       showWhatsNewPopup,
       hideWhatsNewPopup,
-      shouldShowRecoveryPhraseReminder,
-      setRecoveryPhraseReminderHasBeenShown,
       seedPhraseBackedUp,
+      showRecoveryPhraseReminder,
     } = this.props;
 
     if (forgottenPassword) {
@@ -352,10 +361,10 @@ export default class Home extends PureComponent {
         />
         <div className="home__container">
           {showWhatsNew ? <WhatsNewPopup onClose={hideWhatsNewPopup} /> : null}
-          {!showWhatsNew && shouldShowRecoveryPhraseReminder ? (
+          {!showWhatsNew && showRecoveryPhraseReminder ? (
             <RecoveryPhraseReminder
               hasBackedUp={seedPhraseBackedUp}
-              onConfirm={setRecoveryPhraseReminderHasBeenShown}
+              onConfirm={this.onRecoveryPhraseReminderClose}
             />
           ) : null}
           {isPopup && !connectedStatusPopoverHasBeenShown

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -14,6 +14,7 @@ import {
   getInfuraBlocked,
   getShowWhatsNewPopup,
   getSortedNotificationsToShow,
+  getShowRecoveryPhraseReminder,
 } from '../../selectors';
 
 import {
@@ -26,6 +27,7 @@ import {
   setWeb3ShimUsageAlertDismissed,
   setAlertEnabledness,
   setRecoveryPhraseReminderHasBeenShown,
+  setRecoveryPhraseReminderLastShown,
 } from '../../store/actions';
 import { setThreeBoxLastUpdated, hideWhatsNewPopup } from '../../ducks/app/app';
 import { getWeb3ShimUsageAlertEnabledness } from '../../ducks/metamask/metamask';
@@ -54,7 +56,6 @@ const mapStateToProps = (state) => {
     defaultHomeActiveTabName,
     swapsState,
     dismissSeedBackUpReminder,
-    shouldShowRecoveryPhraseReminder,
   } = metamask;
   const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
@@ -109,7 +110,8 @@ const mapStateToProps = (state) => {
     infuraBlocked: getInfuraBlocked(state),
     notificationsToShow: getSortedNotificationsToShow(state).length > 0,
     showWhatsNewPopup: getShowWhatsNewPopup(state),
-    shouldShowRecoveryPhraseReminder,
+    showRecoveryPhraseReminder: getShowRecoveryPhraseReminder(state),
+    seedPhraseBackedUp,
   };
 };
 
@@ -137,6 +139,8 @@ const mapDispatchToProps = (dispatch) => ({
   hideWhatsNewPopup: () => dispatch(hideWhatsNewPopup()),
   setRecoveryPhraseReminderHasBeenShown: () =>
     dispatch(setRecoveryPhraseReminderHasBeenShown()),
+  setRecoveryPhraseReminderLastShown: (lastShown) =>
+    dispatch(setRecoveryPhraseReminderLastShown(lastShown)),
 });
 
 export default compose(

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -25,6 +25,7 @@ import {
   setDefaultHomeActiveTabName,
   setWeb3ShimUsageAlertDismissed,
   setAlertEnabledness,
+  setRecoveryPhraseReminderHasBeenShown,
 } from '../../store/actions';
 import { setThreeBoxLastUpdated, hideWhatsNewPopup } from '../../ducks/app/app';
 import { getWeb3ShimUsageAlertEnabledness } from '../../ducks/metamask/metamask';
@@ -53,6 +54,7 @@ const mapStateToProps = (state) => {
     defaultHomeActiveTabName,
     swapsState,
     dismissSeedBackUpReminder,
+    shouldShowRecoveryPhraseReminder,
   } = metamask;
   const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
@@ -107,6 +109,7 @@ const mapStateToProps = (state) => {
     infuraBlocked: getInfuraBlocked(state),
     notificationsToShow: getSortedNotificationsToShow(state).length > 0,
     showWhatsNewPopup: getShowWhatsNewPopup(state),
+    shouldShowRecoveryPhraseReminder,
   };
 };
 
@@ -132,6 +135,8 @@ const mapDispatchToProps = (dispatch) => ({
   disableWeb3ShimUsageAlert: () =>
     setAlertEnabledness(ALERT_TYPES.web3ShimUsage, false),
   hideWhatsNewPopup: () => dispatch(hideWhatsNewPopup()),
+  setRecoveryPhraseReminderHasBeenShown: () =>
+    dispatch(setRecoveryPhraseReminderHasBeenShown()),
 });
 
 export default compose(

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -23,6 +23,7 @@ import {
 import { TEMPLATED_CONFIRMATION_MESSAGE_TYPES } from '../pages/confirmation/templates';
 
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
+import { DAY } from '../../shared/constants/time';
 import { getNativeCurrency } from './send';
 
 /**
@@ -561,4 +562,16 @@ export function getSortedNotificationsToShow(state) {
     (a, b) => new Date(b.date) - new Date(a.date),
   );
   return notificationsSortedByDate;
+}
+
+export function getShowRecoveryPhraseReminder(state) {
+  const {
+    recoveryPhraseReminderLastShown,
+    recoveryPhraseReminderHasBeenShown,
+  } = state.metamask;
+
+  const currentTime = new Date().getTime();
+  const frequency = recoveryPhraseReminderHasBeenShown ? DAY * 90 : DAY * 2;
+
+  return currentTime - recoveryPhraseReminderLastShown >= frequency;
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2570,6 +2570,16 @@ export function setConnectedStatusPopoverHasBeenShown() {
   };
 }
 
+export function setRecoveryPhraseReminderHasBeenShown() {
+  return () => {
+    background.setRecoveryPhraseReminderHasBeenShown((err) => {
+      if (err) {
+        throw new Error(err.message);
+      }
+    });
+  };
+}
+
 export async function setAlertEnabledness(alertId, enabledness) {
   await promisifiedBackground.setAlertEnabledness(alertId, enabledness);
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2580,6 +2580,16 @@ export function setRecoveryPhraseReminderHasBeenShown() {
   };
 }
 
+export function setRecoveryPhraseReminderLastShown(lastShown) {
+  return () => {
+    background.setRecoveryPhraseReminderLastShown(lastShown, (err) => {
+      if (err) {
+        throw new Error(err.message);
+      }
+    });
+  };
+}
+
 export async function setAlertEnabledness(alertId, enabledness) {
   await promisifiedBackground.setAlertEnabledness(alertId, enabledness);
 }


### PR DESCRIPTION
The goal is to display this reminder two days after wallet creation/import (or in the case of an update, two days from that point). After the user dismisses the reminder, it will subsequently appear every 90 days.

## Manual Test Plan
1. In `app/scripts/controllers/app-state.js`, set `REMINDER_CHECK_INTERVAL` to equal `time.SECOND * 30` (30 seconds), `INITIAL_REMINDER_FREQUENCY` to equal `time.MINUTE * 2` (2 minutes), and `FOLLOWUP_REMINDER_FREQUENCY` to equal `time.MINUTE * 4` (4 minutes)
2. Run a dev build from this branch
3. Create/Import a wallet
4. View Notifications and dismiss "what's new popup" (this notification should not appear when the "what's new popup" is open)
5. Confirm after 2 minutes that the reminder appears.
6. Dismiss the reminder
7. Confirm that after 4 minutes, the reminder appears agin.
8. Dismiss the reminder, re-confirm step 7

## Appearance 

### (User has not backed up their seed phrase)
<img width="540" alt="Screen Shot 2021-05-09 at 8 02 20 PM (1)" src="https://user-images.githubusercontent.com/8732757/117975686-c6f1fc80-b2e3-11eb-9c2c-16ab553c2441.png">

### (User has backed up their seed phrase)
<img width="546" alt="Screen Shot 2021-05-09 at 8 04 13 PM (1)" src="https://user-images.githubusercontent.com/8732757/117975575-a9249780-b2e3-11eb-88b6-ff18313360c9.png">