### PR TITLE
Fix default tooltip color

### DIFF
--- a/ui/components/ui/info-tooltip/info-tooltip.js
+++ b/ui/components/ui/info-tooltip/info-tooltip.js
@@ -17,7 +17,7 @@ export default function InfoTooltip({
   containerClassName,
   wrapperClassName,
   wide,
-  iconFillColor = '',
+  iconFillColor = '#b8b8b8',
 }) {
   return (
     <div className="info-tooltip">

--- a/ui/pages/swaps/fee-card/__snapshots__/fee-card.test.js.snap
+++ b/ui/pages/swaps/fee-card/__snapshots__/fee-card.test.js.snap
@@ -65,7 +65,7 @@ exports[`FeeCard renders the component with initial props 2`] = `
           >
             <path
               d="M5 0C2.2 0 0 2.2 0 5s2.2 5 5 5 5-2.2 5-5-2.2-5-5-5zm0 2c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.2-.7-.6.3-.8.7-.8zm.7 6H4.3V4.3h1.5V8z"
-              fill=""
+              fill="#b8b8b8"
             />
           </svg>
         </div>


### PR DESCRIPTION
## Explanation
Recently some grey tooltips started showing a different color and this PR fixes it.

## Manual testing steps
- Open Swaps
- Tooltips are grey again now

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/80175477/127133529-5a58dc9e-fb5f-41da-900e-a29197e44737.png)

After:
![image](https://user-images.githubusercontent.com/80175477/127133447-cdecdc02-460b-4cca-a1bd-3aee0a1d317d.png)
