### PR TITLE
Move custom gas fee properties from useGasFeeInputs state to redux

### DIFF
--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -15,6 +15,7 @@ import {
   hideSidebar,
   updateTransaction,
 } from '../../../store/actions';
+import { resetCustomData } from '../../../ducks/gas/gas.duck';
 
 export const EDIT_GAS_MODE = {
   SPEED_UP: 'speed-up',
@@ -42,6 +43,7 @@ export default function EditGasPopover({
    * the modal in testing
    */
   const closePopover = useCallback(() => {
+    dispatch(resetCustomData());
     if (onClose) {
       onClose();
     } else if (showSidebar) {

--- a/ui/ducks/gas/gas-action-constants.js
+++ b/ui/ducks/gas/gas-action-constants.js
@@ -12,3 +12,7 @@ export const SET_BASIC_GAS_ESTIMATE_DATA =
 export const SET_CUSTOM_GAS_LIMIT = 'metamask/gas/SET_CUSTOM_GAS_LIMIT';
 export const SET_CUSTOM_GAS_PRICE = 'metamask/gas/SET_CUSTOM_GAS_PRICE';
 export const SET_ESTIMATE_SOURCE = 'metamask/gas/SET_ESTIMATE_SOURCE';
+export const SET_CUSTOM_MAX_FEE_PER_GAS =
+  'metamask/gas/SET_CUSTOM_MAX_FEE_PER_GAS';
+export const SET_CUSTOM_MAX_PRIORITY_FEE_PER_GAS =
+  'metamask/gas/SET_CUSTOM_MAX_PRIORITY_FEE_PER_GAS';

--- a/ui/ducks/gas/gas-duck.test.js
+++ b/ui/ducks/gas/gas-duck.test.js
@@ -50,6 +50,8 @@ describe('Gas Duck', () => {
     customData: {
       price: null,
       limit: null,
+      maxFeePerGas: null,
+      maxPriorityFeePerGas: null,
     },
     basicEstimates: {
       average: null,

--- a/ui/ducks/gas/gas.duck.js
+++ b/ui/ducks/gas/gas.duck.js
@@ -17,6 +17,8 @@ import {
   SET_CUSTOM_GAS_LIMIT,
   SET_CUSTOM_GAS_PRICE,
   SET_ESTIMATE_SOURCE,
+  SET_CUSTOM_MAX_FEE_PER_GAS,
+  SET_CUSTOM_MAX_PRIORITY_FEE_PER_GAS,
 } from './gas-action-constants';
 
 export const BASIC_ESTIMATE_STATES = {
@@ -34,6 +36,8 @@ const initState = {
   customData: {
     price: null,
     limit: null,
+    maxFeePerGas: null,
+    maxPriorityFeePerGas: null,
   },
   basicEstimates: {
     safeLow: null,
@@ -71,6 +75,22 @@ export default function reducer(state = initState, action) {
         customData: {
           ...state.customData,
           limit: action.value,
+        },
+      };
+    case SET_CUSTOM_MAX_FEE_PER_GAS:
+      return {
+        ...state,
+        customData: {
+          ...state.customData,
+          maxFeePerGas: action.value,
+        },
+      };
+    case SET_CUSTOM_MAX_PRIORITY_FEE_PER_GAS:
+      return {
+        ...state,
+        customData: {
+          ...state.customData,
+          maxPriorityFeePerGas: action.value,
         },
       };
     case RESET_CUSTOM_DATA:
@@ -218,9 +238,24 @@ export function setCustomGasPrice(newPrice) {
 }
 
 export function setCustomGasLimit(newLimit) {
+  console.log('newLimit', newLimit);
   return {
     type: SET_CUSTOM_GAS_LIMIT,
     value: newLimit,
+  };
+}
+
+export function setCustomMaxFeePerGas(newMaxFeePerGas) {
+  return {
+    type: SET_CUSTOM_MAX_FEE_PER_GAS,
+    value: newMaxFeePerGas,
+  };
+}
+
+export function setCustomMaxPriorityFeePerGas(newMaxPriorityFeePerGas) {
+  return {
+    type: SET_CUSTOM_MAX_PRIORITY_FEE_PER_GAS,
+    value: newMaxPriorityFeePerGas,
   };
 }
 

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -24,6 +24,14 @@ export function getCustomGasPrice(state) {
   return state.gas.customData.price;
 }
 
+export function getCustomMaxFeePerGas(state) {
+  return state.gas.customData.maxFeePerGas;
+}
+
+export function getCustomMaxPriorityFeePerGas(state) {
+  return state.gas.customData.maxPriorityFeePerGas;
+}
+
 export function getBasicGasEstimateLoadingStatus(state) {
   return state.gas.basicEstimateStatus === 'LOADING';
 }


### PR DESCRIPTION
Necessary for https://github.com/MetaMask/metamask-extension/issues/11474

Necessary because the `edit-gas-popover` and `edit-gas-display` both need to be able to access the custom values set in the advanced form. This will allow us to control the button, and also properly display the error message, based on the state of those values.