### PR TITLE
fix(locales): bad Turkish translation for rejecting a transaction

### DIFF
--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -322,7 +322,7 @@
     "message": "Gelecekte Bu jetonu hesap seçenekleri menüsünde “Jeton ekle”'ye giderek geri ekleyebilirsiniz."
   },
   "reject": {
-    "message": "Reddetmek"
+    "message": "Reddet"
   },
   "rejected": {
     "message": "Rededildi"


### PR DESCRIPTION
Fixes bad reject button translation. It was translated as 'Reddetmek' whereas it should be 'Reddet'. It seems the previous translator did not check the user interface before translating.

![reddetmek](https://user-images.githubusercontent.com/3106907/132236344-833c3a18-cb6b-4d59-bc2c-04032b9f8deb.png)


I did not thoroughly review the translation, there are possibly other errors. But this specific error was making my eyes bleed as it's blatantly wrong, so I decided to spend 15 mins to fix it.

### Shameless plug

The problem with translation freelancing is that there is no incentive for quality work when it's a one-time gig and people try to complete translations in the smallest possible timeframe to maximize profit by reducing time cost. And it's always hard to verify the quality of translation work by the client as most of the time client does not know the target and/or source language. Traditionally we resort to certified/sworn translators to mitigate this problem.

For a decentralized society, we developed a decentralized solution instead, called [Linguo](https://linguo.kleros.io).

- Translations are priced with reverse auction. So the client gets the best price available on the market.
- Translators leave a deposit, to guarantee quality work.
- Each piece of completed work gets put on hold for a week and is open to review by anyone. Anyone who finds that a piece of translation is not satisfying the quality requirements specified in the contract can challenge it by leaving a deposit. This creates a dispute and Kleros resolves this in a fully decentralized manner. If translator wins, receives the fee for translation task plus challengers deposit; if the challenger wins, the client gets reimbursed and challenger wins the deposit of translator.

As an end result, Linguo has these properties: 
- Client gets the best price and correct translations.
- Translators are incentivized to translate correctly to avoid losing their deposit.
- Challengers are incentivized to review all the translations for potential economic gains.

@danfinlay fyi.