### PR TITLE
Send user to account page upon adding a custom network

### DIFF
--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -49,7 +49,7 @@ describe('Stores custom RPC history', function () {
         await chainIdInput.sendKeys(chainId.toString());
 
         await driver.clickElement('.network-form__footer .btn-secondary');
-        await driver.findElement({ text: networkName, tag: 'div' });
+        await driver.findElement({ text: networkName, tag: 'span' });
       },
     );
   });

--- a/ui/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/pages/settings/networks-tab/network-form/network-form.component.js
@@ -41,7 +41,7 @@ export default class NetworkForm extends PureComponent {
     blockExplorerUrl: PropTypes.string,
     rpcPrefs: PropTypes.object,
     networksToRender: PropTypes.array,
-    isFullScreen: PropTypes.bool,
+    onAddNetwork: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -165,7 +165,7 @@ export default class NetworkForm extends PureComponent {
         rpcUrl: propsRpcUrl,
         editRpc,
         rpcPrefs = {},
-        onClear,
+        onAddNetwork,
         networksTabIsInAddMode,
       } = this.props;
       const {
@@ -200,7 +200,7 @@ export default class NetworkForm extends PureComponent {
       }
 
       if (networksTabIsInAddMode) {
-        onClear();
+        onAddNetwork();
       }
     } catch (error) {
       this.setState({
@@ -211,9 +211,9 @@ export default class NetworkForm extends PureComponent {
   };
 
   onCancel = () => {
-    const { isFullScreen, networksTabIsInAddMode, onClear } = this.props;
+    const { networksTabIsInAddMode, onClear } = this.props;
 
-    if (networksTabIsInAddMode || !isFullScreen) {
+    if (networksTabIsInAddMode) {
       onClear();
     } else {
       this.resetForm();

--- a/ui/pages/settings/networks-tab/networks-tab.component.js
+++ b/ui/pages/settings/networks-tab/networks-tab.component.js
@@ -7,6 +7,7 @@ import LockIcon from '../../../components/ui/lock-icon';
 import {
   NETWORKS_ROUTE,
   NETWORKS_FORM_ROUTE,
+  DEFAULT_ROUTE,
 } from '../../../helpers/constants/routes';
 import ColorIndicator from '../../../components/ui/color-indicator';
 import { COLORS, SIZES } from '../../../helpers/constants/design-system';
@@ -212,9 +213,12 @@ export default class NetworksTab extends PureComponent {
             onClear={(shouldUpdateHistory = true) => {
               setNetworksTabAddMode(false);
               setSelectedSettingsRpcUrl('');
-              if (shouldUpdateHistory && !isFullScreen) {
+              if (shouldUpdateHistory) {
                 history.push(NETWORKS_ROUTE);
               }
+            }}
+            onAddNetwork={() => {
+              history.push(DEFAULT_ROUTE);
             }}
             showConfirmDeleteNetworkModal={showConfirmDeleteNetworkModal}
             viewOnly={viewOnly}


### PR DESCRIPTION
Fixes: #11946 // [Notion ticket](https://www.notion.so/After-completing-the-custom-network-form-give-user-confirmation-that-the-network-was-added-successf-fd26108a07484c0d801a945119791ee0)

Explanation:  We should redirect user to the account page (of the newly added network) upon adding a new custom network

Video of current behavior:
https://user-images.githubusercontent.com/34557516/131032739-0d43374b-efd9-480d-ab18-abdd81836aa0.mov

Video of new behavior:
https://user-images.githubusercontent.com/34557516/131033701-2e409a64-33ce-41ac-8992-7ad4c31fba52.mov




