### PR TITLE
Update `@metamask/auto-changelog` from v9.0.1 to v9.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/metamask-extension"
+    "url": "https://github.com/MetaMask/metamask-extension.git"
   },
   "scripts": {
     "setup": "yarn install && yarn setup:postinstall",
@@ -210,7 +210,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.5.5",
     "@lavamoat/allow-scripts": "^1.0.6",
-    "@metamask/auto-changelog": "^2.0.1",
+    "@metamask/auto-changelog": "^2.1.0",
     "@metamask/eslint-config": "^6.0.0",
     "@metamask/eslint-config-jest": "^6.0.0",
     "@metamask/eslint-config-mocha": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2620,10 +2620,10 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
-"@metamask/auto-changelog@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-2.0.1.tgz#c5e9099c11f05d5e77fea91722a612c971764eff"
-  integrity sha512-ugIjpnPcf7nhIKEpGb4bfwTILzfwQae2aNJhrqxicY9LqI+CuTNA4+VFJIaX6zRYrgFINMYpLMgYvMB3Gj61kA==
+"@metamask/auto-changelog@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-2.1.0.tgz#5cb546f05b07695476d9489540b8d2744d350eda"
+  integrity sha512-FO1NsgcrHQY6CWlD9wFEWgmxWgam1GqtfFGiRH7lp4aYSGn/43ktBMkZ/rF0//7XvUDXn27nC2CClRUBCrg8Jg==
   dependencies:
     cross-spawn "^7.0.3"
     diff "^5.0.0"


### PR DESCRIPTION
This update includes a bug fix that made v9.0.1 incompatible with valid entries for the `package.json` "repository" field. Specifically, that field required that the repository be the GitHub repo URL, but the field is meant to point at the _git_ repo URL (the difference between the two on GitHub is the `.git` suffix).

Now that that bug as been fixed, we can update the `repository` field to point at `https://github.com/MetaMask/metamask-extension.git`, which is what it should be.