### PR TITLE
change anonymous id to quotation marks

### DIFF
--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -110,7 +110,9 @@
  *  the page view
  */
 
-export const METAMETRICS_ANONYMOUS_ID = '0x0000000000000000';
+// An empty string "" is a, currently undocumented, way of telling mixpanel
+// that these events are meant to be anonymous and not identified to any user
+export const METAMETRICS_ANONYMOUS_ID = '""';
 
 /**
  * This object is used to identify events that are triggered by the background


### PR DESCRIPTION
Fixes: #11583 

Mixpanel has an undocumented feature that treats the value `""` as a truly anonymous id. Our previous approach was anonymous for us but was being aggregated into a single user in Mixpanel and caused our dashboards to crash because it attempted to keep those events in a single cluster instead of allowing them to flow across many like normal events.

This change aligns with Mixpanel's request for us to stop doing this, and also helps our team to not have to work around this issue in Mixpanel reporting.

remaining items:
- [x] Check in development segment instance if this is curried through the system to mixpanel appropriately!
- [ ] Not required for this to merge: work with mixpanel to migrate all instances of the old anonymous id to the new one. 
