### PR TITLE
Improve flashing behaviour for loading gas estimates (on confirm screen)

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/index.scss
@@ -88,4 +88,8 @@
   .page-container__footer {
     margin-top: auto;
   }
+
+  &__currency-container {
+    position: relative;
+  }
 }

--- a/ui/components/app/transaction-detail/transaction-detail.component.js
+++ b/ui/components/app/transaction-detail/transaction-detail.component.js
@@ -8,7 +8,6 @@ import { getGasLoadingAnimationIsShowing } from '../../../ducks/app/app';
 import { I18nContext } from '../../../contexts/i18n';
 
 import TransactionDetailItem from '../transaction-detail-item/transaction-detail-item.component';
-import LoadingHeartBeat from '../../ui/loading-heartbeat';
 
 export default function TransactionDetail({ rows = [], onEdit }) {
   const t = useContext(I18nContext);
@@ -19,7 +18,6 @@ export default function TransactionDetail({ rows = [], onEdit }) {
 
   return (
     <div className="transaction-detail">
-      {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
       {onEdit && (
         <div className="transaction-detail-edit">
           <button

--- a/ui/components/ui/loading-heartbeat/index.scss
+++ b/ui/components/ui/loading-heartbeat/index.scss
@@ -19,9 +19,7 @@
 }
 
 @keyframes heartbeat {
-  0% { opacity: 0; }
-  25% { opacity: 1; }
-  50% { opacity: 0.5; }
-  75% { opacity: 1; }
-  100% { opacity: 0; }
+  0% { opacity: 0.2; }
+  50% { opacity: 1; }
+  100% { opacity: 0.2; }
 }

--- a/ui/hooks/useShouldAnimateGasEstimations.js
+++ b/ui/hooks/useShouldAnimateGasEstimations.js
@@ -40,7 +40,14 @@ export function useShouldAnimateGasEstimations() {
       showLoadingAnimation === true
     ) {
       dispatch(toggleGasLoadingAnimation(true));
+    }
+  }, [dispatch, isGasLoadingAnimationActive, showLoadingAnimation]);
 
+  useEffect(() => {
+    if (
+      isGasLoadingAnimationActive === true &&
+      showLoadingAnimation === false
+    ) {
       setTimeout(() => {
         dispatch(toggleGasLoadingAnimation(false));
       }, 2000);

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -33,6 +33,7 @@ import { toBuffer } from '../../../shared/modules/buffer-utils';
 import TransactionDetail from '../../components/app/transaction-detail/transaction-detail.component';
 import TransactionDetailItem from '../../components/app/transaction-detail-item/transaction-detail-item.component';
 import InfoTooltip from '../../components/ui/info-tooltip/info-tooltip';
+import LoadingHeartBeat from '../../components/ui/loading-heartbeat';
 import GasTiming from '../../components/app/gas-timing/gas-timing.component';
 
 import { COLORS } from '../../helpers/constants/design-system';
@@ -446,29 +447,43 @@ export default class ConfirmTransactionBase extends Component {
                 txData.dappSuggestedGasFees ? COLORS.SECONDARY1 : COLORS.BLACK
               }
               detailText={
-                <UserPreferencedCurrencyDisplay
-                  type={SECONDARY}
-                  value={hexMinimumTransactionFee}
-                  hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
-                />
+                <div className="confirm-page-container-content__currency-container">
+                  {process.env.IN_TEST === 'true' ? null : (
+                    <LoadingHeartBeat ttt />
+                  )}
+                  <UserPreferencedCurrencyDisplay
+                    type={SECONDARY}
+                    value={hexMinimumTransactionFee}
+                    hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
+                  />
+                </div>
               }
               detailTotal={
-                <UserPreferencedCurrencyDisplay
-                  type={PRIMARY}
-                  value={hexMinimumTransactionFee}
-                  hideLabel={!useNativeCurrencyAsPrimaryCurrency}
-                />
+                <div className="confirm-page-container-content__currency-container">
+                  {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
+                  <UserPreferencedCurrencyDisplay
+                    type={PRIMARY}
+                    value={hexMinimumTransactionFee}
+                    hideLabel={!useNativeCurrencyAsPrimaryCurrency}
+                  />
+                </div>
               }
               subText={t('editGasSubTextFee', [
                 <b key="editGasSubTextFeeLabel">
                   {t('editGasSubTextFeeLabel')}
                 </b>,
-                <UserPreferencedCurrencyDisplay
-                  key="editGasSubTextFeeAmount"
-                  type={PRIMARY}
-                  value={hexMaximumTransactionFee}
-                  hideLabel={!useNativeCurrencyAsPrimaryCurrency}
-                />,
+                <div
+                  key="editGasSubTextFeeValue"
+                  className="confirm-page-container-content__currency-container"
+                >
+                  {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
+                  <UserPreferencedCurrencyDisplay
+                    key="editGasSubTextFeeAmount"
+                    type={PRIMARY}
+                    value={hexMaximumTransactionFee}
+                    hideLabel={!useNativeCurrencyAsPrimaryCurrency}
+                  />
+                </div>,
               ])}
               subTitle={
                 <GasTiming

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -44,6 +44,9 @@ import {
   removePollingTokenFromAppState,
 } from '../../store/actions';
 
+const renderHeartBeatIfNotInTest = () =>
+  process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />;
+
 export default class ConfirmTransactionBase extends Component {
   static contextTypes = {
     t: PropTypes.func,
@@ -448,7 +451,7 @@ export default class ConfirmTransactionBase extends Component {
               }
               detailText={
                 <div className="confirm-page-container-content__currency-container">
-                  {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
+                  {renderHeartBeatIfNotInTest()}
                   <UserPreferencedCurrencyDisplay
                     type={SECONDARY}
                     value={hexMinimumTransactionFee}
@@ -458,7 +461,7 @@ export default class ConfirmTransactionBase extends Component {
               }
               detailTotal={
                 <div className="confirm-page-container-content__currency-container">
-                  {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
+                  {renderHeartBeatIfNotInTest()}
                   <UserPreferencedCurrencyDisplay
                     type={PRIMARY}
                     value={hexMinimumTransactionFee}
@@ -474,7 +477,7 @@ export default class ConfirmTransactionBase extends Component {
                   key="editGasSubTextFeeValue"
                   className="confirm-page-container-content__currency-container"
                 >
-                  {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
+                  {renderHeartBeatIfNotInTest()}
                   <UserPreferencedCurrencyDisplay
                     key="editGasSubTextFeeAmount"
                     type={PRIMARY}

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -448,9 +448,7 @@ export default class ConfirmTransactionBase extends Component {
               }
               detailText={
                 <div className="confirm-page-container-content__currency-container">
-                  {process.env.IN_TEST === 'true' ? null : (
-                    <LoadingHeartBeat ttt />
-                  )}
+                  {process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />}
                   <UserPreferencedCurrencyDisplay
                     type={SECONDARY}
                     value={hexMinimumTransactionFee}


### PR DESCRIPTION
This PR makes a few improvements to the flashing estimates on the confirm screen.

- It ensures that the flashing only happens on the values (not the whole screen)
- It ensures the opacity never goes to 0 (only to 0.2 as specified in figma)
- It ensures that flashing stops after loading completes

When paired with my other PR, it looks like this:


https://user-images.githubusercontent.com/7499938/129625921-18cfba1d-5f1a-4a43-aca7-861a4de5b68f.mp4

