### PR TITLE
EIP-1559 - Prevent Max Fee and Max Amount from wrapping on confirmation screen

### DIFF
--- a/ui/components/app/transaction-detail-item/index.scss
+++ b/ui/components/app/transaction-detail-item/index.scss
@@ -35,4 +35,8 @@
   &__subtext {
     text-align: end;
   }
+
+  .currency-display-component {
+    display: inline;
+  }
 }


### PR DESCRIPTION
The "Max Amount" and "Max Fee" values are wrapping because the currency display is a `<DIV>`; this fixes the wrapping problem.