### PR TITLE
Remove type=number from the max priority fee field.

### DIFF
--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -68,7 +68,6 @@ export default function AdvancedGasControls({
             }}
             value={maxPriorityFee}
             detailText={maxPriorityFeeFiat}
-            numeric
             error={
               gasErrors?.maxPriorityFee
                 ? getGasFormErrorText(gasErrors.maxPriorityFee, t)


### PR DESCRIPTION
Signed-off-by: Akintayo A. Olusegun <akintayo.segun@gmail.com>

Fixes: #11876 

Explanation:  

On the gas override dialog (and really all of the dialogs), type=number is very difficult to interact with as a user.

One major glaring issue is that you can't delete the 0 by hitting the delete key. This results in people typing in 010.

Manual testing steps:  
  - 
  - 
  - 