### PR TITLE
bumped contract-metadata to v1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@lavamoat/preinstall-always-fail": "^1.0.0",
     "@material-ui/core": "^4.11.0",
-    "@metamask/contract-metadata": "^1.27.0",
+    "@metamask/contract-metadata": "^1.28.0",
     "@metamask/controllers": "^12.0.0",
     "@metamask/eth-ledger-bridge-keyring": "^0.6.0",
     "@metamask/eth-token-tracker": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,6 +2678,11 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.27.0.tgz#1e65b821bad6f7d8313dd881116e4366b0662f75"
   integrity sha512-ZAvuROiHjSksy40buCL4M6m16bAmXQl6vjllK/XQxt9+UElhwJSp7PJ1ZULuZXmznBBY64WXlCPjm94JhW4l3g==
 
+"@metamask/contract-metadata@^1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.28.0.tgz#76796f5010aa4aa6d28bf6fe36392017cea687cb"
+  integrity sha512-QZj6Y1nmSs9BHufBS1GSuPX5TVFa5gbtMhEo/KRuSdKyY43OdlbBKuyT36/l5p30krlzfMX8bN0MAWqw3g0Bog==
+
 "@metamask/controllers@^12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-12.0.0.tgz#afc36e6e8eb53133996b6e41dfc30d01c25ba9d9"


### PR DESCRIPTION
Explanation:  Bump the version of contract-metadata to latest published release