### PR TITLE
Restoring mobile sync warning text

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1378,7 +1378,7 @@
     "message": "Don't see your token?"
   },
   "mobileSyncWarning": {
-    "message": "⚠️ Proceeding will display a secret QR code that allows access to your accounts. Do not share it with anyone. Support staff will never ask you for it."
+    "message": "The 'Sync with extension' feature is temporarily disabled. If you want to use your extension wallet on MetaMask mobile, then on your mobile app: go back to the wallet setup options and select the 'Import with Secret Recovery Phrase' option. Use your extension wallet's secret phrase to then import your wallet into mobile."
   },
   "mustSelectOne": {
     "message": "Must select at least 1 token."


### PR DESCRIPTION
This was accidentally overwritten by: https://github.com/MetaMask/metamask-extension/commit/769beb2a26e9beaa94c8ac1006df7c3a4aaa067c#diff-7509d7529ea1cbc57ef79713676f7d124d9d5a446053f94836876c4cd3f3ccd6R1338

Originally implemented in: https://github.com/MetaMask/metamask-extension/pull/11935

<img width="580" alt="Screen Shot 2021-10-05 at 1 40 12 PM" src="https://user-images.githubusercontent.com/8732757/136099917-2e58225b-1eee-418d-b984-64ca7b49a1f9.png">

