### PR TITLE
fix missing conversion rates in swaps token drop down

### DIFF
--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -16,6 +16,7 @@ import { getConversionRate } from '../ducks/metamask/metamask';
 
 import { getSwapsTokens } from '../ducks/swaps/swaps';
 import { isSwapsDefaultTokenSymbol } from '../../shared/modules/swaps.utils';
+import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { useEqualityCheck } from './useEqualityCheck';
 
 const shuffledContractMap = shuffle(
@@ -45,7 +46,7 @@ export function getRenderableTokenData(
     getTokenFiatAmount(
       isSwapsDefaultTokenSymbol(symbol, chainId)
         ? 1
-        : contractExchangeRates[address],
+        : contractExchangeRates[toChecksumHexAddress(address)],
       conversionRate,
       currentCurrency,
       string,
@@ -56,7 +57,7 @@ export function getRenderableTokenData(
     getTokenFiatAmount(
       isSwapsDefaultTokenSymbol(symbol, chainId)
         ? 1
-        : contractExchangeRates[address],
+        : contractExchangeRates[toChecksumHexAddress(address)],
       conversionRate,
       currentCurrency,
       string,
@@ -145,7 +146,7 @@ export function useTokensToSearch({
 
     memoizedSwapsAndUserTokensWithoutDuplicities.forEach((token) => {
       const renderableDataToken = getRenderableTokenData(
-        { ...usersTokensAddressMap[token.address.toLowerCase()], ...token },
+        { ...token, ...usersTokensAddressMap[token.address.toLowerCase()] },
         tokenConversionRates,
         conversionRate,
         currentCurrency,

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -122,7 +122,9 @@ export function useTokensToSearch({
     : [
         memoizedDefaultToken,
         ...shuffledTokenList.filter(
-          (token) => token.symbol !== memoizedDefaultToken.symbol,
+          (token) =>
+            token.symbol !== memoizedDefaultToken.symbol &&
+            token.address !== memoizedDefaultToken.address,
         ),
       ];
 
@@ -140,13 +142,13 @@ export function useTokensToSearch({
     };
 
     const memoizedSwapsAndUserTokensWithoutDuplicities = uniqBy(
-      [...memoizedTokensToSearch, ...memoizedUsersToken],
+      [memoizedDefaultToken, ...memoizedTokensToSearch, ...memoizedUsersToken],
       (token) => token.address.toLowerCase(),
     );
 
     memoizedSwapsAndUserTokensWithoutDuplicities.forEach((token) => {
       const renderableDataToken = getRenderableTokenData(
-        { ...token, ...usersTokensAddressMap[token.address.toLowerCase()] },
+        { ...usersTokensAddressMap[token.address.toLowerCase()], ...token },
         tokenConversionRates,
         conversionRate,
         currentCurrency,
@@ -186,6 +188,7 @@ export function useTokensToSearch({
     conversionRate,
     currentCurrency,
     memoizedTopTokens,
+    memoizedDefaultToken,
     chainId,
     tokenList,
     useTokenDetection,

--- a/ui/hooks/useTokensToSearch.js
+++ b/ui/hooks/useTokensToSearch.js
@@ -122,9 +122,7 @@ export function useTokensToSearch({
     : [
         memoizedDefaultToken,
         ...shuffledTokenList.filter(
-          (token) =>
-            token.symbol !== memoizedDefaultToken.symbol &&
-            token.address !== memoizedDefaultToken.address,
+          (token) => token.symbol !== memoizedDefaultToken.symbol,
         ),
       ];
 


### PR DESCRIPTION
Explanation:  Conversion rates were missing in the swaps "from token" searchable dropdown because contractExchangeRates are keyed with addresses in checksum format.  This is yet another case where [address format normalization needs to take place globally](https://github.com/MetaMask/metamask-extension/issues/7985)

additionally the defaultToken (ETH) appeared to only render conversionRates when `swapsTokens` were unavailable so this PR alters logic for deriving the tokensToSearchBuckets such that we guarantee the defaultToken/native asset has data required to show fiat conversion available.
