### PR TITLE
Improves the autoupdating of estimates in the gas popover

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -422,6 +422,8 @@ export default class TransactionController extends EventEmitter {
       txMeta.simulationFails = simulationFails;
     }
 
+    const originalGasFeeEstimates = {};
+
     if (eip1559Compatibility) {
       // If the dapp has suggested a gas price, but no maxFeePerGas or maxPriorityFeePerGas
       //  then we set maxFeePerGas and maxPriorityFeePerGas to the suggested gasPrice.
@@ -437,6 +439,7 @@ export default class TransactionController extends EventEmitter {
           // If the dapp has not set the gasPrice or the maxFeePerGas, then we set maxFeePerGas
           // with the one returned by the gasFeeController, if that is available.
           txMeta.txParams.maxFeePerGas = defaultMaxFeePerGas;
+          originalGasFeeEstimates.maxFeePerGas = defaultMaxFeePerGas;
         }
 
         if (
@@ -446,6 +449,7 @@ export default class TransactionController extends EventEmitter {
           // If the dapp has not set the gasPrice or the maxPriorityFeePerGas, then we set maxPriorityFeePerGas
           // with the one returned by the gasFeeController, if that is available.
           txMeta.txParams.maxPriorityFeePerGas = defaultMaxPriorityFeePerGas;
+          originalGasFeeEstimates.maxPriorityFeePerGas = defaultMaxPriorityFeePerGas;
         }
 
         if (defaultGasPrice && !txMeta.txParams.maxFeePerGas) {
@@ -489,11 +493,17 @@ export default class TransactionController extends EventEmitter {
       !txMeta.txParams.maxFeePerGas
     ) {
       txMeta.txParams.gasPrice = defaultGasPrice;
+      originalGasFeeEstimates.gasPrice = txMeta.txParams.gasPrice;
     }
 
     if (defaultGasLimit && !txMeta.txParams.gas) {
       txMeta.txParams.gas = defaultGasLimit;
     }
+
+    // We keep track of the gas fee parameters which were most recently set from the remotely fetched estimates.
+    // This will allow us to accurately track whether the user has manually modified gas params.
+    txMeta.originalGasFeeEstimates = originalGasFeeEstimates;
+
     return txMeta;
   }
 

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -109,20 +109,22 @@ export default function EditGasPopover({
       closePopover();
     }
 
-    const newGasSettings = networkSupports1559
+    const newGasFees = networkSupports1559
       ? {
-          gas: decimalToHex(gasLimit),
-          gasLimit: decimalToHex(gasLimit),
           maxFeePerGas: decGWEIToHexWEI(maxFeePerGas ?? gasPrice),
           maxPriorityFeePerGas: decGWEIToHexWEI(
             maxPriorityFeePerGas ?? maxFeePerGas ?? gasPrice,
           ),
         }
       : {
-          gas: decimalToHex(gasLimit),
-          gasLimit: decimalToHex(gasLimit),
           gasPrice: decGWEIToHexWEI(gasPrice),
         };
+
+    const newGasSettings = {
+      gas: decimalToHex(gasLimit),
+      gasLimit: decimalToHex(gasLimit),
+      ...newGasFees,
+    };
 
     switch (mode) {
       case EDIT_GAS_MODES.CANCEL:
@@ -139,6 +141,12 @@ export default function EditGasPopover({
               ...transaction.txParams,
               ...newGasSettings,
             },
+            // If we are setting the gas fee params using remotely fetched estimates, then we update
+            // our record of gas fee params to compare our txParams to in the future. This will allow
+            // us to accurately track whether the user has manually modified gas params.
+            originalGasFeeEstimates: estimateToUse
+              ? newGasFees
+              : transaction.originalGasFeeEstimates,
           }),
         );
         break;
@@ -163,6 +171,7 @@ export default function EditGasPopover({
     maxFeePerGas,
     maxPriorityFeePerGas,
     networkSupports1559,
+    estimateToUse,
   ]);
 
   let title = t('editGasTitle');


### PR DESCRIPTION
This PR ensures that the values displayed to the user in the edit gas popover will be updated to the most recent updates we get from the api, as long as the user has not manually set the gas properties.

Fixes https://github.com/MetaMask/metamask-extension/issues/11707