### PR TITLE
Fix content cutoff issue (Mobile Sync View)

### DIFF
--- a/ui/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/pages/mobile-sync/mobile-sync.component.js
@@ -408,7 +408,10 @@ export default class MobileSyncPage extends Component {
     const { password } = this.state;
 
     return (
-      <div className="new-account-import-form__buttons" style={{ padding: 30 }}>
+      <div
+        className="new-account-import-form__buttons"
+        style={{ padding: 30, marginTop: 0 }}
+      >
         <Button
           type="default"
           large


### PR DESCRIPTION
There was an unneeded `margin-top` value being applied from the `new-account-import-form` rules, which are used elsewhere

Popup view:
<img width="357" alt="Screen Shot 2021-08-18 at 12 22 19 AM" src="https://user-images.githubusercontent.com/8732757/129856431-5c7d5f4e-5be2-4056-80b5-61afd87bc99d.png">