### PR TITLE
EIP-1559 - Don't show submit button  when in education mode, don't duplicate title

### DIFF
--- a/ui/components/app/edit-gas-display-education/edit-gas-display-education.component.js
+++ b/ui/components/app/edit-gas-display-education/edit-gas-display-education.component.js
@@ -14,13 +14,6 @@ export default function EditGasDisplayEducation() {
 
   return (
     <div className="edit-gas-display-education">
-      <Typography
-        color={COLORS.BLACK}
-        variant={TYPOGRAPHY.H4}
-        fontWeight={FONT_WEIGHT.BOLD}
-      >
-        {t('editGasEducationModalTitle')}
-      </Typography>
       <Typography tag="p" color={COLORS.UI4} variant={TYPOGRAPHY.H6}>
         {t('editGasEducationModalIntro')}
       </Typography>

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -168,20 +168,22 @@ export default function EditGasPopover({
         showEducationContent ? () => setShowEducationContent(false) : undefined
       }
       footer={
-        <>
-          <Button
-            type="primary"
-            onClick={onSubmit}
-            disabled={
-              isMaxFeeError ||
-              isMaxPriorityFeeError ||
-              isGasTooLow ||
-              isGasEstimatesLoading
-            }
-          >
-            {footerButtonText}
-          </Button>
-        </>
+        showEducationContent ? null : (
+          <>
+            <Button
+              type="primary"
+              onClick={onSubmit}
+              disabled={
+                isMaxFeeError ||
+                isMaxPriorityFeeError ||
+                isGasTooLow ||
+                isGasEstimatesLoading
+              }
+            >
+              {footerButtonText}
+            </Button>
+          </>
+        )
       }
     >
       <div style={{ padding: '0 20px 20px 20px' }}>


### PR DESCRIPTION
I noticed that the title of the education content displayed twice, both as the popover title and the heading of the content, so I removed that problem.  Additionally, we should hide the submission button when the education content is displaying.