### PR TITLE
Fix to having radio buttons in advanced gas inputs pre-selected

### DIFF
--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -97,7 +97,8 @@ function getMatchingEstimateFromGasFees(
     findKey(gasFeeEstimates, (estimate) => {
       if (process.env.SHOW_EIP_1559_UI) {
         return (
-          Number(estimate?.suggestedMaxPriorityFeePerGas) === Number(maxPriorityFeePerGas) &&
+          Number(estimate?.suggestedMaxPriorityFeePerGas) ===
+            Number(maxPriorityFeePerGas) &&
           Number(estimate?.suggestedMaxFeePerGas) === Number(maxFeePerGas)
         );
       }

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -97,8 +97,8 @@ function getMatchingEstimateFromGasFees(
     findKey(gasFeeEstimates, (estimate) => {
       if (process.env.SHOW_EIP_1559_UI) {
         return (
-          estimate?.suggestedMaxPriorityFeePerGas === maxPriorityFeePerGas &&
-          estimate?.suggestedMaxFeePerGas === maxFeePerGas
+          Number(estimate?.suggestedMaxPriorityFeePerGas) === Number(maxPriorityFeePerGas) &&
+          Number(estimate?.suggestedMaxFeePerGas) === Number(maxFeePerGas)
         );
       }
       return estimate?.gasPrice === gasPrice;


### PR DESCRIPTION
The radio buttons in advanced gas inputs, when on an eip-1559 network, where not being automatically selected because we were matching the set gas fees against the estimated gas fees, but these were of different types. This is because of a `Number()` type cast done elsewhere in `useGasInputs`. This PR ensures that the estimated and set values are of the same type when compared