### PR TITLE
Fix a condition for checking if a token should be added

### DIFF
--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -443,7 +443,7 @@ export const fetchQuotesAndSetQuoteState = (
     if (
       toTokenAddress &&
       toTokenSymbol !== swapsDefaultToken.symbol &&
-      !contractExchangeRates[toTokenAddress]
+      contractExchangeRates[toTokenAddress] === undefined
     ) {
       destinationTokenAddedForSwap = true;
       await dispatch(


### PR DESCRIPTION
Fixes: #10950

## Explanation
We were removing a custom token when a user clicked on `Cancel` in case that `contractExchangeRates[toTokenAddress]` was 0 (check the code below). 

Expected behavior is that we will not add and remove a custom token if a contract exchange rate is 0 for that token (which means that the custom token was already found).

## Manual testing steps
  - Add a custom token, e.g.: 0x7f3eab3491ed282197038f1b89ca33d7e5adffba
  - Open the custom token detail and click on `Swap` there
  - Reverse `From` and `To` tokens, so the `To` token will be your new custom token
  - Fill in `Token From` e.g. with ETH (no need to finish a transaction)
  - Submit it
  - When a quote fails, click on the `Cancel` link in the top right corner below the main header
  - You can still see your custom token in the list of Assets

## Video
https://user-images.githubusercontent.com/80175477/118666229-4a838000-b7f3-11eb-8b65-fbef68584b39.mov

