### PR TITLE
Approve screen header and sub-header improvement

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -142,9 +142,9 @@
   "allowExternalExtensionTo": {
     "message": "Allow this external extension to:"
   },
-  "allowOriginSpendToken": {
-    "message": "Allow $1 to spend your $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
+  "allowSpendToken": {
+    "message": "Give permission to access your $1?",
+    "description": "$1 is the symbol of the token that are requesting to spend"
   },
   "allowThisSiteTo": {
     "message": "Allow this site to:"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2826,8 +2826,7 @@
     "description": "Followed by a link (here) to view token balances"
   },
   "trustSiteApprovePermission": {
-    "message": "Do you trust this site? By granting this permission, you’re allowing $1 to withdraw your $2 and automate transactions for you.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
+    "message": "By granting permission, you are allowing the following $1 to access your funds"
   },
   "tryAgain": {
     "message": "Try again"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "Permitir que esta extensión externa haga lo siguiente:"
   },
-  "allowSpendToken": {
-    "message": "¿Permitir que $1 gaste su $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Permitir que este sitio haga lo siguiente:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "Tuvimos problemas al cargar los saldos de token. Puede verlos ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "¿Este sitio es de confianza? Al conceder este permiso, autoriza que $1 retire su $2 y automatice las transacciones por usted.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Vuelva a intentarlo"

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "Permitir que esta extensión externa haga lo siguiente:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "¿Permitir que $1 gaste su $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "Permitir que esta extensión externa haga lo siguiente:"
   },
-  "allowSpendToken": {
-    "message": "¿Permitir que $1 gaste su $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Permitir que este sitio haga lo siguiente:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "Tuvimos problemas al cargar los saldos de token. Puede verlos ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "¿Este sitio es de confianza? Al conceder este permiso, autoriza que $1 retire su $2 y automatice las transacciones por usted.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Vuelva a intentarlo"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "Permitir que esta extensión externa haga lo siguiente:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "¿Permitir que $1 gaste su $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "इस बाहरी एक्सटेंशन को इसकी अनुमति दें:"
   },
-  "allowSpendToken": {
-    "message": "$1 को आपका $2 खर्च करने की अनुमति दें?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "इस साइट को इसकी अनुमति दें:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "हमें आपके टोकन की शेषराशि लोड करने में परेशानी हुई। आप उन्हें देख सकते हैं ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "क्या आप इस साइट पर भरोसा करते हैं? यह अनुमति देकर, आप $1 को अपने $2 की निकासी करने और आपके लिए लेनदेनों को स्वचालित करने की अनुमति दे रहे हैं।",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "पुनः प्रयास करें"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "इस बाहरी एक्सटेंशन को इसकी अनुमति दें:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "$1 को आपका $2 खर्च करने की अनुमति दें?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "Izinkan ekstensi eksternal ini untuk:"
   },
-  "allowSpendToken": {
-    "message": "Izinkan $1 untuk menggunakan $2 Anda?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Izinkan situs ini untuk:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "Kami mengalami masalah saat memuat saldo token Anda. Anda dapat melihatnya ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "Anda percaya situs ini? Dengan memberikan izin ini, Anda mengizinkan $1 untuk menarik $2 Anda dan mengotomatiskan transaksi untuk Anda.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Coba lagi"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "Izinkan ekstensi eksternal ini untuk:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "Izinkan $1 untuk menggunakan $2 Anda?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -103,7 +103,7 @@
   "allowExternalExtensionTo": {
     "message": "Permetti a questa estensione di:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "Vuoi consentire a $1 di spendere $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -103,10 +103,6 @@
   "allowExternalExtensionTo": {
     "message": "Permetti a questa estensione di:"
   },
-  "allowSpendToken": {
-    "message": "Vuoi consentire a $1 di spendere $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Permetti a questo sito di:"
   },
@@ -1863,10 +1859,6 @@
   "troubleTokenBalances": {
     "message": "Abbiamo avuto un problema a caricare il bilancio dei tuoi token. Puoi vederlo ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "Ti fidi di questo sito? Autorizzandolo, stai consentendo a $1 di ritirare i tuoi $2 e automatizzare transazioni per te.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Prova di nuovo"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "この外部拡張機能に次の操作を許可します"
   },
-  "allowSpendToken": {
-    "message": "$1 に $2 の使用を許可しますか?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "このサイトに次の操作を許可します"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "トークン バランスのロードに問題があります。トークン バランスを表示できます",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "このサイトを信頼しますか?許可を与えることにより、$1 は $2 を取り消して、トランザクションを自動化できます。",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "再試行"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "この外部拡張機能に次の操作を許可します"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "$1 に $2 の使用を許可しますか?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "이 외부 확장을 통해 다음을 하도록 허용:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "$1에서 $2을(를) 지출하도록 허용하시겠어요?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "이 외부 확장을 통해 다음을 하도록 허용:"
   },
-  "allowSpendToken": {
-    "message": "$1에서 $2을(를) 지출하도록 허용하시겠어요?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "이 사이트에서 다음을 하도록 허용:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "토큰 잔액을 로드하는 도중 문제가 발생했습니다. 다음에서 잔액을 확인하세요. ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "이 사이트를 신뢰하시나요? 이 권한을 부여하면 $1에서 귀하의 $2을(를) 인출하고 거래를 자동으로 처리하게 됩니다.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "다시 시도"

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "Payagan ang external extension na ito na:"
   },
-  "allowSpendToken": {
-    "message": "Payagan ang $1 na gastusin ang iyong $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Payagan ang site na ito na:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "Nagkaproblema kami sa pag-load ng mga balanse ng iyong token. Puwede mong tingnan ang mga iyon ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "Pinagkakatiwalaan mo ba ang site na ito? Sa pamamagitan ng pagbibigay ng pahintulot na ito, pinapayagan mo ang $1 na i-withdraw ang iyong $2 at i-automate ang mga transaksyon para sa iyo.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Subukan ulit"

--- a/app/_locales/ph/messages.json
+++ b/app/_locales/ph/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "Payagan ang external extension na ito na:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "Payagan ang $1 na gastusin ang iyong $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "Permitir que esta extensão externa:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "Permitir que $1 gaste seus(suas) $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "Permitir que esta extensão externa:"
   },
-  "allowSpendToken": {
-    "message": "Permitir que $1 gaste seus(suas) $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Permitir que este site:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "Tivemos dificuldade para carregar os saldos do seu token. Você pode exibi-los ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "Você confia neste site? Ao conceder esta permissão, você está permitindo que $1 saque seus(suas) $2 e automatize as transações por você.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Tente novamente"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "Разрешить этому внешнему расширению:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "Разрешить $1 потратить ваши $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "Разрешить этому внешнему расширению:"
   },
-  "allowSpendToken": {
-    "message": "Разрешить $1 потратить ваши $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Разрешить этому сайту:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "У нас возникли проблемы с загрузкой вашего баланса токенов. Вы можете просмотреть их ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "Вы доверяете этому сайту? Предоставляя это разрешение, вы разрешаете $1 вывести ваши $2 и автоматизировать транзакции для вас.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Попробуйте еще раз"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -97,7 +97,7 @@
   "allowExternalExtensionTo": {
     "message": "Payagan ang external extension na ito na:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "Payagan ang $1 na gastusin ang iyong $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -97,10 +97,6 @@
   "allowExternalExtensionTo": {
     "message": "Payagan ang external extension na ito na:"
   },
-  "allowSpendToken": {
-    "message": "Payagan ang $1 na gastusin ang iyong $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Payagan ang site na ito na:"
   },
@@ -1819,10 +1815,6 @@
   "troubleTokenBalances": {
     "message": "Nagkaproblema kami sa pag-load ng mga balanse ng iyong token. Puwede mong tingnan ang mga iyon ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "Pinagkakatiwalaan mo ba ang site na ito? Sa pamamagitan ng pagbibigay ng pahintulot na ito, pinapayagan mo ang $1 na i-withdraw ang iyong $2 at i-automate ang mga transaksyon para sa iyo.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Subukan ulit"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -130,10 +130,6 @@
   "allowExternalExtensionTo": {
     "message": "Cho phép tiện ích bên ngoài này:"
   },
-  "allowSpendToken": {
-    "message": "Cho phép $1 chi tiêu $2 của bạn?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "Cho phép trang web này:"
   },
@@ -2277,10 +2273,6 @@
   "troubleTokenBalances": {
     "message": "Chúng tôi đã gặp phải vấn đề khi tải số dư token của bạn. Bạn có thể xem số dư ",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "Bạn có tin tưởng trang web này không? Bằng việc cấp quyền này, bạn sẽ cho phép $1 rút $2 của bạn và tự động thực hiện các giao dịch cho bạn.",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "Thử lại"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -130,7 +130,7 @@
   "allowExternalExtensionTo": {
     "message": "Cho phép tiện ích bên ngoài này:"
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "Cho phép $1 chi tiêu $2 của bạn?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -103,10 +103,6 @@
   "allowExternalExtensionTo": {
     "message": "允许这个外部扩展到："
   },
-  "allowSpendToken": {
-    "message": "允许 $1 使用您的 $2?",
-    "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
-  },
   "allowThisSiteTo": {
     "message": "允许本网站："
   },
@@ -1843,10 +1839,6 @@
   "troubleTokenBalances": {
     "message": "我们无法加载您的代币余额。您可以查看它们",
     "description": "Followed by a link (here) to view token balances"
-  },
-  "trustSiteApprovePermission": {
-    "message": "您信任这个网站吗？授权即表示您允许 $1 提取您的 $2，并为您自动进行交易。",
-    "description": "$1 is the url requesting permission and $2 is the symbol of the currency that the request is for"
   },
   "tryAgain": {
     "message": "重试"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -103,7 +103,7 @@
   "allowExternalExtensionTo": {
     "message": "允许这个外部扩展到："
   },
-  "allowOriginSpendToken": {
+  "allowSpendToken": {
     "message": "允许 $1 使用您的 $2?",
     "description": "$1 is the url of the site and $2 is the symbol of the token they are requesting to spend"
   },

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -60,6 +60,7 @@ export default class ConfirmApproveContent extends Component {
     tokenImage: PropTypes.string,
     chainId: PropTypes.string,
     rpcPrefs: PropTypes.object,
+    isContract: PropTypes.bool,
   };
 
   state = {
@@ -261,6 +262,7 @@ export default class ConfirmApproveContent extends Component {
       toAddress,
       chainId,
       rpcPrefs,
+      isContract,
     } = this.props;
     const { showFullTxDetails } = this.state;
 
@@ -306,7 +308,9 @@ export default class ConfirmApproveContent extends Component {
           {t('allowOriginSpendToken', [origin, tokenSymbol])}
         </div>
         <div className="confirm-approve-content__description">
-          {t('trustSiteApprovePermission', ['contract'])}
+          {t('trustSiteApprovePermission', [
+            isContract ? 'contract' : 'account',
+          ])}
         </div>
         <Box className="confirm-approve-content__address-display-content">
           <Box display={DISPLAY.FLEX}>

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -275,25 +275,31 @@ export default class ConfirmApproveContent extends Component {
             <ConfirmPageContainerWarning warning={warning} />
           </div>
         )}
-        <Box className="confirm-approve-content__icon-display-content">
-          <Box display={DISPLAY.FLEX}>
+        <Box
+          display={DISPLAY.FLEX}
+          className="confirm-approve-content__icon-display-content"
+        >
+          <Box className="confirm-approve-content__metafoxlogo">
             <MetaFoxLogo useDark={isBeta()} />
-            <Box display={DISPLAY.FLEX} paddingTop={1}>
-              <UrlIcon
-                className="confirm-approve-content__siteimage"
-                fallbackClassName="confirm-approve-content__siteimage"
-                name={getURLHostName(origin)}
-                url={siteImage}
-              />
-              <Typography
-                variant={TYPOGRAPHY.H6}
-                fontWeight={FONT_WEIGHT.NORMAL}
-                color={COLORS.UI4}
-                boxProps={{ marginLeft: 2 }}
-              >
-                {getURLHostName(origin)}
-              </Typography>
-            </Box>
+          </Box>
+          <Box
+            display={DISPLAY.FLEX}
+            className="confirm-approve-content__siteinfo"
+          >
+            <UrlIcon
+              className="confirm-approve-content__siteimage-identicon"
+              fallbackClassName="confirm-approve-content__siteimage-identicon"
+              name={getURLHostName(origin)}
+              url={siteImage}
+            />
+            <Typography
+              variant={TYPOGRAPHY.H6}
+              fontWeight={FONT_WEIGHT.NORMAL}
+              color={COLORS.UI4}
+              boxProps={{ marginLeft: 1, marginTop: 2 }}
+            >
+              {getURLHostName(origin)}
+            </Typography>
           </Box>
         </Box>
         <div className="confirm-approve-content__title">
@@ -305,7 +311,7 @@ export default class ConfirmApproveContent extends Component {
         <Box className="confirm-approve-content__address-display-content">
           <Box display={DISPLAY.FLEX}>
             <Identicon
-              className="confirm-approve-content__identicon"
+              className="confirm-approve-content__address-identicon"
               diameter={20}
               address={toAddress}
               image={tokenImage}

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -264,10 +264,7 @@ export default class ConfirmApproveContent extends Component {
         <Box className="confirm-approve-content__icon-display-content">
           <Box display={DISPLAY.FLEX}>
             <MetaFoxLogo useDark={isBeta()} />
-            <Box
-              display={DISPLAY.FLEX}
-              className="confirm-approve-content__identicon-wrapper"
-            >
+            <Box display={DISPLAY.FLEX}>
               <UrlIcon
                 className="confirm-approve-content__identicon"
                 fallbackClassName="confirm-approve-content__identicon"

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -450,7 +450,7 @@ export default class ConfirmApproveContent extends Component {
                   </div>
                 </div>
               ),
-            })}   
+            })}
         </div>
 
         {ledgerWalletRequiredHidConnection ? (

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -305,11 +305,13 @@ export default class ConfirmApproveContent extends Component {
           </Box>
         </Box>
         <div className="confirm-approve-content__title">
-          {t('allowOriginSpendToken', [origin, tokenSymbol])}
+          {t('allowSpendToken', [tokenSymbol])}
         </div>
         <div className="confirm-approve-content__description">
           {t('trustSiteApprovePermission', [
-            isContract ? 'contract' : 'account',
+            isContract
+              ? t('contract').toLowerCase()
+              : t('account').toLowerCase(),
           ])}
         </div>
         <Box className="confirm-approve-content__address-display-content">

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -11,10 +11,14 @@ import {
   FONT_WEIGHT,
   BLOCK_SIZES,
   JUSTIFY_CONTENT,
+  COLORS,
+  DISPLAY,
 } from '../../../helpers/constants/design-system';
 import Box from '../../../components/ui/box';
 import Button from '../../../components/ui/button';
 import LedgerInstructionField from '../../../components/app/ledger-instruction-field';
+import MetaFoxLogo from '../../../components/ui/metafox-logo';
+import { isBeta } from '../../../helpers/utils/build-types';
 
 export default class ConfirmApproveContent extends Component {
   static contextTypes = {
@@ -257,19 +261,35 @@ export default class ConfirmApproveContent extends Component {
             <ConfirmPageContainerWarning warning={warning} />
           </div>
         )}
-        <div className="confirm-approve-content__identicon-wrapper">
-          <UrlIcon
-            className="confirm-approve-content__identicon"
-            fallbackClassName="confirm-approve-content__identicon"
-            name={getURLHostName(origin)}
-            url={siteImage}
-          />
-        </div>
+        <Box className="confirm-approve-content__icon-display-content">
+          <Box display={DISPLAY.FLEX}>
+            <MetaFoxLogo useDark={isBeta()} />
+            <Box
+              display={DISPLAY.FLEX}
+              className="confirm-approve-content__identicon-wrapper"
+            >
+              <UrlIcon
+                className="confirm-approve-content__identicon"
+                fallbackClassName="confirm-approve-content__identicon"
+                name={getURLHostName(origin)}
+                url={siteImage}
+              />
+              <Typography
+                variant={TYPOGRAPHY.H6}
+                fontWeight={FONT_WEIGHT.NORMAL}
+                color={COLORS.UI4}
+                boxProps={{ marginLeft: 2 }}
+              >
+                {getURLHostName(origin)}
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
         <div className="confirm-approve-content__title">
           {t('allowOriginSpendToken', [origin, tokenSymbol])}
         </div>
         <div className="confirm-approve-content__description">
-          {t('trustSiteApprovePermission', [origin, tokenSymbol])}
+          {t('trustSiteApprovePermission', ['contract'])}
         </div>
         <div className="confirm-approve-content__edit-submission-button-container">
           <div
@@ -348,7 +368,7 @@ export default class ConfirmApproveContent extends Component {
                   </div>
                 </div>
               ),
-            })}
+            })}   
         </div>
 
         {ledgerWalletRequiredHidConnection ? (

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -347,7 +347,7 @@ export default class ConfirmApproveContent extends Component {
                   : t('copyToClipboard')
               }
             >
-              <CopyIcon size={9} color={COLORS.UI4} />
+              <CopyIcon size={9} color="#6a737d" />
             </Button>
             <Button
               type="link"

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -347,7 +347,7 @@ export default class ConfirmApproveContent extends Component {
                   : t('copyToClipboard')
               }
             >
-              <CopyIcon size={9} color="#6a737d" />
+              <CopyIcon size={9} color={COLORS.UI4} />
             </Button>
             <Button
               type="link"

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -6,8 +6,14 @@ import { getTokenTrackerLink, getAccountLink } from '@metamask/etherscan-link';
 import UrlIcon from '../../../components/ui/url-icon';
 import { addressSummary, getURLHostName } from '../../../helpers/utils/util';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
-import { ConfirmPageContainerWarning } from '../../../components/app/confirm-page-container/confirm-page-container-content';
+import { isBeta } from '../../../helpers/utils/build-types';
+import { ellipsify } from '../../send/send.utils';
 import Typography from '../../../components/ui/typography';
+import Box from '../../../components/ui/box';
+import Button from '../../../components/ui/button';
+import MetaFoxLogo from '../../../components/ui/metafox-logo';
+import Identicon from '../../../components/ui/identicon';
+import CopyIcon from '../../../components/ui/icon/copy-icon.component';
 import {
   TYPOGRAPHY,
   FONT_WEIGHT,
@@ -16,15 +22,9 @@ import {
   COLORS,
   DISPLAY,
 } from '../../../helpers/constants/design-system';
-import Box from '../../../components/ui/box';
-import Button from '../../../components/ui/button';
-import LedgerInstructionField from '../../../components/app/ledger-instruction-field';
-import MetaFoxLogo from '../../../components/ui/metafox-logo';
-import { isBeta } from '../../../helpers/utils/build-types';
-import Identicon from '../../../components/ui/identicon';
-import { ellipsify } from '../../send/send.utils';
-import CopyIcon from '../../../components/ui/icon/copy-icon.component';
 import { SECOND } from '../../../../shared/constants/time';
+import { ConfirmPageContainerWarning } from '../../../components/app/confirm-page-container/confirm-page-container-content';
+import LedgerInstructionField from '../../../components/app/ledger-instruction-field';
 
 export default class ConfirmApproveContent extends Component {
   static contextTypes = {

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import copyToClipboard from 'copy-to-clipboard';
-import { getTokenTrackerLink } from '@metamask/etherscan-link';
+import { getTokenTrackerLink, getAccountLink } from '@metamask/etherscan-link';
 import UrlIcon from '../../../components/ui/url-icon';
 import { addressSummary, getURLHostName } from '../../../helpers/utils/util';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
@@ -351,13 +351,16 @@ export default class ConfirmApproveContent extends Component {
               type="link"
               className="confirm-approve-content__etherscan-link"
               onClick={() => {
-                const blockExplorerTokenLink = getTokenTrackerLink(
-                  toAddress,
-                  chainId,
-                  null,
-                  null,
-                  { blockExplorerUrl: rpcPrefs?.blockExplorerUrl ?? null },
-                );
+                const blockExplorerTokenLink = isContract
+                  ? getTokenTrackerLink(toAddress, chainId, null, null, {
+                      blockExplorerUrl: rpcPrefs?.blockExplorerUrl ?? null,
+                    })
+                  : getAccountLink(
+                      toAddress,
+                      chainId,
+                      { blockExplorerUrl: rpcPrefs?.blockExplorerUrl ?? null },
+                      null,
+                    );
                 global.platform.openTab({
                   url: blockExplorerTokenLink,
                 });

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/jest/rendering';
+import ConfirmApproveContent from '.';
+
+const renderComponent = (props) => {
+  const store = configureMockStore([])({ metamask: {} });
+  return renderWithProvider(<ConfirmApproveContent {...props} />, store);
+};
+
+const props = {
+  decimals: 16,
+  siteImage: 'https://metamask.github.io/test-dapp/metamask-fox.svg',
+  // setCustomAmount: () => undefined,
+  customTokenAmount: '10',
+  tokenAmount: '10',
+  origin: 'https://metamask.github.io/test-dapp/',
+  tokenSymbol: 'TST',
+  tokenImage: 'https://metamask.github.io/test-dapp/metamask-fox.svg',
+  tokenBalance: '15',
+  showCustomizeGasModal: jest.fn(),
+  showEditApprovalPermissionModal: jest.fn(),
+  data:
+    '0x095ea7b30000000000000000000000009bc5baf874d2da8d216ae9f137804184ee5afef40000000000000000000000000000000000000000000000000000000000011170',
+  toAddress: '0x9bc5baf874d2da8d216ae9f137804184ee5afef4',
+  currentCurrency: 'TST',
+  nativeCurrency: 'ETH',
+  ethTransactionTotal: '20',
+  fiatTransactionTotal: '10',
+  useNonceField: true,
+  nextNonce: 1,
+  customNonceValue: '2',
+  // updateCustomNonce: () => undefined,
+  // getNextNonce: () => undefined,
+  showCustomizeNonceModal: jest.fn(),
+  chainId: '1337',
+  rpcPrefs: {},
+  isContract: true,
+};
+
+describe('ConfirmApproveContent Component', () => {
+  it('should render Confirm approve page correctly', () => {
+    const { queryByText, getByText, getAllByText } = renderComponent(props);
+    expect(queryByText('metamask.github.io')).toBeInTheDocument();
+    expect(
+      queryByText('Give permission to access your TST?'),
+    ).toBeInTheDocument();
+    expect(
+      queryByText(
+        'By granting permission, you are allowing the following contract to access your funds',
+      ),
+    ).toBeInTheDocument();
+    expect(queryByText('0x9bc5...fef4')).toBeInTheDocument();
+    expect(queryByText('View full transaction details')).toBeInTheDocument();
+
+    expect(queryByText('Edit Permission')).toBeInTheDocument();
+    const editPermission = getByText('Edit Permission');
+    fireEvent.click(editPermission);
+    expect(props.showEditApprovalPermissionModal).toHaveBeenCalledTimes(1);
+
+    const editButtons = getAllByText('Edit');
+
+    expect(queryByText('Transaction Fee')).toBeInTheDocument();
+    expect(
+      queryByText('A fee is associated with this request.'),
+    ).toBeInTheDocument();
+    expect(queryByText(`${props.ethTransactionTotal} ETH`)).toBeInTheDocument();
+    fireEvent.click(editButtons[0]);
+    expect(props.showCustomizeGasModal).toHaveBeenCalledTimes(1);
+
+    expect(queryByText('Nonce')).toBeInTheDocument();
+    expect(queryByText('2')).toBeInTheDocument();
+    fireEvent.click(editButtons[1]);
+    expect(props.showCustomizeNonceModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -12,7 +12,6 @@ const renderComponent = (props) => {
 const props = {
   decimals: 16,
   siteImage: 'https://metamask.github.io/test-dapp/metamask-fox.svg',
-  // setCustomAmount: () => undefined,
   customTokenAmount: '10',
   tokenAmount: '10',
   origin: 'https://metamask.github.io/test-dapp/',
@@ -31,8 +30,6 @@ const props = {
   useNonceField: true,
   nextNonce: 1,
   customNonceValue: '2',
-  // updateCustomNonce: () => undefined,
-  // getNextNonce: () => undefined,
   showCustomizeNonceModal: jest.fn(),
   chainId: '1337',
   rpcPrefs: {},

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -5,12 +5,45 @@
   width: 100%;
   font-style: normal;
 
-  &__siteimage {
-    width: 28px;
-    height: 28px;
+  &__icon-display-content {
+    display: flex;
+    height: 51px;
+    width: 65%;
+    margin-top: 16px;
+    padding: 12px 12px 14px 12px;
+    border: 1px solid $ui-1;
+    box-sizing: border-box;
+    border-radius: 100px;
+    align-items: center;
+    position: relative;
   }
 
-  &__identicon {
+  &__metafoxlogo,
+  &__siteinfo {
+    position: absolute;
+  }
+
+  &__siteinfo {
+    left: 39px;
+  }
+
+  &__address-display-content {
+    display: flex;
+    height: 27px;
+    width: 50%;
+    padding: 12px 12px 14px 12px;
+    background-color: $ui-1;
+    border-radius: 100px;
+    align-items: center;
+  }
+
+  &__siteimage-identicon {
+    width: 33px;
+    height: 33px;
+    border: solid #fff;
+  }
+
+  &__address-identicon {
     margin: 4px 8px 0 4px;
   }
 
@@ -54,6 +87,7 @@
     display: flex;
     justify-content: center;
     text-align: center;
+    // margin-top: 75px;
     margin-top: 22px;
     padding-left: 24px;
     padding-right: 24px;
@@ -348,29 +382,6 @@
     @include H7;
 
     width: auto;
-  }
-
-  &__icon-display-content {
-    display: flex;
-    height: 51px;
-    margin-top: 16px;
-    padding: 12px 12px 14px 12px;
-    border: 1px solid $ui-1;
-    box-sizing: border-box;
-    border-radius: 100px;
-    align-items: center;
-  }
-
-  &__address-display-content {
-    display: flex;
-    height: 27px;
-    // margin-top: 16px;
-    padding: 12px 12px 14px 12px;
-    background-color: $ui-1;
-    // border: 1px solid $ui-1;
-    // box-sizing: border-box;
-    border-radius: 100px;
-    align-items: center;
   }
 }
 

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -5,18 +5,18 @@
   width: 100%;
   font-style: normal;
 
-  &__identicon-wrapper {
-    display: flex;
-    width: 100%;
-    justify-content: center;
-    margin-top: 22px;
-    padding-left: 24px;
-    padding-right: 24px;
+  &__identicon {
+    width: 28px;
+    height: 28px;
   }
 
-  &__identicon {
-    width: 48px;
-    height: 48px;
+  .app-header__logo-container {
+    margin-right: 0;
+  }
+
+  .app-header__metafox-logo--icon {
+    height: 30px;
+    width: 33px;
   }
 
   &__full-tx-content {
@@ -332,6 +332,17 @@
     @include H7;
 
     width: auto;
+  }
+
+  &__icon-display-content {
+    display: flex;
+    height: 51px;
+    margin: 16px 0;
+    padding: 12px 12px 14px 12px;
+    border: 1px solid $ui-1;
+    box-sizing: border-box;
+    border-radius: 100px;
+    align-items: center;
   }
 }
 

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -87,7 +87,6 @@
     display: flex;
     justify-content: center;
     text-align: center;
-    // margin-top: 75px;
     margin-top: 22px;
     padding-left: 24px;
     padding-right: 24px;

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -5,9 +5,25 @@
   width: 100%;
   font-style: normal;
 
-  &__identicon {
+  &__siteimage {
     width: 28px;
     height: 28px;
+  }
+
+  &__identicon {
+    margin: 4px 8px 0 4px;
+  }
+
+  &__copy-address,
+  &__etherscan-link {
+    padding: 0 0 0 8px;
+  }
+
+  &__etherscan-link {
+    img {
+      width: 9px;
+      height: 9px;
+    }
   }
 
   .app-header__logo-container {
@@ -15,7 +31,7 @@
   }
 
   .app-header__metafox-logo--icon {
-    height: 30px;
+    height: 33px;
     width: 33px;
   }
 
@@ -341,6 +357,18 @@
     padding: 12px 12px 14px 12px;
     border: 1px solid $ui-1;
     box-sizing: border-box;
+    border-radius: 100px;
+    align-items: center;
+  }
+
+  &__address-display-content {
+    display: flex;
+    height: 27px;
+    // margin-top: 16px;
+    padding: 12px 12px 14px 12px;
+    background-color: $ui-1;
+    // border: 1px solid $ui-1;
+    // box-sizing: border-box;
     border-radius: 100px;
     align-items: center;
   }

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -337,7 +337,7 @@
   &__icon-display-content {
     display: flex;
     height: 51px;
-    margin: 16px 0;
+    margin-top: 16px;
     padding: 12px 12px 14px 12px;
     border: 1px solid $ui-1;
     box-sizing: border-box;

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import ConfirmTransactionBase from '../confirm-transaction-base';
@@ -133,16 +133,16 @@ export default function ConfirmApprove() {
   }, [customNonceValue, nextNonce]);
 
   const [isContract, setIsContract] = useState(false);
+  const checkIfContract = useCallback(async () => {
+    const { isContractAddress } = await readAddressAsContract(
+      global.eth,
+      toAddress,
+    );
+    setIsContract(isContractAddress);
+  }, [setIsContract, toAddress]);
   useEffect(() => {
-    async function checkIfContract() {
-      const { isContractAddress } = await readAddressAsContract(
-        global.eth,
-        toAddress,
-      );
-      setIsContract(isContractAddress);
-    }
     checkIfContract();
-  }, [toAddress]);
+  }, [checkIfContract]);
 
   const { origin } = transaction;
   const formattedOrigin = origin

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -25,6 +25,8 @@ import {
   getCustomNonceValue,
   getNextSuggestedNonce,
   doesAddressRequireLedgerHidConnection,
+  getCurrentChainId,
+  getRpcPrefsForCurrentProvider,
 } from '../../selectors';
 
 import { useApproveTransaction } from '../../hooks/useApproveTransaction';
@@ -58,6 +60,8 @@ export default function ConfirmApprove() {
   const useNonceField = useSelector(getUseNonceField);
   const nextNonce = useSelector(getNextSuggestedNonce);
   const customNonceValue = useSelector(getCustomNonceValue);
+  const chainId = useSelector(getCurrentChainId);
+  const rpcPrefs = useSelector(getRpcPrefsForCurrentProvider);
 
   const ledgerWalletRequiredHidConnection = useSelector(
     doesAddressRequireLedgerHidConnectionByFromAddress(from),
@@ -83,6 +87,7 @@ export default function ConfirmApprove() {
 
   const tokenSymbol = currentToken?.symbol;
   const decimals = Number(currentToken?.decimals);
+  const tokenImage = Number(currentToken?.image);
   const tokenData = getTokenData(data);
   const tokenValue = getTokenValueParam(tokenData);
   const toAddress = getTokenAddressParam(tokenData);
@@ -158,6 +163,7 @@ export default function ConfirmApprove() {
             tokenAmount={tokenAmount}
             origin={formattedOrigin}
             tokenSymbol={tokenSymbol}
+            tokenImage={tokenImage}
             tokenBalance={tokenBalance}
             showCustomizeGasModal={approveTransaction}
             showEditApprovalPermissionModal={({
@@ -222,6 +228,8 @@ export default function ConfirmApprove() {
             ledgerWalletRequiredHidConnection={
               ledgerWalletRequiredHidConnection
             }
+            chainId={chainId}
+            rpcPrefs={rpcPrefs}
           />
           {showCustomizeGasPopover && (
             <EditGasPopover

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -14,6 +14,7 @@ import {
   getTokenAddressParam,
   getTokenValueParam,
 } from '../../helpers/utils/token-util';
+import { readAddressAsContract } from '../../../shared/modules/contract-utils';
 import { useTokenTracker } from '../../hooks/useTokenTracker';
 import { getTokens, getNativeCurrency } from '../../ducks/metamask/metamask';
 import {
@@ -87,7 +88,7 @@ export default function ConfirmApprove() {
 
   const tokenSymbol = currentToken?.symbol;
   const decimals = Number(currentToken?.decimals);
-  const tokenImage = Number(currentToken?.image);
+  const tokenImage = currentToken?.image;
   const tokenData = getTokenData(data);
   const tokenValue = getTokenValueParam(tokenData);
   const toAddress = getTokenAddressParam(tokenData);
@@ -130,6 +131,19 @@ export default function ConfirmApprove() {
     prevCustomNonce.current = customNonceValue;
     prevNonce.current = nextNonce;
   }, [customNonceValue, nextNonce]);
+
+  const [isContract, setIsContract] = useState(false);
+  useEffect(() => {
+    async function checkIfContract() {
+      const { isContractAddress } = await readAddressAsContract(
+        global.eth,
+        toAddress,
+      );
+      setIsContract(isContractAddress);
+    }
+    checkIfContract();
+  }, [toAddress]);
+
   const { origin } = transaction;
   const formattedOrigin = origin
     ? origin[0].toUpperCase() + origin.slice(1)
@@ -230,6 +244,7 @@ export default function ConfirmApprove() {
             }
             chainId={chainId}
             rpcPrefs={rpcPrefs}
+            isContract={isContract}
           />
           {showCustomizeGasPopover && (
             <EditGasPopover


### PR DESCRIPTION
This is a part of #10345.
Fixes: #7574 

Problem: it is not "the site" that has access to the token. It is "the contract"

Change:

- Update header copy: "Give permission to access your [token]?”
- Update subheader copy: "By granting permission, you are allowing the following [contract/account] to access your funds”
- Include contract address and its jazzicon as additional information; allow users to copy the address or view it in the block explorer
- Use the most recent header icon style to show the site that is interacting with MM

<img width="360" alt="Screen Shot 2021-10-28 at 2 42 26 PM" src="https://user-images.githubusercontent.com/43930900/139316272-c4c520fb-4381-4660-a561-6f0c09f444f2.png">
  