### PR TITLE
Adding usage instructions for Ledger Live users to confirmation screen

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1179,6 +1179,18 @@
   "ledgerLiveApp": {
     "message": "Ledger Live App"
   },
+  "ledgerLiveDialogHeader": {
+    "message": "Prior to clicking confirm:"
+  },
+  "ledgerLiveDialogStepOne": {
+    "message": "Enable Use Ledger Live under Settings > Advanced"
+  },
+  "ledgerLiveDialogStepThree": {
+    "message": "Plug in your Ledger device and select the Ethereum app"
+  },
+  "ledgerLiveDialogStepTwo": {
+    "message": "Open and unlock Ledger Live App"
+  },
   "ledgerLocked": {
     "message": "Cannot connect to Ledger device. Please make sure your device is unlocked and Ethereum app is opened."
   },

--- a/ui/components/app/confirm-page-container/confirm-detail-row/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-detail-row/index.scss
@@ -58,4 +58,12 @@
       width: 90px;
     }
   }
+
+  .ledger-live-dialog {
+    font-weight: bold;
+
+    &--step {
+      display: block;
+    }
+  }
 }

--- a/ui/components/app/confirm-page-container/confirm-detail-row/index.scss
+++ b/ui/components/app/confirm-page-container/confirm-detail-row/index.scss
@@ -58,12 +58,4 @@
       width: 90px;
     }
   }
-
-  .ledger-live-dialog {
-    font-weight: bold;
-
-    &--step {
-      display: block;
-    }
-  }
 }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -35,6 +35,7 @@ import TransactionDetailItem from '../../components/app/transaction-detail-item/
 import InfoTooltip from '../../components/ui/info-tooltip/info-tooltip';
 import LoadingHeartBeat from '../../components/ui/loading-heartbeat';
 import GasTiming from '../../components/app/gas-timing/gas-timing.component';
