### PR TITLE
Adding estimate fields to updateTransaction, createCancelTransaction, and createSpeedUpTransaction

### DIFF
--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -649,6 +649,14 @@ export default class TransactionController extends EventEmitter {
       newGasParams.gas = customGasSettings?.gas ?? GAS_LIMITS.SIMPLE;
     }
 
+    if (customGasSettings.estimateSuggested) {
+      newGasParams.estimateSuggested = customGasSettings.estimateSuggested;
+    }
+
+    if (customGasSettings.estimateUsed) {
+      newGasParams.estimateUsed = customGasSettings.estimateUsed;
+    }
+
     if (isEIP1559Transaction(originalTxMeta)) {
       previousGasParams.maxFeePerGas = txParams.maxFeePerGas;
       previousGasParams.maxPriorityFeePerGas = txParams.maxPriorityFeePerGas;
@@ -1393,7 +1401,14 @@ export default class TransactionController extends EventEmitter {
       status,
       chainId,
       origin: referrer,
-      txParams: { gasPrice, gas: gasLimit, maxFeePerGas, maxPriorityFeePerGas },
+      txParams: {
+        gasPrice,
+        gas: gasLimit,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        estimateSuggested,
+        estimateUsed,
+      },
       metamaskNetworkId: network,
     } = txMeta;
     const source = referrer === 'metamask' ? 'user' : 'dapp';
@@ -1405,6 +1420,14 @@ export default class TransactionController extends EventEmitter {
       gasParams.max_priority_fee_per_gas = maxPriorityFeePerGas;
     } else {
       gasParams.gas_price = gasPrice;
+    }
+
+    if (estimateSuggested) {
+      gasParams.estimate_suggested = estimateSuggested;
+    }
+
+    if (estimateUsed) {
+      gasParams.estimate_used = estimateUsed;
     }
 
     const gasParamsInGwei = this._getGasValuesInGWEI(gasParams);
@@ -1441,6 +1464,8 @@ export default class TransactionController extends EventEmitter {
     for (const param in gasParams) {
       if (isHexString(gasParams[param])) {
         gasValuesInGwei[param] = hexWEIToDecGWEI(gasParams[param]);
+      } else {
+        gasValuesInGwei[param] = gasParams[param];
       }
     }
     return gasValuesInGwei;

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -999,6 +999,8 @@ describe('Transaction Controller', function () {
         to: '0xB09d8505E1F4EF1CeA089D47094f5DD3464083d4',
         gas: '0x5209',
         gasPrice: '0xa',
+        estimateSuggested: 'medium',
+        estimateUsed: 'high',
       };
       txController.txStateManager._addTransactionsToState([
         {
@@ -1698,6 +1700,8 @@ describe('Transaction Controller', function () {
           maxPriorityFeePerGas: '0x77359400',
           gas: '0x7b0d',
           nonce: '0x4b',
+          estimateSuggested: 'medium',
+          estimateUsed: 'high',
         },
         type: TRANSACTION_TYPES.SIMPLE_SEND,
         origin: 'other',
@@ -1724,6 +1728,8 @@ describe('Transaction Controller', function () {
           first_seen: 1624408066355,
           transaction_envelope_type: 'fee-market',
           status: 'unapproved',
+          estimate_suggested: 'medium',
+          estimate_used: 'high',
         },
       };
 
@@ -1787,6 +1793,23 @@ describe('Transaction Controller', function () {
       };
       const expectedParams = {
         gas_price: '15',
+      };
+      const result = txController._getGasValuesInGWEI(params);
+      assert.deepEqual(result, expectedParams);
+    });
+
+    it('converts gas values in hex GWEi to dec GWEI, retains estimate fields', function () {
+      const params = {
+        max_fee_per_gas: '0x77359400',
+        max_priority_fee_per_gas: '0x77359400',
+        estimate_suggested: 'medium',
+        estimate_used: 'high',
+      };
+      const expectedParams = {
+        max_fee_per_gas: '2',
+        max_priority_fee_per_gas: '2',
+        estimate_suggested: 'medium',
+        estimate_used: 'high',
       };
       const result = txController._getGasValuesInGWEI(params);
       assert.deepEqual(result, expectedParams);

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -19,6 +19,8 @@ const normalizers = {
   maxFeePerGas: addHexPrefix,
   maxPriorityFeePerGas: addHexPrefix,
   type: addHexPrefix,
+  estimateSuggested: (estimate) => estimate,
+  estimateUsed: (estimate) => estimate,
 };
 
 export function normalizeAndValidateTxParams(txParams, lowerCase = true) {

--- a/app/scripts/controllers/transactions/lib/util.test.js
+++ b/app/scripts/controllers/transactions/lib/util.test.js
@@ -323,6 +323,8 @@ describe('txUtils', function () {
         gasPrice: '1',
         maxFeePerGas: '1',
         maxPriorityFeePerGas: '1',
+        estimateSuggested: 'medium',
+        estimateUsed: 'high',
         type: '1',
       };
 
@@ -376,6 +378,17 @@ describe('txUtils', function () {
         normalizedTxParams.type,
         '0x1',
         'type should be hex-prefixed',
+      );
+
+      assert.equal(
+        normalizedTxParams.estimateSuggested,
+        'medium',
+        'estimateSuggested should be the string originally provided',
+      );
+      assert.equal(
+        normalizedTxParams.estimateUsed,
+        'high',
+        'estimateSuggested should be the string originally provided',
       );
     });
   });

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -133,20 +133,21 @@ export default function EditGasPopover({
       closePopover();
     }
 
-    const newGasSettings = supportsEIP1559
-      ? {
-          gas: decimalToHex(gasLimit),
-          gasLimit: decimalToHex(gasLimit),
-          maxFeePerGas: decGWEIToHexWEI(maxFeePerGas ?? gasPrice),
-          maxPriorityFeePerGas: decGWEIToHexWEI(
-            maxPriorityFeePerGas ?? maxFeePerGas ?? gasPrice,
-          ),
-        }
-      : {
-          gas: decimalToHex(gasLimit),
-          gasLimit: decimalToHex(gasLimit),
-          gasPrice: decGWEIToHexWEI(gasPrice),
-        };
+    const newGasSettings = {
+      gas: decimalToHex(gasLimit),
+      gasLimit: decimalToHex(gasLimit),
+      estimateSuggested: defaultEstimateToUse,
+      estimateUsed: estimateToUse,
+    };
+
+    if (supportsEIP1559) {
+      newGasSettings.maxFeePerGas = decGWEIToHexWEI(maxFeePerGas ?? gasPrice);
+      newGasSettings.maxPriorityFeePerGas = decGWEIToHexWEI(
+        maxPriorityFeePerGas ?? maxFeePerGas ?? gasPrice,
+      );
+    } else {
+      newGasSettings.gasPrice = decGWEIToHexWEI(gasPrice);
+    }
 
     const cleanTransactionParams = { ...updatedTransaction.txParams };
 
@@ -205,6 +206,7 @@ export default function EditGasPopover({
     supportsEIP1559,
     estimateToUse,
     estimatedBaseFee,
+    defaultEstimateToUse,
   ]);
 
   let title = t('editGasTitle');


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/11519
Adds `estimateSuggested` and `estimateUsed` to `txMeta.txParams` for sped up, cancelled, and updated transactions for use in transaction metrics events.