### PR TITLE
Latest update conversion date  - issue  #10741

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1660,7 +1660,7 @@
     "message": "No, I already have a Secret Recovery Phrase"
   },
   "noConversionDateAvailable": {
-    "message": "No Conversion Date Available"
+    "message": "No Currency Conversion Date Available"
   },
   "noConversionRateAvailable": {
     "message": "No Conversion Rate Available"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1659,6 +1659,9 @@
   "noAlreadyHaveSeed": {
     "message": "No, I already have a Secret Recovery Phrase"
   },
+  "noConversionDateAvailable": {
+    "message": "No Conversion Date Available"
+  },
   "noConversionRateAvailable": {
     "message": "No Conversion Rate Available"
   },

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -45,16 +45,40 @@ export default class SettingsTab extends PureComponent {
     setHideZeroBalanceTokens: PropTypes.func,
   };
 
+  state = {
+    lastFetchedConversionDate: Date.now() / 1000,
+  };
+
   renderCurrentConversion() {
     const { t } = this.context;
-    const { currentCurrency, conversionDate, setCurrentCurrency } = this.props;
+    const {
+      currentCurrency,
+      conversionDate,
+      setCurrentCurrency,
+      warning,
+    } = this.props;
+    const { lastFetchedConversionDate } = this.state;
+
+    if (
+      warning !== null &&
+      !warning.toLocaleLowerCase().includes('failed to fetch')
+    ) {
+      this.setState({ lastFetchedConversionDate: conversionDate });
+    }
 
     return (
       <div className="settings-page__content-row">
         <div className="settings-page__content-item">
           <span>{t('currencyConversion')}</span>
           <span className="settings-page__content-description">
-            {t('updatedWithDate', [new Date(conversionDate * 1000).toString()])}
+            {t('updatedWithDate', [
+              `${
+                warning !== null &&
+                warning.toLocaleLowerCase().includes('failed to fetch')
+                  ? new Date(lastFetchedConversionDate * 1000).toString()
+                  : new Date(conversionDate * 1000).toString()
+              }`,
+            ])}
           </span>
         </div>
         <div className="settings-page__content-item">

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -37,48 +37,32 @@ export default class SettingsTab extends PureComponent {
     currentLocale: PropTypes.string,
     useBlockie: PropTypes.bool,
     currentCurrency: PropTypes.string,
-    conversionDate: PropTypes.number,
     nativeCurrency: PropTypes.string,
     useNativeCurrencyAsPrimaryCurrency: PropTypes.bool,
     setUseNativeCurrencyAsPrimaryCurrencyPreference: PropTypes.func,
     hideZeroBalanceTokens: PropTypes.bool,
     setHideZeroBalanceTokens: PropTypes.func,
-  };
-
-  state = {
-    lastFetchedConversionDate: Date.now() / 1000,
+    lastFetchedConversionDate: PropTypes.number,
   };
 
   renderCurrentConversion() {
     const { t } = this.context;
     const {
       currentCurrency,
-      conversionDate,
       setCurrentCurrency,
-      warning,
+      lastFetchedConversionDate,
     } = this.props;
-    const { lastFetchedConversionDate } = this.state;
-
-    if (
-      warning !== null &&
-      !warning.toLocaleLowerCase().includes('failed to fetch')
-    ) {
-      this.setState({ lastFetchedConversionDate: conversionDate });
-    }
 
     return (
       <div className="settings-page__content-row">
         <div className="settings-page__content-item">
           <span>{t('currencyConversion')}</span>
           <span className="settings-page__content-description">
-            {t('updatedWithDate', [
-              `${
-                warning !== null &&
-                warning.toLocaleLowerCase().includes('failed to fetch')
-                  ? new Date(lastFetchedConversionDate * 1000).toString()
-                  : new Date(conversionDate * 1000).toString()
-              }`,
-            ])}
+            {lastFetchedConversionDate
+              ? t('updatedWithDate', [
+                  new Date(lastFetchedConversionDate * 1000).toString(),
+                ])
+              : t('noConversionDateAvailable')}
           </span>
         </div>
         <div className="settings-page__content-item">

--- a/ui/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/pages/settings/settings-tab/settings-tab.component.js
@@ -54,7 +54,7 @@ export default class SettingsTab extends PureComponent {
         <div className="settings-page__content-item">
           <span>{t('currencyConversion')}</span>
           <span className="settings-page__content-description">
-            {t('updatedWithDate', [Date(conversionDate)])}
+            {t('updatedWithDate', [new Date(conversionDate * 1000).toString()])}
           </span>
         </div>
         <div className="settings-page__content-item">

--- a/ui/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/pages/settings/settings-tab/settings-tab.container.js
@@ -10,14 +10,13 @@ import {
 import { getPreferences } from '../../../selectors';
 import SettingsTab from './settings-tab.component';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
   const {
     appState: { warning },
     metamask,
   } = state;
   const {
     currentCurrency,
-    conversionDate,
     nativeCurrency,
     useBlockie,
     currentLocale,
@@ -27,15 +26,17 @@ const mapStateToProps = (state) => {
     hideZeroBalanceTokens,
   } = getPreferences(state);
 
+  const { lastFetchedConversionDate } = ownProps;
+
   return {
     warning,
     currentLocale,
     currentCurrency,
-    conversionDate,
     nativeCurrency,
     useBlockie,
     useNativeCurrencyAsPrimaryCurrency,
     hideZeroBalanceTokens,
+    lastFetchedConversionDate,
   };
 };
 

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -41,11 +41,31 @@ class SettingsPage extends PureComponent {
     initialBreadCrumbKey: PropTypes.string,
     mostRecentOverviewPage: PropTypes.string.isRequired,
     addNewNetwork: PropTypes.bool,
+    conversionDate: PropTypes.number,
   };
 
   static contextTypes = {
     t: PropTypes.func,
   };
+
+  state = {
+    lastFetchedConversionDate: null,
+  };
+
+  componentDidMount() {
+    this.handleConversionDate();
+  }
+
+  componentDidUpdate() {
+    this.handleConversionDate();
+  }
+
+  handleConversionDate() {
+    const { conversionDate } = this.props;
+    if (conversionDate !== null) {
+      this.setState({ lastFetchedConversionDate: conversionDate });
+    }
+  }
 
   render() {
     const {
@@ -227,7 +247,16 @@ class SettingsPage extends PureComponent {
   renderContent() {
     return (
       <Switch>
-        <Route exact path={GENERAL_ROUTE} component={SettingsTab} />
+        <Route
+          exact
+          path={GENERAL_ROUTE}
+          render={(routeProps) => (
+            <SettingsTab
+              {...routeProps}
+              lastFetchedConversionDate={this.state.lastFetchedConversionDate}
+            />
+          )}
+        />
         <Route exact path={ABOUT_US_ROUTE} component={InfoTab} />
         <Route exact path={ADVANCED_ROUTE} component={AdvancedTab} />
         <Route exact path={ALERTS_ROUTE} component={AlertsTab} />
@@ -251,7 +280,14 @@ class SettingsPage extends PureComponent {
           path={`${CONTACT_VIEW_ROUTE}/:id`}
           component={ContactListTab}
         />
-        <Route component={SettingsTab} />
+        <Route
+          render={(routeProps) => (
+            <SettingsTab
+              {...routeProps}
+              lastFetchedConversionDate={this.state.lastFetchedConversionDate}
+            />
+          )}
+        />
       </Switch>
     );
   }

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -47,6 +47,10 @@ const ROUTES_TO_I18N_KEYS = {
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
   const { pathname } = location;
+  const {
+    metamask: { conversionDate },
+  } = state;
+
   const pathNameTail = pathname.match(/[^/]+$/u)[0];
 
   const isAddressEntryPage = pathNameTail.includes('0x');
@@ -91,6 +95,7 @@ const mapStateToProps = (state, ownProps) => {
     initialBreadCrumbKey,
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     addNewNetwork,
+    conversionDate,
   };
 };
 


### PR DESCRIPTION
Fixes: 
(partial fix): see explanation section  below

- Pass good convert date  object to i18n (unix milliseconds)
- In offline mode, a message or the last conversion date is displayed

Explanation:   
The conversion date timestamp from the state was correct.  The date object passing through i18n helper was not converted correctly.  Thus,  the **_convertDate_** state is **always** sent by the library (even in offline mode). The library function is **_updateExchangeRate_**   and the value is   _**Date.now()**_  

Issue:  https://github.com/MetaMask/metamask-extension/issues/10741

Related to controllers PR: https://github.com/MetaMask/controllers/pull/621
**It is required to have this version of controller to get the expected behaviour**