### PR TITLE
Show advanced options, and hide radio buttons, for advanced gas settings users

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1205,6 +1205,9 @@
   "lockTimeTooGreat": {
     "message": "Lock time is too great"
   },
+  "lowMediumHighOptions": {
+    "message": "Low, medium and high options"
+  },
   "mainnet": {
     "message": "Ethereum Mainnet"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1205,8 +1205,8 @@
   "lockTimeTooGreat": {
     "message": "Lock time is too great"
   },
-  "lowMediumHighOptions": {
-    "message": "Low, medium and high options"
+  "showRecommendations": {
+    "message": "Show Recommendations"
   },
   "mainnet": {
     "message": "Ethereum Mainnet"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1205,9 +1205,6 @@
   "lockTimeTooGreat": {
     "message": "Lock time is too great"
   },
-  "showRecommendations": {
-    "message": "Show Recommendations"
-  },
   "mainnet": {
     "message": "Ethereum Mainnet"
   },
@@ -1937,6 +1934,9 @@
   },
   "showPrivateKeys": {
     "message": "Show Private Keys"
+  },
+  "showRecommendations": {
+    "message": "Show Recommendations"
   },
   "showSeedPhrase": {
     "message": "Show Secret Recovery Phrase"

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -94,7 +94,7 @@ export default function EditGasDisplay({
   );
 
   const showTopError = balanceError || estimatesUnavailableWarning;
-  const showRadioButtons =
+  const radioButtonsEnabled =
     networkAndAccountSupport1559 &&
     gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET &&
     !requireDappAcknowledgement &&
@@ -186,13 +186,13 @@ export default function EditGasDisplay({
           </Button>
         )}
         {!requireDappAcknowledgement &&
-          showRadioButtons &&
+          radioButtonsEnabled &&
           showAdvancedInlineGasIfPossible && (
             <button
               className="edit-gas-display__advanced-button"
               onClick={() => setHideRadioButtons(!hideRadioButtons)}
             >
-              {t('lowMediumHighOptions')}{' '}
+              {t('showRecommendations')}{' '}
               {hideRadioButtons ? (
                 <i className="fa fa-caret-down"></i>
               ) : (
@@ -200,7 +200,7 @@ export default function EditGasDisplay({
               )}
             </button>
           )}
-        {showRadioButtons && !hideRadioButtons && (
+        {radioButtonsEnabled && !hideRadioButtons && (
           <RadioGroup
             name="gas-recommendation"
             options={[
@@ -225,7 +225,7 @@ export default function EditGasDisplay({
             onChange={setEstimateToUse}
           />
         )}
-        {!requireDappAcknowledgement && showRadioButtons && !showAdvancedInlineGasIfPossible && (
+        {!requireDappAcknowledgement && radioButtonsEnabled && !showAdvancedInlineGasIfPossible && (
           <button
             className="edit-gas-display__advanced-button"
             onClick={() => setShowAdvancedForm(!showAdvancedForm)}

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -225,38 +225,41 @@ export default function EditGasDisplay({
             onChange={setEstimateToUse}
           />
         )}
-        {!requireDappAcknowledgement && radioButtonsEnabled && !showAdvancedInlineGasIfPossible && (
-          <button
-            className="edit-gas-display__advanced-button"
-            onClick={() => setShowAdvancedForm(!showAdvancedForm)}
-          >
-            {t('advancedOptions')}{' '}
-            {showAdvancedForm ? (
-              <i className="fa fa-caret-up"></i>
-            ) : (
-              <i className="fa fa-caret-down"></i>
-            )}
-          </button>
-        )}
-        {!requireDappAcknowledgement && (showAdvancedForm || showAdvancedInlineGasIfPossible) && (
-          <AdvancedGasControls
-            gasEstimateType={gasEstimateType}
-            isGasEstimatesLoading={isGasEstimatesLoading}
-            gasLimit={gasLimit}
-            setGasLimit={setGasLimit}
-            maxPriorityFee={maxPriorityFeePerGas}
-            setMaxPriorityFee={setMaxPriorityFeePerGas}
-            maxFee={maxFeePerGas}
-            setMaxFee={setMaxFeePerGas}
-            gasPrice={gasPrice}
-            setGasPrice={setGasPrice}
-            maxPriorityFeeFiat={maxPriorityFeePerGasFiat}
-            maxFeeFiat={maxFeePerGasFiat}
-            gasErrors={gasErrors}
-            onManualChange={onManualChange}
-            minimumGasLimit={minimumGasLimit}
-          />
-        )}
+        {!requireDappAcknowledgement &&
+          radioButtonsEnabled &&
+          !showAdvancedInlineGasIfPossible && (
+            <button
+              className="edit-gas-display__advanced-button"
+              onClick={() => setShowAdvancedForm(!showAdvancedForm)}
+            >
+              {t('advancedOptions')}{' '}
+              {showAdvancedForm ? (
+                <i className="fa fa-caret-up"></i>
+              ) : (
+                <i className="fa fa-caret-down"></i>
+              )}
+            </button>
+          )}
+        {!requireDappAcknowledgement &&
+          (showAdvancedForm || showAdvancedInlineGasIfPossible) && (
+            <AdvancedGasControls
+              gasEstimateType={gasEstimateType}
+              isGasEstimatesLoading={isGasEstimatesLoading}
+              gasLimit={gasLimit}
+              setGasLimit={setGasLimit}
+              maxPriorityFee={maxPriorityFeePerGas}
+              setMaxPriorityFee={setMaxPriorityFeePerGas}
+              maxFee={maxFeePerGas}
+              setMaxFee={setMaxFeePerGas}
+              gasPrice={gasPrice}
+              setGasPrice={setGasPrice}
+              maxPriorityFeeFiat={maxPriorityFeePerGasFiat}
+              maxFeeFiat={maxFeePerGasFiat}
+              gasErrors={gasErrors}
+              onManualChange={onManualChange}
+              minimumGasLimit={minimumGasLimit}
+            />
+          )}
       </div>
       {networkAndAccountSupport1559 &&
         !requireDappAcknowledgement &&

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -87,10 +87,6 @@ export default function EditGasPopover({
     estimatesUnavailableWarning,
   } = useGasFeeInputs(defaultEstimateToUse, transaction, minimumGasLimit, mode);
 
-  const [showAdvancedForm, setShowAdvancedForm] = useState(
-    !estimateToUse || hasGasErrors || !networkAndAccountSupport1559,
-  );
-
   /**
    * Temporary placeholder, this should be managed by the parent component but
    * we will be extracting this component from the hard to maintain modal/
@@ -213,8 +209,6 @@ export default function EditGasPopover({
             <EditGasDisplay
               showEducationButton={showEducationButton}
               warning={warning}
-              showAdvancedForm={showAdvancedForm}
-              setShowAdvancedForm={setShowAdvancedForm}
               dappSuggestedGasFeeAcknowledged={dappSuggestedGasFeeAcknowledged}
               setDappSuggestedGasFeeAcknowledged={
                 setDappSuggestedGasFeeAcknowledged
@@ -245,6 +239,7 @@ export default function EditGasPopover({
               minimumGasLimit={minimumGasLimitDec}
               balanceError={balanceError}
               estimatesUnavailableWarning={estimatesUnavailableWarning}
+              hasGasErrors={hasGasErrors}
               {...editGasDisplayProps}
             />
           </>

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -21,6 +21,7 @@ import {
   checkNetworkAndAccountSupports1559,
   getShouldShowFiat,
   getSelectedAccount,
+  getAdvancedInlineGasShown,
 } from '../selectors';
 
 import {
@@ -249,8 +250,18 @@ export function useGasFeeInputs(
     Number(hexToDecimal(transaction?.txParams?.gas ?? minimumGasLimit)),
   );
 
+  const userPrefersAdvancedGas = useSelector(getAdvancedInlineGasShown);
+  const dontDefaultToAnEstimateLevel =
+    userPrefersAdvancedGas &&
+    transaction?.txParams?.maxPriorityFeePerGas &&
+    transaction?.txParams?.gasPrice;
+
+  const initialEstimateToUse = transaction
+    ? initialMatchingEstimateLevel
+    : defaultEstimateToUse;
+
   const [estimateToUse, setInternalEstimateToUse] = useState(
-    transaction ? initialMatchingEstimateLevel : defaultEstimateToUse,
+    dontDefaultToAnEstimateLevel ? null : initialEstimateToUse,
   );
 
   // We specify whether to use the estimate value by checking if the state


### PR DESCRIPTION
This PR provides an improvement for users with the "Advanced gas controls" setting turned on. These users will be shown those options by default, and have the radio buttons hidden by default, in the edit gas popover on the confirm screen.

Because we are not, at present and post EIP-1559 work, showing inline editing on the confirm or send screen, this at least reduces friction for users who like the inline advanced gas inputs. We want to improve and provide those inline inputs in the very near future, but we are not going to block EIP-1559 on it.

UX after this PR:


https://user-images.githubusercontent.com/7499938/128172689-2f94be1e-0dbd-455f-94fc-808f8cfcbf08.mp4

