### PR TITLE
Fix 12145 - Ledger errors being set as `Error: [object, object]`

### DIFF
--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -521,7 +521,7 @@ export default class TransactionStateManager extends EventEmitter {
 
     const txMeta = this.getTransaction(txId);
     txMeta.err = {
-      message: typeof error === 'object' ? error.message : error.toString(),
+      message: error.message?.toString() || error.toString(),
       rpc: error.value,
       stack: error.stack,
     };

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -521,7 +521,7 @@ export default class TransactionStateManager extends EventEmitter {
 
     const txMeta = this.getTransaction(txId);
     txMeta.err = {
-      message: error.toString(),
+      message: typeof error === 'object' ? error.message : error.toString(),
       rpc: error.value,
       stack: error.stack,
     };

--- a/app/scripts/lib/cleanErrorStack.js
+++ b/app/scripts/lib/cleanErrorStack.js
@@ -14,7 +14,7 @@ export default function cleanErrorStack(err) {
     err.stack = err.message;
   } else if (msg === '') {
     err.stack = err.name;
-  } else {
+  } else if (!err.stack) {
     err.stack = `${err.name}: ${err.message}`;
   }
 


### PR DESCRIPTION
Fixes: #12145

Recently change the way we pass error messages from the ledger bridge to the extension, https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/104. When transactions fail from the ledger side for any reason, the error object would get stringified, and present as `Error: [object, object]` in state and the UI as a result. The PR handles the case where if the error is an error object we preserve the message as is, and fall back to a stringified error for other cases. Also, preserves `err.stack` when it is present, else sets it as `err.message`.