### PR TITLE
Use Swaps dev APIs based on an env variable

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -28,6 +28,10 @@ import {
   TokenListController,
 } from '@metamask/controllers';
 import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
+import {
+  GAS_API_BASE_URL,
+  GAS_DEV_API_BASE_URL,
+} from '../../shared/constants/swaps';
 import { MAINNET_CHAIN_ID } from '../../shared/constants/network';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
 import { UI_NOTIFICATIONS } from '../../shared/notifications';
@@ -179,6 +183,10 @@ export default class MetamaskController extends EventEmitter {
       name: 'GasFeeController',
     });
 
+    const gasApiBaseUrl = process.env.SWAPS_USE_DEV_APIS
+      ? GAS_DEV_API_BASE_URL
+      : GAS_API_BASE_URL;
+
     this.gasFeeController = new GasFeeController({
       interval: 10000,
       messenger: gasFeeMessenger,
@@ -194,8 +202,8 @@ export default class MetamaskController extends EventEmitter {
       getCurrentAccountEIP1559Compatibility: this.getCurrentAccountEIP1559Compatibility.bind(
         this,
       ),
-      legacyAPIEndpoint: `https://gas-api.metaswap.codefi.network/networks/<chain_id>/gasPrices`,
-      EIP1559APIEndpoint: `https://gas-api.metaswap.codefi.network/networks/<chain_id>/suggestedGasFees`,
+      legacyAPIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/gasPrices`,
+      EIP1559APIEndpoint: `${gasApiBaseUrl}/networks/<chain_id>/suggestedGasFees`,
       getCurrentNetworkLegacyGasAPICompatibility: () => {
         const chainId = this.networkController.getCurrentChainId();
         return process.env.IN_TEST || chainId === MAINNET_CHAIN_ID;

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -572,6 +572,7 @@ function getEnvironmentVariables({ devMode, testing }) {
       environment === 'production'
         ? process.env.SEGMENT_PROD_LEGACY_WRITE_KEY
         : metamaskrc.SEGMENT_LEGACY_WRITE_KEY,
+    SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS === '1',
   };
 }
 

--- a/shared/constants/swaps.js
+++ b/shared/constants/swaps.js
@@ -85,6 +85,13 @@ const METASWAP_BSC_API_HOST = 'https://bsc-api.metaswap.codefi.network';
 const SWAPS_TESTNET_CHAIN_ID = '0x539';
 const SWAPS_TESTNET_HOST = 'https://metaswap-api.airswap-dev.codefi.network';
 
+export const SWAPS_API_V2_BASE_URL = 'https://api2.metaswap.codefi.network';
+export const SWAPS_DEV_API_V2_BASE_URL =
+  'https://api2.metaswap-dev.codefi.network';
+export const GAS_API_BASE_URL = 'https://gas-api.metaswap.codefi.network';
+export const GAS_DEV_API_BASE_URL =
+  'https://gas-api.metaswap-dev.codefi.network';
+
 const BSC_DEFAULT_BLOCK_EXPLORER_URL = 'https://bscscan.com/';
 const MAINNET_DEFAULT_BLOCK_EXPLORER_URL = 'https://etherscan.io/';
 const RINKEBY_DEFAULT_BLOCK_EXPLORER_URL = 'https://rinkeby.etherscan.io/';

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -10,6 +10,10 @@ import {
   POLYGON,
   BSC,
   RINKEBY,
+  SWAPS_API_V2_BASE_URL,
+  SWAPS_DEV_API_V2_BASE_URL,
+  GAS_API_BASE_URL,
+  GAS_DEV_API_BASE_URL,
 } from '../../../shared/constants/swaps';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../../shared/constants/transaction';
 import {
@@ -51,25 +55,27 @@ const TOKEN_TRANSFER_LOG_TOPIC_HASH =
 
 const CACHE_REFRESH_FIVE_MINUTES = 300000;
 
-const SWAPS_API_V2_BASE_URL = 'https://api2.metaswap.codefi.network';
-const GAS_API_BASE_URL = 'https://gas-api.metaswap.codefi.network';
-
 /**
  * @param {string} type Type of an API call, e.g. "tokens"
  * @param {string} chainId
  * @returns string
  */
 const getBaseUrlForNewSwapsApi = (type, chainId) => {
+  const useDevApis = process.env.SWAPS_USE_DEV_APIS;
+  const v2ApiBaseUrl = useDevApis
+    ? SWAPS_DEV_API_V2_BASE_URL
+    : SWAPS_API_V2_BASE_URL;
+  const gasApiBaseUrl = useDevApis ? GAS_DEV_API_BASE_URL : GAS_API_BASE_URL;
   const noNetworkSpecificTypes = ['refreshTime']; // These types don't need network info in the URL.
   if (noNetworkSpecificTypes.includes(type)) {
-    return SWAPS_API_V2_BASE_URL;
+    return v2ApiBaseUrl;
   }
   const chainIdDecimal = chainId && parseInt(chainId, 16);
   const gasApiTypes = ['gasPrices'];
   if (gasApiTypes.includes(type)) {
-    return `${GAS_API_BASE_URL}/networks/${chainIdDecimal}`; // Gas calculations are in its own repo.
+    return `${gasApiBaseUrl}/networks/${chainIdDecimal}`; // Gas calculations are in its own repo.
   }
-  return `${SWAPS_API_V2_BASE_URL}/networks/${chainIdDecimal}`;
+  return `${v2ApiBaseUrl}/networks/${chainIdDecimal}`;
 };
 
 const getBaseApi = function (
@@ -410,8 +416,11 @@ export async function fetchTopAssets(chainId, useNewSwapsApi) {
 }
 
 export async function fetchSwapsFeatureFlags() {
+  const v2ApiBaseUrl = process.env.SWAPS_USE_DEV_APIS
+    ? SWAPS_DEV_API_V2_BASE_URL
+    : SWAPS_API_V2_BASE_URL;
   const response = await fetchWithCache(
-    `${SWAPS_API_V2_BASE_URL}/featureFlags`,
+    `${v2ApiBaseUrl}/featureFlags`,
     { method: 'GET' },
     { cacheRefreshTime: 600000 },
   );


### PR DESCRIPTION
## Explanation
Sometimes we want to test Swaps against our dev APIs instead of production ones and this PR enables it based on an env variable.

## Manual testing steps
  - Open Swaps
  - Check the Network tab and see that URLs include the `-dev` string, which indicates our dev APIs

## Screenshots
Dev APIs:
![image](https://user-images.githubusercontent.com/80175477/130798141-17f35243-4a7f-47ea-bb5c-4d252c41d094.png)
![image](https://user-images.githubusercontent.com/80175477/130798168-8534a552-9d85-4c17-b452-7f215e28458c.png)
![image](https://user-images.githubusercontent.com/80175477/130798187-d1eeb48d-5c94-44d7-b516-3fd27e4f1f5f.png)

Production APIs:
![image](https://user-images.githubusercontent.com/80175477/130798221-1cd39715-dfc3-44e8-8bf9-f8d76feedbdd.png)
![image](https://user-images.githubusercontent.com/80175477/130798243-a1a88e83-9e7a-43cb-989c-14425e4b0dfc.png)
