### PR TITLE
fix issue where conversionRates aren't shown for tokens stored in non-checksum format

### DIFF
--- a/ui/hooks/useTokenFiatAmount.js
+++ b/ui/hooks/useTokenFiatAmount.js
@@ -7,6 +7,7 @@ import {
 } from '../selectors';
 import { getTokenFiatAmount } from '../helpers/utils/token-util';
 import { getConversionRate } from '../ducks/metamask/metamask';
+import { isEqualCaseInsensitive } from '../helpers/utils/util';
 
 /**
  * Get the token balance converted to fiat and formatted for display
@@ -33,8 +34,13 @@ export function useTokenFiatAmount(
   const currentCurrency = useSelector(getCurrentCurrency);
   const userPrefersShownFiat = useSelector(getShouldShowFiat);
   const showFiat = overrides.showFiat ?? userPrefersShownFiat;
+  const contractExchangeTokenKey = Object.keys(
+    contractExchangeRates,
+  ).find((key) => isEqualCaseInsensitive(key, tokenAddress));
   const tokenExchangeRate =
-    overrides.exchangeRate ?? contractExchangeRates[tokenAddress];
+    overrides.exchangeRate ??
+    (contractExchangeTokenKey &&
+      contractExchangeRates[contractExchangeTokenKey]);
   const formattedFiat = useMemo(
     () =>
       getTokenFiatAmount(


### PR DESCRIPTION
Fixes: #2 in [10.2.0 RC issues doc](https://docs.google.com/document/d/1BiTKWFKhYHRx697RrEs8Xz7R2qj0aZSN58h0JSsoyU0/edit#heading=h.lwrpcld9iufi)

- This is a bandaid for an issue to do with the lack of standardization around hex address casing throughout both the UI and background. Per [this conversation](https://consensys.slack.com/archives/G1L7H42BT/p1632506572267400) and [this long standing ticket](https://github.com/MetaMask/metamask-extension/issues/7985) we will make a push to standardize around checksummed addresses everywhere. But for the sake of getting this RC ready to go I propose this patch.
