### PR TITLE
Fixing ever-present scrollbar issue on Swaps view

### DIFF
--- a/ui/pages/swaps/index.scss
+++ b/ui/pages/swaps/index.scss
@@ -31,11 +31,7 @@
     height: 100%;
     width: 100%;
     overflow-x: hidden;
-    overflow-y: scroll;
-
-    &--scrollable {
-      overflow: auto;
-    }
+    overflow-y: auto;
 
     @media screen and (min-width: 576px) {
       width: 460px;

--- a/ui/pages/swaps/view-quote/index.scss
+++ b/ui/pages/swaps/view-quote/index.scss
@@ -22,7 +22,7 @@
 
     @media screen and (max-width: 576px) {
       overflow-y: auto;
-      max-height: 428px;
+      max-height: 420px;
     }
   }
 


### PR DESCRIPTION
Related: 

https://github.com/MetaMask/metamask-extension/pull/10988

**With "Always Show Scroll Bars" set, no overflow content**
<img width="674" alt="Screen Shot 2021-05-25 at 12 22 47 PM" src="https://user-images.githubusercontent.com/8732757/119557424-06ddc880-bd55-11eb-828d-e9d72536bef8.png">

**With "Always Show Scroll Bars" set, with overflow content**
<img width="580" alt="Screen Shot 2021-05-25 at 12 26 29 PM" src="https://user-images.githubusercontent.com/8732757/119557434-09d8b900-bd55-11eb-95a4-e48dcbd7c24b.png">
