### PR TITLE
remove EIP-1559 fields from txParams before calling estimateGas

### DIFF
--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -62,8 +62,11 @@ export default class TxGasUtil {
     // `eth_estimateGas` can fail if the user has insufficient balance for the
     // value being sent, or for the gas cost. We don't want to check their
     // balance here, we just want the gas estimate. The gas price is removed
-    // to skip those balance checks. We check balance elsewhere.
+    // to skip those balance checks. We check balance elsewhere. We also delete
+    // maxFeePerGas and maxPriorityFeePerGas to support EIP-1559 txs.
     delete txParams.gasPrice;
+    delete txParams.maxFeePerGas;
+    delete txParams.maxPriorityFeePerGas;
 
     // estimate tx gas requirements
     return await this.query.estimateGas(txParams);


### PR DESCRIPTION
Depends on: #11367 
Explanation:  
Also removes maxFeePerGas and maxPriorityFeePerGas from txParams before estimating gas. Though the JSON RPC spec for EIP-1559 says 'oneOf' the two variations of gas fields should be included, but 'gasPrice' is not required on legacy. I'm getting some validation from geth devs that this will still work. 

Micah essentially confirmed this is correct, supporting screenshots below

<details>
<summary>Question asked</summary>

![image](https://user-images.githubusercontent.com/4448075/123281213-1a548e80-d4cf-11eb-95b4-143b743c2ee8.png)


</details>

<details>
<summary>Response

</summary>

<img width="541" alt="Screen Shot 2021-06-24 at 9 33 18 AM" src="https://user-images.githubusercontent.com/4448075/123281480-57b91c00-d4cf-11eb-9f92-8bbe7b6f540f.png">

Redacted portions are from an unrelated response. 

</details>