### PR TITLE
Ensure that gas fee inputs fallback to tx params values if api is down

### DIFF
--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -93,9 +93,9 @@ function getGasFeeEstimate(
   fallback = '0',
 ) {
   if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
-    return gasFeeEstimates?.[estimateToUse]?.[field] ?? fallback;
+    return gasFeeEstimates?.[estimateToUse]?.[field] ?? String(fallback);
   }
-  return fallback;
+  return String(fallback);
 }
 
 /**

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -90,11 +90,12 @@ function getGasFeeEstimate(
   gasFeeEstimates,
   gasEstimateType,
   estimateToUse,
+  fallback = '0',
 ) {
   if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
-    return gasFeeEstimates?.[estimateToUse]?.[field] ?? '0';
+    return gasFeeEstimates?.[estimateToUse]?.[field] ?? fallback;
   }
-  return '0';
+  return fallback;
 }
 
 /**
@@ -280,6 +281,7 @@ export function useGasFeeInputs(
       gasFeeEstimates,
       gasEstimateType,
       estimateToUse,
+      initialMaxFeePerGas,
     );
 
   const maxPriorityFeePerGasToUse =
@@ -289,6 +291,7 @@ export function useGasFeeInputs(
       gasFeeEstimates,
       gasEstimateType,
       estimateToUse,
+      initialMaxPriorityFeePerGas,
     );
 
   const [initialGasPriceEstimates] = useState(gasFeeEstimates);


### PR DESCRIPTION
If the user opens the edit gas popover, and has not yet manually set any values, and the api is down, the value we show the user should fallback to the value from the transaction parameters, instead of '0'.