### PR TITLE
Add currency symbol validation in the add network form

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -444,6 +444,10 @@
   "chainIdExistsErrorMsg": {
     "message": "This Chain ID is currently used by the $1 network."
   },
+  "chainListReturnedDifferentTickerSymbol": {
+    "message": "The network with chain ID $1 may use a different currency symbol than the one you have entered: $2",
+    "description": "$1 is the chain id currently entered in the network form and $2 is the return value of nativeCurrency.symbol from chainlist.network"
+  },
   "chromeRequiredForHardwareWallets": {
     "message": "You need to use MetaMask on Google Chrome in order to connect to your Hardware Wallet."
   },
@@ -1125,6 +1129,9 @@
   },
   "failedToFetchChainId": {
     "message": "Could not fetch chain ID. Is your RPC URL correct?"
+  },
+  "failedToFetchTickerSymbolData": {
+    "message": "Ticker symbol verification data is currently unavailable, make sure that the symbol you have entered is correct. It will impact the conversion rates that you see for this network"
   },
   "failureMessage": {
     "message": "Something went wrong, and we were unable to complete the action"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -445,7 +445,7 @@
     "message": "This Chain ID is currently used by the $1 network."
   },
   "chainListReturnedDifferentTickerSymbol": {
-    "message": "The network with chain ID $1 may use a different currency symbol than the one you have entered: $2",
+    "message": "The network with chain ID $1 may use a different currency symbol ($2) than the one you have entered. Please verify before continuing.",
     "description": "$1 is the chain id currently entered in the network form and $2 is the return value of nativeCurrency.symbol from chainlist.network"
   },
   "chromeRequiredForHardwareWallets": {
@@ -1021,7 +1021,7 @@
     "message": "Learn more."
   },
   "endpointReturnedDifferentChainId": {
-    "message": "The endpoint returned a different chain ID: $1",
+    "message": "The RPC URL you have entered returned a different chain ID ($1). Please update the Chain ID to match the RPC URL of the network you are trying to add.",
     "description": "$1 is the return value of eth_chainId from an RPC endpoint"
   },
   "ensIllegalCharacter": {

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -14,6 +14,7 @@ describe('Stores custom RPC history', function () {
   it(`creates first custom RPC entry`, async function () {
     const port = 8546;
     const chainId = 1338;
+    const symbol = 'TEST';
     await withFixtures(
       {
         fixtures: 'imported-account',
@@ -38,6 +39,7 @@ describe('Stores custom RPC history', function () {
         const networkNameInput = customRpcInputs[0];
         const rpcUrlInput = customRpcInputs[1];
         const chainIdInput = customRpcInputs[2];
+        const symbolInput = customRpcInputs[3];
 
         await networkNameInput.clear();
         await networkNameInput.sendKeys(networkName);
@@ -47,6 +49,9 @@ describe('Stores custom RPC history', function () {
 
         await chainIdInput.clear();
         await chainIdInput.sendKeys(chainId.toString());
+
+        await symbolInput.clear();
+        await symbolInput.sendKeys(symbol);
 
         await driver.clickElement(
           '.networks-tab__add-network-form-footer .btn-primary',

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -75,7 +75,8 @@ describe('Stores custom RPC history', function () {
         await driver.press('#password', driver.Key.ENTER);
 
         // duplicate network
-        const duplicateRpcUrl = 'http://localhost:8545';
+        const duplicateRpcUrl =
+          'https://mainnet.infura.io/v3/00000000000000000000000000000000';
 
         await driver.clickElement('.network-display');
 
@@ -89,7 +90,7 @@ describe('Stores custom RPC history', function () {
         await rpcUrlInput.clear();
         await rpcUrlInput.sendKeys(duplicateRpcUrl);
         await driver.findElement({
-          text: 'This URL is currently used by the Localhost 8545 network.',
+          text: 'This URL is currently used by the mainnet network.',
           tag: 'h6',
         });
       },

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -103,6 +103,7 @@ describe('Stores custom RPC history', function () {
         fixtures: 'imported-account',
         ganacheOptions,
         title: this.test.title,
+        failOnConsoleError: false,
       },
       async ({ driver }) => {
         await driver.navigate();
@@ -195,6 +196,7 @@ describe('Stores custom RPC history', function () {
         fixtures: 'custom-rpc',
         ganacheOptions,
         title: this.test.title,
+        failOnConsoleError: false,
       },
       async ({ driver }) => {
         await driver.navigate();

--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -122,14 +122,19 @@ describe('Stores custom RPC history', function () {
         const rpcUrlInput = customRpcInputs[1];
         const chainIdInput = customRpcInputs[2];
 
-        await rpcUrlInput.clear();
-        await rpcUrlInput.sendKeys(newRpcUrl);
-
         await chainIdInput.clear();
         await chainIdInput.sendKeys(duplicateChainId);
         await driver.findElement({
           text:
             'This Chain ID is currently used by the Localhost 8545 network.',
+          tag: 'h6',
+        });
+
+        await rpcUrlInput.clear();
+        await rpcUrlInput.sendKeys(newRpcUrl);
+
+        await driver.findElement({
+          text: 'Could not fetch chain ID. Is your RPC URL correct?',
           tag: 'h6',
         });
       },

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -31,6 +31,7 @@ export default function FormField({
   allowDecimals,
   disabled,
   placeholder,
+  warning,
 }) {
   return (
     <div
@@ -111,6 +112,15 @@ export default function FormField({
             {error}
           </Typography>
         )}
+        {warning && (
+          <Typography
+            color={COLORS.ALERT3}
+            variant={TYPOGRAPHY.H7}
+            className="form-field__warning"
+          >
+            {warning}
+          </Typography>
+        )}
       </label>
     </div>
   );
@@ -141,6 +151,10 @@ FormField.propTypes = {
    * Show error message
    */
   error: PropTypes.string,
+  /**
+   * Show warning message
+   */
+  warning: PropTypes.string,
   /**
    * Handler when fields change
    */

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -93,6 +93,7 @@ export default function FormField({
           <input
             className={classNames('form-field__input', {
               'form-field__input--error': error,
+              'form-field__input--warning': warning,
             })}
             onChange={(e) => onChange(e.target.value)}
             value={value}
@@ -114,7 +115,7 @@ export default function FormField({
         )}
         {warning && (
           <Typography
-            color={COLORS.ALERT3}
+            color={COLORS.UI4}
             variant={TYPOGRAPHY.H7}
             className="form-field__warning"
           >

--- a/ui/components/ui/form-field/index.scss
+++ b/ui/components/ui/form-field/index.scss
@@ -45,5 +45,9 @@
     &--error {
       border-color: var(--error-1);
     }
+
+    &--warning {
+      border-color: var(--alert-3);
+    }
   }
 }

--- a/ui/pages/settings/networks-tab/index.scss
+++ b/ui/pages/settings/networks-tab/index.scss
@@ -48,7 +48,7 @@
 
   &__network-form {
     display: flex;
-    flex: 1 0 auto;
+    flex: 1 0;
     flex-direction: column;
     justify-content: space-between;
     max-height: 465px;

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -374,9 +374,13 @@ const NetworksForm = ({
   const validateUrlRpcUrl = useCallback(
     (url) => {
       const isValidUrl = validUrl.isWebUri(url);
-      const [{ rpcUrl: matchingRPCUrl = null } = {}] = networksToRender.filter(
-        (e) => e.rpcUrl === url,
-      );
+      const [
+        {
+          rpcUrl: matchingRPCUrl = null,
+          label: matchingRPCLabel,
+          labelKey: matchingRPCLabelKey,
+        } = {},
+      ] = networksToRender.filter((e) => e.rpcUrl === url);
       const { rpcUrl: selectedNetworkRpcUrl } = selectedNetwork;
 
       if (!isValidUrl && url !== '') {
@@ -398,7 +402,7 @@ const NetworksForm = ({
         return {
           key: 'urlExistsErrorMsg',
           msg: t('urlExistsErrorMsg', [
-            matchingRPCUrl.label ?? matchingRPCUrl.labelKey,
+            matchingRPCLabel ?? matchingRPCLabelKey,
           ]),
         };
       }

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -574,18 +574,14 @@ const NetworksForm = ({
         />
         <FormField
           error={errors.rpcUrl?.msg || ''}
-          onChange={(value) => {
-            setRpcUrl(value);
-          }}
+          onChange={setRpcUrl}
           titleText={t('rpcUrl')}
           value={rpcUrl}
           disabled={viewOnly}
         />
         <FormField
           error={errors.chainId?.msg || ''}
-          onChange={(value) => {
-            setChainId(value);
-          }}
+          onChange={setChainId}
           titleText={t('chainId')}
           value={chainId}
           disabled={viewOnly}
@@ -593,18 +589,14 @@ const NetworksForm = ({
         />
         <FormField
           warning={warnings.ticker?.msg || ''}
-          onChange={(value) => {
-            setTicker(value);
-          }}
+          onChange={setTicker}
           titleText={t('currencySymbol')}
           value={ticker}
           disabled={viewOnly}
         />
         <FormField
           error={errors.blockExplorerUrl?.msg || ''}
-          onChange={(value) => {
-            setBlockExplorerUrl(value);
-          }}
+          onChange={setBlockExplorerUrl}
           titleText={t('blockExplorerUrl')}
           titleUnit={t('optionalWithParanthesis')}
           value={blockExplorerUrl}

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -371,7 +371,7 @@ const NetworksForm = ({
     [t],
   );
 
-  const validateUrlRpcUrl = useCallback(
+  const validateRPCUrl = useCallback(
     (url) => {
       const isValidUrl = validUrl.isWebUri(url);
       const [
@@ -433,7 +433,7 @@ const NetworksForm = ({
       const chainIdError = await validateChainId(chainId);
       const tickerWarning = await validateTickerSymbol(chainId, ticker);
       const blockExplorerError = validateBlockExplorerURL(blockExplorerUrl);
-      const rpcUrlError = validateUrlRpcUrl(rpcUrl);
+      const rpcUrlError = validateRPCUrl(rpcUrl);
       setErrors({
         ...errors,
         chainId: chainIdError,
@@ -463,7 +463,7 @@ const NetworksForm = ({
     validateBlockExplorerURL,
     validateChainId,
     validateTickerSymbol,
-    validateUrlRpcUrl,
+    validateRPCUrl,
   ]);
 
   const onSubmit = async () => {

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.js
@@ -334,6 +334,11 @@ const NetworksForm = ({
     return true;
   };
 
+  const debouncedValidateTickerSymbolOnChange = debounce(
+    validateTickerSymbolOnChange,
+    500,
+  );
+
   /**
    * Validates the chain ID by checking it against the `eth_chainId` return
    * value from the given RPC URL.
@@ -586,7 +591,7 @@ const NetworksForm = ({
             setChainId(value);
             validateChainIdOnChange(value);
             if (ticker && value) {
-              debounce(validateTickerSymbolOnChange(value, ticker), 500);
+              debouncedValidateTickerSymbolOnChange(value, ticker);
             }
           }}
           titleText={t('chainId')}
@@ -599,7 +604,7 @@ const NetworksForm = ({
           onChange={(value) => {
             setTicker(value);
             if (chainId && value) {
-              debounce(validateTickerSymbolOnChange(chainId, value), 500);
+              debouncedValidateTickerSymbolOnChange(chainId, value);
             } else {
               setWarningEmpty('ticker');
             }

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -48,7 +48,7 @@ describe('NetworkForm Component', () => {
     expect(queryByText('Chain ID')).toBeInTheDocument();
     expect(queryByText('Currency Symbol')).toBeInTheDocument();
     expect(queryByText('Block Explorer URL')).toBeInTheDocument();
-    expect(queryAllByText('(Optional)')).toHaveLength(2);
+    expect(queryAllByText('(Optional)')).toHaveLength(1);
     expect(queryByText('Cancel')).toBeInTheDocument();
     expect(queryByText('Save')).toBeInTheDocument();
   });

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -7,36 +7,6 @@ import { defaultNetworksData } from '../networks-tab.constants';
 import { MAINNET_RPC_URL } from '../../../../../shared/constants/network';
 import NetworksForm from '.';
 
-nock('https://chainid.network:443', { encodedQueryParams: true })
-  .get('/chains.json')
-  .reply(200, [
-    {
-      name: 'Polygon Mainnet',
-      chain: 'Polygon',
-      rpc: [
-        'https://polygon-rpc.com/',
-        'https://rpc-mainnet.matic.network',
-        'https://matic-mainnet.chainstacklabs.com',
-        'https://rpc-mainnet.maticvigil.com',
-        'https://rpc-mainnet.matic.quiknode.pro',
-        'https://matic-mainnet-full-rpc.bwarelabs.com',
-      ],
-      nativeCurrency: {
-        name: 'MATIC',
-        symbol: 'MATIC',
-        decimals: 18,
-      },
-      shortName: 'MATIC',
-      chainId: 137,
-    },
-  ]);
-
-nock('https://bsc-dataseed.binance.org:443', {
-  encodedQueryParams: true,
-})
-  .post('/')
-  .reply(200, { jsonrpc: '2.0', id: '1643927040523', result: '0x38' });
-
 const renderComponent = (props) => {
   const store = configureMockStore([])({ metamask: {} });
   return renderWithProvider(<NetworksForm {...props} />, store);
@@ -68,6 +38,50 @@ const propNetworkDisplay = {
 };
 
 describe('NetworkForm Component', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  beforeEach(() => {
+    nock('https://chainid.network:443', { encodedQueryParams: true })
+      .get('/chains.json')
+      .reply(200, [
+        {
+          name: 'Polygon Mainnet',
+          chain: 'Polygon',
+          rpc: [
+            'https://polygon-rpc.com/',
+            'https://rpc-mainnet.matic.network',
+            'https://matic-mainnet.chainstacklabs.com',
+            'https://rpc-mainnet.maticvigil.com',
+            'https://rpc-mainnet.matic.quiknode.pro',
+            'https://matic-mainnet-full-rpc.bwarelabs.com',
+          ],
+          nativeCurrency: {
+            name: 'MATIC',
+            symbol: 'MATIC',
+            decimals: 18,
+          },
+          shortName: 'MATIC',
+          chainId: 137,
+        },
+      ]);
+
+    nock('https://bsc-dataseed.binance.org:443', {
+      encodedQueryParams: true,
+    })
+      .post('/')
+      .reply(200, { jsonrpc: '2.0', id: '1643927040523', result: '0x38' });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   it('should render add new network form correctly', async () => {
     const { queryByText, queryAllByText } = renderComponent(propNewNetwork);
     expect(

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import nock from 'nock';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
 import { defaultNetworksData } from '../networks-tab.constants';
@@ -41,7 +41,7 @@ const propNetworkDisplay = {
 };
 
 describe('NetworkForm Component', () => {
-  it('should render Add new network form correctly', () => {
+  it('should render Add new network form correctly', async () => {
     const { queryByText, queryAllByText } = renderComponent(propNewNetwork);
     expect(
       queryByText(
@@ -56,6 +56,27 @@ describe('NetworkForm Component', () => {
     expect(queryAllByText('(Optional)')).toHaveLength(1);
     expect(queryByText('Cancel')).toBeInTheDocument();
     expect(queryByText('Save')).toBeInTheDocument();
+
+    await fireEvent.change(screen.getByRole('textbox', { name: 'Chain ID' }), {
+      target: { value: '1' },
+    });
+    expect(
+      await screen.findByText(
+        'This Chain ID is currently used by the mainnet network.',
+      ),
+    ).toBeInTheDocument();
+
+    await fireEvent.change(
+      screen.getByRole('textbox', { name: 'New RPC URL' }),
+      {
+        target: { value: 'test' },
+      },
+    );
+    expect(
+      await screen.findByText(
+        'URLs require the appropriate HTTP/HTTPS prefix.',
+      ),
+    ).toBeInTheDocument();
   });
 
   it('should render network form correctly', async () => {
@@ -88,26 +109,6 @@ describe('NetworkForm Component', () => {
     ).toBeInTheDocument();
 
     await fireEvent.change(
-      getByDisplayValue(propNetworkDisplay.selectedNetwork.rpcUrl),
-      {
-        target: { value: 'test' },
-      },
-    );
-    expect(
-      await waitFor(() =>
-        screen.findByText('URLs require the appropriate HTTP/HTTPS prefix.'),
-      ),
-    ).toBeInTheDocument();
-
-    await fireEvent.change(
-      getByDisplayValue(propNetworkDisplay.selectedNetwork.label),
-      {
-        target: { value: 'LocalHost 8545' },
-      },
-    );
-    expect(getByDisplayValue('LocalHost 8545')).toBeInTheDocument();
-
-    await fireEvent.change(
       getByDisplayValue(propNetworkDisplay.selectedNetwork.chainId),
       {
         target: { value: '1' },
@@ -118,5 +119,25 @@ describe('NetworkForm Component', () => {
         'Could not fetch chain ID. Is your RPC URL correct?',
       ),
     ).toBeInTheDocument();
+
+    await fireEvent.change(
+      getByDisplayValue(propNetworkDisplay.selectedNetwork.rpcUrl),
+      {
+        target: { value: 'test' },
+      },
+    );
+    expect(
+      await screen.findByText(
+        'URLs require the appropriate HTTP/HTTPS prefix.',
+      ),
+    ).toBeInTheDocument();
+
+    await fireEvent.change(
+      getByDisplayValue(propNetworkDisplay.selectedNetwork.label),
+      {
+        target: { value: 'LocalHost 8545' },
+      },
+    );
+    expect(getByDisplayValue('LocalHost 8545')).toBeInTheDocument();
   });
 });

--- a/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
+++ b/ui/pages/settings/networks-tab/networks-form/networks-form.test.js
@@ -108,19 +108,7 @@ describe('NetworkForm Component', () => {
       getByDisplayValue(propNetworkDisplay.selectedNetwork.blockExplorerUrl),
     ).toBeInTheDocument();
 
-    await fireEvent.change(
-      getByDisplayValue(propNetworkDisplay.selectedNetwork.chainId),
-      {
-        target: { value: '1' },
-      },
-    );
-    expect(
-      await screen.findByText(
-        'Could not fetch chain ID. Is your RPC URL correct?',
-      ),
-    ).toBeInTheDocument();
-
-    await fireEvent.change(
+    fireEvent.change(
       getByDisplayValue(propNetworkDisplay.selectedNetwork.rpcUrl),
       {
         target: { value: 'test' },
@@ -132,7 +120,20 @@ describe('NetworkForm Component', () => {
       ),
     ).toBeInTheDocument();
 
-    await fireEvent.change(
+    fireEvent.change(
+      getByDisplayValue(propNetworkDisplay.selectedNetwork.chainId),
+      {
+        target: { value: '1' },
+      },
+    );
+
+    expect(
+      await screen.findByText(
+        'Could not fetch chain ID. Is your RPC URL correct?',
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.change(
       getByDisplayValue(propNetworkDisplay.selectedNetwork.label),
       {
         target: { value: 'LocalHost 8545' },

--- a/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
+++ b/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/jest/rendering';
 import { defaultNetworksData } from '../networks-tab.constants';
 import NetworksTabContent from '.';
@@ -45,7 +45,7 @@ const props = {
 };
 
 describe('NetworksTabContent Component', () => {
-  it('should render networks tab content correctly', () => {
+  it('should render networks tab content correctly', async () => {
     const { queryByText, getByDisplayValue } = renderComponent(props);
 
     expect(queryByText('Ethereum Mainnet')).toBeInTheDocument();
@@ -71,22 +71,29 @@ describe('NetworksTabContent Component', () => {
     expect(
       getByDisplayValue(props.selectedNetwork.blockExplorerUrl),
     ).toBeInTheDocument();
-    fireEvent.change(getByDisplayValue(props.selectedNetwork.label), {
+
+    await fireEvent.change(getByDisplayValue(props.selectedNetwork.label), {
       target: { value: 'LocalHost 8545' },
     });
-    expect(getByDisplayValue('LocalHost 8545')).toBeInTheDocument();
-    fireEvent.change(getByDisplayValue(props.selectedNetwork.chainId), {
-      target: { value: '1' },
-    });
-    expect(
-      queryByText('This Chain ID is currently used by the mainnet network.'),
-    ).toBeInTheDocument();
+    expect(await getByDisplayValue('LocalHost 8545')).toBeInTheDocument();
 
-    fireEvent.change(getByDisplayValue(props.selectedNetwork.rpcUrl), {
+    await fireEvent.change(getByDisplayValue(props.selectedNetwork.rpcUrl), {
       target: { value: 'test' },
     });
     expect(
-      queryByText('URLs require the appropriate HTTP/HTTPS prefix.'),
+      await screen.findByText(
+        'URLs require the appropriate HTTP/HTTPS prefix.',
+      ),
+    ).toBeInTheDocument();
+
+    await fireEvent.change(getByDisplayValue(props.selectedNetwork.chainId), {
+      target: { value: '1' },
+    });
+
+    expect(
+      await screen.findByText(
+        'Could not fetch chain ID. Is your RPC URL correct?',
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
+++ b/ui/pages/settings/networks-tab/networks-tab-content/networks-tab-content.test.js
@@ -72,12 +72,12 @@ describe('NetworksTabContent Component', () => {
       getByDisplayValue(props.selectedNetwork.blockExplorerUrl),
     ).toBeInTheDocument();
 
-    await fireEvent.change(getByDisplayValue(props.selectedNetwork.label), {
+    fireEvent.change(getByDisplayValue(props.selectedNetwork.label), {
       target: { value: 'LocalHost 8545' },
     });
     expect(await getByDisplayValue('LocalHost 8545')).toBeInTheDocument();
 
-    await fireEvent.change(getByDisplayValue(props.selectedNetwork.rpcUrl), {
+    fireEvent.change(getByDisplayValue(props.selectedNetwork.rpcUrl), {
       target: { value: 'test' },
     });
     expect(
@@ -86,7 +86,7 @@ describe('NetworksTabContent Component', () => {
       ),
     ).toBeInTheDocument();
 
-    await fireEvent.change(getByDisplayValue(props.selectedNetwork.chainId), {
+    fireEvent.change(getByDisplayValue(props.selectedNetwork.chainId), {
       target: { value: '1' },
     });
 


### PR DESCRIPTION
- Adds (non-blocking) warning when ticker symbol doesn't match what's found on `https://chainid.network/chains.json`
- Refactors `networks-form.js` validation
- Makes `Currency Symbol` a required field in the Add Network Form
- Updates network form error verbiage to match new figma designs 👇 

[Figma designs](https://www.figma.com/file/EUQ1LPxKPU9tga4YnjISn1/Network-specific-assets?node-id=1407%3A20916)

**Further Context:** This work was originally conceived and discussed in PR #12410

**Steps to Manually Test**
 1. Go to add a network form
 2. Add a valid RPC URL
 3. Add the chainId (if you don't enter the correct on you should see an error indicating the correct one for this RPC endpoint)
 4. See that the save button is still not enabled because currency symbol is not yet complete
 5. Enter any string in the currency symbol field. 
 6. See that a warning below that field pops indicating the expected symbol values for this chain Id.

**Demo:**
(scenario user sees warning but can elect to ignore and proceed to add the network) 
https://user-images.githubusercontent.com/34557516/152047015-c400cb03-2000-44d2-9624-a43b1544de24.mov

Related work to do after this PR:
- [ ] Add prompt for user to add ticker symbol to networks they had previously added without one.
- [ ] Add more tests of new validation logic
