### PR TITLE
Normalize extension verison to SemVer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -134,6 +134,7 @@ module.exports = {
         'shared/**/*.test.js',
         'development/**/*.test.js',
         'app/scripts/migrations/*.test.js',
+        'app/scripts/platforms/*.test.js',
       ],
       extends: ['@metamask/eslint-config-mocha'],
       rules: {
@@ -157,6 +158,7 @@ module.exports = {
         'shared/**/*.test.js',
         'development/**/*.test.js',
         'app/scripts/migrations/*.test.js',
+        'app/scripts/platforms/*.test.js',
       ],
       extends: ['@metamask/eslint-config-jest'],
       rules: {

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,7 +1,7 @@
 module.exports = {
   // TODO: Remove the `exit` setting, it can hide broken tests.
   exit: true,
-  ignore: ['./app/scripts/migrations/*.test.js'],
+  ignore: ['./app/scripts/migrations/*.test.js', './app/scripts/platforms/*.test.js'],
   recursive: true,
   require: ['test/env.js', 'test/setup.js'],
 }

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -79,7 +79,36 @@ export default class ExtensionPlatform {
   }
 
   getVersion() {
-    return extension.runtime.getManifest().version;
+    const {
+      version,
+      version_name: versionName,
+    } = extension.runtime.getManifest();
+
+    const versionParts = version.split('.');
+    if (versionName) {
+      // On Chrome, the build type is stored as `version_name` in the manifest, and the fourth part
+      // of the version is the build version.
+      const buildType = versionName;
+      if (versionParts.length < 4) {
+        throw new Error(`Version missing build number: '${version}'`);
+      }
+      const [major, minor, patch, buildVersion] = versionParts;
+
+      return `${major}.${minor}.${patch}-${buildType}.${buildVersion}`;
+    } else if (versionParts.length === 4) {
+      // On Firefox, the build type and build version are in the fourth part of the version.
+      const [major, minor, patch, prerelease] = versionParts;
+      const matches = prerelease.match(/^(\w)+(\d)+$/u);
+      if (matches === null) {
+        throw new Error(`Version contains invalid prerelease: ${version}`);
+      }
+      const [, buildType, buildVersion] = matches;
+      return `${major}.${minor}.${patch}-${buildType}.${buildVersion}`;
+    }
+
+    // If there is no `version_name` and there are only 3 version parts, then this is not a
+    // prerelease and the version requires no modification.
+    return version;
   }
 
   openExtensionInBrowser(route = null, queryString = null) {

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -98,7 +98,7 @@ export default class ExtensionPlatform {
     } else if (versionParts.length === 4) {
       // On Firefox, the build type and build version are in the fourth part of the version.
       const [major, minor, patch, prerelease] = versionParts;
-      const matches = prerelease.match(/^(\w)+(\d)+$/u);
+      const matches = prerelease.match(/^(\w+)(\d)+$/u);
       if (matches === null) {
         throw new Error(`Version contains invalid prerelease: ${version}`);
       }

--- a/app/scripts/platforms/extension.test.js
+++ b/app/scripts/platforms/extension.test.js
@@ -1,0 +1,96 @@
+import extension from 'extensionizer';
+import ExtensionPlatform from './extension';
+
+jest.mock('extensionizer', () => {
+  return {
+    runtime: {
+      getManifest: jest.fn(),
+    },
+  };
+});
+
+describe('extension platform', () => {
+  beforeEach(() => {
+    // TODO: Delete this an enable 'resetMocks' in `jest.config.js` instead
+    jest.resetAllMocks();
+  });
+
+  describe('getVersion', () => {
+    it('should return non-prerelease version', () => {
+      extension.runtime.getManifest.mockReturnValue({ version: '1.2.3' });
+      const extensionPlatform = new ExtensionPlatform();
+
+      const version = extensionPlatform.getVersion();
+
+      expect(version).toBe('1.2.3');
+    });
+
+    it('should return SemVer-formatted version for Chrome style manifest of prerelease', () => {
+      extension.runtime.getManifest.mockReturnValue({
+        version: '1.2.3.0',
+        version_name: 'beta',
+      });
+      const extensionPlatform = new ExtensionPlatform();
+
+      const version = extensionPlatform.getVersion();
+
+      expect(version).toBe('1.2.3-beta.0');
+    });
+
+    it('should return SemVer-formatted version for Firefox style manifest of prerelease', () => {
+      extension.runtime.getManifest.mockReturnValue({
+        version: '1.2.3.beta0',
+      });
+      const extensionPlatform = new ExtensionPlatform();
+
+      const version = extensionPlatform.getVersion();
+
+      expect(version).toBe('1.2.3-beta.0');
+    });
+
+    it('should throw error if build version is missing from Chrome style prerelease manifest', () => {
+      extension.runtime.getManifest.mockReturnValue({
+        version: '1.2.3',
+        version_name: 'beta',
+      });
+      const extensionPlatform = new ExtensionPlatform();
+
+      expect(() => extensionPlatform.getVersion()).toThrow(
+        'Version missing build number:',
+      );
+    });
+
+    it('should throw error if build type is missing from Chrome style prerelease manifest', () => {
+      extension.runtime.getManifest.mockReturnValue({
+        version: '1.2.3.0',
+      });
+      const extensionPlatform = new ExtensionPlatform();
+
+      expect(() => extensionPlatform.getVersion()).toThrow(
+        'Version contains invalid prerelease:',
+      );
+    });
+
+    it('should throw error if build version is missing from Firefox style prerelease manifest', () => {
+      extension.runtime.getManifest.mockReturnValue({
+        version: '1.2.3.beta',
+      });
+      const extensionPlatform = new ExtensionPlatform();
+
+      expect(() => extensionPlatform.getVersion()).toThrow(
+        'Version contains invalid prerelease:',
+      );
+    });
+
+    it('should throw error if build type is missing from Firefox style prerelease manifest', () => {
+      extension.runtime.getManifest.mockReturnValue({
+        version: '1.2.3.0',
+      });
+      const extensionPlatform = new ExtensionPlatform();
+
+      expect(() => extensionPlatform.getVersion()).toThrow(
+        'Version contains invalid prerelease:',
+      );
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
     '<rootDir>/ui/**/*.test.js',
     '<rootDir>/shared/**/*.test.js',
     '<rootDir>/app/scripts/migrations/*.test.js',
+    '<rootDir>/app/scripts/platforms/*.test.js',
   ],
   testTimeout: 2500,
 };


### PR DESCRIPTION
The extension version used throughout the wallet is now normalized to a SemVer-compliant version that matches the version used in `package.json`. We use this version for display on the "About" page, and we attach it to all error reports and metric events, so it's important that we format it consistently so that we can correlate events on the same version across different browsers.

This normalization step is necessary because Firefox and Chrome both have different requirements for the extension version, and neither is SemVer-compliant.

Manual testing steps:  
  - Try adding a `-beta.0` suffix to the version, and see that it is displayed consistently on both Chrome and Firefox
  - Try leaving the version as-is, and ensure it is displayed correctly.