### PR TITLE
Add gas utils shared module

### DIFF
--- a/shared/modules/gas.utils.js
+++ b/shared/modules/gas.utils.js
@@ -1,0 +1,99 @@
+import { addHexPrefix } from 'ethereumjs-util';
+import {
+  addCurrencies,
+  conversionGreaterThan,
+  multiplyCurrencies,
+} from './conversion.utils';
+
+/**
+ * Accepts an options bag containing gas fee parameters in hex format and
+ * returns a gasTotal parameter representing the maximum amount of wei the
+ * transaction will cost.
+ *
+ * @param {object} options - gas fee parameters object
+ * @param {string} [options.gasLimit] - the maximum amount of gas to allow this
+ *  transaction to consume. Value is a hex string
+ * @param {string} [options.gasPrice] - The fee in wei to pay per gas used.
+ *  gasPrice is only set on Legacy type transactions. Value is hex string
+ * @param {string} [options.maxFeePerGas] - The maximum fee in wei to pay per
+ *  gas used. maxFeePerGas is introduced in EIP 1559 and represents the max
+ *  total a user will pay per gas. Actual cost is determined by baseFeePerGas
+ *  on the block + maxPriorityFeePerGas. Value is hex string
+ * @returns {string} - The maximum total cost of transaction in hex wei string
+ */
+export function getMaximumGasTotalInHexWei({
+  gasLimit = '0x0',
+  gasPrice = '0x0',
+  maxFeePerGas,
+} = {}) {
+  if (maxFeePerGas) {
+    return addHexPrefix(
+      multiplyCurrencies(gasLimit, maxFeePerGas, {
+        toNumericBase: 'hex',
+        multiplicandBase: 16,
+        multiplierBase: 16,
+      }),
+    );
+  }
+  return addHexPrefix(
+    multiplyCurrencies(gasLimit, gasPrice, {
+      toNumericBase: 'hex',
+      multiplicandBase: 16,
+      multiplierBase: 16,
+    }),
+  );
+}
+
+/**
+ * Accepts an options bag containing gas fee parameters in hex format and
+ * returns a gasTotal parameter representing the minimum amount of wei the
+ * transaction will cost. For gasPrice types this is the same as max.
+ *
+ * @param {object} options - gas fee parameters object
+ * @param {string} [options.gasLimit] - the maximum amount of gas to allow this
+ *  transaction to consume. Value is a hex string
+ * @param {string} [options.gasPrice] - The fee in wei to pay per gas used.
+ *  gasPrice is only set on Legacy type transactions. Value is hex string
+ * @param {string} [options.maxFeePerGas] - The maximum fee in wei to pay per
+ *  gas used. maxFeePerGas is introduced in EIP 1559 and represents the max
+ *  total a user will pay per gas. Actual cost is determined by baseFeePerGas
+ *  on the block + maxPriorityFeePerGas. Value is hex string
+ * @param {string} [options.maxPriorityFeePerGas] - The maximum fee in wei to
+ *  pay a miner to include this transaction.
+ * @param {string} [options.baseFeePerGas] - The estimated block baseFeePerGas
+ *  that will be burned. Introduced in EIP 1559. Value in hex wei.
+ * @returns {string} - The minimum total cost of transaction in hex wei string
+ */
+export function getMinimumGasTotalInHexWei({
+  gasLimit = '0x0',
+  gasPrice,
+  maxPriorityFeePerGas,
+  maxFeePerGas,
+  baseFeePerGas,
+} = {}) {
+  if (gasPrice) {
+    return getMaximumGasTotalInHexWei({ gasLimit, gasPrice });
+  }
+  const minimumFeePerGas = addCurrencies(baseFeePerGas, maxPriorityFeePerGas, {
+    toNumericBase: 'hex',
+    aBase: 16,
+    bBase: 16,
+  });
+  const minimum = addHexPrefix(
+    multiplyCurrencies(gasLimit, minimumFeePerGas, {
+      toNumericBase: 'hex',
+      multiplicandBase: 16,
+      multiplierBase: 16,
+    }),
+  );
+
+  if (
+    conversionGreaterThan(
+      { value: minimumFeePerGas, fromNumericBase: 'hex' },
+      { value: maxFeePerGas, fromNumericBase: 'hex' },
+    )
+  ) {
+    return getMaximumGasTotalInHexWei({ gasLimit, maxFeePerGas });
+  }
+  return minimum;
+}

