### PR TITLE
Use ESM imports in migrations index.

### DIFF
--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -5,68 +5,130 @@
 // The `migrate` function receives the previous
 // config data format, and returns the new one.
 
+import m002 from './002';
+import m003 from './003';
+import m004 from './004';
+import m005 from './005';
+import m006 from './006';
+import m007 from './007';
+import m008 from './008';
+import m009 from './009';
+import m010 from './010';
+import m011 from './011';
+import m012 from './012';
+import m013 from './013';
+import m014 from './014';
+import m015 from './015';
+import m016 from './016';
+import m017 from './017';
+import m018 from './018';
+import m019 from './019';
+import m020 from './020';
+import m021 from './021';
+import m022 from './022';
+import m023 from './023';
+import m024 from './024';
+import m025 from './025';
+import m026 from './026';
+import m027 from './027';
+import m028 from './028';
+import m029 from './029';
+import m030 from './030';
+import m031 from './031';
+import m032 from './032';
+import m033 from './033';
+import m034 from './034';
+import m035 from './035';
+import m036 from './036';
+import m037 from './037';
+import m038 from './038';
+import m039 from './039';
+import m040 from './040';
+import m041 from './041';
+import m042 from './042';
+import m043 from './043';
+import m044 from './044';
+import m045 from './045';
+import m046 from './046';
+import m047 from './047';
+import m048 from './048';
+import m049 from './049';
+import m050 from './050';
+import m051 from './051';
+import m052 from './052';
+import m053 from './053';
+import m054 from './054';
+import m055 from './055';
+import m056 from './056';
+import m057 from './057';
+import m058 from './058';
+import m059 from './059';
+import m060 from './060';
+import m061 from './061';
+import m062 from './062';
+
 const migrations = [
-  require('./002').default,
-  require('./003').default,
-  require('./004').default,
-  require('./005').default,
-  require('./006').default,
-  require('./007').default,
-  require('./008').default,
-  require('./009').default,
-  require('./010').default,
-  require('./011').default,
-  require('./012').default,
-  require('./013').default,
-  require('./014').default,
-  require('./015').default,
-  require('./016').default,
-  require('./017').default,
-  require('./018').default,
-  require('./019').default,
-  require('./020').default,
-  require('./021').default,
-  require('./022').default,
-  require('./023').default,
-  require('./024').default,
-  require('./025').default,
-  require('./026').default,
-  require('./027').default,
-  require('./028').default,
-  require('./029').default,
-  require('./030').default,
-  require('./031').default,
-  require('./032').default,
-  require('./033').default,
-  require('./034').default,
-  require('./035').default,
-  require('./036').default,
-  require('./037').default,
-  require('./038').default,
-  require('./039').default,
-  require('./040').default,
-  require('./041').default,
-  require('./042').default,
-  require('./043').default,
-  require('./044').default,
-  require('./045').default,
-  require('./046').default,
-  require('./047').default,
-  require('./048').default,
-  require('./049').default,
-  require('./050').default,
-  require('./051').default,
-  require('./052').default,
-  require('./053').default,
-  require('./054').default,
-  require('./055').default,
-  require('./056').default,
-  require('./057').default,
-  require('./058').default,
-  require('./059').default,
-  require('./060').default,
-  require('./061').default,
-  require('./062').default,
+  m002,
+  m003,
+  m004,
+  m005,
+  m006,
+  m007,
+  m008,
+  m009,
+  m010,
+  m011,
+  m012,
+  m013,
+  m014,
+  m015,
+  m016,
+  m017,
+  m018,
+  m019,
+  m020,
+  m021,
+  m022,
+  m023,
+  m024,
+  m025,
+  m026,
+  m027,
+  m028,
+  m029,
+  m030,
+  m031,
+  m032,
+  m033,
+  m034,
+  m035,
+  m036,
+  m037,
+  m038,
+  m039,
+  m040,
+  m041,
+  m042,
+  m043,
+  m044,
+  m045,
+  m046,
+  m047,
+  m048,
+  m049,
+  m050,
+  m051,
+  m052,
+  m053,
+  m054,
+  m055,
+  m056,
+  m057,
+  m058,
+  m059,
+  m060,
+  m061,
+  m062,
 ];
 
 export default migrations;


### PR DESCRIPTION
So that spack does not complain about mixing CommonJs and ESM.

Fixes: N/A

Explanation:  

I am working with @kumavis on LavaMoat and researching creation of a bundler that could be deeply integrated with LavaMoat/SES. Whilst doing this research I ran into an issue using [the SWC library](https://github.com/swc-project/swc/) with the migrations code which is using a mix of ESM -> CommonJs -> ESM that caused bundling to fail using `spack`.

Looking at [migrations/index.js](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/migrations/index.js) I can't think of any reason why `require()` should be used instead of static ESM imports.

This PR replaces the use of `require()` with `import` and allows us to bundle using `spack`.

Manual testing steps:  

I don't know enough about the repository to test this thoroughly so would appreciate some help verifying this works with the existing build process. In theory this should just work.