### PR TITLE
Swaps: Add conditional routing to new APIs based on a feature flag

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1266,6 +1266,9 @@
   "networkNameEthereum": {
     "message": "Ethereum"
   },
+  "networkNamePolygon": {
+    "message": "Polygon"
+  },
   "networkNameTestnet": {
     "message": "Testnet"
   },

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -19,7 +19,6 @@ import { isSwapsDefaultTokenAddress } from '../../../shared/modules/swaps.utils'
 
 import {
   fetchTradesInfo as defaultFetchTradesInfo,
-  fetchSwapsFeatureLiveness as defaultFetchSwapsFeatureLiveness,
   fetchSwapsQuoteRefreshTime as defaultFetchSwapsQuoteRefreshTime,
 } from '../../../ui/pages/swaps/swaps.util';
 import { MINUTE, SECOND } from '../../../shared/constants/time';
@@ -86,7 +85,6 @@ export default class SwapsController {
     getProviderConfig,
     tokenRatesStore,
     fetchTradesInfo = defaultFetchTradesInfo,
-    fetchSwapsFeatureLiveness = defaultFetchSwapsFeatureLiveness,
     fetchSwapsQuoteRefreshTime = defaultFetchSwapsQuoteRefreshTime,
     getCurrentChainId,
   }) {
@@ -95,7 +93,6 @@ export default class SwapsController {
     });
 
     this._fetchTradesInfo = fetchTradesInfo;
