### PR TITLE
add erc-721 token detection and flag to disable sending

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2387,6 +2387,10 @@
     "message": "verify the network details",
     "description": "Serves as link text for the 'unrecognizedChain' key. This text will be embedded inside the translation for that key."
   },
+  "unsendableAsset": {
+    "message": "Sending collectible (ERC-721) tokens is not currently supported",
+    "description": "This is an error message we show the user if they attempt to send a collectible asset type, for which currently don't support sending"
+  },
   "updatedWithDate": {
     "message": "Updated $1"
   },

--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -11,7 +11,7 @@ import PreferencesController from './preferences';
 
 describe('DetectTokensController', function () {
   const sandbox = sinon.createSandbox();
-  let keyringMemStore, network, preferences;
+  let keyringMemStore, network, preferences, provider;
 
   const noop = () => undefined;
 
@@ -23,12 +23,16 @@ describe('DetectTokensController', function () {
     keyringMemStore = new ObservableStore({ isUnlocked: false });
     network = new NetworkController();
     network.setInfuraProjectId('foo');
-    preferences = new PreferencesController({ network });
+    network.initializeProvider(networkControllerProviderConfig);
+    provider = network.getProviderAndBlockTracker().provider;
+    preferences = new PreferencesController({ network, provider });
     preferences.setAddresses([
       '0x7e57e2',
       '0xbc86727e770de68b1060c91f6bb6945c73e10388',
     ]);
-    network.initializeProvider(networkControllerProviderConfig);
+    sandbox
+      .stub(preferences, '_detectIsERC721')
+      .returns(Promise.resolve(false));
   });
 
   after(function () {
@@ -125,6 +129,7 @@ describe('DetectTokensController', function () {
         address: existingTokenAddress.toLowerCase(),
         decimals: existingToken.decimals,
         symbol: existingToken.symbol,
+        isERC721: false,
       },
     ]);
   });
@@ -177,11 +182,13 @@ describe('DetectTokensController', function () {
         address: existingTokenAddress.toLowerCase(),
         decimals: existingToken.decimals,
         symbol: existingToken.symbol,
+        isERC721: false,
       },
       {
         address: tokenAddressToAdd.toLowerCase(),
         decimals: tokenToAdd.decimals,
         symbol: tokenToAdd.symbol,
+        isERC721: false,
       },
     ]);
   });
