### PR TITLE
Ensure send slice gas loading state is set to false upon gas estimation error

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1082,6 +1082,11 @@ const slice = createSlice({
           });
         }
       })
+      .addCase(computeEstimatedGasLimit.rejected, (state) => {
+        // If gas estimation fails, we should set the loading state to false,
+        // because it is no longer loading
+        state.gas.isGasEstimateLoading = false;
+      })
       .addCase(GAS_FEE_ESTIMATES_UPDATED, (state, action) => {
         // When the gasFeeController updates its gas fee estimates we need to
         // update and validate state based on those new values


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11579

As #11579 describes, sending to some contracts cannot be done on v9.8.0. The user is prevented from doing so because the "Next" button is disabled.

The reason for this is that the "Next" button will be disabled while our eth_estimateGas call is in flight. This is represented with the `isGasEstimateLoading` property in the send slice state. A bug with this in v9.8.0 is that `isGasEstimateLoading` does not get set back to false when the eth_estimateGas call results in an error.

This PR corrects this by updating the `isGasEstimateLoading` state in the case of as gas estimation error.

This means that we are not doing anything in response to that error - and just defaulting to a 21000 gas limit - but that was the case before v9.8.0 going back as far as MetaMask v5.0.0, so I believe it is correct to stay consistent with that