### PR TITLE
Changed ETH decimal values to have 8 places for sending

### DIFF
--- a/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
@@ -51,7 +51,7 @@ describe('TransactionBreakdown', () => {
         ['Amount', '-0.01 ETH'],
         ['Gas Limit (units)', '46890'],
         ['Gas price', '2.467043803'],
-        ['Total', '0.010116ETH'],
+        ['Total', '0.01011568ETH'],
       ]);
     });
   });
@@ -90,7 +90,7 @@ describe('TransactionBreakdown', () => {
         ['Priority Fee (GWEI)', '2.467043796'],
         ['Total Gas Fee', '0.000077ETH'],
         ['Max Fee Per Gas', '0.000000003ETH'],
-        ['Total', '0.010077ETH'],
+        ['Total', '0.01007712ETH'],
       ]);
     });
   });

--- a/ui/components/ui/currency-input/currency-input.component.js
+++ b/ui/components/ui/currency-input/currency-input.component.js
@@ -69,7 +69,7 @@ export default class CurrencyInput extends PureComponent {
       : getValueFromWeiHex({
           value: hexValue,
           toCurrency: ETH,
-          numberOfDecimals: 6,
+          numberOfDecimals: 8,
         });
 
     return Number(decimalValueString) || 0;
@@ -134,7 +134,7 @@ export default class CurrencyInput extends PureComponent {
     if (this.shouldUseFiat()) {
       // Display ETH
       currency = nativeCurrency || ETH;
-      numberOfDecimals = 6;
+      numberOfDecimals = 8;
     } else {
       // Display Fiat
       currency = currentCurrency;

--- a/ui/components/ui/currency-input/currency-input.component.test.js
+++ b/ui/components/ui/currency-input/currency-input.component.test.js
@@ -120,7 +120,7 @@ describe('CurrencyInput Component', () => {
       expect(wrapper.find('.unit-input__suffix').text()).toStrictEqual('USD');
       expect(wrapper.find('.unit-input__input').props().value).toStrictEqual(1);
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(
-        '0.004328ETH',
+        '0.00432788ETH',
       );
     });
 
@@ -159,14 +159,14 @@ describe('CurrencyInput Component', () => {
         .find(CurrencyInput)
         .at(0)
         .instance();
-      expect(currencyInputInstance.state.decimalValue).toStrictEqual(0.004328);
+      expect(currencyInputInstance.state.decimalValue).toStrictEqual(0.00432788);
       expect(currencyInputInstance.state.hexValue).toStrictEqual(
         'f602f2234d0ea',
       );
       expect(wrapper.find('.unit-input__suffix')).toHaveLength(1);
       expect(wrapper.find('.unit-input__suffix').text()).toStrictEqual('ETH');
       expect(wrapper.find('.unit-input__input').props().value).toStrictEqual(
-        0.004328,
+        0.00432788,
       );
       expect(
         wrapper.find('.currency-input__conversion-component').text(),
@@ -274,7 +274,7 @@ describe('CurrencyInput Component', () => {
       expect(handleChangeSpy.callCount).toStrictEqual(1);
       expect(handleChangeSpy.calledWith('f602f2234d0ea')).toStrictEqual(true);
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(
-        '0.004328ETH',
+        '0.00432788ETH',
       );
       expect(currencyInputInstance.state.decimalValue).toStrictEqual(1);
       expect(currencyInputInstance.state.hexValue).toStrictEqual(
@@ -375,7 +375,7 @@ describe('CurrencyInput Component', () => {
       const swap = wrapper.find('.currency-input__swap-component');
       swap.simulate('click');
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(
-        '0.004328ETH',
+        '0.00432788ETH',
       );
     });
   });

--- a/ui/components/ui/currency-input/currency-input.component.test.js
+++ b/ui/components/ui/currency-input/currency-input.component.test.js
@@ -159,7 +159,9 @@ describe('CurrencyInput Component', () => {
         .find(CurrencyInput)
         .at(0)
         .instance();
-      expect(currencyInputInstance.state.decimalValue).toStrictEqual(0.00432788);
+      expect(currencyInputInstance.state.decimalValue).toStrictEqual(
+        0.00432788,
+      );
       expect(currencyInputInstance.state.hexValue).toStrictEqual(
         'f602f2234d0ea',
       );

--- a/ui/hooks/useUserPreferencedCurrency.js
+++ b/ui/hooks/useUserPreferencedCurrency.js
@@ -49,7 +49,7 @@ export function useUserPreferencedCurrency(type, opts = {}) {
   ) {
     // Display ETH
     currency = nativeCurrency || ETH;
-    numberOfDecimals = opts.numberOfDecimals || opts.ethNumberOfDecimals || 6;
+    numberOfDecimals = opts.numberOfDecimals || opts.ethNumberOfDecimals || 8;
   } else if (
     (type === SECONDARY && useNativeCurrencyAsPrimaryCurrency) ||
     (type === PRIMARY && !useNativeCurrencyAsPrimaryCurrency)

--- a/ui/hooks/useUserPreferencedCurrency.test.js
+++ b/ui/hooks/useUserPreferencedCurrency.test.js
@@ -20,7 +20,7 @@ const tests = [
     },
     result: {
       currency: 'ETH',
-      numberOfDecimals: 6,
+      numberOfDecimals: 8,
     },
   },
   {
@@ -82,7 +82,7 @@ const tests = [
     },
     result: {
       currency: 'ETH',
-      numberOfDecimals: 6,
+      numberOfDecimals: 8,
     },
   },
   {


### PR DESCRIPTION
**Fixes:** #11420

**Explanation for screenshot number one:**  When user want to send ETH to an address, user can insert 8 decimal places and Metamask round up values after 8 decimal places.

**Screenshot number one:**  
![Screenshot from 2021-10-22 14-08-35](https://user-images.githubusercontent.com/92527393/138452352-def2bbe9-0919-442c-a71f-75e0fa6cfdb2.png)

**Explanation for screenshot number two:** After typing the value 1.23456789, we would expect to see the same value in the input field as well as on the Confirmation screen when we click Next.

**Screenshot number two:** 
![Screenshot from 2021-10-22 14-09-33](https://user-images.githubusercontent.com/92527393/138452361-b58c18ea-3e48-4e59-bf10-881b7e8c384e.png)
