### PR TITLE
Prevent fox mesh JSON warning

### DIFF
--- a/ui/helpers/utils/build-types.js
+++ b/ui/helpers/utils/build-types.js
@@ -20,7 +20,10 @@ export function isBeta() {
 // the current metamask version (i.e. main, beta, etc.)
 export function getBuildSpecificAsset(assetName) {
   const buildType = process.env.METAMASK_BUILD_TYPE;
-  if (!assetList[buildType] || !Object.keys(assetList[buildType]).includes(assetName)) {
+  if (
+    !assetList[buildType] ||
+    !Object.keys(assetList[buildType]).includes(assetName)
+  ) {
     console.warn(
       `Cannot find asset for build ${buildType}: ${assetName}, returning main build asset`,
     );

--- a/ui/helpers/utils/build-types.js
+++ b/ui/helpers/utils/build-types.js
@@ -20,7 +20,7 @@ export function isBeta() {
 // the current metamask version (i.e. main, beta, etc.)
 export function getBuildSpecificAsset(assetName) {
   const buildType = process.env.METAMASK_BUILD_TYPE;
-  if (!assetList[buildType] || !(assetName in assetList[buildType])) {
+  if (!assetList[buildType] || !Object.keys(assetList[buildType]).includes(assetName)) {
     console.warn(
       `Cannot find asset for build ${buildType}: ${assetName}, returning main build asset`,
     );

--- a/ui/helpers/utils/build-types.js
+++ b/ui/helpers/utils/build-types.js
@@ -20,7 +20,7 @@ export function isBeta() {
 // the current metamask version (i.e. main, beta, etc.)
 export function getBuildSpecificAsset(assetName) {
   const buildType = process.env.METAMASK_BUILD_TYPE;
-  if (!assetList[buildType]?.[assetName]) {
+  if (!assetList[buildType] || !(assetName in assetList[buildType])) {
     console.warn(
       `Cannot find asset for build ${buildType}: ${assetName}, returning main build asset`,
     );


### PR DESCRIPTION
Explanation:  The fox mesh was displaying a console warning because its value was correctly `undefined` but the presence check wasn't properly coded to allow an undefined value.