### PR TITLE
Use higher gasfees when attempting to speedup or cancel a transaction

### DIFF
--- a/ui/hooks/useCancelTransaction.test.js
+++ b/ui/hooks/useCancelTransaction.test.js
@@ -6,6 +6,14 @@ import { getConversionRate, getSelectedAccount } from '../selectors';
 import { increaseLastGasPrice } from '../helpers/utils/confirm-tx.util';
 import { useCancelTransaction } from './useCancelTransaction';
 
+jest.mock('../store/actions', () => ({
+  disconnectGasFeeEstimatePoller: jest.fn(),
+  getGasFeeEstimatesAndStartPolling: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve()),
+  addPollingTokenToAppState: jest.fn(),
+}));
+
 describe('useCancelTransaction', function () {
   let useSelector;
   const dispatch = sinon.spy();

--- a/ui/hooks/useRetryTransaction.test.js
+++ b/ui/hooks/useRetryTransaction.test.js
@@ -8,7 +8,7 @@ import * as metricEventHook from './useMetricEvent';
 import { useRetryTransaction } from './useRetryTransaction';
 
 jest.mock('./useGasFeeEstimates', () => ({
-  useGasFeeEstimates: jest.fn(),
+  useGasFeeEstimates: jest.fn().mockImplementation(() => Promise.resolve({})),
 }));
 
 describe('useRetryTransaction', () => {


### PR DESCRIPTION
Possibly Fixes: #11928

Explanation:  When a user wants to speed up or cancel a transaction the fees we should pre-populate the gas popover form with should be the higher of the following two options: the original fee + 10% or the current medium suggested fees (for current market conditions) from our gas estimation api.

Manual testing steps:  
  - Initialize a send transaction with very low maxFee and maxPriorityFee 
  - Attempt to speed up or cancel the transaction
  - The newly suggested fees should be greater than a 10% increase on the originals (unless gas fee prices have precipitously dropped since you sent the transaction)