### PR TITLE
Add event property to event sent on tx:status-update in metamask-controller

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -359,6 +359,7 @@ export default class MetamaskController extends EventEmitter {
         if (txReceipt && txReceipt.status === '0x0') {
           this.metaMetricsController.trackEvent(
             {
+              event: 'Tx Status Update: On-Chain Failure',
               category: 'Background',
               properties: {
                 action: 'Transactions',


### PR DESCRIPTION
The metrics event sent when an onchain failure occurs, in the handler for the `tx:status-update` event in `metamask-controller.js`, was updated in https://github.com/MetaMask/metamask-extension/commit/3d4dfc74a8. However, no `event` property was added

No event name was added. This causes a `Must specify event and category.` event to be registered in sentry.

This PR corrects that.