### PR TITLE
Turning OFF token detection for test nets

### DIFF
--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -33,7 +33,6 @@ export default class DetectTokensController {
     this.network = network;
     this.keyringMemStore = keyringMemStore;
     this.tokenList = tokenList;
-    this.useTokenDetection = this.preferences?.store.getState().useTokenDetection;
     this.selectedAddress = this.preferences?.store.getState().selectedAddress;
     this.tokenAddresses = this.tokensController?.state.tokens.map((token) => {
       return token.address;

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -32,6 +32,7 @@ export default class DetectTokensController {
     this.network = network;
     this.keyringMemStore = keyringMemStore;
     this.tokenList = tokenList;
+    this.useTokenDetection = this.preferences?.store.getState().useTokenDetection;
     this.selectedAddress = this.preferences?.store.getState().selectedAddress;
     this.tokenAddresses = this.tokensController?.state.tokens.map((token) => {
       return token.address;
@@ -79,7 +80,9 @@ export default class DetectTokensController {
     }
 
     const { tokenList } = this._tokenList.state;
-    if (Object.keys(tokenList).length === 0) {
+    console.log(!this.useTokenDetection || Object.keys(tokenList).length === 0);
+    if (!this.useTokenDetection || Object.keys(tokenList).length === 0) {
+      console.log(`this.useTokenDetection: ${this.useTokenDetection}`);
       return;
     }
 

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -4,6 +4,7 @@ import SINGLE_CALL_BALANCES_ABI from 'single-call-balance-checker-abi';
 import { SINGLE_CALL_BALANCES_ADDRESS } from '../constants/contracts';
 import { MINUTE } from '../../../shared/constants/time';
 import { isEqualCaseInsensitive } from '../../../ui/helpers/utils/util';
+import { MAINNET_CHAIN_ID } from '../../../shared/constants/network';
 
 // By default, poll every 3 minutes
 const DEFAULT_INTERVAL = MINUTE * 3;
@@ -80,9 +81,10 @@ export default class DetectTokensController {
     }
 
     const { tokenList } = this._tokenList.state;
-    console.log(!this.useTokenDetection || Object.keys(tokenList).length === 0);
-    if (!this.useTokenDetection || Object.keys(tokenList).length === 0) {
-      console.log(`this.useTokenDetection: ${this.useTokenDetection}`);
+    // since the token detection is currently enabled only on Mainnet
+    // we can use the chainId check to ensure token detection is not triggered for any other network
+    // but once the balance check contract for other networks are deploayed and ready to use, we need to update this check.
+    if (this._network.store.getState().provider.chainId !== MAINNET_CHAIN_ID) {
       return;
     }
 

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -80,11 +80,6 @@ export default class DetectTokensController {
     }
 
     const { tokenList } = this._tokenList.state;
-    console.log(
-      this._network.store.getState().provider.chainId !== MAINNET_CHAIN_ID,
-    );
-    console.log(!this.useTokenDetection);
-    console.log(Object.keys(tokenList).length);
     // since the token detection is currently enabled only on Mainnet
     // we can use the chainId check to ensure token detection is not triggered for any other network
     // but once the balance check contract for other networks are deploayed and ready to use, we need to update this check.

--- a/app/scripts/controllers/detect-tokens.js
+++ b/app/scripts/controllers/detect-tokens.js
@@ -80,10 +80,18 @@ export default class DetectTokensController {
     }
 
     const { tokenList } = this._tokenList.state;
+    console.log(
+      this._network.store.getState().provider.chainId !== MAINNET_CHAIN_ID,
+    );
+    console.log(!this.useTokenDetection);
+    console.log(Object.keys(tokenList).length);
     // since the token detection is currently enabled only on Mainnet
     // we can use the chainId check to ensure token detection is not triggered for any other network
     // but once the balance check contract for other networks are deploayed and ready to use, we need to update this check.
-    if (this._network.store.getState().provider.chainId !== MAINNET_CHAIN_ID) {
+    if (
+      this._network.store.getState().provider.chainId !== MAINNET_CHAIN_ID ||
+      Object.keys(tokenList).length === 0
+    ) {
       return;
     }
 

--- a/app/scripts/controllers/detect-tokens.test.js
+++ b/app/scripts/controllers/detect-tokens.test.js
@@ -42,6 +42,7 @@ describe('DetectTokensController', function () {
       '0x7e57e2',
       '0xbc86727e770de68b1060c91f6bb6945c73e10388',
     ]);
+    preferences.setUseTokenDetection(true);
     sandbox
       .stub(network, 'getLatestBlock')
       .callsFake(() => Promise.resolve({}));


### PR DESCRIPTION
Fixes no 11, in [10.2.0 RC issues doc](https://docs.google.com/document/d/1BiTKWFKhYHRx697RrEs8Xz7R2qj0aZSN58h0JSsoyU0/edit#)

Since the token detection works only for Mainnet at the moment due to the balance check contract we can add the chainId not equal to Mainnet chainId check to block out other networks and testnets. 