### PR TITLE
Ensure transaction controller correctly estimates gas for special custom networks

### DIFF
--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -2,6 +2,10 @@ import extension from 'extensionizer';
 import { stripHexPrefix } from 'ethereumjs-util';
 import BN from 'bn.js';
 import { memoize } from 'lodash';
+import {
+  MAINNET_CHAIN_ID,
+  TEST_CHAINS,
+} from '../../../shared/constants/network';
 
 import {
   ENVIRONMENT_TYPE_POPUP,
@@ -146,6 +150,15 @@ function bnToHex(inputBn) {
   return addHexPrefix(inputBn.toString(16));
 }
 
+function getChainType(chainId) {
+  if (chainId === MAINNET_CHAIN_ID) {
+    return 'mainnet';
+  } else if (TEST_CHAINS.includes(chainId)) {
+    return 'testnet';
+  }
+  return 'custom';
+}
+
 export {
   getPlatform,
   getEnvironmentType,
@@ -154,4 +167,5 @@ export {
   checkForError,
   addHexPrefix,
   bnToHex,
+  getChainType,
 };


### PR DESCRIPTION
This was missed in https://github.com/MetaMask/metamask-extension/pull/11435 and https://github.com/MetaMask/metamask-extension/pull/11418

It ensures that the same desired effect of those PRs happens on transactions created by dapps.