### PR TITLE
Fix #11703 - Provide wiring for approval modal

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -792,13 +792,12 @@ describe('MetaMask', function () {
       await driver.clickElement('.confirm-approve-content__small-blue-text');
       await driver.delay(regularDelayMs);
 
-      // wait for gas modal to be visible
-      const gasModal = await driver.findVisibleElement('span .modal');
-      await driver.clickElement('.page-container__tab:nth-of-type(2)');
-      await driver.delay(regularDelayMs);
+      await driver.clickElement(
+        '.edit-gas-display__dapp-acknowledgement-button',
+      );
 
-      const [gasPriceInput, gasLimitInput] = await driver.findElements(
-        '.advanced-gas-inputs__gas-edit-row__input',
+      const [gasLimitInput, gasPriceInput] = await driver.findElements(
+        '.advanced-gas-controls input[type="number"]',
       );
 
       await gasPriceInput.fill('10');
@@ -808,10 +807,7 @@ describe('MetaMask', function () {
 
       await driver.delay(1000);
 
-      await driver.clickElement('.page-container__footer-button');
-
-      // wait for gas modal to be removed from DOM.
-      await gasModal.waitForElementState('hidden');
+      await driver.clickElement({ text: 'Save', tag: 'button' }, 10000);
 
       const gasFeeInEth = await driver.findElement(
         '.confirm-approve-content__transaction-details-content__secondary-fee',

--- a/ui/components/app/modals/modal.js
+++ b/ui/components/app/modals/modal.js
@@ -11,7 +11,6 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 // Modal Components
 import ConfirmCustomizeGasModal from '../gas-customization/gas-modal-page-container';
 import SwapsGasCustomizationModal from '../../../pages/swaps/swaps-gas-customization-modal';
-import EditGasPopover from '../edit-gas-popover/edit-gas-popover.component';
 import DepositEtherModal from './deposit-ether-modal';
 import AccountDetailsModal from './account-details-modal';
 import ExportPrivateKeyModal from './export-private-key-modal';
@@ -243,35 +242,6 @@ const MODALS = {
     },
     contentStyle: {
       borderRadius: '8px',
-    },
-  },
-
-  CUSTOMIZE_GAS: {
-    contents: <EditGasPopover />,
-    mobileModalStyle: {
-      width: '100vw',
-      height: '100vh',
-      top: '0',
-      transform: 'none',
-      left: '0',
-      right: '0',
-      margin: '0 auto',
-    },
-    laptopModalStyle: {
-      width: 'auto',
-      height: '0px',
-      top: '80px',
-      left: '0px',
-      transform: 'none',
-      margin: '0 auto',
-      position: 'relative',
-    },
-    contentStyle: {
-      borderRadius: '8px',
-    },
-    customOnHideOpts: {
-      action: resetCustomGasData,
-      args: [],
     },
   },
 

--- a/ui/hooks/useApproveTransaction.js
+++ b/ui/hooks/useApproveTransaction.js
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Determine whether a transaction can be approved and provide a method to
+ * kick off the approval process.
+ *
+ * Provides a reusable hook that, given a transactionGroup, will manage
+ * the process of editing gas for approvals
+ * @param {Object} transactionGroup
+ * @return {[boolean, Function]}
+ */
+export function useApproveTransaction() {
+  const [showCustomizeGasPopover, setShowCustomizeGasPopover] = useState(false);
+
+  const closeCustomizeGasPopover = () => setShowCustomizeGasPopover(false);
+
+  const approveTransaction = useCallback(() => {
+    return setShowCustomizeGasPopover(true);
+  }, []);
+
+  return {
+    approveTransaction,
+    showCustomizeGasPopover,
+    closeCustomizeGasPopover,
+  };
+}


### PR DESCRIPTION
Fixes: #11703

Removes the old `modal` call with a hook modeled after cancel and retry.  With this PR, approval gas modification functions properly.