### PR TITLE
Migrate Sentry settings to environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,7 +505,7 @@ jobs:
           at: .
       - run:
           name: sentry sourcemaps upload
-          command: yarn sentry:publish
+          command: SENTRY_ORG=metamask SENTRY_PROJECT=metamask yarn sentry:publish
       - run:
           name: Create GitHub release
           command: |

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -7,9 +7,8 @@ import extractEthjsErrorMessage from './extractEthjsErrorMessage';
 // Destructuring breaks the inlining of the environment variables
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG;
 const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT;
+const SENTRY_DSN_DEV = process.env.SENTRY_DSN_DEV;
 /* eslint-enable prefer-destructuring */
-const SENTRY_DSN_DEV =
-  'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496';
 
 // This describes the subset of Redux state attached to errors sent to Sentry
 // These properties have some potential to be useful for debugging, and they do

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -20,6 +20,9 @@ const metamaskrc = require('rc')('metamask', {
   SEGMENT_HOST: process.env.SEGMENT_HOST,
   SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
   SEGMENT_LEGACY_WRITE_KEY: process.env.SEGMENT_LEGACY_WRITE_KEY,
+  SENTRY_DSN_DEV:
+    process.env.SENTRY_DSN_DEV ||
+    'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496',
 });
 
 const { version } = require('../../package.json');
@@ -431,6 +434,7 @@ function getEnvironmentVariables({ devMode, testing }) {
     PUBNUB_PUB_KEY: process.env.PUBNUB_PUB_KEY || '',
     CONF: devMode ? metamaskrc : {},
     SENTRY_DSN: process.env.SENTRY_DSN,
+    SENTRY_DSN_DEV: metamaskrc.SENTRY_DSN_DEV,
     INFURA_PROJECT_ID: testing
       ? '00000000000000000000000000000000'
       : metamaskrc.INFURA_PROJECT_ID,

--- a/development/sentry-publish.js
+++ b/development/sentry-publish.js
@@ -11,6 +11,12 @@ start().catch((error) => {
 });
 
 async function start() {
+  if (!process.env.SENTRY_ORG) {
+    throw new Error('Missing required "SENTRY_ORG" environment variable');
+  } else if (!process.env.SENTRY_PROJECT) {
+    throw new Error('Missing required "SENTRY_PROJECT" environment variable');
+  }
+
   const authWorked = await checkIfAuthWorks();
   if (!authWorked) {
     throw new Error(`Sentry auth failed`);
@@ -25,15 +31,11 @@ async function start() {
   } else {
     // create sentry release
     console.log(`creating Sentry release for "${VERSION}"...`);
-    await exec(
-      `sentry-cli releases --org 'metamask' --project 'metamask' new ${VERSION}`,
-    );
+    await exec(`sentry-cli releases new ${VERSION}`);
     console.log(
       `removing any existing files from Sentry release "${VERSION}"...`,
     );
-    await exec(
-      `sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} delete --all`,
-    );
+    await exec(`sentry-cli releases files ${VERSION} delete --all`);
   }
 
   // check if version has artifacts or not
@@ -52,26 +54,20 @@ async function start() {
 
 async function checkIfAuthWorks() {
   const itWorked = await doesNotFail(async () => {
-    await exec(
-      `sentry-cli releases --org 'metamask' --project 'metamask' list`,
-    );
+    await exec(`sentry-cli releases list`);
   });
   return itWorked;
 }
 
 async function checkIfVersionExists() {
   const versionAlreadyExists = await doesNotFail(async () => {
-    await exec(
-      `sentry-cli releases --org 'metamask' --project 'metamask' info ${VERSION}`,
-    );
+    await exec(`sentry-cli releases info ${VERSION}`);
   });
   return versionAlreadyExists;
 }
 
 async function checkIfVersionHasArtifacts() {
-  const artifacts = await exec(
-    `sentry-cli releases --org 'metamask' --project 'metamask' files ${VERSION} list`,
-  );
+  const artifacts = await exec(`sentry-cli releases files ${VERSION} list`);
   // When there's no artifacts, we get a response from the shell like this ['', '']
   return artifacts[0] && artifacts[0].length > 0;
 }

--- a/development/sentry-upload-artifacts.sh
+++ b/development/sentry-upload-artifacts.sh
@@ -30,7 +30,7 @@ EOF
 function upload_sourcemaps {
   local release="${1}"; shift
 
-  sentry-cli releases --org 'metamask' --project 'metamask' files "${release}" upload-sourcemaps ./dist/chrome/*.js ./dist/sourcemaps/ --rewrite --url-prefix 'metamask'
+  sentry-cli releases files "${release}" upload-sourcemaps ./dist/chrome/*.js ./dist/sourcemaps/ --rewrite --url-prefix 'metamask'
 }
 
 function main {
@@ -62,6 +62,12 @@ function main {
   if [[ -z $release ]]
   then
     die 'Required parameter "release" missing; either include parameter or set VERSION environment variable'
+  elif [[ -z $SENTRY_ORG ]]
+  then
+    die 'Required environment variable "SENTRY_ORG" missing'
+  elif  [[ -z $SENTRY_PROJECT ]]
+  then
+    die 'Required environment variable "SENTRY_PROJECT" missing'
   fi
 
   printf 'uploading source files and sourcemaps for Sentry release "%s"...\n' "${release}"


### PR DESCRIPTION
Sentry is now configured with environment variables, rather than with hard-coded values. This makes it easier to test Sentry functionality using a different Sentry account, as we did recently during QA of v9.5.1.

The only change for the normal build process is the introduction of the `SENTRY_DSN_DEV` variable, which can be set via `.metamaskrc` or via an environment variable. This determines where error reports are sent. It still defaults to our team Sentry account's `metamask-testing` project.

The `sentry:publish` script now requires SENTRY_ORG and SENTRY_PROJECT to be set in order to publish release artifacts. The CircleCI configuration has been updated with these values, so it should act the same as it did before. Previously we had used a CLI flag to specify the organization and project, but [Sentry already natively supports these environment variables](https://docs.sentry.io/product/cli/configuration/#configuration-values).

Manual testing steps for `SENTRY_DSN_DEV`
  - Create a free Sentry account and log in, and create a project. Take note of the DSN.
  - Build the extension using `yarn build:test` or `yarn dist` (only test/prod builds send Sentry errors, they are disabled for dev)
  - Install the extension
  - Do something that causes an error (it may be easiest to introduce a false error for testing)
  - Observe the network tab of whichever process the error is thrown in, and see that it's sending to the correct DSN. You should also see the error on your Sentry dashboard.
  
  Manual testing steps for release artifact publishing:
  - Create a free Sentry account and log in, and create a project.
  - Navigate to "Settings => Developer Settings => "New Internal Integration"
  - Assign a name to this integration, and grant it a "Release" permission of "Admin".
  - After saving this new integration, take note of the token that should be listed on the integration page.
  - Run the command `yarn sentry:publish` with the environment variable `SENTRY_AUTH_TOKEN` set to the token from that integration, and with `SENTRY_ORG` set to your account name and `SENTRY_PROJECT` set to the project name you created.
  - It should complete successfully. You should see the release under "Releases" with the correct project selected. It should have 22 artifacts.