### PR TITLE
Add confirm-add-token component to Storyboard

### DIFF
--- a/.storybook/initial-states/approval-screens/add-token.js
+++ b/.storybook/initial-states/approval-screens/add-token.js
@@ -1,0 +1,56 @@
+export const tokens = {
+    "0x33f90dee07c6e8b9682dd20f73e6c358b2ed0f03": {
+      "address": "0x33f90dee07c6e8b9682dd20f73e6c358b2ed0f03",
+      "symbol": "TRDT",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0x39013f961c378f02c2b82a6e1d31e9812786fd9d": {
+      "address": "0x39013f961c378f02c2b82a6e1d31e9812786fd9d",
+      "symbol": "SMS",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0x78b7fada55a64dd895d8c8c35779dd8b67fa8a05": {
+      "address": "0x78b7fada55a64dd895d8c8c35779dd8b67fa8a05",
+      "symbol": "ATL",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0xfd8971d5e8e1740ce2d0a84095fca4de729d0c16": {
+      "address": "0xfd8971d5e8e1740ce2d0a84095fca4de729d0c16",
+      "symbol": "ZLA",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0xe83cccfabd4ed148903bf36d4283ee7c8b3494d1": {
+      "address": "0xe83cccfabd4ed148903bf36d4283ee7c8b3494d1",
+      "symbol": "BTT",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0x7a07e1a0c2514d51132183ecfea2a880ec3b7648": {
+      "address": "0x7a07e1a0c2514d51132183ecfea2a880ec3b7648",
+      "symbol": "IXE",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0x467Bccd9d29f223BcE8043b84E8C8B282827790F": {
+      "address": "0x467Bccd9d29f223BcE8043b84E8C8B282827790F",
+      "symbol": "TEL",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0xff20817765cb7f73d4bde2e66e067e58d11095c2": {
+      "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
+      "symbol": "AMP",
+      "decimals": "18",
+      "unlisted": false
+    },
+    "0x15bda08c3afbf5955d6e9b235fd55a1fd0dbc829": {
+      "address": "0x15bda08c3afbf5955d6e9b235fd55a1fd0dbc829",
+      "symbol": "APC",
+      "decimals": "18",
+      "unlisted": false
+    },
+  }

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.stories.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.stories.js
@@ -38,7 +38,7 @@ const PageSet = ({ children }) => {
 };
 
 export const AddSuggestedToken = () => {
-  store.dispatch(updateMetamaskState({ suggestedTokens }));
+  store.dispatch(updateMetamaskState({ suggestedTokens, pendingTokens: {} }));
   return (
     <PageSet>
       <ConfirmAddSuggestedToken />

--- a/ui/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.component.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ADD_TOKEN_ROUTE, ASSET_ROUTE } from '../../helpers/constants/routes';
-
 import Button from '../../components/ui/button';
 import Identicon from '../../components/ui/identicon';
 import TokenBalance from '../../components/ui/token-balance';

--- a/ui/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ADD_TOKEN_ROUTE, ASSET_ROUTE } from '../../helpers/constants/routes';
+import { ASSET_ROUTE, ADD_TOKEN_ROUTE } from '../../helpers/constants/routes';
 import Button from '../../components/ui/button';
 import Identicon from '../../components/ui/identicon';
 import TokenBalance from '../../components/ui/token-balance';

--- a/ui/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.component.js
@@ -1,9 +1,9 @@
-import { ADD_TOKEN_ROUTE, ASSET_ROUTE } from '../../helpers/constants/routes';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { ADD_TOKEN_ROUTE, ASSET_ROUTE } from '../../helpers/constants/routes';
 
 import Button from '../../components/ui/button';
 import Identicon from '../../components/ui/identicon';
