### PR TITLE
move @ethereumjs/common to bg-libs

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -44,7 +44,7 @@ const materialUIDependencies = ['@material-ui/core'];
 const reactDepenendencies = dependencies.filter((dep) => dep.match(/react/u));
 
 const externalDependenciesMap = {
-  background: ['3box'],
+  background: ['3box', '@ethereumjs/common'],
   ui: [...materialUIDependencies, ...reactDepenendencies],
 };
 


### PR DESCRIPTION
Fixes: 

Not much, buys us a little bit of package room to prevent leaky deps #11330 from increasing bundle size past the 4mb mark.

This impacted me in #10965 