### PR TITLE
Adding hex address guard to input validation for token sends

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -858,6 +858,7 @@ const slice = createSlice({
 
         if (
           isSendingToken &&
+          isValidHexAddress(recipient.userInput) &&
           (toChecksumAddress(recipient.userInput) in contractMap ||
             checkExistingAddresses(recipient.userInput, tokens))
         ) {


### PR DESCRIPTION
Related Sentry Error: https://sentry.io/organizations/metamask/issues/2508809557/

After validating the user-entered address for a token send, further checks occur to determine if the recipient is known. `toChecksumAddress` should be guarded with `isValidHexAddress`, as the input may be invalid at that point. This fix correctly results with the "Recipient address is invalid" message in the UI, with no JS errors.

## Test Steps
1. Initiate a token send from the asset list (EG, `Send LINK`)
2. Enter an invalid hex address, such as `300`
3. Confirm the correct error is shown, with no errors in the console