### PR TITLE
Fix a repo URL in docs

### DIFF
--- a/docs/extension_description/en.txt
+++ b/docs/extension_description/en.txt
@@ -5,4 +5,4 @@ The extension injects the Ethereum web3 API into every website's javascript cont
 MetaMask also lets the user create and manage their own identities, so when a Dapp wants to perform a transaction and write to the blockchain, the user gets a secure interface to review the transaction, before approving or rejecting it.
 
 Because it adds functionality to the normal browser context, MetaMask requires the permission to read and write to any webpage. You can always "view the source" of MetaMask the way you do any extension, or view the source code on Github:
-https://github.com/MetaMask/metamask-plugin
+https://github.com/MetaMask/metamask-extension


### PR DESCRIPTION
Explanation:  

https://github.com/MetaMask/metamask-plugin has been redirected to https://github.com/MetaMask/metamask-extension and it's working, but I've updated it.