### PR TITLE
Ensure that gas fee/prices params are not updated while in send edit stage/mode

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1516,10 +1516,18 @@ export function signTransaction() {
       // merge in the modified txParams. Once the transaction has been modified
       // we can send that to the background to update the transaction in state.
       const unapprovedTxs = getUnapprovedTxs(state);
+      // We only update the tx params that can be changed via the edit flow UX
+      const txParamsToUpdate = {
+        data: txParams.data,
+        from: txParams.from,
+        to: txParams.to,
+        value: txParams.value,
+        gas: txParams.gas,
+      };
       const unapprovedTx = unapprovedTxs[id];
       const editingTx = {
         ...unapprovedTx,
-        txParams: Object.assign(unapprovedTx.txParams, txParams),
+        txParams: Object.assign(unapprovedTx.txParams, txParamsToUpdate),
       };
       dispatch(updateTransaction(editingTx));
     } else if (asset.type === ASSET_TYPES.TOKEN) {

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1508,6 +1508,7 @@ export function signTransaction() {
       draftTransaction: { id, txParams },
       recipient: { address },
       amount: { value },
+      eip1559support,
     } = state[name];
     if (stage === SEND_STAGES.EDIT) {
       // When dealing with the edit flow there is already a transaction in
@@ -1517,7 +1518,7 @@ export function signTransaction() {
       // we can send that to the background to update the transaction in state.
       const unapprovedTxs = getUnapprovedTxs(state);
       // We only update the tx params that can be changed via the edit flow UX
-      const txParamsToUpdate = {
+      const eip1559OnlyTxParamsToUpdate = {
         data: txParams.data,
         from: txParams.from,
         to: txParams.to,
@@ -1527,7 +1528,10 @@ export function signTransaction() {
       const unapprovedTx = unapprovedTxs[id];
       const editingTx = {
         ...unapprovedTx,
-        txParams: Object.assign(unapprovedTx.txParams, txParamsToUpdate),
+        txParams: Object.assign(
+          unapprovedTx.txParams,
+          eip1559support ? eip1559OnlyTxParamsToUpdate : txParams,
+        ),
       };
       dispatch(updateTransaction(editingTx));
     } else if (asset.type === ASSET_TYPES.TOKEN) {


### PR DESCRIPTION
This PR fixes the send edit mode/stage. By "send edit mode" I mean: from the confirm screen, click the "< Edit" link in the top left of  the confirm screen, to go to the send screen.

This PR ensures that submission of the send screen form while editing does not update gasPrice/maxPriorityFee/maxFee. These values can change during polling while in the send flow. We may want to make changes to ensure that polling doesn't happen in the future, but for now at least this change is definitely needed, as editing should not change any values that cannot be seen+editing while on the send screen in edit mode.