### PR TITLE
fix xpath to get firefox uuid

### DIFF
--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -76,7 +76,7 @@ class FirefoxDriver {
     return await this._driver
       .wait(
         until.elementLocated(
-          By.xpath("//dl/div[contains(., 'Internal UUID')]/dd"),
+          By.xpath("//dl/div[contains(., 'UUID')]/dd"),
         ),
         1000,
       )

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -75,9 +75,7 @@ class FirefoxDriver {
     await this._driver.get('about:debugging#addons');
     return await this._driver
       .wait(
-        until.elementLocated(
-          By.xpath("//dl/div[contains(., 'UUID')]/dd"),
-        ),
+        until.elementLocated(By.xpath("//dl/div[contains(., 'UUID')]/dd")),
         1000,
       )
       .getText();


### PR DESCRIPTION
When running the test code in Firefox, if the Firefox language setting is not English, the 'Internal UUID' property cannot be fetched and the test can not proceed. So I just changed 'Internal UUID' to 'UUID'

### Before (Cannot access element 'Internal UUID')
![before1](https://user-images.githubusercontent.com/17763340/122157195-61c29580-cea5-11eb-9847-1932a8dd171d.gif)

### After (It works!)
![after](https://user-images.githubusercontent.com/17763340/122153575-3ee0b300-ce9e-11eb-9111-8f6e4cffe490.gif)
