### PR TITLE
Add secrets for beta and Flask builds

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -29,10 +29,15 @@ const bifyModuleGroups = require('bify-module-groups');
 
 const metamaskrc = require('rc')('metamask', {
   INFURA_PROJECT_ID: process.env.INFURA_PROJECT_ID,
+  INFURA_BETA_PROJECT_ID: process.env.INFURA_BETA_PROJECT_ID,
+  INFURA_FLASK_PROJECT_ID: process.env.INFURA_FLASK_PROJECT_ID,
   INFURA_PROD_PROJECT_ID: process.env.INFURA_PROD_PROJECT_ID,
   ONBOARDING_V2: process.env.ONBOARDING_V2,
   SEGMENT_HOST: process.env.SEGMENT_HOST,
   SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
+  SEGMENT_BETA_WRITE_KEY: process.env.SEGMENT_BETA_WRITE_KEY,
+  SEGMENT_FLASK_WRITE_KEY: process.env.SEGMENT_FLASK_WRITE_KEY,
+  SEGMENT_PROD_WRITE_KEY: process.env.SEGMENT_PROD_WRITE_KEY,
   SENTRY_DSN_DEV:
     process.env.SENTRY_DSN_DEV ||
     'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496',
@@ -50,6 +55,7 @@ const {
 const {
   createRemoveFencedCodeTransform,
 } = require('./transforms/remove-fenced-code');
+const { BuildTypes } = require('./utils');
 
 /**
  * The build environment. This describes the environment this build was produced in.
@@ -83,18 +89,47 @@ function getConfigValue(key) {
  * Get the appropriate Infura project ID.
  *
  * @param {object} options - The Infura project ID options.
+ * @param {BuildTypes} options.buildType - The current build type.
  * @param {ENVIRONMENT[keyof ENVIRONMENT]} options.environment - The build environment.
  * @param {boolean} options.testing - Whether the current build is a test build or not.
  * @returns {string} The Infura project ID.
  */
-function getInfuraProjectId({ environment, testing }) {
+function getInfuraProjectId({ buildType, environment, testing }) {
   if (testing) {
     return '00000000000000000000000000000000';
-  } else if (environment === ENVIRONMENT.PRODUCTION) {
+  } else if (environment !== ENVIRONMENT.PRODUCTION) {
+    // Skip validation because this is unset on PRs from forks.
+    return metamaskrc.INFURA_PROJECT_ID;
+  } else if (buildType === BuildTypes.main) {
     return getConfigValue('INFURA_PROD_PROJECT_ID');
+  } else if (buildType === BuildTypes.beta) {
+    return getConfigValue('INFURA_BETA_PROJECT_ID');
+  } else if (buildType === BuildTypes.flask) {
+    return getConfigValue('INFURA_FLASK_PROJECT_ID');
   }
-  // Skip validation because this is unset on PRs from forks
-  return metamaskrc.INFURA_PROJECT_ID;
+  throw new Error(`Invalid build type: '${buildType}'`);
+}
+
+/**
+ * Get the appropriate Segment write key.
+ *
+ * @param {object} options - The Segment write key options.
+ * @param {BuildTypes} options.buildType - The current build type.
+ * @param {keyof ENVIRONMENT} options.enviroment - The current build environment.
+ * @returns {string} The Segment write key.
+ */
+function getSegmentWriteKey({ buildType, environment }) {
+  if (environment !== ENVIRONMENT.PRODUCTION) {
+    // Skip validation because this is unset on PRs from forks, and isn't necessary for development builds.
+    return metamaskrc.SEGMENT_WRITE_KEY;
+  } else if (buildType === BuildTypes.main) {
+    return getConfigValue('SEGMENT_PROD_WRITE_KEY');
+  } else if (buildType === BuildTypes.beta) {
+    return getConfigValue('SEGMENT_BETA_WRITE_KEY');
+  } else if (buildType === BuildTypes.flask) {
+    return getConfigValue('SEGMENT_FLASK_WRITE_KEY');
+  }
+  throw new Error(`Invalid build type: '${buildType}'`);
 }
 
 module.exports = createScriptTasks;
@@ -686,17 +721,9 @@ function getEnvironmentVariables({ buildType, devMode, testing }) {
     CONF: devMode ? metamaskrc : {},
     SENTRY_DSN: process.env.SENTRY_DSN,
     SENTRY_DSN_DEV: metamaskrc.SENTRY_DSN_DEV,
-    INFURA_PROJECT_ID: getInfuraProjectId({ environment, testing }),
+    INFURA_PROJECT_ID: getInfuraProjectId({ buildType, environment, testing }),
     SEGMENT_HOST: metamaskrc.SEGMENT_HOST,
-    // When we're in the 'production' environment we will use a specific key only set in CI
-    // Otherwise we'll use the key from .metamaskrc or from the environment variable. If
-    // the value of SEGMENT_WRITE_KEY that we envify is undefined then no events will be tracked
-    // in the build. This is intentional so that developers can contribute to MetaMask without
-    // inflating event volume.
-    SEGMENT_WRITE_KEY:
-      environment === ENVIRONMENT.PRODUCTION
-        ? process.env.SEGMENT_PROD_WRITE_KEY
-        : metamaskrc.SEGMENT_WRITE_KEY,
+    SEGMENT_WRITE_KEY: getSegmentWriteKey({ buildType, environment }),
     SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS === '1',
     ONBOARDING_V2: metamaskrc.ONBOARDING_V2 === '1',
   };


### PR DESCRIPTION
The build script has been updated to embed the correct Infura project ID and Segment write key for beta and Flask builds. These are set via environment variable or config file. They have already been added in CI as environment variables.

The Segment production write key has also been moved into the set of environment variables that can be set in the configuration file. This was to make the way we reference it more consistent.

The new project IDs and keys are only used in the "production" environment, which right now is the merge step into the `master` branch. This is appropriate for Flask, but it doesn't match our plan for how the beta release would get created. In a future PR, when the beta release automation work is completed, the conditions for when the beta secrets are used should be updated to ensure they're used only for the beta builds.

Closes #11896