### PR TITLE
Separate out non blocking gas errors

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -704,7 +704,7 @@
     "message": "Unknown processing time"
   },
   "editGasTooLowTooltip": {
-    "message": "Your max fee is low for current market conditions. We don’t know when (or if) your transaction will be processed."
+    "message": "Your max fee or max priority fee may be low for current market conditions. We don't know when (or if) your transaction will be processed. "
   },
   "editGasTotalBannerSubtitle": {
     "message": "Up to $1 ($2)",

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -190,9 +190,7 @@ export default function EditGasPopover({
             <Button
               type="primary"
               onClick={onSubmit}
-              disabled={
-                hasGasErrors || isGasEstimatesLoading || balanceError
-              }
+              disabled={hasGasErrors || isGasEstimatesLoading || balanceError}
             >
               {footerButtonText}
             </Button>

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -190,7 +190,9 @@ export default function EditGasPopover({
             <Button
               type="primary"
               onClick={onSubmit}
-              disabled={hasGasErrors || isGasEstimatesLoading || balanceError}
+              disabled={
+                hasGasErrors || isGasEstimatesLoading || balanceError
+              }
             >
               {footerButtonText}
             </Button>

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -438,8 +438,6 @@ export function useGasFeeInputs(
       if (bnLessThanEqualTo(maxPriorityFeePerGasToUse, 0)) {
         gasErrors.maxPriorityFee =
           GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
-      } else if (bnGreaterThan(maxPriorityFeePerGasToUse, maxFeePerGasToUse)) {
-        gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
       } else if (
         !isGasEstimatesLoading &&
         bnLessThan(
@@ -448,6 +446,8 @@ export function useGasFeeInputs(
         )
       ) {
         gasWarnings.maxPriorityFee = GAS_FORM_ERRORS.MAX_PRIORITY_FEE_TOO_LOW;
+      } else if (bnGreaterThan(maxPriorityFeePerGasToUse, maxFeePerGasToUse)) {
+        gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
       } else if (
         gasFeeEstimates?.high &&
         bnGreaterThan(

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -438,6 +438,8 @@ export function useGasFeeInputs(
       if (bnLessThanEqualTo(maxPriorityFeePerGasToUse, 0)) {
         gasErrors.maxPriorityFee =
           GAS_FORM_ERRORS.MAX_PRIORITY_FEE_BELOW_MINIMUM;
+      } else if (bnGreaterThan(maxPriorityFeePerGasToUse, maxFeePerGasToUse)) {
+        gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
       } else if (
         !isGasEstimatesLoading &&
         bnLessThan(
@@ -446,8 +448,6 @@ export function useGasFeeInputs(
         )
       ) {
         gasWarnings.maxPriorityFee = GAS_FORM_ERRORS.MAX_PRIORITY_FEE_TOO_LOW;
-      } else if (bnGreaterThan(maxPriorityFeePerGasToUse, maxFeePerGasToUse)) {
-        gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_IMBALANCE;
       } else if (
         gasFeeEstimates?.high &&
         bnGreaterThan(
@@ -467,7 +467,7 @@ export function useGasFeeInputs(
           gasFeeEstimates?.low?.suggestedMaxFeePerGas,
         )
       ) {
-        gasErrors.maxFee = GAS_FORM_ERRORS.MAX_FEE_TOO_LOW;
+        gasWarnings.maxFee = GAS_FORM_ERRORS.MAX_FEE_TOO_LOW;
       } else if (
         gasFeeEstimates?.high &&
         bnGreaterThan(


### PR DESCRIPTION
**Explanation:**  
_MaxFee too low should no longer block the submission of a transaction._
<img width="332" alt="Screen Shot 2021-08-05 at 3 11 54 PM" src="https://user-images.githubusercontent.com/34557516/128414851-7b6c17fa-c2c5-4ce5-a541-84b7263c1388.png">

**+**
_update tooltip copy_
<img width="499" alt="Screen Shot 2021-08-05 at 3 13 35 PM" src="https://user-images.githubusercontent.com/34557516/128414950-5f7a35f4-4f59-426e-b933-31c5b988872d.png">

Manual testing steps:  
  - Enter send flow
  - Push max fee low very low until you see the error `Max fee too low for network conditions`
  - Check that  form submission is not disabled.