### PR TITLE
Handling non-numeric input for chain id in network form

### DIFF
--- a/ui/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/pages/settings/networks-tab/network-form/network-form.component.js
@@ -358,14 +358,27 @@ export default class NetworkForm extends PureComponent {
   };
 
   validateChainIdOnChange = (selfRpcUrl, chainIdArg = '') => {
+    const { t } = this.context;
     const { networksToRender } = this.props;
     const chainId = chainIdArg.trim();
+
     let errorKey = '';
     let errorMessage = '';
     let radix = 10;
-    const hexChainId = chainId.startsWith('0x')
-      ? chainId
-      : `0x${decimalToHex(chainId)}`;
+    let hexChainId = chainId;
+
+    if (!hexChainId.startsWith('0x')) {
+      try {
+        hexChainId = `0x${decimalToHex(hexChainId)}`;
+      } catch (err) {
+        this.setErrorTo('chainId', {
+          key: 'invalidHexNumber',
+          msg: t('invalidHexNumber'),
+        });
+        return;
+      }
+    }
+
     const [matchingChainId] = networksToRender.filter(
       (e) => e.chainId === hexChainId && e.rpcUrl !== selfRpcUrl,
     );
@@ -375,26 +388,26 @@ export default class NetworkForm extends PureComponent {
       return;
     } else if (matchingChainId) {
       errorKey = 'chainIdExistsErrorMsg';
-      errorMessage = this.context.t('chainIdExistsErrorMsg', [
+      errorMessage = t('chainIdExistsErrorMsg', [
         matchingChainId.label ?? matchingChainId.labelKey,
       ]);
     } else if (chainId.startsWith('0x')) {
       radix = 16;
       if (!/^0x[0-9a-f]+$/iu.test(chainId)) {
         errorKey = 'invalidHexNumber';
-        errorMessage = this.context.t('invalidHexNumber');
+        errorMessage = t('invalidHexNumber');
       } else if (!isPrefixedFormattedHexString(chainId)) {
-        errorMessage = this.context.t('invalidHexNumberLeadingZeros');
+        errorMessage = t('invalidHexNumberLeadingZeros');
       }
     } else if (!/^[0-9]+$/u.test(chainId)) {
       errorKey = 'invalidNumber';
-      errorMessage = this.context.t('invalidNumber');
+      errorMessage = t('invalidNumber');
     } else if (chainId.startsWith('0')) {
       errorKey = 'invalidNumberLeadingZeros';
-      errorMessage = this.context.t('invalidNumberLeadingZeros');
+      errorMessage = t('invalidNumberLeadingZeros');
     } else if (!isSafeChainId(parseInt(chainId, radix))) {
       errorKey = 'invalidChainIdTooBig';
-      errorMessage = this.context.t('invalidChainIdTooBig');
+      errorMessage = t('invalidChainIdTooBig');
     }
 
     this.setErrorTo('chainId', {


### PR DESCRIPTION
 Catches error that throws when non-numeric input is supplied to `decimalToHex`, and renders validation error to user

New Error Behavior:
<img width="385" alt="Screen Shot 2021-07-15 at 3 12 06 AM" src="https://user-images.githubusercontent.com/8732757/125771522-675899fb-1e47-4e3c-9652-12a8833dda32.png">