### PR TITLE
Patch gas price issue - add fallback gas price

### DIFF
--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -18,6 +18,7 @@ import {
 import { getTokenData, sumHexes } from '../../helpers/utils/transactions.util';
 
 import { conversionUtil } from '../../helpers/utils/conversion-util';
+import { getAveragePriceEstimateInHexWEI } from '../../selectors/custom-gas';
 
 // Actions
 const createActionType = (action) => `metamask/confirm-transaction/${action}`;
@@ -198,9 +199,16 @@ export function updateTxDataAndCalculate(txData) {
 
     dispatch(updateTxData(txData));
 
-    const {
-      txParams: { value = '0x0', gas: gasLimit = '0x0', gasPrice = '0x0' } = {},
+    const { txParams: { value = '0x0', gas: gasLimit = '0x0' } = {} } = txData;
+
+    // if the gas price from our infura endpoint is null or undefined
+    // use the metaswap average price estimation as a fallback
+    let {
+      txParams: { gasPrice },
     } = txData;
+    if (!gasPrice) {
+      gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';
+    }
 
     const fiatTransactionAmount = getValueFromWeiHex({
       value,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -12,6 +12,7 @@ import {
 import { sumHexes } from '../helpers/utils/transactions.util';
 import { transactionMatchesNetwork } from '../../shared/modules/transaction.utils';
 import { getNativeCurrency } from '../ducks/metamask/metamask';
+import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import { getCurrentChainId, deprecatedGetCurrentNetworkId } from './selectors';
 
 const unapprovedTxsSelector = (state) => state.metamask.unapprovedTxs;
@@ -218,9 +219,16 @@ export const transactionFeeSelector = function (state, txData) {
   const conversionRate = conversionRateSelector(state);
   const nativeCurrency = getNativeCurrency(state);
 
-  const {
-    txParams: { value = '0x0', gas: gasLimit = '0x0', gasPrice = '0x0' } = {},
+  const { txParams: { value = '0x0', gas: gasLimit = '0x0' } = {} } = txData;
+
+  // if the gas price from our infura endpoint is null or undefined
+  // use the metaswap average price estimation as a fallback
+  let {
+    txParams: { gasPrice },
   } = txData;
+  if (!gasPrice) {
+    gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';
+  }
 
   const fiatTransactionAmount = getValueFromWeiHex({
     value,


### PR DESCRIPTION
Fixes: #11226

Explanation:  Adds a fallback (metaswap average gas price estimation) gas price if the infura gas price estimation endpoint fails.

Manual testing steps:  
  - Requires either modifying data in dev tools because we can't reliably reproduce the issue where infura's api fails