### PR TITLE
E2e remove xLargeDelayMs and xxLargeDelayMs delays

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -12,8 +12,6 @@ const { ensureXServerIsRunning } = require('./x-server');
 const tinyDelayMs = 200;
 const regularDelayMs = tinyDelayMs * 2;
 const largeDelayMs = regularDelayMs * 2;
-const xLargeDelayMs = largeDelayMs * 2;
-const xxLargeDelayMs = xLargeDelayMs * 2;
 
 const dappPort = 8080;
 
@@ -153,7 +151,5 @@ module.exports = {
   tinyDelayMs,
   regularDelayMs,
   largeDelayMs,
-  xLargeDelayMs,
-  xxLargeDelayMs,
   withFixtures,
 };

--- a/test/e2e/tests/permissions.spec.js
+++ b/test/e2e/tests/permissions.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures, xxLargeDelayMs, xLargeDelayMs } = require('../helpers');
+const { withFixtures } = require('../helpers');
 
 describe('Permissions', function () {
   it('sets permissions and connect to Dapp', async function () {
@@ -34,7 +34,6 @@ describe('Permissions', function () {
         await driver.waitUntilXWindowHandles(3);
         const windowHandles = await driver.getAllWindowHandles();
         const extension = windowHandles[0];
-        await driver.delay(xxLargeDelayMs);
         await driver.switchToWindowWithTitle(
           'MetaMask Notification',
           windowHandles,
@@ -62,7 +61,10 @@ describe('Permissions', function () {
           text: 'Connected sites',
           tag: 'h2',
         });
-        await driver.delay(xLargeDelayMs);
+        await driver.waitForSelector({
+          css: '.connected-sites-list__domain-name',
+          text: '127.0.0.1:8080',
+        });
         const domains = await driver.findClickableElements(
           '.connected-sites-list__domain-name',
         );
@@ -76,9 +78,10 @@ describe('Permissions', function () {
           tag: 'button',
         });
 
-        const getAccountsResult = await driver.findElement(
-          '#getAccountsResult',
-        );
+        const getAccountsResult = await driver.waitForSelector({
+          css: '#getAccountsResult',
+          text: publicAddress,
+        });
         assert.equal(
           (await getAccountsResult.getText()).toLowerCase(),
           publicAddress.toLowerCase(),

--- a/test/e2e/tests/provider-events.spec.js
+++ b/test/e2e/tests/provider-events.spec.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { withFixtures, regularDelayMs, xxLargeDelayMs } = require('../helpers');
+const { withFixtures } = require('../helpers');
 
 describe('MetaMask', function () {
   it('provider should inform dapp when switching networks', async function () {
@@ -25,9 +25,14 @@ describe('MetaMask', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         await driver.openNewPage('http://127.0.0.1:8080/');
-        const networkDiv = await driver.findElement('#network');
-        const chainIdDiv = await driver.findElement('#chainId');
-        await driver.delay(xxLargeDelayMs);
+        const networkDiv = await driver.waitForSelector({
+          css: '#network',
+          text: '1337',
+        });
+        const chainIdDiv = await driver.waitForSelector({
+          css: '#chainId',
+          text: '0x539',
+        });
         assert.equal(await networkDiv.getText(), '1337');
         assert.equal(await chainIdDiv.getText(), '0x539');
 
@@ -36,11 +41,16 @@ describe('MetaMask', function () {
 
         await driver.clickElement('.network-display');
         await driver.clickElement({ text: 'Ropsten', tag: 'span' });
-        await driver.delay(regularDelayMs);
 
         await driver.switchToWindowWithTitle('E2E Test Dapp', windowHandles);
-        const switchedNetworkDiv = await driver.findElement('#network');
-        const switchedChainIdDiv = await driver.findElement('#chainId');
+        const switchedNetworkDiv = await driver.waitForSelector({
+          css: '#network',
+          text: '3',
+        });
+        const switchedChainIdDiv = await driver.waitForSelector({
+          css: '#chainId',
+          text: '0x3',
+        });
         const accountsDiv = await driver.findElement('#accounts');
 
         assert.equal(await switchedNetworkDiv.getText(), '3');


### PR DESCRIPTION
Explanation: 
- Removes xLargeDelayMs and xxLargeDelayMs delays
- Replace delays in test with explicit wait

Manual testing steps:  
  - n/a 