### PR TITLE
Ensure createPendingTxMiddleware returns gasPrice for EIP-1559 transactions

### DIFF
--- a/app/scripts/controllers/network/util.js
+++ b/app/scripts/controllers/network/util.js
@@ -36,6 +36,7 @@ export function formatTxMetaForRpcResult(txMeta) {
   };
 
   if (maxFeePerGas && maxPriorityFeePerGas) {
+    formattedTxMeta.gasPrice = maxFeePerGas;
     formattedTxMeta.maxFeePerGas = maxFeePerGas;
     formattedTxMeta.maxPriorityFeePerGas = maxPriorityFeePerGas;
     formattedTxMeta.type = TRANSACTION_ENVELOPE_TYPES.FEE_MARKET;

--- a/app/scripts/controllers/network/util.test.js
+++ b/app/scripts/controllers/network/util.test.js
@@ -33,6 +33,7 @@ describe('network utils', function () {
         blockNumber: null,
         from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
         gas: '0x7b0d',
+        gasPrice: '0x77359400',
         hash:
           '0x4bcb6cd6b182209585f8ad140260ddb35c81a575dd40f508d9767e652a9f60e7',
         input: '0x',


### PR DESCRIPTION
This PR ensures that calls to `eth_getTransactionByHash` for pending transactions includes a `gasPrice` in its response