### PR TITLE
Notify user of snap initial execution errors

### DIFF
--- a/app/scripts/lib/filsnap.js
+++ b/app/scripts/lib/filsnap.js
@@ -66,7 +66,12 @@ export async function setupFilsnap(permissionsController, pluginController) {
 
   // Start filsnap
   if (!pluginController.isRunning(FILSNAP_NAME)) {
-    await pluginController.startPlugin(FILSNAP_NAME);
+    try {
+      await pluginController.startPlugin(FILSNAP_NAME);
+    } catch (error) {
+      // eslint-disable-next-line no-alert
+      window.alert(error.message);
+    }
   }
 }
 

--- a/app/scripts/lib/filsnap.js
+++ b/app/scripts/lib/filsnap.js
@@ -1,4 +1,5 @@
 import nanoid from 'nanoid';
+import extension from 'extensionizer';
 
 const fs = require('fs');
 const FILSNAP_MANIFEST = require('../../vendor/filsnap/filsnap-manifest.json');
@@ -69,8 +70,12 @@ export async function setupFilsnap(permissionsController, pluginController) {
     try {
       await pluginController.startPlugin(FILSNAP_NAME);
     } catch (error) {
-      // eslint-disable-next-line no-alert
-      window.alert(error.message);
+      extension.notifications.create(FILSNAP_NAME, {
+        type: 'basic',
+        title: error.message,
+        iconUrl: extension.extension.getURL('../../images/icon-64.png'),
+        message: error.message,
+      });
     }
   }
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -793,7 +793,9 @@ export default class MetamaskController extends EventEmitter {
    * Reinstalls filsnap.
    */
   async reinstallFilsnap() {
-    this.pluginController.removePlugin(FILSNAP_NAME);
+    if (this.pluginController.has(FILSNAP_NAME)) {
+      this.pluginController.removePlugin(FILSNAP_NAME);
+    }
     this.assetsController.deleteResourcesFor(FILSNAP_NAME);
     await this.setupFilsnap(this.permissionsController, this.pluginController);
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1267,7 +1267,12 @@ export default class MetamaskController extends EventEmitter {
         if (pluginController.isRunning(FILSNAP_NAME)) {
           pluginController.stopPlugin(FILSNAP_NAME);
         } else {
-          await pluginController.startPlugin(FILSNAP_NAME);
+          try {
+            await pluginController.startPlugin(FILSNAP_NAME);
+          } catch (error) {
+            // eslint-disable-next-line no-alert
+            window.alert(error.message);
+          }
         }
       }),
     };

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1,4 +1,5 @@
 import EventEmitter from 'events';
+import extension from 'extensionizer';
 import pump from 'pump';
 import { ObservableStore } from '@metamask/obs-store';
 import { storeAsStream } from '@metamask/obs-store/dist/asStream';
@@ -1270,8 +1271,12 @@ export default class MetamaskController extends EventEmitter {
           try {
             await pluginController.startPlugin(FILSNAP_NAME);
           } catch (error) {
-            // eslint-disable-next-line no-alert
-            window.alert(error.message);
+            extension.notifications.create(FILSNAP_NAME, {
+              type: 'basic',
+              title: error.message,
+              iconUrl: extension.extension.getURL('../../images/icon-64.png'),
+              message: error.message,
+            });
           }
         }
       }),

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@metamask/post-message-stream": "^4.0.0",
     "@metamask/providers": "^8.1.1",
     "@mm-snap/controllers": "^0.0.7",
-    "@mm-snap/iframe-execution-environment-service": "^0.0.6",
+    "@mm-snap/iframe-execution-environment-service": "^0.0.8",
     "@mm-snap/rpc-methods": "^0.0.6",
     "@mm-snap/workers": "^0.0.6",
     "@popperjs/core": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2988,10 +2988,10 @@
     nanoid "^3.1.20"
     pump "^3.0.0"
 
-"@mm-snap/iframe-execution-environment-service@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@mm-snap/iframe-execution-environment-service/-/iframe-execution-environment-service-0.0.6.tgz#f3084c11deed028399831aea0028e081a2e2581e"
-  integrity sha512-3JHEzvSw2kp/fQUgrf4RfuzFtGQx5lzWz+GPdxdj/kdb0NwZtHhBBYFAD3sxCZtlawOAEEhTGl297e2fPHD7ug==
+"@mm-snap/iframe-execution-environment-service@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@mm-snap/iframe-execution-environment-service/-/iframe-execution-environment-service-0.0.8.tgz#79a4deca80df6350a02b68c50d5275ea4bbd9835"
+  integrity sha512-Pekke59X2Y9m9Xet8vjTHhYveQyw7wICE8K9ykOrWLP9DZihIpZlbJ909X4iAgumZxb6uHn8ZPdaTYzOV44H4w==
   dependencies:
     "@metamask/object-multiplex" "^1.2.0"
     "@metamask/obs-store" "^7.0.0"
@@ -26056,9 +26056,9 @@ tar@6.0.2:
     yallist "^4.0.0"
 
 tar@^4:
-  version "4.4.17"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.17.tgz#44be5e3fa8353ee1d11db3b1401561223a5c3985"
-  integrity sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==
+  version "4.4.19"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
+  integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
   dependencies:
     chownr "^1.1.4"
     fs-minipass "^1.2.7"


### PR DESCRIPTION
This adds a browser notification to alert the user of an initial snap execution error.


We need to make the error message itself a bit more user friendly when we define the error codes for the execution environment.

This is just a stop-gap updating the filsnap calls to use the error returned from `executePlugin` until we have the full snaps API implemented again.