### PR TITLE
fix issue where regional locales are not matched against our locales  list

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -68,7 +68,7 @@ export default class PreferencesController {
     this.store.setMaxListeners(12);
     this.openPopup = opts.openPopup;
     this.migrateAddressBookState = opts.migrateAddressBookState;
-
+    this.setCurrentLocale(opts.initLangCode);
     this._subscribeToInfuraAvailability();
 
     global.setPreference = (key, value) => {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -68,7 +68,7 @@ export default class PreferencesController {
     this.store.setMaxListeners(12);
     this.openPopup = opts.openPopup;
     this.migrateAddressBookState = opts.migrateAddressBookState;
-    this.setCurrentLocale(opts.initLangCode);
+
     this._subscribeToInfuraAvailability();
 
     global.setPreference = (key, value) => {

--- a/app/scripts/lib/get-first-preferred-lang-code.js
+++ b/app/scripts/lib/get-first-preferred-lang-code.js
@@ -38,9 +38,23 @@ export default async function getFirstPreferredLangCode() {
     userPreferredLocaleCodes = [];
   }
 
-  const firstPreferredLangCode = userPreferredLocaleCodes
+  let firstPreferredLangCode = userPreferredLocaleCodes
     .map((code) => code.toLowerCase().replace('_', '-'))
-    .find((code) => existingLocaleCodes[code] !== undefined);
+    .find(
+      (code) =>
+        existingLocaleCodes[code] !== undefined ||
+        existingLocaleCodes[code.split('-')[0]] !== undefined,
+    );
+
+  // if we have matched against a code with a '-' present, meaning its a regional
+  // code for which we have a non-regioned locale, we need to set firstPreferredLangCode
+  // to the correct non-regional code.
+  if (
+    firstPreferredLangCode !== undefined &&
+    existingLocaleCodes[firstPreferredLangCode] === undefined
+  ) {
+    firstPreferredLangCode = firstPreferredLangCode.split('-')[0];
+  }
 
   return existingLocaleCodes[firstPreferredLangCode] || 'en';
 }


### PR DESCRIPTION
Fixes: #12353

Explanation:  Some users experience issues in onboarding if their browsers' language settings are set such that their primary language is coded regionally, and another secondary language - for which we have translations - is not. Before this PR we were not normalizing regionally coded language settings to their base (e.g. 'en-us' => 'en') if we didn't have that regional coding in our translations. This PR adds this normalization.

Manual testing steps:  
  - Change the language primary language in your browser's preferences to one with regional coding (e.g. French (Switzerland), code 'fr-CH'), for which we have translations for the non-regionally coded (in this case just French (code 'fr')
  - Reload the app
  - Check that the language is set to the language you just changed it to (French if you followed step 1)
 