### PR TITLE
Throw error if transaction type is not recognized by useTransactionDisplayData

### DIFF
--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -220,6 +220,10 @@ export function useTransactionDisplayData(transactionGroup) {
     category = TRANSACTION_GROUP_CATEGORIES.SEND;
     title = t('send');
     subtitle = t('toAddress', [shortenAddress(recipientAddress)]);
+  } else {
+    throw new Error(
+      `useTransactionDisplayData does not recognize transaction type. Type received is: ${type}`,
+    );
   }
 
   const primaryCurrencyPreferences = useUserPreferencedCurrency(PRIMARY);


### PR DESCRIPTION
Throws an error if the if the transaction type does not match any of the cases in the if else block in useTransactionDisplayData 