### PR TITLE
adding checksum conversion

### DIFF
--- a/ui/helpers/utils/icon-factory.js
+++ b/ui/helpers/utils/icon-factory.js
@@ -1,4 +1,7 @@
-import { isValidHexAddress } from '../../../shared/modules/hexstring-utils';
+import {
+  isValidHexAddress,
+  toChecksumHexAddress,
+} from '../../../shared/modules/hexstring-utils';
 
 let iconFactory;
 
@@ -25,7 +28,9 @@ IconFactory.prototype.iconForAddress = function (
   // So the flag indicates whether the address of tokens currently on the tokenList is checksum or not.
   // And since the token.address from allTokens is checksumaddress
   // tokenAddress have to be changed to lowercase when we are using dynamic list
-  const addr = useTokenDetection ? address.toLowerCase() : address;
+  const addr = useTokenDetection
+    ? address.toLowerCase()
+    : toChecksumHexAddress(address);
   if (iconExistsFor(addr, tokenList)) {
     return imageElFor(addr, useTokenDetection, tokenList);
   }


### PR DESCRIPTION
Fixes no: 1, 6 and  8, in [10.2.0 RC issues doc](https://docs.google.com/document/d/1BiTKWFKhYHRx697RrEs8Xz7R2qj0aZSN58h0JSsoyU0/edit#heading=h.lwrpcld9iufi)

When the token detection is OFF, the address will be converted to a checksum address since the data available in the tokenList will be the static token list from contract-metadata.