### PR TITLE
EIP-1559 - Prevent uncaught exception when passing fees to getGasFeeTimeEstimate

### DIFF
--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import BigNumber from 'bignumber.js';
 
 import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 
@@ -62,13 +63,14 @@ export default function GasTiming({
       (fee && fee !== previousMaxFeePerGas)
     ) {
       // getGasFeeTimeEstimate requires parameters in string format
-      getGasFeeTimeEstimate(priority.toString(), fee.toString()).then(
-        (result) => {
-          if (maxFeePerGas === fee && maxPriorityFeePerGas === priority) {
-            setCustomEstimatedTime(result);
-          }
-        },
-      );
+      getGasFeeTimeEstimate(
+        new BigNumber(priority).toString(10),
+        new BigNumber(fee).toString(10),
+      ).then((result) => {
+        if (maxFeePerGas === fee && maxPriorityFeePerGas === priority) {
+          setCustomEstimatedTime(result);
+        }
+      });
     }
 
     if (isUnknownLow !== false && previousIsUnknownLow === true) {

--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -61,11 +61,14 @@ export default function GasTiming({
       (priority && priority !== previousMaxPriorityFeePerGas) ||
       (fee && fee !== previousMaxFeePerGas)
     ) {
-      getGasFeeTimeEstimate(priority, fee).then((result) => {
-        if (maxFeePerGas === fee && maxPriorityFeePerGas === priority) {
-          setCustomEstimatedTime(result);
-        }
-      });
+      // getGasFeeTimeEstimate requires parameters in string format
+      getGasFeeTimeEstimate(priority.toString(), fee.toString()).then(
+        (result) => {
+          if (maxFeePerGas === fee && maxPriorityFeePerGas === priority) {
+            setCustomEstimatedTime(result);
+          }
+        },
+      );
     }
 
     if (isUnknownLow !== false && previousIsUnknownLow === true) {


### PR DESCRIPTION
Peter was seeing an uncaught exception in our `GasTiming` component because very small decimal values were being converted to scientific notation, and `gasFeeController.getTimeEstimate` requires two strings -- we were passing numbers.