### PR TITLE
Fixing invalid prop type in ConfirmPageContainerHeader

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -781,7 +781,7 @@ export default class ConfirmTransactionBase extends Component {
         toAddress={toAddress}
         toEns={toEns}
         toNickname={toNickname}
-        showEdit={onEdit}
+        showEdit={Boolean(onEdit)}
         action={functionType}
         title={title}
         titleComponent={this.renderTitleComponent()}


### PR DESCRIPTION
<img width="311" alt="Screen Shot 2021-07-11 at 1 52 39 AM" src="https://user-images.githubusercontent.com/8732757/125189098-5edc6b80-e1eb-11eb-99f6-c8245d4c47fd.png">

The `showEdit` prop being passed to `ConfirmTransactionBase` was no longer being coerced to bool as of: https://github.com/MetaMask/metamask-extension/pull/11411/files#diff-a6209b43f1af7f5cf53ecdaba18ee1e22d0bdc774bc369daaefa4583a9d25fb2L712

**Test plan:**
1. Create a Send Transaction
2. Advance to confirmation screen
3. Confirm the invalid prop error is not present in the console
