### PR TITLE
EIP-1559 - Prevent isEIP1559Transaction throwing undefined error

### DIFF
--- a/shared/modules/transaction.utils.js
+++ b/shared/modules/transaction.utils.js
@@ -16,8 +16,8 @@ export function transactionMatchesNetwork(transaction, chainId, networkId) {
  */
 export function isEIP1559Transaction(transaction) {
   return (
-    isHexString(transaction.txParams.maxFeePerGas) &&
-    isHexString(transaction.txParams.maxPriorityFeePerGas)
+    isHexString(transaction?.txParams?.maxFeePerGas) &&
+    isHexString(transaction?.txParams?.maxPriorityFeePerGas)
   );
 }
 


### PR DESCRIPTION
During some hardware wallet experimentation today I got into a state where `isEIP1559Transaction` was throwing an error due to undefined data.  We should look at how this function is being used, especially `txParams`, but this will be helpful.