### PR TITLE
Interacting with MetaMask Notification window

### DIFF
--- a/test/e2e/tests/contract-interactions.spec.js
+++ b/test/e2e/tests/contract-interactions.spec.js
@@ -51,9 +51,12 @@ describe('Deploy contract and call contract methods', function () {
         await driver.clickElement('#deployButton');
 
         // displays the contract creation data
-        await driver.switchToWindow(extension);
-        await driver.clickElement('[data-testid="home__activity-tab"]');
-        await driver.clickElement({ text: 'Contract Deployment', tag: 'h2' });
+        await driver.waitUntilXWindowHandles(3);
+        windowHandles = await driver.getAllWindowHandles();
+        await driver.switchToWindowWithTitle(
+          'MetaMask Notification',
+          windowHandles,
+        );
         await driver.clickElement({ text: 'Data', tag: 'button' });
         await driver.findElement({ text: '127.0.0.1', tag: 'div' });
         const confirmDataDiv = await driver.findElement(
@@ -68,6 +71,9 @@ describe('Deploy contract and call contract methods', function () {
         // confirms a deploy contract transaction
         await driver.clickElement({ text: 'Details', tag: 'button' });
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
+        await driver.waitUntilXWindowHandles(2);
+        await driver.switchToWindow(extension);
+        await driver.clickElement('[data-testid="home__activity-tab"]');
         await driver.waitForSelector(
           '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(1)',
           { timeout: 10000 },
@@ -80,13 +86,13 @@ describe('Deploy contract and call contract methods', function () {
         await driver.switchToWindow(dapp);
         await driver.clickElement('#depositButton');
         await driver.waitUntilXWindowHandles(3);
-
         windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
         );
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
+        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindow(extension);
         await driver.waitForSelector(
           '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(2)',
@@ -110,6 +116,7 @@ describe('Deploy contract and call contract methods', function () {
           windowHandles,
         );
         await driver.clickElement({ text: 'Confirm', tag: 'button' });
+        await driver.waitUntilXWindowHandles(2);
         await driver.switchToWindow(extension);
         await driver.waitForSelector(
           '.transaction-list__completed-transactions .transaction-list-item:nth-of-type(3)',

--- a/test/e2e/tests/signature-request.spec.js
+++ b/test/e2e/tests/signature-request.spec.js
@@ -31,7 +31,7 @@ describe('Signature Request', function () {
         await driver.clickElement('#signTypedDataV4', 10000);
 
         await driver.waitUntilXWindowHandles(3);
-        const windowHandles = await driver.getAllWindowHandles();
+        let windowHandles = await driver.getAllWindowHandles();
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -60,6 +60,8 @@ describe('Signature Request', function () {
 
         // Approve signing typed data
         await driver.clickElement({ text: 'Sign', tag: 'button' }, 10000);
+        await driver.waitUntilXWindowHandles(2);
+        windowHandles = await driver.getAllWindowHandles();
 
         // switch to the Dapp and verify the signed addressed
         await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -275,16 +275,25 @@ class Driver {
     throw new Error('waitUntilXWindowHandles timed out polling window handles');
   }
 
-  async switchToWindowWithTitle(title, windowHandles) {
+  async switchToWindowWithTitle(
+    title,
+    windowHandles,
+    delayStep = 1000,
+    timeout = 5000,
+  ) {
+    let timeElapsed = 0;
     // eslint-disable-next-line no-param-reassign
     windowHandles = windowHandles || (await this.driver.getAllWindowHandles());
-
-    for (const handle of windowHandles) {
-      await this.driver.switchTo().window(handle);
-      const handleTitle = await this.driver.getTitle();
-      if (handleTitle === title) {
-        return handle;
+    while (timeElapsed <= timeout) {
+      for (const handle of windowHandles) {
+        await this.driver.switchTo().window(handle);
+        const handleTitle = await this.driver.getTitle();
+        if (handleTitle === title) {
+          return handle;
+        }
       }
+      await this.delay(delayStep);
+      timeElapsed += delayStep;
     }
 
     throw new Error(`No window with title: ${title}`);


### PR DESCRIPTION
Fixes: Intermittent test failure `Error: No window with title: MetaMask Notification`

Explanation:  Switching to the MetaMask Notification is flaky on CI.
After running the tests locally using Docker, I noticed the title of the MetaMask Notification window is not returned consistently on the first attempt.

Manual testing steps:  
  - n/a