### PR TITLE
gitignore ui/app/css/output css output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ build-artifacts
 
 #ignore css output and sourcemaps
 ui/css/output/
+ui/app/css/output/
 
 notes.txt
 


### PR DESCRIPTION
Adds `ui/app/css/output/`, css output, to the to the gitignore list.