### PR TITLE
Update eth-ledger-bridge-keyring to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.22.0",
     "@metamask/controllers": "^8.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "^0.4.0",
+    "@metamask/eth-ledger-bridge-keyring": "^0.5.0",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.0.0",
     "@metamask/inpage-provider": "^8.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,12 +2714,12 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-6.0.0.tgz#ec53e8ab278073e882411ed89705bc7d06b78c81"
   integrity sha512-LyakGYGwM8UQOGhwWa+5erAI1hXuiTgf/y7USzOomX6H9KiuY09IAUYnPh7ToPG2sedD2F48UF1bUm8yvCoZOw==
 
-"@metamask/eth-ledger-bridge-keyring@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.4.0.tgz#764834adf146fc86ab7688a6c8f1e08708ed0d71"
-  integrity sha512-FkoAsP19YMKHNQzfPL5l9QJwp4YsEaN8d5pbJc+VcMzoC5rkt1iyDQdderERUV9DQlS3flBjxECCZ+QX54HD5w==
+"@metamask/eth-ledger-bridge-keyring@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.5.0.tgz#c1ee89819c493239290a940da6285e6844240383"
+  integrity sha512-p7dvnAQ6n9AFf7JoJFwNsdIKoX5poP0bBwrgmCA/mLAdb5Z+bBAnHMSbKOZrH7rEsj7jExdbmUiJLI5qKnV0zA==
   dependencies:
-    eth-sig-util "^1.4.2"
+    eth-sig-util "^2.0.0"
     ethereumjs-tx "^1.3.4"
     ethereumjs-util "^7.0.9"
     events "^2.0.0"


### PR DESCRIPTION
Fixes: #10240

Explanation:  Updates our Ledger Bridge Keyring to 0.5.0, with support typed signing.