### PR TITLE
update txParams normalization and validation. 

### DIFF
--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -99,8 +99,7 @@ function ensureProperTransactionEnvelopeTypeProvided(txParams, field) {
         txParams.type !== TRANSACTION_ENVELOPE_TYPES.FEE_MARKET
       ) {
         throw ethErrors.rpc.invalidParams(
-          `Invalid transaction envelope type: specified type "${txParams.type}" but including maxFeePerGas and maxPriorityFeePerGas requires type: "${TRANSACTION_ENVELOPE_TYPES.FEE_MARKET}"
-          `,
+          `Invalid transaction envelope type: specified type "${txParams.type}" but including maxFeePerGas and maxPriorityFeePerGas requires type: "${TRANSACTION_ENVELOPE_TYPES.FEE_MARKET}"`,
         );
       }
       break;

--- a/app/scripts/controllers/transactions/lib/util.test.js
+++ b/app/scripts/controllers/transactions/lib/util.test.js
@@ -56,43 +56,70 @@ describe('txUtils', function () {
         const txParams = {
           gasPrice: '0x1',
           type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message: `Invalid transaction envelope type: specified type "0x2" but included a gasPrice instead of maxFeePerGas and maxPriorityFeePerGas`,
+          },
+        );
       });
 
       it('should error when gasPrice is not a string', function () {
         const txParams = {
           gasPrice: 1,
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction params: gasPrice is not a string. got: (1)',
+          },
+        );
       });
 
       it('should error when specifying maxFeePerGas', function () {
         const txParams = {
           gasPrice: '0x1',
           maxFeePerGas: '0x1',
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction params: specified gasPrice but also included maxFeePerGas, these cannot be mixed',
+          },
+        );
       });
 
       it('should error when specifying maxPriorityFeePerGas', function () {
         const txParams = {
           gasPrice: '0x1',
           maxPriorityFeePerGas: '0x1',
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction params: specified gasPrice but also included maxPriorityFeePerGas, these cannot be mixed',
+          },
+        );
       });
 
       it('should validate if gasPrice is set with no type or EIP-1559 gas fields', function () {
@@ -118,32 +145,53 @@ describe('txUtils', function () {
         const txParams = {
           maxFeePerGas: '0x1',
           type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction envelope type: specified type "0x0" but including maxFeePerGas and maxPriorityFeePerGas requires type: "0x2"',
+          },
+        );
       });
 
       it('should error when maxFeePerGas is not a string', function () {
         const txParams = {
           maxFeePerGas: 1,
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction params: maxFeePerGas is not a string. got: (1)',
+          },
+        );
       });
 
       it('should error when specifying gasPrice', function () {
         const txParams = {
           gasPrice: '0x1',
           maxFeePerGas: '0x1',
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction params: specified gasPrice but also included maxFeePerGas, these cannot be mixed',
+          },
+        );
       });
 
       it('should validate if maxFeePerGas is set with no type or gasPrice field', function () {
@@ -169,32 +217,53 @@ describe('txUtils', function () {
         const txParams = {
           maxPriorityFeePerGas: '0x1',
           type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction envelope type: specified type "0x0" but including maxFeePerGas and maxPriorityFeePerGas requires type: "0x2"',
+          },
+        );
       });
 
-      it('should error when maxPriorityFeePerGas is not a string', function () {
+      it('should error when maxFeePerGas is not a string', function () {
         const txParams = {
           maxPriorityFeePerGas: 1,
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction params: maxPriorityFeePerGas is not a string. got: (1)',
+          },
+        );
       });
 
       it('should error when specifying gasPrice', function () {
         const txParams = {
           gasPrice: '0x1',
           maxPriorityFeePerGas: '0x1',
+          to: BURN_ADDRESS,
         };
 
-        assert.throws(() => {
-          txUtils.validateTxParams(txParams);
-        }, Error);
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams);
+          },
+          {
+            message:
+              'Invalid transaction params: specified gasPrice but also included maxPriorityFeePerGas, these cannot be mixed',
+          },
+        );
       });
 
       it('should validate if maxPriorityFeePerGas is set with no type or gasPrice field', function () {

--- a/app/scripts/controllers/transactions/lib/util.test.js
+++ b/app/scripts/controllers/transactions/lib/util.test.js
@@ -1,4 +1,5 @@
 import { strict as assert } from 'assert';
+import { TRANSACTION_ENVELOPE_TYPES } from '../../../../../shared/constants/transaction';
 import * as txUtils from './util';
 
 describe('txUtils', function () {
@@ -58,6 +59,10 @@ describe('txUtils', function () {
         to: null,
         data: '68656c6c6f20776f726c64',
         random: 'hello world',
+        gasPrice: '1',
+        maxFeePerGas: '1',
+        maxPriorityFeePerGas: '1',
+        type: '1',
       };
 
       let normalizedTxParams = txUtils.normalizeTxParams(txParams);
@@ -88,6 +93,28 @@ describe('txUtils', function () {
         normalizedTxParams.to.slice(0, 2),
         '0x',
         'to should be hex-prefixed',
+      );
+
+      assert.equal(
+        normalizedTxParams.gasPrice,
+        '0x1',
+        'gasPrice should be hex-prefixed',
+      );
+
+      assert.equal(
+        normalizedTxParams.maxFeePerGas,
+        '0x1',
+        'maxFeePerGas should be hex-prefixed',
+      );
+      assert.equal(
+        normalizedTxParams.maxPriorityFeePerGas,
+        '0x1',
+        'maxPriorityFeePerGas should be hex-prefixed',
+      );
+      assert.equal(
+        normalizedTxParams.type,
+        '0x1',
+        'type should be hex-prefixed',
       );
     });
   });
@@ -124,6 +151,164 @@ describe('txUtils', function () {
         Error,
         'Invalid recipient address',
       );
+    });
+  });
+
+  describe('#validateGasPrice', function () {
+    it('should error when specifying incorrect type', function () {
+      const txParams = {
+        gasPrice: '0x1',
+        type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
+      };
+
+      assert.throws(() => {
+        txUtils.validateGasPrice(txParams);
+      }, Error);
+    });
+
+    it('should error when gasPrice is not a string', function () {
+      const txParams = {
+        gasPrice: 1,
+      };
+
+      assert.throws(() => {
+        txUtils.validateGasPrice(txParams);
+      }, Error);
+    });
+
+    it('should error when specifying maxFeePerGas', function () {
+      const txParams = {
+        gasPrice: '0x1',
+        maxFeePerGas: '0x1',
+      };
+
+      assert.throws(() => {
+        txUtils.validateGasPrice(txParams);
+      }, Error);
+    });
+
+    it('should error when specifying maxPriorityFeePerGas', function () {
+      const txParams = {
+        gasPrice: '0x1',
+        maxPriorityFeePerGas: '0x1',
+      };
+
+      assert.throws(() => {
+        txUtils.validateGasPrice(txParams);
+      }, Error);
+    });
+
+    it('should validate if gasPrice is set with no type or EIP-1559 gas fields', function () {
+      const txParams = {
+        gasPrice: '0x1',
+      };
+      assert.doesNotThrow(() => txUtils.validateGasPrice(txParams));
+    });
+
+    it('should validate if gasPrice is set with a type of "0x0"', function () {
+      const txParams = {
+        gasPrice: '0x1',
+        type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+      };
+      assert.doesNotThrow(() => txUtils.validateGasPrice(txParams));
+    });
+  });
+
+  describe('#validateMaxFeePerGas', function () {
+    it('should error when specifying incorrect type', function () {
+      const txParams = {
+        maxFeePerGas: '0x1',
+        type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+      };
+
+      assert.throws(() => {
+        txUtils.validateMaxFeePerGas(txParams);
+      }, Error);
+    });
+
+    it('should error when maxFeePerGas is not a string', function () {
+      const txParams = {
+        maxFeePerGas: 1,
+      };
+
+      assert.throws(() => {
+        txUtils.validateMaxFeePerGas(txParams);
+      }, Error);
+    });
+
+    it('should error when specifying gasPrice', function () {
+      const txParams = {
+        gasPrice: '0x1',
+        maxFeePerGas: '0x1',
+      };
+
+      assert.throws(() => {
+        txUtils.validateMaxFeePerGas(txParams);
+      }, Error);
+    });
+
+    it('should validate if maxFeePerGas is set with no type or gasPrice field', function () {
+      const txParams = {
+        maxFeePerGas: '0x1',
+      };
+      assert.doesNotThrow(() => txUtils.validateMaxFeePerGas(txParams));
+    });
+
+    it('should validate if maxFeePerGas is set with a type of "0x2"', function () {
+      const txParams = {
+        maxFeePerGas: '0x1',
+        type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
+      };
+      assert.doesNotThrow(() => txUtils.validateMaxFeePerGas(txParams));
+    });
+  });
+
+  describe('#validateMaxPriorityFeePerGas', function () {
+    it('should error when specifying incorrect type', function () {
+      const txParams = {
+        maxPriorityFeePerGas: '0x1',
+        type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+      };
+
+      assert.throws(() => {
+        txUtils.validateMaxPriorityFeePerGas(txParams);
+      }, Error);
+    });
+
+    it('should error when maxPriorityFeePerGas is not a string', function () {
+      const txParams = {
+        maxPriorityFeePerGas: 1,
+      };
+
+      assert.throws(() => {
+        txUtils.validateMaxPriorityFeePerGas(txParams);
+      }, Error);
+    });
+
+    it('should error when specifying gasPrice', function () {
+      const txParams = {
+        gasPrice: '0x1',
+        maxPriorityFeePerGas: '0x1',
+      };
+
+      assert.throws(() => {
+        txUtils.validateMaxPriorityFeePerGas(txParams);
+      }, Error);
+    });
+
+    it('should validate if maxPriorityFeePerGas is set with no type or gasPrice field', function () {
+      const txParams = {
+        maxPriorityFeePerGas: '0x1',
+      };
+      assert.doesNotThrow(() => txUtils.validateMaxPriorityFeePerGas(txParams));
+    });
+
+    it('should validate if maxPriorityFeePerGas is set with a type of "0x2"', function () {
+      const txParams = {
+        maxPriorityFeePerGas: '0x1',
+        type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
+      };
+      assert.doesNotThrow(() => txUtils.validateMaxPriorityFeePerGas(txParams));
     });
   });
 

