### PR TITLE
fix stuck speedup problem

### DIFF
--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -100,40 +100,32 @@ export default class TransactionBreakdown extends PureComponent {
             />
           </TransactionBreakdownRow>
         )}
-        {isEIP1559Transaction && (
+        {isEIP1559Transaction && typeof baseFee !== 'undefined' ? (
           <TransactionBreakdownRow title={t('transactionHistoryBaseFee')}>
-            {typeof baseFee === 'undefined' ? (
-              '?'
-            ) : (
-              <CurrencyDisplay
-                className="transaction-breakdown__value"
-                data-testid="transaction-breakdown__base-fee"
-                currency={nativeCurrency}
-                denomination={GWEI}
-                value={baseFee}
-                numberOfDecimals={10}
-                hideLabel
-              />
-            )}
+            <CurrencyDisplay
+              className="transaction-breakdown__value"
+              data-testid="transaction-breakdown__base-fee"
+              currency={nativeCurrency}
+              denomination={GWEI}
+              value={baseFee}
+              numberOfDecimals={10}
+              hideLabel
+            />
           </TransactionBreakdownRow>
-        )}
-        {isEIP1559Transaction && (
+        ) : null}
+        {isEIP1559Transaction && typeof priorityFee !== 'undefined' ? (
           <TransactionBreakdownRow title={t('transactionHistoryPriorityFee')}>
-            {typeof priorityFee === 'undefined' ? (
-              '?'
-            ) : (
-              <CurrencyDisplay
-                className="transaction-breakdown__value"
-                data-testid="transaction-breakdown__priority-fee"
-                currency={nativeCurrency}
-                denomination={GWEI}
-                value={priorityFee}
-                numberOfDecimals={10}
-                hideLabel
-              />
-            )}
+            <CurrencyDisplay
+              className="transaction-breakdown__value"
+              data-testid="transaction-breakdown__priority-fee"
+              currency={nativeCurrency}
+              denomination={GWEI}
+              value={priorityFee}
+              numberOfDecimals={10}
+              hideLabel
+            />
           </TransactionBreakdownRow>
-        )}
+        ) : null}
         {!isEIP1559Transaction && (
           <TransactionBreakdownRow title={t('advancedGasPriceTitle')}>
             {typeof gasPrice === 'undefined' ? (

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -281,11 +281,17 @@ export const nonceSortedTransactionsSelector = createSelector(
           nonceProps.initialTransaction = transaction;
         }
 
-        if (type === TRANSACTION_TYPES.RETRY) {
+        if (
+          type === TRANSACTION_TYPES.RETRY &&
+          status in PRIORITY_STATUS_HASH
+        ) {
           nonceProps.hasRetried = true;
         }
 
-        if (type === TRANSACTION_TYPES.CANCEL) {
+        if (
+          type === TRANSACTION_TYPES.CANCEL &&
+          status in PRIORITY_STATUS_HASH
+        ) {
           nonceProps.hasCancelled = true;
         }
       } else {
@@ -294,8 +300,12 @@ export const nonceSortedTransactionsSelector = createSelector(
           transactions: [transaction],
           initialTransaction: transaction,
           primaryTransaction: transaction,
-          hasRetried: transaction.type === TRANSACTION_TYPES.RETRY,
-          hasCancelled: transaction.type === TRANSACTION_TYPES.CANCEL,
+          hasRetried:
+            transaction.type === TRANSACTION_TYPES.RETRY &&
+            transaction.status in PRIORITY_STATUS_HASH,
+          hasCancelled:
+            transaction.type === TRANSACTION_TYPES.CANCEL &&
+            transaction.status in PRIORITY_STATUS_HASH,
         };
 
         insertOrderedNonce(orderedNonces, nonce);


### PR DESCRIPTION
Fixes: #12051 

Explanation: Speed up transactions that are failed should not prevent additional retries. Only speed up transactions that are successfully submitted to the network should prevent the transaction from being retried. In addition this clears up some additional user confusion by simply not rendering the baseFee or priorityFee fields when we can't know them, instead of the `?` mark which doesn't do anything to explain why its there. 

Manual testing steps:  
  - Switch to rinkeby
  - Submit a transaction with max and priority fee of 0.1
  - speed up the transaction, with max and priority fee of 0.109 (109%)
  - On develop you'll see that the speed up button is removed, and the speed up is failed (you'll get a notification) but the original transaction is pending.
  - On this branch you'll see the speed up button remains. 