### PR TITLE
Refix the instance of unsafe destructuring I had introduced and fixed and then reintroduced

### DIFF
--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -223,9 +223,7 @@ export const transactionFeeSelector = function (state, txData) {
 
   // if the gas price from our infura endpoint is null or undefined
   // use the metaswap average price estimation as a fallback
-  let {
-    txParams: { gasPrice },
-  } = txData;
+  let { txParams: { gasPrice } = {} } = txData;
 
   if (!gasPrice) {
     gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';


### PR DESCRIPTION
😜  I fixed this bug in #11351 and then reintroduced it (probably in a bad rebase) in #11210

As is, this unsafe destructuring can lead to an intermittent error state in the confirmation stage of the send flow.