### PR TITLE
Fix e2e to not check for X when running locally

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -84,7 +84,10 @@ async function withFixtures(options, testSuite) {
       });
       await segmentServer.start(9090);
     }
-    if (process.env.SELENIUM_BROWSER === 'chrome') {
+    if (
+      process.env.SELENIUM_BROWSER === 'chrome' &&
+      process.env.CI === 'true'
+    ) {
       await ensureXServerIsRunning();
     }
     const { driver } = await buildWebDriver(driverOptions);


### PR DESCRIPTION
The X server check was only added to make Chrome tests run successfully
on CI.