### PR TITLE
Heading on contact details view in popup should say "Details" instead of contact name

### DIFF
--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -92,7 +92,7 @@ class SettingsPage extends PureComponent {
     let titleText;
 
     if (isPopup && addressName) {
-      titleText = addressName;
+      titleText = t('details');
     } else if (pathnameI18nKey && isPopup) {
       titleText = t(pathnameI18nKey);
     } else {

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -34,7 +34,7 @@ const ROUTES_TO_I18N_KEYS = {
   [GENERAL_ROUTE]: 'general',
   [CONTACT_ADD_ROUTE]: 'newContact',
   [CONTACT_EDIT_ROUTE]: 'editContact',
-  [CONTACT_LIST_ROUTE]: 'contacts',
+  [CONTACT_LIST_ROUTE]: 'details',
   [CONTACT_VIEW_ROUTE]: 'viewContact',
   [NETWORKS_ROUTE]: 'networks',
   [NETWORKS_FORM_ROUTE]: 'networks',

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -34,7 +34,7 @@ const ROUTES_TO_I18N_KEYS = {
   [GENERAL_ROUTE]: 'general',
   [CONTACT_ADD_ROUTE]: 'newContact',
   [CONTACT_EDIT_ROUTE]: 'editContact',
-  [CONTACT_LIST_ROUTE]: 'details',
+  [CONTACT_LIST_ROUTE]: 'contacts',
   [CONTACT_VIEW_ROUTE]: 'viewContact',
   [NETWORKS_ROUTE]: 'networks',
   [NETWORKS_FORM_ROUTE]: 'networks',


### PR DESCRIPTION
Fixes: #12298

Change contact details view in popup to show "Details" instead of contact name