### PR TITLE
Enable Chrome E2E logs

### DIFF
--- a/patches/selenium-webdriver+4.0.0-alpha.7.patch
+++ b/patches/selenium-webdriver+4.0.0-alpha.7.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/selenium-webdriver/chromium.js b/node_modules/selenium-webdriver/chromium.js
+index d828ce5..87176f4 100644
+--- a/node_modules/selenium-webdriver/chromium.js
++++ b/node_modules/selenium-webdriver/chromium.js
+@@ -197,6 +197,14 @@ class ServiceBuilder extends remote.DriverService.Builder {
+     return this.addArguments('--log-path=' + path);
+   }
+ 
++  /**
++   * Enables Chrome logging.
++   * @returns {!ServiceBuilder} A self reference.
++   */
++  enableChromeLogging() {
++    return this.addArguments('--enable-chrome-logs');
++  }
++
+   /**
+    * Enables verbose logging.
+    * @return {!ServiceBuilder} A self reference.

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -14,10 +14,21 @@ class ChromeDriver {
     const builder = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(options);
-    if (port) {
-      const service = new chrome.ServiceBuilder().setPort(port);
-      builder.setChromeService(service);
+    const service = new chrome.ServiceBuilder();
+
+    // Enables Chrome logging.
+    // Especially useful for discovering why Chrome has crashed, but can also
+    // be useful for revealing console errors (from the page or background).
+    if (
+      process.env.ENABLE_CHROME_LOGGING &&
+      process.env.ENABLE_CHROME_LOGGING !== 'false'
+    ) {
+      service.setStdio('inherit').enableChromeLogging();
     }
+    if (port) {
+      service.setPort(port);
+    }
+    builder.setChromeService(service);
     const driver = builder.build();
     const chromeDriver = new ChromeDriver(driver);
     const extensionId = await chromeDriver.getExtensionIdByName('MetaMask');


### PR DESCRIPTION
Chrome logs are now enabled for E2E tests when the 'ENABLE_CHROME_LOGS' environment variable is set to anything other than `false`.

This was helpful to me in debugging Chrome crashes on CI, the ones with the error "unknown error: DevToolsActivePort file doesn't exist". This was the only way to discover the cause of the error. It's also useful for discovering console errors from the background process or from the UI.

It's disabled by default because it makes the test output quite noisy and difficult to read.

This required a patch to `selenium-webdriver`, which has also been submitted upstream here: https://github.com/SeleniumHQ/selenium/pull/9575