### PR TITLE
Truncate long network names

### DIFF
--- a/ui/components/app/app-header/index.scss
+++ b/ui/components/app/app-header/index.scss
@@ -72,6 +72,7 @@
     flex-direction: row;
     align-items: center;
     flex: 0 0 auto;
+    margin-right: 1rem;
 
     &--clickable {
       cursor: pointer;

--- a/ui/components/app/network-display/index.scss
+++ b/ui/components/app/network-display/index.scss
@@ -35,6 +35,11 @@
     background-color: lighten($dodger-blue, 35%);
   }
 
+  &.chip {
+    margin: 0;
+    max-width: 100%;
+  }
+
   & .chip__label {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/ui/css/itcss/components/network.scss
+++ b/ui/css/itcss/components/network.scss
@@ -73,9 +73,6 @@
 .network-name-item {
   flex: 1;
   color: $dusty-gray;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
 }
 
 .network-check,

--- a/ui/css/itcss/components/network.scss
+++ b/ui/css/itcss/components/network.scss
@@ -73,6 +73,9 @@
 .network-name-item {
   flex: 1;
   color: $dusty-gray;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .network-check,


### PR DESCRIPTION
In some languages, network names are longer than the visible width of
the network dropdown. In these cases, the currently selected network will
overflow the bounds of the network dropdown container.

This commit addresses this issue so that the dropdown
container will grow and shrink appropriately, truncating the currently
selected network if needed.

Fixes: #10544

## Before

<img width="391" alt="Screen Shot 2021-09-09 at 4 16 59 PM" src="https://user-images.githubusercontent.com/7371/132769867-25d40814-5671-4043-b4a6-b6c5ddd35e87.png">

## After

https://user-images.githubusercontent.com/7371/132901182-7b00994e-b888-41df-bdb5-6833206a729e.mov