### PR TITLE
Only show dapp suggested gas fee warning if user has not edited the fee

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -14,6 +14,7 @@ import {
   FONT_WEIGHT,
   TEXT_ALIGN,
 } from '../../../helpers/constants/design-system';
+import { areDappSuggestedAndTxParamGasFeesTheSame } from '../../../helpers/utils/confirm-tx.util';
 
 import InfoTooltip from '../../ui/info-tooltip';
 import TransactionTotalBanner from '../transaction-total-banner/transaction-total-banner.component';
@@ -60,8 +61,14 @@ export default function EditGasDisplay({
 
   const alwaysShowForm = !estimateToUse || hasGasErrors || false;
 
+  const dappSuggestedAndTxParamGasFeesAreTheSame = areDappSuggestedAndTxParamGasFeesTheSame(
+    transaction,
+  );
+
   const requireDappAcknowledgement = Boolean(
-    transaction?.dappSuggestedGasFees && !dappSuggestedGasFeeAcknowledged,
+    transaction?.dappSuggestedGasFees &&
+      !dappSuggestedGasFeeAcknowledged &&
+      dappSuggestedAndTxParamGasFeesAreTheSame,
   );
 
   return (

--- a/ui/helpers/utils/confirm-tx.util.js
+++ b/ui/helpers/utils/confirm-tx.util.js
@@ -148,3 +148,42 @@ export function roundExponential(decimalString) {
     ? bigNumberValue.toPrecision(PRECISION)
     : decimalString;
 }
+
+export function areDappSuggestedAndTxParamGasFeesTheSame(txData = {}) {
+  const { txParams, dappSuggestedGasFees } = txData;
+  const {
+    gasPrice: txParamsGasPrice,
+    maxFeePerGas: txParamsMaxFeePerGas,
+    maxPriorityFeePerGas: txParamsMaxPriorityFeePerGas,
+  } = txParams || {};
+  const {
+    gasPrice: dappGasPrice,
+    maxFeePerGas: dappMaxFeePerGas,
+    maxPriorityFeePerGas: dappMaxPriorityFeePerGas,
+  } = dappSuggestedGasFees || {};
+
+  const txParamsDoesNotHaveFeeProperties =
+    !txParamsGasPrice && !txParamsMaxFeePerGas && !txParamsMaxPriorityFeePerGas;
+  const dappDidNotSuggestFeeProperties =
+    !dappGasPrice && !dappMaxFeePerGas && !dappMaxPriorityFeePerGas;
+  if (txParamsDoesNotHaveFeeProperties || dappDidNotSuggestFeeProperties) {
+    return false;
+  }
+
+  const txParamsGasPriceMatchesDappSuggestedGasPrice =
+    txParamsGasPrice && txParamsGasPrice === dappGasPrice;
+  const txParamsEIP1559FeesMatchDappSuggestedGasPrice = [
+    txParamsMaxFeePerGas,
+    txParamsMaxPriorityFeePerGas,
+  ].every((fee) => fee === dappGasPrice);
+  const txParamsEIP1559FeesMatchDappSuggestedEIP1559Fees =
+    txParamsMaxFeePerGas &&
+    txParamsMaxFeePerGas === dappMaxFeePerGas &&
+    txParamsMaxPriorityFeePerGas === dappMaxPriorityFeePerGas;
+
+  return (
+    txParamsGasPriceMatchesDappSuggestedGasPrice ||
+    txParamsEIP1559FeesMatchDappSuggestedGasPrice ||
+    txParamsEIP1559FeesMatchDappSuggestedEIP1559Fees
+  );
+}


### PR DESCRIPTION
This PR proposes a UX modification to the dapp-ackknowledgement-warning in `edit-gas-display.component.js`

Currently, if a dapp creates a transaction with proposed gas prices included, and the user goes to edit the gas fees, a warning is shown which says "This gas fee has been suggested by {dapp origin}. Overriding this may cause a problem with your transaction. Please reach out to $1 if you have questions." The user has to click a confirmation before they can edit.

I think that if they already have edited the fees provided by the dapp, then we should not show the warning. This PR add this update.