### PR TITLE
Add fee education button to swaps

### DIFF
--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -49,7 +49,8 @@ export default function EditGasPopover({
   const shouldAnimate = useShouldAnimateGasEstimations();
 
   const showEducationButton =
-    mode === EDIT_GAS_MODES.MODIFY_IN_PLACE && networkAndAccountSupport1559;
+    (mode === EDIT_GAS_MODES.MODIFY_IN_PLACE || EDIT_GAS_MODES.SWAPS) &&
+    networkAndAccountSupport1559;
   const [showEducationContent, setShowEducationContent] = useState(false);
 
   const [warning] = useState(null);


### PR DESCRIPTION
Adds the 'How should I choose?' section in the Edit Priority priority modal.

<details>
  <summary>Swaps "How to choose?"" education</summary>
  <img src="https://user-images.githubusercontent.com/13376180/128422844-e6ee7628-8f70-4253-bd90-699f9fa4f785.gif">
</details>
