### PR TITLE
EIP-1559 - Restore custom values in Edit Gas Popover

### DIFF
--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -75,7 +75,7 @@ export default function EditGasPopover({
     hasGasErrors,
     gasErrors,
     onManualChange,
-  } = useGasFeeInputs(defaultEstimateToUse);
+  } = useGasFeeInputs(defaultEstimateToUse, transaction);
 
   /**
    * Temporary placeholder, this should be managed by the parent component but
@@ -120,6 +120,12 @@ export default function EditGasPopover({
         dispatch(createSpeedUpTransaction(transaction.id, newGasSettings));
         break;
       case EDIT_GAS_MODES.MODIFY_IN_PLACE:
+        // TODO:  This shouldn't be required by prevents the following error:
+        // Error: Invalid transaction params: specified gasPrice but also included maxFeePerGas, these cannot be mixed
+        if (process.env.SHOW_EIP_1559_UI) {
+          delete transaction.txParams.gasPrice;
+        }
+
         dispatch(
           updateTransaction({
             ...transaction,

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -120,12 +120,6 @@ export default function EditGasPopover({
         dispatch(createSpeedUpTransaction(transaction.id, newGasSettings));
         break;
       case EDIT_GAS_MODES.MODIFY_IN_PLACE:
-        // TODO:  This shouldn't be required by prevents the following error:
-        // Error: Invalid transaction params: specified gasPrice but also included maxFeePerGas, these cannot be mixed
-        if (process.env.SHOW_EIP_1559_UI) {
-          delete transaction.txParams.gasPrice;
-        }
-
         dispatch(
           updateTransaction({
             ...transaction,

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -1,6 +1,8 @@
 import { addHexPrefix } from 'ethereumjs-util';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { findKey } from 'lodash';
+
 import { GAS_ESTIMATE_TYPES } from '../../shared/constants/gas';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import {
@@ -90,19 +92,15 @@ function getMatchingEstimateFromGasFees(
   maxPriorityFeePerGas,
 ) {
   if (process.env.SHOW_EIP_1559_UI) {
-    let matchingGasFee = null;
-    ['low', 'medium', 'high'].forEach((estimateLevel) => {
-      if (
-        gasFeeEstimates?.[estimateLevel]?.suggestedMaxPriorityFeePerGas ===
-          maxPriorityFeePerGas &&
-        gasFeeEstimates?.[estimateLevel]?.suggestedMaxFeePerGas === maxFeePerGas
-      ) {
-        matchingGasFee = estimateLevel;
-      }
-    });
-    return matchingGasFee;
+    return (
+      findKey(
+        gasFeeEstimates,
+        (estimate) =>
+          estimate?.suggestedMaxPriorityFeePerGas === maxPriorityFeePerGas &&
+          estimate?.suggestedMaxFeePerGas === maxFeePerGas,
+      ) || null
+    );
   }
-
   return null;
 }
 

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -14,6 +14,7 @@ import {
   hexWEIToDecGWEI,
   decGWEIToHexWEI,
   decimalToHex,
+  hexToDecimal,
 } from '../helpers/utils/conversions.util';
 import { getShouldShowFiat } from '../selectors';
 import { GAS_FORM_ERRORS } from '../helpers/constants/gas';
@@ -199,8 +200,8 @@ export function useGasFeeInputs(defaultEstimateToUse = 'medium', transaction) {
       : null,
   );
   const [gasLimit, setGasLimit] = useState(
-    transaction?.txParams?.gasLimit
-      ? Number(hexWEIToDecGWEI(transaction.txParams.gasLimit))
+    transaction?.txParams?.gas
+      ? Number(hexToDecimal(transaction.txParams.gas))
       : 21000,
   );
   const [estimateToUse, setInternalEstimateToUse] = useState(

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -90,18 +90,19 @@ function getMatchingEstimateFromGasFees(
   gasFeeEstimates,
   maxFeePerGas,
   maxPriorityFeePerGas,
+  gasPrice,
 ) {
-  if (process.env.SHOW_EIP_1559_UI) {
-    return (
-      findKey(
-        gasFeeEstimates,
-        (estimate) =>
+  return (
+    findKey(gasFeeEstimates, (estimate) => {
+      if (process.env.SHOW_EIP_1559_UI) {
+        return (
           estimate?.suggestedMaxPriorityFeePerGas === maxPriorityFeePerGas &&
-          estimate?.suggestedMaxFeePerGas === maxFeePerGas,
-      ) || null
-    );
-  }
-  return null;
+          estimate?.suggestedMaxFeePerGas === maxFeePerGas
+        );
+      }
+      return estimate?.gasPrice === gasPrice;
+    }) || null
+  );
 }
 
 /**
@@ -208,6 +209,7 @@ export function useGasFeeInputs(defaultEstimateToUse = 'medium', transaction) {
           gasFeeEstimates,
           maxFeePerGas,
           maxPriorityFeePerGas,
+          gasPrice,
         )
       : defaultEstimateToUse,
   );

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -9,6 +9,7 @@ import {
 } from '../../shared/modules/gas.utils';
 import { PRIMARY, SECONDARY } from '../helpers/constants/common';
 import {
+  hexWEIToDecGWEI,
   decGWEIToHexWEI,
   decimalToHex,
 } from '../helpers/utils/conversions.util';
@@ -123,7 +124,7 @@ function getGasFeeEstimate(
  *  './useGasFeeEstimates'
  * ).GasEstimates} - gas fee input state and the GasFeeEstimates object
  */
-export function useGasFeeInputs(defaultEstimateToUse = 'medium') {
+export function useGasFeeInputs(defaultEstimateToUse = 'medium', transaction) {
   // We need to know whether to show fiat conversions or not, so that we can
   // default our fiat values to empty strings if showing fiat is not wanted or
   // possible.
@@ -146,12 +147,28 @@ export function useGasFeeInputs(defaultEstimateToUse = 'medium') {
   // This hook keeps track of a few pieces of transitional state. It is
   // transitional because it is only used to modify a transaction in the
   // metamask (background) state tree.
-  const [maxFeePerGas, setMaxFeePerGas] = useState(null);
-  const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = useState(null);
-  const [gasPrice, setGasPrice] = useState(null);
-  const [gasLimit, setGasLimit] = useState(21000);
+  const [maxFeePerGas, setMaxFeePerGas] = useState(
+    transaction?.txParams?.maxFeePerGas
+      ? Number(hexWEIToDecGWEI(transaction.txParams.maxFeePerGas))
+      : null,
+  );
+  const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = useState(
+    transaction?.txParams?.maxPriorityFeePerGas
+      ? Number(hexWEIToDecGWEI(transaction.txParams.maxPriorityFeePerGas))
+      : null,
+  );
+  const [gasPrice, setGasPrice] = useState(
+    transaction?.txParams?.gasPrice
+      ? Number(hexWEIToDecGWEI(transaction.txParams.gasPrice))
+      : null,
+  );
+  const [gasLimit, setGasLimit] = useState(
+    transaction?.txParams?.gasLimit
+      ? Number(hexWEIToDecGWEI(transaction.txParams.gasLimit))
+      : 21000,
+  );
   const [estimateToUse, setInternalEstimateToUse] = useState(
-    defaultEstimateToUse,
+    transaction ? null : defaultEstimateToUse,
   );
 
   // We need the gas estimates from the GasFeeController in the background.


### PR DESCRIPTION
Here we grab values from an existing transaction so we can restore values chose by the user.  

## ToDo
- [x] Why are these prices being set ahead of time?  We should be defaulting to medium values (are we?)
- [x] Compare those custom values with the gasEstimates to see if we should select any of the radio buttons