### PR TITLE
remove ui lookup of lastGasPrice field

### DIFF
--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -11,8 +11,6 @@ import {
   getHexGasTotal,
   addFiat,
   addEth,
-  increaseLastGasPrice,
-  hexGreaterThan,
 } from '../../helpers/utils/confirm-tx.util';
 
 import { getTokenData, sumHexes } from '../../helpers/utils/transactions.util';
@@ -180,32 +178,6 @@ export function updateNonce(nonce) {
   };
 }
 
-function increaseFromLastGasPrice(txData) {
-  const {
-    lastGasPrice,
-    txParams: { gasPrice: previousGasPrice } = {},
-  } = txData;
-
-  // Set the minimum to a 10% increase from the lastGasPrice.
-  const minimumGasPrice = increaseLastGasPrice(lastGasPrice);
-  const gasPriceBelowMinimum = hexGreaterThan(
-    minimumGasPrice,
-    previousGasPrice,
-  );
-  const gasPrice =
-    !previousGasPrice || gasPriceBelowMinimum
-      ? minimumGasPrice
-      : previousGasPrice;
-
-  return {
-    ...txData,
-    txParams: {
-      ...txData.txParams,
-      gasPrice,
-    },
-  };
-}
-
 export function updateTxDataAndCalculate(txData) {
   return (dispatch, getState) => {
     const state = getState();
@@ -303,12 +275,7 @@ export function setTransactionToConfirm(transactionId) {
     }
 
     if (transaction.txParams) {
-      const { lastGasPrice } = transaction;
-      const txData = lastGasPrice
-        ? increaseFromLastGasPrice(transaction)
-        : transaction;
-      dispatch(updateTxDataAndCalculate(txData));
-
+      dispatch(updateTxDataAndCalculate(transaction));
       const { txParams } = transaction;
 
       if (txParams.data) {

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -51,7 +51,6 @@ export default class ConfirmTransactionBase extends Component {
     hexTransactionAmount: PropTypes.string,
     hexTransactionFee: PropTypes.string,
     hexTransactionTotal: PropTypes.string,
-    isTxReprice: PropTypes.bool,
     methodData: PropTypes.object,
     nonce: PropTypes.string,
     useNonceField: PropTypes.bool,
@@ -649,7 +648,6 @@ export default class ConfirmTransactionBase extends Component {
   render() {
     const { t } = this.context;
     const {
-      isTxReprice,
       fromName,
       fromAddress,
       toName,
@@ -709,7 +707,7 @@ export default class ConfirmTransactionBase extends Component {
         toAddress={toAddress}
         toEns={toEns}
         toNickname={toNickname}
-        showEdit={onEdit && !isTxReprice}
+        showEdit={onEdit}
         action={functionType}
         title={title}
         titleComponent={this.renderTitleComponent()}

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -78,7 +78,7 @@ const mapStateToProps = (state, ownProps) => {
     provider: { chainId },
   } = metamask;
   const { tokenData, txData, tokenProps, nonce } = confirmTransaction;
-  const { txParams = {}, lastGasPrice, id: transactionId, type } = txData;
+  const { txParams = {}, id: transactionId, type } = txData;
   const transaction =
     Object.values(unapprovedTxs).find(
       ({ id }) => id === (transactionId || Number(paramsTransactionId)),
@@ -107,7 +107,6 @@ const mapStateToProps = (state, ownProps) => {
   const addressBookObject = addressBook[checksummedAddress];
   const toEns = ensResolutionsByAddress[checksummedAddress] || '';
   const toNickname = addressBookObject ? addressBookObject.name : '';
-  const isTxReprice = Boolean(lastGasPrice);
   const transactionStatus = transaction ? transaction.status : '';
 
   const {
@@ -165,7 +164,6 @@ const mapStateToProps = (state, ownProps) => {
     tokenData,
     methodData,
     tokenProps,
-    isTxReprice,
     conversionRate,
     transactionStatus,
     nonce,


### PR DESCRIPTION
In the transaction controller when creating a cancel or speed up transaction, a parameter called 'lastGasPrice' is added to the transaction object. It serves a purpose of being used to reference whether or not to use a generated nonce (which can probably also be removed) but I found this code hard to understand how it was used.

Assumptions I need help with:
lastGasPrice will only be available on speed ups and cancels
speed ups and cancels are automatically approved and therefore a confirmation window should never be shown for them.

So in https://github.com/MetaMask/metamask-extension/pull/5282 we updated logic to the controller for this and in https://github.com/MetaMask/metamask-extension/pull/4691 we created the confirm-transaction duck that includes this logic, but I just don't understand the connection and why this was ever required. 