### PR TITLE
Provide EIP 1559 fields in transaction history

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2401,6 +2401,9 @@
   "transactionHistoryBaseFee": {
     "message": "Base fee (GWEI)"
   },
+  "transactionHistoryEffectiveGasPrice": {
+    "message": "Effective gas price"
+  },
   "transactionHistoryPriorityFee": {
     "message": "Priority fee (GWEI)"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2398,6 +2398,12 @@
   "transactionFee": {
     "message": "Transaction Fee"
   },
+  "transactionHistoryBaseFee": {
+    "message": "Base fee (GWEI)"
+  },
+  "transactionHistoryPriorityFee": {
+    "message": "Priority fee (GWEI)"
+  },
   "transactionResubmitted": {
     "message": "Transaction resubmitted with gas fee increased to $1 at $2"
   },

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -25,6 +25,7 @@ export default class TransactionBreakdown extends PureComponent {
     totalInHex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     baseFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     priorityFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    effectiveGasPrice: PropTypes.number,
   };
 
   static defaultProps = {
@@ -46,6 +47,7 @@ export default class TransactionBreakdown extends PureComponent {
       isTokenApprove,
       baseFee,
       priorityFee,
+      effectiveGasPrice,
     } = this.props;
     return (
       <div className={classnames('transaction-breakdown', className)}>
@@ -137,6 +139,24 @@ export default class TransactionBreakdown extends PureComponent {
             )}
           </TransactionBreakdownRow>
         )}
+        <TransactionBreakdownRow
+          title={t('transactionHistoryEffectiveGasPrice')}
+        >
+          <div>
+            <UserPreferencedCurrencyDisplay
+              className="transaction-breakdown__value transaction-breakdown__value--effective-gas-price"
+              type={PRIMARY}
+              value={effectiveGasPrice}
+            />
+            {showFiat && (
+              <UserPreferencedCurrencyDisplay
+                className="transaction-breakdown__value"
+                type={SECONDARY}
+                value={effectiveGasPrice}
+              />
+            )}
+          </div>
+        </TransactionBreakdownRow>
         <TransactionBreakdownRow title={t('total')}>
           <div>
             <UserPreferencedCurrencyDisplay

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -23,6 +23,8 @@ export default class TransactionBreakdown extends PureComponent {
     gasPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     gasUsed: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     totalInHex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    baseFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    priorityFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };
 
   static defaultProps = {
@@ -42,6 +44,8 @@ export default class TransactionBreakdown extends PureComponent {
       totalInHex,
       gasUsed,
       isTokenApprove,
+      baseFee,
+      priorityFee,
     } = this.props;
     return (
       <div className={classnames('transaction-breakdown', className)}>
@@ -85,20 +89,54 @@ export default class TransactionBreakdown extends PureComponent {
             />
           </TransactionBreakdownRow>
         )}
-        <TransactionBreakdownRow title={t('gasPrice')}>
-          {typeof gasPrice === 'undefined' ? (
-            '?'
-          ) : (
-            <CurrencyDisplay
-              className="transaction-breakdown__value"
-              data-testid="transaction-breakdown__gas-price"
-              currency={nativeCurrency}
-              denomination={GWEI}
-              value={gasPrice}
-              hideLabel
-            />
-          )}
-        </TransactionBreakdownRow>
+        {process.env.SHOW_EIP_1559_UI && (
+          <TransactionBreakdownRow title={t('transactionHistoryBaseFee')}>
+            {typeof baseFee === 'undefined' ? (
+              '?'
+            ) : (
+              <CurrencyDisplay
+                className="transaction-breakdown__value"
+                data-testid="transaction-breakdown__base-fee"
+                currency={nativeCurrency}
+                denomination={GWEI}
+                value={baseFee}
+                hideLabel
+              />
+            )}
+          </TransactionBreakdownRow>
+        )}
+        {process.env.SHOW_EIP_1559_UI && (
+          <TransactionBreakdownRow title={t('transactionHistoryPriorityFee')}>
+            {typeof priorityFee === 'undefined' ? (
+              '?'
+            ) : (
+              <CurrencyDisplay
+                className="transaction-breakdown__value"
+                data-testid="transaction-breakdown__priority-fee"
+                currency={nativeCurrency}
+                denomination={GWEI}
+                value={priorityFee}
+                hideLabel
+              />
+            )}
+          </TransactionBreakdownRow>
+        )}
+        {!process.env.SHOW_EIP_1559_UI && (
+          <TransactionBreakdownRow title={t('gasPrice')}>
+            {typeof gasPrice === 'undefined' ? (
+              '?'
+            ) : (
+              <CurrencyDisplay
+                className="transaction-breakdown__value"
+                data-testid="transaction-breakdown__gas-price"
+                currency={nativeCurrency}
+                denomination={GWEI}
+                value={gasPrice}
+                hideLabel
+              />
+            )}
+          </TransactionBreakdownRow>
+        )}
         <TransactionBreakdownRow title={t('total')}>
           <div>
             <UserPreferencedCurrencyDisplay

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -142,36 +142,32 @@ export default class TransactionBreakdown extends PureComponent {
         <TransactionBreakdownRow
           title={t('transactionHistoryEffectiveGasPrice')}
         >
-          <div>
+          <UserPreferencedCurrencyDisplay
+            className="transaction-breakdown__value transaction-breakdown__value--effective-gas-price"
+            type={PRIMARY}
+            value={effectiveGasPrice}
+          />
+          {showFiat && (
             <UserPreferencedCurrencyDisplay
-              className="transaction-breakdown__value transaction-breakdown__value--effective-gas-price"
-              type={PRIMARY}
+              className="transaction-breakdown__value"
+              type={SECONDARY}
               value={effectiveGasPrice}
             />
-            {showFiat && (
-              <UserPreferencedCurrencyDisplay
-                className="transaction-breakdown__value"
-                type={SECONDARY}
-                value={effectiveGasPrice}
-              />
-            )}
-          </div>
+          )}
         </TransactionBreakdownRow>
         <TransactionBreakdownRow title={t('total')}>
-          <div>
+          <UserPreferencedCurrencyDisplay
+            className="transaction-breakdown__value transaction-breakdown__value--eth-total"
+            type={PRIMARY}
+            value={totalInHex}
+          />
+          {showFiat && (
             <UserPreferencedCurrencyDisplay
-              className="transaction-breakdown__value transaction-breakdown__value--eth-total"
-              type={PRIMARY}
+              className="transaction-breakdown__value"
+              type={SECONDARY}
               value={totalInHex}
             />
-            {showFiat && (
-              <UserPreferencedCurrencyDisplay
-                className="transaction-breakdown__value"
-                type={SECONDARY}
-                value={totalInHex}
-              />
-            )}
-          </div>
+          )}
         </TransactionBreakdownRow>
       </div>
     );


### PR DESCRIPTION
This is based on Jake's mockups:  https://www.figma.com/file/NXvUKcZ0Ocu1GPcT7VxRMx/1559---Gas-Controls?node-id=643%3A5

We don't have transaction data properties available to fill this data yet.