### PR TITLE
Add fee level education button to swaps edit gas popover

### DIFF
--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -49,7 +49,9 @@ export default function EditGasPopover({
   const shouldAnimate = useShouldAnimateGasEstimations();
 
   const showEducationButton =
-    mode === EDIT_GAS_MODES.MODIFY_IN_PLACE && networkAndAccountSupport1559;
+    (mode === EDIT_GAS_MODES.MODIFY_IN_PLACE ||
+      mode === EDIT_GAS_MODES.SWAPS) &&
+    networkAndAccountSupport1559;
   const [showEducationContent, setShowEducationContent] = useState(false);
 
   const [warning] = useState(null);


### PR DESCRIPTION
Explanation:  Adds `How should I choose` education button on the swaps edit gas popover

<img width="354" alt="Screen Shot 2021-08-05 at 4 39 18 PM" src="https://user-images.githubusercontent.com/34557516/128424817-a2817a64-bda7-4b5c-a342-b282ea02e4a5.png">