--- a/shared/modules/gas.utils.js
+++ b/shared/modules/gas.utils.js
@@ -26,6 +26,11 @@ export function getMaximumGasTotalInHexWei({
   gasPrice = '0x0',
   maxFeePerGas,
 } = {}) {
+  if (maxFeePerGas && gasPrice) {
+    throw new Error(
+      `getMaximumGasTotalInHexWei expects either gasPrice OR maxFeePerGas but both were provided`,
+    );
+  }
   if (maxFeePerGas) {
     return addHexPrefix(
       multiplyCurrencies(gasLimit, maxFeePerGas, {
@@ -71,6 +76,11 @@ export function getMinimumGasTotalInHexWei({
   maxFeePerGas,
   baseFeePerGas,
 } = {}) {
+  if ((maxFeePerGas || maxPriorityFeePerGas || baseFeePerGas) && gasPrice) {
+    throw new Error(
+      `getMinimumGasTotalInHexWei expects either gasPrice OR the EIP-1559 gas fields, but both were provided`,
+    );
+  }
   if (gasPrice) {
     return getMaximumGasTotalInHexWei({ gasLimit, gasPrice });
   }

--- a/shared/modules/gas.utils.test.js
+++ b/shared/modules/gas.utils.test.js
@@ -1,0 +1,131 @@
+const { addHexPrefix } = require('ethereumjs-util');
+const { conversionUtil } = require('./conversion.utils');
+const {
+  getMaximumGasTotalInHexWei,
+  getMinimumGasTotalInHexWei,
+} = require('./gas.utils');
+
+const feesToTest = [10, 24, 90];
+const tipsToTest = [2, 10, 50];
+const baseFeesToTest = [8, 12, 24];
+const gasLimitsToTest = [21000, 100000];
+
+describe('gas utils', () => {
+  describe('when using EIP 1559 fields', () => {
+    describe('getMaximumGasTotalInHexWei', () => {
+      feesToTest.forEach((maxFeePerGas) => {
+        describe(`when maxFeePerGas is ${maxFeePerGas}`, () => {
+          gasLimitsToTest.forEach((gasLimit) => {
+            const expectedResult = (gasLimit * maxFeePerGas).toString();
+            const gasLimitHex = addHexPrefix(gasLimit.toString(16));
+            const result = conversionUtil(
+              getMaximumGasTotalInHexWei({
+                gasLimit: gasLimitHex,
+                maxFeePerGas: addHexPrefix(maxFeePerGas.toString(16)),
+              }),
+              { fromNumericBase: 'hex', toNumericBase: 'dec' },
+            );
+            it(`returns ${expectedResult} when provided gasLimit: ${gasLimit}`, () => {
+              expect(result).toStrictEqual(expectedResult);
+            });
+          });
+        });
+      });
+    });
+
+    describe('getMinimumGasTotalInHexWei', () => {
+      feesToTest.forEach((maxFeePerGas) => {
+        tipsToTest.forEach((maxPriorityFeePerGas) => {
+          baseFeesToTest.forEach((baseFeePerGas) => {
+            describe(`when baseFee is ${baseFeePerGas}, maxFeePerGas is ${maxFeePerGas} and tip is ${maxPriorityFeePerGas}`, () => {
+              const maximum = maxFeePerGas;
+              const minimum = baseFeePerGas + maxPriorityFeePerGas;
+              const expectedEffectiveGasPrice =
+                minimum < maximum ? minimum : maximum;
+              const results = gasLimitsToTest.map((gasLimit) => {
+                const gasLimitHex = addHexPrefix(gasLimit.toString(16));
+                const result = conversionUtil(
+                  getMinimumGasTotalInHexWei({
+                    gasLimit: gasLimitHex,
+                    maxFeePerGas: addHexPrefix(maxFeePerGas.toString(16)),
+                    maxPriorityFeePerGas: addHexPrefix(
+                      maxPriorityFeePerGas.toString(16),
+                    ),
+                    baseFeePerGas: addHexPrefix(baseFeePerGas.toString(16)),
+                  }),
+                  { fromNumericBase: 'hex', toNumericBase: 'dec' },
+                );
+                return { result, gasLimit };
+              });
+              it(`should use an effective gasPrice of ${expectedEffectiveGasPrice}`, () => {
+                expect(
+                  results.every(({ result, gasLimit }) => {
+                    const effectiveGasPrice = Number(result) / gasLimit;
+                    return effectiveGasPrice === expectedEffectiveGasPrice;
+                  }),
+                ).toBe(true);
+              });
+              results.forEach(({ result, gasLimit }) => {
+                const expectedResult = (
+                  expectedEffectiveGasPrice * gasLimit
+                ).toString();
+                it(`returns ${expectedResult} when provided gasLimit: ${gasLimit}`, () => {
+                  expect(result).toStrictEqual(expectedResult);
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('when using legacy fields', () => {
+    describe('getMaximumGasTotalInHexWei', () => {
+      feesToTest.forEach((gasPrice) => {
+        describe(`when gasPrice is ${gasPrice}`, () => {
+          gasLimitsToTest.forEach((gasLimit) => {
+            const expectedResult = (gasLimit * gasPrice).toString();
+            const gasLimitHex = addHexPrefix(gasLimit.toString(16));
+            it(`returns ${expectedResult} when provided gasLimit of ${gasLimit}`, () => {
+              expect(
+                conversionUtil(
+                  getMaximumGasTotalInHexWei({
+                    gasLimit: gasLimitHex,
+                    gasPrice: addHexPrefix(gasPrice.toString(16)),
+                  }),
+                  { fromNumericBase: 'hex', toNumericBase: 'dec' },
+                ),
+              ).toStrictEqual(expectedResult);
+            });
+          });
+        });
+      });
+    });
+
+    describe('getMinimumGasTotalInHexWei', () => {
+      feesToTest.forEach((gasPrice) => {
+        describe(`when gasPrice is ${gasPrice}`, () => {
+          gasLimitsToTest.forEach((gasLimit) => {
+            const expectedResult = (gasLimit * gasPrice).toString();
+            const gasLimitHex = addHexPrefix(gasLimit.toString(16));
+            it(`returns ${expectedResult} when provided gasLimit of ${gasLimit}`, () => {
+              expect(
+                conversionUtil(
+                  getMinimumGasTotalInHexWei({
+                    gasLimit: gasLimitHex,
+                    gasPrice: addHexPrefix(gasPrice.toString(16)),
+                  }),
+                  {
+                    fromNumericBase: 'hex',
+                    toNumericBase: 'dec',
+                  },
+                ),
+              ).toStrictEqual(expectedResult);
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds some shared gas utilities for calculation max and minimum gas amounts. Currently these accept hex wei strings for gasFee amounts and hex gas limit (gas limit isn't wei/gwei its unit is'gas') 

```
  PASS  shared/modules/gas.utils.test.js
  gas utils
    when using EIP 1559 fields
      getMaximumGasTotalInHexWei
        when maxFeePerGas is 10
          ✓ returns 210000 when provided gasLimit: 21000 (2 ms)
          ✓ returns 1000000 when provided gasLimit: 100000
        when maxFeePerGas is 24
          ✓ returns 504000 when provided gasLimit: 21000
          ✓ returns 2400000 when provided gasLimit: 100000 (1 ms)
        when maxFeePerGas is 90
          ✓ returns 1890000 when provided gasLimit: 21000
          ✓ returns 9000000 when provided gasLimit: 100000
      getMinimumGasTotalInHexWei
        when baseFee is 8, maxFeePerGas is 10 and tip is 2
          ✓ should use an effective gasPrice of 10 (1 ms)
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 12, maxFeePerGas is 10 and tip is 2
          ✓ should use an effective gasPrice of 10
          ✓ returns 210000 when provided gasLimit: 21000 (1 ms)
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 10 and tip is 2
          ✓ should use an effective gasPrice of 10
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 8, maxFeePerGas is 10 and tip is 10
          ✓ should use an effective gasPrice of 10 (1 ms)
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 12, maxFeePerGas is 10 and tip is 10
          ✓ should use an effective gasPrice of 10 (1 ms)
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 10 and tip is 10
          ✓ should use an effective gasPrice of 10
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000 (1 ms)
        when baseFee is 8, maxFeePerGas is 10 and tip is 50
          ✓ should use an effective gasPrice of 10
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 12, maxFeePerGas is 10 and tip is 50
          ✓ should use an effective gasPrice of 10
          ✓ returns 210000 when provided gasLimit: 21000 (1 ms)
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 10 and tip is 50
          ✓ should use an effective gasPrice of 10
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 8, maxFeePerGas is 24 and tip is 2
          ✓ should use an effective gasPrice of 10 (1 ms)
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 12, maxFeePerGas is 24 and tip is 2
          ✓ should use an effective gasPrice of 14
          ✓ returns 294000 when provided gasLimit: 21000 (1 ms)
          ✓ returns 1400000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 24 and tip is 2
          ✓ should use an effective gasPrice of 24
          ✓ returns 504000 when provided gasLimit: 21000
          ✓ returns 2400000 when provided gasLimit: 100000
        when baseFee is 8, maxFeePerGas is 24 and tip is 10
          ✓ should use an effective gasPrice of 18
          ✓ returns 378000 when provided gasLimit: 21000
          ✓ returns 1800000 when provided gasLimit: 100000 (1 ms)
        when baseFee is 12, maxFeePerGas is 24 and tip is 10
          ✓ should use an effective gasPrice of 22
          ✓ returns 462000 when provided gasLimit: 21000
          ✓ returns 2200000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 24 and tip is 10
          ✓ should use an effective gasPrice of 24
          ✓ returns 504000 when provided gasLimit: 21000
          ✓ returns 2400000 when provided gasLimit: 100000
        when baseFee is 8, maxFeePerGas is 24 and tip is 50
          ✓ should use an effective gasPrice of 24 (1 ms)
          ✓ returns 504000 when provided gasLimit: 21000
          ✓ returns 2400000 when provided gasLimit: 100000
        when baseFee is 12, maxFeePerGas is 24 and tip is 50
          ✓ should use an effective gasPrice of 24
          ✓ returns 504000 when provided gasLimit: 21000
          ✓ returns 2400000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 24 and tip is 50
          ✓ should use an effective gasPrice of 24 (1 ms)
          ✓ returns 504000 when provided gasLimit: 21000
          ✓ returns 2400000 when provided gasLimit: 100000
        when baseFee is 8, maxFeePerGas is 90 and tip is 2
          ✓ should use an effective gasPrice of 10
          ✓ returns 210000 when provided gasLimit: 21000
          ✓ returns 1000000 when provided gasLimit: 100000
        when baseFee is 12, maxFeePerGas is 90 and tip is 2
          ✓ should use an effective gasPrice of 14 (1 ms)
          ✓ returns 294000 when provided gasLimit: 21000
          ✓ returns 1400000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 90 and tip is 2
          ✓ should use an effective gasPrice of 26
          ✓ returns 546000 when provided gasLimit: 21000
          ✓ returns 2600000 when provided gasLimit: 100000
        when baseFee is 8, maxFeePerGas is 90 and tip is 10
          ✓ should use an effective gasPrice of 18 (1 ms)
          ✓ returns 378000 when provided gasLimit: 21000
          ✓ returns 1800000 when provided gasLimit: 100000
        when baseFee is 12, maxFeePerGas is 90 and tip is 10
          ✓ should use an effective gasPrice of 22
          ✓ returns 462000 when provided gasLimit: 21000
          ✓ returns 2200000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 90 and tip is 10
          ✓ should use an effective gasPrice of 34
          ✓ returns 714000 when provided gasLimit: 21000 (1 ms)
          ✓ returns 3400000 when provided gasLimit: 100000
        when baseFee is 8, maxFeePerGas is 90 and tip is 50
          ✓ should use an effective gasPrice of 58
          ✓ returns 1218000 when provided gasLimit: 21000
          ✓ returns 5800000 when provided gasLimit: 100000 (2 ms)
        when baseFee is 12, maxFeePerGas is 90 and tip is 50
          ✓ should use an effective gasPrice of 62
          ✓ returns 1302000 when provided gasLimit: 21000
          ✓ returns 6200000 when provided gasLimit: 100000
        when baseFee is 24, maxFeePerGas is 90 and tip is 50
          ✓ should use an effective gasPrice of 74 (1 ms)
          ✓ returns 1554000 when provided gasLimit: 21000
          ✓ returns 7400000 when provided gasLimit: 100000
    when using legacy fields
      getMaximumGasTotalInHexWei
        when gasPrice is 10
          ✓ returns 210000 when provided gasLimit of 21000
          ✓ returns 1000000 when provided gasLimit of 100000
        when gasPrice is 24
          ✓ returns 504000 when provided gasLimit of 21000 (1 ms)
          ✓ returns 2400000 when provided gasLimit of 100000
        when gasPrice is 90
          ✓ returns 1890000 when provided gasLimit of 21000
          ✓ returns 9000000 when provided gasLimit of 100000
      getMinimumGasTotalInHexWei
        when gasPrice is 10
          ✓ returns 210000 when provided gasLimit of 21000 (1 ms)
          ✓ returns 1000000 when provided gasLimit of 100000
        when gasPrice is 24
          ✓ returns 504000 when provided gasLimit of 21000
          ✓ returns 2400000 when provided gasLimit of 100000
        when gasPrice is 90
          ✓ returns 1890000 when provided gasLimit of 21000
          ✓ returns 9000000 when provided gasLimit of 100000 (1 ms)
Test Suites: 1 passed, 1 total
Tests:       99 passed, 99 total
Snapshots:   0 total
Time:        3.394 s
Ran all test suites matching /shared\/modules\/gas.utils.test.js/i.
✨  Done in 4.27s.
```