### PR TITLE
Update Chrome version used for E2E testing to v91

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,7 @@ jobs:
           command: mv ./builds-test ./builds
       - run:
           name: Run page load benchmark
-          command: yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json
+          command: xvfb-run -e /dev/stderr -a yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome --retries 2
+              ENABLE_CHROME_LOGGING=true yarn test:e2e:chrome --retries 2
             fi
           no_output_timeout: 20m
       - store_artifacts:
@@ -370,7 +370,7 @@ jobs:
           command: |
             if .circleci/scripts/test-run-e2e.sh
             then
-              yarn test:e2e:chrome:metrics --retries 2
+              ENABLE_CHROME_LOGGING=true yarn test:e2e:chrome:metrics --retries 2
             fi
           no_output_timeout: 20m
       - store_artifacts:
@@ -448,7 +448,7 @@ jobs:
           command: mv ./builds-test ./builds
       - run:
           name: Run page load benchmark
-          command: xvfb-run -e /dev/stderr -a yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json
+          command: ENABLE_CHROME_LOGGING=true xvfb-run -e /dev/stderr -a yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts

--- a/.circleci/scripts/chrome-install.sh
+++ b/.circleci/scripts/chrome-install.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-CHROME_VERSION='79.0.3945.117-1'
+CHROME_VERSION='91.0.4472.101-1'
 CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 CHROME_BINARY_URL="http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
 
@@ -14,6 +14,9 @@ wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
 
 rm -rf "${CHROME_BINARY}"
 
-sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+sudo sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox --disable-dev-shm-usage|g' "/opt/google/chrome/google-chrome"
 
 printf '%s\n' "CHROME ${CHROME_VERSION} configured"
+
+# Set '/tmp/.X11-unix' to root to silence warning when running xvfb-run
+sudo chown root:root /tmp/.X11-unix

--- a/.circleci/scripts/firefox-install.sh
+++ b/.circleci/scripts/firefox-install.sh
@@ -27,3 +27,6 @@ printf '%s\n' "Firefox ${FIREFOX_VERSION} installed"
 sudo cp .circleci/scripts/firefox.cfg "${FIREFOX_PATH}"
 
 printf '%s\n' "Firefox ${FIREFOX_VERSION} configured"
+
+# Set '/tmp/.X11-unix' to root to silence warning when running xvfb-run
+sudo chown root:root /tmp/.X11-unix

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "brfs": "^2.0.2",
     "browserify": "^16.5.1",
     "chalk": "^3.0.0",
-    "chromedriver": "^79.0.0",
+    "chromedriver": "^91.0.1",
     "concurrently": "^5.2.0",
     "copy-webpack-plugin": "^6.0.3",
     "cross-spawn": "^7.0.3",

--- a/patches/selenium-webdriver+4.0.0-alpha.7.patch
+++ b/patches/selenium-webdriver+4.0.0-alpha.7.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/selenium-webdriver/chromium.js b/node_modules/selenium-webdriver/chromium.js
-index d828ce5..87176f4 100644
+index d828ce5..bca4a0f 100644
 --- a/node_modules/selenium-webdriver/chromium.js
 +++ b/node_modules/selenium-webdriver/chromium.js
