### PR TITLE
Onboarding V2 Cleanups

### DIFF
--- a/ui/components/app/step-progress-bar/index.scss
+++ b/ui/components/app/step-progress-bar/index.scss
@@ -3,6 +3,7 @@
   display: flex;
   justify-content: space-evenly;
   width: 500px;
+  margin: 0 auto;
 }
 
 ul.two-steps {

--- a/ui/helpers/higher-order-components/authenticated/authenticated.component.js
+++ b/ui/helpers/higher-order-components/authenticated/authenticated.component.js
@@ -10,11 +10,6 @@ import {
 export default function Authenticated(props) {
   const { isUnlocked, completedOnboarding } = props;
   switch (true) {
-    // For ONBOARDING_V2 dev purposes,
-    // Remove when ONBOARDING_V2 dev complete
-    case process.env.ONBOARDING_V2 === true:
-      return <Redirect to={{ pathname: ONBOARDING_ROUTE }} />;
-
     case isUnlocked && completedOnboarding:
       return <Route {...props} />;
     case !completedOnboarding:

--- a/ui/pages/onboarding-flow/onboarding-flow.js
+++ b/ui/pages/onboarding-flow/onboarding-flow.js
@@ -55,13 +55,6 @@ export default function OnboardingFlow() {
   const nextRoute = useSelector(getFirstTimeFlowTypeRoute);
 
   useEffect(() => {
-    // For ONBOARDING_V2 dev purposes,
-    // Remove when ONBOARDING_V2 dev complete
-    if (process.env.ONBOARDING_V2) {
-      history.push(ONBOARDING_METAMETRICS);
-      return;
-    }
-
     if (completedOnboarding && seedPhraseBackedUp) {
       history.push(DEFAULT_ROUTE);
       return;

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.js
@@ -10,6 +10,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
+  setCompletedOnboarding,
   setFeatureFlag,
   setUsePhishDetect,
   setUseTokenDetection,
@@ -33,6 +34,7 @@ export default function PrivacySettings() {
     );
     dispatch(setUsePhishDetect(usePhishingDetection));
     dispatch(setUseTokenDetection(turnOnTokenDetection));
+    dispatch(setCompletedOnboarding());
     history.push(ONBOARDING_PIN_EXTENSION_ROUTE);
   };
 

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import * as actions from '../../../store/actions';
-import { renderWithProvider } from '../../../../test/jest';
+import {
+  renderWithProvider,
+  setBackgroundConnection,
+} from '../../../../test/jest';
 import PrivacySettings from './privacy-settings';
 
 describe('Privacy Settings Onboarding View', () => {
@@ -19,11 +21,15 @@ describe('Privacy Settings Onboarding View', () => {
   const setFeatureFlagStub = jest.fn();
   const setUsePhishDetectStub = jest.fn();
   const setUseTokenDetectionStub = jest.fn();
+  const completeOnboardingStub = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve());
 
-  actions._setBackgroundConnection({
+  setBackgroundConnection({
     setFeatureFlag: setFeatureFlagStub,
     setUsePhishDetect: setUsePhishDetectStub,
     setUseTokenDetection: setUseTokenDetectionStub,
+    completeOnboarding: completeOnboardingStub,
   });
 
   it('should update preferences', () => {

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -13,7 +13,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { setFirstTimeFlowType } from '../../../store/actions';
-import { INITIALIZE_METAMETRICS_OPT_IN_ROUTE } from '../../../helpers/constants/routes';
+import { ONBOARDING_METAMETRICS } from '../../../helpers/constants/routes';
 
 export default function OnboardingWelcome() {
   const t = useI18nContext();
@@ -23,12 +23,12 @@ export default function OnboardingWelcome() {
 
   const onCreateClick = () => {
     dispatch(setFirstTimeFlowType('create'));
-    history.push(INITIALIZE_METAMETRICS_OPT_IN_ROUTE);
+    history.push(ONBOARDING_METAMETRICS);
   };
 
   const onImportClick = () => {
     dispatch(setFirstTimeFlowType('import'));
-    history.push(INITIALIZE_METAMETRICS_OPT_IN_ROUTE);
+    history.push(ONBOARDING_METAMETRICS);
   };
 
   return (


### PR DESCRIPTION
- Remove the onboarding V2 feature flags used for initial dev implementation (some remain until we're ready to make the switch)
- Update metametrics route on welcome screen
- Set OnboardingComplete to true upon privacy-settings page submission
  - Required test update
