### PR TITLE
Add eth_feeHistory to safe method list

### DIFF
--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -40,6 +40,7 @@ export const SAFE_METHODS = [
   'eth_coinbase',
   'eth_decrypt',
   'eth_estimateGas',
+  'eth_feeHistory',
   'eth_gasPrice',
   'eth_getBalance',
   'eth_getBlockByHash',


### PR DESCRIPTION
[Some background](https://github.com/MetaMask/rpc-cap/issues/148)

We add the name of this new undocumented geth method to the enum of safe methods so that dapps can access it.

You can test this out using [the api playground](https://metamask.github.io/api-playground/api-documentation/#eth_blockNumber) and manually editing the method to have parameters like this:

```json
{
    "jsonrpc": "2.0",
    "method": "eth_feeHistory",
    "params": [
        5,
        "latest",
        [
            10,
            20,
            30
        ]
    ],
    "id": 0
}
```

Those parameters are `blocksBack`, `endBlock`, and `percentiles`. I don't get what the percentiles value does.

The return object has this shape:

```typescript
export interface FeeHistory {
  baseFeePerGas: Array<string>
  gasUsedRatio: Array<number>
  oldestBlock: number
  reward: Array<Array<string>>
}
```

I've manually confirmed this works.