### PR TITLE
Remove unused `SEGMENT_LEGACY_WRITE_KEY`

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -32,7 +32,6 @@ const metamaskrc = require('rc')('metamask', {
   ONBOARDING_V2: process.env.ONBOARDING_V2,
   SEGMENT_HOST: process.env.SEGMENT_HOST,
   SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
-  SEGMENT_LEGACY_WRITE_KEY: process.env.SEGMENT_LEGACY_WRITE_KEY,
   SENTRY_DSN_DEV:
     process.env.SENTRY_DSN_DEV ||
     'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496',
@@ -653,10 +652,6 @@ function getEnvironmentVariables({ buildType, devMode, testing }) {
       environment === 'production'
         ? process.env.SEGMENT_PROD_WRITE_KEY
         : metamaskrc.SEGMENT_WRITE_KEY,
-    SEGMENT_LEGACY_WRITE_KEY:
-      environment === 'production'
-        ? process.env.SEGMENT_PROD_LEGACY_WRITE_KEY
-        : metamaskrc.SEGMENT_LEGACY_WRITE_KEY,
     SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS === '1',
     ONBOARDING_V2: metamaskrc.ONBOARDING_V2 === '1',
   };

--- a/development/mock-segment.js
+++ b/development/mock-segment.js
@@ -39,7 +39,6 @@ function onError(error) {
  *
  * SEGMENT_HOST='http://localhost:9090'
  * SEGMENT_WRITE_KEY=FAKE
- * SEGMENT_LEGACY_WRITE_KEY=FAKE
  *
  * Note that the Segment keys must also be set - otherwise the extension will not send any
  * metric events.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "benchmark:chrome": "SELENIUM_BROWSER=chrome node test/e2e/benchmark.js",
     "benchmark:firefox": "SELENIUM_BROWSER=firefox node test/e2e/benchmark.js",
     "build:test": "yarn build test",
-    "build:test:metrics": "SEGMENT_HOST='http://localhost:9090' SEGMENT_WRITE_KEY='FAKE' SEGMENT_LEGACY_WRITE_KEY='FAKE' yarn build test",
+    "build:test:metrics": "SEGMENT_HOST='http://localhost:9090' SEGMENT_WRITE_KEY='FAKE' yarn build test",
     "test": "yarn lint && yarn test:unit && yarn test:unit:jest",
     "dapp": "node development/static-server.js node_modules/@metamask/test-dapp/dist --port 8080",
     "dapp-chain": "GANACHE_ARGS='-b 2' concurrently -k -n ganache,dapp -p '[{time}][{name}]' 'yarn ganache:start' 'sleep 5 && yarn dapp'",


### PR DESCRIPTION
This key has not been used since #10915, which is where we stopped using the legacy Segment key.