### PR TITLE
Fix NumericInput PropType error

### DIFF
--- a/ui/components/ui/numeric-input/numeric-input.component.js
+++ b/ui/components/ui/numeric-input/numeric-input.component.js
@@ -40,7 +40,7 @@ export default function NumericInput({
 }
 
 NumericInput.propTypes = {
-  value: PropTypes.number,
+  value: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
   detailText: PropTypes.string,
   onChange: PropTypes.func,
   error: PropTypes.string,


### PR DESCRIPTION
This value could come in as a number value or a string to avoid scientific notation.