### PR TITLE
Use the same wording during onboard for importing a wallet, secret recovery phrase, and remove the term vault

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1054,7 +1054,7 @@
     "message": " Imported accounts will not be associated with your originally created MetaMask account Secret Recovery Phrase. Learn more about imported accounts "
   },
   "importAccountSeedPhrase": {
-    "message": "Import an account with Secret Recovery Phrase"
+    "message": "Import a wallet with Secret Recovery Phrase"
   },
   "importAccountText": {
     "message": "or $1",
@@ -1794,7 +1794,7 @@
     "message": "WARNING: Never disclose your Secret Recovery Phrase. Anyone with this phrase can take your Ether forever."
   },
   "secretPhrase": {
-    "message": "Enter your secret phrase here to restore your vault."
+    "message": "Only the first account on this wallet will auto load. After completing this process, to add additional accounts, click the drop down menu, then select Create Account."
   },
   "secureWallet": {
     "message": "Secure Wallet"


### PR DESCRIPTION
Fixes: #12028 

Explanation:  
We currently use different words for the same thing when importing an existing secret recovery phrase.
Currently says "Import an account with Secret Recovery Phrase" "Enter your secret phrase here to restore your vault". The words used are slightly different (we are using both account / wallet, and import / restore) and also mentioning a vault is very technical and unnecessary.

Change it to:
Import a wallet with Secret Recovery Phrase

Only the first account on this wallet will auto load. After completing this process, to add additional accounts, click the drop down menu, then select Create Account.

Manual testing steps:  
see #12028 
  - 
  - 
  - 