### PR TITLE
EIP-1559 - Only show advanced form toggle when radio buttons are present

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -78,6 +78,11 @@ export default function EditGasDisplay({
   const networkSupports1559 = useSelector(isEIP1559Network);
   const showTopError = balanceError;
 
+  const showRadioButtons =
+    networkSupports1559 &&
+    !requireDappAcknowledgement &&
+    ![EDIT_GAS_MODES.SPEED_UP, EDIT_GAS_MODES.CANCEL].includes(mode);
+
   let errorKey;
   if (balanceError) {
     errorKey = 'insufficientFunds';
@@ -161,35 +166,32 @@ export default function EditGasDisplay({
             {t('gasDisplayAcknowledgeDappButtonText')}
           </Button>
         )}
-        {networkSupports1559 &&
-          !requireDappAcknowledgement &&
-          ![EDIT_GAS_MODES.SPEED_UP, EDIT_GAS_MODES.CANCEL].includes(mode) && (
-            <RadioGroup
-              name="gas-recommendation"
-              options={[
-                {
-                  value: GAS_RECOMMENDATIONS.LOW,
-                  label: t('editGasLow'),
-                  recommended: defaultEstimateToUse === GAS_RECOMMENDATIONS.LOW,
-                },
-                {
-                  value: GAS_RECOMMENDATIONS.MEDIUM,
-                  label: t('editGasMedium'),
-                  recommended:
-                    defaultEstimateToUse === GAS_RECOMMENDATIONS.MEDIUM,
-                },
-                {
-                  value: GAS_RECOMMENDATIONS.HIGH,
-                  label: t('editGasHigh'),
-                  recommended:
-                    defaultEstimateToUse === GAS_RECOMMENDATIONS.HIGH,
-                },
-              ]}
-              selectedValue={estimateToUse}
-              onChange={setEstimateToUse}
-            />
-          )}
-        {!requireDappAcknowledgement && (
+        {showRadioButtons && (
+          <RadioGroup
+            name="gas-recommendation"
+            options={[
+              {
+                value: GAS_RECOMMENDATIONS.LOW,
+                label: t('editGasLow'),
+                recommended: defaultEstimateToUse === GAS_RECOMMENDATIONS.LOW,
+              },
+              {
+                value: GAS_RECOMMENDATIONS.MEDIUM,
+                label: t('editGasMedium'),
+                recommended:
+                  defaultEstimateToUse === GAS_RECOMMENDATIONS.MEDIUM,
+              },
+              {
+                value: GAS_RECOMMENDATIONS.HIGH,
+                label: t('editGasHigh'),
+                recommended: defaultEstimateToUse === GAS_RECOMMENDATIONS.HIGH,
+              },
+            ]}
+            selectedValue={estimateToUse}
+            onChange={setEstimateToUse}
+          />
+        )}
+        {!requireDappAcknowledgement && showRadioButtons && (
           <button
             className="edit-gas-display__advanced-button"
             onClick={() => setShowAdvancedForm(!showAdvancedForm)}


### PR DESCRIPTION
I noticed this on mainnet today:

<img width="848" alt="AdvancedOptionsIssuepng" src="https://user-images.githubusercontent.com/46655/127751546-22124660-aa35-4555-8916-0edb4aa1fc4d.png">

There's no need to show the advanced toggle if the radio group isn't displaying -- doing so allows the user to toggle to essentially seeing only the total, which is pointless.