### PR TITLE
Use eth_gasPrice result for setting too low warning on custom networks

### DIFF
--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -29,12 +29,14 @@ import {
   getCurrentCurrency,
   getCurrentEthBalance,
   getIsMainnet,
+  getIsTestnet,
   getBasicGasEstimateLoadingStatus,
   getCustomGasLimit,
   getCustomGasPrice,
   getDefaultActiveButtonIndex,
   getRenderableBasicEstimateData,
   isCustomPriceSafe,
+  isCustomPriceSafeForCustomNetwork,
   getAveragePriceEstimateInHexWEI,
   isCustomPriceExcessive,
   getIsGasEstimatesFetched,
@@ -113,6 +115,7 @@ const mapStateToProps = (state, ownProps) => {
   const balance = getCurrentEthBalance(state);
 
   const isMainnet = getIsMainnet(state);
+  const isTestnet = getIsTestnet(state);
   const showFiat = getShouldShowFiat(state);
 
   const newTotalEth =
@@ -134,6 +137,16 @@ const mapStateToProps = (state, ownProps) => {
         conversionRate,
       });
   const isGasEstimate = getIsGasEstimatesFetched(state);
+
+  let customPriceIsSafe;
+  if ((isMainnet || process.env.IN_TEST) && isGasEstimate) {
+    customPriceIsSafe = isCustomPriceSafe(state);
+  } else if (isTestnet) {
+    customPriceIsSafe = true;
+  } else {
+    customPriceIsSafe = isCustomPriceSafeForCustomNetwork(state);
+  }
+
   return {
     hideBasic,
     isConfirm: isConfirm(state),
@@ -143,10 +156,7 @@ const mapStateToProps = (state, ownProps) => {
     customGasLimit: calcCustomGasLimit(customModalGasLimitInHex),
     customGasTotal,
     newTotalFiat,
-    customPriceIsSafe:
-      (isMainnet || process.env.IN_TEST) && isGasEstimate
-        ? isCustomPriceSafe(state)
-        : true,
+    customPriceIsSafe,
     customPriceIsExcessive: isCustomPriceExcessive(state),
     maxModeOn,
     gasPriceButtonGroupProps: {

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -101,6 +101,10 @@ export function isCustomPriceSafeForCustomNetwork(state) {
 
   const customGasPrice = getCustomGasPrice(state);
 
+  if (!customGasPrice) {
+    return true;
+  }
+
   const customPriceSafe = conversionGreaterThan(
     {
       value: customGasPrice,

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -96,6 +96,24 @@ export function isCustomPriceSafe(state) {
   return customPriceSafe;
 }
 
+export function isCustomPriceSafeForCustomNetwork(state) {
+  const estimatedPrice = state.gas.basicEstimates.average;
+
+  const customGasPrice = getCustomGasPrice(state);
+
+  const customPriceSafe = conversionGreaterThan(
+    {
+      value: customGasPrice,
+      fromNumericBase: 'hex',
+      fromDenomination: 'WEI',
+      toDenomination: 'GWEI',
+    },
+    { value: estimatedPrice, fromNumericBase: 'dec' },
+  );
+
+  return customPriceSafe;
+}
+
 export function isCustomPriceExcessive(state, checkSend = false) {
   const customPrice = checkSend ? getGasPrice(state) : getCustomGasPrice(state);
   const fastPrice = getFastPriceEstimate(state);


### PR DESCRIPTION
Fixes an issue found by @tmashuang in QA.

Prior to this PR, we were not showing any warning in the gas edit modal on custom networks when the price is too low. We don't want to show them on testnets, but should show them on custom networks. This PR corrects that.