### PR TITLE
Fall back to aggregator name when icon is unavailable (Swaps Load View)

### DIFF
--- a/ui/pages/swaps/loading-swaps-quotes/aggregator-logo.js
+++ b/ui/pages/swaps/loading-swaps-quotes/aggregator-logo.js
@@ -10,22 +10,31 @@ function hexToRGB(hex, alpha) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-export default function AggregatorLogo({ icon, color }) {
+export default function AggregatorLogo({ name, icon, color }) {
   return (
     <div className="loading-swaps-quotes__logo">
-      <div
-        style={{
-          background: color,
-          boxShadow: `0px 4px 20px ${hexToRGB(color, 0.25)}`,
-        }}
-      >
-        <img src={icon} alt="" />
-      </div>
+      {icon && color ? (
+        <div
+          style={{
+            background: color,
+            boxShadow: `0px 4px 20px ${hexToRGB(color, 0.25)}`,
+          }}
+        >
+          <img src={icon} alt="" />
+        </div>
+      ) : (
+        name && (
+          <div>
+            <span>{name}</span>
+          </div>
+        )
+      )}
     </div>
   );
 }
 
 AggregatorLogo.propTypes = {
-  icon: PropTypes.string.isRequired,
-  color: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  icon: PropTypes.string,
+  color: PropTypes.string,
 };

--- a/ui/pages/swaps/loading-swaps-quotes/index.scss
+++ b/ui/pages/swaps/loading-swaps-quotes/index.scss
@@ -107,11 +107,16 @@
       display: flex;
       justify-content: center;
       align-items: center;
+      background: $ui-black;
     }
 
     img {
       width: 74px;
       height: 30px;
+    }
+
+    span {
+      color: $ui-white;
     }
   }
 

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
@@ -220,7 +220,7 @@ export default function LoadingSwapsQuotes({
                 key={`aggregator-logo-${aggName}`}
               >
                 <AggregatorLogo
-                  aggregatorName={aggName}
+                  name={aggregatorMetadata[aggName]?.title}
                   icon={aggregatorMetadata[aggName]?.icon}
                   color={aggregatorMetadata[aggName]?.color}
                 />
@@ -245,6 +245,7 @@ LoadingSwapsQuotes.propTypes = {
   onDone: PropTypes.func.isRequired,
   aggregatorMetadata: PropTypes.objectOf(
     PropTypes.shape({
+      title: PropTypes.string,
       color: PropTypes.string,
       icon: PropTypes.string,
     }),


### PR DESCRIPTION
Related Sentry Error: https://sentry.io/organizations/metamask/issues/2527650528

It is possible for an aggregator's color/icon to be unavailable in the aggregator metadata (https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js#L224) - in that case, this fix will display the aggregator's name in lieu of the logo. If the name not available either, render nothing. 

<img width="309" alt="Screen Shot 2021-08-01 at 10 58 23 PM" src="https://user-images.githubusercontent.com/8732757/127812680-ac56b78d-627c-4170-86f3-c185476d8921.png">
