### PR TITLE
EIP-1559 - Use correct estimateToUse from useGasFeeInputs

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -29,7 +29,6 @@ export default function EditGasDisplay({
   showEducationButton = false,
   onEducationClick,
   transaction,
-  defaultEstimateToUse,
   maxPriorityFeePerGas,
   setMaxPriorityFeePerGas,
   maxPriorityFeePerGasFiat,
@@ -149,19 +148,19 @@ export default function EditGasDisplay({
                 {
                   value: GAS_RECOMMENDATIONS.LOW,
                   label: t('editGasLow'),
-                  recommended: defaultEstimateToUse === GAS_RECOMMENDATIONS.LOW,
+                  recommended: estimateToUse === GAS_RECOMMENDATIONS.LOW,
                 },
                 {
                   value: GAS_RECOMMENDATIONS.MEDIUM,
                   label: t('editGasMedium'),
                   recommended:
-                    defaultEstimateToUse === GAS_RECOMMENDATIONS.MEDIUM,
+                  estimateToUse === GAS_RECOMMENDATIONS.MEDIUM,
                 },
                 {
                   value: GAS_RECOMMENDATIONS.HIGH,
                   label: t('editGasHigh'),
                   recommended:
-                    defaultEstimateToUse === GAS_RECOMMENDATIONS.HIGH,
+                  estimateToUse === GAS_RECOMMENDATIONS.HIGH,
                 },
               ]}
               selectedValue={estimateToUse}
@@ -218,7 +217,6 @@ EditGasDisplay.propTypes = {
   mode: PropTypes.oneOf(Object.values(EDIT_GAS_MODES)),
   showEducationButton: PropTypes.bool,
   onEducationClick: PropTypes.func,
-  defaultEstimateToUse: PropTypes.oneOf(Object.values(GAS_RECOMMENDATIONS)),
   maxPriorityFeePerGas: PropTypes.string,
   setMaxPriorityFeePerGas: PropTypes.func,
   maxPriorityFeePerGasFiat: PropTypes.string,


### PR DESCRIPTION
This *does not* fix https://github.com/MetaMask/metamask-extension/issues/11572 but I noticed we were doing a comparison on the default ETU, which we shouldn't be doing if an estimate already exists.  Since the estimateToUse is set within the `useGasFeeInputs` hook, we don't even need to provide the default to this component.