### PR TITLE
Use verifyPassword instead of submitPassword in exportAccounts in actions.js

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1895,9 +1895,9 @@ export function exportAccount(password, address) {
 
 export function exportAccounts(password, addresses) {
   return function (dispatch) {
-    log.debug(`background.submitPassword`);
+    log.debug(`background.verifyPassword`);
     return new Promise((resolve, reject) => {
-      background.submitPassword(password, function (err) {
+      background.verifyPassword(password, function (err) {
         if (err) {
           log.error('Error in submitting password.');
           reject(err);


### PR DESCRIPTION
Errors during execution of `submitPassword` while logged in could result in an accidentally deleted vault. We don't need to call submit password in `exportAccounts`, we can call `verifyPassword` instead.