### PR TITLE
Add low/medium/high gas recommendations to the speedup/cancel gas popover

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -100,8 +100,7 @@ export default function EditGasDisplay({
   const radioButtonsEnabled =
     networkAndAccountSupport1559 &&
     gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET &&
-    !requireDappAcknowledgement &&
-    ![EDIT_GAS_MODES.SPEED_UP, EDIT_GAS_MODES.CANCEL].includes(mode);
+    !requireDappAcknowledgement;
 
   let errorKey;
   if (balanceError) {


### PR DESCRIPTION
Explanation:  For the speedup and cancel edit gas popovers we currently only show the advanced gas controls pre-populated with values 10% higher than the original values submitted. We should give the users the option to select from updated recommendations of low/medium/high.

If the originally submitted values were very low the 10% bump that we use is still too low:
<img width="428" alt="Screen Shot 2021-08-11 at 3 40 18 PM" src="https://user-images.githubusercontent.com/34557516/129100181-274574b9-9c60-43be-a7e4-34e705ce7a24.png">

User can now opt back into a recommended price that reflects current fee market conditions.
<img width="372" alt="Screen Shot 2021-08-11 at 3 40 21 PM" src="https://user-images.githubusercontent.com/34557516/129100156-22f96e8a-d458-466d-9a90-aa89ad4b6f15.png">
