### PR TITLE
Swaps: Add specific error content if Contract data are not enabled on Ledger

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1963,10 +1963,10 @@
     "message": "No quotes available"
   },
   "swapContractDataDisabledErrorDescription": {
-    "message": "In the Ethereum app on your Ledger go to Settings, allow Contract data and then try to swap again"
+    "message": "In the Ethereum app on your Ledger, go to \"Settings\" and allow contract data. Then, try your swap again."
   },
   "swapContractDataDisabledErrorTitle": {
-    "message": "Contract data is not allowed on your Ledger"
+    "message": "Contract data is not enabled on your Ledger"
   },
   "swapRate": {
     "message": "Rate"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1962,6 +1962,12 @@
   "swapQuotesNotAvailableErrorTitle": {
     "message": "No quotes available"
   },
+  "swapContractDataDisabledErrorDescription": {
+    "message": "In the Ethereum app on your Ledger go to Settings, allow Contract data and then try to swap again"
+  },
+  "swapContractDataDisabledErrorTitle": {
+    "message": "Contract data is not allowed on your Ledger"
+  },
   "swapRate": {
     "message": "Rate"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1820,6 +1820,12 @@
   "swapConfirmWithHwWallet": {
     "message": "Confirm with your hardware wallet"
   },
+  "swapContractDataDisabledErrorDescription": {
+    "message": "In the Ethereum app on your Ledger, go to \"Settings\" and allow contract data. Then, try your swap again."
+  },
+  "swapContractDataDisabledErrorTitle": {
+    "message": "Contract data is not enabled on your Ledger"
+  },
   "swapCustom": {
     "message": "custom"
   },
@@ -1961,12 +1967,6 @@
   },
   "swapQuotesNotAvailableErrorTitle": {
     "message": "No quotes available"
-  },
-  "swapContractDataDisabledErrorDescription": {
-    "message": "In the Ethereum app on your Ledger, go to \"Settings\" and allow contract data. Then, try your swap again."
-  },
-  "swapContractDataDisabledErrorTitle": {
-    "message": "Contract data is not enabled on your Ledger"
   },
   "swapRate": {
     "message": "Rate"

--- a/shared/constants/swaps.js
+++ b/shared/constants/swaps.js
@@ -12,6 +12,7 @@ export const QUOTES_EXPIRED_ERROR = 'quotes-expired';
 export const SWAP_FAILED_ERROR = 'swap-failed-error';
 export const ERROR_FETCHING_QUOTES = 'error-fetching-quotes';
 export const QUOTES_NOT_AVAILABLE_ERROR = 'quotes-not-avilable';
+export const CONTRACT_DATA_DISABLED_ERROR = 'contract-data-disabled';
 export const OFFLINE_FOR_MAINTENANCE = 'offline-for-maintenance';
 export const SWAPS_FETCH_ORDER_CONFLICT = 'swaps-fetch-order-conflict';
 

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -59,6 +59,7 @@ import {
 import {
   ERROR_FETCHING_QUOTES,
   QUOTES_NOT_AVAILABLE_ERROR,
+  CONTRACT_DATA_DISABLED_ERROR,
   SWAP_FAILED_ERROR,
   SWAPS_FETCH_ORDER_CONFLICT,
 } from '../../../shared/constants/swaps';
@@ -781,7 +782,10 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     try {
       await dispatch(updateAndApproveTx(finalTradeTxMeta, true));
     } catch (e) {
-      await dispatch(setSwapsErrorKey(SWAP_FAILED_ERROR));
+      const errorKey = e.message.includes('EthAppPleaseEnableContractData')
+        ? CONTRACT_DATA_DISABLED_ERROR
+        : SWAP_FAILED_ERROR;
+      await dispatch(setSwapsErrorKey(errorKey));
       history.push(SWAPS_ERROR_ROUTE);
       return;
     }

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -31,6 +31,7 @@ import {
   SWAP_FAILED_ERROR,
   ERROR_FETCHING_QUOTES,
   QUOTES_NOT_AVAILABLE_ERROR,
+  CONTRACT_DATA_DISABLED_ERROR,
   OFFLINE_FOR_MAINTENANCE,
   SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP,
 } from '../../../../shared/constants/swaps';
@@ -178,6 +179,11 @@ export default function AwaitingSwap({
     descriptionText = t('swapQuotesNotAvailableErrorDescription');
     submitText = t('tryAgain');
     statusImage = <SwapFailureIcon />;
+  } else if (errorKey === CONTRACT_DATA_DISABLED_ERROR) {
+    headerText = t('swapContractDataDisabledErrorTitle');
+    descriptionText = t('swapContractDataDisabledErrorDescription');
+    submitText = t('tryAgain');
+    statusImage = <SwapFailureIcon />;
   } else if (!errorKey && !swapComplete) {
     headerText = t('swapProcessing');
     statusImage = <PulseLoader />;
@@ -277,6 +283,7 @@ AwaitingSwap.propTypes = {
     ERROR_FETCHING_QUOTES,
     QUOTES_NOT_AVAILABLE_ERROR,
     OFFLINE_FOR_MAINTENANCE,
+    CONTRACT_DATA_DISABLED_ERROR,
   ]),
   submittingSwap: PropTypes.bool,
   inputValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -46,6 +46,7 @@ import {
   ERROR_FETCHING_QUOTES,
   QUOTES_NOT_AVAILABLE_ERROR,
   SWAP_FAILED_ERROR,
+  CONTRACT_DATA_DISABLED_ERROR,
   OFFLINE_FOR_MAINTENANCE,
 } from '../../../shared/constants/swaps';
 
@@ -134,7 +135,7 @@ export default function Swap() {
     tradeTxData?.txReceipt?.status === '0x0';
   const conversionError = approveError || tradeError;
 
-  if (conversionError) {
+  if (conversionError && swapsErrorKey !== CONTRACT_DATA_DISABLED_ERROR) {
     swapsErrorKey = SWAP_FAILED_ERROR;
   }
 
@@ -318,6 +319,8 @@ export default function Swap() {
               path={SWAPS_ERROR_ROUTE}
               exact
               render={() => {
+                console.log('SWAPS_ERROR_ROUTE');
+                console.log(swapsErrorKey);
                 if (swapsErrorKey) {
                   return (
                     <AwaitingSwap

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -319,8 +319,6 @@ export default function Swap() {
               path={SWAPS_ERROR_ROUTE}
               exact
               render={() => {
-                console.log('SWAPS_ERROR_ROUTE');
-                console.log(swapsErrorKey);
                 if (swapsErrorKey) {
                   return (
                     <AwaitingSwap


### PR DESCRIPTION
## Explanation
It seems that by default Ledger has Contract data disabled inside its Ethereum app. When a user tries to use a Ledger device with its default config, they will see a Swaps Failed page when they try to swap tokens and it's not really clear what the user should do.

This PR shows a new error page with specific error and description about how to resolve it, so a user can enable Contract data on their Ledger device and do Swaps successfully.

## Manual testing steps
- Try to use Ledger with default config for swaps
- After agreeing with a quote a new error page is displayed
- Enable Contract data on a Ledger device
- Click on "Try again"
- Swapping works now

## Screenshots
<img width="672" alt="image" src="https://user-images.githubusercontent.com/80175477/118170045-ef840e80-b429-11eb-86e0-f855ba780adb.png">
