### PR TITLE
Updating client side metrics for EIP-1559 UI

### DIFF
--- a/ui/pages/send/send-content/send-gas-row/send-gas-row.component.js
+++ b/ui/pages/send/send-content/send-gas-row/send-gas-row.component.js
@@ -32,11 +32,11 @@ export default class SendGasRow extends Component {
 
   static contextTypes = {
     t: PropTypes.func,
-    metricsEvent: PropTypes.func,
+    trackEvent: PropTypes.func,
   };
 
   renderAdvancedOptionsButton() {
-    const { metricsEvent } = this.context;
+    const { trackEvent } = this.context;
     const {
       showCustomizeGasModal,
       isMainnet,
@@ -54,12 +54,9 @@ export default class SendGasRow extends Component {
       <div
         className="advanced-gas-options-btn"
         onClick={() => {
-          metricsEvent({
-            eventOpts: {
-              category: 'Transactions',
-              action: 'Edit Screen',
-              name: 'Clicked "Advanced Options"',
-            },
+          trackEvent({
+            category: 'Transactions',
+            event: 'Clicked "Advanced Options"',
           });
           showCustomizeGasModal();
         }}
@@ -105,7 +102,7 @@ export default class SendGasRow extends Component {
       isEthGasPrice,
       noGasPrice,
     } = this.props;
-    const { metricsEvent } = this.context;
+    const { trackEvent } = this.context;
     const gasPriceFetchFailure = isEthGasPrice || noGasPrice;
 
     const gasPriceButtonGroup = (
@@ -115,11 +112,11 @@ export default class SendGasRow extends Component {
           showCheck={false}
           {...gasPriceButtonGroupProps}
           handleGasPriceSelection={async (opts) => {
-            metricsEvent({
-              eventOpts: {
-                category: 'Transactions',
-                action: 'Edit Screen',
-                name: 'Changed Gas Button',
+            trackEvent({
+              category: 'Transactions',
+              event: 'User Clicked Gas Estimate Button',
+              properties: {
+                gasEstimateType: opts.gasEstimateType.toLowerCase(),
               },
             });
             await gasPriceButtonGroupProps.handleGasPriceSelection(opts);

--- a/ui/pages/send/send-content/send-gas-row/send-gas-row.component.test.js
+++ b/ui/pages/send/send-content/send-gas-row/send-gas-row.component.test.js
@@ -32,7 +32,7 @@ describe('SendGasRow Component', () => {
             anotherGasPriceButtonGroupProp: 'bar',
           }}
         />,
-        { context: { t: (str) => `${str}_t`, metricsEvent: () => ({}) } },
+        { context: { t: (str) => `${str}_t`, trackEvent: () => ({}) } },
       );
       wrapper.setProps({ isMainnet: true });
     });


### PR DESCRIPTION
- Adding 'Changed Gas Button' metrics event
- Adding gasEstimateType to 'Changed Gas Button' metrics event

Example metrics payload for 'Changed Gas Button':
<img width="575" alt="Screen Shot 2021-06-21 at 11 38 03 AM" src="https://user-images.githubusercontent.com/8732757/122811680-a4111b80-d285-11eb-8a7d-690c1528bc15.png">

