### PR TITLE
Format locale to Intl standard for translated date in notifications.

### DIFF
--- a/shared/notifications/index.js
+++ b/shared/notifications/index.js
@@ -20,13 +20,31 @@ export const UI_NOTIFICATIONS = {
   },
 };
 
+const formatLocale = (locale) => {
+  switch (locale) {
+    case 'pt_BR':
+      return 'pt';
+    case 'pt_PT':
+      return 'pt';
+    case 'zh_CN':
+      return 'zh-Hans-CN';
+    case 'zh_TW':
+      return 'zh-Hans-TW';
+    case 'es_419':
+      return 'es-419';
+    default:
+      return locale;
+  }
+};
+
 export const getTranslatedUINoficiations = (t, locale) => {
+  const formattedLocale = formatLocale(locale);
   return {
     1: {
       ...UI_NOTIFICATIONS[1],
       title: t('notifications1Title'),
       description: t('notifications1Description'),
-      date: new Intl.DateTimeFormat(locale).format(
+      date: new Intl.DateTimeFormat(formattedLocale).format(
         new Date(UI_NOTIFICATIONS[1].date),
       ),
     },
@@ -35,7 +53,7 @@ export const getTranslatedUINoficiations = (t, locale) => {
       title: t('notifications2Title'),
       description: t('notifications2Description'),
       actionText: t('notifications2ActionText'),
-      date: new Intl.DateTimeFormat(locale).format(
+      date: new Intl.DateTimeFormat(formattedLocale).format(
         new Date(UI_NOTIFICATIONS[2].date),
       ),
     },
@@ -44,7 +62,7 @@ export const getTranslatedUINoficiations = (t, locale) => {
       title: t('notifications3Title'),
       description: t('notifications3Description'),
       actionText: t('notifications3ActionText'),
-      date: new Intl.DateTimeFormat(locale).format(
+      date: new Intl.DateTimeFormat(formattedLocale).format(
         new Date(UI_NOTIFICATIONS[3].date),
       ),
     },

--- a/shared/notifications/index.js
+++ b/shared/notifications/index.js
@@ -20,25 +20,8 @@ export const UI_NOTIFICATIONS = {
   },
 };
 
-const formatLocale = (locale) => {
-  switch (locale) {
-    case 'pt_BR':
-      return 'pt';
-    case 'pt_PT':
-      return 'pt';
-    case 'zh_CN':
-      return 'zh-Hans-CN';
-    case 'zh_TW':
-      return 'zh-Hans-TW';
-    case 'es_419':
-      return 'es-419';
-    default:
-      return locale;
-  }
-};
-
 export const getTranslatedUINoficiations = (t, locale) => {
-  const formattedLocale = formatLocale(locale);
+  const formattedLocale = locale.replace('_', '-');
   return {
     1: {
       ...UI_NOTIFICATIONS[1],

--- a/shared/notifications/index.js
+++ b/shared/notifications/index.js
@@ -16,7 +16,7 @@ export const UI_NOTIFICATIONS = {
   },
   3: {
     id: 3,
-    date: '2021-03-8',
+    date: '2021-03-08',
   },
 };
 


### PR DESCRIPTION
Fixes: #11033

Explanation:  Format the incoming locale subtag from out list of translations to `Intl` standard for the date notification, found the full list [here](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).

Primarily this issue is with specific locales that are different subtag formats, for example `zh_CN` vs `zh-Hans-CN`/`zh-Hans` and `es_419` vs `es-419`/`419`.

Manual testing steps:  
The two conditions that need to be met are to have one of the non-Intl standard languages selected before reading/viewing the new What's new notification modal.

Don't know if the alternative of outright changing our own subtag locale folder would interfere with the initial browser language detection, or other ramifications.  If that method seems more appropriate, that can be achieved as well.