### PR TITLE
remove unnecessary conversion call

### DIFF
--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -8,8 +8,6 @@ import { useGasFeeEstimates } from '../../../hooks/useGasFeeEstimates';
 import { usePrevious } from '../../../hooks/usePrevious';
 import { I18nContext } from '../../../contexts/i18n';
 
-import { hexWEIToDecGWEI } from '../../../helpers/utils/conversions.util';
-
 import Typography from '../../ui/typography/typography';
 import {
   TYPOGRAPHY,
@@ -63,10 +61,7 @@ export default function GasTiming({
       (priority && priority !== previousMaxPriorityFeePerGas) ||
       (fee && fee !== previousMaxFeePerGas)
     ) {
-      getGasFeeTimeEstimate(
-        hexWEIToDecGWEI(priority),
-        hexWEIToDecGWEI(fee),
-      ).then((result) => {
+      getGasFeeTimeEstimate(priority, fee).then((result) => {
         if (maxFeePerGas === fee && maxPriorityFeePerGas === priority) {
           setCustomEstimatedTime(result);
         }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -19,7 +19,6 @@ import {
 } from '../../helpers/constants/error-keys';
 import UserPreferencedCurrencyDisplay from '../../components/app/user-preferenced-currency-display';
 import { PRIMARY, SECONDARY } from '../../helpers/constants/common';
-
 import TextField from '../../components/ui/text-field';
 import {
   TRANSACTION_TYPES,
@@ -27,6 +26,7 @@ import {
 } from '../../../shared/constants/transaction';
 import { getTransactionTypeTitle } from '../../helpers/utils/transactions.util';
 import { toBuffer } from '../../../shared/modules/buffer-utils';
+import { hexWEIToDecGWEI } from '../../helpers/utils/conversions.util';
 
 import TransactionDetail from '../../components/app/transaction-detail/transaction-detail.component';
 import TransactionDetailItem from '../../components/app/transaction-detail-item/transaction-detail-item.component';
@@ -397,8 +397,8 @@ export default class ConfirmTransactionBase extends Component {
               }
               subTitle={
                 <GasTiming
-                  maxPriorityFeePerGas={txData.txParams.maxPriorityFeePerGas}
-                  maxFeePerGas={txData.txParams.maxFeePerGas}
+                  maxPriorityFeePerGas={hexWEIToDecGWEI(txData.txParams.maxPriorityFeePerGas)}
+                  maxFeePerGas={hexWEIToDecGWEI(txData.txParams.maxFeePerGas)}
                 />
               }
             />,

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -5,7 +5,11 @@ import { getEnvironmentType } from '../../../app/scripts/lib/util';
 import ConfirmPageContainer from '../../components/app/confirm-page-container';
 import { isBalanceSufficient } from '../send/send.utils';
 import { getHexGasTotal } from '../../helpers/utils/confirm-tx.util';
-import { addHexes, hexToDecimal } from '../../helpers/utils/conversions.util';
+import {
+  addHexes,
+  hexToDecimal,
+  hexWEIToDecGWEI,
+} from '../../helpers/utils/conversions.util';
 import {
   CONFIRM_TRANSACTION_ROUTE,
   DEFAULT_ROUTE,
@@ -26,7 +30,6 @@ import {
 } from '../../../shared/constants/transaction';
 import { getTransactionTypeTitle } from '../../helpers/utils/transactions.util';
 import { toBuffer } from '../../../shared/modules/buffer-utils';
-import { hexWEIToDecGWEI } from '../../helpers/utils/conversions.util';
 
 import TransactionDetail from '../../components/app/transaction-detail/transaction-detail.component';
 import TransactionDetailItem from '../../components/app/transaction-detail-item/transaction-detail-item.component';
@@ -397,7 +400,9 @@ export default class ConfirmTransactionBase extends Component {
               }
               subTitle={
                 <GasTiming
-                  maxPriorityFeePerGas={hexWEIToDecGWEI(txData.txParams.maxPriorityFeePerGas)}
+                  maxPriorityFeePerGas={hexWEIToDecGWEI(
+                    txData.txParams.maxPriorityFeePerGas,
+                  )}
                   maxFeePerGas={hexWEIToDecGWEI(txData.txParams.maxFeePerGas)}
                 />
               }


### PR DESCRIPTION
Fixes: number 8 on https://docs.google.com/document/d/1jRyoxmVWXGv-jPCFCpdVBvMwAt7ERkGtfRnPAjEp2y0/edit#heading=h.3339otjz3k8e

Explanation:  We were unnecessarily attempting to convert decimal values *as if they were hex* to decimals.

Manual testing steps:  
  - Enter send flow,
  - Enter a really tiny amount (e.g. 0.0000000000001) into either max fee or max-priority fee.
  - Make sure no BigNumber error occurs