-@@ -197,6 +197,14 @@ class ServiceBuilder extends remote.DriverService.Builder {
+@@ -197,6 +197,27 @@ class ServiceBuilder extends remote.DriverService.Builder {
      return this.addArguments('--log-path=' + path);
    }
  
@@ -12,6 +12,19 @@ index d828ce5..87176f4 100644
 +   */
 +  enableChromeLogging() {
 +    return this.addArguments('--enable-chrome-logs');
++  }
++
++  /**
++   * Set the remote IPs that are allowed to connect to ChromeDriver
++   *
++   * @param {Array<string>=} allowedIps A list of remote IPs to allow
++   * @returns {!ServiceBuilder} A self reference.
++   */
++   setAllowedIps(allowedIps) {
++     if (allowedIps) {
++      return this.addArguments('--allowed-ips=' + allowedIps.join(','));
++     }
++     return this.addArguments('--allowed-ips');
 +  }
 +
    /**

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -63,8 +63,17 @@ async function main() {
     throw error;
   }
 
+  let command = 'yarn';
+  const args = ['mocha', '--no-timeouts', e2eTestPath];
+
+  // Run test with virtual display on CI
+  if (process.env.CI === 'true') {
+    command = 'xvfb-run';
+    args.unshift(...['-e', '/dev/stderr', '-a', 'yarn']);
+  }
+
   await retry(retries, async () => {
-    await runInShell('yarn', ['mocha', '--no-timeouts', e2eTestPath]);
+    await runInShell(command, args);
   });
 }
 

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -14,7 +14,13 @@ class ChromeDriver {
     const builder = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(options);
-    const service = new chrome.ServiceBuilder();
+
+    // By default, ChromeDriver allows local connections over IPv4 and IPv6.
+    // When run in a Docker environment without IPv6 enabled (e.g. like on
+    // GitHub Actions), an error is thrown about failing to bind to a port.
+    // Setting the allowed IPs to just IPv4 localhost prevents it from trying
+    // and failing to allow connections on IPv6 localhost.
+    const service = new chrome.ServiceBuilder().setAllowedIps(['127.0.0.1']);
 
     // Enables Chrome logging.
     // Especially useful for discovering why Chrome has crashed, but can also

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,6 +3551,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testim/chrome-version@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
+  integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
+
 "@testing-library/dom@^7.17.1":
   version "7.22.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.2.tgz#6deaa828500993cc94bdd62875c251b5b5b70d69"
@@ -4069,6 +4074,13 @@
   integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  dependencies:
+    "@types/node" "*"
 
 "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.21.0"
@@ -7598,15 +7610,17 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^79.0.0:
-  version "79.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-79.0.0.tgz#1660ac29924dfcd847911025593d6b6746aeea35"
-  integrity sha512-DO29C7ntJfzu6q1vuoWwCON8E9x5xzopt7Q41A7Dr7hBKcdNpGw1l9DTt9b+l1qviOWiJLGsD+jHw21ptEHubA==
+chromedriver@^91.0.1:
+  version "91.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-91.0.1.tgz#4d70a569901e356c978a41de3019c464f2a8ebd0"
+  integrity sha512-9LktpHiUxM4UWUsr+jI1K1YKx2GENt6BKKJ2mibPj1Wc6ODzX/3fFIlr8CZ4Ftuyga+dHTTbAyPWKwKvybEbKA==
   dependencies:
-    del "^4.1.1"
-    extract-zip "^1.6.7"
-    mkdirp "^0.5.1"
-    request "^2.88.0"
+    "@testim/chrome-version" "^1.0.7"
+    axios "^0.21.1"
+    del "^6.0.0"
+    extract-zip "^2.0.1"
+    https-proxy-agent "^5.0.0"
+    proxy-from-env "^1.1.0"
     tcp-port-used "^1.0.1"
 
 ci-info@^1.5.0:
@@ -9063,18 +9077,19 @@ del@^3.0.0:
     pify "^3.0.0"
     rimraf "^2.2.8"
 
-del@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
-  integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
+del@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
+  integrity sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
   dependencies:
-    "@types/glob" "^7.1.1"
-    globby "^6.1.0"
-    is-path-cwd "^2.0.0"
-    is-path-in-cwd "^2.0.0"
-    p-map "^2.0.0"
-    pify "^4.0.1"
-    rimraf "^2.6.3"
+    globby "^11.0.1"
+    graceful-fs "^4.2.4"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.2"
+    p-map "^4.0.0"
+    rimraf "^3.0.2"
+    slash "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -11590,7 +11605,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^1.0.3, extract-zip@^1.6.7:
+extract-zip@^1.0.3:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
   integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
@@ -11599,6 +11614,17 @@ extract-zip@^1.0.3, extract-zip@^1.6.7:
     debug "^2.6.9"
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
+
+extract-zip@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -15160,7 +15186,7 @@ is-path-cwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
   integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
 
-is-path-cwd@^2.0.0:
+is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
@@ -15172,13 +15198,6 @@ is-path-in-cwd@^1.0.0:
   dependencies:
     is-path-inside "^1.0.0"
 
-is-path-in-cwd@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb"
-  integrity sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==
-  dependencies:
-    is-path-inside "^2.1.0"
-
 is-path-inside@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
@@ -15186,12 +15205,10 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-path-inside@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
-  integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
-  dependencies:
-    path-is-inside "^1.0.2"
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -22831,7 +22848,7 @@ request-promise-native@^1.0.9:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.79.0, request@^2.83.0, request@^2.85.0, request@^2.88.0, request@^2.88.2, request@~2.88.0:
+request@^2.79.0, request@^2.83.0, request@^2.85.0, request@^2.88.2, request@~2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
The Chrome version used for E2E testing has been updated from v79 to v91. This was delayed so long because all attempts to do this in the past had failed. We have since discovered that the failure was caused by a lack of a display to render to. This was resolved by using `xvfb` to create a virtual display when running tests.

Fixes: #

Explanation:  

Manual testing steps:  
  - Try running `yarn test:e2e:chrome` locally with Chrome v91 installed. It should just work!
  - All e2e tests (chrome and firefox) and the benchmark script should work correctly on CI
  - All e2e tests should behave as they did before locally  