### PR TITLE
Stringify gas estimate in backend, before it is serialized and sent to ui

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1962,7 +1962,7 @@ export default class MetamaskController extends EventEmitter {
             return reject(err);
           }
 
-          return resolve(res);
+          return resolve(res.toString(16));
         },
       );
     });

--- a/ui/pages/send/send.utils.js
+++ b/ui/pages/send/send.utils.js
@@ -253,11 +253,7 @@ async function estimateGasForSend({
   // run tx
   try {
     const estimatedGas = await estimateGasMethod(paramsForGasEstimate);
-    const estimateWithBuffer = addGasBuffer(
-      estimatedGas.toString(16),
-      blockGasLimit,
-      1.5,
-    );
+    const estimateWithBuffer = addGasBuffer(estimatedGas, blockGasLimit, 1.5);
     return addHexPrefix(estimateWithBuffer);
   } catch (error) {
     const simulationFailed =

--- a/ui/pages/send/send.utils.test.js
+++ b/ui/pages/send/send.utils.test.js
@@ -289,7 +289,7 @@ describe('send utils', () => {
         if (typeof to === 'string' && to.match(/willFailBecauseOf:/u)) {
           throw new Error(to.match(/:(.+)$/u)[1]);
         }
-        return { toString: (n) => `0xabc${n}` };
+        return '0xabc16';
       }),
     };
     const baseexpectedCall = {


### PR DESCRIPTION
Fixes: #11255

It seems that firefox and chrome are serializing the result of the metamask controller `estimateGas` method differently. All we need this method to return is a string, and that will fix issues related to this difference in serialization. This PR makes that change.

