### PR TITLE
Ensure that gas fee minimum errors show when api is down

### DIFF
--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -409,6 +409,13 @@ export function useGasFeeInputs(
     gasErrors.gasLimit = GAS_FORM_ERRORS.GAS_LIMIT_OUT_OF_BOUNDS;
   }
 
+  if (networkAndAccountSupports1559 && (maxPriorityFeePerGasToUse <= 0)) {
+    gasErrors.maxPriorityFee =
+      GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
+  } else if (networkAndAccountSupports1559 && (maxPriorityFeePerGasToUse >= maxFeePerGasToUse)) {
+    gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
+  }
+
   switch (gasEstimateType) {
     case GAS_ESTIMATE_TYPES.FEE_MARKET:
       if (maxPriorityFeePerGasToUse <= 0) {

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -409,11 +409,15 @@ export function useGasFeeInputs(
     gasErrors.gasLimit = GAS_FORM_ERRORS.GAS_LIMIT_OUT_OF_BOUNDS;
   }
 
-  if (networkAndAccountSupports1559 && (maxPriorityFeePerGasToUse <= 0)) {
-    gasErrors.maxPriorityFee =
-      GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
-  } else if (networkAndAccountSupports1559 && (maxPriorityFeePerGasToUse >= maxFeePerGasToUse)) {
-    gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
+  // This ensures these are applied when the api fails to return a fee market type
+  // It is okay if these errors get overwritten below, as those overwrites can only
+  // happen when the estimate api is live.
+  if (networkAndAccountSupports1559) {
+    if (maxPriorityFeePerGasToUse <= 0) {
+      gasErrors.maxPriorityFee = GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
+    } else if (maxPriorityFeePerGasToUse >= maxFeePerGasToUse) {
+      gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
+    }
   }
 
   switch (gasEstimateType) {


### PR DESCRIPTION
Ensures that minimum errors are correctly shown for max fee and max priority fee, even when gas fee api is down

![Screenshot from 2021-08-04 19-42-20](https://user-images.githubusercontent.com/7499938/128262090-6946c45b-1101-4e8e-bf54-3393cb11651f.png)
![Screenshot from 2021-08-04 19-42-10](https://user-images.githubusercontent.com/7499938/128262092-037169e7-bda9-4732-b12a-a61180474517.png)
