### PR TITLE
Set account nickname to ENS when ENS is available

### DIFF
--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { getAccountLink } from '@metamask/etherscan-link';
 
@@ -7,96 +7,110 @@ import QrView from '../../../ui/qr-code';
 import EditableLabel from '../../../ui/editable-label';
 import Button from '../../../ui/button';
 
-export default class AccountDetailsModal extends Component {
-  static propTypes = {
-    selectedIdentity: PropTypes.object,
-    chainId: PropTypes.string,
-    showExportPrivateKeyModal: PropTypes.func,
-    setAccountLabel: PropTypes.func,
-    keyrings: PropTypes.array,
-    rpcPrefs: PropTypes.object,
-  };
+export default function AccountDetailsModal(props, context) {
+  const {
+    selectedIdentity,
+    chainId,
+    showExportPrivateKeyModal,
+    setAccountLabel,
+    keyrings,
+    rpcPrefs,
+    tryReverseResolveAddress,
+    ensName,
+  } = props;
 
-  static contextTypes = {
-    t: PropTypes.func,
-    trackEvent: PropTypes.func,
-  };
+  const { name, address } = selectedIdentity;
 
-  render() {
-    const {
-      selectedIdentity,
-      chainId,
-      showExportPrivateKeyModal,
-      setAccountLabel,
-      keyrings,
-      rpcPrefs,
-    } = this.props;
-    const { name, address } = selectedIdentity;
-
-    const keyring = keyrings.find((kr) => {
-      return kr.accounts.includes(address);
-    });
-
-    let exportPrivateKeyFeatureEnabled = true;
-    // This feature is disabled for hardware wallets
-    if (keyring?.type?.search('Hardware') !== -1) {
-      exportPrivateKeyFeatureEnabled = false;
+  useEffect(() => {
+    if (address) {
+      tryReverseResolveAddress(address);
     }
+  });
 
-    return (
-      <AccountModalContainer className="account-details-modal">
-        <EditableLabel
-          className="account-details-modal__name"
-          defaultValue={name}
-          onSubmit={(label) => setAccountLabel(address, label)}
-        />
+  const keyring = keyrings.find((kr) => {
+    return kr.accounts.includes(address);
+  });
 
-        <QrView
-          Qr={{
-            data: address,
-          }}
-        />
+  let exportPrivateKeyFeatureEnabled = true;
+  // This feature is disabled for hardware wallets
+  if (keyring?.type?.search('Hardware') !== -1) {
+    exportPrivateKeyFeatureEnabled = false;
+  }
 
-        <div className="account-details-modal__divider" />
+  const hasNickName = (accountLabel) => {
+    const regExp = /Account [1-9][0-9]*$/;
+    return regExp.test(accountLabel);
+  };
 
+  return (
+    <AccountModalContainer className="account-details-modal">
+      <EditableLabel
+        className="account-details-modal__name"
+        defaultValue={hasNickName(name) ? ensName || name : name}
+        onSubmit={(label) => setAccountLabel(address, label)}
+      />
+
+      <QrView
+        Qr={{
+          data: address,
+        }}
+      />
+
+      <div className="account-details-modal__divider" />
+
+      <Button
+        type="secondary"
+        className="account-details-modal__button"
+        onClick={() => {
+          const accountLink = getAccountLink(address, chainId, rpcPrefs);
+          context.trackEvent({
+            category: 'Navigation',
+            event: 'Clicked Block Explorer Link',
+            properties: {
+              link_type: 'Account Tracker',
+              action: 'Account Details Modal',
+              block_explorer_domain: accountLink
+                ? new URL(accountLink)?.hostname
+                : '',
+            },
+          });
+          global.platform.openTab({
+            url: accountLink,
+          });
+        }}
+      >
+        {rpcPrefs.blockExplorerUrl
+          ? context.t('blockExplorerView', [
+              rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1],
+            ])
+          : context.t('viewOnEtherscan')}
+      </Button>
+
+      {exportPrivateKeyFeatureEnabled ? (
         <Button
           type="secondary"
           className="account-details-modal__button"
-          onClick={() => {
-            const accountLink = getAccountLink(address, chainId, rpcPrefs);
-            this.context.trackEvent({
-              category: 'Navigation',
-              event: 'Clicked Block Explorer Link',
-              properties: {
-                link_type: 'Account Tracker',
-                action: 'Account Details Modal',
-                block_explorer_domain: accountLink
-                  ? new URL(accountLink)?.hostname
-                  : '',
-              },
-            });
-            global.platform.openTab({
-              url: accountLink,
-            });
-          }}
+          onClick={() => showExportPrivateKeyModal()}
         >
-          {rpcPrefs.blockExplorerUrl
-            ? this.context.t('blockExplorerView', [
-                rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1],
-              ])
-            : this.context.t('viewOnEtherscan')}
+          {context.t('exportPrivateKey')}
         </Button>
-
-        {exportPrivateKeyFeatureEnabled ? (
-          <Button
-            type="secondary"
-            className="account-details-modal__button"
-            onClick={() => showExportPrivateKeyModal()}
-          >
-            {this.context.t('exportPrivateKey')}
-          </Button>
-        ) : null}
-      </AccountModalContainer>
-    );
-  }
+      ) : null}
+    </AccountModalContainer>
+  );
 }
