### PR TITLE
Show Optimism L1 fees when sending transactions

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1458,6 +1458,9 @@
   "mobileSyncWarning": {
     "message": "The 'Sync with extension' feature is temporarily disabled. If you want to use your extension wallet on MetaMask mobile, then on your mobile app: go back to the wallet setup options and select the 'Import with Secret Recovery Phrase' option. Use your extension wallet's secret phrase to then import your wallet into mobile."
   },
+  "multilayerNetworkGasInfo": {
+    "message": "The current layer 2 network requires that fees be paid on layer 1 (ethereum mainnet) and the layer 2 network itself."
+  },
   "mustSelectOne": {
     "message": "Must select at least 1 token."
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2849,6 +2849,15 @@
   "transactionHistoryBaseFee": {
     "message": "Base Fee (GWEI)"
   },
+  "transactionHistoryL1GasLabel": {
+    "message": "Total L1 gas fee"
+  },
+  "transactionHistoryL2GasLimitLabel": {
+    "message": "L2 gas limit`"
+  },
+  "transactionHistoryL2GasPriceLabel": {
+    "message": "L2 gas price`"
+  },
   "transactionHistoryMaxFeePerGas": {
     "message": "Max Fee Per Gas"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2825,6 +2825,12 @@
   "transactionDetailGasTotalSubtitle": {
     "message": "Amount + gas fee"
   },
+  "transactionDetailL1GasHeading": {
+    "message": "Estimated L1 gas fee"
+  },
+  "transactionDetailL2GasHeading": {
+    "message": "Estimated L2 gas fee"
+  },
   "transactionDropped": {
     "message": "Transaction dropped at $2."
   },

--- a/lavamoat/browserify/policy.json
+++ b/lavamoat/browserify/policy.json
@@ -84,6 +84,12 @@
         "multihashes": true
       }
     },
+    "@eth-optimism/contracts": {
+      "packages": {
+        "@ethersproject/abstract-provider": true,
+        "ethers": true
+      }
+    },
     "@ethereumjs/common": {
       "packages": {
         "buffer": true,

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@babel/runtime": "^7.5.5",
     "@download/blockies": "^1.0.3",
     "@ensdomains/content-hash": "^2.5.6",
+    "@eth-optimism/contracts": "0.0.0-2021919175625",
     "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/tx": "^3.2.1",
     "@formatjs/intl-relativetimeformat": "^5.2.6",
@@ -367,7 +368,9 @@
       "github:assemblyscript/assemblyscript": false,
       "tiny-secp256k1": false,
       "@lavamoat/preinstall-always-fail": false,
-      "fsevents": false
+      "fsevents": false,
+      "node-hid": false,
+      "usb": false
     }
   }
 }

--- a/test/jest/rendering.js
+++ b/test/jest/rendering.js
@@ -1,12 +1,19 @@
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import PropTypes from 'prop-types';
-
-import { I18nContext, LegacyI18nProvider } from '../../ui/contexts/i18n';
-import { getMessage } from '../../ui/helpers/utils/i18n-helper';
 import * as en from '../../app/_locales/en/messages.json';
