### PR TITLE
Guarding against null keyring (Hardware Wallet Selectors)

### DIFF
--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -100,7 +100,7 @@ export function checkNetworkAndAccountSupports1559(state) {
  */
 export function isHardwareWallet(state) {
   const keyring = getCurrentKeyring(state);
-  return keyring.type.includes('Hardware');
+  return Boolean(keyring?.type?.includes('Hardware'));
 }
 
 /**
@@ -110,7 +110,7 @@ export function isHardwareWallet(state) {
  */
 export function getHardwareWalletType(state) {
   const keyring = getCurrentKeyring(state);
-  return keyring.type.includes('Hardware') ? keyring.type : undefined;
+  return isHardwareWallet(state) ? keyring.type : undefined;
 }
 
 export function getAccountType(state) {


### PR DESCRIPTION
Related Sentry Error: https://sentry.io/organizations/metamask/issues/2588041346

It is possible for the `getCurrentKeyring` selector to return `null`: https://github.com/MetaMask/metamask-extension/blob/develop/ui/selectors/selectors.js#L69 - we should factor in that scenario when handling results from it