### PR TITLE
Swaps: Add anonymized tracking for HW wallet and HW wallet type

### DIFF
--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -15,6 +15,12 @@
     "provider": {
       "chainId": "0x4"
     },
+    "keyrings": [
+      {
+        "type": "Ledger Hardware",
+        "accounts": ["0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc"]
+      }
+    ],
     "identities": {
       "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc": {
         "address": "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -54,6 +54,7 @@ import {
   getSwapsDefaultToken,
   getCurrentChainId,
   isHardwareWallet,
+  getHardwareWalletType,
 } from '../../selectors';
 import {
   ERROR_FETCHING_QUOTES,
@@ -483,6 +484,8 @@ export const fetchQuotesAndSetQuoteState = (
 
     dispatch(setFromToken(selectedFromToken));
 
+    const hardwareWalletUsed = isHardwareWallet(state);
+    const hardwareWalletType = getHardwareWalletType(state);
     metaMetricsEvent({
       event: 'Quotes Requested',
       category: 'swaps',
@@ -493,6 +496,8 @@ export const fetchQuotesAndSetQuoteState = (
         request_type: balanceError ? 'Quote' : 'Order',
         slippage: maxSlippage,
         custom_slippage: maxSlippage !== 2,
+        is_hardware_wallet: hardwareWalletUsed,
+        hardware_wallet_type: hardwareWalletType,
         anonymizedData: true,
       },
     });
@@ -563,6 +568,8 @@ export const fetchQuotesAndSetQuoteState = (
             response_time: Date.now() - fetchStartTime,
             best_quote_source: newSelectedQuote.aggregator,
             available_quotes: Object.values(fetchedQuotes)?.length,
+            is_hardware_wallet: hardwareWalletUsed,
+            hardware_wallet_type: hardwareWalletType,
             anonymizedData: true,
           },
         });

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -88,6 +88,16 @@ export function isHardwareWallet(state) {
   return keyring.type.includes('Hardware');
 }
 
+/**
+ * Get a HW wallet type, e.g. "Ledger Hardware"
+ * @param {Object} state
+ * @returns {String|undefined}
+ */
+export function getHardwareWalletType(state) {
+  const keyring = getCurrentKeyring(state);
+  return keyring.type.includes('Hardware') ? keyring.type : undefined;
+}
+
 export function getAccountType(state) {
   const currentKeyring = getCurrentKeyring(state);
   const type = currentKeyring && currentKeyring.type;

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -15,6 +15,44 @@ describe('Selectors', () => {
     });
   });
 
+  describe('#isHardwareWallet', () => {
+    it('returns false if it is not a HW wallet', () => {
+      mockState.metamask.keyrings[0].type = 'Simple Key Pair';
+      expect(selectors.isHardwareWallet(mockState)).toBe(false);
+    });
+
+    it('returns true if it is a Ledger HW wallet', () => {
+      mockState.metamask.keyrings[0].type = 'Ledger Hardware';
+      expect(selectors.isHardwareWallet(mockState)).toBe(true);
+    });
+
+    it('returns true if it is a Trezor HW wallet', () => {
+      mockState.metamask.keyrings[0].type = 'Trezor Hardware';
+      expect(selectors.isHardwareWallet(mockState)).toBe(true);
+    });
+  });
+
+  describe('#getHardwareWalletType', () => {
+    it('returns undefined if it is not a HW wallet', () => {
+      mockState.metamask.keyrings[0].type = 'Simple Key Pair';
+      expect(selectors.getHardwareWalletType(mockState)).toBeUndefined();
+    });
+
+    it('returns "Ledger Hardware" if it is a Ledger HW wallet', () => {
+      mockState.metamask.keyrings[0].type = 'Ledger Hardware';
+      expect(selectors.getHardwareWalletType(mockState)).toBe(
+        'Ledger Hardware',
+      );
+    });
+
+    it('returns "Trezor Hardware" if it is a Trezor HW wallet', () => {
+      mockState.metamask.keyrings[0].type = 'Trezor Hardware';
+      expect(selectors.getHardwareWalletType(mockState)).toBe(
+        'Trezor Hardware',
+      );
+    });
+  });
+
   it('returns selected identity', () => {
     expect(selectors.getSelectedIdentity(mockState)).toStrictEqual({
       address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',


### PR DESCRIPTION
## Explanation
We want to see how many users use a HW wallet and which type during swaps, so we can make better data-driven decisions about upcoming features / priorities. Tracking of these 2 params is anonymized.

## Manual testing steps
- Click on "Swap" on the main page
- Select "Token From" and "Token To"
- When submitted, we log the first event called "Quotes Requested"
- After receiving quotes, we track another event called "Quotes Received"