### PR TITLE
Migrate version from `_base` manifest to `package.json`

### DIFF
--- a/.circleci/scripts/release-bump-manifest-version.sh
+++ b/.circleci/scripts/release-bump-manifest-version.sh
@@ -19,9 +19,7 @@ fi
 printf '%s\n' 'Updating the manifest version if needed'
 
 version="${CIRCLE_BRANCH/Version-v/}"
-updated_manifest="$(jq ".version = \"$version\"" app/manifest/_base.json)"
-printf '%s\n' "$updated_manifest" > app/manifest/_base.json
-yarn prettier --write app/manifest/_base.json
+yarn version --no-git-tag-version --new-version "${version}"
 
 if [[ -z $(git status --porcelain) ]]
 then

--- a/.circleci/scripts/release-commit-version-bump.sh
+++ b/.circleci/scripts/release-commit-version-bump.sh
@@ -28,7 +28,7 @@ fi
 
 printf '%s\n' 'Commit the manifest version and changelog if the manifest has changed'
 
-if git diff --quiet app/manifest/_base.json;
+if git diff --quiet package.json;
 then
     printf '%s\n' 'No manifest changes to commit'
     exit 0
@@ -38,7 +38,7 @@ git \
     -c user.name='MetaMask Bot' \
     -c user.email='metamaskbot@users.noreply.github.com' \
     commit --message "${CIRCLE_BRANCH/-/ }" \
-        CHANGELOG.md app/manifest/_base.json
+        CHANGELOG.md package.json
 
 repo_slug="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 git push "https://$GITHUB_TOKEN_USER:$GITHUB_TOKEN@github.com/$repo_slug" "$CIRCLE_BRANCH"

--- a/app/manifest/_base.json
+++ b/app/manifest/_base.json
@@ -71,6 +71,5 @@
     "notifications"
   ],
   "short_name": "__MSG_appName__",
-  "version": "9.5.0",
   "web_accessible_resources": ["inpage.js", "phishing.html"]
 }

--- a/development/announcer.js
+++ b/development/announcer.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { version } = require('../app/manifest/_base.json');
+const { version } = require('../package.json');
 
 const changelog = fs.readFileSync(
   path.join(__dirname, '..', 'CHANGELOG.md'),

--- a/development/build/etc.js
+++ b/development/build/etc.js
@@ -4,7 +4,7 @@ const gulpZip = require('gulp-zip');
 const del = require('del');
 const pify = require('pify');
 const pump = pify(require('pump'));
-const baseManifest = require('../../app/manifest/_base.json');
+const { version } = require('../../package.json');
 const { createTask, composeParallel } = require('./task');
 
 module.exports = createEtcTasks;
@@ -38,7 +38,7 @@ function createZipTask(target) {
   return async () => {
     await pump(
       gulp.src(`dist/${target}/**`),
-      gulpZip(`metamask-${target}-${baseManifest.version}.zip`),
+      gulpZip(`metamask-${target}-${version}.zip`),
       gulp.dest('builds'),
     );
   };

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { merge, cloneDeep } = require('lodash');
 
 const baseManifest = require('../../app/manifest/_base.json');
+const { version } = require('../../package.json');
 
 const { createTask, composeSeries } = require('./task');
 
@@ -23,7 +24,11 @@ function createManifestTasks({ browserPlatforms }) {
             `${platform}.json`,
           ),
         );
-        const result = merge(cloneDeep(baseManifest), platformModifications);
+        const result = merge(
+          cloneDeep(baseManifest),
+          { version },
+          platformModifications,
+        );
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });
         await writeJson(result, path.join(dir, 'manifest.json'));

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -22,7 +22,7 @@ const metamaskrc = require('rc')('metamask', {
   SEGMENT_LEGACY_WRITE_KEY: process.env.SEGMENT_LEGACY_WRITE_KEY,
 });
 
-const baseManifest = require('../../app/manifest/_base.json');
+const { version } = require('../../package.json');
 
 const packageJSON = require('../../package.json');
 const {
@@ -424,7 +424,7 @@ function getEnvironmentVariables({ devMode, testing }) {
   return {
     METAMASK_DEBUG: devMode,
     METAMASK_ENVIRONMENT: environment,
-    METAMASK_VERSION: baseManifest.version,
+    METAMASK_VERSION: version,
     NODE_ENV: devMode ? 'development' : 'production',
     IN_TEST: testing ? 'true' : false,
     PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY || '',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "0.0.0",
+  "version": "9.5.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -103,6 +103,7 @@
     "@metamask/jazzicon": "^2.0.0",
     "@metamask/logo": "^2.5.0",
     "@metamask/obs-store": "^5.0.0",
+    "@metamask/post-message-stream": "^4.0.0",
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.5.0",
     "@sentry/browser": "^5.26.0",
@@ -162,7 +163,6 @@
     "nonce-tracker": "^1.0.0",
     "obj-multiplex": "^1.0.0",
     "pify": "^5.0.0",
-    "@metamask/post-message-stream": "^4.0.0",
     "promise-to-callback": "^1.0.0",
     "prop-types": "^15.6.1",
     "pubnub": "4.27.3",

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -3,7 +3,7 @@ const os = require('os');
 const path = require('path');
 const { Builder, By, until } = require('selenium-webdriver');
 const firefox = require('selenium-webdriver/firefox');
-const { version } = require('../../../app/manifest/_base.json');
+const { version } = require('../../../package.json');
 
 /**
  * The prefix for temporary Firefox profiles. All Firefox profiles used for e2e tests


### PR DESCRIPTION
The version field is now stored in the main `package.json` file rather than in the base manifest. It is built into the final manifest during the build script.

This makes it easier to communicate what the current version should be to our `auto-changelog` script. It's also generally a more conventional place to keep track of the version, even considering that we're not publishing to npm.