### PR TITLE
Supporting existing default networks in switchEthereumChain

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
@@ -2,6 +2,11 @@ import { ethErrors } from 'eth-rpc-errors';
 import { omit } from 'lodash';
 import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 import {
+  ETH_SYMBOL,
+  CHAIN_ID_TO_TYPE_MAP,
+  NETWORK_TO_NAME_MAP,
+} from '../../../../../shared/constants/network';
+import {
   isPrefixedFormattedHexString,
   isSafeChainId,
 } from '../../../../../shared/modules/network.utils';
@@ -11,6 +16,18 @@ const switchEthereumChain = {
   implementation: switchEthereumChainHandler,
 };
 export default switchEthereumChain;
+
+function findExistingNetwork(chainId, findCustomRpcBy) {
+  if (chainId in CHAIN_ID_TO_TYPE_MAP) {
+    return {
+      chainId,
+      nickname: NETWORK_TO_NAME_MAP[chainId],
+      ticker: ETH_SYMBOL,
+    };
+  }
+
+  return findCustomRpcBy({ chainId });
+}
 
 async function switchEthereumChainHandler(
   req,
@@ -61,7 +78,7 @@ async function switchEthereumChainHandler(
     );
   }
 
-  const existingNetwork = findCustomRpcBy({ chainId: _chainId });
+  const existingNetwork = findExistingNetwork(_chainId, findCustomRpcBy);
 
   if (existingNetwork) {
     const currentChainId = getCurrentChainId();
@@ -75,7 +92,6 @@ async function switchEthereumChainHandler(
           origin,
           type: MESSAGE_TYPE.SWITCH_ETHEREUM_CHAIN,
           requestData: {
-            rpcUrl: existingNetwork.rpcUrl,
             chainId: existingNetwork.chainId,
             nickname: existingNetwork.nickname,
             ticker: existingNetwork.ticker,

--- a/ui/pages/confirmation/templates/switch-ethereum-chain.js
+++ b/ui/pages/confirmation/templates/switch-ethereum-chain.js
@@ -1,5 +1,8 @@
 import { ethErrors } from 'eth-rpc-errors';
-import { NETWORK_TYPE_RPC } from '../../../../shared/constants/network';
+import {
+  CHAIN_ID_TO_TYPE_MAP,
+  NETWORK_TYPE_RPC,
+} from '../../../../shared/constants/network';
 import {
   JUSTIFY_CONTENT,
   SEVERITIES,
@@ -22,6 +25,14 @@ const PENDING_TX_DROP_NOTICE = {
 
 async function getAlerts() {
   return [PENDING_TX_DROP_NOTICE];
+}
+
+function getNetworkType(chainId) {
+  if (chainId in CHAIN_ID_TO_TYPE_MAP) {
+    return CHAIN_ID_TO_TYPE_MAP[chainId];
+  }
+
+  return NETWORK_TYPE_RPC;
 }
 
 function getValues(pendingApproval, t, actions) {
@@ -65,7 +76,7 @@ function getValues(pendingApproval, t, actions) {
             colored: false,
             outline: true,
             targetNetwork: {
-              type: NETWORK_TYPE_RPC,
+              type: getNetworkType(pendingApproval.requestData.chainId),
               nickname: pendingApproval.requestData.nickname,
             },
           },


### PR DESCRIPTION
Supports existing default networks:
<img width="399" alt="Screen Shot 2021-05-25 at 6 54 42 PM" src="https://user-images.githubusercontent.com/8732757/119591261-25f74d00-bd8b-11eb-8ebf-0ab8ad507dfb.png">

Continues to work with added custom networks
<img width="407" alt="Screen Shot 2021-05-25 at 6 55 11 PM" src="https://user-images.githubusercontent.com/8732757/119591294-35769600-bd8b-11eb-80d7-95cc58f0674a.png">

