### PR TITLE
Adding "Enable smart contract data" step to Ledger Instructions (Confirmation Screen)

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1213,6 +1213,9 @@
   "ledgerLiveDialogHeader": {
     "message": "Prior to clicking confirm:"
   },
+  "ledgerLiveDialogStepFour": {
+    "message": "Enable smart contract data on your Ledger device"
+  },
   "ledgerLiveDialogStepOne": {
     "message": "Enable Use Ledger Live under Settings > Advanced"
   },

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -401,45 +401,37 @@ export default class ConfirmTransactionBase extends Component {
       </div>
     ) : null;
 
+    const renderLedgerLiveStep = (text, show = true) => {
+      return (
+        show && (
+          <Typography
+            boxProps={{ margin: 0 }}
+            color={COLORS.PRIMARY3}
+            fontWeight={FONT_WEIGHT.BOLD}
+            variant={TYPOGRAPHY.H7}
+          >
+            {text}
+          </Typography>
+        )
+      );
+    };
+
     const ledgerInstructionField = isLedgerAccount ? (
       <div>
         <div className="confirm-detail-row">
           <Dialog type="message">
             <div className="ledger-live-dialog">
-              <Typography
-                boxProps={{ margin: 0 }}
-                color={COLORS.PRIMARY3}
-                fontWeight={FONT_WEIGHT.BOLD}
-                variant={TYPOGRAPHY.H7}
-              >
-                {t('ledgerLiveDialogHeader')}
-              </Typography>
-              {!isFirefox && (
-                <Typography
-                  boxProps={{ margin: 0 }}
-                  color={COLORS.PRIMARY3}
-                  fontWeight={FONT_WEIGHT.BOLD}
-                  variant={TYPOGRAPHY.H7}
-                >
-                  {`- ${t('ledgerLiveDialogStepOne')}`}
-                </Typography>
+              {renderLedgerLiveStep(t('ledgerLiveDialogHeader'))}
+              {renderLedgerLiveStep(
+                `- ${t('ledgerLiveDialogStepOne')}`,
+                !isFirefox,
               )}
-              <Typography
-                boxProps={{ margin: 0 }}
-                color={COLORS.PRIMARY3}
-                fontWeight={FONT_WEIGHT.BOLD}
-                variant={TYPOGRAPHY.H7}
-              >
-                {`- ${t('ledgerLiveDialogStepTwo')}`}
-              </Typography>
-              <Typography
-                boxProps={{ margin: 0 }}
-                color={COLORS.PRIMARY3}
-                fontWeight={FONT_WEIGHT.BOLD}
-                variant={TYPOGRAPHY.H7}
-              >
-                {`- ${t('ledgerLiveDialogStepThree')}`}
-              </Typography>
+              {renderLedgerLiveStep(`- ${t('ledgerLiveDialogStepTwo')}`)}
+              {renderLedgerLiveStep(`- ${t('ledgerLiveDialogStepThree')}`)}
+              {renderLedgerLiveStep(
+                `- ${t('ledgerLiveDialogStepFour')}`,
+                Boolean(txData.txParams?.data),
+              )}
             </div>
           </Dialog>
         </div>


### PR DESCRIPTION
Follows up: https://github.com/MetaMask/metamask-extension/pull/12020
(Note: This step only shows for transactions containing method data)

<img width="454" alt="Screen Shot 2021-09-15 at 6 04 55 AM" src="https://user-images.githubusercontent.com/8732757/133439286-6a9e4c3a-7a2b-4d07-bfdf-c61ceba91db2.png">
<img width="449" alt="Screen Shot 2021-09-15 at 6 02 47 AM" src="https://user-images.githubusercontent.com/8732757/133439290-773a5e0d-32e8-4f93-841e-6324e9ce579e.png">
<img width="366" alt="Screen Shot 2021-09-15 at 6 05 50 AM" src="https://user-images.githubusercontent.com/8732757/133439276-16077a17-2ee6-4626-9563-a10050903029.png">
