### PR TITLE
Add list of custom networks with special gas limit buffers

### DIFF
--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -19,6 +19,8 @@ export const GOERLI_CHAIN_ID = '0x5';
 export const KOVAN_CHAIN_ID = '0x2a';
 export const LOCALHOST_CHAIN_ID = '0x539';
 export const BSC_CHAIN_ID = '0x38';
+export const OPTIMISM_CHAIN_ID = '0xa';
+export const OPTIMISM_TESTNET_CHAIN_ID = '0x45';
 
 /**
  * The largest possible chain ID we can handle.
@@ -140,4 +142,9 @@ export const INFURA_BLOCKED_KEY = 'countryBlocked';
 export const HARDFORKS = {
   BERLIN: 'berlin',
   LONDON: 'london',
+};
+
+export const CHAIN_ID_TO_GAS_LIMIT_BUFFER_MAP = {
+  [OPTIMISM_CHAIN_ID]: 1,
+  [OPTIMISM_TESTNET_CHAIN_ID]: 1,
 };


### PR DESCRIPTION
This PR adds special gas limit buffer multipliers for specific custom networks. In the future we will look for a way to standardize this so that specific networks do not need to be hardcoded; this is a temporary solution.