### PR TITLE
Ensure simple send gas estimation happens after the recipient is iden…

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -437,7 +437,8 @@ export const initializeSendState = createAsyncThunk(
         : GAS_LIMITS.SIMPLE;
     if (
       basicEstimateStatus === BASIC_ESTIMATE_STATES.READY &&
-      stage !== SEND_STAGES.EDIT
+      stage !== SEND_STAGES.EDIT &&
+      recipient.address
     ) {
       // Run our estimateGasLimit logic to get a more accurate estimation of
       // required gas. If this value isn't nullish, set it as the new gasLimit
@@ -1267,12 +1268,9 @@ export function useMyAccountsForRecipientSearch() {
  * @returns {void}
  */
 export function updateRecipient({ address, nickname }) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     await dispatch(actions.updateRecipient({ address, nickname }));
-    const state = getState();
-    if (state.send.asset.type === ASSET_TYPES.TOKEN) {
-      await dispatch(computeEstimatedGasLimit());
-    }
+    await dispatch(computeEstimatedGasLimit());
   };
 }
 

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1400,7 +1400,7 @@ describe('Send Slice', () => {
         );
       });
 
-      it('should create actions to update recipient and recalculate gas limit if the asset is a token', async () => {
+      it('should create actions to reset recipient input and ens, calculate gas and then validate input', async () => {
         const tokenState = {
           metamask: {
             blockGasLimit: '',

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1348,7 +1348,7 @@ describe('Send Slice', () => {
         nickname: '',
       };
 
-      it('should create actions to update recipient and recalculate gas limit if the asset type is not set ', async () => {
+      it('should create actions to update recipient and recalculate gas limit if the asset type is not set', async () => {
         global.eth = {
           getCode: sinon.stub(),
         };

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1349,10 +1349,34 @@ describe('Send Slice', () => {
       };
 
       it('should create an action to update recipient', async () => {
+        global.eth = {
+          getCode: sinon.stub(),
+        };
+
         const updateRecipientState = {
+          metamask: {
+            provider: {
+              chainId: '0x1',
+            },
+          },
           send: {
+            account: {
+              balance: '',
+            },
             asset: {
               type: '',
+            },
+            gas: {
+              gasPrice: '',
+            },
+            recipient: {
+              address: '',
+            },
+            amount: {
+              value: '',
+            },
+            draftTransaction: {
+              userInputHexData: '',
             },
           },
         };
@@ -1363,15 +1387,17 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        const expectedActionResult = [
-          {
-            type: 'send/updateRecipient',
-            payload: recipient,
-          },
-        ];
-
-        expect(actionResult).toHaveLength(1);
-        expect(actionResult).toStrictEqual(expectedActionResult);
+        expect(actionResult).toHaveLength(4);
+        expect(actionResult[0].type).toStrictEqual('send/updateRecipient');
+        expect(actionResult[1].type).toStrictEqual(
+          'send/computeEstimatedGasLimit/pending',
+        );
+        expect(actionResult[2].type).toStrictEqual(
+          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
+        );
+        expect(actionResult[3].type).toStrictEqual(
+          'send/computeEstimatedGasLimit/fulfilled',
+        );
       });
 
       it('should create actions to update recipient and recalculate gas limit if the asset is a token', async () => {
@@ -1443,6 +1469,13 @@ describe('Send Slice', () => {
               address: 'Address',
               nickname: 'NickName',
             },
+            gas: {
+              gasPrice: '0x1',
+            },
+            amount: {
+              value: '0x1',
+            },
+            draftTransaction: {},
           },
         };
 
@@ -1451,14 +1484,23 @@ describe('Send Slice', () => {
         await store.dispatch(resetRecipientInput());
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(4);
+        expect(actionResult).toHaveLength(7);
         expect(actionResult[0].type).toStrictEqual(
           'send/updateRecipientUserInput',
         );
         expect(actionResult[0].payload).toStrictEqual('');
         expect(actionResult[1].type).toStrictEqual('send/updateRecipient');
-        expect(actionResult[2].type).toStrictEqual('ENS/resetEnsResolution');
+        expect(actionResult[2].type).toStrictEqual(
+          'send/computeEstimatedGasLimit/pending',
+        );
         expect(actionResult[3].type).toStrictEqual(
+          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
+        );
+        expect(actionResult[4].type).toStrictEqual(
+          'send/computeEstimatedGasLimit/fulfilled',
+        );
+        expect(actionResult[5].type).toStrictEqual('ENS/resetEnsResolution');
+        expect(actionResult[6].type).toStrictEqual(
           'send/validateRecipientUserInput',
         );
       });

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1348,7 +1348,7 @@ describe('Send Slice', () => {
         nickname: '',
       };
 
-      it('should create an action to update recipient', async () => {
+      it('should create actions to update recipient and recalculate gas limit if the asset type is not set ', async () => {
         global.eth = {
           getCode: sinon.stub(),
         };


### PR DESCRIPTION
Issue found in QA:

>Custom Network Gas Limits have increased not only for Optimism, but for xDai and Binance. Their eth_estimateGas returns 53000 on those networks for just “simple sends” when 21000 is default/sufficient for “simple sends”. I have a feeling we are incorrectly passing the incorrect params to eth_estimateGas for xDai/Binance. It seems that params for eth_estimateGas just need to be params: [{“to”: “ADDRESS”}] for simple sends, and params: [{“to”: “ADDRESS”, data: “DATA”}] for txs with data. Looks like we are passing “from” as the param, rather than “to”. Possible further discussion on here or Slack.

This was happening because without the 'to' address in the parameters passed to `estimateGas`, estimates for "simple sends" were actually returning estimates for contract deployments.

This PR fixes this by ensuring that estimateGas calls only happen once the recipient is set.  