### PR TITLE
move metamask state selectors out of send

### DIFF
--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -11,10 +11,10 @@ import { useMetricEvent } from '../../../hooks/useMetricEvent';
 import { useUserPreferencedCurrency } from '../../../hooks/useUserPreferencedCurrency';
 import {
   getCurrentAccountWithSendEtherInfo,
-  getNativeCurrency,
   getShouldShowFiat,
   getNativeCurrencyImage,
 } from '../../../selectors';
+import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';
 
 const AssetList = ({ onClickAsset }) => {

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.container.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.container.js
@@ -2,9 +2,9 @@ import { connect } from 'react-redux';
 import { findLastIndex } from 'lodash';
 import {
   conversionRateSelector,
-  getNativeCurrency,
   getRpcPrefsForCurrentProvider,
 } from '../../../selectors';
+import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import TransactionActivityLog from './transaction-activity-log.component';
 import { combineTransactionHistories } from './transaction-activity-log.util';
 import {

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -1,9 +1,6 @@
 import { connect } from 'react-redux';
-import {
-  getIsMainnet,
-  getNativeCurrency,
-  getPreferences,
-} from '../../../selectors';
+import { getIsMainnet, getPreferences } from '../../../selectors';
+import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util';
 import { sumHexes } from '../../../helpers/utils/transactions.util';
 import TransactionBreakdown from './transaction-breakdown.component';

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -2,8 +2,8 @@ import {
   conversionRateSelector,
   currentCurrencySelector,
   unconfirmedTransactionsHashSelector,
-  getNativeCurrency,
 } from '../../selectors';
+import { getNativeCurrency } from '../metamask/metamask';
 
 import {
   getValueFromWeiHex,

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -1,6 +1,10 @@
 import * as actionConstants from '../../store/actionConstants';
 import { ALERT_TYPES } from '../../../shared/constants/alerts';
 import { NETWORK_TYPE_RPC } from '../../../shared/constants/network';
+import {
+  accountsWithSendEtherInfoSelector,
+  getAddressBook,
+} from '../../selectors';
 
 export default function reduceMetamask(state = {}, action) {
   const metamaskState = {
@@ -35,6 +39,7 @@ export default function reduceMetamask(state = {}, action) {
     featureFlags: {},
     welcomeScreenSeen: false,
     currentLocale: '',
+    currentBlockGasLimit: '',
     preferences: {
       autoLockTimeLimit: undefined,
       showFiatInTestnets: false,
@@ -46,6 +51,8 @@ export default function reduceMetamask(state = {}, action) {
     participateInMetaMetrics: null,
     metaMetricsSendCount: 0,
     nextNonce: null,
+    conversionRate: null,
+    nativeCurrency: 'ETH',
     ...state,
   };
 
@@ -378,3 +385,29 @@ export const getUnconnectedAccountAlertShown = (state) =>
   state.metamask.unconnectedAccountAlertShownOrigins;
 
 export const getTokens = (state) => state.metamask.tokens;
+
+export function getBlockGasLimit(state) {
+  return state.metamask.currentBlockGasLimit;
+}
+
+export function getConversionRate(state) {
+  return state.metamask.conversionRate;
+}
+
+export function getNativeCurrency(state) {
+  return state.metamask.nativeCurrency;
+}
+
+export function getSendHexDataFeatureFlagState(state) {
+  return state.metamask.featureFlags.sendHexData;
+}
+
+export function getSendToAccounts(state) {
+  const fromAccounts = accountsWithSendEtherInfoSelector(state);
+  const addressBookAccounts = getAddressBook(state);
+  return [...fromAccounts, ...addressBookAccounts];
+}
+
+export function getUnapprovedTxs(state) {
+  return state.metamask.unapprovedTxs;
+}

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -1,9 +1,111 @@
+import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 import * as actionConstants from '../../store/actionConstants';
-import reduceMetamask from './metamask';
+import reduceMetamask, {
+  getBlockGasLimit,
+  getConversionRate,
+  getNativeCurrency,
+  getSendHexDataFeatureFlagState,
+  getSendToAccounts,
+  getUnapprovedTxs,
+} from './metamask';
 
 describe('MetaMask Reducers', () => {
+  const mockState = {
+    metamask: reduceMetamask(
+      {
+        isInitialized: true,
+        isUnlocked: true,
+        featureFlags: { sendHexData: true },
+        identities: {
+          '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825': {
+            address: '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825',
+            name: 'Send Account 1',
+          },
+          '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb': {
+            address: '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb',
+            name: 'Send Account 2',
+          },
+          '0x2f8d4a878cfa04a6e60d46362f5644deab66572d': {
+            address: '0x2f8d4a878cfa04a6e60d46362f5644deab66572d',
+            name: 'Send Account 3',
+          },
+          '0xd85a4b6a394794842887b8284293d69163007bbb': {
+            address: '0xd85a4b6a394794842887b8284293d69163007bbb',
+            name: 'Send Account 4',
+          },
+        },
+        cachedBalances: {},
+        currentBlockGasLimit: '0x4c1878',
+        conversionRate: 1200.88200327,
+        nativeCurrency: 'ETH',
+        network: '3',
+        provider: {
+          type: 'testnet',
+          chainId: '0x3',
+        },
+        accounts: {
+          '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825': {
+            code: '0x',
+            balance: '0x47c9d71831c76efe',
+            nonce: '0x1b',
+            address: '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825',
+          },
+          '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb': {
+            code: '0x',
+            balance: '0x37452b1315889f80',
+            nonce: '0xa',
+            address: '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb',
+          },
+          '0x2f8d4a878cfa04a6e60d46362f5644deab66572d': {
+            code: '0x',
+            balance: '0x30c9d71831c76efe',
+            nonce: '0x1c',
+            address: '0x2f8d4a878cfa04a6e60d46362f5644deab66572d',
+          },
+          '0xd85a4b6a394794842887b8284293d69163007bbb': {
+            code: '0x',
+            balance: '0x0',
+            nonce: '0x0',
+            address: '0xd85a4b6a394794842887b8284293d69163007bbb',
+          },
+        },
+        addressBook: {
+          '0x3': {
+            '0x06195827297c7a80a443b6894d3bdb8824b43896': {
+              address: '0x06195827297c7a80a443b6894d3bdb8824b43896',
+              name: 'Address Book Account 1',
+              chainId: '0x3',
+            },
+          },
+        },
+        unapprovedTxs: {
+          4768706228115573: {
+            id: 4768706228115573,
+            time: 1487363153561,
+            status: TRANSACTION_STATUSES.UNAPPROVED,
+            gasMultiplier: 1,
+            metamaskNetworkId: '3',
+            txParams: {
+              from: '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb',
+              to: '0x18a3462427bcc9133bb46e88bcbe39cd7ef0e761',
+              value: '0xde0b6b3a7640000',
+              metamaskId: 4768706228115573,
+              metamaskNetworkId: '3',
+              gas: '0x5209',
+            },
+            txFee: '17e0186e60800',
+            txValue: 'de0b6b3a7640000',
+            maxCost: 'de234b52e4a0800',
+            gasPrice: '4a817c800',
+          },
+        },
+      },
+      {},
+    ),
+  };
   it('init state', () => {
     const initState = reduceMetamask(undefined, {});
+
     expect.anything(initState);
   });
 
@@ -402,5 +504,95 @@ describe('MetaMask Reducers', () => {
 
     expect(state.send.ensResolutionError).toStrictEqual('ens name not found');
     expect(state.send.ensResolution).toBeNull();
+  });
+
+  describe('metamask state selectors', () => {
+    describe('getBlockGasLimit', () => {
+      it('should return the current block gas limit', () => {
+        expect(getBlockGasLimit(mockState)).toStrictEqual('0x4c1878');
+      });
+    });
+
+    describe('getConversionRate()', () => {
+      it('should return the eth conversion rate', () => {
+        expect(getConversionRate(mockState)).toStrictEqual(1200.88200327);
+      });
+    });
+
+    describe('getNativeCurrency()', () => {
+      it('should return the ticker symbol of the selected network', () => {
+        expect(getNativeCurrency(mockState)).toStrictEqual('ETH');
+      });
+    });
+
+    describe('getSendHexDataFeatureFlagState()', () => {
+      it('should return the sendHexData feature flag state', () => {
+        expect(getSendHexDataFeatureFlagState(mockState)).toStrictEqual(true);
+      });
+    });
+
+    describe('getSendToAccounts()', () => {
+      it('should return an array including all the users accounts and the address book', () => {
+        expect(getSendToAccounts(mockState)).toStrictEqual([
+          {
+            code: '0x',
+            balance: '0x47c9d71831c76efe',
+            nonce: '0x1b',
+            address: '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825',
+            name: 'Send Account 1',
+          },
+          {
+            code: '0x',
+            balance: '0x37452b1315889f80',
+            nonce: '0xa',
+            address: '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb',
+            name: 'Send Account 2',
+          },
+          {
+            code: '0x',
+            balance: '0x30c9d71831c76efe',
+            nonce: '0x1c',
+            address: '0x2f8d4a878cfa04a6e60d46362f5644deab66572d',
+            name: 'Send Account 3',
+          },
+          {
+            code: '0x',
+            balance: '0x0',
+            nonce: '0x0',
+            address: '0xd85a4b6a394794842887b8284293d69163007bbb',
+            name: 'Send Account 4',
+          },
+          {
+            address: '0x06195827297c7a80a443b6894d3bdb8824b43896',
+            name: 'Address Book Account 1',
+            chainId: '0x3',
+          },
+        ]);
+      });
+    });
+
+    it('should return the unapproved txs', () => {
+      expect(getUnapprovedTxs(mockState)).toStrictEqual({
+        4768706228115573: {
+          id: 4768706228115573,
+          time: 1487363153561,
+          status: TRANSACTION_STATUSES.UNAPPROVED,
+          gasMultiplier: 1,
+          metamaskNetworkId: '3',
+          txParams: {
+            from: '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb',
+            to: '0x18a3462427bcc9133bb46e88bcbe39cd7ef0e761',
+            value: '0xde0b6b3a7640000',
+            metamaskId: 4768706228115573,
+            metamaskNetworkId: '3',
+            gas: '0x5209',
+          },
+          txFee: '17e0186e60800',
+          txValue: 'de0b6b3a7640000',
+          maxCost: 'de234b52e4a0800',
+          gasPrice: '4a817c800',
+        },
+      });
+    });
   });
 });

--- a/ui/hooks/useCancelTransaction.js
+++ b/ui/hooks/useCancelTransaction.js
@@ -7,11 +7,9 @@ import {
   getHexGasTotal,
   increaseLastGasPrice,
 } from '../helpers/utils/confirm-tx.util';
-import {
-  getConversionRate,
-  getSelectedAccount,
-  getIsMainnet,
-} from '../selectors';
+import { getSelectedAccount, getIsMainnet } from '../selectors';
+import { getConversionRate } from '../ducks/metamask/metamask';
+
 import {
   setCustomGasLimit,
   setCustomGasPriceForRetry,

--- a/ui/hooks/useCurrencyDisplay.js
+++ b/ui/hooks/useCurrencyDisplay.js
@@ -4,11 +4,11 @@ import {
   formatCurrency,
   getValueFromWeiHex,
 } from '../helpers/utils/confirm-tx.util';
+import { getCurrentCurrency } from '../selectors';
 import {
-  getCurrentCurrency,
   getConversionRate,
   getNativeCurrency,
-} from '../selectors';
+} from '../ducks/metamask/metamask';
 
 /**
  * Defines the shape of the options parameter for useCurrencyDisplay

--- a/ui/hooks/useCurrencyDisplay.test.js
+++ b/ui/hooks/useCurrencyDisplay.test.js
@@ -1,11 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks';
 import * as reactRedux from 'react-redux';
 import sinon from 'sinon';
+import { getCurrentCurrency } from '../selectors';
 import {
-  getCurrentCurrency,
-  getNativeCurrency,
   getConversionRate,
-} from '../selectors';
+  getNativeCurrency,
+} from '../ducks/metamask/metamask';
 import { useCurrencyDisplay } from './useCurrencyDisplay';
 
 const tests = [

--- a/ui/hooks/useEthFiatAmount.js
+++ b/ui/hooks/useEthFiatAmount.js
@@ -1,12 +1,9 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import {
-  getConversionRate,
-  getCurrentCurrency,
-  getShouldShowFiat,
-} from '../selectors';
+import { getCurrentCurrency, getShouldShowFiat } from '../selectors';
 import { decEthToConvertedCurrency } from '../helpers/utils/conversions.util';
 import { formatCurrency } from '../helpers/utils/confirm-tx.util';
+import { getConversionRate } from '../ducks/metamask/metamask';
 
 /**
  * Get an Eth amount converted to fiat and formatted for display

--- a/ui/hooks/useTokenFiatAmount.js
+++ b/ui/hooks/useTokenFiatAmount.js
@@ -2,11 +2,11 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
   getTokenExchangeRates,
-  getConversionRate,
   getCurrentCurrency,
   getShouldShowFiat,
 } from '../selectors';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
+import { getConversionRate } from '../ducks/metamask/metamask';
 
 /**
  * Get the token balance converted to fiat and formatted for display

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -6,11 +6,12 @@ import { isEqual, shuffle, uniqBy } from 'lodash';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
 import {
   getTokenExchangeRates,
-  getConversionRate,
   getCurrentCurrency,
   getSwapsDefaultToken,
   getCurrentChainId,
 } from '../selectors';
+import { getConversionRate } from '../ducks/metamask/metamask';
+
 import { getSwapsTokens } from '../ducks/swaps/swaps';
 import { isSwapsDefaultTokenSymbol } from '../../shared/modules/swaps.utils';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -7,11 +7,10 @@ import transactions from '../../test/data/transaction-data.json';
 import {
   getPreferences,
   getShouldShowFiat,
-  getNativeCurrency,
   getCurrentCurrency,
   getCurrentChainId,
 } from '../selectors';
-import { getTokens } from '../ducks/metamask/metamask';
+import { getTokens, getNativeCurrency } from '../ducks/metamask/metamask';
 import { getMessage } from '../helpers/utils/i18n-helper';
 import messages from '../../app/_locales/en/messages.json';
 import { ASSET_ROUTE, DEFAULT_ROUTE } from '../helpers/constants/routes';

--- a/ui/hooks/useUserPreferencedCurrency.js
+++ b/ui/hooks/useUserPreferencedCurrency.js
@@ -1,9 +1,7 @@
 import { useSelector } from 'react-redux';
-import {
-  getPreferences,
-  getShouldShowFiat,
-  getNativeCurrency,
-} from '../selectors';
+import { getPreferences, getShouldShowFiat } from '../selectors';
+import { getNativeCurrency } from '../ducks/metamask/metamask';
+
 import { PRIMARY, SECONDARY, ETH } from '../helpers/constants/common';
 
 /**

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -14,13 +14,12 @@ import {
   getTokenValueParam,
 } from '../../helpers/utils/token-util';
 import { useTokenTracker } from '../../hooks/useTokenTracker';
-import { getTokens } from '../../ducks/metamask/metamask';
+import { getTokens, getNativeCurrency } from '../../ducks/metamask/metamask';
 import {
   transactionFeeSelector,
   txDataSelector,
   getCurrentCurrency,
   getDomainMetadata,
-  getNativeCurrency,
   getUseNonceField,
   getCustomNonceValue,
   getNextSuggestedNonce,
@@ -28,6 +27,7 @@ import {
   getIsEthGasPriceFetched,
   getIsMainnet,
 } from '../../selectors';
+
 import { currentNetworkTxListSelector } from '../../selectors/transactions';
 import Loading from '../../components/ui/loading-screen';
 import { getCustomTxParamsData } from './confirm-approve.util';

--- a/ui/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/pages/permissions-connect/permissions-connect.container.js
@@ -2,12 +2,12 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   getPermissionsRequests,
-  getNativeCurrency,
   getAccountsWithLabels,
   getLastConnectedInfo,
   getDomainMetadata,
   getSelectedAddress,
 } from '../../selectors';
+import { getNativeCurrency } from '../../ducks/metamask/metamask';
 
 import { formatDate } from '../../helpers/utils/util';
 import {

--- a/ui/pages/send/send-content/send-amount-row/send-amount-row.container.js
+++ b/ui/pages/send/send-content/send-amount-row/send-amount-row.container.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import {
-  getConversionRate,
   getGasTotal,
   getPrimaryCurrency,
   getSendToken,
@@ -13,6 +12,7 @@ import {
 import { getAmountErrorObject, getGasFeeErrorObject } from '../../send.utils';
 import { setMaxModeTo, updateSendAmount } from '../../../../store/actions';
 import { updateSendErrors } from '../../../../ducks/send/send.duck';
+import { getConversionRate } from '../../../../ducks/metamask/metamask';
 import SendAmountRow from './send-amount-row.component';
 
 export default connect(mapStateToProps, mapDispatchToProps)(SendAmountRow);

--- a/ui/pages/send/send-content/send-asset-row/send-asset-row.container.js
+++ b/ui/pages/send/send-content/send-asset-row/send-asset-row.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
+import { getNativeCurrency } from '../../../../ducks/metamask/metamask';
 import {
   getMetaMaskAccounts,
-  getNativeCurrency,
   getNativeCurrencyImage,
   getSendTokenAddress,
   getAssetImages,

--- a/ui/pages/send/send-content/send-gas-row/send-gas-row.container.js
+++ b/ui/pages/send/send-content/send-gas-row/send-gas-row.container.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import {
-  getConversionRate,
   getGasTotal,
   getGasPrice,
   getGasLimit,
@@ -39,6 +38,7 @@ import {
   setGasTotal,
   updateSendAmount,
 } from '../../../../store/actions';
+import { getConversionRate } from '../../../../ducks/metamask/metamask';
 import SendGasRow from './send-gas-row.component';
 
 export default connect(

--- a/ui/pages/send/send-footer/send-footer.container.js
+++ b/ui/pages/send/send-footer/send-footer.container.js
@@ -15,10 +15,8 @@ import {
   getSendEditingTransactionId,
   getSendFromObject,
   getSendTo,
-  getSendToAccounts,
   getSendHexData,
   getTokenBalance,
-  getUnapprovedTxs,
   getSendErrors,
   isSendFormInError,
   getGasIsLoading,
@@ -28,6 +26,10 @@ import {
 } from '../../../selectors';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
+import {
+  getSendToAccounts,
+  getUnapprovedTxs,
+} from '../../../ducks/metamask/metamask';
 import SendFooter from './send-footer.component';
 import {
   addressIsNew,

--- a/ui/pages/send/send.container.js
+++ b/ui/pages/send/send.container.js
@@ -3,8 +3,6 @@ import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import {
-  getBlockGasLimit,
-  getConversionRate,
   getGasLimit,
   getGasPrice,
   getGasTotal,
@@ -13,7 +11,6 @@ import {
   getSendTokenContract,
   getSendAmount,
   getSendEditingTransactionId,
-  getSendHexDataFeatureFlagState,
   getSendFromObject,
   getSendTo,
   getSendToNickname,
@@ -38,7 +35,12 @@ import {
 } from '../../store/actions';
 import { resetSendState, updateSendErrors } from '../../ducks/send/send.duck';
 import { fetchBasicGasEstimates } from '../../ducks/gas/gas.duck';
-import { getTokens } from '../../ducks/metamask/metamask';
+import {
+  getBlockGasLimit,
+  getConversionRate,
+  getSendHexDataFeatureFlagState,
+  getTokens,
+} from '../../ducks/metamask/metamask';
 import { isValidDomainName } from '../../helpers/utils/util';
 import { calcGasTotal } from './send.utils';
 import SendEther from './send.component';

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -16,7 +16,7 @@ import { I18nContext } from '../../../contexts/i18n';
 import DropdownInputPair from '../dropdown-input-pair';
 import DropdownSearchList from '../dropdown-search-list';
 import SlippageButtons from '../slippage-buttons';
-import { getTokens } from '../../../ducks/metamask/metamask';
+import { getTokens, getConversionRate } from '../../../ducks/metamask/metamask';
 import InfoTooltip from '../../../components/ui/info-tooltip';
 import ActionableMessage from '../actionable-message';
 
@@ -33,11 +33,11 @@ import {
 import {
   getSwapsDefaultToken,
   getTokenExchangeRates,
-  getConversionRate,
   getCurrentCurrency,
   getCurrentChainId,
   getRpcPrefsForCurrentProvider,
 } from '../../../selectors';
+
 import {
   getValueFromWeiHex,
   hexToDecimal,

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
@@ -8,9 +8,9 @@ import {
   getDefaultActiveButtonIndex,
   getRenderableGasButtonData,
   getUSDConversionRate,
-  getNativeCurrency,
   getSwapsDefaultToken,
 } from '../../../selectors';
+import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 
 import {
   getSwapsCustomizationModalPrice,

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -38,12 +38,13 @@ import {
   getTokenExchangeRates,
   getSwapsDefaultToken,
   getCurrentChainId,
-  getNativeCurrency,
   isHardwareWallet,
   getHardwareWalletType,
 } from '../../../selectors';
+import { getNativeCurrency, getTokens } from '../../../ducks/metamask/metamask';
+
 import { toPrecisionWithoutTrailingZeros } from '../../../helpers/utils/util';
-import { getTokens } from '../../../ducks/metamask/metamask';
+
 import {
   safeRefetchQuotes,
   setCustomApproveTxData,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -11,8 +11,8 @@ import {
 } from '../helpers/utils/confirm-tx.util';
 import { sumHexes } from '../helpers/utils/transactions.util';
 import { transactionMatchesNetwork } from '../../shared/modules/transaction.utils';
+import { getNativeCurrency } from '../ducks/metamask/metamask';
 import { getCurrentChainId, deprecatedGetCurrentNetworkId } from './selectors';
-import { getNativeCurrency } from '.';
 
 const unapprovedTxsSelector = (state) => state.metamask.unapprovedTxs;
 const unapprovedMsgsSelector = (state) => state.metamask.unapprovedMsgs;

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -24,7 +24,7 @@ import { TEMPLATED_CONFIRMATION_MESSAGE_TYPES } from '../pages/confirmation/temp
 
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { DAY } from '../../shared/constants/time';
-import { getNativeCurrency } from './send';
+import { getNativeCurrency } from '../ducks/metamask/metamask';
 
 /**
  * One of the only remaining valid uses of selecting the network subkey of the

--- a/ui/selectors/send.js
+++ b/ui/selectors/send.js
@@ -1,24 +1,10 @@
 import abi from 'human-standard-token-abi';
 import { calcGasTotal } from '../pages/send/send.utils';
 import {
-  accountsWithSendEtherInfoSelector,
-  getAddressBook,
   getSelectedAccount,
   getTargetAccount,
   getAveragePriceEstimateInHexWEI,
 } from '.';
-
-export function getBlockGasLimit(state) {
-  return state.metamask.currentBlockGasLimit;
-}
-
-export function getConversionRate(state) {
-  return state.metamask.conversionRate;
-}
-
-export function getNativeCurrency(state) {
-  return state.metamask.nativeCurrency;
-}
 
 export function getGasLimit(state) {
   return state.metamask.send.gasLimit || '0';
@@ -58,10 +44,6 @@ export function getSendAmount(state) {
 
 export function getSendHexData(state) {
   return state.metamask.send.data;
-}
-
-export function getSendHexDataFeatureFlagState(state) {
-  return state.metamask.featureFlags.sendHexData;
 }
 
 export function getSendEditingTransactionId(state) {
@@ -104,11 +86,6 @@ export function getSendToNickname(state) {
   return state.metamask.send.toNickname;
 }
 
-export function getSendToAccounts(state) {
-  const fromAccounts = accountsWithSendEtherInfoSelector(state);
-  const addressBookAccounts = getAddressBook(state);
-  return [...fromAccounts, ...addressBookAccounts];
-}
 export function getTokenBalance(state) {
   return state.metamask.send.tokenBalance;
 }
@@ -119,10 +96,6 @@ export function getSendEnsResolution(state) {
 
 export function getSendEnsResolutionError(state) {
   return state.metamask.send.ensResolutionError;
-}
-
-export function getUnapprovedTxs(state) {
-  return state.metamask.unapprovedTxs;
 }
 
 export function getQrCodeData(state) {

--- a/ui/selectors/send.test.js
+++ b/ui/selectors/send.test.js
@@ -1,9 +1,5 @@
 import sinon from 'sinon';
-import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
 import {
-  getBlockGasLimit,
-  getConversionRate,
-  getNativeCurrency,
   getGasLimit,
   getGasPrice,
   getGasTotal,
@@ -17,12 +13,9 @@ import {
   getSendFrom,
   getSendFromBalance,
   getSendFromObject,
-  getSendHexDataFeatureFlagState,
   getSendMaxModeState,
   getSendTo,
-  getSendToAccounts,
   getTokenBalance,
-  getUnapprovedTxs,
   gasFeeIsInError,
   getGasLoadingError,
   getGasButtonGroupShown,
@@ -84,18 +77,6 @@ describe('send selectors', () => {
     });
   });
 
-  describe('getBlockGasLimit', () => {
-    it('should return the current block gas limit', () => {
-      expect(getBlockGasLimit(mockState)).toStrictEqual('0x4c1878');
-    });
-  });
-
-  describe('getConversionRate()', () => {
-    it('should return the eth conversion rate', () => {
-      expect(getConversionRate(mockState)).toStrictEqual(1200.88200327);
-    });
-  });
-
   describe('getCurrentAccountWithSendEtherInfo()', () => {
     it('should return the currently selected account with identity info', () => {
       expect(getCurrentAccountWithSendEtherInfo(mockState)).toStrictEqual({
@@ -105,12 +86,6 @@ describe('send selectors', () => {
         address: '0xd85a4b6a394794842887b8284293d69163007bbb',
         name: 'Send Account 4',
       });
-    });
-  });
-
-  describe('getNativeCurrency()', () => {
-    it('should return the ticker symbol of the selected network', () => {
-      expect(getNativeCurrency(mockState)).toStrictEqual('ETH');
     });
   });
 
@@ -207,12 +182,6 @@ describe('send selectors', () => {
     });
   });
 
-  describe('getSendHexDataFeatureFlagState()', () => {
-    it('should return the sendHexData feature flag state', () => {
-      expect(getSendHexDataFeatureFlagState(mockState)).toStrictEqual(true);
-    });
-  });
-
   describe('getSendFrom()', () => {
     it('should return the send.from', () => {
       expect(getSendFrom(mockState)).toStrictEqual(
@@ -279,75 +248,9 @@ describe('send selectors', () => {
     });
   });
 
-  describe('getSendToAccounts()', () => {
-    it('should return an array including all the users accounts and the address book', () => {
-      expect(getSendToAccounts(mockState)).toStrictEqual([
-        {
-          code: '0x',
-          balance: '0x47c9d71831c76efe',
-          nonce: '0x1b',
-          address: '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825',
-          name: 'Send Account 1',
-        },
-        {
-          code: '0x',
-          balance: '0x37452b1315889f80',
-          nonce: '0xa',
-          address: '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb',
-          name: 'Send Account 2',
-        },
-        {
-          code: '0x',
-          balance: '0x30c9d71831c76efe',
-          nonce: '0x1c',
-          address: '0x2f8d4a878cfa04a6e60d46362f5644deab66572d',
-          name: 'Send Account 3',
-        },
-        {
-          code: '0x',
-          balance: '0x0',
-          nonce: '0x0',
-          address: '0xd85a4b6a394794842887b8284293d69163007bbb',
-          name: 'Send Account 4',
-        },
-        {
-          address: '0x06195827297c7a80a443b6894d3bdb8824b43896',
-          name: 'Address Book Account 1',
-          chainId: '0x3',
-        },
-      ]);
-    });
-  });
-
   describe('getTokenBalance()', () => {
     it('should', () => {
       expect(getTokenBalance(mockState)).toStrictEqual(3434);
-    });
-  });
-
-  describe('getUnapprovedTxs()', () => {
-    it('should return the unapproved txs', () => {
-      expect(getUnapprovedTxs(mockState)).toStrictEqual({
-        4768706228115573: {
-          id: 4768706228115573,
-          time: 1487363153561,
-          status: TRANSACTION_STATUSES.UNAPPROVED,
-          gasMultiplier: 1,
-          metamaskNetworkId: '3',
-          txParams: {
-            from: '0xc5b8dbac4c1d3f152cdeb400e2313f309c410acb',
-            to: '0x18a3462427bcc9133bb46e88bcbe39cd7ef0e761',
-            value: '0xde0b6b3a7640000',
-            metamaskId: 4768706228115573,
-            metamaskNetworkId: '3',
-            gas: '0x5209',
-          },
-          txFee: '17e0186e60800',
-          txValue: 'de0b6b3a7640000',
-          maxCost: 'de234b52e4a0800',
-          gasPrice: '4a817c800',
-        },
-      });
     });
   });
 


### PR DESCRIPTION
Moves selectors from the 'send' file in the selectors folder to the metamask duck, which more closely aligns with where the values are derived from. Previously they were in the send selectors because they are predominately used in that flow but that isn't the best organization model. This is pulled out of #10965 