### PR TITLE
Fixing type issue with auto-filled custom token decimals value

### DIFF
--- a/ui/helpers/utils/token-util.js
+++ b/ui/helpers/utils/token-util.js
@@ -73,7 +73,7 @@ async function getDecimals(tokenAddress) {
     const contractMetadataInfo = getContractMetadata(tokenAddress);
 
     if (contractMetadataInfo) {
-      decimals = contractMetadataInfo.decimals;
+      decimals = contractMetadataInfo.decimals?.toString();
     }
   }
 


### PR DESCRIPTION
Related Sentry Error: https://sentry.io/organizations/metamask/issues/2455739694/?project=273505&query=is%3Aunresolved

An attempt to auto-fill custom token information occurs when a user pastes in a token address in the custom form.  (https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/add-token/add-token.component.js#L165)

The errors occurs when we need to grab the info from the contract-metadata, where decimals values are stored as type `number` (https://github.com/MetaMask/metamask-extension/blob/develop/ui/helpers/utils/token-util.js#L72) - t