### PR TITLE
Pass "maxFeePerGas" to the <GasTiming> component from Swaps

### DIFF
--- a/ui/pages/swaps/fee-card/fee-card.js
+++ b/ui/pages/swaps/fee-card/fee-card.js
@@ -39,6 +39,7 @@ export default function FeeCard({
   chainId,
   EIP1559Network,
   maxPriorityFeePerGasDecGWEI,
+  maxFeePerGasDecGWEI,
 }) {
   const t = useContext(I18nContext);
 
@@ -143,6 +144,7 @@ export default function FeeCard({
                 subTitle={
                   <GasTiming
                     maxPriorityFeePerGas={maxPriorityFeePerGasDecGWEI}
+                    maxFeePerGas={maxFeePerGasDecGWEI}
                   />
                 }
                 subText={
@@ -304,4 +306,5 @@ FeeCard.propTypes = {
   chainId: PropTypes.string.isRequired,
   EIP1559Network: PropTypes.bool.isRequired,
   maxPriorityFeePerGasDecGWEI: PropTypes.string,
+  maxFeePerGasDecGWEI: PropTypes.string,
 };

--- a/ui/pages/swaps/fee-card/fee-card.test.js
+++ b/ui/pages/swaps/fee-card/fee-card.test.js
@@ -86,6 +86,7 @@ describe('FeeCard', () => {
     const props = createProps({
       EIP1559Network: true,
       maxPriorityFeePerGasDecGWEI: '3',
+      maxFeePerGasDecGWEI: '4',
     });
     const { getByText } = renderWithProvider(<FeeCard {...props} />, store);
     expect(getByText('Using the best quote')).toBeInTheDocument();

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -754,6 +754,7 @@ export default function ViewQuote() {
             chainId={chainId}
             EIP1559Network={EIP1559Network}
             maxPriorityFeePerGasDecGWEI={hexWEIToDecGWEI(maxPriorityFeePerGas)}
+            maxFeePerGasDecGWEI={hexWEIToDecGWEI(maxFeePerGas)}
           />
         </div>
       </div>


### PR DESCRIPTION
## Explanation
Pass `maxFeePerGas` to the `<GasTiming>` component from Swaps

## Manual testing steps
  - Open Swaps on a network that supports EIP-1559 (e.g. on Rinkeby)
  - Select Token from and to, click on the `Review Swap` button
  - `<GasTiming>` component displays correct time estimation on the `View Quote` page