+import { I18nContext, LegacyI18nProvider } from '../../ui/contexts/i18n';
+import {
+  MetaMetricsProvider,
+  LegacyMetaMetricsProvider,
+} from '../../ui/contexts/metametrics';
+import {
+  MetaMetricsProvider as NewMetaMetricsProvider,
+  LegacyMetaMetricsProvider as NewLegacyMetaMetricsProvider,
+} from '../../ui/contexts/metametrics.new';
+import { getMessage } from '../../ui/helpers/utils/i18n-helper';
 
 export const I18nProvider = (props) => {
   const { currentLocale, current, en: eng } = props;
@@ -38,16 +45,26 @@ export function renderWithProvider(component, store) {
     const WithoutStore = () => (
       <MemoryRouter initialEntries={['/']} initialIndex={0}>
         <I18nProvider currentLocale="en" current={en} en={en}>
-          <LegacyI18nProvider>{children}</LegacyI18nProvider>
+          <LegacyI18nProvider>
+            <MetaMetricsProvider>
+              <LegacyMetaMetricsProvider>
+                <NewMetaMetricsProvider>
+                  <NewLegacyMetaMetricsProvider>
+                    {children}
+                  </NewLegacyMetaMetricsProvider>
+                </NewMetaMetricsProvider>
+              </LegacyMetaMetricsProvider>
+            </MetaMetricsProvider>
+          </LegacyI18nProvider>
         </I18nProvider>
       </MemoryRouter>
     );
     return store ? (
       <Provider store={store}>
-        <WithoutStore></WithoutStore>
+        <WithoutStore />
       </Provider>
     ) : (
-      <WithoutStore></WithoutStore>
+      <WithoutStore />
     );
   };
 

--- a/test/jest/rendering.js
+++ b/test/jest/rendering.js
@@ -1,18 +1,10 @@
-import React, { useMemo } from 'react';
+import React, { Component, useMemo, createContext } from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import * as en from '../../app/_locales/en/messages.json';
 import { I18nContext, LegacyI18nProvider } from '../../ui/contexts/i18n';
-import {
-  MetaMetricsProvider,
-  LegacyMetaMetricsProvider,
-} from '../../ui/contexts/metametrics';
-import {
-  MetaMetricsProvider as NewMetaMetricsProvider,
-  LegacyMetaMetricsProvider as NewLegacyMetaMetricsProvider,
-} from '../../ui/contexts/metametrics.new';
 import { getMessage } from '../../ui/helpers/utils/i18n-helper';
 
 export const I18nProvider = (props) => {
@@ -40,21 +32,41 @@ I18nProvider.defaultProps = {
   children: undefined,
 };
 
+const MetaMetricsContext = createContext((args) => args);
+
+class LegacyMetaMetricsProvider extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+  };
+
+  static defaultProps = {
+    children: undefined,
+  };
+
+  static contextType = MetaMetricsContext;
+
+  static childContextTypes = {
+    metricsEvent: PropTypes.func,
+  };
+
+  getChildContext() {
+    return {
+      metricsEvent: this.context,
+    };
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
 export function renderWithProvider(component, store) {
   const Wrapper = ({ children }) => {
     const WithoutStore = () => (
       <MemoryRouter initialEntries={['/']} initialIndex={0}>
         <I18nProvider currentLocale="en" current={en} en={en}>
           <LegacyI18nProvider>
-            <MetaMetricsProvider>
-              <LegacyMetaMetricsProvider>
-                <NewMetaMetricsProvider>
-                  <NewLegacyMetaMetricsProvider>
-                    {children}
-                  </NewLegacyMetaMetricsProvider>
-                </NewMetaMetricsProvider>
-              </LegacyMetaMetricsProvider>
-            </MetaMetricsProvider>
+            <LegacyMetaMetricsProvider>{children}</LegacyMetaMetricsProvider>
           </LegacyI18nProvider>
         </I18nProvider>
       </MemoryRouter>

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.component.js
@@ -7,6 +7,7 @@ import FormField from '../../ui/form-field';
 import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { getGasFormErrorText } from '../../../helpers/constants/gas';
 import { getIsGasEstimatesLoading } from '../../../ducks/metamask/metamask';
+import { getNetworkSupportsSettingGasPrice } from '../../../selectors/selectors';
 
 export default function AdvancedGasControls({
   gasEstimateType,
@@ -33,6 +34,10 @@ export default function AdvancedGasControls({
     (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET ||
       gasEstimateType === GAS_ESTIMATE_TYPES.ETH_GASPRICE ||
       isGasEstimatesLoading);
+
+  const networkSupportsSettingGasPrice = useSelector(
+    getNetworkSupportsSettingGasPrice,
+  );
 
   return (
     <div className="advanced-gas-controls">
@@ -89,26 +94,25 @@ export default function AdvancedGasControls({
             }
           />
         </>
-      ) : (
-        <>
-          <FormField
-            titleText={t('advancedGasPriceTitle')}
-            titleUnit="(GWEI)"
-            onChange={(value) => {
-              onManualChange?.();
-              setGasPrice(value);
-            }}
-            tooltipText={t('editGasPriceTooltip')}
-            value={gasPrice}
-            numeric
-            error={
-              gasErrors?.gasPrice
-                ? getGasFormErrorText(gasErrors.gasPrice, t)
-                : null
-            }
-          />
-        </>
-      )}
+      ) : null}
+      {networkSupportsSettingGasPrice ? (
+        <FormField
+          titleText={t('advancedGasPriceTitle')}
+          titleUnit="(GWEI)"
+          onChange={(value) => {
+            onManualChange?.();
+            setGasPrice(value);
+          }}
+          tooltipText={t('editGasPriceTooltip')}
+          value={gasPrice}
+          numeric
+          error={
+            gasErrors?.gasPrice
+              ? getGasFormErrorText(gasErrors.gasPrice, t)
+              : null
+          }
+        />
+      ) : null}
     </div>
   );
 }

--- a/ui/components/app/advanced-gas-controls/advanced-gas-controls.test.js
+++ b/ui/components/app/advanced-gas-controls/advanced-gas-controls.test.js
@@ -1,12 +1,18 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-
 import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { renderWithProvider } from '../../../../test/jest/rendering';
-
+import { getNetworkSupportsSettingGasPrice } from '../../../selectors/selectors';
 import AdvancedGasControls from './advanced-gas-controls.component';
 
-const renderComponent = (props) => {
+jest.mock('../../../selectors/selectors', () => {
+  return {
+    ...jest.requireActual('../../../selectors/selectors'),
+    getNetworkSupportsSettingGasPrice: jest.fn(),
+  };
+});
+
+const renderComponent = (props = {}) => {
   const store = configureMockStore([])({ metamask: { identities: [] } });
   return renderWithProvider(<AdvancedGasControls {...props} />, store);
 };
@@ -21,7 +27,6 @@ describe('AdvancedGasControls Component', () => {
   it('should not render maxFee and maxPriorityFee inputs if supportsEIP1559 is false', () => {
     const { queryByText } = renderComponent({ supportsEIP1559: false });
     expect(queryByText('Gas Limit')).toBeInTheDocument();
-    expect(queryByText('Gas price')).toBeInTheDocument();
     expect(queryByText('Max fee')).not.toBeInTheDocument();
     expect(queryByText('Max priority fee')).not.toBeInTheDocument();
   });
@@ -31,9 +36,20 @@ describe('AdvancedGasControls Component', () => {
       gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
       supportsEIP1559: true,
     });
-    expect(queryByText('Gas price')).not.toBeInTheDocument();
     expect(queryByText('Gas Limit')).toBeInTheDocument();
     expect(queryByText('Max fee')).toBeInTheDocument();
     expect(queryByText('Max priority fee')).toBeInTheDocument();
+  });
+
+  it('should render the gas price input if getNetworkSupportsSettingGasPrice is true', () => {
+    getNetworkSupportsSettingGasPrice.mockReturnValue(true);
+    const { queryByText } = renderComponent({ supportsEIP1559: false });
+    expect(queryByText('Gas price')).toBeInTheDocument();
+  });
+
+  it('should not render the gas price input if getNetworkSupportsSettingGasPrice is false', () => {
+    getNetworkSupportsSettingGasPrice.mockReturnValue(false);
+    const { queryByText } = renderComponent({ supportsEIP1559: false });
+    expect(queryByText('Gas price')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
+++ b/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.component.js
@@ -20,10 +20,12 @@ export default class AdvancedGasInputs extends Component {
     customGasLimitMessage: PropTypes.string,
     minimumGasLimit: PropTypes.number,
     customPriceIsExcessive: PropTypes.bool,
+    networkSupportsSettingGasPrice: PropTypes.bool,
   };
 
   static defaultProps = {
     customPriceIsExcessive: false,
+    networkSupportsSettingGasPrice: true,
   };
 
   constructor(props) {
@@ -194,6 +196,7 @@ export default class AdvancedGasInputs extends Component {
       customGasLimitMessage,
       minimumGasLimit,
       customPriceIsExcessive,
+      networkSupportsSettingGasPrice,
     } = this.props;
     const { gasPrice, gasLimit } = this.state;
 
@@ -235,15 +238,16 @@ export default class AdvancedGasInputs extends Component {
 
     return (
       <div className="advanced-gas-inputs__gas-edit-rows">
-        {this.renderGasInput({
-          label: this.context.t('gasPrice'),
-          testId: 'gas-price',
-          tooltipTitle: this.context.t('gasPriceInfoTooltipContent'),
-          value: this.state.gasPrice,
-          onChange: this.onChangeGasPrice,
-          errorComponent: gasPriceErrorComponent,
-          errorType: gasPriceErrorType,
-        })}
+        {networkSupportsSettingGasPrice &&
+          this.renderGasInput({
+            label: this.context.t('gasPrice'),
+            testId: 'gas-price',
+            tooltipTitle: this.context.t('gasPriceInfoTooltipContent'),
+            value: this.state.gasPrice,
+            onChange: this.onChangeGasPrice,
+            errorComponent: gasPriceErrorComponent,
+            errorType: gasPriceErrorType,
+          })}
         {this.renderGasInput({
           label: this.context.t('gasLimit'),
           testId: 'gas-limit',

--- a/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
+++ b/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.container.js
@@ -4,6 +4,7 @@ import {
   decimalToHex,
   hexWEIToDecGWEI,
 } from '../../../../helpers/utils/conversions.util';
+import { getNetworkSupportsSettingGasPrice } from '../../../../selectors/selectors';
 import { MIN_GAS_LIMIT_DEC } from '../../../../pages/send/send.constants';
 import AdvancedGasInputs from './advanced-gas-inputs.component';
 
@@ -19,7 +20,13 @@ function convertMinimumGasLimitForInputs(minimumGasLimit = MIN_GAS_LIMIT_DEC) {
   return parseInt(minimumGasLimit, 10);
 }
 
-const mergeProps = (stateProps, dispatchProps, ownProps) => {
+function mapStateToProps(state) {
+  return {
+    networkSupportsSettingGasPrice: getNetworkSupportsSettingGasPrice(state),
+  };
+}
+
+function mergeProps(stateProps, dispatchProps, ownProps) {
   const {
     customGasPrice,
     customGasLimit,
@@ -38,6 +45,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       updateCustomGasPrice(decGWEIToHexWEI(price)),
     updateCustomGasLimit: (limit) => updateCustomGasLimit(decimalToHex(limit)),
   };
-};
+}
 
-export default connect(null, null, mergeProps)(AdvancedGasInputs);
+export default connect(mapStateToProps, null, mergeProps)(AdvancedGasInputs);

--- a/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.test.js
+++ b/ui/components/app/gas-customization/advanced-gas-inputs/advanced-gas-inputs.test.js
@@ -2,7 +2,15 @@ import React from 'react';
 import sinon from 'sinon';
 import { renderWithProvider, fireEvent } from '../../../../../test/jest';
 import configureStore from '../../../../store/store';
+import { getNetworkSupportsSettingGasPrice } from '../../../../selectors/selectors';
 import AdvancedGasInputs from '.';
+
+jest.mock('../../../../selectors/selectors', () => {
+  return {
+    ...jest.requireActual('../../../../selectors/selectors'),
+    getNetworkSupportsSettingGasPrice: jest.fn(),
+  };
+});
 
 describe('AdvancedGasInputs', () => {
   let clock;
@@ -115,5 +123,15 @@ describe('AdvancedGasInputs', () => {
     );
 
     expect(queryByText('Gas Price Is Excessive')).toBeInTheDocument();
+  });
+
+  it('does not render the gas price input if the network does not support setting the gas price', () => {
+    getNetworkSupportsSettingGasPrice.mockReturnValue(false);
+    const { queryByTestId } = renderWithProvider(
+      <AdvancedGasInputs {...props} networkSupportsSettingGasPrice={false} />,
+      store,
+    );
+
+    expect(queryByTestId('gas-price')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -196,21 +196,6 @@ export default class TransactionBreakdown extends PureComponent {
             )}
           </TransactionBreakdownRow>
         )}
-        <TransactionBreakdownRow title={t('total')}>
-          <UserPreferencedCurrencyDisplay
-            className="transaction-breakdown__value transaction-breakdown__value--eth-total"
-            type={PRIMARY}
-            value={totalInHex}
-            numberOfDecimals={isOptimism ? 18 : null}
-          />
-          {showFiat && (
-            <UserPreferencedCurrencyDisplay
-              className="transaction-breakdown__value"
-              type={SECONDARY}
-              value={totalInHex}
-            />
-          )}
-        </TransactionBreakdownRow>
         {isOptimism && (
           <TransactionBreakdownRow title={t('transactionHistoryL1GasLabel')}>
             <UserPreferencedCurrencyDisplay
@@ -229,6 +214,21 @@ export default class TransactionBreakdown extends PureComponent {
             )}
           </TransactionBreakdownRow>
         )}
+        <TransactionBreakdownRow title={t('total')}>
+          <UserPreferencedCurrencyDisplay
+            className="transaction-breakdown__value transaction-breakdown__value--eth-total"
+            type={PRIMARY}
+            value={totalInHex}
+            numberOfDecimals={isOptimism ? 18 : null}
+          />
+          {showFiat && (
+            <UserPreferencedCurrencyDisplay
+              className="transaction-breakdown__value"
+              type={SECONDARY}
+              value={totalInHex}
+            />
+          )}
+        </TransactionBreakdownRow>
       </div>
     );
   }

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -33,6 +33,8 @@ export default class TransactionBreakdown extends PureComponent {
     priorityFee: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     hexGasTotal: PropTypes.string,
     isEIP1559Transaction: PropTypes.bool,
+    isOptimism: PropTypes.bool,
+    l1HexGasTotal: PropTypes.string,
   };
 
   static defaultProps = {
@@ -57,6 +59,8 @@ export default class TransactionBreakdown extends PureComponent {
       priorityFee,
       hexGasTotal,
       isEIP1559Transaction,
+      isOptimism,
+      l1HexGasTotal,
     } = this.props;
     return (
       <div className={classnames('transaction-breakdown', className)}>
@@ -77,7 +81,11 @@ export default class TransactionBreakdown extends PureComponent {
           </span>
         </TransactionBreakdownRow>
         <TransactionBreakdownRow
-          title={`${t('gasLimit')} (${t('units')})`}
+          title={
+            isOptimism
+              ? t('transactionHistoryL2GasLimitLabel')
+              : `${t('gasLimit')} (${t('units')})`
+          }
           className="transaction-breakdown__row-title"
         >
           {typeof gas === 'undefined' ? (
@@ -127,7 +135,13 @@ export default class TransactionBreakdown extends PureComponent {
           </TransactionBreakdownRow>
         ) : null}
         {!isEIP1559Transaction && (
-          <TransactionBreakdownRow title={t('advancedGasPriceTitle')}>
+          <TransactionBreakdownRow
+            title={
+              isOptimism
+                ? t('transactionHistoryL2GasPriceLabel')
+                : t('advancedGasPriceTitle')
+            }
+          >
             {typeof gasPrice === 'undefined' ? (
               '?'
             ) : (
@@ -187,6 +201,7 @@ export default class TransactionBreakdown extends PureComponent {
             className="transaction-breakdown__value transaction-breakdown__value--eth-total"
             type={PRIMARY}
             value={totalInHex}
+            numberOfDecimals={isOptimism ? 18 : null}
           />
           {showFiat && (
             <UserPreferencedCurrencyDisplay
@@ -196,6 +211,24 @@ export default class TransactionBreakdown extends PureComponent {
             />
           )}
         </TransactionBreakdownRow>
+        {isOptimism && (
+          <TransactionBreakdownRow title={t('transactionHistoryL1GasLabel')}>
+            <UserPreferencedCurrencyDisplay
+              className="transaction-breakdown__value"
+              data-testid="transaction-breakdown__l1-gas-total"
+              numberOfDecimals={18}
+              value={l1HexGasTotal}
+              type={PRIMARY}
+            />
+            {showFiat && (
+              <UserPreferencedCurrencyDisplay
+                className="transaction-breakdown__value"
+                type={SECONDARY}
+                value={l1HexGasTotal}
+              />
+            )}
+          </TransactionBreakdownRow>
+        )}
       </div>
     );
   }

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -34,9 +34,14 @@ const mapStateToProps = (state, ownProps) => {
       usedGasPrice &&
       getHexGasTotal({ gasLimit, gasPrice: usedGasPrice })) ||
     '0x0';
-  const totalInHex = sumHexes(hexGasTotal, value);
+
+  let totalInHex = sumHexes(hexGasTotal, value);
 
   const isOptimism = getIsOptimism(state);
+
+  if (isOptimism) {
+    totalInHex = sumHexes(totalInHex, l1HexGasTotal);
+  }
 
   return {
     nativeCurrency: getNativeCurrency(state),

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -5,13 +5,14 @@ import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util';
 import { subtractHexes } from '../../../helpers/utils/conversions.util';
 import { sumHexes } from '../../../helpers/utils/transactions.util';
 import { isEIP1559Transaction } from '../../../../shared/modules/transaction.utils';
+import { getIsOptimism } from '../../../ducks/optimism';
 import TransactionBreakdown from './transaction-breakdown.component';
 
 const mapStateToProps = (state, ownProps) => {
   const { transaction, isTokenApprove } = ownProps;
   const {
     txParams: { gas, gasPrice, maxFeePerGas, value } = {},
-    txReceipt: { gasUsed, effectiveGasPrice } = {},
+    txReceipt: { gasUsed, effectiveGasPrice, l1Fee: l1HexGasTotal } = {},
     baseFeePerGas,
   } = transaction;
 
@@ -35,6 +36,8 @@ const mapStateToProps = (state, ownProps) => {
     '0x0';
   const totalInHex = sumHexes(hexGasTotal, value);
 
+  const isOptimism = getIsOptimism(state);
+
   return {
     nativeCurrency: getNativeCurrency(state),
     showFiat: getShouldShowFiat(state),
@@ -48,6 +51,8 @@ const mapStateToProps = (state, ownProps) => {
     priorityFee,
     baseFee: baseFeePerGas,
     isEIP1559Transaction: isEIP1559Transaction(transaction),
+    isOptimism,
+    l1HexGasTotal,
   };
 };
 

--- a/ui/components/app/transaction-detail-item/index.scss
+++ b/ui/components/app/transaction-detail-item/index.scss
@@ -2,6 +2,13 @@
   color: $ui-4;
   padding: 20px 0;
   border-bottom: 1px solid $ui-3;
+  margin-bottom: 5px;
+
+  &:last-child {
+    border-top: 1px solid $ui-3;
+    padding-top: 20px;
+    margin-top: 20px;
+  }
 
   &__row {
     display: flex;

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
@@ -45,27 +45,29 @@ export default function TransactionDetailItem({
           {detailTotal}
         </Typography>
       </div>
-      <div className="transaction-detail-item__row">
-        {React.isValidElement(subTitle) ? (
-          <div className="transaction-detail-item__subtitle">{subTitle}</div>
-        ) : (
+      {subTitle && subText ? (
+        <div className="transaction-detail-item__row">
+          {React.isValidElement(subTitle) ? (
+            <div className="transaction-detail-item__subtitle">{subTitle}</div>
+          ) : (
+            <Typography
+              variant={TYPOGRAPHY.H7}
+              className="transaction-detail-item__subtitle"
+              color={COLORS.UI4}
+            >
+              {subTitle}
+            </Typography>
+          )}
+
           <Typography
             variant={TYPOGRAPHY.H7}
-            className="transaction-detail-item__subtitle"
             color={COLORS.UI4}
+            className="transaction-detail-item__subtext"
           >
-            {subTitle}
+            {subText}
           </Typography>
-        )}
-
-        <Typography
-          variant={TYPOGRAPHY.H7}
-          color={COLORS.UI4}
-          className="transaction-detail-item__subtext"
-        >
-          {subText}
-        </Typography>
-      </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import InfoTooltip from '../../ui/info-tooltip/info-tooltip';
-import GasTiming from '../gas-timing/gas-timing.component';
+import { COLORS } from '../../../helpers/constants/design-system';
+import Typography from '../../ui/typography/typography';
 import TransactionDetailItem from '.';
 
 export default {
@@ -8,7 +9,7 @@ export default {
   id: __filename,
 };
 
-export const basic = () => {
+export const Minimal = () => {
   return (
     <div style={{ width: '400px' }}>
       <TransactionDetailItem
@@ -22,7 +23,47 @@ export const basic = () => {
         }
         detailText="16565.30"
         detailTotal="0.0089 ETH"
-        subTitle={<GasTiming maxPriorityFeePerGas="1" />}
+      />
+    </div>
+  );
+};
+
+export const WithSubTitleAndTextBasedSubText = () => {
+  return (
+    <div style={{ width: '400px' }}>
+      <TransactionDetailItem
+        detailTitle={
+          <>
+            <strong>Estimated gas fee</strong>
+            <InfoTooltip contentText="This is the tooltip text" position="top">
+              <i className="fa fa-info-circle" />
+            </InfoTooltip>
+          </>
+        }
+        detailText="16565.30"
+        detailTotal="0.0089 ETH"
+        subTitle="Max amount"
+        subText="$12000"
+      />
+    </div>
+  );
+};
+
+export const WithSubtitleAndComponentBasedSubText = () => {
+  return (
+    <div style={{ width: '400px' }}>
+      <TransactionDetailItem
+        detailTitle={
+          <>
+            <strong>Estimated gas fee</strong>
+            <InfoTooltip contentText="This is the tooltip text" position="top">
+              <i className="fa fa-info-circle" />
+            </InfoTooltip>
+          </>
+        }
+        detailText="16565.30"
+        detailTotal="0.0089 ETH"
+        subTitle={<Typography color={COLORS.SECONDARY1}>Max amount</Typography>}
         subText={
           <>
             From <strong>$16565 - $19000</strong>

--- a/ui/ducks/index.js
+++ b/ui/ducks/index.js
@@ -10,6 +10,7 @@ import gasReducer from './gas/gas.duck';
 import { invalidCustomNetwork, unconnectedAccount } from './alerts';
 import swapsReducer from './swaps/swaps';
 import historyReducer from './history/history';
+import { reducer as optimismReducer } from './optimism';
 
 export default combineReducers({
   [ALERT_TYPES.invalidCustomNetwork]: invalidCustomNetwork,
@@ -24,4 +25,5 @@ export default combineReducers({
   swaps: swapsReducer,
   gas: gasReducer,
   localeMessages: localeMessagesReducer,
+  optimism: optimismReducer,
 });

--- a/ui/ducks/optimism/buildUnserializedTransaction.js
+++ b/ui/ducks/optimism/buildUnserializedTransaction.js
@@ -1,0 +1,33 @@
+import { omit } from 'lodash';
+import { BN, stripHexPrefix } from 'ethereumjs-util';
+import Common, { Chain, Hardfork } from '@ethereumjs/common';
+import { TransactionFactory } from '@ethereumjs/tx';
+
+function buildTxParams(txMeta) {
+  return {
+    ...omit(txMeta.txParams, 'gas'),
+    gasLimit: txMeta.txParams.gas,
+  };
+}
+
+function buildTransactionCommon(txMeta) {
+  // This produces a transaction whose information does not completely match an
+  // Optimism transaction — for instance, DEFAULT_CHAIN is still 'mainnet' and
+  // genesis points to the mainnet genesis, not the Optimism genesis — but
+  // considering that all we want to do is serialize a transaction, this works
+  // fine for our use case.
+  return Common.forCustomChain(Chain.Mainnet, {
+    chainId: new BN(stripHexPrefix(txMeta.chainId), 16),
+    networkId: new BN(txMeta.metamaskNetworkId, 10),
+    // Optimism only supports type-0 transactions; it does not support any of
+    // the newer EIPs since EIP-155. Source:
+    // <https://github.com/ethereum-optimism/optimism/blob/develop/specs/l2geth/transaction-types.md>
+    defaultHardfork: Hardfork.SpuriousDragon,
+  });
+}
+
+export default function buildUnserializedTransaction(txMeta) {
+  const txParams = buildTxParams(txMeta);
+  const common = buildTransactionCommon(txMeta);
+  return TransactionFactory.fromTxData(txParams, { common });
+}

--- a/ui/ducks/optimism/buildUnserializedTransaction.test.js
+++ b/ui/ducks/optimism/buildUnserializedTransaction.test.js
@@ -1,0 +1,28 @@
+import { BN } from 'ethereumjs-util';
+import { times } from 'lodash';
+import buildUnserializedTransaction from './buildUnserializedTransaction';
+
+describe('buildUnserializedTransaction', () => {
+  it('returns a transaction that can be serialized and fed to an Optimism smart contract', () => {
+    const unserializedTransaction = buildUnserializedTransaction({
+      txParams: {
+        nonce: '0x0',
+        gasPrice: `0x${new BN('100').toString(16)}`,
+        gas: `0x${new BN('21000').toString(16)}`,
+        to: '0x0000000000000000000000000000000000000000',
+        value: `0x${new BN('10000000000000').toString(16)}`,
+        data: '0x0',
+      },
+    });
+    expect(unserializedTransaction).toMatchObject({
+      nonce: new BN('00', 16),
+      gasPrice: new BN('64', 16),
+      gasLimit: new BN('5208', 16),
+      to: expect.objectContaining({
+        buf: Buffer.from(times(20, 0)),
+      }),
+      value: new BN('09184e72a000', 16),
+      data: Buffer.from([0]),
+    });
+  });
+});

--- a/ui/ducks/optimism/fetchEstimatedL1Fee.js
+++ b/ui/ducks/optimism/fetchEstimatedL1Fee.js
@@ -1,0 +1,22 @@
+import * as ethers from 'ethers';
+import * as optimismContracts from '@eth-optimism/contracts';
+import buildUnserializedTransaction from './buildUnserializedTransaction';
+
+function buildOVMGasPriceOracleContract(eth) {
+  const OVMGasPriceOracle = optimismContracts
+    .getContractFactory('OVM_GasPriceOracle')
+    .attach(optimismContracts.predeploys.OVM_GasPriceOracle);
+  const abi = JSON.parse(
+    OVMGasPriceOracle.interface.format(ethers.utils.FormatTypes.json),
+  );
+  return eth.contract(abi).at(OVMGasPriceOracle.address);
+}
+
+export default async function fetchEstimatedL1Fee(eth, txMeta) {
+  const contract = buildOVMGasPriceOracleContract(eth);
+  const serializedTransaction = buildUnserializedTransaction(
+    txMeta,
+  ).serialize();
+  const result = await contract.getL1Fee(serializedTransaction);
+  return result[0];
+}

--- a/ui/ducks/optimism/index.js
+++ b/ui/ducks/optimism/index.js
@@ -1,0 +1,67 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { BN } from 'ethereumjs-util';
+import {
+  OPTIMISM_CHAIN_ID,
+  OPTIMISM_TESTNET_CHAIN_ID,
+} from '../../../shared/constants/network';
+import { getCurrentChainId } from '../../selectors';
+import fetchEstimatedL1Fee from './fetchEstimatedL1Fee';
+
+const name = 'optimism';
+
+// Thunks
+
+export const fetchEstimatedOptimismL1Fee = createAsyncThunk(
+  'optimism/fetchEstimatedOptimismL1Fee',
+  (txMeta) => {
+    return fetchEstimatedL1Fee(global.eth, txMeta);
+  },
+);
+
+// Reducer
+
+const { reducer } = createSlice({
+  name,
+  initialState: { estimatedL1Fee: new BN('0') },
+  extraReducers: (builder) => {
+    builder.addCase(fetchEstimatedOptimismL1Fee.fulfilled, (state, action) => {
+      state.estimatedL1Fee = action.payload;
+    });
+  },
+});
+
+export { reducer };
+
+// Selectors
+
+const selectors = {
+  getEstimatedOptimismL1Fee(state) {
+    return state[name].estimatedL1Fee;
+  },
+
+  getIsOptimism(state) {
+    return selectors.getIsOptimismTestnet(state);
+  },
+
+  getIsOptimismMainnet(state) {
+    return getCurrentChainId(state) === OPTIMISM_CHAIN_ID;
+  },
+
+  getIsOptimismTestnet(state) {
+    return getCurrentChainId(state) === OPTIMISM_TESTNET_CHAIN_ID;
+  },
+};
+
+const {
+  getEstimatedOptimismL1Fee,
+  getIsOptimism,
+  getIsOptimismMainnet,
+  getIsOptimismTestnet,
+} = selectors;
+
+export {
+  getEstimatedOptimismL1Fee,
+  getIsOptimism,
+  getIsOptimismMainnet,
+  getIsOptimismTestnet,
+};

--- a/ui/ducks/optimism/index.js
+++ b/ui/ducks/optimism/index.js
@@ -39,16 +39,19 @@ const selectors = {
     return state[name].estimatedL1Fee;
   },
 
-  getIsOptimism(state) {
-    return selectors.getIsOptimismTestnet(state);
-  },
-
   getIsOptimismMainnet(state) {
     return getCurrentChainId(state) === OPTIMISM_CHAIN_ID;
   },
 
   getIsOptimismTestnet(state) {
     return getCurrentChainId(state) === OPTIMISM_TESTNET_CHAIN_ID;
+  },
+
+  getIsOptimism(state) {
+    return (
+      selectors.getIsOptimismTestnet(state) ||
+      selectors.getIsOptimismMainnet(state)
+    );
   },
 };
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -346,21 +346,7 @@ export default class ConfirmTransactionBase extends Component {
                   t('transactionDetailDappGasTooltip')
                 ) : (
                   <>
-                    <p>
-                      {t('transactionDetailGasTooltipIntro', [
-                        isMainnet ? t('networkNameEthereum') : '',
-                      ])}
-                    </p>
-                    <p>{t('transactionDetailGasTooltipExplanation')}</p>
-                    <p>
-                      <a
-                        href="https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {t('transactionDetailGasTooltipConversion')}
-                      </a>
-                    </p>
+                    <p>{t('multilayerNetworkGasInfo')}</p>
                   </>
                 )
               }
@@ -413,34 +399,36 @@ export default class ConfirmTransactionBase extends Component {
           {isStandardNetwork
             ? t('transactionDetailGasHeading')
             : t('transactionDetailL1GasHeading')}
-          <InfoTooltip
-            contentText={
-              txData.dappSuggestedGasFees ? (
-                t('transactionDetailDappGasTooltip')
-              ) : (
-                <>
-                  <p>
-                    {t('transactionDetailGasTooltipIntro', [
-                      isMainnet ? t('networkNameEthereum') : '',
-                    ])}
-                  </p>
-                  <p>{t('transactionDetailGasTooltipExplanation')}</p>
-                  <p>
-                    <a
-                      href="https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {t('transactionDetailGasTooltipConversion')}
-                    </a>
-                  </p>
-                </>
-              )
-            }
-            position="top"
-          >
-            <i className="fa fa-info-circle" />
-          </InfoTooltip>
+          {isStandardNetwork ? (
+            <InfoTooltip
+              contentText={
+                txData.dappSuggestedGasFees ? (
+                  t('transactionDetailDappGasTooltip')
+                ) : (
+                  <>
+                    <p>
+                      {t('transactionDetailGasTooltipIntro', [
+                        isMainnet ? t('networkNameEthereum') : '',
+                      ])}
+                    </p>
+                    <p>{t('transactionDetailGasTooltipExplanation')}</p>
+                    <p>
+                      <a
+                        href="https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {t('transactionDetailGasTooltipConversion')}
+                      </a>
+                    </p>
+                  </>
+                )
+              }
+              position="top"
+            >
+              <i className="fa fa-info-circle" />
+            </InfoTooltip>
+          ) : null}
         </>
       );
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -371,14 +371,13 @@ export default class ConfirmTransactionBase extends Component {
           </>
         );
 
-        const detailText = (
+        const detailText = isStandardNetwork && (
           <div className="confirm-page-container-content__currency-container">
             {renderHeartBeatIfNotInTest()}
             <UserPreferencedCurrencyDisplay
               type={SECONDARY}
               value={hexMinimumTransactionFee}
               hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
-              ethNumberOfDecimals={15}
             />
           </div>
         );
@@ -390,6 +389,7 @@ export default class ConfirmTransactionBase extends Component {
               type={PRIMARY}
               value={hexMinimumTransactionFee}
               hideLabel={!useNativeCurrencyAsPrimaryCurrency}
+              numberOfDecimals={15}
             />
           </div>
         );
@@ -444,12 +444,12 @@ export default class ConfirmTransactionBase extends Component {
         </>
       );
 
-      const detailText = (
+      const detailText = isStandardNetwork && (
         <div className="confirm-page-container-content__currency-container">
           {renderHeartBeatIfNotInTest()}
           <UserPreferencedCurrencyDisplay
             type={SECONDARY}
-            value={hexEstimatedL1Fee || hexMinimumTransactionFee}
+            value={hexMinimumTransactionFee}
             hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
           />
         </div>
@@ -462,6 +462,7 @@ export default class ConfirmTransactionBase extends Component {
             type={PRIMARY}
             value={hexEstimatedL1Fee || hexMinimumTransactionFee}
             hideLabel={!useNativeCurrencyAsPrimaryCurrency}
+            numberOfDecimals={hexEstimatedL1Fee ? 18 : null}
           />
         </div>
       );
@@ -657,7 +658,7 @@ export default class ConfirmTransactionBase extends Component {
       ) : null,
       renderEstimatedL2GasFeeItem(),
       renderEstimatedL1GasFeeItem(),
-      renderEstimatedTotalItem(),
+      isStandardNetwork && renderEstimatedTotalItem(),
     ];
 
     return (

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -138,6 +138,7 @@ export default class ConfirmTransactionBase extends Component {
     fetchOptimismL1Fee: PropTypes.func.isRequired,
     isOptimism: PropTypes.bool,
     hexEstimatedL1Fee: PropTypes.string.isRequired,
+    isStandardNetwork: PropTypes.bool,
   };
 
   state = {
@@ -330,6 +331,7 @@ export default class ConfirmTransactionBase extends Component {
       supportsEIP1559,
       isOptimism,
       hexEstimatedL1Fee,
+      isStandardNetwork,
     } = this.props;
     const { t } = this.context;
 
@@ -376,6 +378,7 @@ export default class ConfirmTransactionBase extends Component {
               type={SECONDARY}
               value={hexMinimumTransactionFee}
               hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
+              ethNumberOfDecimals={15}
             />
           </div>
         );
@@ -407,7 +410,7 @@ export default class ConfirmTransactionBase extends Component {
     const renderEstimatedL1GasFeeItem = () => {
       const detailTitle = (
         <>
-          {hexEstimatedL1Fee === null
+          {isStandardNetwork
             ? t('transactionDetailGasHeading')
             : t('transactionDetailL1GasHeading')}
           <InfoTooltip
@@ -463,51 +466,49 @@ export default class ConfirmTransactionBase extends Component {
         </div>
       );
 
-      const subTitle =
-        hexEstimatedL1Fee === null ? (
-          <>
-            {txData.dappSuggestedGasFees ? (
-              <Typography
-                variant={TYPOGRAPHY.H7}
-                fontStyle={FONT_STYLE.ITALIC}
-                color={COLORS.UI4}
-              >
-                {t('transactionDetailDappGasMoreInfo')}
-              </Typography>
-            ) : (
-              ''
-            )}
-            {supportsEIP1559 && (
-              <GasTiming
-                maxPriorityFeePerGas={hexWEIToDecGWEI(
-                  maxPriorityFeePerGas || txData.txParams.maxPriorityFeePerGas,
-                )}
-                maxFeePerGas={hexWEIToDecGWEI(
-                  maxFeePerGas || txData.txParams.maxFeePerGas,
-                )}
-              />
-            )}
-          </>
-        ) : null;
+      const subTitle = isStandardNetwork ? (
+        <>
+          {txData.dappSuggestedGasFees ? (
+            <Typography
+              variant={TYPOGRAPHY.H7}
+              fontStyle={FONT_STYLE.ITALIC}
+              color={COLORS.UI4}
+            >
+              {t('transactionDetailDappGasMoreInfo')}
+            </Typography>
+          ) : (
+            ''
+          )}
+          {supportsEIP1559 && (
+            <GasTiming
+              maxPriorityFeePerGas={hexWEIToDecGWEI(
+                maxPriorityFeePerGas || txData.txParams.maxPriorityFeePerGas,
+              )}
+              maxFeePerGas={hexWEIToDecGWEI(
+                maxFeePerGas || txData.txParams.maxFeePerGas,
+              )}
+            />
+          )}
+        </>
+      ) : null;
 
-      const subText =
-        hexEstimatedL1Fee === null
-          ? t('editGasSubTextFee', [
-              <b key="editGasSubTextFeeLabel">{t('editGasSubTextFeeLabel')}</b>,
-              <div
-                key="editGasSubTextFeeValue"
-                className="confirm-page-container-content__currency-container"
-              >
-                {renderHeartBeatIfNotInTest()}
-                <UserPreferencedCurrencyDisplay
-                  key="editGasSubTextFeeAmount"
-                  type={PRIMARY}
-                  value={hexMaximumTransactionFee}
-                  hideLabel={!useNativeCurrencyAsPrimaryCurrency}
-                />
-              </div>,
-            ])
-          : null;
+      const subText = isStandardNetwork
+        ? t('editGasSubTextFee', [
+            <b key="editGasSubTextFeeLabel">{t('editGasSubTextFeeLabel')}</b>,
+            <div
+              key="editGasSubTextFeeValue"
+              className="confirm-page-container-content__currency-container"
+            >
+              {renderHeartBeatIfNotInTest()}
+              <UserPreferencedCurrencyDisplay
+                key="editGasSubTextFeeAmount"
+                type={PRIMARY}
+                value={hexMaximumTransactionFee}
+                hideLabel={!useNativeCurrencyAsPrimaryCurrency}
+              />
+            </div>,
+          ])
+        : null;
 
       return (
         <TransactionDetailItem
@@ -583,20 +584,18 @@ export default class ConfirmTransactionBase extends Component {
     };
 
     const renderEstimatedTotalItem = () => {
-      const subTitle =
-        hexEstimatedL1Fee === null
-          ? t('transactionDetailGasTotalSubtitle')
-          : null;
+      const subTitle = isStandardNetwork
+        ? t('transactionDetailGasTotalSubtitle')
+        : null;
 
-      const subText =
-        hexEstimatedL1Fee === null
-          ? t('editGasSubTextAmount', [
-              <b key="editGasSubTextAmountLabel">
-                {t('editGasSubTextAmountLabel')}
-              </b>,
-              renderTotalMaxAmount(),
-            ])
-          : null;
+      const subText = isStandardNetwork
+        ? t('editGasSubTextAmount', [
+            <b key="editGasSubTextAmountLabel">
+              {t('editGasSubTextAmountLabel')}
+            </b>,
+            renderTotalMaxAmount(),
+          ])
+        : null;
 
       return (
         <TransactionDetailItem
@@ -984,7 +983,6 @@ export default class ConfirmTransactionBase extends Component {
     window.addEventListener('beforeunload', this._beforeUnloadForGasPolling);
 
     if (isOptimism) {
-      console.log('[componentDidMount] Fetching Optimism L1 fee...');
       // here `txData` is the same thing as `txMeta` elsewhere
       fetchOptimismL1Fee(txData);
     }

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -139,6 +139,7 @@ export default class ConfirmTransactionBase extends Component {
     isOptimism: PropTypes.bool,
     hexEstimatedL1Fee: PropTypes.string.isRequired,
     isStandardNetwork: PropTypes.bool,
+    multilayerTotal: PropTypes.bool,
   };
 
   state = {
@@ -332,6 +333,7 @@ export default class ConfirmTransactionBase extends Component {
       isOptimism,
       hexEstimatedL1Fee,
       isStandardNetwork,
+      multilayerTotal,
     } = this.props;
     const { t } = this.context;
 
@@ -562,8 +564,9 @@ export default class ConfirmTransactionBase extends Component {
           <UserPreferencedCurrencyDisplay
             type={SECONDARY}
             key="total-detail-text"
-            value={hexTransactionTotal}
-            hideLabel={Boolean(useNativeCurrencyAsPrimaryCurrency)}
+            value={multilayerTotal || hexTransactionTotal}
+            hideLabel={useNativeCurrencyAsPrimaryCurrency && !multilayerTotal}
+            numberOfDecimals={multilayerTotal ? 18 : null}
           />
         );
       }
@@ -591,7 +594,7 @@ export default class ConfirmTransactionBase extends Component {
           key="total-item"
           detailTitle={t('total')}
           detailText={renderTotalDetailText()}
-          detailTotal={renderTotalDetailTotal()}
+          detailTotal={isStandardNetwork && renderTotalDetailTotal()}
           subTitle={subTitle}
           subText={subText}
         />
@@ -646,7 +649,7 @@ export default class ConfirmTransactionBase extends Component {
       ) : null,
       renderEstimatedL2GasFeeItem(),
       renderEstimatedL1GasFeeItem(),
-      isStandardNetwork && renderEstimatedTotalItem(),
+      renderEstimatedTotalItem(),
     ];
 
     return (

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -184,6 +184,9 @@ const mapStateToProps = (state, ownProps) => {
     fromAddress,
   );
 
+  const isOptimism = getIsOptimism(state);
+  const isStandardNetwork = !isOptimism;
+
   return {
     balance,
     fromAddress,
@@ -232,7 +235,8 @@ const mapStateToProps = (state, ownProps) => {
     showLedgerSteps: fromAddressIsLedger,
     nativeCurrency,
     hardwareWalletRequiresConnection,
-    isOptimism: getIsOptimism(state),
+    isOptimism,
+    isStandardNetwork,
     hexEstimatedL1Fee,
   };
 };

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -53,6 +53,7 @@ import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
 import { getGasLoadingAnimationIsShowing } from '../../ducks/app/app';
 import { isLegacyTransaction } from '../../helpers/utils/transactions.util';
 import { CUSTOM_GAS_ESTIMATE } from '../../../shared/constants/gas';
+import { addHexes } from '../../helpers/utils/conversions.util';
 import ConfirmTransactionBase from './confirm-transaction-base.component';
 
 let customNonceValue = '';
@@ -187,6 +188,11 @@ const mapStateToProps = (state, ownProps) => {
   const isOptimism = getIsOptimism(state);
   const isStandardNetwork = !isOptimism;
 
+  let multilayerTotal;
+  if (!isStandardNetwork) {
+    multilayerTotal = addHexes(hexEstimatedL1Fee, hexMinimumTransactionFee);
+  }
+
   return {
     balance,
     fromAddress,
@@ -238,6 +244,7 @@ const mapStateToProps = (state, ownProps) => {
     isOptimism,
     isStandardNetwork,
     hexEstimatedL1Fee,
+    multilayerTotal,
   };
 };
 

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.container.js
@@ -13,6 +13,10 @@ import {
   tryReverseResolveAddress,
   setDefaultHomeActiveTabName,
 } from '../../store/actions';
+import {
+  fetchEstimatedOptimismL1Fee,
+  getIsOptimism,
+} from '../../ducks/optimism';
 import { isBalanceSufficient, calcGasTotal } from '../send/send.utils';
 import { shortenAddress, valuesFor } from '../../helpers/utils/util';
 import {
@@ -129,6 +133,7 @@ const mapStateToProps = (state, ownProps) => {
   const {
     hexTransactionAmount,
     hexMinimumTransactionFee,
+    hexEstimatedL1Fee,
     hexMaximumTransactionFee,
     hexTransactionTotal,
     gasEstimationObject,
@@ -227,6 +232,8 @@ const mapStateToProps = (state, ownProps) => {
     showLedgerSteps: fromAddressIsLedger,
     nativeCurrency,
     hardwareWalletRequiresConnection,
+    isOptimism: getIsOptimism(state),
+    hexEstimatedL1Fee,
   };
 };
 
@@ -260,6 +267,9 @@ export const mapDispatchToProps = (dispatch) => {
       dispatch(setDefaultHomeActiveTabName(tabName)),
     updateTransactionGasFees: (gasFees) => {
       dispatch(updateTransactionGasFees({ ...gasFees, expectHexWei: true }));
+    },
+    fetchOptimismL1Fee: (txMeta) => {
+      dispatch(fetchEstimatedOptimismL1Fee(txMeta));
     },
   };
 };

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -1,0 +1,190 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  renderWithProvider,
+  setBackgroundConnection,
+} from '../../../test/jest';
+import configureStore from '../../store/store';
+import { updateTxData } from '../../ducks/confirm-transaction/confirm-transaction.duck';
+import {
+  getAccountsWithLabels,
+  getMetaMaskAccounts,
+  getPreferences,
+  getSelectedAccount,
+  getSelectedAddress,
+  getTokenList,
+  transactionFeeSelector,
+} from '../../selectors';
+import {
+  fetchEstimatedOptimismL1Fee,
+  getIsOptimism,
+} from '../../ducks/optimism';
+import ConfirmTransactionBase from '.';
+
+jest.mock('react-router-dom', () => {
+  return {
+    ...jest.requireActual('react-router-dom'),
+    useHistory: jest.fn(),
+  };
+});
+
+jest.mock('../../selectors', () => {
+  return {
+    ...jest.requireActual('../../selectors'),
+    __esModule: true,
+    checkNetworkAndAccountSupports1559: jest.fn(),
+    doesAddressRequireLedgerHidConnection: jest.fn(),
+    getAccountsWithLabels: jest.fn(),
+    getAdvancedInlineGasShown: jest.fn(),
+    getCustomNonceValue: jest.fn(),
+    getIsEthGasPriceFetched: jest.fn(),
+    getIsMainnet: jest.fn(),
+    getKnownMethodData: jest.fn(),
+    getMetaMaskAccounts: jest.fn(),
+    getNoGasPriceFetched: jest.fn(),
+    getPreferences: jest.fn(),
+    getSelectedAccount: jest.fn(),
+    getSelectedAddress: jest.fn(),
+    getShouldShowFiat: jest.fn(),
+    getTokenList: jest.fn(),
+    getUseNonceField: jest.fn(),
+    getUseTokenDetection: jest.fn(),
+    transactionFeeSelector: jest.fn(),
+  };
+});
+
+jest.mock('../../ducks/optimism', () => {
+  return {
+    ...jest.requireActual('../../ducks/optimism'),
+    __esModule: true,
+    fetchEstimatedOptimismL1Fee: jest.fn(),
+    getIsOptimism: jest.fn(),
+  };
+});
+
+const backgroundConnection = {
+  getGasFeeEstimatesAndStartPolling: jest.fn(),
+  getNextNonce: jest.fn(),
+  trackMetaMetricsEvent: jest.fn(),
+  trackMetaMetricsPage: jest.fn(),
+  tryReverseResolveAddress: jest.fn(),
+};
+
+setBackgroundConnection(backgroundConnection);
+
+describe('ConfirmTransactionBase', () => {
+  const transactionId = 111111111;
+  const fromAddress = '0x1111';
+  const account = {
+    [fromAddress]: { address: fromAddress },
+  };
+  const toAddress = '0x2222';
+  const store = configureStore({
+    confirmTransaction: {
+      txData: {
+        id: transactionId,
+        origin: 'something',
+      },
+    },
+    metamask: {
+      accounts: {
+        [fromAddress]: account,
+      },
+      addressBook: {},
+      cachedBalances: {},
+      ensResolutionsByAddress: {},
+      identities: {
+        [fromAddress]: {},
+      },
+      keyrings: [],
+      provider: {},
+      unapprovedTxs: [
+        {
+          id: transactionId,
+          txParams: {
+            from: fromAddress,
+            to: toAddress,
+            gasPrice: '0x0',
+            gas: '0x0',
+            value: '0x0',
+            data: '0x0',
+          },
+        },
+      ],
+    },
+  });
+
+  beforeEach(() => {
+    useHistory.mockReturnValue({
+      listen: jest.fn(),
+    });
+
+    getAccountsWithLabels.mockReturnValue([]);
+    getMetaMaskAccounts.mockReturnValue({
+      [fromAddress]: {
+        address: fromAddress,
+        balance: '0x0',
+      },
+    });
+    getPreferences.mockReturnValue({});
+    getSelectedAccount.mockReturnValue(account);
+    getSelectedAddress.mockReturnValue(fromAddress);
+    getTokenList.mockReturnValue({});
+    transactionFeeSelector.mockReturnValue({
+      hexEstimatedL1Fee: '0x0',
+      gasEstimationObject: {},
+    });
+
+    fetchEstimatedOptimismL1Fee.mockReturnValue(async () => {
+      return '0x0';
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('if the current network is Optimism', () => {
+    beforeEach(() => {
+      getIsOptimism.mockReturnValue(true);
+    });
+
+    it('kicks off a request to fetch the L1 fee from Optimism on mount', () => {
+      renderWithProvider(<ConfirmTransactionBase />, store);
+      expect(fetchEstimatedOptimismL1Fee).toHaveBeenCalled();
+    });
+
+    it('kicks off a fresh request to fetch the L1 fee from Optimism when txData is updated', () => {
+      renderWithProvider(<ConfirmTransactionBase />, store);
+      store.dispatch(
+        updateTxData({
+          id: transactionId,
+          origin: 'something else',
+        }),
+      );
+      expect(fetchEstimatedOptimismL1Fee).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('if the current network is not Optimism', () => {
+    beforeEach(() => {
+      getIsOptimism.mockReturnValue(false);
+    });
+
+    it('does not kick off a request to fetch the L1 fee from Optimism on mount', () => {
+      renderWithProvider(<ConfirmTransactionBase />, store);
+      expect(fetchEstimatedOptimismL1Fee).not.toHaveBeenCalled();
+    });
+
+    it('does not kick off a fresh request to fetch the L1 fee from Optimism when txData is updated', () => {
+      renderWithProvider(<ConfirmTransactionBase />, store);
+      store.dispatch(
+        updateTxData({
+          id: transactionId,
+          origin: 'something else',
+        }),
+      );
+      expect(fetchEstimatedOptimismL1Fee).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.test.js
@@ -84,6 +84,9 @@ describe('ConfirmTransactionBase', () => {
       txData: {
         id: transactionId,
         origin: 'something',
+        txParams: {
+          value: '0x0',
+        },
       },
     },
     metamask: {
@@ -172,12 +175,18 @@ describe('ConfirmTransactionBase', () => {
     });
 
     it('does not kick off a request to fetch the L1 fee from Optimism on mount', () => {
-      renderWithProvider(<ConfirmTransactionBase />, store);
+      renderWithProvider(
+        <ConfirmTransactionBase hexMaximumTransactionFee="0x1" />,
+        store,
+      );
       expect(fetchEstimatedOptimismL1Fee).not.toHaveBeenCalled();
     });
 
     it('does not kick off a fresh request to fetch the L1 fee from Optimism when txData is updated', () => {
-      renderWithProvider(<ConfirmTransactionBase />, store);
+      renderWithProvider(
+        <ConfirmTransactionBase hexMaximumTransactionFee="0x1" />,
+        store,
+      );
       store.dispatch(
         updateTxData({
           id: transactionId,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -251,8 +251,6 @@ export const transactionFeeSelector = function (state, txData) {
   const ethEstimatedL1Fee = conversionUtil(estimatedL1Fee, {
     fromNumericBase: 'BN',
     toNumericBase: 'dec',
-    fromDenomination: 'GWEI',
-    toDenomination: 'WEI',
   });
   const hexEstimatedL1Fee = addHexPrefix(
     conversionUtil(ethEstimatedL1Fee, {

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { addHexPrefix } from 'ethereumjs-util';
 import txHelper from '../helpers/utils/tx-helper';
 import { calcTokenAmount } from '../helpers/utils/token-util';
 import {
@@ -8,6 +9,7 @@ import {
   addFiat,
   addEth,
 } from '../helpers/utils/confirm-tx.util';
+import { conversionUtil } from '../../shared/modules/conversion.utils';
 import { sumHexes } from '../helpers/utils/transactions.util';
 import { transactionMatchesNetwork } from '../../shared/modules/transaction.utils';
 import {
@@ -26,6 +28,7 @@ import {
   getMinimumGasTotalInHexWei,
 } from '../../shared/modules/gas.utils';
 import { isEqualCaseInsensitive } from '../helpers/utils/util';
+import { getEstimatedOptimismL1Fee } from '../ducks/optimism';
 import { getAveragePriceEstimateInHexWEI } from './custom-gas';
 import { getCurrentChainId, deprecatedGetCurrentNetworkId } from './selectors';
 import { checkNetworkAndAccountSupports1559 } from '.';
@@ -244,6 +247,28 @@ export const transactionFeeSelector = function (state, txData) {
     state,
   );
 
+  const estimatedL1Fee = getEstimatedOptimismL1Fee(state);
+  const ethEstimatedL1Fee = conversionUtil(estimatedL1Fee, {
+    fromNumericBase: 'BN',
+    toNumericBase: 'dec',
+    fromDenomination: 'GWEI',
+    toDenomination: 'WEI',
+  });
+  const hexEstimatedL1Fee = addHexPrefix(
+    conversionUtil(ethEstimatedL1Fee, {
+      fromNumericBase: 'dec',
+      toNumericBase: 'hex',
+    }),
+  );
+  const fiatEstimatedL1Fee = conversionUtil(ethEstimatedL1Fee, {
+    fromNumericBase: 'dec',
+    toNumericBase: 'dec',
+    fromCurrency: nativeCurrency,
+    toCurrency: currentCurrency,
+    numberOfDecimals: 2,
+    conversionRate,
+  });
+
   const gasEstimationObject = {
     gasLimit: txData.txParams?.gas ?? '0x0',
   };
@@ -347,10 +372,19 @@ export const transactionFeeSelector = function (state, txData) {
 
   const fiatTransactionTotal = addFiat(
     fiatMinimumTransactionFee,
+    fiatEstimatedL1Fee,
     fiatTransactionAmount,
   );
-  const ethTransactionTotal = addEth(ethTransactionFee, ethTransactionAmount);
-  const hexTransactionTotal = sumHexes(value, hexMinimumTransactionFee);
+  const ethTransactionTotal = addEth(
+    ethTransactionFee,
+    ethTransactionAmount,
+    ethEstimatedL1Fee,
+  );
+  const hexTransactionTotal = sumHexes(
+    value,
+    hexMinimumTransactionFee,
+    hexEstimatedL1Fee,
+  );
 
   return {
     hexTransactionAmount: value,
@@ -358,6 +392,7 @@ export const transactionFeeSelector = function (state, txData) {
     ethTransactionAmount,
     hexMinimumTransactionFee,
     fiatMinimumTransactionFee,
+    hexEstimatedL1Fee,
     hexMaximumTransactionFee,
     fiatMaximumTransactionFee,
     ethTransactionFee,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -12,6 +12,7 @@ import {
   LEDGER_TRANSPORT_TYPES,
   TRANSPORT_STATES,
 } from '../../shared/constants/hardware-wallets';
+import { getIsOptimism } from '../ducks/optimism';
 
 import {
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
@@ -450,6 +451,10 @@ export function getShouldHideZeroBalanceTokens(state) {
 
 export function getAdvancedInlineGasShown(state) {
   return Boolean(state.metamask.featureFlags.advancedInlineGas);
+}
+
+export function getNetworkSupportsSettingGasPrice(state) {
+  return !getIsOptimism(state);
 }
 
 export function getUseNonceField(state) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,6 +2401,28 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@eth-optimism/contracts@0.0.0-2021919175625":
+  version "0.0.0-2021919175625"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.0.0-2021919175625.tgz#551ed5d98ac4405596e97f723c28ee6376e65546"
+  integrity sha512-vf/rH0lUk5TRvY7/Rq8jAYXfJvAixcgnYyHVPPBdPUdWlOPfnUx1bG5N1xfaBI/zKJ1zen5gsJW4zaM+rUVKsQ==
+  dependencies:
+    "@eth-optimism/core-utils" "^0.0.0-2021919175625"
+    "@ethersproject/abstract-provider" "^5.4.1"
+    "@ethersproject/abstract-signer" "^5.4.1"
+    "@ethersproject/contracts" "^5.4.1"
+    "@ethersproject/hardware-wallets" "^5.4.0"
+
+"@eth-optimism/core-utils@^0.0.0-2021919175625":
+  version "0.0.0-2021919175625"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.0.0-2021919175625.tgz#0769495b54d797b313c55ef84c6f8d9bd3227374"
+  integrity sha512-2AGVJKEILtbyVAxzAhtrJPDK2aIg5PmCFs1h5zGZgV5/NpygTWjMF2fq4gcGy9qW54ofChrLHdMqCOXKZuZCsQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.1"
+    "@ethersproject/providers" "^5.4.5"
+    chai "^4.3.4"
+    ethers "^5.4.5"
+    lodash "^4.17.21"
+
 "@ethereumjs/common@^2.3.1", "@ethereumjs/common@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.4.0.tgz#2d67f6e6ba22246c5c89104e6b9a119fb3039766"
@@ -2447,6 +2469,36 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@ethersproject/abi@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.1.tgz#6ac28fafc9ef6f5a7a37e30356a2eb31fa05d39b"
+  integrity sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/abi@5.5.0", "@ethersproject/abi@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.5.0.tgz#fb52820e22e50b854ff15ce1647cc508d6660613"
+  integrity sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==
+  dependencies:
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
 "@ethersproject/abstract-provider@5.4.0", "@ethersproject/abstract-provider@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz#415331031b0f678388971e1987305244edc04e1d"
@@ -2460,7 +2512,7 @@
     "@ethersproject/transactions" "^5.4.0"
     "@ethersproject/web" "^5.4.0"
 
-"@ethersproject/abstract-provider@5.4.1":
+"@ethersproject/abstract-provider@5.4.1", "@ethersproject/abstract-provider@^5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
   integrity sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==
@@ -2472,6 +2524,19 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/transactions" "^5.4.0"
     "@ethersproject/web" "^5.4.0"
+
+"@ethersproject/abstract-provider@5.5.1", "@ethersproject/abstract-provider@^5.5.0":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
+  integrity sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/networks" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/web" "^5.5.0"
 
 "@ethersproject/abstract-provider@^5.0.4":
   version "5.0.5"
@@ -2497,7 +2562,7 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
 
-"@ethersproject/abstract-signer@5.4.1":
+"@ethersproject/abstract-signer@5.4.1", "@ethersproject/abstract-signer@^5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz#e4e9abcf4dd4f1ba0db7dff9746a5f78f355ea81"
   integrity sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==
@@ -2507,6 +2572,17 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/abstract-signer@5.5.0", "@ethersproject/abstract-signer@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
+  integrity sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
 
 "@ethersproject/abstract-signer@^5.0.6":
   version "5.0.7"
@@ -2530,6 +2606,17 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/rlp" "^5.4.0"
 
+"@ethersproject/address@5.5.0", "@ethersproject/address@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
+  integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+
 "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.5.tgz#2caa65f6b7125015395b1b54c985ee0b27059cc7"
@@ -2549,6 +2636,13 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
 
+"@ethersproject/base64@5.5.0", "@ethersproject/base64@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
+  integrity sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+
 "@ethersproject/base64@^5.0.3":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.0.4.tgz#b0d8fdbf3dda977cf546dcd35725a7b1d5256caa"
@@ -2564,6 +2658,14 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
 
+"@ethersproject/basex@5.5.0", "@ethersproject/basex@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.5.0.tgz#e40a53ae6d6b09ab4d977bd037010d4bed21b4d3"
+  integrity sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+
 "@ethersproject/bignumber@5.4.1", "@ethersproject/bignumber@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.1.tgz#64399d3b9ae80aa83d483e550ba57ea062c1042d"
@@ -2571,6 +2673,24 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bignumber@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.2.tgz#44232e015ae4ce82ac034de549eb3583c71283d8"
+  integrity sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.5.0.tgz#875b143f04a216f4f8b96245bde942d42d279527"
+  integrity sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
 "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.0.8":
@@ -2588,6 +2708,13 @@
   integrity sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==
   dependencies:
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/bytes@5.5.0", "@ethersproject/bytes@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
+  integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
 
 "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.4":
   version "5.0.5"
@@ -2609,6 +2736,13 @@
   integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
   dependencies:
     "@ethersproject/bignumber" "^5.4.0"
+
+"@ethersproject/constants@5.5.0", "@ethersproject/constants@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
+  integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
 
 "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.0.4":
   version "5.0.5"
@@ -2633,7 +2767,7 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/transactions" "^5.4.0"
 
-"@ethersproject/contracts@5.4.1":
+"@ethersproject/contracts@5.4.1", "@ethersproject/contracts@^5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.4.1.tgz#3eb4f35b7fe60a962a75804ada2746494df3e470"
   integrity sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==
@@ -2649,6 +2783,34 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/transactions" "^5.4.0"
 
+"@ethersproject/contracts@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.5.0.tgz#b735260d4bd61283a670a82d5275e2a38892c197"
+  integrity sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==
+  dependencies:
+    "@ethersproject/abi" "^5.5.0"
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+
+"@ethersproject/hardware-wallets@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hardware-wallets/-/hardware-wallets-5.4.0.tgz#bce275b395e26b6f50481095331157614490a473"
+  integrity sha512-Ea4ymm4etZoSWy93OcEGZkuVqyYdl/RjMlaXY6yQIYjsGi75sm4apbTiBA8DA9uajkv1FVakJZEBBTaVGgnBLA==
+  dependencies:
+    "@ledgerhq/hw-app-eth" "5.27.2"
+    "@ledgerhq/hw-transport" "5.26.0"
+    "@ledgerhq/hw-transport-u2f" "5.26.0"
+    ethers "^5.4.0"
+  optionalDependencies:
+    "@ledgerhq/hw-transport-node-hid" "5.26.0"
+
 "@ethersproject/hash@5.4.0", "@ethersproject/hash@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
@@ -2662,6 +2824,20 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/hash@5.5.0", "@ethersproject/hash@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
+  integrity sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
 
 "@ethersproject/hash@>=5.0.0-beta.128":
   version "5.0.6"
@@ -2695,6 +2871,24 @@
     "@ethersproject/transactions" "^5.4.0"
     "@ethersproject/wordlists" "^5.4.0"
 
+"@ethersproject/hdnode@5.5.0", "@ethersproject/hdnode@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.5.0.tgz#4a04e28f41c546f7c978528ea1575206a200ddf6"
+  integrity sha512-mcSOo9zeUg1L0CoJH7zmxwUG5ggQHU1UrRf8jyTYy6HxdZV+r0PBoL1bxr+JHIPXRzS6u/UW4mEn43y0tmyF8Q==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/basex" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/pbkdf2" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/signing-key" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/wordlists" "^5.5.0"
+
 "@ethersproject/json-wallets@5.4.0", "@ethersproject/json-wallets@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz#2583341cfe313fc9856642e8ace3080154145e95"
@@ -2714,6 +2908,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.5.0", "@ethersproject/json-wallets@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz#dd522d4297e15bccc8e1427d247ec8376b60e325"
+  integrity sha512-9lA21XQnCdcS72xlBn1jfQdj2A1VUxZzOzi9UkNdnokNKke/9Ya2xA9aIK1SC3PQyBDLt4C+dfps7ULpkvKikQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/hdnode" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/pbkdf2" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.4.0", "@ethersproject/keccak256@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.4.0.tgz#7143b8eea4976080241d2bd92e3b1f1bf7025318"
@@ -2721,6 +2934,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
     js-sha3 "0.5.7"
+
+"@ethersproject/keccak256@5.5.0", "@ethersproject/keccak256@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
+  integrity sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    js-sha3 "0.8.0"
 
 "@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.0.3":
   version "5.0.4"
@@ -2734,6 +2955,16 @@
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.0.tgz#f39adadf62ad610c420bcd156fd41270e91b3ca9"
   integrity sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==
+
+"@ethersproject/logger@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.1.tgz#503bd33683538b923c578c07d1c2c0dd18672054"
+  integrity sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==
+
+"@ethersproject/logger@5.5.0", "@ethersproject/logger@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
+  integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
 
 "@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.0.5":
   version "5.0.6"
@@ -2759,6 +2990,13 @@
   dependencies:
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/networks@5.5.0", "@ethersproject/networks@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.0.tgz#babec47cab892c51f8dd652ce7f2e3e14283981a"
+  integrity sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/networks@^5.0.3":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.0.4.tgz#6d320a5e15a0cda804f5da88be0ba846156f6eec"
@@ -2774,12 +3012,34 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/sha2" "^5.4.0"
 
+"@ethersproject/pbkdf2@5.5.0", "@ethersproject/pbkdf2@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz#e25032cdf02f31505d47afbf9c3e000d95c4a050"
+  integrity sha512-SaDvQFvXPnz1QGpzr6/HToLifftSXGoXrbpZ6BvoZhmx4bNLHrxDe8MZisuecyOziP1aVEwzC2Hasj+86TgWVg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+
 "@ethersproject/properties@5.4.0", "@ethersproject/properties@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.0.tgz#38ba20539b44dcc5d5f80c45ad902017dcdbefe7"
   integrity sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==
   dependencies:
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/properties@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.1.tgz#9f051f976ce790142c6261ccb7b826eaae1f2f36"
+  integrity sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/properties@5.5.0", "@ethersproject/properties@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
+  integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
 
 "@ethersproject/properties@>=5.0.0-beta.131", "@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.0.4":
   version "5.0.4"
@@ -2820,10 +3080,10 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/providers@5.4.3":
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.3.tgz#4cd7ccd9e12bc3875b33df8b24abf735663958a5"
-  integrity sha512-VURwkaWPoUj7jq9NheNDT5Iyy64Qcyf6BOFDwVdHsmLmX/5prNjFrgSX3GHPE4z1BRrVerDxe2yayvXKFm/NNg==
+"@ethersproject/providers@5.4.5", "@ethersproject/providers@^5.4.5":
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.5.tgz#eb2ea2a743a8115f79604a8157233a3a2c832928"
+  integrity sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==
   dependencies:
     "@ethersproject/abstract-provider" "^5.4.0"
     "@ethersproject/abstract-signer" "^5.4.0"
@@ -2845,6 +3105,31 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.0.tgz#bc2876a8fe5e0053ed9828b1f3767ae46e43758b"
+  integrity sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/basex" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/networks" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/web" "^5.5.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.4.0", "@ethersproject/random@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.4.0.tgz#9cdde60e160d024be39cc16f8de3b9ce39191e16"
@@ -2853,6 +3138,14 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/random@5.5.0", "@ethersproject/random@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.0.tgz#305ed9e033ca537735365ac12eed88580b0f81f9"
+  integrity sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/rlp@5.4.0", "@ethersproject/rlp@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.4.0.tgz#de61afda5ff979454e76d3b3310a6c32ad060931"
@@ -2860,6 +3153,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/rlp@5.5.0", "@ethersproject/rlp@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
+  integrity sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
 
 "@ethersproject/rlp@^5.0.3":
   version "5.0.4"
@@ -2878,6 +3179,15 @@
     "@ethersproject/logger" "^5.4.0"
     hash.js "1.1.7"
 
+"@ethersproject/sha2@5.5.0", "@ethersproject/sha2@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
+  integrity sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    hash.js "1.1.7"
+
 "@ethersproject/signing-key@5.4.0", "@ethersproject/signing-key@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.4.0.tgz#2f05120984e81cf89a3d5f6dec5c68ee0894fbec"
@@ -2886,6 +3196,18 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.5.0", "@ethersproject/signing-key@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"
+  integrity sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
     bn.js "^4.11.9"
     elliptic "6.5.4"
     hash.js "1.1.7"
@@ -2911,6 +3233,18 @@
     "@ethersproject/sha2" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@ethersproject/solidity@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.5.0.tgz#2662eb3e5da471b85a20531e420054278362f93f"
+  integrity sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
 "@ethersproject/strings@5.4.0", "@ethersproject/strings@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
@@ -2919,6 +3253,15 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/constants" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/strings@5.5.0", "@ethersproject/strings@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.5.0.tgz#e6784d00ec6c57710755699003bc747e98c5d549"
+  integrity sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
 
 "@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.0.4":
   version "5.0.5"
@@ -2944,6 +3287,21 @@
     "@ethersproject/rlp" "^5.4.0"
     "@ethersproject/signing-key" "^5.4.0"
 
+"@ethersproject/transactions@5.5.0", "@ethersproject/transactions@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.5.0.tgz#7e9bf72e97bcdf69db34fe0d59e2f4203c7a2908"
+  integrity sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==
+  dependencies:
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/signing-key" "^5.5.0"
+
 "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.0.5":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.0.6.tgz#b8b27938be6e9ed671dbdd35fe98af8b14d0df7c"
@@ -2968,6 +3326,15 @@
     "@ethersproject/constants" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/units@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.5.0.tgz#104d02db5b5dc42cc672cc4587bafb87a95ee45e"
+  integrity sha512-7+DpjiZk4v6wrikj+TCyWWa9dXLNU73tSTa7n0TSJDxkYbV3Yf1eRh9ToMLlZtuctNYu9RDNNy2USq3AdqSbag==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/wallet@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.4.0.tgz#fa5b59830b42e9be56eadd45a16a2e0933ad9353"
@@ -2989,6 +3356,27 @@
     "@ethersproject/transactions" "^5.4.0"
     "@ethersproject/wordlists" "^5.4.0"
 
+"@ethersproject/wallet@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.5.0.tgz#322a10527a440ece593980dca6182f17d54eae75"
+  integrity sha512-Mlu13hIctSYaZmUOo7r2PhNSd8eaMPVXe1wxrz4w4FCE4tDYBywDH+bAR1Xz2ADyXGwqYMwstzTrtUVIsKDO0Q==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/hdnode" "^5.5.0"
+    "@ethersproject/json-wallets" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/signing-key" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/wordlists" "^5.5.0"
+
 "@ethersproject/web@5.4.0", "@ethersproject/web@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.4.0.tgz#49fac173b96992334ed36a175538ba07a7413d1f"
@@ -2999,6 +3387,17 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/web@5.5.0", "@ethersproject/web@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.0.tgz#0e5bb21a2b58fb4960a705bfc6522a6acf461e28"
+  integrity sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==
+  dependencies:
+    "@ethersproject/base64" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
 
 "@ethersproject/web@^5.0.6":
   version "5.0.9"
@@ -3021,6 +3420,17 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/wordlists@5.5.0", "@ethersproject/wordlists@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.5.0.tgz#aac74963aa43e643638e5172353d931b347d584f"
+  integrity sha512-bL0UTReWDiaQJJYOC9sh/XcRu/9i2jMrzf8VLRmPKx58ckSlOJiohODkECCO50dtLZHcGU6MLXQ4OOrgBwP77Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
 
 "@formatjs/intl-relativetimeformat@^5.2.6":
   version "5.2.6"
@@ -3563,6 +3973,97 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@lavamoat/preinstall-always-fail/-/preinstall-always-fail-1.0.0.tgz#e78a6e3d9e212a4fef869ec37d4f5fb498dea373"
   integrity sha512-vD2DcC0ffJj1w2y1Lu0OU39wHmlPEd2tCDW04Bm6Kf4LyRnCHCezTsS8yzeSJ+4so7XP+TITuR5FGJRWxPb+GA==
+
+"@ledgerhq/cryptoassets@^5.27.2":
+  version "5.53.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.53.0.tgz#11dcc93211960c6fd6620392e4dd91896aaabe58"
+  integrity sha512-M3ibc3LRuHid5UtL7FI3IC6nMEppvly98QHFoSa7lJU0HDzQxY6zHec/SPM4uuJUC8sXoGVAiRJDkgny54damw==
+  dependencies:
+    invariant "2"
+
+"@ledgerhq/devices@^5.26.0", "@ledgerhq/devices@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.51.1.tgz#d741a4a5d8f17c2f9d282fd27147e6fe1999edb7"
+  integrity sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==
+  dependencies:
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/logs" "^5.50.0"
+    rxjs "6"
+    semver "^7.3.5"
+
+"@ledgerhq/errors@^5.26.0", "@ledgerhq/errors@^5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.50.0.tgz#e3a6834cb8c19346efca214c1af84ed28e69dad9"
+  integrity sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==
+
+"@ledgerhq/hw-app-eth@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.27.2.tgz#65a2ed613a69340e0cd69c942147455ec513d006"
+  integrity sha512-llNdrE894cCN8j6yxJEUniciyLVcLmu5N0UmIJLOObztG+5rOF4bX54h4SreTWK+E10Z0CzHSeyE5Lz/tVcqqQ==
+  dependencies:
+    "@ledgerhq/cryptoassets" "^5.27.2"
+    "@ledgerhq/errors" "^5.26.0"
+    "@ledgerhq/hw-transport" "^5.26.0"
+    bignumber.js "^9.0.1"
+    rlp "^2.2.6"
+
+"@ledgerhq/hw-transport-node-hid-noevents@^5.26.0":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-5.51.1.tgz#71f37f812e448178ad0bcc2258982150d211c1ab"
+  integrity sha512-9wFf1L8ZQplF7XOY2sQGEeOhpmBRzrn+4X43kghZ7FBDoltrcK+s/D7S+7ffg3j2OySyP6vIIIgloXylao5Scg==
+  dependencies:
+    "@ledgerhq/devices" "^5.51.1"
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/hw-transport" "^5.51.1"
+    "@ledgerhq/logs" "^5.50.0"
+    node-hid "2.1.1"
+
+"@ledgerhq/hw-transport-node-hid@5.26.0":
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.26.0.tgz#69bc4f8067cdd9c09ef4aed0e0b3c58328936e4b"
+  integrity sha512-qhaefZVZatJ6UuK8Wb6WSFNOLWc2mxcv/xgsfKi5HJCIr4bPF/ecIeN+7fRcEaycxj4XykY6Z4A7zDVulfFH4w==
+  dependencies:
+    "@ledgerhq/devices" "^5.26.0"
+    "@ledgerhq/errors" "^5.26.0"
+    "@ledgerhq/hw-transport" "^5.26.0"
+    "@ledgerhq/hw-transport-node-hid-noevents" "^5.26.0"
+    "@ledgerhq/logs" "^5.26.0"
+    lodash "^4.17.20"
+    node-hid "1.3.0"
+    usb "^1.6.3"
+
+"@ledgerhq/hw-transport-u2f@5.26.0":
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.26.0.tgz#b7d9d13193eb82b051fd7a838cd652372f907ec5"
+  integrity sha512-QTxP1Rsh+WZ184LUOelYVLeaQl3++V3I2jFik+l9JZtakwEHjD0XqOT750xpYNL/vfHsy31Wlz+oicdxGzFk+w==
+  dependencies:
+    "@ledgerhq/errors" "^5.26.0"
+    "@ledgerhq/hw-transport" "^5.26.0"
+    "@ledgerhq/logs" "^5.26.0"
+    u2f-api "0.2.7"
+
+"@ledgerhq/hw-transport@5.26.0":
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.26.0.tgz#bfedc3d48400ad2fe48278d9444344b72aa9d0fe"
+  integrity sha512-NFeJOJmyEfAX8uuIBTpocWHcz630sqPcXbu864Q+OCBm4EK5UOKV1h/pX7e0xgNIKY8zhJ/O4p4cIZp9tnXLHQ==
+  dependencies:
+    "@ledgerhq/devices" "^5.26.0"
+    "@ledgerhq/errors" "^5.26.0"
+    events "^3.2.0"
+
+"@ledgerhq/hw-transport@^5.26.0", "@ledgerhq/hw-transport@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz#8dd14a8e58cbee4df0c29eaeef983a79f5f22578"
+  integrity sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==
+  dependencies:
+    "@ledgerhq/devices" "^5.51.1"
+    "@ledgerhq/errors" "^5.50.0"
+    events "^3.3.0"
+
+"@ledgerhq/logs@^5.26.0", "@ledgerhq/logs@^5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
+  integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
 "@material-ui/core@^4.11.0":
   version "4.11.0"
@@ -6771,6 +7272,11 @@ assertion-error@^1.0.1:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
   integrity sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -8024,6 +8530,15 @@ bl@^3.0.0:
   dependencies:
     readable-stream "^3.0.1"
 
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 "blake2b-wasm@https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b":
   version "2.0.0"
   resolved "https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b"
@@ -8076,6 +8591,11 @@ bn.js@^5.1.1, bn.js@^5.1.2:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
+
+bn.js@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 bo-selector@0.0.10:
   version "0.0.10"
@@ -8970,6 +9490,18 @@ chai-checkmark@^1.0.1:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
+chai@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
+  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chain-function@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
@@ -9054,6 +9586,11 @@ charenc@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 checkpoint-store@^1.1.0:
   version "1.1.0"
@@ -10514,6 +11051,13 @@ decompress-response@^3.2.0, decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -10525,6 +11069,13 @@ deep-eql@^0.1.3:
   integrity sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=
   dependencies:
     type-detect "0.1.1"
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-equal@^1.0.0, deep-equal@^1.0.1, deep-equal@^1.1.0:
   version "1.1.1"
@@ -10842,7 +11393,7 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -12901,18 +13452,18 @@ ethers@^5.0.8, ethers@^5.4.1:
     "@ethersproject/web" "5.4.0"
     "@ethersproject/wordlists" "5.4.0"
 
-ethers@^5.4.2:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.4.tgz#35cce530505b84c699da944162195cfb3f894947"
-  integrity sha512-zaTs8yaDjfb0Zyj8tT6a+/hEkC+kWAA350MWRp6yP5W7NdGcURRPMOpOU+6GtkfxV9wyJEShWesqhE/TjdqpMA==
+ethers@^5.4.0, ethers@^5.4.5:
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.7.tgz#0fd491a5da7c9793de2d6058d76b41b1e7efba8f"
+  integrity sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==
   dependencies:
-    "@ethersproject/abi" "5.4.0"
+    "@ethersproject/abi" "5.4.1"
     "@ethersproject/abstract-provider" "5.4.1"
     "@ethersproject/abstract-signer" "5.4.1"
     "@ethersproject/address" "5.4.0"
     "@ethersproject/base64" "5.4.0"
     "@ethersproject/basex" "5.4.0"
-    "@ethersproject/bignumber" "5.4.1"
+    "@ethersproject/bignumber" "5.4.2"
     "@ethersproject/bytes" "5.4.0"
     "@ethersproject/constants" "5.4.0"
     "@ethersproject/contracts" "5.4.1"
@@ -12920,11 +13471,11 @@ ethers@^5.4.2:
     "@ethersproject/hdnode" "5.4.0"
     "@ethersproject/json-wallets" "5.4.0"
     "@ethersproject/keccak256" "5.4.0"
-    "@ethersproject/logger" "5.4.0"
+    "@ethersproject/logger" "5.4.1"
     "@ethersproject/networks" "5.4.2"
     "@ethersproject/pbkdf2" "5.4.0"
-    "@ethersproject/properties" "5.4.0"
-    "@ethersproject/providers" "5.4.3"
+    "@ethersproject/properties" "5.4.1"
+    "@ethersproject/providers" "5.4.5"
     "@ethersproject/random" "5.4.0"
     "@ethersproject/rlp" "5.4.0"
     "@ethersproject/sha2" "5.4.0"
@@ -12936,6 +13487,42 @@ ethers@^5.4.2:
     "@ethersproject/wallet" "5.4.0"
     "@ethersproject/web" "5.4.0"
     "@ethersproject/wordlists" "5.4.0"
+
+ethers@^5.4.2:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.1.tgz#d3259a95a42557844aa543906c537106c0406fbf"
+  integrity sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==
+  dependencies:
+    "@ethersproject/abi" "5.5.0"
+    "@ethersproject/abstract-provider" "5.5.1"
+    "@ethersproject/abstract-signer" "5.5.0"
+    "@ethersproject/address" "5.5.0"
+    "@ethersproject/base64" "5.5.0"
+    "@ethersproject/basex" "5.5.0"
+    "@ethersproject/bignumber" "5.5.0"
+    "@ethersproject/bytes" "5.5.0"
+    "@ethersproject/constants" "5.5.0"
+    "@ethersproject/contracts" "5.5.0"
+    "@ethersproject/hash" "5.5.0"
+    "@ethersproject/hdnode" "5.5.0"
+    "@ethersproject/json-wallets" "5.5.0"
+    "@ethersproject/keccak256" "5.5.0"
+    "@ethersproject/logger" "5.5.0"
+    "@ethersproject/networks" "5.5.0"
+    "@ethersproject/pbkdf2" "5.5.0"
+    "@ethersproject/properties" "5.5.0"
+    "@ethersproject/providers" "5.5.0"
+    "@ethersproject/random" "5.5.0"
+    "@ethersproject/rlp" "5.5.0"
+    "@ethersproject/sha2" "5.5.0"
+    "@ethersproject/signing-key" "5.5.0"
+    "@ethersproject/solidity" "5.5.0"
+    "@ethersproject/strings" "5.5.0"
+    "@ethersproject/transactions" "5.5.0"
+    "@ethersproject/units" "5.5.0"
+    "@ethersproject/wallet" "5.5.0"
+    "@ethersproject/web" "5.5.0"
+    "@ethersproject/wordlists" "5.5.0"
 
 ethjs-abi@0.2.0:
   version "0.2.0"
@@ -13193,6 +13780,11 @@ events@^3.0.0, events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -13310,6 +13902,11 @@ expand-range@^1.8.1:
   integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
   dependencies:
     fill-range "^2.1.0"
+
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
@@ -14513,6 +15110,11 @@ get-folder-size@^2.0.0:
     gar "^1.0.4"
     tiny-each-async "2.0.3"
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -14611,6 +15213,11 @@ git-url-parse@^11.1.2:
   integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
   dependencies:
     git-up "^4.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
 github-slugger@^1.0.0:
   version "1.4.0"
@@ -16143,7 +16750,7 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-invariant@2.2.4, invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@2, invariant@2.2.4, invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -18045,6 +18652,11 @@ js-sha3@0.5.7, js-sha3@^0.5.7:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
+js-sha3@0.8.0, js-sha3@^0.8.0, js-sha3@~0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 js-sha3@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.6.1.tgz#5b89f77a7477679877f58c4a075240934b1f95c0"
@@ -18054,11 +18666,6 @@ js-sha3@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.7.0.tgz#0a5c57b36f79882573b2d84051f8bb85dd1bd63a"
   integrity sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==
-
-js-sha3@^0.8.0, js-sha3@~0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
 js-string-escape@^1.0.1:
   version "1.0.1"
@@ -20514,6 +21121,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -20649,7 +21261,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp-classic@^0.5.2:
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
@@ -21126,6 +21738,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+
 napi-macros@~1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-1.8.2.tgz#299265c1d8aa401351ad0675107d751228c03eda"
@@ -21247,10 +21864,27 @@ nock@^9.0.14:
     qs "^6.5.1"
     semver "^5.3.0"
 
+node-abi@^2.18.0, node-abi@^2.21.0, node-abi@^2.7.0:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.30.1.tgz#c437d4b1fe0e285aaf290d45b45d4d7afedac4cf"
+  integrity sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==
+  dependencies:
+    semver "^5.4.1"
+
 node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
+node-addon-api@^3.0.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-addon-api@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.2.0.tgz#117cbb5a959dff0992e1c586ae0393573e4d2a87"
+  integrity sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q==
 
 node-dir@^0.1.10:
   version "0.1.17"
@@ -21295,6 +21929,11 @@ node-gyp-build@^4.2.0, node-gyp-build@^4.2.3:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
+node-gyp-build@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+
 node-gyp-build@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.7.0.tgz#daa77a4f547b9aed3e2aac779eaf151afd60ec8d"
@@ -21325,6 +21964,25 @@ node-gyp@^7.1.0:
     semver "^7.3.2"
     tar "^6.0.2"
     which "^2.0.2"
+
+node-hid@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-1.3.0.tgz#346a468505cee13d69ccd760052cbaf749f66a41"
+  integrity sha512-BA6G4V84kiNd1uAChub/Z/5s/xS3EHBCxotQ0nyYrUG65mXewUDHE1tWOSqA2dp3N+mV0Ffq9wo2AW9t4p/G7g==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.14.0"
+    node-abi "^2.18.0"
+    prebuild-install "^5.3.4"
+
+node-hid@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-2.1.1.tgz#f83c8aa0bb4e6758b5f7383542477da93f67359d"
+  integrity sha512-Skzhqow7hyLZU93eIPthM9yjot9lszg9xrKxESleEs05V2NcbUptZc5HFqzjOkSmL0sFlZFr3kmvaYebx06wrw==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^3.0.2"
+    prebuild-install "^6.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -21476,6 +22134,11 @@ nonce-tracker@^1.0.0:
     await-semaphore "^0.1.3"
     ethjs-query "^0.3.8"
 
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
+  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -21585,7 +22248,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -22830,6 +23493,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
@@ -23414,6 +24082,46 @@ postmsg-rpc@^2.4.0:
   integrity sha512-adGH2zGSxhCUOfUfAXdRn4tgZVWauaSP2X8on+g7uBA45sxkzORL1oia95eXZtcZk5Sp4JTZmDFOTe+D24avBQ==
   dependencies:
     shortid "^2.2.8"
+
+prebuild-install@^5.3.4:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
+  integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^2.7.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
+prebuild-install@^6.0.0:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.4.tgz#ae3c0142ad611d58570b89af4986088a4937e00f"
+  integrity sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^2.21.0"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
 
 precinct@^8.0.0:
   version "8.1.0"
@@ -25776,6 +26484,13 @@ rlp@^2.0.0, rlp@^2.2.1, rlp@^2.2.2, rlp@^2.2.3, rlp@^2.2.4:
   dependencies:
     bn.js "^4.11.1"
 
+rlp@^2.2.6:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.7.tgz#33f31c4afac81124ac4b283e2bd4d9720b30beaf"
+  integrity sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==
+  dependencies:
+    bn.js "^5.2.0"
+
 rn-host-detect@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rn-host-detect/-/rn-host-detect-1.2.0.tgz#8b0396fc05631ec60c1cb8789e5070cdb04d0da0"
@@ -25883,6 +26598,13 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
   integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
+
+rxjs@6:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
 
 rxjs@^6.4.0, rxjs@^6.5.2:
   version "6.5.4"
@@ -26509,6 +27231,15 @@ simple-get@^2.7.0:
   integrity sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==
   dependencies:
     decompress-response "^3.3.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
+  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
+  dependencies:
+    decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -27813,12 +28544,33 @@ tape@^4.6.3, tape@^4.8.0:
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
 tar-stream@^2.0.0, tar-stream@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.0.tgz#d1aaa3661f05b38b5acc9b7020efdca5179a2cc3"
   integrity sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==
   dependencies:
     bl "^3.0.0"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
     end-of-stream "^1.4.1"
     fs-constants "^1.0.0"
     inherits "^2.0.3"
@@ -28506,7 +29258,7 @@ type-detect@0.1.1:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
   integrity sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
 
-type-detect@4.0.8, type-detect@^4.0.8:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -28592,6 +29344,11 @@ typical@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-5.1.0.tgz#7116ca103caf2574985fc84fbaa8fd0ee5ea1684"
   integrity sha512-t5Ik8UAwBal1P1XzuVE4dc+RYQZicLUGJdvqr/vdqsED7SQECgsGBylldSsfWZL7RQjxT3xhQcKHWhLaVSR6YQ==
+
+u2f-api@0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
+  integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
 
 uint8arrays@1.1.0:
   version "1.1.0"
@@ -29014,6 +29771,14 @@ ursa-optional@~0.9.10:
   dependencies:
     bindings "^1.3.0"
     nan "^2.11.1"
+
+usb@^1.6.3:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-1.8.0.tgz#aec44c61558e618c699a2cbd31c86e3dc7f64d87"
+  integrity sha512-lA0q2tjDEAq1YUsW6nQ+asw92TtFrQ8rhMd11jAoFhK3xItZUupJ7npZDSmVOpQqQhhdFmX/YciqyywupA/wOQ==
+  dependencies:
+    node-addon-api "^4.2.0"
+    node-gyp-build "^4.3.0"
 
 use-composed-ref@^1.0.0:
   version "1.1.0"
@@ -30043,6 +30808,11 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which-typed-array@^1.1.2:
   version "1.1.4"


### PR DESCRIPTION
Adds support for these changes: https://community.optimism.io/docs/developers/l2/new-fees.html#for-frontend-and-wallet-developers

TODO:

- [x] Get the smart contract call working
- [x] Actually show the fee on the confirm screen
- [x] Total the L1 and L2 fee ourselves to come up with an augmented total and show that
- ~~[ ] Figure out a better way to check for Optimism without actually checking for Optimism (or put the check in a more central place)~~
- [ ] Resolved other TODOs I've left as comments