### PR TITLE
Cap resubmit transaction retries to within 50 blocks of first submission

### DIFF
--- a/app/scripts/controllers/transactions/pending-tx-tracker.js
+++ b/app/scripts/controllers/transactions/pending-tx-tracker.js
@@ -136,8 +136,8 @@ export default class PendingTransactionTracker extends EventEmitter {
 
     const retryCount = txMeta.retryCount || 0;
 
-    // Exponential backoff to limit retries at publishing
-    if (txBlockDistance <= Math.pow(2, retryCount) - 1) {
+    // Exponential backoff to limit retries at publishing (capped at ~15 minutes between retries)
+    if (txBlockDistance < Math.min(50, Math.pow(2, retryCount))) {
       return undefined;
     }
 


### PR DESCRIPTION
Explanation:  Currently we do not limit the distance between resubmission attempts when a submitted transaction is not confirmed by the network. This can lead to retries many hours apart when a retry might succeed sooner.