### PR TITLE
Feature/use zeroAddress

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "ethereum-ens-network-map": "^1.0.2",
     "ethereumjs-abi": "^0.6.4",
     "ethereumjs-tx": "1.3.7",
-    "ethereumjs-util": "^7.0.9",
+    "ethereumjs-util": "^7.0.10",
     "ethereumjs-wallet": "^0.6.4",
     "ethers": "^5.0.8",
     "ethjs": "^0.4.0",

--- a/shared/modules/hexstring-utils.js
+++ b/shared/modules/hexstring-utils.js
@@ -4,9 +4,10 @@ import {
   isValidChecksumAddress,
   addHexPrefix,
   toChecksumAddress,
+  zeroAddress,
 } from 'ethereumjs-util';
 
-export const BURN_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const BURN_ADDRESS = zeroAddress();
 
 export function isBurnAddress(address) {
   return address === BURN_ADDRESS;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10916,6 +10916,18 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
+ethereumjs-util@^7.0.10:
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
+  integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
+
 ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.9:
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.9.tgz#2038baeb30f370a3e576ec175bd70bbbb6807d42"


### PR DESCRIPTION
Noticed this the other day... We can actually get the burn address from `ethereumjs-util@7.0.10`. This PR updates `ethereumjs-util` to that version and uses `zeroAddress()`