### PR TITLE
Migrate beta version to the main version field

### DIFF
--- a/app/manifest/_beta_modifications.json
+++ b/app/manifest/_beta_modifications.json
@@ -22,6 +22,5 @@
     "512": "images/icon-512.png"
   },
   "name": "__MSG_appName__ Beta",
-  "short_name": "__MSG_appName__ Beta",
-  "version": ""
+  "short_name": "__MSG_appName__ Beta"
 }

--- a/development/build/README.md
+++ b/development/build/README.md
@@ -40,8 +40,6 @@ Commands:
                         e2e tests.
 
 Options:
-  --beta-version      If the build type is "beta", the beta version number.
-                                                           [number] [default: 0]
   --build-type        The "type" of build to create. One of: "beta", "main"
                                                       [string] [default: "main"]
   --lint-fence-files  Whether files with code fences should be linted after

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -1,24 +1,5 @@
-/**
- * @returns {Object} An object with browser as key and next version of beta
- * as the value.  E.g. { firefox: '9.6.0.beta0', chrome: '9.6.0.1' }
- */
-function getNextBetaVersionMap(currentVersion, betaVersion, platforms) {
-  const [major, minor] = currentVersion.split('.');
-
-  return platforms.reduce((platformMap, platform) => {
-    platformMap[platform] = [
-      // Keeps the current major
-      major,
-      // Bump the minor version
-      Number(minor) + 1,
-      // This isn't typically used
-      0,
-      // The beta number
-      `${platform === 'firefox' ? 'beta' : ''}${betaVersion}`,
-    ].join('.');
-    return platformMap;
-  }, {});
-}
+const semver = require('semver');
+const { version } = require('../../package.json');
 
 const BuildTypes = {
   beta: 'beta',
@@ -26,7 +7,58 @@ const BuildTypes = {
   main: 'main',
 };
 
+/**
+ * Map the current version to a format that is compatible with each browser.
+ *
+ * The given version number is assumed to be a SemVer version number. Additionally, if the version
+ * has a prerelease component, it is assumed to have the format "<build type>.<build version",
+ * where the build version is a positive integer.
+ *
+ * @param {string} currentVersion - The current version.
+ * @param {string[]} platforms - A list of browsers to generate versions for.
+ * @returns {Object} An object with the browser as the key and the browser-specific version object
+ * as the value.  For example, the version `9.6.0-beta.1` would return the object
+ * `{ firefox: { version: '9.6.0.beta1' }, chrome: { version: '9.6.0.1', version_name: 'beta' } }`.
+ */
+function getBrowserVersionMap(platforms) {
+  const major = semver.major(version);
+  const minor = semver.minor(version);
+  const patch = semver.patch(version);
+  const prerelease = semver.prerelease(version);
+
+  let buildType;
+  let buildVersion;
+  if (prerelease) {
+    if (prerelease.length !== 2) {
+      throw new Error(`Invalid prerelease version: '${prerelease.join('.')}'`);
+    }
+    buildType = prerelease[0];
+    buildVersion = prerelease[1];
+    if (!String(buildVersion).match(/^\d+$/u)) {
+      throw new Error(`Invalid prerelease build version: '${buildVersion}'`);
+    } else if (buildType !== BuildTypes.beta) {
+      throw new Error(`Invalid prerelease build type: ${buildType}`);
+    }
+  }
+
+  return platforms.reduce((platformMap, platform) => {
+    const versionParts = [major, minor, patch];
+    const browserSpecificVersion = {};
+    if (prerelease) {
+      if (platform === 'firefox') {
+        versionParts.push(`${buildType}${buildVersion}`);
+      } else {
+        versionParts.push(buildVersion);
+        browserSpecificVersion.version_name = buildType;
+      }
+    }
+    browserSpecificVersion.version = versionParts.join('.');
+    platformMap[platform] = browserSpecificVersion;
+    return platformMap;
+  }, {});
+}
+
 module.exports = {
   BuildTypes,
-  getNextBetaVersionMap,
+  getBrowserVersionMap,
 };

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -32,8 +32,7 @@ function getBrowserVersionMap(platforms) {
     if (prerelease.length !== 2) {
       throw new Error(`Invalid prerelease version: '${prerelease.join('.')}'`);
     }
-    buildType = prerelease[0];
-    buildVersion = prerelease[1];
+    [buildType, buildVersion] = prerelease;
     if (!String(buildVersion).match(/^\d+$/u)) {
       throw new Error(`Invalid prerelease build version: '${buildVersion}'`);
     } else if (buildType !== BuildTypes.beta) {

--- a/lavamoat/node/policy.json
+++ b/lavamoat/node/policy.json
@@ -2862,6 +2862,11 @@
         "js-tokens": true
       }
     },
+    "lru-cache": {
+      "packages": {
+        "yallist": true
+      }
+    },
     "lru-queue": {
       "packages": {
         "es5-ext": true
@@ -3724,6 +3729,9 @@
       "globals": {
         "console": true,
         "process": true
+      },
+      "packages": {
+        "lru-cache": true
       }
     },
     "set-value": {

--- a/package.json
+++ b/package.json
@@ -312,6 +312,7 @@
     "sass": "^1.32.4",
     "sass-loader": "^10.1.1",
     "selenium-webdriver": "4.0.0-alpha.7",
+    "semver": "^7.3.5",
     "serve-handler": "^6.1.2",
     "sinon": "^9.0.0",
     "source-map": "^0.7.2",


### PR DESCRIPTION
The main `version` field in `package.json` will now include the beta version (if present) rather than it being passed in via the CLI when building. The `version` field is now a fully SemVer-compatible version, with the added restriction that any prerelease portion of the version must match the format `<build type>.<build version>`.

This brings the build in-line with the future release process we will be using for the beta version. The plan is for each future release to enter a "beta phase" where the version would get updated to reflect that it's a beta, and we would increment this beta version over time as we update the beta. The manifest gives us a place to store this beta version. It was also important to replace the automatic minor bump logic that was being used previously, because the version in beta might not be a minor bump.

Additionally, the filename logic used for beta builds was updated to be generic across all build types rather than beta-specific. This will be useful for Flask builds in the future.

Manual testing steps:  
  - Build "main" and "beta" builds (`yarn dist` and `yarn dist --build-type beta`) and ensure both versions work, and that the correct assets are used throughout the app.
  - Try adding a `-beta.<number>` suffix to the `version` field in `package.json` and ensure both beta and non-beta builds work.
  - Try adding invalid suffixes to `version` in `package.json` and ensure the build fails (e.g. anything other than `-beta.<positive integer>`.