### PR TITLE
Switch hardfork in getCommonConfiguration when EIP-1559 support is detected

### DIFF
--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -50,6 +50,7 @@ describe('Transaction Controller', function () {
         return '0xee6b2800';
       },
       networkStore: new ObservableStore(currentNetworkId),
+      getEIP1559Compatibility: () => Promise.resolve(true),
       txHistoryLimit: 10,
       blockTracker: blockTrackerStub,
       signTransaction: (ethTx) =>

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -326,6 +326,9 @@ export default class MetamaskController extends EventEmitter {
       getProviderConfig: this.networkController.getProviderConfig.bind(
         this.networkController,
       ),
+      getEIP1559Compatibility: this.networkController.getEIP1559Compatibility.bind(
+        this.networkController,
+      ),
       networkStore: this.networkController.networkStore,
       getCurrentChainId: this.networkController.getCurrentChainId.bind(
         this.networkController,

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -120,3 +120,24 @@ export const NATIVE_CURRENCY_TOKEN_IMAGE_MAP = {
 };
 
 export const INFURA_BLOCKED_KEY = 'countryBlocked';
+
+/**
+ * Hardforks are points in the chain where logic is changed significantly
+ * enough where there is a fork and the new fork becomes the active chain.
+ * These constants are presented in chronological order starting with BERLIN
+ * because when we first needed to track the hardfork we had launched support
+ * for EIP-2718 (where transactions can have types and different shapes) and
+ * EIP-2930 (optional access lists), which were included in BERLIN.
+ *
+ * BERLIN - forked at block number 12,244,000, included typed transactions and
+ *  optional access lists
+ * LONDON - future, upcoming fork that introduces the baseFeePerGas, an amount
+ *  of the ETH transaction fees that will be burned instead of given to the
+ *  miner. This change necessitated the third type of transaction envelope to
+ *  specify maxFeePerGas and maxPriorityFeePerGas moving the fee bidding system
+ *  to a second price auction model.
+ */
+export const HARDFORKS = {
+  BERLIN: 'berlin',
+  LONDON: 'london',
+};


### PR DESCRIPTION
Switches out which hardfork we supply to our @ethereumjs/common constructor based on EIP-1559 support. @rickycodes 