### PR TITLE
Add back strict equality checks in typed-message-manager

### DIFF
--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import assert from 'assert';
+import { strict as assert } from 'assert';
 import { ObservableStore } from '@metamask/obs-store';
 import { ethErrors } from 'eth-rpc-errors';
 import { typedSignatureHash, TYPED_MESSAGE_SCHEMA } from 'eth-sig-util';
@@ -177,7 +177,7 @@ export default class TypedMessageManager extends EventEmitter {
         break;
       case 'V3':
       case 'V4': {
-        assert.strictEqual(
+        assert.equal(
           typeof params.data,
           'string',
           '"params.data" must be a string.',
@@ -191,18 +191,21 @@ export default class TypedMessageManager extends EventEmitter {
           data.primaryType in data.types,
           `Primary type of "${data.primaryType}" has no type definition.`,
         );
-        assert.strictEqual(
+        assert.equal(
           validation.errors.length,
           0,
           'Signing data must conform to EIP-712 schema. See https://git.io/fNtcx.',
         );
-        const { chainId } = data.domain;
+        let { chainId } = data.domain;
         if (chainId) {
           const activeChainId = parseInt(this._getCurrentChainId(), 16);
           assert.ok(
             !Number.isNaN(activeChainId),
             `Cannot sign messages for chainId "${chainId}", because MetaMask is switching networks.`,
           );
+          if (typeof chainId === 'string') {
+            chainId = parseInt(chainId, 16);
+          }
           assert.equal(
             chainId,
             activeChainId,


### PR DESCRIPTION
Add back strict equality checks in typed-message-manager and ensure that chainId comparison bases are both ints

Fixes: #11310

Explanation:  We hotfix patched a bug introduced in 9.6.0 where valid chainId parameters passed to signTypedData were incorrectly throwing an error. This loops back and adds a more deliberate type check to insure we are comparing two chainIds both as integers.

Manual testing steps:  
  - for qa this requires a small code change to the e2e test dapp.[ I've opened a PR](https://github.com/MetaMask/test-dapp/pull/116) to try and add that change so that we have some coverage on regressions around  this in the future.