### PR TITLE
Return an empty string when date is not provided [Date display utils]

### DIFF
--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -16,6 +16,9 @@ import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
 
 // formatData :: ( date: <Unix Timestamp> ) -> String
 export function formatDate(date, format = "M/d/y 'at' T") {
+  if (!date) {
+    return '';
+  }
   return DateTime.fromMillis(date).toFormat(format);
 }
 
@@ -24,6 +27,9 @@ export function formatDateWithYearContext(
   formatThisYear = 'MMM d',
   fallback = 'MMM d, y',
 ) {
+  if (!date) {
+    return '';
+  }
   const dateTime = DateTime.fromMillis(date);
   const now = DateTime.local();
   return dateTime.toFormat(

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -80,7 +80,7 @@ export function useTransactionDisplayData(transactionGroup) {
 
   const primaryValue = primaryTransaction.txParams?.value;
   let prefix = '-';
-  const date = formatDateWithYearContext(initialTransaction.time || 0);
+  const date = formatDateWithYearContext(initialTransaction.time);
   let subtitle;
   let subtitleContainsOrigin = false;
   let recipientAddress = to;


### PR DESCRIPTION
Related sentry error: https://sentry.io/organizations/metamask/issues/2142276505/?project=273505&query=is%3Aunresolved+release%3A10.0.1&sort=freq&statsPeriod=14d

These functions return a formatted date for tx display purposes. In the case that date (such as a tx submitted timestamp) is undefined, return an empty string instead of a date based off of `0` or another incorrect value