### PR TITLE
Make showFiatInTestnets only apply to known Testnets, not all non-mainnet networks

### DIFF
--- a/test/e2e/tests/send-edit.spec.js
+++ b/test/e2e/tests/send-edit.spec.js
@@ -34,7 +34,7 @@ describe('Editing Confirm Transaction', function () {
         const transactionAmount = transactionAmounts[0];
         assert.equal(await transactionAmount.getText(), '1');
 
-        const transactionFee = transactionAmounts[1];
+        const transactionFee = transactionAmounts[3];
         assert.equal(await transactionFee.getText(), '0.00025');
 
         await driver.clickElement(
@@ -62,12 +62,12 @@ describe('Editing Confirm Transaction', function () {
 
         // has correct updated value on the confirm screen the transaction
         const editedTransactionAmounts = await driver.findElements(
-          '.transaction-detail-item__row .transaction-detail-item__detail-text .currency-display-component__text',
+          '.currency-display-component__text',
         );
-        const editedTransactionAmount = editedTransactionAmounts[0];
+        const editedTransactionAmount = editedTransactionAmounts[3];
         assert.equal(await editedTransactionAmount.getText(), '0.0008');
 
-        const editedTransactionFee = editedTransactionAmounts[1];
+        const editedTransactionFee = editedTransactionAmounts[6];
         assert.equal(await editedTransactionFee.getText(), '2.2008');
 
         // confirms the transaction

--- a/ui/components/ui/currency-input/currency-input.container.test.js
+++ b/ui/components/ui/currency-input/currency-input.container.test.js
@@ -52,6 +52,7 @@ describe('CurrencyInput container', () => {
             },
             provider: {
               type: 'rinkeby',
+              chainId: '0x4',
             },
           },
         },
@@ -76,6 +77,7 @@ describe('CurrencyInput container', () => {
             },
             provider: {
               type: 'rinkeby',
+              chainId: '0x4',
             },
           },
         },
@@ -96,10 +98,11 @@ describe('CurrencyInput container', () => {
             currentCurrency: 'usd',
             nativeCurrency: 'ETH',
             preferences: {
-              showFiatInTestnets: true,
+              showFiatInTestnets: false,
             },
             provider: {
               type: 'mainnet',
+              chainId: '0x1',
             },
           },
         },
@@ -108,6 +111,54 @@ describe('CurrencyInput container', () => {
           currentCurrency: 'usd',
           nativeCurrency: 'ETH',
           hideFiat: false,
+        },
+      },
+      {
+        comment:
+          'should return correct props when on custom network (not mainnet or known testnet) and showFiatInTestnets is false',
+        mockState: {
+          metamask: {
+            conversionRate: 280.45,
+            currentCurrency: 'usd',
+            nativeCurrency: 'BSC',
+            preferences: {
+              showFiatInTestnets: false,
+            },
+            provider: {
+              type: 'custom',
+              chainId: '0x38',
+            },
+          },
+        },
+        expected: {
+          conversionRate: 280.45,
+          currentCurrency: 'usd',
+          nativeCurrency: 'BSC',
+          hideFiat: false,
+        },
+      },
+      {
+        comment:
+          'should return correct props when on custom network (not mainnet or known testnet) and showFiatInTestnets is false and conversionRate is null',
+        mockState: {
+          metamask: {
+            conversionRate: null,
+            currentCurrency: 'usd',
+            nativeCurrency: 'BSC',
+            preferences: {
+              showFiatInTestnets: false,
+            },
+            provider: {
+              type: 'custom',
+              chainId: '0x38',
+            },
+          },
+        },
+        expected: {
+          conversionRate: null,
+          currentCurrency: 'usd',
+          nativeCurrency: 'BSC',
+          hideFiat: true,
         },
       },
     ];

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -421,10 +421,10 @@ export function getPreferences({ metamask }) {
 }
 
 export function getShouldShowFiat(state) {
-  const isMainNet = getIsMainnet(state);
+  const isTestNet = getIsTestnet(state);
   const conversionRate = getConversionRate(state);
   const { showFiatInTestnets } = getPreferences(state);
-  return Boolean((isMainNet || showFiatInTestnets) && conversionRate);
+  return Boolean((!isTestNet || showFiatInTestnets) && conversionRate);
 }
 
 export function getShouldHideZeroBalanceTokens(state) {


### PR DESCRIPTION
Fixes: #12119

Explanation: For a long time there has been a setting/preference called showFiatInTestNets corresponding to 
<img width="396" alt="Screen Shot 2021-10-19 at 5 15 05 PM" src="https://user-images.githubusercontent.com/34557516/137998105-39543d5b-4c97-42f8-8093-648d55fac08a.png">
in advanced settings.

I've raised and [discussed](https://consensys.slack.com/archives/G1L7H42BT/p1631727338156600) the fact that this setting actually applies to all non-mainnet networks. Its not a large code change so I thought I'd just make it. But I still think we need to be very careful here. While this makes the setting actually do what it claims to do, it reinforces a potentially problematic pattern where we are showing users fiat (or whatever secondary currency they choose) conversion rates for networks purely on the basis of a string match against the user (or API) input value for currency symbol in the network form, which is vulnerable to user error and malicious usages of the `addCustomRpc` method:
<img width="367" alt="Screen Shot 2021-10-19 at 5 20 54 PM" src="https://user-images.githubusercontent.com/34557516/137998640-290f62ff-7f96-4a67-b731-8e115842fa2b.png">
This problem already exists if a user has the preference toggled on but this change would impose it on all users. I'm probably missing some parts of the picture here but wanted to re-raise the topic.
