### PR TITLE
Connect ledger via webhid if that option is available

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -5,6 +5,7 @@ import { ethers } from 'ethers';
 import log from 'loglevel';
 import { NETWORK_TYPE_TO_ID_MAP } from '../../../shared/constants/network';
 import { isPrefixedFormattedHexString } from '../../../shared/modules/network.utils';
+import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
 import { NETWORK_EVENTS } from './network';
 
 export default class PreferencesController {
@@ -58,7 +59,9 @@ export default class PreferencesController {
       // ENS decentralized website resolution
       ipfsGateway: 'dweb.link',
       infuraBlocked: null,
-      ledgerTransportType: '',
+      ledgerTransportType: window.navigator.hid
+        ? LEDGER_TRANSPORT_TYPES.WEBHID
+        : LEDGER_TRANSPORT_TYPES.U2F,
       ...opts.initState,
     };
 
@@ -517,7 +520,7 @@ export default class PreferencesController {
 
   /**
    * A setter for the `useWebHid` property
-   * @param {string} ledgerTransportType - Either 'ledgerLive' or 'webhid'
+   * @param {string} ledgerTransportType - Either 'ledgerLive', 'webhid' or 'u2f'
    * @returns {Promise<string>} A promise of the update to useWebHid
    */
   setLedgerTransportPreference(ledgerTransportType) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -58,7 +58,7 @@ export default class PreferencesController {
       // ENS decentralized website resolution
       ipfsGateway: 'dweb.link',
       infuraBlocked: null,
-      useLedgerLive: false,
+      ledgerTransportType: '',
       ...opts.initState,
     };
 
@@ -516,39 +516,21 @@ export default class PreferencesController {
   }
 
   /**
-   * A setter for the `useLedgerLive` property
-   * @param {bool} useLedgerLive - Value for ledger live support
-   * @returns {Promise<string>} A promise of the update to useLedgerLive
-   */
-  async setLedgerLivePreference(useLedgerLive) {
-    this.store.updateState({ useLedgerLive });
-    return useLedgerLive;
-  }
-
-  /**
-   * A getter for the `useLedgerLive` property
-   * @returns {boolean} User preference of using Ledger Live
-   */
-  getLedgerLivePreference() {
-    return this.store.getState().useLedgerLive;
-  }
-
-  /**
    * A setter for the `useWebHid` property
-   * @param {bool} useWebHid - Whether the user wants to use WebHid to connect their ledger
+   * @param {string} ledgerTransportType - Either 'ledgerLive' or 'webhid'
    * @returns {Promise<string>} A promise of the update to useWebHid
    */
-  async setLedgerWebHidPreference(useWebHidForLedger) {
-    this.store.updateState({ useWebHidForLedger });
-    return useWebHidForLedger;
+  async setLedgerTransportPreference(ledgerTransportType) {
+    this.store.updateState({ ledgerTransportType });
+    return ledgerTransportType;
   }
 
   /**
-   * A getter for the `useWebHidForLedger` property
+   * A getter for the `ledgerTransportType` property
    * @returns {boolean} User preference of using WebHid to connect Ledger
    */
-  getLedgerWebHidPreference() {
-    return this.store.getState().useWebHidForLedger;
+  getLedgerTransportPreference() {
+    return this.store.getState().ledgerTransportType;
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -534,6 +534,24 @@ export default class PreferencesController {
   }
 
   /**
+   * A setter for the `useWebHid` property
+   * @param {bool} useWebHid - Whether the user wants to use WebHid to connect their ledger
+   * @returns {Promise<string>} A promise of the update to useWebHid
+   */
+  async setLedgerWebHidPreference(useWebHidForLedger) {
+    this.store.updateState({ useWebHidForLedger });
+    return useWebHidForLedger;
+  }
+
+  /**
+   * A getter for the `useWebHidForLedger` property
+   * @returns {boolean} User preference of using WebHid to connect Ledger
+   */
+  getLedgerWebHidPreference() {
+    return this.store.getState().useWebHidForLedger;
+  }
+
+  /**
    * A setter for the user preference to dismiss the seed phrase backup reminder
    * @param {bool} dismissBackupReminder- User preference for dismissing the back up reminder
    * @returns {void}

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -520,7 +520,7 @@ export default class PreferencesController {
    * @param {string} ledgerTransportType - Either 'ledgerLive' or 'webhid'
    * @returns {Promise<string>} A promise of the update to useWebHid
    */
-  async setLedgerTransportPreference(ledgerTransportType) {
+  setLedgerTransportPreference(ledgerTransportType) {
     this.store.updateState({ ledgerTransportType });
     return ledgerTransportType;
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1484,14 +1484,8 @@ export default class MetamaskController extends EventEmitter {
     // Optimistically called to not block Metamask login due to
     // Ledger Keyring GitHub downtime
     const transportPreference = this.preferencesController.getLedgerTransportPreference();
-    if (transportPreference === 'ledgerLive') {
-      this.setLedgerLivePreference(true);
-    } else if (transportPreference === ' webhid') {
-      this.setLedgerWebHidPreference(true);
-    } else {
-      this.setLedgerLivePreference(false);
-      // this.setLedgerWebHidPreference(false)
-    }
+
+    this.setLedgerTransportPreference(transportPreference);
 
     return this.keyringController.fullUpdate();
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -842,6 +842,7 @@ export default class MetamaskController extends EventEmitter {
         this,
       ),
       setLedgerLivePreference: nodeify(this.setLedgerLivePreference, this),
+      setLedgerWebHidPreference: nodeify(this.setLedgerWebHidPreference, this),
 
       // mobile
       fetchInfoToSync: nodeify(this.fetchInfoToSync, this),
@@ -1482,6 +1483,9 @@ export default class MetamaskController extends EventEmitter {
     // Ledger Keyring GitHub downtime
     this.setLedgerLivePreference(
       this.preferencesController.getLedgerLivePreference(),
+    );
+    this.setLedgerWebHidPreference(
+      this.preferencesController.getLedgerWebHidPreference(),
     );
 
     return this.keyringController.fullUpdate();
@@ -2994,6 +2998,27 @@ export default class MetamaskController extends EventEmitter {
         // If there was an error updating the transport, we should
         // fall back to the original value
         this.preferencesController.setLedgerLivePreference(currentValue);
+        throw e;
+      });
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Sets the WebHid preference to use for Ledger hardware wallet support
+   * @param {bool} bool - the value representing if the users wants to use WebHid to connect to Ledger
+   */
+  async setLedgerWebHidPreference(bool) {
+    const currentValue = this.preferencesController.getLedgerWebHidPreference();
+    this.preferencesController.setLedgerWebHidPreference(bool);
+
+    const keyring = await this.getKeyringForDevice('ledger');
+    if (keyring?.updateTransportMethod) {
+      return keyring.updateTransportMethod(undefined, bool).catch((e) => {
+        // If there was an error updating the transport, we should
+        // fall back to the original value
+        this.preferencesController.setLedgerWebHidPreference(currentValue);
         throw e;
       });
     }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2989,12 +2989,12 @@ export default class MetamaskController extends EventEmitter {
    * @param {bool} bool - the value representing if the users wants to use Ledger Live
    */
   async setLedgerLivePreference(bool) {
-    const currentValue = this.preferencesController.getLedgerLivePreference();
-    this.preferencesController.setLedgerLivePreference(bool);
+    const currentValue = this.preferencesController.getLedgerTransportPreference();
+    this.preferencesController.setLedgerLivePreference('ledgerLive');
 
     const keyring = await this.getKeyringForDevice('ledger');
     if (keyring?.updateTransportMethod) {
-      return keyring.updateTransportMethod(bool).catch((e) => {
+      return keyring.updateTransportMethod('ledgerLive').catch((e) => {
         // If there was an error updating the transport, we should
         // fall back to the original value
         this.preferencesController.setLedgerLivePreference(currentValue);
@@ -3010,12 +3010,12 @@ export default class MetamaskController extends EventEmitter {
    * @param {bool} bool - the value representing if the users wants to use WebHid to connect to Ledger
    */
   async setLedgerWebHidPreference(bool) {
-    const currentValue = this.preferencesController.getLedgerWebHidPreference();
-    this.preferencesController.setLedgerWebHidPreference(bool);
+    const currentValue = this.preferencesController.getLedgerTransportPreference();
+    this.preferencesController.setLedgerTransportPreference('webhid');
 
     const keyring = await this.getKeyringForDevice('ledger');
     if (keyring?.updateTransportMethod) {
-      return keyring.updateTransportMethod(undefined, bool).catch((e) => {
+      return keyring.updateTransportMethod('webhid').catch((e) => {
         // If there was an error updating the transport, we should
         // fall back to the original value
         this.preferencesController.setLedgerWebHidPreference(currentValue);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -841,7 +841,10 @@ export default class MetamaskController extends EventEmitter {
         this.unlockHardwareWalletAccount,
         this,
       ),
-      setLedgerTransportPreference: nodeify(this.setLedgerTransportPreference, this),
+      setLedgerTransportPreference: nodeify(
+        this.setLedgerTransportPreference,
+        this,
+      ),
 
       // mobile
       fetchInfoToSync: nodeify(this.fetchInfoToSync, this),
@@ -1482,11 +1485,11 @@ export default class MetamaskController extends EventEmitter {
     // Ledger Keyring GitHub downtime
     const transportPreference = this.preferencesController.getLedgerTransportPreference();
     if (transportPreference === 'ledgerLive') {
-      this.setLedgerLivePreference(true)
+      this.setLedgerLivePreference(true);
     } else if (transportPreference === ' webhid') {
-      this.setLedgerWebHidPreference(true)
+      this.setLedgerWebHidPreference(true);
     } else {
-      this.setLedgerLivePreference(false)
+      this.setLedgerLivePreference(false);
       // this.setLedgerWebHidPreference(false)
     }
 
@@ -2992,12 +2995,13 @@ export default class MetamaskController extends EventEmitter {
    */
   async setLedgerTransportPreference(transportType) {
     const currentValue = this.preferencesController.getLedgerTransportPreference();
-    const newValue = 
-    this.preferencesController.setLedgerTransportPreference(transportType);
+    const newValue = this.preferencesController.setLedgerTransportPreference(
+      transportType,
+    );
 
     const keyring = await this.getKeyringForDevice('ledger');
     if (keyring?.updateTransportMethod) {
-      return keyring.updateTransportMethod(transportType).catch((e) => {
+      return keyring.updateTransportMethod(newValue).catch((e) => {
         // If there was an error updating the transport, we should
         // fall back to the original value
         this.preferencesController.setLedgerTransportPreference(currentValue);

--- a/app/scripts/migrations/066.js
+++ b/app/scripts/migrations/066.js
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash';
+import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
 
 const version = 66;
 
@@ -18,12 +19,17 @@ export default {
 };
 
 function transformState(state) {
+  const defaultTransportType = window.navigator.hid
+    ? LEDGER_TRANSPORT_TYPES.WEBHID
+    : LEDGER_TRANSPORT_TYPES.U2F;
   const useLedgerLive = state?.PreferencesController?.useLedgerLive;
   const newState = {
     ...state,
     PreferencesController: {
       ...state?.PreferencesController,
-      ledgerTransportType: useLedgerLive ? 'ledgerLive' : '',
+      ledgerTransportType: useLedgerLive
+        ? LEDGER_TRANSPORT_TYPES.LIVE
+        : defaultTransportType,
     },
   };
   delete newState.PreferencesController.useLedgerLive;

--- a/app/scripts/migrations/066.js
+++ b/app/scripts/migrations/066.js
@@ -22,7 +22,7 @@ function transformState(state) {
   const defaultTransportType = window.navigator.hid
     ? LEDGER_TRANSPORT_TYPES.WEBHID
     : LEDGER_TRANSPORT_TYPES.U2F;
-  const useLedgerLive = state?.PreferencesController?.useLedgerLive;
+  const useLedgerLive = Boolean(state?.PreferencesController?.useLedgerLive);
   const newState = {
     ...state,
     PreferencesController: {

--- a/app/scripts/migrations/066.js
+++ b/app/scripts/migrations/066.js
@@ -1,0 +1,31 @@
+import { cloneDeep } from 'lodash';
+
+const version = 66;
+
+/**
+ * Changes the useLedgerLive boolean property to the ledgerTransportType enum
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    const newState = transformState(state);
+    versionedData.data = newState;
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  const useLedgerLive = state?.PreferencesController?.useLedgerLive;
+  const newState = {
+    ...state,
+    PreferencesController: {
+      ...state?.PreferencesController,
+      ledgerTransportType: useLedgerLive ? 'ledgerLive' : '',
+    },
+  };
+  delete newState.PreferencesController.useLedgerLive;
+  return newState;
+}

--- a/app/scripts/migrations/066.test.js
+++ b/app/scripts/migrations/066.test.js
@@ -1,3 +1,4 @@
+import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
 import migration66 from './066';
 
 describe('migration #66', () => {
@@ -15,7 +16,7 @@ describe('migration #66', () => {
     });
   });
 
-  it('should set ledgerTransportType to an empty string if no preferences controller exists', async () => {
+  it('should set ledgerTransportType to `u2f` if no preferences controller exists and webhid is not available', async () => {
     const oldStorage = {
       meta: {},
       data: {},
@@ -24,10 +25,10 @@ describe('migration #66', () => {
     const newStorage = await migration66.migrate(oldStorage);
     expect(
       newStorage.data.PreferencesController.ledgerTransportType,
-    ).toStrictEqual('');
+    ).toStrictEqual(LEDGER_TRANSPORT_TYPES.U2F);
   });
 
-  it('should set ledgerTransportType to an empty string if no useLedgerLive property exists', async () => {
+  it('should set ledgerTransportType to `u2f` if no useLedgerLive property exists and webhid is not available', async () => {
     const oldStorage = {
       meta: {},
       data: {
@@ -38,10 +39,10 @@ describe('migration #66', () => {
     const newStorage = await migration66.migrate(oldStorage);
     expect(
       newStorage.data.PreferencesController.ledgerTransportType,
-    ).toStrictEqual('');
+    ).toStrictEqual(LEDGER_TRANSPORT_TYPES.U2F);
   });
 
-  it('should set ledgerTransportType to an empty string if useLedgerLive is false', async () => {
+  it('should set ledgerTransportType to `u2f` if useLedgerLive is false and webhid is not available', async () => {
     const oldStorage = {
       meta: {},
       data: {
@@ -54,7 +55,25 @@ describe('migration #66', () => {
     const newStorage = await migration66.migrate(oldStorage);
     expect(
       newStorage.data.PreferencesController.ledgerTransportType,
-    ).toStrictEqual('');
+    ).toStrictEqual(LEDGER_TRANSPORT_TYPES.U2F);
+  });
+
+  it('should set ledgerTransportType to `webhid` if useLedgerLive is false and webhid is available', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          useLedgerLive: false,
+        },
+      },
+    };
+    const tempNavigatorHid = window.navigator.hid;
+    window.navigator.hid = true;
+    const newStorage = await migration66.migrate(oldStorage);
+    window.navigator.hid = tempNavigatorHid;
+    expect(
+      newStorage.data.PreferencesController.ledgerTransportType,
+    ).toStrictEqual(LEDGER_TRANSPORT_TYPES.WEBHID);
   });
 
   it('should set ledgerTransportType to `ledgerLive` if useLedgerLive is true', async () => {

--- a/app/scripts/migrations/066.test.js
+++ b/app/scripts/migrations/066.test.js
@@ -1,0 +1,75 @@
+import migration66 from './066';
+
+describe('migration #66', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 65,
+      },
+      data: {},
+    };
+
+    const newStorage = await migration66.migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version: 66,
+    });
+  });
+
+  it('should set ledgerTransportType to an empty string if no preferences controller exists', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {},
+    };
+
+    const newStorage = await migration66.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.ledgerTransportType,
+    ).toStrictEqual('');
+  });
+
+  it('should set ledgerTransportType to an empty string if no useLedgerLive property exists', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {},
+      },
+    };
+
+    const newStorage = await migration66.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.ledgerTransportType,
+    ).toStrictEqual('');
+  });
+
+  it('should set ledgerTransportType to an empty string if useLedgerLive is false', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          useLedgerLive: false,
+        },
+      },
+    };
+
+    const newStorage = await migration66.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.ledgerTransportType,
+    ).toStrictEqual('');
+  });
+
+  it('should set ledgerTransportType to `ledgerLive` if useLedgerLive is true', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          useLedgerLive: true,
+        },
+      },
+    };
+
+    const newStorage = await migration66.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.ledgerTransportType,
+    ).toStrictEqual('ledgerLive');
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -69,6 +69,7 @@ import m062 from './062';
 import m063 from './063';
 import m064 from './064';
 import m065 from './065';
+import m066 from './066';
 
 const migrations = [
   m002,
@@ -135,6 +136,7 @@ const migrations = [
   m063,
   m064,
   m065,
+  m066,
 ];
 
 export default migrations;

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.28.0",
     "@metamask/controllers": "^17.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "git://github.com/MetaMask/eth-ledger-bridge-keyring.git#version09",
+    "@metamask/eth-ledger-bridge-keyring": "^0.9.0",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.1.0",
     "@metamask/jazzicon": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.28.0",
     "@metamask/controllers": "^17.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "^0.7.0",
+    "@metamask/eth-ledger-bridge-keyring": "git://github.com/MetaMask/eth-ledger-bridge-keyring.git#version09",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.1.0",
     "@metamask/jazzicon": "^2.0.0",

--- a/shared/constants/hardware-wallets.js
+++ b/shared/constants/hardware-wallets.js
@@ -14,6 +14,7 @@ export const KEYRING_TYPES = {
 export const LEDGER_TRANSPORT_TYPES = {
   LIVE: 'ledgerLive',
   WEBHID: 'webhid',
+  U2F: 'u2f',
 };
 
 export const LEDGER_USB_VENDOR_ID = '0x2c97';

--- a/shared/constants/hardware-wallets.js
+++ b/shared/constants/hardware-wallets.js
@@ -15,3 +15,5 @@ export const LEDGER_TRANSPORT_TYPES = {
   LIVE: 'ledgerLive',
   WEBHID: 'webhid',
 };
+
+export const LEDGER_USB_VENDOR_ID = '0x2c97';

--- a/shared/constants/hardware-wallets.js
+++ b/shared/constants/hardware-wallets.js
@@ -7,3 +7,11 @@ export const KEYRING_TYPES = {
   LEDGER: 'Ledger Hardware',
   TREZOR: 'Trezor Hardware',
 };
+
+/**
+ * Used for setting the users preference for ledger transport type
+ */
+export const LEDGER_TRANSPORT_TYPES = {
+  LIVE: 'ledgerLive',
+  WEBHID: 'webhid',
+};

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -36,6 +36,7 @@ import InfoTooltip from '../../components/ui/info-tooltip/info-tooltip';
 import LoadingHeartBeat from '../../components/ui/loading-heartbeat';
 import GasTiming from '../../components/app/gas-timing/gas-timing.component';
 import Dialog from '../../components/ui/dialog';
+import { LEDGER_TRANSPORT_TYPES } from '../../../shared/constants/hardware-wallets';
 
 import {
   COLORS,
@@ -129,6 +130,7 @@ export default class ConfirmTransactionBase extends Component {
     isFirefox: PropTypes.bool.isRequired,
     nativeCurrency: PropTypes.string,
     supportsEIP1559: PropTypes.bool,
+    ledgerTransportType: PropTypes.string,
   };
 
   state = {
@@ -311,8 +313,11 @@ export default class ConfirmTransactionBase extends Component {
       showLedgerSteps,
       isFirefox,
       supportsEIP1559,
+      ledgerTransportType,
     } = this.props;
     const { t } = this.context;
+
+    const usingLedgerLive = ledgerTransportType === LEDGER_TRANSPORT_TYPES.LIVE;
 
     const renderTotalMaxAmount = () => {
       if (
@@ -427,11 +432,11 @@ export default class ConfirmTransactionBase extends Component {
               {renderLedgerLiveStep(t('ledgerLiveDialogHeader'))}
               {renderLedgerLiveStep(
                 `- ${t('ledgerLiveDialogStepOne')}`,
-                !isFirefox,
+                !isFirefox && usingLedgerLive,
               )}
               {renderLedgerLiveStep(
                 `- ${t('ledgerLiveDialogStepTwo')}`,
-                !isFirefox,
+                !isFirefox && usingLedgerLive,
               )}
               {renderLedgerLiveStep(`- ${t('ledgerLiveDialogStepThree')}`)}
               {renderLedgerLiveStep(

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -81,6 +81,7 @@ const mapStateToProps = (state, ownProps) => {
     unapprovedTxs,
     nextNonce,
     provider: { chainId },
+    ledgerTransportType,
   } = metamask;
   const { tokenData, txData, tokenProps, nonce } = confirmTransaction;
   const { txParams = {}, id: transactionId, type } = txData;
@@ -222,6 +223,7 @@ const mapStateToProps = (state, ownProps) => {
     showLedgerSteps,
     isFirefox,
     nativeCurrency,
+    ledgerTransportType,
   };
 };
 

--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -262,7 +262,7 @@ class ConnectHardwareForm extends Component {
         <SelectHardware
           connectToHardwareWallet={this.connectToHardwareWallet}
           browserSupported={this.state.browserSupported}
-          useLedgerLive={this.props.useLedgerLive}
+          ledgerTransportType={this.props.ledgerTransportType}
         />
       );
     }
@@ -313,7 +313,7 @@ ConnectHardwareForm.propTypes = {
   connectedAccounts: PropTypes.array.isRequired,
   defaultHdPaths: PropTypes.object,
   mostRecentOverviewPage: PropTypes.string.isRequired,
-  useLedgerLive: PropTypes.bool.isRequired,
+  ledgerTransportType: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = (state) => ({
@@ -323,7 +323,7 @@ const mapStateToProps = (state) => ({
   connectedAccounts: getMetaMaskAccountsConnected(state),
   defaultHdPaths: state.appState.defaultHdPaths,
   mostRecentOverviewPage: getMostRecentOverviewPage(state),
-  useLedgerLive: state.metamask.useLedgerLive,
+  ledgerTransportType: state.metamask.ledgerTransportType,
 });
 
 const mapDispatchToProps = (dispatch) => {

--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -137,7 +137,7 @@ export default class SelectHardware extends Component {
 
   renderLedgerTutorialSteps() {
     const steps = [];
-    if (this.props.ledgerTransportType !== LEDGER_TRANSPORT_TYPES.LIVE) {
+    if (this.props.ledgerTransportType === LEDGER_TRANSPORT_TYPES.LIVE) {
       steps.push({
         title: this.context.t('step1LedgerWallet'),
         message: this.context.t('step1LedgerWalletMsg', [

--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -11,7 +11,7 @@ export default class SelectHardware extends Component {
   static propTypes = {
     connectToHardwareWallet: PropTypes.func.isRequired,
     browserSupported: PropTypes.bool.isRequired,
-    useLedgerLive: PropTypes.bool.isRequired,
+    ledgerTransportType: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -136,7 +136,7 @@ export default class SelectHardware extends Component {
 
   renderLedgerTutorialSteps() {
     const steps = [];
-    if (this.props.useLedgerLive) {
+    if (this.props.ledgerTransportType !== 'ledgerLive') {
       steps.push({
         title: this.context.t('step1LedgerWallet'),
         message: this.context.t('step1LedgerWalletMsg', [

--- a/ui/pages/create-account/connect-hardware/select-hardware.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.js
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Button from '../../../components/ui/button';
+import { LEDGER_TRANSPORT_TYPES } from '../../../../shared/constants/hardware-wallets';
 
 export default class SelectHardware extends Component {
   static contextTypes = {
@@ -136,7 +137,7 @@ export default class SelectHardware extends Component {
 
   renderLedgerTutorialSteps() {
     const steps = [];
-    if (this.props.ledgerTransportType !== 'ledgerLive') {
+    if (this.props.ledgerTransportType !== LEDGER_TRANSPORT_TYPES.LIVE) {
       steps.push({
         title: this.context.t('step1LedgerWallet'),
         message: this.context.t('step1LedgerWalletMsg', [

--- a/ui/pages/create-account/connect-hardware/select-hardware.stories.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 import SelectHardware from './select-hardware';
+import { LEDGER_TRANSPORT_TYPES } from '../../../../shared/constants/hardware-wallets';
 
 export default {
   title: 'Connect Hardware Wallet',
@@ -14,7 +15,7 @@ export const SelectHardwareComponent = () => {
       connectToHardwareWallet={(selectedDevice) =>
         action(`Continue connect to ${selectedDevice}`)()
       }
-      ledgerTransportType="ledgerLive"
+      ledgerTransportType={ LEDGER_TRANSPORT_TYPES.LIVE }
     />
   );
 };
@@ -23,7 +24,7 @@ export const BrowserNotSupported = () => {
     <SelectHardware
       browserSupported={false}
       connectToHardwareWallet={() => undefined}
-      ledgerTransportType="ledgerLive"
+      ledgerTransportType={ LEDGER_TRANSPORT_TYPES.LIVE }
     />
   );
 };

--- a/ui/pages/create-account/connect-hardware/select-hardware.stories.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.stories.js
@@ -14,7 +14,7 @@ export const SelectHardwareComponent = () => {
       connectToHardwareWallet={(selectedDevice) =>
         action(`Continue connect to ${selectedDevice}`)()
       }
-      useLedgerLive
+      ledgerTransportType="ledgerLive"
     />
   );
 };
@@ -23,7 +23,7 @@ export const BrowserNotSupported = () => {
     <SelectHardware
       browserSupported={false}
       connectToHardwareWallet={() => undefined}
-      useLedgerLive
+      ledgerTransportType="ledgerLive"
     />
   );
 };

--- a/ui/pages/create-account/connect-hardware/select-hardware.stories.js
+++ b/ui/pages/create-account/connect-hardware/select-hardware.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import SelectHardware from './select-hardware';
 import { LEDGER_TRANSPORT_TYPES } from '../../../../shared/constants/hardware-wallets';
+import SelectHardware from './select-hardware';
 
 export default {
   title: 'Connect Hardware Wallet',
@@ -15,7 +15,7 @@ export const SelectHardwareComponent = () => {
       connectToHardwareWallet={(selectedDevice) =>
         action(`Continue connect to ${selectedDevice}`)()
       }
-      ledgerTransportType={ LEDGER_TRANSPORT_TYPES.LIVE }
+      ledgerTransportType={LEDGER_TRANSPORT_TYPES.LIVE}
     />
   );
 };
@@ -24,7 +24,7 @@ export const BrowserNotSupported = () => {
     <SelectHardware
       browserSupported={false}
       connectToHardwareWallet={() => undefined}
-      ledgerTransportType={ LEDGER_TRANSPORT_TYPES.LIVE }
+      ledgerTransportType={LEDGER_TRANSPORT_TYPES.LIVE}
     />
   );
 };

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -11,6 +11,10 @@ import { getPlatform } from '../../../../app/scripts/lib/util';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { LEDGER_TRANSPORT_TYPES } from '../../../../shared/constants/hardware-wallets';
 
+const defaultTransportType = window.navigator.hid
+  ? LEDGER_TRANSPORT_TYPES.WEBHID
+  : LEDGER_TRANSPORT_TYPES.U2F;
+
 export default class AdvancedTab extends PureComponent {
   static contextTypes = {
     t: PropTypes.func,
@@ -410,7 +414,7 @@ export default class AdvancedTab extends PureComponent {
               value={ledgerTransportType === LEDGER_TRANSPORT_TYPES.LIVE}
               onToggle={(value) =>
                 setLedgerLivePreference(
-                  value ? '' : LEDGER_TRANSPORT_TYPES.LIVE,
+                  value ? defaultTransportType : LEDGER_TRANSPORT_TYPES.LIVE,
                 )
               }
               offLabel={t('off')}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -407,7 +407,9 @@ export default class AdvancedTab extends PureComponent {
           <div className="settings-page__content-item-col">
             <ToggleButton
               value={ledgerTransportType === 'ledgerLive'}
-              onToggle={(value) => setLedgerLivePreference(value ? 'ledgerLive' : '')}
+              onToggle={(value) =>
+                setLedgerLivePreference(value ? 'ledgerLive' : '')
+              }
               offLabel={t('off')}
               onLabel={t('on')}
               disabled={getPlatform() === PLATFORM_FIREFOX}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -408,7 +408,7 @@ export default class AdvancedTab extends PureComponent {
             <ToggleButton
               value={ledgerTransportType === 'ledgerLive'}
               onToggle={(value) =>
-                setLedgerLivePreference(value ? 'ledgerLive' : '')
+                setLedgerLivePreference(value ? '' : 'ledgerLive')
               }
               offLabel={t('off')}
               onLabel={t('on')}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -41,7 +41,7 @@ export default class AdvancedTab extends PureComponent {
     threeBoxDisabled: PropTypes.bool.isRequired,
     setIpfsGateway: PropTypes.func.isRequired,
     ipfsGateway: PropTypes.string.isRequired,
-    ledgerTransportType: PropTypes.bool.isRequired,
+    ledgerTransportType: PropTypes.string.isRequired,
     setLedgerLivePreference: PropTypes.func.isRequired,
     setDismissSeedBackUpReminder: PropTypes.func.isRequired,
     dismissSeedBackUpReminder: PropTypes.bool.isRequired,

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -36,7 +36,7 @@ export default class AdvancedTab extends PureComponent {
     threeBoxDisabled: PropTypes.bool.isRequired,
     setIpfsGateway: PropTypes.func.isRequired,
     ipfsGateway: PropTypes.string.isRequired,
-    useLedgerLive: PropTypes.bool.isRequired,
+    ledgerTransportType: PropTypes.bool.isRequired,
     setLedgerLivePreference: PropTypes.func.isRequired,
     setDismissSeedBackUpReminder: PropTypes.func.isRequired,
     dismissSeedBackUpReminder: PropTypes.bool.isRequired,
@@ -393,7 +393,7 @@ export default class AdvancedTab extends PureComponent {
 
   renderLedgerLiveControl() {
     const { t } = this.context;
-    const { useLedgerLive, setLedgerLivePreference } = this.props;
+    const { ledgerTransportType, setLedgerLivePreference } = this.props;
 
     return (
       <div className="settings-page__content-row">
@@ -406,8 +406,8 @@ export default class AdvancedTab extends PureComponent {
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
             <ToggleButton
-              value={useLedgerLive}
-              onToggle={(value) => setLedgerLivePreference(!value)}
+              value={ledgerTransportType === 'ledgerLive'}
+              onToggle={(value) => setLedgerLivePreference(value ? 'ledgerLive' : '')}
               offLabel={t('off')}
               onLabel={t('on')}
               disabled={getPlatform() === PLATFORM_FIREFOX}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -9,6 +9,7 @@ import { MOBILE_SYNC_ROUTE } from '../../../helpers/constants/routes';
 
 import { getPlatform } from '../../../../app/scripts/lib/util';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import { LEDGER_TRANSPORT_TYPES } from '../../../../shared/constants/hardware-wallets';
 
 export default class AdvancedTab extends PureComponent {
   static contextTypes = {
@@ -406,9 +407,11 @@ export default class AdvancedTab extends PureComponent {
         <div className="settings-page__content-item">
           <div className="settings-page__content-item-col">
             <ToggleButton
-              value={ledgerTransportType === 'ledgerLive'}
+              value={ledgerTransportType === LEDGER_TRANSPORT_TYPES.LIVE}
               onToggle={(value) =>
-                setLedgerLivePreference(value ? '' : 'ledgerLive')
+                setLedgerLivePreference(
+                  value ? '' : LEDGER_TRANSPORT_TYPES.LIVE,
+                )
               }
               offLabel={t('off')}
               onLabel={t('on')}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -15,7 +15,7 @@ describe('AdvancedTab Component', () => {
         setThreeBoxSyncingPermission={() => undefined}
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
-        useLedgerLive={false}
+        ledgerTransportType={''}
         setLedgerLivePreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         dismissSeedBackUpReminder={false}
@@ -41,7 +41,7 @@ describe('AdvancedTab Component', () => {
         setThreeBoxSyncingPermission={() => undefined}
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
-        useLedgerLive={false}
+        ledgerTransportType={''}
         setLedgerLivePreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         dismissSeedBackUpReminder={false}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import TextField from '../../../components/ui/text-field';
+import { LEDGER_TRANSPORT_TYPES } from '../../../../shared/constants/hardware-wallets';
 import AdvancedTab from './advanced-tab.component';
 
 describe('AdvancedTab Component', () => {
@@ -15,7 +16,7 @@ describe('AdvancedTab Component', () => {
         setThreeBoxSyncingPermission={() => undefined}
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
-        ledgerTransportType=""
+        ledgerTransportType={LEDGER_TRANSPORT_TYPES.U2F}
         setLedgerLivePreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         dismissSeedBackUpReminder={false}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -15,7 +15,7 @@ describe('AdvancedTab Component', () => {
         setThreeBoxSyncingPermission={() => undefined}
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
-        ledgerTransportType={''}
+        ledgerTransportType=""
         setLedgerLivePreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         dismissSeedBackUpReminder={false}
@@ -41,7 +41,7 @@ describe('AdvancedTab Component', () => {
         setThreeBoxSyncingPermission={() => undefined}
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
-        ledgerTransportType={''}
+        ledgerTransportType=""
         setLedgerLivePreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         dismissSeedBackUpReminder={false}

--- a/ui/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.container.js
@@ -28,7 +28,7 @@ export const mapStateToProps = (state) => {
     threeBoxDisabled,
     useNonceField,
     ipfsGateway,
-    useLedgerLive,
+    ledgerTransportType,
     dismissSeedBackUpReminder,
   } = metamask;
   const { showFiatInTestnets, autoLockTimeLimit } = getPreferences(state);
@@ -43,7 +43,7 @@ export const mapStateToProps = (state) => {
     threeBoxDisabled,
     useNonceField,
     ipfsGateway,
-    useLedgerLive,
+    ledgerTransportType,
     dismissSeedBackUpReminder,
   };
 };

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -412,9 +412,9 @@ export function connectHardware(deviceName, page, hdPath) {
           await window.navigator.hid.requestDevice({
             filters: [{ vendorId: '0x2c97' }],
           });
-          await setLedgerWebHidPreference(true);
+          await promisifiedBackground.setLedgerTransportPreference('webhid');
         } catch (e) {
-          await setLedgerWebHidPreference(true);
+          await promisifiedBackground.setLedgerTransportPreference('u2f');
           throw e;
         }
       }
@@ -2760,15 +2760,7 @@ export function getCurrentWindowTab() {
 export function setLedgerLivePreference(value) {
   return async (dispatch) => {
     dispatch(showLoadingIndication());
-    await promisifiedBackground.setLedgerLivePreference(value);
-    dispatch(hideLoadingIndication());
-  };
-}
-
-export function setLedgerWebHidPreference(value) {
-  return async (dispatch) => {
-    dispatch(showLoadingIndication());
-    await promisifiedBackground.setLedgerWebHidPreference(value);
+    await promisifiedBackground.setLedgerTransportPreference(value ? 'ledgerLive' : 'u2f');
     dispatch(hideLoadingIndication());
   };
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -408,9 +408,15 @@ export function connectHardware(deviceName, page, hdPath) {
       const { useLedgerLive } = getState().metamask;
 
       if (browserSupportsHid && deviceName === 'ledger' && !useLedgerLive) {
-        await window.navigator.hid.requestDevice({
-          filters: [{ vendorId: '0x2c97' }],
-        });
+        try {
+          await window.navigator.hid.requestDevice({
+            filters: [{ vendorId: '0x2c97' }],
+          });
+          await setLedgerWebHidPreference(true);
+        } catch (e) {
+          await setLedgerWebHidPreference(true);
+          throw e;
+        }
       }
 
       accounts = await promisifiedBackground.connectHardware(
@@ -2755,6 +2761,14 @@ export function setLedgerLivePreference(value) {
   return async (dispatch) => {
     dispatch(showLoadingIndication());
     await promisifiedBackground.setLedgerLivePreference(value);
+    dispatch(hideLoadingIndication());
+  };
+}
+
+export function setLedgerWebHidPreference(value) {
+  return async (dispatch) => {
+    dispatch(showLoadingIndication());
+    await promisifiedBackground.setLedgerWebHidPreference(value);
     dispatch(hideLoadingIndication());
   };
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -397,13 +397,22 @@ export function forgetDevice(deviceName) {
 
 export function connectHardware(deviceName, page, hdPath) {
   log.debug(`background.connectHardware`, deviceName, page, hdPath);
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     dispatch(
       showLoadingIndication(`Looking for your ${capitalize(deviceName)}...`),
     );
 
     let accounts;
     try {
+      const browserSupportsHid = 'hid' in window.navigator;
+      const { useLedgerLive } = getState().metamask;
+
+      if (browserSupportsHid && deviceName === 'ledger' && !useLedgerLive) {
+        await window.navigator.hid.requestDevice({
+          filters: [{ vendorId: '0x2c97' }],
+        });
+      }
+
       accounts = await promisifiedBackground.connectHardware(
         deviceName,
         page,

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -416,17 +416,12 @@ export function connectHardware(deviceName, page, hdPath) {
         deviceName === 'ledger' &&
         ledgerTransportType !== LEDGER_TRANSPORT_TYPES.LIVE
       ) {
-        try {
-          await window.navigator.hid.requestDevice({
-            filters: [{ vendorId: LEDGER_USB_VENDOR_ID }],
-          });
-          await promisifiedBackground.setLedgerTransportPreference(
-            LEDGER_TRANSPORT_TYPES.WEBHID,
-          );
-        } catch (e) {
-          await promisifiedBackground.setLedgerTransportPreference('');
-          throw e;
-        }
+        await window.navigator.hid.requestDevice({
+          filters: [{ vendorId: LEDGER_USB_VENDOR_ID }],
+        });
+        await promisifiedBackground.setLedgerTransportPreference(
+          LEDGER_TRANSPORT_TYPES.WEBHID,
+        );
       }
 
       accounts = await promisifiedBackground.connectHardware(

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -28,6 +28,7 @@ import { computeEstimatedGasLimit, resetSendState } from '../ducks/send';
 import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-account';
 import { getUnconnectedAccountAlertEnabledness } from '../ducks/metamask/metamask';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
+import { LEDGER_TRANSPORT_TYPES } from '../../shared/constants/hardware-wallets';
 import * as actionConstants from './actionConstants';
 
 let background = null;
@@ -412,9 +413,11 @@ export function connectHardware(deviceName, page, hdPath) {
           await window.navigator.hid.requestDevice({
             filters: [{ vendorId: '0x2c97' }],
           });
-          await promisifiedBackground.setLedgerTransportPreference('webhid');
+          await promisifiedBackground.setLedgerTransportPreference(
+            LEDGER_TRANSPORT_TYPES.WEBHID,
+          );
         } catch (e) {
-          await promisifiedBackground.setLedgerTransportPreference('u2f');
+          await promisifiedBackground.setLedgerTransportPreference('');
           throw e;
         }
       }
@@ -2760,9 +2763,7 @@ export function getCurrentWindowTab() {
 export function setLedgerLivePreference(value) {
   return async (dispatch) => {
     dispatch(showLoadingIndication());
-    await promisifiedBackground.setLedgerTransportPreference(
-      value ? 'ledgerLive' : 'u2f',
-    );
+    await promisifiedBackground.setLedgerTransportPreference(value);
     dispatch(hideLoadingIndication());
   };
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2760,7 +2760,9 @@ export function getCurrentWindowTab() {
 export function setLedgerLivePreference(value) {
   return async (dispatch) => {
     dispatch(showLoadingIndication());
-    await promisifiedBackground.setLedgerTransportPreference(value ? 'ledgerLive' : 'u2f');
+    await promisifiedBackground.setLedgerTransportPreference(
+      value ? 'ledgerLive' : 'u2f',
+    );
     dispatch(hideLoadingIndication());
   };
 }

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -409,9 +409,13 @@ export function connectHardware(deviceName, page, hdPath) {
     let accounts;
     try {
       const browserSupportsHid = 'hid' in window.navigator;
-      const { useLedgerLive } = getState().metamask;
+      const { ledgerTransportType } = getState().metamask;
 
-      if (browserSupportsHid && deviceName === 'ledger' && !useLedgerLive) {
+      if (
+        browserSupportsHid &&
+        deviceName === 'ledger' &&
+        ledgerTransportType !== LEDGER_TRANSPORT_TYPES.LIVE
+      ) {
         try {
           await window.navigator.hid.requestDevice({
             filters: [{ vendorId: LEDGER_USB_VENDOR_ID }],

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -28,7 +28,10 @@ import { computeEstimatedGasLimit, resetSendState } from '../ducks/send';
 import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-account';
 import { getUnconnectedAccountAlertEnabledness } from '../ducks/metamask/metamask';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
-import { LEDGER_TRANSPORT_TYPES } from '../../shared/constants/hardware-wallets';
+import {
+  LEDGER_TRANSPORT_TYPES,
+  LEDGER_USB_VENDOR_ID,
+} from '../../shared/constants/hardware-wallets';
 import * as actionConstants from './actionConstants';
 
 let background = null;
@@ -411,7 +414,7 @@ export function connectHardware(deviceName, page, hdPath) {
       if (browserSupportsHid && deviceName === 'ledger' && !useLedgerLive) {
         try {
           await window.navigator.hid.requestDevice({
-            filters: [{ vendorId: '0x2c97' }],
+            filters: [{ vendorId: LEDGER_USB_VENDOR_ID }],
           });
           await promisifiedBackground.setLedgerTransportPreference(
             LEDGER_TRANSPORT_TYPES.WEBHID,

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -416,12 +416,16 @@ export function connectHardware(deviceName, page, hdPath) {
         deviceName === 'ledger' &&
         ledgerTransportType !== LEDGER_TRANSPORT_TYPES.LIVE
       ) {
-        await window.navigator.hid.requestDevice({
-          filters: [{ vendorId: LEDGER_USB_VENDOR_ID }],
-        });
-        await promisifiedBackground.setLedgerTransportPreference(
-          LEDGER_TRANSPORT_TYPES.WEBHID,
-        );
+        try {
+          await window.navigator.hid.requestDevice({
+            filters: [{ vendorId: LEDGER_USB_VENDOR_ID }],
+          });
+          await promisifiedBackground.setLedgerTransportPreference(
+            LEDGER_TRANSPORT_TYPES.WEBHID,
+          );
+        } catch (e) {
+          log.error(e);
+        }
       }
 
       accounts = await promisifiedBackground.connectHardware(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,9 +2821,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-6.0.0.tgz#ec53e8ab278073e882411ed89705bc7d06b78c81"
   integrity sha512-LyakGYGwM8UQOGhwWa+5erAI1hXuiTgf/y7USzOomX6H9KiuY09IAUYnPh7ToPG2sedD2F48UF1bUm8yvCoZOw==
 
-"@metamask/eth-ledger-bridge-keyring@git://github.com/MetaMask/eth-ledger-bridge-keyring.git#version09":
+"@metamask/eth-ledger-bridge-keyring@^0.9.0":
   version "0.9.0"
-  resolved "git://github.com/MetaMask/eth-ledger-bridge-keyring.git#5f51abc1527efdce3e549a0da6c2674be6480883"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.9.0.tgz#42e98e7dfeaaa08e7c9ceff261facddd7320df80"
+  integrity sha512-EuNKvodbdJxQPzr+zAE5TE1iKUzuIRWKeVaYoYwpi18RjjtSQMKmZcb3VXY8hmQu+Fj4Ld/ujj22qSYjYAjtPg==
   dependencies:
     "@ethereumjs/tx" "^3.2.0"
     eth-sig-util "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,10 +2821,9 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-6.0.0.tgz#ec53e8ab278073e882411ed89705bc7d06b78c81"
   integrity sha512-LyakGYGwM8UQOGhwWa+5erAI1hXuiTgf/y7USzOomX6H9KiuY09IAUYnPh7ToPG2sedD2F48UF1bUm8yvCoZOw==
 
-"@metamask/eth-ledger-bridge-keyring@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.7.0.tgz#7d80e1e3dfab91ba2b6a1a2a5e352320e948b568"
-  integrity sha512-0UOEb/c3/fkatDK+se3gOHaGQ0RTRLbG5DqsoeowZ/JcO4wcMxBhOiIgOY4domOqUTekKKVPNC7Pc0mHpM9sAQ==
+"@metamask/eth-ledger-bridge-keyring@git://github.com/MetaMask/eth-ledger-bridge-keyring.git#version09":
+  version "0.9.0"
+  resolved "git://github.com/MetaMask/eth-ledger-bridge-keyring.git#5f51abc1527efdce3e549a0da6c2674be6480883"
   dependencies:
     "@ethereumjs/tx" "^3.2.0"
     eth-sig-util "^2.0.0"


### PR DESCRIPTION
This PR adds a permission request to connect the extension to a ledger hardware wallet device, if that option is available in the current browser.

Associated PRs: https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/106 and https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/107

This PR should also update the version of `eth-ledger-bridge-keyring` once PR 107 is merged and a new version of that module is released.