### PR TITLE
Hide gasTiming on edit-gas-popover when form is in error

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -173,10 +173,12 @@ export default function EditGasDisplay({
             ])
           }
           timing={
-            <GasTiming
-              maxFeePerGas={maxFeePerGas}
-              maxPriorityFeePerGas={maxPriorityFeePerGas}
-            />
+            hasGasErrors === false && (
+              <GasTiming
+                maxFeePerGas={maxFeePerGas}
+                maxPriorityFeePerGas={maxPriorityFeePerGas}
+              />
+            )
           }
         />
         {requireDappAcknowledgement && (

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -61,6 +61,7 @@ export default function EditGasDisplay({
   setDappSuggestedGasFeeAcknowledged,
   warning,
   gasErrors,
+  gasWarnings,
   onManualChange,
   minimumGasLimit,
   balanceError,
@@ -177,6 +178,7 @@ export default function EditGasDisplay({
               <GasTiming
                 maxFeePerGas={maxFeePerGas}
                 maxPriorityFeePerGas={maxPriorityFeePerGas}
+                gasWarnings={gasWarnings}
               />
             )
           }
@@ -308,6 +310,7 @@ EditGasDisplay.propTypes = {
   warning: PropTypes.string,
   transaction: PropTypes.object,
   gasErrors: PropTypes.object,
+  gasWarnings: PropTypes.object,
   onManualChange: PropTypes.func,
   minimumGasLimit: PropTypes.number,
   balanceError: PropTypes.bool,

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -86,6 +86,7 @@ export default function EditGasPopover({
     estimatedMaximumFiat,
     hasGasErrors,
     gasErrors,
+    gasWarnings,
     onManualChange,
     balanceError,
     estimatesUnavailableWarning,
@@ -245,6 +246,7 @@ export default function EditGasPopover({
               mode={mode}
               transaction={transaction}
               gasErrors={gasErrors}
+              gasWarnings={gasWarnings}
               onManualChange={onManualChange}
               minimumGasLimit={minimumGasLimitDec}
               balanceError={balanceError}

--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -53,9 +53,8 @@ export default function GasTiming({
   // the time to show
   const isUnknownLow =
     gasFeeEstimates?.low &&
-    (Number(maxPriorityFeePerGas) <
-      Number(gasFeeEstimates.low.suggestedMaxPriorityFeePerGas) ||
-      Number(maxFeePerGas) < Number(gasFeeEstimates.low.suggestedMaxFeePerGas));
+    Number(maxPriorityFeePerGas) <
+      Number(gasFeeEstimates.low.suggestedMaxPriorityFeePerGas);
 
   const previousMaxFeePerGas = usePrevious(maxFeePerGas);
   const previousMaxPriorityFeePerGas = usePrevious(maxPriorityFeePerGas);

--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -23,6 +23,7 @@ import {
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
 
 import { getGasFeeTimeEstimate } from '../../../store/actions';
+import { GAS_FORM_ERRORS } from '../../../helpers/constants/gas';
 
 // Once we reach this second threshold, we switch to minutes as a unit
 const SECOND_CUTOFF = 90;
@@ -38,20 +39,23 @@ const toHumanReadableTime = (milliseconds = 1, t) => {
 export default function GasTiming({
   maxFeePerGas = 0,
   maxPriorityFeePerGas = 0,
+  gasWarnings,
 }) {
   const gasEstimateType = useSelector(getGasEstimateType);
   const gasFeeEstimates = useSelector(getGasFeeEstimates);
   const isGasEstimatesLoading = useSelector(getIsGasEstimatesLoading);
 
   const [customEstimatedTime, setCustomEstimatedTime] = useState(null);
+  const t = useContext(I18nContext);
 
   // If the user has chosen a value lower than the low gas fee estimate,
   // We'll need to use the useEffect hook below to make a call to calculate
   // the time to show
   const isUnknownLow =
     gasFeeEstimates?.low &&
-    Number(maxPriorityFeePerGas) <
-      Number(gasFeeEstimates.low.suggestedMaxPriorityFeePerGas);
+    (Number(maxPriorityFeePerGas) <
+      Number(gasFeeEstimates.low.suggestedMaxPriorityFeePerGas) ||
+      Number(maxFeePerGas) < Number(gasFeeEstimates.low.suggestedMaxFeePerGas));
 
   const previousMaxFeePerGas = usePrevious(maxFeePerGas);
   const previousMaxPriorityFeePerGas = usePrevious(maxPriorityFeePerGas);
@@ -89,7 +93,27 @@ export default function GasTiming({
     previousIsUnknownLow,
   ]);
 
-  const t = useContext(I18nContext);
+  const unknownProcessingTimeText = () => (
+    <>
+      {t('editGasTooLow')}{' '}
+      <InfoTooltip position="top" contentText={t('editGasTooLowTooltip')} />
+    </>
+  );
+
+  if (
+    gasWarnings?.maxPriorityFee === GAS_FORM_ERRORS.MAX_PRIORITY_FEE_TOO_LOW ||
+    gasWarnings?.maxFee === GAS_FORM_ERRORS.MAX_FEE_TOO_LOW
+  ) {
+    return (
+      <Typography
+        variant={TYPOGRAPHY.H7}
+        fontWeight={FONT_WEIGHT.BOLD}
+        className={classNames('gas-timing', 'gas-timing--negative')}
+      >
+        {unknownProcessingTimeText()}
+      </Typography>
+    );
+  }
 
   // Don't show anything if we don't have enough information
   if (
@@ -137,15 +161,7 @@ export default function GasTiming({
         customEstimatedTime?.upperTimeBound === 'unknown'
       ) {
         fontWeight = FONT_WEIGHT.BOLD;
-        text = (
-          <>
-            {t('editGasTooLow')}{' '}
-            <InfoTooltip
-              position="top"
-              contentText={t('editGasTooLowTooltip')}
-            />
-          </>
-        );
+        text = unknownProcessingTimeText();
       } else {
         text = t('gasTimingNegative', [
           toHumanReadableTime(Number(customEstimatedTime?.upperTimeBound), t),
@@ -174,4 +190,5 @@ export default function GasTiming({
 GasTiming.propTypes = {
   maxPriorityFeePerGas: PropTypes.string,
   maxFeePerGas: PropTypes.string,
+  gasWarnings: PropTypes.object,
 };

--- a/ui/components/app/gas-timing/gas-timing.component.js
+++ b/ui/components/app/gas-timing/gas-timing.component.js
@@ -92,7 +92,7 @@ export default function GasTiming({
     previousIsUnknownLow,
   ]);
 
-  const unknownProcessingTimeText = () => (
+  const unknownProcessingTimeText = (
     <>
       {t('editGasTooLow')}{' '}
       <InfoTooltip position="top" contentText={t('editGasTooLowTooltip')} />
@@ -109,7 +109,7 @@ export default function GasTiming({
         fontWeight={FONT_WEIGHT.BOLD}
         className={classNames('gas-timing', 'gas-timing--negative')}
       >
-        {unknownProcessingTimeText()}
+        {unknownProcessingTimeText}
       </Typography>
     );
   }
@@ -160,7 +160,7 @@ export default function GasTiming({
         customEstimatedTime?.upperTimeBound === 'unknown'
       ) {
         fontWeight = FONT_WEIGHT.BOLD;
-        text = unknownProcessingTimeText();
+        text = unknownProcessingTimeText;
       } else {
         text = t('gasTimingNegative', [
           toHumanReadableTime(Number(customEstimatedTime?.upperTimeBound), t),

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -531,6 +531,7 @@ export function useGasFeeInputs(
     estimatedGasFeeTimeBounds,
     gasErrors: errorsAndWarnings,
     hasGasErrors: hasBlockingGasErrors,
+    gasWarnings,
     onManualChange: () => {
       setInternalEstimateToUse('custom');
       handleGasLimitOutOfBoundError();


### PR DESCRIPTION
Hides gasTiming on edit-gas-popover when form is in error because we don't have a valid time estimate for an invalid transaction. 

<img width="327" alt="Screen Shot 2021-08-06 at 2 00 30 PM" src="https://user-images.githubusercontent.com/34557516/128559324-46100ab2-a5d9-407c-a946-2e5014f1116a.png">

<img width="332" alt="Screen Shot 2021-08-06 at 2 00 37 PM" src="https://user-images.githubusercontent.com/34557516/128559271-531065ec-3c98-43e0-98e9-203e5c58d403.png">

