### PR TITLE
Add target object word to "View on Etherscan" links

### DIFF
--- a/app/_locales/am/messages.json
+++ b/app/_locales/am/messages.json
@@ -1124,15 +1124,6 @@
   "viewContact": {
     "message": "ዕውቂያን ይመልከቱ"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "በ $1ይመልከቱ"
-  },
-  "viewOnEtherscan": {
-    "message": "በ Etherscan ላይ ይመልከቱ"
-  },
-  "viewinExplorer": {
-    "message": "በኤክስፕሎረር ተመልከት"
-  },
   "visitWebSite": {
     "message": "ድረ ገጻችንን ይጎብኙ"
   },

--- a/app/_locales/ar/messages.json
+++ b/app/_locales/ar/messages.json
@@ -1120,15 +1120,6 @@
   "viewContact": {
     "message": "عرض جهة الاتصال"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "عرض في $1"
-  },
-  "viewOnEtherscan": {
-    "message": "عرضه على Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "عرض في متصفح Explorer"
-  },
   "visitWebSite": {
     "message": "قم بزيارة موقعنا على الإنترنت"
   },

--- a/app/_locales/bg/messages.json
+++ b/app/_locales/bg/messages.json
@@ -1123,15 +1123,6 @@
   "viewContact": {
     "message": "Преглед на контакта"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Преглед на $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Преглед на Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Преглед в Explorer"
-  },
   "visitWebSite": {
     "message": "Посетете нашият уеб сайт"
   },

--- a/app/_locales/bn/messages.json
+++ b/app/_locales/bn/messages.json
@@ -1127,15 +1127,6 @@
   "viewContact": {
     "message": "পরিচিতি দেখুন"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "$1 এ দেখুন"
-  },
-  "viewOnEtherscan": {
-    "message": "Etherscan দেখুন"
-  },
-  "viewinExplorer": {
-    "message": "এক্সপ্লোরারে দেখুন"
-  },
   "visitWebSite": {
     "message": "আমাদের ওয়েবসাইট দেখুন"
   },

--- a/app/_locales/ca/messages.json
+++ b/app/_locales/ca/messages.json
@@ -1096,15 +1096,6 @@
   "viewContact": {
     "message": "Veure Contacte"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Mostra a $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Veure a Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Mostra a Explorer"
-  },
   "visitWebSite": {
     "message": "Visita el nostre lloc web"
   },

--- a/app/_locales/da/messages.json
+++ b/app/_locales/da/messages.json
@@ -1096,15 +1096,6 @@
   "viewContact": {
     "message": "Vis kontakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Se på $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Se på Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Vis i stifinder"
-  },
   "visitWebSite": {
     "message": "Besøg vores webside"
   },

