### PR TITLE
Provider correct getGasFeeTimeEstimate call to Gas Timing

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2792,7 +2792,7 @@ export function disconnectGasFeeEstimatePoller(pollToken) {
 }
 
 export function getGasTimeEstimate(maxPriorityFeePerGas, maxFeePerGas) {
-  return promisifiedBackground.getGasTimeEstimate(
+  return promisifiedBackground.getGasFeeTimeEstimate(
     maxPriorityFeePerGas,
     maxFeePerGas,
   );


### PR DESCRIPTION
There's a typo in the method name for getting the gas fee time estimate.