### PR TITLE
Do not attempt to track tx metrics event if txMeta is not available

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1383,6 +1383,10 @@ export default class TransactionController extends EventEmitter {
    * @param {Object} extraParams - optional props and values to include in sensitiveProperties
    */
   _trackTransactionMetricsEvent(txMeta, event, extraParams = {}) {
+    if (!txMeta) {
+      return;
+    }
+
     const {
       type,
       time,


### PR DESCRIPTION
Related sentry error: https://sentry.io/organizations/metamask/issues/2502760408/?project=273505&query=is%3Aunresolved&sort=freq&statsPeriod=14d

It is possible for the transaction meta to be undefined (https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/controllers/transactions/tx-state-manager.js#L608) for a transaction when setting the status - if that is the case, we should not attempt to de-structure `txMeta` and send a metrics event.

Alternative: Perhaps send the metrics event anyway in this case with message denoting the absence of transaction meta? 