### PR TITLE
Use current block gas limit as the limit passed eth_estimateGas

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -350,7 +350,7 @@ export const computeEstimatedGasLimit = createAsyncThunk(
     if (send.stage !== SEND_STAGES.EDIT) {
       const gasLimit = await estimateGasLimitForSend({
         gasPrice: send.gas.gasPrice,
-        blockGasLimit: metamask.blockGasLimit,
+        blockGasLimit: metamask.currentBlockGasLimit,
         selectedAddress: metamask.selectedAddress,
         sendToken: send.asset.details,
         to: send.recipient.address?.toLowerCase(),
@@ -425,7 +425,7 @@ export const initializeSendState = createAsyncThunk(
       // required gas. If this value isn't nullish, set it as the new gasLimit
       const estimatedGasLimit = await estimateGasLimitForSend({
         gasPrice: getGasPriceInHexWei(basicEstimates.average),
-        blockGasLimit: metamask.blockGasLimit,
+        blockGasLimit: metamask.currentBlockGasLimit,
         selectedAddress: fromAddress,
         sendToken: asset.details,
         to: recipient.address.toLowerCase(),


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11647

We stopped using `state.metamask.currentBlockGasLimit` with this change: https://github.com/MetaMask/metamask-extension/pull/10965/files#diff-4090152fe396753053c3582bfd4e1e51e7aea1c1e1833e4e9993cd0b7709f7c4L54 and instead started using `state.metamask.blockGasLimit`, which can be undefined.

This PR returns us to using the property from state that was used before that change.