### PR TITLE
fix forget device not working

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1589,7 +1589,7 @@ export default class MetamaskController extends EventEmitter {
    */
   async forgetDevice(deviceName) {
     const keyring = await this.getKeyringForDevice(deviceName);
-    keyring.forgetDevice();
+    this.keyringController.forgetKeyring(keyring);
     return true;
   }
 


### PR DESCRIPTION
Fixes: Fix the issue that currently MetaMask Extension did not update KeyringController state after forget device so that the addresses should be forgot still remained in redux store and displayed.

Explanation:  Currently after forget the device, the keyringController's memStore was not called to update. This PR fix this by cooperating with PR: https://github.com/MetaMask/KeyringController/pull/124

Manual testing steps:  
  -  import any hardware wallet
  -  forget the device just imported
  -  check the addresses belong to the hardware was deleted. 