### PR TITLE
Fix for 12024: wallet_watchAsset called multiple times shows a popup of all assets, but only adds the first one.

### DIFF
--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -62,27 +62,22 @@ export default class ConfirmAddSuggestedToken extends Component {
     const reusesName = this.checkNameReuse(pendingTokens, tokens);
 
     const addTokens = async () => {
-      const tokenEntries = Object.entries(pendingTokens);
-      for (const tokenEntry of tokenEntries) {
-        const [, token] = tokenEntry;
-        await addToken(token);
-      }
-
-      removeSuggestedTokens()
-        .then(() => {
-          this.context.trackEvent({
-            event: 'Token Added',
-            category: 'Wallet',
-            sensitiveProperties: {
-              token_symbol: pendingToken.symbol,
-              token_contract_address: pendingToken.address,
-              token_decimal_precision: pendingToken.decimals,
-              unlisted: pendingToken.unlisted,
-              source: 'dapp',
-            },
-          });
-        })
-        .then(() => history.push(mostRecentOverviewPage));
+      await Promise.all(
+        Object.values(pendingTokens).map((token) => addToken(token)),
+      );
+      await removeSuggestedTokens();
+      this.context.trackEvent({
+        event: 'Token Added',
+        category: 'Wallet',
+        sensitiveProperties: {
+          token_symbol: pendingToken.symbol,
+          token_contract_address: pendingToken.address,
+          token_decimal_precision: pendingToken.decimals,
+          unlisted: pendingToken.unlisted,
+          source: 'dapp',
+        },
+      });
+      history.push(mostRecentOverviewPage);
     };
 
     return (

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -63,27 +63,27 @@ export default class ConfirmAddSuggestedToken extends Component {
 
     const addTokens = async () => {
       const tokenEntries = Object.entries(pendingTokens);
-      for(let tokenEntry of tokenEntries) {
-        const [key, token] = tokenEntry;
+      for (const tokenEntry of tokenEntries) {
+        const [, token] = tokenEntry;
         await addToken(token);
       }
 
       removeSuggestedTokens()
-      .then(() => {
-        this.context.trackEvent({
-          event: 'Token Added',
-          category: 'Wallet',
-          sensitiveProperties: {
-            token_symbol: pendingToken.symbol,
-            token_contract_address: pendingToken.address,
-            token_decimal_precision: pendingToken.decimals,
-            unlisted: pendingToken.unlisted,
-            source: 'dapp',
-          },
-        });
-      })
-      .then(() => history.push(mostRecentOverviewPage));      
-    }
+        .then(() => {
+          this.context.trackEvent({
+            event: 'Token Added',
+            category: 'Wallet',
+            sensitiveProperties: {
+              token_symbol: pendingToken.symbol,
+              token_contract_address: pendingToken.address,
+              token_decimal_precision: pendingToken.decimals,
+              unlisted: pendingToken.unlisted,
+              source: 'dapp',
+            },
+          });
+        })
+        .then(() => history.push(mostRecentOverviewPage));
+    };
 
     return (
       <div className="page-container">

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.component.js
@@ -61,6 +61,30 @@ export default class ConfirmAddSuggestedToken extends Component {
     const hasTokenDuplicates = this.checkTokenDuplicates(pendingTokens, tokens);
     const reusesName = this.checkNameReuse(pendingTokens, tokens);
 
+    const addTokens = async () => {
+      const tokenEntries = Object.entries(pendingTokens);
+      for(let tokenEntry of tokenEntries) {
+        const [key, token] = tokenEntry;
+        await addToken(token);
+      }
+
+      removeSuggestedTokens()
+      .then(() => {
+        this.context.trackEvent({
+          event: 'Token Added',
+          category: 'Wallet',
+          sensitiveProperties: {
+            token_symbol: pendingToken.symbol,
+            token_contract_address: pendingToken.address,
+            token_decimal_precision: pendingToken.decimals,
+            unlisted: pendingToken.unlisted,
+            source: 'dapp',
+          },
+        });
+      })
+      .then(() => history.push(mostRecentOverviewPage));      
+    }
+
     return (
       <div className="page-container">
         <div className="page-container__header">
@@ -137,24 +161,7 @@ export default class ConfirmAddSuggestedToken extends Component {
               large
               className="page-container__footer-button"
               disabled={pendingTokens.length === 0}
-              onClick={() => {
-                addToken(pendingToken)
-                  .then(() => removeSuggestedTokens())
-                  .then(() => {
-                    this.context.trackEvent({
-                      event: 'Token Added',
-                      category: 'Wallet',
-                      sensitiveProperties: {
-                        token_symbol: pendingToken.symbol,
-                        token_contract_address: pendingToken.address,
-                        token_decimal_precision: pendingToken.decimals,
-                        unlisted: pendingToken.unlisted,
-                        source: 'dapp',
-                      },
-                    });
-                  })
-                  .then(() => history.push(mostRecentOverviewPage));
-              }}
+              onClick={() => addTokens()}
             >
               {this.context.t('addToken')}
             </Button>


### PR DESCRIPTION
Fixes: #12024 

Explanation:  

Calling wallet_watchAsset multiple times (almost one after the another) shows the "Add suggested token" popup in Metamask with all the suggested assets (which is ok), but after the user approves the modal, only the first one is added to the wallet. All of the rest are ignored.

Manual testing steps:  

Here's a [fiddle](https://jsfiddle.net/q4uxma2L/) to reproduce it (you need to be connected first with Metamask)

you can also check full description on #12024 


  - 
  - 
  - 