### PR TITLE
Preventing swaps data re-fetch when navigating back to home screen

### DIFF
--- a/ui/pages/swaps/index.js
+++ b/ui/pages/swaps/index.js
@@ -118,6 +118,7 @@ export default function Swap() {
   const chainId = useSelector(getCurrentChainId);
   const isSwapsChain = useSelector(getIsSwapsChain);
   const useNewSwapsApi = useSelector(getUseNewSwapsApi);
+  const prevUseNewSwapsApi = useRef(useNewSwapsApi);
   const networkAndAccountSupports1559 = useSelector(
     checkNetworkAndAccountSupports1559,
   );
@@ -193,7 +194,7 @@ export default function Swap() {
 
   // eslint-disable-next-line
   useEffect(() => {
-    if (isFeatureFlagLoaded) {
+    if (isFeatureFlagLoaded && prevUseNewSwapsApi.current === useNewSwapsApi) {
       fetchTokens(chainId, useNewSwapsApi)
         .then((tokens) => {
           dispatch(setSwapsTokens(tokens));
@@ -214,6 +215,7 @@ export default function Swap() {
         dispatch(prepareToLeaveSwaps());
       };
     }
+    prevUseNewSwapsApi.current = useNewSwapsApi;
   }, [
     dispatch,
     chainId,


### PR DESCRIPTION
Resolves many of: https://sentry.io/organizations/metamask/issues/?project=273505&query=is%3Aunresolved+Swaps+API+calls+are+disabled+for+chainId&sort=freq&statsPeriod=14d

Steps to reproduce/test:

1. Add the Polygon (Matic network)
2. Switch to the network
3. Click "Swap"
4. Click "Cancel"
5. Observe the errors per Sentry in the console

<img width="394" alt="Screen Shot 2021-10-16 at 5 26 24 PM" src="https://user-images.githubusercontent.com/8732757/137605421-baec1b6a-a7f1-4377-a806-5718af6608e0.png">

This occurs because the swaps state is reset before pushing the default route to history, that sets `useNewSwapsApi` from `true` -> `false`, thereby re-triggering [this](https://github.com/MetaMask/metamask-extension/blob/develop/ui/pages/swaps/index.js#L195) block to run again with the new parameter. The fix includes caching the existing `useNewSwapsApi`, and preventing a refetch if it changes. (This fetch needs to only happen once)

A general smoke/regression test for Swaps would be a good thing to do when testing this fix out.