### PR TITLE
Add retries to the benchmark script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,7 @@ jobs:
           command: mv ./builds-test ./builds
       - run:
           name: Run page load benchmark
-          command: yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json
+          command: yarn benchmark:chrome --out test-artifacts/chrome/benchmark/pageload.json --retries 2
       - store_artifacts:
           path: test-artifacts
           destination: test-artifacts

--- a/development/lib/retry.js
+++ b/development/lib/retry.js
@@ -1,5 +1,3 @@
-const { exitWithError } = require('./exit-with-error');
-
 /**
  * Run the given function, retrying it upon failure until reaching the
  * specified number of retries.
@@ -19,7 +17,7 @@ async function retry(retries, functionToRetry) {
       attempts += 1;
     }
   }
-  exitWithError('Retry limit reached');
+  throw new Error('Retry limit reached');
 }
 
 module.exports = { retry };


### PR DESCRIPTION
The benchmark script can now be set to retry upon failure, like the E2E tests do. The default is zero, just as with the E2E tests. A retry of 2 has been set in CI to match the E2E tests as well.

The `retry` module had to be adjusted to throw an error in the case of failure. Previously it just set the exit code, but that only worked because it was the last thing called before the process ended. That is no longer the case.

Manual testing steps:  
  - Try out the `yarn benchmark:chrome` and `yarn benchmark:firefox` npm scripts with the `--retries` option! I'd suggest passing in the `--samples` option though - the default is 20, which takes quite a while. Be sure to use at least 2 samples though - it throws an error with 1.