### PR TITLE
test/e2e - add longer timeouts

### DIFF
--- a/test/e2e/benchmark.js
+++ b/test/e2e/benchmark.js
@@ -7,7 +7,7 @@ const { hideBin } = require('yargs/helpers');
 const ttest = require('ttest');
 const { retry } = require('../../development/lib/retry');
 const { exitWithError } = require('../../development/lib/exit-with-error');
-const { withFixtures } = require('./helpers');
+const { withFixtures, tinyDelayMs } = require('./helpers');
 const { PAGES } = require('./webdriver/driver');
 
 const DEFAULT_NUM_SAMPLES = 20;
@@ -16,6 +16,7 @@ const ALL_PAGES = Object.values(PAGES);
 async function measurePage(pageName) {
   let metrics;
   await withFixtures({ fixtures: 'imported-account' }, async ({ driver }) => {
+    await driver.delay(tinyDelayMs);
     await driver.navigate();
     await driver.fill('#password', 'correct horse battery staple');
     await driver.press('#password', driver.Key.ENTER);

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -11,6 +11,8 @@ const { buildWebDriver } = require('./webdriver');
 const tinyDelayMs = 200;
 const regularDelayMs = tinyDelayMs * 2;
 const largeDelayMs = regularDelayMs * 2;
+const xLargeDelayMs = largeDelayMs * 2;
+const xxLargeDelayMs = xLargeDelayMs * 2;
 
 const dappPort = 8080;
 
@@ -144,5 +146,7 @@ module.exports = {
   tinyDelayMs,
   regularDelayMs,
   largeDelayMs,
+  xLargeDelayMs,
+  xxLargeDelayMs,
   withFixtures,
 };

--- a/test/e2e/metrics.spec.js
+++ b/test/e2e/metrics.spec.js
@@ -1,6 +1,6 @@
 const { strict: assert } = require('assert');
 const waitUntilCalled = require('../lib/wait-until-called');
-const { withFixtures } = require('./helpers');
+const { withFixtures, tinyDelayMs } = require('./helpers');
 
 /**
  * WARNING: These tests must be run using a build created with `yarn build:test:metrics`, so that it has
@@ -30,6 +30,7 @@ describe('Segment metrics', function () {
         const threeSegmentEventsReceived = waitUntilCalled(segmentStub, null, {
           callCount: 3,
         });
+        await driver.delay(tinyDelayMs);
         await driver.navigate();
 
         await driver.fill('#password', 'correct horse battery staple');

--- a/test/e2e/tests/permissions.spec.js
+++ b/test/e2e/tests/permissions.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures } = require('../helpers');
+const { withFixtures, xxLargeDelayMs } = require('../helpers');
 
 describe('Permissions', function () {
   it('sets permissions and connect to Dapp', async function () {
@@ -34,6 +34,7 @@ describe('Permissions', function () {
         await driver.waitUntilXWindowHandles(3);
         const windowHandles = await driver.getAllWindowHandles();
         const extension = windowHandles[0];
+        await driver.delay(xxLargeDelayMs);
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,

--- a/test/e2e/tests/provider-events.spec.js
+++ b/test/e2e/tests/provider-events.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures, regularDelayMs } = require('../helpers');
+const { withFixtures, regularDelayMs, xxLargeDelayMs } = require('../helpers');
 
 describe('MetaMask', function () {
   it('provider should inform dapp when switching networks', async function () {
@@ -27,7 +27,7 @@ describe('MetaMask', function () {
         await driver.openNewPage('http://127.0.0.1:8080/');
         const networkDiv = await driver.findElement('#network');
         const chainIdDiv = await driver.findElement('#chainId');
-        await driver.delay(regularDelayMs);
+        await driver.delay(xxLargeDelayMs);
         assert.equal(await networkDiv.getText(), '1337');
         assert.equal(await chainIdDiv.getText(), '0x539');
 


### PR DESCRIPTION
this is a requirement for lavamoat-protected builds of the webapp

merging separately to keep the lavamoat pr diff minimal