-import PropTypes from 'prop-types';
 import TokenBalance from '../../components/ui/token-balance';
 
 export default class ConfirmAddToken extends Component {

--- a/ui/pages/confirm-add-token/confirm-add-token.component.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.component.js
@@ -1,8 +1,9 @@
+import { ADD_TOKEN_ROUTE, ASSET_ROUTE } from '../../helpers/constants/routes';
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { ASSET_ROUTE, ADD_TOKEN_ROUTE } from '../../helpers/constants/routes';
+
 import Button from '../../components/ui/button';
 import Identicon from '../../components/ui/identicon';
+import PropTypes from 'prop-types';
 import TokenBalance from '../../components/ui/token-balance';
 
 export default class ConfirmAddToken extends Component {

--- a/ui/pages/confirm-add-token/confirm-add-token.stories.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.stories.js
@@ -9,6 +9,7 @@ import ConfirmAddToken from '.';
 import { createBrowserHistory } from "history";
 import { currentNetworkTxListSelector } from '../../selectors/transactions';
 import { store } from '../../../.storybook/preview';
+import {suggestedTokens} from '../../../.storybook/initial-states/approval-screens/add-suggested-token'
 import { text } from '@storybook/addon-knobs';
 import { updateMetamaskState } from '../../store/actions';
 import { useParams } from 'react-router-dom';
@@ -22,7 +23,31 @@ const history = createBrowserHistory();
 
 const PageSet = ({ children }) => {
 
+  const symbol = text('symbol', 'DAI');
+  const image = text(
+    'Icon URL',
+    'https://assets.coingecko.com/coins/images/9956/small/dai-multi-collateral-mcd.png?1574218774',
+  );
+
+  const state = store.getState();
+  const suggestedTokensState = state.metamask.suggestedTokens
+
+  useEffect(() => {
+    suggestedTokensState["0x6b175474e89094c44da98b954eedeac495271d0f"].symbol = symbol
+    store.dispatch(
+      updateMetamaskState({ suggestedTokens: suggestedTokensState})
+      
+    );
+  }, [symbol]);
+  useEffect(() => {
+    suggestedTokensState["0x6b175474e89094c44da98b954eedeac495271d0f"].image = image
+    store.dispatch(
+      updateMetamaskState({ suggestedTokens: suggestedTokensState})
+    );
+  }, [image]);
+
   return children;
+
 };
 
 export const AddToken = () => {
@@ -30,9 +55,10 @@ export const AddToken = () => {
   //   updateMetamaskState({ currentNetworkTxList: [currentNetworkTxListSample] }),
   // );
   // store.dispatch(updateMetamaskState({ domainMetadata }));
+  store.dispatch(updateMetamaskState({ suggestedTokens: suggestedTokens}))
   return (
        <ConfirmAddToken
         history={history}
-       />
+       /> 
   );
 };

--- a/ui/pages/confirm-add-token/confirm-add-token.stories.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.stories.js
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect } from 'react';
 
-import ConfirmAddToken from '.';
-import { createBrowserHistory } from "history";
-import { store } from '../../../.storybook/preview';
-import { tokens } from '../../../.storybook/initial-states/approval-screens/add-token'
+import { createBrowserHistory } from 'history';
 import { text } from '@storybook/addon-knobs';
+import { store } from '../../../.storybook/preview';
+import { tokens } from '../../../.storybook/initial-states/approval-screens/add-token';
 import { updateMetamaskState } from '../../store/actions';
+import ConfirmAddToken from '.';
 
 export default {
   title: 'Confirmation Screens',
@@ -17,27 +17,22 @@ const history = createBrowserHistory();
 const PageSet = ({ children }) => {
   const symbol = text('symbol', 'TRDT');
   const state = store.getState();
-  const pendingTokensState = state.metamask.pendingTokens
+  const pendingTokensState = state.metamask.pendingTokens;
   // only change the first token in the list
   useEffect(() => {
-    const pendingTokens = Object.assign({}, pendingTokensState)
-    pendingTokens["0x33f90dee07c6e8b9682dd20f73e6c358b2ed0f03"].symbol = symbol
-    store.dispatch(
-      updateMetamaskState({ pendingTokens: pendingTokens})
-    );
+    const pendingTokens = { ...pendingTokensState };
+    pendingTokens['0x33f90dee07c6e8b9682dd20f73e6c358b2ed0f03'].symbol = symbol;
+    store.dispatch(updateMetamaskState({ pendingTokens }));
   }, [symbol, pendingTokensState]);
 
   return children;
-
 };
 
 export const AddToken = () => {
-  store.dispatch(updateMetamaskState({ pendingTokens: tokens}))
+  store.dispatch(updateMetamaskState({ pendingTokens: tokens }));
   return (
     <PageSet>
-       <ConfirmAddToken
-        history={history}
-       /> 
-       </PageSet>
+      <ConfirmAddToken history={history} />
+    </PageSet>
   );
 };

--- a/ui/pages/confirm-add-token/confirm-add-token.stories.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.stories.js
@@ -22,7 +22,6 @@ export default {
 const history = createBrowserHistory();
 
 const PageSet = ({ children }) => {
-
   const symbol = text('symbol', 'DAI');
   const image = text(
     'Icon URL',
@@ -30,19 +29,17 @@ const PageSet = ({ children }) => {
   );
 
   const state = store.getState();
-  const suggestedTokensState = state.metamask.suggestedTokens
-
+  const suggestedTokensState = state.metamask.pendingTokens
   useEffect(() => {
     suggestedTokensState["0x6b175474e89094c44da98b954eedeac495271d0f"].symbol = symbol
     store.dispatch(
-      updateMetamaskState({ suggestedTokens: suggestedTokensState})
-      
+      updateMetamaskState({ pendingTokens: suggestedTokensState})
     );
   }, [symbol]);
   useEffect(() => {
     suggestedTokensState["0x6b175474e89094c44da98b954eedeac495271d0f"].image = image
     store.dispatch(
-      updateMetamaskState({ suggestedTokens: suggestedTokensState})
+      updateMetamaskState({ pendingTokens: suggestedTokensState})
     );
   }, [image]);
 
@@ -51,14 +48,17 @@ const PageSet = ({ children }) => {
 };
 
 export const AddToken = () => {
+  
   // store.dispatch(
   //   updateMetamaskState({ currentNetworkTxList: [currentNetworkTxListSample] }),
   // );
   // store.dispatch(updateMetamaskState({ domainMetadata }));
-  store.dispatch(updateMetamaskState({ suggestedTokens: suggestedTokens}))
+  store.dispatch(updateMetamaskState({ pendingTokens: suggestedTokens}))
   return (
+    <PageSet>
        <ConfirmAddToken
         history={history}
        /> 
+       </PageSet>
   );
 };

--- a/ui/pages/confirm-add-token/confirm-add-token.stories.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.stories.js
@@ -1,0 +1,38 @@
+/* eslint-disable react/prop-types */
+import React, { useEffect } from 'react';
+import {
+  currentNetworkTxListSample,
+  domainMetadata,
+} from '../../../.storybook/initial-states/approval-screens/token-approval';
+
+import ConfirmAddToken from '.';
+import { createBrowserHistory } from "history";
+import { currentNetworkTxListSelector } from '../../selectors/transactions';
+import { store } from '../../../.storybook/preview';
+import { text } from '@storybook/addon-knobs';
+import { updateMetamaskState } from '../../store/actions';
+import { useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+export default {
+  title: 'Confirmation Screens',
+};
+
+const history = createBrowserHistory();
+
+const PageSet = ({ children }) => {
+
+  return children;
+};
+
+export const AddToken = () => {
+  // store.dispatch(
+  //   updateMetamaskState({ currentNetworkTxList: [currentNetworkTxListSample] }),
+  // );
+  // store.dispatch(updateMetamaskState({ domainMetadata }));
+  return (
+       <ConfirmAddToken
+        history={history}
+       />
+  );
+};

--- a/ui/pages/confirm-add-token/confirm-add-token.stories.js
+++ b/ui/pages/confirm-add-token/confirm-add-token.stories.js
@@ -1,19 +1,12 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect } from 'react';
-import {
-  currentNetworkTxListSample,
-  domainMetadata,
-} from '../../../.storybook/initial-states/approval-screens/token-approval';
 
 import ConfirmAddToken from '.';
 import { createBrowserHistory } from "history";
-import { currentNetworkTxListSelector } from '../../selectors/transactions';
 import { store } from '../../../.storybook/preview';
-import {suggestedTokens} from '../../../.storybook/initial-states/approval-screens/add-suggested-token'
+import { tokens } from '../../../.storybook/initial-states/approval-screens/add-token'
 import { text } from '@storybook/addon-knobs';
 import { updateMetamaskState } from '../../store/actions';
-import { useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 
 export default {
   title: 'Confirmation Screens',
@@ -22,38 +15,24 @@ export default {
 const history = createBrowserHistory();
 
 const PageSet = ({ children }) => {
-  const symbol = text('symbol', 'DAI');
-  const image = text(
-    'Icon URL',
-    'https://assets.coingecko.com/coins/images/9956/small/dai-multi-collateral-mcd.png?1574218774',
-  );
-
+  const symbol = text('symbol', 'TRDT');
   const state = store.getState();
-  const suggestedTokensState = state.metamask.pendingTokens
+  const pendingTokensState = state.metamask.pendingTokens
+  // only change the first token in the list
   useEffect(() => {
-    suggestedTokensState["0x6b175474e89094c44da98b954eedeac495271d0f"].symbol = symbol
+    const pendingTokens = Object.assign({}, pendingTokensState)
+    pendingTokens["0x33f90dee07c6e8b9682dd20f73e6c358b2ed0f03"].symbol = symbol
     store.dispatch(
-      updateMetamaskState({ pendingTokens: suggestedTokensState})
+      updateMetamaskState({ pendingTokens: pendingTokens})
     );
-  }, [symbol]);
-  useEffect(() => {
-    suggestedTokensState["0x6b175474e89094c44da98b954eedeac495271d0f"].image = image
-    store.dispatch(
-      updateMetamaskState({ pendingTokens: suggestedTokensState})
-    );
-  }, [image]);
+  }, [symbol, pendingTokensState]);
 
   return children;
 
 };
 
 export const AddToken = () => {
-  
-  // store.dispatch(
-  //   updateMetamaskState({ currentNetworkTxList: [currentNetworkTxListSample] }),
-  // );
-  // store.dispatch(updateMetamaskState({ domainMetadata }));
-  store.dispatch(updateMetamaskState({ pendingTokens: suggestedTokens}))
+  store.dispatch(updateMetamaskState({ pendingTokens: tokens}))
   return (
     <PageSet>
        <ConfirmAddToken


### PR DESCRIPTION
- Similar to `confirm-add-suggested-token` but with a different token list.
- Knob to change the symbol of the first token in the list.