### PR TITLE
EIP-1559 - Ensure minimum value for maxFeePerGas

### DIFF
--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -433,8 +433,9 @@ export function useGasFeeInputs(
       }
 
       if (
-        !isGasEstimatesLoading &&
-        maxFeePerGasToUse < gasFeeEstimates?.low?.suggestedMaxFeePerGas
+        (!isGasEstimatesLoading &&
+          maxFeePerGasToUse < gasFeeEstimates?.low?.suggestedMaxFeePerGas) ||
+        maxFeePerGasToUse <= 0
       ) {
         gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_TOO_LOW;
       } else if (


### PR DESCRIPTION
I noticed when the API is offline that we don't ensure a minimum value for maxFeePerGas, despite doing so with maxFee and gasLimit.  We should provide one for maxFeePerGas as well.