### PR TITLE
Use consistent naming for welcome route of onboarding

### DIFF
--- a/ui/helpers/constants/routes.js
+++ b/ui/helpers/constants/routes.js
@@ -65,7 +65,7 @@ const ONBOARDING_IMPORT_MOBILE_ROUTE = '/onboarding/import-mobile';
 const ONBOARDING_SECURE_YOUR_WALLET_ROUTE = '/onboarding/secure-your-wallet';
 const ONBOARDING_PRIVACY_SETTINGS_ROUTE = '/onboarding/privacy-settings';
 const ONBOARDING_PIN_EXTENSION_ROUTE = '/onboarding/pin-extension';
-const ONBOARDING_WELCOME = '/onboarding/welcome';
+const ONBOARDING_WELCOME_ROUTE = '/onboarding/welcome';
 
 const CONFIRM_TRANSACTION_ROUTE = '/confirm-transaction';
 const CONFIRM_SEND_ETHER_PATH = '/send-ether';
@@ -226,5 +226,5 @@ export {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_UNLOCK_ROUTE,
   ONBOARDING_PIN_EXTENSION_ROUTE,
-  ONBOARDING_WELCOME,
+  ONBOARDING_WELCOME_ROUTE,
 };

--- a/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.js
+++ b/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.js
@@ -6,7 +6,7 @@ import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_UNLOCK_ROUTE,
   LOCK_ROUTE,
-  ONBOARDING_WELCOME,
+  ONBOARDING_WELCOME_ROUTE,
 } from '../../../helpers/constants/routes';
 import {
   getCompletedOnboarding,
@@ -34,7 +34,7 @@ export default function OnboardingFlowSwitch() {
   }
 
   if (!isInitialized) {
-    return <Redirect to={{ pathname: ONBOARDING_WELCOME }} />;
+    return <Redirect to={{ pathname: ONBOARDING_WELCOME_ROUTE }} />;
   }
 
   return <Redirect to={{ pathname: ONBOARDING_UNLOCK_ROUTE }} />;

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -7,7 +7,7 @@ import {
   ONBOARDING_REVIEW_SRP_ROUTE,
   ONBOARDING_CONFIRM_SRP_ROUTE,
   ONBOARDING_UNLOCK_ROUTE,
-  ONBOARDING_WELCOME,
+  ONBOARDING_WELCOME_ROUTE,
   DEFAULT_ROUTE,
   ONBOARDING_SECURE_YOUR_WALLET_ROUTE,
   ONBOARDING_PRIVACY_SETTINGS_ROUTE,
@@ -152,7 +152,10 @@ export default function OnboardingFlow() {
             path={ONBOARDING_COMPLETION_ROUTE}
             component={CreationSuccessful}
           />
-          <Route path={ONBOARDING_WELCOME} component={OnboardingWelcome} />
+          <Route
+            path={ONBOARDING_WELCOME_ROUTE}
+            component={OnboardingWelcome}
+          />
           <Route exact path="*" component={OnboardingFlowSwitch} />
         </Switch>
       </div>


### PR DESCRIPTION
This was the only route that didn't end in `ROUTE`, so I've fixed that.