### PR TITLE
Restore CLA bot permissions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,6 +9,9 @@ jobs:
   CLABot:
     if: github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')
     runs-on: ubuntu-latest
+    permissions:
+      pull requests: write
+      contents: write
     steps:
       - name: "CLA Signature Bot"
         uses: MetaMask/cla-signature-bot@v3.0.2


### PR DESCRIPTION
The CLA bot had its write permissions revoked recently when our organization-wide settings were updated to restrict actions to read access by default. This PR restores write access to PRs and to the repository itself for the CLA bot. It needs PR write access to leave comments, and needs write access to the repo itself to commit new signatures.