### PR TITLE
Remove whitespace from inputs

### DIFF
--- a/ui/pages/settings/networks-tab/network-form/network-form.component.js
+++ b/ui/pages/settings/networks-tab/network-form/network-form.component.js
@@ -316,7 +316,7 @@ export default class NetworkForm extends PureComponent {
   setStateWithValue = (stateKey, validator) => {
     return (e) => {
       validator?.(e.target.value, stateKey);
-      this.setState({ [stateKey]: e.target.value });
+      this.setState({ [stateKey]: e.target.value.trim() });
     };
   };
 


### PR DESCRIPTION
Fixes:
Add trim functionality for inputs.

Explanation:  
There are some unexpected use cases when adding custom network. When User copy and paste, it might have unnecessary spaces at the end of string, that causes errors, even if User put correct ones.
Here is a screenshot.
https://share.getcloudapp.com/6quYGAYX

Manual testing steps:  
  - 
  - 
  - 