### PR TITLE
Replace `isBeta` with `buildType`

### DIFF
--- a/development/build/etc.js
+++ b/development/build/etc.js
@@ -7,13 +7,14 @@ const pump = pify(require('pump'));
 const { version } = require('../../package.json');
 
 const { createTask, composeParallel } = require('./task');
+const { BuildTypes } = require('./utils');
 
 module.exports = createEtcTasks;
 
 function createEtcTasks({
   betaVersionsMap,
   browserPlatforms,
-  isBeta,
+  buildType,
   livereload,
 }) {
   const clean = createTask('clean', async function clean() {
@@ -34,7 +35,10 @@ function createEtcTasks({
     'zip',
     composeParallel(
       ...browserPlatforms.map((platform) =>
-        createZipTask(platform, isBeta ? betaVersionsMap[platform] : undefined),
+        createZipTask(
+          platform,
+          buildType === BuildTypes.beta ? betaVersionsMap[platform] : undefined,
+        ),
       ),
     ),
   );

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -37,7 +37,6 @@ function defineAndRunBuildTasks() {
     betaVersion,
     buildType,
     entryTask,
-    isBeta,
     isLavaMoat,
     shouldIncludeLockdown,
     shouldLintFenceFiles,
@@ -47,7 +46,7 @@ function defineAndRunBuildTasks() {
   const browserPlatforms = ['firefox', 'chrome', 'brave', 'opera'];
 
   let betaVersionsMap;
-  if (isBeta) {
+  if (buildType === BuildTypes.beta) {
     betaVersionsMap = getNextBetaVersionMap(
       version,
       betaVersion,
@@ -59,13 +58,13 @@ function defineAndRunBuildTasks() {
     livereload,
     browserPlatforms,
     shouldIncludeLockdown,
-    isBeta,
+    buildType,
   });
 
   const manifestTasks = createManifestTasks({
     browserPlatforms,
     betaVersionsMap,
-    isBeta,
+    buildType,
   });
 
   const styleTasks = createStyleTasks({ livereload });
@@ -82,7 +81,7 @@ function defineAndRunBuildTasks() {
     livereload,
     browserPlatforms,
     betaVersionsMap,
-    isBeta,
+    buildType,
   });
 
   // build for development (livereload)
@@ -201,7 +200,6 @@ function parseArgv() {
     betaVersion: String(betaVersion),
     buildType,
     entryTask,
-    isBeta: argv[NamedArgs.BuildType] === BuildTypes.beta,
     isLavaMoat: process.argv[0].includes('lavamoat'),
     shouldIncludeLockdown: argv[NamedArgs.OmitLockdown],
     shouldLintFenceFiles,

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -7,10 +7,11 @@ const { version } = require('../../package.json');
 const betaManifestModifications = require('../../app/manifest/_beta_modifications.json');
 
 const { createTask, composeSeries } = require('./task');
+const { BuildTypes } = require('./utils');
 
 module.exports = createManifestTasks;
 
-function createManifestTasks({ betaVersionsMap, browserPlatforms, isBeta }) {
+function createManifestTasks({ betaVersionsMap, browserPlatforms, buildType }) {
   // merge base manifest with per-platform manifests
   const prepPlatforms = async () => {
     return Promise.all(
@@ -28,7 +29,7 @@ function createManifestTasks({ betaVersionsMap, browserPlatforms, isBeta }) {
         const result = merge(
           cloneDeep(baseManifest),
           platformModifications,
-          isBeta
+          buildType === BuildTypes.beta
             ? getBetaModifications(platform, betaVersionsMap)
             : { version },
         );

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -6,6 +6,7 @@ const glob = require('fast-glob');
 const locales = require('../../app/_locales/index.json');
 
 const { createTask, composeSeries } = require('./task');
+const { BuildTypes } = require('./utils');
 
 const EMPTY_JS_FILE = './development/empty.js';
 
@@ -13,7 +14,7 @@ module.exports = function createStaticAssetTasks({
   livereload,
   browserPlatforms,
   shouldIncludeLockdown = true,
-  isBeta,
+  buildType,
 }) {
   const [copyTargetsProd, copyTargetsDev] = getCopyTargets(
     shouldIncludeLockdown,
@@ -27,7 +28,8 @@ module.exports = function createStaticAssetTasks({
     },
   ];
 
-  const targets = isBeta ? copyTargetsBeta : copyTargetsProd;
+  const targets =
+    buildType === BuildTypes.beta ? copyTargetsBeta : copyTargetsProd;
 
   const prod = createTask(
     'static:prod',


### PR DESCRIPTION
This is a refactor to replace the `isBeta` boolean with `buildType` throughout the build system. This will allow us to modify the behaviour of each step of the build process for Flask as well.

This should result in no functional changes.