### PR TITLE
e2e test - fix graceful shutdown of dapp server

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -130,7 +130,7 @@ async function withFixtures(options, testSuite) {
       if (webDriver) {
         await webDriver.quit();
       }
-      if (dappServer) {
+      if (dappServer && dappServer.listening) {
         await new Promise((resolve, reject) => {
           dappServer.close((error) => {
             if (error) {


### PR DESCRIPTION
original error gets swallowed if the server failed to listen and then we attempt to close it

https://nodejs.org/api/net.html#net_server_listening