### PR TITLE
Trimming whitespace in EnsInput

### DIFF
--- a/ui/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/pages/send/send-content/add-recipient/ens-input.component.js
@@ -37,16 +37,17 @@ export default class EnsInput extends Component {
 
   onPaste = (event) => {
     event.clipboardData.items[0].getAsString((text) => {
+      const input = text.trim();
       if (
-        !isBurnAddress(text) &&
-        isValidHexAddress(text, { mixedCaseUseChecksum: true })
+        !isBurnAddress(input) &&
+        isValidHexAddress(input, { mixedCaseUseChecksum: true })
       ) {
-        this.props.onPaste(text);
+        this.props.onPaste(input);
       }
     });
   };
 
-  onChange = (e) => {
+  onChange = ({ target: { value } }) => {
     const {
       onValidAddressTyped,
       internalSearch,
@@ -54,7 +55,7 @@ export default class EnsInput extends Component {
       lookupEnsName,
       resetEnsResolution,
     } = this.props;
-    const input = e.target.value;
+    const input = value.trim();
 
     onChange(input);
     if (internalSearch) {


### PR DESCRIPTION
Related sentry error: https://sentry.io/organizations/metamask/issues/2513489798

Entering an address containing leading whitespace was causing an error in validation. This value should be trimmed upon input.

**Before:**
<img width="237" alt="Screen Shot 2021-07-26 at 11 02 56 PM" src="https://user-images.githubusercontent.com/8732757/127103725-d13a9681-49f3-4ed7-861d-4df06de27af9.png">

**After:**
<img width="245" alt="Screen Shot 2021-07-26 at 11 05 16 PM" src="https://user-images.githubusercontent.com/8732757/127103957-4d35871a-c134-497a-8198-ea97bf7484e0.png">

## Test Plan
1. Initiate the send flow
2. Paste `"    0x2f318C334780961FB129D2a6c30D0763d9a5C970"` in to the address input field
3. Confirm that address is validated correctly and the send flow can continue
