### PR TITLE
Update changelog for v`10.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#11999](https://github.com/MetaMask/metamask-extension/pull/11999): Add eth_feeHistory to API callable by dapps
 - [#11849](https://github.com/MetaMask/metamask-extension/pull/11849): Add subtitles for additional languages (Secret Recovery Phrase Video)
 - [#11772](https://github.com/MetaMask/metamask-extension/pull/11772): Add tooltip to better explain possible effects of setting gas fees below MetaMask's estimates
+- [#11796](https://github.com/MetaMask/metamask-extension/pull/11796): Add "Max fee" label to maximum fee amount in edit gas display
 
 ### Changed
 - [#12019](https://github.com/MetaMask/metamask-extension/pull/12019): Show the user's address book name for a contract, instead of the contract address, when on the confirmation screen
@@ -35,19 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#11795](https://github.com/MetaMask/metamask-extension/pull/11795): Autofocus the Amount field on the Send screen
 - [#11889](https://github.com/MetaMask/metamask-extension/pull/11889): Improve gas controls descriptions
 - [#11805](https://github.com/MetaMask/metamask-extension/pull/11805): Update tooltip text for gas fees to avoid referring to custom networks as "Ethereum".
-- [#11796](https://github.com/MetaMask/metamask-extension/pull/11796): Update Max Fee label in the edit gas display
 - [#11845](https://github.com/MetaMask/metamask-extension/pull/11845): Wrapping and unwrapping native currencies (e.g. ETH -> WETH) through Swaps now uses the wrapping contracts directly
 - [#12056](https://github.com/MetaMask/metamask-extension/pull/12056): Improve the text for the "Cancel Edit" button, and allow rejecting the transaction from the Edit screen.
 
 ### Fixed
-- [#12140](https://github.com/MetaMask/metamask-extension/pull/12140): Fixed max priority fee field so that there are not errors when attempting to enter more than 15 significant digits
+- [#12140](https://github.com/MetaMask/metamask-extension/pull/12140): Prevent the user from entering more than 15 significant digits in numeric fields, such as Max Priority Fee
+  - Previously, entering more than 15 significant digits would result in an error.
 - [#12169](https://github.com/MetaMask/metamask-extension/pull/12169): Fix handling of erroneous ERC-20 Token amount on the confirmation screen
   - Previously, if you entered a token amount with too many decimal places, it would corrupt the token amount in the transaction. Now we truncate any decimals beyond what the token allows instead.
 - [#12074](https://github.com/MetaMask/metamask-extension/pull/12074): Prevent the addition of a duplicate, zero-balance account after importing a wallet with seed phrase
-- [#11944](https://github.com/MetaMask/metamask-extension/pull/11944): Fixed import account page layout
+- [#11944](https://github.com/MetaMask/metamask-extension/pull/11944): Improve the "Import account" page layout
 - [#11967](https://github.com/MetaMask/metamask-extension/pull/11967): Fix the display of long contact names on the contact settings pages.
 - [#12122](https://github.com/MetaMask/metamask-extension/pull/12122): Ensure failed speedups don't prevent further speedup attempts, and hide the Base Fee and Priority Fee fields when we don't have that information
-- [#12098](https://github.com/MetaMask/metamask-extension/pull/12098): Fixed scrolling input issue in advanced gas options
+- [#12098](https://github.com/MetaMask/metamask-extension/pull/12098): Scroll down to show all fields when "Advanced options" is toggled in the advanced gas options
 - [#11963](https://github.com/MetaMask/metamask-extension/pull/11963): Show scrollbar in the accounts menu
   - This makes the accounts list scrollable for users with no mouse scroll wheel. 
 - [#12058](https://github.com/MetaMask/metamask-extension/pull/12058): Fix clipping issue with long network names in the network dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,228 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [10.2.0]
-### Uncategorized
-- Adding base to BigNumber constructor to round off value ([#12140](https://github.com/MetaMask/metamask-extension/pull/12140))
-- Fix 12145 - Ledger errors being set as `Error: [object, object]` ([#12176](https://github.com/MetaMask/metamask-extension/pull/12176))
-- fix issue where duplicate tokens without icons appear in swap-to token list dropdown ([#12148](https://github.com/MetaMask/metamask-extension/pull/12148))
-- Jestify continue ([#12173](https://github.com/MetaMask/metamask-extension/pull/12173))
-- Hardening property check for stopPropagation in ConfirmTxScreen ([#12158](https://github.com/MetaMask/metamask-extension/pull/12158))
-- Truncate extra decimal places from token amount for sending ([#12169](https://github.com/MetaMask/metamask-extension/pull/12169))
-- Fix case of password env variable ([#12120](https://github.com/MetaMask/metamask-extension/pull/12120))
-- sync `master` with `develop` ([#12171](https://github.com/MetaMask/metamask-extension/pull/12171))
-- Jestify migrations/ ([#12106](https://github.com/MetaMask/metamask-extension/pull/12106))
-- fix sync conflicts
-- Merge remote-tracking branch 'origin/develop' into master-sync
-- fix pubnub dep vulnerabiltiy ([#12170](https://github.com/MetaMask/metamask-extension/pull/12170))
-- Fixing ledger steps display (Confirm TX) ([#12163](https://github.com/MetaMask/metamask-extension/pull/12163))
-- Adding a Token detection announcement in Search tab ([#12152](https://github.com/MetaMask/metamask-extension/pull/12152))
-- Add client id header for Swaps Apis ([#12137](https://github.com/MetaMask/metamask-extension/pull/12137))
-- Add add-recipient to Storybook ([#12076](https://github.com/MetaMask/metamask-extension/pull/12076))
-- Fix translation ([#12161](https://github.com/MetaMask/metamask-extension/pull/12161))
-- Moving UseTokenDetection toggle to new Experimental tab ([#12136](https://github.com/MetaMask/metamask-extension/pull/12136))
-- E2e remove xLargeDelayMs and xxLargeDelayMs delays ([#12160](https://github.com/MetaMask/metamask-extension/pull/12160))
-- Updating swaps availability tooltip text ([#12157](https://github.com/MetaMask/metamask-extension/pull/12157))
-- Change remote redux devtools url to redux devtools ([#12151](https://github.com/MetaMask/metamask-extension/pull/12151))
-- Interacting with MetaMask Notification window ([#12147](https://github.com/MetaMask/metamask-extension/pull/12147))
-- Changing cancel button labels in send screen when in editing stage ([#12056](https://github.com/MetaMask/metamask-extension/pull/12056))
-- Fixes #12073: Extra account with zero balance always added when importing wallet with seed and when first account's balance is non-zero  ([#12074](https://github.com/MetaMask/metamask-extension/pull/12074))
-- bump @metamask/controllers to v16.0.0 ([#12133](https://github.com/MetaMask/metamask-extension/pull/12133))
-- Revisit #12019 : Show save dialog when calling a smart contract method and use the saved contact is already saved ([#12090](https://github.com/MetaMask/metamask-extension/pull/12090))
-- Changing Use Token detection to  OFF by default ([#12129](https://github.com/MetaMask/metamask-extension/pull/12129))
-- Adding "Enable smart contract data" step to Ledger Instructions (Confirmation Screen) ([#12115](https://github.com/MetaMask/metamask-extension/pull/12115))
-- Build: Lint files after removing their code fences ([#12075](https://github.com/MetaMask/metamask-extension/pull/12075))
-- Fixes tx list item test formatting, importing, and useDispatch mocking. ([#12123](https://github.com/MetaMask/metamask-extension/pull/12123))
-- Replace hardcoded sent ether label on confirm screen ([#11802](https://github.com/MetaMask/metamask-extension/pull/11802))
-- fix stuck speedup problem ([#12122](https://github.com/MetaMask/metamask-extension/pull/12122))
-- Hook up shared TokenRatesController ([#12066](https://github.com/MetaMask/metamask-extension/pull/12066))
-- Fix failing transaction-list-item.component test by mocking useLayoutEffect ([#12118](https://github.com/MetaMask/metamask-extension/pull/12118))
-- CI - add metamaskbot comment "highlights" section for showing relevant storybook changes ([#12095](https://github.com/MetaMask/metamask-extension/pull/12095))
-- Using design system breakpoint values across ui/ ([#11976](https://github.com/MetaMask/metamask-extension/pull/11976))
-- Adding search tab in import tokens for custom networks ([#12110](https://github.com/MetaMask/metamask-extension/pull/12110))
-- Quotes prefetching in Swaps ([#11915](https://github.com/MetaMask/metamask-extension/pull/11915))
-- Scroll all inputs into view when clicking Advanced options in gas edit modal ([#12098](https://github.com/MetaMask/metamask-extension/pull/12098))
-- change anonymous id to quotation marks ([#12068](https://github.com/MetaMask/metamask-extension/pull/12068))
-- Add build-time code exclusion using code fencing ([#12060](https://github.com/MetaMask/metamask-extension/pull/12060))
-- E2e fixtures navigate transactions ([#12101](https://github.com/MetaMask/metamask-extension/pull/12101))
-- limit x server check to CI ([#12099](https://github.com/MetaMask/metamask-extension/pull/12099))
-- Scroll all inputs into view when clicking Advanced options in gas edit modal
-- Add send-gas-row to Storybook ([#12083](https://github.com/MetaMask/metamask-extension/pull/12083))
-- Add send-footer to Storybook ([#12082](https://github.com/MetaMask/metamask-extension/pull/12082))
-- Add contact-list-tab to Storybook ([#12079](https://github.com/MetaMask/metamask-extension/pull/12079))
-- Add advanced-tab to Storybook ([#12077](https://github.com/MetaMask/metamask-extension/pull/12077))
-- Add transaction-list to Storybook ([#12011](https://github.com/MetaMask/metamask-extension/pull/12011))
-- Truncate long network names ([#12058](https://github.com/MetaMask/metamask-extension/pull/12058))
-- Fixing breakpoint fallthroughs
-- Using design system breakpoint values across ui/
-- changing token address to lowercase for dynamic token list ([#12071](https://github.com/MetaMask/metamask-extension/pull/12071))
-- Adding fake token warning and replacing `Add Token` labels with `Import Tokens` ([#11798](https://github.com/MetaMask/metamask-extension/pull/11798))
-- Adding `Refresh list` and `import tokens` link to the main page ([#11755](https://github.com/MetaMask/metamask-extension/pull/11755))
-- Adding Token Detection Toggle to Security & Privacy ([#11851](https://github.com/MetaMask/metamask-extension/pull/11851))
-- Integrate TokensController ([#11552](https://github.com/MetaMask/metamask-extension/pull/11552))
-- Bump @metamask/controllers from 15.0.2 to 15.1.0 ([#12054](https://github.com/MetaMask/metamask-extension/pull/12054))
-- Integrating the TokenListController to Extension ([#11398](https://github.com/MetaMask/metamask-extension/pull/11398))
-- Use the same wording during onboard for importing a wallet, secret recovery phrase, and remove the term vault ([#12044](https://github.com/MetaMask/metamask-extension/pull/12044))
-- Rationalize build system arguments ([#12047](https://github.com/MetaMask/metamask-extension/pull/12047))
-- Update verbiage of Main Net to Mainnet ([#11880](https://github.com/MetaMask/metamask-extension/pull/11880))
-- remove unused sidebar component ([#12048](https://github.com/MetaMask/metamask-extension/pull/12048))
-- Add scrollbar in My Accounts Menu ([#11963](https://github.com/MetaMask/metamask-extension/pull/11963))
-- Fix padding at bottom of custom network form in popup view ([#12039](https://github.com/MetaMask/metamask-extension/pull/12039))
-- Upgrade chromedriver to 93 ([#11990](https://github.com/MetaMask/metamask-extension/pull/11990))
-- Create MetaMask Beta build ([#10985](https://github.com/MetaMask/metamask-extension/pull/10985))
-- Use the same wording during onboard for importing a wallet, secret recovery phrase, and remove the term vault
-- Add support for swaps via a direct contract for wrapping and unwrapping ([#11845](https://github.com/MetaMask/metamask-extension/pull/11845))
-- Add Max Fee Per Gas to transaction breakdown ([#12042](https://github.com/MetaMask/metamask-extension/pull/12042))
-- Fix e2e to not check for X when running locally ([#12043](https://github.com/MetaMask/metamask-extension/pull/12043))
-- Set up Jest minimum threshold for "ui" and "shared" folders ([#11922](https://github.com/MetaMask/metamask-extension/pull/11922))
-- Use Swaps dev APIs based on an env variable ([#11924](https://github.com/MetaMask/metamask-extension/pull/11924))
-- A typo in the button name ([#12040](https://github.com/MetaMask/metamask-extension/pull/12040))
-- Disabled spell-check on ens input ([#11964](https://github.com/MetaMask/metamask-extension/pull/11964))
-- Fix for: Confirmation screen should show local nicknames even when invoking a contract method ([#12019](https://github.com/MetaMask/metamask-extension/pull/12019))
-- A typo in the button name
-- Fix padding at bottom of custom network form in popup view
-- Update eth_sign warning language ([#12034](https://github.com/MetaMask/metamask-extension/pull/12034))
-- fix state problems with Storybook ([#11984](https://github.com/MetaMask/metamask-extension/pull/11984))
-- Refactor contact name code using ternary operator.
-- Use variable to check if should display dialog and display dialog inline.
-- Sync `master` with `develop` ([#12033](https://github.com/MetaMask/metamask-extension/pull/12033))
-- Merge remote-tracking branch 'origin/develop' into master-sync
-- Separate container from component as per https://github.com/MetaMask/metamask-extension/pull/12019#discussion_r703804969
-- fix(locales): bad Turkish translation for rejecting a transaction ([#12021](https://github.com/MetaMask/metamask-extension/pull/12021))
-- Improving warning text for eth_sign ([#12013](https://github.com/MetaMask/metamask-extension/pull/12013))
-- Added `getPersistentState` support for V2 controllers `persist` metadata ([#12007](https://github.com/MetaMask/metamask-extension/pull/12007))
-- Fix for: Confirmation screen should show local nicknames even when invoking a contract method #11148
-- Sort contacts alphabetically ([#11982](https://github.com/MetaMask/metamask-extension/pull/11982))
-- Autofilling new issue link with url and domain (Phishing detect page) ([#12000](https://github.com/MetaMask/metamask-extension/pull/12000))
-- fix import account page layout ([#11944](https://github.com/MetaMask/metamask-extension/pull/11944))
-- fix contact settings layout issues ([#11967](https://github.com/MetaMask/metamask-extension/pull/11967))
-- send user to account page upon adding a custom network ([#11945](https://github.com/MetaMask/metamask-extension/pull/11945))
-- Bump tar from 4.4.15 to 4.4.19 ([#11998](https://github.com/MetaMask/metamask-extension/pull/11998))
-- bump @metamask/controllers to v15.0.2 and remove AbortController workaround in e2e tests ([#11988](https://github.com/MetaMask/metamask-extension/pull/11988))
-- cap resubmit transaction retries to within 50 blocks of first submission ([#12003](https://github.com/MetaMask/metamask-extension/pull/12003))
-- Add eth_feeHistory to safe method list ([#11999](https://github.com/MetaMask/metamask-extension/pull/11999))
-- Fixing horizontal line for gas recommendations ([#11890](https://github.com/MetaMask/metamask-extension/pull/11890))
-- Bump minimum Chrome version to 66 ([#11995](https://github.com/MetaMask/metamask-extension/pull/11995))
-- Update copy in dapp suggested gas fee tooltip to: "Edit to use MetaMask's recommended gas fee based on the latest block." #11952 ([#11986](https://github.com/MetaMask/metamask-extension/pull/11986))
-- Fix 'yarn setup' on M1 Macs ([#11887](https://github.com/MetaMask/metamask-extension/pull/11887))
-- @metamask/controllers@15.0.0 ([#11975](https://github.com/MetaMask/metamask-extension/pull/11975))
-- Allow excluding lockdown at build time ([#11937](https://github.com/MetaMask/metamask-extension/pull/11937))
-- send-content ([#11962](https://github.com/MetaMask/metamask-extension/pull/11962))
-- token-placeholder ([#11961](https://github.com/MetaMask/metamask-extension/pull/11961))
-- token-search ([#11960](https://github.com/MetaMask/metamask-extension/pull/11960))
-- gas-fee-display ([#11959](https://github.com/MetaMask/metamask-extension/pull/11959))
-- add-token ([#11957](https://github.com/MetaMask/metamask-extension/pull/11957))
-- account-list-item ([#11956](https://github.com/MetaMask/metamask-extension/pull/11956))
-- unlock-page ([#11955](https://github.com/MetaMask/metamask-extension/pull/11955))
-- swaps-gas-customization ([#11938](https://github.com/MetaMask/metamask-extension/pull/11938))
-- import token ([#11657](https://github.com/MetaMask/metamask-extension/pull/11657))
-- Add first time flow components to Storybook ([#11655](https://github.com/MetaMask/metamask-extension/pull/11655))
-- create-password ([#11646](https://github.com/MetaMask/metamask-extension/pull/11646))
-- Add mobile-sync component to Storybook ([#11645](https://github.com/MetaMask/metamask-extension/pull/11645))
-- Add permissions-connect component to Storybook ([#11644](https://github.com/MetaMask/metamask-extension/pull/11644))
-- Add new-account component to Storybook ([#11638](https://github.com/MetaMask/metamask-extension/pull/11638))
-- Add connected-accounts component to Storybook ([#11637](https://github.com/MetaMask/metamask-extension/pull/11637))
-- Add connected-sites component to Storybook ([#11415](https://github.com/MetaMask/metamask-extension/pull/11415))
-- Add confirm-send-token component to Storybook ([#11399](https://github.com/MetaMask/metamask-extension/pull/11399))
-- confirm-transaction-base ([#11396](https://github.com/MetaMask/metamask-extension/pull/11396))
-- Add confirm-send-ether component to Storybook ([#11395](https://github.com/MetaMask/metamask-extension/pull/11395))
-- Make all named intrinsics non-modifiable ([#11953](https://github.com/MetaMask/metamask-extension/pull/11953))
-- disabled spell-check on ens input
-- fixed scrolling issue with many accounts
-- Guarding against null keyring (Hardware Wallet Selectors) ([#11893](https://github.com/MetaMask/metamask-extension/pull/11893))
-- Sync `master` with `develop` ([#11941](https://github.com/MetaMask/metamask-extension/pull/11941))
-- Merge remote-tracking branch 'origin/develop' into master-sync
-- refactor account details test to use fixtures ([#11926](https://github.com/MetaMask/metamask-extension/pull/11926))
-- Updating message about disabled Mobile Sync ([#11935](https://github.com/MetaMask/metamask-extension/pull/11935))
-- Fixing error handling for `publish()` (MobileSync) ([#11909](https://github.com/MetaMask/metamask-extension/pull/11909))
-- Localize import account warning messages ([#11910](https://github.com/MetaMask/metamask-extension/pull/11910))
-- Adding UI helpers for URL parsing ([#11899](https://github.com/MetaMask/metamask-extension/pull/11899))
-- Bump @metamask/contract-metadata from 1.28.0 to 1.29.0 ([#11914](https://github.com/MetaMask/metamask-extension/pull/11914))
-- Update header on Send page to be more accurate ([#11895](https://github.com/MetaMask/metamask-extension/pull/11895))
-- Gas controls copy updates (EIP-1559) ([#11889](https://github.com/MetaMask/metamask-extension/pull/11889))
-- Fix typo in mobile sync warning message ([#11888](https://github.com/MetaMask/metamask-extension/pull/11888))
-- Adding subtitles for additional languages (SRP Video) ([#11849](https://github.com/MetaMask/metamask-extension/pull/11849))
-- Adding yarn scripts for changelog validation ([#11868](https://github.com/MetaMask/metamask-extension/pull/11868))
-- Sync `master` with `develop` ([#11878](https://github.com/MetaMask/metamask-extension/pull/11878))
-- Merge remote-tracking branch 'origin/develop' into master-sync
-- Using "Secret Recovery Phrase" throughout the onboarding flow ([#11850](https://github.com/MetaMask/metamask-extension/pull/11850))
-- Fix content cutoff issue (Mobile Sync View ([#11871](https://github.com/MetaMask/metamask-extension/pull/11871))
-- Improving handling for non-existent props in state migrations ([#11829](https://github.com/MetaMask/metamask-extension/pull/11829))
-- Allow submission of transactions with dapp suggested gas fees, while estimates are loading ([#11858](https://github.com/MetaMask/metamask-extension/pull/11858))
-- Allow advanced inline gas editing when there is an estimates unavailable error ([#11859](https://github.com/MetaMask/metamask-extension/pull/11859))
-- Removing unnecessary console log from the preferences controller ([#11828](https://github.com/MetaMask/metamask-extension/pull/11828))
-- Add confirm-add-suggested-token &  confirm-add-token components to Storybook ([#11175](https://github.com/MetaMask/metamask-extension/pull/11175))
-- Add confirm-token-transaction-base component to Storybook ([#11414](https://github.com/MetaMask/metamask-extension/pull/11414))
-- awaiting signature ([#11656](https://github.com/MetaMask/metamask-extension/pull/11656))
-- Do not attempt to track tx metrics events if txMeta is not available ([#11823](https://github.com/MetaMask/metamask-extension/pull/11823))
-- Improve traduction "off" in french ([#11844](https://github.com/MetaMask/metamask-extension/pull/11844))
-- Gas Timing with Negative attitude should be bold with tooltip ([#11772](https://github.com/MetaMask/metamask-extension/pull/11772))
-- EIP-1559 - Update tooltip text for gas fees ([#11805](https://github.com/MetaMask/metamask-extension/pull/11805))
-- Keep radio group contained and equal width ([#11771](https://github.com/MetaMask/metamask-extension/pull/11771))
-- Fixing persisting error message from MobileSyncPage ([#11835](https://github.com/MetaMask/metamask-extension/pull/11835))
-- Bump @metamask/controllers from 14.1.0 to 14.2.0 ([#11825](https://github.com/MetaMask/metamask-extension/pull/11825))
-- Fix URL ([#11832](https://github.com/MetaMask/metamask-extension/pull/11832))
-- Fix Insufficient number of substitutions for key "swapYourTokenBalance" ([#11833](https://github.com/MetaMask/metamask-extension/pull/11833))
-- Return an empty string when date is not provided [Date display utils] ([#11831](https://github.com/MetaMask/metamask-extension/pull/11831))
-- Hardening clipboardData handling in EnsInput ([#11822](https://github.com/MetaMask/metamask-extension/pull/11822))
-- Remove unwanted console.log from codebase ([#11820](https://github.com/MetaMask/metamask-extension/pull/11820))
-- Sync `master` with `develop` ([#11819](https://github.com/MetaMask/metamask-extension/pull/11819))
-- Merge remote-tracking branch 'origin/develop' into master-sync
-- Bump @metamask/controllers from 14.0.2 to 14.1.0 ([#11793](https://github.com/MetaMask/metamask-extension/pull/11793))
-- Bump @metamask/auto-changelog from 2.4.0 to 2.5.0 ([#11691](https://github.com/MetaMask/metamask-extension/pull/11691))
-- Update out of sync yarn.lock file ([#11815](https://github.com/MetaMask/metamask-extension/pull/11815))
-- Sync `master` with `develop` ([#11804](https://github.com/MetaMask/metamask-extension/pull/11804))
-- Adjusting Max Fee label in EditGasDisplay per designs ([#11796](https://github.com/MetaMask/metamask-extension/pull/11796))
-- Revert "Add temporary entry to cla bot allowlist to workaround cla-bot bug"
-- Merge remote-tracking branch 'origin/develop' into master-sync
-- Fixing devDependencies package ordering ([#11806](https://github.com/MetaMask/metamask-extension/pull/11806))
-- add appropriate test timeouts ([#11667](https://github.com/MetaMask/metamask-extension/pull/11667))
-- Correct the vertical margins on the RadioGroup component ([#11769](https://github.com/MetaMask/metamask-extension/pull/11769))
-- Autofocus the unit fiend in send screen ([#11795](https://github.com/MetaMask/metamask-extension/pull/11795))
-- Fixing EditGasDisplay console errors ([#11797](https://github.com/MetaMask/metamask-extension/pull/11797))
-- bump path-parse version to address security vulnerability ([#11807](https://github.com/MetaMask/metamask-extension/pull/11807))
-- Selected radio group label should be black ([#11770](https://github.com/MetaMask/metamask-extension/pull/11770))
-- Ensure transaction activity log supports EIP-1559 ([#11794](https://github.com/MetaMask/metamask-extension/pull/11794))
-- Hide gasTiming on edit-gas-popover when form is in error ([#11792](https://github.com/MetaMask/metamask-extension/pull/11792))
-- Fixes updates on the confirm screen. ([#11788](https://github.com/MetaMask/metamask-extension/pull/11788))
-- Fix fee level content ([#11790](https://github.com/MetaMask/metamask-extension/pull/11790))
-- EIP-1559 - Ensure form always displays when there are errors ([#11787](https://github.com/MetaMask/metamask-extension/pull/11787))
-- fix confirm transaction details to match spec ([#11779](https://github.com/MetaMask/metamask-extension/pull/11779))
-- Restore heartbeat to transaction confirmation, use isGasEstimatesLoading more broadly ([#11781](https://github.com/MetaMask/metamask-extension/pull/11781))
-- Separate out non blocking gas errors ([#11783](https://github.com/MetaMask/metamask-extension/pull/11783))
-- Add fee level education button to swaps edit gas popover ([#11785](https://github.com/MetaMask/metamask-extension/pull/11785))
-- Fix NumericInput proptype error ([#11773](https://github.com/MetaMask/metamask-extension/pull/11773))
-- Allow max fee to be equal to max priority fee ([#11778](https://github.com/MetaMask/metamask-extension/pull/11778))
-- Bump tar from 4.4.11 to 4.4.15 ([#11753](https://github.com/MetaMask/metamask-extension/pull/11753))
-- Use bignumber for number comparisons in useGasFeeInput ([#11776](https://github.com/MetaMask/metamask-extension/pull/11776))
-- Ensure that gas fee inputs fallback to tx params values if api is down ([#11775](https://github.com/MetaMask/metamask-extension/pull/11775))
-- Ensure that gas fee minimum errors show when api is down ([#11767](https://github.com/MetaMask/metamask-extension/pull/11767))
-- Fix legacy unapproved tx handling ([#11766](https://github.com/MetaMask/metamask-extension/pull/11766))
-- Update `eth-phishing-detect` to latest version ([#11756](https://github.com/MetaMask/metamask-extension/pull/11756))
-- tiny lost code change from 9.8.4 RC ([#11764](https://github.com/MetaMask/metamask-extension/pull/11764))
-- EIP-1559 - Fix mislabeled MaxPriority fee key ([#11758](https://github.com/MetaMask/metamask-extension/pull/11758))
-- Stop GasFeeController polling when pop closes ([#11746](https://github.com/MetaMask/metamask-extension/pull/11746))
-- Provide pointer cursor for radio group buttons ([#11763](https://github.com/MetaMask/metamask-extension/pull/11763))
-- Show advanced options, and hide radio buttons, for advanced gas settings users ([#11751](https://github.com/MetaMask/metamask-extension/pull/11751))
-- EIP-1559 - Prevent uncaught exception when passing fees to getGasFeeTimeEstimate ([#11759](https://github.com/MetaMask/metamask-extension/pull/11759))
-- EIP-1559 - Temporarily remove the loading heartbeat from the transaction detail ([#11762](https://github.com/MetaMask/metamask-extension/pull/11762))
-- EIP-1559 - Remove unncessary props from AdvancedFormControls ([#11757](https://github.com/MetaMask/metamask-extension/pull/11757))
-- Ensure gas fees update in popover on poll for new values ([#11760](https://github.com/MetaMask/metamask-extension/pull/11760))
-- remove unnecessary conversion call ([#11742](https://github.com/MetaMask/metamask-extension/pull/11742))
-- Fixing errors in EditGasDisplay ([#11748](https://github.com/MetaMask/metamask-extension/pull/11748))
-- Allow max priority fee to be below 1, and only require it to be greater than 0 ([#11749](https://github.com/MetaMask/metamask-extension/pull/11749))
-- Allows users to set a max priority fee below suggested, just showing a warning in that case ([#11750](https://github.com/MetaMask/metamask-extension/pull/11750))
-- Rename effective gas price field to total gas fee ([#11754](https://github.com/MetaMask/metamask-extension/pull/11754))
-- Fix ipfs dependency vulernability ([#11745](https://github.com/MetaMask/metamask-extension/pull/11745))
-- Remove estimate detail above advanced gas controls in non-1559 network ([#11744](https://github.com/MetaMask/metamask-extension/pull/11744))
-- Fall back to aggregator name when icon is unavailable (Swaps Load View) ([#11718](https://github.com/MetaMask/metamask-extension/pull/11718))
-- EIP-1559 - Show minium native currency in banner when on testnets ([#11743](https://github.com/MetaMask/metamask-extension/pull/11743))
-- Fix a position of a tooltip icon ([#11739](https://github.com/MetaMask/metamask-extension/pull/11739))
-- Add gasPrice to be used on non-1559 networks for transaction details on confirm screen ([#11741](https://github.com/MetaMask/metamask-extension/pull/11741))
-- EIP-1559 - Provide better validation for gas price and gas limit ([#11736](https://github.com/MetaMask/metamask-extension/pull/11736))
-- EIP-1559 - Fix education modal typo ([#11740](https://github.com/MetaMask/metamask-extension/pull/11740))
-- Ensure that gas price in popover updates when api provided estimate updates ([#11727](https://github.com/MetaMask/metamask-extension/pull/11727))
-- EIP-1559 - Ensure transaction detail font-size and icon colors are consistent with Figma design ([#11735](https://github.com/MetaMask/metamask-extension/pull/11735))
-- EIP-1559 - Return null from GasTiming if on non-1559 network ([#11733](https://github.com/MetaMask/metamask-extension/pull/11733))
+### Added
+- [#12066](https://github.com/MetaMask/metamask-extension/pull/12066): Enable token conversion rates for primary currencies on some non-Mainnet networks
+- [#12110](https://github.com/MetaMask/metamask-extension/pull/12110): Add search tab in import tokens for custom networks
+  - Tab will be hidden when the `Use Token Detection` setting is disabled
+- [#11798](https://github.com/MetaMask/metamask-extension/pull/11798): Add fake token warning and replacing `Add Token` labels with `Import Tokens`
+- [#11755](https://github.com/MetaMask/metamask-extension/pull/11755): Add `Refresh list` and `import tokens` link to the main page
+  - Links will be hidden when the `Use Token Detection` setting is disabled
+- [#11851](https://github.com/MetaMask/metamask-extension/pull/11851): Add Token Detection Toggle to Security & Privacy (Settings)
+- [#12042](https://github.com/MetaMask/metamask-extension/pull/12042): Add Max Fee Per Gas to transaction breakdown
+- [#11999](https://github.com/MetaMask/metamask-extension/pull/11999): Add eth_feeHistory to API callable by dapps
+- [#11849](https://github.com/MetaMask/metamask-extension/pull/11849): Add subtitles for additional languages (Secret Recovery Phrase Video)
+- [#11772](https://github.com/MetaMask/metamask-extension/pull/11772): Add tooltip to better explain possible effects of setting gas fees below MetaMask's estimates
+
+### Changed
+- [#12019](https://github.com/MetaMask/metamask-extension/pull/12019): Show the user's address book name for a contract, instead of the contract address, when on the confirmation screen
+- [#11915](https://github.com/MetaMask/metamask-extension/pull/11915): Improved time to see Swaps quotes
+- [#11802](https://github.com/MetaMask/metamask-extension/pull/11802): Replace hardcoded sent ether label on confirmation screen
+- [#11982](https://github.com/MetaMask/metamask-extension/pull/11982): Sort addresses within letter groups in address book / contacts alphabetically
+- [#12000](https://github.com/MetaMask/metamask-extension/pull/12000): Autofilling new issue link with url and domain (Phishing detect page)
+- [#11964](https://github.com/MetaMask/metamask-extension/pull/11964): Disabled spell-check on ens input
+- [#12013](https://github.com/MetaMask/metamask-extension/pull/12013): Improving warning text for eth_sign transactions
+- [#11945](https://github.com/MetaMask/metamask-extension/pull/11945): Send user to account page upon adding a custom network
+- [#11895](https://github.com/MetaMask/metamask-extension/pull/11895): Update header on Send page from `Add Recipient` -> `Send to`
+- [#11850](https://github.com/MetaMask/metamask-extension/pull/11850): Use "Secret Recovery Phrase" text throughout the onboarding flow
+- [#11795](https://github.com/MetaMask/metamask-extension/pull/11795): Autofocus the unit field in send screen
+- [#11889](https://github.com/MetaMask/metamask-extension/pull/11889): Update gas controls copy
+- [#11805](https://github.com/MetaMask/metamask-extension/pull/11805): Update tooltip text for gas fees
+- [#11796](https://github.com/MetaMask/metamask-extension/pull/11796): Update Max Fee label in the edit gas display
+- [#11845](https://github.com/MetaMask/metamask-extension/pull/11845): Wrapping and unwrapping native currencies (e.g. ETH -> WETH) through Swaps now uses the wrapping contracts directly
+- [#12056](https://github.com/MetaMask/metamask-extension/pull/12056): Updated labels and behaviour of duplicate cancel buttons on the send screen when editing a transaction
+
+### Fixed
+- [#12140](https://github.com/MetaMask/metamask-extension/pull/12140): Fixed max priority fee field so that there are not errors when attempting to enter more than 15 significant digits
+- [#12169](https://github.com/MetaMask/metamask-extension/pull/12169): Fixed erroneous ERC-20 Token amount on the confirmation screen
+- [#12074](https://github.com/MetaMask/metamask-extension/pull/12074): Fixed the addition of a duplicate, zero-balance account after importing a wallet with seed phrase
+- [#11944](https://github.com/MetaMask/metamask-extension/pull/11944): Fixed import account page layout
+- [#11967](https://github.com/MetaMask/metamask-extension/pull/11967): Fixed contact settings layout issues
+- [#12122](https://github.com/MetaMask/metamask-extension/pull/12122): Fixed stuck speedup transactions caused by prior failed speed up attempts
+- [#12098](https://github.com/MetaMask/metamask-extension/pull/12098): Fixed scrolling input issue in advanced gas options
+- [#11963](https://github.com/MetaMask/metamask-extension/pull/11963): Fixed scrolling issue in accounts dropdown
+- [#12058](https://github.com/MetaMask/metamask-extension/pull/12058): Fixed clipping issue with long network names (header)
+- [#12039](https://github.com/MetaMask/metamask-extension/pull/12039): Fixed padding issue at bottom of custom network form in popup view
+- [#11890](https://github.com/MetaMask/metamask-extension/pull/11890): Fixed horizontal line for gas recommendations
 
 ## [10.1.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#11755](https://github.com/MetaMask/metamask-extension/pull/11755): Add `Refresh list` and `import tokens` link to the main page
   - Links will be hidden when the `Use Token Detection` setting is disabled
 - [#11851](https://github.com/MetaMask/metamask-extension/pull/11851): Add Token Detection Toggle to Security & Privacy (Settings)
+  - This feature is experimental and is off by default, when enabled, it will add auto-detected tokens to a user's asset list
 - [#12042](https://github.com/MetaMask/metamask-extension/pull/12042): Add Max Fee Per Gas to transaction breakdown
 - [#11999](https://github.com/MetaMask/metamask-extension/pull/11999): Add eth_feeHistory to API callable by dapps
 - [#11849](https://github.com/MetaMask/metamask-extension/pull/11849): Add subtitles for additional languages (Secret Recovery Phrase Video)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [10.2.0]
 ### Added
 - [#12066](https://github.com/MetaMask/metamask-extension/pull/12066): Enable token conversion rates for primary currencies on some non-Mainnet networks
-- [#12110](https://github.com/MetaMask/metamask-extension/pull/12110): Add search tab in import tokens for custom networks
+- [#12110](https://github.com/MetaMask/metamask-extension/pull/12110): Enable search tab on "Import Tokens" page on supported custom networks
   - Tab will be hidden when the `Use Token Detection` setting is disabled
-- [#11798](https://github.com/MetaMask/metamask-extension/pull/11798): Add fake token warning and replacing `Add Token` labels with `Import Tokens`
-- [#11755](https://github.com/MetaMask/metamask-extension/pull/11755): Add `Refresh list` and `import tokens` link to the main page
-  - Links will be hidden when the `Use Token Detection` setting is disabled
-- [#11851](https://github.com/MetaMask/metamask-extension/pull/11851): Add Token Detection Toggle to Security & Privacy (Settings)
+- [#11798](https://github.com/MetaMask/metamask-extension/pull/11798): Add warning about fake tokens, and rename `Add Token` page to `Import Tokens`
+- [#11755](https://github.com/MetaMask/metamask-extension/pull/11755): Add `Refresh list` button to the main page
+  - This button is shown only when the `Use Token Detection` setting is disabled
+- [#11851](https://github.com/MetaMask/metamask-extension/pull/11851): Add Token Detection toggle to experimental settings
   - This feature is experimental and is off by default, when enabled, it will add auto-detected tokens to a user's asset list
 - [#12042](https://github.com/MetaMask/metamask-extension/pull/12042): Add Max Fee Per Gas to transaction breakdown
 - [#11999](https://github.com/MetaMask/metamask-extension/pull/11999): Add eth_feeHistory to API callable by dapps
@@ -24,33 +24,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [#12019](https://github.com/MetaMask/metamask-extension/pull/12019): Show the user's address book name for a contract, instead of the contract address, when on the confirmation screen
 - [#11915](https://github.com/MetaMask/metamask-extension/pull/11915): Improved time to see Swaps quotes
-- [#11802](https://github.com/MetaMask/metamask-extension/pull/11802): Replace hardcoded sent ether label on confirmation screen
-- [#11982](https://github.com/MetaMask/metamask-extension/pull/11982): Sort addresses within letter groups in address book / contacts alphabetically
-- [#12000](https://github.com/MetaMask/metamask-extension/pull/12000): Autofilling new issue link with url and domain (Phishing detect page)
-- [#11964](https://github.com/MetaMask/metamask-extension/pull/11964): Disabled spell-check on ens input
+- [#11802](https://github.com/MetaMask/metamask-extension/pull/11802): Display the correct currency symbol in function type label for simple send transactions on custom networks
+- [#11982](https://github.com/MetaMask/metamask-extension/pull/11982): Sort contacts alphabetically within each letter group in the contact list.
+- [#12000](https://github.com/MetaMask/metamask-extension/pull/12000): Include the blocked URL in the link to report an incorrectly blocked page.
+- [#11964](https://github.com/MetaMask/metamask-extension/pull/11964): Disable spell-check in the address input
 - [#12013](https://github.com/MetaMask/metamask-extension/pull/12013): Improving warning text for eth_sign transactions
 - [#11945](https://github.com/MetaMask/metamask-extension/pull/11945): Send user to account page upon adding a custom network
 - [#11895](https://github.com/MetaMask/metamask-extension/pull/11895): Update header on Send page from `Add Recipient` -> `Send to`
 - [#11850](https://github.com/MetaMask/metamask-extension/pull/11850): Use "Secret Recovery Phrase" text throughout the onboarding flow
-- [#11795](https://github.com/MetaMask/metamask-extension/pull/11795): Autofocus the unit field in send screen
-- [#11889](https://github.com/MetaMask/metamask-extension/pull/11889): Update gas controls copy
-- [#11805](https://github.com/MetaMask/metamask-extension/pull/11805): Update tooltip text for gas fees
+- [#11795](https://github.com/MetaMask/metamask-extension/pull/11795): Autofocus the Amount field on the Send screen
+- [#11889](https://github.com/MetaMask/metamask-extension/pull/11889): Improve gas controls descriptions
+- [#11805](https://github.com/MetaMask/metamask-extension/pull/11805): Update tooltip text for gas fees to avoid referring to custom networks as "Ethereum".
 - [#11796](https://github.com/MetaMask/metamask-extension/pull/11796): Update Max Fee label in the edit gas display
 - [#11845](https://github.com/MetaMask/metamask-extension/pull/11845): Wrapping and unwrapping native currencies (e.g. ETH -> WETH) through Swaps now uses the wrapping contracts directly
-- [#12056](https://github.com/MetaMask/metamask-extension/pull/12056): Updated labels and behaviour of duplicate cancel buttons on the send screen when editing a transaction
+- [#12056](https://github.com/MetaMask/metamask-extension/pull/12056): Improve the text for the "Cancel Edit" button, and allow rejecting the transaction from the Edit screen.
 
 ### Fixed
 - [#12140](https://github.com/MetaMask/metamask-extension/pull/12140): Fixed max priority fee field so that there are not errors when attempting to enter more than 15 significant digits
-- [#12169](https://github.com/MetaMask/metamask-extension/pull/12169): Fixed erroneous ERC-20 Token amount on the confirmation screen
-- [#12074](https://github.com/MetaMask/metamask-extension/pull/12074): Fixed the addition of a duplicate, zero-balance account after importing a wallet with seed phrase
+- [#12169](https://github.com/MetaMask/metamask-extension/pull/12169): Fix handling of erroneous ERC-20 Token amount on the confirmation screen
+  - Previously, if you entered a token amount with too many decimal places, it would corrupt the token amount in the transaction. Now we truncate any decimals beyond what the token allows instead.
+- [#12074](https://github.com/MetaMask/metamask-extension/pull/12074): Prevent the addition of a duplicate, zero-balance account after importing a wallet with seed phrase
 - [#11944](https://github.com/MetaMask/metamask-extension/pull/11944): Fixed import account page layout
-- [#11967](https://github.com/MetaMask/metamask-extension/pull/11967): Fixed contact settings layout issues
-- [#12122](https://github.com/MetaMask/metamask-extension/pull/12122): Fixed stuck speedup transactions caused by prior failed speed up attempts
+- [#11967](https://github.com/MetaMask/metamask-extension/pull/11967): Fix the display of long contact names on the contact settings pages.
+- [#12122](https://github.com/MetaMask/metamask-extension/pull/12122): Ensure failed speedups don't prevent further speedup attempts, and hide the Base Fee and Priority Fee fields when we don't have that information
 - [#12098](https://github.com/MetaMask/metamask-extension/pull/12098): Fixed scrolling input issue in advanced gas options
-- [#11963](https://github.com/MetaMask/metamask-extension/pull/11963): Fixed scrolling issue in accounts dropdown
-- [#12058](https://github.com/MetaMask/metamask-extension/pull/12058): Fixed clipping issue with long network names (header)
-- [#12039](https://github.com/MetaMask/metamask-extension/pull/12039): Fixed padding issue at bottom of custom network form in popup view
-- [#11890](https://github.com/MetaMask/metamask-extension/pull/11890): Fixed horizontal line for gas recommendations
+- [#11963](https://github.com/MetaMask/metamask-extension/pull/11963): Show scrollbar in the accounts menu
+  - This makes the accounts list scrollable for users with no mouse scroll wheel. 
+- [#12058](https://github.com/MetaMask/metamask-extension/pull/12058): Fix clipping issue with long network names in the network dropdown
+- [#12039](https://github.com/MetaMask/metamask-extension/pull/12039): Add missing padding at the bottom of the custom network form in the popup view
+- [#11890](https://github.com/MetaMask/metamask-extension/pull/11890): Fix alignment of horizontal line shown under gas recommendations
 
 ## [10.1.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#11805](https://github.com/MetaMask/metamask-extension/pull/11805): Update tooltip text for gas fees to avoid referring to custom networks as "Ethereum".
 - [#11845](https://github.com/MetaMask/metamask-extension/pull/11845): Wrapping and unwrapping native currencies (e.g. ETH -> WETH) through Swaps now uses the wrapping contracts directly
 - [#12056](https://github.com/MetaMask/metamask-extension/pull/12056): Improve the text for the "Cancel Edit" button, and allow rejecting the transaction from the Edit screen.
+- [#12098](https://github.com/MetaMask/metamask-extension/pull/12098): Scroll down to show all fields when "Advanced options" is toggled in the advanced gas options
+- [#11944](https://github.com/MetaMask/metamask-extension/pull/11944): Improve the "Import account" page layout
 
 ### Fixed
 - [#12140](https://github.com/MetaMask/metamask-extension/pull/12140): Prevent the user from entering more than 15 significant digits in numeric fields, such as Max Priority Fee
@@ -45,15 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#12169](https://github.com/MetaMask/metamask-extension/pull/12169): Fix handling of erroneous ERC-20 Token amount on the confirmation screen
   - Previously, if you entered a token amount with too many decimal places, it would corrupt the token amount in the transaction. Now we truncate any decimals beyond what the token allows instead.
 - [#12074](https://github.com/MetaMask/metamask-extension/pull/12074): Prevent the addition of a duplicate, zero-balance account after importing a wallet with seed phrase
-- [#11944](https://github.com/MetaMask/metamask-extension/pull/11944): Improve the "Import account" page layout
 - [#11967](https://github.com/MetaMask/metamask-extension/pull/11967): Fix the display of long contact names on the contact settings pages.
 - [#12122](https://github.com/MetaMask/metamask-extension/pull/12122): Ensure failed speedups don't prevent further speedup attempts, and hide the Base Fee and Priority Fee fields when we don't have that information
-- [#12098](https://github.com/MetaMask/metamask-extension/pull/12098): Scroll down to show all fields when "Advanced options" is toggled in the advanced gas options
 - [#11963](https://github.com/MetaMask/metamask-extension/pull/11963): Show scrollbar in the accounts menu
   - This makes the accounts list scrollable for users with no mouse scroll wheel. 
 - [#12058](https://github.com/MetaMask/metamask-extension/pull/12058): Fix clipping issue with long network names in the network dropdown
 - [#12039](https://github.com/MetaMask/metamask-extension/pull/12039): Add missing padding at the bottom of the custom network form in the popup view
 - [#11890](https://github.com/MetaMask/metamask-extension/pull/11890): Fix alignment of horizontal line shown under gas recommendations
+- [#12244](https://github.com/MetaMask/metamask-extension/pull/12244): Fix form prefilling with values on the Build Quote page [Swaps]
 
 ## [10.1.1]
 ### Added


### PR DESCRIPTION
## [10.2.0]
### Added
- [#12066](https://github.com/MetaMask/metamask-extension/pull/12066): Enable token conversion rates for primary currencies on some non-Mainnet networks
- [#12110](https://github.com/MetaMask/metamask-extension/pull/12110): Enable search tab on "Import Tokens" page on supported custom networks
  - Tab will be hidden when the `Use Token Detection` setting is disabled
- [#11798](https://github.com/MetaMask/metamask-extension/pull/11798): Add warning about fake tokens, and rename `Add Token` page to `Import Tokens`
- [#11755](https://github.com/MetaMask/metamask-extension/pull/11755): Add `Refresh list` button to the main page
  - This button is shown only when the `Use Token Detection` setting is disabled
- [#11851](https://github.com/MetaMask/metamask-extension/pull/11851): Add Token Detection toggle to experimental settings
  - This feature is experimental and is off by default, when enabled, it will add auto-detected tokens to a user's asset list
- [#12042](https://github.com/MetaMask/metamask-extension/pull/12042): Add Max Fee Per Gas to transaction breakdown
- [#11999](https://github.com/MetaMask/metamask-extension/pull/11999): Add eth_feeHistory to API callable by dapps
- [#11849](https://github.com/MetaMask/metamask-extension/pull/11849): Add subtitles for additional languages (Secret Recovery Phrase Video)
- [#11772](https://github.com/MetaMask/metamask-extension/pull/11772): Add tooltip to better explain possible effects of setting gas fees below MetaMask's estimates
- [#11796](https://github.com/MetaMask/metamask-extension/pull/11796): Add "Max fee" label to maximum fee amount in edit gas display

### Changed
- [#12019](https://github.com/MetaMask/metamask-extension/pull/12019): Show the user's address book name for a contract, instead of the contract address, when on the confirmation screen
- [#11915](https://github.com/MetaMask/metamask-extension/pull/11915): Improved time to see Swaps quotes
- [#11802](https://github.com/MetaMask/metamask-extension/pull/11802): Display the correct currency symbol in function type label for simple send transactions on custom networks
- [#11982](https://github.com/MetaMask/metamask-extension/pull/11982): Sort contacts alphabetically within each letter group in the contact list.
- [#12000](https://github.com/MetaMask/metamask-extension/pull/12000): Include the blocked URL in the link to report an incorrectly blocked page.
- [#11964](https://github.com/MetaMask/metamask-extension/pull/11964): Disable spell-check in the address input
- [#12013](https://github.com/MetaMask/metamask-extension/pull/12013): Improving warning text for eth_sign transactions
- [#11945](https://github.com/MetaMask/metamask-extension/pull/11945): Send user to account page upon adding a custom network
- [#11895](https://github.com/MetaMask/metamask-extension/pull/11895): Update header on Send page from `Add Recipient` -> `Send to`
- [#11850](https://github.com/MetaMask/metamask-extension/pull/11850): Use "Secret Recovery Phrase" text throughout the onboarding flow
- [#11795](https://github.com/MetaMask/metamask-extension/pull/11795): Autofocus the Amount field on the Send screen
- [#11889](https://github.com/MetaMask/metamask-extension/pull/11889): Improve gas controls descriptions
- [#11805](https://github.com/MetaMask/metamask-extension/pull/11805): Update tooltip text for gas fees to avoid referring to custom networks as "Ethereum".
- [#11845](https://github.com/MetaMask/metamask-extension/pull/11845): Wrapping and unwrapping native currencies (e.g. ETH -> WETH) through Swaps now uses the wrapping contracts directly
- [#12056](https://github.com/MetaMask/metamask-extension/pull/12056): Improve the text for the "Cancel Edit" button, and allow rejecting the transaction from the Edit screen.
- [#12098](https://github.com/MetaMask/metamask-extension/pull/12098): Scroll down to show all fields when "Advanced options" is toggled in the advanced gas options
- [#11944](https://github.com/MetaMask/metamask-extension/pull/11944): Improve the "Import account" page layout

### Fixed
- [#12140](https://github.com/MetaMask/metamask-extension/pull/12140): Prevent the user from entering more than 15 significant digits in numeric fields, such as Max Priority Fee
  - Previously, entering more than 15 significant digits would result in an error.
- [#12169](https://github.com/MetaMask/metamask-extension/pull/12169): Fix handling of erroneous ERC-20 Token amount on the confirmation screen
  - Previously, if you entered a token amount with too many decimal places, it would corrupt the token amount in the transaction. Now we truncate any decimals beyond what the token allows instead.
- [#12074](https://github.com/MetaMask/metamask-extension/pull/12074): Prevent the addition of a duplicate, zero-balance account after importing a wallet with seed phrase
- [#11967](https://github.com/MetaMask/metamask-extension/pull/11967): Fix the display of long contact names on the contact settings pages.
- [#12122](https://github.com/MetaMask/metamask-extension/pull/12122): Ensure failed speedups don't prevent further speedup attempts, and hide the Base Fee and Priority Fee fields when we don't have that information
- [#11963](https://github.com/MetaMask/metamask-extension/pull/11963): Show scrollbar in the accounts menu
  - This makes the accounts list scrollable for users with no mouse scroll wheel. 
- [#12058](https://github.com/MetaMask/metamask-extension/pull/12058): Fix clipping issue with long network names in the network dropdown
- [#12039](https://github.com/MetaMask/metamask-extension/pull/12039): Add missing padding at the bottom of the custom network form in the popup view
- [#11890](https://github.com/MetaMask/metamask-extension/pull/11890): Fix alignment of horizontal line shown under gas recommendations
- [#12244](https://github.com/MetaMask/metamask-extension/pull/12244): Fix form prefilling with values on the Build Quote page [Swaps]
