### PR TITLE
Revert "Use current block gas limit as the limit passed eth_estimateGas"

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -350,7 +350,7 @@ export const computeEstimatedGasLimit = createAsyncThunk(
     if (send.stage !== SEND_STAGES.EDIT) {
       const gasLimit = await estimateGasLimitForSend({
         gasPrice: send.gas.gasPrice,
-        blockGasLimit: metamask.currentBlockGasLimit,
+        blockGasLimit: metamask.blockGasLimit,
         selectedAddress: metamask.selectedAddress,
         sendToken: send.asset.details,
         to: send.recipient.address?.toLowerCase(),
@@ -425,7 +425,7 @@ export const initializeSendState = createAsyncThunk(
       // required gas. If this value isn't nullish, set it as the new gasLimit
       const estimatedGasLimit = await estimateGasLimitForSend({
         gasPrice: getGasPriceInHexWei(basicEstimates.average),
-        blockGasLimit: metamask.currentBlockGasLimit,
+        blockGasLimit: metamask.blockGasLimit,
         selectedAddress: fromAddress,
         sendToken: asset.details,
         to: recipient.address.toLowerCase(),


### PR DESCRIPTION
Reverts https://github.com/MetaMask/metamask-extension/pull/11658 as it was incorrectly merged to `master`