### PR TITLE
centralize min gas const

### DIFF
--- a/shared/constants/gas.js
+++ b/shared/constants/gas.js
@@ -1,11 +1,11 @@
 import { addHexPrefix } from 'ethereumjs-util';
+import { MIN_GAS_LIMIT_HEX } from '../../ui/pages/send/send.constants';
 
-const TWENTY_ONE_THOUSAND = 21000;
 const ONE_HUNDRED_THOUSAND = 100000;
 
 export const GAS_LIMITS = {
   // maximum gasLimit of a simple send
-  SIMPLE: addHexPrefix(TWENTY_ONE_THOUSAND.toString(16)),
+  SIMPLE: addHexPrefix(MIN_GAS_LIMIT_HEX),
   // a base estimate for token transfers.
   BASE_TOKEN_ESTIMATE: addHexPrefix(ONE_HUNDRED_THOUSAND.toString(16)),
 };

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -51,6 +51,7 @@ import {
 } from '../../store/actions';
 
 import Typography from '../../components/ui/typography/typography';
+import { MIN_GAS_LIMIT_DEC } from '../send/send.constants';
 
 const renderHeartBeatIfNotInTest = () =>
   process.env.IN_TEST === 'true' ? null : <LoadingHeartBeat />;
@@ -232,7 +233,7 @@ export default class ConfirmTransactionBase extends Component {
       };
     }
 
-    if (hexToDecimal(customGas.gasLimit) < 21000) {
+    if (hexToDecimal(customGas.gasLimit) < Number(MIN_GAS_LIMIT_DEC)) {
       return {
         valid: false,
         errorKey: GAS_LIMIT_TOO_LOW_ERROR_KEY,


### PR DESCRIPTION
Explanation:  We should have one centralized const for defining the min gas limit and use is it where possible.
