### PR TITLE
EIP-1559 - Only show education link if on 1559-compatible network

### DIFF
--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -41,7 +41,8 @@ export default function EditGasPopover({
   const dispatch = useDispatch();
   const showSidebar = useSelector((state) => state.appState.sidebar.isOpen);
 
-  const showEducationButton = mode === EDIT_GAS_MODES.MODIFY_IN_PLACE;
+  const showEducationButton =
+    mode === EDIT_GAS_MODES.MODIFY_IN_PLACE && process.env.SHOW_EIP_1559_UI;
   const [showEducationContent, setShowEducationContent] = useState(false);
 
   const [warning] = useState(null);


### PR DESCRIPTION
Looking at the Figma mockups, the education button should only display if on a 1559-compatible network.