### PR TITLE
update send slice to work with EIP 1559 networks

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -27,7 +27,11 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
-import { GAS_LIMITS } from '../../../../shared/constants/gas';
+import {
+  GAS_LIMITS,
+  GAS_ESTIMATE_TYPES,
+} from '../../../../shared/constants/gas';
+import { decGWEIToHexWEI } from '../../../../shared/modules/conversion.utils';
 import {
   HARDFORKS,
   MAINNET,
@@ -107,6 +111,7 @@ export default class TransactionController extends EventEmitter {
     this.inProcessOfSigning = new Set();
     this._trackMetaMetricsEvent = opts.trackMetaMetricsEvent;
     this._getParticipateInMetrics = opts.getParticipateInMetrics;
+    this._getEIP1559GasFeeEstimates = opts.getEIP1559GasFeeEstimates;
 
     this.memStore = new ObservableStore({});
     this.query = new EthQuery(this.provider);
@@ -399,7 +404,13 @@ export default class TransactionController extends EventEmitter {
    * @returns {Promise<object>} resolves with txMeta
    */
   async addTxGasDefaults(txMeta, getCodeResponse) {
-    const defaultGasPrice = await this._getDefaultGasPrice(txMeta);
+    const eip1559Compatibility = await this.getEIP1559Compatibility();
+
+    const {
+      gasPrice: defaultGasPrice,
+      maxFeePerGas: defaultMaxFeePerGas,
+      maxPriorityFeePerGas: defaultMaxPriorityFeePerGas,
+    } = await this._getDefaultGasFees(txMeta, eip1559Compatibility);
     const {
       gasLimit: defaultGasLimit,
       simulationFails,
@@ -410,6 +421,67 @@ export default class TransactionController extends EventEmitter {
     if (simulationFails) {
       txMeta.simulationFails = simulationFails;
     }
+
+    if (eip1559Compatibility) {
+      // If the dapp has suggested a gas price, but no maxFeePerGas or maxPriorityFeePerGas
+      //  then we set maxFeePerGas and maxPriorityFeePerGas to the suggested gasPrice.
+      if (
+        txMeta.txParams.gasPrice &&
+        !txMeta.txParams.maxFeePerGas &&
+        !txMeta.txParams.maxPriorityFeePerGas
+      ) {
+        txMeta.txParams.maxFeePerGas = txMeta.txParams.gasPrice;
+        txMeta.txParams.maxPriorityFeePerGas = txMeta.txParams.gasPrice;
+      } else {
+        if (defaultMaxFeePerGas && !txMeta.txParams.maxFeePerGas) {
+          // If the dapp has not set the gasPrice or the maxFeePerGas, then we set maxFeePerGas
+          // with the one returned by the gasFeeController, if that is available.
+          txMeta.txParams.maxFeePerGas = defaultMaxFeePerGas;
+        }
+
+        if (
+          defaultMaxPriorityFeePerGas &&
+          !txMeta.txParams.maxPriorityFeePerGas
+        ) {
+          // If the dapp has not set the gasPrice or the maxPriorityFeePerGas, then we set maxPriorityFeePerGas
+          // with the one returned by the gasFeeController, if that is available.
+          txMeta.txParams.maxPriorityFeePerGas = defaultMaxPriorityFeePerGas;
+        }
+
+        if (defaultGasPrice && !txMeta.txParams.maxFeePerGas) {
+          // If the dapp has not set the gasPrice or the maxFeePerGas, and no maxFeePerGas is available
+          // from the gasFeeController, then we set maxFeePerGas to the defaultGasPrice, assuming it is
+          // available.
+          txMeta.txParams.maxFeePerGas = defaultGasPrice;
+        }
+
+        if (
+          txMeta.txParams.maxFeePerGas &&
+          !txMeta.txParams.maxPriorityFeePerGas
+        ) {
+          // If the dapp has not set the gasPrice or the maxPriorityFeePerGas, and no maxPriorityFeePerGas is
+          // available from the gasFeeController, then we set maxPriorityFeePerGas to
+          // txMeta.txParams.maxFeePerGas, which will either be the gasPrice from the controller, the maxFeePerGas
+          // set by the dapp, or the maxFeePerGas from the controller.
+          txMeta.txParams.maxPriorityFeePerGas = txMeta.txParams.maxFeePerGas;
+        }
+      }
+
+      // We remove the gasPrice param entirely when on an eip1559 compatible network
+
+      delete txMeta.txParams.gasPrice;
+    } else {
+      // We ensure that maxFeePerGas and maxPriorityFeePerGas are not in the transaction params
+      // when not on a EIP1559 compatible network
+
+      delete txMeta.txParams.maxPriorityFeePerGas;
+      delete txMeta.txParams.maxFeePerGas;
+    }
+
+    // If we have gotten to this point, and none of gasPrice, maxPriorityFeePerGas or maxFeePerGas are
+    // set on txParams, it means that either we are on a non-EIP1559 network and the dapp didn't suggest
+    // a gas price, or we are on an EIP1559 network, and none of gasPrice, maxPriorityFeePerGas or maxFeePerGas
+    // were available from either the dapp or the network.
     if (
       defaultGasPrice &&
       !txMeta.txParams.gasPrice &&
@@ -418,6 +490,7 @@ export default class TransactionController extends EventEmitter {
     ) {
       txMeta.txParams.gasPrice = defaultGasPrice;
     }
+
     if (defaultGasLimit && !txMeta.txParams.gas) {
       txMeta.txParams.gas = defaultGasLimit;
     }
@@ -425,20 +498,59 @@ export default class TransactionController extends EventEmitter {
   }
 
   /**
-   * Gets default gas price, or returns `undefined` if gas price is already set
+   * Gets default gas fees, or returns `undefined` if gas fees are already set
    * @param {Object} txMeta - The txMeta object
    * @returns {Promise<string|undefined>} The default gas price
    */
-  async _getDefaultGasPrice(txMeta) {
+  async _getDefaultGasFees(txMeta, eip1559Compatibility) {
     if (
-      txMeta.txParams.gasPrice ||
+      (!eip1559Compatibility && txMeta.txParams.gasPrice) ||
       (txMeta.txParams.maxFeePerGas && txMeta.txParams.maxPriorityFeePerGas)
     ) {
-      return undefined;
+      return {};
     }
+
+    try {
+      const {
+        gasFeeEstimates,
+        gasEstimateType,
+      } = await this._getEIP1559GasFeeEstimates();
+      if (
+        eip1559Compatibility &&
+        gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET
+      ) {
+        const {
+          medium: { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } = {},
+        } = gasFeeEstimates;
+
+        if (suggestedMaxPriorityFeePerGas && suggestedMaxFeePerGas) {
+          return {
+            maxFeePerGas: decGWEIToHexWEI(suggestedMaxFeePerGas),
+            maxPriorityFeePerGas: decGWEIToHexWEI(
+              suggestedMaxPriorityFeePerGas,
+            ),
+          };
+        }
+      } else if (gasEstimateType === GAS_ESTIMATE_TYPES.LEGACY) {
+        // The LEGACY type includes low, medium and high estimates of
+        // gas price values.
+        return {
+          gasPrice: decGWEIToHexWEI(gasFeeEstimates.medium),
+        };
+      } else if (gasEstimateType === GAS_ESTIMATE_TYPES.ETH_GASPRICE) {
+        // The ETH_GASPRICE type just includes a single gas price property,
+        // which we can assume was retrieved from eth_gasPrice
+        return {
+          gasPrice: decGWEIToHexWEI(gasFeeEstimates.gasPrice),
+        };
+      }
+    } catch (e) {
+      console.error(e);
+    }
+
     const gasPrice = await this.query.gasPrice();
 
-    return addHexPrefix(gasPrice.toString(16));
+    return { gasPrice: gasPrice && addHexPrefix(gasPrice.toString(16)) };
   }
 
   /**
@@ -682,6 +794,7 @@ export default class TransactionController extends EventEmitter {
       this.txStateManager.setTxStatusApproved(txId);
       // get next nonce
       const txMeta = this.txStateManager.getTransaction(txId);
+
       const fromAddress = txMeta.txParams.from;
       // wait for a nonce
       let { customNonceValue } = txMeta;

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -14,6 +14,7 @@ import {
   TRANSACTION_TYPES,
 } from '../../../../shared/constants/transaction';
 import { SECOND } from '../../../../shared/constants/time';
+import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
 import TransactionController, { TRANSACTION_EVENTS } from '.';
 
@@ -50,9 +51,8 @@ describe('Transaction Controller', function () {
         return '0xee6b2800';
       },
       networkStore: new ObservableStore(currentNetworkId),
-      getEIP1559Compatibility: () => Promise.resolve(true),
-      getCurrentNetworkEIP1559Compatibility: () => Promise.resolve(true),
-      getCurrentAccountEIP1559Compatibility: () => true,
+      getCurrentNetworkEIP1559Compatibility: () => Promise.resolve(false),
+      getCurrentAccountEIP1559Compatibility: () => false,
       txHistoryLimit: 10,
       blockTracker: blockTrackerStub,
       signTransaction: (ethTx) =>
@@ -64,6 +64,7 @@ describe('Transaction Controller', function () {
       getCurrentChainId: () => currentChainId,
       getParticipateInMetrics: () => false,
       trackMetaMetricsEvent: () => undefined,
+      getEIP1559GasFeeEstimates: () => undefined,
     });
     txController.nonceTracker.getNonceLock = () =>
       Promise.resolve({ nextNonce: 0, releaseLock: noop });
@@ -418,6 +419,237 @@ describe('Transaction Controller', function () {
         txMetaWithDefaults.txParams.gas,
         'should have added the gas field',
       );
+    });
+
+    it('should add EIP1559 tx defaults', async function () {
+      const TEST_MAX_FEE_PER_GAS = '0x12a05f200';
+      const TEST_MAX_PRIORITY_FEE_PER_GAS = '0x77359400';
+
+      const stub1 = sinon
+        .stub(txController, 'getEIP1559Compatibility')
+        .returns(true);
+
+      const stub2 = sinon
+        .stub(txController, '_getDefaultGasFees')
+        .callsFake(() => ({
+          maxFeePerGas: TEST_MAX_FEE_PER_GAS,
+          maxPriorityFeePerGas: TEST_MAX_PRIORITY_FEE_PER_GAS,
+        }));
+
+      txController.txStateManager._addTransactionsToState([
+        {
+          id: 1,
+          status: TRANSACTION_STATUSES.UNAPPROVED,
+          metamaskNetworkId: currentNetworkId,
+          txParams: {
+            to: VALID_ADDRESS,
+            from: VALID_ADDRESS_TWO,
+          },
+          history: [{}],
+        },
+      ]);
+      const txMeta = {
+        id: 1,
+        txParams: {
+          from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+          to: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+        },
+        history: [{}],
+      };
+      providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
+      providerResultStub.eth_estimateGas = '5209';
+
+      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+
+      assert.equal(
+        txMetaWithDefaults.txParams.maxFeePerGas,
+        TEST_MAX_FEE_PER_GAS,
+        'should have added the correct max fee per gas',
+      );
+      assert.equal(
+        txMetaWithDefaults.txParams.maxPriorityFeePerGas,
+        TEST_MAX_PRIORITY_FEE_PER_GAS,
+        'should have added the correct max priority fee per gas',
+      );
+      stub1.restore();
+      stub2.restore();
+    });
+
+    it('should add gasPrice as maxFeePerGas and maxPriorityFeePerGas if there are no sources of other fee data available', async function () {
+      const TEST_GASPRICE = '0x12a05f200';
+
+      const stub1 = sinon
+        .stub(txController, 'getEIP1559Compatibility')
+        .returns(true);
+
+      const stub2 = sinon
+        .stub(txController, '_getDefaultGasFees')
+        .callsFake(() => ({ gasPrice: TEST_GASPRICE }));
+
+      txController.txStateManager._addTransactionsToState([
+        {
+          id: 1,
+          status: TRANSACTION_STATUSES.UNAPPROVED,
+          metamaskNetworkId: currentNetworkId,
+          txParams: {
+            to: VALID_ADDRESS,
+            from: VALID_ADDRESS_TWO,
+          },
+          history: [{}],
+        },
+      ]);
+      const txMeta = {
+        id: 1,
+        txParams: {
+          from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+          to: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+        },
+        history: [{}],
+      };
+      providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
+      providerResultStub.eth_estimateGas = '5209';
+
+      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+
+      assert.equal(
+        txMetaWithDefaults.txParams.maxFeePerGas,
+        TEST_GASPRICE,
+        'should have added the correct max fee per gas',
+      );
+      assert.equal(
+        txMetaWithDefaults.txParams.maxPriorityFeePerGas,
+        TEST_GASPRICE,
+        'should have added the correct max priority fee per gas',
+      );
+      stub1.restore();
+      stub2.restore();
+    });
+
+    it('should not add gasPrice if the fee data is available from the dapp', async function () {
+      const TEST_GASPRICE = '0x12a05f200';
+      const TEST_MAX_FEE_PER_GAS = '0x12a05f200';
+      const TEST_MAX_PRIORITY_FEE_PER_GAS = '0x77359400';
+
+      const stub1 = sinon
+        .stub(txController, 'getEIP1559Compatibility')
+        .returns(true);
+
+      const stub2 = sinon
+        .stub(txController, '_getDefaultGasFees')
+        .callsFake(() => ({ gasPrice: TEST_GASPRICE }));
+
+      txController.txStateManager._addTransactionsToState([
+        {
+          id: 1,
+          status: TRANSACTION_STATUSES.UNAPPROVED,
+          metamaskNetworkId: currentNetworkId,
+          txParams: {
+            to: VALID_ADDRESS,
+            from: VALID_ADDRESS_TWO,
+            maxFeePerGas: TEST_MAX_FEE_PER_GAS,
+            maxPriorityFeePerGas: TEST_MAX_PRIORITY_FEE_PER_GAS,
+          },
+          history: [{}],
+        },
+      ]);
+      const txMeta = {
+        id: 1,
+        txParams: {
+          from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+          to: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+        },
+        history: [{}],
+      };
+      providerResultStub.eth_getBlockByNumber = { gasLimit: '47b784' };
+      providerResultStub.eth_estimateGas = '5209';
+
+      const txMetaWithDefaults = await txController.addTxGasDefaults(txMeta);
+
+      assert.equal(
+        txMetaWithDefaults.txParams.maxFeePerGas,
+        TEST_MAX_FEE_PER_GAS,
+        'should have added the correct max fee per gas',
+      );
+      assert.equal(
+        txMetaWithDefaults.txParams.maxPriorityFeePerGas,
+        TEST_MAX_PRIORITY_FEE_PER_GAS,
+        'should have added the correct max priority fee per gas',
+      );
+      stub1.restore();
+      stub2.restore();
+    });
+  });
+
+  describe('_getDefaultGasFees', function () {
+    let getGasFeeStub;
+
+    beforeEach(function () {
+      getGasFeeStub = sinon.stub(txController, '_getEIP1559GasFeeEstimates');
+    });
+
+    afterEach(function () {
+      getGasFeeStub.restore();
+    });
+
+    it('should return the correct fee data when the gas estimate type is FEE_MARKET', async function () {
+      const EXPECTED_MAX_FEE_PER_GAS = '12a05f200';
+      const EXPECTED_MAX_PRIORITY_FEE_PER_GAS = '77359400';
+
+      getGasFeeStub.callsFake(() => ({
+        gasFeeEstimates: {
+          medium: {
+            suggestedMaxPriorityFeePerGas: '2',
+            suggestedMaxFeePerGas: '5',
+          },
+        },
+        gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
+      }));
+
+      const defaultGasFees = await txController._getDefaultGasFees(
+        { txParams: {} },
+        true,
+      );
+
+      assert.deepEqual(defaultGasFees, {
+        maxPriorityFeePerGas: EXPECTED_MAX_PRIORITY_FEE_PER_GAS,
+        maxFeePerGas: EXPECTED_MAX_FEE_PER_GAS,
+      });
+    });
+
+    it('should return the correct fee data when the gas estimate type is LEGACY', async function () {
+      const EXPECTED_GAS_PRICE = '77359400';
+
+      getGasFeeStub.callsFake(() => ({
+        gasFeeEstimates: { medium: '2' },
+        gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
+      }));
+
+      const defaultGasFees = await txController._getDefaultGasFees(
+        { txParams: {} },
+        false,
+      );
+
+      assert.deepEqual(defaultGasFees, {
+        gasPrice: EXPECTED_GAS_PRICE,
+      });
+    });
+
+    it('should return the correct fee data when the gas estimate type is ETH_GASPRICE', async function () {
+      const EXPECTED_GAS_PRICE = '77359400';
+
+      getGasFeeStub.callsFake(() => ({
+        gasFeeEstimates: { gasPrice: '2' },
+        gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,
+      }));
+
+      const defaultGasFees = await txController._getDefaultGasFees(
+        { txParams: {} },
+        false,
+      );
+
+      assert.deepEqual(defaultGasFees, {
+        gasPrice: EXPECTED_GAS_PRICE,
+      });
     });
   });
 
@@ -807,6 +1039,9 @@ describe('Transaction Controller', function () {
     });
 
     it('sets txParams.type to 0x2 (EIP-1559)', async function () {
+      const eip1559CompatibilityStub = sinon
+        .stub(txController, 'getEIP1559Compatibility')
+        .returns(true);
       txController.txStateManager._addTransactionsToState([
         {
           status: TRANSACTION_STATUSES.UNAPPROVED,
@@ -825,6 +1060,7 @@ describe('Transaction Controller', function () {
       ]);
       await txController.signTransaction('2');
       assert.equal(fromTxDataSpy.getCall(0).args[0].type, '0x2');
+      eip1559CompatibilityStub.restore();
     });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -423,6 +423,9 @@ export default class MetamaskController extends EventEmitter {
       ),
       getParticipateInMetrics: () =>
         this.metaMetricsController.state.participateInMetaMetrics,
+      getEIP1559GasFeeEstimates: this.gasFeeController.fetchGasFeeEstimates.bind(
+        this.gasFeeController,
+      ),
     });
     this.txController.on('newUnapprovedTx', () => opts.showUserConfirmation());
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,10 @@
 module.exports = {
   restoreMocks: true,
   coverageDirectory: 'jest-coverage/',
-  collectCoverageFrom: ['<rootDir>/ui/**/swaps/**'],
+  collectCoverageFrom: [
+    '<rootDir>/ui/**/swaps/**',
+    '<rootDir>/ui/ducks/send/**',
+  ],
   coveragePathIgnorePatterns: ['.stories.js', '.snap'],
   coverageThreshold: {
     global: {

--- a/shared/modules/conversion.utils.js
+++ b/shared/modules/conversion.utils.js
@@ -268,7 +268,7 @@ const toNegative = (n, options = {}) => {
   return multiplyCurrencies(n, -1, options);
 };
 
-export function decGWEIToHexWEI(decGWEI) {
+function decGWEIToHexWEI(decGWEI) {
   return conversionUtil(decGWEI, {
     fromNumericBase: 'dec',
     toNumericBase: 'hex',
@@ -288,4 +288,5 @@ export {
   conversionMax,
   toNegative,
   subtractCurrencies,
+  decGWEIToHexWEI,
 };

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -34,31 +34,33 @@ export default function AdvancedGasControls({
   maxFeeFiat,
   gasErrors,
   minimumGasLimit = 21000,
+  networkSupportsEIP1559,
 }) {
   const t = useContext(I18nContext);
 
   const suggestedValues = {};
 
-  switch (gasEstimateType) {
-    case GAS_ESTIMATE_TYPES.FEE_MARKET:
-      suggestedValues.maxPriorityFeePerGas =
-        gasFeeEstimates?.[estimateToUse]?.suggestedMaxPriorityFeePerGas;
-      suggestedValues.maxFeePerGas =
-        gasFeeEstimates?.[estimateToUse]?.suggestedMaxFeePerGas;
-      break;
-    case GAS_ESTIMATE_TYPES.LEGACY:
-      suggestedValues.gasPrice = gasFeeEstimates?.[estimateToUse];
-      break;
-    case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
-      suggestedValues.gasPrice = gasFeeEstimates?.gasPrice;
-      break;
-    default:
-      break;
+  if (networkSupportsEIP1559) {
+    suggestedValues.maxFeePerGas =
+      gasFeeEstimates?.[estimateToUse]?.suggestedMaxFeePerGas ||
+      gasFeeEstimates?.gasPrice;
+    suggestedValues.maxPriorityFeePerGas =
+      gasFeeEstimates?.[estimateToUse]?.suggestedMaxPriorityFeePerGas ||
+      suggestedValues.maxFeePerGas;
+  } else {
+    switch (gasEstimateType) {
+      case GAS_ESTIMATE_TYPES.LEGACY:
+        suggestedValues.gasPrice = gasFeeEstimates?.[estimateToUse];
+        break;
+      case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
+        suggestedValues.gasPrice = gasFeeEstimates?.gasPrice;
+        break;
+      default:
+        break;
+    }
   }
 
-  const showFeeMarketFields =
-    process.env.SHOW_EIP_1559_UI &&
-    gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET;
+  const showFeeMarketFields = networkSupportsEIP1559;
 
   return (
     <div className="advanced-gas-controls">
@@ -233,4 +235,5 @@ AdvancedGasControls.propTypes = {
   maxFeeFiat: PropTypes.string,
   gasErrors: PropTypes.object,
   minimumGasLimit: PropTypes.number,
+  networkSupportsEIP1559: PropTypes.object,
 };

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -7,10 +7,10 @@ import {
   EDIT_GAS_MODES,
 } from '../../../../shared/constants/gas';
 
-import { isEIP1559Network } from '../../../ducks/metamask/metamask';
-
 import Button from '../../ui/button';
 import Typography from '../../ui/typography/typography';
+import { isEIP1559Network } from '../../../ducks/metamask/metamask';
+
 import {
   COLORS,
   TYPOGRAPHY,
@@ -63,6 +63,7 @@ export default function EditGasDisplay({
   balanceError,
 }) {
   const t = useContext(I18nContext);
+  const supportsEIP1559 = useSelector(isEIP1559Network);
 
   const dappSuggestedAndTxParamGasFeesAreTheSame = areDappSuggestedAndTxParamGasFeesTheSame(
     transaction,
@@ -220,6 +221,7 @@ export default function EditGasDisplay({
             gasErrors={gasErrors}
             onManualChange={onManualChange}
             minimumGasLimit={minimumGasLimit}
+            networkSupportsEIP1559={supportsEIP1559}
           />
         )}
       </div>

--- a/ui/hooks/useGasFeeEstimates.test.js
+++ b/ui/hooks/useGasFeeEstimates.test.js
@@ -173,11 +173,11 @@ describe('useGasFeeEstimates', () => {
     });
   });
 
-  it('indicates that gas estimates are loading when gasEstimateType is not FEE_MARKET but network supports EIP-1559', () => {
+  it('indicates that gas estimates are loading when gasEstimateType is not FEE_MARKET or ETH_GASPRICE, but network supports EIP-1559', () => {
     useSelector.mockImplementation(
       generateUseSelectorRouter({
         isEIP1559Network: true,
-        gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,
+        gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
         gasFeeEstimates: {
           gasPrice: '10',
         },
@@ -189,7 +189,7 @@ describe('useGasFeeEstimates', () => {
     } = renderHook(() => useGasFeeEstimates());
     expect(current).toMatchObject({
       gasFeeEstimates: { gasPrice: '10' },
-      gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,
+      gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
       estimatedGasFeeTimeBounds: undefined,
       isGasEstimatesLoading: true,
     });

--- a/ui/hooks/useGasFeeInputs.test.js
+++ b/ui/hooks/useGasFeeInputs.test.js
@@ -3,9 +3,11 @@ import { useSelector } from 'react-redux';
 import { GAS_ESTIMATE_TYPES } from '../../shared/constants/gas';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import {
+  isEIP1559Network,
   getConversionRate,
   getNativeCurrency,
 } from '../ducks/metamask/metamask';
+
 import { ETH, PRIMARY } from '../helpers/constants/common';
 import {
   getCurrentCurrency,
@@ -102,7 +104,9 @@ const HIGH_FEE_MARKET_ESTIMATE_RETURN_VALUE = {
   estimatedGasFeeTimeBounds: {},
 };
 
-const generateUseSelectorRouter = () => (selector) => {
+const generateUseSelectorRouter = ({ isEIP1559NetworkResponse } = {}) => (
+  selector,
+) => {
   if (selector === getConversionRate) {
     return MOCK_ETH_USD_CONVERSION_RATE;
   }
@@ -126,6 +130,9 @@ const generateUseSelectorRouter = () => (selector) => {
     return {
       balance: '0x440aa47cc2556',
     };
+  }
+  if (selector === isEIP1559Network) {
+    return isEIP1559NetworkResponse;
   }
   return undefined;
 };
@@ -178,6 +185,9 @@ describe('useGasFeeInputs', () => {
     });
 
     it('updates values when user modifies gasPrice', () => {
+      useSelector.mockImplementation(
+        generateUseSelectorRouter({ isEIP1559NetworkResponse: false }),
+      );
       const { result } = renderHook(() => useGasFeeInputs());
       expect(result.current.gasPrice).toBe(
         LEGACY_GAS_ESTIMATE_RETURN_VALUE.gasFeeEstimates.medium,
@@ -242,6 +252,9 @@ describe('useGasFeeInputs', () => {
     });
 
     it('updates values when user modifies maxFeePerGas', () => {
+      useSelector.mockImplementation(
+        generateUseSelectorRouter({ isEIP1559NetworkResponse: true }),
+      );
       const { result } = renderHook(() => useGasFeeInputs());
       expect(result.current.maxFeePerGas).toBe(
         FEE_MARKET_ESTIMATE_RETURN_VALUE.gasFeeEstimates.medium
@@ -297,7 +310,9 @@ describe('useGasFeeInputs', () => {
       useGasFeeEstimates.mockImplementation(
         () => HIGH_FEE_MARKET_ESTIMATE_RETURN_VALUE,
       );
-      useSelector.mockImplementation(generateUseSelectorRouter());
+      useSelector.mockImplementation(
+        generateUseSelectorRouter({ isEIP1559NetworkResponse: true }),
+      );
     });
 
     it('should return true', () => {

--- a/ui/hooks/useSafeGasEstimatePolling.js
+++ b/ui/hooks/useSafeGasEstimatePolling.js
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import {
+  disconnectGasFeeEstimatePoller,
+  getGasFeeEstimatesAndStartPolling,
+} from '../store/actions';
+
+/**
+ * Provides a reusable hook that can be used for safely updating the polling
+ * data in the gas fee controller. It makes a request to get estimates and
+ * begin polling, keeping track of the poll token for the lifetime of the hook.
+ * It then disconnects polling upon unmount. If the hook is unmounted while waiting
+ * for `getGasFeeEstimatesAndStartPolling` to resolve, the `active` flag ensures
+ * that a call to disconnect happens after promise resolution.
+ */
+export function useSafeGasEstimatePolling() {
+  useEffect(() => {
+    let active = true;
+    let pollToken;
+    getGasFeeEstimatesAndStartPolling().then((newPollToken) => {
+      if (active) {
+        pollToken = newPollToken;
+      } else {
+        disconnectGasFeeEstimatePoller(newPollToken);
+      }
+    });
+    return () => {
+      active = false;
+      if (pollToken) {
+        disconnectGasFeeEstimatePoller(pollToken);
+      }
+    };
+  }, []);
+}

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -39,6 +39,10 @@ import InfoTooltip from '../../components/ui/info-tooltip/info-tooltip';
 import GasTiming from '../../components/app/gas-timing/gas-timing.component';
 
 import { COLORS } from '../../helpers/constants/design-system';
+import {
+  disconnectGasFeeEstimatePoller,
+  getGasFeeEstimatesAndStartPolling,
+} from '../../store/actions';
 
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
@@ -58,7 +62,8 @@ export default class ConfirmTransactionBase extends Component {
     fromAddress: PropTypes.string,
     fromName: PropTypes.string,
     hexTransactionAmount: PropTypes.string,
-    hexTransactionFee: PropTypes.string,
+    hexMinimumTransactionFee: PropTypes.string,
+    hexMaximumTransactionFee: PropTypes.string,
     hexTransactionTotal: PropTypes.string,
     methodData: PropTypes.object,
     nonce: PropTypes.string,
@@ -191,7 +196,7 @@ export default class ConfirmTransactionBase extends Component {
     const {
       balance,
       conversionRate,
-      hexTransactionFee,
+      hexMaximumTransactionFee,
       txData: { simulationFails, txParams: { value: amount } = {} } = {},
       customGas,
       noGasPrice,
@@ -201,7 +206,7 @@ export default class ConfirmTransactionBase extends Component {
       balance &&
       !isBalanceSufficient({
         amount,
-        gasTotal: hexTransactionFee || '0x0',
+        gasTotal: hexMaximumTransactionFee || '0x0',
         balance,
         conversionRate,
       });
@@ -282,7 +287,7 @@ export default class ConfirmTransactionBase extends Component {
     const {
       primaryTotalTextOverride,
       secondaryTotalTextOverride,
-      hexTransactionFee,
+      hexMinimumTransactionFee,
       hexTransactionTotal,
       useNonceField,
       customNonceValue,
@@ -422,14 +427,14 @@ export default class ConfirmTransactionBase extends Component {
                 detailText={
                   <UserPreferencedCurrencyDisplay
                     type={PRIMARY}
-                    value={hexTransactionFee}
+                    value={hexMinimumTransactionFee}
                     hideLabel={false}
                   />
                 }
                 detailTotal={
                   <UserPreferencedCurrencyDisplay
                     type={SECONDARY}
-                    value={hexTransactionFee}
+                    value={hexMinimumTransactionFee}
                     hideLabel
                   />
                 }
@@ -496,7 +501,7 @@ export default class ConfirmTransactionBase extends Component {
         <div className="confirm-page-container-content__gas-fee">
           <ConfirmDetailRow
             label={t('gasFee')}
-            value={hexTransactionFee}
+            value={hexMinimumTransactionFee}
             headerText={showGasEditButton ? t('edit') : ''}
             headerTextClassName={
               showGasEditButton ? 'confirm-detail-row__header-text--edit' : ''
@@ -769,6 +774,7 @@ export default class ConfirmTransactionBase extends Component {
   };
 
   componentDidMount() {
+    this._isMounted = true;
     const {
       toAddress,
       txData: { origin } = {},
@@ -795,9 +801,28 @@ export default class ConfirmTransactionBase extends Component {
     if (toAddress) {
       tryReverseResolveAddress(toAddress);
     }
+
+    /**
+     * This makes a request to get estimates and begin polling, keeping track of the poll
+     * token in component state.
+     * It then disconnects polling upon componentWillUnmount. If the hook is unmounted
+     * while waiting for `getGasFeeEstimatesAndStartPolling` to resolve, the `_isMounted`
+     * flag ensures that a call to disconnect happens after promise resolution.
+     */
+    getGasFeeEstimatesAndStartPolling().then((pollingToken) => {
+      if (this._isMounted) {
+        this.setState({ pollingToken });
+      } else {
+        disconnectGasFeeEstimatePoller(pollingToken);
+      }
+    });
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
+    if (this.state.pollingToken) {
+      disconnectGasFeeEstimatePoller(this.state.pollingToken);
+    }
     this._removeBeforeUnload();
   }
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -38,7 +38,10 @@ import {
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { transactionMatchesNetwork } from '../../../shared/modules/transaction.utils';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
-import { updateTransactionGasFees } from '../../ducks/metamask/metamask';
+import {
+  updateTransactionGasFees,
+  isEIP1559Network,
+} from '../../ducks/metamask/metamask';
 import ConfirmTransactionBase from './confirm-transaction-base.component';
 
 const casedContractMap = Object.keys(contractMap).reduce((acc, base) => {
@@ -65,6 +68,7 @@ const mapStateToProps = (state, ownProps) => {
   } = ownProps;
   const { id: paramsTransactionId } = params;
   const isMainnet = getIsMainnet(state);
+  const supportsEIP1599 = isEIP1559Network(state);
   const { confirmTransaction, metamask } = state;
   const {
     ensResolutionsByAddress,
@@ -111,7 +115,8 @@ const mapStateToProps = (state, ownProps) => {
 
   const {
     hexTransactionAmount,
-    hexTransactionFee,
+    hexMinimumTransactionFee,
+    hexMaximumTransactionFee,
     hexTransactionTotal,
   } = transactionFeeSelector(state, transaction);
 
@@ -158,7 +163,8 @@ const mapStateToProps = (state, ownProps) => {
     toName,
     toNickname,
     hexTransactionAmount,
-    hexTransactionFee,
+    hexMinimumTransactionFee,
+    hexMaximumTransactionFee,
     hexTransactionTotal,
     txData: fullTxData,
     tokenData,
@@ -187,6 +193,7 @@ const mapStateToProps = (state, ownProps) => {
     isMainnet,
     isEthGasPrice,
     noGasPrice,
+    supportsEIP1599,
   };
 };
 

--- a/ui/pages/send/send-header/send-header.component.js
+++ b/ui/pages/send/send-header/send-header.component.js
@@ -27,10 +27,7 @@ export default function SendHeader() {
 
   let title = asset.type === ASSET_TYPES.NATIVE ? t('send') : t('sendTokens');
 
-  if (
-    stage === SEND_STAGES.ADD_RECIPIENT ||
-    stage === SEND_STAGES.UNINITIALIZED
-  ) {
+  if (stage === SEND_STAGES.ADD_RECIPIENT || stage === SEND_STAGES.INACTIVE) {
     title = t('addRecipient');
   } else if (stage === SEND_STAGES.EDIT) {
     title = t('edit');

--- a/ui/pages/send/send-header/send-header.component.test.js
+++ b/ui/pages/send/send-header/send-header.component.test.js
@@ -21,7 +21,7 @@ jest.mock('react-router-dom', () => {
 
 describe('SendHeader Component', () => {
   describe('Title', () => {
-    it('should render "Add Recipient" for UNINITIALIZED or ADD_RECIPIENT stages', () => {
+    it('should render "Add Recipient" for INACTIVE or ADD_RECIPIENT stages', () => {
       const { getByText, rerender } = renderWithProvider(
         <SendHeader />,
         configureMockStore(middleware)({

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -4,14 +4,25 @@ import { calcTokenAmount } from '../helpers/utils/token-util';
 import {
   roundExponential,
   getValueFromWeiHex,
-  getHexGasTotal,
   getTransactionFee,
   addFiat,
   addEth,
 } from '../helpers/utils/confirm-tx.util';
 import { sumHexes } from '../helpers/utils/transactions.util';
 import { transactionMatchesNetwork } from '../../shared/modules/transaction.utils';
-import { getNativeCurrency } from '../ducks/metamask/metamask';
+import {
+  getGasEstimateType,
+  getGasFeeEstimates,
+  getNativeCurrency,
+  isEIP1559Network,
+} from '../ducks/metamask/metamask';
+import { TRANSACTION_ENVELOPE_TYPES } from '../../shared/constants/transaction';
+import { decGWEIToHexWEI } from '../helpers/utils/conversions.util';
+import { GAS_ESTIMATE_TYPES } from '../../shared/constants/gas';
+import {
+  getMaximumGasTotalInHexWei,
+  getMinimumGasTotalInHexWei,
+} from '../../shared/modules/gas.utils';
 import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import { getCurrentChainId, deprecatedGetCurrentNetworkId } from './selectors';
 
@@ -218,16 +229,55 @@ export const transactionFeeSelector = function (state, txData) {
   const currentCurrency = currentCurrencySelector(state);
   const conversionRate = conversionRateSelector(state);
   const nativeCurrency = getNativeCurrency(state);
+  const gasFeeEstimates = getGasFeeEstimates(state) || {};
+  const gasEstimateType = getGasEstimateType(state);
+  const networkSupportsEIP1559 = isEIP1559Network(state);
 
-  const { txParams: { value = '0x0', gas: gasLimit = '0x0' } = {} } = txData;
+  const gasEstimationObject = {
+    gasLimit: txData.txParams?.gas ?? '0x0',
+  };
 
-  // if the gas price from our infura endpoint is null or undefined
-  // use the metaswap average price estimation as a fallback
-  let { txParams: { gasPrice } = {} } = txData;
-
-  if (!gasPrice) {
-    gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';
+  if (networkSupportsEIP1559) {
+    const { medium = {}, gasPrice = '0' } = gasFeeEstimates;
+    if (txData.txParams?.type === TRANSACTION_ENVELOPE_TYPES.LEGACY) {
+      gasEstimationObject.gasPrice =
+        txData.txParams?.gasPrice ?? decGWEIToHexWEI(gasPrice);
+    } else {
+      const { suggestedMaxPriorityFeePerGas, suggestedMaxFeePerGas } = medium;
+      gasEstimationObject.maxFeePerGas =
+        txData.txParams?.maxFeePerGas ??
+        decGWEIToHexWEI(suggestedMaxFeePerGas || gasPrice);
+      gasEstimationObject.maxPriorityFeePerGas =
+        txData.txParams?.maxPriorityFeePerGas ??
+        ((suggestedMaxPriorityFeePerGas &&
+          decGWEIToHexWEI(suggestedMaxPriorityFeePerGas)) ||
+          gasEstimationObject.maxFeePerGas);
+      gasEstimationObject.baseFeePerGas = decGWEIToHexWEI(
+        gasFeeEstimates.estimatedBaseFee,
+      );
+    }
+  } else {
+    switch (gasEstimateType) {
+      case GAS_ESTIMATE_TYPES.NONE:
+        gasEstimationObject.gasPrice = txData.txParams?.gasPrice ?? '0x0';
+        break;
+      case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
+        gasEstimationObject.gasPrice =
+          txData.txParams?.gasPrice ??
+          decGWEIToHexWEI(gasFeeEstimates.gasPrice);
+        break;
+      case GAS_ESTIMATE_TYPES.LEGACY:
+        gasEstimationObject.gasPrice =
+          txData.txParams?.gasPrice ?? getAveragePriceEstimateInHexWEI(state);
+        break;
+      case GAS_ESTIMATE_TYPES.FEE_MARKET:
+        break;
+      default:
+        break;
+    }
   }
+
+  const { txParams: { value = '0x0' } = {} } = txData;
 
   const fiatTransactionAmount = getValueFromWeiHex({
     value,
@@ -244,17 +294,31 @@ export const transactionFeeSelector = function (state, txData) {
     numberOfDecimals: 6,
   });
 
-  const hexTransactionFee = getHexGasTotal({ gasLimit, gasPrice });
+  const hexMinimumTransactionFee = getMinimumGasTotalInHexWei(
+    gasEstimationObject,
+  );
+  const hexMaximumTransactionFee = getMaximumGasTotalInHexWei(
+    gasEstimationObject,
+  );
 
-  const fiatTransactionFee = getTransactionFee({
-    value: hexTransactionFee,
+  const fiatMinimumTransactionFee = getTransactionFee({
+    value: hexMinimumTransactionFee,
     fromCurrency: nativeCurrency,
     toCurrency: currentCurrency,
     numberOfDecimals: 2,
     conversionRate,
   });
+
+  const fiatMaximumTransactionFee = getTransactionFee({
+    value: hexMaximumTransactionFee,
+    fromCurrency: nativeCurrency,
+    toCurrency: currentCurrency,
+    numberOfDecimals: 2,
+    conversionRate,
+  });
+
   const ethTransactionFee = getTransactionFee({
-    value: hexTransactionFee,
+    value: hexMinimumTransactionFee,
     fromCurrency: nativeCurrency,
     toCurrency: nativeCurrency,
     numberOfDecimals: 6,
@@ -262,18 +326,20 @@ export const transactionFeeSelector = function (state, txData) {
   });
 
   const fiatTransactionTotal = addFiat(
-    fiatTransactionFee,
+    fiatMinimumTransactionFee,
     fiatTransactionAmount,
   );
   const ethTransactionTotal = addEth(ethTransactionFee, ethTransactionAmount);
-  const hexTransactionTotal = sumHexes(value, hexTransactionFee);
+  const hexTransactionTotal = sumHexes(value, hexMinimumTransactionFee);
 
   return {
     hexTransactionAmount: value,
     fiatTransactionAmount,
     ethTransactionAmount,
-    hexTransactionFee,
-    fiatTransactionFee,
+    hexMinimumTransactionFee,
+    fiatMinimumTransactionFee,
+    hexMaximumTransactionFee,
+    fiatMaximumTransactionFee,
     ethTransactionFee,
     fiatTransactionTotal,
     ethTransactionTotal,


### PR DESCRIPTION
Opening for QA

### What does this PR do? 
1. updates the send slice state to work with either gasPrice or maxFeePerGas/maxPriorityFeePerGas, including generating a fully formed type 2 (0x2) EIP 1559 transaction for submission.
2. Hooks up the minimum gas paid estimation on confirmations to work with EIP 1559 fields.

### Steps to QA:
With SHOW_EIP_1559_UI set to `0` or `false`:
1. Try to send transactions on the major test nets and make sure that the confirmation page quotes align with expectations.
2. Do this on mainnet, but on testnets also submit transactions and confirm the fields in the block explorer.
3. Modify gas prices using the edit modal and make sure the changes are reflected in the confirmation screen AND on the block explorer on test nets.

With SHOW_EIP_1559_UI set to `1`:
1. Same as above, but note you will not see the gas fields on send screen so it becomes more difficult to validate. You can check redux but I have had some trouble with it since the build system was updated.
2. You'll want to test sending transactions on the various testnets and mainnet. Note, mainnet will be a gasPrice network. You can also run ganache locally and connect to local host for a test network to test sending gasPrice transactions on.
3. In confirmation screens the gas estimate will be `estimatedBaseFee + maxPriorityFeePerGas` or maxFeePerGas, whichever is lowest. 

