### PR TITLE
Stop GasFeeController polling when pop closes

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -330,9 +330,9 @@ function setupController(initState, initLangCode) {
 
       if (processName === ENVIRONMENT_TYPE_POPUP) {
         popupIsOpen = true;
-
         endOfStream(portStream, () => {
           popupIsOpen = false;
+          controller.onPopUpClose();
           controller.isClientOpen = isClientOpenStatus();
         });
       }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -299,8 +299,16 @@ function setupController(initState, initLangCode) {
       popupIsOpen ||
       Boolean(Object.keys(openMetamaskTabsIDs).length) ||
       notificationIsOpen
-    );
-  };
+      );
+    };
+
+    const checkAndSetClientOpenStatus = () => {
+      const isClientOpen = isClientOpenStatus()
+      controller.isClientOpen = isClientOpen;
+      if (!isClientOpen) {
+        controller.onClientClosed();
+      }
+    };
 
   /**
    * A runtime.Port object, as provided by the browser:
@@ -332,8 +340,7 @@ function setupController(initState, initLangCode) {
         popupIsOpen = true;
         endOfStream(portStream, () => {
           popupIsOpen = false;
-          controller.onPopUpClose();
-          controller.isClientOpen = isClientOpenStatus();
+          checkAndSetClientOpenStatus();
         });
       }
 
@@ -352,7 +359,7 @@ function setupController(initState, initLangCode) {
 
         endOfStream(portStream, () => {
           delete openMetamaskTabsIDs[tabId];
-          controller.isClientOpen = isClientOpenStatus();
+          checkAndSetClientOpenStatus();
         });
       }
     } else {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -18,7 +18,6 @@ import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_FULLSCREEN,
-  POLLING_TOKEN_ENVIRONMENT_TYPES,
 } from '../../shared/constants/app';
 import { SECOND } from '../../shared/constants/time';
 import migrations from './migrations';
@@ -303,7 +302,7 @@ function setupController(initState, initLangCode) {
     );
   };
 
-  const disconnectGasPollingForEnvironmentTypeOrAll = (isClientOpen, environmentType) => {
+  const onCloseEnvironmentInstances = (isClientOpen, environmentType) => {
     // if all instances of metamask are closed we call a method on the controller to stop gasFeeController polling
     if (isClientOpen === false) {
       controller.onClientClosed();
@@ -353,7 +352,7 @@ function setupController(initState, initLangCode) {
           popupIsOpen = false;
           const isClientOpen = isClientOpenStatus();
           controller.isClientOpen = isClientOpen;
-          disconnectGasPollingForEnvironmentTypeOrAll(isClientOpen, ENVIRONMENT_TYPE_POPUP);
+          onCloseEnvironmentInstances(isClientOpen, ENVIRONMENT_TYPE_POPUP);
         });
       }
 
@@ -364,7 +363,9 @@ function setupController(initState, initLangCode) {
           notificationIsOpen = false;
           const isClientOpen = isClientOpenStatus();
           controller.isClientOpen = isClientOpen;
-          disconnectGasPollingForEnvironmentTypeOrAll(isClientOpen, ENVIRONMENT_TYPE_NOTIFICATION,
+          onCloseEnvironmentInstances(
+            isClientOpen,
+            ENVIRONMENT_TYPE_NOTIFICATION,
           );
         });
       }
@@ -377,7 +378,9 @@ function setupController(initState, initLangCode) {
           delete openMetamaskTabsIDs[tabId];
           const isClientOpen = isClientOpenStatus();
           controller.isClientOpen = isClientOpen;
-          disconnectGasPollingForEnvironmentTypeOrAll(isClientOpen, ENVIRONMENT_TYPE_FULLSCREEN,
+          onCloseEnvironmentInstances(
+            isClientOpen,
+            ENVIRONMENT_TYPE_FULLSCREEN,
           );
         });
       }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -299,16 +299,16 @@ function setupController(initState, initLangCode) {
       popupIsOpen ||
       Boolean(Object.keys(openMetamaskTabsIDs).length) ||
       notificationIsOpen
-      );
-    };
+    );
+  };
 
-    const checkAndSetClientOpenStatus = () => {
-      const isClientOpen = isClientOpenStatus()
-      controller.isClientOpen = isClientOpen;
-      if (!isClientOpen) {
-        controller.onClientClosed();
-      }
-    };
+  const checkAndSetClientOpenStatus = () => {
+    const isClientOpen = isClientOpenStatus();
+    controller.isClientOpen = isClientOpen;
+    if (!isClientOpen) {
+      controller.onClientClosed();
+    }
+  };
 
   /**
    * A runtime.Port object, as provided by the browser:

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -349,7 +349,7 @@ function setupController(initState, initLangCode) {
 
         endOfStream(portStream, () => {
           notificationIsOpen = false;
-          controller.isClientOpen = isClientOpenStatus();
+          checkAndSetClientOpenStatus();
         });
       }
 

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -303,9 +303,7 @@ function setupController(initState, initLangCode) {
     );
   };
 
-  const setClientOpenStatusAndDisconnectGasPolling = (environmentType) => {
-    const isClientOpen = isClientOpenStatus();
-    controller.isClientOpen = isClientOpen;
+  const disconnectGasPollingForEnvironmentTypeOrAll = (isClientOpen, environmentType) => {
     // if all instances of metamask are closed we call a method on the controller to stop gasFeeController polling
     if (isClientOpen === false) {
       controller.onClientClosed();
@@ -319,15 +317,7 @@ function setupController(initState, initLangCode) {
       ) {
         return;
       }
-      const tokensToDisconnect = controller.appStateController.store.getState()[
-        POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType]
-      ];
-      tokensToDisconnect.forEach((token) => {
-        controller.disconnectAndRemovePollingToken(
-          token,
-          POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType],
-        );
-      });
+      controller.onEnvironmentTypeClosed(environmentType);
     }
   };
 
@@ -361,7 +351,9 @@ function setupController(initState, initLangCode) {
         popupIsOpen = true;
         endOfStream(portStream, () => {
           popupIsOpen = false;
-          setClientOpenStatusAndDisconnectGasPolling(ENVIRONMENT_TYPE_POPUP);
+          const isClientOpen = isClientOpenStatus();
+          controller.isClientOpen = isClientOpen;
+          disconnectGasPollingForEnvironmentTypeOrAll(isClientOpen, ENVIRONMENT_TYPE_POPUP);
         });
       }
 
@@ -370,8 +362,9 @@ function setupController(initState, initLangCode) {
 
         endOfStream(portStream, () => {
           notificationIsOpen = false;
-          setClientOpenStatusAndDisconnectGasPolling(
-            ENVIRONMENT_TYPE_NOTIFICATION,
+          const isClientOpen = isClientOpenStatus();
+          controller.isClientOpen = isClientOpen;
+          disconnectGasPollingForEnvironmentTypeOrAll(isClientOpen, ENVIRONMENT_TYPE_NOTIFICATION,
           );
         });
       }
@@ -382,8 +375,9 @@ function setupController(initState, initLangCode) {
 
         endOfStream(portStream, () => {
           delete openMetamaskTabsIDs[tabId];
-          setClientOpenStatusAndDisconnectGasPolling(
-            ENVIRONMENT_TYPE_FULLSCREEN,
+          const isClientOpen = isClientOpenStatus();
+          controller.isClientOpen = isClientOpen;
+          disconnectGasPollingForEnvironmentTypeOrAll(isClientOpen, ENVIRONMENT_TYPE_FULLSCREEN,
           );
         });
       }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -206,6 +206,10 @@ export default class AppStateController extends EventEmitter {
     });
   }
 
+  /**
+   * removes a pollingToken for a given environmentType
+   * @returns {void}
+   */
   removePollingToken(pollingToken, pollingTokenType) {
     const prevState = this.store.getState()[pollingTokenType];
     this.store.updateState({
@@ -213,6 +217,10 @@ export default class AppStateController extends EventEmitter {
     });
   }
 
+  /**
+   * clears all pollingTokens
+   * @returns {void}
+   */
   clearPollingTokens() {
     this.store.updateState({
       popupGasPollTokens: [],

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -217,12 +217,4 @@ export default class AppStateController extends EventEmitter {
       ],
     });
   }
-
-  clearPollingTokens() {
-    this.store.updateState({
-      fullScreenGasPollTokens: [],
-      popupGasPollTokens: [],
-      notificationGasPollTokens: [],
-    });
-  }
 }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -209,9 +209,15 @@ export default class AppStateController extends EventEmitter {
   removePollingToken(pollingToken, pollingTokenType) {
     const prevState = this.store.getState()[pollingTokenType];
     this.store.updateState({
-      [pollingTokenType]: [
-        ...prevState.filter((token) => token !== pollingToken),
-      ],
+      [pollingTokenType]: prevState.filter((token) => token !== pollingToken),
+    });
+  }
+
+  clearPollingTokens() {
+    this.store.updateState({
+      popupGasPollTokens: [],
+      notificationGasPollTokens: [],
+      fullScreenGasPollTokens: [],
     });
   }
 }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -25,6 +25,9 @@ export default class AppStateController extends EventEmitter {
       connectedStatusPopoverHasBeenShown: true,
       defaultHomeActiveTabName: null,
       browserEnvironment: {},
+      popupGasPollTokens: [],
+      notificationGasPollTokens: [],
+      fullScreenGasPollTokens: [],
       recoveryPhraseReminderHasBeenShown: false,
       recoveryPhraseReminderLastShown: new Date().getTime(),
       ...initState,
@@ -190,5 +193,36 @@ export default class AppStateController extends EventEmitter {
    */
   setBrowserEnvironment(os, browser) {
     this.store.updateState({ browserEnvironment: { os, browser } });
+  }
+
+  /**
+   * Adds a pollingToken for a given environmentType
+   * @returns {void}
+   */
+  addPollingToken(pollingToken, pollingTokenType) {
+    this.store.updateState({
+      [pollingTokenType]: [
+        ...this.store.getState()[pollingTokenType],
+        pollingToken,
+      ],
+    });
+  }
+
+  removePollingToken(pollingToken, pollingTokenType) {
+    this.store.updateState({
+      [pollingTokenType]: [
+        ...this.store
+          .getState()
+          [pollingTokenType].filter((token) => token !== pollingToken),
+      ],
+    });
+  }
+
+  clearPollingTokens() {
+    this.store.updateState({
+      fullScreenGasPollTokens: [],
+      popupGasPollTokens: [],
+      notificationGasPollTokens: [],
+    });
   }
 }

--- a/app/scripts/controllers/app-state.js
+++ b/app/scripts/controllers/app-state.js
@@ -200,20 +200,17 @@ export default class AppStateController extends EventEmitter {
    * @returns {void}
    */
   addPollingToken(pollingToken, pollingTokenType) {
+    const prevState = this.store.getState()[pollingTokenType];
     this.store.updateState({
-      [pollingTokenType]: [
-        ...this.store.getState()[pollingTokenType],
-        pollingToken,
-      ],
+      [pollingTokenType]: [...prevState, pollingToken],
     });
   }
 
   removePollingToken(pollingToken, pollingTokenType) {
+    const prevState = this.store.getState()[pollingTokenType];
     this.store.updateState({
       [pollingTokenType]: [
-        ...this.store
-          .getState()
-          [pollingTokenType].filter((token) => token !== pollingToken),
+        ...prevState.filter((token) => token !== pollingToken),
       ],
     });
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2999,6 +2999,18 @@ export default class MetamaskController extends EventEmitter {
     }
   }
 
+  onEnvironmentTypeClosed(environmentType) {
+    const tokensToDisconnect = this.appStateController.store.getState()[
+      POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType]
+    ];
+    tokensToDisconnect.forEach((token) => {
+      controller.disconnectAndRemovePollingToken(
+        token,
+        POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType],
+      );
+    });
+  }
+
   disconnectAndRemovePollingToken(pollingToken, environmentType) {
     this.gasFeeController.disconnectPoller(pollingToken);
     this.appStateController.removePollingToken(pollingToken, environmentType);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2972,19 +2972,16 @@ export default class MetamaskController extends EventEmitter {
    * @param {boolean} open
    */
   set isClientOpen(open) {
-    if (!open) {
-      this.onPopUpClose();
-    }
     this._isClientOpen = open;
     this.detectTokensController.isOpen = open;
   }
   /* eslint-enable accessor-pairs */
 
   /**
-   * A method that is called by the background when a popUp closes.
+   * A method that is called by the background when all instances of metamask are closed.
    * Currently used to stop polling in the gasFeeController.
    */
-  onPopUpClose() {
+  onClientClosed() {
     try {
       this.gasFeeController.stopPolling();
     } catch (error) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2973,11 +2973,21 @@ export default class MetamaskController extends EventEmitter {
    * @param {boolean} open
    */
   set isClientOpen(open) {
+    if (!open) {
+      onPopUpClose();
+    }
     this._isClientOpen = open;
     this.detectTokensController.isOpen = open;
   }
   /* eslint-enable accessor-pairs */
 
+  onPopUpClose() {
+    try {
+      this.gasFeeController.stopPolling();
+    } catch (error) {
+      console.error(error);
+    }
+  }
   /**
    * Adds a domain to the PhishingController safelist
    * @param {string} hostname - the domain to safelist

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -32,6 +32,7 @@ import { MAINNET_CHAIN_ID } from '../../shared/constants/network';
 import { UI_NOTIFICATIONS } from '../../shared/notifications';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { MILLISECOND } from '../../shared/constants/time';
+import { POLLING_TOKEN_ENVIRONMENT_TYPES } from '../../shared/constants/app';
 
 import { hexToDecimal } from '../../ui/helpers/utils/conversions.util';
 import ComposableObservableStore from './lib/ComposableObservableStore';
@@ -3000,20 +3001,13 @@ export default class MetamaskController extends EventEmitter {
   }
 
   onEnvironmentTypeClosed(environmentType) {
-    const tokensToDisconnect = this.appStateController.store.getState()[
+    const pollingTokensToDisconnect = this.appStateController.store.getState()[
       POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType]
     ];
-    tokensToDisconnect.forEach((token) => {
-      controller.disconnectAndRemovePollingToken(
-        token,
-        POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType],
-      );
+    pollingTokensToDisconnect.forEach((pollingToken) => {
+      this.gasFeeController.disconnectPoller(pollingToken);
+      this.appStateController.removePollingToken(pollingToken, environmentType);
     });
-  }
-
-  disconnectAndRemovePollingToken(pollingToken, environmentType) {
-    this.gasFeeController.disconnectPoller(pollingToken);
-    this.appStateController.removePollingToken(pollingToken, environmentType);
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2995,6 +2995,7 @@ export default class MetamaskController extends EventEmitter {
   onClientClosed() {
     try {
       this.gasFeeController.stopPolling();
+      this.appStateController.clearPollingTokens();
     } catch (error) {
       console.error(error);
     }
@@ -3006,7 +3007,10 @@ export default class MetamaskController extends EventEmitter {
     ];
     pollingTokensToDisconnect.forEach((pollingToken) => {
       this.gasFeeController.disconnectPoller(pollingToken);
-      this.appStateController.removePollingToken(pollingToken, environmentType);
+      this.appStateController.removePollingToken(
+        pollingToken,
+        POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType],
+      );
     });
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1130,6 +1130,16 @@ export default class MetamaskController extends EventEmitter {
         this.gasFeeController.getTimeEstimate,
         this.gasFeeController,
       ),
+
+      addPollingTokenToAppState: nodeify(
+        this.appStateController.addPollingToken,
+        this.appStateController,
+      ),
+
+      removePollingTokenFromAppState: nodeify(
+        this.appStateController.removePollingToken,
+        this.appStateController,
+      ),
     };
   }
 
@@ -2987,6 +2997,11 @@ export default class MetamaskController extends EventEmitter {
     } catch (error) {
       console.error(error);
     }
+  }
+
+  disconnectAndRemovePollingToken(pollingToken, environmentType) {
+    this.gasFeeController.disconnectPoller(pollingToken);
+    this.appStateController.removePollingToken(pollingToken, environmentType);
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2969,18 +2969,21 @@ export default class MetamaskController extends EventEmitter {
   /* eslint-disable accessor-pairs */
   /**
    * A method for recording whether the MetaMask user interface is open or not.
-   * @private
    * @param {boolean} open
    */
   set isClientOpen(open) {
     if (!open) {
-      onPopUpClose();
+      this.onPopUpClose();
     }
     this._isClientOpen = open;
     this.detectTokensController.isOpen = open;
   }
   /* eslint-enable accessor-pairs */
 
+  /**
+   * A method that is called by the background when a popUp closes.
+   * Currently used to stop polling in the gasFeeController.
+   */
   onPopUpClose() {
     try {
       this.gasFeeController.stopPolling();
@@ -2988,6 +2991,7 @@ export default class MetamaskController extends EventEmitter {
       console.error(error);
     }
   }
+
   /**
    * Adds a domain to the PhishingController safelist
    * @param {string} hostname - the domain to safelist

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3001,15 +3001,21 @@ export default class MetamaskController extends EventEmitter {
     }
   }
 
+  /**
+   * A method that is called by the background when a particular environment type is closed (fullscreen, popup, notification).
+   * Currently used to stop polling in the gasFeeController for only that environement type
+   */
   onEnvironmentTypeClosed(environmentType) {
+    const appStatePollingTokenType =
+      POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType];
     const pollingTokensToDisconnect = this.appStateController.store.getState()[
-      POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType]
+      appStatePollingTokenType
     ];
     pollingTokensToDisconnect.forEach((pollingToken) => {
       this.gasFeeController.disconnectPoller(pollingToken);
       this.appStateController.removePollingToken(
         pollingToken,
-        POLLING_TOKEN_ENVIRONMENT_TYPES[environmentType],
+        appStatePollingTokenType,
       );
     });
   }

--- a/shared/constants/app.js
+++ b/shared/constants/app.js
@@ -30,3 +30,9 @@ export const MESSAGE_TYPE = {
   ADD_ETHEREUM_CHAIN: 'wallet_addEthereumChain',
   SWITCH_ETHEREUM_CHAIN: 'wallet_switchEthereumChain',
 };
+
+export const POLLING_TOKEN_ENVIRONMENT_TYPES = {
+  [ENVIRONMENT_TYPE_POPUP]: 'popupGasPollTokens',
+  [ENVIRONMENT_TYPE_NOTIFICATION]: 'notificationGasPollTokens',
+  [ENVIRONMENT_TYPE_FULLSCREEN]: 'fullScreenGasPollTokens',
+};

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-component.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-component.test.js
@@ -13,6 +13,7 @@ jest.mock('../../../../store/actions', () => ({
   getGasFeeEstimatesAndStartPolling: jest
     .fn()
     .mockImplementation(() => Promise.resolve()),
+  addPollingTokenToAppState: jest.fn(),
 }));
 
 const propsMethodSpies = {

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -68,6 +68,7 @@ export default class GasModalPageContainer extends Component {
   };
 
   componentWillUnmount() {
+    this._beforeUnload();
     window.removeEventListener('beforeunload', this._beforeUnload);
   }
 

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -5,6 +5,8 @@ import { Tabs, Tab } from '../../../ui/tabs';
 import {
   disconnectGasFeeEstimatePoller,
   getGasFeeEstimatesAndStartPolling,
+  addPollingTokenToAppState,
+  removePollingTokenFromAppState,
 } from '../../../../store/actions';
 import AdvancedTabContent from './advanced-tab-content';
 import BasicTabContent from './basic-tab-content';
@@ -52,9 +54,11 @@ export default class GasModalPageContainer extends Component {
     this._isMounted = true;
     getGasFeeEstimatesAndStartPolling().then((pollingToken) => {
       if (this._isMounted) {
+        addPollingTokenToAppState(pollingToken);
         this.setState({ pollingToken });
       } else {
         disconnectGasFeeEstimatePoller(pollingToken);
+        removePollingTokenFromAppState(pollingToken);
       }
     });
     window.addEventListener('beforeunload', this._beforeUnload);
@@ -64,6 +68,7 @@ export default class GasModalPageContainer extends Component {
     this._isMounted = false;
     if (this.state.pollingToken) {
       disconnectGasFeeEstimatePoller(this.state.pollingToken);
+      removePollingTokenFromAppState(this.state.pollingToken);
     }
   };
 

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.component.js
@@ -57,13 +57,18 @@ export default class GasModalPageContainer extends Component {
         disconnectGasFeeEstimatePoller(pollingToken);
       }
     });
+    window.addEventListener('beforeunload', this._beforeUnload);
   }
 
-  componentWillUnmount() {
+  _beforeUnload = () => {
     this._isMounted = false;
     if (this.state.pollingToken) {
       disconnectGasFeeEstimatePoller(this.state.pollingToken);
     }
+  };
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this._beforeUnload);
   }
 
   renderBasicTabContent(gasPriceButtonGroupProps) {

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -50,6 +50,8 @@ import {
   showLoadingIndication,
   updateTokenType,
   updateTransaction,
+  addPollingTokenToAppState,
+  removePollingTokenFromAppState,
 } from '../../store/actions';
 import { setCustomGasLimit } from '../gas/gas.duck';
 import {
@@ -84,7 +86,6 @@ import {
 import { CHAIN_ID_TO_GAS_LIMIT_BUFFER_MAP } from '../../../shared/constants/network';
 import { ETH, GWEI } from '../../helpers/constants/common';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../../shared/constants/transaction';
-
 // typedefs
 /**
  * @typedef {import('@reduxjs/toolkit').PayloadAction} PayloadAction
@@ -437,6 +438,9 @@ export const initializeSendState = createAsyncThunk(
 
     // Instruct the background process that polling for gas prices should begin
     gasEstimatePollToken = await getGasFeeEstimatesAndStartPolling();
+
+    addPollingTokenToAppState(gasEstimatePollToken);
+
     const {
       metamask: { gasFeeEstimates, gasEstimateType },
     } = thunkApi.getState();
@@ -1298,6 +1302,7 @@ export function resetSendState() {
       await disconnectGasFeeEstimatePoller(
         state[name].gas.gasEstimatePollToken,
       );
+      removePollingTokenFromAppState(state[name].gas.gasEstimatePollToken);
     }
   };
 }

--- a/ui/hooks/useGasFeeEstimates.test.js
+++ b/ui/hooks/useGasFeeEstimates.test.js
@@ -16,6 +16,8 @@ import { useGasFeeEstimates } from './useGasFeeEstimates';
 jest.mock('../store/actions', () => ({
   disconnectGasFeeEstimatePoller: jest.fn(),
   getGasFeeEstimatesAndStartPolling: jest.fn(),
+  addPollingTokenToAppState: jest.fn(),
+  removePollingTokenFromAppState: jest.fn(),
 }));
 
 jest.mock('react-redux', () => {

--- a/ui/hooks/useSafeGasEstimatePolling.js
+++ b/ui/hooks/useSafeGasEstimatePolling.js
@@ -16,6 +16,14 @@ export function useSafeGasEstimatePolling() {
   useEffect(() => {
     let active = true;
     let pollToken;
+
+    const cleanup = () => {
+      active = false;
+      if (pollToken) {
+        disconnectGasFeeEstimatePoller(pollToken);
+      }
+    };
+
     getGasFeeEstimatesAndStartPolling().then((newPollToken) => {
       if (active) {
         pollToken = newPollToken;
@@ -23,11 +31,12 @@ export function useSafeGasEstimatePolling() {
         disconnectGasFeeEstimatePoller(newPollToken);
       }
     });
+
+    window.addEventListener('beforeunload', cleanup);
+
     return () => {
-      active = false;
-      if (pollToken) {
-        disconnectGasFeeEstimatePoller(pollToken);
-      }
+      cleanup();
+      window.removeEventListener('beforeunload', cleanup);
     };
   }, []);
 }

--- a/ui/hooks/useSafeGasEstimatePolling.js
+++ b/ui/hooks/useSafeGasEstimatePolling.js
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 import {
   disconnectGasFeeEstimatePoller,
   getGasFeeEstimatesAndStartPolling,
+  addPollingTokenToAppState,
+  removePollingTokenFromAppState,
 } from '../store/actions';
 
 /**
@@ -21,14 +23,17 @@ export function useSafeGasEstimatePolling() {
       active = false;
       if (pollToken) {
         disconnectGasFeeEstimatePoller(pollToken);
+        removePollingTokenFromAppState(pollToken);
       }
     };
 
     getGasFeeEstimatesAndStartPolling().then((newPollToken) => {
       if (active) {
         pollToken = newPollToken;
+        addPollingTokenToAppState(pollToken);
       } else {
         disconnectGasFeeEstimatePoller(newPollToken);
+        removePollingTokenFromAppState(pollToken);
       }
     });
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -37,6 +37,8 @@ import { COLORS } from '../../helpers/constants/design-system';
 import {
   disconnectGasFeeEstimatePoller,
   getGasFeeEstimatesAndStartPolling,
+  addPollingTokenToAppState,
+  removePollingTokenFromAppState,
 } from '../../store/actions';
 
 export default class ConfirmTransactionBase extends Component {
@@ -678,6 +680,7 @@ export default class ConfirmTransactionBase extends Component {
     this._isMounted = false;
     if (this.state.pollingToken) {
       disconnectGasFeeEstimatePoller(this.state.pollingToken);
+      removePollingTokenFromAppState(this.state.pollingToken);
     }
   };
 
@@ -726,9 +729,11 @@ export default class ConfirmTransactionBase extends Component {
      */
     getGasFeeEstimatesAndStartPolling().then((pollingToken) => {
       if (this._isMounted) {
+        addPollingTokenToAppState(pollingToken);
         this.setState({ pollingToken });
       } else {
         disconnectGasFeeEstimatePoller(pollingToken);
+        removePollingTokenFromAppState(this.state.pollingToken);
       }
     });
     window.addEventListener('beforeunload', this._beforeUnloadForGasPolling);

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -674,10 +674,18 @@ export default class ConfirmTransactionBase extends Component {
     cancelTransaction({ id });
   };
 
+  _beforeUnloadForGasPolling = () => {
+    this._isMounted = false;
+    if (this.state.pollingToken) {
+      disconnectGasFeeEstimatePoller(this.state.pollingToken);
+    }
+  };
+
   _removeBeforeUnload = () => {
     if (getEnvironmentType() === ENVIRONMENT_TYPE_NOTIFICATION) {
       window.removeEventListener('beforeunload', this._beforeUnload);
     }
+    window.removeEventListener('beforeunload', this._beforeUnloadForGasPolling);
   };
 
   componentDidMount() {
@@ -723,13 +731,11 @@ export default class ConfirmTransactionBase extends Component {
         disconnectGasFeeEstimatePoller(pollingToken);
       }
     });
+    window.addEventListener('beforeunload', this._beforeUnloadForGasPolling);
   }
 
   componentWillUnmount() {
-    this._isMounted = false;
-    if (this.state.pollingToken) {
-      disconnectGasFeeEstimatePoller(this.state.pollingToken);
-    }
+    this._beforeUnloadForGasPolling();
     this._removeBeforeUnload();
   }
 

--- a/ui/pages/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirm-transaction/confirm-transaction.component.js
@@ -57,6 +57,13 @@ export default class ConfirmTransaction extends Component {
     this.state = {};
   }
 
+  _beforeUnload = () => {
+    this._isMounted = false;
+    if (this.state.pollingToken) {
+      disconnectGasFeeEstimatePoller(this.state.pollingToken);
+    }
+  };
+
   componentDidMount() {
     this._isMounted = true;
     const {
@@ -80,6 +87,8 @@ export default class ConfirmTransaction extends Component {
       }
     });
 
+    window.addEventListener('beforeunload', this._beforeUnload);
+
     if (!totalUnapprovedCount && !sendTo) {
       history.replace(mostRecentOverviewPage);
       return;
@@ -96,10 +105,8 @@ export default class ConfirmTransaction extends Component {
   }
 
   componentWillUnmount() {
-    this._isMounted = false;
-    if (this.state.pollingToken) {
-      disconnectGasFeeEstimatePoller(this.state.pollingToken);
-    }
+    this._beforeUnload();
+    window.removeEventListener('beforeunload', this._beforeUnload);
   }
 
   componentDidUpdate(prevProps) {

--- a/ui/pages/confirm-transaction/confirm-transaction.component.js
+++ b/ui/pages/confirm-transaction/confirm-transaction.component.js
@@ -28,6 +28,8 @@ import {
 import {
   disconnectGasFeeEstimatePoller,
   getGasFeeEstimatesAndStartPolling,
+  addPollingTokenToAppState,
+  removePollingTokenFromAppState,
 } from '../../store/actions';
 import ConfTx from './conf-tx';
 
@@ -61,6 +63,7 @@ export default class ConfirmTransaction extends Component {
     this._isMounted = false;
     if (this.state.pollingToken) {
       disconnectGasFeeEstimatePoller(this.state.pollingToken);
+      removePollingTokenFromAppState(this.state.pollingToken);
     }
   };
 
@@ -82,8 +85,10 @@ export default class ConfirmTransaction extends Component {
     getGasFeeEstimatesAndStartPolling().then((pollingToken) => {
       if (this._isMounted) {
         this.setState({ pollingToken });
+        addPollingTokenToAppState(pollingToken);
       } else {
         disconnectGasFeeEstimatePoller(pollingToken);
+        removePollingTokenFromAppState(pollingToken);
       }
     });
 

--- a/ui/pages/send/send.js
+++ b/ui/pages/send/send.js
@@ -64,11 +64,19 @@ export default function SendTransactionScreen() {
     }
   }, [location, dispatch]);
 
+  const cleanup = () => {
+    dispatch(resetSendState())
+  };
+
   useEffect(() => {
+    window.addEventListener('beforeunload', cleanup);
+
     return () => {
       dispatch(resetSendState());
+      window.removeEventListener('beforeunload', cleanup)
     };
   }, [dispatch]);
+
 
   let content;
 

--- a/ui/pages/send/send.js
+++ b/ui/pages/send/send.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import {
@@ -47,11 +47,17 @@ export default function SendTransactionScreen() {
   });
 
   const dispatch = useDispatch();
+
+  const cleanup = useCallback(() => {
+    dispatch(resetSendState());
+  }, [dispatch]);
+
   useEffect(() => {
     if (chainId !== undefined) {
       dispatch(initializeSendState());
+      window.addEventListener('beforeunload', cleanup);
     }
-  }, [chainId, dispatch]);
+  }, [chainId, dispatch, cleanup]);
 
   useEffect(() => {
     if (location.search === '?scan=true') {
@@ -64,19 +70,12 @@ export default function SendTransactionScreen() {
     }
   }, [location, dispatch]);
 
-  const cleanup = () => {
-    dispatch(resetSendState())
-  };
-
   useEffect(() => {
-    window.addEventListener('beforeunload', cleanup);
-
     return () => {
       dispatch(resetSendState());
-      window.removeEventListener('beforeunload', cleanup)
+      window.removeEventListener('beforeunload', cleanup);
     };
-  }, [dispatch]);
-
+  }, [dispatch, cleanup]);
 
   let content;
 

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -10,7 +10,10 @@ import {
 import { getMethodDataAsync } from '../helpers/utils/transactions.util';
 import { getSymbolAndDecimals } from '../helpers/utils/token-util';
 import switchDirection from '../helpers/utils/switch-direction';
-import { ENVIRONMENT_TYPE_NOTIFICATION } from '../../shared/constants/app';
+import {
+  ENVIRONMENT_TYPE_NOTIFICATION,
+  POLLING_TOKEN_ENVIRONMENT_TYPES,
+} from '../../shared/constants/app';
 import { hasUnconfirmedTransactions } from '../helpers/utils/confirm-tx.util';
 import txHelper from '../helpers/utils/tx-helper';
 import { getEnvironmentType, addHexPrefix } from '../../app/scripts/lib/util';
@@ -2785,6 +2788,20 @@ export function getGasFeeEstimatesAndStartPolling() {
  */
 export function disconnectGasFeeEstimatePoller(pollToken) {
   return promisifiedBackground.disconnectGasFeeEstimatePoller(pollToken);
+}
+
+export async function addPollingTokenToAppState(pollingToken) {
+  return promisifiedBackground.addPollingTokenToAppState(
+    pollingToken,
+    POLLING_TOKEN_ENVIRONMENT_TYPES[getEnvironmentType()],
+  );
+}
+
+export async function removePollingTokenFromAppState(pollingToken) {
+  return promisifiedBackground.removePollingTokenFromAppState(
+    pollingToken,
+    POLLING_TOKEN_ENVIRONMENT_TYPES[getEnvironmentType()],
+  );
 }
 
 export function getGasFeeTimeEstimate(maxPriorityFeePerGas, maxFeePerGas) {


### PR DESCRIPTION
Fixes: (#)1 on [RC v10.0 feedback doc](https://docs.google.com/document/d/1jRyoxmVWXGv-jPCFCpdVBvMwAt7ERkGtfRnPAjEp2y0/edit#heading=h.rtflwh1n2ugq)

Explanation: This stops polling in the gasFeeController when a users closes confirmation screen/window with a pending transaction unfinished.
