### PR TITLE
Rejecting EIP-1559 transactions on unsupported networks

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -327,8 +327,9 @@ export default class TransactionController extends EventEmitter {
   async addUnapprovedTransaction(txParams, origin) {
     // validate
     const normalizedTxParams = txUtils.normalizeTxParams(txParams);
+    const eip1559Compatibility = await this.getEIP1559Compatibility();
 
-    txUtils.validateTxParams(normalizedTxParams);
+    txUtils.validateTxParams(normalizedTxParams, eip1559Compatibility);
 
     /**
     `generateTxMeta` adds the default txMeta properties to the passed object.

--- a/app/scripts/controllers/transactions/lib/util.test.js
+++ b/app/scripts/controllers/transactions/lib/util.test.js
@@ -283,6 +283,33 @@ describe('txUtils', function () {
         assert.doesNotThrow(() => txUtils.validateTxParams(txParams));
       });
     });
+
+    describe('when validating EIP-1559 transactions', function () {
+      it('should error when network does not support EIP-1559', function () {
+        const txParams = {
+          maxPriorityFeePerGas: '0x1',
+          maxFeePerGas: '0x1',
+          to: BURN_ADDRESS,
+        };
+        assert.throws(
+          () => {
+            txUtils.validateTxParams(txParams, false);
+          },
+          {
+            message:
+              'Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559',
+          },
+        );
+      });
+      it('should validate when network does support EIP-1559', function () {
+        const txParams = {
+          maxPriorityFeePerGas: '0x1',
+          maxFeePerGas: '0x1',
+          to: BURN_ADDRESS,
+        };
+        assert.doesNotThrow(() => txUtils.validateTxParams(txParams, true));
+      });
+    });
   });
 
   describe('#normalizeTxParams', function () {


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11550

The thought here was it was better to reject in this case inside the validation function _prior_ to the actual submission of the transaction