### PR TITLE
Fixing account search results ordering

### DIFF
--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -78,7 +78,6 @@ export default class AccountMenu extends Component {
   };
 
   addressFuse = new Fuse([], {
-    shouldSort: false,
     threshold: 0.45,
     location: 0,
     distance: 100,


### PR DESCRIPTION
Sorting of the results by score was disabled, this enables it.

Fixes MetaMask/metamask-extension#10991

<img width="353" alt="Screen Shot 2021-05-13 at 11 16 02 PM" src="https://user-images.githubusercontent.com/8732757/118231136-8610f980-b443-11eb-9752-faf55a22350c.png">

Though the scroll bar does not appear, results are completely scrollable
<img width="379" alt="Screen Shot 2021-05-13 at 11 16 15 PM" src="https://user-images.githubusercontent.com/8732757/118231162-9032f800-b443-11eb-98ce-509f1fe4e589.png">