--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -1087,15 +1087,6 @@
   "viewContact": {
     "message": "Kontakt anzeigen"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Für $1 ansehen"
-  },
-  "viewOnEtherscan": {
-    "message": "Auf Etherscan ansehen"
-  },
-  "viewinExplorer": {
-    "message": "Im Explorer anzeigen"
-  },
   "visitWebSite": {
     "message": "Gehe zu unserer Webseite"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -1121,15 +1121,6 @@
   "viewContact": {
     "message": "Εμφάνιση Επαφής"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Προβολή σε $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Προβολή στο Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Προβολή στον Εξερευνητή"
-  },
   "visitWebSite": {
     "message": "Επισκεφθείτε τον ιστότοπό μας"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -262,7 +262,7 @@
   "blockExplorerAccountAction": {
     "message": "Account"
   },
-  "blockExplorerAseetAction": {
+  "blockExplorerAssetAction": {
     "message": "Asset"
   },
   "blockExplorerSwapAction": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2781,13 +2781,16 @@
     "message": "View More"
   },
   "viewOnCustomBlockExplorer": {
-    "message": "View $1 at $2"
+    "message": "View $1 at $2",
+    "description": "$1 is the action type. e.g (Account, Transaction, Swap) and $2 is the Custom Block Exporer URL"
   },
   "viewOnEtherscan": {
-    "message": "View $1 on Etherscan"
+    "message": "View $1 on Etherscan",
+    "description": "$1 is the action type. e.g (Account, Transaction, Swap)"
   },
   "viewinExplorer": {
-    "message": "View $1 in Explorer"
+    "message": "View $1 in Explorer",
+    "description": "$1 is the action type. e.g (Account, Transaction, Swap)"
   },
   "visitWebSite": {
     "message": "Visit our web site"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -260,16 +260,20 @@
     "message": "Welcome to MetaMask Beta"
   },
   "blockExplorerAccountAction": {
-    "message": "Account"
+    "message": "Account",
+    "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Account in Explorer"
   },
   "blockExplorerAssetAction": {
-    "message": "Asset"
+    "message": "Asset",
+    "description": "This is used with viewOnEtherscan and viewInExplorer e.g View Asset in Explorer"
   },
   "blockExplorerSwapAction": {
-    "message": "Swap"
+    "message": "Swap",
+    "description": "This is used with viewOnEtherscan e.g View Swap on Etherscan"
   },
   "blockExplorerTransactionAction": {
-    "message": "Transaction"
+    "message": "Transaction",
+    "description": "This is used with viewOnCustomBlockExplorer and viewOnEtherscan e.g View Transaction on Etherscan"
   },
   "blockExplorerUrl": {
     "message": "Block Explorer URL"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2781,13 +2781,13 @@
     "message": "View More"
   },
   "viewOnCustomBlockExplorer": {
-    "message": "View at $1"
+    "message": "View $1 at $2"
   },
   "viewOnEtherscan": {
-    "message": "View on Etherscan"
+    "message": "View $1 on Etherscan"
   },
   "viewinExplorer": {
-    "message": "View in Explorer"
+    "message": "View $1 in Explorer"
   },
   "visitWebSite": {
     "message": "Visit our web site"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -259,6 +259,18 @@
   "betaWelcome": {
     "message": "Welcome to MetaMask Beta"
   },
+  "blockExplorerAccountAction": {
+    "message": "Account"
+  },
+  "blockExplorerAseetAction": {
+    "message": "Asset"
+  },
+  "blockExplorerSwapAction": {
+    "message": "Swap"
+  },
+  "blockExplorerTransactionAction": {
+    "message": "Transaction"
+  },
   "blockExplorerUrl": {
     "message": "Block Explorer URL"
   },
@@ -2792,18 +2804,6 @@
     "message": "View $1 in Explorer",
     "description": "$1 is the action type. e.g (Account, Transaction, Swap)"
   },
-  "blockExplorerSwapAction": {
-    "message": "Swap"
-  },
-  "blockExplorerAccountAction": {
-    "message": "Account"
-  },  
-  "blockExplorerTransactionAction": {
-    "message": "Transaction"
-  },    
-  "blockExplorerAseetAction": {
-    "message": "Asset"
-  },    
   "visitWebSite": {
     "message": "Visit our web site"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2792,6 +2792,18 @@
     "message": "View $1 in Explorer",
     "description": "$1 is the action type. e.g (Account, Transaction, Swap)"
   },
+  "blockExplorerSwapAction": {
+    "message": "Swap"
+  },
+  "blockExplorerAccountAction": {
+    "message": "Account"
+  },  
+  "blockExplorerTransactionAction": {
+    "message": "Transaction"
+  },    
+  "blockExplorerAseetAction": {
+    "message": "Asset"
+  },    
   "visitWebSite": {
     "message": "Visit our web site"
   },

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "Ver más"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Ver en $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Ver en Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Ver en el explorador"
-  },
   "visitWebSite": {
     "message": "Visite nuestro sitio web"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "Ver más"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Ver en $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Ver en Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Ver en el explorador"
-  },
   "visitWebSite": {
     "message": "Visite nuestro sitio web"
   },

--- a/app/_locales/et/messages.json
+++ b/app/_locales/et/messages.json
@@ -1117,15 +1117,6 @@
   "viewContact": {
     "message": "Kuva kontakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Vaata $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Kuva Etherscanil"
-  },
-  "viewinExplorer": {
-    "message": "Kuva Exploreris"
-  },
   "visitWebSite": {
     "message": "Külastage meie veebilehte"
   },

--- a/app/_locales/fa/messages.json
+++ b/app/_locales/fa/messages.json
@@ -1127,15 +1127,6 @@
   "viewContact": {
     "message": "مشاهده تماس"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "مشاهده در 1$1"
-  },
-  "viewOnEtherscan": {
-    "message": "مشاهده در ایترسکن"
-  },
-  "viewinExplorer": {
-    "message": "مشاهده در براوزر"
-  },
   "visitWebSite": {
     "message": "از وب سایت ما دیدن نمایید"
   },

--- a/app/_locales/fi/messages.json
+++ b/app/_locales/fi/messages.json
@@ -1124,15 +1124,6 @@
   "viewContact": {
     "message": "Näytä yhteyshenkilö"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Tarkastele kohdassa $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Näytä Etherscanissa"
-  },
-  "viewinExplorer": {
-    "message": "Tarkastele Explorerissa"
-  },
   "visitWebSite": {
     "message": "Vieraile verkkosivustollamme"
   },

--- a/app/_locales/fil/messages.json
+++ b/app/_locales/fil/messages.json
@@ -1021,15 +1021,6 @@
   "viewContact": {
     "message": "Tingnan ang Contact"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Tingnan sa $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Tingnan sa Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Tingnan sa Explorer"
-  },
   "visitWebSite": {
     "message": "Bisitahin ang aming web site"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -1103,15 +1103,6 @@
   "viewContact": {
     "message": "Voir contact"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Afficher sur $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Voir sur Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Afficher dans Explorer"
-  },
   "visitWebSite": {
     "message": "Visitez notre site web"
   },

--- a/app/_locales/he/messages.json
+++ b/app/_locales/he/messages.json
@@ -1121,15 +1121,6 @@
   "viewContact": {
     "message": "הצג איש קשר"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "הצג ב- $1"
-  },
-  "viewOnEtherscan": {
-    "message": "הצג ב-Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "הצג באקספלורר"
-  },
   "visitWebSite": {
     "message": "בקר/י באתר שלנו"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "और देखें"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "$1 पर देखें"
-  },
-  "viewOnEtherscan": {
-    "message": "Etherscan पर देखें"
-  },
-  "viewinExplorer": {
-    "message": "एक्सप्लोरर में देखें"
-  },
   "visitWebSite": {
     "message": "हमारी वेबसाइट पर जाएँ"
   },

--- a/app/_locales/hr/messages.json
+++ b/app/_locales/hr/messages.json
@@ -1117,15 +1117,6 @@
   "viewContact": {
     "message": "Prikaži kontakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Prikaži u $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Prikaži na Etherscanu"
-  },
-  "viewinExplorer": {
-    "message": "Prikaži u Exploreru"
-  },
   "visitWebSite": {
     "message": "Posjetite naše mrežno mjesto"
   },

--- a/app/_locales/ht/messages.json
+++ b/app/_locales/ht/messages.json
@@ -688,9 +688,6 @@
   "viewAccount": {
     "message": "Wè Kont"
   },
-  "viewOnEtherscan": {
-    "message": "Wè sou Etherscan"
-  },
   "visitWebSite": {
     "message": "Vizite sit entènèt nou an"
   },

--- a/app/_locales/hu/messages.json
+++ b/app/_locales/hu/messages.json
@@ -1117,15 +1117,6 @@
   "viewContact": {
     "message": "Névjegy megtekintése"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Megtekintés $1-kor"
-  },
-  "viewOnEtherscan": {
-    "message": "Nézze meg Etherscanen"
-  },
-  "viewinExplorer": {
-    "message": "Megtekintés Explorerben"
-  },
   "visitWebSite": {
     "message": "Látogass el weboldalunkra"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "Lihat Selengkapnya"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Lihat di $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Lihat di Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Lihat di Explorer"
-  },
   "visitWebSite": {
     "message": "Kunjungi situs web kami"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1947,15 +1947,6 @@
   "viewContact": {
     "message": "Visualizza contatto"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Vedi su $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Vedi su Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Vista in Explorer"
-  },
   "visitWebSite": {
     "message": "Visita il nostro sito web"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "詳細を表示"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "$1 に表示"
-  },
-  "viewOnEtherscan": {
-    "message": "Etherscan で表示"
-  },
-  "viewinExplorer": {
-    "message": "Explorer で表示"
-  },
   "visitWebSite": {
     "message": "当社の Web サイトにアクセス"
   },

--- a/app/_locales/kn/messages.json
+++ b/app/_locales/kn/messages.json
@@ -1127,15 +1127,6 @@
   "viewContact": {
     "message": "ಸಂಪರ್ಕವನ್ನು ವೀಕ್ಷಿಸಿ"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "$1 ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ"
-  },
-  "viewOnEtherscan": {
-    "message": "ಎಥೆರ್‌ಸ್ಕ್ಯಾನ್‌ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ"
-  },
-  "viewinExplorer": {
-    "message": "ಎಕ್ಸ್‌ಪ್ಲೋರರ್‌ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ"
-  },
   "visitWebSite": {
     "message": "ನಮ್ಮ ವೆಬ್ ಸೈಟ್ ಅನ್ನು ಭೇಟಿ ಮಾಡಿ"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "더 보기"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "$1에서 보기"
-  },
-  "viewOnEtherscan": {
-    "message": "Etherscan에서 보기"
-  },
-  "viewinExplorer": {
-    "message": "탐색기에서 보기"
-  },
   "visitWebSite": {
     "message": "당사 웹사이트 방문하기"
   },

--- a/app/_locales/lt/messages.json
+++ b/app/_locales/lt/messages.json
@@ -1127,15 +1127,6 @@
   "viewContact": {
     "message": "Peržiūrėti kontaktą"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Peržiūrėti $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Peržiūrėti „Etherscan“"
-  },
-  "viewinExplorer": {
-    "message": "Peržiūrėti naršyklėje"
-  },
   "visitWebSite": {
     "message": "Apsilankykite mūsų svetainėje"
   },

--- a/app/_locales/lv/messages.json
+++ b/app/_locales/lv/messages.json
@@ -1123,15 +1123,6 @@
   "viewContact": {
     "message": "Skatīt līgumu"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Skatīt $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Skatīt Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Skatīt Explorer"
-  },
   "visitWebSite": {
     "message": "Apmeklējiet mūsu tīmekļa vietni"
   },

--- a/app/_locales/ms/messages.json
+++ b/app/_locales/ms/messages.json
@@ -1101,15 +1101,6 @@
   "viewContact": {
     "message": "Lihat Kenalan"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Lihat pada $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Lihat di Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Lihat di Explorer"
-  },
   "visitWebSite": {
     "message": "Kunjungi laman web kami"
   },

--- a/app/_locales/no/messages.json
+++ b/app/_locales/no/messages.json
@@ -1102,15 +1102,6 @@
   "viewContact": {
     "message": "Se kontrakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Vis ved $1 "
-  },
-  "viewOnEtherscan": {
-    "message": "Vis på Etherscan "
-  },
-  "viewinExplorer": {
-    "message": "Se i Explorer"
-  },
   "visitWebSite": {
     "message": "Besøk nettsiden vår "
   },

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "Tumingin Pa"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Tingnan sa $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Tingnan sa Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Tingnan sa Explorer"
-  },
   "visitWebSite": {
     "message": "Bisitahin ang aming website"
   },

--- a/app/_locales/pl/messages.json
+++ b/app/_locales/pl/messages.json
@@ -1115,15 +1115,6 @@
   "viewContact": {
     "message": "Wyświetl kontakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Wyświetl w $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Zobacz na Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Wyświetl w przeglądarce"
-  },
   "visitWebSite": {
     "message": "Odwiedź naszą stronę"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "Exibir Mais"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Exibir em $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Exibir no Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Exibir no Explorer"
-  },
   "visitWebSite": {
     "message": "Visite nosso website"
   },

--- a/app/_locales/ro/messages.json
+++ b/app/_locales/ro/messages.json
@@ -1108,15 +1108,6 @@
   "viewContact": {
     "message": "Vizualizare contact"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Vizualizați la $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Vizualizați pe Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Vizualizare în Explorator"
-  },
   "visitWebSite": {
     "message": "Accesați site-ul nostru"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "Посмотреть больше"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Посмотреть на $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Посмотреть на Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Проводник в проводнике"
-  },
   "visitWebSite": {
     "message": "Посетите наш веб-сайт"
   },

--- a/app/_locales/sk/messages.json
+++ b/app/_locales/sk/messages.json
@@ -1084,15 +1084,6 @@
   "viewContact": {
     "message": "Zobraziť kontakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Zobraziť na $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Zobraziť na Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Zobraziť v Exploreri"
-  },
   "visitWebSite": {
     "message": "Navštivte naši stránku"
   },

--- a/app/_locales/sl/messages.json
+++ b/app/_locales/sl/messages.json
@@ -1112,15 +1112,6 @@
   "viewContact": {
     "message": "Ogled stika"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Ogled na $1 "
-  },
-  "viewOnEtherscan": {
-    "message": "Poglej na Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Ogled v Explorerju"
-  },
   "visitWebSite": {
     "message": "Obiščite našo spletno stran"
   },

--- a/app/_locales/sr/messages.json
+++ b/app/_locales/sr/messages.json
@@ -1112,15 +1112,6 @@
   "viewContact": {
     "message": "Pogledaj kontakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Pogledaj na $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Pogledaj na Etherscan-u"
-  },
-  "viewinExplorer": {
-    "message": "Pogledati u Explorer-u"
-  },
   "visitWebSite": {
     "message": "Posetite našu veb lokaciju"
   },

--- a/app/_locales/sv/messages.json
+++ b/app/_locales/sv/messages.json
@@ -1102,15 +1102,6 @@
   "viewContact": {
     "message": "Visa kontakt"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Visa vid $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Visa på Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Visa i Utforskaren"
-  },
   "visitWebSite": {
     "message": "Besök vår hemsida"
   },

--- a/app/_locales/sw/messages.json
+++ b/app/_locales/sw/messages.json
@@ -1105,15 +1105,6 @@
   "viewContact": {
     "message": "Tazama Mawasiliano"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Tazama kwenye $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Tazama kwenye Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Tazama kwenye Explorer"
-  },
   "visitWebSite": {
     "message": "Tembelea Tovuti yetu"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1900,15 +1900,6 @@
   "viewContact": {
     "message": "Tingnan ang Contact"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Tingnan sa $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Tingnan sa Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Tingnan sa Explorer"
-  },
   "visitWebSite": {
     "message": "Bisitahin ang aming website"
   },

--- a/app/_locales/uk/messages.json
+++ b/app/_locales/uk/messages.json
@@ -1127,15 +1127,6 @@
   "viewContact": {
     "message": "Переглянути контакт"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Дивитись на $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Дивитись на Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Дивитись в Explorer"
-  },
   "visitWebSite": {
     "message": "Відвідайте наш веб-сайт"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -2386,15 +2386,6 @@
   "viewMore": {
     "message": "Xem thêm"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "Xem tại $1"
-  },
-  "viewOnEtherscan": {
-    "message": "Xem trên Etherscan"
-  },
-  "viewinExplorer": {
-    "message": "Xem trên trình khám phá"
-  },
   "visitWebSite": {
     "message": "Truy cập trang web của chúng tôi"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1924,15 +1924,6 @@
   "viewContact": {
     "message": "查看联系人"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "在 $1 查看"
-  },
-  "viewOnEtherscan": {
-    "message": "在 Etherscan（以太坊浏览器）上查看"
-  },
-  "viewinExplorer": {
-    "message": "在浏览器中查看"
-  },
   "visitWebSite": {
     "message": "访问我们的网站"
   },

--- a/app/_locales/zh_TW/messages.json
+++ b/app/_locales/zh_TW/messages.json
@@ -1115,15 +1115,6 @@
   "viewContact": {
     "message": "觀看聯絡資訊"
   },
-  "viewOnCustomBlockExplorer": {
-    "message": "在 $1 瀏覽"
-  },
-  "viewOnEtherscan": {
-    "message": "在 Etherscan 上瀏覽"
-  },
-  "viewinExplorer": {
-    "message": "在 Explorer 上瀏覽"
-  },
   "visitWebSite": {
     "message": "造訪我們的網站"
   },

--- a/ui/components/app/menu-bar/account-options-menu.js
+++ b/ui/components/app/menu-bar/account-options-menu.js
@@ -36,8 +36,6 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
   const { blockExplorerUrl } = rpcPrefs;
   const blockExplorerUrlSubTitle = getURLHostName(blockExplorerUrl);
 
-  const blockExplorerViewAction = 'Account';
-
   const openFullscreenEvent = useMetricEvent({
     eventOpts: {
       category: 'Navigation',
@@ -120,8 +118,8 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
         iconClassName="fas fa-external-link-alt"
       >
         {rpcPrefs.blockExplorerUrl
-          ? t('viewinExplorer', [blockExplorerViewAction])
-          : t('viewOnEtherscan', [blockExplorerViewAction])}
+          ? t('viewinExplorer', [t('blockExplorerAccountAction')])
+          : t('viewOnEtherscan', [t('blockExplorerAccountAction')])}
       </MenuItem>
       <MenuItem
         data-testid="account-options-menu__connected-sites"

--- a/ui/components/app/menu-bar/account-options-menu.js
+++ b/ui/components/app/menu-bar/account-options-menu.js
@@ -36,6 +36,8 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
   const { blockExplorerUrl } = rpcPrefs;
   const blockExplorerUrlSubTitle = getURLHostName(blockExplorerUrl);
 
+  const blockExplorerViewAction = 'Account';
+
   const openFullscreenEvent = useMetricEvent({
     eventOpts: {
       category: 'Navigation',
@@ -117,7 +119,9 @@ export default function AccountOptionsMenu({ anchorElement, onClose }) {
         }
         iconClassName="fas fa-external-link-alt"
       >
-        {rpcPrefs.blockExplorerUrl ? t('viewinExplorer') : t('viewOnEtherscan')}
+        {rpcPrefs.blockExplorerUrl
+          ? t('viewinExplorer', [blockExplorerViewAction])
+          : t('viewOnEtherscan', [blockExplorerViewAction])}
       </MenuItem>
       <MenuItem
         data-testid="account-options-menu__connected-sites"

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -83,7 +83,9 @@ export default class AccountDetailsModal extends Component {
             ? this.context.t('blockExplorerView', [
                 rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1],
               ])
-            : this.context.t('viewOnEtherscan', [this.context.t('blockExplorerAccountAction')])}
+            : this.context.t('viewOnEtherscan', [
+                this.context.t('blockExplorerAccountAction'),
+              ])}
         </Button>
 
         {exportPrivateKeyFeatureEnabled ? (

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -34,6 +34,8 @@ export default class AccountDetailsModal extends Component {
     } = this.props;
     const { name, address } = selectedIdentity;
 
+    const blockExplorerViewAction = 'Account';
+
     const keyring = keyrings.find((kr) => {
       return kr.accounts.includes(address);
     });
@@ -83,7 +85,7 @@ export default class AccountDetailsModal extends Component {
             ? this.context.t('blockExplorerView', [
                 rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1],
               ])
-            : this.context.t('viewOnEtherscan')}
+            : this.context.t('viewOnEtherscan', [blockExplorerViewAction])}
         </Button>
 
         {exportPrivateKeyFeatureEnabled ? (

--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -34,8 +34,6 @@ export default class AccountDetailsModal extends Component {
     } = this.props;
     const { name, address } = selectedIdentity;
 
-    const blockExplorerViewAction = 'Account';
-
     const keyring = keyrings.find((kr) => {
       return kr.accounts.includes(address);
     });
@@ -85,7 +83,7 @@ export default class AccountDetailsModal extends Component {
             ? this.context.t('blockExplorerView', [
                 rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1],
               ])
-            : this.context.t('viewOnEtherscan', [blockExplorerViewAction])}
+            : this.context.t('viewOnEtherscan', [this.context.t('blockExplorerAccountAction')])}
         </Button>
 
         {exportPrivateKeyFeatureEnabled ? (

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -139,6 +139,8 @@ export default class TransactionListItemDetails extends PureComponent {
     } = transactionGroup;
     const { hash } = transaction;
 
+    const blockExplorerViewAction = 'Transaction';
+
     return (
       <Popover title={title} onClose={onClose}>
         <div className="transaction-list-item-details">
@@ -181,8 +183,11 @@ export default class TransactionListItemDetails extends PureComponent {
                 containerClassName="transaction-list-item-details__header-button-tooltip-container"
                 title={
                   blockExplorerUrl
-                    ? t('viewOnCustomBlockExplorer', [blockExplorerUrl])
-                    : t('viewOnEtherscan')
+                    ? t('viewOnCustomBlockExplorer', [
+                        blockExplorerViewAction,
+                        blockExplorerUrl,
+                      ])
+                    : t('viewOnEtherscan', [blockExplorerViewAction])
                 }
               >
                 <Button

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -139,8 +139,6 @@ export default class TransactionListItemDetails extends PureComponent {
     } = transactionGroup;
     const { hash } = transaction;
 
-    const blockExplorerViewAction = 'Transaction';
-
     return (
       <Popover title={title} onClose={onClose}>
         <div className="transaction-list-item-details">
@@ -184,10 +182,10 @@ export default class TransactionListItemDetails extends PureComponent {
                 title={
                   blockExplorerUrl
                     ? t('viewOnCustomBlockExplorer', [
-                        blockExplorerViewAction,
+                      t('blockExplorerTransactionAction'),
                         blockExplorerUrl,
                       ])
-                    : t('viewOnEtherscan', [blockExplorerViewAction])
+                    : t('viewOnEtherscan', [t('blockExplorerTransactionAction')])
                 }
               >
                 <Button

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -182,10 +182,12 @@ export default class TransactionListItemDetails extends PureComponent {
                 title={
                   blockExplorerUrl
                     ? t('viewOnCustomBlockExplorer', [
-                      t('blockExplorerTransactionAction'),
+                        t('blockExplorerTransactionAction'),
                         blockExplorerUrl,
                       ])
-                    : t('viewOnEtherscan', [t('blockExplorerTransactionAction')])
+                    : t('viewOnEtherscan', [
+                        t('blockExplorerTransactionAction'),
+                      ])
                 }
               >
                 <Button

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -30,7 +30,7 @@ const expectedResults = [
     category: TRANSACTION_GROUP_CATEGORIES.SEND,
     subtitle: 'To: 0xffe5...1a97',
     subtitleContainsOrigin: false,
-    date: 'May 12, 2020',
+    date: 'May 13, 2020',
     primaryCurrency: '-1 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -30,7 +30,7 @@ const expectedResults = [
     category: TRANSACTION_GROUP_CATEGORIES.SEND,
     subtitle: 'To: 0xffe5...1a97',
     subtitleContainsOrigin: false,
-    date: 'May 13, 2020',
+    date: 'May 12, 2020',
     primaryCurrency: '-1 ETH',
     senderAddress: '0x9eca64466f257793eaa52fcfff5066894b76a149',
     recipientAddress: '0xffe5bc4e8f1f969934d773fa67da095d2e491a97',

--- a/ui/pages/asset/components/asset-options.js
+++ b/ui/pages/asset/components/asset-options.js
@@ -18,6 +18,7 @@ const AssetOptions = ({
   );
   const [assetOptionsOpen, setAssetOptionsOpen] = useState(false);
 
+  const blockExplorerViewAction = 'Asset';
   return (
     <>
       <button
@@ -50,7 +51,9 @@ const AssetOptions = ({
               onClickBlockExplorer();
             }}
           >
-            {isEthNetwork ? t('viewOnEtherscan') : t('viewinExplorer')}
+            {isEthNetwork
+              ? t('viewOnEtherscan', [blockExplorerViewAction])
+              : t('viewinExplorer', [blockExplorerViewAction])}
           </MenuItem>
           {isNativeAsset ? null : (
             <MenuItem

--- a/ui/pages/asset/components/asset-options.js
+++ b/ui/pages/asset/components/asset-options.js
@@ -18,7 +18,6 @@ const AssetOptions = ({
   );
   const [assetOptionsOpen, setAssetOptionsOpen] = useState(false);
 
-  const blockExplorerViewAction = 'Asset';
   return (
     <>
       <button
@@ -52,8 +51,8 @@ const AssetOptions = ({
             }}
           >
             {isEthNetwork
-              ? t('viewOnEtherscan', [blockExplorerViewAction])
-              : t('viewinExplorer', [blockExplorerViewAction])}
+              ? t('viewOnEtherscan', [t('blockExplorerAssetAction')])
+              : t('viewinExplorer', [t('blockExplorerAssetAction')])}
           </MenuItem>
           {isNativeAsset ? null : (
             <MenuItem

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.test.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.test.js
@@ -43,7 +43,7 @@ describe('AwaitingSwap', () => {
     );
     expect(getByText('Transaction complete')).toBeInTheDocument();
     expect(getByText('tokens received: ETH')).toBeInTheDocument();
-    expect(getByText('View at etherscan.io')).toBeInTheDocument();
+    expect(getByText('View Swap at etherscan.io')).toBeInTheDocument();
     expect(getByText('Create a new swap')).toBeInTheDocument();
   });
 });

--- a/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/__snapshots__/view-on-ether-scan-link.test.js.snap
+++ b/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/__snapshots__/view-on-ether-scan-link.test.js.snap
@@ -5,7 +5,7 @@ exports[`ViewOnEtherScanLink renders the component with a custom block explorer 
   <div
     class="awaiting-swap__view-on-etherscan awaiting-swap__view-on-etherscan--visible"
   >
-    View at custom-blockchain.explorer
+    View Swap at custom-blockchain.explorer
   </div>
 </div>
 `;
@@ -15,7 +15,7 @@ exports[`ViewOnEtherScanLink renders the component with initial props 1`] = `
   <div
     class="awaiting-swap__view-on-etherscan awaiting-swap__view-on-etherscan--visible"
   >
-    View on Etherscan
+    View Swap on Etherscan
   </div>
 </div>
 `;

--- a/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
+++ b/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
@@ -12,6 +12,8 @@ export default function ViewOnEtherScanLink({
 }) {
   const t = useContext(I18nContext);
 
+  const blockExplorerViewAction = 'Swap';
+
   const blockExplorerLinkClickedEvent = useNewMetricEvent({
     category: 'Swaps',
     event: 'Clicked Block Explorer Link',
@@ -34,8 +36,11 @@ export default function ViewOnEtherScanLink({
       }}
     >
       {isCustomBlockExplorerUrl
-        ? t('viewOnCustomBlockExplorer', [getURLHostName(blockExplorerUrl)])
-        : t('viewOnEtherscan')}
+        ? t('viewOnCustomBlockExplorer', [
+            blockExplorerViewAction,
+            getURLHostName(blockExplorerUrl),
+          ])
+        : t('viewOnEtherscan', [blockExplorerViewAction])}
     </div>
   );
 }

--- a/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
+++ b/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
@@ -12,8 +12,6 @@ export default function ViewOnEtherScanLink({
 }) {
   const t = useContext(I18nContext);
 
-  const blockExplorerViewAction = 'Swap';
-
   const blockExplorerLinkClickedEvent = useNewMetricEvent({
     category: 'Swaps',
     event: 'Clicked Block Explorer Link',
@@ -37,10 +35,10 @@ export default function ViewOnEtherScanLink({
     >
       {isCustomBlockExplorerUrl
         ? t('viewOnCustomBlockExplorer', [
-            blockExplorerViewAction,
+          t('blockExplorerSwapAction'),
             getURLHostName(blockExplorerUrl),
           ])
-        : t('viewOnEtherscan', [blockExplorerViewAction])}
+        : t('viewOnEtherscan', [t('blockExplorerSwapAction')])}
     </div>
   );
 }

--- a/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
+++ b/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.js
@@ -35,7 +35,7 @@ export default function ViewOnEtherScanLink({
     >
       {isCustomBlockExplorerUrl
         ? t('viewOnCustomBlockExplorer', [
-          t('blockExplorerSwapAction'),
+            t('blockExplorerSwapAction'),
             getURLHostName(blockExplorerUrl),
           ])
         : t('viewOnEtherscan', [t('blockExplorerSwapAction')])}

--- a/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.test.js
+++ b/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.test.js
@@ -18,7 +18,7 @@ describe('ViewOnEtherScanLink', () => {
     const { container, getByText } = renderWithProvider(
       <ViewOnEtherScanLink {...createProps()} />,
     );
-    expect(getByText('View on Etherscan')).toBeInTheDocument();
+    expect(getByText('View Swap on Etherscan')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 
@@ -31,7 +31,7 @@ describe('ViewOnEtherScanLink', () => {
         })}
       />,
     );
-    expect(getByText('View at custom-blockchain.explorer')).toBeInTheDocument();
+    expect(getByText('View Swap at custom-blockchain.explorer')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 });

--- a/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.test.js
+++ b/ui/pages/swaps/awaiting-swap/view-on-ether-scan-link/view-on-ether-scan-link.test.js
@@ -31,7 +31,9 @@ describe('ViewOnEtherScanLink', () => {
         })}
       />,
     );
-    expect(getByText('View Swap at custom-blockchain.explorer')).toBeInTheDocument();
+    expect(
+      getByText('View Swap at custom-blockchain.explorer'),
+    ).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Fixes: #9476 

Explanation:  
We have "View on Etherscan" in a few places, and it means different things (accounts or tokens). We know this can be confusing to users. One simple way to mitigate this confusion is to update the wording in each case to clarify what is being viewed.

Manual testing steps:  
  - 
  - 
  - 