### PR TITLE
Update `@metamask/contract-metadata` from v1.25 to v1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@lavamoat/preinstall-always-fail": "^1.0.0",
     "@material-ui/core": "^4.11.0",
-    "@metamask/contract-metadata": "^1.22.0",
+    "@metamask/contract-metadata": "^1.26.0",
     "@metamask/controllers": "^9.0.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.5.0",
     "@metamask/eth-token-tracker": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,10 +2630,15 @@
     semver "^7.3.5"
     yargs "^17.0.1"
 
-"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.22.0", "@metamask/contract-metadata@^1.25.0":
+"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.25.0":
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.25.0.tgz#442ace91fb40165310764b68d8096d0017bb0492"
   integrity sha512-yhmYB9CQPv0dckNcPoWDcgtrdUp0OgK0uvkRE5QIBv4b3qENI1/03BztvK2ijbTuMlORUpjPq7/1MQDUPoRPVw==
+
+"@metamask/contract-metadata@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.26.0.tgz#06be4f4dc645da69f6364f75cb2bd47afa642fe6"
+  integrity sha512-58A8csapIPoc854n6AI+3jwJcQfh75BzVrl6SAySgJ9fWTa1XItm9Tx/ORaqYrwaR/9JqH4SnkbXtqyFwuUL6w==
 
 "@metamask/controllers@^5.0.0":
   version "5.1.0"


### PR DESCRIPTION
This update includes various new tokens. See: https://github.com/MetaMask/contract-metadata/compare/v1.25.0...v1.26.0