### PR TITLE
update implementation to match latest

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -194,6 +194,11 @@ export default class MetamaskController extends EventEmitter {
       getCurrentAccountEIP1559Compatibility: this.getCurrentAccountEIP1559Compatibility.bind(
         this,
       ),
+      getCurrentNetworkLegacyGasAPICompatibility: () =>
+        this.networkController.getCurrentChainId() === MAINNET_CHAIN_ID,
+      getChainId: this.networkController.getCurrentChainId.bind(
+        this.networkController,
+      ),
     });
 
     this.appStateController = new AppStateController({

--- a/shared/constants/gas.js
+++ b/shared/constants/gas.js
@@ -1,3 +1,4 @@
+import { GAS_ESTIMATE_TYPES as GasFeeControllerEstimateTypes } from '@metamask/controllers';
 import { addHexPrefix } from 'ethereumjs-util';
 
 const TWENTY_ONE_THOUSAND = 21000;
@@ -9,3 +10,5 @@ export const GAS_LIMITS = {
   // a base estimate for token transfers.
   BASE_TOKEN_ESTIMATE: addHexPrefix(ONE_HUNDRED_THOUSAND.toString(16)),
 };
+
+export const GAS_ESTIMATE_TYPES = { ...GasFeeControllerEstimateTypes };

--- a/shared/constants/gas.js
+++ b/shared/constants/gas.js
@@ -1,4 +1,3 @@
-import { GAS_ESTIMATE_TYPES as GasFeeControllerEstimateTypes } from '@metamask/controllers';
 import { addHexPrefix } from 'ethereumjs-util';
 
 const TWENTY_ONE_THOUSAND = 21000;
@@ -11,4 +10,13 @@ export const GAS_LIMITS = {
   BASE_TOKEN_ESTIMATE: addHexPrefix(ONE_HUNDRED_THOUSAND.toString(16)),
 };
 
-export const GAS_ESTIMATE_TYPES = { ...GasFeeControllerEstimateTypes };
+/**
+ * These are already declared in @metamask/controllers but importing them from
+ * that module and re-exporting causes the UI bundle size to expand beyond 4MB
+ */
+export const GAS_ESTIMATE_TYPES = {
+  FEE_MARKET: 'fee-market',
+  LEGACY: 'legacy',
+  ETH_GASPRICE: 'eth_gasPrice',
+  NONE: 'none',
+};

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -288,6 +288,10 @@ export function isEIP1559Network(state) {
   return state.metamask.networkDetails.EIPS[1559] === true;
 }
 
+export function getGasEstimateType(state) {
+  return state.metamask.gasEstimateType;
+}
+
 export function getGasFeeEstimates(state) {
   return state.metamask.gasFeeEstimates;
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -1067,6 +1067,7 @@ export function updateMetamaskState(newState) {
         type: actionConstants.GAS_FEE_ESTIMATES_UPDATED,
         payload: {
           gasFeeEstimates: newState.gasFeeEstimates,
+          gasEstimateType: newState.gasEstimateType,
           isEIP1559Network: isEIP1559Network({ metamask: newState }),
         },
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10622,7 +10622,7 @@ eth-json-rpc-middleware@^6.0.0:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-keyring-controller@^6.1.0, eth-keyring-controller@^6.2.0:
+eth-keyring-controller@^6.1.0, eth-keyring-controller@^6.2.0, eth-keyring-controller@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-6.2.1.tgz#61901071fc74059ed37cb5ae93870fdcae6e3781"
   integrity sha512-x2gTM1iHp2Kbvdtd9Eslysw0qzVZiqOzpVB3AU/ni2Xiit+rlcv2H80zYKjrEwlfWFDj4YILD3bOqlnEMmRJOA==
@@ -26368,7 +26368,7 @@ uuid@^3.1.0, uuid@^3.2.1, uuid@^3.2.2, uuid@^3.3.2, uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
-uuid@^8.0.0, uuid@^8.3.0:
+uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION

#### Metaswaps API support
The gas fee controller has been updated to use the legacy metaswaps API endpoint, and this PR updates the configuration such that it will work under those conditions.

#### Specific Types
the gas fee controller now exports GAS_ESTIMATE_TYPES which has 'NONE' 'LEGACY' 'FEE_MARKET' and 'ETH_GASPRICE' keys. These each correspond to a specific type of estimate state:

`NONE` refers to the state where an estimate has not yet been fetched
`LEGACY` refers to legacy metaswaps api estimates, (slow/avg/fast), but responds in the new low/medium/high format
`ETH_GASPRICE` refers to estimates gained from eth_gasPrice
`FEE_MARKET` refers to new estimates in the low/medium/high and estimatedBaseFee format


