### PR TITLE
fix 'confirm popup' ui

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -3,7 +3,6 @@
   flex-flow: column;
   align-items: center;
   width: 100%;
-  height: 100%;
   font-style: normal;
 
   &__identicon-wrapper {


### PR DESCRIPTION
Fixes: #11313 

Explanation: just removed  'height:100%' from element

![fix-style](https://user-images.githubusercontent.com/17763340/122317038-cf2efe80-cf57-11eb-8470-8557ce36b2fd.gif)
 

