### PR TITLE
use ERC721 interface id instead of ERC721 metadata interface ID for identifying ERC721 tokens

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -15,7 +15,7 @@ import {
 } from '../../../shared/modules/hexstring-utils';
 import { NETWORK_EVENTS } from './network';
 
-const ERC721METADATA_INTERFACE_ID = '0x5b5e139f';
+const ERC721_INTERFACE_ID = '0x80ac58cd';
 
 export default class PreferencesController {
   /**
@@ -803,7 +803,7 @@ export default class PreferencesController {
     );
 
     return await tokenContract
-      .supportsInterface(ERC721METADATA_INTERFACE_ID)
+      .supportsInterface(ERC721_INTERFACE_ID)
       .catch((error) => {
         console.log('error', error);
         log.debug(error);


### PR DESCRIPTION
Fixes: Issue (#)4 in 9.8.0 [QA bugs doc](https://docs.google.com/document/d/1-RpPcuYaPRmubH7fCBNN4eyEwfh_QyzgOY0VDSLtcKk/edit#heading=h.h03r4zgpzai6)

Explanation:  [When I initially implemented ERC721 detection in the extension](https://github.com/MetaMask/metamask-extension/pull/11210) to prevent users from attempting to send ERC721 tokens (functionality we don't currently support), I used the incorrect interfaceID. The metadata interface (the id of which we are currently using) is implemented for most ERC-721 tokens but not all so we should use the ERC-721  interface ID (ERC-165 identifier) specified in [EIP-721](https://eips.ethereum.org/EIPS/eip-721) which is a required implementation for all ERC721 tokens.

Manual testing steps:  
  - Purchase an ENS domain on a test net
  - Import the token into metamask
  - Make sure that the send option is disable as soon as you import it.