### PR TITLE
pull some logic out of advanced gas modal and into a shared method.

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { PageContainerFooter } from '../../ui/page-container';
+import EditGasPopover from '../edit-gas-popover';
 import {
   ConfirmPageContainerHeader,
   ConfirmPageContainerContent,
@@ -60,6 +61,8 @@ export default class ConfirmPageContainer extends Component {
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func,
     disabled: PropTypes.bool,
+    editingGas: PropTypes.bool,
+    handleCloseEditGas: PropTypes.func,
   };
 
   render() {
@@ -105,6 +108,8 @@ export default class ConfirmPageContainer extends Component {
       showAccountInHeader,
       origin,
       ethGasPriceWarning,
+      editingGas,
+      handleCloseEditGas,
     } = this.props;
     const renderAssetImage = contentComponent || !identiconAddress;
 
@@ -183,6 +188,7 @@ export default class ConfirmPageContainer extends Component {
             )}
           </PageContainerFooter>
         )}
+        {editingGas && <EditGasPopover onClose={handleCloseEditGas} />}
       </div>
     );
   }

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -14,6 +14,7 @@ export default function EditGasPopover({
   popoverTitle,
   confirmButtonText,
   editGasDisplayProps,
+  onClose,
 }) {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
@@ -27,12 +28,14 @@ export default function EditGasPopover({
    * the modal in testing
    */
   const closePopover = useCallback(() => {
-    if (showSidebar) {
+    if (onClose) {
+      onClose();
+    } else if (showSidebar) {
       dispatch(hideSidebar());
     } else {
       dispatch(hideModal());
     }
-  }, [showSidebar, dispatch]);
+  }, [showSidebar, onClose, dispatch]);
 
   const title = showEducationContent
     ? t('editGasEducationModalTitle')
@@ -73,6 +76,7 @@ EditGasPopover.propTypes = {
   editGasDisplayProps: PropTypes.object,
   confirmButtonText: PropTypes.string,
   showEducationButton: PropTypes.bool,
+  onClose: PropTypes.func,
 };
 
 EditGasPopover.defaultProps = {

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
@@ -49,6 +49,10 @@ jest.mock('../../../../store/actions', () => ({
   updateTransaction: jest.fn(),
 }));
 
+jest.mock('../../../../ducks/metamask/metamask.js', () => ({
+  updateTransactionGasFees: jest.fn(),
+}));
+
 jest.mock('../../../../ducks/gas/gas.duck', () => ({
   setCustomGasPrice: jest.fn(),
   setCustomGasLimit: jest.fn(),
@@ -79,6 +83,7 @@ describe('gas-modal-page-container container', () => {
 
     afterEach(() => {
       dispatchSpy.resetHistory();
+      jest.clearAllMocks();
     });
 
     describe('useCustomGas()', () => {
@@ -137,17 +142,6 @@ describe('gas-modal-page-container container', () => {
         expect(updateGasPrice).toHaveBeenCalledWith('aaaa');
       });
     });
-
-    describe('updateConfirmTxGasAndCalculate()', () => {
-      it('should dispatch a updateGasAndCalculate action with the correct props', () => {
-        mapDispatchToPropsObject.updateConfirmTxGasAndCalculate('ffff', 'aaaa');
-        expect(dispatchSpy.callCount).toStrictEqual(3);
-        expect(setCustomGasPrice).toHaveBeenCalled();
-        expect(setCustomGasLimit).toHaveBeenCalled();
-        expect(setCustomGasLimit).toHaveBeenCalledWith('0xffff');
-        expect(setCustomGasPrice).toHaveBeenCalledWith('0xaaaa');
-      });
-    });
   });
 
   describe('mergeProps', () => {
@@ -169,7 +163,7 @@ describe('gas-modal-page-container container', () => {
         updateCustomGasPrice: sinon.spy(),
         useCustomGas: sinon.spy(),
         setGasData: sinon.spy(),
-        updateConfirmTxGasAndCalculate: sinon.spy(),
+        updateTransactionGasFees: sinon.spy(),
         someOtherDispatchProp: sinon.spy(),
         createSpeedUpTransaction: sinon.spy(),
         hideSidebar: sinon.spy(),
@@ -192,18 +186,14 @@ describe('gas-modal-page-container container', () => {
       ).toStrictEqual('bar');
       expect(result.someOwnProp).toStrictEqual(123);
 
-      expect(
-        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
-      ).toStrictEqual(0);
+      expect(dispatchProps.updateTransactionGasFees.callCount).toStrictEqual(0);
       expect(dispatchProps.setGasData.callCount).toStrictEqual(0);
       expect(dispatchProps.useCustomGas.callCount).toStrictEqual(0);
       expect(dispatchProps.hideModal.callCount).toStrictEqual(0);
 
       result.onSubmit();
 
-      expect(
-        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
-      ).toStrictEqual(1);
+      expect(dispatchProps.updateTransactionGasFees.callCount).toStrictEqual(1);
       expect(dispatchProps.setGasData.callCount).toStrictEqual(0);
       expect(dispatchProps.useCustomGas.callCount).toStrictEqual(0);
       expect(dispatchProps.hideModal.callCount).toStrictEqual(1);
@@ -236,18 +226,14 @@ describe('gas-modal-page-container container', () => {
       ).toStrictEqual('bar');
       expect(result.someOwnProp).toStrictEqual(123);
 
-      expect(
-        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
-      ).toStrictEqual(0);
+      expect(dispatchProps.updateTransactionGasFees.callCount).toStrictEqual(0);
       expect(dispatchProps.setGasData.callCount).toStrictEqual(0);
       expect(dispatchProps.useCustomGas.callCount).toStrictEqual(0);
       expect(dispatchProps.cancelAndClose.callCount).toStrictEqual(0);
 
       result.onSubmit('mockNewLimit', 'mockNewPrice');
 
-      expect(
-        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
-      ).toStrictEqual(0);
+      expect(dispatchProps.updateTransactionGasFees.callCount).toStrictEqual(0);
       expect(dispatchProps.setGasData.callCount).toStrictEqual(1);
       expect(dispatchProps.setGasData.getCall(0).args).toStrictEqual([
         'mockNewLimit',
@@ -276,9 +262,7 @@ describe('gas-modal-page-container container', () => {
 
       result.onSubmit();
 
-      expect(
-        dispatchProps.updateConfirmTxGasAndCalculate.callCount,
-      ).toStrictEqual(0);
+      expect(dispatchProps.updateTransactionGasFees.callCount).toStrictEqual(0);
       expect(dispatchProps.setGasData.callCount).toStrictEqual(0);
       expect(dispatchProps.useCustomGas.callCount).toStrictEqual(0);
       expect(dispatchProps.cancelAndClose.callCount).toStrictEqual(1);

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -5,7 +5,6 @@ import {
   createRetryTransaction,
   createSpeedUpTransaction,
   hideSidebar,
-  updateTransaction,
 } from '../../../../store/actions';
 import {
   setCustomGasPrice,
@@ -59,6 +58,7 @@ import {
 import { MIN_GAS_LIMIT_DEC } from '../../../../pages/send/send.constants';
 import { TRANSACTION_STATUSES } from '../../../../../shared/constants/transaction';
 import { GAS_LIMITS } from '../../../../../shared/constants/gas';
+import { updateTransactionGasFees } from '../../../../ducks/metamask/metamask';
 import GasModalPageContainer from './gas-modal-page-container.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -208,17 +208,15 @@ const mapDispatchToProps = (dispatch) => {
     },
     hideModal: () => dispatch(hideModal()),
     useCustomGas: () => dispatch(useCustomGas()),
+    updateTransactionGasFees: (gasFees) => {
+      dispatch(updateTransactionGasFees({ ...gasFees, expectHexWei: true }));
+    },
     updateCustomGasPrice,
     updateCustomGasLimit: (newLimit) =>
       dispatch(setCustomGasLimit(addHexPrefix(newLimit))),
     setGasData: (newLimit, newPrice) => {
       dispatch(updateGasLimit(newLimit));
       dispatch(updateGasPrice(newPrice));
-    },
-    updateConfirmTxGasAndCalculate: (gasLimit, gasPrice, updatedTx) => {
-      updateCustomGasPrice(gasPrice);
-      dispatch(setCustomGasLimit(addHexPrefix(gasLimit.toString(16))));
-      return dispatch(updateTransaction(updatedTx));
     },
     createRetryTransaction: (txId, gasPrice, gasLimit) => {
       return dispatch(createRetryTransaction(txId, gasPrice, gasLimit));
@@ -247,9 +245,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const {
     useCustomGas: dispatchUseCustomGas,
     setGasData: dispatchSetGasData,
-    updateConfirmTxGasAndCalculate: dispatchUpdateConfirmTxGasAndCalculate,
     createSpeedUpTransaction: dispatchCreateSpeedUpTransaction,
     createRetryTransaction: dispatchCreateRetryTransaction,
+    updateTransactionGasFees: dispatchUpdateTransactionGasFees,
     hideSidebar: dispatchHideSidebar,
     cancelAndClose: dispatchCancelAndClose,
     hideModal: dispatchHideModal,
@@ -268,16 +266,14 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         return;
       }
       if (isConfirm) {
-        const updatedTx = {
-          ...transaction,
-          txParams: {
-            ...transaction.txParams,
-            gas: gasLimit,
-            gasPrice,
-          },
-        };
-        dispatchUpdateConfirmTxGasAndCalculate(gasLimit, gasPrice, updatedTx);
+        dispatchUpdateTransactionGasFees({
+          gasLimit,
+          gasPrice,
+          transaction,
+          isModal: true,
+        });
         dispatchHideModal();
+        dispatchCancelAndClose();
       } else if (isSpeedUp) {
         dispatchCreateSpeedUpTransaction(txId, gasPrice, gasLimit);
         dispatchHideSidebar();


### PR DESCRIPTION
This PR starts to remove the old gas modal, this is done in a few ways:

1. While the SHOW_EIP_1559_UI variable is true, the gas modal doesn't open when clicking edit on confirmations. Instead, the EditGasPopover is rendered directly. 
2. Logic from the gas modal for updating confirmation transactions gas fees has been extracted into a new method and that method has been made to support EIP-1559
3. Some logic improvements for when to show the 'edit' link on the SHOW_EIP_1559_UI branch
