### PR TITLE
Update header on Send page to be more accurate

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "አውታረ መረብ አክል"
   },
-  "addRecipient": {
-    "message": "ተቀባይ አክል"
-  },
   "addSuggestedTokens": {
     "message": "የተጠቆሙ ተለዋጭ ስሞችን አክል"
   },

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "أضف شبكة"
   },
-  "addRecipient": {
-    "message": "إضافة مستلم"
-  },
   "addSuggestedTokens": {
     "message": "أضف العملات الرمزية المقترحة"
   },

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Добавяне на мрежа"
   },
-  "addRecipient": {
-    "message": "Добавете получател"
-  },
   "addSuggestedTokens": {
     "message": "Добавете препоръчани жетони"
   },

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "নেটওয়ার্ক যোগ করুন"
   },
-  "addRecipient": {
-    "message": "প্রাপক যোগ করুন"
-  },
   "addSuggestedTokens": {
     "message": "প্রস্তাবিত টোকেনগুলি যোগ করুন"
   },

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Afegir Xarxa"
   },
-  "addRecipient": {
-    "message": "Afegeix un recipient"
-  },
   "addSuggestedTokens": {
     "message": "Afegir Fitxes Suggerides"
   },

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Tilføj netværk"
   },
-  "addRecipient": {
-    "message": "Tilføj modtager"
-  },
   "addSuggestedTokens": {
     "message": "Tilføj foreslåede tokens"
   },

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -35,9 +35,6 @@
   "addNetwork": {
     "message": "Netzwerk hinzufügen"
   },
-  "addRecipient": {
-    "message": "Empfänger hinzufügen"
-  },
   "addSuggestedTokens": {
     "message": "Vorgeschlagene Token hinzufügen"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Προσθήκη Δικτύου"
   },
-  "addRecipient": {
-    "message": "Προσθήκη Παραλήπτη"
-  },
   "addSuggestedTokens": {
     "message": "Προσθέστε τα Προτεινόμενα Tokens"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Add Network"
   },
-  "addRecipient": {
-    "message": "Add Recipient"
-  },
   "addSuggestedTokens": {
     "message": "Add Suggested Tokens"
   },
@@ -1896,6 +1893,9 @@
   "sendSpecifiedTokens": {
     "message": "Send $1",
     "description": "Symbol of the specified token"
+  },
+  "sendTo": {
+    "message": "Send to"
   },
   "sendTokens": {
     "message": "Send Tokens"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Agregar red"
   },
-  "addRecipient": {
-    "message": "Agregar destinatario"
-  },
   "addSuggestedTokens": {
     "message": "Agregar tokens sugeridos"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Agregar red"
   },
-  "addRecipient": {
-    "message": "Agregar destinatario"
-  },
   "addSuggestedTokens": {
     "message": "Agregar tokens sugeridos"
   },

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Lisage võrk"
   },
-  "addRecipient": {
-    "message": "Lisa saaja"
-  },
   "addSuggestedTokens": {
     "message": "Lisa soovitatud lube"
   },

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "اضافه شبکه"
   },
-  "addRecipient": {
-    "message": "اضافه کردن دریافت کننده"
-  },
   "addSuggestedTokens": {
     "message": "اضافه رمزیاب های پیشنهاد شده"
   },

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Lisää verkko"
   },
-  "addRecipient": {
-    "message": "Lisää vastaanottaja"
-  },
   "addSuggestedTokens": {
     "message": "Lisää ehdotetut käyttötunnukset"
   },

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -35,9 +35,6 @@
   "addNetwork": {
     "message": "Magdagdag ng Network"
   },
-  "addRecipient": {
-    "message": "Magdagdag ng Recipient"
-  },
   "addSuggestedTokens": {
     "message": "Magdagdag ng Mga Iminungkahing Token"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Ajouter un réseau"
   },
-  "addRecipient": {
-    "message": "Ajouter destinataire"
-  },
   "addSuggestedTokens": {
     "message": "Ajouter les jetons suggérés"
   },

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "הוסף/י רשת"
   },
-  "addRecipient": {
-    "message": "הוסף נמען"
-  },
   "addSuggestedTokens": {
     "message": "הוסף/י אסימונים מוצעים"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "नेटवर्क जोड़ें"
   },
-  "addRecipient": {
-    "message": "प्राप्तकर्ता को जोड़ें"
-  },
   "addSuggestedTokens": {
     "message": "सुझाए गए टोकन जोड़ें"
   },

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Dodaj mrežu"
   },
-  "addRecipient": {
-    "message": "Dodaj primatelja"
-  },
   "addSuggestedTokens": {
     "message": "Dodaj predložene tokene"
   },

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Hálózat hozzáadása"
   },
