### PR TITLE
Show warning when network request for fee market estimates fails

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -901,6 +901,9 @@
     "message": "This gas fee has been suggested by $1. Overriding this may cause a problem with your transaction. Please reach out to $1 if you have questions.",
     "description": "$1 represents the Dapp's origin"
   },
+  "gasEstimatesUnavailableWarning": {
+    "message": "Our low, medium and high estimates are not available."
+  },
   "gasFee": {
     "message": "Gas Fee"
   },

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import {
   GAS_RECOMMENDATIONS,
   EDIT_GAS_MODES,
+  GAS_ESTIMATE_TYPES,
 } from '../../../../shared/constants/gas';
 
 import Button from '../../ui/button';
@@ -62,6 +63,7 @@ export default function EditGasDisplay({
   onManualChange,
   minimumGasLimit,
   balanceError,
+  estimatesUnavailableWarning,
 }) {
   const t = useContext(I18nContext);
   const supportsEIP1559 = useSelector(isEIP1559Network);
@@ -78,16 +80,19 @@ export default function EditGasDisplay({
   );
 
   const networkSupports1559 = useSelector(isEIP1559Network);
-  const showTopError = balanceError;
+  const showTopError = balanceError || estimatesUnavailableWarning;
 
   const showRadioButtons =
     networkSupports1559 &&
+    gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET &&
     !requireDappAcknowledgement &&
     ![EDIT_GAS_MODES.SPEED_UP, EDIT_GAS_MODES.CANCEL].includes(mode);
 
   let errorKey;
   if (balanceError) {
     errorKey = 'insufficientFunds';
+  } else if (estimatesUnavailableWarning) {
+    errorKey = 'gasEstimatesUnavailableWarning';
   }
 
   return (
@@ -275,4 +280,5 @@ EditGasDisplay.propTypes = {
   onManualChange: PropTypes.func,
   minimumGasLimit: PropTypes.number,
   balanceError: PropTypes.bool,
+  estimatesUnavailableWarning: PropTypes.bool,
 };

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -82,6 +82,7 @@ export default function EditGasPopover({
     gasErrors,
     onManualChange,
     balanceError,
+    estimatesUnavailableWarning,
   } = useGasFeeInputs(defaultEstimateToUse, transaction, minimumGasLimit, mode);
 
   const [showAdvancedForm, setShowAdvancedForm] = useState(
@@ -241,6 +242,7 @@ export default function EditGasPopover({
               onManualChange={onManualChange}
               minimumGasLimit={minimumGasLimitDec}
               balanceError={balanceError}
+              estimatesUnavailableWarning={estimatesUnavailableWarning}
               {...editGasDisplayProps}
             />
           </>

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -360,6 +360,8 @@ export function useGasFeeInputs(
     },
   );
 
+  let estimatesUnavailableWarning = null;
+
   // Separating errors from warnings so we can know which value problems
   // are blocking or simply useful information for the users
   const gasErrors = {};
@@ -408,6 +410,13 @@ export function useGasFeeInputs(
             HIGH_FEE_WARNING_MULTIPLIER
       ) {
         gasWarnings.maxFee = GAS_FORM_ERRORS.MAX_FEE_HIGH_WARNING;
+      }
+      break;
+    case GAS_ESTIMATE_TYPES.LEGACY:
+    case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
+    case GAS_ESTIMATE_TYPES.NONE:
+      if (networkSupportsEIP1559) {
+        estimatesUnavailableWarning = true;
       }
       break;
     default:
@@ -466,5 +475,6 @@ export function useGasFeeInputs(
       setMaxPriorityFeePerGas(maxPriorityFeePerGasToUse);
     },
     balanceError,
+    estimatesUnavailableWarning,
   };
 }


### PR DESCRIPTION
Fixes #11708

If the user is on an EIP-1559 network, and opens the popover, but the fetch for low, medium and high gas estimates has failed, we show a warning.


https://user-images.githubusercontent.com/7499938/127905073-0bc4fc80-3714-418f-834a-b69c1f52a364.mp4

