### PR TITLE
Remove gasPrice defaults for eip-1559 txs

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -376,7 +376,12 @@ export default class TransactionController extends EventEmitter {
     if (simulationFails) {
       txMeta.simulationFails = simulationFails;
     }
-    if (defaultGasPrice && !txMeta.txParams.gasPrice) {
+    if (
+      defaultGasPrice &&
+      !txMeta.txParams.gasPrice &&
+      !txMeta.txParams.maxPriorityFeePerGas &&
+      !txMeta.txParams.maxFeePerGas
+    ) {
       txMeta.txParams.gasPrice = defaultGasPrice;
     }
     if (defaultGasLimit && !txMeta.txParams.gas) {
@@ -391,7 +396,10 @@ export default class TransactionController extends EventEmitter {
    * @returns {Promise<string|undefined>} The default gas price
    */
   async _getDefaultGasPrice(txMeta) {
-    if (txMeta.txParams.gasPrice) {
+    if (
+      txMeta.txParams.gasPrice ||
+      (txMeta.txParams.maxFeePerGas && txMeta.txParams.maxPriorityFeePerGas)
+    ) {
       return undefined;
     }
     const gasPrice = await this.query.gasPrice();


### PR DESCRIPTION
When we boot up, and add an unapproved tx, we check for gasPrice and if it doesn't exist add an estimate. the gasPrice field being present will prevent a transaction that also has maxFeePerGas and maxPriorityFeePerGas from being assumed to be a EIP-1559 tx. This prevents a default being fetched or added for these types of txs. 