-  "addRecipient": {
-    "message": "Címzett hozzáadása"
-  },
   "addSuggestedTokens": {
     "message": "Javasolt tokenek hozzáadása"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Tambahkan Jaringan"
   },
-  "addRecipient": {
-    "message": "Tambahkan Penerima"
-  },
   "addSuggestedTokens": {
     "message": "Tambahkan Token yang Disarankan"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -52,9 +52,6 @@
   "addNetwork": {
     "message": "Aggiungi Rete"
   },
-  "addRecipient": {
-    "message": "Aggiungi destinatario"
-  },
   "addSuggestedTokens": {
     "message": "Aggiungi Token Suggeriti"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "ネットワークの追加"
   },
-  "addRecipient": {
-    "message": "受信者の追加"
-  },
   "addSuggestedTokens": {
     "message": "推奨されたトークンの追加"
   },

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "ನೆಟ್‌ವರ್ಕ್ ಸೇರಿಸಿ"
   },
-  "addRecipient": {
-    "message": "ಸ್ವೀಕೃತಿದಾರರನ್ನು ಸೇರಿಸಿ"
-  },
   "addSuggestedTokens": {
     "message": "ಸೂಚಿಸಲಾದ ಟೋಕನ್‌ಗಳನ್ನು ಸೇರಿಸಿ"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "네트워크 추가"
   },
-  "addRecipient": {
-    "message": "수신인 추가"
-  },
   "addSuggestedTokens": {
     "message": "추천 토큰 추가"
   },

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Pridėti tinklą"
   },
-  "addRecipient": {
-    "message": "Pridėti gavėją"
-  },
   "addSuggestedTokens": {
     "message": "Pridėti siūlomų žetonų"
   },

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Pievienot tīklu"
   },
-  "addRecipient": {
-    "message": "Pievienot saņēmēju"
-  },
   "addSuggestedTokens": {
     "message": "Pievienot ieteiktos marķierus"
   },

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Tambah Rangkaian"
   },
-  "addRecipient": {
-    "message": "Tambah Penerima"
-  },
   "addSuggestedTokens": {
     "message": "Tambah Token yang Disyorkan"
   },

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Legg til nettverk"
   },
-  "addRecipient": {
-    "message": "Legg til mottaker "
-  },
   "addSuggestedTokens": {
     "message": "Legg til foreslåtte tokener "
   },

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Magdagdag ng Network"
   },
-  "addRecipient": {
-    "message": "Magdagdag ng Recipient"
-  },
   "addSuggestedTokens": {
     "message": "Magdagdag ng Mga Iminumungkahing Token"
   },

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Dodaj sieć"
   },
-  "addRecipient": {
-    "message": "Dodaj odbiorcę"
-  },
   "addSuggestedTokens": {
     "message": "Dodaj sugerowane tokeny."
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Adicionar rede"
   },
-  "addRecipient": {
-    "message": "Adicionar destinatário"
-  },
   "addSuggestedTokens": {
     "message": "Adicionar tokens sugeridos"
   },

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Adăugați rețea"
   },
-  "addRecipient": {
-    "message": "Adăugați destinatarul"
-  },
   "addSuggestedTokens": {
     "message": "Adăugați indicativele sugerate"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Добавить сеть"
   },
-  "addRecipient": {
-    "message": "Добавить получателя"
-  },
   "addSuggestedTokens": {
     "message": "Добавить предложенные токены"
   },

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Pridať sieť"
   },
-  "addRecipient": {
-    "message": "Pridať príjemcu"
-  },
   "addSuggestedTokens": {
     "message": "Pridať navrhované tokeny"
   },

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Dodaj omrežje"
   },
-  "addRecipient": {
-    "message": "Dodaj prejemnika"
-  },
   "addSuggestedTokens": {
     "message": "Dodaj priporočene žetone"
   },

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Dodajte mrežu"
   },
-  "addRecipient": {
-    "message": "Dodaj primaoca"
-  },
   "addSuggestedTokens": {
     "message": "Dodajte sugerisane tokene"
   },

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Lägg till nätverk"
   },
-  "addRecipient": {
-    "message": "Lägg till mottagare"
-  },
   "addSuggestedTokens": {
     "message": "Lägg till föreslagna tokens"
   },

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Ongeza Mtandao"
   },
