### PR TITLE
Fix Sentry release configuration

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -36,7 +36,7 @@ const metamaskrc = require('rc')('metamask', {
 });
 
 const { streamFlatMap } = require('../stream-flat-map.js');
-const baseManifest = require('../../app/manifest/_base.json');
+const { version } = require('../../package.json');
 const {
   createTask,
   composeParallel,
@@ -522,7 +522,7 @@ function getEnvironmentVariables({ devMode, testing }) {
   return {
     METAMASK_DEBUG: devMode,
     METAMASK_ENVIRONMENT: environment,
-    METAMASK_VERSION: baseManifest.version,
+    METAMASK_VERSION: version,
     NODE_ENV: devMode ? 'development' : 'production',
     IN_TEST: testing ? 'true' : false,
     PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY || '',


### PR DESCRIPTION
The Sentry `release` was not being configured correctly. It was being left blank. This is because the location of the extension version was moved in #11029. The build script was correctly updated in that PR, but that work was accidentally undone in a merge error that was included in #11080.