### PR TITLE
Fixing confirmation layout when dapp has suggested a price (EIP-1559)

### DIFF
--- a/ui/components/app/transaction-detail-item/index.scss
+++ b/ui/components/app/transaction-detail-item/index.scss
@@ -3,6 +3,7 @@
 
   &__row {
     display: flex;
+    grid-gap: 5px;
   }
 
   &__title {
@@ -13,10 +14,6 @@
   .info-tooltip {
     display: inline-block;
     margin-inline-start: 4px;
-  }
-
-  &__detail-text {
-    margin-inline-end: 20px !important;
   }
 
   &__total {

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -301,6 +301,14 @@ export default class ConfirmTransactionBase extends Component {
     } = this.props;
     const { t } = this.context;
 
+    const getRequestingOrigin = () => {
+      try {
+        return new URL(txData.origin)?.hostname;
+      } catch (err) {
+        return '';
+      }
+    };
+
     const notMainnetOrTest = !(isMainnet || process.env.IN_TEST);
     const gasPriceFetchFailure = isEthGasPrice || noGasPrice;
 
@@ -371,7 +379,9 @@ export default class ConfirmTransactionBase extends Component {
                 detailTitle={
                   txData.dappSuggestedGasFees ? (
                     <>
-                      {t('transactionDetailDappGasHeading', [txData.origin])}
+                      {t('transactionDetailDappGasHeading', [
+                        getRequestingOrigin(),
+                      ])}
                       <InfoTooltip
                         contentText={t('transactionDetailDappGasTooltip')}
                         position="top"


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11612

- Only displaying dapp hostname as opposed to protocol + hostname
- Adjusting spacing in detail rows

<img width="179" alt="Screen Shot 2021-07-27 at 7 31 45 AM" src="https://user-images.githubusercontent.com/8732757/127172925-f9dd892a-b3f5-4acf-9168-6af9cfac9d29.png">
<img width="182" alt="Screen Shot 2021-07-27 at 7 30 31 AM" src="https://user-images.githubusercontent.com/8732757/127172931-cdf40b6e-23dc-45d8-9263-b9ecb3ab85a1.png">


