### PR TITLE
Add more global snap hooks

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -444,6 +444,8 @@ export default class MetamaskController extends EventEmitter {
       state: initState.PluginController,
       messenger: pluginControllerMessenger,
     });
+    this._setupSnapGlobals();
+
     this.permissionsController.initializePermissions(
       initState.PermissionsController,
       getRestrictedMethods,
@@ -720,17 +722,29 @@ export default class MetamaskController extends EventEmitter {
 
     // TODO:LegacyProvider: Delete
     this.publicConfigStore = this.createPublicConfigStore();
+  }
 
-    // Setup some background hooks
-    global.clearPermissions = () =>
-      this.permissionsController.clearPermissions();
-    global.clearPlugins = () => {
-      this.pluginController.clearState();
-      this.assetsController.clearResources();
-    };
-    global.clearPermsAndPlugins = () => {
-      global.clearPermissions();
-      global.clearPlugins();
+  /**
+   * Temporary constructor helper: Set up global snap functions for dev purposes
+   * TODO:snaps Remove.
+   */
+  _setupSnapGlobals() {
+    globalThis.snaps = {
+      clearPermissions: () => this.permissionsController.clearPermissions(),
+      clearPlugins: () => this.pluginController.clearState(),
+      clearPermsAndPlugins: () => {
+        this.permissionsController.clearPermissions();
+        this.pluginController.clearState();
+      },
+      hasPlugin: (...args) => this.pluginController.has(args),
+      isPluginRunning: (...args) => this.pluginController.isRunning(args),
+      removePlugin: (...args) => this.pluginController.removePlugin(args),
+      runExistingPlugins: () => this.pluginController.runExistingPlugins(),
+      startInlinePlugin: () => this.pluginController.runInlinePlugin(),
+      stopInlinePlugin: () => this.pluginController.removeInlinePlugin(),
+      startPlugin: (...args) => this.pluginController.startPlugin(args),
+      stopPlugin: (...args) => this.pluginController.stopPlugin(args),
+      getState: () => this.pluginController.state,
     };
   }
 

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -555,7 +555,7 @@ async function bundleIt(buildConfiguration) {
 
 function getEnvironmentVariables({ buildType, devMode, testing }) {
   const environment = getEnvironment({ devMode, testing });
-  if (environment === 'production' && !process.env.SENTRY_DSN) {
+  if (environment.includes('production') && !process.env.SENTRY_DSN) {
     throw new Error('Missing SENTRY_DSN environment variable');
   }
   return {
@@ -579,10 +579,10 @@ function getEnvironmentVariables({ buildType, devMode, testing }) {
     // the value of SEGMENT_WRITE_KEY that we envify is undefined then no events will be tracked
     // in the build. This is intentional so that developers can contribute to MetaMask without
     // inflating event volume.
-    SEGMENT_WRITE_KEY: environment?.includes('production')
+    SEGMENT_WRITE_KEY: environment.includes('production')
       ? process.env.SEGMENT_PROD_WRITE_KEY
       : metamaskrc.SEGMENT_WRITE_KEY,
-    SEGMENT_LEGACY_WRITE_KEY: environment?.includes('production')
+    SEGMENT_LEGACY_WRITE_KEY: environment.includes('production')
       ? process.env.SEGMENT_PROD_LEGACY_WRITE_KEY
       : metamaskrc.SEGMENT_LEGACY_WRITE_KEY,
     SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS === '1',

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -555,7 +555,7 @@ async function bundleIt(buildConfiguration) {
 
 function getEnvironmentVariables({ buildType, devMode, testing }) {
   const environment = getEnvironment({ devMode, testing });
-  if (environment?.includes('production') && !process.env.SENTRY_DSN) {
+  if (environment === 'production' && !process.env.SENTRY_DSN) {
     throw new Error('Missing SENTRY_DSN environment variable');
   }
   return {

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -555,7 +555,7 @@ async function bundleIt(buildConfiguration) {
 
 function getEnvironmentVariables({ buildType, devMode, testing }) {
   const environment = getEnvironment({ devMode, testing });
-  if (environment.includes('production') && !process.env.SENTRY_DSN) {
+  if (environment?.includes('production') && !process.env.SENTRY_DSN) {
     throw new Error('Missing SENTRY_DSN environment variable');
   }
   return {
@@ -579,10 +579,10 @@ function getEnvironmentVariables({ buildType, devMode, testing }) {
     // the value of SEGMENT_WRITE_KEY that we envify is undefined then no events will be tracked
     // in the build. This is intentional so that developers can contribute to MetaMask without
     // inflating event volume.
-    SEGMENT_WRITE_KEY: environment.includes('production')
+    SEGMENT_WRITE_KEY: environment?.includes('production')
       ? process.env.SEGMENT_PROD_WRITE_KEY
       : metamaskrc.SEGMENT_WRITE_KEY,
-    SEGMENT_LEGACY_WRITE_KEY: environment.includes('production')
+    SEGMENT_LEGACY_WRITE_KEY: environment?.includes('production')
       ? process.env.SEGMENT_PROD_LEGACY_WRITE_KEY
       : metamaskrc.SEGMENT_LEGACY_WRITE_KEY,
     SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS === '1',


### PR DESCRIPTION
This updates / adds more snap functions to the global object. They're now namespaced under `globalThis.snaps` instead of directly on the global.