### PR TITLE
EIP-1559 - Allow wrapping for dapp suggested origin

### DIFF
--- a/ui/components/app/transaction-detail-item/index.scss
+++ b/ui/components/app/transaction-detail-item/index.scss
@@ -7,11 +7,7 @@
 
   &__title {
     flex-grow: 1;
-  }
-
-  &__title--dapp-suggested {
-    color: $secondary-1;
-    font-weight: bold;
+    word-break: break-word;
   }
 
   .info-tooltip {


### PR DESCRIPTION
Dapp origins that are long push the fiat value off screen, so we need to break on those origins.