### PR TITLE
Changing Use Token detection to  OFF by default

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -35,7 +35,7 @@ export default class PreferencesController {
 
       // set to true means the dynamic list from the API is being used
       // set to false will be using the static list from contract-metadata
-      useTokenDetection: true,
+      useTokenDetection: false,
 
       // WARNING: Do not use feature flags for security-sensitive things.
       // Feature flag toggling is available in the global namespace

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -262,7 +262,7 @@ describe('preferences controller', function () {
       preferencesController.setUseTokenDetection(true);
       assert.equal(
         preferencesController.store.getState().useTokenDetection,
-        false,
+        true,
       );
     });
   });

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -249,17 +249,17 @@ describe('preferences controller', function () {
     });
   });
   describe('setUseTokenDetection', function () {
-    it('should default to true', function () {
+    it('should default to false', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.useTokenDetection, true);
+      assert.equal(state.useTokenDetection, false);
     });
 
     it('should set the useTokenDetection property in state', function () {
       assert.equal(
         preferencesController.store.getState().useTokenDetection,
-        true,
+        false,
       );
-      preferencesController.setUseTokenDetection(false);
+      preferencesController.setUseTokenDetection(true);
       assert.equal(
         preferencesController.store.getState().useTokenDetection,
         false,


### PR DESCRIPTION
This is part of #12128 

We are keeping the token detection OFF by default so that the users can opt-in based on their network and helps us to get early feedback reducing the risk of shipping any regression to our whole user base.