### PR TITLE
Fixing error handling for `publish()` (MobileSync)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2415,6 +2415,9 @@
   "symbolBetweenZeroTwelve": {
     "message": "Symbol must be 11 characters or fewer."
   },
+  "syncFailed": {
+    "message": "Sync failed"
+  },
   "syncInProgress": {
     "message": "Sync in progress"
   },

--- a/ui/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/pages/mobile-sync/mobile-sync.component.js
@@ -201,9 +201,9 @@ export default class MobileSyncPage extends Component {
           sendByPost: false, // true to send via post
           storeInHistory: false,
         },
-        (status, response) => {
+        (status, _response) => {
           if (status.error) {
-            reject(response);
+            reject(status.errorData);
           } else {
             resolve();
           }
@@ -225,6 +225,7 @@ export default class MobileSyncPage extends Component {
       preferences,
       transactions,
     } = await this.props.fetchInfoToSync();
+    const { t } = this.context;
 
     const allDataStr = JSON.stringify({
       accounts,
@@ -245,7 +246,7 @@ export default class MobileSyncPage extends Component {
         await this.sendMessage(chunks[i], i + 1, totalChunks);
       }
     } catch (e) {
-      this.props.displayWarning('Sync failed :(');
+      this.props.displayWarning(`${t('syncFailed')} :(`);
       this.setState({ syncing: false });
       this.syncing = false;
       this.notifyError(e.toString());
@@ -266,9 +267,9 @@ export default class MobileSyncPage extends Component {
           sendByPost: false, // true to send via post
           storeInHistory: false,
         },
-        (status, response) => {
+        (status, _response) => {
           if (status.error) {
-            reject(response);
+            reject(status.errorData);
           } else {
             resolve();
           }


### PR DESCRIPTION
Related Sentry Error: https://sentry.io/organizations/metamask/issues/2213968901/?project=273505&query=is%3Aunresolved+toString&statsPeriod=14d

When `publish` resolves with errors, we shouldn't `reject` with the `response` (which is undefined in error cases), rather `status.errorData`, which contains the `Error` object we want to throw. (https://www.pubnub.com/docs/sdks/javascript/api-reference/publish-and-subscribe)

Also localized the sync failure message