### PR TITLE
Add yarn build:dev script to run subprocesses not in Lavamoat

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start:lavamoat": "yarn build dev",
     "dist": "yarn build prod",
     "build": "lavamoat development/build/index.js",
+    "build:dev": "node development/build/index.js",
     "start:test": "yarn build testDev",
     "benchmark:chrome": "SELENIUM_BROWSER=chrome node test/e2e/benchmark.js",
     "benchmark:firefox": "SELENIUM_BROWSER=firefox node test/e2e/benchmark.js",


### PR DESCRIPTION
fixes problem caused by #11417 
```
scripts:core:dev:phishing-detect: error Command "build:dev" not found.
MetaMask build: Encountered an error while running task "dev".
Error: MetaMask build: runInChildProcess for task "scripts:core:dev:background" encountered an error 1
    at ChildProcess.<anonymous> (/Users/dan/Code/consensys/metamask-extension/development/build/task.js:100:13)
    at Object.onceWrapper (events.js:422:26)
    at ChildProcess.emit (events.js:315:20)
    at ChildProcess.EventEmitter.emit (domain.js:467:12)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:277:12)
```