### PR TITLE
Remove autofocus from gas limit input on advance gas popup

### DIFF
--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -54,7 +54,6 @@ export default function AdvancedGasControls({
         value={gasLimit}
         allowDecimals={false}
         numeric
-        autoFocus
       />
       {showFeeMarketFields ? (
         <>


### PR DESCRIPTION
Fixes: #12274

Explanation:  Focus on inputs in advance gas popup by default can interfere with scrolling in long popup and create a bad UX. The PR removes autofocus from gas limit input

Manual testing steps:  
  - Open the advance gas editing menu
  - None of the inputs should be focused by default