### PR TITLE
EIP-1559 - Fix duplicated networkSupports1559 variables

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -60,7 +60,6 @@ export default function EditGasDisplay({
   warning,
   gasErrors,
   onManualChange,
-  networkSupports1559,
 }) {
   const t = useContext(I18nContext);
 
@@ -267,5 +266,4 @@ EditGasDisplay.propTypes = {
   transaction: PropTypes.object,
   gasErrors: PropTypes.object,
   onManualChange: PropTypes.func,
-  networkSupports1559: PropTypes.boolean,
 };

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useGasFeeInputs } from '../../../hooks/useGasFeeInputs';
 import { useShouldAnimateGasEstimations } from '../../../hooks/useShouldAnimateGasEstimations';
 
-import { isEIP1559Network } from '../../../ducks/metamask/metamask';
 import {
   GAS_ESTIMATE_TYPES,
   EDIT_GAS_MODES,
@@ -43,7 +42,6 @@ export default function EditGasPopover({
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   const showSidebar = useSelector((state) => state.appState.sidebar.isOpen);
-  const networkSupports1559 = useSelector(isEIP1559Network);
 
   const shouldAnimate = useShouldAnimateGasEstimations();
 
@@ -229,7 +227,6 @@ export default function EditGasPopover({
               hasGasErrors={hasGasErrors}
               gasErrors={gasErrors}
               onManualChange={onManualChange}
-              networkSupports1559={networkSupports1559}
               {...editGasDisplayProps}
             />
           </>


### PR DESCRIPTION
My local build is failing because `networkSupports1559` is declared twice.