### PR TITLE
remove estimation appearance from edit-gas-popover on non-1559 networks

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -57,6 +57,7 @@ export default function EditGasDisplay({
   warning,
   gasErrors,
   onManualChange,
+  networkSupports1559,
 }) {
   const t = useContext(I18nContext);
 
@@ -107,9 +108,14 @@ export default function EditGasDisplay({
           </div>
         )}
         <TransactionTotalBanner
-          total={estimatedMinimumFiat}
+          total={
+            networkSupports1559
+              ? `~ ${estimatedMinimumFiat}`
+              : estimatedMaximumNative
+          }
           detail={
-            process.env.SHOW_EIP_1559_UI &&
+            networkSupports1559 &&
+            estimatedMaximumFiat !== undefined &&
             t('editGasTotalBannerSubtitle', [
               <Typography
                 fontWeight={FONT_WEIGHT.BOLD}
@@ -253,4 +259,5 @@ EditGasDisplay.propTypes = {
   transaction: PropTypes.object,
   gasErrors: PropTypes.object,
   onManualChange: PropTypes.func,
+  networkSupports1559: PropTypes.boolean,
 };

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useGasFeeInputs } from '../../../hooks/useGasFeeInputs';
 import { useShouldAnimateGasEstimations } from '../../../hooks/useShouldAnimateGasEstimations';
 
+import { isEIP1559Network } from '../../../ducks/metamask/metamask';
 import {
   GAS_ESTIMATE_TYPES,
   EDIT_GAS_MODES,
@@ -42,6 +43,7 @@ export default function EditGasPopover({
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   const showSidebar = useSelector((state) => state.appState.sidebar.isOpen);
+  const networkSupports1559 = useSelector(isEIP1559Network);
 
   const shouldAnimate = useShouldAnimateGasEstimations();
 
@@ -227,6 +229,7 @@ export default function EditGasPopover({
               hasGasErrors={hasGasErrors}
               gasErrors={gasErrors}
               onManualChange={onManualChange}
+              networkSupports1559={networkSupports1559}
               {...editGasDisplayProps}
             />
           </>

--- a/ui/components/app/transaction-total-banner/transaction-total-banner.component.js
+++ b/ui/components/app/transaction-total-banner/transaction-total-banner.component.js
@@ -12,7 +12,7 @@ export default function TransactionTotalBanner({
   return (
     <div className="transaction-total-banner">
       <Typography color={COLORS.BLACK} variant={TYPOGRAPHY.H1}>
-        ~ {total}
+        {total}
       </Typography>
       {detail && (
         <Typography


### PR DESCRIPTION
Partially Fixes: #11649

Explanation:  
Removes tilde (and up to...) from edit gas popover banner when on a network that does not support EIP1559:

<img width="343" alt="Screen Shot 2021-07-29 at 12 06 25 PM" src="https://user-images.githubusercontent.com/34557516/127534862-5662adb0-7176-4baf-836e-8bc03ba3d81f.png">
