### PR TITLE
change erc20 token symbol length limit from 11 to 20

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -985,8 +985,8 @@
   "symbol": {
     "message": "ምልክት"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "ምልክቱ 11 ቁምፊዎች ወይም ከዚያ ያነሰ መሆን አለበት።"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "ምልክቱ 20 ቁምፊዎች ወይም ከዚያ ያነሰ መሆን አለበት።"
   },
   "syncWithMobile": {
     "message": "ከሞባይል ጋር አሳምር"

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -981,8 +981,8 @@
   "symbol": {
     "message": "رمز"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "يجب أن يكون الرمز 11 حرفًا أو أقل."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "يجب أن يكون الرمز 20 حرفًا أو أقل."
   },
   "syncWithMobile": {
     "message": "مزامنة مع الهاتف المحمول"

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -984,8 +984,8 @@
   "symbol": {
     "message": "Символ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Символът трябва да е 11 символа или по-малко."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Символът трябва да е 20 символа или по-малко."
   },
   "syncWithMobile": {
     "message": "Синхронизиране с мобилни устройства"

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -988,8 +988,8 @@
   "symbol": {
     "message": "প্রতীক"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "প্রতীকটি 11 টি অক্ষর বা তার চেয়ে কম হতে হবে।"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "প্রতীকটি 20 টি অক্ষর বা তার চেয়ে কম হতে হবে।"
   },
   "syncWithMobile": {
     "message": "মোবাইল দিয়ে সিঙ্ক করুন"

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -966,8 +966,8 @@
   "symbol": {
     "message": "Símbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "El símbol ha de tenir com a mínim 11 caràcters."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "El símbol ha de tenir com a mínim 20 caràcters."
   },
   "syncWithMobile": {
     "message": "Sincronitza amb el mòbil"

--- a/app/_locales/cs/messages.json
+++ b/app/_locales/cs/messages.json
@@ -386,8 +386,8 @@
   "supportCenter": {
     "message": "Navštivte naše centrum podpory"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol musí mít 11 nebo méně znaků."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbol musí mít 20 nebo méně znaků."
   },
   "terms": {
     "message": "Podmínky použití"

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -963,8 +963,8 @@
   "switchNetworks": {
     "message": "Skift Netværk"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolet skal være mindst 11 tegn."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbolet skal være mindst 20 tegn."
   },
   "syncWithMobile": {
     "message": "Synkronisér med mobil"

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -954,8 +954,8 @@
   "switchNetworks": {
     "message": "Netzwerk wechseln"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Das Symbol darf maximal 11 Zeichen lang sein."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Das Symbol darf maximal 20 Zeichen lang sein."
   },
   "syncWithMobile": {
     "message": "Mit Mobilgerät synchronisieren"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -985,8 +985,8 @@
   "symbol": {
     "message": "Σύμβολο"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Το σύμβολο πρέπει να είναι τουλάχιστον 11 χαρακτήρες."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Το σύμβολο πρέπει να είναι τουλάχιστον 20 χαρακτήρες."
   },
   "syncWithMobile": {
     "message": "Συγχρονισμός με κινητό"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2130,8 +2130,8 @@
   "symbol": {
     "message": "Symbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol must be 11 characters or fewer."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbol must be 20 characters or fewer."
   },
   "syncWithMobile": {
     "message": "Sync with mobile"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -1761,8 +1761,8 @@
   "symbol": {
     "message": "Símbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "El símbolo debe tener 11 caracteres o menos."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "El símbolo debe tener 20 caracteres o menos."
   },
   "syncWithMobile": {
     "message": "Sincronizar con el móvil"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1752,8 +1752,8 @@
   "symbol": {
     "message": "Símbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "El símbolo debe tener 11 caracteres o menos."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "El símbolo debe tener 20 caracteres o menos."
   },
   "syncWithMobile": {
     "message": "Sincronizar con un dispositivo móvil"

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -978,8 +978,8 @@
   "symbol": {
     "message": "Sümbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Sümbol peab olema 11 tähemärki või vähem."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Sümbol peab olema 20 tähemärki või vähem."
   },
   "syncWithMobile": {
     "message": "Mobiiliga sünkroonimine"

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -988,8 +988,8 @@
   "symbol": {
     "message": "سمبول"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "نماد باید 11 کاراکتر یا کمتر باشد."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "نماد باید 20 کاراکتر یا کمتر باشد."
   },
   "syncWithMobile": {
     "message": "همگام سازی با موبایل"

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -985,8 +985,8 @@
   "symbol": {
     "message": "Symboli"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolin on oltava 11 merkkiä tai vähemmän."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbolin on oltava 20 merkkiä tai vähemmän."
   },
   "syncWithMobile": {
     "message": "Synkronoi mobiililaitteelle"

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -894,8 +894,8 @@
   "symbol": {
     "message": "Simbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Ang simbolo ay dapat na 11 character o mas kaunti."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Ang simbolo ay dapat na 20 character o mas kaunti."
   },
   "syncWithMobile": {
     "message": "I-sync sa mobile"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -970,8 +970,8 @@
   "symbol": {
     "message": "Symbole"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Le symbole doit comporter 11 caractères ou moins."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Le symbole doit comporter 20 caractères ou moins."
   },
   "syncWithMobile": {
     "message": "Synchroniser avec le mobile"

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -982,8 +982,8 @@
   "symbol": {
     "message": "סמל"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "הסמל חייב להיות 11 תווים או פחות."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "הסמל חייב להיות 20 תווים או פחות."
   },
   "syncWithMobile": {
     "message": "סנכרן עם הנייד"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1731,8 +1731,8 @@
   "symbol": {
     "message": "प्रतीक"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "प्रतीक 11 वर्ण या उससे कम का होना चाहिए।"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "प्रतीक 20 वर्ण या उससे कम का होना चाहिए।"
   },
   "syncWithMobile": {
     "message": "मोबाइल के साथ सिंक करें"

--- a/app/_locales/hn/messages.json
+++ b/app/_locales/hn/messages.json
@@ -354,8 +354,8 @@
   "supportCenter": {
     "message": "हमारे सहायता केंद्र पर जाएं"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "प्रतीक 11 वर्ण या उससे कम का होना चाहिए।"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "प्रतीक 20 वर्ण या उससे कम का होना चाहिए।"
   },
   "terms": {
     "message": "उपयोग की शर्तें"

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -981,8 +981,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mora biti 11 znakova ili manje."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbol mora biti 20 znakova ili manje."
   },
   "syncWithMobile": {
     "message": "Sinkroniziraj s mobilnim telefonom"

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -609,8 +609,8 @@
   "supportCenter": {
     "message": "Vizite Sant Sipò Nou"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Senbòl yo dwe 11 karaktè oswa mwens."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Senbòl yo dwe 20 karaktè oswa mwens."
   },
   "terms": {
     "message": "Tèm pou itilize"

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -981,8 +981,8 @@
   "symbol": {
     "message": "Szimbólum"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "A szimbólum 0 és 12 karakter között kell legyen."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "A szimbólum 1 és 20 karakter között kell legyen."
   },
   "syncWithMobile": {
     "message": "Szinkronizálás telefonnal"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1731,8 +1731,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol harus terdiri dari 11 karakter atau kurang."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbol harus terdiri dari 20 karakter atau kurang."
   },
   "syncWithMobile": {
     "message": "Sinkronisasi dengan seluler"

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1772,8 +1772,8 @@
   "symbol": {
     "message": "Simbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Il simbolo deve essere lungo tra 0 e 12 caratteri."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Il simbolo deve essere lungo tra 0 e 20 caratteri."
   },
   "syncWithMobile": {
     "message": "Sincronizza con dispositivo mobile"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1761,8 +1761,8 @@
   "symbol": {
     "message": "シンボル"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "シンボルは11文字以下にする必要があります。"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "シンボルは20文字以下にする必要があります。"
   },
   "syncWithMobile": {
     "message": "モバイルアプリと同期"

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -988,8 +988,8 @@
   "symbol": {
     "message": "ಚಿಹ್ನೆ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "ಚಿಹ್ನೆಯು 0 ಮತ್ತು 12 ಅಕ್ಷರಗಳ ನಡುವೆ ಇರಬೇಕು."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "ಚಿಹ್ನೆಯು 0 ಮತ್ತು 20 ಅಕ್ಷರಗಳ ನಡುವೆ ಇರಬೇಕು."
   },
   "syncWithMobile": {
     "message": "ಮೊಬೈಲ್‌ನೊಂದಿಗೆ ಸಿಂಕ್ ಮಾಡಿ"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1731,8 +1731,8 @@
   "symbol": {
     "message": "기호"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "기호는 11자 이하여야 합니다."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "기호는 20자 이하여야 합니다."
   },
   "syncWithMobile": {
     "message": "모바일과 동기화"

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -988,8 +988,8 @@
   "symbol": {
     "message": "Simbolis"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbolis turi būti ne ilgesnis nei 11 simbolių."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbolis turi būti ne ilgesnis nei 20 simbolių."
   },
   "syncWithMobile": {
     "message": "Sinchronizuoti su mobiliuoju"

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -984,8 +984,8 @@
   "symbol": {
     "message": "Simbols"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbolā nedrīkst būt vairāk par 11 rakstzīmēm."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbolā nedrīkst būt vairāk par 20 rakstzīmēm."
   },
   "syncWithMobile": {
     "message": "Sinhronizēt ar tālruni"

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -965,8 +965,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mestilah 11 aksara atau kurang."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbol mestilah 20 aksara atau kurang."
   },
   "syncWithMobile": {
     "message": "Segerakkan dengan telefon mudah alih"

--- a/app/_locales/nl/messages.json
+++ b/app/_locales/nl/messages.json
@@ -344,8 +344,8 @@
   "supportCenter": {
     "message": "Bezoek ons ​​ondersteuningscentrum"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbool moet 11 tekens of minder zijn."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbool moet 20 tekens of minder zijn."
   },
   "terms": {
     "message": "Gebruiksvoorwaarden"

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -966,8 +966,8 @@
   "switchNetworks": {
     "message": "Bytt nettverk "
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolet må være 11 tegn eller færre."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbolet må være 20 tegn eller færre."
   },
   "syncWithMobile": {
     "message": "Synkroniser med mobil "

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -979,8 +979,8 @@
   "switchNetworks": {
     "message": "Zmień sieci"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol musi mieć maksymalnie 11 znaków."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbol musi mieć maksymalnie 20 znaków."
   },
   "syncWithMobile": {
     "message": "Synchronizuj z telefonem"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -354,8 +354,8 @@
   "supportCenter": {
     "message": "Visitar o nosso Centro de Suporte"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "O símbolo deve ter 11 caracteres ou menos."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "O símbolo deve ter 20 caracteres ou menos."
   },
   "terms": {
     "message": "Termos de Uso"

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -991,8 +991,8 @@
   "symbol": {
     "message": "Símbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "O símbolo deve ter 11 caracteres ou menos."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "O símbolo deve ter 20 caracteres ou menos."
   },
   "syncWithMobile": {
     "message": "Sincronizar com o celular"

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -975,8 +975,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbolul trebuie să fie de 11 caractere sau mai puțin."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbolul trebuie să fie de 20 caractere sau mai puțin."
   },
   "syncWithMobile": {
     "message": "Sincronizați cu dispozitivul mobil"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1731,8 +1731,8 @@
   "symbol": {
     "message": "Символ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Символ должен состоять из 11 или менее знаков."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Символ должен состоять из 20 или менее знаков."
   },
   "syncWithMobile": {
     "message": "Синхронизировать с мобильным приложением"

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -948,8 +948,8 @@
   "switchNetworks": {
     "message": "Prepnúť siete"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbol musí být mezi 0 a 12 znaky."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbol musí být mezi 0 a 20 znaky."
   },
   "syncWithMobile": {
     "message": "Synchronizácia s mobilom"

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -973,8 +973,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mora biti največ 11 znakov ali manj."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbol mora biti največ 20 znakov ali manj."
   },
   "syncWithMobile": {
     "message": "Sinhroniziraj z mobilnimi telefonom"

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -979,8 +979,8 @@
   "symbol": {
     "message": "Simbol"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Simbol mora biti 11 znakova ili manje."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Simbol mora biti 20 znakova ili manje."
   },
   "syncWithMobile": {
     "message": "Sinhronizacija sa mobilnim telefonom"

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -969,8 +969,8 @@
   "switchNetworks": {
     "message": "Växla nätverk"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Symbolen måste vara 11 tecken eller färre."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Symbolen måste vara 20 tecken eller färre."
   },
   "syncWithMobile": {
     "message": "Synka med mobil"

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -966,8 +966,8 @@
   "symbol": {
     "message": "Ishara"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Alama lazima iwe na herufi 11 au chache."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Alama lazima iwe na herufi 20 au chache."
   },
   "syncWithMobile": {
     "message": "Oanisha na simu"

--- a/app/_locales/ta/messages.json
+++ b/app/_locales/ta/messages.json
@@ -468,8 +468,8 @@
   "supportCenter": {
     "message": "எங்கள் ஆதரவு மையத்தைப் பார்வையிடவும்"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "கசின்னம் 11 எழுத்துக்கள் அல்லது குறைவாக இருக்க வேண்டும்."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "கசின்னம் 20 எழுத்துக்கள் அல்லது குறைவாக இருக்க வேண்டும்."
   },
   "terms": {
     "message": "பயன்பாட்டு விதிமுறைகளை"

--- a/app/_locales/th/messages.json
+++ b/app/_locales/th/messages.json
@@ -474,8 +474,8 @@
   "symbol": {
     "message": "เครื่องหมาย"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "สัญลักษณ์จะต้องมีความยาว 11 ตัวอักษร"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "สัญลักษณ์จะต้องมีความยาว 20 ตัวอักษร"
   },
   "syncWithMobileComplete": {
     "message": "ซิงค์ข้อมูลของคุณเรียบร้อยแล้ว ใช้แอพ MetaMask ให้สนุกนะ!"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1728,8 +1728,8 @@
   "symbol": {
     "message": "Simbolo"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Dapat ay 11 character o mas kaunti ang simbolo."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Dapat ay 20 character o mas kaunti ang simbolo."
   },
   "syncWithMobile": {
     "message": "I-sync sa mobile"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -408,8 +408,8 @@
   "supportCenter": {
     "message": "Destek merkezimizi ziyaret edin"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Sembol 11 karakter veya daha az olmalıdır."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Sembol 20 karakter veya daha az olmalıdır."
   },
   "terms": {
     "message": "Kullanım şartları"

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -988,8 +988,8 @@
   "symbol": {
     "message": "Символ"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Символ повинен містити 11 символів або менше."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Символ повинен містити 20 символів або менше."
   },
   "syncWithMobile": {
     "message": "Синхронізувати з мобільним пристроєм"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1731,8 +1731,8 @@
   "symbol": {
     "message": "Ký hiệu"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "Ký hiệu không được dài quá 11 ký tự."
+  "symbolBetweenZeroTwentyOne": {
+    "message": "Ký hiệu không được dài quá 20 ký tự."
   },
   "syncWithMobile": {
     "message": "Đồng bộ hóa với thiết bị di động"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1752,8 +1752,8 @@
   "symbol": {
     "message": "符号"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "符号不得超过 11 个字符。"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "符号不得超过 20 个字符。"
   },
   "syncWithMobile": {
     "message": "使用移动设备同步"

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -976,8 +976,8 @@
   "symbol": {
     "message": "符號"
   },
-  "symbolBetweenZeroTwelve": {
-    "message": "符號不得超過11個字符。"
+  "symbolBetweenZeroTwentyOne": {
+    "message": "符號不得超過20個字符。"
   },
   "syncWithMobile": {
     "message": "和移動裝置同步"

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -856,9 +856,9 @@ export default class PreferencesController {
         `Invalid symbol "${symbol}": shorter than a character.`,
       );
     }
-    if (!(symbol.length < 12)) {
+    if (!(symbol.length < 21)) {
       throw ethErrors.rpc.invalidParams(
-        `Invalid symbol "${symbol}": longer than 11 characters.`,
+        `Invalid symbol "${symbol}": longer than 20 characters.`,
       );
     }
     const numDecimals = parseInt(decimals, 10);

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -571,7 +571,7 @@ describe('preferences controller', function () {
         () =>
           validate({
             address: '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07',
-            symbol: 'ABCDEFGHIJKLM',
+            symbol: 'ABCDEFGHIJKLMNOPQRSTU',
             decimals: 0,
           }),
         'long symbol should fail',

--- a/ui/components/ui/currency-display/currency-display.component.js
+++ b/ui/components/ui/currency-display/currency-display.component.js
@@ -41,7 +41,10 @@ export default function CurrencyDisplay({
         {parts.value}
       </span>
       {parts.suffix && (
-        <span className="currency-display-component__suffix">
+        <span
+          className="currency-display-component__suffix"
+          title={parts.suffix}
+        >
           {parts.suffix}
         </span>
       )}

--- a/ui/components/ui/currency-display/index.scss
+++ b/ui/components/ui/currency-display/index.scss
@@ -12,5 +12,11 @@
 
   &__suffix {
     padding-left: 4px;
+    white-space: nowrap;
+    max-width: 300px;
+    min-width: 0;
+    flex: 0 1 auto;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 }

--- a/ui/pages/add-token/add-token.component.js
+++ b/ui/pages/add-token/add-token.component.js
@@ -215,8 +215,8 @@ class AddToken extends Component {
     const symbolLength = customSymbol.length;
     let customSymbolError = null;
 
-    if (symbolLength <= 0 || symbolLength >= 12) {
-      customSymbolError = this.context.t('symbolBetweenZeroTwelve');
+    if (symbolLength <= 0 || symbolLength >= 21) {
+      customSymbolError = this.context.t('symbolBetweenZeroTwentyOne');
     }
 
     this.setState({ customSymbol, customSymbolError });

--- a/ui/pages/asset/asset.scss
+++ b/ui/pages/asset/asset.scss
@@ -21,6 +21,12 @@
 
   color: $Black-100;
   background-color: inherit;
+  white-space: nowrap;
+  max-width: 100%;
+  min-width: 0;
+  flex: 0 1 auto;
+  text-overflow: ellipsis;
+  overflow: hidden;
 
   &__chevron {
     font-size: $font-size-paragraph;


### PR DESCRIPTION
**Fixes:** #9243

**Explanation:**  
The token symbol length requirement of 11 characters is too short, we should raise it to 20. 

Newer DeFi protocols, which often do _something_ with existing tokens, need effective ways to communicate that in the symbol. At Yearn, we preface our vault tokens with `yv-`, and add additional considerations for LP vault tokens. For example, our yVault that accepts tokens from Curve's Compound pool is `yvCurve-Compound` (16 chars), and tokens for a YFI-ETH Sushi LP vault would be `yvSushi-YFI-ETH` (15 chars). Many other protocols have compound token nomenclature such as this, so it makes sense to expand the acceptable limit.

As an example example Uniswaps's [tokenlist standard](https://github.com/Uniswap/token-lists/blob/b5865fbded944da8715e65fa2f3286efc6c18f87/src/tokenlist.schema.json#L180) defines an hard limit of 20 characters for a token symbol. 

This PR replaces the 11 characters limit with a 20 character limits, updates relevant i18n & test files and adds small tweaks for the UI to handle edge cases.

**Screenshots for the relevant UI tweaks:**  

<div>
<kbd >
<img src="https://user-images.githubusercontent.com/74881121/119240227-99f8e180-bb4e-11eb-97bc-3753bcd2368b.png" />
</kbd>
<kbd>
<img src="https://user-images.githubusercontent.com/74881121/119240231-9d8c6880-bb4e-11eb-922e-a8fdd967e667.png" />
</kbd>
<kbd>
<img src="https://user-images.githubusercontent.com/74881121/119240236-a0875900-bb4e-11eb-8b3a-ea0aa10454d7.png" />
</kbd>
</div>