### PR TITLE
Fix failing transaction-list-item.component test by mocking useLayoutEffect

### DIFF
--- a/ui/components/app/transaction-list-item/transaction-list-item.component.test.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.test.js
@@ -63,6 +63,14 @@ setBackgroundConnection({
   getGasFeeEstimatesAndStartPolling: jest.fn(),
 });
 
+jest.mock('react', () => {
+  const originReact = jest.requireActual('react');
+  return {
+    ...originReact,
+    useLayoutEffect: jest.fn(),
+  };
+});
+
 const generateUseSelectorRouter = (opts) => (selector) => {
   if (selector === getConversionRate) {
     return 1;


### PR DESCRIPTION
Fixes: Broken test on develop (result of merging [12069](https://github.com/MetaMask/metamask-extension/pull/12069) without pulling down develop)

Explanation:  an instance of useLayoutEffect was introduced between when I last pulled down develop and merge #12069 which resulted in a broken test on develop. Here is the fix!
