### PR TITLE
Add gasPrice to be used on non-1559 networks for transaction details on confirm screen

### DIFF
--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -385,7 +385,9 @@ export default class ConfirmTransactionBase extends Component {
                       key="gas-subtext"
                       type={SECONDARY}
                       value={getHexGasTotal({
-                        gasPrice: txData.txParams.maxFeePerGas,
+                        gasPrice:
+                          txData.txParams.maxFeePerGas ??
+                          txData.txParams.gasPrice,
                         gasLimit: txData.txParams.gas,
                       })}
                       hideLabel
@@ -430,7 +432,9 @@ export default class ConfirmTransactionBase extends Component {
                       value={addHexes(
                         txData.txParams.value,
                         getHexGasTotal({
-                          gasPrice: txData.txParams.maxFeePerGas,
+                          gasPrice:
+                            txData.txParams.maxFeePerGas ??
+                            txData.txParams.gasPrice,
                           gasLimit: txData.txParams.gas,
                         }),
                       )}


### PR DESCRIPTION
Fixes: number 7 on https://docs.google.com/document/d/1jRyoxmVWXGv-jPCFCpdVBvMwAt7ERkGtfRnPAjEp2y0/edit#heading=h.hmbwv7dd02cd

Explanation:  Now shows accurate transaction details for both 1559 and non-1559 networks on confirmation screen:

<img width="356" alt="Screen Shot 2021-08-03 at 10 14 16 AM" src="https://user-images.githubusercontent.com/34557516/128040544-260cc144-bb2f-493f-be65-7d730024ee06.png">

<img width="360" alt="Screen Shot 2021-08-03 at 10 15 00 AM" src="https://user-images.githubusercontent.com/34557516/128040667-ab105141-2807-4897-9fdc-e9ecf9c3bb21.png">

