### PR TITLE
tiny lost code change from 9.8.4 RC

### DIFF
--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -143,6 +143,7 @@ export default class TransactionBreakdown extends PureComponent {
                 currency={nativeCurrency}
                 denomination={GWEI}
                 value={gasPrice}
+                numberOfDecimals={9}
                 hideLabel
               />
             )}


### PR DESCRIPTION
Explanation:  A single line of code was lost in a bad rebase somewhere since [v9.8.4 RC.](https://github.com/MetaMask/metamask-extension/pull/11662/files) This adds it back.
