### PR TITLE
_locales/en/messages.json - The default network ... is Mainnet.

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -267,7 +267,7 @@
     "message": "Die Dezimalangabe muss mindestens 0 und nicht höher als 36 sein."
   },
   "defaultNetwork": {
-    "message": "Das Standardnetzwerk für Ether Transaktionen ist das Main Net."
+    "message": "Das Standardnetzwerk für Ether Transaktionen ist das Mainnet."
   },
   "delete": {
     "message": "Löschen"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -549,7 +549,7 @@
     "message": "Decrypt request"
   },
   "defaultNetwork": {
-    "message": "The default network for Ether transactions is Main Net."
+    "message": "The default network for Ether transactions is Mainnet."
   },
   "delete": {
     "message": "Delete"


### PR DESCRIPTION

not "Main Net", see https://eips.ethereum.org/EIPS/eip-2228


Explanation:  The name of the network is correct, but comment was incorrect

Manual testing steps:  
  - this is only resource string(s)