### PR TITLE
Improving warning text for eth_sign

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1958,7 +1958,7 @@
     "message": "Sign"
   },
   "signNotice": {
-    "message": "We are unable to estimate the result of this signature. This signature could potentially perform any operation on your account's behalf, including granting complete control of your account and all of its assets to the requesting site. Only sign this message if you know what you're doing or completely trust the requesting site."
+    "message": "We are unable to predict the result of this signature. This signature could potentially perform any operation on your account's behalf, including granting complete control of your account and all of its assets to the requesting site. Only sign this message if you know what you're doing or completely trust the requesting site."
   },
   "signatureRequest": {
     "message": "Signature Request"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1958,7 +1958,7 @@
     "message": "Sign"
   },
   "signNotice": {
-    "message": "Signing this message can have \ndangerous side effects. Only sign messages from \nsites you fully trust with your entire account.\n This dangerous method will be removed in a future version. "
+    "message": "We are unable to estimate the result of this signature. This signature could potentially perform any operation on your account's behalf, including granting complete control of your account and all of its assets to the requesting site. Only sign this message if you know what you're doing or completely trust the requesting site."
   },
   "signatureRequest": {
     "message": "Signature Request"

--- a/ui/components/app/signature-request-original/index.scss
+++ b/ui/components/app/signature-request-original/index.scss
@@ -182,6 +182,7 @@
 
   &__notice {
     color: $dusty-gray;
+    padding: 0 10px;
   }
 
   &__warning {
@@ -228,6 +229,7 @@
     cursor: pointer;
     text-decoration: underline;
     color: $primary-blue;
+    margin-inline-start: 3px;
   }
 
   &__footer {


### PR DESCRIPTION
Implements the first two steps for: https://github.com/MetaMask/metamask-extension/issues/11337

<img width="363" alt="Screen Shot 2021-09-03 at 11 22 51 AM" src="https://user-images.githubusercontent.com/8732757/132050853-9bdfac14-9e63-4e2f-922b-61ce98187c13.png">
