### PR TITLE
Use hardware constants everywhere

### DIFF
--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -9,6 +9,7 @@ import proxyquire from 'proxyquire';
 import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
 import createTxMeta from '../../test/lib/createTxMeta';
 import { NETWORK_TYPE_RPC } from '../../shared/constants/network';
+import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
 import { addHexPrefix } from './lib/util';
 
 const Ganache = require('../../test/e2e/ganache');
@@ -506,11 +507,11 @@ describe('MetaMaskController', function () {
       sinon.spy(metamaskController.keyringController, 'addNewKeyring');
       await metamaskController.connectHardware('trezor', 0).catch(() => null);
       const keyrings = await metamaskController.keyringController.getKeyringsByType(
-        'Trezor Hardware',
+        KEYRING_TYPES.TREZOR,
       );
       assert.deepEqual(
         metamaskController.keyringController.addNewKeyring.getCall(0).args,
-        ['Trezor Hardware'],
+        [KEYRING_TYPES.TREZOR],
       );
       assert.equal(keyrings.length, 1);
     });
@@ -519,11 +520,11 @@ describe('MetaMaskController', function () {
       sinon.spy(metamaskController.keyringController, 'addNewKeyring');
       await metamaskController.connectHardware('ledger', 0).catch(() => null);
       const keyrings = await metamaskController.keyringController.getKeyringsByType(
-        'Ledger Hardware',
+        KEYRING_TYPES.LEDGER,
       );
       assert.deepEqual(
         metamaskController.keyringController.addNewKeyring.getCall(0).args,
-        ['Ledger Hardware'],
+        [KEYRING_TYPES.LEDGER],
       );
       assert.equal(keyrings.length, 1);
     });
@@ -567,7 +568,7 @@ describe('MetaMaskController', function () {
       await metamaskController.connectHardware('trezor', 0).catch(() => null);
       await metamaskController.forgetDevice('trezor');
       const keyrings = await metamaskController.keyringController.getKeyringsByType(
-        'Trezor Hardware',
+        KEYRING_TYPES.TREZOR,
       );
 
       assert.deepEqual(keyrings[0].accounts, []);
@@ -626,7 +627,7 @@ describe('MetaMaskController', function () {
 
     it('should set unlockedAccount in the keyring', async function () {
       const keyrings = await metamaskController.keyringController.getKeyringsByType(
-        'Trezor Hardware',
+        KEYRING_TYPES.TREZOR,
       );
       assert.equal(keyrings[0].unlockedAccount, accountToUnlock);
     });

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -235,7 +235,7 @@ export default class AccountMenu extends Component {
 
     switch (type) {
       case KEYRING_TYPES.TREZOR:
-      case KEYRING_TYPES.LEDGETR:
+      case KEYRING_TYPES.LEDGER:
         label = t('hardware');
         break;
       case 'Simple Key Pair':

--- a/ui/components/app/account-menu/account-menu.component.js
+++ b/ui/components/app/account-menu/account-menu.component.js
@@ -10,6 +10,7 @@ import Identicon from '../../ui/identicon';
 import SiteIcon from '../../ui/site-icon';
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display';
 import { PRIMARY } from '../../../helpers/constants/common';
+import { KEYRING_TYPES } from '../../../../shared/constants/hardware-wallets';
 import {
   SETTINGS_ROUTE,
   NEW_ACCOUNT_ROUTE,
@@ -233,8 +234,8 @@ export default class AccountMenu extends Component {
     let label;
 
     switch (type) {
-      case 'Trezor Hardware':
-      case 'Ledger Hardware':
+      case KEYRING_TYPES.TREZOR:
+      case KEYRING_TYPES.LEDGETR:
         label = t('hardware');
         break;
       case 'Simple Key Pair':

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -140,8 +140,8 @@ export function getAccountType(state) {
   const type = currentKeyring && currentKeyring.type;
 
   switch (type) {
-    case 'Trezor Hardware':
-    case 'Ledger Hardware':
+    case KEYRING_TYPES.TREZOR:
+    case KEYRING_TYPES.LEDGER:
       return 'hardware';
     case 'Simple Key Pair':
       return 'imported';

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1,4 +1,5 @@
 import mockState from '../../test/data/mock-state.json';
+import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
 import * as selectors from './selectors';
 
 describe('Selectors', () => {
@@ -22,12 +23,12 @@ describe('Selectors', () => {
     });
 
     it('returns true if it is a Ledger HW wallet', () => {
-      mockState.metamask.keyrings[0].type = 'Ledger Hardware';
+      mockState.metamask.keyrings[0].type = KEYRING_TYPES.LEDGER;
       expect(selectors.isHardwareWallet(mockState)).toBe(true);
     });
 
     it('returns true if it is a Trezor HW wallet', () => {
-      mockState.metamask.keyrings[0].type = 'Trezor Hardware';
+      mockState.metamask.keyrings[0].type = KEYRING_TYPES.TREZOR;
       expect(selectors.isHardwareWallet(mockState)).toBe(true);
     });
   });
@@ -39,16 +40,16 @@ describe('Selectors', () => {
     });
 
     it('returns "Ledger Hardware" if it is a Ledger HW wallet', () => {
-      mockState.metamask.keyrings[0].type = 'Ledger Hardware';
+      mockState.metamask.keyrings[0].type = KEYRING_TYPES.LEDGER;
       expect(selectors.getHardwareWalletType(mockState)).toBe(
-        'Ledger Hardware',
+        KEYRING_TYPES.LEDGER,
       );
     });
 
     it('returns "Trezor Hardware" if it is a Trezor HW wallet', () => {
-      mockState.metamask.keyrings[0].type = 'Trezor Hardware';
+      mockState.metamask.keyrings[0].type = KEYRING_TYPES.TREZOR;
       expect(selectors.getHardwareWalletType(mockState)).toBe(
-        'Trezor Hardware',
+        KEYRING_TYPES.TREZOR,
       );
     });
   });
@@ -86,7 +87,7 @@ describe('Selectors', () => {
           ...mockState.metamask,
           keyrings: [
             {
-              type: 'Ledger Hardware',
+              type: KEYRING_TYPES.LEDGER,
               accounts: ['0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'],
             },
           ],
@@ -126,7 +127,7 @@ describe('Selectors', () => {
             ...mockState.metamask,
             keyrings: [
               {
-                type: 'Trezor Hardware',
+                type: KEYRING_TYPES.TREZOR,
                 accounts: ['0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc'],
               },
             ],


### PR DESCRIPTION
Should help to avoid any hardcoded string issues.