### PR TITLE
Fix benchmark script with 1 sample

### DIFF
--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -38,6 +38,9 @@ const minResult = calculateResult((array) => Math.min(...array));
 const maxResult = calculateResult((array) => Math.max(...array));
 const averageResult = calculateResult((array) => calculateAverage(array));
 const standardDeviationResult = calculateResult((array) => {
+  if (array.length === 1) {
+    return 0;
+  }
   const average = calculateAverage(array);
   const squareDiffs = array.map((value) => Math.pow(value - average, 2));
   return Math.sqrt(calculateAverage(squareDiffs));
@@ -46,7 +49,7 @@ const standardDeviationResult = calculateResult((array) => {
 const calculateMarginOfError = (array) =>
   ttest(array).confidence()[1] - calculateAverage(array);
 const marginOfErrorResult = calculateResult((array) =>
-  calculateMarginOfError(array),
+  array.length === 1 ? 0 : calculateMarginOfError(array),
 );
 
 async function profilePageLoad(pages, numSamples) {


### PR DESCRIPTION
Previously the benchmark script would throw an error if asked to take just 1 sample. Now it works, though the stats returned are of dubious use.

The problem was that it was impossible to calculate the standard deviation or margin of error of a set of 1. Instead it now returns zero for both of those values in the single-sample case, which is what it would return for two identical samples.

Manual testing steps:  
  - Try out the `yarn benchmark:chrome` and `yarn benchmark:firefox` npm scripts with `--samples` set to 1.