### PR TITLE
test - switchToWindowWithTitle - refresh window handles on each retry loop

### DIFF
--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -277,13 +277,13 @@ class Driver {
 
   async switchToWindowWithTitle(
     title,
-    windowHandles,
+    initialWindowHandles,
     delayStep = 1000,
     timeout = 5000,
   ) {
+    let windowHandles =
+      initialWindowHandles || (await this.driver.getAllWindowHandles());
     let timeElapsed = 0;
-    // eslint-disable-next-line no-param-reassign
-    windowHandles = windowHandles || (await this.driver.getAllWindowHandles());
     while (timeElapsed <= timeout) {
       for (const handle of windowHandles) {
         await this.driver.switchTo().window(handle);
@@ -294,6 +294,8 @@ class Driver {
       }
       await this.delay(delayStep);
       timeElapsed += delayStep;
+      // refresh the window handles
+      windowHandles = await this.driver.getAllWindowHandles();
     }
 
     throw new Error(`No window with title: ${title}`);


### PR DESCRIPTION
should improve flakiness due to grabbing the wrong window handles