### PR TITLE
Create different label for Gas Price with GWEI included

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -103,6 +103,9 @@
   "advanced": {
     "message": "Advanced"
   },
+  "advancedGasPriceTitle": {
+    "message": "Gas price"
+  },
   "advancedOptions": {
     "message": "Advanced Options"
   },

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -149,7 +149,7 @@ export default function AdvancedGasControls({
       ) : (
         <>
           <FormField
-            titleText={t('gasPrice')}
+            titleText={t('advancedGasPriceTitle')}
             titleUnit="(GWEI)"
             onChange={(value) => {
               setGasPrice(value);

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -124,7 +124,7 @@ export default class TransactionBreakdown extends PureComponent {
           </TransactionBreakdownRow>
         )}
         {!process.env.SHOW_EIP_1559_UI && (
-          <TransactionBreakdownRow title={t('gasPrice')}>
+          <TransactionBreakdownRow title={t('advancedGasPriceTitle')}>
             {typeof gasPrice === 'undefined' ? (
               '?'
             ) : (


### PR DESCRIPTION
The current gas price text is `Gas price (GWEI)` but we need just `Gas price`