### PR TITLE
Revert "Sync `master` with `develop` (#11666)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.8.4]
-### Changed
-- [#11652](https://github.com/MetaMask/metamask-extension/pull/11652): Allow higher precision gas prices in send flow
-
-### Fixed
-- [#11658](https://github.com/MetaMask/metamask-extension/pull/11658): Fixed incorrect gas limit estimates for send transactions
-
 ## [9.8.3]
 ### Fixed
 - [#11594](https://github.com/MetaMask/metamask-extension/pull/11594): Fixed ERC20 token maximum send
@@ -2361,8 +2354,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Uncategorized
 - Added the ability to restore accounts from seed words.
 
-[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v9.8.4...HEAD
-[9.8.4]: https://github.com/MetaMask/metamask-extension/compare/v9.8.3...v9.8.4
+[Unreleased]: https://github.com/MetaMask/metamask-extension/compare/v9.8.3...HEAD
 [9.8.3]: https://github.com/MetaMask/metamask-extension/compare/v9.8.2...v9.8.3
 [9.8.2]: https://github.com/MetaMask/metamask-extension/compare/v9.8.1...v9.8.2
 [9.8.1]: https://github.com/MetaMask/metamask-extension/compare/v9.8.0...v9.8.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "9.8.4",
+  "version": "9.8.3",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
The last sync with master was merged using a squash and merge commit. This messes up history and can create conflicts in future merge attempts.

To fix this we can revert the squashed commit and then redo the master-sync PR. This PR reverts the squashed commit. It will need to be followed by a new PR that is identical to: https://github.com/MetaMask/metamask-extension/pull/11666 (except this time we will use the merge commit option)