### PR TITLE
implement safer to buffer

### DIFF
--- a/shared/modules/buffer-utils.js
+++ b/shared/modules/buffer-utils.js
@@ -1,0 +1,16 @@
+import { toBuffer as ethUtilToBuffer, isHexString } from 'ethereumjs-util';
+
+/**
+ * Returns a buffer from the provided input, via ethereumjs-util.toBuffer but
+ * additionally handling non hex strings. This is a failsafe as in most cases
+ * we should be primarily dealing with hex prefixed strings with this utility
+ * but we do not want to break the extension for users.
+ * @param {import('ethereumjs-util').ToBufferInputTypes | string} input
+ * @returns {Buffer}
+ */
+export function toBuffer(input) {
+  if (typeof input === 'string' && isHexString(input) === false) {
+    return Buffer.from(input);
+  }
+  return ethUtilToBuffer(input);
+}

--- a/shared/modules/buffer-utils.test.js
+++ b/shared/modules/buffer-utils.test.js
@@ -1,0 +1,69 @@
+import { strict as assert } from 'assert';
+import BN from 'bn.js';
+import { toBuffer } from './buffer-utils';
+
+describe('buffer utils', function () {
+  describe('toBuffer', function () {
+    it('should work with prefixed hex strings', function () {
+      const result = toBuffer('0xe');
+      assert.equal(result.length, 1);
+    });
+
+    it('should work with non prefixed hex strings', function () {
+      const result = toBuffer('e');
+      assert.equal(result.length, 1);
+    });
+
+    it('should work with weirdly 0x prefixed non-hex strings', function () {
+      const result = toBuffer('0xtest');
+      assert.equal(result.length, 6);
+    });
+
+    it('should work with regular strings', function () {
+      const result = toBuffer('test');
+      assert.equal(result.length, 4);
+    });
+
+    it('should work with BN', function () {
+      const result = toBuffer(new BN(100));
+      assert.equal(result.length, 1);
+    });
+
+    it('should work with Buffer', function () {
+      const result = toBuffer(Buffer.from('test'));
+      assert.equal(result.length, 4);
+    });
+
+    it('should work with a number', function () {
+      const result = toBuffer(100);
+      assert.equal(result.length, 1);
+    });
+
+    it('should work with null or undefined', function () {
+      const result = toBuffer(null);
+      const result2 = toBuffer(undefined);
+      assert.equal(result.length, 0);
+      assert.equal(result2.length, 0);
+    });
+
+    it('should work with UInt8Array', function () {
+      const uint8 = new Uint8Array(2);
+      const result = toBuffer(uint8);
+      assert.equal(result.length, 2);
+    });
+
+    it('should work with objects that have a toBuffer property', function () {
+      const result = toBuffer({
+        toBuffer: () => Buffer.from('hi'),
+      });
+      assert.equal(result.length, 2);
+    });
+
+    it('should work with objects that have a toArray property', function () {
+      const result = toBuffer({
+        toArray: () => ['hi'],
+      });
+      assert.equal(result.length, 1);
+    });
+  });
+});

--- a/ui/pages/confirm-deploy-contract/confirm-deploy-contract.component.js
+++ b/ui/pages/confirm-deploy-contract/confirm-deploy-contract.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { toBuffer } from 'ethereumjs-util';
 import ConfirmTransactionBase from '../confirm-transaction-base';
+import { toBuffer } from '../../../shared/modules/buffer-utils';
 
 export default class ConfirmDeployContract extends Component {
   static contextTypes = {

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -1,4 +1,3 @@
-import { toBuffer } from 'ethereumjs-util';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../../shared/constants/app';
@@ -29,6 +28,7 @@ import {
 } from '../../../shared/constants/transaction';
 import { getTransactionTypeTitle } from '../../helpers/utils/transactions.util';
 import ErrorMessage from '../../components/ui/error-message';
+import { toBuffer } from '../../../shared/modules/buffer-utils';
 
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {


### PR DESCRIPTION
Fixes another sentry issue that has surfaced related to ethereumjs-util upgrade. This time the toBuffer method from ethereumjs-util is the issue. I have made a new buffer-utils file in shared/modules that is safe to use even with non hex prefixed strings, but I don't know that we always want to allow for that kind of input. There are two cases where I haven't replaced using toBuffer with this method, which are in the transaction controller and account import code. I feel like we'd want an error thrown in these cases if ever a non prefixed hex string is returned from either signing a transaction or importing an account.