### PR TITLE
Adding edit navigation button flow back to send token flow

### DIFF
--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -12,6 +12,7 @@ import ConfirmTransactionReducer, * as actions from './confirm-transaction.duck'
 const initialState = {
   txData: {},
   tokenData: {},
+  tokenProps: {},
   fiatTransactionAmount: '',
   fiatTransactionFee: '',
   fiatTransactionTotal: '',
@@ -307,8 +308,8 @@ describe('Confirm Transaction Duck', () => {
           nonce: '',
           tokenData: {},
           tokenProps: {
-            tokenDecimals: '',
-            tokenSymbol: '',
+            decimals: '',
+            symbol: '',
           },
           txData: {
             ...txData,

--- a/ui/ducks/send/send-duck.test.js
+++ b/ui/ducks/send/send-duck.test.js
@@ -28,6 +28,7 @@ describe('Send Duck', () => {
     ensResolution: null,
     ensResolutionError: '',
     gasIsLoading: false,
+    token: null,
   };
   const OPEN_TO_DROPDOWN = 'metamask/send/OPEN_TO_DROPDOWN';
   const CLOSE_TO_DROPDOWN = 'metamask/send/CLOSE_TO_DROPDOWN';

--- a/ui/ducks/send/send.duck.js
+++ b/ui/ducks/send/send.duck.js
@@ -47,6 +47,7 @@ const initState = {
   ensResolution: null,
   ensResolutionError: '',
   gasIsLoading: false,
+  token: null,
 };
 
 // Reducer
@@ -180,6 +181,7 @@ export default function reducer(state = initState, action) {
         maxModeOn: false,
         editingTransactionId: null,
         toNickname: '',
+        token: null,
       };
     case GAS_LOADING_STARTED:
       return {

--- a/ui/pages/confirm-send-token/confirm-send-token.container.js
+++ b/ui/pages/confirm-send-token/confirm-send-token.container.js
@@ -28,9 +28,8 @@ const mapDispatchToProps = (dispatch) => {
         txParams: { from, to: tokenAddress, gas: gasLimit, gasPrice } = {},
       } = txData;
 
-      const to = getTokenValueParam(tokenData);
-      const tokenAmountInDec = getTokenAddressParam(tokenData);
-
+      const to = getTokenAddressParam(tokenData);
+      const tokenAmountInDec = getTokenValueParam(tokenData);
       const tokenAmountInHex = conversionUtil(tokenAmountInDec, {
         fromNumericBase: 'dec',
         toNumericBase: 'hex',

--- a/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
+++ b/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
@@ -23,6 +23,7 @@ export default function ConfirmTokenTransactionBase({
   contractExchangeRate,
   conversionRate,
   currentCurrency,
+  onEdit,
 }) {
   const t = useContext(I18nContext);
 
@@ -69,6 +70,7 @@ export default function ConfirmTokenTransactionBase({
   return (
     <ConfirmTransactionBase
       toAddress={toAddress}
+      onEdit={onEdit}
       identiconAddress={tokenAddress}
       title={tokensText}
       subtitleComponent={
@@ -105,4 +107,5 @@ ConfirmTokenTransactionBase.propTypes = {
   contractExchangeRate: PropTypes.number,
   conversionRate: PropTypes.number,
   currentCurrency: PropTypes.string,
+  onEdit: PropTypes.func,
 };

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -159,7 +159,7 @@ const contractExchangeRatesSelector = (state) =>
 
 const tokenDecimalsSelector = createSelector(
   tokenPropsSelector,
-  (tokenProps) => tokenProps && tokenProps.tokenDecimals,
+  (tokenProps) => tokenProps && tokenProps.decimals,
 );
 
 const tokenDataArgsSelector = createSelector(

--- a/ui/selectors/confirm-transaction.test.js
+++ b/ui/selectors/confirm-transaction.test.js
@@ -58,8 +58,8 @@ describe('Confirm Transaction Selector', () => {
           }),
         },
         tokenProps: {
-          tokenDecimals: '2',
-          tokenSymbol: 'META',
+          decimals: '2',
+          symbol: 'META',
         },
       },
     };


### PR DESCRIPTION
Fixes: #11317

Explanation:  While reviewing @brad-decker send slice refactor PR I found [invalid logic](https://github.com/MetaMask/metamask-extension/compare/add-edit-back-send-tokens?expand=1#diff-25bd56a27f74d50f95a8063ba5e8186a8ef9e608cf2ceff651d964d11c2c77eb) around editing a transaction in the send flow where the recipient address and amount were switched. Upon further digging I realized this wasn't causing a visible issue because the (back to) edit option that is available for ETH transactions is not available for token transactions (where this logic would be used). This PR adds back the edit navigation button for the send-token flow and fixes the faulty logic.

Manual testing steps:  
- Start to send a token (on any network, and token that is not its native asset)
- Once at the confirm screen look for the edit button in the top left corner and click it
- Edit the transaction and click forward again to confirm.
- Send the transaction and verify that the transaction sent the correct amount to the correct address