### PR TITLE
Avoid showing  "Gas price extremely low" warning in advanced tab for testnets

### DIFF
--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -142,7 +142,8 @@ const mapStateToProps = (state, ownProps) => {
     customGasLimit: calcCustomGasLimit(customModalGasLimitInHex),
     customGasTotal,
     newTotalFiat,
-    customPriceIsSafe: isCustomPriceSafe(state),
+    customPriceIsSafe:
+      isMainnet || process.env.IN_TEST ? isCustomPriceSafe(state) : true,
     customPriceIsExcessive: isCustomPriceExcessive(state),
     maxModeOn,
     gasPriceButtonGroupProps: {

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -38,6 +38,7 @@ import {
   getSendMaxModeState,
   getAveragePriceEstimateInHexWEI,
   isCustomPriceExcessive,
+  getIsEthGasPriceFetched,
 } from '../../../../selectors';
 
 import {
@@ -132,7 +133,7 @@ const mapStateToProps = (state, ownProps) => {
         balance,
         conversionRate,
       });
-
+  const isEthGasPrice = getIsEthGasPriceFetched(state);
   return {
     hideBasic,
     isConfirm: isConfirm(state),
@@ -143,7 +144,9 @@ const mapStateToProps = (state, ownProps) => {
     customGasTotal,
     newTotalFiat,
     customPriceIsSafe:
-      isMainnet || process.env.IN_TEST ? isCustomPriceSafe(state) : true,
+      (isMainnet || process.env.IN_TEST) && !isEthGasPrice
+        ? isCustomPriceSafe(state)
+        : true,
     customPriceIsExcessive: isCustomPriceExcessive(state),
     maxModeOn,
     gasPriceButtonGroupProps: {

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -38,7 +38,7 @@ import {
   getSendMaxModeState,
   getAveragePriceEstimateInHexWEI,
   isCustomPriceExcessive,
-  getIsEthGasPriceFetched,
+  getIsGasEstimatesFetched,
 } from '../../../../selectors';
 
 import {
@@ -133,7 +133,7 @@ const mapStateToProps = (state, ownProps) => {
         balance,
         conversionRate,
       });
-  const isEthGasPrice = getIsEthGasPriceFetched(state);
+  const isGasEstimate = getIsGasEstimatesFetched(state);
   return {
     hideBasic,
     isConfirm: isConfirm(state),
@@ -144,7 +144,7 @@ const mapStateToProps = (state, ownProps) => {
     customGasTotal,
     newTotalFiat,
     customPriceIsSafe:
-      (isMainnet || process.env.IN_TEST) && !isEthGasPrice
+      (isMainnet || process.env.IN_TEST) && isGasEstimate
         ? isCustomPriceSafe(state)
         : true,
     customPriceIsExcessive: isCustomPriceExcessive(state),

--- a/ui/ducks/gas/gas.duck.js
+++ b/ui/ducks/gas/gas.duck.js
@@ -11,13 +11,13 @@ import {
 import { getIsMainnet, getCurrentChainId } from '../../selectors';
 import fetchWithCache from '../../helpers/utils/fetch-with-cache';
 
-const BASIC_ESTIMATE_STATES = {
+export const BASIC_ESTIMATE_STATES = {
   LOADING: 'LOADING',
   FAILED: 'FAILED',
   READY: 'READY',
 };
 
-const GAS_SOURCE = {
+export const GAS_SOURCE = {
   METASWAPS: 'MetaSwaps',
   ETHGASPRICE: 'eth_gasprice',
 };

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -9,6 +9,7 @@ import { formatETHFee } from '../helpers/utils/formatters';
 import { calcGasTotal } from '../pages/send/send.utils';
 
 import { GAS_ESTIMATE_TYPES } from '../helpers/constants/common';
+import { BASIC_ESTIMATE_STATES, GAS_SOURCE } from '../ducks/gas/gas.duck';
 import {
   getCurrentCurrency,
   getIsMainnet,
@@ -361,13 +362,21 @@ export function getRenderableEstimateDataForSmallButtonsFromGWEI(state) {
 export function getIsEthGasPriceFetched(state) {
   const gasState = state.gas;
   return Boolean(
-    gasState.estimateSource === 'eth_gasprice' &&
-      gasState.basicEstimateStatus === 'READY' &&
+    gasState.estimateSource === GAS_SOURCE.ETHGASPRICE &&
+      gasState.basicEstimateStatus === BASIC_ESTIMATE_STATES.READY &&
       getIsMainnet(state),
   );
 }
 
 export function getNoGasPriceFetched(state) {
   const gasState = state.gas;
-  return Boolean(gasState.basicEstimateStatus === 'FAILED');
+  return Boolean(gasState.basicEstimateStatus === BASIC_ESTIMATE_STATES.FAILED);
+}
+
+export function getIsGasEstimatesFetched(state) {
+  const gasState = state.gas;
+  return Boolean(
+    gasState.estimateSource === GAS_SOURCE.METASWAPS &&
+      gasState.basicEstimateStatus === BASIC_ESTIMATE_STATES.READY,
+  );
 }


### PR DESCRIPTION
Fixes: #11076 

Explanation:  
Problem: While speeding up or canceling a transaction on testnets, the gasprice on the advanced tab is showing "Gas price extremely low" warning no matter what price is entered.

Fix: On testnets, we don't use the gas prices API to get slow, medium, and fast estimates. Instead, we just get a single estimate via eth_gasprice. So the isCustomPriceSafe() will be called only for Mainnet and e2e test and a default `true` value will be sent for testnets.

Manual testing steps:  

- Add a custom network (e.g. https://consensys.slack.com/archives/C01CZRZ9H0T/p1618512321118000)
- Send a transaction on that network
- Try to speed up the transaction, check the advanced input tab and try adjusting the gasPrice.