+import Dialog from '../../components/ui/dialog';
 
 import {
   COLORS,
@@ -124,6 +125,7 @@ export default class ConfirmTransactionBase extends Component {
     baseFeePerGas: PropTypes.string,
     isMainnet: PropTypes.bool,
     gasFeeIsCustom: PropTypes.bool,
+    isLedgerAccount: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -303,6 +305,7 @@ export default class ConfirmTransactionBase extends Component {
       maxFeePerGas,
       maxPriorityFeePerGas,
       isMainnet,
+      isLedgerAccount,
     } = this.props;
     const { t } = this.context;
 
@@ -392,6 +395,29 @@ export default class ConfirmTransactionBase extends Component {
               value={customNonceValue || ''}
             />
           </div>
+        </div>
+      </div>
+    ) : null;
+
+    const ledgerInstructionField = isLedgerAccount ? (
+      <div>
+        <div className="confirm-detail-row">
+          <Dialog type="message">
+            <div className="ledger-live-dialog">
+              <span className="ledger-live-dialog--step">
+                {t('ledgerLiveDialogHeader')}
+              </span>
+              <span className="ledger-live-dialog--step">
+                {`- ${t('ledgerLiveDialogStepOne')}`}
+              </span>
+              <span className="ledger-live-dialog--step">
+                {`- ${t('ledgerLiveDialogStepTwo')}`}
+              </span>
+              <span className="ledger-live-dialog--step">
+                {`- ${t('ledgerLiveDialogStepThree')}`}
+              </span>
+            </div>
+          </Dialog>
         </div>
       </div>
     ) : null;
@@ -523,6 +549,7 @@ export default class ConfirmTransactionBase extends Component {
           ]}
         />
         {nonceField}
+        {ledgerInstructionField}
       </div>
     );
   }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -40,6 +40,7 @@ import Dialog from '../../components/ui/dialog';
 import {
   COLORS,
   FONT_STYLE,
+  FONT_WEIGHT,
   TYPOGRAPHY,
 } from '../../helpers/constants/design-system';
 import {
@@ -404,18 +405,38 @@ export default class ConfirmTransactionBase extends Component {
         <div className="confirm-detail-row">
           <Dialog type="message">
             <div className="ledger-live-dialog">
-              <span className="ledger-live-dialog--step">
+              <Typography
+                boxProps={{ margin: 0 }}
+                color={COLORS.PRIMARY3}
+                fontWeight={FONT_WEIGHT.BOLD}
+                variant={TYPOGRAPHY.H7}
+              >
                 {t('ledgerLiveDialogHeader')}
-              </span>
-              <span className="ledger-live-dialog--step">
+              </Typography>
+              <Typography
+                boxProps={{ margin: 0 }}
+                color={COLORS.PRIMARY3}
+                fontWeight={FONT_WEIGHT.BOLD}
+                variant={TYPOGRAPHY.H7}
+              >
                 {`- ${t('ledgerLiveDialogStepOne')}`}
-              </span>
-              <span className="ledger-live-dialog--step">
+              </Typography>
+              <Typography
+                boxProps={{ margin: 0 }}
+                color={COLORS.PRIMARY3}
+                fontWeight={FONT_WEIGHT.BOLD}
+                variant={TYPOGRAPHY.H7}
+              >
                 {`- ${t('ledgerLiveDialogStepTwo')}`}
-              </span>
-              <span className="ledger-live-dialog--step">
+              </Typography>
+              <Typography
+                boxProps={{ margin: 0 }}
+                color={COLORS.PRIMARY3}
+                fontWeight={FONT_WEIGHT.BOLD}
+                variant={TYPOGRAPHY.H7}
+              >
                 {`- ${t('ledgerLiveDialogStepThree')}`}
-              </span>
+              </Typography>
             </div>
           </Dialog>
         </div>

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -127,6 +127,7 @@ export default class ConfirmTransactionBase extends Component {
     isMainnet: PropTypes.bool,
     gasFeeIsCustom: PropTypes.bool,
     isLedgerAccount: PropTypes.bool.isRequired,
+    isFirefox: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -307,6 +308,7 @@ export default class ConfirmTransactionBase extends Component {
       maxPriorityFeePerGas,
       isMainnet,
       isLedgerAccount,
+      isFirefox,
     } = this.props;
     const { t } = this.context;
 
@@ -413,14 +415,16 @@ export default class ConfirmTransactionBase extends Component {
               >
                 {t('ledgerLiveDialogHeader')}
               </Typography>
-              <Typography
-                boxProps={{ margin: 0 }}
-                color={COLORS.PRIMARY3}
-                fontWeight={FONT_WEIGHT.BOLD}
-                variant={TYPOGRAPHY.H7}
-              >
-                {`- ${t('ledgerLiveDialogStepOne')}`}
-              </Typography>
+              {!isFirefox && (
+                <Typography
+                  boxProps={{ margin: 0 }}
+                  color={COLORS.PRIMARY3}
+                  fontWeight={FONT_WEIGHT.BOLD}
+                  variant={TYPOGRAPHY.H7}
+                >
+                  {`- ${t('ledgerLiveDialogStepOne')}`}
+                </Typography>
+              )}
               <Typography
                 boxProps={{ margin: 0 }}
                 color={COLORS.PRIMARY3}

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -29,12 +29,14 @@ import {
   getShouldShowFiat,
   checkNetworkAndAccountSupports1559,
   getPreferences,
+  getAccountType,
 } from '../../selectors';
 import { getMostRecentOverviewPage } from '../../ducks/history/history';
 import {
   transactionMatchesNetwork,
   txParamsAreDappSuggested,
 } from '../../../shared/modules/transaction.utils';
+import { KEYRING_TYPES } from '../../../shared/constants/hardware-wallets';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
 import {
   updateTransactionGasFees,
@@ -161,6 +163,7 @@ const mapStateToProps = (state, ownProps) => {
   const gasFeeIsCustom =
     fullTxData.userFeeLevel === 'custom' ||
     txParamsAreDappSuggested(fullTxData);
+  const isLedgerAccount = getAccountType(state) === KEYRING_TYPES.LEDGER;
 
   return {
     balance,
@@ -208,6 +211,7 @@ const mapStateToProps = (state, ownProps) => {
     maxPriorityFeePerGas: gasEstimationObject.maxPriorityFeePerGas,
     baseFeePerGas: gasEstimationObject.baseFeePerGas,
     gasFeeIsCustom,
+    isLedgerAccount,
   };
 };
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -37,6 +37,8 @@ import {
   txParamsAreDappSuggested,
 } from '../../../shared/modules/transaction.utils';
 import { KEYRING_TYPES } from '../../../shared/constants/hardware-wallets';
+import { getPlatform } from '../../../app/scripts/lib/util';
+import { PLATFORM_FIREFOX } from '../../../shared/constants/app';
 import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
 import {
   updateTransactionGasFees,
@@ -164,6 +166,7 @@ const mapStateToProps = (state, ownProps) => {
     fullTxData.userFeeLevel === 'custom' ||
     txParamsAreDappSuggested(fullTxData);
   const isLedgerAccount = getAccountType(state) === KEYRING_TYPES.LEDGER;
+  const isFirefox = getPlatform() === PLATFORM_FIREFOX;
 
   return {
     balance,
@@ -212,6 +215,7 @@ const mapStateToProps = (state, ownProps) => {
     baseFeePerGas: gasEstimationObject.baseFeePerGas,
     gasFeeIsCustom,
     isLedgerAccount,
+    isFirefox,
   };
 };
 


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/12014

<img width="453" alt="Screen Shot 2021-09-07 at 9 55 38 AM" src="https://user-images.githubusercontent.com/8732757/132384350-97e8f807-3169-4ecc-aa98-d9ad75d37306.png">

