### PR TITLE
Update warning message when Ledger app has contract data/blind signin…

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1245,7 +1245,7 @@
     "message": "Prior to clicking confirm:"
   },
   "ledgerLiveDialogStepFour": {
-    "message": "Enable smart contract data on your Ledger device"
+    "message": "Enable \"smart contract data\" or \"blind signing\" on your Ledger device"
   },
   "ledgerLiveDialogStepOne": {
     "message": "Enable Use Ledger Live under Settings > Advanced"


### PR DESCRIPTION
…g setting disabled

Explanation:  

Since Ethereum app v1.9.6, the setting "Enable contract data" has been updated to "Enable Blind Signing". 
(see https://github.com/LedgerHQ/app-ethereum/commit/fa355a5d970d30029cf17ba35c40209209a327fa#diff-505735aabef6c5a02c985965bbd815d8a79571140dec87d7757c633e7dace64aR59 )
This PR updates Metamask error message so that it handles both cases, new and legacy.

Manual testing steps:  
  - Disable contract data/blind signing in ethereum app
  - Try to sign a transaction that interacts with a dapp
  - Check that Metamask displays the new error message "Enable \"smart contract data\" or \"blind signing\" on your Ledger device"