### PR TITLE
Improve handling for block explorer url host extraction (AccountOptionsMenu)

### DIFF
--- a/ui/components/app/menu-bar/account-options-menu.js
+++ b/ui/components/app/menu-bar/account-options-menu.js
@@ -32,6 +32,15 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
   const selectedIdentity = useSelector(getSelectedIdentity);
   const { address } = selectedIdentity;
   const addressLink = getAccountLink(address, chainId, rpcPrefs);
+  const { blockExplorerUrl } = rpcPrefs;
+
+  const getBlockExplorerUrlHost = () => {
+    try {
+      return new URL(blockExplorerUrl)?.hostname;
+    } catch (err) {
+      return '';
+    }
+  };
 
   const openFullscreenEvent = useMetricEvent({
     eventOpts: {
@@ -67,6 +76,7 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
   });
 
   const isRemovable = keyring.type !== 'HD Key Tree';
+  const blockExplorerUrlSubTitle = getBlockExplorerUrlHost();
 
   return (
     <Menu
@@ -106,9 +116,9 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
           onClose();
         }}
         subtitle={
-          rpcPrefs.blockExplorerUrl ? (
+          blockExplorerUrlSubTitle ? (
             <span className="account-options-menu__explorer-origin">
-              {rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1]}
+              {blockExplorerUrlSubTitle}
             </span>
           ) : null
         }


### PR DESCRIPTION
(Sentry error fix) In the event a user has an invalid block explorer url for the current network, (follow up: investigate how this may be given we validate urls in the network form) the existing regex method for host extraction will fail. At any rate, this lets `URL` do the heavy lifting.