### PR TITLE
EIP-1559 - Provide the nonce field in the new transaction display

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -465,6 +465,7 @@ export default class ConfirmTransactionBase extends Component {
               />,
             ]}
           />
+          {nonceField}
         </div>
       );
     }


### PR DESCRIPTION
When switching to the conditional render block for 1559, we lost the Nonce field.  Adding it to the 1559 display.