### PR TITLE
Fix display of inline estimates in advanced gas fee form

### DIFF
--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -45,15 +45,16 @@ export default function AdvancedGasControls({
 
   if (networkSupportsEIP1559) {
     suggestedValues.maxFeePerGas =
-      gasFeeEstimates?.[estimateToUse]?.suggestedMaxFeePerGas ||
-      gasFeeEstimates?.gasPrice;
+      gasFeeEstimates?.[estimateToUse || DEFAULT_ESTIMATES_LEVEL]
+        ?.suggestedMaxFeePerGas || gasFeeEstimates?.gasPrice;
     suggestedValues.maxPriorityFeePerGas =
-      gasFeeEstimates?.[estimateToUse]?.suggestedMaxPriorityFeePerGas ||
-      suggestedValues.maxFeePerGas;
+      gasFeeEstimates?.[estimateToUse || DEFAULT_ESTIMATES_LEVEL]
+        ?.suggestedMaxPriorityFeePerGas || suggestedValues.maxFeePerGas;
   } else {
     switch (gasEstimateType) {
       case GAS_ESTIMATE_TYPES.LEGACY:
-        suggestedValues.gasPrice = gasFeeEstimates?.[estimateToUse];
+        suggestedValues.gasPrice =
+          gasFeeEstimates?.[estimateToUse || DEFAULT_ESTIMATES_LEVEL];
         break;
       case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
         suggestedValues.gasPrice = gasFeeEstimates?.gasPrice;
@@ -113,10 +114,7 @@ export default function AdvancedGasControls({
                     color={COLORS.UI4}
                     variant={TYPOGRAPHY.H8}
                   >
-                    {
-                      gasFeeEstimates?.[DEFAULT_ESTIMATES_LEVEL]
-                        ?.suggestedMaxPriorityFeePerGas
-                    }
+                    {suggestedValues.maxPriorityFeePerGas}
                   </Typography>
                 </>
               )
@@ -154,10 +152,7 @@ export default function AdvancedGasControls({
                     color={COLORS.UI4}
                     variant={TYPOGRAPHY.H8}
                   >
-                    {
-                      gasFeeEstimates?.[DEFAULT_ESTIMATES_LEVEL]
-                        ?.suggestedMaxFeePerGas
-                    }
+                    {suggestedValues.maxFeePerGas}
                   </Typography>
                 </>
               )


### PR DESCRIPTION
Fixes #11707
Fixes #11708

This PR corrects the variable that are being used to display the estimates on the gas fields in the advanced form.

After (on EIP1559 network, including when the eip1559 estimates api call fails):

https://user-images.githubusercontent.com/7499938/127881695-80daa7ac-31e2-4a79-9894-991e935391b9.mp4

After (on mainnet):


https://user-images.githubusercontent.com/7499938/127881808-29853e25-a7f1-4262-b922-9469e5ebb594.mp4

