### PR TITLE
Add scrollbar in My Accounts Menu

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -127,7 +127,7 @@
     overflow-y: auto;
     position: relative;
     max-height: 256px;
-    scrollbar-width: none;
+    scrollbar-width: auto;
 
     &::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
Fixes: #8905 

Explanation:  Added scrollbar when needing to view multiple accounts

Manual testing steps:  
  - Click your account in the top right.
  -  Add 9 accounts(or more)
  - There should be a scrollbar for individuals who prefer to scroll manually instead as an alternative of using the scroll down button.