### PR TITLE
Allow higher precision gas prices in the send flow

### DIFF
--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -95,6 +95,7 @@ export default class TransactionBreakdown extends PureComponent {
               currency={nativeCurrency}
               denomination={GWEI}
               value={gasPrice}
+              numberOfDecimals={9}
               hideLabel
             />
           )}

--- a/ui/ducks/gas/gas-duck.test.js
+++ b/ui/ducks/gas/gas-duck.test.js
@@ -198,7 +198,7 @@ describe('Gas Duck', () => {
         {
           type: SET_BASIC_GAS_ESTIMATE_DATA,
           value: {
-            average: 0.0482,
+            average: 0.048199313,
           },
         },
       ]);

--- a/ui/ducks/gas/gas.duck.js
+++ b/ui/ducks/gas/gas.duck.js
@@ -173,7 +173,7 @@ async function fetchEthGasPriceEstimates(state) {
   const gasPrice = await global.eth.gasPrice();
   const averageGasPriceInDecGWEI = getValueFromWeiHex({
     value: gasPrice.toString(16),
-    numberOfDecimals: 4,
+    numberOfDecimals: 9,
     toDenomination: 'GWEI',
   });
   const basicEstimates = {


### PR DESCRIPTION
On the palm network, gas prices can be lower than 0.0001, so we need to allow the gas price estimates to have a higher precision.