### PR TITLE
Fix issue where duplicate tokens without icons appear in swap-to token list dropdown

### DIFF
--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -66,7 +66,8 @@ export function getRenderableTokenData(
   const usedIconUrl =
     iconUrl ||
     (tokenList[tokenAddress] &&
-      `images/contract/${tokenList[tokenAddress].iconUrl}`);
+      `images/contract/${tokenList[tokenAddress].iconUrl}`) ||
+    token?.image;
   return {
     ...token,
     primaryLabel: symbol,
@@ -127,7 +128,7 @@ export function useTokensToSearch({
   const memoizedTokensToSearch = useEqualityCheck(tokensToSearch);
   return useMemo(() => {
     const usersTokensAddressMap = memoizedUsersToken.reduce(
-      (acc, token) => ({ ...acc, [token.address]: token }),
+      (acc, token) => ({ ...acc, [token.address.toLowerCase()]: token }),
       {},
     );
 
@@ -139,12 +140,12 @@ export function useTokensToSearch({
 
     const memoizedSwapsAndUserTokensWithoutDuplicities = uniqBy(
       [...memoizedTokensToSearch, ...memoizedUsersToken],
-      'address',
+      (token) => token.address.toLowerCase(),
     );
 
     memoizedSwapsAndUserTokensWithoutDuplicities.forEach((token) => {
       const renderableDataToken = getRenderableTokenData(
-        { ...usersTokensAddressMap[token.address], ...token },
+        { ...usersTokensAddressMap[token.address.toLowerCase()], ...token },
         tokenConversionRates,
         conversionRate,
         currentCurrency,
@@ -154,12 +155,12 @@ export function useTokensToSearch({
       );
       if (
         isSwapsDefaultTokenSymbol(renderableDataToken.symbol, chainId) ||
-        usersTokensAddressMap[token.address]
+        usersTokensAddressMap[token.address.toLowerCase()]
       ) {
         tokensToSearchBuckets.owned.push(renderableDataToken);
-      } else if (memoizedTopTokens[token.address]) {
+      } else if (memoizedTopTokens[token.address.toLowerCase()]) {
         tokensToSearchBuckets.top[
-          memoizedTopTokens[token.address].index
+          memoizedTopTokens[token.address.toLowerCase()].index
         ] = renderableDataToken;
       } else {
         tokensToSearchBuckets.others.push(renderableDataToken);


### PR DESCRIPTION
Fixes: #12103 
co-authored with @mcmire 

Explanation:  User tokens weren't being matched correctly against swaps tokensToSearch list (casing issue), resulting in duplicates icon and aggregator data.

**Outstanding tech debt to consider**: 
- [ ] We should agree on and apply normalized casing for token addresses (and all addresses for that matter) from coingecko, contract-metadata and throughout wherever else addresses are stored or received.
- [ ] We noticed a strange bug with the swaps duck (the duck state intermittently doesn't reset correctly):
https://user-images.githubusercontent.com/34557516/133833994-243774ca-3510-4c6d-9799-5d69031ec7c5.mov
https://user-images.githubusercontent.com/34557516/133834055-98714376-e427-414b-9458-cc12a366423d.mov

Fixed behavior in PR:
https://user-images.githubusercontent.com/34557516/133832688-44ac6f66-6798-4252-ae31-05d7a03b29f5.mov

https://user-images.githubusercontent.com/34557516/133832883-13fa77a0-bbd1-40ef-96e5-690038c74bf5.mov


Manual testing steps:  
1)
  - Import token(s) from our enumerated token list
  - Initialize a swap
  - Make sure that there isn't a duplicate of added token(s) in the `Swap to` dropdown
 2)
 - Initialize a swap
 - Select a new token (not currently in your added token list) in the `Swap to` dropdown
 - Click back into the `Swap to` drop down and ensure the token you just selected isn't duplicated in the dropdown list. 