### PR TITLE
Allows users to set a max priority fee below suggested, just showing a warning in that case

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -672,7 +672,7 @@
     "message": "Max priority fee is higher than necessary. You may pay more than needed."
   },
   "editGasMaxPriorityFeeLow": {
-    "message": "Max priority fee too low for network conditions"
+    "message": "Max priority fee extremely low for network conditions"
   },
   "editGasMaxPriorityFeeTooltip": {
     "message": "Max priority fee (aka “miner tip”) goes directly to miners and incentivizes them to prioritize your transaction. You’ll most often pay your max setting"

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -397,7 +397,7 @@ export function useGasFeeInputs(
         maxPriorityFeePerGasToUse <
           gasFeeEstimates?.low?.suggestedMaxPriorityFeePerGas
       ) {
-        gasErrors.maxPriorityFee = GAS_FORM_ERRORS.MAX_PRIORITY_FEE_TOO_LOW;
+        gasWarnings.maxPriorityFee = GAS_FORM_ERRORS.MAX_PRIORITY_FEE_TOO_LOW;
       } else if (maxPriorityFeePerGasToUse >= maxFeePerGasToUse) {
         gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
       } else if (


### PR DESCRIPTION
I believe we should allow users to submit a maxPriorityFee below our suggested low fee. We should just show a warning instead of preventing it entirely.