### PR TITLE
Minor spelling correction to buildContactList

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -256,7 +256,7 @@
   "browserNotSupported": {
     "message": "Your Browser is not supported..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Build your contact list"
   },
   "builtInCalifornia": {

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "El explorador no es compatible…"
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Cree su lista de contactos"
   },
   "builtInCalifornia": {

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "El explorador no es compatible…"
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Cree su lista de contactos"
   },
   "builtInCalifornia": {

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "आपका ब्राउज़र समर्थित नहीं है..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "अपनी संपर्क सूची बनाएं"
   },
   "builtInCalifornia": {

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "Browser Anda tidak didukung..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Buat daftar kontak Anda"
   },
   "builtInCalifornia": {

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "ご使用のブラウザーはサポートされていません..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "連絡先リストを作成する"
   },
   "builtInCalifornia": {

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "지원되지 않는 브라우저입니다..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "연락처 목록 작성하기"
   },
   "builtInCalifornia": {

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "Hindi sinusuportahan ang iyong Browser..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Buuin ang iyong listahan ng contact"
   },
   "builtInCalifornia": {

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "Seu navegador não é compatível..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Crie sua lista de contatos"
   },
   "builtInCalifornia": {

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "Ваш браузер не поддерживается..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Создайте список контактов"
   },
   "builtInCalifornia": {

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -249,7 +249,7 @@
   "browserNotSupported": {
     "message": "Trình duyệt của bạn không được hỗ trợ..."
   },
-  "builContactList": {
+  "buildContactList": {
     "message": "Xây dựng danh sách liên hệ của bạn"
   },
   "builtInCalifornia": {

--- a/ui/pages/settings/contact-list-tab/contact-list-tab.component.js
+++ b/ui/pages/settings/contact-list-tab/contact-list-tab.component.js
@@ -50,7 +50,7 @@ export default class ContactListTab extends Component {
       <div className="address-book__container">
         <div>
           <img src="./images/address-book.svg" alt="Address book icon" />
-          <h4 className="address-book__title">{t('builContactList')}</h4>
+          <h4 className="address-book__title">{t('buildContactList')}</h4>
           <p className="address-book__sub-title">
             {t('addFriendsAndAddresses')}
           </p>


### PR DESCRIPTION
Spelling corrections for key `buildContactList`  in message.json files and ContactListTab.component  from builContactList to buildContactList.