### PR TITLE
Hide basic tab in advanced gas modal for speedup and cancel when on testnets

### DIFF
--- a/ui/components/app/sidebars/sidebar.component.js
+++ b/ui/components/app/sidebars/sidebar.component.js
@@ -30,12 +30,16 @@ export default class Sidebar extends Component {
 
   renderSidebarContent() {
     const { type, sidebarProps = {} } = this.props;
-    const { transaction = {}, onSubmit } = sidebarProps;
+    const { transaction = {}, onSubmit, hideBasic } = sidebarProps;
     switch (type) {
       case 'customize-gas':
         return (
           <div className="sidebar-left">
-            <CustomizeGas transaction={transaction} onSubmit={onSubmit} />
+            <CustomizeGas
+              transaction={transaction}
+              onSubmit={onSubmit}
+              hideBasic={hideBasic}
+            />
           </div>
         );
       default:

--- a/ui/hooks/useCancelTransaction.js
+++ b/ui/hooks/useCancelTransaction.js
@@ -7,7 +7,11 @@ import {
   getHexGasTotal,
   increaseLastGasPrice,
 } from '../helpers/utils/confirm-tx.util';
-import { getConversionRate, getSelectedAccount } from '../selectors';
+import {
+  getConversionRate,
+  getSelectedAccount,
+  getIsMainnet,
+} from '../selectors';
 import {
   setCustomGasLimit,
   setCustomGasPriceForRetry,
@@ -43,7 +47,8 @@ export function useCancelTransaction(transactionGroup) {
       multiplierBase: 10,
     }),
   );
-
+  const isMainnet = useSelector(getIsMainnet);
+  const hideBasic = !(isMainnet || process.env.IN_TEST);
   const cancelTransaction = useCallback(
     (event) => {
       event.stopPropagation();
@@ -62,6 +67,7 @@ export function useCancelTransaction(transactionGroup) {
           transitionName: 'sidebar-left',
           type: 'customize-gas',
           props: {
+            hideBasic,
             transaction: tx,
             onSubmit: (newGasLimit, newGasPrice) => {
               const userCustomizedGasTotal = getHexGasTotal({
@@ -82,7 +88,7 @@ export function useCancelTransaction(transactionGroup) {
         }),
       );
     },
-    [dispatch, transaction, defaultNewGasPrice],
+    [dispatch, transaction, defaultNewGasPrice, hideBasic],
   );
 
   const hasEnoughCancelGas =

--- a/ui/hooks/useRetryTransaction.js
+++ b/ui/hooks/useRetryTransaction.js
@@ -1,4 +1,5 @@
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+
 import { useCallback } from 'react';
 import { showSidebar } from '../store/actions';
 import {
@@ -7,8 +8,8 @@ import {
   setCustomGasLimit,
 } from '../ducks/gas/gas.duck';
 import { increaseLastGasPrice } from '../helpers/utils/confirm-tx.util';
+import { getIsMainnet } from '../selectors';
 import { useMetricEvent } from './useMetricEvent';
-
 /**
  * Provides a reusable hook that, given a transactionGroup, will return
  * a method for beginning the retry process
@@ -17,6 +18,8 @@ import { useMetricEvent } from './useMetricEvent';
  */
 export function useRetryTransaction(transactionGroup) {
   const { primaryTransaction } = transactionGroup;
+  const isMainnet = useSelector(getIsMainnet);
+  const hideBasic = !(isMainnet || process.env.IN_TEST);
   // Signature requests do not have a txParams, but this hook is called indiscriminately
   const gasPrice = primaryTransaction.txParams?.gasPrice;
   const trackMetricsEvent = useMetricEvent({
@@ -46,11 +49,11 @@ export function useRetryTransaction(transactionGroup) {
         showSidebar({
           transitionName: 'sidebar-left',
           type: 'customize-gas',
-          props: { transaction },
+          props: { transaction, hideBasic },
         }),
       );
     },
-    [dispatch, trackMetricsEvent, gasPrice, primaryTransaction],
+    [dispatch, trackMetricsEvent, gasPrice, primaryTransaction, hideBasic],
   );
 
   return retryTransaction;


### PR DESCRIPTION
Fixes: #11114 

Since on testnets, we don't use the gas prices API to get slow, medium, and fast estimates. Instead, we just get a single estimate via eth_gasprice. 

This PR will hide the basic modal of the advanced gas modal when opened as `sidebar` during speedup and cancel of a transaction.
