### PR TITLE
Suppress prop types warning in RadioGroupComponent

### DIFF
--- a/ui/components/ui/radio-group/radio-group.component.js
+++ b/ui/components/ui/radio-group/radio-group.component.js
@@ -24,8 +24,8 @@ function Connector({ isFirst, isLast }) {
 }
 
 Connector.propTypes = {
-  isFirst: PropTypes.boolean,
-  isLast: PropTypes.boolean,
+  isFirst: PropTypes.bool,
+  isLast: PropTypes.bool,
 };
 
 export default function RadioGroup({ options, name, selectedValue, onChange }) {


### PR DESCRIPTION
When editing the gas fee for a transaction, the following warning is
being output to the console:

    Warning: Failed prop type: Connector: prop type `isFirst` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.

This commit fixes this issue.