### PR TITLE
Fix inpage provider behavior on unlock

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2626,8 +2626,8 @@ export default class MetamaskController extends EventEmitter {
         ? (origin) => payload(origin)
         : () => payload;
 
-    Object.values(this.connections).forEach((origin) => {
-      Object.values(origin).forEach(async (conn) => {
+    Object.keys(this.connections).forEach((origin) => {
+      Object.values(this.connections[origin]).forEach(async (conn) => {
         if (conn.engine) {
           conn.engine.emit('notification', await getPayload(origin));
         }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -380,7 +380,7 @@ export default class MetamaskController extends EventEmitter {
     this.keyringController.memStore.subscribe((state) =>
       this._onKeyringControllerUpdate(state),
     );
-    this.keyringController.on('unlock', () => this.emit('unlock'));
+    this.keyringController.on('unlock', () => this._onUnlock());
     this.keyringController.on('lock', () => this._onLock());
 
     this.permissionsController = new PermissionsController(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2629,8 +2629,8 @@ export default class MetamaskController extends EventEmitter {
     Object.values(this.connections).forEach((origin) => {
       Object.values(origin).forEach(async (conn) => {
         if (conn.engine) {
-          const payload = await getPayload();
-          conn.engine.emit('notification', payload);
+          const _payload = await getPayload();
+          conn.engine.emit('notification', _payload);
         }
       });
     });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2627,9 +2627,10 @@ export default class MetamaskController extends EventEmitter {
         : () => payload;
 
     Object.values(this.connections).forEach((origin) => {
-      Object.values(origin).forEach((conn) => {
+      Object.values(origin).forEach(async (conn) => {
         if (conn.engine) {
-          conn.engine.emit('notification', getPayload(origin));
+          const payload = await getPayload();
+          conn.engine.emit('notification', payload);
         }
       });
     });
@@ -2664,12 +2665,12 @@ export default class MetamaskController extends EventEmitter {
    * Notifies all connections that the extension is unlocked.
    */
   _onUnlock() {
-    this.notifyAllConnections((origin) => {
+    this.notifyAllConnections(async (origin) => {
       return {
         method: NOTIFICATION_NAMES.unlockStateChanged,
         params: {
           isUnlocked: true,
-          accounts: this.permissionsController.getAccounts(origin),
+          accounts: await this.permissionsController.getAccounts(origin),
         },
       };
     });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2629,8 +2629,7 @@ export default class MetamaskController extends EventEmitter {
     Object.values(this.connections).forEach((origin) => {
       Object.values(origin).forEach(async (conn) => {
         if (conn.engine) {
-          const _payload = await getPayload();
-          conn.engine.emit('notification', _payload);
+          conn.engine.emit('notification', await getPayload(origin));
         }
       });
     });


### PR DESCRIPTION
This fixes a bug where we were failing to notify the inpage provider (i.e., all dapps) of the user's currently selected account when the extension becomes unlocked.

To test: go to [the test dapp](https://metamask.github.io/test-dapp/), lock and unlock the extension repeatedly, observe that the account changes every time you do it. Without this change, the account will "disappear" when the extension is locked, and never reappear unless the page is refreshed.