### PR TITLE
updaing copy to "Send ether"

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -940,7 +940,7 @@
   "sendTokens": {
     "message": "ተለዋጭ ስሞችን ላክ"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "የተላከ ether"
   },
   "separateEachWord": {

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -936,7 +936,7 @@
   "sendTokens": {
     "message": "إرسال عملات رمزية"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "أرسل عملة إيثير"
   },
   "separateEachWord": {

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -939,7 +939,7 @@
   "sendTokens": {
     "message": "Изпращане на жетони"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "изпратен етер"
   },
   "separateEachWord": {

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -943,7 +943,7 @@
   "sendTokens": {
     "message": "টোকেনগুলি পাঠান"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "পাঠানো ইথার "
   },
   "separateEachWord": {

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -921,7 +921,7 @@
   "sendTokens": {
     "message": "Enviar Fitxes"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "envia ether"
   },
   "separateEachWord": {

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -921,7 +921,7 @@
   "sendTokens": {
     "message": "Send tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "sendte ether"
   },
   "separateEachWord": {

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -912,7 +912,7 @@
   "sendTokens": {
     "message": "Token senden"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Ether senden"
   },
   "separateEachWord": {

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -940,7 +940,7 @@
   "sendTokens": {
     "message": "Στείλτε Tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "απεσταλμένα ether"
   },
   "separateEachWord": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1522,7 +1522,7 @@
     "message": "Send Tokens"
   },
   "sentEther": {
-    "message": "sent ether"
+    "message": "send ether"
   },
   "separateEachWord": {
     "message": "Separate each word with a single space"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1521,7 +1521,7 @@
   "sendTokens": {
     "message": "Send Tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "send ether"
   },
   "separateEachWord": {

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1419,7 +1419,7 @@
   "sendTokens": {
     "message": "Enviar tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Ether enviado"
   },
   "separateEachWord": {

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1419,7 +1419,7 @@
   "sendTokens": {
     "message": "Enviar tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Ether enviado"
   },
   "separateEachWord": {

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -933,7 +933,7 @@
   "sendTokens": {
     "message": "Saada lube"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "saadetud eeter"
   },
   "separateEachWord": {

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -943,7 +943,7 @@
   "sendTokens": {
     "message": "رمزیاب ها را ارسال کنید"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "ایتر ارسال شد"
   },
   "separateEachWord": {

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -940,7 +940,7 @@
   "sendTokens": {
     "message": "Lähetä tietueita"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "lähetä etheriä"
   },
   "separateEachWord": {

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -855,7 +855,7 @@
   "sendTokens": {
     "message": "Magpadala ng Mga Token"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "nagpadala ng ether"
   },
   "separateEachWord": {

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -925,7 +925,7 @@
   "sendTokens": {
     "message": "Envoyer des jetons"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Ether envoyé"
   },
   "separateEachWord": {

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -937,7 +937,7 @@
   "sendTokens": {
     "message": "שלח טוקנים"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "את'ר שנשלח"
   },
   "separateEachWord": {

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1410,7 +1410,7 @@
   "sendTokens": {
     "message": "टोकन भेजें"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Ether भेजा गया"
   },
   "separateEachWord": {

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -936,7 +936,7 @@
   "sendTokens": {
     "message": "Pošalji tokene"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "pošalji ether"
   },
   "separateEachWord": {

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -591,7 +591,7 @@
   "sendTokens": {
     "message": "Voye Tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Voye ether"
   },
   "separateEachWord": {

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -936,7 +936,7 @@
   "sendTokens": {
     "message": "Token küldése"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "elküldött ether"
   },
   "separateEachWord": {

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1410,7 +1410,7 @@
   "sendTokens": {
     "message": "Kirim Token"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "ether terkirim"
   },
   "separateEachWord": {

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1425,7 +1425,7 @@
   "sendTokens": {
     "message": "Invia Tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "ether inviati"
   },
   "separateEachWord": {

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1419,7 +1419,7 @@
   "sendTokens": {
     "message": "トークンを送る"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Etherの送金"
   },
   "separateEachWord": {

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -943,7 +943,7 @@
   "sendTokens": {
     "message": "ಟೋಕನ್‌ಗಳನ್ನು ಕಳುಹಿಸಿ"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "ಕಳುಹಿಸಲಾದ ಎಥರ್"
   },
   "separateEachWord": {

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1407,7 +1407,7 @@
   "sendTokens": {
     "message": "토큰 보내기"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "Ether 보냄"
   },
   "separateEachWord": {

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -943,7 +943,7 @@
   "sendTokens": {
     "message": "Siųsti žetonus"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "siųsti eterių"
   },
   "separateEachWord": {

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -939,7 +939,7 @@
   "sendTokens": {
     "message": "Nosūtīt marķierus"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "nosūtītie ether"
   },
   "separateEachWord": {

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -920,7 +920,7 @@
   "sendTokens": {
     "message": "Hantar Token"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "menghantar ether"
   },
   "separateEachWord": {

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -921,7 +921,7 @@
   "sendTokens": {
     "message": "Send tokener"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "sendt ether"
   },
   "separateEachWord": {

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -937,7 +937,7 @@
   "sendTokens": {
     "message": "Wyślij tokeny"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "wyślij eter"
   },
   "separateEachWord": {

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -931,7 +931,7 @@
   "sendTokens": {
     "message": "Enviar Tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "ether enviado"
   },
   "separateEachWord": {

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -930,7 +930,7 @@
   "sendTokens": {
     "message": "Trimiteți indicative"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "trimiteți ether"
   },
   "separateEachWord": {

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1410,7 +1410,7 @@
   "sendTokens": {
     "message": "Отправить токены"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "отправленный Ether"
   },
   "separateEachWord": {

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -906,7 +906,7 @@
   "sendTokens": {
     "message": "Odeslat tokeny"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "poslaný ether"
   },
   "separateEachWord": {

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -925,7 +925,7 @@
   "sendTokens": {
     "message": "Pošlji žetone"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "poslani ether"
   },
   "separateEachWord": {

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -934,7 +934,7 @@
   "sendTokens": {
     "message": "Pošalji tokene"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "ether je poslat"
   },
   "separateEachWord": {

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -927,7 +927,7 @@
   "sendTokens": {
     "message": "Skicka tokens"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "skickat ether"
   },
   "separateEachWord": {

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -921,7 +921,7 @@
   "sendTokens": {
     "message": "Tuma Vianzio"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "ether iliyotumwa"
   },
   "separateEachWord": {

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1407,7 +1407,7 @@
   "sendTokens": {
     "message": "Magpadala ng Mga Token"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "nagpadala ng ether"
   },
   "separateEachWord": {

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -943,7 +943,7 @@
   "sendTokens": {
     "message": "Надіслати токени"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "надісланий ефір"
   },
   "separateEachWord": {

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1410,7 +1410,7 @@
   "sendTokens": {
     "message": "Gửi token"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "đã gửi ether"
   },
   "separateEachWord": {

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1419,7 +1419,7 @@
   "sendTokens": {
     "message": "发送代币"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "发送 Ether"
   },
   "separateEachWord": {

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -931,7 +931,7 @@
   "sendTokens": {
     "message": "發送代幣"
   },
-  "sentEther": {
+  "ethSendAction": {
     "message": "發送以太幣"
   },
   "separateEachWord": {

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -347,7 +347,7 @@ export default class TransactionController extends EventEmitter {
       return {};
     } else if (
       txMeta.txParams.to &&
-      txMeta.transactionCategory === TRANSACTION_CATEGORIES.SENT_ETHER
+      txMeta.transactionCategory === TRANSACTION_CATEGORIES.SEND_ETHER
     ) {
       // if there's data in the params, but there's no contract code, it's not a valid transaction
       if (txMeta.txParams.data) {
@@ -849,7 +849,7 @@ export default class TransactionController extends EventEmitter {
       const codeIsEmpty = !code || code === '0x' || code === '0x0';
 
       result = codeIsEmpty
-        ? TRANSACTION_CATEGORIES.SENT_ETHER
+        ? TRANSACTION_CATEGORIES.SEND_ETHER
         : TRANSACTION_CATEGORIES.CONTRACT_INTERACTION;
     }
 

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -63,7 +63,7 @@ export const TRANSACTION_STATUSES = {
  * @property {'approve'} TOKEN_METHOD_APPROVE - A token transaction requesting an
  *  allowance of the token to spend on behalf of the user
  * @property {'incoming'} INCOMING - An incoming (deposit) transaction
- * @property {'sentEther'} SENT_ETHER - A transaction sending ether to a recipient
+ * @property {'ethSendAction'} SEND_ETHER - A transaction sending ether to a recipient
  * @property {'contractInteraction'} CONTRACT_INTERACTION - A transaction that is
  *  interacting with a smart contract's methods that we have not treated as a special
  *  case, such as approve, transfer, and transferfrom
@@ -85,7 +85,7 @@ export const TRANSACTION_CATEGORIES = {
   TOKEN_METHOD_TRANSFER_FROM: 'transferfrom',
   TOKEN_METHOD_APPROVE: 'approve',
   INCOMING: 'incoming',
-  SENT_ETHER: 'sentEther',
+  SEND_ETHER: 'ethSendAction',
   CONTRACT_INTERACTION: 'contractInteraction',
   DEPLOY_CONTRACT: 'contractDeployment',
   SWAP: 'swap',

--- a/test/data/transaction-data.json
+++ b/test/data/transaction-data.json
@@ -17,7 +17,7 @@
       },
       "type": "standard",
       "origin": "metamask",
-      "transactionCategory": "sentEther",
+      "transactionCategory": "ethSendAction",
       "nonceDetails": {
         "params": {
           "highestLocallyConfirmed": 12,
@@ -78,7 +78,7 @@
       },
       "type": "standard",
       "origin": "metamask",
-      "transactionCategory": "sentEther",
+      "transactionCategory": "ethSendAction",
       "nonceDetails": {
         "params": {
           "highestLocallyConfirmed": 12,
@@ -144,7 +144,7 @@
       },
       "type": "standard",
       "origin": "metamask",
-      "transactionCategory": "sentEther",
+      "transactionCategory": "ethSendAction",
       "nonceDetails": {
         "params": {
           "highestLocallyConfirmed": 0,
@@ -205,7 +205,7 @@
       },
       "type": "standard",
       "origin": "metamask",
-      "transactionCategory": "sentEther",
+      "transactionCategory": "ethSendAction",
       "nonceDetails": {
         "params": {
           "highestLocallyConfirmed": 0,
@@ -271,7 +271,7 @@
       },
       "type": "standard",
       "origin": "metamask",
-      "transactionCategory": "sentEther",
+      "transactionCategory": "ethSendAction",
       "nonceDetails": {
         "params": {
           "highestLocallyConfirmed": 0,
@@ -333,7 +333,7 @@
       },
       "type": "standard",
       "origin": "metamask",
-      "transactionCategory": "sentEther",
+      "transactionCategory": "ethSendAction",
       "nonceDetails": {
         "params": {
           "highestLocallyConfirmed": 0,

--- a/test/unit/app/controllers/network/stubs.js
+++ b/test/unit/app/controllers/network/stubs.js
@@ -14,7 +14,7 @@ export const txMetaStub = {
       metamaskNetworkId: '4',
       status: TRANSACTION_STATUSES.UNAPPROVED,
       time: 1572395156620,
-      transactionCategory: TRANSACTION_CATEGORIES.SENT_ETHER,
+      transactionCategory: TRANSACTION_CATEGORIES.SEND_ETHER,
       txParams: {
         from: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
         gas: '0x5208',
@@ -196,7 +196,7 @@ export const txMetaStub = {
   status: TRANSACTION_STATUSES.SUBMITTED,
   submittedTime: 1572395158570,
   time: 1572395156620,
-  transactionCategory: TRANSACTION_CATEGORIES.SENT_ETHER,
+  transactionCategory: TRANSACTION_CATEGORIES.SEND_ETHER,
   txParams: {
     from: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
     gas: '0x5208',

--- a/test/unit/app/controllers/transactions/tx-controller.test.js
+++ b/test/unit/app/controllers/transactions/tx-controller.test.js
@@ -783,7 +783,7 @@ describe('Transaction Controller', function () {
         data: '',
       });
       assert.deepEqual(result, {
-        transactionCategory: TRANSACTION_CATEGORIES.SENT_ETHER,
+        transactionCategory: TRANSACTION_CATEGORIES.SEND_ETHER,
         getCodeResponse: null,
       });
     });
@@ -829,7 +829,7 @@ describe('Transaction Controller', function () {
         data: '0xabd',
       });
       assert.deepEqual(result, {
-        transactionCategory: TRANSACTION_CATEGORIES.SENT_ETHER,
+        transactionCategory: TRANSACTION_CATEGORIES.SEND_ETHER,
         getCodeResponse: '0x',
       });
     });
@@ -840,7 +840,7 @@ describe('Transaction Controller', function () {
         data: '0xabd',
       });
       assert.deepEqual(result, {
-        transactionCategory: TRANSACTION_CATEGORIES.SENT_ETHER,
+        transactionCategory: TRANSACTION_CATEGORIES.SEND_ETHER,
         getCodeResponse: null,
       });
     });

--- a/ui/app/helpers/utils/transactions.util.js
+++ b/ui/app/helpers/utils/transactions.util.js
@@ -211,8 +211,8 @@ export function getTransactionCategoryTitle(t, transactionCategory) {
     case TRANSACTION_CATEGORIES.TOKEN_METHOD_APPROVE: {
       return t('approve');
     }
-    case TRANSACTION_CATEGORIES.SENT_ETHER: {
-      return t('sentEther');
+    case TRANSACTION_CATEGORIES.SEND_ETHER: {
+      return t('ethSendAction');
     }
     case TRANSACTION_CATEGORIES.CONTRACT_INTERACTION: {
       return t('contractInteraction');

--- a/ui/app/hooks/useTransactionDisplayData.js
+++ b/ui/app/hooks/useTransactionDisplayData.js
@@ -211,7 +211,7 @@ export function useTransactionDisplayData(transactionGroup) {
     title = t('sendSpecifiedTokens', [token?.symbol || t('token')]);
     recipientAddress = getTokenAddressParam(tokenData);
     subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
-  } else if (transactionCategory === TRANSACTION_CATEGORIES.SENT_ETHER) {
+  } else if (transactionCategory === TRANSACTION_CATEGORIES.SEND_ETHER) {
     category = TRANSACTION_GROUP_CATEGORIES.SEND;
     title = t('sendETH');
     subtitle = t('toAddress', [shortenAddress(recipientAddress)]);

--- a/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
+++ b/ui/app/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
@@ -31,7 +31,7 @@ export default class ConfirmTransactionSwitch extends Component {
       return <Redirect to={{ pathname }} />;
     }
 
-    if (transactionCategory === TRANSACTION_CATEGORIES.SENT_ETHER) {
+    if (transactionCategory === TRANSACTION_CATEGORIES.SEND_ETHER) {
       const pathname = `${CONFIRM_TRANSACTION_ROUTE}/${id}${CONFIRM_SEND_ETHER_PATH}`;
       return <Redirect to={{ pathname }} />;
     }


### PR DESCRIPTION
Closes: https://github.com/MetaMask/metamask-extension/issues/10974

Explanation:  
- Changing the past tense "sent ether" on the transaction type at confirmation screen. Updating it to present tense "Send Ether"