### PR TITLE
EIP-1559 - Show minium native currency in banner when on testnets

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -45,6 +45,7 @@ export default function EditGasDisplay({
   setMaxFeePerGas,
   maxFeePerGasFiat,
   estimatedMaximumNative,
+  estimatedMinimumNative,
   isGasEstimatesLoading,
   gasFeeEstimates,
   gasEstimateType,
@@ -140,9 +141,9 @@ export default function EditGasDisplay({
         )}
         <TransactionTotalBanner
           total={
-            networkAndAccountSupport1559 || isMainnet
+            (networkAndAccountSupport1559 || isMainnet) && estimatedMinimumFiat
               ? `~ ${estimatedMinimumFiat}`
-              : estimatedMaximumNative
+              : estimatedMinimumNative
           }
           detail={
             networkAndAccountSupport1559 &&
@@ -260,6 +261,7 @@ EditGasDisplay.propTypes = {
   setMaxFeePerGas: PropTypes.func,
   maxFeePerGasFiat: PropTypes.string,
   estimatedMaximumNative: PropTypes.string,
+  estimatedMinimumNative: PropTypes.string,
   isGasEstimatesLoading: PropTypes.boolean,
   gasFeeEstimates: PropTypes.object,
   gasEstimateType: PropTypes.string,

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -69,6 +69,7 @@ export default function EditGasPopover({
     setMaxFeePerGas,
     maxFeePerGasFiat,
     estimatedMaximumNative,
+    estimatedMinimumNative,
     isGasEstimatesLoading,
     gasFeeEstimates,
     gasEstimateType,
@@ -226,6 +227,7 @@ export default function EditGasPopover({
               setMaxFeePerGas={setMaxFeePerGas}
               maxFeePerGasFiat={maxFeePerGasFiat}
               estimatedMaximumNative={estimatedMaximumNative}
+              estimatedMinimumNative={estimatedMinimumNative}
               isGasEstimatesLoading={isGasEstimatesLoading}
               gasFeeEstimates={gasFeeEstimates}
               gasEstimateType={gasEstimateType}

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -357,6 +357,11 @@ export function useGasFeeInputs(
     currency: primaryCurrency,
   });
 
+  const [estimatedMinimumNative] = useCurrencyDisplay(minimumCostInHexWei, {
+    numberOfDecimals: primaryNumberOfDecimals,
+    currency: primaryCurrency,
+  });
+
   // We also need to display our closest estimate of the low end of estimation
   // in fiat.
   const [, { value: estimatedMinimumFiat }] = useCurrencyDisplay(
@@ -490,6 +495,7 @@ export function useGasFeeInputs(
     estimatedMinimumFiat: showFiat ? estimatedMinimumFiat : '',
     estimatedMaximumFiat: showFiat ? maxFeePerGasFiat : '',
     estimatedMaximumNative,
+    estimatedMinimumNative,
     isGasEstimatesLoading,
     gasFeeEstimates,
     gasEstimateType,


### PR DESCRIPTION
In the case that we're on a test network and the user doesn't turn on the advanced setting for real conversion rates, we should default to the minimumNative value.