### PR TITLE
Autofocus the unit field in send screen

### DIFF
--- a/ui/components/ui/unit-input/unit-input.component.js
+++ b/ui/components/ui/unit-input/unit-input.component.js
@@ -106,6 +106,7 @@ export default class UnitInput extends PureComponent {
               ref={(ref) => {
                 this.unitInput = ref;
               }}
+              autoFocus
             />
             {suffix && <div className="unit-input__suffix">{suffix}</div>}
           </div>


### PR DESCRIPTION
During all of the testing this past week, I was annoyed needing to click into the unit field.  Once a user has an address selected, let them type ASAP.


https://user-images.githubusercontent.com/46655/128583759-73c0968a-0dda-4022-9d24-eddbb53c6792.mp4

