### PR TITLE
Set up minimum Jest threshold for "ui" and "shared" folders

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,14 @@
 module.exports = {
   restoreMocks: true,
   coverageDirectory: 'jest-coverage/',
-  collectCoverageFrom: [
-    '<rootDir>/ui/**/swaps/**',
-    '<rootDir>/ui/ducks/send/**',
-  ],
+  collectCoverageFrom: ['<rootDir>/ui/**/*.js', '<rootDir>/shared/**/*.js'],
   coveragePathIgnorePatterns: ['.stories.js', '.snap'],
   coverageThreshold: {
     global: {
-      branches: 45.24,
-      functions: 51.94,
-      lines: 58.36,
-      statements: 58.6,
+      branches: 35,
+      functions: 37,
+      lines: 43,
+      statements: 43,
     },
   },
   setupFiles: ['./test/setup.js', './test/env.js'],


### PR DESCRIPTION
## Explanation
Up until now we have been using minimum Jest threshold only for the Swaps feature and a little bit of the Send feature.

This PR enforces minimum Jest test coverage for all JavaScript files in the "ui" and "shared" folders, which means that most PRs will need to include unit tests in order to be green. Right now the minimum threshold is pretty low (around 40%), so it should be pretty simple to add enough unit tests to reach it.

This PR is a simple change, which will have high impact on quality, because the more unit tests we have, the less bugs we will have in production, refactoring will be less stressful and can happen more often because of that and we will have more confidence in our production pushes.

I understand that people will need to get used to it, but it's necessary in order to increase our standards.

## Manual testing steps
  - Send a PR with new business logic without any unit tests
  - PR will not be green until you meet the minimum Jest threshold

## Screenshots
Not enough coverage (`yarn test:coverage:jest`):
![image](https://user-images.githubusercontent.com/80175477/130786726-52aabfa4-38c4-48e2-adf9-ad836b829465.png)

Enough coverage (`yarn test:coverage:jest`):
![image](https://user-images.githubusercontent.com/80175477/130786749-cb93eb8f-cd2c-4ebf-be7b-844b9260f788.png)
