### PR TITLE
Adds sign typed data type to metrics payload for sign typed data events

### DIFF
--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -285,7 +285,9 @@ export default class SignatureRequestOriginal extends Component {
       history,
       mostRecentOverviewPage,
       sign,
+      txData: { type },
     } = this.props;
+    const { metricsEvent, t } = this.context;
 
     return (
       <div className="request-signature__footer">
@@ -296,18 +298,21 @@ export default class SignatureRequestOriginal extends Component {
           onClick={async (event) => {
             this._removeBeforeUnload();
             await cancel(event);
-            this.context.metricsEvent({
+            metricsEvent({
               eventOpts: {
                 category: 'Transactions',
                 action: 'Sign Request',
                 name: 'Cancel',
+              },
+              customVariables: {
+                type,
               },
             });
             clearConfirmTransaction();
             history.push(mostRecentOverviewPage);
           }}
         >
-          {this.context.t('cancel')}
+          {t('cancel')}
         </Button>
         <Button
           data-testid="request-signature__sign"
@@ -317,18 +322,21 @@ export default class SignatureRequestOriginal extends Component {
           onClick={async (event) => {
             this._removeBeforeUnload();
             await sign(event);
-            this.context.metricsEvent({
+            metricsEvent({
               eventOpts: {
                 category: 'Transactions',
                 action: 'Sign Request',
                 name: 'Confirm',
+              },
+              customVariables: {
+                type,
               },
             });
             clearConfirmTransaction();
             history.push(mostRecentOverviewPage);
           }}
         >
-          {this.context.t('sign')}
+          {t('sign')}
         </Button>
       </div>
     );

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -33,13 +33,20 @@ export default class SignatureRequest extends PureComponent {
   }
 
   _beforeUnload = (event) => {
-    const { clearConfirmTransaction, cancel } = this.props;
+    const {
+      clearConfirmTransaction,
+      cancel,
+      txData: { type },
+    } = this.props;
     const { metricsEvent } = this.context;
     metricsEvent({
       eventOpts: {
         category: 'Transactions',
         action: 'Sign Request',
         name: 'Cancel Sig Request Via Notification Close',
+      },
+      customVariables: {
+        type,
       },
     });
     clearConfirmTransaction();
@@ -58,21 +65,43 @@ export default class SignatureRequest extends PureComponent {
       fromAccount,
       txData: {
         msgParams: { data, origin },
+        type,
       },
       cancel,
       sign,
     } = this.props;
     const { address: fromAddress } = fromAccount;
     const { message, domain = {} } = JSON.parse(data);
+    const { metricsEvent } = this.context;
 
     const onSign = (event) => {
       window.removeEventListener('beforeunload', this._beforeUnload);
       sign(event);
+      metricsEvent({
+        eventOpts: {
+          category: 'Transactions',
+          action: 'Sign Request',
+          name: 'Confirm',
+        },
+        customVariables: {
+          type,
+        },
+      });
     };
 
     const onCancel = (event) => {
       window.removeEventListener('beforeunload', this._beforeUnload);
       cancel(event);
+      metricsEvent({
+        eventOpts: {
+          category: 'Transactions',
+          action: 'Sign Request',
+          name: 'Cancel',
+        },
+        customVariables: {
+          type,
+        },
+      });
     };
 
     return (

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -64,7 +64,7 @@ export default class SignatureRequest extends PureComponent {
     const {
       fromAccount,
       txData: {
-        msgParams: { data, origin },
+        msgParams: { data, origin, version },
         type,
       },
       cancel,
@@ -85,6 +85,7 @@ export default class SignatureRequest extends PureComponent {
         },
         customVariables: {
           type,
+          version,
         },
       });
     };
@@ -100,6 +101,7 @@ export default class SignatureRequest extends PureComponent {
         },
         customVariables: {
           type,
+          version,
         },
       });
     };


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/10250

Additionally adds tracking events for `eth_signTypedData_v3` and `eth_signTypedData_v4`

Example payloads: 
<img width="209" alt="Screen Shot 2021-10-08 at 1 51 17 PM" src="https://user-images.githubusercontent.com/8732757/136623764-e7c685a2-03ad-42fa-903c-7ecc07d62aaf.png">

<img width="223" alt="Screen Shot 2021-10-08 at 1 51 03 PM" src="https://user-images.githubusercontent.com/8732757/136623765-0618eb52-3865-4cb9-82b6-753e27ad70e7.png">

<img width="229" alt="Screen Shot 2021-10-08 at 1 51 41 PM" src="https://user-images.githubusercontent.com/8732757/136623761-1ae87fcb-335d-445e-ada3-853f1667ced8.png">

<img width="205" alt="Screen Shot 2021-10-08 at 1 51 29 PM" src="https://user-images.githubusercontent.com/8732757/136623763-aeeee073-04f9-43b7-8a6b-bd0915c3cfb0.png">


