### PR TITLE
fix jsconfig woes

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,14 +1,7 @@
 {
-  "exclude": [
-    "*.log",
-    "builds",
-    "coverage",
-    "dist",
-    "docs",
-    "lavamoat",
-    "node:console",
-    "node_modules",
-    "patches",
-    "test-artifacts"
-  ]
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs"
+  },
+  "include": ["ui/**/*.js", "app/**/*.js", "shared/**/*.js"]
 }


### PR DESCRIPTION
in #11011 @rekmarks correctly identified an issue that was slowing down our vscode experience, for some reason the dist folder is like a black hole sucking all autocomplete into it. If you ignore it, initializing language features takes *forever* and crashes frequently. If you don't ignore it autocomplete is fast but you get warned about slow features.

The solution seems to *only* include our three primary js directories. 