### PR TITLE
Temporarily Disabling Mobile Sync

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1298,7 +1298,7 @@
     "description": "Serves as link text for the 'mismatchedChain' key. This text will be embedded inside the translation for that key."
   },
   "mobileSyncWarning": {
-    "message": "⚠️ Proceeding will display a secret QR code that allows access to your accounts. Do not share it with anyone. Support staff will never ask you for it."
+    "message": "This feature has been temporarily disabled, if you are trying to sync with MetaMask mobile, please use your Secret Recovery Phrase instead for now. As usual, never share it with anyone."
   },
   "mustSelectOne": {
     "message": "Must select at least 1 token."

--- a/ui/pages/mobile-sync/mobile-sync.component.js
+++ b/ui/pages/mobile-sync/mobile-sync.component.js
@@ -321,12 +321,7 @@ export default class MobileSyncPage extends Component {
     }
 
     return screen === PASSWORD_PROMPT_SCREEN ? (
-      <div>
-        {this.renderWarning(this.context.t('mobileSyncWarning'))}
-        <div className="reveal-seed__content">
-          {this.renderPasswordPromptContent()}
-        </div>
-      </div>
+      <div>{this.renderWarning(this.context.t('mobileSyncWarning'))}</div>
     ) : (
       <div>
         {this.renderWarning(this.context.t('syncWithMobileBeCareful'))}


### PR DESCRIPTION
<img width="1130" alt="Screen Shot 2021-08-25 at 11 02 54 AM" src="https://user-images.githubusercontent.com/8732757/130842724-9dd92226-5dc2-4953-92f5-6b7321746728.png">

Without password entry, there is no ability to proceed. Also, repurposed the `mobileSyncWarning` key to prevent an unused translation error