### PR TITLE
Allow excluding lockdown at build time

### DIFF
--- a/development/build/index.js
+++ b/development/build/index.js
@@ -28,12 +28,17 @@ require('@babel/preset-react');
 require('@babel/core');
 
 const browserPlatforms = ['firefox', 'chrome', 'brave', 'opera'];
+const shouldIncludeLockdown = !process.argv.includes('--omit-lockdown');
 
 defineAllTasks();
 detectAndRunEntryTask();
 
 function defineAllTasks() {
-  const staticTasks = createStaticAssetTasks({ livereload, browserPlatforms });
+  const staticTasks = createStaticAssetTasks({
+    livereload,
+    browserPlatforms,
+    shouldIncludeLockdown,
+  });
   const manifestTasks = createManifestTasks({ browserPlatforms });
   const styleTasks = createStyleTasks({ livereload });
   const scriptTasks = createScriptTasks({ livereload, browserPlatforms });

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -7,103 +7,17 @@ const locales = require('../../app/_locales/index.json');
 
 const { createTask, composeSeries } = require('./task');
 
-module.exports = createStaticAssetTasks;
+const EMPTY_JS_FILE = './development/empty.js';
 
-const copyTargets = [
-  {
-    src: `./app/_locales/`,
-    dest: `_locales`,
-  },
-  {
-    src: `./app/images/`,
-    dest: `images`,
-  },
-  {
-    src: `./node_modules/@metamask/contract-metadata/images/`,
-    dest: `images/contract`,
-  },
-  {
-    src: `./app/fonts/`,
-    dest: `fonts`,
-  },
-  {
-    src: `./app/vendor/`,
-    dest: `vendor`,
-  },
-  {
-    src: `./node_modules/@fortawesome/fontawesome-free/webfonts/`,
-    dest: `fonts/fontawesome`,
-  },
-  {
-    src: `./ui/css/output/`,
-    pattern: `*.css`,
-    dest: ``,
-  },
-  {
-    src: `./app/loading.html`,
-    dest: `loading.html`,
-  },
-  {
-    src: `./node_modules/globalthis/dist/browser.js`,
-    dest: `globalthis.js`,
-  },
-  {
-    src: `./node_modules/ses/dist/lockdown.umd.min.js`,
-    dest: `lockdown-install.js`,
-  },
-  {
-    src: `./app/scripts/lockdown-run.js`,
-    dest: `lockdown-run.js`,
-  },
-  {
-    // eslint-disable-next-line node/no-extraneous-require
-    src: require.resolve('@lavamoat/lavapack/src/runtime-cjs.js'),
-    dest: `runtime-cjs.js`,
-  },
-];
+module.exports = function createStaticAssetTasks({
+  livereload,
+  browserPlatforms,
+  shouldIncludeLockdown = true,
+}) {
+  const [copyTargetsProd, copyTargetsDev] = getCopyTargets(
+    shouldIncludeLockdown,
+  );
 
-const languageTags = new Set();
-for (const locale of locales) {
-  const { code } = locale;
-  const tag = code.split('_')[0];
-  languageTags.add(tag);
-}
-
-for (const tag of languageTags) {
-  copyTargets.push({
-    src: `./node_modules/@formatjs/intl-relativetimeformat/dist/locale-data/${tag}.json`,
-    dest: `intl/${tag}/relative-time-format-data.json`,
-  });
-}
-
-const copyTargetsDev = [
-  ...copyTargets,
-  {
-    src: './development',
-    pattern: '/chromereload.js',
-    dest: ``,
-  },
-  // empty files to suppress missing file errors
-  {
-    src: './development/empty.js',
-    dest: `bg-libs.js`,
-  },
-  {
-    src: './development/empty.js',
-    dest: `ui-libs.js`,
-  },
-];
-
-const copyTargetsProd = [
-  ...copyTargets,
-  // empty files to suppress missing file errors
-  {
-    src: './development/empty.js',
-    dest: `chromereload.js`,
-  },
-];
-
-function createStaticAssetTasks({ livereload, browserPlatforms }) {
   const prod = createTask(
     'static:prod',
     composeSeries(
@@ -165,4 +79,106 @@ function createStaticAssetTasks({ livereload, browserPlatforms }) {
       }),
     );
   }
+};
+
+function getCopyTargets(shouldIncludeLockdown) {
+  const allCopyTargets = [
+    {
+      src: `./app/_locales/`,
+      dest: `_locales`,
+    },
+    {
+      src: `./app/images/`,
+      dest: `images`,
+    },
+    {
+      src: `./node_modules/@metamask/contract-metadata/images/`,
+      dest: `images/contract`,
+    },
+    {
+      src: `./app/fonts/`,
+      dest: `fonts`,
+    },
+    {
+      src: `./app/vendor/`,
+      dest: `vendor`,
+    },
+    {
+      src: `./node_modules/@fortawesome/fontawesome-free/webfonts/`,
+      dest: `fonts/fontawesome`,
+    },
+    {
+      src: `./ui/css/output/`,
+      pattern: `*.css`,
+      dest: ``,
+    },
+    {
+      src: `./app/loading.html`,
+      dest: `loading.html`,
+    },
+    {
+      src: `./node_modules/globalthis/dist/browser.js`,
+      dest: `globalthis.js`,
+    },
+    {
+      src: shouldIncludeLockdown
+        ? `./node_modules/ses/dist/lockdown.umd.min.js`
+        : EMPTY_JS_FILE,
+      dest: `lockdown-install.js`,
+    },
+    {
+      src: shouldIncludeLockdown
+        ? `./app/scripts/lockdown-run.js`
+        : EMPTY_JS_FILE,
+      dest: `lockdown-run.js`,
+    },
+    {
+      // eslint-disable-next-line node/no-extraneous-require
+      src: require.resolve('@lavamoat/lavapack/src/runtime-cjs.js'),
+      dest: `runtime-cjs.js`,
+    },
+  ];
+
+  const languageTags = new Set();
+  for (const locale of locales) {
+    const { code } = locale;
+    const tag = code.split('_')[0];
+    languageTags.add(tag);
+  }
+
+  for (const tag of languageTags) {
+    allCopyTargets.push({
+      src: `./node_modules/@formatjs/intl-relativetimeformat/dist/locale-data/${tag}.json`,
+      dest: `intl/${tag}/relative-time-format-data.json`,
+    });
+  }
+
+  const copyTargetsDev = [
+    ...allCopyTargets,
+    {
+      src: './development',
+      pattern: '/chromereload.js',
+      dest: ``,
+    },
+    // empty files to suppress missing file errors
+    {
+      src: EMPTY_JS_FILE,
+      dest: `bg-libs.js`,
+    },
+    {
+      src: EMPTY_JS_FILE,
+      dest: `ui-libs.js`,
+    },
+  ];
+
+  const copyTargetsProd = [
+    ...allCopyTargets,
+    // empty files to suppress missing file errors
+    {
+      src: EMPTY_JS_FILE,
+      dest: `chromereload.js`,
+    },
+  ];
+
+  return [copyTargetsProd, copyTargetsDev];
 }


### PR DESCRIPTION
This adds an `--omit-lockdown` flag to our build script, which will cause SES `lockdown` to be omitted from the resulting bundle. Useful for development when we don't want the environment to be locked down.

Thanks to @kumavis for the suggestion.