### PR TITLE
Add isHex check for addresses supplied to Identicon

### DIFF
--- a/ui/components/ui/identicon/identicon.component.js
+++ b/ui/components/ui/identicon/identicon.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import contractMap from '@metamask/contract-metadata';
 
-import { checksumAddress } from '../../../helpers/utils/util';
+import { checksumAddress, isHex } from '../../../helpers/utils/util';
 import Jazzicon from '../jazzicon';
 import BlockieIdenticon from './blockieIdenticon';
 
@@ -85,10 +85,12 @@ export default class Identicon extends PureComponent {
     }
 
     if (address) {
-      const checksummedAddress = checksumAddress(address);
+      if (isHex(address)) {
+        const checksummedAddress = checksumAddress(address);
 
-      if (contractMap[checksummedAddress]?.logo) {
-        return this.renderJazzicon();
+        if (contractMap[checksummedAddress]?.logo) {
+          return this.renderJazzicon();
+        }
       }
 
       return (

--- a/ui/helpers/utils/icon-factory.js
+++ b/ui/helpers/utils/icon-factory.js
@@ -1,5 +1,5 @@
 import contractMap from '@metamask/contract-metadata';
-import { isValidAddress, checksumAddress } from './util';
+import { isValidAddress, checksumAddress, isHex } from './util';
 
 let iconFactory;
 
@@ -16,7 +16,12 @@ function IconFactory(jazzicon) {
 }
 
 IconFactory.prototype.iconForAddress = function (address, diameter) {
-  const addr = checksumAddress(address);
+  let addr = address;
+
+  if (isHex(address)) {
+    addr = checksumAddress(address);
+  }
+
   if (iconExistsFor(addr)) {
     return imageElFor(addr);
   }


### PR DESCRIPTION
Fixes: #11067

Explanation:  
Allows in-app sending for custom networks without erroring. Partly addresses the issue with sending non-addresses  in the address prop of the Identicon by checking if it is hex, and if not show the address as a Blockie of it.

Manual testing steps:  

1. Add a custom network other than Binance ie, xDai
```
ethereum.request({
  method: 'wallet_addEthereumChain',
  params: [{
    chainId: '0x64',
    chainName: 'xDai',
    rpcUrls: ['https://rpc.xdaichain.com/'],
    nativeCurrency: {symbol: 'xDai', decimals: 18},
    blockExplorerUrls: ['https://blockscout.com/xdai/mainnet']
  }]
})
```
2. In-app Send via wallet overview Send button and either input a address or transfer between accounts.
3. Custom network Asset should be a Blockie of the custom network's symbol.

<details>
<summary>After</summary>
<img src='https://user-images.githubusercontent.com/13376180/118048483-33471d00-b331-11eb-940b-8fe10fcdd1a6.png'>
</details>

This is more a patch, rather than addressing the root problem of passing non address/hex strings to the address prop of the Identicon.
