### PR TITLE
Update all radio button sizes to 18px

### DIFF
--- a/ui/components/ui/radio-button/index.js
+++ b/ui/components/ui/radio-button/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function RadioButton({
+  name,
+  id = '',
+  checked = false,
+  value,
+  onChange,
+}) {
+  return (
+    <input
+      type="radio"
+      name={name}
+      id={id}
+      checked={checked}
+      value={value}
+      onChange={onChange}
+    />
+  );
+}
+
+RadioButton.propTypes = {
+  name: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  checked: PropTypes.bool,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+};

--- a/ui/components/ui/radio-button/index.scss
+++ b/ui/components/ui/radio-button/index.scss
@@ -1,0 +1,4 @@
+input[type=radio] {
+  width: 18px;
+  height: 18px;
+}

--- a/ui/components/ui/radio-group/index.scss
+++ b/ui/components/ui/radio-group/index.scss
@@ -65,6 +65,8 @@
     input {
       cursor: pointer;
       margin: 0;
+      width: 18px;
+      height: 18px;
     }
   }
 

--- a/ui/components/ui/radio-group/radio-group.component.js
+++ b/ui/components/ui/radio-group/radio-group.component.js
@@ -8,6 +8,7 @@ import {
   FONT_WEIGHT,
   TYPOGRAPHY,
 } from '../../../helpers/constants/design-system';
+import RadioButton from '../radio-button';
 
 function Connector({ isFirst, isLast }) {
   if (isFirst) {
@@ -56,7 +57,7 @@ export default function RadioGroup({ options, name, selectedValue, onChange }) {
                 </Typography>
               )}
               <div className="radio-group__column-radio">
-                <input
+                <RadioButton
                   type="radio"
                   name={name}
                   checked={checked}

--- a/ui/components/ui/ui-components.scss
+++ b/ui/components/ui/ui-components.scss
@@ -41,6 +41,7 @@
 @import 'popover/index';
 @import 'pulse-loader/index';
 @import 'qr-code/index';
+@import 'radio-button/index';
 @import 'radio-group/index';
 @import 'readonly-input/index';
 @import 'sender-to-recipient/index';

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -4,6 +4,7 @@ import availableCurrencies from '../../../helpers/constants/available-conversion
 import Dropdown from '../../../components/ui/dropdown';
 import ToggleButton from '../../../components/ui/toggle-button';
 import locales from '../../../../app/_locales/index.json';
+import RadioButton from '../../../components/ui/radio-button';
 
 const sortedCurrencies = availableCurrencies.sort((a, b) => {
   return a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase());
@@ -169,8 +170,7 @@ export default class SettingsTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <div className="settings-tab__radio-buttons">
               <div className="settings-tab__radio-button">
-                <input
-                  type="radio"
+                <RadioButton
                   id="native-primary-currency"
                   onChange={() =>
                     setUseNativeCurrencyAsPrimaryCurrencyPreference(true)
@@ -185,8 +185,7 @@ export default class SettingsTab extends PureComponent {
                 </label>
               </div>
               <div className="settings-tab__radio-button">
-                <input
-                  type="radio"
+                <RadioButton
                   id="fiat-primary-currency"
                   onChange={() =>
                     setUseNativeCurrencyAsPrimaryCurrencyPreference(false)

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -171,10 +171,12 @@ export default class SettingsTab extends PureComponent {
             <div className="settings-tab__radio-buttons">
               <div className="settings-tab__radio-button">
                 <RadioButton
+                  name="preferred-currency"
                   id="native-primary-currency"
                   onChange={() =>
                     setUseNativeCurrencyAsPrimaryCurrencyPreference(true)
                   }
+                  value="native"
                   checked={Boolean(useNativeCurrencyAsPrimaryCurrency)}
                 />
                 <label
@@ -186,10 +188,12 @@ export default class SettingsTab extends PureComponent {
               </div>
               <div className="settings-tab__radio-button">
                 <RadioButton
+                  name="preferred-currency"
                   id="fiat-primary-currency"
                   onChange={() =>
                     setUseNativeCurrencyAsPrimaryCurrencyPreference(false)
                   }
+                  value="fiat"
                   checked={!useNativeCurrencyAsPrimaryCurrency}
                 />
                 <label

--- a/ui/pages/settings/settings-tab/settings-tab.container.test.js
+++ b/ui/pages/settings/settings-tab/settings-tab.container.test.js
@@ -44,7 +44,7 @@ describe('Settings Tab', () => {
   });
 
   it('sets fiat primary currency', () => {
-    const selectFiat = wrapper.find('#fiat-primary-currency');
+    const selectFiat = wrapper.find('#fiat-primary-currency').first();
 
     selectFiat.simulate('change');
     expect(


### PR DESCRIPTION
Fixes an item in https://github.com/MetaMask/metamask-extension/issues/11761

@jakehaugen  wants all radio buttons to be `18px x 18px` instead of default sizes.  Form controls are notoriously different and strict on different operating systems but I tested in Mac+Chrome, Mac+Firefox, and Windows+Chrome, and this looked good.