### PR TITLE
Allow advanced inline gas editing when there is an estimates unavailable error

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -252,6 +252,7 @@ export default function EditGasDisplay({
         {!requireDappAcknowledgement &&
           (showAdvancedForm ||
             hasGasErrors ||
+            estimatesUnavailableWarning ||
             showAdvancedInlineGasIfPossible) && (
             <AdvancedGasControls
               gasEstimateType={gasEstimateType}


### PR DESCRIPTION
This PR fixes an issue found by @PeterYinusa when QAing v10.0.2

It ensures that if estimates from our api are not available, the user is able to do inline editing in the advanced gas popover.

![Screenshot from 2021-08-17 10-41-33](https://user-images.githubusercontent.com/7499938/129731859-b4b4f7f8-d8cd-4afe-aa6c-067587971db9.png)
