### PR TITLE
add optional chaining in isLegacyTransaction method to prevent blow up on view quote page

### DIFF
--- a/ui/helpers/utils/transactions.util.js
+++ b/ui/helpers/utils/transactions.util.js
@@ -163,7 +163,7 @@ export function sumHexes(...args) {
 }
 
 export function isLegacyTransaction(txParams) {
-  return txParams.type === TRANSACTION_ENVELOPE_TYPES.LEGACY;
+  return txParams?.type === TRANSACTION_ENVELOPE_TYPES.LEGACY;
 }
 
 /**


### PR DESCRIPTION
Explanation:  There is a use of useGasFeeInputs on the view quotes (swaps) page and the addition of the isLegacyTransaction helper method was added without anticipating a transaction passed in without txParams, as we do in this case. This optional chaining just adds protection for this case.
