### PR TITLE
Add `--leave-running` flag to E2E test script

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -20,6 +20,8 @@ describe('MetaMask', function () {
 
   this.bail(true);
 
+  let failed = false;
+
   before(async function () {
     await ganacheServer.start();
     const dappDirectory = path.resolve(
@@ -54,11 +56,15 @@ describe('MetaMask', function () {
       }
     }
     if (this.currentTest.state === 'failed') {
+      failed = true;
       await driver.verboseReportOnFailure(this.currentTest.title);
     }
   });
 
   after(async function () {
+    if (process.env.E2E_LEAVE_RUNNING === 'true' && failed) {
+      return;
+    }
     await ganacheServer.quit();
     await driver.quit();
     await new Promise((resolve, reject) => {

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -24,6 +24,12 @@ async function main() {
               'Set how many times the test should be retried upon failure.',
             type: 'number',
           })
+          .option('leave-running', {
+            default: false,
+            description:
+              'Leaves the browser running after a test fails, along with anything else that the test used (ganache, the test dapp, etc.)',
+            type: 'boolean',
+          })
           .positional('e2e-test-path', {
             describe: 'The path for the E2E test to run.',
             type: 'string',
@@ -33,7 +39,7 @@ async function main() {
     .strict()
     .help('help');
 
-  const { browser, e2eTestPath, retries } = argv;
+  const { browser, e2eTestPath, retries, leaveRunning } = argv;
 
   if (!browser) {
     exitWithError(
@@ -61,6 +67,10 @@ async function main() {
       return;
     }
     throw error;
+  }
+
+  if (leaveRunning) {
+    process.env.E2E_LEAVE_RUNNING = 'true';
   }
 
   await retry(retries, async () => {


### PR DESCRIPTION
The `--leave-running` flag has been added to the E2E test runner. This ensures the browser, ganache, and everything else stays running upon test failure. This is useful for local debugging, for investigating what state the extension was in when it failed.

Manual testing steps:  
  - Try running `yarn test:e2e:single --browser firefox --leave-running` to see that it works correctly for a working test (it should exit normally).
  - Try running `yarn test:e2e:single --browser firefox --leave-running` on a test that will fail (e.g. one that you introduced an error into). Everything should stay running. It should all exit cleanly after sending an interrupt (CTRL+C).