### PR TITLE
Hide top, large eth amount for contract transactions that are not sending any eth #12342

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -35,6 +35,7 @@ export default class ConfirmPageContainerContent extends Component {
     disabled: PropTypes.bool,
     unapprovedTxCount: PropTypes.number,
     rejectNText: PropTypes.string,
+    type: PropTypes.string,
   };
 
   renderContent() {
@@ -89,6 +90,7 @@ export default class ConfirmPageContainerContent extends Component {
       rejectNText,
       origin,
       ethGasPriceWarning,
+      type,
     } = this.props;
 
     return (
@@ -110,6 +112,7 @@ export default class ConfirmPageContainerContent extends Component {
           identiconAddress={identiconAddress}
           nonce={nonce}
           origin={origin}
+          type={type}
         />
         {this.renderContent()}
         {(errorKey || errorMessage) && (

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Identicon from '../../../../ui/identicon';
+import { TRANSACTION_TYPES } from '../../../../../../shared/constants/transaction';
 
 const ConfirmPageContainerSummary = (props) => {
   const {
@@ -14,6 +15,7 @@ const ConfirmPageContainerSummary = (props) => {
     identiconAddress,
     nonce,
     origin,
+    type,
   } = props;
 
   return (
@@ -37,9 +39,14 @@ const ConfirmPageContainerSummary = (props) => {
             address={identiconAddress}
           />
         )}
-        <div className="confirm-page-container-summary__title-text">
-          {titleComponent || title}
-        </div>
+        {(type !== TRANSACTION_TYPES.CONTRACT_INTERACTION ||
+          type !== TRANSACTION_TYPES.DEPLOY_CONTRACT) &&
+          titleComponent &&
+          titleComponent.props.value !== '0x0' && (
+            <div className="confirm-page-container-summary__title-text">
+              {titleComponent || title}
+            </div>
+          )}
       </div>
       {hideSubtitle || (
         <div className="confirm-page-container-summary__subtitle">
@@ -60,6 +67,7 @@ ConfirmPageContainerSummary.propTypes = {
   identiconAddress: PropTypes.string,
   nonce: PropTypes.string,
   origin: PropTypes.string.isRequired,
+  type: PropTypes.string,
 };
 
 export default ConfirmPageContainerSummary;

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -69,6 +69,7 @@ export default class ConfirmPageContainer extends Component {
     showAddToAddressBookModal: PropTypes.func,
     contact: PropTypes.object,
     isOwnedAccount: PropTypes.bool,
+    type: PropTypes.string,
   };
 
   render() {
@@ -119,6 +120,7 @@ export default class ConfirmPageContainer extends Component {
       showAddToAddressBookModal,
       contact = {},
       isOwnedAccount,
+      type,
     } = this.props;
 
     const showAddToAddressDialog =
@@ -190,6 +192,7 @@ export default class ConfirmPageContainer extends Component {
             rejectNText={this.context.t('rejectTxsN', [unapprovedTxCount])}
             origin={origin}
             ethGasPriceWarning={ethGasPriceWarning}
+            type={type}
           />
         )}
         {contentComponent && (

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -960,6 +960,7 @@ export default class ConfirmTransactionBase extends Component {
         editingGas={editingGas}
         handleCloseEditGas={() => this.handleCloseEditGas()}
         currentTransaction={txData}
+        type={type}
       />
     );
   }


### PR DESCRIPTION
Fixes: Removed top eth amount 
https://github.com/MetaMask/metamask-extension/issues/12342
![Screenshot from 2021-10-22 12-15-13](https://user-images.githubusercontent.com/92531782/138438871-c7c82a5c-cae0-457a-88cb-7eb0c83d3414.png)

