### PR TITLE
A typo in the button name

### DIFF
--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1552,7 +1552,7 @@
     "message": "Новый URL RPC"
   },
   "save": {
-    "message": "«»Сохранить"
+    "message": "Сохранить"
   },
   "saveAsCsvFile": {
     "message": "Сохранить как файл CSV"


### PR DESCRIPTION
Unnecessary quotes in russian locale.

Fixes: Remove quotes.

Explanation: No need to quotes here.

Manual testing steps:  
Switch to Russian language and open network settings in extension.