### PR TITLE
Fix actionable message icon size

### DIFF
--- a/ui/components/ui/actionable-message/index.scss
+++ b/ui/components/ui/actionable-message/index.scss
@@ -17,7 +17,7 @@
     justify-content: normal;
   }
 
-  &__icon {
+  svg {
     width: 16px;
     height: 16px;
     position: absolute;


### PR DESCRIPTION
A few PRs collided and the actionable message icon selector no longer matches and was showing at a huge size -- this fixes the selector.