### PR TITLE
Fix: native currency symbol on signature popup

### DIFF
--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -75,10 +75,7 @@ export default class SignatureRequestOriginal extends Component {
   };
 
   renderBalance = () => {
-    const {
-      conversionRate,
-      nativeCurrency,
-    } = this.props;
+    const { conversionRate, nativeCurrency } = this.props;
 
     const {
       fromAccount: { balance },

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -78,8 +78,11 @@ export default class SignatureRequestOriginal extends Component {
     const {
       conversionRate,
       nativeCurrency,
-      fromAccount: { balance },
     } = this.props;
+
+    const {
+      fromAccount: { balance },
+    } = this.state;
 
     const nativeCurrencyBalance = conversionUtil(balance, {
       fromNumericBase: 'hex',

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -75,12 +75,13 @@ export default class SignatureRequestOriginal extends Component {
   };
 
   renderBalance = () => {
-    const { conversionRate, nativeCurrency } = this.props;
     const {
+      conversionRate,
+      nativeCurrency,
       fromAccount: { balance },
-    } = this.state;
+    } = this.props;
 
-    const balanceInBaseAsset = conversionUtil(balance, {
+    const nativeCurrencyBalance = conversionUtil(balance, {
       fromNumericBase: 'hex',
       toNumericBase: 'dec',
       fromDenomination: 'WEI',
@@ -94,7 +95,7 @@ export default class SignatureRequestOriginal extends Component {
           {`${this.context.t('balance')}:`}
         </div>
         <div className="request-signature__balance-value">
-          {`${balanceInBaseAsset} ${nativeCurrency}`}
+          {`${nativeCurrencyBalance} ${nativeCurrency}`}
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes: #11950 

Explanation:  
- use native currency symbol instead of static ETH on signature popup