### PR TITLE
Adding copy icon to home screen account address

### DIFF
--- a/ui/components/app/selected-account/index.scss
+++ b/ui/components/app/selected-account/index.scss
@@ -53,7 +53,7 @@
 
   &__copy {
     height: 13px;
-    margin-left: 3px;
     display: inline-block;
+    margin-inline-start: 3px;
   }
 }

--- a/ui/components/app/selected-account/index.scss
+++ b/ui/components/app/selected-account/index.scss
@@ -26,6 +26,8 @@
     @include H7;
 
     color: #989a9b;
+    display: flex;
+    align-items: center;
   }
 
   &__clickable {
@@ -47,5 +49,11 @@
     &:active {
       background-color: #d9d7da;
     }
+  }
+
+  &__copy {
+    height: 13px;
+    margin-left: 3px;
+    display: inline-block;
   }
 }

--- a/ui/components/app/selected-account/selected-account.component.js
+++ b/ui/components/app/selected-account/selected-account.component.js
@@ -4,6 +4,7 @@ import copyToClipboard from 'copy-to-clipboard';
 import { shortenAddress } from '../../../helpers/utils/util';
 
 import Tooltip from '../../ui/tooltip';
+import CopyIcon from '../../ui/icon/copy-icon.component';
 import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import { SECOND } from '../../../../shared/constants/time';
 
@@ -61,6 +62,9 @@ class SelectedAccount extends Component {
             </div>
             <div className="selected-account__address">
               {shortenAddress(checksummedAddress)}
+              <div className="selected-account__copy">
+                <CopyIcon size={11} color="#989a9b" />
+              </div>
             </div>
           </button>
         </Tooltip>


### PR DESCRIPTION
Fixes MetaMask/metamask-extension#10145

<img width="270" alt="Screen Shot 2021-07-05 at 11 40 04 PM" src="https://user-images.githubusercontent.com/8732757/124555093-89918300-ddeb-11eb-800b-fdccdb0df29f.png">
