### PR TITLE
Fix legacy unapproved tx handling

### DIFF
--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -207,10 +207,15 @@ export function useGasFeeInputs(
   } = useGasFeeEstimates();
 
   const [initialMaxFeePerGas] = useState(
-    Number(hexWEIToDecGWEI(transaction?.txParams?.maxFeePerGas)),
+    networkAndAccountSupports1559 && !transaction?.txParams?.maxFeePerGas
+      ? Number(hexWEIToDecGWEI(transaction?.txParams?.gasPrice))
+      : Number(hexWEIToDecGWEI(transaction?.txParams?.maxFeePerGas)),
   );
   const [initialMaxPriorityFeePerGas] = useState(
-    Number(hexWEIToDecGWEI(transaction?.txParams?.maxPriorityFeePerGas)),
+    networkAndAccountSupports1559 &&
+      !transaction?.txParams?.maxPriorityFeePerGas
+      ? initialMaxFeePerGas
+      : Number(hexWEIToDecGWEI(transaction?.txParams?.maxPriorityFeePerGas)),
   );
   const [initialGasPrice] = useState(
     Number(hexWEIToDecGWEI(transaction?.txParams?.gasPrice)),


### PR DESCRIPTION
This PR handles the following case:

- user is on v9.8.4
- user has an unapproved transaction
- user updates to v10.0.0
- user opens the unapproved transaction again

Currently this will result in the user seeing `0` in the max fee and max priority fee field.

To fix this, we default max fee and max priority fee to gas price if on an eip 1559 network but they do not exist.