### PR TITLE
Removing unnecessary console log from the preferences controller

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -816,7 +816,6 @@ export default class PreferencesController {
     return await tokenContract
       .supportsInterface(ERC721_INTERFACE_ID)
       .catch((error) => {
-        console.log('error', error);
         log.debug(error);
         return false;
       });


### PR DESCRIPTION
The error was already being logged via `log.debug`