### PR TITLE
Dont default gas limit in gas popover when non is available on transaction params

### DIFF
--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -229,7 +229,7 @@ export function useGasFeeInputs(
     initialGasPrice && initialFeeParamsAreCustom ? initialGasPrice : null,
   );
   const [gasLimit, setGasLimit] = useState(
-    Number(hexToDecimal(transaction?.txParams?.gas ?? minimumGasLimit)),
+    Number(hexToDecimal(transaction?.txParams?.gas ?? '0x0')),
   );
 
   const userPrefersAdvancedGas = useSelector(getAdvancedInlineGasShown);

--- a/ui/hooks/useGasFeeInputs.test.js
+++ b/ui/hooks/useGasFeeInputs.test.js
@@ -323,7 +323,12 @@ describe('useGasFeeInputs', () => {
     });
 
     it('should return true', () => {
-      const { result } = renderHook(() => useGasFeeInputs());
+      const { result } = renderHook(() =>
+        useGasFeeInputs(null, {
+          userFeeLevel: 'medium',
+          txParams: { gas: '0x5208' },
+        }),
+      );
       expect(result.current.balanceError).toBe(true);
     });
   });


### PR DESCRIPTION
This PR removes the default value for gas limit in our gas editing popover. This case will only occur if no gas limit was suggested by a dapp, and calls to `eth_estimateGas` have failed not due to a simulation error, but a network failure. This would happen if the user is disconnected from the internet, or there is a failure connecting to the provider. In such a case, defaulting to 0 is safe because it requires the user to be intentional about the gas limit.