### PR TITLE
Bump minimum Chrome version to 66

### DIFF
--- a/app/manifest/chrome.json
+++ b/app/manifest/chrome.json
@@ -3,5 +3,5 @@
     "matches": ["https://metamask.io/*"],
     "ids": ["*"]
   },
-  "minimum_chrome_version": "63"
+  "minimum_chrome_version": "66"
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,7 @@ module.exports = function (api) {
         '@babel/preset-env',
         {
           targets: {
-            browsers: ['chrome >= 63', 'firefox >= 68'],
+            browsers: ['chrome >= 66', 'firefox >= 68'],
           },
         },
       ],


### PR DESCRIPTION
This PR updates our minimum supported Chrome version from 63 to 66, so that we may use the `AbortController` browser API without polyfilling it.

Our minimum Firefox version supports the `AbortController`, but our current minimum Chrome version (63, released in December 2017) does not. Chrome shipped the `AbortController` in version 66, in April 2018. We have determined that an extremely small number of users are on Chrome 63 < 66, and that this change is therefore acceptable.