### PR TITLE
Fixing invalid minimumGasLimit prop (AdvancedGasInputs)

### DIFF
--- a/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { debounce } from 'lodash';
 import Tooltip from '../../../ui/tooltip';
-import { MIN_GAS_LIMIT_DEC } from '../../../../pages/send/send.constants';
 
 export default class AdvancedGasInputs extends Component {
   static contextTypes = {
@@ -24,7 +23,6 @@ export default class AdvancedGasInputs extends Component {
   };
 
   static defaultProps = {
-    minimumGasLimit: Number(MIN_GAS_LIMIT_DEC),
     customPriceIsExcessive: false,
   };
 

--- a/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
+++ b/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
@@ -4,6 +4,7 @@ import {
   decimalToHex,
   hexWEIToDecGWEI,
 } from '../../../../helpers/utils/conversions.util';
+import { MIN_GAS_LIMIT_DEC } from '../../../../pages/send/send.constants';
 import AdvancedGasInputs from './advanced-gas-inputs.component';
 
 function convertGasPriceForInputs(gasPriceInHexWEI) {
@@ -14,12 +15,17 @@ function convertGasLimitForInputs(gasLimitInHexWEI) {
   return parseInt(gasLimitInHexWEI, 16) || 0;
 }
 
+function convertMinimumGasLimitForInputs(minimumGasLimit = MIN_GAS_LIMIT_DEC) {
+  return parseInt(minimumGasLimit, 10);
+}
+
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const {
     customGasPrice,
     customGasLimit,
     updateCustomGasPrice,
     updateCustomGasLimit,
+    minimumGasLimit,
   } = ownProps;
   return {
     ...ownProps,
@@ -27,6 +33,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...dispatchProps,
     customGasPrice: convertGasPriceForInputs(customGasPrice),
     customGasLimit: convertGasLimitForInputs(customGasLimit),
+    minimumGasLimit: convertMinimumGasLimitForInputs(minimumGasLimit),
     updateCustomGasPrice: (price) =>
       updateCustomGasPrice(decGWEIToHexWEI(price)),
     updateCustomGasLimit: (limit) => updateCustomGasLimit(decimalToHex(limit)),


### PR DESCRIPTION
<img width="576" alt="Screen Shot 2021-06-28 at 7 16 11 PM" src="https://user-images.githubusercontent.com/8732757/123730747-ba9e1080-d84b-11eb-82c1-527f79e986da.png">

Manual testing steps:  
  - Enter Send Flow on a testnet
  - Enter a recipient address
  - Confirm when the amount/gas inputs view loads, that the above error does not exist (Extra check, ensure that the gas limit is appropriately 21000 or otherwise (of type `number`)