### PR TITLE
Keep radio group contained and equal width

### DIFF
--- a/ui/components/ui/radio-group/index.scss
+++ b/ui/components/ui/radio-group/index.scss
@@ -1,8 +1,8 @@
 .radio-group {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 33% 33% 33%;
   grid-template-rows: 60px;
-  width: 300px;
+  width: 100%;
 
   &--has-recommendation {
     grid-template-rows: 100px;


### PR DESCRIPTION
The current radiogroup stretches slightly out of the current margins, as well as gives more space to the "low" panel than the other two options.  This keeps the radio group in bounds, and gives equal widths.

When we come back to reinstating the "Recommended" stuff, we'll need to look at these widths again.