### PR TITLE
EIP-1559 - Remove unncessary props from AdvancedFormControls

### DIFF
--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -4,16 +4,11 @@ import { useSelector } from 'react-redux';
 
 import { I18nContext } from '../../../contexts/i18n';
 import FormField from '../../ui/form-field';
-import {
-  GAS_ESTIMATE_TYPES,
-  GAS_RECOMMENDATIONS,
-} from '../../../../shared/constants/gas';
+import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { getGasFormErrorText } from '../../../helpers/constants/gas';
 import { checkNetworkAndAccountSupports1559 } from '../../../selectors';
 
 export default function AdvancedGasControls({
-  estimateToUse,
-  gasFeeEstimates,
   gasEstimateType,
   maxPriorityFee,
   maxFee,
@@ -33,28 +28,6 @@ export default function AdvancedGasControls({
   const networkAndAccountSupport1559 = useSelector(
     checkNetworkAndAccountSupports1559,
   );
-
-  const suggestedValues = {};
-
-  if (networkAndAccountSupport1559) {
-    suggestedValues.maxFeePerGas =
-      gasFeeEstimates?.[estimateToUse]?.suggestedMaxFeePerGas ||
-      gasFeeEstimates?.gasPrice;
-    suggestedValues.maxPriorityFeePerGas =
-      gasFeeEstimates?.[estimateToUse]?.suggestedMaxPriorityFeePerGas ||
-      suggestedValues.maxFeePerGas;
-  } else {
-    switch (gasEstimateType) {
-      case GAS_ESTIMATE_TYPES.LEGACY:
-        suggestedValues.gasPrice = gasFeeEstimates?.[estimateToUse];
-        break;
-      case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
-        suggestedValues.gasPrice = gasFeeEstimates?.gasPrice;
-        break;
-      default:
-        break;
-    }
-  }
 
   const showFeeMarketFields =
     networkAndAccountSupport1559 &&
@@ -142,23 +115,6 @@ export default function AdvancedGasControls({
 }
 
 AdvancedGasControls.propTypes = {
-  estimateToUse: PropTypes.oneOf(Object.values(GAS_RECOMMENDATIONS)),
-  gasFeeEstimates: PropTypes.oneOf([
-    PropTypes.shape({
-      gasPrice: PropTypes.string,
-    }),
-    PropTypes.shape({
-      low: PropTypes.string,
-      medium: PropTypes.string,
-      high: PropTypes.string,
-    }),
-    PropTypes.shape({
-      low: PropTypes.object,
-      medium: PropTypes.object,
-      high: PropTypes.object,
-      estimatedBaseFee: PropTypes.string,
-    }),
-  ]),
   gasEstimateType: PropTypes.oneOf(Object.values(GAS_ESTIMATE_TYPES)),
   setMaxPriorityFee: PropTypes.func,
   setMaxFee: PropTypes.func,

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -47,7 +47,6 @@ export default function EditGasDisplay({
   estimatedMaximumNative,
   estimatedMinimumNative,
   isGasEstimatesLoading,
-  gasFeeEstimates,
   gasEstimateType,
   gasPrice,
   setGasPrice,
@@ -216,9 +215,7 @@ export default function EditGasDisplay({
         )}
         {!requireDappAcknowledgement && showAdvancedForm && (
           <AdvancedGasControls
-            gasFeeEstimates={gasFeeEstimates}
             gasEstimateType={gasEstimateType}
-            estimateToUse={estimateToUse}
             isGasEstimatesLoading={isGasEstimatesLoading}
             gasLimit={gasLimit}
             setGasLimit={setGasLimit}
@@ -263,7 +260,6 @@ EditGasDisplay.propTypes = {
   estimatedMaximumNative: PropTypes.string,
   estimatedMinimumNative: PropTypes.string,
   isGasEstimatesLoading: PropTypes.bool,
-  gasFeeEstimates: PropTypes.object,
   gasEstimateType: PropTypes.string,
   gasPrice: PropTypes.string,
   setGasPrice: PropTypes.func,

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -71,7 +71,6 @@ export default function EditGasPopover({
     estimatedMaximumNative,
     estimatedMinimumNative,
     isGasEstimatesLoading,
-    gasFeeEstimates,
     gasEstimateType,
     gasPrice,
     setGasPrice,
@@ -229,7 +228,6 @@ export default function EditGasPopover({
               estimatedMaximumNative={estimatedMaximumNative}
               estimatedMinimumNative={estimatedMinimumNative}
               isGasEstimatesLoading={isGasEstimatesLoading}
-              gasFeeEstimates={gasFeeEstimates}
               gasEstimateType={gasEstimateType}
               gasPrice={gasPrice}
               setGasPrice={setGasPrice}


### PR DESCRIPTION
When we removed the estimate values due to user confusion, we left around some variables and props we didn't need.