### PR TITLE
Hardening property check for `stopPropagation` in `ConfirmTxScreen`

### DIFF
--- a/ui/pages/confirm-transaction/conf-tx.js
+++ b/ui/pages/confirm-transaction/conf-tx.js
@@ -135,7 +135,7 @@ class ConfirmTxScreen extends Component {
   }
 
   stopPropagation(event) {
-    if (event.stopPropagation) {
+    if (event?.stopPropagation) {
       event.stopPropagation();
     }
   }


### PR DESCRIPTION
Fixes this fairly noisy sentry error: https://sentry.io/organizations/metamask/issues/2255929540/

We check for the existence of the `stopPropagation` on `event` before calling it, but we should also consider if the `event` is there at all