### PR TITLE
Fix redirection to the Build Quote page from the Swaps Failed page

### DIFF
--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -270,7 +270,7 @@ export default function Swap() {
               render={() => {
                 if (tradeTxData && !conversionError) {
                   return <Redirect to={{ pathname: AWAITING_SWAP_ROUTE }} />;
-                } else if (tradeTxData) {
+                } else if (tradeTxData && routeState) {
                   return <Redirect to={{ pathname: SWAPS_ERROR_ROUTE }} />;
                 } else if (routeState === 'loading' && aggregatorMetadata) {
                   return <Redirect to={{ pathname: LOADING_QUOTES_ROUTE }} />;


### PR DESCRIPTION
## Explanation
The "Try again" button on the Swaps Failed page didn't work. This PR fixes that by redirecting a user to the Build Quote page. 

I've added an additional check for `routeState` before rendering the Swaps Failed page, because when a user clicks on "Try again" on the Swaps Failed page, we set an empty string into `routeState`. If it's empty, we shouldn't go to the Swaps Failed page.

## Manual testing steps
- Wait until `nonce` starts failing on Testnet (probably there is an easier way to get to the Swaps Failed page, but this one works 100% of the time)
- Try to make a Swap
- Swaps Failed page is displayed
- Click on "Try again"
- Build Quote page is displayed with prefilled values

## Screenshots
Build Quote page is displayed with prefilled values:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/80175477/117666961-aff8c080-b1a4-11eb-936b-29763eb6f22d.png">
