### PR TITLE
Fix toggle button 'off' color setting

### DIFF
--- a/ui/components/ui/toggle-button/toggle-button.component.js
+++ b/ui/components/ui/toggle-button/toggle-button.component.js
@@ -34,7 +34,7 @@ const colors = {
     base: '#037DD6',
   },
   inactiveThumb: {
-    base: '#037DD6',
+    base: '#6A737D',
   },
   active: {
     base: '#ffffff',


### PR DESCRIPTION
Fixes: #12296 

Explanation:  Updated color setting in the toggle button component. 

<img width="1209" alt="toggle buttons with correct color scheme" src="https://user-images.githubusercontent.com/84106309/136859279-93ee585b-46c7-4ae9-b775-ace9b77efa5d.png">

