### PR TITLE
Remove estimate detail above advanced gas controls in non-1559 network

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -907,9 +907,6 @@
   "gasEstimatesUnavailableWarning": {
     "message": "Our low, medium and high estimates are not available."
   },
-  "gasFeeEstimate": {
-    "message": "Estimate"
-  },
   "gasLimit": {
     "message": "Gas Limit"
   },

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -135,27 +135,6 @@ export default function AdvancedGasControls({
             tooltipText={t('editGasPriceTooltip')}
             value={gasPrice}
             numeric
-            titleDetail={
-              suggestedValues.gasPrice && (
-                <>
-                  <Typography
-                    tag="span"
-                    color={COLORS.UI4}
-                    variant={TYPOGRAPHY.H8}
-                    fontWeight={FONT_WEIGHT.BOLD}
-                  >
-                    {t('gasFeeEstimate')}:
-                  </Typography>{' '}
-                  <Typography
-                    tag="span"
-                    color={COLORS.UI4}
-                    variant={TYPOGRAPHY.H8}
-                  >
-                    {suggestedValues.gasPrice}
-                  </Typography>
-                </>
-              )
-            }
             error={
               gasErrors?.gasPrice
                 ? getGasFormErrorText(gasErrors.gasPrice, t)

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -3,12 +3,6 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import { I18nContext } from '../../../contexts/i18n';
-import Typography from '../../ui/typography/typography';
-import {
-  FONT_WEIGHT,
-  TYPOGRAPHY,
-  COLORS,
-} from '../../../helpers/constants/design-system';
 import FormField from '../../ui/form-field';
 import {
   GAS_ESTIMATE_TYPES,

--- a/ui/components/app/advanced-gas-controls/index.scss
+++ b/ui/components/app/advanced-gas-controls/index.scss
@@ -3,17 +3,8 @@
     margin-bottom: 20px;
   }
 
-  &__row-heading {
-    display: flex;
-  }
-
   .info-tooltip {
     display: inline-block;
-  }
-
-  &__row-heading-detail {
-    flex-grow: 1;
-    align-self: center;
   }
 
   .form-field__row--error .form-field__heading-title h6 {


### PR DESCRIPTION
Fixes: #11737

Explanation:  Removes estimate text per UX decision that it is confusing:
<img width="356" alt="Screen Shot 2021-08-03 at 1 09 22 PM" src="https://user-images.githubusercontent.com/34557516/128064905-37fea44d-a480-4cde-86d3-6eeaafb65fde.png">
