### PR TITLE
limit x server check to CI

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -40,7 +40,10 @@ describe('MetaMask', function () {
       dappServer.on('listening', resolve);
       dappServer.on('error', reject);
     });
-    if (process.env.SELENIUM_BROWSER === 'chrome') {
+    if (
+      process.env.SELENIUM_BROWSER === 'chrome' &&
+      process.env.CI === 'true'
+    ) {
       await ensureXServerIsRunning();
     }
     const result = await buildWebDriver();


### PR DESCRIPTION
Related: #12043

Explanation:  Allows you to run `metamask-ui.spec.js` e2e tests locally using Chrome