### PR TITLE
Fixing invalid prop type for ActionableMessage (ImportToken)

### DIFF
--- a/ui/components/ui/actionable-message/actionable-message.js
+++ b/ui/components/ui/actionable-message/actionable-message.js
@@ -11,6 +11,7 @@ const CLASSNAME_WITH_RIGHT_BUTTON = 'actionable-message--with-right-button';
 const typeHash = {
   warning: CLASSNAME_WARNING,
   danger: CLASSNAME_DANGER,
+  default: '',
 };
 
 export default function ActionableMessage({
@@ -20,7 +21,7 @@ export default function ActionableMessage({
   className = '',
   infoTooltipText = '',
   withRightButton = false,
-  type = false,
+  type = 'default',
   useIcon = false,
   iconFillColor = '',
 }) {

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -406,7 +406,6 @@ class ImportToken extends Component {
               {this.context.t('enableFromSettings')}
             </Button>,
           ])}
-          type={false}
           withRightButton
           useIcon
           iconFillColor="#037DD6"


### PR DESCRIPTION
Warning after clicking on "import tokens"
<img width="634" alt="Screen Shot 2021-10-17 at 3 18 02 PM" src="https://user-images.githubusercontent.com/8732757/137647035-5768d400-94ae-485e-97c0-cc3320aa442e.png">

Default style is maintained:
<img width="460" alt="Screen Shot 2021-10-17 at 3 19 41 PM" src="https://user-images.githubusercontent.com/8732757/137647037-7ee32c70-9265-485e-a490-d1cde4a9eda8.png">

