### PR TITLE
add edit button support to transaction-detail-item

### DIFF
--- a/ui/components/app/transaction-detail-item/index.scss
+++ b/ui/components/app/transaction-detail-item/index.scss
@@ -3,6 +3,20 @@
 
   &__row {
     display: flex;
+
+    &--action-row {
+      justify-content: flex-end;
+      align-items: flex-start;
+      margin-bottom: 4px;
+    }
+  }
+
+  &__action-button.button {
+    @include H7;
+
+    width: auto;
+    padding: 0;
+    text-transform: uppercase;
   }
 
   &__title {

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
@@ -7,6 +7,7 @@ import {
   FONT_WEIGHT,
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
+import Button from '../../ui/button';
 
 export default function TransactionDetailItem({
   detailTitle,
@@ -14,9 +15,22 @@ export default function TransactionDetailItem({
   detailTotal,
   subTitle,
   subText,
+  handleActionClick,
+  actionText,
 }) {
   return (
     <div className="transaction-detail-item">
+      {actionText && (
+        <div className="transaction-detail-item__row transaction-detail-item__row--action-row">
+          <Button
+            className="transaction-detail-item__action-button"
+            onClick={handleActionClick}
+            type="link"
+          >
+            {actionText}
+          </Button>
+        </div>
+      )}
       <div className="transaction-detail-item__row">
         <Typography
           color={COLORS.BLACK}
@@ -63,6 +77,8 @@ export default function TransactionDetailItem({
 }
 
 TransactionDetailItem.propTypes = {
+  handleActionClick: PropTypes.func,
+  actionText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   detailTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   detailText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   detailTotal: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
@@ -20,7 +20,7 @@ export default function TransactionDetailItem({
 }) {
   return (
     <div className="transaction-detail-item">
-      {actionText && (
+      {actionText && handleActionClick && (
         <div className="transaction-detail-item__row transaction-detail-item__row--action-row">
           <Button
             className="transaction-detail-item__action-button"


### PR DESCRIPTION
Adds the styles for the edit button that can hover just over the details for the gas total. 