-    this._fetchSwapsFeatureLiveness = fetchSwapsFeatureLiveness;
     this._fetchSwapsQuoteRefreshTime = fetchSwapsQuoteRefreshTime;
     this._getCurrentChainId = getCurrentChainId;
 

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -462,8 +462,9 @@ export default class SwapsController {
 
   setSwapsLiveness(swapsLiveness) {
     const { swapsState } = this.store.getState();
+    const { swapsFeatureIsLive, useNewSwapsApi } = swapsLiveness;
     this.store.updateState({
-      swapsState: { ...swapsState, ...swapsLiveness },
+      swapsState: { ...swapsState, swapsFeatureIsLive, useNewSwapsApi },
     });
   }
 

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -659,6 +659,7 @@ describe('SwapsController', function () {
         const quotes = await swapsController.fetchAndSetQuotes(undefined);
         assert.strictEqual(quotes, null);
       });
+
       it('calls fetchTradesInfo with the given fetchParams and returns the correct quotes', async function () {
         fetchTradesInfoStub.resolves(getMockQuotes());
         fetchSwapsQuoteRefreshTimeStub.resolves(getMockQuoteRefreshTime());
@@ -696,15 +697,15 @@ describe('SwapsController', function () {
           metaMaskFeeInEth: '0.5050505050505050505',
           ethValueOfTokens: '50',
         });
-
         assert.strictEqual(
-          fetchTradesInfoStub.calledOnceWithExactly(
-            MOCK_FETCH_PARAMS,
-            MOCK_FETCH_METADATA,
-          ),
+          fetchTradesInfoStub.calledOnceWithExactly(MOCK_FETCH_PARAMS, {
+            ...MOCK_FETCH_METADATA,
+            useNewSwapsApi: false,
+          }),
           true,
         );
       });
+
       it('performs the allowance check', async function () {
         fetchTradesInfoStub.resolves(getMockQuotes());
         fetchSwapsQuoteRefreshTimeStub.resolves(getMockQuoteRefreshTime());
@@ -879,12 +880,14 @@ describe('SwapsController', function () {
         const tokens = 'test';
         const fetchParams = 'test';
         const swapsFeatureIsLive = false;
+        const useNewSwapsApi = false;
         const swapsQuoteRefreshTime = 0;
         swapsController.store.updateState({
           swapsState: {
             tokens,
             fetchParams,
             swapsFeatureIsLive,
+            useNewSwapsApi,
             swapsQuoteRefreshTime,
           },
         });

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -135,7 +135,6 @@ const EMPTY_INIT_STATE = {
 
 const sandbox = sinon.createSandbox();
 const fetchTradesInfoStub = sandbox.stub();
-const fetchSwapsFeatureLivenessStub = sandbox.stub();
 const fetchSwapsQuoteRefreshTimeStub = sandbox.stub();
 const getCurrentChainIdStub = sandbox.stub();
 getCurrentChainIdStub.returns(MAINNET_CHAIN_ID);
@@ -151,7 +150,6 @@ describe('SwapsController', function () {
       getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
       tokenRatesStore: MOCK_TOKEN_RATES_STORE,
       fetchTradesInfo: fetchTradesInfoStub,
-      fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
       fetchSwapsQuoteRefreshTime: fetchSwapsQuoteRefreshTimeStub,
       getCurrentChainId: getCurrentChainIdStub,
     });
@@ -202,7 +200,6 @@ describe('SwapsController', function () {
         getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
         tokenRatesStore: MOCK_TOKEN_RATES_STORE,
         fetchTradesInfo: fetchTradesInfoStub,
-        fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
         getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
@@ -227,7 +224,6 @@ describe('SwapsController', function () {
         getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
         tokenRatesStore: MOCK_TOKEN_RATES_STORE,
         fetchTradesInfo: fetchTradesInfoStub,
-        fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
         getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;
@@ -252,7 +248,6 @@ describe('SwapsController', function () {
         getProviderConfig: MOCK_GET_PROVIDER_CONFIG,
         tokenRatesStore: MOCK_TOKEN_RATES_STORE,
         fetchTradesInfo: fetchTradesInfoStub,
-        fetchSwapsFeatureLiveness: fetchSwapsFeatureLivenessStub,
         getCurrentChainId: getCurrentChainIdStub,
       });
       const currentEthersInstance = swapsController.ethersProvider;

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -128,6 +128,7 @@ const EMPTY_INIT_STATE = {
     topAggId: null,
     routeState: '',
     swapsFeatureIsLive: true,
+    useNewSwapsApi: false,
     swapsQuoteRefreshTime: 60000,
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['.stories.js', '.snap'],
   coverageThreshold: {
     global: {
-      branches: 45.37,
+      branches: 45.24,
       functions: 51.94,
       lines: 58.36,
       statements: 58.6,

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['.stories.js', '.snap'],
   coverageThreshold: {
     global: {
-      branches: 45.45,
-      functions: 55.29,
-      lines: 60.22,
-      statements: 60.43,
+      branches: 45.37,
+      functions: 51.94,
+      lines: 58.36,
+      statements: 58.6,
     },
   },
   setupFiles: ['./test/setup.js', './test/env.js'],

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -4,6 +4,9 @@ export const KOVAN = 'kovan';
 export const MAINNET = 'mainnet';
 export const GOERLI = 'goerli';
 export const NETWORK_TYPE_RPC = 'rpc';
+export const ETHEREUM = 'ethereum';
+export const POLYGON = 'polygon';
+export const BSC = 'bsc';
 
 export const MAINNET_NETWORK_ID = '1';
 export const ROPSTEN_NETWORK_ID = '3';
@@ -21,6 +24,7 @@ export const LOCALHOST_CHAIN_ID = '0x539';
 export const BSC_CHAIN_ID = '0x38';
 export const OPTIMISM_CHAIN_ID = '0xa';
 export const OPTIMISM_TESTNET_CHAIN_ID = '0x45';
+export const POLYGON_CHAIN_ID = '0x89';
 
 /**
  * The largest possible chain ID we can handle.

--- a/shared/constants/network.js
+++ b/shared/constants/network.js
@@ -4,9 +4,6 @@ export const KOVAN = 'kovan';
 export const MAINNET = 'mainnet';
 export const GOERLI = 'goerli';
 export const NETWORK_TYPE_RPC = 'rpc';
-export const ETHEREUM = 'ethereum';
-export const POLYGON = 'polygon';
-export const BSC = 'bsc';
 
 export const MAINNET_NETWORK_ID = '1';
 export const ROPSTEN_NETWORK_ID = '3';

--- a/shared/constants/swaps.js
+++ b/shared/constants/swaps.js
@@ -93,3 +93,7 @@ export const SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP = {
   [BSC_CHAIN_ID]: BSC_DEFAULT_BLOCK_EXPLORER_URL,
   [MAINNET_CHAIN_ID]: MAINNET_DEFAULT_BLOCK_EXPLORER_URL,
 };
+
+export const ETHEREUM = 'ethereum';
+export const POLYGON = 'polygon';
+export const BSC = 'bsc';

--- a/test/data/fetch-mocks.json
+++ b/test/data/fetch-mocks.json
@@ -8,9 +8,21 @@
     "mockMetaMetricsResponse": true
   },
   "swaps": {
-    "featureFlag": {
-      "status": {
-        "active": true
+    "featureFlags": {
+      "bsc": {
+        "mobile_active": false,
+        "extension_active": true,
+        "fallback_to_v1": true
+      },
+      "ethereum": {
+        "mobile_active": false,
+        "extension_active": true,
+        "fallback_to_v1": true
+      },
+      "polygon": {
+        "mobile_active": false,
+        "extension_active": true,
+        "fallback_to_v1": false
       }
     }
   }

--- a/test/e2e/webdriver/index.js
+++ b/test/e2e/webdriver/index.js
@@ -48,9 +48,9 @@ async function setupFetchMocking(driver) {
         return { json: async () => clone(mockResponses.gasPricesBasic) };
       } else if (url.match(/chromeextensionmm/u)) {
         return { json: async () => clone(mockResponses.metametrics) };
-      } else if (url.match(/^https:\/\/(api\.metaswap|.*airswap-dev)/u)) {
-        if (url.match(/featureFlag$/u)) {
-          return { json: async () => clone(mockResponses.swaps.featureFlag) };
+      } else if (url.match(/^https:\/\/(api2\.metaswap\.codefi\.network)/u)) {
+        if (url.match(/featureFlags$/u)) {
+          return { json: async () => clone(mockResponses.swaps.featureFlags) };
         }
       }
       return window.origFetch(...args);

--- a/test/jest/constants.js
+++ b/test/jest/constants.js
@@ -1,1 +1,2 @@
 export const METASWAP_BASE_URL = 'https://api.metaswap.codefi.network';
+export const METASWAP_API_V2_BASE_URL = 'https://api2.metaswap.codefi.network';

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -220,6 +220,7 @@ export const createSwapsMockStore = () => {
         topAggId: null,
         routeState: '',
         swapsFeatureIsLive: false,
+        useNewSwapsApi: false,
       },
     },
     appState: {

--- a/test/jest/mocks.js
+++ b/test/jest/mocks.js
@@ -60,20 +60,22 @@ export const TOKENS_GET_RESPONSE = [
   },
 ];
 
-export const FEATURE_FLAGS_RESPONSE = {
-  bsc: {
-    mobile_active: false,
-    extension_active: true,
-    fallback_to_v1: true,
-  },
-  ethereum: {
-    mobile_active: false,
-    extension_active: true,
-    fallback_to_v1: true,
-  },
-  polygon: {
-    mobile_active: false,
-    extension_active: true,
-    fallback_to_v1: false,
-  },
+export const createFeatureFlagsResponse = () => {
+  return {
+    bsc: {
+      mobile_active: false,
+      extension_active: true,
+      fallback_to_v1: true,
+    },
+    ethereum: {
+      mobile_active: false,
+      extension_active: true,
+      fallback_to_v1: true,
+    },
+    polygon: {
+      mobile_active: false,
+      extension_active: true,
+      fallback_to_v1: false,
+    },
+  };
 };

--- a/test/jest/mocks.js
+++ b/test/jest/mocks.js
@@ -59,3 +59,21 @@ export const TOKENS_GET_RESPONSE = [
     address: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
   },
 ];
+
+export const FEATURE_FLAGS_RESPONSE = {
+  bsc: {
+    mobile_active: false,
+    extension_active: true,
+    fallback_to_v1: true,
+  },
+  ethereum: {
+    mobile_active: false,
+    extension_active: true,
+    fallback_to_v1: true,
+  },
+  polygon: {
+    mobile_active: false,
+    extension_active: true,
+    fallback_to_v1: false,
+  },
+};

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -34,9 +34,10 @@ import {
   SWAPS_MAINTENANCE_ROUTE,
 } from '../../helpers/constants/routes';
 import {
-  fetchSwapsFeatureLiveness,
+  fetchSwapsFeatureFlags,
   fetchSwapsGasPrices,
   isContractAddressValid,
+  getSwapsLivenessForNetwork,
 } from '../../pages/swaps/swaps.util';
 import { calcGasTotal } from '../../pages/send/send.utils';
 import {
@@ -223,8 +224,11 @@ export function shouldShowCustomPriceTooLowWarning(state) {
 
 const getSwapsState = (state) => state.metamask.swapsState;
 
-export const getSwapsFeatureLiveness = (state) =>
+export const getSwapsFeatureIsLive = (state) =>
   state.metamask.swapsState.swapsFeatureIsLive;
+
+export const getUseNewSwapsApi = (state) =>
+  state.metamask.swapsState.useNewSwapsApi;
 
 export const getSwapsQuoteRefreshTime = (state) =>
   state.metamask.swapsState.swapsQuoteRefreshTime;
@@ -373,16 +377,21 @@ export const fetchAndSetSwapsGasPriceInfo = () => {
 
 export const fetchSwapsLiveness = () => {
   return async (dispatch, getState) => {
-    let swapsFeatureIsLive = false;
+    let swapsLivenessForNetwork = {
+      swapsFeatureIsLive: false,
+      useNewSwapsApi: false,
+    };
     try {
-      swapsFeatureIsLive = await fetchSwapsFeatureLiveness(
+      const swapsFeatureFlags = await fetchSwapsFeatureFlags();
+      swapsLivenessForNetwork = getSwapsLivenessForNetwork(
+        swapsFeatureFlags,
         getCurrentChainId(getState()),
       );
     } catch (error) {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);
     }
-    await dispatch(setSwapsLiveness(swapsFeatureIsLive));
-    return swapsFeatureIsLive;
+    await dispatch(setSwapsLiveness(swapsLivenessForNetwork));
+    return swapsLivenessForNetwork.swapsFeatureIsLive;
   };
 };
 
@@ -395,15 +404,22 @@ export const fetchQuotesAndSetQuoteState = (
   return async (dispatch, getState) => {
     const state = getState();
     const chainId = getCurrentChainId(state);
-    let swapsFeatureIsLive = false;
+    let swapsLivenessForNetwork = {
+      swapsFeatureIsLive: false,
+      useNewSwapsApi: false,
+    };
     try {
-      swapsFeatureIsLive = await fetchSwapsFeatureLiveness(chainId);
+      const swapsFeatureFlags = await fetchSwapsFeatureFlags();
+      swapsLivenessForNetwork = getSwapsLivenessForNetwork(
+        swapsFeatureFlags,
+        getCurrentChainId(getState()),
+      );
     } catch (error) {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);
     }
-    await dispatch(setSwapsLiveness(swapsFeatureIsLive));
+    await dispatch(setSwapsLiveness(swapsLivenessForNetwork));
 
-    if (!swapsFeatureIsLive) {
+    if (!swapsLivenessForNetwork.swapsFeatureIsLive) {
       await history.push(SWAPS_MAINTENANCE_ROUTE);
       return;
     }
@@ -600,15 +616,22 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     const state = getState();
     const chainId = getCurrentChainId(state);
     const hardwareWalletUsed = isHardwareWallet(state);
-    let swapsFeatureIsLive = false;
+    let swapsLivenessForNetwork = {
+      swapsFeatureIsLive: false,
+      useNewSwapsApi: false,
+    };
     try {
-      swapsFeatureIsLive = await fetchSwapsFeatureLiveness(chainId);
+      const swapsFeatureFlags = await fetchSwapsFeatureFlags();
+      swapsLivenessForNetwork = getSwapsLivenessForNetwork(
+        swapsFeatureFlags,
+        getCurrentChainId(getState()),
+      );
     } catch (error) {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);
     }
-    await dispatch(setSwapsLiveness(swapsFeatureIsLive));
+    await dispatch(setSwapsLiveness(swapsLivenessForNetwork));
 
-    if (!swapsFeatureIsLive) {
+    if (!swapsLivenessForNetwork.swapsFeatureIsLive) {
       await history.push(SWAPS_MAINTENANCE_ROUTE);
       return;
     }
@@ -808,12 +831,13 @@ export function fetchMetaSwapsGasPriceEstimates() {
   return async (dispatch, getState) => {
     const state = getState();
     const chainId = getCurrentChainId(state);
+    const useNewSwapsApi = getUseNewSwapsApi(state);
 
     dispatch(swapGasPriceEstimatesFetchStarted());
 
     let priceEstimates;
     try {
-      priceEstimates = await fetchSwapsGasPrices(chainId);
+      priceEstimates = await fetchSwapsGasPrices(chainId, useNewSwapsApi);
     } catch (e) {
       log.warn('Fetching swaps gas prices failed:', e);
 

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -412,7 +412,7 @@ export const fetchQuotesAndSetQuoteState = (
       const swapsFeatureFlags = await fetchSwapsFeatureFlags();
       swapsLivenessForNetwork = getSwapsLivenessForNetwork(
         swapsFeatureFlags,
-        getCurrentChainId(getState()),
+        chainId,
       );
     } catch (error) {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);
@@ -624,7 +624,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       const swapsFeatureFlags = await fetchSwapsFeatureFlags();
       swapsLivenessForNetwork = getSwapsLivenessForNetwork(
         swapsFeatureFlags,
-        getCurrentChainId(getState()),
+        chainId,
       );
     } catch (error) {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -391,7 +391,7 @@ export const fetchSwapsLiveness = () => {
       log.error('Failed to fetch Swaps liveness, defaulting to false.', error);
     }
     await dispatch(setSwapsLiveness(swapsLivenessForNetwork));
-    return swapsLivenessForNetwork.swapsFeatureIsLive;
+    return swapsLivenessForNetwork;
   };
 };
 

--- a/ui/ducks/swaps/swaps.test.js
+++ b/ui/ducks/swaps/swaps.test.js
@@ -25,21 +25,41 @@ describe('Ducks - Swaps', () => {
   describe('fetchSwapsLiveness', () => {
     const cleanFeatureFlagApiCache = () => {
       setStorageItem(
-        'cachedFetch:https://api.metaswap.codefi.network/featureFlag',
+        'cachedFetch:https://api2.metaswap.codefi.network/featureFlags',
         null,
       );
+    };
+
+    const createFeatureFlagsResponse = () => {
+      return {
+        bsc: {
+          mobile_active: false,
+          extension_active: true,
+          fallback_to_v1: true,
+        },
+        ethereum: {
+          mobile_active: false,
+          extension_active: true,
+          fallback_to_v1: true,
+        },
+        polygon: {
+          mobile_active: false,
+          extension_active: true,
+          fallback_to_v1: false,
+        },
+      };
     };
 
     afterEach(() => {
       cleanFeatureFlagApiCache();
     });
 
-    const mockFeatureFlagApiResponse = ({
-      active = false,
+    const mockFeatureFlagsApiResponse = ({
+      featureFlagsResponse,
       replyWithError = false,
     } = {}) => {
-      const apiNock = nock('https://api.metaswap.codefi.network').get(
-        '/featureFlag',
+      const apiNock = nock('https://api2.metaswap.codefi.network').get(
+        '/featureFlags',
       );
       if (replyWithError) {
         return apiNock.replyWithError({
@@ -47,9 +67,7 @@ describe('Ducks - Swaps', () => {
           code: 'serverSideError',
         });
       }
-      return apiNock.reply(200, {
-        active,
-      });
+      return apiNock.reply(200, featureFlagsResponse);
     };
 
     const createGetState = () => {
@@ -58,61 +76,111 @@ describe('Ducks - Swaps', () => {
       });
     };
 
-    it('returns true if the Swaps feature is enabled', async () => {
+    it('checks that Swaps for ETH are enabled and can use new API', async () => {
       const mockDispatch = jest.fn();
-      const featureFlagApiNock = mockFeatureFlagApiResponse({ active: true });
-      const isSwapsFeatureEnabled = await swaps.fetchSwapsLiveness()(
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: true,
+        useNewSwapsApi: true,
+      };
+      const featureFlagsResponse = createFeatureFlagsResponse();
+      const featureFlagApiNock = mockFeatureFlagsApiResponse({
+        featureFlagsResponse,
+      });
+      const swapsLiveness = await swaps.fetchSwapsLiveness()(
         mockDispatch,
         createGetState(),
       );
       expect(featureFlagApiNock.isDone()).toBe(true);
       expect(mockDispatch).toHaveBeenCalledTimes(1);
-      expect(setSwapsLiveness).toHaveBeenCalledWith(true);
-      expect(isSwapsFeatureEnabled).toBe(true);
+      expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
+      expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
     });
 
-    it('returns false if the Swaps feature is disabled', async () => {
+    it('checks that Swaps for ETH are disabled for API v2 and enabled for API v1', async () => {
       const mockDispatch = jest.fn();
-      const featureFlagApiNock = mockFeatureFlagApiResponse({ active: false });
-      const isSwapsFeatureEnabled = await swaps.fetchSwapsLiveness()(
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: true,
+        useNewSwapsApi: false,
+      };
+      const featureFlagsResponse = createFeatureFlagsResponse();
+      featureFlagsResponse.ethereum.extension_active = false;
+      const featureFlagApiNock = mockFeatureFlagsApiResponse({
+        featureFlagsResponse,
+      });
+      const swapsLiveness = await swaps.fetchSwapsLiveness()(
         mockDispatch,
         createGetState(),
       );
       expect(featureFlagApiNock.isDone()).toBe(true);
       expect(mockDispatch).toHaveBeenCalledTimes(1);
-      expect(setSwapsLiveness).toHaveBeenCalledWith(false);
-      expect(isSwapsFeatureEnabled).toBe(false);
+      expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
+      expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
     });
 
-    it('returns false if the /featureFlag API call throws an error', async () => {
+    it('checks that Swaps for ETH are disabled for API v1 and v2', async () => {
       const mockDispatch = jest.fn();
-      const featureFlagApiNock = mockFeatureFlagApiResponse({
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: false,
+        useNewSwapsApi: false,
+      };
+      const featureFlagsResponse = createFeatureFlagsResponse();
+      featureFlagsResponse.ethereum.extension_active = false;
+      featureFlagsResponse.ethereum.fallback_to_v1 = false;
+      const featureFlagApiNock = mockFeatureFlagsApiResponse({
+        featureFlagsResponse,
+      });
+      const swapsLiveness = await swaps.fetchSwapsLiveness()(
+        mockDispatch,
+        createGetState(),
+      );
+      expect(featureFlagApiNock.isDone()).toBe(true);
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
+      expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
+    });
+
+    it('checks that Swaps for ETH are disabled if the /featureFlags API call throws an error', async () => {
+      const mockDispatch = jest.fn();
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: false,
+        useNewSwapsApi: false,
+      };
+      const featureFlagApiNock = mockFeatureFlagsApiResponse({
         replyWithError: true,
       });
-      const isSwapsFeatureEnabled = await swaps.fetchSwapsLiveness()(
+      const swapsLiveness = await swaps.fetchSwapsLiveness()(
         mockDispatch,
         createGetState(),
       );
       expect(featureFlagApiNock.isDone()).toBe(true);
       expect(mockDispatch).toHaveBeenCalledTimes(1);
-      expect(setSwapsLiveness).toHaveBeenCalledWith(false);
-      expect(isSwapsFeatureEnabled).toBe(false);
+      expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
+      expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
     });
 
-    it('only calls the API once and returns true from cache for the second call', async () => {
+    it('only calls the API once and returns response from cache for the second call', async () => {
       const mockDispatch = jest.fn();
-      const featureFlagApiNock = mockFeatureFlagApiResponse({ active: true });
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: true,
+        useNewSwapsApi: true,
+      };
+      const featureFlagsResponse = createFeatureFlagsResponse();
+      const featureFlagApiNock = mockFeatureFlagsApiResponse({
+        featureFlagsResponse,
+      });
       await swaps.fetchSwapsLiveness()(mockDispatch, createGetState());
       expect(featureFlagApiNock.isDone()).toBe(true);
-      const featureFlagApiNock2 = mockFeatureFlagApiResponse({ active: true });
-      const isSwapsFeatureEnabled = await swaps.fetchSwapsLiveness()(
+      const featureFlagApiNock2 = mockFeatureFlagsApiResponse({
+        featureFlagsResponse,
+      });
+      const swapsLiveness = await swaps.fetchSwapsLiveness()(
         mockDispatch,
         createGetState(),
       );
       expect(featureFlagApiNock2.isDone()).toBe(false); // Second API call wasn't made, cache was used instead.
       expect(mockDispatch).toHaveBeenCalledTimes(2);
-      expect(setSwapsLiveness).toHaveBeenCalledWith(true);
-      expect(isSwapsFeatureEnabled).toBe(true);
+      expect(setSwapsLiveness).toHaveBeenCalledWith(expectedSwapsLiveness);
+      expect(swapsLiveness).toMatchObject(expectedSwapsLiveness);
     });
   });
 });

--- a/ui/ducks/swaps/swaps.test.js
+++ b/ui/ducks/swaps/swaps.test.js
@@ -1,5 +1,6 @@
 import nock from 'nock';
 
+import { MOCKS } from '../../../test/jest';
 import { setSwapsLiveness } from '../../store/actions';
 import { setStorageItem } from '../../helpers/utils/storage-helpers';
 import * as swaps from './swaps';
@@ -28,26 +29,6 @@ describe('Ducks - Swaps', () => {
         'cachedFetch:https://api2.metaswap.codefi.network/featureFlags',
         null,
       );
-    };
-
-    const createFeatureFlagsResponse = () => {
-      return {
-        bsc: {
-          mobile_active: false,
-          extension_active: true,
-          fallback_to_v1: true,
-        },
-        ethereum: {
-          mobile_active: false,
-          extension_active: true,
-          fallback_to_v1: true,
-        },
-        polygon: {
-          mobile_active: false,
-          extension_active: true,
-          fallback_to_v1: false,
-        },
-      };
     };
 
     afterEach(() => {
@@ -82,7 +63,7 @@ describe('Ducks - Swaps', () => {
         swapsFeatureIsLive: true,
         useNewSwapsApi: true,
       };
-      const featureFlagsResponse = createFeatureFlagsResponse();
+      const featureFlagsResponse = MOCKS.createFeatureFlagsResponse();
       const featureFlagApiNock = mockFeatureFlagsApiResponse({
         featureFlagsResponse,
       });
@@ -102,7 +83,7 @@ describe('Ducks - Swaps', () => {
         swapsFeatureIsLive: true,
         useNewSwapsApi: false,
       };
-      const featureFlagsResponse = createFeatureFlagsResponse();
+      const featureFlagsResponse = MOCKS.createFeatureFlagsResponse();
       featureFlagsResponse.ethereum.extension_active = false;
       const featureFlagApiNock = mockFeatureFlagsApiResponse({
         featureFlagsResponse,
@@ -123,7 +104,7 @@ describe('Ducks - Swaps', () => {
         swapsFeatureIsLive: false,
         useNewSwapsApi: false,
       };
-      const featureFlagsResponse = createFeatureFlagsResponse();
+      const featureFlagsResponse = MOCKS.createFeatureFlagsResponse();
       featureFlagsResponse.ethereum.extension_active = false;
       featureFlagsResponse.ethereum.fallback_to_v1 = false;
       const featureFlagApiNock = mockFeatureFlagsApiResponse({
@@ -164,7 +145,7 @@ describe('Ducks - Swaps', () => {
         swapsFeatureIsLive: true,
         useNewSwapsApi: true,
       };
-      const featureFlagsResponse = createFeatureFlagsResponse();
+      const featureFlagsResponse = MOCKS.createFeatureFlagsResponse();
       const featureFlagApiNock = mockFeatureFlagsApiResponse({
         featureFlagsResponse,
       });

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -31,7 +31,7 @@ import {
 } from '../../store/actions';
 import { setThreeBoxLastUpdated, hideWhatsNewPopup } from '../../ducks/app/app';
 import { getWeb3ShimUsageAlertEnabledness } from '../../ducks/metamask/metamask';
-import { getSwapsFeatureLiveness } from '../../ducks/swaps/swaps';
+import { getSwapsFeatureIsLive } from '../../ducks/swaps/swaps';
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import {
   ENVIRONMENT_TYPE_NOTIFICATION,
@@ -60,7 +60,7 @@ const mapStateToProps = (state) => {
   const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
   const totalUnapprovedCount = getTotalUnapprovedCount(state);
-  const swapsEnabled = getSwapsFeatureLiveness(state);
+  const swapsEnabled = getSwapsFeatureIsLive(state);
   const pendingConfirmations = getUnapprovedTemplatedConfirmations(state);
 
   const envType = getEnvironmentType();

--- a/ui/pages/swaps/build-quote/build-quote.js
+++ b/ui/pages/swaps/build-quote/build-quote.js
@@ -141,7 +141,9 @@ export default function BuildQuote({
   const toTokenIsNotDefault =
     selectedToToken?.address &&
     !isSwapsDefaultTokenAddress(selectedToToken?.address, chainId);
-  const occurances = Number(selectedToToken?.occurances || 0);
+  const occurrences = Number(
+    selectedToToken?.occurances || selectedToToken?.occurrences || 0,
+  );
   const {
     address: fromTokenAddress,
     symbol: fromTokenSymbol,
@@ -354,11 +356,11 @@ export default function BuildQuote({
 
   let tokenVerificationDescription = '';
   if (blockExplorerTokenLink) {
-    if (occurances === 1) {
+    if (occurrences === 1) {
       tokenVerificationDescription = t('verifyThisTokenOn', [
         <BlockExplorerLink key="block-explorer-link" />,
       ]);
-    } else if (occurances === 0) {
+    } else if (occurrences === 0) {
       tokenVerificationDescription = t('verifyThisUnconfirmedTokenOn', [
         <BlockExplorerLink key="block-explorer-link" />,
       ]);
@@ -470,13 +472,13 @@ export default function BuildQuote({
           />
         </div>
         {toTokenIsNotDefault &&
-          (occurances < 2 ? (
+          (occurrences < 2 ? (
             <ActionableMessage
-              type={occurances === 1 ? 'warning' : 'danger'}
+              type={occurrences === 1 ? 'warning' : 'danger'}
               message={
                 <div className="build-quote__token-verification-warning-message">
                   <div className="build-quote__bold">
-                    {occurances === 1
+                    {occurrences === 1
                       ? t('swapTokenVerificationOnlyOneSource')
                       : t('swapTokenVerificationAddedManually')}
                   </div>
@@ -503,7 +505,7 @@ export default function BuildQuote({
                 className="build-quote__bold"
                 key="token-verification-bold-text"
               >
-                {t('swapTokenVerificationSources', [occurances])}
+                {t('swapTokenVerificationSources', [occurrences])}
               </span>
               {blockExplorerTokenLink && (
                 <>
@@ -563,7 +565,7 @@ export default function BuildQuote({
           !selectedToToken?.address ||
           Number(maxSlippage) < 0 ||
           Number(maxSlippage) > MAX_ALLOWED_SLIPPAGE ||
-          (toTokenIsNotDefault && occurances < 2 && !verificationClicked)
+          (toTokenIsNotDefault && occurrences < 2 && !verificationClicked)
         }
         hideCancel
         showTermsOfService

--- a/ui/pages/swaps/fee-card/fee-card.js
+++ b/ui/pages/swaps/fee-card/fee-card.js
@@ -6,6 +6,7 @@ import {
   MAINNET_CHAIN_ID,
   BSC_CHAIN_ID,
   LOCALHOST_CHAIN_ID,
+  POLYGON_CHAIN_ID,
 } from '../../../../shared/constants/network';
 
 export default function FeeCard({
@@ -38,6 +39,8 @@ export default function FeeCard({
         return t('networkNameEthereum');
       case BSC_CHAIN_ID:
         return t('networkNameBSC');
+      case POLYGON_CHAIN_ID:
+        return t('networkNamePolygon');
       case LOCALHOST_CHAIN_ID:
         return t('networkNameTestnet');
       default:

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -167,6 +167,7 @@ export default function Swap() {
     };
   }, []);
 
+  // eslint-disable-next-line
   useEffect(() => {
     if (isFeatureFlagLoaded) {
       fetchTokens(chainId, useNewSwapsApi)
@@ -187,7 +188,7 @@ export default function Swap() {
         dispatch(prepareToLeaveSwaps());
       };
     }
-  }, [dispatch, chainId, isFeatureFlagLoaded]);
+  }, [dispatch, chainId, isFeatureFlagLoaded, useNewSwapsApi]);
 
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -29,10 +29,11 @@ import {
   getAggregatorMetadata,
   getBackgroundSwapRouteState,
   getSwapsErrorKey,
-  getSwapsFeatureLiveness,
+  getSwapsFeatureIsLive,
   prepareToLeaveSwaps,
   fetchAndSetSwapsGasPriceInfo,
   fetchSwapsLiveness,
+  getUseNewSwapsApi,
 } from '../../ducks/swaps/swaps';
 import {
   AWAITING_SIGNATURES_ROUTE,
@@ -103,9 +104,10 @@ export default function Swap() {
   const aggregatorMetadata = useSelector(getAggregatorMetadata);
   const fetchingQuotes = useSelector(getFetchingQuotes);
   let swapsErrorKey = useSelector(getSwapsErrorKey);
-  const swapsEnabled = useSelector(getSwapsFeatureLiveness);
+  const swapsEnabled = useSelector(getSwapsFeatureIsLive);
   const chainId = useSelector(getCurrentChainId);
   const isSwapsChain = useSelector(getIsSwapsChain);
+  const useNewSwapsApi = useSelector(getUseNewSwapsApi);
 
   const {
     balance: ethBalance,
@@ -166,26 +168,26 @@ export default function Swap() {
   }, []);
 
   useEffect(() => {
-    fetchTokens(chainId)
-      .then((tokens) => {
-        dispatch(setSwapsTokens(tokens));
-      })
-      .catch((error) => console.error(error));
-
-    fetchTopAssets(chainId).then((topAssets) => {
-      dispatch(setTopAssets(topAssets));
-    });
-
-    fetchAggregatorMetadata(chainId).then((newAggregatorMetadata) => {
-      dispatch(setAggregatorMetadata(newAggregatorMetadata));
-    });
-
-    dispatch(fetchAndSetSwapsGasPriceInfo(chainId));
-
-    return () => {
-      dispatch(prepareToLeaveSwaps());
-    };
-  }, [dispatch, chainId]);
+    if (isFeatureFlagLoaded) {
+      fetchTokens(chainId, useNewSwapsApi)
+        .then((tokens) => {
+          dispatch(setSwapsTokens(tokens));
+        })
+        .catch((error) => console.error(error));
+      fetchTopAssets(chainId, useNewSwapsApi).then((topAssets) => {
+        dispatch(setTopAssets(topAssets));
+      });
+      fetchAggregatorMetadata(chainId, useNewSwapsApi).then(
+        (newAggregatorMetadata) => {
+          dispatch(setAggregatorMetadata(newAggregatorMetadata));
+        },
+      );
+      dispatch(fetchAndSetSwapsGasPriceInfo(chainId));
+      return () => {
+        dispatch(prepareToLeaveSwaps());
+      };
+    }
+  }, [dispatch, chainId, isFeatureFlagLoaded]);
 
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);

--- a/ui/pages/swaps/index.test.js
+++ b/ui/pages/swaps/index.test.js
@@ -24,7 +24,7 @@ setBackgroundConnection({
 });
 
 describe('Swap', () => {
-  let tokensNock;
+  let featureFlagsNock;
 
   beforeEach(() => {
     nock(CONSTANTS.METASWAP_BASE_URL)
@@ -43,9 +43,13 @@ describe('Swap', () => {
       .get('/gasPrices')
       .reply(200, MOCKS.GAS_PRICES_GET_RESPONSE);
 
-    tokensNock = nock(CONSTANTS.METASWAP_BASE_URL)
+    nock(CONSTANTS.METASWAP_BASE_URL)
       .get('/tokens')
       .reply(200, MOCKS.TOKENS_GET_RESPONSE);
+
+    featureFlagsNock = nock(CONSTANTS.METASWAP_API_V2_BASE_URL)
+      .get('/featureFlags')
+      .reply(200, MOCKS.FEATURE_FLAGS_RESPONSE);
   });
 
   afterAll(() => {
@@ -55,7 +59,7 @@ describe('Swap', () => {
   it('renders the component with initial props', async () => {
     const store = configureMockStore(middleware)(createSwapsMockStore());
     const { container, getByText } = renderWithProvider(<Swap />, store);
-    await waitFor(() => expect(tokensNock.isDone()).toBe(true));
+    await waitFor(() => expect(featureFlagsNock.isDone()).toBe(true));
     expect(getByText('Swap')).toBeInTheDocument();
     expect(getByText('Cancel')).toBeInTheDocument();
     expect(container).toMatchSnapshot();

--- a/ui/pages/swaps/index.test.js
+++ b/ui/pages/swaps/index.test.js
@@ -49,7 +49,7 @@ describe('Swap', () => {
 
     featureFlagsNock = nock(CONSTANTS.METASWAP_API_V2_BASE_URL)
       .get('/featureFlags')
-      .reply(200, MOCKS.FEATURE_FLAGS_RESPONSE);
+      .reply(200, MOCKS.createFeatureFlagsResponse());
   });
 
   afterAll(() => {

--- a/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
+++ b/ui/pages/swaps/searchable-item-list/list-item-search/list-item-search.component.js
@@ -9,6 +9,7 @@ import { usePrevious } from '../../../../hooks/usePrevious';
 import { isValidHexAddress } from '../../../../../shared/modules/hexstring-utils';
 import { fetchToken } from '../../swaps.util';
 import { getCurrentChainId } from '../../../../selectors/selectors';
+import { getUseNewSwapsApi } from '../../../../ducks/swaps/swaps';
 
 const renderAdornment = () => (
   <InputAdornment position="start" style={{ marginRight: '12px' }}>
@@ -28,6 +29,7 @@ export default function ListItemSearch({
   const fuseRef = useRef();
   const [searchQuery, setSearchQuery] = useState('');
   const chainId = useSelector(getCurrentChainId);
+  const useNewSwapsApi = useSelector(getUseNewSwapsApi);
 
   /**
    * Search a custom token for import based on a contract address.
@@ -36,7 +38,7 @@ export default function ListItemSearch({
   const handleSearchTokenForImport = async (contractAddress) => {
     setSearchQuery(contractAddress);
     try {
-      const token = await fetchToken(contractAddress, chainId);
+      const token = await fetchToken(contractAddress, chainId, useNewSwapsApi);
       if (token) {
         token.primaryLabel = token.symbol;
         token.secondaryLabel = token.name;

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -49,13 +49,18 @@ const TOKEN_TRANSFER_LOG_TOPIC_HASH =
 const CACHE_REFRESH_FIVE_MINUTES = 300000;
 
 const SWAPS_API_V2_BASE_URL = 'https://api2.metaswap.codefi.network';
+const GAS_API_BASE_URL = 'https://api2.metaswap.codefi.network';
 
 /**
  * @param {string} type Type of an API call, e.g. "tokens"
  * @param {string} chainId
  * @returns string
  */
-const getBaseUrlForApiV2 = (type, chainId) => {
+const getBaseUrlForNewSwapsApi = (type, chainId) => {
+  const gasApiTypes = ['gasPrices'];
+  if (gasApiTypes.includes(type)) {
+    return GAS_API_BASE_URL; // Gas calculations are in its own repo.
+  }
   const noNetworkTypes = ['refreshTime']; // These types don't need network info in the URL.
   if (noNetworkTypes.includes(type)) {
     return SWAPS_API_V2_BASE_URL;
@@ -70,7 +75,7 @@ const getBaseApi = function (
   useNewSwapsApi = false,
 ) {
   const baseUrl = useNewSwapsApi
-    ? getBaseUrlForApiV2(type, chainId)
+    ? getBaseUrlForNewSwapsApi(type, chainId)
     : METASWAP_CHAINID_API_HOST_MAP[chainId];
   switch (type) {
     case 'trade':

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -48,19 +48,24 @@ const TOKEN_TRANSFER_LOG_TOPIC_HASH =
 
 const CACHE_REFRESH_FIVE_MINUTES = 300000;
 
-const SWAPS_NEW_API_URL = 'https://api2.metaswap.codefi.network/networks';
+const SWAPS_API_V2_BASE_URL = 'https://api2.metaswap.codefi.network';
 
-const SWAPS_FEATURE_FLAGS_API_URL =
-  'https://api2.metaswap.codefi.network/featureFlags';
+const getBaseUrlForApiV2 = (type, chainId) => {
+  const noNetworkTypes = ['refreshTime'];
+  if (noNetworkTypes.includes(type)) {
+    return SWAPS_API_V2_BASE_URL;
+  }
+  const chainIdDecimal = parseInt(chainId, 16);
+  return `${SWAPS_API_V2_BASE_URL}/networks/${chainIdDecimal}`;
+};
 
 const getBaseApi = function (
   type,
   chainId = MAINNET_CHAIN_ID,
   useNewSwapsApi = false,
 ) {
-  const chainIdDecimal = parseInt(chainId, 16);
   const baseUrl = useNewSwapsApi
-    ? `${SWAPS_NEW_API_URL}/${chainIdDecimal}`
+    ? getBaseUrlForApiV2(type, chainId)
     : METASWAP_CHAINID_API_HOST_MAP[chainId];
   switch (type) {
     case 'trade':
@@ -402,7 +407,7 @@ export async function fetchSwapsFeatureLiveness(chainId) {
 
 export async function fetchSwapsFeatureFlags() {
   const response = await fetchWithCache(
-    SWAPS_FEATURE_FLAGS_API_URL,
+    `${SWAPS_API_V2_BASE_URL}/featureFlags`,
     { method: 'GET' },
     { cacheRefreshTime: 600000 },
   );

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -781,7 +781,7 @@ export const getNetworkNameByChainId = (chainId) => {
     case POLYGON_CHAIN_ID:
       return POLYGON;
     default:
-      throw new Error(`Cannot find network name for chainId: ${chainId}`);
+      return '';
   }
 };
 

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -50,8 +50,13 @@ const CACHE_REFRESH_FIVE_MINUTES = 300000;
 
 const SWAPS_API_V2_BASE_URL = 'https://api2.metaswap.codefi.network';
 
+/**
+ * @param {string} type Type of an API call, e.g. "tokens"
+ * @param {string} chainId
+ * @returns string
+ */
 const getBaseUrlForApiV2 = (type, chainId) => {
-  const noNetworkTypes = ['refreshTime'];
+  const noNetworkTypes = ['refreshTime']; // These types don't need network info in the URL.
   if (noNetworkTypes.includes(type)) {
     return SWAPS_API_V2_BASE_URL;
   }

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -6,6 +6,9 @@ import {
   METASWAP_CHAINID_API_HOST_MAP,
   SWAPS_CHAINID_CONTRACT_ADDRESS_MAP,
   ETH_WETH_CONTRACT_ADDRESS,
+  ETHEREUM,
+  POLYGON,
+  BSC,
 } from '../../../shared/constants/swaps';
 import {
   isSwapsDefaultTokenAddress,
@@ -18,9 +21,6 @@ import {
   BSC_CHAIN_ID,
   POLYGON_CHAIN_ID,
   LOCALHOST_CHAIN_ID,
-  ETHEREUM,
-  POLYGON,
-  BSC,
 } from '../../../shared/constants/network';
 import { SECOND } from '../../../shared/constants/time';
 import {

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -400,7 +400,6 @@ export async function fetchTopAssets(chainId, useNewSwapsApi) {
   return topAssetsMap;
 }
 
-// We only use this function with the old API. With the new API we call "fetchSwapsFeatureFlags"
 export async function fetchSwapsFeatureLiveness(chainId) {
   const status = await fetchWithCache(
     getBaseApi('featureFlag', chainId),

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -775,7 +775,6 @@ export const isContractAddressValid = (
 export const getNetworkNameByChainId = (chainId) => {
   switch (chainId) {
     case MAINNET_CHAIN_ID:
-    case LOCALHOST_CHAIN_ID:
       return ETHEREUM;
     case BSC_CHAIN_ID:
       return BSC;

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -781,7 +781,7 @@ export const getNetworkNameByChainId = (chainId) => {
     case POLYGON_CHAIN_ID:
       return POLYGON;
     default:
-      throw new Error('This network is not supported for token swaps');
+      throw new Error(`Cannot find network name for chainId: ${chainId}`);
   }
 };
 

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -81,8 +81,6 @@ const getBaseApi = function (
       return `${baseUrl}/token`;
     case 'topAssets':
       return `${baseUrl}/topAssets`;
-    case 'featureFlag':
-      return `${baseUrl}/featureFlag`;
     case 'aggregatorMetadata':
       return `${baseUrl}/aggregatorMetadata`;
     case 'gasPrices':
@@ -398,15 +396,6 @@ export async function fetchTopAssets(chainId, useNewSwapsApi) {
     return _topAssetsMap;
   }, {});
   return topAssetsMap;
-}
-
-export async function fetchSwapsFeatureLiveness(chainId) {
-  const status = await fetchWithCache(
-    getBaseApi('featureFlag', chainId),
-    { method: 'GET' },
-    { cacheRefreshTime: 600000 },
-  );
-  return status?.active;
 }
 
 export async function fetchSwapsFeatureFlags() {

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -49,7 +49,7 @@ const TOKEN_TRANSFER_LOG_TOPIC_HASH =
 const CACHE_REFRESH_FIVE_MINUTES = 300000;
 
 const SWAPS_API_V2_BASE_URL = 'https://api2.metaswap.codefi.network';
-const GAS_API_BASE_URL = 'https://api2.metaswap.codefi.network';
+const GAS_API_BASE_URL = 'https://gas-api.metaswap.codefi.network';
 
 /**
  * @param {string} type Type of an API call, e.g. "tokens"
@@ -57,15 +57,15 @@ const GAS_API_BASE_URL = 'https://api2.metaswap.codefi.network';
  * @returns string
  */
 const getBaseUrlForNewSwapsApi = (type, chainId) => {
-  const gasApiTypes = ['gasPrices'];
-  if (gasApiTypes.includes(type)) {
-    return GAS_API_BASE_URL; // Gas calculations are in its own repo.
-  }
-  const noNetworkTypes = ['refreshTime']; // These types don't need network info in the URL.
-  if (noNetworkTypes.includes(type)) {
+  const noNetworkSpecificTypes = ['refreshTime']; // These types don't need network info in the URL.
+  if (noNetworkSpecificTypes.includes(type)) {
     return SWAPS_API_V2_BASE_URL;
   }
-  const chainIdDecimal = parseInt(chainId, 16);
+  const chainIdDecimal = chainId && parseInt(chainId, 16);
+  const gasApiTypes = ['gasPrices'];
+  if (gasApiTypes.includes(type)) {
+    return `${GAS_API_BASE_URL}/networks/${chainIdDecimal}`; // Gas calculations are in its own repo.
+  }
   return `${SWAPS_API_V2_BASE_URL}/networks/${chainIdDecimal}`;
 };
 

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -8,13 +8,13 @@ import {
   POLYGON_CHAIN_ID,
   LOCALHOST_CHAIN_ID,
   RINKEBY_CHAIN_ID,
-  ETHEREUM,
-  POLYGON,
-  BSC,
 } from '../../../shared/constants/network';
 import {
   SWAPS_CHAINID_CONTRACT_ADDRESS_MAP,
   ETH_WETH_CONTRACT_ADDRESS,
+  ETHEREUM,
+  POLYGON,
+  BSC,
 } from '../../../shared/constants/swaps';
 import {
   TOKENS,

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -1,10 +1,16 @@
 import nock from 'nock';
+import { MOCKS } from '../../../test/jest';
 import {
   ETH_SYMBOL,
   WETH_SYMBOL,
   MAINNET_CHAIN_ID,
   BSC_CHAIN_ID,
+  POLYGON_CHAIN_ID,
   LOCALHOST_CHAIN_ID,
+  RINKEBY_CHAIN_ID,
+  ETHEREUM,
+  POLYGON,
+  BSC,
 } from '../../../shared/constants/network';
 import {
   SWAPS_CHAINID_CONTRACT_ADDRESS_MAP,
@@ -17,13 +23,14 @@ import {
   AGGREGATOR_METADATA,
   TOP_ASSETS,
 } from './swaps-util-test-constants';
-
 import {
   fetchTradesInfo,
   fetchTokens,
   fetchAggregatorMetadata,
   fetchTopAssets,
   isContractAddressValid,
+  getNetworkNameByChainId,
+  getSwapsLivenessForNetwork,
 } from './swaps.util';
 
 jest.mock('../../helpers/utils/storage-helpers.js', () => ({
@@ -370,6 +377,77 @@ describe('Swaps Util', () => {
           LOCALHOST_CHAIN_ID,
         ),
       ).toBe(false);
+    });
+  });
+
+  describe('getNetworkNameByChainId', () => {
+    it('returns "ethereum" for mainnet chain ID', () => {
+      expect(getNetworkNameByChainId(MAINNET_CHAIN_ID)).toBe(ETHEREUM);
+    });
+
+    it('returns "bsc" for mainnet chain ID', () => {
+      expect(getNetworkNameByChainId(BSC_CHAIN_ID)).toBe(BSC);
+    });
+
+    it('returns "polygon" for mainnet chain ID', () => {
+      expect(getNetworkNameByChainId(POLYGON_CHAIN_ID)).toBe(POLYGON);
+    });
+
+    it('returns an empty string for an unsupported network', () => {
+      expect(getNetworkNameByChainId(RINKEBY_CHAIN_ID)).toBe('');
+    });
+  });
+
+  describe('getSwapsLivenessForNetwork', () => {
+    it('returns info that Swaps are enabled and cannot use API v2 for localhost chain ID', () => {
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: true,
+        useNewSwapsApi: false,
+      };
+      expect(
+        getSwapsLivenessForNetwork(
+          MOCKS.createFeatureFlagsResponse(),
+          LOCALHOST_CHAIN_ID,
+        ),
+      ).toMatchObject(expectedSwapsLiveness);
+    });
+
+    it('returns info that Swaps are disabled and cannot use API v2 if network name is not found', () => {
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: false,
+        useNewSwapsApi: false,
+      };
+      expect(
+        getSwapsLivenessForNetwork(
+          MOCKS.createFeatureFlagsResponse(),
+          RINKEBY_CHAIN_ID,
+        ),
+      ).toMatchObject(expectedSwapsLiveness);
+    });
+
+    it('returns info that Swaps are enabled and can use API v2 for mainnet chain ID', () => {
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: true,
+        useNewSwapsApi: true,
+      };
+      expect(
+        getSwapsLivenessForNetwork(
+          MOCKS.createFeatureFlagsResponse(),
+          MAINNET_CHAIN_ID,
+        ),
+      ).toMatchObject(expectedSwapsLiveness);
+    });
+
+    it('returns info that Swaps are enabled but can only use API v1 for mainnet chain ID', () => {
+      const expectedSwapsLiveness = {
+        swapsFeatureIsLive: true,
+        useNewSwapsApi: false,
+      };
+      const swapsFeatureFlags = MOCKS.createFeatureFlagsResponse();
+      swapsFeatureFlags[ETHEREUM].extension_active = false;
+      expect(
+        getSwapsLivenessForNetwork(swapsFeatureFlags, MAINNET_CHAIN_ID),
+      ).toMatchObject(expectedSwapsLiveness);
     });
   });
 });

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2121,9 +2121,9 @@ export function setPendingTokens(pendingTokens) {
 
 // Swaps
 
-export function setSwapsLiveness(swapsFeatureIsLive) {
+export function setSwapsLiveness(swapsLiveness) {
   return async (dispatch) => {
-    await promisifiedBackground.setSwapsLiveness(swapsFeatureIsLive);
+    await promisifiedBackground.setSwapsLiveness(swapsLiveness);
     await forceUpdateMetamaskState(dispatch);
   };
 }


### PR DESCRIPTION
## Explanation
This PR adds conditional routing to either v1 or v2 APIs for Swaps, based on feature flags from our backend. The goal is to migrate to v2 APIs only, but we want to have a fallback solution to v1, just to be on the safe side.

## Manual testing steps
v1 API calls:
- Open the `swaps.util.js` file and return the following from the `fetchSwapsFeatureFlags` function:
```
return {
    bsc: {
      mobile_active: false,
      extension_active: false,
      fallback_to_v1: true,
    },
    ethereum: {
      mobile_active: false,
      extension_active: false,
      fallback_to_v1: true,
    },
    polygon: {
      mobile_active: false,
      extension_active: false,
      fallback_to_v1: false,
    },
  };
```
- Run `yarn start` with a branch that includes this PR
- Open the extension
- On the main page click on Swaps
- Check that network calls are going to our old APIs

v2 API calls:
- Open the `swaps.util.js` file and return the following from the `fetchSwapsFeatureFlags` function:
```
return {
    bsc: {
      mobile_active: false,
      extension_active: true,
      fallback_to_v1: true,
    },
    ethereum: {
      mobile_active: false,
      extension_active: true,
      fallback_to_v1: true,
    },
    polygon: {
      mobile_active: false,
      extension_active: true,
      fallback_to_v1: false,
    },
  };
```
- Run `yarn start` with a branch that includes this PR
- Open the extension
- On the main page click on Swaps
- Check that network calls are going to our new APIs (`https://api2.metaswap.codefi.network/`)

## Screenshots
v2 /featureFlags API:
![image](https://user-images.githubusercontent.com/80175477/124759089-8e5f4f80-df2f-11eb-98f0-e5684a2ba4aa.png)

v1 API calls:
![image](https://user-images.githubusercontent.com/80175477/124758834-44766980-df2f-11eb-9fe0-d6f3e759bc48.png)

v1 successful swapping:
![image](https://user-images.githubusercontent.com/80175477/124761155-c9628280-df31-11eb-9f37-10b18960fffc.png)

v2 API calls:
![image](https://user-images.githubusercontent.com/80175477/124759141-9dde9880-df2f-11eb-881a-94eb7b78ba67.png)
