### PR TITLE
fix up ens/hex address validation error handling

### DIFF
--- a/ui/ducks/ens.js
+++ b/ui/ducks/ens.js
@@ -92,18 +92,20 @@ const slice = createSlice({
     },
     disableEnsLookup: (state) => {
       state.stage = 'NO_NETWORK_SUPPORT';
-      state.error = ENS_NOT_SUPPORTED_ON_NETWORK;
+      state.error = null;
       state.warning = null;
       state.resolution = null;
       state.network = null;
     },
-    resetResolution: (state) => {
+    ensNotSupported: (state) => {
       state.resolution = null;
       state.warning = null;
-      state.error =
-        state.stage === 'NO_NETWORK_SUPPORT'
-          ? ENS_NOT_SUPPORTED_ON_NETWORK
-          : null;
+      state.error = ENS_NOT_SUPPORTED_ON_NETWORK;
+    },
+    resetEnsResolution: (state) => {
+      state.resolution = null;
+      state.warning = null;
+      state.error = null;
     },
   },
   extraReducers: (builder) => {
@@ -123,9 +125,10 @@ const {
   disableEnsLookup,
   ensLookup,
   enableEnsLookup,
-  resetResolution,
+  ensNotSupported,
+  resetEnsResolution,
 } = actions;
-export { resetResolution };
+export { resetEnsResolution };
 
 export function initializeEnsSlice() {
   return (dispatch, getState) => {
@@ -159,7 +162,7 @@ export function lookupEnsName(ensName) {
       ) &&
       !isHexString(trimmedEnsName)
     ) {
-      await dispatch(resetResolution());
+      await dispatch(ensNotSupported());
     } else {
       log.info(`ENS attempting to resolve name: ${trimmedEnsName}`);
       let address;

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -75,7 +75,7 @@ import {
   isValidDomainName,
 } from '../../helpers/utils/util';
 import { getTokens, getUnapprovedTxs } from '../metamask/metamask';
-import { resetResolution } from '../ens';
+import { resetEnsResolution } from '../ens';
 import {
   isBurnAddress,
   isValidHexAddress,
@@ -1218,7 +1218,7 @@ export function resetRecipientInput() {
   return async (dispatch) => {
     await dispatch(updateRecipientUserInput(''));
     await dispatch(updateRecipient({ address: '', nickname: '' }));
-    await dispatch(resetResolution());
+    await dispatch(resetEnsResolution());
     await dispatch(validateRecipientUserInput());
   };
 }

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1456,7 +1456,7 @@ describe('Send Slice', () => {
         );
         expect(actionResult[0].payload).toStrictEqual('');
         expect(actionResult[1].type).toStrictEqual('send/updateRecipient');
-        expect(actionResult[2].type).toStrictEqual('ENS/resetResolution');
+        expect(actionResult[2].type).toStrictEqual('ENS/resetEnsResolution');
         expect(actionResult[3].type).toStrictEqual(
           'send/validateRecipientUserInput',
         );

--- a/ui/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/pages/send/send-content/add-recipient/ens-input.component.js
@@ -62,18 +62,19 @@ export default class EnsInput extends Component {
     }
     // Empty ENS state if input is empty
     // maybe scan ENS
-
     if (isValidDomainName(input)) {
       lookupEnsName(input);
-    } else if (
-      onValidAddressTyped &&
-      !isBurnAddress(input) &&
-      isValidHexAddress(input, { mixedCaseUseChecksum: true })
-    ) {
-      onValidAddressTyped(input);
     } else {
       resetEnsResolution();
+      if (
+        onValidAddressTyped &&
+        !isBurnAddress(input) &&
+        isValidHexAddress(input, { mixedCaseUseChecksum: true })
+      ) {
+        onValidAddressTyped(input);
+      }
     }
+
     return null;
   };
 

--- a/ui/pages/send/send-content/add-recipient/ens-input.container.js
+++ b/ui/pages/send/send-content/add-recipient/ens-input.container.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import {
   lookupEnsName,
   initializeEnsSlice,
-  resetResolution,
+  resetEnsResolution,
 } from '../../../../ducks/ens';
 import EnsInput from './ens-input.component';
 
@@ -11,7 +11,7 @@ function mapDispatchToProps(dispatch) {
   return {
     lookupEnsName: debounce((ensName) => dispatch(lookupEnsName(ensName)), 150),
     initializeEnsSlice: () => dispatch(initializeEnsSlice()),
-    resetEnsResolution: debounce(() => dispatch(resetResolution()), 300),
+    resetEnsResolution: debounce(() => dispatch(resetEnsResolution()), 300),
   };
 }
 

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -27,7 +27,7 @@ export default class AddContact extends PureComponent {
     qrCodeDetected: PropTypes.func,
     ensResolution: PropTypes.string,
     ensError: PropTypes.string,
-    resetResolution: PropTypes.func,
+    resetEnsResolution: PropTypes.func,
   };
 
   state = {
@@ -88,7 +88,7 @@ export default class AddContact extends PureComponent {
           this.validate(text);
         }}
         onReset={() => {
-          this.props.resetResolution();
+          this.props.resetEnsResolution();
           this.setState({ ethAddress: '', input: '' });
         }}
         userInput={this.state.input}

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
@@ -7,7 +7,11 @@ import {
   qrCodeDetected,
 } from '../../../../store/actions';
 import { getQrCodeData } from '../../../../ducks/app/app';
-import { getEnsError, getEnsResolution, resetEnsResolution } from '../../../../ducks/ens';
+import {
+  getEnsError,
+  getEnsResolution,
+  resetEnsResolution,
+} from '../../../../ducks/ens';
 import AddContact from './add-contact.component';
 
 const mapStateToProps = (state) => {

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
@@ -7,11 +7,7 @@ import {
   qrCodeDetected,
 } from '../../../../store/actions';
 import { getQrCodeData } from '../../../../ducks/app/app';
-import {
-  getEnsError,
-  getEnsResolution,
-  resetResolution,
-} from '../../../../ducks/ens';
+import { getEnsError, getEnsResolution, resetEnsResolution } from '../../../../ducks/ens';
 import AddContact from './add-contact.component';
 
 const mapStateToProps = (state) => {
@@ -28,7 +24,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(addToAddressBook(recipient, nickname)),
     scanQrCode: () => dispatch(showQrScanner()),
     qrCodeDetected: (data) => dispatch(qrCodeDetected(data)),
-    resetResolution: () => dispatch(resetResolution()),
+    resetEnsResolution: () => dispatch(resetEnsResolution()),
   };
 };
 


### PR DESCRIPTION
Fixes: The following issue raised in the [v9.8.0 bug/regression report](https://docs.google.com/document/d/1-RpPcuYaPRmubH7fCBNN4eyEwfh_QyzgOY0VDSLtcKk/edit#) : Upon landing on the send/add recipient page, while on a network that doesn’t support ENS, the error “Network does not support ENS” is shown immediately. Additionally, entering an incorrect address should update the error to “Recipient address is invalid”, screenshot is an address without the last character. Before, user input would trigger the appropriate error messages and their priority/case. 

