### PR TITLE
Hook up shared TokenRatesController

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -529,8 +529,7 @@ export default class SwapsController {
   }
 
   async _findTopQuoteAndCalculateSavings(quotes = {}) {
-    const tokenConversionRates = this.tokenRatesStore.getState()
-      .contractExchangeRates;
+    const tokenConversionRates = this.tokenRatesStore.contractExchangeRates;
     const {
       swapsState: { customGasPrice, customMaxPriorityFeePerGas },
     } = this.store.getState();

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import { ethers } from 'ethers';
 import { mapValues } from 'lodash';
 import BigNumber from 'bignumber.js';
-import { ObservableStore } from '@metamask/obs-store';
 import {
   ROPSTEN_NETWORK_ID,
   MAINNET_NETWORK_ID,
@@ -83,12 +82,12 @@ const MOCK_FETCH_METADATA = {
   chainId: MAINNET_CHAIN_ID,
 };
 
-const MOCK_TOKEN_RATES_STORE = new ObservableStore({
+const MOCK_TOKEN_RATES_STORE = {
   contractExchangeRates: {
     '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': 2,
     '0x1111111111111111111111111111111111111111': 0.1,
   },
-});
+};
 
 const MOCK_GET_PROVIDER_CONFIG = () => ({ type: 'FAKE_NETWORK' });
 
@@ -822,9 +821,9 @@ describe('SwapsController', function () {
           .stub(swapsController, '_getERC20Allowance')
           .resolves(ethers.BigNumber.from(1));
 
-        swapsController.tokenRatesStore.updateState({
+        swapsController.tokenRatesStore = {
           contractExchangeRates: {},
-        });
+        };
         const [newQuotes, topAggId] = await swapsController.fetchAndSetQuotes(
           MOCK_FETCH_PARAMS,
           MOCK_FETCH_METADATA,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -22,6 +22,7 @@ import {
   getMaximumGasTotalInHexWei,
   getMinimumGasTotalInHexWei,
 } from '../../shared/modules/gas.utils';
+import { isEqualCaseInsensitive } from '../helpers/utils/util';
 import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import { getCurrentChainId, deprecatedGetCurrentNetworkId } from './selectors';
 import { checkNetworkAndAccountSupports1559 } from '.';
@@ -222,7 +223,12 @@ export const sendTokenTokenAmountAndToAddressSelector = createSelector(
 export const contractExchangeRateSelector = createSelector(
   contractExchangeRatesSelector,
   tokenAddressSelector,
-  (contractExchangeRates, tokenAddress) => contractExchangeRates[tokenAddress],
+  (contractExchangeRates, tokenAddress) =>
+    contractExchangeRates[
+      Object.keys(contractExchangeRates).find((address) =>
+        isEqualCaseInsensitive(address, tokenAddress),
+      )
+    ],
 );
 
 export const transactionFeeSelector = function (state, txData) {


### PR DESCRIPTION
Explanation:  Enables token fiat conversion rates (for network/token pairs that are supported by coingecko api). Cu

Manual testing steps:  
  - In settings, enable `show fiat on testnets`
  - Go to Binance Smart Chain and import a token (like [Binance-Peg Ethereum Token](https://bscscan.com/token/0x2170ed0880ac9a755fd29b2688956bd959f933f8)).
  - You should see a fiat conversion for this token (you may need a balance to fully confirm)
  - Verify that token rate conversions are up and accurate on Mainnet
  - The API is still limited in the native currencies that it supports to get conversion rates against so it will require a change on the tokenRatesController to get broader support - [currently working on it here](https://github.com/MetaMask/controllers/pull/585)