### PR TITLE
Hiding refresh list on non-Mainnet networks

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1632,6 +1632,9 @@
   "optionalCurrencySymbol": {
     "message": "Currency Symbol (optional)"
   },
+  "or": {
+    "message": "or"
+  },
   "origin": {
     "message": "Origin"
   },

--- a/ui/components/app/asset-list/asset-list.js
+++ b/ui/components/app/asset-list/asset-list.js
@@ -13,6 +13,7 @@ import {
   getCurrentAccountWithSendEtherInfo,
   getShouldShowFiat,
   getNativeCurrencyImage,
+  getIsMainnet,
 } from '../../../selectors';
 import { getNativeCurrency } from '../../../ducks/metamask/metamask';
 import { useCurrencyDisplay } from '../../../hooks/useCurrencyDisplay';
@@ -75,6 +76,7 @@ const AssetList = ({ onClickAsset }) => {
   });
 
   const primaryTokenImage = useSelector(getNativeCurrencyImage);
+  const isMainnet = useSelector(getIsMainnet) || process.env.IN_TEST;
 
   return (
     <>
@@ -106,6 +108,7 @@ const AssetList = ({ onClickAsset }) => {
           </Typography>
         </Box>
         <ImportTokenLink
+          isMainnet={isMainnet}
           onClick={() => {
             history.push(IMPORT_TOKEN_ROUTE);
             addTokenEvent();

--- a/ui/components/app/import-token-link/import-token-link.component.js
+++ b/ui/components/app/import-token-link/import-token-link.component.js
@@ -23,15 +23,17 @@ export default function ImportTokenLink({ isMainnet }) {
   return (
     <Box className="import-token-link" textAlign={TEXT_ALIGN.CENTER}>
       {isMainnet && (
-        <Button
-          className="import-token-link__link"
-          type="link"
-          onClick={() => detectNewTokens()}
-        >
-          {t('refreshList')}
-        </Button>
+        <>
+          <Button
+            className="import-token-link__link"
+            type="link"
+            onClick={() => detectNewTokens()}
+          >
+            {t('refreshList')}
+          </Button>
+          {t('or')}
+        </>
       )}
-      {isMainnet && ' or '}
       <Button
         className="import-token-link__link"
         type="link"

--- a/ui/components/app/import-token-link/import-token-link.component.js
+++ b/ui/components/app/import-token-link/import-token-link.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { useMetricEvent } from '../../../hooks/useMetricEvent';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -8,7 +9,7 @@ import Box from '../../ui/box/box';
 import { TEXT_ALIGN } from '../../../helpers/constants/design-system';
 import { detectNewTokens } from '../../../store/actions';
 
-export default function ImportTokenLink() {
+export default function ImportTokenLink({ isMainnet }) {
   const addTokenEvent = useMetricEvent({
     eventOpts: {
       category: 'Navigation',
@@ -21,14 +22,16 @@ export default function ImportTokenLink() {
 
   return (
     <Box className="import-token-link" textAlign={TEXT_ALIGN.CENTER}>
-      <Button
-        className="import-token-link__link"
-        type="link"
-        onClick={() => detectNewTokens()}
-      >
-        {t('refreshList')}
-      </Button>
-      {' or '}
+      {isMainnet && (
+        <Button
+          className="import-token-link__link"
+          type="link"
+          onClick={() => detectNewTokens()}
+        >
+          {t('refreshList')}
+        </Button>
+      )}
+      {isMainnet && ' or '}
       <Button
         className="import-token-link__link"
         type="link"
@@ -37,8 +40,15 @@ export default function ImportTokenLink() {
           addTokenEvent();
         }}
       >
-        {t('importTokens')}
+        {isMainnet
+          ? t('importTokens')
+          : t('importTokens').charAt(0).toUpperCase() +
+            t('importTokens').slice(1)}
       </Button>
     </Box>
   );
 }
+
+ImportTokenLink.propTypes = {
+  isMainnet: PropTypes.bool,
+};

--- a/ui/components/app/import-token-link/index.scss
+++ b/ui/components/app/import-token-link/index.scss
@@ -3,6 +3,6 @@
     @include H6;
 
     display: inline;
-    padding: 0 0 16px;
+    padding: 0 5px 16px;
   }
 }


### PR DESCRIPTION
Fixes no 7, in [10.2.0 RC issues doc](https://docs.google.com/document/d/1BiTKWFKhYHRx697RrEs8Xz7R2qj0aZSN58h0JSsoyU0/edit#heading=h.lwrpcld9iufi)

The token detection is currently available only on Mainnet, so the `refresh list` link has to be displayed on Mainnet only.