### PR TITLE
Allow setting lower max fee per gas saving

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -660,7 +660,7 @@
     "message": "Max fee is higher than necessary"
   },
   "editGasMaxFeeLow": {
-    "message": "Max fee too low for network conditions"
+    "message": "Max fee too low for network conditions, can lead to longer wait times and clog your transaction queue."
   },
   "editGasMaxFeePriorityImbalance": {
     "message": "Max fee cannot be lower than max priority fee"

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -190,7 +190,7 @@ export default function EditGasPopover({
             <Button
               type="primary"
               onClick={onSubmit}
-              disabled={hasGasErrors || isGasEstimatesLoading || balanceError}
+              disabled={isGasEstimatesLoading || balanceError}
             >
               {footerButtonText}
             </Button>


### PR DESCRIPTION
Explanation:  
Allows users to set the max fee to lower than what we estimate.

Add extra error clause that lower than normal max fees can lead to longer wait times and halt subsequent txs to be confirmed.

Manual testing steps:  
Initiate an in-app tx and edit the gas priority's max fee to lower than the preset low, should not disable the `Save` button.

Screenshot:
<details>
  <summary>Questionable Error message Update</summary>
  <img src='https://user-images.githubusercontent.com/13376180/128404800-24db5720-f019-4afc-a695-0f954828556c.png'/>
</details>
