### PR TITLE
add method to detect EIP 1559 support

### DIFF
--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -31,6 +31,9 @@ describe('DetectTokensController', function () {
       '0xbc86727e770de68b1060c91f6bb6945c73e10388',
     ]);
     sandbox
+      .stub(network, 'getLatestBlock')
+      .callsFake(() => Promise.resolve({}));
+    sandbox
       .stub(preferences, '_detectIsERC721')
       .returns(Promise.resolve(false));
   });

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -22,7 +22,6 @@ describe('NetworkController', function () {
       setProviderTypeAndWait = () =>
         new Promise((resolve) => {
           networkController.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {
-            console.log('here');
             resolve();
           });
           networkController.setProviderType('mainnet');

--- a/app/scripts/controllers/network/network-controller.test.js
+++ b/app/scripts/controllers/network/network-controller.test.js
@@ -1,11 +1,13 @@
 import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { getNetworkDisplayName } from './util';
-import NetworkController from './network';
+import NetworkController, { NETWORK_EVENTS } from './network';
 
 describe('NetworkController', function () {
   describe('controller', function () {
     let networkController;
+    let getLatestBlockStub;
+    let setProviderTypeAndWait;
     const noop = () => undefined;
     const networkControllerProviderConfig = {
       getAccounts: noop,
@@ -13,7 +15,22 @@ describe('NetworkController', function () {
 
     beforeEach(function () {
       networkController = new NetworkController();
+      getLatestBlockStub = sinon
+        .stub(networkController, 'getLatestBlock')
+        .callsFake(() => Promise.resolve({}));
       networkController.setInfuraProjectId('foo');
+      setProviderTypeAndWait = () =>
+        new Promise((resolve) => {
+          networkController.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {
+            console.log('here');
+            resolve();
+          });
+          networkController.setProviderType('mainnet');
+        });
+    });
+
+    afterEach(function () {
+      getLatestBlockStub.reset();
     });
 
     describe('#provider', function () {
@@ -65,6 +82,59 @@ describe('NetworkController', function () {
           spy.calledOnceWithExactly('loading'),
           'should have called with "loading" first',
         );
+      });
+    });
+
+    describe('#getEIP1559Compatibility', function () {
+      it('should return false when baseFeePerGas is not in the block header', async function () {
+        networkController.initializeProvider(networkControllerProviderConfig);
+        const supportsEIP1559 = await networkController.getEIP1559Compatibility();
+        assert.equal(supportsEIP1559, false);
+      });
+
+      it('should return true when baseFeePerGas is in block header', async function () {
+        networkController.initializeProvider(networkControllerProviderConfig);
+        getLatestBlockStub.callsFake(() =>
+          Promise.resolve({ baseFeePerGas: '0xa ' }),
+        );
+        const supportsEIP1559 = await networkController.getEIP1559Compatibility();
+        assert.equal(supportsEIP1559, true);
+      });
+
+      it('should store EIP1559 support in state to reduce calls to getLatestBlock', async function () {
+        networkController.initializeProvider(networkControllerProviderConfig);
+        getLatestBlockStub.callsFake(() =>
+          Promise.resolve({ baseFeePerGas: '0xa ' }),
+        );
+        await networkController.getEIP1559Compatibility();
+        const supportsEIP1559 = await networkController.getEIP1559Compatibility();
+        assert.equal(getLatestBlockStub.calledOnce, true);
+        assert.equal(supportsEIP1559, true);
+      });
+
+      it('should clear stored EIP1559 support when changing networks', async function () {
+        networkController.initializeProvider(networkControllerProviderConfig);
+        networkController.consoleThis = true;
+        getLatestBlockStub.callsFake(() =>
+          Promise.resolve({ baseFeePerGas: '0xa ' }),
+        );
+        await networkController.getEIP1559Compatibility();
+        assert.equal(
+          networkController.networkDetails.getState().EIPS[1559],
+          true,
+        );
+        getLatestBlockStub.callsFake(() => Promise.resolve({}));
+        await setProviderTypeAndWait('mainnet');
+        assert.equal(
+          networkController.networkDetails.getState().EIPS[1559],
+          undefined,
+        );
+        await networkController.getEIP1559Compatibility();
+        assert.equal(
+          networkController.networkDetails.getState().EIPS[1559],
+          false,
+        );
+        assert.equal(getLatestBlockStub.calledTwice, true);
       });
     });
   });

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -375,7 +375,7 @@ export default class NetworkController extends EventEmitter {
   }
 
   _switchNetwork(opts) {
-    // Indicate to subsribers that network is about to change
+    // Indicate to subscribers that network is about to change
     this.emit(NETWORK_EVENTS.NETWORK_WILL_CHANGE);
     // Set loading state
     this.setNetworkState('loading');

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -83,9 +83,11 @@ export default class NetworkController extends EventEmitter {
     // will require a decent sized refactor of how we're accessing network
     // state. Currently this is only used for detecting EIP 1559 support but
     // can be extended to track other network details.
-    this.networkDetails = new ObservableStore({
-      ...defaultNetworkDetailsState,
-    });
+    this.networkDetails = new ObservableStore(
+      opts.networkDetails || {
+        ...defaultNetworkDetailsState,
+      },
+    );
     this.store = new ComposedStore({
       provider: this.providerStore,
       previousProviderStore: this.previousProviderStore,

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -158,7 +158,7 @@ export default class NetworkController extends EventEmitter {
   /**
    * Method to check if the block header contains fields that indicate EIP 1559
    * support (baseFeePerGas).
-   * @returns {boolean} true if current network supports EIP 1559
+   * @returns {Promise<boolean>} true if current network supports EIP 1559
    */
   async getEIP1559Compatibility() {
     const { EIPS } = this.networkDetails.getState();

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -51,6 +51,10 @@ const defaultProviderConfig = {
   ...defaultProviderConfigOpts,
 };
 
+const defaultNetworkDetailsState = {
+  EIPS: { 1559: undefined },
+};
+
 export const NETWORK_EVENTS = {
   // Fired after the actively selected network is changed
   NETWORK_DID_CHANGE: 'networkDidChange',
@@ -74,10 +78,19 @@ export default class NetworkController extends EventEmitter {
       this.providerStore.getState(),
     );
     this.networkStore = new ObservableStore('loading');
+    // We need to keep track of a few details about the current network
+    // Ideally we'd merge this.networkStore with this new store, but doing so
+    // will require a decent sized refactor of how we're accessing network
+    // state. Currently this is only used for detecting EIP 1559 support but
+    // can be extended to track other network details.
+    this.networkDetails = new ObservableStore({
+      ...defaultNetworkDetailsState,
+    });
     this.store = new ComposedStore({
       provider: this.providerStore,
       previousProviderStore: this.previousProviderStore,
       network: this.networkStore,
+      networkDetails: this.networkDetails,
     });
 
     // provider and block tracker
@@ -120,6 +133,42 @@ export default class NetworkController extends EventEmitter {
     return { provider, blockTracker };
   }
 
+  /**
+   * Method to return the latest block for the current network
+   * @returns {Object} Block header
+   */
+  getLatestBlock() {
+    return new Promise((resolve, reject) => {
+      const { provider } = this.getProviderAndBlockTracker();
+      const ethQuery = new EthQuery(provider);
+      ethQuery.sendAsync(
+        { method: 'eth_getBlockByNumber', params: ['latest', false] },
+        (err, block) => {
+          if (err) {
+            return reject(err);
+          }
+          return resolve(block);
+        },
+      );
+    });
+  }
+
+  /**
+   * Method to check if the block header contains fields that indicate EIP 1559
+   * support (baseFeePerGas).
+   * @returns {boolean} true if current network supports EIP 1559
+   */
+  async getEIP1559Compatibility() {
+    const { EIPS } = this.networkDetails.getState();
+    if (EIPS[1559] !== undefined) {
+      return EIPS[1559];
+    }
+    const latestBlock = await this.getLatestBlock();
+    const supportsEIP1559 = latestBlock.baseFeePerGas !== undefined;
+    this.setNetworkEIPSupport(1559, supportsEIP1559);
+    return supportsEIP1559;
+  }
+
   verifyNetwork() {
     // Check network when restoring connectivity:
     if (this.isNetworkLoading()) {
@@ -133,6 +182,26 @@ export default class NetworkController extends EventEmitter {
 
   setNetworkState(network) {
     this.networkStore.putState(network);
+  }
+
+  /**
+   * Set EIP support indication in the networkDetails store
+   * @param {number} EIPNumber - The number of the EIP to mark support for
+   * @param {boolean} isSupported - True if the EIP is supported
+   */
+  setNetworkEIPSupport(EIPNumber, isSupported) {
+    this.networkDetails.updateState({
+      EIPS: {
+        [EIPNumber]: isSupported,
+      },
+    });
+  }
+
+  /**
+   * Reset EIP support to default (no support)
+   */
+  clearNetworkDetails() {
+    this.networkDetails.putState({ ...defaultNetworkDetailsState });
   }
 
   isNetworkLoading() {
@@ -154,6 +223,8 @@ export default class NetworkController extends EventEmitter {
         'NetworkController - lookupNetwork aborted due to missing chainId',
       );
       this.setNetworkState('loading');
+      // keep network details in sync with network state
+      this.clearNetworkDetails();
       return;
     }
 
@@ -174,10 +245,14 @@ export default class NetworkController extends EventEmitter {
       if (initialNetwork === currentNetwork) {
         if (err) {
           this.setNetworkState('loading');
+          // keep network details in sync with network state
+          this.clearNetworkDetails();
           return;
         }
 
         this.setNetworkState(networkVersion);
+        // look up EIP-1559 support
+        this.getEIP1559Compatibility();
       }
     });
   }
@@ -298,9 +373,15 @@ export default class NetworkController extends EventEmitter {
   }
 
   _switchNetwork(opts) {
+    // Indicate to subsribers that network is about to change
     this.emit(NETWORK_EVENTS.NETWORK_WILL_CHANGE);
+    // Set loading state
     this.setNetworkState('loading');
+    // Reset network details
+    this.clearNetworkDetails();
+    // Configure the provider appropriately
     this._configureProvider(opts);
+    // Notify subscribers that network has changed
     this.emit(NETWORK_EVENTS.NETWORK_DID_CHANGE, opts.type);
   }
 

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -30,6 +30,9 @@ describe('preferences controller', function () {
     network.initializeProvider(networkControllerProviderConfig);
     provider = network.getProviderAndBlockTracker().provider;
 
+    sandbox
+      .stub(network, 'getLatestBlock')
+      .callsFake(() => Promise.resolve({}));
     sandbox.stub(network, 'getCurrentChainId').callsFake(() => currentChainId);
     sandbox
       .stub(network, 'getProviderConfig')

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -21,6 +21,11 @@ const firstTimeState = {
       rpcUrl: 'http://localhost:8545',
       chainId: '0x539',
     },
+    networkDetails: {
+      EIPS: {
+        1559: false,
+      },
+    },
   },
 };
 

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -245,3 +245,7 @@ export function getSendToAccounts(state) {
 export function getUnapprovedTxs(state) {
   return state.metamask.unapprovedTxs;
 }
+
+export function isEIP1559Network(state) {
+  return state.metamask.networkDetails.EIPS[1559] === true;
+}


### PR DESCRIPTION
Adds getEIP1559Compatibility method to network controller that detects EIP-1559 support by checking the baseFeePerGas property on blockHeader. Fully wired up and ready for consumption (Properly detects that Ropsten has support and providers a selector for UI work) 