### PR TITLE
Validating seed phrase in restoration flow

### DIFF
--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { ethers } from 'ethers';
 import {
   createNewVaultAndRestore,
   unMarkPasswordForgotten,
@@ -9,6 +10,8 @@ import {
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import TextField from '../../components/ui/text-field';
 import Button from '../../components/ui/button';
+
+const { isValidMnemonic } = ethers.utils;
 
 class RestoreVaultPage extends Component {
   static contextTypes = {
@@ -38,6 +41,7 @@ class RestoreVaultPage extends Component {
     (seedPhrase || '').trim().toLowerCase().match(/\w+/gu)?.join(' ') || '';
 
   handleSeedPhraseChange(seedPhrase) {
+    const { t } = this.context;
     let seedPhraseError = null;
 
     const wordCount = this.parseSeedPhrase(seedPhrase).split(/\s/u).length;
@@ -45,7 +49,9 @@ class RestoreVaultPage extends Component {
       seedPhrase &&
       (wordCount % 3 !== 0 || wordCount < 12 || wordCount > 24)
     ) {
-      seedPhraseError = this.context.t('seedPhraseReq');
+      seedPhraseError = t('seedPhraseReq');
+    } else if (!isValidMnemonic(seedPhrase)) {
+      seedPhraseError = t('invalidSeedPhrase');
     }
 
     this.setState({ seedPhrase, seedPhraseError });


### PR DESCRIPTION
Related Sentry Error: https://sentry.io/organizations/metamask/issues/2396016249/?project=273505&query=is%3Aunresolved

Currently the restoration flow does not check that the entered seed phrase is a valid mnemonic, which we do on import: https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js#L60

This adds the same validation/error flow for invalid seed phrases, and will resolve the particular error in `createNewVaultAndRestore`

New validation:
<img width="456" alt="Screen Shot 2021-07-22 at 2 46 43 AM" src="https://user-images.githubusercontent.com/8732757/126620823-3c944193-535a-488d-a1d7-f0980188641b.png">
