### PR TITLE
Fix chromereload while on development build

### DIFF
--- a/development/build/static.js
+++ b/development/build/static.js
@@ -76,7 +76,7 @@ for (const tag of languageTags) {
 const copyTargetsDev = [
   ...copyTargets,
   {
-    src: './app/scripts/',
+    src: './development',
     pattern: '/chromereload.js',
     dest: ``,
   },


### PR DESCRIPTION
Our build was looking for chromereload.js in the wrong place. As such, the background was not automatically reloading on a chance to files in the `app/` directory. This PR fixes that.