### PR TITLE
Fixing lint warnings in confirm-approve.stories.js

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve.stories.js
+++ b/ui/pages/confirm-approve/confirm-approve.stories.js
@@ -35,7 +35,7 @@ const PageSet = ({ children }) => {
     store.dispatch(
       updateMetamaskState({ currentNetworkTxList: [transaction] }),
     );
-  }, [origin]);
+  }, [origin, transaction]);
 
   useEffect(() => {
     store.dispatch(
@@ -47,7 +47,7 @@ const PageSet = ({ children }) => {
         },
       }),
     );
-  }, [domainIconUrl]);
+  }, [domainIconUrl, origin]);
 
   const params = useParams();
   params.id = txId;


### PR DESCRIPTION
Quiets the following warnings when running `yarn lint`:

```
38:6  warning  React Hook useEffect has a missing dependency: 'transaction'. Either include it or remove the dependency array
50:6  warning  React Hook useEffect has a missing dependency: 'origin'. Either include it or remove the dependency array

2 problems (0 errors, 2 warnings)
```
