### PR TITLE
Fix for: Confirmation screen should show local nicknames even when invoking a contract method

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -1,12 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { PageContainerFooter } from '../../ui/page-container';
 import EditGasPopover from '../edit-gas-popover';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
-import { getAddressBookEntry } from '../../../selectors';
-import * as actions from '../../../store/actions';
 import Dialog from '../../ui/dialog';
 import {
   ConfirmPageContainerHeader,
@@ -14,7 +11,7 @@ import {
   ConfirmPageContainerNavigation,
 } from '.';
 
-class ConfirmPageContainer extends Component {
+export default class ConfirmPageContainer extends Component {
   static contextTypes = {
     t: PropTypes.func,
   };
@@ -229,42 +226,3 @@ class ConfirmPageContainer extends Component {
     );
   }
 }
-
-function mapStateToProps(state, ownProps) {
-  const to = ownProps.toAddress;
-
-  const contact = getAddressBookEntry(state, to);
-  return {
-    contact,
-    toName: contact && contact.name ? contact.name : ownProps.toName,
-    to,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    showAddToAddressBookModal: (recipient) =>
-      dispatch(
-        actions.showModal({
-          name: 'ADD_TO_ADDRESSBOOK',
-          recipient,
-        }),
-      ),
-  };
-}
-
-function mergeProps(stateProps, dispatchProps, ownProps) {
-  const { to, ...restStateProps } = stateProps;
-  return {
-    ...ownProps,
-    ...restStateProps,
-    showAddToAddressBookModal: () =>
-      dispatchProps.showAddToAddressBookModal(to),
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps,
-)(ConfirmPageContainer);

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -71,25 +71,6 @@ export default class ConfirmPageContainer extends Component {
     contact: PropTypes.object,
   };
 
-  maybeRenderAddContact() {
-    const { t } = this.context;
-    const { showAddToAddressBookModal, toAddress, contact = {} } = this.props;
-
-    if (contact.name || toAddress === undefined) {
-      return null;
-    }
-
-    return (
-      <Dialog
-        type="message"
-        className="send__dialog"
-        onClick={() => showAddToAddressBookModal()}
-      >
-        {t('newAccountDetectedDialogMessage')}
-      </Dialog>
-    );
-  }
-
   render() {
     const {
       showEdit,
@@ -136,8 +117,13 @@ export default class ConfirmPageContainer extends Component {
       editingGas,
       handleCloseEditGas,
       currentTransaction,
+      showAddToAddressBookModal,
+      contact = {},
     } = this.props;
     const renderAssetImage = contentComponent || !identiconAddress;
+
+    const showAddToAddressDialog =
+      contact.name === undefined && toAddress !== undefined;
 
     return (
       <div className="page-container">
@@ -171,7 +157,17 @@ export default class ConfirmPageContainer extends Component {
             />
           )}
         </ConfirmPageContainerHeader>
-        <div>{this.maybeRenderAddContact()}</div>
+        <div>
+          {showAddToAddressDialog && (
+            <Dialog
+              type="message"
+              className="send__dialog"
+              onClick={() => showAddToAddressBookModal()}
+            >
+              {this.context.t('newAccountDetectedDialogMessage')}
+            </Dialog>
+          )}
+        </div>
         {contentComponent || (
           <ConfirmPageContainerContent
             action={action}

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -9,7 +9,7 @@ function mapStateToProps(state, ownProps) {
   const contact = getAddressBookEntry(state, to);
   return {
     contact,
-    toName: contact && contact.name ? contact.name : ownProps.toName,
+    toName: contact?.name || ownProps.name,
     to,
   };
 }

--- a/ui/components/app/confirm-page-container/confirm-page-container.container.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.container.js
@@ -1,0 +1,43 @@
+import { connect } from 'react-redux';
+import { getAddressBookEntry } from '../../../selectors';
+import * as actions from '../../../store/actions';
+import ConfirmPageContainer from './confirm-page-container.component';
+
+function mapStateToProps(state, ownProps) {
+  const to = ownProps.toAddress;
+
+  const contact = getAddressBookEntry(state, to);
+  return {
+    contact,
+    toName: contact && contact.name ? contact.name : ownProps.toName,
+    to,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    showAddToAddressBookModal: (recipient) =>
+      dispatch(
+        actions.showModal({
+          name: 'ADD_TO_ADDRESSBOOK',
+          recipient,
+        }),
+      ),
+  };
+}
+
+function mergeProps(stateProps, dispatchProps, ownProps) {
+  const { to, ...restStateProps } = stateProps;
+  return {
+    ...ownProps,
+    ...restStateProps,
+    showAddToAddressBookModal: () =>
+      dispatchProps.showAddToAddressBookModal(to),
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+)(ConfirmPageContainer);

--- a/ui/components/app/confirm-page-container/index.js
+++ b/ui/components/app/confirm-page-container/index.js
@@ -1,4 +1,4 @@
-export { default } from './confirm-page-container.component';
+export { default } from './confirm-page-container.container';
 export { default as ConfirmPageContainerHeader } from './confirm-page-container-header';
 export { default as ConfirmDetailRow } from './confirm-detail-row';
 export { default as ConfirmPageContainerNavigation } from './confirm-page-container-navigation';


### PR DESCRIPTION
Fixes: #11148 

Explanation:  

1. Display the new address detected dialog if the contract is not in the address book
2. Use the address book if exists, else use the default.

Manual testing steps:  

1. Go to https://metamask.github.io/test-dapp/
2. Click Deploy Contract - You should see recipient as New Contract
3. After deploying contract successfully, click Deposit - You should see contract address as recipient and a dialog that says add to address book
4. Click the dialog, and  provide a nickname
5. The recipient should now show the Nickname
6. Cancel (or continue the transaction, doesn't matter)
7. Click Deposit Again, the Nickname should now show as sender and the dialog should not show.
  - 
  - 
  - 