### PR TITLE
Fix a position of a tooltip icon

### DIFF
--- a/ui/components/ui/info-tooltip/index.scss
+++ b/ui/components/ui/info-tooltip/index.scss
@@ -3,6 +3,12 @@
     height: 12px;
     width: 12px;
   }
+
+  &__tooltip-container {
+    svg {
+      position: static;
+    }
+  }
 }
 
 .tippy-popper[x-placement^=top] .tippy-tooltip-info-theme [x-arrow],


### PR DESCRIPTION
## Explanation
After we changed tooltip img to svg, some of them became misplaced (see screenshots below). This PR fixes it.

Related commit: https://github.com/MetaMask/metamask-extension/commit/d8984d3cf32b77d4fc5411331212b9303d9d1d0b#diff-1d67d75cb53afc645ffff9afc410bda31256363ba3bd24ccbccea564d12ca153R25

## Manual testing steps
  - Open Swaps
  - In the `Swap to` field insert: `0x7f3eab3491ed282197038f1b89ca33d7e5adffba` and import the token
  - Alert message is displayed with a tooltip in the right place

## Screenshots
Misplaced tooltip icon in Swaps (before):
![image](https://user-images.githubusercontent.com/80175477/128033833-7d2b5f0e-e930-43fe-beef-77c88a84eb22.png)

Tooltip icon placed correctly in Swaps (after):
![image](https://user-images.githubusercontent.com/80175477/128033793-c0409bf9-681f-486a-9ee2-9f6977222ea0.png)