### PR TITLE
Start dapp directly from `metamask-ui.spec.js`

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -1,24 +1,42 @@
 const { strict: assert } = require('assert');
+const path = require('path');
 
 const enLocaleMessages = require('../../app/_locales/en/messages.json');
+const createStaticServer = require('../../development/create-static-server');
 const { tinyDelayMs, regularDelayMs, largeDelayMs } = require('./helpers');
 const { buildWebDriver } = require('./webdriver');
 const Ganache = require('./ganache');
 
 const ganacheServer = new Ganache();
+const dappPort = 8080;
 
 describe('MetaMask', function () {
   let driver;
+  let dappServer;
   let tokenAddress;
 
   const testSeedPhrase =
     'phrase upgrade clock rough situate wedding elder clever doctor stamp excess tent';
 
-  this.timeout(0);
   this.bail(true);
 
   before(async function () {
     await ganacheServer.start();
+    const dappDirectory = path.resolve(
+      __dirname,
+      '..',
+      '..',
+      'node_modules',
+      '@metamask',
+      'test-dapp',
+      'dist',
+    );
+    dappServer = createStaticServer(dappDirectory);
+    dappServer.listen(dappPort);
+    await new Promise((resolve, reject) => {
+      dappServer.on('listening', resolve);
+      dappServer.on('error', reject);
+    });
     const result = await buildWebDriver();
     driver = result.driver;
     await driver.navigate();
@@ -43,6 +61,14 @@ describe('MetaMask', function () {
   after(async function () {
     await ganacheServer.quit();
     await driver.quit();
+    await new Promise((resolve, reject) => {
+      dappServer.close((error) => {
+        if (error) {
+          return reject(error);
+        }
+        return resolve();
+      });
+    });
   });
 
   describe('Going through the first time flow', function () {

--- a/test/e2e/run-all.sh
+++ b/test/e2e/run-all.sh
@@ -28,10 +28,4 @@ do
   retry mocha --no-timeouts "${spec}"
 done
 
-retry concurrently --kill-others \
-  --names 'dapp,e2e' \
-  --prefix '[{time}][{name}]' \
-  --success first \
-  'yarn dapp' \
-  'mocha test/e2e/metamask-ui.spec'
-
+retry mocha --no-timeouts test/e2e/metamask-ui.spec


### PR DESCRIPTION
The dapp is now started directly from the `metamask-ui.spec.js` test module. This makes it easier to run independently, and brings it in-line with our other E2E tests. Mainly this was done to facilitate further refactors which will come in later PRs.