### PR TITLE
Removing dead post-send tx code from ConfirmTransactionBase

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -693,8 +693,6 @@ export default class ConfirmTransactionBase extends Component {
       sendTransaction,
       clearConfirmTransaction,
       txData,
-      history,
-      mostRecentOverviewPage,
       updateCustomNonce,
       maxFeePerGas,
       maxPriorityFeePerGas,
@@ -733,18 +731,7 @@ export default class ConfirmTransactionBase extends Component {
         this._removeBeforeUnload();
 
         sendTransaction(txData)
-          .then(() => {
-            clearConfirmTransaction();
-            this.setState(
-              {
-                submitting: false,
-              },
-              () => {
-                history.push(mostRecentOverviewPage);
-                updateCustomNonce('');
-              },
-            );
-          })
+          .then(() => clearConfirmTransaction())
           .catch((error) => {
             this.setState({
               submitting: false,


### PR DESCRIPTION
<img width="573" alt="Screen Shot 2021-07-11 at 2 15 17 AM" src="https://user-images.githubusercontent.com/8732757/125189801-cc3dcb80-e1ee-11eb-8d63-ccd47ac0920d.png">

This code wasn't being reached as the component is unmounted at that point, the same logic is already covered in the `updateAndApproveTx` action (https://github.com/MetaMask/metamask-extension/blob/develop/ui/store/actions.js#L711)

**Test Plan:**
1. Create a send transaction
2. Confirm the transaction
3. Confirm that the error is no longer present once redirection the home page happens
