### PR TITLE
Bumping contract-metadata -> 1.27.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@lavamoat/preinstall-always-fail": "^1.0.0",
     "@material-ui/core": "^4.11.0",
-    "@metamask/contract-metadata": "^1.26.0",
+    "@metamask/contract-metadata": "^1.27.0",
     "@metamask/controllers": "^10.0.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.6.0",
     "@metamask/eth-token-tracker": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,7 +2646,7 @@
     semver "^7.3.5"
     yargs "^17.0.1"
 
-"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.25.0", "@metamask/contract-metadata@^1.26.0":
+"@metamask/contract-metadata@^1.19.0", "@metamask/contract-metadata@^1.25.0", "@metamask/contract-metadata@^1.27.0":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.27.0.tgz#1e65b821bad6f7d8313dd881116e4366b0662f75"
   integrity sha512-ZAvuROiHjSksy40buCL4M6m16bAmXQl6vjllK/XQxt9+UElhwJSp7PJ1ZULuZXmznBBY64WXlCPjm94JhW4l3g==


### PR DESCRIPTION
This was already bumped via https://github.com/MetaMask/metamask-extension/pull/11430 in `yarn.lock`, but this keeps the package.json entry up to date.