### PR TITLE
Fix CLA Signature bot workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event_name == 'pull_request_target' || contains(github.event.comment.html_url, '/pull/')
     runs-on: ubuntu-latest
     permissions:
-      pull requests: write
+      pull-requests: write
       contents: write
     steps:
       - name: "CLA Signature Bot"


### PR DESCRIPTION
In a recent PR (#11240) the workflow was updated to explicitly add the required permissions. Unfortunately the "pull-requests" permission was added with a space instead of a dash, which apparently breaks the workflow. It now has a dash, as shown in [the example in the docs](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#example-1-passing-the-github_token-as-an-input).