### PR TITLE
Fix for: erroneous ERC-20 Token amount

### DIFF
--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -78,8 +78,13 @@ export default class TokenInput extends PureComponent {
   handleChange = (decimalValue) => {
     const { token: { decimals } = {}, onChange } = this.props;
 
+    let newDecimalValue = decimalValue;
+    if (decimals) {
+      newDecimalValue = parseFloat(decimalValue).toFixed(decimals);
+    }
+
     const multiplier = Math.pow(10, Number(decimals || 0));
-    const hexValue = multiplyCurrencies(decimalValue || 0, multiplier, {
+    const hexValue = multiplyCurrencies(newDecimalValue || 0, multiplier, {
       multiplicandBase: 10,
       multiplierBase: 10,
       toNumericBase: 'hex',


### PR DESCRIPTION
Fixes: #11917

Explanation:  If user enters more decimal places for transferring token that what the token supports it results in abrupt value in transaction data. I found that values was getting messed up by `ethers` and `ethereumjs-abi` library methods. Although the error existed for both new transaction and editing it was visible while editing transaction as during editing we decode transaction data for draft transaction.

The PR truncates extra decimal places from value entered by user. Additional change here could be that we do not allow user to enter decimal places more than what token allows.

Manual testing steps:  
- Click the send button for an ERC-20 Token
- Enter a valid amount on the Send page, then click Next
- Click the Edit button to go back to the Send page
- Append decimal places to the amount, ensuring you specify more than the token allows, click Next
- It truncate the trailing decimal place, the correct amount is shown on the confirmation screen