### PR TITLE
Ensure gas fees update in popover on poll for new values

### DIFF
--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -206,41 +206,51 @@ export function useGasFeeInputs(
     estimatedGasFeeTimeBounds,
   } = useGasFeeEstimates();
 
+  const [initialMaxFeePerGas] = useState(
+    Number(hexWEIToDecGWEI(transaction?.txParams?.maxFeePerGas)),
+  );
+  const [initialMaxPriorityFeePerGas] = useState(
+    Number(hexWEIToDecGWEI(transaction?.txParams?.maxPriorityFeePerGas)),
+  );
+  const [initialGasPrice] = useState(
+    Number(hexWEIToDecGWEI(transaction?.txParams?.gasPrice)),
+  );
+
+  const [initialMatchingEstimateLevel] = useState(
+    getMatchingEstimateFromGasFees(
+      gasFeeEstimates,
+      initialMaxFeePerGas,
+      initialMaxPriorityFeePerGas,
+      initialGasPrice,
+      networkAndAccountSupports1559,
+    ),
+  );
+
   // This hook keeps track of a few pieces of transitional state. It is
   // transitional because it is only used to modify a transaction in the
   // metamask (background) state tree.
   const [maxFeePerGas, setMaxFeePerGas] = useState(
-    transaction?.txParams?.maxFeePerGas
-      ? Number(hexWEIToDecGWEI(transaction.txParams.maxFeePerGas))
+    initialMaxFeePerGas && !initialMatchingEstimateLevel
+      ? initialMaxFeePerGas
       : null,
   );
   const [maxPriorityFeePerGas, setMaxPriorityFeePerGas] = useState(
-    transaction?.txParams?.maxPriorityFeePerGas
-      ? Number(hexWEIToDecGWEI(transaction.txParams.maxPriorityFeePerGas))
+    initialMaxPriorityFeePerGas && !initialMatchingEstimateLevel
+      ? initialMaxPriorityFeePerGas
       : null,
   );
   const [gasPriceHasBeenManuallySet, setGasPriceHasBeenManuallySet] = useState(
     false,
   );
   const [gasPrice, setGasPrice] = useState(
-    transaction?.txParams?.gasPrice
-      ? Number(hexWEIToDecGWEI(transaction.txParams.gasPrice))
-      : null,
+    initialGasPrice && !initialMatchingEstimateLevel ? initialGasPrice : null,
   );
   const [gasLimit, setGasLimit] = useState(
     Number(hexToDecimal(transaction?.txParams?.gas ?? minimumGasLimit)),
   );
 
   const [estimateToUse, setInternalEstimateToUse] = useState(
-    transaction
-      ? getMatchingEstimateFromGasFees(
-          gasFeeEstimates,
-          maxFeePerGas,
-          maxPriorityFeePerGas,
-          gasPrice,
-          networkAndAccountSupports1559,
-        )
-      : defaultEstimateToUse,
+    transaction ? initialMatchingEstimateLevel : defaultEstimateToUse,
   );
 
   // We specify whether to use the estimate value by checking if the state


### PR DESCRIPTION
Fixes an issue where the gas price estimates in the edit gas popover were not automatically updating after first opening the popover. This PR ensures that the `maxFeePerGas` and `maxPriorityFeePerGas` get set to null on initiatilization of `useGasFeeInputs` if the initial values (those that come from the transaction) are the same as one of the gas fee estimates