### PR TITLE
Fixing accounts scrollbar for chrome

### DIFF
--- a/ui/components/app/account-menu/index.scss
+++ b/ui/components/app/account-menu/index.scss
@@ -129,10 +129,6 @@
     max-height: 256px;
     scrollbar-width: auto;
 
-    &::-webkit-scrollbar {
-      display: none;
-    }
-
     @media screen and (max-width: $break-small) {
       max-height: 228px;
     }


### PR DESCRIPTION
Follow up to https://github.com/MetaMask/metamask-extension/pull/11963

on MacOS when `Show scroll bars`: is set to `Always`:
<img width="380" alt="Screen Shot 2021-09-24 at 8 40 48 AM" src="https://user-images.githubusercontent.com/8732757/134703316-ef0be88b-b771-4e0d-835c-852e1451ec85.png">
<img width="388" alt="Screen Shot 2021-09-24 at 8 40 12 AM" src="https://user-images.githubusercontent.com/8732757/134703318-6f503ae2-2869-4a6f-8ff5-9d2a92768db7.png">

When `Show scroll bars`: is set to `When scrolling`:

https://user-images.githubusercontent.com/8732757/134703384-0d2898de-80cf-4674-a7e7-013f4b3e9930.mov


