### PR TITLE
No longer deconstructing account menu ref if it isn't rendered

### DIFF
--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -253,12 +253,13 @@ export default class AccountMenu extends Component {
   }
 
   setShouldShowScrollButton = () => {
+    if (!this.accountsRef) {
+      return;
+    }
+
     const { scrollTop, offsetHeight, scrollHeight } = this.accountsRef;
-
     const canScroll = scrollHeight > offsetHeight;
-
     const atAccountListBottom = scrollTop + offsetHeight >= scrollHeight;
-
     const shouldShowScrollButton = canScroll && !atAccountListBottom;
 
     this.setState({ shouldShowScrollButton });


### PR DESCRIPTION
Related Sentry error:
https://sentry.io/organizations/metamask/issues/2211680764/?project=273505&query=is%3Aunresolved

`setShouldShowScrollButton` is called in a few places throughout the component. There's a race condition scenario if it's called in the instant before the account menu renders. We can safely return inside `setShouldShowScrollButton` if the ref isn't set. 