### PR TITLE
fix issue with importing ui module space inside shared

### DIFF
--- a/shared/constants/gas.js
+++ b/shared/constants/gas.js
@@ -1,9 +1,11 @@
 import { addHexPrefix } from 'ethereumjs-util';
-import { decimalToHex } from '../../ui/helpers/utils/conversions.util';
+
+const TWENTY_ONE_THOUSAND = 21000;
+const ONE_HUNDRED_THOUSAND = 100000;
 
 export const GAS_LIMITS = {
   // maximum gasLimit of a simple send
-  SIMPLE: addHexPrefix(decimalToHex(21_000)),
+  SIMPLE: addHexPrefix(TWENTY_ONE_THOUSAND.toString(16)),
   // a base estimate for token transfers.
-  BASE_TOKEN_ESTIMATE: addHexPrefix(decimalToHex(100_000)),
+  BASE_TOKEN_ESTIMATE: addHexPrefix(ONE_HUNDRED_THOUSAND.toString(16)),
 };


### PR DESCRIPTION
I accidently created an issue where we are importing the UI module space inside the shared module space which would inadvertently cause leaking of imports across UI into the app/ folder when importing the gas file. Because the numbers involved are lower than the max safe integer value it's safe to just use toString(16) 