### PR TITLE
EIP-1559 - Disable gas form submission if estimates are loading state

### DIFF
--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -171,7 +171,12 @@ export default function EditGasPopover({
           <Button
             type="primary"
             onClick={onSubmit}
-            disabled={isMaxFeeError || isMaxPriorityFeeError || isGasTooLow}
+            disabled={
+              isMaxFeeError ||
+              isMaxPriorityFeeError ||
+              isGasTooLow ||
+              isGasEstimatesLoading
+            }
           >
             {footerButtonText}
           </Button>


### PR DESCRIPTION
As discussed in the morning meeting, we want to disable form submission if the gas estimates are loading.