### PR TITLE
Use isValidAddress helper instead of ethereumJsUtil.isValidAddress

### DIFF
--- a/ui/helpers/utils/icon-factory.js
+++ b/ui/helpers/utils/icon-factory.js
@@ -1,6 +1,5 @@
-import { isValidAddress } from 'ethereumjs-util';
 import contractMap from '@metamask/contract-metadata';
-import { checksumAddress } from './util';
+import { isValidAddress, checksumAddress } from './util';
 
 let iconFactory;
 

--- a/ui/pages/add-token/add-token.component.js
+++ b/ui/pages/add-token/add-token.component.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { isValidAddress } from 'ethereumjs-util';
-import { checkExistingAddresses } from '../../helpers/utils/util';
+import {
+  checkExistingAddresses,
+  isValidAddress,
+} from '../../helpers/utils/util';
 import { tokenInfoGetter } from '../../helpers/utils/token-util';
 import { CONFIRM_ADD_TOKEN_ROUTE } from '../../helpers/constants/routes';
 import TextField from '../../components/ui/text-field';

--- a/ui/pages/send/send.component.js
+++ b/ui/pages/send/send.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { isValidAddress } from 'ethereumjs-util';
 import { debounce } from 'lodash';
+import { isValidAddress } from '../../helpers/utils/util';
 import {
   getAmountErrorObject,
   getGasFeeErrorObject,


### PR DESCRIPTION
Replaces use of `ethereumJsUtil.isValidAddress` with our own `isValidAddress` helper/wrapper in cases where it will help avoid errors and won't block desired behaviour.