### PR TITLE
Fix issue with chainId comparison in sign typed message param validation

### DIFF
--- a/app/scripts/lib/typed-message-manager.js
+++ b/app/scripts/lib/typed-message-manager.js
@@ -204,7 +204,7 @@ export default class TypedMessageManager extends EventEmitter {
             `Cannot sign messages for chainId "${chainId}", because MetaMask is switching networks.`,
           );
           if (typeof chainId === 'string') {
-            chainId = parseInt(chainId, 16);
+            chainId = parseInt(chainId, chainId.startsWith('0x') ? 16 : 10);
           }
           assert.equal(
             chainId,


### PR DESCRIPTION
Fixes: #11847

Explanation:  Some dapps pass a non-hex string for chainId in signTypedData calls. We should support this.

Manual testing steps:  
  - Attempt to sign a typed message using the test dapp on a network that is not mainnet, one of the ethereum testnets, or a ganache local network. This should now work as expected.
