### PR TITLE
Fixing EditGasDisplay console errors

### DIFF
--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -140,5 +140,5 @@ AdvancedGasControls.propTypes = {
   maxPriorityFeeFiat: PropTypes.string,
   maxFeeFiat: PropTypes.string,
   gasErrors: PropTypes.object,
-  minimumGasLimit: PropTypes.number,
+  minimumGasLimit: PropTypes.string,
 };

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -312,7 +312,7 @@ EditGasDisplay.propTypes = {
   gasErrors: PropTypes.object,
   gasWarnings: PropTypes.object,
   onManualChange: PropTypes.func,
-  minimumGasLimit: PropTypes.number,
+  minimumGasLimit: PropTypes.string,
   balanceError: PropTypes.bool,
   estimatesUnavailableWarning: PropTypes.bool,
   hasGasErrors: PropTypes.bool,

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -309,6 +309,7 @@ export default class ConfirmTransactionBase extends Component {
         return (
           <UserPreferencedCurrencyDisplay
             type={PRIMARY}
+            key="total-max-amount"
             value={addHexes(txData.txParams.value, hexMaximumTransactionFee)}
             hideLabel={!useNativeCurrencyAsPrimaryCurrency}
           />
@@ -329,6 +330,7 @@ export default class ConfirmTransactionBase extends Component {
         return (
           <UserPreferencedCurrencyDisplay
             type={PRIMARY}
+            key="total-detail-value"
             value={hexTransactionTotal}
             hideLabel={!useNativeCurrencyAsPrimaryCurrency}
           />
@@ -347,6 +349,7 @@ export default class ConfirmTransactionBase extends Component {
         return (
           <UserPreferencedCurrencyDisplay
             type={SECONDARY}
+            key="total-detail-text"
             value={hexTransactionTotal}
             hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
           />


### PR DESCRIPTION
<img width="315" alt="Screen Shot 2021-08-08 at 10 35 35 PM" src="https://user-images.githubusercontent.com/8732757/128665908-d6dedf5c-3b8c-4961-8ff1-e759f26f7213.png">
<img width="442" alt="Screen Shot 2021-08-08 at 11 01 45 PM" src="https://user-images.githubusercontent.com/8732757/128665915-ce387802-a3de-4cc3-8952-a4705bd2ba32.png">

`minimumGasLimit` was ultimately being used to display in error text in `AdvancedGasControls`, so it didn't need to be of type `number`