### PR TITLE
Add stringified payload to metametrics controller trackEvent error message

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -331,9 +331,15 @@ export default class MetaMetricsController {
     // event and category are required fields for all payloads
     if (!payload.event || !payload.category) {
       throw new Error(
-        `Must specify event and category. Passed payload was: ${JSON.stringify(
+        `Must specify event and category. Event was: ${
+          payload.event
+        }. Category was: ${payload.category}. Payload keys were: ${Object.keys(
           payload,
-        )}`,
+        )}. ${
+          typeof payload.properties === 'object'
+            ? `Payload property keys were: ${Object.keys(payload.properties)}`
+            : ''
+        }`,
       );
     }
 

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -330,7 +330,11 @@ export default class MetaMetricsController {
   async trackEvent(payload, options) {
     // event and category are required fields for all payloads
     if (!payload.event || !payload.category) {
-      throw new Error('Must specify event and category.');
+      throw new Error(
+        `Must specify event and category. Passed payload was: ${JSON.stringify(
+          payload,
+        )}`,
+      );
     }
 
     if (!this.state.participateInMetaMetrics && !options?.isOptIn) {


### PR DESCRIPTION
This adds the stringified payload to the error message thrown when their is no event or category passed to the `trackEvent` method  of the metametrics controller. This will make it easier to identify the source of the error.