### PR TITLE
Retrieve state after async action before updating state in _setSwapsQuoteRefreshTime

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -130,8 +130,10 @@ export default class SwapsController {
       console.error('Request for swaps quote refresh time failed: ', e);
     }
 
+    const { swapsState: latestSwapsState } = this.store.getState();
+
     this.store.updateState({
-      swapsState: { ...swapsState, swapsQuoteRefreshTime },
+      swapsState: { ...latestSwapsState, swapsQuoteRefreshTime },
     });
   }
 


### PR DESCRIPTION
This fixes an issue introduced with v9.8.0

The bug this fixes can be reproduced as follows:

1. Request quotes in swaps
2. Once on the view quote screen click "Back"
3. Once on the build quote screen click "Review Swap" again
4. You will see an error screen

In #11470, we moved the `getState()` call in `_setSwapsQuoteRefreshTime`. So the `updateState` call in that method might now overwrite state with a version of state from before the async call in that method. If state changed during the async call, the update within `_setSwapsQuoteRefreshTime` would overwrite those changes.

This PR fixes the issue by again retrieving state after the async call, so that the most recent state is not getting overwritten.  