### PR TITLE
Removing unused prop/code paths from EditContact

### DIFF
--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -25,8 +25,6 @@ export default class EditContact extends PureComponent {
     memo: PropTypes.string,
     viewRoute: PropTypes.string,
     listRoute: PropTypes.string,
-    setAccountLabel: PropTypes.func,
-    showingMyAccounts: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -52,8 +50,6 @@ export default class EditContact extends PureComponent {
       memo,
       name,
       removeFromAddressBook,
-      setAccountLabel,
-      showingMyAccounts,
       viewRoute,
     } = this.props;
 
@@ -65,18 +61,16 @@ export default class EditContact extends PureComponent {
       <div className="settings-page__content-row address-book__edit-contact">
         <div className="settings-page__header address-book__header--edit">
           <Identicon address={address} diameter={60} />
-          {showingMyAccounts ? null : (
-            <Button
-              type="link"
-              className="settings-page__address-book-button"
-              onClick={async () => {
-                await removeFromAddressBook(chainId, address);
-                history.push(listRoute);
-              }}
-            >
-              {t('deleteAccount')}
-            </Button>
-          )}
+          <Button
+            type="link"
+            className="settings-page__address-book-button"
+            onClick={async () => {
+              await removeFromAddressBook(chainId, address);
+              history.push(listRoute);
+            }}
+          >
+            {t('deleteAccount')}
+          </Button>
         </div>
         <div className="address-book__edit-contact__content">
           <div className="address-book__view-contact__group">
@@ -157,12 +151,6 @@ export default class EditContact extends PureComponent {
                   this.state.newName || name,
                   this.state.newMemo || memo,
                 );
-                if (showingMyAccounts) {
-                  setAccountLabel(
-                    this.state.newAddress,
-                    this.state.newName || name,
-                  );
-                }
                 history.push(listRoute);
               } else {
                 this.setState({ error: this.context.t('invalidAddress') });
@@ -174,9 +162,6 @@ export default class EditContact extends PureComponent {
                 this.state.newName || name,
                 this.state.newMemo || memo,
               );
-              if (showingMyAccounts) {
-                setAccountLabel(address, this.state.newName || name);
-              }
               history.push(listRoute);
             }
           }}

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
@@ -9,7 +9,6 @@ import {
 import {
   addToAddressBook,
   removeFromAddressBook,
-  setAccountLabel,
 } from '../../../../store/actions';
 import EditContact from './edit-contact.component';
 
@@ -44,8 +43,6 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(addToAddressBook(recipient, nickname, memo)),
     removeFromAddressBook: (chainId, addressToRemove) =>
       dispatch(removeFromAddressBook(chainId, addressToRemove)),
-    setAccountLabel: (address, label) =>
-      dispatch(setAccountLabel(address, label)),
   };
 };
 


### PR DESCRIPTION
The `showingMyAccounts` prop became obsolete as of: https://github.com/MetaMask/metamask-extension/pull/10680 - it's presence was producing the following warning while editing a contact: 
<img width="696" alt="Screen Shot 2021-10-20 at 1 37 36 PM" src="https://user-images.githubusercontent.com/8732757/138169449-ef4766ae-353f-4778-bb6c-7020536f5ddb.png">

`setAccountLabel` also became unneeded as a result of this removal

