### PR TITLE
EIP-1559 - Show advanced form controls by default when user has selected custom values or there are gas warnings/errors

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -25,7 +25,6 @@ import { I18nContext } from '../../../contexts/i18n';
 
 export default function EditGasDisplay({
   mode = EDIT_GAS_MODES.MODIFY_IN_PLACE,
-  alwaysShowForm = false,
   showEducationButton = false,
   onEducationClick,
   transaction,
@@ -58,6 +57,8 @@ export default function EditGasDisplay({
   onManualChange,
 }) {
   const t = useContext(I18nContext);
+
+  const alwaysShowForm = !estimateToUse || hasGasErrors || false;
 
   const requireDappAcknowledgement = Boolean(
     transaction?.dappSuggestedGasFees && !dappSuggestedGasFeeAcknowledged,
@@ -216,7 +217,6 @@ export default function EditGasDisplay({
 }
 
 EditGasDisplay.propTypes = {
-  alwaysShowForm: PropTypes.bool,
   mode: PropTypes.oneOf(Object.values(EDIT_GAS_MODES)),
   showEducationButton: PropTypes.bool,
   onEducationClick: PropTypes.func,


### PR DESCRIPTION
This is a big UX improvement I came across when writing https://github.com/MetaMask/metamask-extension/pull/11589 .  If the user has selected custom gas values, or if there were warnings when they chose their values, the next time they click "Edit" to edit gas we should simply show the advanced gas controls by default, since none of the radio buttons will be selected.  Otherwise it's an extra step for the user to see their custom values.