### PR TITLE
Improve traduction "off" in french

### DIFF
--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -660,7 +660,7 @@
     "message": "de"
   },
   "off": {
-    "message": "Déconnecté"
+    "message": "Désactivé"
   },
   "on": {
     "message": "Activé"


### PR DESCRIPTION
Fixes: Change traduction for "off" in french.

Explanation:  
"Off" means in french "Désactivé" and not "Déconnecté".
"Déconnecté" in english means "Disconnected" or "Offline".