### PR TITLE
Check for the "fromToken" existence before checking decimals

### DIFF
--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -298,7 +298,8 @@ export default function Swap() {
                   // "setBalanceError" is just a warning, a user can still click on the "Review Swap" button.
                   dispatch(setBalanceError(balanceError));
                   setTokenFromError(
-                    countDecimals(newInputValue) > fromToken.decimals
+                    fromToken &&
+                      countDecimals(newInputValue) > fromToken.decimals
                       ? 'tooManyDecimals'
                       : null,
                   );


### PR DESCRIPTION
## Explanation
Check for the "fromToken" existence before checking decimals

## Manual testing steps
  - Go to "Swaps"
  - Select "Swap from" and "Swap to", enter amount and click on "Review Swap"
  - Wait for the "View Quote" page to load
  - Close the extension
  - Open the extension
  - Click on the back button
  - The "Build Quote" page is displayed correctly
