### PR TITLE
Update NumericInput to remove PropTypes warning

### DIFF
--- a/ui/components/ui/numeric-input/numeric-input.component.js
+++ b/ui/components/ui/numeric-input/numeric-input.component.js
@@ -47,7 +47,7 @@ export default function NumericInput({
 }
 
 NumericInput.propTypes = {
-  value: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   detailText: PropTypes.string,
   onChange: PropTypes.func,
   error: PropTypes.string,


### PR DESCRIPTION
Use oneOfType, not oneOf, to specify a union type.