### PR TITLE
Fix padding at bottom of custom network form in popup view

### DIFF
--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -226,7 +226,7 @@
   &__footer {
     display: flex;
     flex-flow: row nowrap;
-    margin: 0.75rem 0;
+    padding: 0.75rem 0;
 
     @media screen and (max-width: 575px) {
       width: 93%;


### PR DESCRIPTION
Fixes: #
https://github.com/MetaMask/metamask-extension/issues/12035

Explanation:  
Custom network form when opened in popup view had no padding at bottom. The PR fixes this issue.  This is how it looks after the fix:

<img width="355" alt="Screenshot 2021-09-08 at 9 07 26 PM" src="https://user-images.githubusercontent.com/2182307/132541595-4f0b6e19-c8e2-4f3f-9c8a-f20ba0b7ef6b.png">

Manual testing steps:  
  - Open metamask in popup view
  - Go to Custom RPC
  - Scroll down to the bottom - there should be a clear padding at bottom

I have read the CLA Document and I hereby sign the CLA