### PR TITLE
Fix assets for beta dev build

### DIFF
--- a/development/build/static.js
+++ b/development/build/static.js
@@ -20,21 +20,24 @@ module.exports = function createStaticAssetTasks({
     shouldIncludeLockdown,
   );
 
-  const copyTargetsBeta = [
-    ...copyTargetsProd,
-    {
-      src: './app/build-types/beta/',
-      dest: `images`,
-    },
-  ];
+  const additionalBuildTargets = {
+    [BuildTypes.beta]: [
+      {
+        src: './app/build-types/beta/',
+        dest: `images`,
+      },
+    ],
+  };
 
-  const targets =
-    buildType === BuildTypes.beta ? copyTargetsBeta : copyTargetsProd;
+  if (Object.keys(additionalBuildTargets).includes(buildType)) {
+    copyTargetsProd.push(...additionalBuildTargets[buildType]);
+    copyTargetsDev.push(...additionalBuildTargets[buildType]);
+  }
 
   const prod = createTask(
     'static:prod',
     composeSeries(
-      ...targets.map((target) => {
+      ...copyTargetsProd.map((target) => {
         return async function copyStaticAssets() {
           await performCopy(target);
         };


### PR DESCRIPTION
The MetaMask logo used for beta development builds was wrong. The lock screen (and any other place using the `@metamask/logo` logo) showed the correct logo, but all of our static assets used the "regular" logo.

Now the beta logo should be used everywhere for beta development builds.

Manual testing steps:  
  - Run `yarn start --build-type beta
  - See that the logos are correct