### PR TITLE
Fix 11705 - Reset gas limit when radio button clicked

### DIFF
--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -77,7 +77,10 @@ export default function AdvancedGasControls({
             ? getGasFormErrorText(gasErrors.gasLimit, t, { minimumGasLimit })
             : null
         }
-        onChange={setGasLimit}
+        onChange={(value) => {
+          onManualChange?.();
+          setGasLimit(value);
+        }}
         tooltipText={t('editGasLimitTooltip')}
         value={gasLimit}
         allowDecimals={false}

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -429,13 +429,19 @@ export function useGasFeeInputs(
     (estimateLevel) => {
       setInternalEstimateToUse(estimateLevel);
       if (gasErrors.gasLimit === GAS_FORM_ERRORS.GAS_LIMIT_OUT_OF_BOUNDS) {
-        setGasLimit(hexToDecimal(transaction?.txParams?.gas));
+        const transactionGasLimit = hexToDecimal(transaction?.txParams?.gas);
+        const minimumGasLimitDec = hexToDecimal(minimumGasLimit);
+        setGasLimit(
+          transactionGasLimit > minimumGasLimitDec
+            ? transactionGasLimit
+            : minimumGasLimitDec,
+        );
       }
       setMaxFeePerGas(null);
       setMaxPriorityFeePerGas(null);
       setGasPrice(null);
     },
-    [gasErrors.gasLimit, transaction],
+    [minimumGasLimit, gasErrors.gasLimit, transaction],
   );
 
   return {

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -103,6 +103,8 @@ function getMatchingEstimateFromGasFees(
   maxFeePerGas,
   maxPriorityFeePerGas,
   gasPrice,
+  gasLimit,
+  minimumGasLimit,
   supportsEIP1559,
 ) {
   return (
@@ -111,7 +113,8 @@ function getMatchingEstimateFromGasFees(
         return (
           Number(estimate?.suggestedMaxPriorityFeePerGas) ===
             Number(maxPriorityFeePerGas) &&
-          Number(estimate?.suggestedMaxFeePerGas) === Number(maxFeePerGas)
+          Number(estimate?.suggestedMaxFeePerGas) === Number(maxFeePerGas) && 
+          Number(gasLimit) === Number(minimumGasLimit)
         );
       }
       return estimate?.gasPrice === gasPrice;
@@ -235,6 +238,8 @@ export function useGasFeeInputs(
           maxFeePerGas,
           maxPriorityFeePerGas,
           gasPrice,
+          gasLimit,
+          hexToDecimal(minimumGasLimit),
           supportsEIP1559,
         )
       : defaultEstimateToUse,

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -223,7 +223,7 @@ export function useGasFeeInputs(
   const [gasLimit, setGasLimit] = useState(
     Number(
       hexToDecimal(
-        transaction?.txParams?.gas ? transaction.txParams.gas : minimumGasLimit,
+        transaction?.txParams?.gas ?? minimumGasLimit,
       ),
     ),
   );

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -103,8 +103,6 @@ function getMatchingEstimateFromGasFees(
   maxFeePerGas,
   maxPriorityFeePerGas,
   gasPrice,
-  gasLimit,
-  minimumGasLimit,
   supportsEIP1559,
 ) {
   return (
@@ -113,8 +111,7 @@ function getMatchingEstimateFromGasFees(
         return (
           Number(estimate?.suggestedMaxPriorityFeePerGas) ===
             Number(maxPriorityFeePerGas) &&
-          Number(estimate?.suggestedMaxFeePerGas) === Number(maxFeePerGas) && 
-          Number(gasLimit) === Number(minimumGasLimit)
+          Number(estimate?.suggestedMaxFeePerGas) === Number(maxFeePerGas)
         );
       }
       return estimate?.gasPrice === gasPrice;
@@ -238,8 +235,6 @@ export function useGasFeeInputs(
           maxFeePerGas,
           maxPriorityFeePerGas,
           gasPrice,
-          gasLimit,
-          hexToDecimal(minimumGasLimit),
           supportsEIP1559,
         )
       : defaultEstimateToUse,

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -221,10 +221,13 @@ export function useGasFeeInputs(
       : null,
   );
   const [gasLimit, setGasLimit] = useState(
-    transaction?.txParams?.gas
-      ? Number(hexToDecimal(transaction.txParams.gas))
-      : 21000,
+    Number(
+      hexToDecimal(
+        transaction?.txParams?.gas ? transaction.txParams.gas : minimumGasLimit,
+      ),
+    ),
   );
+
   const [estimateToUse, setInternalEstimateToUse] = useState(
     transaction
       ? getMatchingEstimateFromGasFees(
@@ -240,12 +243,16 @@ export function useGasFeeInputs(
   // When a user selects an estimate level, it will wipe out what they have
   // previously put in the inputs. This returns the inputs to the estimated
   // values at the level specified.
-  const setEstimateToUse = useCallback((estimateLevel) => {
-    setInternalEstimateToUse(estimateLevel);
-    setMaxFeePerGas(null);
-    setMaxPriorityFeePerGas(null);
-    setGasPrice(null);
-  }, []);
+  const setEstimateToUse = useCallback(
+    (estimateLevel) => {
+      setInternalEstimateToUse(estimateLevel);
+      setGasLimit(hexToDecimal(minimumGasLimit));
+      setMaxFeePerGas(null);
+      setMaxPriorityFeePerGas(null);
+      setGasPrice(null);
+    },
+    [minimumGasLimit],
+  );
 
   // We specify whether to use the estimate value by checking if the state
   // value has been set. The state value is only set by user input and is wiped


### PR DESCRIPTION
* Resets the gas limit from custom when the user clicks a radio button
* Adds gas limit as a comparison for when finding a matching estimate