### PR TITLE
feat: allow adding rpc endpoints with same chain id

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -113,14 +113,6 @@ async function addEthereumChainHandler(
     );
   }
 
-  if (CHAIN_ID_TO_NETWORK_ID_MAP[_chainId]) {
-    return end(
-      ethErrors.rpc.invalidParams({
-        message: `May not specify default MetaMask chain.`,
-      }),
-    );
-  }
-
   const existingNetwork = findCustomRpcBy({ chainId: _chainId });
 
   if (existingNetwork) {


### PR DESCRIPTION
As title, the motivation is to allow adding new RPCs with existing chain ids. 

An example of that is the Flashbots RPC which provides users with frontrunning/backrunning protection and non-reverting transactions.