### PR TITLE
Autofilling new issue link with url and domain (Phishing detect page)

### DIFF
--- a/app/phishing.html
+++ b/app/phishing.html
@@ -51,7 +51,7 @@
           <a href="https://github.com/metamask/eth-phishing-detect">Ethereum Phishing Detector</a>.
           Domains on these warning lists may include outright malicious websites and legitimate websites that have been compromised by a malicious actor.
         </p>
-        <p>To read more about this site <a id="csdbLink">please search for the domain on CryptoScamDB</a>.</p>
+        <p>To read more about this site <a id="csdbLink" href="https://cryptoscamdb.org/search">please search for the domain on CryptoScamDB</a>.</p>
         <p>
           Note that this warning list is compiled on a voluntary basis. This list may be inaccurate or incomplete.
           Just because a domain does not appear on this list is not an implicit guarantee of that domain's safety.
@@ -60,7 +60,7 @@
         </p>
         <p>
           If you think this domain is incorrectly flagged or if a blocked legitimate website has resolved its security issues,
-          <a href="https://github.com/metamask/eth-phishing-detect/issues/new">please file an issue</a>.
+          <a id="new-issue-link" href="https://github.com/metamask/eth-phishing-detect/issues/new">please file an issue</a>.
         </p>
       </div>
     </div>

--- a/app/scripts/phishing-detect.js
+++ b/app/scripts/phishing-detect.js
@@ -12,7 +12,12 @@ function start() {
   const hash = window.location.hash.substring(1);
   const suspect = querystring.parse(hash);
 
-  document.getElementById('csdbLink').href = `https://cryptoscamdb.org/search`;
+  const newIssueLink = document.getElementById('new-issue-link');
+  const newIssueUrl = `https://github.com/MetaMask/eth-phishing-detect/issues/new`;
+  const newIssueParams = `?title=[Legitimate%20Site%20Blocked]%20${encodeURIComponent(
+    suspect.hostname,
+  )}&body=${encodeURIComponent(suspect.href)}`;
+  newIssueLink.href = `${newIssueUrl}${newIssueParams}`;
 
   global.platform = new ExtensionPlatform();
 


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11997

Example:
https://github.com/MetaMask/eth-phishing-detect/issues/new?title=[Legitimate%20Site%20Blocked]%20altus.finance&body=https://altus.finance/
<img width="565" alt="Screen Shot 2021-09-01 at 8 52 23 PM" src="https://user-images.githubusercontent.com/8732757/131779255-0109d9eb-816e-43e8-884f-9549e532de8d.png">
