### PR TITLE
Make network-display component only appear clickable when passed a function for onClick

### DIFF
--- a/ui/components/app/network-display/index.scss
+++ b/ui/components/app/network-display/index.scss
@@ -5,7 +5,6 @@
   padding: 0 10px;
   border-radius: 4px;
   min-height: 25px;
-  cursor: pointer;
   user-select: none;
 
   &--disabled {
@@ -36,7 +35,6 @@
     background-color: lighten($dodger-blue, 35%);
   }
 
-
   & .chip__label {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -55,5 +53,9 @@
     height: 8px;
     width: 12px;
     display: block;
+  }
+
+  &--clickable {
+    cursor: pointer;
   }
 }

--- a/ui/components/app/network-display/network-display.js
+++ b/ui/components/app/network-display/network-display.js
@@ -74,6 +74,7 @@ export default function NetworkDisplay({
         'network-display--colored': colored,
         'network-display--disabled': disabled,
         [`network-display--${networkType}`]: colored && networkType,
+        'network-display--clickable': typeof onClick === 'function',
       })}
       labelProps={{
         variant: TYPOGRAPHY.H7,


### PR DESCRIPTION
Fixes (confusing UX): #11349

Explanation:  Makes network display chip `cursor = pointer` only when passed a function for onClick. Some network display chips appear clickable that should not, including on the switch-ethereum-chain component causing [some user confusion](#11349). 

Manual testing steps:  
  - Navigate to any Dapp that requires use of a non-mainnet chain - with mainnet active on Metamask when you do.
  - After the connect prompt, see that on the switch chain prompt, the Chip under `This will switch the selected network within MetaMask to a previously added network:` no longer appears to be clickable (the cursor doesn't change to a pointer finger):
 
<img width="363" alt="Screen Shot 2021-06-24 at 2 00 27 PM" src="https://user-images.githubusercontent.com/34557516/123318255-a2995a80-d4f4-11eb-9d1f-e40755021937.png">

  - Ensure that the cursor still switches to pointer finger when hovering over other network-display chips where clickable functionality is expected:
<img width="379" alt="Screen Shot 2021-06-24 at 1 56 53 PM" src="https://user-images.githubusercontent.com/34557516/123317981-50f0d000-d4f4-11eb-93ba-8e28771ebeb1.png">