### PR TITLE
Scroll all inputs into view when clicking Advanced options in gas edit modal

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useLayoutEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -70,6 +70,8 @@ export default function EditGasDisplay({
   txParamsHaveBeenCustomized,
 }) {
   const t = useContext(I18nContext);
+  const scrollRef = useRef(null);
+
   const isMainnet = useSelector(getIsMainnet);
   const networkAndAccountSupport1559 = useSelector(
     checkNetworkAndAccountSupports1559,
@@ -86,6 +88,12 @@ export default function EditGasDisplay({
   const [hideRadioButtons, setHideRadioButtons] = useState(
     showAdvancedInlineGasIfPossible,
   );
+
+  useLayoutEffect(() => {
+    if (showAdvancedForm && scrollRef.current) {
+      scrollRef.current.scrollIntoView();
+    }
+  }, [showAdvancedForm]);
 
   const dappSuggestedAndTxParamGasFeesAreTheSame = areDappSuggestedAndTxParamGasFeesTheSame(
     transaction,
@@ -285,6 +293,7 @@ export default function EditGasDisplay({
             </button>
           </div>
         )}
+      <div ref={scrollRef} className="edit-gas-display__scroll-bottom" />
     </div>
   );
 }

--- a/ui/components/app/edit-gas-display/index.scss
+++ b/ui/components/app/edit-gas-display/index.scss
@@ -67,4 +67,9 @@
     position: relative;
     margin-top: 4px;
   }
+
+  &__scroll-bottom {
+    margin-bottom: -20px;
+    margin-top: 20px;
+  }
 }


### PR DESCRIPTION
Fixes: #12088, #12049 

Explanation:  Advance gas editing screen had a UX issue, as user clicks "Advanced Options" out of 3 numeric inputs only one "Gas Limit" was visible to use. Gas limit input is focused by default and thus even if user uses arrow keys it does not scroll down to show other inputs but only changes value in numeric input for gas limit. Thus users are missing other 2 inputs for "Max Priority Fee" and "Max Fee". 

PR fixes the issue by scrolling popup content to bottom when user clicks "Advanced Options".

Manual testing steps:  
  - Go to advance gas editing screen and click "Advanced Options"
  - Advance options open screen should be scrolled to bottom with all 3 inputs visible

Recording after changes: https://www.loom.com/share/f8b12c2891ed4885b33f6d18d1caf89f