### PR TITLE
Adding edit navigation button flow back to send token flow

### DIFF
--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -3,7 +3,7 @@ import {
   currentCurrencySelector,
   unconfirmedTransactionsHashSelector,
 } from '../../selectors';
-import { getNativeCurrency } from '../metamask/metamask';
+import { getNativeCurrency, getTokens } from '../metamask/metamask';
 
 import {
   getValueFromWeiHex,
@@ -25,6 +25,7 @@ const createActionType = (action) => `metamask/confirm-transaction/${action}`;
 
 const UPDATE_TX_DATA = createActionType('UPDATE_TX_DATA');
 const UPDATE_TOKEN_DATA = createActionType('UPDATE_TOKEN_DATA');
+const UPDATE_TOKEN_PROPS = createActionType('UPDATE_TOKEN_PROPS');
 const CLEAR_CONFIRM_TRANSACTION = createActionType('CLEAR_CONFIRM_TRANSACTION');
 const UPDATE_TRANSACTION_AMOUNTS = createActionType(
   'UPDATE_TRANSACTION_AMOUNTS',
@@ -37,6 +38,7 @@ const UPDATE_NONCE = createActionType('UPDATE_NONCE');
 const initState = {
   txData: {},
   tokenData: {},
+  tokenProps: {},
   fiatTransactionAmount: '',
   fiatTransactionFee: '',
   fiatTransactionTotal: '',
@@ -63,6 +65,13 @@ export default function reducer(state = initState, action = {}) {
       return {
         ...state,
         tokenData: {
+          ...action.payload,
+        },
+      };
+    case UPDATE_TOKEN_PROPS:
+      return {
+        ...state,
+        tokenProps: {
           ...action.payload,
         },
       };
@@ -133,6 +142,13 @@ export function updateTokenData(tokenData) {
   return {
     type: UPDATE_TOKEN_DATA,
     payload: tokenData,
+  };
+}
+
+export function updateTokenProps(tokenProps) {
+  return {
+    type: UPDATE_TOKEN_PROPS,
+    payload: tokenProps,
   };
 }
 
@@ -296,9 +312,20 @@ export function setTransactionToConfirm(transactionId) {
       const { txParams } = transaction;
 
       if (txParams.data) {
-        const { data } = txParams;
+        const { to: tokenAddress, data } = txParams;
 
         const tokenData = getTokenData(data);
+        const tokens = getTokens(state);
+        const currentToken = tokens?.find(
+          ({ address }) => tokenAddress === address,
+        );
+
+        dispatch(
+          updateTokenProps({
+            decimals: currentToken?.decimals,
+            symbol: currentToken?.symbol,
+          }),
+        );
         dispatch(updateTokenData(tokenData));
       }
 

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.test.js
@@ -12,6 +12,7 @@ import ConfirmTransactionReducer, * as actions from './confirm-transaction.duck'
 const initialState = {
   txData: {},
   tokenData: {},
+  tokenProps: {},
   fiatTransactionAmount: '',
   fiatTransactionFee: '',
   fiatTransactionTotal: '',
@@ -307,8 +308,8 @@ describe('Confirm Transaction Duck', () => {
           nonce: '',
           tokenData: {},
           tokenProps: {
-            tokenDecimals: '',
-            tokenSymbol: '',
+            decimals: '',
+            symbol: '',
           },
           txData: {
             ...txData,

--- a/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
+++ b/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
@@ -23,6 +23,7 @@ export default function ConfirmTokenTransactionBase({
   contractExchangeRate,
   conversionRate,
   currentCurrency,
+  onEdit,
 }) {
   const t = useContext(I18nContext);
 
@@ -69,6 +70,7 @@ export default function ConfirmTokenTransactionBase({
   return (
     <ConfirmTransactionBase
       toAddress={toAddress}
+      onEdit={onEdit}
       identiconAddress={tokenAddress}
       title={tokensText}
       subtitleComponent={
@@ -105,4 +107,5 @@ ConfirmTokenTransactionBase.propTypes = {
   contractExchangeRate: PropTypes.number,
   conversionRate: PropTypes.number,
   currentCurrency: PropTypes.string,
+  onEdit: PropTypes.func,
 };

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -159,7 +159,7 @@ const contractExchangeRatesSelector = (state) =>
 
 const tokenDecimalsSelector = createSelector(
   tokenPropsSelector,
-  (tokenProps) => tokenProps && tokenProps.tokenDecimals,
+  (tokenProps) => tokenProps && tokenProps.decimals,
 );
 
 const tokenDataArgsSelector = createSelector(

--- a/ui/selectors/confirm-transaction.test.js
+++ b/ui/selectors/confirm-transaction.test.js
@@ -58,8 +58,8 @@ describe('Confirm Transaction Selector', () => {
           }),
         },
         tokenProps: {
-          tokenDecimals: '2',
-          tokenSymbol: 'META',
+          decimals: '2',
+          symbol: 'META',
         },
       },
     };


### PR DESCRIPTION
Fixes: #11317

Explanation: While reviewing @brad-decker send slice refactor PR I found invalid logic around editing a transaction in the send flow where the recipient address and amount were switched. Upon further digging I realized this wasn't causing a visible issue because the (back to) edit option that is available for ETH transactions is not available for token transactions (where this logic would be used). This PR adds back the edit navigation button for the send-token flow and fixes the faulty logic.

Manual testing steps:
- Start to send a token (on any network, and token that is not its native asset)
- Once at the confirm screen look for the edit button in the top left corner and click it
- Edit the transaction and click forward again to confirm.
- Send the transaction and verify that the transaction sent the correct amount to the correct address