### PR TITLE
bump @metamask/controllers to v15.0.2 and remove AbortController workaround in e2e tests

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2,9 +2,6 @@
  * @file The entry point for the web extension singleton process.
  */
 
-// polyfills
-import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
-
 import endOfStream from 'end-of-stream';
 import pump from 'pump';
 import debounce from 'debounce-stream';

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -109,7 +109,6 @@ describe('MetaMaskController', function () {
   const noop = () => undefined;
 
   before(async function () {
-    globalThis.AbortController = window.AbortController;
     await ganacheServer.start();
   });
 
@@ -158,7 +157,6 @@ describe('MetaMaskController', function () {
 
   after(async function () {
     await ganacheServer.quit();
-    delete globalThis.AbortController;
   });
 
   describe('#getAccounts', function () {

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -1,5 +1,4 @@
 // polyfills
-import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 import '@formatjs/intl-relativetimeformat/polyfill';
 
 // dev only, "react-devtools" import is skipped in prod builds

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "@sentry/browser": "^5.26.0",
     "@sentry/integrations": "^5.26.0",
     "@zxing/library": "^0.8.0",
-    "abortcontroller-polyfill": "^1.4.0",
     "analytics-node": "^3.4.0-beta.3",
     "await-semaphore": "^0.1.1",
     "base32-encode": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.28.0",
-    "@metamask/controllers": "^15.0.0",
+    "@metamask/controllers": "^15.0.1",
     "@metamask/eth-ledger-bridge-keyring": "^0.7.0",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.28.0",
-    "@metamask/controllers": "^15.0.1",
+    "@metamask/controllers": "^15.0.2",
     "@metamask/eth-ledger-bridge-keyring": "^0.7.0",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.1.0",

--- a/shared/modules/fetch-with-timeout.test.js
+++ b/shared/modules/fetch-with-timeout.test.js
@@ -30,7 +30,9 @@ describe('getFetchWithTimeout', function () {
       throw new Error('Request should throw');
     };
 
-    await expect(fetchWithTimeoutThrowsError()).rejects.toThrow('Aborted');
+    await expect(fetchWithTimeoutThrowsError()).rejects.toThrow(
+      'The user aborted a request.',
+    );
   });
 
   it('should abort the request when the custom timeout is hit', async function () {
@@ -48,7 +50,9 @@ describe('getFetchWithTimeout', function () {
       throw new Error('Request should be aborted');
     };
 
-    await expect(fetchWithTimeoutThrowsError()).rejects.toThrow('Aborted');
+    await expect(fetchWithTimeoutThrowsError()).rejects.toThrow(
+      'The user aborted a request.',
+    );
   });
 
   it('throws on invalid timeout', async function () {

--- a/test/helpers/setup-helper.js
+++ b/test/helpers/setup-helper.js
@@ -56,16 +56,11 @@ const popoverContent = window.document.createElement('div');
 popoverContent.setAttribute('id', 'popover-content');
 window.document.body.appendChild(popoverContent);
 
-// delete AbortController added by jsdom so it can be polyfilled correctly below
-delete window.AbortController;
-
 // fetch
 const fetch = require('node-fetch');
 
 const { Headers, Request, Response } = fetch;
 Object.assign(window, { fetch, Headers, Request, Response });
-
-require('abortcontroller-polyfill/dist/polyfill-patch-fetch');
 
 // localStorage
 window.localStorage = {

--- a/ui/helpers/utils/fetch-with-cache.test.js
+++ b/ui/helpers/utils/fetch-with-cache.test.js
@@ -79,7 +79,10 @@ describe('Fetch with cache', () => {
         {},
         { timeout: 20 },
       ),
-    ).rejects.toThrow({ name: 'AbortError', message: 'Aborted' });
+    ).rejects.toThrow({
+      name: 'AbortError',
+      message: 'The user aborted a request.',
+    });
   });
 
   it('throws when the response is unsuccessful', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,10 +2730,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.29.0.tgz#4ca86a2f03d4dad4350d09216a7fe92f9dd21c8e"
   integrity sha512-wxsC0ZCyhPKqThvmsL8+2zVWGWPqofSo8HNtOuOnQM9oGbXX9294imJ3T+A/Lov8fkX4jAWZOeNV0uR80zkNtA==
 
-"@metamask/controllers@^15.0.1":
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-15.0.1.tgz#31fdb9b5581f395e154d3b695495bfd1a8c857c1"
-  integrity sha512-GgPvAE5Z2aokEMDmRZTpc8SYCl7Icjm7/pWC4VFizRMV8npWpA3qG7V/N6K1zSjfncghCPC9pjDlNnPJoJssRQ==
+"@metamask/controllers@^15.0.2":
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-15.0.2.tgz#b4012a8bf28bd2c8dbb3c96f4d934d6cf1bb778c"
+  integrity sha512-MPxfZ2OOTzEa5lUzDsSkINtlTDU4q4udjpBNM5Dq1yCnLKIuPKzYC5nl/rA88Ssr9Hs6babCtMbnUpbbjQjLOg==
   dependencies:
     "@ethereumjs/common" "^2.3.1"
     "@ethereumjs/tx" "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4643,11 +4643,6 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abortcontroller-polyfill@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz#0d5eb58e522a461774af8086414f68e1dda7a6c4"
-  integrity sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==
-
 abstract-leveldown@0.12.3:
   version "0.12.3"
   resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz#116b1ec5c7710ef7a2d5706768bbdb4440be1070"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,15 +2730,16 @@
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.29.0.tgz#4ca86a2f03d4dad4350d09216a7fe92f9dd21c8e"
   integrity sha512-wxsC0ZCyhPKqThvmsL8+2zVWGWPqofSo8HNtOuOnQM9oGbXX9294imJ3T+A/Lov8fkX4jAWZOeNV0uR80zkNtA==
 
-"@metamask/controllers@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-15.0.0.tgz#b7e816e12e02debaf32f7bab5f8d612cbd7a5170"
-  integrity sha512-vYVwDVctxdmBRBYDzPfpab3GoVtePykaMKfOdgD+OT8Cz8tlDrEIRc5+DZhr6HembWg8LkNfw9Gh5lKfAFSGLg==
+"@metamask/controllers@^15.0.1":
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/controllers/-/controllers-15.0.1.tgz#31fdb9b5581f395e154d3b695495bfd1a8c857c1"
+  integrity sha512-GgPvAE5Z2aokEMDmRZTpc8SYCl7Icjm7/pWC4VFizRMV8npWpA3qG7V/N6K1zSjfncghCPC9pjDlNnPJoJssRQ==
   dependencies:
     "@ethereumjs/common" "^2.3.1"
     "@ethereumjs/tx" "^3.2.1"
     "@metamask/contract-metadata" "^1.29.0"
     "@types/uuid" "^8.3.0"
+    abort-controller "^3.0.0"
     async-mutex "^0.2.6"
     babel-runtime "^6.26.0"
     eth-ens-namehash "^2.0.8"


### PR DESCRIPTION
Explanation:  @metamask/controllers v15.0.0 introduced the use of the global AbortController. The global AbortController was first introduced in Node 15, so this unintentionally broke support for the extension which only requires Node ^14.15.1. @metmask/controllers v15.0.1 introduces a polyfill for AbortController to restore full compatibility with the extension.

This PR also removes [the workaround](https://github.com/MetaMask/metamask-extension/blob/8a8ce3a0c0095fe99764186b15a0d1e70a03e074/app/scripts/metamask-controller.test.js#L112) we introduced in tests to get around the broken contract.