### PR TITLE
Remove unused parameters from `setProviderType`

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -205,7 +205,7 @@ export default class NetworkController extends EventEmitter {
     });
   }
 
-  async setProviderType(type, rpcUrl = '', ticker = 'ETH', nickname = '') {
+  async setProviderType(type) {
     assert.notStrictEqual(
       type,
       NETWORK_TYPE_RPC,
@@ -216,7 +216,13 @@ export default class NetworkController extends EventEmitter {
       `Unknown Infura provider type "${type}".`,
     );
     const { chainId } = NETWORK_TYPE_TO_ID_MAP[type];
-    this.setProviderConfig({ type, rpcUrl, chainId, ticker, nickname });
+    this.setProviderConfig({
+      type,
+      rpcUrl: '',
+      chainId,
+      ticker: 'ETH',
+      nickname: '',
+    });
   }
 
   resetConnection() {


### PR DESCRIPTION
Only the first parameter, `type`, was ever passed in. The others are superfluous. The defaults have been set directly instead.

It's a bit silly to set the `rpcUrl` and `nickname` to an empty string, but to make this more sensible would take much more effort. This at least is simpler and guaranteed to be equivalent.