### PR TITLE
Ensure gas limit estimation for token sends has correct default/base gas

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -182,6 +182,7 @@ async function estimateGasLimitForSend({
 }) {
   let isSimpleSendOnNonStandardNetwork = false;
 
+  // blockGasLimit may be a falsy, but defined, value when we receive it from
   // state, so we use logical or to fall back to MIN_GAS_LIMIT_HEX. Some
   // network implementations check the gas parameter supplied to
   // eth_estimateGas for validity. For this reason, we set token sends

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -182,9 +182,19 @@ async function estimateGasLimitForSend({
 }) {
   let isSimpleSendOnNonStandardNetwork = false;
 
-  // blockGasLimit may be a falsy, but defined, value when we receive it from
-  // state, so we use logical or to fall back to MIN_GAS_LIMIT_HEX.
-  const blockGasLimit = options.blockGasLimit || MIN_GAS_LIMIT_HEX;
+  // state, so we use logical or to fall back to MIN_GAS_LIMIT_HEX. Some
+  // network implementations check the gas parameter supplied to
+  // eth_estimateGas for validity. For this reason, we set token sends
+  // blockGasLimit default to a higher number. Note that the current gasLimit
+  // on a BLOCK is 15,000,000 and will be 30,000,000 on mainnet after London.
+  // Meanwhile, MIN_GAS_LIMIT_HEX is 0x5208.
+  let blockGasLimit = MIN_GAS_LIMIT_HEX;
+  if (options.blockGasLimit) {
+    blockGasLimit = options.blockGasLimit;
+  } else if (sendToken) {
+    blockGasLimit = GAS_LIMITS.BASE_TOKEN_ESTIMATE;
+  }
+
   // The parameters below will be sent to our background process to estimate
   // how much gas will be used for a transaction. That background process is
   // located in tx-gas-utils.js in the transaction controller folder.


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11558

TODO: Provide full explanation as to why the bug occured and why this works.

Note: This change is on develop, brought in by https://github.com/MetaMask/metamask-extension/pull/11511, this PR picks out that part of that change, so that it can be shipped independently. @brad-decker discovered this bug during work on EIP-1559, and believed it to only affect local ganache on develop, but it is affecting some (but not all) custom networks as well.