### PR TITLE
Disabled spell-check on ens input

### DIFF
--- a/ui/pages/send/send-content/add-recipient/ens-input.component.js
+++ b/ui/pages/send/send-content/add-recipient/ens-input.component.js
@@ -128,6 +128,7 @@ export default class EnsInput extends Component {
                 placeholder={t('recipientAddressPlaceholder')}
                 onChange={this.onChange}
                 onPaste={this.onPaste}
+                spellCheck="false"
                 value={selectedAddress || userInput}
                 autoFocus
                 data-testid="ens-input"


### PR DESCRIPTION
Fixes: #7397

Explanation:  Disables spellcheck for address fields using the ens-input component

Manual testing steps:
  - Go to Contacts
  - misspell a word
  - spellcheck shouldn't be enabled