### PR TITLE
fix unsafe destructuring instance

### DIFF
--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -203,9 +203,7 @@ export function updateTxDataAndCalculate(txData) {
 
     // if the gas price from our infura endpoint is null or undefined
     // use the metaswap average price estimation as a fallback
-    let {
-      txParams: { gasPrice },
-    } = txData;
+    let { txParams: { gasPrice } = {} } = txData;
     if (!gasPrice) {
       gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';
     }

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -223,9 +223,7 @@ export const transactionFeeSelector = function (state, txData) {
 
   // if the gas price from our infura endpoint is null or undefined
   // use the metaswap average price estimation as a fallback
-  let {
-    txParams: { gasPrice },
-  } = txData;
+  let { txParams: { gasPrice } = {} } = txData;
   if (!gasPrice) {
     gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';
   }


### PR DESCRIPTION
Fixes: #11350

Explanation:  I introduced a bug in a PR I merged a few days ago. gasPrice was being destructed from an object that had no default so if undefined an error was thrown. 

Manual testing steps:  
  - Make sure that send flow works consistently with various gas prices