### PR TITLE
Converting gas params for tx metrics to decimal GWEI

### DIFF
--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -1219,7 +1219,7 @@ describe('Transaction Controller', function () {
         category: 'Transactions',
         sensitiveProperties: {
           chain_id: '0x2a',
-          gas_price: '0x77359400',
+          gas_price: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'legacy',
@@ -1264,7 +1264,7 @@ describe('Transaction Controller', function () {
         category: 'Transactions',
         sensitiveProperties: {
           chain_id: '0x2a',
-          gas_price: '0x77359400',
+          gas_price: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'legacy',
@@ -1311,7 +1311,7 @@ describe('Transaction Controller', function () {
           baz: 3.0,
           foo: 'bar',
           chain_id: '0x2a',
-          gas_price: '0x77359400',
+          gas_price: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'legacy',
@@ -1363,8 +1363,8 @@ describe('Transaction Controller', function () {
           baz: 3.0,
           foo: 'bar',
           chain_id: '0x2a',
-          max_fee_per_gas: '0x77359400',
-          max_priority_fee_per_gas: '0x77359400',
+          max_fee_per_gas: '2',
+          max_priority_fee_per_gas: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'fee-market',
@@ -1413,6 +1413,32 @@ describe('Transaction Controller', function () {
       const submittedTime = 1625781995397;
       const result = txController._getTransactionCompletionTime(submittedTime);
       assert.equal(result, '21');
+    });
+  });
+
+  describe('#_getGasValuesInGWEI', function () {
+    it('converts gas values in hex GWEi to dec GWEI (EIP-1559)', function () {
+      const params = {
+        max_fee_per_gas: '0x77359400',
+        max_priority_fee_per_gas: '0x77359400',
+      };
+      const expectedParams = {
+        max_fee_per_gas: '2',
+        max_priority_fee_per_gas: '2',
+      };
+      const result = txController._getGasValuesInGWEI(params);
+      assert.deepEqual(result, expectedParams);
+    });
+
+    it('converts gas values in hex GWEi to dec GWEI (non EIP-1559)', function () {
+      const params = {
+        gas_price: '0x37e11d600',
+      };
+      const expectedParams = {
+        gas_price: '15',
+      };
+      const result = txController._getGasValuesInGWEI(params);
+      assert.deepEqual(result, expectedParams);
     });
   });
 });


### PR DESCRIPTION
This will convert `gasPrice`, `maxFeePerGas`, and `maxPriorityFeePerGas` from hex to decimal when applicable for transaction tracking events. 