### PR TITLE
Fix width and padding of the hide token modal in popup view

### DIFF
--- a/ui/components/app/modals/modal.js
+++ b/ui/components/app/modals/modal.js
@@ -184,8 +184,13 @@ const MODALS = {
       top: getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '52vh' : '36.5vh',
     },
     laptopModalStyle: {
-      width: '449px',
+      width:
+        getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '357px' : '449px',
       top: 'calc(33% + 45px)',
+      paddingLeft:
+        getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '16px' : null,
+      paddingRight:
+        getEnvironmentType() === ENVIRONMENT_TYPE_POPUP ? '16px' : null,
     },
   },
 


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/12344

Fix width and padding of the hide token modal in popup view.

![Screenshot from 2021-10-18 10-21-13](https://user-images.githubusercontent.com/92310504/137701569-04e4f9b0-a201-40d1-bdfa-228f4fca5824.png)

