### PR TITLE
Add build type to Sentry environment

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import { Dedupe, ExtraErrorData } from '@sentry/integrations';
 
+import { BuildType } from '../../../shared/constants/app';
 import extractEthjsErrorMessage from './extractEthjsErrorMessage';
 
 /* eslint-disable prefer-destructuring */
@@ -8,6 +9,7 @@ import extractEthjsErrorMessage from './extractEthjsErrorMessage';
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG;
 const METAMASK_ENVIRONMENT = process.env.METAMASK_ENVIRONMENT;
 const SENTRY_DSN_DEV = process.env.SENTRY_DSN_DEV;
+const METAMASK_BUILD_TYPE = process.env.METAMASK_BUILD_TYPE;
 /* eslint-enable prefer-destructuring */
 
 // This describes the subset of Redux state attached to errors sent to Sentry
@@ -87,10 +89,15 @@ export default function setupSentry({ release, getState }) {
     sentryTarget = SENTRY_DSN_DEV;
   }
 
+  const environment =
+    METAMASK_BUILD_TYPE === BuildType.main
+      ? METAMASK_ENVIRONMENT
+      : `${METAMASK_ENVIRONMENT}-${METAMASK_BUILD_TYPE}`;
+
   Sentry.init({
     dsn: sentryTarget,
     debug: METAMASK_DEBUG,
-    environment: METAMASK_ENVIRONMENT,
+    environment,
     integrations: [new Dedupe(), new ExtraErrorData()],
     release,
     beforeSend: (report) => rewriteReport(report),

--- a/development/build/etc.js
+++ b/development/build/etc.js
@@ -6,7 +6,7 @@ const pify = require('pify');
 const pump = pify(require('pump'));
 const { version } = require('../../package.json');
 const { createTask, composeParallel } = require('./task');
-const { BuildTypes } = require('./utils');
+const { BuildType } = require('./utils');
 
 module.exports = createEtcTasks;
 
@@ -38,7 +38,7 @@ function createEtcTasks({ browserPlatforms, buildType, livereload }) {
 function createZipTask(platform, buildType) {
   return async () => {
     const path =
-      buildType === BuildTypes.main
+      buildType === BuildType.main
         ? `metamask-${platform}-${version}`
         : `metamask-${buildType}-${platform}-${version}`;
     await pump(

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -16,7 +16,7 @@ const createScriptTasks = require('./scripts');
 const createStyleTasks = require('./styles');
 const createStaticAssetTasks = require('./static');
 const createEtcTasks = require('./etc');
-const { BuildTypes, getBrowserVersionMap } = require('./utils');
+const { BuildType, getBrowserVersionMap } = require('./utils');
 
 // packages required dynamically via browserify configuration in dependencies
 require('loose-envify');
@@ -149,7 +149,7 @@ function parseArgv() {
     ],
     string: [NamedArgs.BuildType],
     default: {
-      [NamedArgs.BuildType]: BuildTypes.main,
+      [NamedArgs.BuildType]: BuildType.main,
       [NamedArgs.LintFenceFiles]: true,
       [NamedArgs.OmitLockdown]: false,
       [NamedArgs.SkipStats]: false,
@@ -168,7 +168,7 @@ function parseArgv() {
   }
 
   const buildType = argv[NamedArgs.BuildType];
-  if (!(buildType in BuildTypes)) {
+  if (!(buildType in BuildType)) {
     throw new Error(`MetaMask build: Invalid build type: "${buildType}"`);
   }
 

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -6,7 +6,7 @@ const baseManifest = require('../../app/manifest/_base.json');
 const betaManifestModifications = require('../../app/manifest/_beta_modifications.json');
 
 const { createTask, composeSeries } = require('./task');
-const { BuildTypes } = require('./utils');
+const { BuildType } = require('./utils');
 
 module.exports = createManifestTasks;
 
@@ -114,7 +114,7 @@ async function writeJson(obj, file) {
 
 function getBuildModifications(buildType) {
   const buildModifications = {};
-  if (buildType === BuildTypes.beta) {
+  if (buildType === BuildType.beta) {
     Object.assign(buildModifications, betaManifestModifications);
   }
   return buildModifications;

--- a/development/build/static.js
+++ b/development/build/static.js
@@ -6,7 +6,7 @@ const glob = require('fast-glob');
 const locales = require('../../app/_locales/index.json');
 
 const { createTask, composeSeries } = require('./task');
-const { BuildTypes } = require('./utils');
+const { BuildType } = require('./utils');
 
 const EMPTY_JS_FILE = './development/empty.js';
 
@@ -21,7 +21,7 @@ module.exports = function createStaticAssetTasks({
   );
 
   const additionalBuildTargets = {
-    [BuildTypes.beta]: [
+    [BuildType.beta]: [
       {
         src: './app/build-types/beta/',
         dest: `images`,

--- a/development/build/transforms/remove-fenced-code.js
+++ b/development/build/transforms/remove-fenced-code.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { PassThrough, Transform } = require('stream');
-const { BuildTypes } = require('../utils');
+const { BuildType } = require('../utils');
 const { lintTransformedFile } = require('./utils');
 
 const hasOwnProperty = (obj, key) => Reflect.hasOwnProperty.call(obj, key);
@@ -86,7 +86,7 @@ function createRemoveFencedCodeTransform(
   buildType,
   shouldLintTransformedFiles = true,
 ) {
-  if (!hasOwnProperty(BuildTypes, buildType)) {
+  if (!hasOwnProperty(BuildType, buildType)) {
     throw new Error(
       `Code fencing transform received unrecognized build type "${buildType}".`,
     );
@@ -136,7 +136,7 @@ const CommandValidators = {
     }
 
     params.forEach((param) => {
-      if (!hasOwnProperty(BuildTypes, param)) {
+      if (!hasOwnProperty(BuildType, param)) {
         throw new Error(
           getInvalidParamsMessage(
             filePath,

--- a/development/build/transforms/remove-fenced-code.test.js
+++ b/development/build/transforms/remove-fenced-code.test.js
@@ -1,5 +1,5 @@
 const deepFreeze = require('deep-freeze-strict');
-const { BuildTypes } = require('../utils');
+const { BuildType } = require('../utils');
 const {
   createRemoveFencedCodeTransform,
   removeFencedCode,
@@ -191,7 +191,7 @@ describe('build/transforms/remove-fenced-code', () => {
     const mockFileName = 'file.js';
 
     // Valid inputs
-    Object.keys(BuildTypes).forEach((buildType) => {
+    Object.keys(BuildType).forEach((buildType) => {
       it(`transforms file with fences for build type "${buildType}"`, () => {
         expect(
           removeFencedCode(
@@ -224,7 +224,7 @@ describe('build/transforms/remove-fenced-code', () => {
       expect(
         removeFencedCode(
           mockFileName,
-          BuildTypes.flask,
+          BuildType.flask,
           getMinimalFencedCode('main'),
         ),
       ).toStrictEqual(['', true]);
@@ -243,7 +243,7 @@ describe('build/transforms/remove-fenced-code', () => {
         expect(
           removeFencedCode(
             mockFileName,
-            BuildTypes.flask,
+            BuildType.flask,
             getMinimalFencedCode('main').concat(ignoredLine),
           ),
         ).toStrictEqual([ignoredLine, true]);
@@ -256,7 +256,7 @@ describe('build/transforms/remove-fenced-code', () => {
         expect(
           removeFencedCode(
             mockFileName,
-            BuildTypes.flask,
+            BuildType.flask,
             modifiedInputWithoutFences,
           ),
         ).toStrictEqual([modifiedInputWithoutFences, false]);
@@ -286,7 +286,7 @@ describe('build/transforms/remove-fenced-code', () => {
 
       inputs.forEach((input) => {
         expect(() =>
-          removeFencedCode(mockFileName, BuildTypes.flask, input),
+          removeFencedCode(mockFileName, BuildType.flask, input),
         ).toThrow(
           `Empty fence found in file "${mockFileName}":\n${emptyFence}`,
         );
@@ -313,7 +313,7 @@ describe('build/transforms/remove-fenced-code', () => {
         expect(() =>
           removeFencedCode(
             mockFileName,
-            BuildTypes.flask,
+            BuildType.flask,
             getMinimalFencedCode().replace(
               fenceSentinelAndTerminusRegex,
               replacement,
@@ -373,7 +373,7 @@ describe('build/transforms/remove-fenced-code', () => {
         expect(() =>
           removeFencedCode(
             mockFileName,
-            BuildTypes.flask,
+            BuildType.flask,
             getMinimalFencedCode().replace(directiveString, replacement),
           ),
         ).toThrow(
@@ -419,7 +419,7 @@ describe('build/transforms/remove-fenced-code', () => {
         expect(() =>
           removeFencedCode(
             mockFileName,
-            BuildTypes.flask,
+            BuildType.flask,
             getMinimalFencedCode().replace(directiveString, replacement),
           ),
         ).toThrow(
@@ -440,7 +440,7 @@ describe('build/transforms/remove-fenced-code', () => {
         expect(() =>
           removeFencedCode(
             mockFileName,
-            BuildTypes.flask,
+            BuildType.flask,
             getMinimalFencedCode().concat(addition),
           ),
         ).toThrow(
@@ -460,7 +460,7 @@ describe('build/transforms/remove-fenced-code', () => {
           expect(() =>
             removeFencedCode(
               mockFileName,
-              BuildTypes.flask,
+              BuildType.flask,
               getMinimalFencedCode().replace(validTerminus, replacement),
             ),
           ).toThrow(
@@ -484,7 +484,7 @@ describe('build/transforms/remove-fenced-code', () => {
           expect(() =>
             removeFencedCode(
               mockFileName,
-              BuildTypes.flask,
+              BuildType.flask,
               getMinimalFencedCode().replace(validCommand, replacement),
             ),
           ).toThrow(
@@ -513,7 +513,7 @@ describe('build/transforms/remove-fenced-code', () => {
           expect(() =>
             removeFencedCode(
               mockFileName,
-              BuildTypes.flask,
+              BuildType.flask,
               getMinimalFencedCode(replacement),
             ),
           ).toThrow(
@@ -526,7 +526,7 @@ describe('build/transforms/remove-fenced-code', () => {
       expect(() =>
         removeFencedCode(
           mockFileName,
-          BuildTypes.flask,
+          BuildType.flask,
           getMinimalFencedCode('').replace('()', ''),
         ),
       ).toThrow(/No params specified.$/u);
@@ -562,7 +562,7 @@ describe('build/transforms/remove-fenced-code', () => {
         expect(() =>
           removeFencedCode(
             mockFileName,
-            BuildTypes.flask,
+            BuildType.flask,
             input.replace(target, replacement),
           ),
         ).toThrow(expectedError);

--- a/development/build/utils.js
+++ b/development/build/utils.js
@@ -1,7 +1,12 @@
 const semver = require('semver');
 const { version } = require('../../package.json');
 
-const BuildTypes = {
+/**
+ * The distribution this build is intended for.
+ *
+ * This should be kept in-sync with the `BuildType` map in `shared/constants/app.js`.
+ */
+const BuildType = {
   beta: 'beta',
   flask: 'flask',
   main: 'main',
@@ -35,7 +40,7 @@ function getBrowserVersionMap(platforms) {
     [buildType, buildVersion] = prerelease;
     if (!String(buildVersion).match(/^\d+$/u)) {
       throw new Error(`Invalid prerelease build version: '${buildVersion}'`);
-    } else if (buildType !== BuildTypes.beta) {
+    } else if (buildType !== BuildType.beta) {
       throw new Error(`Invalid prerelease build type: ${buildType}`);
     }
   }
@@ -58,6 +63,6 @@ function getBrowserVersionMap(platforms) {
 }
 
 module.exports = {
-  BuildTypes,
+  BuildType,
   getBrowserVersionMap,
 };

--- a/shared/constants/app.js
+++ b/shared/constants/app.js
@@ -11,6 +11,17 @@ export const ENVIRONMENT_TYPE_NOTIFICATION = 'notification';
 export const ENVIRONMENT_TYPE_FULLSCREEN = 'fullscreen';
 export const ENVIRONMENT_TYPE_BACKGROUND = 'background';
 
+/**
+ * The distribution this build is intended for.
+ *
+ * This should be kept in-sync with the `BuildType` map in `development/build/utils.js`.
+ */
+export const BuildType = {
+  beta: 'beta',
+  flask: 'flask',
+  main: 'main',
+};
+
 export const PLATFORM_BRAVE = 'Brave';
 export const PLATFORM_CHROME = 'Chrome';
 export const PLATFORM_EDGE = 'Edge';


### PR DESCRIPTION
The build type (i.e. the distribution) is now included in the Sentry environment during setup, for all builds except the "main" build. This will allow us to track Flask and beta errors separately from other errors.

A constant was created for the build types. The equivalent constant in our build scripts was updated to match it more closely, for consistency. We can't use the same constant in both places because our shared constants are in modules that use ES6 exports, and our build script does not yet support ES6 exports.

The singular `BuildType` was used rather than `BuildTypes` to match our naming conventions elsewhere for enums. We name them like classes or types, rather than like a collection.

Relates to #11896