### PR TITLE
Avoid storybook-build directory when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     'nyc_output/**',
     '.vscode/**',
     'lavamoat/*/policy.json',
+    'storybook-build/**',
   ],
 
   extends: [


### PR DESCRIPTION
My `yarn lint:fix` has been hanging for a few weeks now.  After running `./node_modules/eslint/bin/eslint.js . --ext js --debug`, I noticed the last item being used was in the `storybook-build` directory.  Ignoring that directory made the linting finish, albeit in it still took ~80 seconds.