### PR TITLE
Use UrlIcon instead of Identicon on approve screen

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Identicon from '../../../components/ui/identicon';
+import UrlIcon from '../../../components/ui/url-icon';
 import { addressSummary } from '../../../helpers/utils/util';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
 import { ConfirmPageContainerWarning } from '../../../components/app/confirm-page-container/confirm-page-container-content';
@@ -253,11 +253,11 @@ export default class ConfirmApproveContent extends Component {
           </div>
         )}
         <div className="confirm-approve-content__identicon-wrapper">
-          <Identicon
+          <UrlIcon
             className="confirm-approve-content__identicon"
-            diameter={48}
-            address={origin}
-            image={siteImage}
+            fallbackClassName="confirm-approve-content__identicon"
+            name={origin ? (new URL(origin)).hostname : ''}
+            url={siteImage}
           />
         </div>
         <div className="confirm-approve-content__title">

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -256,7 +256,7 @@ export default class ConfirmApproveContent extends Component {
           <UrlIcon
             className="confirm-approve-content__identicon"
             fallbackClassName="confirm-approve-content__identicon"
-            name={origin ? (new URL(origin)).hostname : ''}
+            name={origin ? new URL(origin).hostname : ''}
             url={siteImage}
           />
         </div>

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -15,6 +15,11 @@
     padding-right: 24px;
   }
 
+  &__identicon {
+    width: 48px;
+    height: 48px;
+  }
+
   &__full-tx-content {
     display: flex;
     flex-flow: column;


### PR DESCRIPTION
We were passing an origin to the identicon component in `ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js`. Instead we should have been using the `UrlIcon` component.

This also resolves instances we have seen of the `Error: This method only supports 0x-prefixed hex strings but input was: ` error