### PR TITLE
Locale en message fix- "not connected this site"

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -405,7 +405,7 @@
     "message": "You have 1 account connected to this site."
   },
   "connectedAccountsEmptyDescription": {
-    "message": "MetaMask is not connected this site. To connect to a web3 site, find the connect button on their site."
+    "message": "MetaMask is not connected to this site. To connect to a web3 site, find and click the connect button."
   },
   "connectedSites": {
     "message": "Connected sites"


### PR DESCRIPTION

Fixes: Connection Error Message.
Explanation:  
Bug.  "MetaMask is not connected this site. To connect to a web3 site, find the connect button on their site."
Manual testing steps:  
 - more compact than previous version, no overflow. 
 
 @darkwing 

replaces #12064 