### PR TITLE
add MODIFY_IN_PLACE as mode prop on edit-gas-popover

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { PageContainerFooter } from '../../ui/page-container';
 import EditGasPopover from '../edit-gas-popover';
+import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
 import {
   ConfirmPageContainerHeader,
   ConfirmPageContainerContent,
@@ -193,6 +194,7 @@ export default class ConfirmPageContainer extends Component {
         )}
         {editingGas && (
           <EditGasPopover
+            mode={EDIT_GAS_MODES.MODIFY_IN_PLACE}
             onClose={handleCloseEditGas}
             transaction={currentTransaction}
           />


### PR DESCRIPTION
This is necessary for the submit method to call the right background process


It was also the only tweak necessary to allow our new UI to modify and submit adjusted maxFee/maxPriorityFee