### PR TITLE
Fix Sentry sourcemaps

### DIFF
--- a/development/sentry-upload-artifacts.sh
+++ b/development/sentry-upload-artifacts.sh
@@ -27,33 +27,10 @@ Options:
 EOF
 }
 
-function upload_bundles {
-  local release="${1}"; shift
-
-  for filepath in ./dist/chrome/*.js
-  do
-    if [[ -f $filepath ]]
-    then
-      upload_bundle "${release}" "${filepath}"
-    fi
-  done
-}
-
-function upload_bundle {
-  local release="${1}"; shift
-  local filepath="${1}"; shift
-  local filename
-
-  filename="$( basename "${filepath}" )"
-
-  printf 'Uploading %s\n' "${filename}"
-  sentry-cli releases --org 'metamask' --project 'metamask' files "${release}" upload "${filepath}" "metamask/${filename}"
-}
-
 function upload_sourcemaps {
   local release="${1}"; shift
 
-  sentry-cli releases --org 'metamask' --project 'metamask' files "${release}" upload-sourcemaps ./dist/sourcemaps/ --url-prefix 'sourcemaps'
+  sentry-cli releases --org 'metamask' --project 'metamask' files "${release}" upload-sourcemaps ./dist/chrome/ ./dist/sourcemaps/ --rewrite --url-prefix 'metamask'
 }
 
 function main {
@@ -87,9 +64,7 @@ function main {
     die 'Required parameter "release" missing; either include parameter or set VERSION environment variable'
   fi
 
-  printf 'uploading source files Sentry release "%s"...\n' "${release}"
-  upload_bundles "${release}"
-  printf 'uploading sourcemaps Sentry release "%s"...\n' "${release}"
+  printf 'uploading source files and sourcemaps for Sentry release "%s"...\n' "${release}"
   upload_sourcemaps "${release}"
   printf 'all done!\n'
 }

--- a/development/sentry-upload-artifacts.sh
+++ b/development/sentry-upload-artifacts.sh
@@ -30,7 +30,7 @@ EOF
 function upload_sourcemaps {
   local release="${1}"; shift
 
-  sentry-cli releases --org 'metamask' --project 'metamask' files "${release}" upload-sourcemaps ./dist/chrome/ ./dist/sourcemaps/ --rewrite --url-prefix 'metamask'
+  sentry-cli releases --org 'metamask' --project 'metamask' files "${release}" upload-sourcemaps ./dist/chrome/*.js ./dist/sourcemaps/ --rewrite --url-prefix 'metamask'
 }
 
 function main {


### PR DESCRIPTION
The method used for uploading release artifacts to Sentry has been updated to allow `sentry-cli` to associate our minified bundles with the corresponding source map file. This should help Sentry display rich stack traces.

Previously Sentry had used the `sourceMappingURL` to associate source maps with bundles, but we recently removed this in #10695. The hope is that this change to the upload process will ensure the mapping works correctly without the `sourceMappingURL` comment.

The `upload_bundles` function was removed because the later `upload_sourcemaps` function actually uploaded both the bundles and source maps.

The `--rewrite` flag was added to enable a newer ["rewrite" feature of the Sentry CLI that they recommend using](https://docs.sentry.io/product/cli/releases/#sentry-cli-sourcemaps). This rewrite is where they associate source maps with bundles.

The `url-prefix` has been updated to be `metamask` rather than `sourcemaps`. I don't think `sourcemaps` was ever the correct prefix. We normalize our errors to have the path `metamask/` before sending any reports to Sentry.