### PR TITLE
EIP-1559 - Update tooltip text for gas fees

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2523,7 +2523,7 @@
     "message": "Gas fees are set by the network and fluctuate based on network traffic and transaction complexity."
   },
   "transactionDetailGasTooltipIntro": {
-    "message": "Gas fees are paid to crypto miners who process transactions on the Ethereum network. MetaMask does not profit from gas fees."
+    "message": "Gas fees are paid to crypto miners who process transactions on the $1 network. MetaMask does not profit from gas fees."
   },
   "transactionDetailGasTotalSubtitle": {
     "message": "Amount + gas fee"

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -112,6 +112,7 @@ export default class ConfirmTransactionBase extends Component {
     maxFeePerGas: PropTypes.string,
     maxPriorityFeePerGas: PropTypes.string,
     baseFeePerGas: PropTypes.string,
+    isMainnet: PropTypes.bool,
   };
 
   state = {
@@ -289,6 +290,7 @@ export default class ConfirmTransactionBase extends Component {
       primaryTotalTextOverrideMaxAmount,
       maxFeePerGas,
       maxPriorityFeePerGas,
+      isMainnet,
     } = this.props;
     const { t } = this.context;
 
@@ -416,7 +418,11 @@ export default class ConfirmTransactionBase extends Component {
                     <InfoTooltip
                       contentText={
                         <>
-                          <p>{t('transactionDetailGasTooltipIntro')}</p>
+                          <p>
+                            {t('transactionDetailGasTooltipIntro', [
+                              isMainnet ? t('networkNameEthereum') : '',
+                            ])}
+                          </p>
                           <p>{t('transactionDetailGasTooltipExplanation')}</p>
                           <p>
                             <a


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11801

Per Jake:

> In mobile we use “the Ethereum network” and for everything else we just say “the network”.