### PR TITLE
✏️ fix typo of middleware imported from eth-json-rpc-middleware

### DIFF
--- a/app/scripts/controllers/network/createInfuraClient.js
+++ b/app/scripts/controllers/network/createInfuraClient.js
@@ -1,8 +1,8 @@
 import { createScaffoldMiddleware, mergeMiddleware } from 'json-rpc-engine';
-import createBlockReRefMiddleware from 'eth-json-rpc-middleware/block-ref';
+import createBlockRefMiddleware from 'eth-json-rpc-middleware/block-ref';
 import createRetryOnEmptyMiddleware from 'eth-json-rpc-middleware/retryOnEmpty';
 import createBlockCacheMiddleware from 'eth-json-rpc-middleware/block-cache';
-import createInflightMiddleware from 'eth-json-rpc-middleware/inflight-cache';
+import createInflightCacheMiddleware from 'eth-json-rpc-middleware/inflight-cache';
 import createBlockTrackerInspectorMiddleware from 'eth-json-rpc-middleware/block-tracker-inspector';
 import providerFromMiddleware from 'eth-json-rpc-middleware/providerFromMiddleware';
 import createInfuraMiddleware from 'eth-json-rpc-infura';
@@ -23,8 +23,8 @@ export default function createInfuraClient({ network, projectId }) {
   const networkMiddleware = mergeMiddleware([
     createNetworkAndChainIdMiddleware({ network }),
     createBlockCacheMiddleware({ blockTracker }),
-    createInflightMiddleware(),
-    createBlockReRefMiddleware({ blockTracker, provider: infuraProvider }),
+    createInflightCacheMiddleware(),
+    createBlockRefMiddleware({ blockTracker, provider: infuraProvider }),
     createRetryOnEmptyMiddleware({ blockTracker, provider: infuraProvider }),
     createBlockTrackerInspectorMiddleware({ blockTracker }),
     infuraMiddleware,


### PR DESCRIPTION
Fixes:  typo of imported eth-json-rpc-middleware

Explanation:   
- `createBlockReRefMiddleware` can be changed to `createBlockRefMiddleware`, which is the name of the exported middleware.
- `createInflightMiddleware` can be changed to `createInflightCacheMiddleware`, which is the name of the exported middleware.