--- a/app/scripts/controllers/transactions/lib/util.test.js
+++ b/app/scripts/controllers/transactions/lib/util.test.js
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../../../../shared/constants/transaction';
+import { BURN_ADDRESS } from '../../../../../shared/modules/hexstring-utils';
 import * as txUtils from './util';
 
 describe('txUtils', function () {
@@ -47,6 +48,170 @@ describe('txUtils', function () {
       };
       assert.throws(() => txUtils.validateTxParams(sample), {
         message: 'Invalid transaction value "-0x01": not a positive number.',
+      });
+    });
+
+    describe('when validating gasPrice', function () {
+      it('should error when specifying incorrect type', function () {
+        const txParams = {
+          gasPrice: '0x1',
+          type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should error when gasPrice is not a string', function () {
+        const txParams = {
+          gasPrice: 1,
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should error when specifying maxFeePerGas', function () {
+        const txParams = {
+          gasPrice: '0x1',
+          maxFeePerGas: '0x1',
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should error when specifying maxPriorityFeePerGas', function () {
+        const txParams = {
+          gasPrice: '0x1',
+          maxPriorityFeePerGas: '0x1',
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should validate if gasPrice is set with no type or EIP-1559 gas fields', function () {
+        const txParams = {
+          gasPrice: '0x1',
+          to: BURN_ADDRESS,
+        };
+        assert.doesNotThrow(() => txUtils.validateTxParams(txParams));
+      });
+
+      it('should validate if gasPrice is set with a type of "0x0"', function () {
+        const txParams = {
+          gasPrice: '0x1',
+          type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+          to: BURN_ADDRESS,
+        };
+        assert.doesNotThrow(() => txUtils.validateTxParams(txParams));
+      });
+    });
+
+    describe('when validating maxFeePerGas', function () {
+      it('should error when specifying incorrect type', function () {
+        const txParams = {
+          maxFeePerGas: '0x1',
+          type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should error when maxFeePerGas is not a string', function () {
+        const txParams = {
+          maxFeePerGas: 1,
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should error when specifying gasPrice', function () {
+        const txParams = {
+          gasPrice: '0x1',
+          maxFeePerGas: '0x1',
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should validate if maxFeePerGas is set with no type or gasPrice field', function () {
+        const txParams = {
+          maxFeePerGas: '0x1',
+          to: BURN_ADDRESS,
+        };
+        assert.doesNotThrow(() => txUtils.validateTxParams(txParams));
+      });
+
+      it('should validate if maxFeePerGas is set with a type of "0x2"', function () {
+        const txParams = {
+          maxFeePerGas: '0x1',
+          type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
+          to: BURN_ADDRESS,
+        };
+        assert.doesNotThrow(() => txUtils.validateTxParams(txParams));
+      });
+    });
+
+    describe('when validating maxPriorityFeePerGas', function () {
+      it('should error when specifying incorrect type', function () {
+        const txParams = {
+          maxPriorityFeePerGas: '0x1',
+          type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should error when maxPriorityFeePerGas is not a string', function () {
+        const txParams = {
+          maxPriorityFeePerGas: 1,
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should error when specifying gasPrice', function () {
+        const txParams = {
+          gasPrice: '0x1',
+          maxPriorityFeePerGas: '0x1',
+        };
+
+        assert.throws(() => {
+          txUtils.validateTxParams(txParams);
+        }, Error);
+      });
+
+      it('should validate if maxPriorityFeePerGas is set with no type or gasPrice field', function () {
+        const txParams = {
+          maxPriorityFeePerGas: '0x1',
+          to: BURN_ADDRESS,
+        };
+        assert.doesNotThrow(() => txUtils.validateTxParams(txParams));
+      });
+
+      it('should validate if maxPriorityFeePerGas is set with a type of "0x2"', function () {
+        const txParams = {
+          maxPriorityFeePerGas: '0x1',
+          type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
+          to: BURN_ADDRESS,
+        };
+        assert.doesNotThrow(() => txUtils.validateTxParams(txParams));
       });
     });
   });
@@ -151,164 +316,6 @@ describe('txUtils', function () {
         Error,
         'Invalid recipient address',
       );
-    });
-  });
-
-  describe('#validateGasPrice', function () {
-    it('should error when specifying incorrect type', function () {
-      const txParams = {
-        gasPrice: '0x1',
-        type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
-      };
-
-      assert.throws(() => {
-        txUtils.validateGasPrice(txParams);
-      }, Error);
-    });
-
-    it('should error when gasPrice is not a string', function () {
-      const txParams = {
-        gasPrice: 1,
-      };
-
-      assert.throws(() => {
-        txUtils.validateGasPrice(txParams);
-      }, Error);
-    });
-
-    it('should error when specifying maxFeePerGas', function () {
-      const txParams = {
-        gasPrice: '0x1',
-        maxFeePerGas: '0x1',
-      };
-
-      assert.throws(() => {
-        txUtils.validateGasPrice(txParams);
-      }, Error);
-    });
-
-    it('should error when specifying maxPriorityFeePerGas', function () {
-      const txParams = {
-        gasPrice: '0x1',
-        maxPriorityFeePerGas: '0x1',
-      };
-
-      assert.throws(() => {
-        txUtils.validateGasPrice(txParams);
-      }, Error);
-    });
-
-    it('should validate if gasPrice is set with no type or EIP-1559 gas fields', function () {
-      const txParams = {
-        gasPrice: '0x1',
-      };
-      assert.doesNotThrow(() => txUtils.validateGasPrice(txParams));
-    });
-
-    it('should validate if gasPrice is set with a type of "0x0"', function () {
-      const txParams = {
-        gasPrice: '0x1',
-        type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
-      };
-      assert.doesNotThrow(() => txUtils.validateGasPrice(txParams));
-    });
-  });
-
-  describe('#validateMaxFeePerGas', function () {
-    it('should error when specifying incorrect type', function () {
-      const txParams = {
-        maxFeePerGas: '0x1',
-        type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
-      };
-
-      assert.throws(() => {
-        txUtils.validateMaxFeePerGas(txParams);
-      }, Error);
-    });
-
-    it('should error when maxFeePerGas is not a string', function () {
-      const txParams = {
-        maxFeePerGas: 1,
-      };
-
-      assert.throws(() => {
-        txUtils.validateMaxFeePerGas(txParams);
-      }, Error);
-    });
-
-    it('should error when specifying gasPrice', function () {
-      const txParams = {
-        gasPrice: '0x1',
-        maxFeePerGas: '0x1',
-      };
-
-      assert.throws(() => {
-        txUtils.validateMaxFeePerGas(txParams);
-      }, Error);
-    });
-
-    it('should validate if maxFeePerGas is set with no type or gasPrice field', function () {
-      const txParams = {
-        maxFeePerGas: '0x1',
-      };
-      assert.doesNotThrow(() => txUtils.validateMaxFeePerGas(txParams));
-    });
-
-    it('should validate if maxFeePerGas is set with a type of "0x2"', function () {
-      const txParams = {
-        maxFeePerGas: '0x1',
-        type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
-      };
-      assert.doesNotThrow(() => txUtils.validateMaxFeePerGas(txParams));
-    });
-  });
-
-  describe('#validateMaxPriorityFeePerGas', function () {
-    it('should error when specifying incorrect type', function () {
-      const txParams = {
-        maxPriorityFeePerGas: '0x1',
-        type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
-      };
-
-      assert.throws(() => {
-        txUtils.validateMaxPriorityFeePerGas(txParams);
-      }, Error);
-    });
-
-    it('should error when maxPriorityFeePerGas is not a string', function () {
-      const txParams = {
-        maxPriorityFeePerGas: 1,
-      };
-
-      assert.throws(() => {
-        txUtils.validateMaxPriorityFeePerGas(txParams);
-      }, Error);
-    });
-
-    it('should error when specifying gasPrice', function () {
-      const txParams = {
-        gasPrice: '0x1',
-        maxPriorityFeePerGas: '0x1',
-      };
-
-      assert.throws(() => {
-        txUtils.validateMaxPriorityFeePerGas(txParams);
-      }, Error);
-    });
-
-    it('should validate if maxPriorityFeePerGas is set with no type or gasPrice field', function () {
-      const txParams = {
-        maxPriorityFeePerGas: '0x1',
-      };
-      assert.doesNotThrow(() => txUtils.validateMaxPriorityFeePerGas(txParams));
-    });
-
-    it('should validate if maxPriorityFeePerGas is set with a type of "0x2"', function () {
-      const txParams = {
-        maxPriorityFeePerGas: '0x1',
-        type: TRANSACTION_ENVELOPE_TYPES.FEE_MARKET,
-      };
-      assert.doesNotThrow(() => txUtils.validateMaxPriorityFeePerGas(txParams));
     });
   });
 

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -61,6 +61,33 @@ export const TRANSACTION_TYPES = {
 };
 
 /**
+ * In EIP-2718 typed transaction envelopes were specified, with the very first
+ * typed envelope being 'legacy' and describing the shape of the base
+ * transaction params that were hitherto the only transaction type sent on
+ * Ethereum.
+ * @typedef {Object} TransactionEnvelopeTypes
+ * @property {'0x0'} LEGACY - A legacy transaction, the very first type.
+ * @property {'0x1'} ACCESS_LIST - EIP-2930 defined the access list transaction
+ *  type that allowed for specifying the state that a transaction would act
+ *  upon in advance and theoretically save on gas fees.
+ * @property {'0x2'} FEE_MARKET - The type introduced comes from EIP-1559,
+ *  Fee Market describes the addition of a baseFee to blocks that will be
+ *  burned instead of distributed to miners. Transactions of this type have
+ *  both a maxFeePerGas (maximum total amount in gwei per gas to spend on the
+ *  transaction) which is inclusive of the maxPriorityFeePerGas (maximum amount
+ *  of gwei per gas from the transaction fee to distribute to miner).
+ */
+
+/**
+ * @type {TransactionEnvelopeTypes}
+ */
+export const TRANSACTION_ENVELOPE_TYPES = {
+  LEGACY: '0x0',
+  ACCESS_LIST: '0x1',
+  FEE_MARKET: '0x2',
+};
+
+/**
  * Transaction Status is a mix of Ethereum and MetaMask terminology, used internally
  * for transaction processing.
  * @typedef {Object} TransactionStatuses


### PR DESCRIPTION
Adds new TRANSACTION_ENVELOPE_TYPES constant to add types for EIP-2718 'type' field on txParams.

Also updates normalize / validate txParams methods to take into consideration these fields such that a dapp will get error messages useful in debugging when submitting transactions of various types. Note, we don't currently support EIP-2930 access lists and I am not working on that thread until after EIP-1559


  - 