### PR TITLE
Fix trezor pairing through WebUSB

### DIFF
--- a/development/build/static.js
+++ b/development/build/static.js
@@ -44,6 +44,10 @@ const copyTargets = [
     dest: `loading.html`,
   },
   {
+    src: `./app/trezor-usb-permissions.html`,
+    dest: `trezor-usb-permissions.html`,
+  },
+  {
     src: `./node_modules/globalthis/dist/browser.js`,
     dest: `globalthis.js`,
   },


### PR DESCRIPTION
Fixes: #11809

Explanation:  The trezor usb permissions dialog got dropped during a refactor. Explicitly add it to copyTargets.