### PR TITLE
Add support for EIP1559 transactions to transaction breakdown

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -801,7 +801,7 @@ export default class TransactionController extends EventEmitter {
    * @param {number} txId - The tx's ID
    * @returns {Promise<void>}
    */
-  async confirmTransaction(txId, txReceipt) {
+  async confirmTransaction(txId, txReceipt, baseFeePerGas) {
     // get the txReceipt before marking the transaction confirmed
     // to ensure the receipt is gotten before the ui revives the tx
     const txMeta = this.txStateManager.getTransaction(txId);
@@ -822,6 +822,11 @@ export default class TransactionController extends EventEmitter {
         ...txReceipt,
         gasUsed,
       };
+
+      if (baseFeePerGas) {
+        txMeta.baseFeePerGas = baseFeePerGas;
+      }
+
       this.txStateManager.setTxStatusConfirmed(txId);
       this._markNonceDuplicatesDropped(txId);
 
@@ -1000,8 +1005,10 @@ export default class TransactionController extends EventEmitter {
     this.pendingTxTracker.on('tx:failed', (txId, error) => {
       this._failTransaction(txId, error);
     });
-    this.pendingTxTracker.on('tx:confirmed', (txId, transactionReceipt) =>
-      this.confirmTransaction(txId, transactionReceipt),
+    this.pendingTxTracker.on(
+      'tx:confirmed',
+      (txId, transactionReceipt, baseFeePerGas) =>
+        this.confirmTransaction(txId, transactionReceipt, baseFeePerGas),
     );
     this.pendingTxTracker.on('tx:dropped', (txId) => {
       this._dropTransaction(txId);

--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -193,7 +193,11 @@ export default class PendingTransactionTracker extends EventEmitter {
     try {
       const transactionReceipt = await this.query.getTransactionReceipt(txHash);
       if (transactionReceipt?.blockNumber) {
-        this.emit('tx:confirmed', txId, transactionReceipt);
+        const { baseFeePerGas } = await this.query.getBlockByHash(
+          transactionReceipt?.blockHash,
+          false,
+        );
+        this.emit('tx:confirmed', txId, transactionReceipt, baseFeePerGas);
         return;
       }
     } catch (err) {

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -4,7 +4,12 @@ import classnames from 'classnames';
 import CurrencyDisplay from '../../ui/currency-display';
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display';
 import HexToDecimal from '../../ui/hex-to-decimal';
-import { GWEI, PRIMARY, SECONDARY } from '../../../helpers/constants/common';
+import {
+  GWEI,
+  PRIMARY,
+  SECONDARY,
+  ETH,
+} from '../../../helpers/constants/common';
 import TransactionBreakdownRow from './transaction-breakdown-row';
 
 export default class TransactionBreakdown extends PureComponent {
@@ -25,7 +30,7 @@ export default class TransactionBreakdown extends PureComponent {
     totalInHex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     baseFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     priorityFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    effectiveGasPrice: PropTypes.number,
+    hexGasTotal: PropTypes.string,
   };
 
   static defaultProps = {
@@ -47,7 +52,7 @@ export default class TransactionBreakdown extends PureComponent {
       isTokenApprove,
       baseFee,
       priorityFee,
-      effectiveGasPrice,
+      hexGasTotal,
     } = this.props;
     return (
       <div className={classnames('transaction-breakdown', className)}>
@@ -102,6 +107,7 @@ export default class TransactionBreakdown extends PureComponent {
                 currency={nativeCurrency}
                 denomination={GWEI}
                 value={baseFee}
+                numberOfDecimals={10}
                 hideLabel
               />
             )}
@@ -118,6 +124,7 @@ export default class TransactionBreakdown extends PureComponent {
                 currency={nativeCurrency}
                 denomination={GWEI}
                 value={priorityFee}
+                numberOfDecimals={10}
                 hideLabel
               />
             )}
@@ -142,16 +149,19 @@ export default class TransactionBreakdown extends PureComponent {
         <TransactionBreakdownRow
           title={t('transactionHistoryEffectiveGasPrice')}
         >
-          <UserPreferencedCurrencyDisplay
-            className="transaction-breakdown__value transaction-breakdown__value--effective-gas-price"
-            type={PRIMARY}
-            value={effectiveGasPrice}
+          <CurrencyDisplay
+            className="transaction-breakdown__value"
+            data-testid="transaction-breakdown__effective-gas-price"
+            currency={nativeCurrency}
+            denomination={ETH}
+            numberOfDecimals={6}
+            value={hexGasTotal}
           />
           {showFiat && (
             <UserPreferencedCurrencyDisplay
               className="transaction-breakdown__value"
               type={SECONDARY}
-              value={effectiveGasPrice}
+              value={hexGasTotal}
             />
           )}
         </TransactionBreakdownRow>

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -149,13 +149,14 @@ export default class TransactionBreakdown extends PureComponent {
         <TransactionBreakdownRow
           title={t('transactionHistoryEffectiveGasPrice')}
         >
-          <CurrencyDisplay
+          <UserPreferencedCurrencyDisplay
             className="transaction-breakdown__value"
             data-testid="transaction-breakdown__effective-gas-price"
             currency={nativeCurrency}
             denomination={ETH}
             numberOfDecimals={6}
             value={hexGasTotal}
+            type={PRIMARY}
           />
           {showFiat && (
             <UserPreferencedCurrencyDisplay

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -31,6 +31,7 @@ export default class TransactionBreakdown extends PureComponent {
     baseFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     priorityFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     hexGasTotal: PropTypes.string,
+    supportsEIP1559: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -53,6 +54,7 @@ export default class TransactionBreakdown extends PureComponent {
       baseFee,
       priorityFee,
       hexGasTotal,
+      supportsEIP1559,
     } = this.props;
     return (
       <div className={classnames('transaction-breakdown', className)}>
@@ -96,7 +98,7 @@ export default class TransactionBreakdown extends PureComponent {
             />
           </TransactionBreakdownRow>
         )}
-        {process.env.SHOW_EIP_1559_UI && (
+        {process.env.SHOW_EIP_1559_UI && supportsEIP1559 && (
           <TransactionBreakdownRow title={t('transactionHistoryBaseFee')}>
             {typeof baseFee === 'undefined' ? (
               '?'
@@ -113,7 +115,7 @@ export default class TransactionBreakdown extends PureComponent {
             )}
           </TransactionBreakdownRow>
         )}
-        {process.env.SHOW_EIP_1559_UI && (
+        {process.env.SHOW_EIP_1559_UI && supportsEIP1559 && (
           <TransactionBreakdownRow title={t('transactionHistoryPriorityFee')}>
             {typeof priorityFee === 'undefined' ? (
               '?'
@@ -130,7 +132,7 @@ export default class TransactionBreakdown extends PureComponent {
             )}
           </TransactionBreakdownRow>
         )}
-        {!process.env.SHOW_EIP_1559_UI && (
+        {(!process.env.SHOW_EIP_1559_UI || !supportsEIP1559) && (
           <TransactionBreakdownRow title={t('advancedGasPriceTitle')}>
             {typeof gasPrice === 'undefined' ? (
               '?'
@@ -146,26 +148,28 @@ export default class TransactionBreakdown extends PureComponent {
             )}
           </TransactionBreakdownRow>
         )}
-        <TransactionBreakdownRow
-          title={t('transactionHistoryEffectiveGasPrice')}
-        >
-          <UserPreferencedCurrencyDisplay
-            className="transaction-breakdown__value"
-            data-testid="transaction-breakdown__effective-gas-price"
-            currency={nativeCurrency}
-            denomination={ETH}
-            numberOfDecimals={6}
-            value={hexGasTotal}
-            type={PRIMARY}
-          />
-          {showFiat && (
+        {process.env.SHOW_EIP_1559_UI && supportsEIP1559 && (
+          <TransactionBreakdownRow
+            title={t('transactionHistoryEffectiveGasPrice')}
+          >
             <UserPreferencedCurrencyDisplay
               className="transaction-breakdown__value"
-              type={SECONDARY}
+              data-testid="transaction-breakdown__effective-gas-price"
+              currency={nativeCurrency}
+              denomination={ETH}
+              numberOfDecimals={6}
               value={hexGasTotal}
+              type={PRIMARY}
             />
-          )}
-        </TransactionBreakdownRow>
+            {showFiat && (
+              <UserPreferencedCurrencyDisplay
+                className="transaction-breakdown__value"
+                type={SECONDARY}
+                value={hexGasTotal}
+              />
+            )}
+          </TransactionBreakdownRow>
+        )}
         <TransactionBreakdownRow title={t('total')}>
           <UserPreferencedCurrencyDisplay
             className="transaction-breakdown__value transaction-breakdown__value--eth-total"

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -24,6 +24,11 @@ const mapStateToProps = (state, ownProps) => {
     baseFeePerGas &&
     subtractHexes(effectiveGasPrice, baseFeePerGas);
 
+  // To calculate the total cost of the transaction, we use gasPrice if it is in the txParam,
+  // which will only be the case on non-EIP1559 networks. If it is not in the params, we can
+  // use the effectiveGasPrice from the receipt, which will ultimately represent to true cost
+  // of the transaction. Either of these are used the same way with gasLimit to calculate total
+  // cost. effectiveGasPrice will be available on the txReciept for all EIP1559 networks
   const usedGasPrice = gasPrice || effectiveGasPrice;
   const hexGasTotal =
     (gasLimit &&

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 import { getShouldShowFiat } from '../../../selectors';
-import { getNativeCurrency } from '../../../ducks/metamask/metamask';
+import {
+  getNativeCurrency,
+  isEIP1559Network,
+} from '../../../ducks/metamask/metamask';
 import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util';
 import { subtractHexes } from '../../../helpers/utils/conversions.util';
 import { sumHexes } from '../../../helpers/utils/transactions.util';
@@ -29,6 +32,8 @@ const mapStateToProps = (state, ownProps) => {
     '0x0';
   const totalInHex = sumHexes(hexGasTotal, value);
 
+  const supportsEIP1559 = isEIP1559Network(state);
+
   return {
     nativeCurrency: getNativeCurrency(state),
     showFiat: getShouldShowFiat(state),
@@ -41,6 +46,7 @@ const mapStateToProps = (state, ownProps) => {
     hexGasTotal,
     priorityFee,
     baseFee: baseFeePerGas,
+    supportsEIP1559,
   };
 };
 

--- a/ui/helpers/utils/conversions.util.js
+++ b/ui/helpers/utils/conversions.util.js
@@ -171,6 +171,15 @@ export function addHexes(aHexWEI, bHexWEI) {
   });
 }
 
+export function subtractHexes(aHexWEI, bHexWEI) {
+  return addCurrencies(aHexWEI, bHexWEI, {
+    aBase: 16,
+    bBase: 16,
+    toNumericBase: 'hex',
+    numberOfDecimals: 6,
+  });
+}
+
 export function sumHexWEIs(hexWEIs) {
   return hexWEIs.filter(Boolean).reduce(addHexes);
 }


### PR DESCRIPTION
This PR ensures that the user can see the "Base fee", "Priority Fee" and total fee in the transaction breakdown for an eip 1559 transaction.

![Screenshot from 2021-07-26 12-33-16](https://user-images.githubusercontent.com/7499938/127011961-2f1237d2-78f0-4bc1-b4c8-18999ff60de1.png)
