### PR TITLE
Allow run-ganache script to have additional command line options

### DIFF
--- a/development/run-ganache.sh
+++ b/development/run-ganache.sh
@@ -4,7 +4,9 @@ set -e
 set -u
 set -o pipefail
 
-ganache_cli="$(yarn bin)/ganache-cli"
+# Notice that you can add additional parameters with $@
+# example `./run-ganache --db /tmp/my-persistance`.
+ganache_cli="$(yarn bin)/ganache-cli $@"
 seed_phrase="${GANACHE_SEED_PHRASE:-phrase upgrade clock rough situate wedding elder clever doctor stamp excess tent}"
 
 _term () {


### PR DESCRIPTION
So you can do for example

```
./run-ganache.sh --db /tmp/lololol
```

And be able to persist your development blockchain across runs.