### PR TITLE
Using native network currency for encryption public key requests

### DIFF
--- a/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
+++ b/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.component.js
@@ -30,6 +30,7 @@ export default class ConfirmEncryptionPublicKey extends Component {
     txData: PropTypes.object,
     domainMetadata: PropTypes.object,
     mostRecentOverviewPage: PropTypes.string.isRequired,
+    nativeCurrency: PropTypes.string.isRequired,
   };
 
   state = {
@@ -108,13 +109,13 @@ export default class ConfirmEncryptionPublicKey extends Component {
   };
 
   renderBalance = () => {
-    const { conversionRate } = this.props;
+    const { conversionRate, nativeCurrency } = this.props;
     const { t } = this.context;
     const {
       fromAccount: { balance },
     } = this.state;
 
-    const balanceInEther = conversionUtil(balance, {
+    const nativeCurrencyBalance = conversionUtil(balance, {
       fromNumericBase: 'hex',
       toNumericBase: 'dec',
       fromDenomination: 'WEI',
@@ -128,7 +129,7 @@ export default class ConfirmEncryptionPublicKey extends Component {
           {`${t('balance')}:`}
         </div>
         <div className="request-encryption-public-key__balance-value">
-          {`${balanceInEther} ETH`}
+          {`${nativeCurrencyBalance} ${nativeCurrency}`}
         </div>
       </div>
     );

--- a/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.container.js
+++ b/ui/pages/confirm-encryption-public-key/confirm-encryption-public-key.container.js
@@ -16,6 +16,7 @@ import {
 
 import { clearConfirmTransaction } from '../../ducks/confirm-transaction/confirm-transaction.duck';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
+import { getNativeCurrency } from '../../ducks/metamask/metamask';
 import ConfirmEncryptionPublicKey from './confirm-encryption-public-key.component';
 
 function mapStateToProps(state) {
@@ -39,6 +40,7 @@ function mapStateToProps(state) {
     requesterAddress: null,
     conversionRate: conversionRateSelector(state),
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
+    nativeCurrency: getNativeCurrency(state),
   };
 }
 


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#11247

Test snippet:
```
ethereum
  .request({
    method: 'eth_getEncryptionPublicKey',
    params: [ethereum.selectedAddress],
  })
  .then((result) => {
    console.log(result)
  })
  .catch((error) => {
    console.log(error)
  });
```

**Rinkeby**
<img width="477" alt="Screen Shot 2021-06-09 at 1 49 38 AM" src="https://user-images.githubusercontent.com/8732757/121324423-92af3300-c8c5-11eb-8645-99bf5f7b5998.png">

**BSC**
<img width="466" alt="Screen Shot 2021-06-09 at 1 49 23 AM" src="https://user-images.githubusercontent.com/8732757/121324354-81662680-c8c5-11eb-8594-7922c483aa55.png">

