### PR TITLE
Improve detection of whether a whats new notification was 'seen'

### DIFF
--- a/ui/components/app/whats-new-popup/index.scss
+++ b/ui/components/app/whats-new-popup/index.scss
@@ -10,6 +10,19 @@
     flex-direction: column;
     margin: 0 24px 24px 24px;
     border-bottom: 1px solid $Grey-100;
+    position: relative;
+  }
+
+  &__last-notification {
+    > * {
+      &:nth-last-child(2) {
+        margin-bottom: 0;
+      };
+    }
+
+    .whats-new-popup__intersection-observable {
+      bottom: 8px;
+    }
   }
 
   &__notification {
@@ -52,6 +65,13 @@
 
     font-weight: bold;
     margin-bottom: 8px;
+  }
+
+  &__intersection-observable {
+    bottom: 22px;
+    position: absolute;
+    height: 1px;
+    width: 100%;
   }
 }
 

--- a/ui/components/app/whats-new-popup/whats-new-popup.js
+++ b/ui/components/app/whats-new-popup/whats-new-popup.js
@@ -68,7 +68,7 @@ const renderDescription = (description) => {
   );
 };
 
-const renderFirstNotification = (notification, idRefMap, history) => {
+const renderFirstNotification = (notification, idRefMap, history, isLast) => {
   const { id, date, title, description, image, actionText } = notification;
   const actionFunction = getActionFunctionById(id, history);
   const imageComponent = image && (
@@ -84,9 +84,11 @@ const renderFirstNotification = (notification, idRefMap, history) => {
     <div
       className={classnames(
         'whats-new-popup__notification whats-new-popup__first-notification',
+        {
+          'whats-new-popup__last-notification': isLast,
+        },
       )}
       key={`whats-new-popop-notification-${id}`}
-      ref={idRefMap[id]}
     >
       {!placeImageBelowDescription && imageComponent}
       <div className="whats-new-popup__notification-title">{title}</div>
@@ -107,19 +109,29 @@ const renderFirstNotification = (notification, idRefMap, history) => {
           {actionText}
         </Button>
       )}
+      <div
+        className="whats-new-popup__intersection-observable"
+        ref={idRefMap[id]}
+      />
     </div>
   );
 };
 
-const renderSubsequentNotification = (notification, idRefMap, history) => {
+const renderSubsequentNotification = (
+  notification,
+  idRefMap,
+  history,
+  isLast,
+) => {
   const { id, date, title, description, actionText } = notification;
 
   const actionFunction = getActionFunctionById(id, history);
   return (
     <div
-      className={classnames('whats-new-popup__notification')}
+      className={classnames('whats-new-popup__notification', {
+        'whats-new-popup__last-notification': isLast,
+      })}
       key={`whats-new-popop-notification-${id}`}
-      ref={idRefMap[id]}
     >
       <div className="whats-new-popup__notification-title">{title}</div>
       <div className="whats-new-popup__description-and-date">
@@ -133,6 +145,10 @@ const renderSubsequentNotification = (notification, idRefMap, history) => {
           {`${actionText} >`}
         </div>
       )}
+      <div
+        className="whats-new-popup__intersection-observable"
+        ref={idRefMap[id]}
+      />
     </div>
   );
 };
@@ -207,10 +223,16 @@ export default function WhatsNewPopup({ onClose }) {
       <div className="whats-new-popup__notifications">
         {notifications.map(({ id }, index) => {
           const notification = getTranslatedUINoficiations(t, locale)[id];
+          const isLast = index === notifications.length - 1;
           // Display the swaps notification with full image
           return index === 0 || id === 1
-            ? renderFirstNotification(notification, idRefMap, history)
-            : renderSubsequentNotification(notification, idRefMap, history);
+            ? renderFirstNotification(notification, idRefMap, history, isLast)
+            : renderSubsequentNotification(
+                notification,
+                idRefMap,
+                history,
+                isLast,
+              );
         })}
       </div>
     </Popover>


### PR DESCRIPTION
Fixes: #11220

The most recently added "What's New" notification, when opened in the browser popup (by clicking the fox in the top right of the browser) is larger than the div which is its "root element" in the `IntersectionObserver`. This causes it never to "intersect" when it is the only notification in the list and viewed through the browser popup. Therefore, it is never set as "seen" and the user will see the notification again and again, regardless of how many times they close it. (Videos of this behaviour can be seen in the above linked issue)

To fix this, this PR adds a new div to be observed. This div is put in a position that is about 8px higher than the bottom element in the notification. The effect of this is to set a notification as "seen" if all but the bottom few pixels of the notification have come in to view. To do this, we have to account for the margins that exist below the elements that make up a notification.

Regardless of the bug this is responding to, this is an improvement overall, as another existing issue would be that if there were multiple notifications and a user is scrolling through them and they scroll almost to the bottom of a notification, see all relevant information and then close the notification popover, they will still see the notification because they didn't scroll _all the way to the very bottom_ of it. Such scrolling should not be necessary, and the solution in this PR better approximate what it means for a notification to be "seen".

Now, this PR doesn't address the following issue: if a notification is ever added that is so long that this new observable div only comes in to view after scrolling, users could still get frustrated trying to close the popover and have the notification appear and not realize they need to scroll to make it go away. This can be addressed in a future improvement. We may want to explicitly allow the user to "Dismiss all" or "Remind me later". Or, if we end up adding a place where all past notifications can be viewed,  we may choose to have a much lower threshold for what counts as "seen" (e.g. just the title and the top 50px of the notification or something like that)