### PR TITLE
Adding ToggleButton story to storybook

### DIFF
--- a/ui/components/ui/toggle-button/toggle-button.stories.js
+++ b/ui/components/ui/toggle-button/toggle-button.stories.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import ToggleButton from './toggle-button.component';
+
+export default {
+  title: 'ToggleButton',
+  component: ToggleButton,
+  id: __filename,
+};
+
+export const DefaultStory = () => {
+  const [checked, setChecked] = useState(false);
+  const handleOnToggle = (e) => {
+    action('onToggle')(e);
+    setChecked(!checked);
+  };
+  return (
+    <ToggleButton
+      offLabel={text('offLabel', 'off')}
+      onLabel={text('onLabel', 'on')}
+      disabled={boolean('disabled', false)}
+      value={checked}
+      onToggle={handleOnToggle}
+    />
+  );
+};
+
+DefaultStory.story = {
+  name: 'Default',
+};


### PR DESCRIPTION
Fixes: #12250

Explanation: Adding `ToggleButton` story to storybook

Manual testing steps:  
  -  In repository run`yarn storybook`
  -  Search "ToggleButton" in search in storybook or head [http://localhost:6006/?path=/story/ui-components-ui-toggle-button-toggle-button-stories-js--default-story](http://localhost:6006/?path=/story/ui-components-ui-toggle-button-toggle-button-stories-js--default-story)
  
  ![Screen Shot 2021-10-07 at 4 29 27 PM](https://user-images.githubusercontent.com/8112138/136475760-427f7cb6-8592-4467-9c58-a51bb7887471.png)

- Check knobs and actions work
 
![Screen Shot 2021-10-08 at 8 44 34 AM](https://user-images.githubusercontent.com/8112138/136585968-1d67658e-a6bf-47a6-9330-b17df861d5bd.png)
![Screen Shot 2021-10-08 at 8 45 07 AM](https://user-images.githubusercontent.com/8112138/136585971-13d24a77-8bd4-4a0f-a4f5-752ebc316e09.png)

Ideally we should be using [storybook docs](https://storybook.js.org/docs/react/writing-docs/docs-page) and the [controls addon](https://storybook.js.org/docs/react/essentials/controls) as a way of documenting and interacting with the component but will save that for another PR