### PR TITLE
EIP-1559 - Only show orange confirmation heading when fee is Dapp suggested

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -399,7 +399,9 @@ export default class ConfirmTransactionBase extends Component {
                     </>
                   )
                 }
-                detailTitleColor={COLORS.SECONDARY1}
+                detailTitleColor={
+                  txData.dappSuggestedGasFees ? COLORS.SECONDARY1 : COLORS.BLACK
+                }
                 detailText={
                   <UserPreferencedCurrencyDisplay
                     type={PRIMARY}


### PR DESCRIPTION
We should only show the orange heading when the fee is being suggested by the Dapp