### PR TITLE
Upgrading dns-packet to ^5.2.2 to resolve vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "**/xmlhttprequest-ssl": "^1.6.2",
     "3box/ipfs/ipld-zcash/zcash-bitcore-lib/lodash": "^4.17.21",
     "3box/ipfs/ipld-zcash/zcash-bitcore-lib/elliptic": "^6.5.4",
+    "3box/ipfs/libp2p-mdns/multicast-dns/dns-packet": "^5.2.2",
     "3box/**/libp2p-crypto/node-forge": "^0.10.0",
     "3box/**/libp2p-keychain/node-forge": "^0.10.0",
     "analytics-node/axios": "^0.21.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9325,13 +9325,12 @@ dnd-core@^7.4.4:
     invariant "^2.2.4"
     redux "^4.0.1"
 
-dns-packet@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-4.2.0.tgz#3fd6f5ff5a4ec3194ed0b15312693ffe8776b343"
-  integrity sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==
+dns-packet@^4.0.0, dns-packet@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.2.2.tgz#e4c7d12974cc320b0c0d4b9bbbf68ac151cfe81e"
+  integrity sha512-sQN+vLwC3PvOXiCH/oHcdzML2opFeIdVh8gjjMZrM45n4dR80QF6o3AzInQy6F9Eoc0VJYog4JpQTilt4RFLYQ==
   dependencies:
     ip "^1.1.5"
-    safe-buffer "^5.1.1"
 
 doctrine@1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Advisory: https://www.npmjs.com/advisories/1745

Noticed when creating the `9.5.5` RC: https://app.circleci.com/pipelines/github/MetaMask/metamask-extension/9703/workflows/ae06d077-1b20-486e-b717-faf036871687/jobs/282157