### PR TITLE
update speedup and cancel to make room for EIP-1559

### DIFF
--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -739,11 +739,11 @@ describe('Transaction Controller', function () {
       const addTransactionArgs = addTransactionSpy.getCall(0).args[0];
       assert.deepEqual(addTransactionArgs.txParams, expectedTxParams);
 
-      const { lastGasPrice, type } = addTransactionArgs;
+      const { previousGasParams, type } = addTransactionArgs;
       assert.deepEqual(
-        { lastGasPrice, type },
+        { gasPrice: previousGasParams.gasPrice, type },
         {
-          lastGasPrice: '0xa',
+          gasPrice: '0xa',
           type: TRANSACTION_TYPES.RETRY,
         },
       );
@@ -762,11 +762,11 @@ describe('Transaction Controller', function () {
 
       assert.deepEqual(result.txParams, expectedTxParams);
 
-      const { lastGasPrice, type } = result;
+      const { previousGasParams, type } = result;
       assert.deepEqual(
-        { lastGasPrice, type },
+        { gasPrice: previousGasParams.gasPrice, type },
         {
-          lastGasPrice: '0xa',
+          gasPrice: '0xa',
           type: TRANSACTION_TYPES.RETRY,
         },
       );

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1972,27 +1972,40 @@ export default class MetamaskController extends EventEmitter {
   //=============================================================================
 
   /**
-   * Allows a user to attempt to cancel a previously submitted transaction by creating a new
-   * transaction.
-   * @param {number} originalTxId - the id of the txMeta that you want to attempt to cancel
-   * @param {string} [customGasPrice] - the hex value to use for the cancel transaction
+   * Allows a user to attempt to cancel a previously submitted transaction
+   * by creating a new transaction.
+   * @param {number} originalTxId - the id of the txMeta that you want to
+   *  attempt to cancel
+   * @param {import(
+   *  './controllers/transactions'
+   * ).CustomGasSettings} [customGasSettings] - overrides to use for gas params
+   *  instead of allowing this method to generate them
    * @returns {Object} MetaMask state
    */
-  async createCancelTransaction(originalTxId, customGasPrice, customGasLimit) {
+  async createCancelTransaction(originalTxId, customGasSettings) {
     await this.txController.createCancelTransaction(
       originalTxId,
-      customGasPrice,
-      customGasLimit,
+      customGasSettings,
     );
     const state = await this.getState();
     return state;
   }
 
-  async createSpeedUpTransaction(originalTxId, customGasPrice, customGasLimit) {
+  /**
+   * Allows a user to attempt to speed up a previously submitted transaction
+   * by creating a new transaction.
+   * @param {number} originalTxId - the id of the txMeta that you want to
+   *  attempt to speed up
+   * @param {import(
+   *  './controllers/transactions'
+   * ).CustomGasSettings} [customGasSettings] - overrides to use for gas params
+   *  instead of allowing this method to generate them
+   * @returns {Object} MetaMask state
+   */
+  async createSpeedUpTransaction(originalTxId, customGasSettings) {
     await this.txController.createSpeedUpTransaction(
       originalTxId,
-      customGasPrice,
-      customGasLimit,
+      customGasSettings,
     );
     const state = await this.getState();
     return state;

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -264,7 +264,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       if (ownProps.onSubmit) {
         dispatchHideSidebar();
         dispatchCancelAndClose();
-        console.log('here');
         ownProps.onSubmit({ gasLimit, gasPrice });
         return;
       }

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -220,11 +220,11 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(setCustomGasLimit(addHexPrefix(gasLimit.toString(16))));
       return dispatch(updateTransaction(updatedTx));
     },
-    createRetryTransaction: (txId, gasPrice, gasLimit) => {
-      return dispatch(createRetryTransaction(txId, gasPrice, gasLimit));
+    createRetryTransaction: (txId, customGasSettings) => {
+      return dispatch(createRetryTransaction(txId, customGasSettings));
     },
-    createSpeedUpTransaction: (txId, gasPrice, gasLimit) => {
-      return dispatch(createSpeedUpTransaction(txId, gasPrice, gasLimit));
+    createSpeedUpTransaction: (txId, customGasSettings) => {
+      return dispatch(createSpeedUpTransaction(txId, customGasSettings));
     },
     hideSidebar: () => dispatch(hideSidebar()),
     fetchBasicGasEstimates: () => dispatch(fetchBasicGasEstimates()),
@@ -264,7 +264,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       if (ownProps.onSubmit) {
         dispatchHideSidebar();
         dispatchCancelAndClose();
-        ownProps.onSubmit(gasLimit, gasPrice);
+        console.log('here');
+        ownProps.onSubmit({ gasLimit, gasPrice });
         return;
       }
       if (isConfirm) {
@@ -279,11 +280,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         dispatchUpdateConfirmTxGasAndCalculate(gasLimit, gasPrice, updatedTx);
         dispatchHideModal();
       } else if (isSpeedUp) {
-        dispatchCreateSpeedUpTransaction(txId, gasPrice, gasLimit);
+        dispatchCreateSpeedUpTransaction(txId, { gasPrice, gasLimit });
         dispatchHideSidebar();
         dispatchCancelAndClose();
       } else if (isRetry) {
-        dispatchCreateRetryTransaction(txId, gasPrice, gasLimit);
+        dispatchCreateRetryTransaction(txId, { gasPrice, gasLimit });
         dispatchHideSidebar();
         dispatchCancelAndClose();
       } else {

--- a/ui/components/app/modals/cancel-transaction/cancel-transaction.container.js
+++ b/ui/components/app/modals/cancel-transaction/cancel-transaction.container.js
@@ -10,8 +10,7 @@ const mapStateToProps = (state, ownProps) => {
     transactionId,
     originalGasPrice,
     newGasFee,
-    defaultNewGasPrice,
-    gasLimit,
+    customGasSettings,
   } = ownProps;
   const { currentNetworkTxList } = metamask;
   const transaction = currentNetworkTxList.find(
@@ -23,18 +22,15 @@ const mapStateToProps = (state, ownProps) => {
     transactionId,
     transactionStatus,
     originalGasPrice,
-    defaultNewGasPrice,
+    customGasSettings,
     newGasFee,
-    gasLimit,
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    createCancelTransaction: (txId, customGasPrice, customGasLimit) => {
-      return dispatch(
-        createCancelTransaction(txId, customGasPrice, customGasLimit),
-      );
+    createCancelTransaction: (txId, customGasSettings) => {
+      return dispatch(createCancelTransaction(txId, customGasSettings));
     },
     showTransactionConfirmedModal: () =>
       dispatch(showModal({ name: 'TRANSACTION_CONFIRMED' })),
@@ -42,12 +38,7 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const {
-    transactionId,
-    defaultNewGasPrice,
-    gasLimit,
-    ...restStateProps
-  } = stateProps;
+  const { transactionId, customGasSettings, ...restStateProps } = stateProps;
   // eslint-disable-next-line no-shadow
   const { createCancelTransaction, ...restDispatchProps } = dispatchProps;
 
@@ -56,7 +47,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...restDispatchProps,
     ...ownProps,
     createCancelTransaction: () =>
-      createCancelTransaction(transactionId, defaultNewGasPrice, gasLimit),
+      createCancelTransaction(transactionId, customGasSettings),
   };
 };
 

--- a/ui/hooks/useCancelTransaction.js
+++ b/ui/hooks/useCancelTransaction.js
@@ -1,12 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback } from 'react';
-import { addHexPrefix } from 'ethereumjs-util';
 import { showModal, showSidebar } from '../store/actions';
 import { isBalanceSufficient } from '../pages/send/send.utils';
-import {
-  getHexGasTotal,
-  increaseLastGasPrice,
-} from '../helpers/utils/confirm-tx.util';
 import { getSelectedAccount, getIsMainnet } from '../selectors';
 import { getConversionRate } from '../ducks/metamask/metamask';
 
@@ -14,8 +9,10 @@ import {
   setCustomGasLimit,
   setCustomGasPriceForRetry,
 } from '../ducks/gas/gas.duck';
-import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import { GAS_LIMITS } from '../../shared/constants/gas';
+import { isLegacyTransaction } from '../../shared/modules/transaction.utils';
+import { getMaximumGasTotalInHexWei } from '../../shared/modules/gas.utils';
+import { useIncrementedGasFees } from './useIncrementedGasFees';
 
 /**
  * Determine whether a transaction can be cancelled and provide a method to
@@ -30,33 +27,27 @@ import { GAS_LIMITS } from '../../shared/constants/gas';
 export function useCancelTransaction(transactionGroup) {
   const { primaryTransaction } = transactionGroup;
 
-  const transactionGasPrice = primaryTransaction.txParams?.gasPrice;
-  const gasPrice =
-    transactionGasPrice === undefined || transactionGasPrice?.startsWith('-')
-      ? '0x0'
-      : primaryTransaction.txParams?.gasPrice;
-  const transaction = primaryTransaction;
+  const customGasSettings = useIncrementedGasFees(transactionGroup);
+
   const dispatch = useDispatch();
   const selectedAccount = useSelector(getSelectedAccount);
   const conversionRate = useSelector(getConversionRate);
-  const defaultNewGasPrice = addHexPrefix(
-    multiplyCurrencies(gasPrice, 1.1, {
-      toNumericBase: 'hex',
-      multiplicandBase: 16,
-      multiplierBase: 10,
-    }),
-  );
   const isMainnet = useSelector(getIsMainnet);
   const hideBasic = !(isMainnet || process.env.IN_TEST);
   const cancelTransaction = useCallback(
     (event) => {
       event.stopPropagation();
-      dispatch(setCustomGasLimit(GAS_LIMITS.SIMPLE));
-      dispatch(setCustomGasPriceForRetry(defaultNewGasPrice));
+      if (isLegacyTransaction(primaryTransaction)) {
+        // To support the current process of cancelling or speeding up
+        // a transaction, we have to inform the custom gas state of the new
+        // gasPrice/gasLimit to start at.
+        dispatch(setCustomGasPriceForRetry(customGasSettings.gasPrice));
+        dispatch(setCustomGasLimit(GAS_LIMITS.SIMPLE));
+      }
       const tx = {
-        ...transaction,
+        ...primaryTransaction,
         txParams: {
-          ...transaction.txParams,
+          ...primaryTransaction.txParams,
           gas: GAS_LIMITS.SIMPLE,
           value: '0x0',
         },
@@ -68,18 +59,16 @@ export function useCancelTransaction(transactionGroup) {
           props: {
             hideBasic,
             transaction: tx,
-            onSubmit: (newGasLimit, newGasPrice) => {
-              const userCustomizedGasTotal = getHexGasTotal({
-                gasPrice: newGasPrice,
-                gasLimit: newGasLimit,
-              });
+            onSubmit: (newGasSettings) => {
+              const userCustomizedGasTotal = getMaximumGasTotalInHexWei(
+                newGasSettings,
+              );
               dispatch(
                 showModal({
                   name: 'CANCEL_TRANSACTION',
                   newGasFee: userCustomizedGasTotal,
-                  transactionId: transaction.id,
-                  defaultNewGasPrice: newGasPrice,
-                  gasLimit: newGasLimit,
+                  transactionId: primaryTransaction.id,
+                  customGasSettings: newGasSettings,
                 }),
               );
             },
@@ -87,17 +76,14 @@ export function useCancelTransaction(transactionGroup) {
         }),
       );
     },
-    [dispatch, transaction, defaultNewGasPrice, hideBasic],
+    [dispatch, primaryTransaction, customGasSettings, hideBasic],
   );
 
   const hasEnoughCancelGas =
     primaryTransaction.txParams &&
     isBalanceSufficient({
       amount: '0x0',
-      gasTotal: getHexGasTotal({
-        gasPrice: increaseLastGasPrice(gasPrice),
-        gasLimit: primaryTransaction.txParams.gas,
-      }),
+      gasTotal: getMaximumGasTotalInHexWei(customGasSettings),
       balance: selectedAccount.balance,
       conversionRate,
     });

--- a/ui/hooks/useCancelTransaction.test.js
+++ b/ui/hooks/useCancelTransaction.test.js
@@ -77,10 +77,10 @@ describe('useCancelTransaction', function () {
         ).toStrictEqual(transactionId);
 
         // call onSubmit myself
-        dispatchAction[dispatchAction.length - 1][0].value.props.onSubmit(
-          GAS_LIMITS.SIMPLE,
-          '0x1',
-        );
+        dispatchAction[dispatchAction.length - 1][0].value.props.onSubmit({
+          gasLimit: GAS_LIMITS.SIMPLE,
+          gasPrice: '0x1',
+        });
 
         expect(
           dispatch.calledWith(
@@ -88,8 +88,10 @@ describe('useCancelTransaction', function () {
               name: 'CANCEL_TRANSACTION',
               transactionId,
               newGasFee: GAS_LIMITS.SIMPLE,
-              defaultNewGasPrice: '0x1',
-              gasLimit: GAS_LIMITS.SIMPLE,
+              customGasSettings: {
+                gasPrice: '0x1',
+                gasLimit: GAS_LIMITS.SIMPLE,
+              },
             }),
           ),
         ).toStrictEqual(true);
@@ -147,10 +149,10 @@ describe('useCancelTransaction', function () {
             .id,
         ).toStrictEqual(transactionId);
 
-        dispatchAction[dispatchAction.length - 1][0].value.props.onSubmit(
-          GAS_LIMITS.SIMPLE,
-          '0x1',
-        );
+        dispatchAction[dispatchAction.length - 1][0].value.props.onSubmit({
+          gasLimit: GAS_LIMITS.SIMPLE,
+          gasPrice: '0x1',
+        });
 
         expect(
           dispatch.calledWith(
@@ -158,8 +160,10 @@ describe('useCancelTransaction', function () {
               name: 'CANCEL_TRANSACTION',
               transactionId,
               newGasFee: GAS_LIMITS.SIMPLE,
-              defaultNewGasPrice: '0x1',
-              gasLimit: GAS_LIMITS.SIMPLE,
+              customGasSettings: {
+                gasPrice: '0x1',
+                gasLimit: GAS_LIMITS.SIMPLE,
+              },
             }),
           ),
         ).toStrictEqual(true);

--- a/ui/hooks/useIncrementedGasFees.js
+++ b/ui/hooks/useIncrementedGasFees.js
@@ -1,0 +1,73 @@
+import { addHexPrefix } from 'ethereumjs-util';
+import { useMemo } from 'react';
+import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
+import { isEIP1559Transaction } from '../../shared/modules/transaction.utils';
+
+/**
+ * Simple helper to save on duplication to multiply the supplied wei hex string
+ * by 1.10 to get bare minimum new gas fee.
+ *
+ * @param {string} hexStringValue - hex value in wei to be incremented
+ * @returns {string} - hex value in WEI 10% higher than the param.
+ */
+function addTenPercent(hexStringValue) {
+  return addHexPrefix(
+    multiplyCurrencies(hexStringValue, 1.1, {
+      toNumericBase: 'hex',
+      multiplicandBase: 16,
+      multiplierBase: 10,
+    }),
+  );
+}
+
+/**
+ * When initializing cancellations or speed ups we need to set the baseline
+ * gas fees to be 10% higher, which is the bare minimum that the network will
+ * accept for transactions of the same nonce. Anything lower than this will be
+ * discarded by the network to avoid DoS attacks. This hook returns an object
+ * that either has gasPrice or maxFeePerGas/maxPriorityFeePerGas specified. In
+ * addition the gasLimit will also be included.
+ * @param {} transactionGroup
+ * @returns {import(
+ *   '../../app/scripts/controllers/transactions'
+ * ).CustomGasSettings} - Gas settings for cancellations/speed ups
+ */
+export function useIncrementedGasFees(transactionGroup) {
+  const { primaryTransaction } = transactionGroup;
+
+  // We memoize this value so that it can be relied upon in other hooks.
+  const customGasSettings = useMemo(() => {
+    // This hook is called indiscriminantly on all transactions appearing in
+    // the activity list. This includes transitional items such as signature
+    // requests. These types of "transactions" are not really transactions and
+    // do not have txParams. This is why we use optional chaining on the
+    // txParams object in this hook.
+    const temporaryGasSettings = {
+      gasLimit: primaryTransaction.txParams?.gas,
+    };
+    if (isEIP1559Transaction(primaryTransaction)) {
+      const transactionMaxFeePerGas = primaryTransaction.txParams?.maxFeePerGas;
+      const transactionMaxPriorityFeePerGas =
+        primaryTransaction.txParams?.maxPriorityFeePerGas;
+      temporaryGasSettings.maxFeePerGas =
+        transactionMaxFeePerGas === undefined ||
+        transactionMaxFeePerGas.startsWith('-')
+          ? '0x0'
+          : addTenPercent(transactionMaxFeePerGas);
+      temporaryGasSettings.maxPriorityFeePerGas =
+        transactionMaxPriorityFeePerGas === undefined ||
+        transactionMaxPriorityFeePerGas.startsWith('-')
+          ? '0x0'
+          : addTenPercent(transactionMaxPriorityFeePerGas);
+    } else {
+      const transactionGasPrice = primaryTransaction.txParams?.gasPrice;
+      temporaryGasSettings.gasPrice =
+        transactionGasPrice === undefined || transactionGasPrice.startsWith('-')
+          ? '0x0'
+          : addTenPercent(transactionGasPrice);
+    }
+    return temporaryGasSettings;
+  }, [primaryTransaction]);
+
+  return customGasSettings;
+}

--- a/ui/hooks/useRetryTransaction.js
+++ b/ui/hooks/useRetryTransaction.js
@@ -7,9 +7,10 @@ import {
   setCustomGasPriceForRetry,
   setCustomGasLimit,
 } from '../ducks/gas/gas.duck';
-import { increaseLastGasPrice } from '../helpers/utils/confirm-tx.util';
 import { getIsMainnet } from '../selectors';
+import { isLegacyTransaction } from '../../shared/modules/transaction.utils';
 import { useMetricEvent } from './useMetricEvent';
+import { useIncrementedGasFees } from './useIncrementedGasFees';
 /**
  * Provides a reusable hook that, given a transactionGroup, will return
  * a method for beginning the retry process
@@ -20,8 +21,7 @@ export function useRetryTransaction(transactionGroup) {
   const { primaryTransaction } = transactionGroup;
   const isMainnet = useSelector(getIsMainnet);
   const hideBasic = !(isMainnet || process.env.IN_TEST);
-  // Signature requests do not have a txParams, but this hook is called indiscriminately
-  const gasPrice = primaryTransaction.txParams?.gasPrice;
+  const customGasSettings = useIncrementedGasFees(transactionGroup);
   const trackMetricsEvent = useMetricEvent({
     eventOpts: {
       category: 'Navigation',
@@ -36,24 +36,32 @@ export function useRetryTransaction(transactionGroup) {
       event.stopPropagation();
 
       trackMetricsEvent();
-      await dispatch(fetchBasicGasEstimates);
-      const transaction = primaryTransaction;
-      const increasedGasPrice = increaseLastGasPrice(gasPrice);
-      await dispatch(
-        setCustomGasPriceForRetry(
-          increasedGasPrice || transaction.txParams.gasPrice,
-        ),
-      );
-      dispatch(setCustomGasLimit(transaction.txParams.gas));
+      if (process.env.SHOW_EIP_1559_UI === true) {
+        await dispatch(fetchBasicGasEstimates);
+      }
+      if (isLegacyTransaction(primaryTransaction)) {
+        // To support the current process of cancelling or speeding up
+        // a transaction, we have to inform the custom gas state of the new
+        // gasPrice to start at.
+        dispatch(setCustomGasPriceForRetry(customGasSettings.gasPrice));
+        dispatch(setCustomGasLimit(primaryTransaction.txParams.gas));
+      }
+
       dispatch(
         showSidebar({
           transitionName: 'sidebar-left',
           type: 'customize-gas',
-          props: { transaction, hideBasic },
+          props: { transaction: primaryTransaction, hideBasic },
         }),
       );
     },
-    [dispatch, trackMetricsEvent, gasPrice, primaryTransaction, hideBasic],
+    [
+      dispatch,
+      trackMetricsEvent,
+      customGasSettings,
+      primaryTransaction,
+      hideBasic,
+    ],
   );
 
   return retryTransaction;

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1324,7 +1324,7 @@ export function clearPendingTokens() {
   };
 }
 
-export function createCancelTransaction(txId, customGasPrice, customGasLimit) {
+export function createCancelTransaction(txId, customGasSettings) {
   log.debug('background.cancelTransaction');
   let newTxId;
 
@@ -1332,8 +1332,7 @@ export function createCancelTransaction(txId, customGasPrice, customGasLimit) {
     return new Promise((resolve, reject) => {
       background.createCancelTransaction(
         txId,
-        customGasPrice,
-        customGasLimit,
+        customGasSettings,
         (err, newState) => {
           if (err) {
             dispatch(displayWarning(err.message));
@@ -1353,7 +1352,7 @@ export function createCancelTransaction(txId, customGasPrice, customGasLimit) {
   };
 }
 
-export function createSpeedUpTransaction(txId, customGasPrice, customGasLimit) {
+export function createSpeedUpTransaction(txId, customGasSettings) {
   log.debug('background.createSpeedUpTransaction');
   let newTx;
 
@@ -1361,8 +1360,7 @@ export function createSpeedUpTransaction(txId, customGasPrice, customGasLimit) {
     return new Promise((resolve, reject) => {
       background.createSpeedUpTransaction(
         txId,
-        customGasPrice,
-        customGasLimit,
+        customGasSettings,
         (err, newState) => {
           if (err) {
             dispatch(displayWarning(err.message));
@@ -1381,16 +1379,14 @@ export function createSpeedUpTransaction(txId, customGasPrice, customGasLimit) {
   };
 }
 
-export function createRetryTransaction(txId, customGasPrice, customGasLimit) {
-  log.debug('background.createRetryTransaction');
+export function createRetryTransaction(txId, customGasSettings) {
   let newTx;
 
   return (dispatch) => {
     return new Promise((resolve, reject) => {
       background.createSpeedUpTransaction(
         txId,
-        customGasPrice,
-        customGasLimit,
+        customGasSettings,
         (err, newState) => {
           if (err) {
             dispatch(displayWarning(err.message));


### PR DESCRIPTION
Makes the positional arguments of createCancelTransaction and createSpeedUpTransaction an option bag so that other fields (maxFeePerGas, etc) can be included in future PRs, this also updates configuring new gas properties so that when EIP-1559 transactions roll in they will be handled in the background. Right now in this PR if a user were to create a EIP-1559 transaction and then attempt to speed it up with a custom gas value this would not be used. Instead a 1.10 multiplier would be applied to both gas fields. 

### Manual Testing Steps
1. Make sure SHOW_EIP_1559_UI is false/0
2. Submit a transaction with low gasPrice (< 0.5) on any testnet
3. Attempt to cancel the transaction, and see that the suggested gasPrice is 10% higher than the original.
4. Attempt to speed up the cancellation and see that the gasPrice is 10% higher than the cancel.
5. Check transaction details for the proper history of resubmitting

Repeat the steps with a plain speed up and no cancel. 