### PR TITLE
EIP-1559 - Return null from GasTiming if on non-1559 network

### DIFF
--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -168,6 +168,6 @@ export default function GasTiming({
 }
 
 GasTiming.propTypes = {
-  maxPriorityFeePerGas: PropTypes.string.isRequired,
-  maxFeePerGas: PropTypes.string.isRequired,
+  maxPriorityFeePerGas: PropTypes.string,
+  maxFeePerGas: PropTypes.string,
 };


### PR DESCRIPTION
I noticed a PropTypes warning when testing on Ledger, and it's due to the fact that non-1559 networks/accounts don't have the required maxFeePerGas / maxPriorityFeePerGas to calculate and render the timing.  Thus, we should just return null when we don't have timing information.