### PR TITLE
Correct the vertical margins on the RadioGroup component

### DIFF
--- a/ui/components/ui/radio-group/index.scss
+++ b/ui/components/ui/radio-group/index.scss
@@ -1,8 +1,12 @@
 .radio-group {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: 100px;
+  grid-template-rows: 60px;
   width: 300px;
+
+  &--has-recommendation {
+    grid-template-rows: 100px;
+  }
 
   label {
     cursor: pointer;

--- a/ui/components/ui/radio-group/radio-group.component.js
+++ b/ui/components/ui/radio-group/radio-group.component.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { I18nContext } from '../../../contexts/i18n';
 import Typography from '../typography/typography';
 import {
@@ -11,21 +12,30 @@ import {
 export default function RadioGroup({ options, name, selectedValue, onChange }) {
   const t = useContext(I18nContext);
 
+  const hasRecommendation = Boolean(
+    options.find((option) => option.recommended),
+  );
+
   return (
-    <div className="radio-group">
+    <div
+      className={classNames('radio-group', {
+        'radio-group--has-recommendation': hasRecommendation,
+      })}
+    >
       {options.map((option) => {
         const checked = option.value === selectedValue;
         return (
           <div className="radio-group__column" key={`${name}-${option.value}`}>
             <label>
-              <Typography
-                color={COLORS.SUCCESS3}
-                className="radio-group__column-recommended"
-                variant={TYPOGRAPHY.H7}
-              >
-                {option.recommended ? t('recommendedGasLabel') : ''}
-              </Typography>
-
+              {hasRecommendation && (
+                <Typography
+                  color={COLORS.SUCCESS3}
+                  className="radio-group__column-recommended"
+                  variant={TYPOGRAPHY.H7}
+                >
+                  {option.recommended ? t('recommendedGasLabel') : ''}
+                </Typography>
+              )}
               <div className="radio-group__column-radio">
                 <input
                   type="radio"


### PR DESCRIPTION
Fixes an issue here:  https://github.com/MetaMask/metamask-extension/issues/11761

The extra vertical space is for the recommendation system which we've not used yet.