### PR TITLE
EIP-1559 - Ensure form always displays when there are errors

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -77,7 +77,7 @@ export default function EditGasDisplay({
   );
 
   const [showAdvancedForm, setShowAdvancedForm] = useState(
-    !estimateToUse || hasGasErrors || !networkAndAccountSupport1559,
+    !estimateToUse || !networkAndAccountSupport1559,
   );
   const [hideRadioButtons, setHideRadioButtons] = useState(
     showAdvancedInlineGasIfPossible,
@@ -241,7 +241,9 @@ export default function EditGasDisplay({
             </button>
           )}
         {!requireDappAcknowledgement &&
-          (showAdvancedForm || showAdvancedInlineGasIfPossible) && (
+          (showAdvancedForm ||
+            hasGasErrors ||
+            showAdvancedInlineGasIfPossible) && (
             <AdvancedGasControls
               gasEstimateType={gasEstimateType}
               isGasEstimatesLoading={isGasEstimatesLoading}


### PR DESCRIPTION
This is a small but useful UX fix -- we default `showAdvancedForm` to `true` if we start with errors, but if I start with `Medium` and no errors, then pick `High` and there are errors, we need to open the form so they know why the submit button is disabled.