### PR TITLE
Updating decimal precision to 9 (getRoundedGasPrice)

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -384,7 +384,7 @@ export const computeEstimatedGasLimit = createAsyncThunk(
  */
 function getRoundedGasPrice(gasPriceEstimate) {
   const gasPriceInDecGwei = conversionUtil(gasPriceEstimate, {
-    numberOfDecimals: 4,
+    numberOfDecimals: 9,
     toDenomination: GWEI,
     fromNumericBase: 'dec',
     toNumericBase: 'dec',


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11898

This change was originally implemented in the send flow here: https://github.com/MetaMask/metamask-extension/pull/11652/files - but was lost in the EIP-1559 refactor
