### PR TITLE
tx-list-item - show primaryWarning

### DIFF
--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -64,6 +64,7 @@ export default function TransactionListItem({
     displayedStatusKey,
     isPending,
     senderAddress,
+    primaryWarning,
   } = useTransactionDisplayData(transactionGroup);
 
   const isSignatureReq =
@@ -193,6 +194,7 @@ export default function TransactionListItem({
         }
       >
         <div className="transaction-list-item__pending-actions">
+          {primaryWarning && `⚠ ${primaryWarning.error}`}
           {speedUpButton}
           {cancelButton}
         </div>

--- a/ui/components/app/transaction-list-item/transaction-list-item.stories.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { text } from '@storybook/addon-knobs';
-import TransactionListItem from './token-list-item.component';
+import TransactionListItem from './transaction-list-item.component';
 
 export default {
   title: 'TransactionListItem',
@@ -10,6 +10,38 @@ export default {
 const addressFixture = '0xe206e3DCa498258f1B7EEc1c640B5AEE7BB88Fd0'
 
 // modified from .storybook/test-data.js
+/**
+ * An object representing a transaction, in whatever state it is in.
+ * @typedef {Object} TransactionMeta
+ *
+ * @property {string} [blockNumber] - The block number this transaction was
+ *  included in. Currently only present on incoming transactions!
+ * @property {number} id - An internally unique tx identifier.
+ * @property {number} time - Time the transaction was first suggested, in unix
+ *  epoch time (ms).
+ * @property {TransactionTypeString} type - The type of transaction this txMeta
+ *  represents.
+ * @property {TransactionStatusString} status - The current status of the
+ *  transaction.
+ * @property {string} metamaskNetworkId - The transaction's network ID, used
+ *  for EIP-155 compliance.
+ * @property {boolean} loadingDefaults - TODO: Document
+ * @property {TxParams} txParams - The transaction params as passed to the
+ *  network provider.
+ * @property {Object[]} history - A history of mutations to this
+ *  TransactionMeta object.
+ * @property {string} origin - A string representing the interface that
+ *  suggested the transaction.
+ * @property {Object} nonceDetails - A metadata object containing information
+ *  used to derive the suggested nonce, useful for debugging nonce issues.
+ * @property {string} rawTx - A hex string of the final signed transaction,
+ *  ready to submit to the network.
+ * @property {string} hash - A hex string of the transaction hash, used to
+ *  identify the transaction on the network.
+ * @property {number} [submittedTime] - The time the transaction was submitted to
+ *  the network, in Unix epoch time (ms).
+ * @property {TxError} [err] - The error encountered during the transaction
+ */
 const txFixture = {
   "id": 3111025347726181,
   "time": 1620710815484,
@@ -64,14 +96,17 @@ const txFixture = {
   }
 }
 
-
-// * @property {string} nonce - The nonce that the transactions within this transactionGroup share.
-// * @property {Object[]} transactions - An array of transaction (txMeta) objects.
-// * @property {Object} initialTransaction - The transaction (txMeta) with the lowest "time".
-// * @property {Object} primaryTransaction - Either the latest transaction or the confirmed
-// * transaction.
-// * @property {boolean} hasRetried - True if a transaction in the group was a retry transaction.
-// * @property {boolean} hasCancelled - True if a transaction in the group was a cancel transaction.
+/**
+ * Contains transactions and properties associated with those transactions of the same nonce.
+ * @typedef {Object} transactionGroup
+ * @property {string} nonce - The nonce that the transactions within this transactionGroup share.
+ * @property {Object[]} transactions - An array of transaction (txMeta) objects.
+ * @property {Object} initialTransaction - The transaction (txMeta) with the lowest "time".
+ * @property {Object} primaryTransaction - Either the latest transaction or the confirmed
+ * transaction.
+ * @property {boolean} hasRetried - True if a transaction in the group was a retry transaction.
+ * @property {boolean} hasCancelled - True if a transaction in the group was a cancel transaction.
+*/
 const txGroupFixture = {
   transactions: [
     txFixture,

--- a/ui/components/app/transaction-list-item/transaction-list-item.stories.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.stories.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { text } from '@storybook/addon-knobs';
+import TransactionListItem from './token-list-item.component';
+
+export default {
+  title: 'TransactionListItem',
+};
+
+const addressFixture = '0xe206e3DCa498258f1B7EEc1c640B5AEE7BB88Fd0'
+
+// modified from .storybook/test-data.js
+const txFixture = {
+  "id": 3111025347726181,
+  "time": 1620710815484,
+  "status": "unapproved",
+  "metamaskNetworkId": "3",
+  "chainId": "0x3",
+  "loadingDefaults": false,
+  "txParams": {
+    "from": "0x64a845a5b02460acf8a3d84503b0d68d028b4bb4",
+    "to": "0xaD6D458402F60fD3Bd25163575031ACDce07538D",
+    "value": "0x0",
+    "data": "0xa9059cbb000000000000000000000000b19ac54efa18cc3a14a5b821bfec73d284bf0c5e0000000000000000000000000000000000000000000000003782dace9d900000",
+    "gas": "0xcb28",
+    "gasPrice": "0x77359400"
+  },
+  "type": "standard",
+  "origin": "metamask",
+  "transactionCategory": "transfer",
+  "history": [
+    {
+      "id": 7786962153682822,
+      "time": 1620710815484,
+      "status": "unapproved",
+      "metamaskNetworkId": "3",
+      "chainId": "0x3",
+      "loadingDefaults": true,
+      "txParams": {
+        "from": "0x64a845a5b02460acf8a3d84503b0d68d028b4bb4",
+        "to": "0xaD6D458402F60fD3Bd25163575031ACDce07538D",
+        "value": "0x0",
+        "data": "0xa9059cbb000000000000000000000000b19ac54efa18cc3a14a5b821bfec73d284bf0c5e0000000000000000000000000000000000000000000000003782dace9d900000",
+        "gas": "0xcb28",
+        "gasPrice": "0x77359400"
+      },
+      "type": "standard",
+      "origin": "metamask",
+      "transactionCategory": "transfer"
+    },
+    [
+      {
+        "op": "replace",
+        "path": "/loadingDefaults",
+        "value": false,
+        "note": "Added new unapproved transaction.",
+        "timestamp": 1620710815497
+      }
+    ]
+  ],
+  warning: {
+    error: "[ethjs-query] while formatting outputs from RPC '{\"value\":{\"code\":-32603}}'",
+    message: "There was a problem loading this transaction."
+  }
+}
+
+
+// * @property {string} nonce - The nonce that the transactions within this transactionGroup share.
+// * @property {Object[]} transactions - An array of transaction (txMeta) objects.
+// * @property {Object} initialTransaction - The transaction (txMeta) with the lowest "time".
+// * @property {Object} primaryTransaction - Either the latest transaction or the confirmed
+// * transaction.
+// * @property {boolean} hasRetried - True if a transaction in the group was a retry transaction.
+// * @property {boolean} hasCancelled - True if a transaction in the group was a cancel transaction.
+const txGroupFixture = {
+  transactions: [
+    txFixture,
+  ],
+  initialTransaction: txFixture,
+  primaryTransaction: txFixture,
+  hasRetried: true,
+  hasCancelled: false,
+}
+
+export const warning = () => (
+  <TransactionListItem
+    transactionGroup={txGroupFixture}
+  />
+);

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -74,6 +74,7 @@ export function useTransactionDisplayData(transactionGroup) {
       getKnownMethodData(state, initialTransaction?.txParams?.data),
     ) || {};
 
+  const { warning: primaryWarning } = primaryTransaction
   const displayedStatusKey = getStatusKey(primaryTransaction);
   const isPending = displayedStatusKey in PENDING_STATUS_HASH;
   const isSubmitted = displayedStatusKey === TRANSACTION_STATUSES.SUBMITTED;
@@ -265,5 +266,6 @@ export function useTransactionDisplayData(transactionGroup) {
     displayedStatusKey,
     isPending,
     isSubmitted,
+    primaryWarning,
   };
 }

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -74,7 +74,7 @@ export function useTransactionDisplayData(transactionGroup) {
       getKnownMethodData(state, initialTransaction?.txParams?.data),
     ) || {};
 
-  const { warning: primaryWarning } = primaryTransaction
+  const { warning: primaryWarning } = primaryTransaction;
   const displayedStatusKey = getStatusKey(primaryTransaction);
   const isPending = displayedStatusKey in PENDING_STATUS_HASH;
   const isSubmitted = displayedStatusKey === TRANSACTION_STATUSES.SUBMITTED;

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -38,6 +38,7 @@ const expectedResults = [
     isPending: false,
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
     isSubmitted: false,
+    primaryWarning: undefined,
   },
   {
     title: 'Send',
@@ -51,6 +52,7 @@ const expectedResults = [
     secondaryCurrency: '-2 ETH',
     isPending: false,
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
+    primaryWarning: undefined,
   },
   {
     title: 'Send',
@@ -64,6 +66,7 @@ const expectedResults = [
     secondaryCurrency: '-2 ETH',
     isPending: false,
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
+    primaryWarning: undefined,
   },
   {
     title: 'Receive',
@@ -77,6 +80,7 @@ const expectedResults = [
     secondaryCurrency: '18.75 ETH',
     isPending: false,
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
+    primaryWarning: undefined,
   },
   {
     title: 'Receive',
@@ -90,6 +94,7 @@ const expectedResults = [
     secondaryCurrency: '0 ETH',
     isPending: false,
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
+    primaryWarning: undefined,
   },
   {
     title: 'Receive',
@@ -103,6 +108,7 @@ const expectedResults = [
     secondaryCurrency: '1 ETH',
     isPending: false,
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
+    primaryWarning: undefined,
   },
   {
     title: 'Swap ETH to ABC',
@@ -116,6 +122,7 @@ const expectedResults = [
     secondaryCurrency: undefined,
     isPending: false,
     displayedStatusKey: TRANSACTION_STATUSES.CONFIRMED,
+    primaryWarning: undefined,
   },
 ];
 


### PR DESCRIPTION
Unknown resubmission errors are captured as `txMeta.warning`
this is a sketch of how we could render that warning in the txMeta
