### PR TITLE
Fix form prefilling in Swaps on the Build Quote page

### DIFF
--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -79,6 +79,7 @@ const initialState = {
     routeState: '',
     swapsFeatureIsLive: true,
     useNewSwapsApi: false,
+    isFetchingQuotes: false,
     swapsQuoteRefreshTime: FALLBACK_QUOTE_REFRESH_TIME,
     swapsQuotePrefetchingRefreshTime: FALLBACK_QUOTE_REFRESH_TIME,
   },
@@ -229,6 +230,8 @@ export default class SwapsController {
     const indexOfCurrentCall = this.indexOfNewestCallInFlight + 1;
     this.indexOfNewestCallInFlight = indexOfCurrentCall;
 
+    this.setIsFetchingQuotes(true);
+
     let [newQuotes] = await Promise.all([
       this._fetchTradesInfo(fetchParams, {
         ...fetchParamsMetaData,
@@ -236,6 +239,20 @@ export default class SwapsController {
       }),
       this._setSwapsRefreshRates(),
     ]);
+
+    const {
+      swapsState: { isFetchingQuotes },
+    } = this.store.getState();
+
+    // If isFetchingQuotes is false, it means a user left Swaps (we cleaned the state)
+    // and we don't want to set any API response with quotes into state.
+    if (!isFetchingQuotes) {
+      return [
+        {}, // quotes
+        null, // selectedAggId
+      ];
+    }
+    this.setIsFetchingQuotes(false);
 
     newQuotes = mapValues(newQuotes, (quote) => ({
       ...quote,
@@ -538,6 +555,13 @@ export default class SwapsController {
   setBackgroundSwapRouteState(routeState) {
     const { swapsState } = this.store.getState();
     this.store.updateState({ swapsState: { ...swapsState, routeState } });
+  }
+
+  setIsFetchingQuotes(status) {
+    const { swapsState } = this.store.getState();
+    this.store.updateState({
+      swapsState: { ...swapsState, isFetchingQuotes: status },
+    });
   }
 
   setSwapsLiveness(swapsLiveness) {

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -594,7 +594,6 @@ export default class SwapsController {
     this.store.updateState({
       swapsState: {
         ...initialState.swapsState,
-        tokens: swapsState.tokens,
         swapsQuoteRefreshTime: swapsState.swapsQuoteRefreshTime,
         swapsQuotePrefetchingRefreshTime:
           swapsState.swapsQuotePrefetchingRefreshTime,

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -135,6 +135,7 @@ const EMPTY_INIT_STATE = {
     swapsQuoteRefreshTime: 60000,
     swapsQuotePrefetchingRefreshTime: 60000,
     swapsUserFeeLevel: '',
+    isFetchingQuotes: false,
   },
 };
 


### PR DESCRIPTION
## Explanation
This PR fixes an issue where a user saw prefilled values on the Build Quote page after they left Swaps and entered it again when certain conditions were met. Now every time a user leaves and enters Swaps, they will start from a clean slate and only the "Swap from" field will be preselected.

## Manual testing steps
- Go to Swaps
- Select swap from, amount and swap to. Once you select all of them, wait for about 2 seconds and click on the Fox head / Cancel link to exit Swaps
- Enter Swaps again
- Only the "Swap from" field will be prefilled