### PR TITLE
Fix gas-modal-page-container.container check for custom gas price safety

### DIFF
--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -138,12 +138,10 @@ const mapStateToProps = (state, ownProps) => {
       });
   const isGasEstimate = getIsGasEstimatesFetched(state);
 
-  let customPriceIsSafe;
+  let customPriceIsSafe = true;
   if ((isMainnet || process.env.IN_TEST) && isGasEstimate) {
     customPriceIsSafe = isCustomPriceSafe(state);
-  } else if (isTestnet) {
-    customPriceIsSafe = true;
-  } else {
+  } else if (!(isMainnet || process.env.IN_TEST || isTestnet)) {
     customPriceIsSafe = isCustomPriceSafeForCustomNetwork(state);
   }
 

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -41,6 +41,7 @@ import {
   isCustomPriceExcessive,
   getIsGasEstimatesFetched,
   getShouldShowFiat,
+  getIsCustomNetworkGasPriceFetched,
 } from '../../../../selectors';
 
 import {
@@ -137,11 +138,17 @@ const mapStateToProps = (state, ownProps) => {
         conversionRate,
       });
   const isGasEstimate = getIsGasEstimatesFetched(state);
+  const customNetworkEstimateWasFetched = getIsCustomNetworkGasPriceFetched(
+    state,
+  );
 
   let customPriceIsSafe = true;
   if ((isMainnet || process.env.IN_TEST) && isGasEstimate) {
     customPriceIsSafe = isCustomPriceSafe(state);
-  } else if (!(isMainnet || process.env.IN_TEST || isTestnet)) {
+  } else if (
+    !(isMainnet || process.env.IN_TEST || isTestnet) &&
+    customNetworkEstimateWasFetched
+  ) {
     customPriceIsSafe = isCustomPriceSafeForCustomNetwork(state);
   }
 

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -386,6 +386,15 @@ export function getIsEthGasPriceFetched(state) {
   );
 }
 
+export function getIsCustomNetworkGasPriceFetched(state) {
+  const gasState = state.gas;
+  return Boolean(
+    gasState.estimateSource === GAS_SOURCE.ETHGASPRICE &&
+      gasState.basicEstimateStatus === BASIC_ESTIMATE_STATES.READY &&
+      !getIsMainnet(state),
+  );
+}
+
 export function getNoGasPriceFetched(state) {
   const gasState = state.gas;
   return Boolean(gasState.basicEstimateStatus === BASIC_ESTIMATE_STATES.FAILED);

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -105,6 +105,10 @@ export function isCustomPriceSafeForCustomNetwork(state) {
     return true;
   }
 
+  if (!estimatedPrice) {
+    return false;
+  }
+
   const customPriceSafe = conversionGreaterThan(
     {
       value: customGasPrice,


### PR DESCRIPTION
There is a bug in v9.7.0 that can be recreated like this:

1. Create a transaction with a gas price that is too low, so will be pending a long time
2. While the transaction is still pending, close metamask
3. Open the browser, open metamask
4. Try to "speed up" or cancel the pending transaction (before doing anything else)

Users will hit an error page with a "bignumber" error.

This is because we were calling `isCustomPriceSafeForCustomNetwork` when on mainnet but `isGasEstimate` is false. `isGasEstimate` is set to true after fetching the price when hitting the send screen. If there is no cached price, then this error will be hit.

The fix is to ensure that we only call `isCustomPriceSafeForCustomNetwork` when we are on a custom network.