### PR TITLE
Hide top, large eth amount for contract transactions that are not sending any eth #12342

### DIFF
--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-content.component.js
@@ -35,6 +35,7 @@ export default class ConfirmPageContainerContent extends Component {
     disabled: PropTypes.bool,
     unapprovedTxCount: PropTypes.number,
     rejectNText: PropTypes.string,
+    hideTitle: PropTypes.boolean,
   };
 
   renderContent() {
@@ -89,6 +90,7 @@ export default class ConfirmPageContainerContent extends Component {
       rejectNText,
       origin,
       ethGasPriceWarning,
+      hideTitle,
     } = this.props;
 
     return (
@@ -110,6 +112,7 @@ export default class ConfirmPageContainerContent extends Component {
           identiconAddress={identiconAddress}
           nonce={nonce}
           origin={origin}
+          hideTitle={hideTitle}
         />
         {this.renderContent()}
         {(errorKey || errorMessage) && (

--- a/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container-content/confirm-page-container-summary/confirm-page-container-summary.component.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-negated-condition */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -14,6 +15,7 @@ const ConfirmPageContainerSummary = (props) => {
     identiconAddress,
     nonce,
     origin,
+    hideTitle,
   } = props;
 
   return (
@@ -37,9 +39,11 @@ const ConfirmPageContainerSummary = (props) => {
             address={identiconAddress}
           />
         )}
-        <div className="confirm-page-container-summary__title-text">
-          {titleComponent || title}
-        </div>
+        {!hideTitle ? (
+          <div className="confirm-page-container-summary__title-text">
+            {titleComponent || title}
+          </div>
+        ) : null}
       </div>
       {hideSubtitle || (
         <div className="confirm-page-container-summary__subtitle">
@@ -60,6 +64,7 @@ ConfirmPageContainerSummary.propTypes = {
   identiconAddress: PropTypes.string,
   nonce: PropTypes.string,
   origin: PropTypes.string.isRequired,
+  hideTitle: PropTypes.boolean,
 };
 
 export default ConfirmPageContainerSummary;

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -5,6 +5,7 @@ import { PageContainerFooter } from '../../ui/page-container';
 import EditGasPopover from '../edit-gas-popover';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
 import ErrorMessage from '../../ui/error-message';
+import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
 import Dialog from '../../ui/dialog';
 import {
   ConfirmPageContainerHeader,
@@ -128,6 +129,11 @@ export default class ConfirmPageContainer extends Component {
     const shouldDisplayWarning =
       contentComponent && disabled && (errorKey || errorMessage);
 
+    const hideTitle =
+      (currentTransaction.type === TRANSACTION_TYPES.CONTRACT_INTERACTION ||
+        currentTransaction.type === TRANSACTION_TYPES.DEPLOY_CONTRACT) &&
+      currentTransaction.txParams?.value === '0x0';
+
     return (
       <div className="page-container">
         <ConfirmPageContainerNavigation
@@ -194,6 +200,7 @@ export default class ConfirmPageContainer extends Component {
             rejectNText={this.context.t('rejectTxsN', [unapprovedTxCount])}
             origin={origin}
             ethGasPriceWarning={ethGasPriceWarning}
+            hideTitle={hideTitle}
           />
         )}
         {shouldDisplayWarning && (


### PR DESCRIPTION
Fixes: Removed top eth amount 
https://github.com/MetaMask/metamask-extension/issues/12342
![Screenshot from 2021-10-22 12-15-13](https://user-images.githubusercontent.com/92531782/138438871-c7c82a5c-cae0-457a-88cb-7eb0c83d3414.png)

