### PR TITLE
Use EIP-1191 checksums

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -285,6 +285,9 @@
   "chainIdDefinition": {
     "message": "The chain ID used to sign transactions for this network."
   },
+  "checksumUsesChainId": {
+    "message": "Checksum uses Chain ID"
+  },
   "chromeRequiredForHardwareWallets": {
     "message": "You need to use MetaMask on Google Chrome in order to connect to your Hardware Wallet."
   },
@@ -1154,6 +1157,9 @@
   },
   "networkSettingsChainIdDescription": {
     "message": "The chain ID is used for signing transactions. It must match the chain ID returned by the network. You can enter a decimal or '0x'-prefixed hexadecimal number, but we will display the number in decimal."
+  },
+  "networkSettingsChecksumUsesChainIdDescription": {
+    "message": "When selected, calculate EIP1191 checksums using Chain ID."
   },
   "networkSettingsDescription": {
     "message": "Add and edit custom RPC networks"

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -186,7 +186,14 @@ export default class NetworkController extends EventEmitter {
     return NETWORK_TYPE_TO_ID_MAP[type]?.chainId || configChainId;
   }
 
-  setRpcTarget(rpcUrl, chainId, ticker = 'ETH', nickname = '', rpcPrefs) {
+  setRpcTarget(
+    rpcUrl,
+    chainId,
+    checksumUsesChainId,
+    ticker = 'ETH',
+    nickname = '',
+    rpcPrefs,
+  ) {
     assert.ok(
       isPrefixedFormattedHexString(chainId),
       `Invalid chain ID "${chainId}": invalid hex string.`,
@@ -199,6 +206,7 @@ export default class NetworkController extends EventEmitter {
       type: NETWORK_TYPE_RPC,
       rpcUrl,
       chainId,
+      checksumUsesChainId,
       ticker,
       nickname,
       rpcPrefs,

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -555,7 +555,7 @@ export default class PreferencesController {
   addToFrequentRpcList(
     rpcUrl,
     chainId,
-    checksumUsesChainId,
+    checksumUsesChainId = false,
     ticker = 'ETH',
     nickname = '',
     rpcPrefs = {},

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -458,6 +458,7 @@ export default class PreferencesController {
    * @param {Object} newRpcDetails - Options bag.
    * @param {string} newRpcDetails.rpcUrl - The RPC url to add to frequentRpcList.
    * @param {string} newRpcDetails.chainId - The chainId of the selected network.
+   * @param {bool} newRpcDetails.checksumUsesChainId - If checksum calculation on the selected network uses chainId (EIP-1191).
    * @param {string} [newRpcDetails.ticker] - Optional ticker symbol of the selected network.
    * @param {string} [newRpcDetails.nickname] - Optional nickname of the selected network.
    * @param {Object} [newRpcDetails.rpcPrefs] - Optional RPC preferences, such as the block explorer URL
@@ -524,11 +525,19 @@ export default class PreferencesController {
       const {
         rpcUrl,
         chainId,
+        checksumUsesChainId,
         ticker,
         nickname,
         rpcPrefs = {},
       } = newRpcDetails;
-      this.addToFrequentRpcList(rpcUrl, chainId, ticker, nickname, rpcPrefs);
+      this.addToFrequentRpcList(
+        rpcUrl,
+        chainId,
+        checksumUsesChainId,
+        ticker,
+        nickname,
+        rpcPrefs,
+      );
     }
   }
 
@@ -537,6 +546,7 @@ export default class PreferencesController {
    *
    * @param {string} rpcUrl - The RPC url to add to frequentRpcList.
    * @param {string} chainId - The chainId of the selected network.
+   * @param {bool} checksumUsesChainId - If checksum calculation on the selected network uses chainId (EIP-1191).
    * @param {string} [ticker] - Ticker symbol of the selected network.
    * @param {string} [nickname] - Nickname of the selected network.
    * @param {Object} [rpcPrefs] - Optional RPC preferences, such as the block explorer URL
@@ -545,6 +555,7 @@ export default class PreferencesController {
   addToFrequentRpcList(
     rpcUrl,
     chainId,
+    checksumUsesChainId,
     ticker = 'ETH',
     nickname = '',
     rpcPrefs = {},
@@ -562,7 +573,14 @@ export default class PreferencesController {
       throw new Error(`Invalid chainId: "${chainId}"`);
     }
 
-    rpcList.push({ rpcUrl, chainId, ticker, nickname, rpcPrefs });
+    rpcList.push({
+      rpcUrl,
+      chainId,
+      checksumUsesChainId,
+      ticker,
+      nickname,
+      rpcPrefs,
+    });
     this.store.updateState({ frequentRpcListDetail: rpcList });
   }
 

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -671,6 +671,7 @@ describe('preferences controller', function () {
           {
             rpcUrl: 'rpc_url',
             chainId: '0x1',
+            checksumUsesChainId: false,
             ticker: 'ETH',
             nickname: '',
             rpcPrefs: {},
@@ -684,6 +685,7 @@ describe('preferences controller', function () {
           {
             rpcUrl: 'rpc_url',
             chainId: '0x1',
+            checksumUsesChainId: false,
             ticker: 'ETH',
             nickname: '',
             rpcPrefs: {},
@@ -706,6 +708,7 @@ describe('preferences controller', function () {
           {
             rpcUrl: 'rpc_url',
             chainId: '0x1',
+            checksumUsesChainId: false,
             ticker: 'ETH',
             nickname: '',
             rpcPrefs: {},

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2179,16 +2179,24 @@ export default class MetamaskController extends EventEmitter {
         requestUserApproval: this.approvalController.addAndShowApprovalRequest.bind(
           this.approvalController,
         ),
-        updateRpcTarget: ({ rpcUrl, chainId, ticker, nickname }) => {
+        updateRpcTarget: ({
+          rpcUrl,
+          chainId,
+          checksumUsesChainId,
+          ticker,
+          nickname,
+        }) => {
           this.networkController.setRpcTarget(
             rpcUrl,
             chainId,
+            checksumUsesChainId,
             ticker,
             nickname,
           );
         },
         addCustomRpc: async ({
           chainId,
+          checksumUsesChainId,
           blockExplorerUrl,
           ticker,
           chainName,
@@ -2197,6 +2205,7 @@ export default class MetamaskController extends EventEmitter {
           await this.preferencesController.addToFrequentRpcList(
             rpcUrl,
             chainId,
+            checksumUsesChainId,
             ticker,
             chainName,
             {
@@ -2530,6 +2539,7 @@ export default class MetamaskController extends EventEmitter {
    * A method for selecting a custom URL for an ethereum RPC provider and updating it
    * @param {string} rpcUrl - A URL for a valid Ethereum RPC API.
    * @param {string} chainId - The chainId of the selected network.
+   * @param {bool} checksumUsesChainId - If checksum calculation on the selected network uses chainId (EIP-1191).
    * @param {string} ticker - The ticker symbol of the selected network.
    * @param {string} [nickname] - Nickname of the selected network.
    * @param {Object} [rpcPrefs] - RPC preferences.
@@ -2539,6 +2549,7 @@ export default class MetamaskController extends EventEmitter {
   async updateAndSetCustomRpc(
     rpcUrl,
     chainId,
+    checksumUsesChainId,
     ticker = 'ETH',
     nickname,
     rpcPrefs,
@@ -2546,6 +2557,7 @@ export default class MetamaskController extends EventEmitter {
     this.networkController.setRpcTarget(
       rpcUrl,
       chainId,
+      checksumUsesChainId,
       ticker,
       nickname,
       rpcPrefs,
@@ -2553,6 +2565,7 @@ export default class MetamaskController extends EventEmitter {
     await this.preferencesController.updateRpc({
       rpcUrl,
       chainId,
+      checksumUsesChainId,
       ticker,
       nickname,
       rpcPrefs,
@@ -2571,6 +2584,7 @@ export default class MetamaskController extends EventEmitter {
   async setCustomRpc(
     rpcUrl,
     chainId,
+    checksumUsesChainId,
     ticker = 'ETH',
     nickname = '',
     rpcPrefs = {},
@@ -2584,6 +2598,7 @@ export default class MetamaskController extends EventEmitter {
       this.networkController.setRpcTarget(
         rpcSettings.rpcUrl,
         rpcSettings.chainId,
+        rpcSettings.checksumUsesChainId,
         rpcSettings.ticker,
         rpcSettings.nickname,
         rpcPrefs,
@@ -2592,6 +2607,7 @@ export default class MetamaskController extends EventEmitter {
       this.networkController.setRpcTarget(
         rpcUrl,
         chainId,
+        checksumUsesChainId,
         ticker,
         nickname,
         rpcPrefs,
@@ -2599,6 +2615,7 @@ export default class MetamaskController extends EventEmitter {
       await this.preferencesController.addToFrequentRpcList(
         rpcUrl,
         chainId,
+        checksumUsesChainId,
         ticker,
         nickname,
         rpcPrefs,

--- a/ui/components/app/account-list-item/account-list-item-component.test.js
+++ b/ui/components/app/account-list-item/account-list-item-component.test.js
@@ -25,6 +25,8 @@ describe('AccountListItem Component', () => {
             name: 'mockName',
             balance: 'mockBalance',
           }}
+          chainId="0x539"
+          checksumUsesChainId
           className="mockClassName"
           displayAddress={false}
           handleClick={propsMethodSpies.handleClick}
@@ -128,6 +130,8 @@ describe('AccountListItem Component', () => {
       ).toStrictEqual('mockCheckSumAddress');
       expect(checksumAddressStub.getCall(0).args).toStrictEqual([
         'mockAddress',
+        '0x539',
+        true,
       ]);
     });
 

--- a/ui/components/app/account-list-item/account-list-item.container.js
+++ b/ui/components/app/account-list-item/account-list-item.container.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+} from '../../../selectors';
+import AccountListItem from './account-list-item';
+
+const mapStateToProps = (state) => {
+  return {
+    chainId: getCurrentChainId(state),
+    checksumUsesChainId: getCurrentChecksumUsesChainId(state),
+  };
+};
+
+export default connect(mapStateToProps)(AccountListItem);

--- a/ui/components/app/account-list-item/account-list-item.js
+++ b/ui/components/app/account-list-item/account-list-item.js
@@ -6,6 +6,8 @@ import AccountMismatchWarning from '../../ui/account-mismatch-warning/account-mi
 
 export default function AccountListItem({
   account,
+  chainId,
+  checksumUsesChainId,
   className,
   displayAddress = false,
   handleClick,
@@ -34,7 +36,7 @@ export default function AccountListItem({
 
       {displayAddress && name && (
         <div className="account-list-item__account-address">
-          {checksumAddress(address)}
+          {checksumAddress(address, chainId, checksumUsesChainId)}
         </div>
       )}
     </div>
@@ -43,6 +45,8 @@ export default function AccountListItem({
 
 AccountListItem.propTypes = {
   account: PropTypes.object,
+  chainId: PropTypes.string,
+  checksumUsesChainId: PropTypes.bool,
   className: PropTypes.string,
   displayAddress: PropTypes.bool,
   handleClick: PropTypes.func,

--- a/ui/components/app/account-list-item/index.js
+++ b/ui/components/app/account-list-item/index.js
@@ -1,1 +1,1 @@
-export { default } from './account-list-item';
+export { default } from './account-list-item.container';

--- a/ui/components/app/dropdowns/network-dropdown.js
+++ b/ui/components/app/dropdowns/network-dropdown.js
@@ -47,8 +47,16 @@ function mapDispatchToProps(dispatch) {
     setProviderType: (type) => {
       dispatch(actions.setProviderType(type));
     },
-    setRpcTarget: (target, chainId, ticker, nickname) => {
-      dispatch(actions.setRpcTarget(target, chainId, ticker, nickname));
+    setRpcTarget: (target, chainId, checksumUsesChainId, ticker, nickname) => {
+      dispatch(
+        actions.setRpcTarget(
+          target,
+          chainId,
+          checksumUsesChainId,
+          ticker,
+          nickname,
+        ),
+      );
     },
     hideNetworkDropdown: () => dispatch(actions.hideNetworkDropdown()),
     setNetworksTabAddMode: (isInAddMode) => {
@@ -122,7 +130,13 @@ class NetworkDropdown extends Component {
     const reversedRpcListDetail = rpcListDetail.slice().reverse();
 
     return reversedRpcListDetail.map((entry) => {
-      const { rpcUrl, chainId, ticker = 'ETH', nickname = '' } = entry;
+      const {
+        rpcUrl,
+        chainId,
+        checksumUsesChainId,
+        ticker = 'ETH',
+        nickname = '',
+      } = entry;
       const isCurrentRpcTarget =
         provider.type === NETWORK_TYPE_RPC && rpcUrl === provider.rpcUrl;
 
@@ -132,7 +146,13 @@ class NetworkDropdown extends Component {
           closeMenu={() => this.props.hideNetworkDropdown()}
           onClick={() => {
             if (isPrefixedFormattedHexString(chainId)) {
-              this.props.setRpcTarget(rpcUrl, chainId, ticker, nickname);
+              this.props.setRpcTarget(
+                rpcUrl,
+                chainId,
+                checksumUsesChainId,
+                ticker,
+                nickname,
+              );
             } else {
               this.props.displayInvalidCustomNetworkAlert(nickname || rpcUrl);
             }

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.component.js
@@ -11,6 +11,7 @@ export default class ConfirmRemoveAccount extends Component {
     removeAccount: PropTypes.func.isRequired,
     identity: PropTypes.object.isRequired,
     chainId: PropTypes.string.isRequired,
+    checksumUsesChainId: PropTypes.bool.isRequired,
     rpcPrefs: PropTypes.object.isRequired,
   };
 
@@ -29,7 +30,7 @@ export default class ConfirmRemoveAccount extends Component {
   };
 
   renderSelectedAccount() {
-    const { identity } = this.props;
+    const { chainId, checksumUsesChainId, identity } = this.props;
     return (
       <div className="confirm-remove-account__account">
         <div className="confirm-remove-account__account__identicon">
@@ -44,7 +45,13 @@ export default class ConfirmRemoveAccount extends Component {
             Public Address
           </span>
           <span className="account_value">
-            {addressSummary(identity.address, 4, 4)}
+            {addressSummary(
+              identity.address,
+              chainId,
+              checksumUsesChainId,
+              4,
+              4,
+            )}
           </span>
         </div>
         <div className="confirm-remove-account__account__link">

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.container.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.container.js
@@ -3,6 +3,7 @@ import { compose } from 'redux';
 import withModalProps from '../../../../helpers/higher-order-components/with-modal-props';
 import {
   getCurrentChainId,
+  getCurrentChecksumUsesChainId,
   getRpcPrefsForCurrentProvider,
 } from '../../../../selectors';
 import { removeAccount } from '../../../../store/actions';
@@ -11,6 +12,7 @@ import ConfirmRemoveAccount from './confirm-remove-account.component';
 const mapStateToProps = (state) => {
   return {
     chainId: getCurrentChainId(state),
+    checksumUsesChainId: getCurrentChecksumUsesChainId(state),
     rpcPrefs: getRpcPrefsForCurrentProvider(state),
   };
 };

--- a/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
+++ b/ui/components/app/modals/confirm-remove-account/confirm-remove-account.test.js
@@ -10,7 +10,11 @@ describe('Confirm Remove Account', () => {
   let wrapper;
 
   const state = {
-    metamask: {},
+    metamask: {
+      provider: {
+        chainId: '0x539',
+      },
+    },
   };
 
   const props = {

--- a/ui/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
+++ b/ui/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
@@ -20,6 +20,8 @@ export default class ExportPrivateKeyModal extends Component {
   };
 
   static propTypes = {
+    chainId: PropTypes.string,
+    checksumUsesChainId: PropTypes.bool,
     exportAccount: PropTypes.func.isRequired,
     selectedIdentity: PropTypes.object.isRequired,
     warning: PropTypes.node,
@@ -129,6 +131,8 @@ export default class ExportPrivateKeyModal extends Component {
 
   render() {
     const {
+      chainId,
+      checksumUsesChainId,
       selectedIdentity,
       warning,
       showAccountDetailModal,
@@ -149,7 +153,7 @@ export default class ExportPrivateKeyModal extends Component {
         <span className="export-private-key-modal__account-name">{name}</span>
         <ReadOnlyInput
           wrapperClass="ellip-address-wrapper"
-          value={checksumAddress(address)}
+          value={checksumAddress(address, chainId, checksumUsesChainId)}
         />
         <div className="export-private-key-modal__divider" />
         <span className="export-private-key-modal__body-title">

--- a/ui/components/app/modals/export-private-key-modal/export-private-key-modal.container.js
+++ b/ui/components/app/modals/export-private-key-modal/export-private-key-modal.container.js
@@ -6,7 +6,11 @@ import {
   hideModal,
   clearAccountDetails,
 } from '../../../../store/actions';
-import { getSelectedIdentity } from '../../../../selectors';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+  getSelectedIdentity,
+} from '../../../../selectors';
 import ExportPrivateKeyModal from './export-private-key-modal.component';
 
 function mapStateToPropsFactory() {
@@ -18,6 +22,8 @@ function mapStateToPropsFactory() {
     // which is the expected behavior that we are side-stepping.
     selectedIdentity = selectedIdentity || getSelectedIdentity(state);
     return {
+      chainId: getCurrentChainId(state),
+      checksumUsesChainId: getCurrentChecksumUsesChainId(state),
       warning: state.appState.warning,
       privateKey: state.appState.accountDetail.privateKey,
       selectedIdentity,

--- a/ui/components/app/selected-account/selected-account.component.js
+++ b/ui/components/app/selected-account/selected-account.component.js
@@ -15,6 +15,8 @@ class SelectedAccount extends Component {
   };
 
   static propTypes = {
+    chainId: PropTypes.string,
+    checksumUsesChainId: PropTypes.bool,
     selectedIdentity: PropTypes.object.isRequired,
   };
 
@@ -31,8 +33,12 @@ class SelectedAccount extends Component {
 
   render() {
     const { t } = this.context;
-    const { selectedIdentity } = this.props;
-    const checksummedAddress = checksumAddress(selectedIdentity.address);
+    const { selectedIdentity, chainId, checksumUsesChainId } = this.props;
+    const checksummedAddress = checksumAddress(
+      selectedIdentity.address,
+      chainId,
+      checksumUsesChainId,
+    );
 
     return (
       <div className="selected-account">

--- a/ui/components/app/selected-account/selected-account.container.js
+++ b/ui/components/app/selected-account/selected-account.container.js
@@ -1,9 +1,15 @@
 import { connect } from 'react-redux';
-import { getSelectedIdentity } from '../../../selectors';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+  getSelectedIdentity,
+} from '../../../selectors';
 import SelectedAccount from './selected-account.component';
 
 const mapStateToProps = (state) => {
   return {
+    chainId: getCurrentChainId(state),
+    checksumUsesChainId: getCurrentChecksumUsesChainId(state),
     selectedIdentity: getSelectedIdentity(state),
   };
 };

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -3,6 +3,8 @@ import { checksumAddress } from '../../../helpers/utils/util';
 import { tryReverseResolveAddress } from '../../../store/actions';
 import {
   getAddressBook,
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
   getRpcPrefsForCurrentProvider,
 } from '../../../selectors';
 import TransactionListItemDetails from './transaction-list-item-details.component';
@@ -11,9 +13,15 @@ const mapStateToProps = (state, ownProps) => {
   const { metamask } = state;
   const { ensResolutionsByAddress } = metamask;
   const { recipientAddress, senderAddress } = ownProps;
+  const chainId = getCurrentChainId(state);
+  const checksumUsesChainId = getCurrentChecksumUsesChainId(state);
   let recipientEns;
   if (recipientAddress) {
-    const address = checksumAddress(recipientAddress);
+    const address = checksumAddress(
+      recipientAddress,
+      chainId,
+      checksumUsesChainId,
+    );
     recipientEns = ensResolutionsByAddress[address] || '';
   }
   const addressBook = getAddressBook(state);

--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -17,6 +17,8 @@ export default class Identicon extends PureComponent {
   static propTypes = {
     addBorder: PropTypes.bool,
     address: PropTypes.string,
+    chainId: PropTypes.string,
+    checksumUsesChainId: PropTypes.bool,
     className: PropTypes.string,
     diameter: PropTypes.number,
     image: PropTypes.string,
@@ -78,14 +80,26 @@ export default class Identicon extends PureComponent {
   }
 
   render() {
-    const { address, image, useBlockie, addBorder, diameter } = this.props;
+    const {
+      address,
+      chainId,
+      checksumUsesChainId,
+      image,
+      useBlockie,
+      addBorder,
+      diameter,
+    } = this.props;
 
     if (image) {
       return this.renderImage();
     }
 
     if (address) {
-      const checksummedAddress = checksumAddress(address);
+      const checksummedAddress = checksumAddress(
+        address,
+        chainId,
+        checksumUsesChainId,
+      );
 
       if (contractMap[checksummedAddress]?.logo) {
         return this.renderJazzicon();

--- a/ui/components/ui/identicon/identicon.component.test.js
+++ b/ui/components/ui/identicon/identicon.component.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import { mount } from 'enzyme';
@@ -8,6 +9,9 @@ describe('Identicon', () => {
   const state = {
     metamask: {
       useBlockie: false,
+      provider: {
+        chainId: '0x539',
+      },
     },
   };
 
@@ -16,7 +20,11 @@ describe('Identicon', () => {
   const store = mockStore(state);
 
   it('renders empty identicon with no props', () => {
-    const wrapper = mount(<Identicon store={store} />);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Identicon />
+      </Provider>,
+    );
 
     expect(wrapper.find('div').prop('className')).toStrictEqual(
       'identicon__image-border',
@@ -25,7 +33,9 @@ describe('Identicon', () => {
 
   it('renders custom image and add className props', () => {
     const wrapper = mount(
-      <Identicon store={store} className="test-image" image="test-image" />,
+      <Provider store={store}>
+        <Identicon className="test-image" image="test-image" />,
+      </Provider>,
     );
 
     expect(wrapper.find('img.test-image').prop('className')).toStrictEqual(
@@ -38,7 +48,9 @@ describe('Identicon', () => {
 
   it('renders div with address prop', () => {
     const wrapper = mount(
-      <Identicon store={store} className="test-address" address="0x0" />,
+      <Provider store={store}>
+        <Identicon className="test-address" address="0x0" />,
+      </Provider>,
     );
 
     expect(wrapper.find('div.test-address').prop('className')).toStrictEqual(

--- a/ui/components/ui/identicon/identicon.container.js
+++ b/ui/components/ui/identicon/identicon.container.js
@@ -1,4 +1,8 @@
 import { connect } from 'react-redux';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+} from '../../../selectors';
 import Identicon from './identicon.component';
 
 const mapStateToProps = (state) => {
@@ -7,6 +11,8 @@ const mapStateToProps = (state) => {
   } = state;
 
   return {
+    chainId: getCurrentChainId(state),
+    checksumUsesChainId: getCurrentChecksumUsesChainId(state),
     useBlockie,
   };
 };

--- a/ui/components/ui/jazzicon/index.js
+++ b/ui/components/ui/jazzicon/index.js
@@ -1,1 +1,1 @@
-export { default } from './jazzicon.component';
+export { default } from './jazzicon.container';

--- a/ui/components/ui/jazzicon/jazzicon.component.js
+++ b/ui/components/ui/jazzicon/jazzicon.component.js
@@ -12,6 +12,8 @@ const iconFactory = iconFactoryGenerator(jazzicon);
 export default class Jazzicon extends PureComponent {
   static propTypes = {
     address: PropTypes.string.isRequired,
+    chainId: PropTypes.string,
+    checksumUsesChainId: PropTypes.bool,
     className: PropTypes.string,
     diameter: PropTypes.number,
     style: PropTypes.object,
@@ -46,8 +48,13 @@ export default class Jazzicon extends PureComponent {
   }
 
   appendJazzicon() {
-    const { address, diameter } = this.props;
-    const image = iconFactory.iconForAddress(address, diameter);
+    const { address, chainId, checksumUsesChainId, diameter } = this.props;
+    const image = iconFactory.iconForAddress(
+      address,
+      chainId,
+      checksumUsesChainId,
+      diameter,
+    );
     this.container.current.appendChild(image);
   }
 

--- a/ui/components/ui/jazzicon/jazzicon.container.js
+++ b/ui/components/ui/jazzicon/jazzicon.container.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+} from '../../../selectors';
+import Jazzicon from './jazzicon.component';
+
+const mapStateToProps = (state) => {
+  return {
+    chainId: getCurrentChainId(state),
+    checksumUsesChainId: getCurrentChecksumUsesChainId(state),
+  };
+};
+
+export default connect(mapStateToProps)(Jazzicon);

--- a/ui/components/ui/qr-code/qr-code.js
+++ b/ui/components/ui/qr-code/qr-code.js
@@ -3,6 +3,10 @@ import React from 'react';
 import qrCode from 'qrcode-generator';
 import { connect } from 'react-redux';
 import { isHexPrefixed } from 'ethereumjs-util';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+} from '../../../selectors';
 import ReadOnlyInput from '../readonly-input/readonly-input';
 import { checksumAddress } from '../../../helpers/utils/util';
 
@@ -10,18 +14,24 @@ export default connect(mapStateToProps)(QrCodeView);
 
 function mapStateToProps(state) {
   const { buyView, warning } = state.appState;
+  const chainId = getCurrentChainId(state);
+  const checksumUsesChainId = getCurrentChecksumUsesChainId(state);
   return {
     // Qr code is not fetched from state. 'message' and 'data' props are passed instead.
     buyView,
     warning,
+    chainId,
+    checksumUsesChainId,
   };
 }
 
 function QrCodeView(props) {
-  const { Qr, warning } = props;
+  const { Qr, warning, chainId, checksumUsesChainId } = props;
   const { message, data } = Qr;
   const address = `${isHexPrefixed(data) ? 'ethereum:' : ''}${checksumAddress(
     data,
+    chainId,
+    checksumUsesChainId,
   )}`;
   const qrImage = qrCode(4, 'M');
   qrImage.addData(address);
@@ -65,4 +75,6 @@ QrCodeView.propTypes = {
     ]),
     data: PropTypes.string.isRequired,
   }).isRequired,
+  chainId: PropTypes.string,
+  checksumUsesChainId: PropTypes.bool,
 };

--- a/ui/components/ui/sender-to-recipient/index.js
+++ b/ui/components/ui/sender-to-recipient/index.js
@@ -1,1 +1,1 @@
-export { default } from './sender-to-recipient.component';
+export { default } from './sender-to-recipient.container';

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -56,7 +56,7 @@ function SenderAddress({
     >
       {!addressOnly && (
         <div className="sender-to-recipient__sender-icon">
-          <Identicon address={checksumAddress(senderAddress)} diameter={24} />
+          <Identicon address={checksummedSenderAddress} diameter={24} />
         </div>
       )}
       <Tooltip
@@ -201,10 +201,20 @@ export default function SenderToRecipient({
   recipientAddress,
   variant,
   warnUserOnAccountMismatch,
+  chainId,
+  checksumUsesChainId,
 }) {
   const t = useI18nContext();
-  const checksummedSenderAddress = checksumAddress(senderAddress);
-  const checksummedRecipientAddress = checksumAddress(recipientAddress);
+  const checksummedSenderAddress = checksumAddress(
+    senderAddress,
+    chainId,
+    checksumUsesChainId,
+  );
+  const checksummedRecipientAddress = checksumAddress(
+    recipientAddress,
+    chainId,
+    checksumUsesChainId,
+  );
 
   return (
     <div className={classnames('sender-to-recipient', variantHash[variant])}>
@@ -255,4 +265,6 @@ SenderToRecipient.propTypes = {
   onRecipientClick: PropTypes.func,
   onSenderClick: PropTypes.func,
   warnUserOnAccountMismatch: PropTypes.bool,
+  chainId: PropTypes.string,
+  checksumUsesChainId: PropTypes.bool,
 };

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.container.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.container.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+} from '../../../selectors';
+import SenderToRecipient from './sender-to-recipient.component';
+
+const mapStateToProps = (state) => {
+  return {
+    chainId: getCurrentChainId(state),
+    checksumUsesChainId: getCurrentChecksumUsesChainId(state),
+  };
+};
+
+export default connect(mapStateToProps)(SenderToRecipient);

--- a/ui/helpers/utils/icon-factory.js
+++ b/ui/helpers/utils/icon-factory.js
@@ -16,8 +16,13 @@ function IconFactory(jazzicon) {
   this.cache = {};
 }
 
-IconFactory.prototype.iconForAddress = function (address, diameter) {
-  const addr = checksumAddress(address);
+IconFactory.prototype.iconForAddress = function (
+  address,
+  chainId,
+  checksumUsesChainId,
+  diameter,
+) {
+  const addr = checksumAddress(address, chainId, checksumUsesChainId);
   if (iconExistsFor(addr)) {
     return imageElFor(addr);
   }

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -60,6 +60,8 @@ export function valuesFor(obj) {
 
 export function addressSummary(
   address,
+  chainId,
+  checksumUsesChainId,
   firstSegLength = 10,
   lastSegLength = 4,
   includeHex = true,
@@ -67,7 +69,7 @@ export function addressSummary(
   if (!address) {
     return '';
   }
-  let checked = checksumAddress(address);
+  let checked = checksumAddress(address, chainId, checksumUsesChainId);
   if (!includeHex) {
     checked = ethUtil.stripHexPrefix(checked);
   }

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -226,11 +226,16 @@ export function exportAsFile(filename, data, type = 'text/csv') {
  * Safely checksumms a potentially-null address
  *
  * @param {string} [address] - address to checksum
+ * @param {string} [chainId] - chainId to use in EIP-1191 checksum
+ * @param {bool} [useChainId] - whether to generate EIP-1191 or EIP-55 checksum
  * @returns {string} checksummed address
  *
  */
-export function checksumAddress(address) {
-  const checksummed = address ? ethUtil.toChecksumAddress(address) : '';
+export function checksumAddress(address, chainId, useChainId) {
+  const chainIdParam = useChainId ? chainId : undefined;
+  const checksummed = address
+    ? ethUtil.toChecksumAddress(address, chainIdParam)
+    : '';
   return checksummed;
 }
 

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -36,14 +36,25 @@ describe('util', () => {
   describe('#addressSummary', () => {
     it('should add case-sensitive checksum', () => {
       const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825';
-      const result = util.addressSummary(address);
-      expect(result).toStrictEqual('0xFDEa65C8...b825');
+      const chainId = '0x539';
+      const checksumUsesChainId = true;
+      const result = util.addressSummary(address, chainId, checksumUsesChainId);
+      expect(result).toStrictEqual('0xfDea65C8...b825');
     });
 
     it('should accept arguments for firstseg, lastseg, and keepPrefix', () => {
       const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825';
-      const result = util.addressSummary(address, 4, 4, false);
-      expect(result).toStrictEqual('FDEa...b825');
+      const chainId = '0x539';
+      const checksumUsesChainId = true;
+      const result = util.addressSummary(
+        address,
+        chainId,
+        checksumUsesChainId,
+        4,
+        4,
+        false,
+      );
+      expect(result).toStrictEqual('fDea...b825');
     });
   });
 

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -249,6 +249,35 @@ describe('util', () => {
     });
   });
 
+  describe('#checksumAddress', () => {
+    it('should return EIP-55 checksum when chainId is undefined', () => {
+      const address = '0x5Fda30Bb72B8Dfe20e48A00dFc108d0915BE9Bb0';
+      const chainId = undefined;
+      const useChainId = true;
+      const result = util.checksumAddress(address, chainId, useChainId);
+      const addressChecksum = '0x5Fda30Bb72B8Dfe20e48A00dFc108d0915BE9Bb0';
+      expect(result).toStrictEqual(addressChecksum);
+    });
+
+    it('should return EIP-55 checksum when useChainId is false', () => {
+      const address = '0x5Fda30Bb72B8Dfe20e48A00dFc108d0915BE9Bb0';
+      const chainId = '0x539';
+      const useChainId = false;
+      const result = util.checksumAddress(address, chainId, useChainId);
+      const addressChecksum = '0x5Fda30Bb72B8Dfe20e48A00dFc108d0915BE9Bb0';
+      expect(result).toStrictEqual(addressChecksum);
+    });
+
+    it('should return EIP-1191 checksum', () => {
+      const address = '0x5Fda30Bb72B8Dfe20e48A00dFc108d0915BE9Bb0';
+      const chainId = '0x539';
+      const useChainId = true;
+      const result = util.checksumAddress(address, chainId, useChainId);
+      const addressChecksum = '0x5FdA30bB72B8Dfe20E48A00DfC108D0915BE9BB0';
+      expect(result).toStrictEqual(addressChecksum);
+    });
+  });
+
   describe('normalizing values', function () {
     describe('#isHex', function () {
       it('should return true when given a hex string', function () {

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -172,5 +172,6 @@ export function useTokensToSearch({ usersTokens = [], topTokens = {} }) {
     currentCurrency,
     memoizedTopTokens,
     chainId,
+    checksumUsesChainId,
   ]);
 }

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -11,6 +11,7 @@ import {
   getCurrentCurrency,
   getSwapsDefaultToken,
   getCurrentChainId,
+  getCurrentChecksumUsesChainId,
 } from '../selectors';
 import { getSwapsTokens } from '../ducks/swaps/swaps';
 import { isSwapsDefaultTokenSymbol } from '../../shared/modules/swaps.utils';
@@ -31,6 +32,7 @@ export function getRenderableTokenData(
   conversionRate,
   currentCurrency,
   chainId,
+  checksumUsesChainId,
 ) {
   const { symbol, name, address, iconUrl, string, balance, decimals } = token;
 
@@ -58,12 +60,16 @@ export function getRenderableTokenData(
     ) || '';
   const usedIconUrl =
     iconUrl ||
-    (contractMap[checksumAddress(address)] &&
-      `images/contract/${contractMap[checksumAddress(address)].logo}`);
+    (contractMap[checksumAddress(address, chainId, checksumUsesChainId)] &&
+      `images/contract/${
+        contractMap[checksumAddress(address, chainId, checksumUsesChainId)].logo
+      }`);
   return {
     ...token,
     primaryLabel: symbol,
-    secondaryLabel: name || contractMap[checksumAddress(address)]?.name,
+    secondaryLabel:
+      name ||
+      contractMap[checksumAddress(address, chainId, checksumUsesChainId)]?.name,
     rightPrimaryLabel:
       string && `${new BigNumber(string).round(6).toString()} ${symbol}`,
     rightSecondaryLabel: formattedFiat,
@@ -71,13 +77,16 @@ export function getRenderableTokenData(
     identiconAddress: usedIconUrl ? null : address,
     balance,
     decimals,
-    name: name || contractMap[checksumAddress(address)]?.name,
+    name:
+      name ||
+      contractMap[checksumAddress(address, chainId, checksumUsesChainId)]?.name,
     rawFiat,
   };
 }
 
 export function useTokensToSearch({ usersTokens = [], topTokens = {} }) {
   const chainId = useSelector(getCurrentChainId);
+  const checksumUsesChainId = useSelector(getCurrentChecksumUsesChainId);
   const tokenConversionRates = useSelector(getTokenExchangeRates, isEqual);
   const conversionRate = useSelector(getConversionRate);
   const currentCurrency = useSelector(getCurrentCurrency);
@@ -92,6 +101,7 @@ export function useTokensToSearch({ usersTokens = [], topTokens = {} }) {
     conversionRate,
     currentCurrency,
     chainId,
+    checksumUsesChainId,
   );
   const memoizedDefaultToken = useEqualityCheck(defaultToken);
 
@@ -126,6 +136,7 @@ export function useTokensToSearch({ usersTokens = [], topTokens = {} }) {
         conversionRate,
         currentCurrency,
         chainId,
+        checksumUsesChainId,
       );
       if (
         isSwapsDefaultTokenSymbol(renderableDataToken.symbol, chainId) ||

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -21,6 +21,8 @@ export default class ConfirmApproveContent extends Component {
   };
 
   static propTypes = {
+    chainId: PropTypes.string,
+    checksumUsesChainId: PropTypes.bool,
     decimals: PropTypes.number,
     tokenAmount: PropTypes.string,
     customTokenAmount: PropTypes.string,
@@ -124,6 +126,8 @@ export default class ConfirmApproveContent extends Component {
   renderPermissionContent() {
     const { t } = this.context;
     const {
+      chainId,
+      checksumUsesChainId,
       customTokenAmount,
       tokenAmount,
       tokenSymbol,
@@ -149,7 +153,7 @@ export default class ConfirmApproveContent extends Component {
             {t('toWithColon')}
           </div>
           <div className="confirm-approve-content__medium-text">
-            {addressSummary(toAddress)}
+            {addressSummary(toAddress, chainId, checksumUsesChainId)}
           </div>
         </div>
       </div>

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.container.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.container.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+} from '../../../selectors';
+import ConfirmApproveContent from './confirm-approve-content.component';
+
+const mapStateToProps = (state) => {
+  return {
+    chainId: getCurrentChainId(state),
+    checksumUsesChainId: getCurrentChecksumUsesChainId(state),
+  };
+};
+
+export default connect(mapStateToProps)(ConfirmApproveContent);

--- a/ui/pages/confirm-approve/confirm-approve-content/index.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.js
@@ -1,1 +1,1 @@
-export { default } from './confirm-approve-content.component';
+export { default } from './confirm-approve-content.container';

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -40,6 +40,7 @@ import {
   transactionFeeSelector,
   getNoGasPriceFetched,
   getIsEthGasPriceFetched,
+  getCurrentChecksumUsesChainId,
 } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { transactionMatchesNetwork } from '../../../shared/modules/transaction.utils';
@@ -103,13 +104,18 @@ const mapStateToProps = (state, ownProps) => {
   const { balance } = accounts[fromAddress];
   const { name: fromName } = identities[fromAddress];
   const toAddress = propsToAddress || txParamsToAddress;
+  const checksumUsesChainId = getCurrentChecksumUsesChainId(state);
 
   const toName =
     identities[toAddress]?.name ||
     casedContractMap[toAddress]?.name ||
-    shortenAddress(checksumAddress(toAddress));
+    shortenAddress(checksumAddress(toAddress, chainId, checksumUsesChainId));
 
-  const checksummedAddress = checksumAddress(toAddress);
+  const checksummedAddress = checksumAddress(
+    toAddress,
+    chainId,
+    checksumUsesChainId,
+  );
   const addressBookObject = addressBook[checksummedAddress];
   const toEns = ensResolutionsByAddress[checksummedAddress] || '';
   const toNickname = addressBookObject ? addressBookObject.name : '';

--- a/ui/pages/settings/contact-list-tab/view-contact/view-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/view-contact/view-contact.container.js
@@ -1,7 +1,11 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { getAddressBookEntry } from '../../../../selectors';
+import {
+  getAddressBookEntry,
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
+} from '../../../../selectors';
 import { checksumAddress } from '../../../../helpers/utils/util';
 import {
   CONTACT_EDIT_ROUTE,
@@ -22,10 +26,13 @@ const mapStateToProps = (state, ownProps) => {
     getAddressBookEntry(state, address) || state.metamask.identities[address];
   const { memo, name } = contact || {};
 
+  const chainId = getCurrentChainId(state);
+  const checksumUsesChainId = getCurrentChecksumUsesChainId(state);
+
   return {
     name,
     address: contact ? address : null,
-    checkSummedAddress: checksumAddress(address),
+    checkSummedAddress: checksumAddress(address, chainId, checksumUsesChainId),
     memo,
     editRoute: CONTACT_EDIT_ROUTE,
     listRoute: CONTACT_LIST_ROUTE,

--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -78,7 +78,6 @@
   }
 
   &__network-form-checkbox-wrapper {
-
     @media screen and (max-width: 575px) {
       width: 93%;
     }

--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -77,6 +77,22 @@
     }
   }
 
+  &__network-form-checkbox-wrapper {
+
+    @media screen and (max-width: 575px) {
+      width: 93%;
+    }
+
+    width: 100%;
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+  }
+
+  &__network-form-checkbox {
+    margin-right: 8px;
+  }
+
   &__network-form-label {
     display: flex;
     align-items: center;

--- a/ui/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/pages/settings/networks-tab/networks-tab.component.js
@@ -183,6 +183,7 @@ export default class NetworksTab extends PureComponent {
         label,
         rpcUrl,
         chainId,
+        checksumUsesChainId,
         ticker,
         viewOnly,
         rpcPrefs,
@@ -208,6 +209,7 @@ export default class NetworksTab extends PureComponent {
             networkName={label || (labelKey && t(labelKey)) || ''}
             rpcUrl={rpcUrl}
             chainId={chainId}
+            checksumUsesChainId={checksumUsesChainId}
             ticker={ticker}
             onClear={(shouldUpdateHistory = true) => {
               setNetworksTabAddMode(false);

--- a/ui/pages/settings/networks-tab/networks-tab.container.js
+++ b/ui/pages/settings/networks-tab/networks-tab.container.js
@@ -41,6 +41,7 @@ const mapStateToProps = (state, ownProps) => {
       providerType: NETWORK_TYPE_RPC,
       rpcUrl: rpc.rpcUrl,
       chainId: rpc.chainId,
+      checksumUsesChainId: rpc.checksumUsesChainId,
       ticker: rpc.ticker,
       blockExplorerUrl: rpc.rpcPrefs?.blockExplorerUrl || '',
     };
@@ -86,9 +87,23 @@ const mapDispatchToProps = (dispatch) => {
   return {
     setSelectedSettingsRpcUrl: (newRpcUrl) =>
       dispatch(setSelectedSettingsRpcUrl(newRpcUrl)),
-    setRpcTarget: (newRpc, chainId, ticker, nickname, rpcPrefs) => {
+    setRpcTarget: (
+      newRpc,
+      chainId,
+      checksumUsesChainId,
+      ticker,
+      nickname,
+      rpcPrefs,
+    ) => {
       return dispatch(
-        updateAndSetCustomRpc(newRpc, chainId, ticker, nickname, rpcPrefs),
+        updateAndSetCustomRpc(
+          newRpc,
+          chainId,
+          checksumUsesChainId,
+          ticker,
+          nickname,
+          rpcPrefs,
+        ),
       );
     },
     showConfirmDeleteNetworkModal: ({ target, onConfirm }) => {
@@ -99,9 +114,25 @@ const mapDispatchToProps = (dispatch) => {
     displayWarning: (warning) => dispatch(displayWarning(warning)),
     setNetworksTabAddMode: (isInAddMode) =>
       dispatch(setNetworksTabAddMode(isInAddMode)),
-    editRpc: (oldRpc, newRpc, chainId, ticker, nickname, rpcPrefs) => {
+    editRpc: (
+      oldRpc,
+      newRpc,
+      chainId,
+      checksumUsesChainId,
+      ticker,
+      nickname,
+      rpcPrefs,
+    ) => {
       return dispatch(
-        editRpc(oldRpc, newRpc, chainId, ticker, nickname, rpcPrefs),
+        editRpc(
+          oldRpc,
+          newRpc,
+          chainId,
+          checksumUsesChainId,
+          ticker,
+          nickname,
+          rpcPrefs,
+        ),
       );
     },
   };

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -255,8 +255,12 @@ export function getAddressBook(state) {
 
 export function getAddressBookEntry(state, address) {
   const addressBook = getAddressBook(state);
+  const chainId = getCurrentChainId(state);
+  const checksumUsesChainId = getCurrentChecksumUsesChainId(state);
   const entry = addressBook.find(
-    (contact) => contact.address === checksumAddress(address),
+    (contact) =>
+      contact.address ===
+      checksumAddress(address, chainId, checksumUsesChainId),
   );
   return entry;
 }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -59,6 +59,11 @@ export function getCurrentChainId(state) {
   return chainId;
 }
 
+export function getCurrentChecksumUsesChainId(state) {
+  const { checksumUsesChainId } = state.metamask.provider;
+  return checksumUsesChainId;
+}
+
 export function getCurrentKeyring(state) {
   const identity = getSelectedIdentity(state);
 

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -18,6 +18,8 @@ import { setCustomGasLimit } from '../ducks/gas/gas.duck';
 import txHelper from '../helpers/utils/tx-helper';
 import { getEnvironmentType, addHexPrefix } from '../../app/scripts/lib/util';
 import {
+  getCurrentChainId,
+  getCurrentChecksumUsesChainId,
   getPermittedAccountsForCurrentTab,
   getSelectedAddress,
 } from '../selectors';
@@ -1723,12 +1725,14 @@ export function addToAddressBook(recipient, nickname = '', memo = '') {
   log.debug(`background.addToAddressBook`);
 
   return async (dispatch, getState) => {
-    const { chainId } = getState().metamask.provider;
+    const state = getState();
+    const chainId = getCurrentChainId(state);
+    const checksumUsesChainId = getCurrentChecksumUsesChainId(state);
 
     let set;
     try {
       set = await promisifiedBackground.setAddressBook(
-        checksumAddress(recipient),
+        checksumAddress(recipient, chainId, checksumUsesChainId),
         nickname,
         chainId,
         memo,
@@ -1751,10 +1755,12 @@ export function addToAddressBook(recipient, nickname = '', memo = '') {
 export function removeFromAddressBook(chainId, addressToRemove) {
   log.debug(`background.removeFromAddressBook`);
 
-  return async () => {
+  return async (_, getState) => {
+    const state = getState();
+    const checksumUsesChainId = getCurrentChecksumUsesChainId(state);
     await promisifiedBackground.removeFromAddressBook(
       chainId,
-      checksumAddress(addressToRemove),
+      checksumAddress(addressToRemove, chainId, checksumUsesChainId),
     );
   };
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1590,19 +1590,21 @@ export function updateProviderType(type) {
 export function updateAndSetCustomRpc(
   newRpc,
   chainId,
+  checksumUsesChainId,
   ticker = 'ETH',
   nickname,
   rpcPrefs,
 ) {
   return async (dispatch) => {
     log.debug(
-      `background.updateAndSetCustomRpc: ${newRpc} ${chainId} ${ticker} ${nickname}`,
+      `background.updateAndSetCustomRpc: ${newRpc} ${chainId} ${checksumUsesChainId} ${ticker} ${nickname}`,
     );
 
     try {
       await promisifiedBackground.updateAndSetCustomRpc(
         newRpc,
         chainId,
+        checksumUsesChainId,
         ticker,
         nickname || newRpc,
         rpcPrefs,
@@ -1624,6 +1626,7 @@ export function editRpc(
   oldRpc,
   newRpc,
   chainId,
+  checksumUsesChainId,
   ticker = 'ETH',
   nickname,
   rpcPrefs,
@@ -1642,6 +1645,7 @@ export function editRpc(
       await promisifiedBackground.updateAndSetCustomRpc(
         newRpc,
         chainId,
+        checksumUsesChainId,
         ticker,
         nickname || newRpc,
         rpcPrefs,
@@ -1659,16 +1663,23 @@ export function editRpc(
   };
 }
 
-export function setRpcTarget(newRpc, chainId, ticker = 'ETH', nickname) {
+export function setRpcTarget(
+  newRpc,
+  chainId,
+  checksumUsesChainId,
+  ticker = 'ETH',
+  nickname,
+) {
   return async (dispatch) => {
     log.debug(
-      `background.setRpcTarget: ${newRpc} ${chainId} ${ticker} ${nickname}`,
+      `background.setRpcTarget: ${newRpc} ${chainId} ${checksumUsesChainId} ${ticker} ${nickname}`,
     );
 
     try {
       await promisifiedBackground.setCustomRpc(
         newRpc,
         chainId,
+        checksumUsesChainId,
         ticker,
         nickname || newRpc,
       );


### PR DESCRIPTION
Fixes: https://github.com/rsksmart/rsk-gitcoin-hackathon-2021/issues/11

Explanation:  See [EIP-1191](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1191.md). MetaMask accepts chain ID in network configuration, but does not currently use it in checksum calculation. The PR adds this feature.

![image](https://user-images.githubusercontent.com/44864521/117780426-3d97e700-b25d-11eb-998a-e7e008145902.png)


Manual testing steps:  
  - Add custom network, specify chain ID.
  - Toggle "Checksum uses Chain ID" checkbox and see updated checksum in one of many places where it is rendered (export private key modal, confirm remove account etc.)