### PR TITLE
Allow submission of transactions with dapp suggested gas fees, while estimates are loading

### DIFF
--- a/shared/modules/transaction.utils.js
+++ b/shared/modules/transaction.utils.js
@@ -38,3 +38,23 @@ export function isLegacyTransaction(transaction) {
       isHexString(transaction.txParams.gasPrice))
   );
 }
+
+/**
+ * Determine if a transactions gas fees in txParams match those in its dappSuggestedGasFees property
+ * @param {import("../constants/transaction").TransactionMeta} transaction -
+ *  the transaction to check
+ * @returns {boolean} true if both the txParams and dappSuggestedGasFees are objects with truthy gas fee properties,
+ *   and those properties are strictly equal
+ */
+export function txParamsAreDappSuggested(transaction) {
+  const { gasPrice, maxPriorityFeePerGas, maxFeePerGas } =
+    transaction?.txParams || {};
+  return (
+    (gasPrice && gasPrice === transaction?.dappSuggestedGasFees?.gasPrice) ||
+    (maxPriorityFeePerGas &&
+      maxFeePerGas &&
+      transaction?.dappSuggestedGasFees?.maxPriorityFeePerGas ===
+        maxPriorityFeePerGas &&
+      transaction?.dappSuggestedGasFees?.maxFeePerGas === maxFeePerGas)
+  );
+}

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -25,7 +25,7 @@ export default function AdvancedGasControls({
   maxFeeFiat,
   gasErrors,
   minimumGasLimit,
-  estimateToUse,
+  txParamsHaveBeenCustomized,
 }) {
   const t = useContext(I18nContext);
   const networkAndAccountSupport1559 = useSelector(
@@ -36,7 +36,7 @@ export default function AdvancedGasControls({
     getGasLoadingAnimationIsShowing,
   );
   const disableFormFields =
-    estimateToUse !== 'custom' &&
+    !txParamsHaveBeenCustomized &&
     (isGasEstimatesLoading || isGasLoadingAnimationIsShowing);
 
   const showFeeMarketFields =
@@ -143,5 +143,5 @@ AdvancedGasControls.propTypes = {
   maxFeeFiat: PropTypes.string,
   gasErrors: PropTypes.object,
   minimumGasLimit: PropTypes.string,
-  estimateToUse: PropTypes.bool,
+  txParamsHaveBeenCustomized: PropTypes.bool,
 };

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -25,7 +25,6 @@ export default function AdvancedGasControls({
   maxFeeFiat,
   gasErrors,
   minimumGasLimit,
-  txParamsHaveBeenCustomized,
 }) {
   const t = useContext(I18nContext);
   const networkAndAccountSupport1559 = useSelector(
@@ -35,9 +34,6 @@ export default function AdvancedGasControls({
   const isGasLoadingAnimationIsShowing = useSelector(
     getGasLoadingAnimationIsShowing,
   );
-  const disableFormFields =
-    !txParamsHaveBeenCustomized &&
-    (isGasEstimatesLoading || isGasLoadingAnimationIsShowing);
 
   const showFeeMarketFields =
     networkAndAccountSupport1559 &&
@@ -82,7 +78,6 @@ export default function AdvancedGasControls({
                 ? getGasFormErrorText(gasErrors.maxPriorityFee, t)
                 : null
             }
-            disabled={disableFormFields}
           />
           <FormField
             titleText={t('maxFee')}
@@ -100,7 +95,6 @@ export default function AdvancedGasControls({
                 ? getGasFormErrorText(gasErrors.maxFee, t)
                 : null
             }
-            disabled={disableFormFields}
           />
         </>
       ) : (
@@ -120,7 +114,6 @@ export default function AdvancedGasControls({
                 ? getGasFormErrorText(gasErrors.gasPrice, t)
                 : null
             }
-            disabled={disableFormFields}
           />
         </>
       )}

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -8,7 +8,6 @@ import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { getGasFormErrorText } from '../../../helpers/constants/gas';
 import { checkNetworkAndAccountSupports1559 } from '../../../selectors';
 import { getIsGasEstimatesLoading } from '../../../ducks/metamask/metamask';
-import { getGasLoadingAnimationIsShowing } from '../../../ducks/app/app';
 
 export default function AdvancedGasControls({
   gasEstimateType,
@@ -31,9 +30,6 @@ export default function AdvancedGasControls({
     checkNetworkAndAccountSupports1559,
   );
   const isGasEstimatesLoading = useSelector(getIsGasEstimatesLoading);
-  const isGasLoadingAnimationIsShowing = useSelector(
-    getGasLoadingAnimationIsShowing,
-  );
 
   const showFeeMarketFields =
     networkAndAccountSupport1559 &&
@@ -136,5 +132,4 @@ AdvancedGasControls.propTypes = {
   maxFeeFiat: PropTypes.string,
   gasErrors: PropTypes.object,
   minimumGasLimit: PropTypes.string,
-  txParamsHaveBeenCustomized: PropTypes.bool,
 };

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -67,6 +67,7 @@ export default function EditGasDisplay({
   balanceError,
   estimatesUnavailableWarning,
   hasGasErrors,
+  txParamsHaveBeenCustomized,
 }) {
   const t = useContext(I18nContext);
   const isMainnet = useSelector(getIsMainnet);
@@ -269,7 +270,7 @@ export default function EditGasDisplay({
               gasErrors={gasErrors}
               onManualChange={onManualChange}
               minimumGasLimit={minimumGasLimit}
-              estimateToUse={estimateToUse}
+              txParamsHaveBeenCustomized={txParamsHaveBeenCustomized}
             />
           )}
       </div>
@@ -320,4 +321,5 @@ EditGasDisplay.propTypes = {
   balanceError: PropTypes.bool,
   estimatesUnavailableWarning: PropTypes.bool,
   hasGasErrors: PropTypes.bool,
+  txParamsHaveBeenCustomized: PropTypes.bool,
 };

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -270,7 +270,6 @@ export default function EditGasDisplay({
               gasErrors={gasErrors}
               onManualChange={onManualChange}
               minimumGasLimit={minimumGasLimit}
-              txParamsHaveBeenCustomized={txParamsHaveBeenCustomized}
             />
           )}
       </div>

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -97,7 +97,9 @@ export default function EditGasDisplay({
       dappSuggestedAndTxParamGasFeesAreTheSame,
   );
 
-  const showTopError = (balanceError || estimatesUnavailableWarning) && (!isGasEstimatesLoading || txParamsHaveBeenCustomized);
+  const showTopError =
+    (balanceError || estimatesUnavailableWarning) &&
+    (!isGasEstimatesLoading || txParamsHaveBeenCustomized);
   const radioButtonsEnabled =
     networkAndAccountSupport1559 &&
     gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET &&

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -97,7 +97,7 @@ export default function EditGasDisplay({
       dappSuggestedAndTxParamGasFeesAreTheSame,
   );
 
-  const showTopError = balanceError || estimatesUnavailableWarning;
+  const showTopError = (balanceError || estimatesUnavailableWarning) && (!isGasEstimatesLoading || txParamsHaveBeenCustomized);
   const radioButtonsEnabled =
     networkAndAccountSupport1559 &&
     gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET &&
@@ -121,7 +121,7 @@ export default function EditGasDisplay({
             />
           </div>
         )}
-        {showTopError && !isGasEstimatesLoading && (
+        {showTopError && (
           <div className="edit-gas-display__warning">
             <ErrorMessage errorKey={errorKey} />
           </div>

--- a/ui/components/app/edit-gas-display/index.scss
+++ b/ui/components/app/edit-gas-display/index.scss
@@ -64,5 +64,7 @@
 
   &__warning {
     margin-bottom: 24px;
+    position: relative;
+    margin-top: 4px;
   }
 }

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useGasFeeInputs } from '../../../hooks/useGasFeeInputs';
 import { getGasLoadingAnimationIsShowing } from '../../../ducks/app/app';
-
+import {
+  txParamsAreDappSuggested,
+} from '../../../../shared/modules/transaction.utils';
 import { EDIT_GAS_MODES, GAS_LIMITS } from '../../../../shared/constants/gas';
 
 import {
@@ -92,6 +94,8 @@ export default function EditGasPopover({
     estimatesUnavailableWarning,
     estimatedBaseFee,
   } = useGasFeeInputs(defaultEstimateToUse, transaction, minimumGasLimit, mode);
+
+  const txParamsHaveBeenCustomized = estimateToUse === 'custom' || txParamsAreDappSuggested(transaction)
 
   /**
    * Temporary placeholder, this should be managed by the parent component but
@@ -212,7 +216,7 @@ export default function EditGasPopover({
                 hasGasErrors ||
                 balanceError ||
                 ((isGasEstimatesLoading || gasLoadingAnimationIsShowing) &&
-                  !estimateToUse === 'custom')
+                  !txParamsHaveBeenCustomized)
               }
             >
               {footerButtonText}
@@ -262,6 +266,7 @@ export default function EditGasPopover({
               balanceError={balanceError}
               estimatesUnavailableWarning={estimatesUnavailableWarning}
               hasGasErrors={hasGasErrors}
+              txParamsHaveBeenCustomized={txParamsHaveBeenCustomized}
               {...editGasDisplayProps}
             />
           </>

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -132,11 +132,17 @@ export default function EditGasPopover({
           gasPrice: decGWEIToHexWEI(gasPrice),
         };
 
+    const cleanTransactionParams = { ...transaction.txParams };
+
+    if (networkAndAccountSupport1559) {
+      delete cleanTransactionParams.gasPrice;
+    }
+
     const updatedTxMeta = {
       ...transaction,
       userFeeLevel: estimateToUse || 'custom',
       txParams: {
-        ...transaction.txParams,
+        ...cleanTransactionParams,
         ...newGasSettings,
       },
     };

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useGasFeeInputs } from '../../../hooks/useGasFeeInputs';
 import { getGasLoadingAnimationIsShowing } from '../../../ducks/app/app';
-import {
-  txParamsAreDappSuggested,
-} from '../../../../shared/modules/transaction.utils';
+import { txParamsAreDappSuggested } from '../../../../shared/modules/transaction.utils';
 import { EDIT_GAS_MODES, GAS_LIMITS } from '../../../../shared/constants/gas';
 
 import {
@@ -95,7 +93,8 @@ export default function EditGasPopover({
     estimatedBaseFee,
   } = useGasFeeInputs(defaultEstimateToUse, transaction, minimumGasLimit, mode);
 
-  const txParamsHaveBeenCustomized = estimateToUse === 'custom' || txParamsAreDappSuggested(transaction)
+  const txParamsHaveBeenCustomized =
+    estimateToUse === 'custom' || txParamsAreDappSuggested(transaction);
 
   /**
    * Temporary placeholder, this should be managed by the parent component but

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -456,7 +456,10 @@ export function useGasFeeInputs(
       if (networkAndAccountSupports1559) {
         estimatesUnavailableWarning = true;
       }
-      if ((!networkAndAccountSupports1559 || transaction?.txParams?.gasPrice) && bnLessThanEqualTo(gasPriceToUse, 0)) {
+      if (
+        (!networkAndAccountSupports1559 || transaction?.txParams?.gasPrice) &&
+        bnLessThanEqualTo(gasPriceToUse, 0)
+      ) {
         gasErrors.gasPrice = GAS_FORM_ERRORS.GAS_PRICE_TOO_LOW;
       }
       break;

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -456,7 +456,7 @@ export function useGasFeeInputs(
       if (networkAndAccountSupports1559) {
         estimatesUnavailableWarning = true;
       }
-      if (bnLessThanEqualTo(gasPriceToUse, 0)) {
+      if ((!networkAndAccountSupports1559 || transaction?.txParams?.gasPrice) && bnLessThanEqualTo(gasPriceToUse, 0)) {
         gasErrors.gasPrice = GAS_FORM_ERRORS.GAS_PRICE_TOO_LOW;
       }
       break;

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -31,7 +31,10 @@ import {
   getPreferences,
 } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
-import { transactionMatchesNetwork } from '../../../shared/modules/transaction.utils';
+import {
+  transactionMatchesNetwork,
+  txParamsAreDappSuggested,
+} from '../../../shared/modules/transaction.utils';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
 import {
   updateTransactionGasFees,
@@ -155,7 +158,9 @@ const mapStateToProps = (state, ownProps) => {
   const isEthGasPrice = getIsEthGasPriceFetched(state);
   const noGasPrice = !supportsEIP1599 && getNoGasPriceFetched(state);
   const { useNativeCurrencyAsPrimaryCurrency } = getPreferences(state);
-  const gasFeeIsCustom = fullTxData.userFeeLevel === 'custom';
+  const gasFeeIsCustom =
+    fullTxData.userFeeLevel === 'custom' ||
+    txParamsAreDappSuggested(fullTxData);
 
   return {
     balance,


### PR DESCRIPTION
In response to an issue found by @PeterYinusa while QAing v10.0.2

This expands on the fix applied in https://github.com/MetaMask/metamask-extension/pull/11853

It allows the user to submit transactions while gas fee estimates are loading if the fees have been suggested by a dapp.