-  "addRecipient": {
-    "message": "Ongeza Mpokeaji"
-  },
   "addSuggestedTokens": {
     "message": "Ongeza Vianzio Vilivyopendekezwa"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -52,9 +52,6 @@
   "addNetwork": {
     "message": "Magdagdag ng Network"
   },
-  "addRecipient": {
-    "message": "Magdagdag ng Recipient"
-  },
   "addSuggestedTokens": {
     "message": "Magdagdag ng Mga Iminumungkahing Token"
   },

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -38,9 +38,6 @@
   "addNetwork": {
     "message": "Додати мережу"
   },
-  "addRecipient": {
-    "message": "Додати отримувача"
-  },
   "addSuggestedTokens": {
     "message": "Додати рекомендовані токени"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -79,9 +79,6 @@
   "addNetwork": {
     "message": "Thêm mạng"
   },
-  "addRecipient": {
-    "message": "Thêm người nhận"
-  },
   "addSuggestedTokens": {
     "message": "Thêm token được đề xuất"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -52,9 +52,6 @@
   "addNetwork": {
     "message": "添加网络"
   },
-  "addRecipient": {
-    "message": "添加接收方"
-  },
   "addSuggestedTokens": {
     "message": "添加推荐代币"
   },

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -41,9 +41,6 @@
   "addNetwork": {
     "message": "新增網路"
   },
-  "addRecipient": {
-    "message": "新增接收人"
-  },
   "addSuggestedTokens": {
     "message": "加入建議的代幣"
   },

--- a/ui/pages/send/send-header/send-header.component.js
+++ b/ui/pages/send/send-header/send-header.component.js
@@ -28,7 +28,7 @@ export default function SendHeader() {
   let title = asset.type === ASSET_TYPES.NATIVE ? t('send') : t('sendTokens');
 
   if (stage === SEND_STAGES.ADD_RECIPIENT || stage === SEND_STAGES.INACTIVE) {
-    title = t('addRecipient');
+    title = t('sendTo');
   } else if (stage === SEND_STAGES.EDIT) {
     title = t('edit');
   }

--- a/ui/pages/send/send-header/send-header.component.test.js
+++ b/ui/pages/send/send-header/send-header.component.test.js
@@ -21,7 +21,7 @@ jest.mock('react-router-dom', () => {
 
 describe('SendHeader Component', () => {
   describe('Title', () => {
-    it('should render "Add Recipient" for INACTIVE or ADD_RECIPIENT stages', () => {
+    it('should render "Send to" for INACTIVE or ADD_RECIPIENT stages', () => {
       const { getByText, rerender } = renderWithProvider(
         <SendHeader />,
         configureMockStore(middleware)({
@@ -30,7 +30,7 @@ describe('SendHeader Component', () => {
           history: { mostRecentOverviewPage: 'activity' },
         }),
       );
-      expect(getByText('Add Recipient')).toBeTruthy();
+      expect(getByText('Send to')).toBeTruthy();
       rerender(
         <SendHeader />,
         configureMockStore(middleware)({
@@ -39,7 +39,7 @@ describe('SendHeader Component', () => {
           history: { mostRecentOverviewPage: 'activity' },
         }),
       );
-      expect(getByText('Add Recipient')).toBeTruthy();
+      expect(getByText('Send to')).toBeTruthy();
     });
 
     it('should render "Send" for DRAFT stage when asset type is NATIVE', () => {

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -124,11 +124,11 @@ describe('Send Page', () => {
     });
   });
 
-  describe('Add Recipient Flow', () => {
-    it('should render the header with Add Recipient displayed', () => {
+  describe('Send Flow', () => {
+    it('should render the header with Send to displayed', () => {
       const store = configureMockStore(middleware)(baseStore);
       const { getByText } = renderWithProvider(<Send />, store);
-      expect(getByText('Add Recipient')).toBeTruthy();
+      expect(getByText('Send to')).toBeTruthy();
     });
 
     it('should render the EnsInput field', () => {
@@ -146,7 +146,7 @@ describe('Send Page', () => {
     });
   });
 
-  describe('Send and Edit Flow', () => {
+  describe('Send and Edit Flow (draft)', () => {
     it('should render the header with Send displayed', () => {
       const store = configureMockStore(middleware)({
         ...baseStore,


### PR DESCRIPTION
Change "Add Recipient" to "Send to".

Fixes: #11875.

Manual testing steps:  
* Go to home
* Click on "Send"
* Header should read "Send to"
* Click on avatar
* Change language to something else, e.g., Spanish
* Click on equivalent of "Send"
* Header should still read "Send to"

---

<img width="362" alt="Screen Shot 2021-08-19 at 12 10 48 PM" src="https://user-images.githubusercontent.com/7371/130121971-c9ca6e3d-0cf7-4689-8000-7cd7dcb1c6c5.png">
