### PR TITLE
Using URL util to parse hostname for block explorer link

### DIFF
--- a/ui/components/app/modals/account-details-modal/account-details-modal.component.js
+++ b/ui/components/app/modals/account-details-modal/account-details-modal.component.js
@@ -81,7 +81,7 @@ export default class AccountDetailsModal extends Component {
         >
           {rpcPrefs.blockExplorerUrl
             ? this.context.t('blockExplorerView', [
-                rpcPrefs.blockExplorerUrl.match(/^https?:\/\/(.+)/u)[1],
+                getURLHostName(rpcPrefs.blockExplorerUrl),
               ])
             : this.context.t('viewOnEtherscan', [
                 this.context.t('blockExplorerAccountAction'),


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/metamask/issues/2071695182/

This error appeared to present in cases where a user had bad block explorer url data prior to some of our added validation. Also in general, we shouldn't access hard indexes for the result of a regex `match`