@@ -234,11 +241,13 @@ describe('DetectTokensController', function () {
         address: existingTokenAddress.toLowerCase(),
         decimals: existingToken.decimals,
         symbol: existingToken.symbol,
+        isERC721: false,
       },
       {
         address: tokenAddressToAdd.toLowerCase(),
         decimals: tokenToAdd.decimals,
         symbol: tokenToAdd.symbol,
+        isERC721: false,
       },
     ]);
   });

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -506,11 +506,8 @@ export default class PreferencesController {
         let addressBookKey = rpcDetail.chainId;
         if (!addressBookKey) {
           // We need to find the networkId to determine what these addresses were keyed by
-          const provider = new ethers.providers.JsonRpcProvider(
-            rpcDetail.rpcUrl,
-          );
           try {
-            addressBookKey = await provider.send('net_version');
+            addressBookKey = await this.ethersProvider.send('net_version');
             assert(typeof addressBookKey === 'string');
           } catch (error) {
             log.debug(error);

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -796,17 +796,28 @@ export default class PreferencesController {
     if (contractsMap[checksumAddress]?.erc721 === true) {
       return Promise.resolve(true);
     }
-    const tokenContract = await new ethers.Contract(
+    const tokenContract = await this._createEthersContract(
       tokenAddress,
       abiERC721,
       this.ethersProvider,
     );
+
     return await tokenContract
       .supportsInterface(ERC721METADATA_INTERFACE_ID)
       .catch((error) => {
+        console.log('error', error);
         log.debug(error);
         return false;
       });
+  }
+
+  async _createEthersContract(tokenAddress, abi, ethersProvider) {
+    const tokenContract = await new ethers.Contract(
+      tokenAddress,
+      abi,
+      ethersProvider,
+    );
+    return tokenContract;
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -419,6 +419,14 @@ export default class PreferencesController {
     return Promise.resolve(tokens);
   }
 
+  /**
+   * Adds isERC721 field to token object
+   * (Called when a user attempts to add tokens that were previously added which do not yet had isERC721 field)
+   *
+   * @param {string} tokenAddress - The contract address of the token requiring the isERC721 field added.
+   * @returns {Promise<object>} The new token object with the added isERC721 field.
+   *
+   */
   async updateTokenType(tokenAddress) {
     const { tokens } = this.store.getState();
     const tokenIndex = tokens.findIndex((token) => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -132,11 +132,17 @@ export default class MetamaskController extends EventEmitter {
     this.networkController = new NetworkController(initState.NetworkController);
     this.networkController.setInfuraProjectId(opts.infuraProjectId);
 
+    // now we can initialize the RPC provider, which other controllers require
+    this.initializeProvider();
+    this.provider = this.networkController.getProviderAndBlockTracker().provider;
+    this.blockTracker = this.networkController.getProviderAndBlockTracker().blockTracker;
+
     this.preferencesController = new PreferencesController({
       initState: initState.PreferencesController,
       initLangCode: opts.initLangCode,
       openPopup: opts.openPopup,
       network: this.networkController,
+      provider: this.provider,
       migrateAddressBookState: this.migrateAddressBookState.bind(this),
     });
 
@@ -182,11 +188,6 @@ export default class MetamaskController extends EventEmitter {
       { allNotifications: UI_NOTIFICATIONS },
       initState.NotificationController,
     );
-
-    // now we can initialize the RPC provider, which other controllers require
-    this.initializeProvider();
-    this.provider = this.networkController.getProviderAndBlockTracker().provider;
-    this.blockTracker = this.networkController.getProviderAndBlockTracker().blockTracker;
 
     // token exchange rate tracker
     this.tokenRatesController = new TokenRatesController({
@@ -731,6 +732,10 @@ export default class MetamaskController extends EventEmitter {
         preferencesController,
       ),
       addToken: nodeify(preferencesController.addToken, preferencesController),
+      updateTokenType: nodeify(
+        preferencesController.updateTokenType,
+        preferencesController,
+      ),
       removeToken: nodeify(
         preferencesController.removeToken,
         preferencesController,

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "fast-safe-stringify": "^2.0.7",
     "fuse.js": "^3.2.0",
     "globalthis": "^1.0.1",
+    "human-standard-collectible-abi": "^1.0.2",
     "human-standard-token-abi": "^2.0.0",
     "immer": "^8.0.1",
     "json-rpc-engine": "^6.1.0",

--- a/ui/components/app/asset-list-item/asset-list-item.js
+++ b/ui/components/app/asset-list-item/asset-list-item.js
@@ -27,6 +27,7 @@ const AssetListItem = ({
   primary,
   secondary,
   identiconBorder,
+  isERC721,
 }) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
@@ -121,10 +122,12 @@ const AssetListItem = ({
       }
       midContent={midContent}
       rightContent={
-        <>
-          <i className="fas fa-chevron-right asset-list-item__chevron-right" />
-          {sendTokenButton}
-        </>
+        !isERC721 && (
+          <>
+            <i className="fas fa-chevron-right asset-list-item__chevron-right" />
+            {sendTokenButton}
+          </>
+        )
       }
     />
   );
@@ -143,6 +146,7 @@ AssetListItem.propTypes = {
   'primary': PropTypes.string,
   'secondary': PropTypes.string,
   'identiconBorder': PropTypes.bool,
+  'isERC721': PropTypes.bool,
 };
 
 AssetListItem.defaultProps = {

--- a/ui/components/app/token-cell/token-cell.js
+++ b/ui/components/app/token-cell/token-cell.js
@@ -15,6 +15,7 @@ export default function TokenCell({
   string,
   image,
   onClick,
+  isERC721,
 }) {
   const userAddress = useSelector(getSelectedAddress);
   const t = useI18nContext();
@@ -50,6 +51,7 @@ export default function TokenCell({
       warning={warning}
       primary={`${string || 0}`}
       secondary={formattedFiat}
+      isERC721={isERC721}
     />
   );
 }
@@ -62,6 +64,7 @@ TokenCell.propTypes = {
   string: PropTypes.string,
   image: PropTypes.string,
   onClick: PropTypes.func.isRequired,
+  isERC721: PropTypes.bool,
 };
 
 TokenCell.defaultProps = {

--- a/ui/components/app/token-list/token-list.js
+++ b/ui/components/app/token-list/token-list.js
@@ -46,18 +46,8 @@ export default function TokenList({ onTokenClick }) {
   return (
     <div>
       {tokensWithBalances.map((tokenData, index) => {
-        const additionalTokenData = tokens.find(
-          (token) => token.address === tokenData.address,
-        );
         tokenData.image = assetImages[tokenData.address];
-        return (
-          <TokenCell
-            key={index}
-            {...tokenData}
-            isERC721={additionalTokenData?.isERC721}
-            onClick={onTokenClick}
-          />
-        );
+        return <TokenCell key={index} {...tokenData} onClick={onTokenClick} />;
       })}
     </div>
   );

--- a/ui/components/app/token-list/token-list.js
+++ b/ui/components/app/token-list/token-list.js
@@ -46,8 +46,18 @@ export default function TokenList({ onTokenClick }) {
   return (
     <div>
       {tokensWithBalances.map((tokenData, index) => {
+        const { isERC721 } = tokens.find(
+          (token) => token.address === tokenData.address,
+        );
         tokenData.image = assetImages[tokenData.address];
-        return <TokenCell key={index} {...tokenData} onClick={onTokenClick} />;
+        return (
+          <TokenCell
+            key={index}
+            {...tokenData}
+            isERC721={isERC721}
+            onClick={onTokenClick}
+          />
+        );
       })}
     </div>
   );

--- a/ui/components/app/token-list/token-list.js
+++ b/ui/components/app/token-list/token-list.js
@@ -46,7 +46,7 @@ export default function TokenList({ onTokenClick }) {
   return (
     <div>
       {tokensWithBalances.map((tokenData, index) => {
-        const { isERC721 } = tokens.find(
+        const additionalTokenData = tokens.find(
           (token) => token.address === tokenData.address,
         );
         tokenData.image = assetImages[tokenData.address];
@@ -54,7 +54,7 @@ export default function TokenList({ onTokenClick }) {
           <TokenCell
             key={index}
             {...tokenData}
-            isERC721={isERC721}
+            isERC721={additionalTokenData?.isERC721}
             onClick={onTokenClick}
           />
         );

--- a/ui/components/app/wallet-overview/token-overview.js
+++ b/ui/components/app/wallet-overview/token-overview.js
@@ -91,6 +91,7 @@ const TokenOverview = ({ className, token }) => {
             Icon={SendIcon}
             label={t('send')}
             data-testid="eth-overview-send"
+            disabled={token.isERC721}
           />
           <IconButton
             className="token-overview__button"
@@ -145,6 +146,7 @@ TokenOverview.propTypes = {
     address: PropTypes.string.isRequired,
     decimals: PropTypes.number,
     symbol: PropTypes.string,
+    isERC721: PropTypes.bool,
   }).isRequired,
 };
 

--- a/ui/helpers/constants/error-keys.js
+++ b/ui/helpers/constants/error-keys.js
@@ -5,3 +5,4 @@ export const TRANSACTION_NO_CONTRACT_ERROR_KEY = 'transactionErrorNoContract';
 export const ETH_GAS_PRICE_FETCH_WARNING_KEY = 'ethGasPriceFetchWarning';
 export const GAS_PRICE_FETCH_FAILURE_ERROR_KEY = 'gasPriceFetchFailed';
 export const GAS_PRICE_EXCESSIVE_ERROR_KEY = 'gasPriceExcessive';
+export const UNSENDABLE_ASSET_ERROR_KEY = 'unsendableAsset';

--- a/ui/hooks/useTokenTracker.js
+++ b/ui/hooks/useTokenTracker.js
@@ -23,11 +23,19 @@ export function useTokenTracker(
       const matchingTokens = hideZeroBalanceTokens
         ? tokenWithBalances.filter((token) => Number(token.balance) > 0)
         : tokenWithBalances;
-      setTokensWithBalances(matchingTokens);
+      // TODO: improve this pattern for adding this field when we improve support for
+      // EIP721 tokens.
+      const matchingTokensWithIsERC721Flag = matchingTokens.map((token) => {
+        const additionalTokenData = tokens.find(
+          (t) => t.address === token.address,
+        );
+        return { ...token, isERC721: additionalTokenData?.isERC721 };
+      });
+      setTokensWithBalances(matchingTokensWithIsERC721Flag);
       setLoading(false);
       setError(null);
     },
-    [hideZeroBalanceTokens],
+    [hideZeroBalanceTokens, tokens],
   );
 
   const showError = useCallback((err) => {

--- a/ui/hooks/useTokenTracker.js
+++ b/ui/hooks/useTokenTracker.js
@@ -26,7 +26,7 @@ export function useTokenTracker(
       // TODO: improve this pattern for adding this field when we improve support for
       // EIP721 tokens.
       const matchingTokensWithIsERC721Flag = matchingTokens.map((token) => {
-        const additionalTokenData = tokens.find(
+        const additionalTokenData = memoizedTokens.find(
           (t) => t.address === token.address,
         );
         return { ...token, isERC721: additionalTokenData?.isERC721 };
@@ -35,7 +35,7 @@ export function useTokenTracker(
       setLoading(false);
       setError(null);
     },
-    [hideZeroBalanceTokens, tokens],
+    [hideZeroBalanceTokens, memoizedTokens],
   );
 
   const showError = useCallback((err) => {

--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.container.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.container.js
@@ -6,7 +6,11 @@ import {
   getSendTokenAddress,
   getAssetImages,
 } from '../../../../selectors';
-import { updateSendToken } from '../../../../ducks/send/send.duck';
+import { updateTokenType } from '../../../../store/actions';
+import {
+  updateSendErrors,
+  updateSendToken,
+} from '../../../../ducks/send/send.duck';
 import SendAssetRow from './send-asset-row.component';
 
 function mapStateToProps(state) {
@@ -24,6 +28,10 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     setSendToken: (token) => dispatch(updateSendToken(token)),
+    updateTokenType: (tokenAddress) => dispatch(updateTokenType(tokenAddress)),
+    updateSendErrors: (error) => {
+      dispatch(updateSendErrors(error));
+    },
   };
 }
 

--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -6,6 +6,7 @@ import {
   ETH_GAS_PRICE_FETCH_WARNING_KEY,
   GAS_PRICE_FETCH_FAILURE_ERROR_KEY,
   GAS_PRICE_EXCESSIVE_ERROR_KEY,
+  UNSENDABLE_ASSET_ERROR_KEY,
 } from '../../../helpers/constants/error-keys';
 import SendAmountRow from './send-amount-row';
 import SendGasRow from './send-gas-row';
@@ -15,6 +16,10 @@ import SendAssetRow from './send-asset-row';
 export default class SendContent extends Component {
   static contextTypes = {
     t: PropTypes.func,
+  };
+
+  state = {
+    unsendableAssetError: false,
   };
 
   static propTypes = {
@@ -32,6 +37,9 @@ export default class SendContent extends Component {
 
   updateGas = (updateData) => this.props.updateGas(updateData);
 
+  setUnsendableAssetError = (unsendableAssetError) =>
+    this.setState({ unsendableAssetError });
+
   render() {
     const {
       warning,
@@ -41,6 +49,7 @@ export default class SendContent extends Component {
       noGasPrice,
     } = this.props;
 
+    const { unsendableAssetError } = this.state;
     let gasError;
     if (gasIsExcessive) gasError = GAS_PRICE_EXCESSIVE_ERROR_KEY;
     else if (noGasPrice) gasError = GAS_PRICE_FETCH_FAILURE_ERROR_KEY;
@@ -50,10 +59,13 @@ export default class SendContent extends Component {
         <div className="send-v2__form">
           {gasError && this.renderError(gasError)}
           {isEthGasPrice && this.renderWarning(ETH_GAS_PRICE_FETCH_WARNING_KEY)}
-          {error && this.renderError()}
+          {unsendableAssetError && this.renderError(UNSENDABLE_ASSET_ERROR_KEY)}
+          {error && this.renderError(error)}
           {warning && this.renderWarning()}
           {this.maybeRenderAddContact()}
-          <SendAssetRow />
+          <SendAssetRow
+            setUnsendableAssetError={this.setUnsendableAssetError}
+          />
           <SendAmountRow updateGas={this.updateGas} />
           <SendGasRow />
           {this.props.showHexData && (
@@ -97,12 +109,11 @@ export default class SendContent extends Component {
     );
   }
 
-  renderError(gasError = '') {
+  renderError(error) {
     const { t } = this.context;
-    const { error } = this.props;
     return (
       <Dialog type="error" className="send__error-dialog">
-        {gasError === '' ? t(error) : t(gasError)}
+        {t(error)}
       </Dialog>
     );
   }

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -223,7 +223,10 @@ export const transactionFeeSelector = function (state, txData) {
 
   // if the gas price from our infura endpoint is null or undefined
   // use the metaswap average price estimation as a fallback
-  let { txParams: { gasPrice } = {} } = txData;
+  let {
+    txParams: { gasPrice },
+  } = txData;
+
   if (!gasPrice) {
     gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';
   }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1234,6 +1234,21 @@ export function addToken(
   };
 }
 
+export function updateTokenType(tokenAddress) {
+  return async (dispatch) => {
+    let token = {};
+    dispatch(showLoadingIndication());
+    try {
+      token = await promisifiedBackground.updateTokenType(tokenAddress);
+    } catch (error) {
+      log.error(error);
+    } finally {
+      dispatch(hideLoadingIndication());
+    }
+    return token;
+  };
+}
+
 export function removeToken(address) {
   return (dispatch) => {
     dispatch(showLoadingIndication());


### PR DESCRIPTION
Fixes: #10625

Explanation:  Adds detection of ERC-721 tokens and a flag to the token object in preference controller state indicating whether or not this token supports the ERC-721 interface. The UI then disables sending for tokens for which `isERC721 === true`.

Manual testing steps:  
  - [Add an ERC-721 token](https://etherscan.io/token/0x629a673a8242c2ac4b7b8c5d8735fbeac21a6205)
  - Check that the send button is disabled.
  - Add an ERC-20 token 
  - Make sure that the send button is enabled 
