### PR TITLE
Allow max priority fee to be below 1, and only require it to be greater than 0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -668,6 +668,9 @@
   "editGasMaxFeeTooltip": {
     "message": "The max fee is the most you’ll pay (base fee + priority fee)."
   },
+  "editGasMaxPriorityFeeBelowMinimum": {
+    "message": "Max priority fee must be greater than 0 GWEI"
+  },
   "editGasMaxPriorityFeeHigh": {
     "message": "Max priority fee is higher than necessary. You may pay more than needed."
   },
@@ -676,9 +679,6 @@
   },
   "editGasMaxPriorityFeeTooltip": {
     "message": "Max priority fee (aka “miner tip”) goes directly to miners and incentivizes them to prioritize your transaction. You’ll most often pay your max setting"
-  },
-  "editGasMaxPriorityFeeZeroError": {
-    "message": "Max priority fee must be at least 1 GWEI"
   },
   "editGasMedium": {
     "message": "Medium"

--- a/ui/helpers/constants/gas.js
+++ b/ui/helpers/constants/gas.js
@@ -17,8 +17,8 @@ export function getGasFormErrorText(type, t, { minimumGasLimit } = {}) {
       return t('editGasMaxPriorityFeeLow');
     case GAS_FORM_ERRORS.MAX_FEE_TOO_LOW:
       return t('editGasMaxFeeLow');
-    case GAS_FORM_ERRORS.MAX_PRIORITY_FEE_ZERO:
-      return t('editGasMaxPriorityFeeZeroError');
+    case GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM:
+      return t('editGasMaxPriorityFeeBelowMinimum');
     case GAS_FORM_ERRORS.MAX_PRIORITY_FEE_HIGH_WARNING:
       return t('editGasMaxPriorityFeeHigh');
     case GAS_FORM_ERRORS.MAX_FEE_HIGH_WARNING:

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -390,8 +390,9 @@ export function useGasFeeInputs(
 
   switch (gasEstimateType) {
     case GAS_ESTIMATE_TYPES.FEE_MARKET:
-      if (maxPriorityFeePerGasToUse < 1) {
-        gasErrors.maxPriorityFee = GAS_FORM_ERRORS.MAX_PRIORITY_FEE_ZERO;
+      if (maxPriorityFeePerGasToUse <= 0) {
+        gasErrors.maxPriorityFee =
+          GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
       } else if (
         !isGasEstimatesLoading &&
         maxPriorityFeePerGasToUse <


### PR DESCRIPTION
Addresses this report in QA from @dpazdan:

> Should we allow for sub 1 priority fee under advanced gas options? we have a warning but also do not allow it on extension.  On mobile it warns but allows the user to proceed