+
+AccountDetailsModal.contextTypes = {
+  t: PropTypes.func,
+  trackEvent: PropTypes.func,
+};
+
+AccountDetailsModal.propTypes = {
+  selectedIdentity: PropTypes.object,
+  chainId: PropTypes.string,
+  showExportPrivateKeyModal: PropTypes.func,
+  setAccountLabel: PropTypes.func,
+  keyrings: PropTypes.array,
+  rpcPrefs: PropTypes.object,
+  tryReverseResolveAddress: PropTypes.func.isRequired,
+  ensName: PropTypes.string,
+};

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -38,7 +38,7 @@ export default function AccountDetailsModal(props, context) {
   }
 
   const hasNickName = (accountLabel) => {
-    const regExp = /Account [1-9][0-9]*$/;
+    const regExp = /Account [1-9][0-9]*$/u;
     return regExp.test(accountLabel);
   };
 

--- a/ui/components/app/modals/account-details-modal/account-details-modal.container.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.container.js
@@ -1,18 +1,34 @@
 import { connect } from 'react-redux';
-import { showModal, setAccountLabel } from '../../../../store/actions';
+import {
+  showModal,
+  setAccountLabel,
+  tryReverseResolveAddress,
+} from '../../../../store/actions';
+
 import {
   getSelectedIdentity,
   getRpcPrefsForCurrentProvider,
   getCurrentChainId,
 } from '../../../../selectors';
+import { toChecksumHexAddress } from '../../../../../shared/modules/hexstring-utils';
 import AccountDetailsModal from './account-details-modal.component';
 
 const mapStateToProps = (state) => {
+  const { metamask } = state;
+  const { ensResolutionsByAddress } = metamask;
+  const selectedIdentity = getSelectedIdentity(state);
+  const { address } = selectedIdentity;
+  let ensName;
+  if (address) {
+    const checksummedAddress = toChecksumHexAddress(address);
+    ensName = ensResolutionsByAddress[checksummedAddress] || '';
+  }
   return {
     chainId: getCurrentChainId(state),
-    selectedIdentity: getSelectedIdentity(state),
+    selectedIdentity,
     keyrings: state.metamask.keyrings,
     rpcPrefs: getRpcPrefsForCurrentProvider(state),
+    ensName,
   };
 };
 
@@ -22,6 +38,8 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(showModal({ name: 'EXPORT_PRIVATE_KEY' })),
     setAccountLabel: (address, label) =>
       dispatch(setAccountLabel(address, label)),
+    tryReverseResolveAddress: (address) =>
+      dispatch(tryReverseResolveAddress(address)),
   };
 };
 

--- a/ui/components/ui/editable-label/editable-label.js
+++ b/ui/components/ui/editable-label/editable-label.js
@@ -15,7 +15,7 @@ class EditableLabel extends Component {
     hasAlreadyUpdatedOnce: false,
   };
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(_prevProps, prevState) {
     if (!prevState.hasAlreadyUpdatedOnce) {
       this.setState({
         value: this.props.defaultValue,

--- a/ui/components/ui/editable-label/editable-label.js
+++ b/ui/components/ui/editable-label/editable-label.js
@@ -12,7 +12,17 @@ class EditableLabel extends Component {
   state = {
     isEditing: false,
     value: this.props.defaultValue || '',
+    hasAlreadyUpdatedOnce: false,
   };
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevState.hasAlreadyUpdatedOnce) {
+      this.setState({
+        value: this.props.defaultValue,
+        hasAlreadyUpdatedOnce: true,
+      });
+    }
+  }
 
   handleSubmit() {
     const { value } = this.state;

--- a/yarn.lock
+++ b/yarn.lock
@@ -25922,9 +25922,9 @@ tar@6.0.2:
     yallist "^4.0.0"
 
 tar@^4:
-  version "4.4.17"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.17.tgz#44be5e3fa8353ee1d11db3b1401561223a5c3985"
-  integrity sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==
+  version "4.4.19"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
+  integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
   dependencies:
     chownr "^1.1.4"
     fs-minipass "^1.2.7"


### PR DESCRIPTION
I have a problem for previous PR(#11345 )  and I'm requesting it again :)

Fixes: #11273

Explanation: If the user has not changed the account nickname and ENS is available, ENS reverse-resolved name is displayed on Account detail view instead of the nickname such as 'Account 1'.

Manual testing steps:

Import the account registered in ENS to Metamask
Set the alias of the account to a default value such as 'Account 1'
Go to the Account detail view and check if the ENS value is loaded.