### PR TITLE
EIP-1559 - Fall back to gasLimit and gasPrice for hardware wallets

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -187,7 +187,7 @@ export default class TransactionController extends EventEmitter {
 
   async getEIP1559Compatibility(fromAddress) {
     const currentNetworkIsCompatible = await this._getCurrentNetworkEIP1559Compatibility();
-    const fromAccountIsCompatible = this._getCurrentAccountEIP1559Compatibility(
+    const fromAccountIsCompatible = await this._getCurrentAccountEIP1559Compatibility(
       fromAddress,
     );
     return currentNetworkIsCompatible && fromAccountIsCompatible;
@@ -506,7 +506,9 @@ export default class TransactionController extends EventEmitter {
   async _getDefaultGasFees(txMeta, eip1559Compatibility) {
     if (
       (!eip1559Compatibility && txMeta.txParams.gasPrice) ||
-      (txMeta.txParams.maxFeePerGas && txMeta.txParams.maxPriorityFeePerGas)
+      (eip1559Compatibility &&
+        txMeta.txParams.maxFeePerGas &&
+        txMeta.txParams.maxPriorityFeePerGas)
     ) {
       return {};
     }
@@ -857,8 +859,8 @@ export default class TransactionController extends EventEmitter {
       ? TRANSACTION_ENVELOPE_TYPES.FEE_MARKET
       : TRANSACTION_ENVELOPE_TYPES.LEGACY;
     const txParams = {
-      type,
       ...txMeta.txParams,
+      type,
       chainId,
       gasLimit: txMeta.txParams.gas,
     };

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2059,10 +2059,10 @@ export default class MetamaskController extends EventEmitter {
    * client utilities for EIP-1559
    * @returns {boolean} true if the keyring type supports EIP-1559
    */
-  getCurrentAccountEIP1559Compatibility(fromAddress) {
+  async getCurrentAccountEIP1559Compatibility(fromAddress) {
     const address =
       fromAddress || this.preferencesController.getSelectedAddress();
-    const keyring = this.keyringController.getKeyringForAccount(address);
+    const keyring = await this.keyringController.getKeyringForAccount(address);
     return (
       keyring.type !== KEYRING_TYPES.LEDGER &&
       keyring.type !== KEYRING_TYPES.TREZOR

--- a/test/e2e/tests/send-edit.spec.js
+++ b/test/e2e/tests/send-edit.spec.js
@@ -68,10 +68,10 @@ describe('Editing Confirm Transaction', function () {
           '.currency-display-component__text',
         );
         const editedTransactionAmount = editedTransactionAmounts[0];
-        assert.equal(await editedTransactionAmount.getText(), '0.0008');
+        assert.equal(await editedTransactionAmount.getText(), '2.2');
 
         const editedTransactionFee = editedTransactionAmounts[1];
-        assert.equal(await editedTransactionFee.getText(), '2.2');
+        assert.equal(await editedTransactionFee.getText(), '0.0008');
 
         // confirms the transaction
         await driver.clickElement({ text: 'Confirm', tag: 'button' });

--- a/test/e2e/tests/send-edit.spec.js
+++ b/test/e2e/tests/send-edit.spec.js
@@ -68,10 +68,10 @@ describe('Editing Confirm Transaction', function () {
           '.currency-display-component__text',
         );
         const editedTransactionAmount = editedTransactionAmounts[0];
-        assert.equal(await editedTransactionAmount.getText(), '2.2');
+        assert.equal(await editedTransactionAmount.getText(), '0.0008');
 
         const editedTransactionFee = editedTransactionAmounts[1];
-        assert.equal(await editedTransactionFee.getText(), '0.0008');
+        assert.equal(await editedTransactionFee.getText(), '2.2');
 
         // confirms the transaction
         await driver.clickElement({ text: 'Confirm', tag: 'button' });

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -121,6 +121,9 @@ describe('Send ETH from inside MetaMask using fast gas option', function () {
 
         const inputValue = await inputAmount.getAttribute('value');
         assert.equal(inputValue, '1');
+        
+        // Set the gas price
+        await driver.clickElement({ text: 'Fast', tag: 'button/div/div' });
 
         // Continue to next screen
         await driver.clickElement({ text: 'Next', tag: 'button' });

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -121,7 +121,7 @@ describe('Send ETH from inside MetaMask using fast gas option', function () {
 
         const inputValue = await inputAmount.getAttribute('value');
         assert.equal(inputValue, '1');
-        
+
         // Set the gas price
         await driver.clickElement({ text: 'Fast', tag: 'button/div/div' });
 

--- a/test/e2e/tests/send-eth.spec.js
+++ b/test/e2e/tests/send-eth.spec.js
@@ -122,9 +122,6 @@ describe('Send ETH from inside MetaMask using fast gas option', function () {
         const inputValue = await inputAmount.getAttribute('value');
         assert.equal(inputValue, '1');
 
-        // Set the gas price
-        await driver.clickElement({ text: 'Fast', tag: 'button/div/div' });
-
         // Continue to next screen
         await driver.clickElement({ text: 'Next', tag: 'button' });
 

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
-import { isEIP1559Network } from '../../../ducks/metamask/metamask';
 import { I18nContext } from '../../../contexts/i18n';
 import Typography from '../../ui/typography/typography';
 import {
@@ -16,6 +15,7 @@ import {
   GAS_RECOMMENDATIONS,
 } from '../../../../shared/constants/gas';
 import { getGasFormErrorText } from '../../../helpers/constants/gas';
+import { networkAndAccountSupports1559 } from '../../../selectors';
 
 export default function AdvancedGasControls({
   estimateToUse,
@@ -33,15 +33,14 @@ export default function AdvancedGasControls({
   maxPriorityFeeFiat,
   maxFeeFiat,
   gasErrors,
-  networkSupportsEIP1559,
   minimumGasLimit,
 }) {
   const t = useContext(I18nContext);
-  const networkSupports1559 = useSelector(isEIP1559Network);
+  const use1559 = useSelector(networkAndAccountSupports1559);
 
   const suggestedValues = {};
 
-  if (networkSupportsEIP1559) {
+  if (use1559) {
     suggestedValues.maxFeePerGas =
       gasFeeEstimates?.[estimateToUse]?.suggestedMaxFeePerGas ||
       gasFeeEstimates?.gasPrice;
@@ -62,7 +61,7 @@ export default function AdvancedGasControls({
   }
 
   const showFeeMarketFields =
-    networkSupports1559 &&
+    use1559 &&
     (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET ||
       gasEstimateType === GAS_ESTIMATE_TYPES.ETH_GASPRICE);
 
@@ -194,5 +193,4 @@ AdvancedGasControls.propTypes = {
   maxFeeFiat: PropTypes.string,
   gasErrors: PropTypes.object,
   minimumGasLimit: PropTypes.number,
-  networkSupportsEIP1559: PropTypes.object,
 };

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -15,7 +15,7 @@ import {
   GAS_RECOMMENDATIONS,
 } from '../../../../shared/constants/gas';
 import { getGasFormErrorText } from '../../../helpers/constants/gas';
-import { networkAndAccountSupports1559 } from '../../../selectors';
+import { checkNetworkAndAccountSupports1559 } from '../../../selectors';
 
 export default function AdvancedGasControls({
   estimateToUse,
@@ -36,11 +36,13 @@ export default function AdvancedGasControls({
   minimumGasLimit,
 }) {
   const t = useContext(I18nContext);
-  const use1559 = useSelector(networkAndAccountSupports1559);
+  const networkAndAccountSupport1559 = useSelector(
+    checkNetworkAndAccountSupports1559,
+  );
 
   const suggestedValues = {};
 
-  if (use1559) {
+  if (networkAndAccountSupport1559) {
     suggestedValues.maxFeePerGas =
       gasFeeEstimates?.[estimateToUse]?.suggestedMaxFeePerGas ||
       gasFeeEstimates?.gasPrice;
@@ -61,7 +63,7 @@ export default function AdvancedGasControls({
   }
 
   const showFeeMarketFields =
-    use1559 &&
+    networkAndAccountSupport1559 &&
     (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET ||
       gasEstimateType === GAS_ESTIMATE_TYPES.ETH_GASPRICE);
 

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -12,7 +12,7 @@ import Button from '../../ui/button';
 import Typography from '../../ui/typography/typography';
 import {
   getIsMainnet,
-  networkAndAccountSupports1559,
+  checkNetworkAndAccountSupports1559,
 } from '../../../selectors';
 
 import {
@@ -69,7 +69,9 @@ export default function EditGasDisplay({
 }) {
   const t = useContext(I18nContext);
   const isMainnet = useSelector(getIsMainnet);
-  const use1559 = useSelector(networkAndAccountSupports1559);
+  const networkAndAccountSupport1559 = useSelector(
+    checkNetworkAndAccountSupports1559,
+  );
 
   const dappSuggestedAndTxParamGasFeesAreTheSame = areDappSuggestedAndTxParamGasFeesTheSame(
     transaction,
@@ -83,7 +85,7 @@ export default function EditGasDisplay({
 
   const showTopError = balanceError || estimatesUnavailableWarning;
   const showRadioButtons =
-    use1559 &&
+    networkAndAccountSupport1559 &&
     gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET &&
     !requireDappAcknowledgement &&
     ![EDIT_GAS_MODES.SPEED_UP, EDIT_GAS_MODES.CANCEL].includes(mode);
@@ -138,12 +140,12 @@ export default function EditGasDisplay({
         )}
         <TransactionTotalBanner
           total={
-            use1559 || isMainnet
+            networkAndAccountSupport1559 || isMainnet
               ? `~ ${estimatedMinimumFiat}`
               : estimatedMaximumNative
           }
           detail={
-            use1559 &&
+            networkAndAccountSupport1559 &&
             estimatedMaximumFiat !== undefined &&
             t('editGasTotalBannerSubtitle', [
               <Typography
@@ -173,7 +175,7 @@ export default function EditGasDisplay({
             {t('gasDisplayAcknowledgeDappButtonText')}
           </Button>
         )}
-        {use1559 && showRadioButtons && (
+        {networkAndAccountSupport1559 && showRadioButtons && (
           <RadioGroup
             name="gas-recommendation"
             options={[
@@ -233,13 +235,15 @@ export default function EditGasDisplay({
           />
         )}
       </div>
-      {use1559 && !requireDappAcknowledgement && showEducationButton && (
-        <div className="edit-gas-display__education">
-          <button onClick={onEducationClick}>
-            {t('editGasEducationButtonText')}
-          </button>
-        </div>
-      )}
+      {networkAndAccountSupport1559 &&
+        !requireDappAcknowledgement &&
+        showEducationButton && (
+          <div className="edit-gas-display__education">
+            <button onClick={onEducationClick}>
+              {t('editGasEducationButtonText')}
+            </button>
+          </div>
+        )}
     </div>
   );
 }

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -10,8 +10,10 @@ import {
 
 import Button from '../../ui/button';
 import Typography from '../../ui/typography/typography';
-import { isEIP1559Network } from '../../../ducks/metamask/metamask';
-import { getIsMainnet } from '../../../selectors';
+import {
+  getIsMainnet,
+  networkAndAccountSupports1559,
+} from '../../../selectors';
 
 import {
   COLORS,
@@ -66,8 +68,8 @@ export default function EditGasDisplay({
   estimatesUnavailableWarning,
 }) {
   const t = useContext(I18nContext);
-  const supportsEIP1559 = useSelector(isEIP1559Network);
   const isMainnet = useSelector(getIsMainnet);
+  const use1559 = useSelector(networkAndAccountSupports1559);
 
   const dappSuggestedAndTxParamGasFeesAreTheSame = areDappSuggestedAndTxParamGasFeesTheSame(
     transaction,
@@ -79,11 +81,9 @@ export default function EditGasDisplay({
       dappSuggestedAndTxParamGasFeesAreTheSame,
   );
 
-  const networkSupports1559 = useSelector(isEIP1559Network);
   const showTopError = balanceError || estimatesUnavailableWarning;
-
   const showRadioButtons =
-    networkSupports1559 &&
+    use1559 &&
     gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET &&
     !requireDappAcknowledgement &&
     ![EDIT_GAS_MODES.SPEED_UP, EDIT_GAS_MODES.CANCEL].includes(mode);
@@ -138,12 +138,12 @@ export default function EditGasDisplay({
         )}
         <TransactionTotalBanner
           total={
-            networkSupports1559 || isMainnet
+            use1559 || isMainnet
               ? `~ ${estimatedMinimumFiat}`
               : estimatedMaximumNative
           }
           detail={
-            networkSupports1559 &&
+            use1559 &&
             estimatedMaximumFiat !== undefined &&
             t('editGasTotalBannerSubtitle', [
               <Typography
@@ -173,7 +173,7 @@ export default function EditGasDisplay({
             {t('gasDisplayAcknowledgeDappButtonText')}
           </Button>
         )}
-        {showRadioButtons && (
+        {use1559 && showRadioButtons && (
           <RadioGroup
             name="gas-recommendation"
             options={[
@@ -230,19 +230,16 @@ export default function EditGasDisplay({
             gasErrors={gasErrors}
             onManualChange={onManualChange}
             minimumGasLimit={minimumGasLimit}
-            networkSupportsEIP1559={supportsEIP1559}
           />
         )}
       </div>
-      {networkSupports1559 &&
-        !requireDappAcknowledgement &&
-        showEducationButton && (
-          <div className="edit-gas-display__education">
-            <button onClick={onEducationClick}>
-              {t('editGasEducationButtonText')}
-            </button>
-          </div>
-        )}
+      {use1559 && !requireDappAcknowledgement && showEducationButton && (
+        <div className="edit-gas-display__education">
+          <button onClick={onEducationClick}>
+            {t('editGasEducationButtonText')}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -175,7 +175,7 @@ export default function EditGasDisplay({
             {t('gasDisplayAcknowledgeDappButtonText')}
           </Button>
         )}
-        {networkAndAccountSupport1559 && showRadioButtons && (
+        {showRadioButtons && (
           <RadioGroup
             name="gas-recommendation"
             options={[

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -27,7 +27,7 @@ import {
   updateCustomSwapsEIP1559GasParams,
 } from '../../../store/actions';
 import LoadingHeartBeat from '../../ui/loading-heartbeat';
-import { networkAndAccountSupports1559 } from '../../../selectors';
+import { checkNetworkAndAccountSupports1559 } from '../../../selectors';
 
 export default function EditGasPopover({
   popoverTitle = '',
@@ -42,12 +42,14 @@ export default function EditGasPopover({
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   const showSidebar = useSelector((state) => state.appState.sidebar.isOpen);
-  const use1559 = useSelector(networkAndAccountSupports1559);
+  const networkAndAccountSupport1559 = useSelector(
+    checkNetworkAndAccountSupports1559,
+  );
 
   const shouldAnimate = useShouldAnimateGasEstimations();
 
   const showEducationButton =
-    mode === EDIT_GAS_MODES.MODIFY_IN_PLACE && use1559;
+    mode === EDIT_GAS_MODES.MODIFY_IN_PLACE && networkAndAccountSupport1559;
   const [showEducationContent, setShowEducationContent] = useState(false);
 
   const [warning] = useState(null);
@@ -86,7 +88,7 @@ export default function EditGasPopover({
   } = useGasFeeInputs(defaultEstimateToUse, transaction, minimumGasLimit, mode);
 
   const [showAdvancedForm, setShowAdvancedForm] = useState(
-    !estimateToUse || hasGasErrors || !use1559,
+    !estimateToUse || hasGasErrors || !networkAndAccountSupport1559,
   );
 
   /**
@@ -110,7 +112,7 @@ export default function EditGasPopover({
       closePopover();
     }
 
-    const newGasSettings = use1559
+    const newGasSettings = networkAndAccountSupport1559
       ? {
           gas: decimalToHex(gasLimit),
           gasLimit: decimalToHex(gasLimit),
@@ -145,7 +147,7 @@ export default function EditGasPopover({
         break;
       case EDIT_GAS_MODES.SWAPS:
         // This popover component should only be used for the "FEE_MARKET" type in Swaps.
-        if (use1559) {
+        if (networkAndAccountSupport1559) {
           dispatch(updateCustomSwapsEIP1559GasParams(newGasSettings));
         }
         break;
@@ -163,7 +165,7 @@ export default function EditGasPopover({
     gasPrice,
     maxFeePerGas,
     maxPriorityFeePerGas,
-    use1559,
+    networkAndAccountSupport1559,
   ]);
 
   let title = t('editGasTitle');

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { isEIP1559Network } from '../../../ducks/metamask/metamask';
 import { useGasFeeInputs } from '../../../hooks/useGasFeeInputs';
 import { useShouldAnimateGasEstimations } from '../../../hooks/useShouldAnimateGasEstimations';
 
@@ -28,6 +27,7 @@ import {
   updateCustomSwapsEIP1559GasParams,
 } from '../../../store/actions';
 import LoadingHeartBeat from '../../ui/loading-heartbeat';
+import { networkAndAccountSupports1559 } from '../../../selectors';
 
 export default function EditGasPopover({
   popoverTitle = '',
@@ -42,12 +42,12 @@ export default function EditGasPopover({
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
   const showSidebar = useSelector((state) => state.appState.sidebar.isOpen);
-  const networkSupports1559 = useSelector(isEIP1559Network);
+  const use1559 = useSelector(networkAndAccountSupports1559);
 
   const shouldAnimate = useShouldAnimateGasEstimations();
 
   const showEducationButton =
-    mode === EDIT_GAS_MODES.MODIFY_IN_PLACE && networkSupports1559;
+    mode === EDIT_GAS_MODES.MODIFY_IN_PLACE && use1559;
   const [showEducationContent, setShowEducationContent] = useState(false);
 
   const [warning] = useState(null);
@@ -86,7 +86,7 @@ export default function EditGasPopover({
   } = useGasFeeInputs(defaultEstimateToUse, transaction, minimumGasLimit, mode);
 
   const [showAdvancedForm, setShowAdvancedForm] = useState(
-    !estimateToUse || hasGasErrors,
+    !estimateToUse || hasGasErrors || !use1559,
   );
 
   /**
@@ -110,7 +110,7 @@ export default function EditGasPopover({
       closePopover();
     }
 
-    const newGasSettings = networkSupports1559
+    const newGasSettings = use1559
       ? {
           gas: decimalToHex(gasLimit),
           gasLimit: decimalToHex(gasLimit),
@@ -145,7 +145,7 @@ export default function EditGasPopover({
         break;
       case EDIT_GAS_MODES.SWAPS:
         // This popover component should only be used for the "FEE_MARKET" type in Swaps.
-        if (networkSupports1559) {
+        if (use1559) {
           dispatch(updateCustomSwapsEIP1559GasParams(newGasSettings));
         }
         break;
@@ -163,7 +163,7 @@ export default function EditGasPopover({
     gasPrice,
     maxFeePerGas,
     maxPriorityFeePerGas,
-    networkSupports1559,
+    use1559,
   ]);
 
   let title = t('editGasTitle');

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -38,6 +38,7 @@ import {
   getSelectedAddress,
   getTargetAccount,
   getIsNonStandardEthChain,
+  checkNetworkAndAccountSupports1559,
 } from '../../selectors';
 import {
   disconnectGasFeeEstimatePoller,
@@ -73,8 +74,8 @@ import {
   getGasEstimateType,
   getTokens,
   getUnapprovedTxs,
-  isEIP1559Network,
 } from '../metamask/metamask';
+
 import { resetEnsResolution } from '../ens';
 import {
   isBurnAddress,
@@ -409,7 +410,7 @@ export const initializeSendState = createAsyncThunk(
     const state = thunkApi.getState();
     const isNonStandardEthChain = getIsNonStandardEthChain(state);
     const chainId = getCurrentChainId(state);
-    const eip1559support = isEIP1559Network(state);
+    const eip1559support = checkNetworkAndAccountSupports1559(state);
     const {
       send: { asset, stage, recipient, amount, draftTransaction },
       metamask,

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1085,7 +1085,9 @@ describe('Send Slice', () => {
             gasEstimateType: GAS_ESTIMATE_TYPES.NONE,
             gasFeeEstimates: {},
             networkDetails: {
-              EIPS: {},
+              EIPS: {
+                1559: true,
+              },
             },
             accounts: {
               '0xAddress': {

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1089,6 +1089,14 @@ describe('Send Slice', () => {
                 1559: true,
               },
             },
+            selectedAddress: '0xAddress',
+            identities: { '0xAddress': { address: '0xAddress' } },
+            keyrings: [
+              {
+                type: 'HD Key Tree',
+                accounts: ['0xAddress'],
+              },
+            ],
             accounts: {
               '0xAddress': {
                 address: '0xAddress',
@@ -1100,13 +1108,11 @@ describe('Send Slice', () => {
                 '0xAddress': '0x0',
               },
             },
-            selectedAddress: '0xAddress',
             provider: {
               chainId: '0x4',
             },
           },
           send: initialState,
-
           gas: {
             basicEstimateStatus: 'LOADING',
             basicEstimatesStatus: {

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -512,7 +512,9 @@ export const fetchQuotesAndSetQuoteState = (
 
     const hardwareWalletUsed = isHardwareWallet(state);
     const hardwareWalletType = getHardwareWalletType(state);
-    const networkAndAccountSupportsEIP1559 = checkNetworkAndAccountSupports1559(state);
+    const networkAndAccountSupports1559 = checkNetworkAndAccountSupports1559(
+      state,
+    );
     metaMetricsEvent({
       event: 'Quotes Requested',
       category: 'swaps',
@@ -554,7 +556,7 @@ export const fetchQuotesAndSetQuoteState = (
         ),
       );
 
-      const gasPriceFetchPromise = networkAndAccountSupportsEIP1559
+      const gasPriceFetchPromise = networkAndAccountSupports1559
         ? null // For EIP 1559 we can get gas prices via "useGasFeeEstimates".
         : dispatch(fetchAndSetSwapsGasPriceInfo());
 
@@ -628,7 +630,9 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     const state = getState();
     const chainId = getCurrentChainId(state);
     const hardwareWalletUsed = isHardwareWallet(state);
-    const networkAndAccountSupportsEIP1559 = checkNetworkAndAccountSupports1559(state);
+    const networkAndAccountSupports1559 = checkNetworkAndAccountSupports1559(
+      state,
+    );
     let swapsLivenessForNetwork = {
       swapsFeatureIsLive: false,
       useNewSwapsApi: false,
@@ -668,7 +672,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     let maxPriorityFeePerGas;
     let baseAndPriorityFeePerGas;
 
-    if (networkAndAccountSupportsEIP1559) {
+    if (networkAndAccountSupports1559) {
       const {
         high: { suggestedMaxFeePerGas, suggestedMaxPriorityFeePerGas },
         estimatedBaseFee = '0',
@@ -703,7 +707,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
 
     const usedGasPrice = getUsedSwapsGasPrice(state);
     usedTradeTxParams.gas = maxGasLimit;
-    if (networkAndAccountSupportsEIP1559) {
+    if (networkAndAccountSupports1559) {
       usedTradeTxParams.maxFeePerGas = maxFeePerGas;
       usedTradeTxParams.maxPriorityFeePerGas = maxPriorityFeePerGas;
       delete usedTradeTxParams.gasPrice;
@@ -725,7 +729,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     const gasEstimateTotalInUSD = getValueFromWeiHex({
       value: calcGasTotal(
         totalGasLimitEstimate,
-        EIP1559Network ? baseAndPriorityFeePerGas : usedGasPrice,
+        networkAndAccountSupports1559 ? baseAndPriorityFeePerGas : usedGasPrice,
       ),
       toCurrency: 'usd',
       conversionRate: usdConversionRate,
@@ -758,7 +762,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       is_hardware_wallet: hardwareWalletUsed,
       hardware_wallet_type: getHardwareWalletType(state),
     };
-    if (EIP1559Network) {
+    if (networkAndAccountSupports1559) {
       swapMetaData.max_fee_per_gas = maxFeePerGas;
       swapMetaData.max_priority_fee_per_gas = maxPriorityFeePerGas;
       swapMetaData.base_and_priority_fee_per_gas = baseAndPriorityFeePerGas;
@@ -793,7 +797,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     }
 
     if (approveTxParams) {
-      if (networkAndAccountSupportsEIP1559) {
+      if (networkAndAccountSupports1559) {
         approveTxParams.maxFeePerGas = maxFeePerGas;
         approveTxParams.maxPriorityFeePerGas = maxPriorityFeePerGas;
         delete approveTxParams.gasPrice;

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -57,6 +57,7 @@ import {
   getCurrentChainId,
   isHardwareWallet,
   getHardwareWalletType,
+  checkNetworkAndAccountSupports1559,
 } from '../../selectors';
 import {
   ERROR_FETCHING_QUOTES,
@@ -66,7 +67,7 @@ import {
   SWAPS_FETCH_ORDER_CONFLICT,
 } from '../../../shared/constants/swaps';
 import { TRANSACTION_TYPES } from '../../../shared/constants/transaction';
-import { isEIP1559Network, getGasFeeEstimates } from '../metamask/metamask';
+import { getGasFeeEstimates } from '../metamask/metamask';
 
 const GAS_PRICES_LOADING_STATES = {
   INITIAL: 'INITIAL',
@@ -511,7 +512,7 @@ export const fetchQuotesAndSetQuoteState = (
 
     const hardwareWalletUsed = isHardwareWallet(state);
     const hardwareWalletType = getHardwareWalletType(state);
-    const EIP1559Network = isEIP1559Network(state);
+    const EIP1559Network = checkNetworkAndAccountSupports1559(state);
     metaMetricsEvent({
       event: 'Quotes Requested',
       category: 'swaps',
@@ -627,7 +628,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     const state = getState();
     const chainId = getCurrentChainId(state);
     const hardwareWalletUsed = isHardwareWallet(state);
-    const EIP1559Network = isEIP1559Network(state);
+    const EIP1559Network = checkNetworkAndAccountSupports1559(state);
     let swapsLivenessForNetwork = {
       swapsFeatureIsLive: false,
       useNewSwapsApi: false,

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -512,7 +512,7 @@ export const fetchQuotesAndSetQuoteState = (
 
     const hardwareWalletUsed = isHardwareWallet(state);
     const hardwareWalletType = getHardwareWalletType(state);
-    const EIP1559Network = checkNetworkAndAccountSupports1559(state);
+    const networkAndAccountSupportsEIP1559 = checkNetworkAndAccountSupports1559(state);
     metaMetricsEvent({
       event: 'Quotes Requested',
       category: 'swaps',
@@ -554,7 +554,7 @@ export const fetchQuotesAndSetQuoteState = (
         ),
       );
 
-      const gasPriceFetchPromise = EIP1559Network
+      const gasPriceFetchPromise = networkAndAccountSupportsEIP1559
         ? null // For EIP 1559 we can get gas prices via "useGasFeeEstimates".
         : dispatch(fetchAndSetSwapsGasPriceInfo());
 
@@ -628,7 +628,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     const state = getState();
     const chainId = getCurrentChainId(state);
     const hardwareWalletUsed = isHardwareWallet(state);
-    const EIP1559Network = checkNetworkAndAccountSupports1559(state);
+    const networkAndAccountSupportsEIP1559 = checkNetworkAndAccountSupports1559(state);
     let swapsLivenessForNetwork = {
       swapsFeatureIsLive: false,
       useNewSwapsApi: false,
@@ -668,7 +668,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     let maxPriorityFeePerGas;
     let baseAndPriorityFeePerGas;
 
-    if (EIP1559Network) {
+    if (networkAndAccountSupportsEIP1559) {
       const {
         high: { suggestedMaxFeePerGas, suggestedMaxPriorityFeePerGas },
         estimatedBaseFee = '0',
@@ -703,7 +703,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
 
     const usedGasPrice = getUsedSwapsGasPrice(state);
     usedTradeTxParams.gas = maxGasLimit;
-    if (EIP1559Network) {
+    if (networkAndAccountSupportsEIP1559) {
       usedTradeTxParams.maxFeePerGas = maxFeePerGas;
       usedTradeTxParams.maxPriorityFeePerGas = maxPriorityFeePerGas;
       delete usedTradeTxParams.gasPrice;
@@ -793,7 +793,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
     }
 
     if (approveTxParams) {
-      if (EIP1559Network) {
+      if (networkAndAccountSupportsEIP1559) {
         approveTxParams.maxFeePerGas = maxFeePerGas;
         approveTxParams.maxPriorityFeePerGas = maxPriorityFeePerGas;
         delete approveTxParams.gasPrice;

--- a/ui/hooks/useGasFeeEstimates.js
+++ b/ui/hooks/useGasFeeEstimates.js
@@ -4,8 +4,8 @@ import {
   getEstimatedGasFeeTimeBounds,
   getGasEstimateType,
   getGasFeeEstimates,
-  isEIP1559Network,
 } from '../ducks/metamask/metamask';
+import { checkNetworkAndAccountSupports1559 } from '../selectors';
 import { useSafeGasEstimatePolling } from './useSafeGasEstimatePolling';
 
 /**
@@ -35,7 +35,9 @@ import { useSafeGasEstimatePolling } from './useSafeGasEstimatePolling';
  * @returns {GasFeeEstimates} - GasFeeEstimates object
  */
 export function useGasFeeEstimates() {
-  const supportsEIP1559 = useSelector(isEIP1559Network);
+  const networkAndAccountSupports1559 = useSelector(
+    checkNetworkAndAccountSupports1559,
+  );
   const gasEstimateType = useSelector(getGasEstimateType);
   const gasFeeEstimates = useSelector(getGasFeeEstimates);
   const estimatedGasFeeTimeBounds = useSelector(getEstimatedGasFeeTimeBounds);
@@ -49,8 +51,9 @@ export function useGasFeeEstimates() {
     gasEstimateType === GAS_ESTIMATE_TYPES.ETH_GASPRICE;
   const isGasEstimatesLoading =
     gasEstimateType === GAS_ESTIMATE_TYPES.NONE ||
-    (supportsEIP1559 && !isEIP1559TolerableEstimateType) ||
-    (!supportsEIP1559 && gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET);
+    (networkAndAccountSupports1559 && !isEIP1559TolerableEstimateType) ||
+    (!networkAndAccountSupports1559 &&
+      gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET);
 
   return {
     gasFeeEstimates,

--- a/ui/hooks/useGasFeeEstimates.test.js
+++ b/ui/hooks/useGasFeeEstimates.test.js
@@ -5,8 +5,8 @@ import createRandomId from '../../shared/modules/random-id';
 import {
   getGasEstimateType,
   getGasFeeEstimates,
-  isEIP1559Network,
 } from '../ducks/metamask/metamask';
+import { checkNetworkAndAccountSupports1559 } from '../selectors';
 import {
   disconnectGasFeeEstimatePoller,
   getGasFeeEstimatesAndStartPolling,
@@ -28,7 +28,7 @@ jest.mock('react-redux', () => {
 });
 
 const DEFAULT_OPTS = {
-  isEIP1559Network: false,
+  checkNetworkAndAccountSupports1559: false,
   gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
   gasFeeEstimates: {
     low: '10',
@@ -38,8 +38,11 @@ const DEFAULT_OPTS = {
 };
 
 const generateUseSelectorRouter = (opts = DEFAULT_OPTS) => (selector) => {
-  if (selector === isEIP1559Network) {
-    return opts.isEIP1559Network ?? DEFAULT_OPTS.isEIP1559Network;
+  if (selector === checkNetworkAndAccountSupports1559) {
+    return (
+      opts.checkNetworkAndAccountSupports1559 ??
+      DEFAULT_OPTS.checkNetworkAndAccountSupports1559
+    );
   }
   if (selector === getGasEstimateType) {
     return opts.gasEstimateType ?? DEFAULT_OPTS.gasEstimateType;
@@ -137,7 +140,7 @@ describe('useGasFeeEstimates', () => {
     };
     useSelector.mockImplementation(
       generateUseSelectorRouter({
-        isEIP1559Network: true,
+        checkNetworkAndAccountSupports1559: true,
         gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
         gasFeeEstimates,
       }),
@@ -176,7 +179,7 @@ describe('useGasFeeEstimates', () => {
   it('indicates that gas estimates are loading when gasEstimateType is not FEE_MARKET or ETH_GASPRICE, but network supports EIP-1559', () => {
     useSelector.mockImplementation(
       generateUseSelectorRouter({
-        isEIP1559Network: true,
+        checkNetworkAndAccountSupports1559: true,
         gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
         gasFeeEstimates: {
           gasPrice: '10',
@@ -219,7 +222,7 @@ describe('useGasFeeEstimates', () => {
     };
     useSelector.mockImplementation(
       generateUseSelectorRouter({
-        isEIP1559Network: false,
+        checkNetworkAndAccountSupports1559: false,
         gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
         gasFeeEstimates,
       }),

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -409,7 +409,7 @@ export function useGasFeeInputs(
     case GAS_ESTIMATE_TYPES.LEGACY:
     case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
     case GAS_ESTIMATE_TYPES.NONE:
-      if (networkSupportsEIP1559) {
+      if (networkAndAccountSupports1559) {
         estimatesUnavailableWarning = true;
       }
       break;

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -18,7 +18,11 @@ import {
   getMinimumGasTotalInHexWei,
 } from '../../shared/modules/gas.utils';
 import { PRIMARY, SECONDARY } from '../helpers/constants/common';
-import { isEIP1559Network } from '../ducks/metamask/metamask';
+import {
+  checkNetworkAndAccountSupports1559,
+  getShouldShowFiat,
+  getSelectedAccount,
+} from '../selectors';
 
 import {
   hexWEIToDecGWEI,
@@ -28,7 +32,7 @@ import {
   addHexes,
 } from '../helpers/utils/conversions.util';
 import { GAS_FORM_ERRORS } from '../helpers/constants/gas';
-import { getShouldShowFiat, getSelectedAccount } from '../selectors';
+
 import { useCurrencyDisplay } from './useCurrencyDisplay';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 import { useUserPreferencedCurrency } from './useUserPreferencedCurrency';
@@ -171,12 +175,14 @@ export function useGasFeeInputs(
   editGasMode,
 ) {
   const { balance: ethBalance } = useSelector(getSelectedAccount);
-  const networkSupportsEIP1559 = useSelector(isEIP1559Network);
+  const networkSupportsEIP1559 = useSelector(
+    checkNetworkAndAccountSupports1559,
+  );
   // We need to know whether to show fiat conversions or not, so that we can
   // default our fiat values to empty strings if showing fiat is not wanted or
   // possible.
   const showFiat = useSelector(getShouldShowFiat);
-  const supportsEIP1559 = useSelector(isEIP1559Network);
+  const supportsEIP1559 = useSelector(checkNetworkAndAccountSupports1559);
 
   // We need to know the current network's currency and its decimal precision
   // to calculate the amount to display to the user.

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -107,11 +107,11 @@ function getMatchingEstimateFromGasFees(
   maxFeePerGas,
   maxPriorityFeePerGas,
   gasPrice,
-  supportsEIP1559,
+  networkAndAccountSupports1559,
 ) {
   return (
     findKey(gasFeeEstimates, (estimate) => {
-      if (supportsEIP1559) {
+      if (networkAndAccountSupports1559) {
         return (
           Number(estimate?.suggestedMaxPriorityFeePerGas) ===
             Number(maxPriorityFeePerGas) &&
@@ -175,14 +175,13 @@ export function useGasFeeInputs(
   editGasMode,
 ) {
   const { balance: ethBalance } = useSelector(getSelectedAccount);
-  const networkSupportsEIP1559 = useSelector(
+  const networkAndAccountSupports1559 = useSelector(
     checkNetworkAndAccountSupports1559,
   );
   // We need to know whether to show fiat conversions or not, so that we can
   // default our fiat values to empty strings if showing fiat is not wanted or
   // possible.
   const showFiat = useSelector(getShouldShowFiat);
-  const supportsEIP1559 = useSelector(checkNetworkAndAccountSupports1559);
 
   // We need to know the current network's currency and its decimal precision
   // to calculate the amount to display to the user.
@@ -237,7 +236,7 @@ export function useGasFeeInputs(
           maxFeePerGas,
           maxPriorityFeePerGas,
           gasPrice,
-          supportsEIP1559,
+          networkAndAccountSupports1559,
         )
       : defaultEstimateToUse,
   );
@@ -277,7 +276,7 @@ export function useGasFeeInputs(
   const gasSettings = {
     gasLimit: decimalToHex(gasLimit),
   };
-  if (networkSupportsEIP1559) {
+  if (networkAndAccountSupports1559) {
     gasSettings.maxFeePerGas = maxFeePerGasToUse
       ? decGWEIToHexWEI(maxFeePerGasToUse)
       : decGWEIToHexWEI(gasPriceToUse || '0');

--- a/ui/hooks/useGasFeeInputs.test.js
+++ b/ui/hooks/useGasFeeInputs.test.js
@@ -3,18 +3,19 @@ import { useSelector } from 'react-redux';
 import { GAS_ESTIMATE_TYPES } from '../../shared/constants/gas';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import {
-  isEIP1559Network,
   getConversionRate,
   getNativeCurrency,
 } from '../ducks/metamask/metamask';
-
-import { ETH, PRIMARY } from '../helpers/constants/common';
 import {
+  checkNetworkAndAccountSupports1559,
   getCurrentCurrency,
   getShouldShowFiat,
   txDataSelector,
   getSelectedAccount,
 } from '../selectors';
+
+import { ETH, PRIMARY } from '../helpers/constants/common';
+
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 import { useGasFeeInputs } from './useGasFeeInputs';
 import { useUserPreferencedCurrency } from './useUserPreferencedCurrency';
@@ -104,9 +105,9 @@ const HIGH_FEE_MARKET_ESTIMATE_RETURN_VALUE = {
   estimatedGasFeeTimeBounds: {},
 };
 
-const generateUseSelectorRouter = ({ isEIP1559NetworkResponse } = {}) => (
-  selector,
-) => {
+const generateUseSelectorRouter = ({
+  checkNetworkAndAccountSupports1559Response,
+} = {}) => (selector) => {
   if (selector === getConversionRate) {
     return MOCK_ETH_USD_CONVERSION_RATE;
   }
@@ -131,8 +132,8 @@ const generateUseSelectorRouter = ({ isEIP1559NetworkResponse } = {}) => (
       balance: '0x440aa47cc2556',
     };
   }
-  if (selector === isEIP1559Network) {
-    return isEIP1559NetworkResponse;
+  if (selector === checkNetworkAndAccountSupports1559) {
+    return checkNetworkAndAccountSupports1559Response;
   }
   return undefined;
 };
@@ -186,7 +187,9 @@ describe('useGasFeeInputs', () => {
 
     it('updates values when user modifies gasPrice', () => {
       useSelector.mockImplementation(
-        generateUseSelectorRouter({ isEIP1559NetworkResponse: false }),
+        generateUseSelectorRouter({
+          checkNetworkAndAccountSupports1559Response: false,
+        }),
       );
       const { result } = renderHook(() => useGasFeeInputs());
       expect(result.current.gasPrice).toBe(
@@ -253,7 +256,9 @@ describe('useGasFeeInputs', () => {
 
     it('updates values when user modifies maxFeePerGas', () => {
       useSelector.mockImplementation(
-        generateUseSelectorRouter({ isEIP1559NetworkResponse: true }),
+        generateUseSelectorRouter({
+          checkNetworkAndAccountSupports1559Response: true,
+        }),
       );
       const { result } = renderHook(() => useGasFeeInputs());
       expect(result.current.maxFeePerGas).toBe(
@@ -311,7 +316,9 @@ describe('useGasFeeInputs', () => {
         () => HIGH_FEE_MARKET_ESTIMATE_RETURN_VALUE,
       );
       useSelector.mockImplementation(
-        generateUseSelectorRouter({ isEIP1559NetworkResponse: true }),
+        generateUseSelectorRouter({
+          checkNetworkAndAccountSupports1559Response: true,
+        }),
       );
     });
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -27,14 +27,12 @@ import {
   getNoGasPriceFetched,
   getIsEthGasPriceFetched,
   getShouldShowFiat,
+  checkNetworkAndAccountSupports1559,
 } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import { transactionMatchesNetwork } from '../../../shared/modules/transaction.utils';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
-import {
-  updateTransactionGasFees,
-  isEIP1559Network,
-} from '../../ducks/metamask/metamask';
+import { updateTransactionGasFees } from '../../ducks/metamask/metamask';
 import ConfirmTransactionBase from './confirm-transaction-base.component';
 
 const casedContractMap = Object.keys(contractMap).reduce((acc, base) => {
@@ -61,7 +59,7 @@ const mapStateToProps = (state, ownProps) => {
   } = ownProps;
   const { id: paramsTransactionId } = params;
   const isMainnet = getIsMainnet(state);
-  const supportsEIP1599 = isEIP1559Network(state);
+  const supportsEIP1599 = checkNetworkAndAccountSupports1559(state);
   const { confirmTransaction, metamask } = state;
   const {
     ensResolutionsByAddress,

--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -29,7 +29,7 @@ export default class SendContent extends Component {
     gasIsExcessive: PropTypes.bool.isRequired,
     isEthGasPrice: PropTypes.bool,
     noGasPrice: PropTypes.bool,
-    isEIP1559Network: PropTypes.bool,
+    networkAndAccountSupports1559: PropTypes.bool,
   };
 
   render() {
@@ -40,7 +40,7 @@ export default class SendContent extends Component {
       isEthGasPrice,
       noGasPrice,
       isAssetSendable,
-      isEIP1559Network,
+      networkAndAccountSupports1559,
     } = this.props;
 
     let gasError;
@@ -59,7 +59,7 @@ export default class SendContent extends Component {
           {this.maybeRenderAddContact()}
           <SendAssetRow />
           <SendAmountRow />
-          {!isEIP1559Network && <SendGasRow />}
+          {!networkAndAccountSupports1559 && <SendGasRow />}
           {this.props.showHexData && <SendHexDataRow />}
         </div>
       </PageContainerContent>

--- a/ui/pages/send/send-content/send-content.component.test.js
+++ b/ui/pages/send/send-content/send-content.component.test.js
@@ -14,7 +14,7 @@ describe('SendContent Component', () => {
   const defaultProps = {
     showHexData: true,
     gasIsExcessive: false,
-    isEIP1559Network: true,
+    networkAndAccountSupports1559: true,
   };
 
   beforeEach(() => {

--- a/ui/pages/send/send-content/send-content.container.js
+++ b/ui/pages/send/send-content/send-content.container.js
@@ -4,8 +4,8 @@ import {
   getAddressBookEntry,
   getIsEthGasPriceFetched,
   getNoGasPriceFetched,
+  checkNetworkAndAccountSupports1559,
 } from '../../../selectors';
-import { isEIP1559Network } from '../../../ducks/metamask/metamask';
 import { getIsAssetSendable, getSendTo } from '../../../ducks/send';
 
 import * as actions from '../../../store/actions';
@@ -25,7 +25,7 @@ function mapStateToProps(state) {
     isEthGasPrice: getIsEthGasPriceFetched(state),
     noGasPrice: getNoGasPriceFetched(state),
     to,
-    isEIP1559Network: isEIP1559Network(state),
+    networkAndAccountSupports1559: checkNetworkAndAccountSupports1559(state),
   };
 }
 

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -48,6 +48,13 @@ const baseStore = {
       medium: '1',
       fast: '2',
     },
+    selectedAddress: '0x0',
+    keyrings: [
+      {
+        type: 'HD Key Tree',
+        accounts: ['0x0'],
+      },
+    ],
     networkDetails: {
       EIPS: {},
     },
@@ -72,7 +79,7 @@ const baseStore = {
     accounts: {
       '0x0': { balance: '0x0', address: '0x0' },
     },
-    identities: { '0x0': {} },
+    identities: { '0x0': { address: '0x0' } },
   },
 };
 

--- a/ui/pages/swaps/fee-card/fee-card.js
+++ b/ui/pages/swaps/fee-card/fee-card.js
@@ -37,7 +37,7 @@ export default function FeeCard({
   onQuotesClick,
   tokenConversionRate,
   chainId,
-  EIP1559Network,
+  networkAndAccountSupportsEIP1559,
   maxPriorityFeePerGasDecGWEI,
   maxFeePerGasDecGWEI,
 }) {
@@ -96,7 +96,7 @@ export default function FeeCard({
         </div>
       </div>
       <div className="fee-card__main">
-        {EIP1559Network && (
+        {networkAndAccountSupportsEIP1559 && (
           <TransactionDetail
             rows={[
               <TransactionDetailItem
@@ -172,7 +172,7 @@ export default function FeeCard({
             ]}
           />
         )}
-        {!EIP1559Network && (
+        {!networkAndAccountSupportsEIP1559 && (
           <div
             className="fee-card__row-header"
             data-testid="fee-card__row-header"
@@ -221,7 +221,7 @@ export default function FeeCard({
             </div>
           </div>
         )}
-        {!EIP1559Network && (
+        {!networkAndAccountSupportsEIP1559 && (
           <div
             className="fee-card__row-header"
             onClick={() => onFeeCardMaxRowClick()}
@@ -304,7 +304,7 @@ FeeCard.propTypes = {
   numberOfQuotes: PropTypes.number.isRequired,
   tokenConversionRate: PropTypes.number,
   chainId: PropTypes.string.isRequired,
-  EIP1559Network: PropTypes.bool.isRequired,
+  networkAndAccountSupportsEIP1559: PropTypes.bool.isRequired,
   maxPriorityFeePerGasDecGWEI: PropTypes.string,
   maxFeePerGasDecGWEI: PropTypes.string,
 };

--- a/ui/pages/swaps/fee-card/fee-card.js
+++ b/ui/pages/swaps/fee-card/fee-card.js
@@ -37,7 +37,7 @@ export default function FeeCard({
   onQuotesClick,
   tokenConversionRate,
   chainId,
-  networkAndAccountSupportsEIP1559,
+  networkAndAccountSupports1559,
   maxPriorityFeePerGasDecGWEI,
   maxFeePerGasDecGWEI,
 }) {
@@ -96,7 +96,7 @@ export default function FeeCard({
         </div>
       </div>
       <div className="fee-card__main">
-        {networkAndAccountSupportsEIP1559 && (
+        {networkAndAccountSupports1559 && (
           <TransactionDetail
             rows={[
               <TransactionDetailItem
@@ -172,7 +172,7 @@ export default function FeeCard({
             ]}
           />
         )}
-        {!networkAndAccountSupportsEIP1559 && (
+        {!networkAndAccountSupports1559 && (
           <div
             className="fee-card__row-header"
             data-testid="fee-card__row-header"
@@ -221,7 +221,7 @@ export default function FeeCard({
             </div>
           </div>
         )}
-        {!networkAndAccountSupportsEIP1559 && (
+        {!networkAndAccountSupports1559 && (
           <div
             className="fee-card__row-header"
             onClick={() => onFeeCardMaxRowClick()}
@@ -304,7 +304,7 @@ FeeCard.propTypes = {
   numberOfQuotes: PropTypes.number.isRequired,
   tokenConversionRate: PropTypes.number,
   chainId: PropTypes.string.isRequired,
-  networkAndAccountSupportsEIP1559: PropTypes.bool.isRequired,
+  networkAndAccountSupports1559: PropTypes.bool.isRequired,
   maxPriorityFeePerGasDecGWEI: PropTypes.string,
   maxFeePerGasDecGWEI: PropTypes.string,
 };

--- a/ui/pages/swaps/fee-card/fee-card.test.js
+++ b/ui/pages/swaps/fee-card/fee-card.test.js
@@ -58,7 +58,7 @@ const createProps = (customProps = {}) => {
     onQuotesClick: jest.fn(),
     tokenConversionRate: 0.015,
     chainId: MAINNET_CHAIN_ID,
-    EIP1559Network: false,
+    networkAndAccountSupportsEIP1559: false,
     ...customProps,
   };
 };
@@ -89,7 +89,7 @@ describe('FeeCard', () => {
   it('renders the component with EIP-1559 enabled', () => {
     const store = configureMockStore(middleware)(createSwapsMockStore());
     const props = createProps({
-      EIP1559Network: true,
+      networkAndAccountSupportsEIP1559: true,
       maxPriorityFeePerGasDecGWEI: '3',
       maxFeePerGasDecGWEI: '4',
     });

--- a/ui/pages/swaps/fee-card/fee-card.test.js
+++ b/ui/pages/swaps/fee-card/fee-card.test.js
@@ -58,7 +58,7 @@ const createProps = (customProps = {}) => {
     onQuotesClick: jest.fn(),
     tokenConversionRate: 0.015,
     chainId: MAINNET_CHAIN_ID,
-    networkAndAccountSupportsEIP1559: false,
+    networkAndAccountSupports1559: false,
     ...customProps,
   };
 };
@@ -89,7 +89,7 @@ describe('FeeCard', () => {
   it('renders the component with EIP-1559 enabled', () => {
     const store = configureMockStore(middleware)(createSwapsMockStore());
     const props = createProps({
-      networkAndAccountSupportsEIP1559: true,
+      networkAndAccountSupports1559: true,
       maxPriorityFeePerGasDecGWEI: '3',
       maxFeePerGasDecGWEI: '4',
     });

--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -36,7 +36,10 @@ import {
   getUseNewSwapsApi,
   getFromToken,
 } from '../../ducks/swaps/swaps';
-import { isEIP1559Network } from '../../ducks/metamask/metamask';
+import {
+  checkNetworkAndAccountSupports1559,
+  currentNetworkTxListSelector,
+} from '../../selectors';
 import {
   AWAITING_SIGNATURES_ROUTE,
   AWAITING_SWAP_ROUTE,
@@ -62,7 +65,7 @@ import {
   setBackgroundSwapRouteState,
   setSwapsErrorKey,
 } from '../../store/actions';
-import { currentNetworkTxListSelector } from '../../selectors';
+
 import { useNewMetricEvent } from '../../hooks/useMetricEvent';
 import { useGasFeeEstimates } from '../../hooks/useGasFeeEstimates';
 import FeatureToggledRoute from '../../helpers/higher-order-components/feature-toggled-route';
@@ -112,10 +115,12 @@ export default function Swap() {
   const chainId = useSelector(getCurrentChainId);
   const isSwapsChain = useSelector(getIsSwapsChain);
   const useNewSwapsApi = useSelector(getUseNewSwapsApi);
-  const EIP1559Network = useSelector(isEIP1559Network);
+  const networkAndAccountSupports1559 = useSelector(
+    checkNetworkAndAccountSupports1559,
+  );
   const fromToken = useSelector(getFromToken);
 
-  if (EIP1559Network) {
+  if (networkAndAccountSupports1559) {
     // This will pre-load gas fees before going to the View Quote page.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useGasFeeEstimates();
@@ -195,14 +200,20 @@ export default function Swap() {
           dispatch(setAggregatorMetadata(newAggregatorMetadata));
         },
       );
-      if (!EIP1559Network) {
+      if (!networkAndAccountSupports1559) {
         dispatch(fetchAndSetSwapsGasPriceInfo(chainId));
       }
       return () => {
         dispatch(prepareToLeaveSwaps());
       };
     }
-  }, [dispatch, chainId, isFeatureFlagLoaded, useNewSwapsApi, EIP1559Network]);
+  }, [
+    dispatch,
+    chainId,
+    isFeatureFlagLoaded,
+    useNewSwapsApi,
+    networkAndAccountSupports1559,
+  ]);
 
   const hardwareWalletUsed = useSelector(isHardwareWallet);
   const hardwareWalletType = useSelector(getHardwareWalletType);

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -659,7 +659,7 @@ export function getSwapsTokensReceivedFromTxMeta(
   chainId,
 ) {
   const txReceipt = txMeta?.txReceipt;
-  const EIP1559Network =
+  const networkAndAccountSupportsEIP1559 =
     txMeta?.txReceipt?.type === TRANSACTION_ENVELOPE_TYPES.FEE_MARKET;
   if (isSwapsDefaultTokenSymbol(tokenSymbol, chainId)) {
     if (
@@ -675,7 +675,7 @@ export function getSwapsTokensReceivedFromTxMeta(
     if (approvalTxMeta && approvalTxMeta.txReceipt) {
       approvalTxGasCost = calcGasTotal(
         approvalTxMeta.txReceipt.gasUsed,
-        EIP1559Network
+        networkAndAccountSupportsEIP1559
           ? approvalTxMeta.txReceipt.effectiveGasPrice // Base fee + priority fee.
           : approvalTxMeta.txParams.gasPrice,
       );
@@ -683,7 +683,7 @@ export function getSwapsTokensReceivedFromTxMeta(
 
     const gasCost = calcGasTotal(
       txReceipt.gasUsed,
-      EIP1559Network ? txReceipt.effectiveGasPrice : txMeta.txParams.gasPrice,
+      networkAndAccountSupportsEIP1559 ? txReceipt.effectiveGasPrice : txMeta.txParams.gasPrice,
     );
     const totalGasCost = new BigNumber(gasCost, 16)
       .plus(approvalTxGasCost, 16)

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -659,7 +659,7 @@ export function getSwapsTokensReceivedFromTxMeta(
   chainId,
 ) {
   const txReceipt = txMeta?.txReceipt;
-  const networkAndAccountSupportsEIP1559 =
+  const networkAndAccountSupports1559 =
     txMeta?.txReceipt?.type === TRANSACTION_ENVELOPE_TYPES.FEE_MARKET;
   if (isSwapsDefaultTokenSymbol(tokenSymbol, chainId)) {
     if (
@@ -675,7 +675,7 @@ export function getSwapsTokensReceivedFromTxMeta(
     if (approvalTxMeta && approvalTxMeta.txReceipt) {
       approvalTxGasCost = calcGasTotal(
         approvalTxMeta.txReceipt.gasUsed,
-        networkAndAccountSupportsEIP1559
+        networkAndAccountSupports1559
           ? approvalTxMeta.txReceipt.effectiveGasPrice // Base fee + priority fee.
           : approvalTxMeta.txParams.gasPrice,
       );
@@ -683,7 +683,9 @@ export function getSwapsTokensReceivedFromTxMeta(
 
     const gasCost = calcGasTotal(
       txReceipt.gasUsed,
-      networkAndAccountSupportsEIP1559 ? txReceipt.effectiveGasPrice : txMeta.txParams.gasPrice,
+      networkAndAccountSupports1559
+        ? txReceipt.effectiveGasPrice
+        : txMeta.txParams.gasPrice,
     );
     const totalGasCost = new BigNumber(gasCost, 16)
       .plus(approvalTxGasCost, 16)

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -14,7 +14,6 @@ import {
   getGasEstimateType,
   getGasFeeEstimates,
   getNativeCurrency,
-  isEIP1559Network,
 } from '../ducks/metamask/metamask';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../shared/constants/transaction';
 import { decGWEIToHexWEI } from '../helpers/utils/conversions.util';
@@ -25,6 +24,7 @@ import {
 } from '../../shared/modules/gas.utils';
 import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import { getCurrentChainId, deprecatedGetCurrentNetworkId } from './selectors';
+import { checkNetworkAndAccountSupports1559 } from '.';
 
 const unapprovedTxsSelector = (state) => state.metamask.unapprovedTxs;
 const unapprovedMsgsSelector = (state) => state.metamask.unapprovedMsgs;
@@ -231,13 +231,15 @@ export const transactionFeeSelector = function (state, txData) {
   const nativeCurrency = getNativeCurrency(state);
   const gasFeeEstimates = getGasFeeEstimates(state) || {};
   const gasEstimateType = getGasEstimateType(state);
-  const networkSupportsEIP1559 = isEIP1559Network(state);
+  const networkAndAccountSupportsEIP1559 = checkNetworkAndAccountSupports1559(
+    state,
+  );
 
   const gasEstimationObject = {
     gasLimit: txData.txParams?.gas ?? '0x0',
   };
 
-  if (networkSupportsEIP1559) {
+  if (networkAndAccountSupportsEIP1559) {
     const { medium = {}, gasPrice = '0' } = gasFeeEstimates;
     if (txData.txParams?.type === TRANSACTION_ENVELOPE_TYPES.LEGACY) {
       gasEstimationObject.gasPrice =

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -86,7 +86,7 @@ export function isEIP1559Account(state) {
   return !isHardwareWallet(state);
 }
 
-export function networkAndAccountSupports1559(state) {
+export function checkNetworkAndAccountSupports1559(state) {
   const networkSupports1559 = isEIP1559Network(state);
   const accountSupports1559 = isEIP1559Account(state);
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -27,6 +27,7 @@ import { DAY } from '../../shared/constants/time';
 import {
   getNativeCurrency,
   getConversionRate,
+  isEIP1559Network,
 } from '../ducks/metamask/metamask';
 
 /**
@@ -78,6 +79,18 @@ export function getCurrentKeyring(state) {
   });
 
   return keyring;
+}
+
+export function isEIP1559Account(state) {
+  // Neither hardware wallet supports 1559 at this time
+  return !isHardwareWallet(state);
+}
+
+export function networkAndAccountSupports1559(state) {
+  const networkSupports1559 = isEIP1559Network(state);
+  const accountSupports1559 = isEIP1559Account(state);
+
+  return networkSupports1559 && accountSupports1559;
 }
 
 /**

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -21,10 +21,7 @@ import {
 } from '../selectors';
 import { computeEstimatedGasLimit, resetSendState } from '../ducks/send';
 import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-account';
-import {
-  getUnconnectedAccountAlertEnabledness,
-  isEIP1559Network,
-} from '../ducks/metamask/metamask';
+import { getUnconnectedAccountAlertEnabledness } from '../ducks/metamask/metamask';
 import { LISTED_CONTRACT_ADDRESSES } from '../../shared/constants/tokens';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import * as actionConstants from './actionConstants';
@@ -1069,7 +1066,6 @@ export function updateMetamaskState(newState) {
         payload: {
           gasFeeEstimates: newState.gasFeeEstimates,
           gasEstimateType: newState.gasEstimateType,
-          isEIP1559Network: isEIP1559Network({ metamask: newState }),
         },
       });
     }


### PR DESCRIPTION
This PR tries to ensure both the network and the account support 1559.

## ToDo:

- [x] The following error displays upon edit gas popover submission:  "Invalid transaction envelope type: specified type "0x2" but included a gasPrice instead of maxFeePerGas and maxPriorityFeePerGas"
- [x] Ensure gasLimit and gasPrice are used in the background.