### PR TITLE
moving some properties to identifiable payload

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1238,13 +1238,15 @@ export default class TransactionController extends EventEmitter {
     this._trackMetaMetricsEvent({
       event,
       category: 'Transactions',
-      sensitiveProperties: {
-        type,
-        status,
+      properties: {
+        chain_id: chainId,
         referrer,
         source,
         network,
-        chain_id: chainId,
+        type,
+      },
+      sensitiveProperties: {
+        status,
         transaction_envelope_type: isEIP1559Transaction(txMeta)
           ? 'fee-market'
           : 'legacy',

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -1217,17 +1217,19 @@ describe('Transaction Controller', function () {
       const expectedPayload = {
         event: 'Transaction Added',
         category: 'Transactions',
-        sensitiveProperties: {
+        properties: {
           chain_id: '0x2a',
+          network: '42',
+          referrer: 'metamask',
+          source: 'user',
+          type: 'sentEther',
+        },
+        sensitiveProperties: {
           gas_price: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'legacy',
-          network: '42',
-          referrer: 'metamask',
-          source: 'user',
           status: 'unapproved',
-          type: 'sentEther',
         },
       };
 
@@ -1262,17 +1264,19 @@ describe('Transaction Controller', function () {
       const expectedPayload = {
         event: 'Transaction Added',
         category: 'Transactions',
-        sensitiveProperties: {
+        properties: {
           chain_id: '0x2a',
+          network: '42',
+          referrer: 'other',
+          source: 'dapp',
+          type: 'sentEther',
+        },
+        sensitiveProperties: {
           gas_price: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'legacy',
-          network: '42',
-          referrer: 'other',
-          source: 'dapp',
           status: 'unapproved',
-          type: 'sentEther',
         },
       };
 
@@ -1307,19 +1311,21 @@ describe('Transaction Controller', function () {
       const expectedPayload = {
         event: 'Transaction Added',
         category: 'Transactions',
+        properties: {
+          network: '42',
+          referrer: 'other',
+          source: 'dapp',
+          type: 'sentEther',
+          chain_id: '0x2a',
+        },
         sensitiveProperties: {
           baz: 3.0,
           foo: 'bar',
-          chain_id: '0x2a',
           gas_price: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'legacy',
-          network: '42',
-          referrer: 'other',
-          source: 'dapp',
           status: 'unapproved',
-          type: 'sentEther',
         },
       };
 
@@ -1359,20 +1365,22 @@ describe('Transaction Controller', function () {
       const expectedPayload = {
         event: 'Transaction Added',
         category: 'Transactions',
+        properties: {
+          chain_id: '0x2a',
+          network: '42',
+          referrer: 'other',
+          source: 'dapp',
+          type: 'sentEther',
+        },
         sensitiveProperties: {
           baz: 3.0,
           foo: 'bar',
-          chain_id: '0x2a',
           max_fee_per_gas: '2',
           max_priority_fee_per_gas: '2',
           gas_limit: '0x7b0d',
           first_seen: 1624408066355,
           transaction_envelope_type: 'fee-market',
-          network: '42',
-          referrer: 'other',
-          source: 'dapp',
           status: 'unapproved',
-          type: 'sentEther',
         },
       };
 


### PR DESCRIPTION
Moves the following fields to the identifiable payload:
1 - chain_id, this was previously on the `properties` payload, and isn't enough information to fully identify the transaction.
2 - type, this is a new thing, but doesn't provide enough details even in combination with other fields to identify the transaction.
3 - network (same as chainId)
4 - referrer - this was always on the properties object and doesn't relate to on-chain data directly. in any event it doesn't identify the tx.
5 - source - derived from the referrer. 