### PR TITLE
Update `yazl` to fix Buffer warning

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -28935,9 +28935,9 @@ yauzl@2.10.0, yauzl@^2.10.0:
     fd-slicer "~1.1.0"
 
 yazl@^2.1.0:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.4.3.tgz#ec26e5cc87d5601b9df8432dbdd3cd2e5173a071"
-  integrity sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
 


### PR DESCRIPTION
We were using an outdated version of the package `yazl` in our build system, resulting in a Buffer warning during the production and test builds about the use of the deprecated Buffer constructor.

`yazl` has been updated to the latest version, and no longer uses the deprecated Buffer constructor that caused this warning.

The warning looked like this:
```
(node:52293) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

Manual testing steps:  
  - Run `yarn dist` and see that the warning does not appear.
  - Run `yarn build test` and see that the warning does not appear.