### PR TITLE
Ignore; this is a test

### DIFF
--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 retry () {
   retry=0
-  limit="${METAMASK_E2E_RETRY_LIMIT:-3}"
+  limit="${METAMASK_E2E_RETRY_LIMIT:-1}"
   while [[ $retry -lt $limit ]]
   do
     "$@" && break

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -14,10 +14,11 @@ class ChromeDriver {
     const builder = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(options);
+    const service = new chrome.ServiceBuilder().setStdio('inherit');
     if (port) {
-      const service = new chrome.ServiceBuilder().setPort(port);
-      builder.setChromeService(service);
+      service.setPort(port);
     }
+    builder.setChromeService(service);
     const driver = builder.build();
     const chromeDriver = new ChromeDriver(driver);
     const extensionId = await chromeDriver.getExtensionIdByName('MetaMask');


### PR DESCRIPTION
This is an attempt to get logs for an intermittent Chrome E2E test failure. Error logs should now be included if it fails again.