### PR TITLE
Standardize the use of zero value into a constant

### DIFF
--- a/app/scripts/controllers/incoming-transactions.test.js
+++ b/app/scripts/controllers/incoming-transactions.test.js
@@ -20,7 +20,7 @@ import {
   TRANSACTION_STATUSES,
 } from '../../../shared/constants/transaction';
 import { MILLISECOND } from '../../../shared/constants/time';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 const IncomingTransactionsController = proxyquire('./incoming-transactions', {
   '../../../shared/modules/random-id': { default: () => 54321 },
@@ -312,11 +312,11 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: ZERO_VALUE,
-                gasPrice: ZERO_VALUE,
+                gas: HEX_ZERO_VALUE,
+                gasPrice: HEX_ZERO_VALUE,
                 nonce: '0x64',
                 to: '0x0101',
-                value: ZERO_VALUE,
+                value: HEX_ZERO_VALUE,
               },
             },
             '0xfakeeip1559': {
@@ -329,12 +329,12 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: ZERO_VALUE,
+                gas: HEX_ZERO_VALUE,
                 maxFeePerGas: '0xa',
                 maxPriorityFeePerGas: '0x1',
                 nonce: '0x64',
                 to: '0x0101',
-                value: ZERO_VALUE,
+                value: HEX_ZERO_VALUE,
               },
             },
           },
@@ -607,11 +607,11 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: ZERO_VALUE,
-                gasPrice: ZERO_VALUE,
+                gas: HEX_ZERO_VALUE,
+                gasPrice: HEX_ZERO_VALUE,
                 nonce: '0x64',
                 to: '0x01019',
-                value: ZERO_VALUE,
+                value: HEX_ZERO_VALUE,
               },
             },
           },
@@ -745,11 +745,11 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: ZERO_VALUE,
-                gasPrice: ZERO_VALUE,
+                gas: HEX_ZERO_VALUE,
+                gasPrice: HEX_ZERO_VALUE,
                 nonce: '0x64',
                 to: '0x0101',
-                value: ZERO_VALUE,
+                value: HEX_ZERO_VALUE,
               },
             },
           },

--- a/app/scripts/controllers/incoming-transactions.test.js
+++ b/app/scripts/controllers/incoming-transactions.test.js
@@ -20,6 +20,7 @@ import {
   TRANSACTION_STATUSES,
 } from '../../../shared/constants/transaction';
 import { MILLISECOND } from '../../../shared/constants/time';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 const IncomingTransactionsController = proxyquire('./incoming-transactions', {
   '../../../shared/modules/random-id': { default: () => 54321 },
@@ -311,11 +312,11 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: '0x0',
-                gasPrice: '0x0',
+                gas: ZERO_VALUE,
+                gasPrice: ZERO_VALUE,
                 nonce: '0x64',
                 to: '0x0101',
-                value: '0x0',
+                value: ZERO_VALUE,
               },
             },
             '0xfakeeip1559': {
@@ -328,12 +329,12 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: '0x0',
+                gas: ZERO_VALUE,
                 maxFeePerGas: '0xa',
                 maxPriorityFeePerGas: '0x1',
                 nonce: '0x64',
                 to: '0x0101',
-                value: '0x0',
+                value: ZERO_VALUE,
               },
             },
           },
@@ -606,11 +607,11 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: '0x0',
-                gasPrice: '0x0',
+                gas: ZERO_VALUE,
+                gasPrice: ZERO_VALUE,
                 nonce: '0x64',
                 to: '0x01019',
-                value: '0x0',
+                value: ZERO_VALUE,
               },
             },
           },
@@ -744,11 +745,11 @@ describe('IncomingTransactionsController', function () {
               type: TRANSACTION_TYPES.INCOMING,
               txParams: {
                 from: '0xfake',
-                gas: '0x0',
-                gasPrice: '0x0',
+                gas: ZERO_VALUE,
+                gasPrice: ZERO_VALUE,
                 nonce: '0x64',
                 to: '0x0101',
-                value: '0x0',
+                value: ZERO_VALUE,
               },
             },
           },

--- a/app/scripts/controllers/network/pending-middleware.test.js
+++ b/app/scripts/controllers/network/pending-middleware.test.js
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { GAS_LIMITS } from '../../../../shared/constants/gas';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../../../shared/constants/transaction';
 import { txMetaStub } from '../../../../test/stub/tx-meta-stub';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import {
   createPendingNonceMiddleware,
   createPendingTxMiddleware,
@@ -68,7 +68,7 @@ describe('PendingNonceMiddleware', function () {
       type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
       to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
       transactionIndex: null,
-      value: ZERO_VALUE,
+      value: HEX_ZERO_VALUE,
       v: '0x2c',
       r: '0x5f973e540f2d3c2f06d3725a626b75247593cb36477187ae07ecfe0a4db3cf57',
       s: '0x0259b52ee8c58baaa385fb05c3f96116e58de89bcc165cb3bfdfc708672fed8a',

--- a/app/scripts/controllers/network/pending-middleware.test.js
+++ b/app/scripts/controllers/network/pending-middleware.test.js
@@ -2,6 +2,7 @@ import { strict as assert } from 'assert';
 import { GAS_LIMITS } from '../../../../shared/constants/gas';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../../../shared/constants/transaction';
 import { txMetaStub } from '../../../../test/stub/tx-meta-stub';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import {
   createPendingNonceMiddleware,
   createPendingTxMiddleware,
@@ -67,7 +68,7 @@ describe('PendingNonceMiddleware', function () {
       type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
       to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
       transactionIndex: null,
-      value: '0x0',
+      value: ZERO_VALUE,
       v: '0x2c',
       r: '0x5f973e540f2d3c2f06d3725a626b75247593cb36477187ae07ecfe0a4db3cf57',
       s: '0x0259b52ee8c58baaa385fb05c3f96116e58de89bcc165cb3bfdfc708672fed8a',

--- a/app/scripts/controllers/network/util.js
+++ b/app/scripts/controllers/network/util.js
@@ -1,6 +1,6 @@
 import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 
 export const getNetworkDisplayName = (key) => NETWORK_TO_NAME_MAP[key];
 
@@ -29,7 +29,7 @@ export function formatTxMetaForRpcResult(txMeta) {
     hash,
     nonce,
     input: data || '0x',
-    value: value || ZERO_VALUE,
+    value: value || HEX_ZERO_VALUE,
     accessList: accessList || null,
     blockHash: txReceipt?.blockHash || null,
     blockNumber: txReceipt?.blockNumber || null,

--- a/app/scripts/controllers/network/util.js
+++ b/app/scripts/controllers/network/util.js
@@ -1,5 +1,6 @@
 import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 import { TRANSACTION_ENVELOPE_TYPES } from '../../../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 
 export const getNetworkDisplayName = (key) => NETWORK_TO_NAME_MAP[key];
 
@@ -28,7 +29,7 @@ export function formatTxMetaForRpcResult(txMeta) {
     hash,
     nonce,
     input: data || '0x',
-    value: value || '0x0',
+    value: value || ZERO_VALUE,
     accessList: accessList || null,
     blockHash: txReceipt?.blockHash || null,
     blockNumber: txReceipt?.blockNumber || null,

--- a/app/scripts/controllers/network/util.test.js
+++ b/app/scripts/controllers/network/util.test.js
@@ -5,6 +5,7 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
 
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { formatTxMetaForRpcResult } from './util';
 
 describe('network utils', function () {
@@ -51,7 +52,7 @@ describe('network utils', function () {
         transactionIndex: null,
         type: '0x2',
         v: '0x29',
-        value: '0x0',
+        value: ZERO_VALUE,
       };
       const result = formatTxMetaForRpcResult(txMeta);
       assert.deepEqual(result, expectedResult);
@@ -96,7 +97,7 @@ describe('network utils', function () {
         transactionIndex: null,
         type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
         v: '0x29',
-        value: '0x0',
+        value: ZERO_VALUE,
       };
       const result = formatTxMetaForRpcResult(txMeta);
       assert.deepEqual(result, expectedResult);

--- a/app/scripts/controllers/network/util.test.js
+++ b/app/scripts/controllers/network/util.test.js
@@ -5,7 +5,7 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
 
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { formatTxMetaForRpcResult } from './util';
 
 describe('network utils', function () {
@@ -52,7 +52,7 @@ describe('network utils', function () {
         transactionIndex: null,
         type: '0x2',
         v: '0x29',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       };
       const result = formatTxMetaForRpcResult(txMeta);
       assert.deepEqual(result, expectedResult);
@@ -97,7 +97,7 @@ describe('network utils', function () {
         transactionIndex: null,
         type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
         v: '0x29',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       };
       const result = formatTxMetaForRpcResult(txMeta);
       assert.deepEqual(result, expectedResult);

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -19,6 +19,7 @@ import {
   SWAPS_CHAINID_CONTRACT_ADDRESS_MAP,
 } from '../../../shared/constants/swaps';
 import { GAS_ESTIMATE_TYPES } from '../../../shared/constants/gas';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 import { isSwapsDefaultTokenAddress } from '../../../shared/modules/swaps.utils';
 
@@ -623,7 +624,7 @@ export default class SwapsController {
       gasEstimateType,
     } = await this._getEIP1559GasFeeEstimates();
 
-    let usedGasPrice = '0x0';
+    let usedGasPrice = ZERO_VALUE;
 
     if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
       const {
@@ -672,7 +673,7 @@ export default class SwapsController {
         : new BigNumber(averageGas || MAX_GAS_LIMIT, 10);
 
       const totalGasLimitForCalculation = tradeGasLimitForCalculation
-        .plus(approvalNeeded?.gas || '0x0', 16)
+        .plus(approvalNeeded?.gas || ZERO_VALUE, 16)
         .toString(16);
 
       const gasTotalInWeiHex = calcGasTotal(

--- a/app/scripts/controllers/swaps.js
+++ b/app/scripts/controllers/swaps.js
@@ -19,7 +19,7 @@ import {
   SWAPS_CHAINID_CONTRACT_ADDRESS_MAP,
 } from '../../../shared/constants/swaps';
 import { GAS_ESTIMATE_TYPES } from '../../../shared/constants/gas';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 import { isSwapsDefaultTokenAddress } from '../../../shared/modules/swaps.utils';
 
@@ -624,7 +624,7 @@ export default class SwapsController {
       gasEstimateType,
     } = await this._getEIP1559GasFeeEstimates();
 
-    let usedGasPrice = ZERO_VALUE;
+    let usedGasPrice = HEX_ZERO_VALUE;
 
     if (gasEstimateType === GAS_ESTIMATE_TYPES.FEE_MARKET) {
       const {
@@ -673,7 +673,7 @@ export default class SwapsController {
         : new BigNumber(averageGas || MAX_GAS_LIMIT, 10);
 
       const totalGasLimitForCalculation = tradeGasLimitForCalculation
-        .plus(approvalNeeded?.gas || ZERO_VALUE, 16)
+        .plus(approvalNeeded?.gas || HEX_ZERO_VALUE, 16)
         .toString(16);
 
       const gasTotalInWeiHex = calcGasTotal(

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -13,7 +13,7 @@ import { ETH_SWAPS_TOKEN_OBJECT } from '../../../shared/constants/swaps';
 import { createTestProviderTools } from '../../../test/stub/provider';
 import { SECOND } from '../../../shared/constants/time';
 import { GAS_ESTIMATE_TYPES } from '../../../shared/constants/gas';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import SwapsController, { utils } from './swaps';
 import { NETWORK_EVENTS } from './network';
 
@@ -1134,7 +1134,7 @@ function getMockQuotes() {
     [TEST_AGG_ID_1]: {
       trade: {
         from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         gas: '0x61a80', // 4e5
         to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
       },
@@ -1168,7 +1168,7 @@ function getMockQuotes() {
     [TEST_AGG_ID_BEST]: {
       trade: {
         from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         gas: '0x61a80',
         to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
       },
@@ -1202,7 +1202,7 @@ function getMockQuotes() {
     [TEST_AGG_ID_2]: {
       trade: {
         from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         gas: '0x61a80',
         to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
       },
@@ -1255,7 +1255,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1269,7 +1269,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1283,7 +1283,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1297,7 +1297,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1311,7 +1311,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1325,7 +1325,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       },
       fee: 1,
     },

--- a/app/scripts/controllers/swaps.test.js
+++ b/app/scripts/controllers/swaps.test.js
@@ -13,6 +13,7 @@ import { ETH_SWAPS_TOKEN_OBJECT } from '../../../shared/constants/swaps';
 import { createTestProviderTools } from '../../../test/stub/provider';
 import { SECOND } from '../../../shared/constants/time';
 import { GAS_ESTIMATE_TYPES } from '../../../shared/constants/gas';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import SwapsController, { utils } from './swaps';
 import { NETWORK_EVENTS } from './network';
 
@@ -1133,7 +1134,7 @@ function getMockQuotes() {
     [TEST_AGG_ID_1]: {
       trade: {
         from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-        value: '0x0',
+        value: ZERO_VALUE,
         gas: '0x61a80', // 4e5
         to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
       },
@@ -1167,7 +1168,7 @@ function getMockQuotes() {
     [TEST_AGG_ID_BEST]: {
       trade: {
         from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-        value: '0x0',
+        value: ZERO_VALUE,
         gas: '0x61a80',
         to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
       },
@@ -1201,7 +1202,7 @@ function getMockQuotes() {
     [TEST_AGG_ID_2]: {
       trade: {
         from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-        value: '0x0',
+        value: ZERO_VALUE,
         gas: '0x61a80',
         to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
       },
@@ -1254,7 +1255,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: '0x0',
+        value: ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1268,7 +1269,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: '0x0',
+        value: ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1282,7 +1283,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: '0x0',
+        value: ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1296,7 +1297,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: '0x0',
+        value: ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1310,7 +1311,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: '0x0',
+        value: ZERO_VALUE,
       },
       fee: 1,
     },
@@ -1324,7 +1325,7 @@ function getTopQuoteAndSavingsMockQuotes() {
       sourceAmount: '10000000000000000000',
       sourceToken: '0xsomeERC20TokenAddress',
       trade: {
-        value: '0x0',
+        value: ZERO_VALUE,
       },
       fee: 1,
     },

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -26,7 +26,7 @@ import {
   TRANSACTION_TYPES,
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
 import {
   GAS_LIMITS,
@@ -373,7 +373,7 @@ export default class TransactionController extends EventEmitter {
     // ensure value
     txMeta.txParams.value = txMeta.txParams.value
       ? addHexPrefix(txMeta.txParams.value)
-      : ZERO_VALUE;
+      : HEX_ZERO_VALUE;
 
     this.addTransaction(txMeta);
     this.emit('newUnapprovedTx', txMeta);
@@ -729,7 +729,7 @@ export default class TransactionController extends EventEmitter {
         from,
         to: from,
         nonce,
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         ...newGasParams,
       },
       previousGasParams,

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -26,6 +26,7 @@ import {
   TRANSACTION_TYPES,
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
 import {
   GAS_LIMITS,
@@ -372,7 +373,7 @@ export default class TransactionController extends EventEmitter {
     // ensure value
     txMeta.txParams.value = txMeta.txParams.value
       ? addHexPrefix(txMeta.txParams.value)
-      : '0x0';
+      : ZERO_VALUE;
 
     this.addTransaction(txMeta);
     this.emit('newUnapprovedTx', txMeta);
@@ -728,7 +729,7 @@ export default class TransactionController extends EventEmitter {
         from,
         to: from,
         nonce,
-        value: '0x0',
+        value: ZERO_VALUE,
         ...newGasParams,
       },
       previousGasParams,

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -15,7 +15,7 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
 
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { SECOND } from '../../../../shared/constants/time';
 import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
@@ -344,7 +344,7 @@ describe('Transaction Controller', function () {
       assert.ok('history' in txMeta, 'should have a history');
       assert.equal(
         txMeta.txParams.value,
-        ZERO_VALUE,
+        HEX_ZERO_VALUE,
         'should have added 0x0 as the value',
       );
 

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -15,6 +15,7 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
 
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { SECOND } from '../../../../shared/constants/time';
 import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
@@ -343,7 +344,7 @@ describe('Transaction Controller', function () {
       assert.ok('history' in txMeta, 'should have a history');
       assert.equal(
         txMeta.txParams.value,
-        '0x0',
+        ZERO_VALUE,
         'should have added 0x0 as the value',
       );
 

--- a/app/scripts/controllers/transactions/tx-gas-utils.test.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.test.js
@@ -2,6 +2,7 @@ import { strict as assert } from 'assert';
 import { TransactionFactory } from '@ethereumjs/tx';
 import Common from '@ethereumjs/common';
 import { hexToBn, bnToHex } from '../../lib/util';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import TxUtils from './tx-gas-utils';
 
 describe('txUtils', function () {
@@ -25,7 +26,7 @@ describe('txUtils', function () {
       const txParams = {
         to: '0x70ad465e0bab6504002ad58c744ed89c7da38524',
         from: '0x69ad465e0bab6504002ad58c744ed89c7da38525',
-        value: '0x0',
+        value: ZERO_VALUE,
         gas: '0x7b0c',
         gasPrice: '0x199c82cc00',
         data: '0x',

--- a/app/scripts/controllers/transactions/tx-gas-utils.test.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.test.js
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { TransactionFactory } from '@ethereumjs/tx';
 import Common from '@ethereumjs/common';
 import { hexToBn, bnToHex } from '../../lib/util';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import TxUtils from './tx-gas-utils';
 
 describe('txUtils', function () {
@@ -26,7 +26,7 @@ describe('txUtils', function () {
       const txParams = {
         to: '0x70ad465e0bab6504002ad58c744ed89c7da38524',
         from: '0x69ad465e0bab6504002ad58c744ed89c7da38525',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         gas: '0x7b0c',
         gasPrice: '0x199c82cc00',
         data: '0x',

--- a/app/scripts/controllers/transactions/tx-state-manager.test.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.test.js
@@ -11,6 +11,7 @@ import {
   KOVAN_NETWORK_ID,
 } from '../../../../shared/constants/network';
 import { GAS_LIMITS } from '../../../../shared/constants/gas';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import TxStateManager from './tx-state-manager';
 import { snapshotFromTxMeta } from './lib/tx-state-history-helpers';
 
@@ -518,7 +519,7 @@ describe('TransactionStateManager', function () {
         nonce: '0x3',
         gas: '0x77359400',
         gasPrice: '0x77359400',
-        value: '0x0',
+        value: ZERO_VALUE,
         data: '0x0',
       };
       const invalidValues = [1, true, {}, Symbol('1')];
@@ -782,7 +783,7 @@ describe('TransactionStateManager', function () {
         nonce: '0x3',
         gas: '0x77359400',
         gasPrice: '0x77359400',
-        value: '0x0',
+        value: ZERO_VALUE,
         data: '0x0',
       };
       const invalidValues = [1, true, {}, Symbol('1')];
@@ -1091,8 +1092,8 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: '0x0',
-        gasPrice: '0x0',
+        value: ZERO_VALUE,
+        gasPrice: ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,
@@ -1106,9 +1107,9 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: '0x0',
-        maxFeePerGas: '0x0',
-        maxPriorityFeePerGas: '0x0',
+        value: ZERO_VALUE,
+        maxFeePerGas: ZERO_VALUE,
+        maxPriorityFeePerGas: ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,
@@ -1119,27 +1120,27 @@ describe('TransactionStateManager', function () {
 
     it('records dappSuggestedGasFees when origin is provided and is not "metamask"', function () {
       const eip1559GasFeeFields = {
-        maxFeePerGas: '0x0',
-        maxPriorityFeePerGas: '0x0',
+        maxFeePerGas: ZERO_VALUE,
+        maxPriorityFeePerGas: ZERO_VALUE,
         gas: GAS_LIMITS.SIMPLE,
       };
 
       const legacyGasFeeFields = {
-        gasPrice: '0x0',
+        gasPrice: ZERO_VALUE,
         gas: GAS_LIMITS.SIMPLE,
       };
 
       const eip1559TxParams = {
         from: '0x0000',
         to: '0x000',
-        value: '0x0',
+        value: ZERO_VALUE,
         ...eip1559GasFeeFields,
       };
 
       const legacyTxParams = {
         from: '0x0000',
         to: '0x000',
-        value: '0x0',
+        value: ZERO_VALUE,
         ...legacyGasFeeFields,
       };
       const eip1559GeneratedTransaction = txStateManager.generateTxMeta({
@@ -1176,9 +1177,9 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: '0x0',
-        maxFeePerGas: '0x0',
-        maxPriorityFeePerGas: '0x0',
+        value: ZERO_VALUE,
+        maxFeePerGas: ZERO_VALUE,
+        maxPriorityFeePerGas: ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,
@@ -1193,9 +1194,9 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: '0x0',
-        maxFeePerGas: '0x0',
-        maxPriorityFeePerGas: '0x0',
+        value: ZERO_VALUE,
+        maxFeePerGas: ZERO_VALUE,
+        maxPriorityFeePerGas: ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,

--- a/app/scripts/controllers/transactions/tx-state-manager.test.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.test.js
@@ -11,7 +11,7 @@ import {
   KOVAN_NETWORK_ID,
 } from '../../../../shared/constants/network';
 import { GAS_LIMITS } from '../../../../shared/constants/gas';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import TxStateManager from './tx-state-manager';
 import { snapshotFromTxMeta } from './lib/tx-state-history-helpers';
 
@@ -519,7 +519,7 @@ describe('TransactionStateManager', function () {
         nonce: '0x3',
         gas: '0x77359400',
         gasPrice: '0x77359400',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         data: '0x0',
       };
       const invalidValues = [1, true, {}, Symbol('1')];
@@ -783,7 +783,7 @@ describe('TransactionStateManager', function () {
         nonce: '0x3',
         gas: '0x77359400',
         gasPrice: '0x77359400',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         data: '0x0',
       };
       const invalidValues = [1, true, {}, Symbol('1')];
@@ -1092,8 +1092,8 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: ZERO_VALUE,
-        gasPrice: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
+        gasPrice: HEX_ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,
@@ -1107,9 +1107,9 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: ZERO_VALUE,
-        maxFeePerGas: ZERO_VALUE,
-        maxPriorityFeePerGas: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
+        maxFeePerGas: HEX_ZERO_VALUE,
+        maxPriorityFeePerGas: HEX_ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,
@@ -1120,27 +1120,27 @@ describe('TransactionStateManager', function () {
 
     it('records dappSuggestedGasFees when origin is provided and is not "metamask"', function () {
       const eip1559GasFeeFields = {
-        maxFeePerGas: ZERO_VALUE,
-        maxPriorityFeePerGas: ZERO_VALUE,
+        maxFeePerGas: HEX_ZERO_VALUE,
+        maxPriorityFeePerGas: HEX_ZERO_VALUE,
         gas: GAS_LIMITS.SIMPLE,
       };
 
       const legacyGasFeeFields = {
-        gasPrice: ZERO_VALUE,
+        gasPrice: HEX_ZERO_VALUE,
         gas: GAS_LIMITS.SIMPLE,
       };
 
       const eip1559TxParams = {
         from: '0x0000',
         to: '0x000',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         ...eip1559GasFeeFields,
       };
 
       const legacyTxParams = {
         from: '0x0000',
         to: '0x000',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
         ...legacyGasFeeFields,
       };
       const eip1559GeneratedTransaction = txStateManager.generateTxMeta({
@@ -1177,9 +1177,9 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: ZERO_VALUE,
-        maxFeePerGas: ZERO_VALUE,
-        maxPriorityFeePerGas: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
+        maxFeePerGas: HEX_ZERO_VALUE,
+        maxPriorityFeePerGas: HEX_ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,
@@ -1194,9 +1194,9 @@ describe('TransactionStateManager', function () {
         gas: GAS_LIMITS.SIMPLE,
         from: '0x0000',
         to: '0x000',
-        value: ZERO_VALUE,
-        maxFeePerGas: ZERO_VALUE,
-        maxPriorityFeePerGas: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
+        maxFeePerGas: HEX_ZERO_VALUE,
+        maxPriorityFeePerGas: HEX_ZERO_VALUE,
       };
       const generatedTransaction = txStateManager.generateTxMeta({
         txParams,

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -20,6 +20,7 @@ import {
   ROPSTEN_CHAIN_ID,
   KOVAN_CHAIN_ID,
 } from '../../../shared/constants/network';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 import {
   SINGLE_CALL_BALANCES_ADDRESS,
@@ -274,7 +275,7 @@ export default class AccountTracker {
     const ethContract = this.web3.eth
       .contract(SINGLE_CALL_BALANCES_ABI)
       .at(deployedContractAddress);
-    const ethBalance = ['0x0'];
+    const ethBalance = [ZERO_VALUE];
 
     ethContract.balances(addresses, ethBalance, (error, result) => {
       if (error) {
@@ -286,7 +287,7 @@ export default class AccountTracker {
         return;
       }
       addresses.forEach((address, index) => {
-        const balance = result[index] ? bnToHex(result[index]) : '0x0';
+        const balance = result[index] ? bnToHex(result[index]) : ZERO_VALUE;
         accounts[address] = { address, balance };
       });
       this.store.updateState({ accounts });

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -20,7 +20,7 @@ import {
   ROPSTEN_CHAIN_ID,
   KOVAN_CHAIN_ID,
 } from '../../../shared/constants/network';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 import {
   SINGLE_CALL_BALANCES_ADDRESS,
@@ -275,7 +275,7 @@ export default class AccountTracker {
     const ethContract = this.web3.eth
       .contract(SINGLE_CALL_BALANCES_ABI)
       .at(deployedContractAddress);
-    const ethBalance = [ZERO_VALUE];
+    const ethBalance = [HEX_ZERO_VALUE];
 
     ethContract.balances(addresses, ethBalance, (error, result) => {
       if (error) {
@@ -287,7 +287,7 @@ export default class AccountTracker {
         return;
       }
       addresses.forEach((address, index) => {
-        const balance = result[index] ? bnToHex(result[index]) : ZERO_VALUE;
+        const balance = result[index] ? bnToHex(result[index]) : HEX_ZERO_VALUE;
         accounts[address] = { address, balance };
       });
       this.store.updateState({ accounts });

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -40,6 +40,7 @@ import { UI_NOTIFICATIONS } from '../../shared/notifications';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { MILLISECOND } from '../../shared/constants/time';
 import { POLLING_TOKEN_ENVIRONMENT_TYPES } from '../../shared/constants/app';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 
 import { hexToDecimal } from '../../ui/helpers/utils/conversions.util';
 import ComposableObservableStore from './lib/ComposableObservableStore';
@@ -1302,7 +1303,7 @@ export default class MetamaskController extends EventEmitter {
       }
 
       // seek out the first zero balance
-      while (lastBalance !== '0x0') {
+      while (lastBalance !== ZERO_VALUE) {
         await keyringController.addNewAccount(primaryKeyring);
         accounts = await keyringController.getAccounts();
         lastBalance = await this.getBalance(
@@ -1312,7 +1313,7 @@ export default class MetamaskController extends EventEmitter {
       }
 
       // remove extra zero balance account potentially created from seeking ahead
-      if (accounts.length > 1 && lastBalance === '0x0') {
+      if (accounts.length > 1 && lastBalance === ZERO_VALUE) {
         await this.removeAccount(accounts[accounts.length - 1]);
         accounts = await keyringController.getAccounts();
       }
@@ -1343,7 +1344,7 @@ export default class MetamaskController extends EventEmitter {
             reject(error);
             log.error(error);
           } else {
-            resolve(balance || '0x0');
+            resolve(balance || ZERO_VALUE);
           }
         });
       }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -40,7 +40,7 @@ import { UI_NOTIFICATIONS } from '../../shared/notifications';
 import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { MILLISECOND } from '../../shared/constants/time';
 import { POLLING_TOKEN_ENVIRONMENT_TYPES } from '../../shared/constants/app';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 
 import { hexToDecimal } from '../../ui/helpers/utils/conversions.util';
 import ComposableObservableStore from './lib/ComposableObservableStore';
@@ -1303,7 +1303,7 @@ export default class MetamaskController extends EventEmitter {
       }
 
       // seek out the first zero balance
-      while (lastBalance !== ZERO_VALUE) {
+      while (lastBalance !== HEX_ZERO_VALUE) {
         await keyringController.addNewAccount(primaryKeyring);
         accounts = await keyringController.getAccounts();
         lastBalance = await this.getBalance(
@@ -1313,7 +1313,7 @@ export default class MetamaskController extends EventEmitter {
       }
 
       // remove extra zero balance account potentially created from seeking ahead
-      if (accounts.length > 1 && lastBalance === ZERO_VALUE) {
+      if (accounts.length > 1 && lastBalance === HEX_ZERO_VALUE) {
         await this.removeAccount(accounts[accounts.length - 1]);
         accounts = await keyringController.getAccounts();
       }
@@ -1344,7 +1344,7 @@ export default class MetamaskController extends EventEmitter {
             reject(error);
             log.error(error);
           } else {
-            resolve(balance || ZERO_VALUE);
+            resolve(balance || HEX_ZERO_VALUE);
           }
         });
       }

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -10,6 +10,7 @@ import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
 import createTxMeta from '../../test/lib/createTxMeta';
 import { NETWORK_TYPE_RPC } from '../../shared/constants/network';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 import { addHexPrefix } from './lib/util';
 
 const Ganache = require('../../test/e2e/ganache');
@@ -286,7 +287,7 @@ describe('MetaMaskController', function () {
       const password = 'what-what-what';
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve('0x0');
+        return Promise.resolve(ZERO_VALUE);
       });
 
       await metamaskController
@@ -303,7 +304,7 @@ describe('MetaMaskController', function () {
     it('should clear previous identities after vault restoration', async function () {
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve('0x0');
+        return Promise.resolve(ZERO_VALUE);
       });
 
       let startTime = Date.now();
@@ -366,7 +367,7 @@ describe('MetaMaskController', function () {
         return Promise.resolve('0x14ced5122ce0a000');
       });
       metamaskController.getBalance.withArgs(TEST_ADDRESS_2).callsFake(() => {
-        return Promise.resolve('0x0');
+        return Promise.resolve(ZERO_VALUE);
       });
       metamaskController.getBalance.withArgs(TEST_ADDRESS_3).callsFake(() => {
         return Promise.resolve('0x14ced5122ce0a000');
@@ -840,7 +841,7 @@ describe('MetaMaskController', function () {
     beforeEach(async function () {
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve('0x0');
+        return Promise.resolve(ZERO_VALUE);
       });
 
       await metamaskController.createNewVaultAndRestore(
@@ -906,7 +907,7 @@ describe('MetaMaskController', function () {
     beforeEach(async function () {
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve('0x0');
+        return Promise.resolve(ZERO_VALUE);
       });
 
       await metamaskController.createNewVaultAndRestore(

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -10,7 +10,7 @@ import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
 import createTxMeta from '../../test/lib/createTxMeta';
 import { NETWORK_TYPE_RPC } from '../../shared/constants/network';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 import { addHexPrefix } from './lib/util';
 
 const Ganache = require('../../test/e2e/ganache');
@@ -287,7 +287,7 @@ describe('MetaMaskController', function () {
       const password = 'what-what-what';
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve(ZERO_VALUE);
+        return Promise.resolve(HEX_ZERO_VALUE);
       });
 
       await metamaskController
@@ -304,7 +304,7 @@ describe('MetaMaskController', function () {
     it('should clear previous identities after vault restoration', async function () {
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve(ZERO_VALUE);
+        return Promise.resolve(HEX_ZERO_VALUE);
       });
 
       let startTime = Date.now();
@@ -367,7 +367,7 @@ describe('MetaMaskController', function () {
         return Promise.resolve('0x14ced5122ce0a000');
       });
       metamaskController.getBalance.withArgs(TEST_ADDRESS_2).callsFake(() => {
-        return Promise.resolve(ZERO_VALUE);
+        return Promise.resolve(HEX_ZERO_VALUE);
       });
       metamaskController.getBalance.withArgs(TEST_ADDRESS_3).callsFake(() => {
         return Promise.resolve('0x14ced5122ce0a000');
@@ -841,7 +841,7 @@ describe('MetaMaskController', function () {
     beforeEach(async function () {
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve(ZERO_VALUE);
+        return Promise.resolve(HEX_ZERO_VALUE);
       });
 
       await metamaskController.createNewVaultAndRestore(
@@ -907,7 +907,7 @@ describe('MetaMaskController', function () {
     beforeEach(async function () {
       sandbox.stub(metamaskController, 'getBalance');
       metamaskController.getBalance.callsFake(() => {
-        return Promise.resolve(ZERO_VALUE);
+        return Promise.resolve(HEX_ZERO_VALUE);
       });
 
       await metamaskController.createNewVaultAndRestore(

--- a/shared/constants/hex-values.js
+++ b/shared/constants/hex-values.js
@@ -1,1 +1,1 @@
-export const ZERO_VALUE = '0x0';
+export const HEX_ZERO_VALUE = '0x0';

--- a/shared/constants/hex-values.js
+++ b/shared/constants/hex-values.js
@@ -1,0 +1,1 @@
+export const ZERO_VALUE = '0x0';

--- a/shared/modules/gas.utils.js
+++ b/shared/modules/gas.utils.js
@@ -1,5 +1,5 @@
 import { addHexPrefix } from 'ethereumjs-util';
-import { ZERO_VALUE } from '../constants/hex-values';
+import { HEX_ZERO_VALUE } from '../constants/hex-values';
 import {
   addCurrencies,
   conversionGreaterThan,
@@ -23,7 +23,7 @@ import {
  * @returns {string} - The maximum total cost of transaction in hex wei string
  */
 export function getMaximumGasTotalInHexWei({
-  gasLimit = ZERO_VALUE,
+  gasLimit = HEX_ZERO_VALUE,
   gasPrice,
   maxFeePerGas,
 } = {}) {
@@ -71,7 +71,7 @@ export function getMaximumGasTotalInHexWei({
  * @returns {string} - The minimum total cost of transaction in hex wei string
  */
 export function getMinimumGasTotalInHexWei({
-  gasLimit = ZERO_VALUE,
+  gasLimit = HEX_ZERO_VALUE,
   gasPrice,
   maxPriorityFeePerGas,
   maxFeePerGas,

--- a/shared/modules/gas.utils.js
+++ b/shared/modules/gas.utils.js
@@ -1,4 +1,5 @@
 import { addHexPrefix } from 'ethereumjs-util';
+import { ZERO_VALUE } from '../constants/hex-values';
 import {
   addCurrencies,
   conversionGreaterThan,
@@ -22,7 +23,7 @@ import {
  * @returns {string} - The maximum total cost of transaction in hex wei string
  */
 export function getMaximumGasTotalInHexWei({
-  gasLimit = '0x0',
+  gasLimit = ZERO_VALUE,
   gasPrice,
   maxFeePerGas,
 } = {}) {
@@ -70,7 +71,7 @@ export function getMaximumGasTotalInHexWei({
  * @returns {string} - The minimum total cost of transaction in hex wei string
  */
 export function getMinimumGasTotalInHexWei({
-  gasLimit = '0x0',
+  gasLimit = ZERO_VALUE,
   gasPrice,
   maxPriorityFeePerGas,
   maxFeePerGas,

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -1,10 +1,11 @@
 import { MAINNET_CHAIN_ID } from '../../shared/constants/network';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 
 export const createSwapsMockStore = () => {
   return {
     swaps: {
       customGas: {
-        limit: '0x0',
+        limit: ZERO_VALUE,
         fallBackPrice: 5,
         priceEstimates: {
           blockTime: 14.1,
@@ -57,11 +58,11 @@ export const createSwapsMockStore = () => {
       accounts: {
         '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
           address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-          balance: '0x0',
+          balance: ZERO_VALUE,
         },
         '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b': {
           address: '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
-          balance: '0x0',
+          balance: ZERO_VALUE,
         },
       },
       selectedAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
@@ -100,7 +101,7 @@ export const createSwapsMockStore = () => {
           TEST_AGG_1: {
             trade: {
               from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-              value: '0x0',
+              value: ZERO_VALUE,
               gas: '0x61a80', // 4e5
               to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
             },
@@ -134,7 +135,7 @@ export const createSwapsMockStore = () => {
           TEST_AGG_BEST: {
             trade: {
               from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-              value: '0x0',
+              value: ZERO_VALUE,
               gas: '0x61a80',
               to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
             },
@@ -167,7 +168,7 @@ export const createSwapsMockStore = () => {
           TEST_AGG_2: {
             trade: {
               from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-              value: '0x0',
+              value: ZERO_VALUE,
               gas: '0x61a80',
               to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
             },

--- a/test/jest/mock-store.js
+++ b/test/jest/mock-store.js
@@ -1,11 +1,11 @@
 import { MAINNET_CHAIN_ID } from '../../shared/constants/network';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 
 export const createSwapsMockStore = () => {
   return {
     swaps: {
       customGas: {
-        limit: ZERO_VALUE,
+        limit: HEX_ZERO_VALUE,
         fallBackPrice: 5,
         priceEstimates: {
           blockTime: 14.1,
@@ -58,11 +58,11 @@ export const createSwapsMockStore = () => {
       accounts: {
         '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
           address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-          balance: ZERO_VALUE,
+          balance: HEX_ZERO_VALUE,
         },
         '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b': {
           address: '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
-          balance: ZERO_VALUE,
+          balance: HEX_ZERO_VALUE,
         },
       },
       selectedAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
@@ -101,7 +101,7 @@ export const createSwapsMockStore = () => {
           TEST_AGG_1: {
             trade: {
               from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-              value: ZERO_VALUE,
+              value: HEX_ZERO_VALUE,
               gas: '0x61a80', // 4e5
               to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
             },
@@ -135,7 +135,7 @@ export const createSwapsMockStore = () => {
           TEST_AGG_BEST: {
             trade: {
               from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-              value: ZERO_VALUE,
+              value: HEX_ZERO_VALUE,
               gas: '0x61a80',
               to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
             },
@@ -168,7 +168,7 @@ export const createSwapsMockStore = () => {
           TEST_AGG_2: {
             trade: {
               from: '0xe18035bf8712672935fdb4e5e431b1a0183d2dfc',
-              value: ZERO_VALUE,
+              value: HEX_ZERO_VALUE,
               gas: '0x61a80',
               to: '0x881D40237659C251811CEC9c364ef91dC08D300C',
             },

--- a/test/stub/tx-meta-stub.js
+++ b/test/stub/tx-meta-stub.js
@@ -3,6 +3,7 @@ import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
 } from '../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 
 export const txMetaStub = {
   firstRetryBlockNumber: '0x51a402',
@@ -20,7 +21,7 @@ export const txMetaStub = {
         gas: GAS_LIMITS.SIMPLE,
         gasPrice: '0x1e8480',
         to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
-        value: '0x0',
+        value: ZERO_VALUE,
       },
     },
     [
@@ -202,7 +203,7 @@ export const txMetaStub = {
     gasPrice: '0x1e8480',
     nonce: '0x4',
     to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
-    value: '0x0',
+    value: ZERO_VALUE,
   },
   v: '0x2c',
 };

--- a/test/stub/tx-meta-stub.js
+++ b/test/stub/tx-meta-stub.js
@@ -3,7 +3,7 @@ import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
 } from '../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 
 export const txMetaStub = {
   firstRetryBlockNumber: '0x51a402',
@@ -21,7 +21,7 @@ export const txMetaStub = {
         gas: GAS_LIMITS.SIMPLE,
         gasPrice: '0x1e8480',
         to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
-        value: ZERO_VALUE,
+        value: HEX_ZERO_VALUE,
       },
     },
     [
@@ -203,7 +203,7 @@ export const txMetaStub = {
     gasPrice: '0x1e8480',
     nonce: '0x4',
     to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
-    value: ZERO_VALUE,
+    value: HEX_ZERO_VALUE,
   },
   v: '0x2c',
 };

--- a/ui/components/app/account-menu/account-menu.test.js
+++ b/ui/components/app/account-menu/account-menu.test.js
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { mountWithRouter } from '../../../../test/lib/render-helpers';
 import Button from '../../ui/button';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import AccountMenu from '.';
 
 describe('Account Menu', () => {
@@ -29,12 +30,12 @@ describe('Account Menu', () => {
       {
         address: '0x00',
         name: 'Account 1',
-        balance: '0x0',
+        balance: ZERO_VALUE,
       },
       {
         address: '0x1',
         name: 'Imported Account 1',
-        balance: '0x0',
+        balance: ZERO_VALUE,
       },
     ],
     keyrings: [

--- a/ui/components/app/account-menu/account-menu.test.js
+++ b/ui/components/app/account-menu/account-menu.test.js
@@ -4,7 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { mountWithRouter } from '../../../../test/lib/render-helpers';
 import Button from '../../ui/button';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import AccountMenu from '.';
 
 describe('Account Menu', () => {
@@ -30,12 +30,12 @@ describe('Account Menu', () => {
       {
         address: '0x00',
         name: 'Account 1',
-        balance: ZERO_VALUE,
+        balance: HEX_ZERO_VALUE,
       },
       {
         address: '0x1',
         name: 'Imported Account 1',
-        balance: ZERO_VALUE,
+        balance: HEX_ZERO_VALUE,
       },
     ],
     keyrings: [

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
@@ -11,7 +11,7 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers';
 
 import * as actions from '../../../../store/actions';
 import { KOVAN_CHAIN_ID } from '../../../../../shared/constants/network';
-import { ZERO_VALUE } from '../../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../../shared/constants/hex-values';
 import UnconnectedAccountAlert from '.';
 
 describe('Unconnected Account Alert', () => {
@@ -31,11 +31,11 @@ describe('Unconnected Account Alert', () => {
   const accounts = {
     '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
       address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-      balance: ZERO_VALUE,
+      balance: HEX_ZERO_VALUE,
     },
     '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b': {
       address: '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
-      balance: ZERO_VALUE,
+      balance: HEX_ZERO_VALUE,
     },
   };
 

--- a/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
+++ b/ui/components/app/alerts/unconnected-account-alert/unconnected-account-alert.test.js
@@ -11,6 +11,7 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers';
 
 import * as actions from '../../../../store/actions';
 import { KOVAN_CHAIN_ID } from '../../../../../shared/constants/network';
+import { ZERO_VALUE } from '../../../../../shared/constants/hex-values';
 import UnconnectedAccountAlert from '.';
 
 describe('Unconnected Account Alert', () => {
@@ -30,11 +31,11 @@ describe('Unconnected Account Alert', () => {
   const accounts = {
     '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc': {
       address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
-      balance: '0x0',
+      balance: ZERO_VALUE,
     },
     '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b': {
       address: '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b',
-      balance: '0x0',
+      balance: ZERO_VALUE,
     },
   };
 

--- a/ui/components/app/cancel-button/cancel-button.js
+++ b/ui/components/app/cancel-button/cancel-button.js
@@ -10,7 +10,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useIncrementedGasFees } from '../../../hooks/useIncrementedGasFees';
 import { isBalanceSufficient } from '../../../pages/send/send.utils';
 import { getSelectedAccount } from '../../../selectors';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 
 export default function CancelButton({
   cancelTransaction,
@@ -25,7 +25,7 @@ export default function CancelButton({
   const conversionRate = useSelector(getConversionRate);
 
   const hasEnoughCancelGas = isBalanceSufficient({
-    amount: ZERO_VALUE,
+    amount: HEX_ZERO_VALUE,
     gasTotal: getMaximumGasTotalInHexWei(customCancelGasSettings),
     balance: selectedAccount.balance,
     conversionRate,

--- a/ui/components/app/cancel-button/cancel-button.js
+++ b/ui/components/app/cancel-button/cancel-button.js
@@ -10,6 +10,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useIncrementedGasFees } from '../../../hooks/useIncrementedGasFees';
 import { isBalanceSufficient } from '../../../pages/send/send.utils';
 import { getSelectedAccount } from '../../../selectors';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 
 export default function CancelButton({
   cancelTransaction,
@@ -24,7 +25,7 @@ export default function CancelButton({
   const conversionRate = useSelector(getConversionRate);
 
   const hasEnoughCancelGas = isBalanceSufficient({
-    amount: '0x0',
+    amount: ZERO_VALUE,
     gasTotal: getMaximumGasTotalInHexWei(customCancelGasSettings),
     balance: selectedAccount.balance,
     conversionRate,

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
@@ -14,7 +14,7 @@ import {
   updateGasPrice,
 } from '../../../../ducks/send';
 
-import { ZERO_VALUE } from '../../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../../shared/constants/hex-values';
 
 let mapDispatchToProps;
 let mergeProps;
@@ -27,9 +27,9 @@ jest.mock('react-redux', () => ({
   },
 }));
 
-const mockGetCurrentEthBalance = (state) => state.metamask.balance || ZERO_VALUE;
-const mockGetCustomGasPrice = (state) => state.gas.customData.price || ZERO_VALUE;
-const mockGetCustomGasLimit = (state) => state.gas.customData.limit || ZERO_VALUE;
+const mockGetCurrentEthBalance = (state) => state.metamask.balance || HEX_ZERO_VALUE;
+const mockGetCustomGasPrice = (state) => state.gas.customData.price || HEX_ZERO_VALUE;
+const mockGetCustomGasLimit = (state) => state.gas.customData.limit || HEX_ZERO_VALUE;
 
 jest.mock('../../../../selectors', () => ({
   getBasicGasEstimateLoadingStatus: (s) =>
@@ -205,7 +205,7 @@ describe('gas-modal-page-container container', () => {
 
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(0);
       result.gasPriceButtonGroupProps.handleGasPriceSelection({
-        gasPrice: ZERO_VALUE,
+        gasPrice: HEX_ZERO_VALUE,
       });
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(1);
 
@@ -249,7 +249,7 @@ describe('gas-modal-page-container container', () => {
 
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(0);
       result.gasPriceButtonGroupProps.handleGasPriceSelection({
-        gasPrice: ZERO_VALUE,
+        gasPrice: HEX_ZERO_VALUE,
       });
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(1);
 

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
@@ -14,6 +14,8 @@ import {
   updateGasPrice,
 } from '../../../../ducks/send';
 
+import { ZERO_VALUE } from '../../../../../shared/constants/hex-values';
+
 let mapDispatchToProps;
 let mergeProps;
 
@@ -31,9 +33,9 @@ jest.mock('../../../../selectors', () => ({
   getRenderableBasicEstimateData: (s) =>
     `mockRenderableBasicEstimateData:${Object.keys(s).length}`,
   getDefaultActiveButtonIndex: (a, b) => a + b,
-  getCurrentEthBalance: (state) => state.metamask.balance || '0x0',
-  getCustomGasPrice: (state) => state.gas.customData.price || '0x0',
-  getCustomGasLimit: (state) => state.gas.customData.limit || '0x0',
+  getCurrentEthBalance: (state) => state.metamask.balance || ZERO_VALUE,
+  getCustomGasPrice: (state) => state.gas.customData.price || ZERO_VALUE,
+  getCustomGasLimit: (state) => state.gas.customData.limit || ZERO_VALUE,
   getCurrentCurrency: jest.fn().mockReturnValue('usd'),
   conversionRateSelector: jest.fn().mockReturnValue(50),
   getSendMaxModeState: jest.fn().mockReturnValue(false),
@@ -199,7 +201,7 @@ describe('gas-modal-page-container container', () => {
 
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(0);
       result.gasPriceButtonGroupProps.handleGasPriceSelection({
-        gasPrice: '0x0',
+        gasPrice: ZERO_VALUE,
       });
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(1);
 
@@ -243,7 +245,7 @@ describe('gas-modal-page-container container', () => {
 
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(0);
       result.gasPriceButtonGroupProps.handleGasPriceSelection({
-        gasPrice: '0x0',
+        gasPrice: ZERO_VALUE,
       });
       expect(dispatchProps.updateCustomGasPrice.callCount).toStrictEqual(1);
 

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
@@ -27,15 +27,19 @@ jest.mock('react-redux', () => ({
   },
 }));
 
+const mockGetCurrentEthBalance = (state) => state.metamask.balance || ZERO_VALUE;
+const mockGetCustomGasPrice = (state) => state.gas.customData.price || ZERO_VALUE;
+const mockGetCustomGasLimit = (state) => state.gas.customData.limit || ZERO_VALUE;
+
 jest.mock('../../../../selectors', () => ({
   getBasicGasEstimateLoadingStatus: (s) =>
     `mockBasicGasEstimateLoadingStatus:${Object.keys(s).length}`,
   getRenderableBasicEstimateData: (s) =>
     `mockRenderableBasicEstimateData:${Object.keys(s).length}`,
   getDefaultActiveButtonIndex: (a, b) => a + b,
-  getCurrentEthBalance: (state) => state.metamask.balance || ZERO_VALUE,
-  getCustomGasPrice: (state) => state.gas.customData.price || ZERO_VALUE,
-  getCustomGasLimit: (state) => state.gas.customData.limit || ZERO_VALUE,
+  getCurrentEthBalance: mockGetCurrentEthBalance,
+  getCustomGasPrice: mockGetCustomGasPrice,
+  getCustomGasLimit: mockGetCustomGasLimit,
   getCurrentCurrency: jest.fn().mockReturnValue('usd'),
   conversionRateSelector: jest.fn().mockReturnValue(50),
   getSendMaxModeState: jest.fn().mockReturnValue(false),

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container-container.test.js
@@ -27,9 +27,12 @@ jest.mock('react-redux', () => ({
   },
 }));
 
-const mockGetCurrentEthBalance = (state) => state.metamask.balance || HEX_ZERO_VALUE;
-const mockGetCustomGasPrice = (state) => state.gas.customData.price || HEX_ZERO_VALUE;
-const mockGetCustomGasLimit = (state) => state.gas.customData.limit || HEX_ZERO_VALUE;
+const mockGetCurrentEthBalance = (state) =>
+  state.metamask.balance || HEX_ZERO_VALUE;
+const mockGetCustomGasPrice = (state) =>
+  state.gas.customData.price || HEX_ZERO_VALUE;
+const mockGetCustomGasLimit = (state) =>
+  state.gas.customData.limit || HEX_ZERO_VALUE;
 
 jest.mock('../../../../selectors', () => ({
   getBasicGasEstimateLoadingStatus: (s) =>

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -56,7 +56,7 @@ import {
 import { MIN_GAS_LIMIT_DEC } from '../../../../pages/send/send.constants';
 import { TRANSACTION_STATUSES } from '../../../../../shared/constants/transaction';
 import { GAS_LIMITS } from '../../../../../shared/constants/gas';
-import { ZERO_VALUE } from '../../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../../shared/constants/hex-values';
 import { updateTransactionGasFees } from '../../../../ducks/metamask/metamask';
 import GasModalPageContainer from './gas-modal-page-container.component';
 
@@ -80,7 +80,7 @@ const mapStateToProps = (state, ownProps) => {
     : {
         gas: gasLimit || GAS_LIMITS.SIMPLE,
         gasPrice: gasPrice || getAveragePriceEstimateInHexWEI(state, true),
-        value: asset.type === ASSET_TYPES.TOKEN ? ZERO_VALUE : amount,
+        value: asset.type === ASSET_TYPES.TOKEN ? HEX_ZERO_VALUE : amount,
       };
 
   const { gasPrice: currentGasPrice, gas: currentGasLimit } = txParams;
@@ -120,13 +120,13 @@ const mapStateToProps = (state, ownProps) => {
 
   const newTotalEth =
     maxModeOn && asset.type === ASSET_TYPES.NATIVE
-      ? sumHexWEIsToRenderableEth([balance, ZERO_VALUE])
+      ? sumHexWEIsToRenderableEth([balance, HEX_ZERO_VALUE])
       : sumHexWEIsToRenderableEth([value, customGasTotal]);
 
   const sendAmount =
     maxModeOn && asset.type === ASSET_TYPES.NATIVE
       ? subtractHexWEIsFromRenderableEth(balance, customGasTotal)
-      : sumHexWEIsToRenderableEth([value, ZERO_VALUE]);
+      : sumHexWEIsToRenderableEth([value, HEX_ZERO_VALUE]);
 
   const insufficientBalance = maxModeOn
     ? false
@@ -180,7 +180,7 @@ const mapStateToProps = (state, ownProps) => {
       originalTotalEth: sumHexWEIsToRenderableEth([value, customGasTotal]),
       newTotalFiat: showFiat ? newTotalFiat : '',
       newTotalEth,
-      transactionFee: sumHexWEIsToRenderableEth([ZERO_VALUE, customGasTotal]),
+      transactionFee: sumHexWEIsToRenderableEth([HEX_ZERO_VALUE, customGasTotal]),
       sendAmount,
     },
     transaction: txData || transaction,

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -56,6 +56,7 @@ import {
 import { MIN_GAS_LIMIT_DEC } from '../../../../pages/send/send.constants';
 import { TRANSACTION_STATUSES } from '../../../../../shared/constants/transaction';
 import { GAS_LIMITS } from '../../../../../shared/constants/gas';
+import { ZERO_VALUE } from '../../../../../shared/constants/hex-values';
 import { updateTransactionGasFees } from '../../../../ducks/metamask/metamask';
 import GasModalPageContainer from './gas-modal-page-container.component';
 
@@ -79,7 +80,7 @@ const mapStateToProps = (state, ownProps) => {
     : {
         gas: gasLimit || GAS_LIMITS.SIMPLE,
         gasPrice: gasPrice || getAveragePriceEstimateInHexWEI(state, true),
-        value: asset.type === ASSET_TYPES.TOKEN ? '0x0' : amount,
+        value: asset.type === ASSET_TYPES.TOKEN ? ZERO_VALUE : amount,
       };
 
   const { gasPrice: currentGasPrice, gas: currentGasLimit } = txParams;
@@ -119,13 +120,13 @@ const mapStateToProps = (state, ownProps) => {
 
   const newTotalEth =
     maxModeOn && asset.type === ASSET_TYPES.NATIVE
-      ? sumHexWEIsToRenderableEth([balance, '0x0'])
+      ? sumHexWEIsToRenderableEth([balance, ZERO_VALUE])
       : sumHexWEIsToRenderableEth([value, customGasTotal]);
 
   const sendAmount =
     maxModeOn && asset.type === ASSET_TYPES.NATIVE
       ? subtractHexWEIsFromRenderableEth(balance, customGasTotal)
-      : sumHexWEIsToRenderableEth([value, '0x0']);
+      : sumHexWEIsToRenderableEth([value, ZERO_VALUE]);
 
   const insufficientBalance = maxModeOn
     ? false
@@ -179,7 +180,7 @@ const mapStateToProps = (state, ownProps) => {
       originalTotalEth: sumHexWEIsToRenderableEth([value, customGasTotal]),
       newTotalFiat: showFiat ? newTotalFiat : '',
       newTotalEth,
-      transactionFee: sumHexWEIsToRenderableEth(['0x0', customGasTotal]),
+      transactionFee: sumHexWEIsToRenderableEth([ZERO_VALUE, customGasTotal]),
       sendAmount,
     },
     transaction: txData || transaction,

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -180,7 +180,10 @@ const mapStateToProps = (state, ownProps) => {
       originalTotalEth: sumHexWEIsToRenderableEth([value, customGasTotal]),
       newTotalFiat: showFiat ? newTotalFiat : '',
       newTotalEth,
-      transactionFee: sumHexWEIsToRenderableEth([HEX_ZERO_VALUE, customGasTotal]),
+      transactionFee: sumHexWEIsToRenderableEth([
+        HEX_ZERO_VALUE,
+        customGasTotal,
+      ]),
       sendAmount,
     },
     transaction: txData || transaction,

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
@@ -1,5 +1,5 @@
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util';
 import { sumHexes } from '../../../helpers/utils/transactions.util';
 
@@ -70,8 +70,8 @@ export function getActivities(transaction, isFirstTransaction = false) {
     paramsEstimatedBaseFee &&
     paramsMaxPriorityFeePerGas &&
     sumHexes(paramsEstimatedBaseFee, paramsMaxPriorityFeePerGas);
-  let cachedGasLimit = ZERO_VALUE;
-  let cachedGasPrice = ZERO_VALUE;
+  let cachedGasLimit = HEX_ZERO_VALUE;
+  let cachedGasPrice = HEX_ZERO_VALUE;
 
   const historyActivities = history.reduce((acc, base, index) => {
     // First history item should be transaction creation
@@ -81,7 +81,7 @@ export function getActivities(transaction, isFirstTransaction = false) {
         estimatedBaseFee,
         txParams: {
           value,
-          gas = ZERO_VALUE,
+          gas = HEX_ZERO_VALUE,
           gasPrice,
           maxPriorityFeePerGas,
         } = {},
@@ -95,7 +95,7 @@ export function getActivities(transaction, isFirstTransaction = false) {
       // need to cache these values because the status update history events don't provide us with
       // the latest gas limit and gas price.
       cachedGasLimit = gas;
-      cachedGasPrice = eip1559Price || gasPrice || ZERO_VALUE;
+      cachedGasPrice = eip1559Price || gasPrice || HEX_ZERO_VALUE;
 
       if (isFirstTransaction) {
         return acc.concat({
@@ -124,7 +124,7 @@ export function getActivities(transaction, isFirstTransaction = false) {
           switch (path) {
             case STATUS_PATH: {
               const gasFee =
-                cachedGasLimit === ZERO_VALUE && cachedGasPrice === ZERO_VALUE
+                cachedGasLimit === HEX_ZERO_VALUE && cachedGasPrice === HEX_ZERO_VALUE
                   ? getHexGasTotal({
                       gasLimit: paramsGasLimit,
                       gasPrice: paramsEip1559Price || paramsGasPrice,

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
@@ -1,4 +1,5 @@
 import { TRANSACTION_TYPES } from '../../../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util';
 import { sumHexes } from '../../../helpers/utils/transactions.util';
 
@@ -69,8 +70,8 @@ export function getActivities(transaction, isFirstTransaction = false) {
     paramsEstimatedBaseFee &&
     paramsMaxPriorityFeePerGas &&
     sumHexes(paramsEstimatedBaseFee, paramsMaxPriorityFeePerGas);
-  let cachedGasLimit = '0x0';
-  let cachedGasPrice = '0x0';
+  let cachedGasLimit = ZERO_VALUE;
+  let cachedGasPrice = ZERO_VALUE;
 
   const historyActivities = history.reduce((acc, base, index) => {
     // First history item should be transaction creation
@@ -78,7 +79,12 @@ export function getActivities(transaction, isFirstTransaction = false) {
       const {
         time: timestamp,
         estimatedBaseFee,
-        txParams: { value, gas = '0x0', gasPrice, maxPriorityFeePerGas } = {},
+        txParams: {
+          value,
+          gas = ZERO_VALUE,
+          gasPrice,
+          maxPriorityFeePerGas,
+        } = {},
       } = base;
 
       const eip1559Price =
@@ -89,7 +95,7 @@ export function getActivities(transaction, isFirstTransaction = false) {
       // need to cache these values because the status update history events don't provide us with
       // the latest gas limit and gas price.
       cachedGasLimit = gas;
-      cachedGasPrice = eip1559Price || gasPrice || '0x0';
+      cachedGasPrice = eip1559Price || gasPrice || ZERO_VALUE;
 
       if (isFirstTransaction) {
         return acc.concat({
@@ -118,7 +124,7 @@ export function getActivities(transaction, isFirstTransaction = false) {
           switch (path) {
             case STATUS_PATH: {
               const gasFee =
-                cachedGasLimit === '0x0' && cachedGasPrice === '0x0'
+                cachedGasLimit === ZERO_VALUE && cachedGasPrice === ZERO_VALUE
                   ? getHexGasTotal({
                       gasLimit: paramsGasLimit,
                       gasPrice: paramsEip1559Price || paramsGasPrice,

--- a/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
+++ b/ui/components/app/transaction-activity-log/transaction-activity-log.util.js
@@ -124,7 +124,8 @@ export function getActivities(transaction, isFirstTransaction = false) {
           switch (path) {
             case STATUS_PATH: {
               const gasFee =
-                cachedGasLimit === HEX_ZERO_VALUE && cachedGasPrice === HEX_ZERO_VALUE
+                cachedGasLimit === HEX_ZERO_VALUE &&
+                cachedGasPrice === HEX_ZERO_VALUE
                   ? getHexGasTotal({
                       gasLimit: paramsGasLimit,
                       gasPrice: paramsEip1559Price || paramsGasPrice,

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -5,7 +5,7 @@ import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util';
 import { subtractHexes } from '../../../helpers/utils/conversions.util';
 import { sumHexes } from '../../../helpers/utils/transactions.util';
 import { isEIP1559Transaction } from '../../../../shared/modules/transaction.utils';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import TransactionBreakdown from './transaction-breakdown.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -33,7 +33,7 @@ const mapStateToProps = (state, ownProps) => {
     (gasLimit &&
       usedGasPrice &&
       getHexGasTotal({ gasLimit, gasPrice: usedGasPrice })) ||
-    ZERO_VALUE;
+    HEX_ZERO_VALUE;
   const totalInHex = sumHexes(hexGasTotal, value);
 
   return {

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.container.js
@@ -5,6 +5,7 @@ import { getHexGasTotal } from '../../../helpers/utils/confirm-tx.util';
 import { subtractHexes } from '../../../helpers/utils/conversions.util';
 import { sumHexes } from '../../../helpers/utils/transactions.util';
 import { isEIP1559Transaction } from '../../../../shared/modules/transaction.utils';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import TransactionBreakdown from './transaction-breakdown.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -32,7 +33,7 @@ const mapStateToProps = (state, ownProps) => {
     (gasLimit &&
       usedGasPrice &&
       getHexGasTotal({ gasLimit, gasPrice: usedGasPrice })) ||
-    '0x0';
+    ZERO_VALUE;
   const totalInHex = sumHexes(hexGasTotal, value);
 
   return {

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -19,7 +19,7 @@ import { conversionUtil } from '../../../shared/modules/conversion.utils';
 import { getAveragePriceEstimateInHexWEI } from '../../selectors/custom-gas';
 import { isEqualCaseInsensitive } from '../../helpers/utils/util';
 
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 // Actions
 const createActionType = (action) => `metamask/confirm-transaction/${action}`;
@@ -191,14 +191,14 @@ export function updateTxDataAndCalculate(txData) {
     dispatch(updateTxData(txData));
 
     const {
-      txParams: { value = ZERO_VALUE, gas: gasLimit = ZERO_VALUE } = {},
+      txParams: { value = HEX_ZERO_VALUE, gas: gasLimit = HEX_ZERO_VALUE } = {},
     } = txData;
 
     // if the gas price from our infura endpoint is null or undefined
     // use the metaswap average price estimation as a fallback
     let { txParams: { gasPrice } = {} } = txData;
     if (!gasPrice) {
-      gasPrice = getAveragePriceEstimateInHexWEI(state) || ZERO_VALUE;
+      gasPrice = getAveragePriceEstimateInHexWEI(state) || HEX_ZERO_VALUE;
     }
 
     const fiatTransactionAmount = getValueFromWeiHex({

--- a/ui/ducks/confirm-transaction/confirm-transaction.duck.js
+++ b/ui/ducks/confirm-transaction/confirm-transaction.duck.js
@@ -19,6 +19,8 @@ import { conversionUtil } from '../../../shared/modules/conversion.utils';
 import { getAveragePriceEstimateInHexWEI } from '../../selectors/custom-gas';
 import { isEqualCaseInsensitive } from '../../helpers/utils/util';
 
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+
 // Actions
 const createActionType = (action) => `metamask/confirm-transaction/${action}`;
 
@@ -188,13 +190,15 @@ export function updateTxDataAndCalculate(txData) {
 
     dispatch(updateTxData(txData));
 
-    const { txParams: { value = '0x0', gas: gasLimit = '0x0' } = {} } = txData;
+    const {
+      txParams: { value = ZERO_VALUE, gas: gasLimit = ZERO_VALUE } = {},
+    } = txData;
 
     // if the gas price from our infura endpoint is null or undefined
     // use the metaswap average price estimation as a fallback
     let { txParams: { gasPrice } = {} } = txData;
     if (!gasPrice) {
-      gasPrice = getAveragePriceEstimateInHexWEI(state) || '0x0';
+      gasPrice = getAveragePriceEstimateInHexWEI(state) || ZERO_VALUE;
     }
 
     const fiatTransactionAmount = getValueFromWeiHex({

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -1,5 +1,5 @@
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import * as actionConstants from '../../store/actionConstants';
 import reduceMetamask, {
   getBlockGasLimit,
@@ -66,7 +66,7 @@ describe('MetaMask Reducers', () => {
           },
           '0xd85a4b6a394794842887b8284293d69163007bbb': {
             code: '0x',
-            balance: ZERO_VALUE,
+            balance: HEX_ZERO_VALUE,
             nonce: '0x0',
             address: '0xd85a4b6a394794842887b8284293d69163007bbb',
           },
@@ -345,7 +345,7 @@ describe('MetaMask Reducers', () => {
           },
           {
             code: '0x',
-            balance: ZERO_VALUE,
+            balance: HEX_ZERO_VALUE,
             nonce: '0x0',
             address: '0xd85a4b6a394794842887b8284293d69163007bbb',
             name: 'Send Account 4',

--- a/ui/ducks/metamask/metamask.test.js
+++ b/ui/ducks/metamask/metamask.test.js
@@ -1,4 +1,5 @@
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import * as actionConstants from '../../store/actionConstants';
 import reduceMetamask, {
   getBlockGasLimit,
@@ -65,7 +66,7 @@ describe('MetaMask Reducers', () => {
           },
           '0xd85a4b6a394794842887b8284293d69163007bbb': {
             code: '0x',
-            balance: '0x0',
+            balance: ZERO_VALUE,
             nonce: '0x0',
             address: '0xd85a4b6a394794842887b8284293d69163007bbb',
           },
@@ -344,7 +345,7 @@ describe('MetaMask Reducers', () => {
           },
           {
             code: '0x',
-            balance: '0x0',
+            balance: ZERO_VALUE,
             nonce: '0x0',
             address: '0xd85a4b6a394794842887b8284293d69163007bbb',
             name: 'Send Account 4',

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -20,7 +20,7 @@ import {
   MIN_GAS_LIMIT_HEX,
   NEGATIVE_ETH_ERROR,
 } from '../../pages/send/send.constants';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 import {
   addGasBuffer,
@@ -217,7 +217,7 @@ async function estimateGasLimitForSend({
       // represented in the gas shared constants.
       return GAS_LIMITS.BASE_TOKEN_ESTIMATE;
     }
-    paramsForGasEstimate.value = ZERO_VALUE;
+    paramsForGasEstimate.value = HEX_ZERO_VALUE;
     // We have to generate the erc20 contract call to transfer tokens in
     // order to get a proper estimate for gasLimit.
     paramsForGasEstimate.data = generateTokenTransferData({
@@ -321,7 +321,7 @@ export async function getERC20Balance(token, accountAddress) {
   const contract = global.eth.contract(abi).at(token.address);
   const usersToken = (await contract.balanceOf(accountAddress)) ?? null;
   if (!usersToken) {
-    return ZERO_VALUE;
+    return HEX_ZERO_VALUE;
   }
   const amount = calcTokenAmount(
     usersToken.balance.toString(),
@@ -462,7 +462,7 @@ export const initializeSendState = createAsyncThunk(
     } else {
       gasPrice = gasFeeEstimates.gasPrice
         ? getRoundedGasPrice(gasFeeEstimates.gasPrice)
-        : ZERO_VALUE;
+        : HEX_ZERO_VALUE;
     }
 
     // Set a basic gasLimit in the event that other estimation fails
@@ -540,7 +540,7 @@ export const initialState = {
     // the original transaction was sent from in the case of the EDIT stage
     address: null,
     // balance of the from account
-    balance: ZERO_VALUE,
+    balance: HEX_ZERO_VALUE,
   },
   gas: {
     // indicate whether the gas estimate is loading
@@ -550,18 +550,18 @@ export const initialState = {
     // has the user set custom gas in the custom gas modal
     isCustomGasSet: false,
     // maximum gas needed for tx
-    gasLimit: ZERO_VALUE,
+    gasLimit: HEX_ZERO_VALUE,
     // price in wei to pay per gas
-    gasPrice: ZERO_VALUE,
+    gasPrice: HEX_ZERO_VALUE,
     // maximum price in wei to pay per gas
-    maxFeePerGas: ZERO_VALUE,
+    maxFeePerGas: HEX_ZERO_VALUE,
     // maximum priority fee in wei to pay per gas
-    maxPriorityFeePerGas: ZERO_VALUE,
+    maxPriorityFeePerGas: HEX_ZERO_VALUE,
     // expected price in wei necessary to pay per gas used for a transaction
     // to be included in a reasonable timeframe. Comes from GasFeeController.
-    gasPriceEstimate: ZERO_VALUE,
+    gasPriceEstimate: HEX_ZERO_VALUE,
     // maximum total price in wei to pay
-    gasTotal: ZERO_VALUE,
+    gasTotal: HEX_ZERO_VALUE,
     // minimum supported gasLimit
     minimumGasLimit: GAS_LIMITS.SIMPLE,
     // error to display for gas fields
@@ -573,7 +573,7 @@ export const initialState = {
     // asset balance
     mode: AMOUNT_MODES.INPUT,
     // Current value of the transaction, how much of the asset are we sending
-    value: ZERO_VALUE,
+    value: HEX_ZERO_VALUE,
     // error to display for amount field
     error: null,
   },
@@ -581,7 +581,7 @@ export const initialState = {
     // type can be either NATIVE such as ETH or TOKEN for ERC20 tokens
     type: ASSET_TYPES.NATIVE,
     // the balance the user holds at the from address for this asset
-    balance: ZERO_VALUE,
+    balance: HEX_ZERO_VALUE,
     // In the case of tokens, the address, decimals and symbol of the token
     // will be included in details
     details: null,
@@ -600,9 +600,9 @@ export const initialState = {
       to: '',
       from: '',
       data: undefined,
-      value: ZERO_VALUE,
-      gas: ZERO_VALUE,
-      gasPrice: ZERO_VALUE,
+      value: HEX_ZERO_VALUE,
+      gas: HEX_ZERO_VALUE,
+      gasPrice: HEX_ZERO_VALUE,
       type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
     },
   },
@@ -651,7 +651,7 @@ const slice = createSlice({
      * revalidate the field and form and recomputes the draftTransaction
      */
     updateAmountToMax: (state) => {
-      let amount = ZERO_VALUE;
+      let amount = HEX_ZERO_VALUE;
       if (state.asset.type === ASSET_TYPES.TOKEN) {
         const decimals = state.asset.details?.decimals ?? 0;
         const multiplier = Math.pow(10, Number(decimals));
@@ -771,7 +771,7 @@ const slice = createSlice({
         // the field.
         if (
           action.payload.isAutomaticUpdate !== true ||
-          state.gas.gasPriceEstimate === ZERO_VALUE ||
+          state.gas.gasPriceEstimate === HEX_ZERO_VALUE ||
           state.gas.gasPrice === state.gas.gasPriceEstimate
         ) {
           state.gas.gasPrice = addHexPrefix(action.payload.gasPrice);
@@ -785,7 +785,7 @@ const slice = createSlice({
      */
     updateGasFeeEstimates: (state, action) => {
       const { gasFeeEstimates, gasEstimateType } = action.payload;
-      let gasPriceEstimate = ZERO_VALUE;
+      let gasPriceEstimate = HEX_ZERO_VALUE;
       switch (gasEstimateType) {
         case GAS_ESTIMATE_TYPES.FEE_MARKET:
           slice.caseReducers.updateGasFees(state, {
@@ -861,7 +861,7 @@ const slice = createSlice({
       if (state.amount.mode === AMOUNT_MODES.MAX) {
         slice.caseReducers.updateAmountToMax(state);
       } else {
-        slice.caseReducers.updateSendAmount(state, { payload: ZERO_VALUE });
+        slice.caseReducers.updateSendAmount(state, { payload: HEX_ZERO_VALUE });
       }
       // validate send state
       slice.caseReducers.validateSendState(state);
@@ -910,7 +910,7 @@ const slice = createSlice({
             // is generated from the recipient address, token being sent and
             // amount.
             state.draftTransaction.txParams.to = state.asset.details.address;
-            state.draftTransaction.txParams.value = ZERO_VALUE;
+            state.draftTransaction.txParams.value = HEX_ZERO_VALUE;
             state.draftTransaction.txParams.data = generateTokenTransferData({
               toAddress: state.recipient.address,
               amount: state.amount.value,
@@ -942,14 +942,14 @@ const slice = createSlice({
 
           if (
             !state.draftTransaction.txParams.maxFeePerGas ||
-            state.draftTransaction.txParams.maxFeePerGas === ZERO_VALUE
+            state.draftTransaction.txParams.maxFeePerGas === HEX_ZERO_VALUE
           ) {
             state.draftTransaction.txParams.maxFeePerGas = state.gas.gasPrice;
           }
 
           if (
             !state.draftTransaction.txParams.maxPriorityFeePerGas ||
-            state.draftTransaction.txParams.maxPriorityFeePerGas === ZERO_VALUE
+            state.draftTransaction.txParams.maxPriorityFeePerGas === HEX_ZERO_VALUE
           ) {
             state.draftTransaction.txParams.maxPriorityFeePerGas =
               state.draftTransaction.txParams.maxFeePerGas;
@@ -1037,7 +1037,7 @@ const slice = createSlice({
           !isBalanceSufficient({
             amount: state.amount.value,
             balance: state.asset.balance,
-            gasTotal: state.gas.gasTotal ?? ZERO_VALUE,
+            gasTotal: state.gas.gasTotal ?? HEX_ZERO_VALUE,
           }):
           state.amount.error = INSUFFICIENT_FUNDS_ERROR;
           break;
@@ -1045,7 +1045,7 @@ const slice = createSlice({
         // than the amount of token the user is attempting to send.
         case state.asset.type === ASSET_TYPES.TOKEN &&
           !isTokenBalanceSufficient({
-            tokenBalance: state.asset.balance ?? ZERO_VALUE,
+            tokenBalance: state.asset.balance ?? HEX_ZERO_VALUE,
             amount: state.amount.value,
             decimals: state.asset.details.decimals,
           }):
@@ -1073,9 +1073,9 @@ const slice = createSlice({
         amount:
           state.asset.type === ASSET_TYPES.NATIVE
             ? state.amount.value
-            : ZERO_VALUE,
+            : HEX_ZERO_VALUE,
         balance: state.account.balance,
-        gasTotal: state.gas.gasTotal ?? ZERO_VALUE,
+        gasTotal: state.gas.gasTotal ?? HEX_ZERO_VALUE,
       });
 
       state.gas.error = insufficientFunds ? INSUFFICIENT_FUNDS_ERROR : null;
@@ -1504,7 +1504,7 @@ export function toggleSendMaxMode() {
     const state = getState();
     if (state.send.amount.mode === AMOUNT_MODES.MAX) {
       await dispatch(actions.updateAmountMode(AMOUNT_MODES.INPUT));
-      await dispatch(actions.updateSendAmount(ZERO_VALUE));
+      await dispatch(actions.updateSendAmount(HEX_ZERO_VALUE));
     } else {
       await dispatch(actions.updateAmountMode(AMOUNT_MODES.MAX));
       await dispatch(actions.updateAmountToMax());

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -20,6 +20,7 @@ import {
   MIN_GAS_LIMIT_HEX,
   NEGATIVE_ETH_ERROR,
 } from '../../pages/send/send.constants';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 import {
   addGasBuffer,
@@ -216,7 +217,7 @@ async function estimateGasLimitForSend({
       // represented in the gas shared constants.
       return GAS_LIMITS.BASE_TOKEN_ESTIMATE;
     }
-    paramsForGasEstimate.value = '0x0';
+    paramsForGasEstimate.value = ZERO_VALUE;
     // We have to generate the erc20 contract call to transfer tokens in
     // order to get a proper estimate for gasLimit.
     paramsForGasEstimate.data = generateTokenTransferData({
@@ -320,7 +321,7 @@ export async function getERC20Balance(token, accountAddress) {
   const contract = global.eth.contract(abi).at(token.address);
   const usersToken = (await contract.balanceOf(accountAddress)) ?? null;
   if (!usersToken) {
-    return '0x0';
+    return ZERO_VALUE;
   }
   const amount = calcTokenAmount(
     usersToken.balance.toString(),
@@ -461,7 +462,7 @@ export const initializeSendState = createAsyncThunk(
     } else {
       gasPrice = gasFeeEstimates.gasPrice
         ? getRoundedGasPrice(gasFeeEstimates.gasPrice)
-        : '0x0';
+        : ZERO_VALUE;
     }
 
     // Set a basic gasLimit in the event that other estimation fails
@@ -539,7 +540,7 @@ export const initialState = {
     // the original transaction was sent from in the case of the EDIT stage
     address: null,
     // balance of the from account
-    balance: '0x0',
+    balance: ZERO_VALUE,
   },
   gas: {
     // indicate whether the gas estimate is loading
@@ -549,18 +550,18 @@ export const initialState = {
     // has the user set custom gas in the custom gas modal
     isCustomGasSet: false,
     // maximum gas needed for tx
-    gasLimit: '0x0',
+    gasLimit: ZERO_VALUE,
     // price in wei to pay per gas
-    gasPrice: '0x0',
+    gasPrice: ZERO_VALUE,
     // maximum price in wei to pay per gas
-    maxFeePerGas: '0x0',
+    maxFeePerGas: ZERO_VALUE,
     // maximum priority fee in wei to pay per gas
-    maxPriorityFeePerGas: '0x0',
+    maxPriorityFeePerGas: ZERO_VALUE,
     // expected price in wei necessary to pay per gas used for a transaction
     // to be included in a reasonable timeframe. Comes from GasFeeController.
-    gasPriceEstimate: '0x0',
+    gasPriceEstimate: ZERO_VALUE,
     // maximum total price in wei to pay
-    gasTotal: '0x0',
+    gasTotal: ZERO_VALUE,
     // minimum supported gasLimit
     minimumGasLimit: GAS_LIMITS.SIMPLE,
     // error to display for gas fields
@@ -572,7 +573,7 @@ export const initialState = {
     // asset balance
     mode: AMOUNT_MODES.INPUT,
     // Current value of the transaction, how much of the asset are we sending
-    value: '0x0',
+    value: ZERO_VALUE,
     // error to display for amount field
     error: null,
   },
@@ -580,7 +581,7 @@ export const initialState = {
     // type can be either NATIVE such as ETH or TOKEN for ERC20 tokens
     type: ASSET_TYPES.NATIVE,
     // the balance the user holds at the from address for this asset
-    balance: '0x0',
+    balance: ZERO_VALUE,
     // In the case of tokens, the address, decimals and symbol of the token
     // will be included in details
     details: null,
@@ -599,9 +600,9 @@ export const initialState = {
       to: '',
       from: '',
       data: undefined,
-      value: '0x0',
-      gas: '0x0',
-      gasPrice: '0x0',
+      value: ZERO_VALUE,
+      gas: ZERO_VALUE,
+      gasPrice: ZERO_VALUE,
       type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
     },
   },
@@ -650,7 +651,7 @@ const slice = createSlice({
      * revalidate the field and form and recomputes the draftTransaction
      */
     updateAmountToMax: (state) => {
-      let amount = '0x0';
+      let amount = ZERO_VALUE;
       if (state.asset.type === ASSET_TYPES.TOKEN) {
         const decimals = state.asset.details?.decimals ?? 0;
         const multiplier = Math.pow(10, Number(decimals));
@@ -770,7 +771,7 @@ const slice = createSlice({
         // the field.
         if (
           action.payload.isAutomaticUpdate !== true ||
-          state.gas.gasPriceEstimate === '0x0' ||
+          state.gas.gasPriceEstimate === ZERO_VALUE ||
           state.gas.gasPrice === state.gas.gasPriceEstimate
         ) {
           state.gas.gasPrice = addHexPrefix(action.payload.gasPrice);
@@ -784,7 +785,7 @@ const slice = createSlice({
      */
     updateGasFeeEstimates: (state, action) => {
       const { gasFeeEstimates, gasEstimateType } = action.payload;
-      let gasPriceEstimate = '0x0';
+      let gasPriceEstimate = ZERO_VALUE;
       switch (gasEstimateType) {
         case GAS_ESTIMATE_TYPES.FEE_MARKET:
           slice.caseReducers.updateGasFees(state, {
@@ -860,7 +861,7 @@ const slice = createSlice({
       if (state.amount.mode === AMOUNT_MODES.MAX) {
         slice.caseReducers.updateAmountToMax(state);
       } else {
-        slice.caseReducers.updateSendAmount(state, { payload: '0x0' });
+        slice.caseReducers.updateSendAmount(state, { payload: ZERO_VALUE });
       }
       // validate send state
       slice.caseReducers.validateSendState(state);
@@ -909,7 +910,7 @@ const slice = createSlice({
             // is generated from the recipient address, token being sent and
             // amount.
             state.draftTransaction.txParams.to = state.asset.details.address;
-            state.draftTransaction.txParams.value = '0x0';
+            state.draftTransaction.txParams.value = ZERO_VALUE;
             state.draftTransaction.txParams.data = generateTokenTransferData({
               toAddress: state.recipient.address,
               amount: state.amount.value,
@@ -941,14 +942,14 @@ const slice = createSlice({
 
           if (
             !state.draftTransaction.txParams.maxFeePerGas ||
-            state.draftTransaction.txParams.maxFeePerGas === '0x0'
+            state.draftTransaction.txParams.maxFeePerGas === ZERO_VALUE
           ) {
             state.draftTransaction.txParams.maxFeePerGas = state.gas.gasPrice;
           }
 
           if (
             !state.draftTransaction.txParams.maxPriorityFeePerGas ||
-            state.draftTransaction.txParams.maxPriorityFeePerGas === '0x0'
+            state.draftTransaction.txParams.maxPriorityFeePerGas === ZERO_VALUE
           ) {
             state.draftTransaction.txParams.maxPriorityFeePerGas =
               state.draftTransaction.txParams.maxFeePerGas;
@@ -1036,7 +1037,7 @@ const slice = createSlice({
           !isBalanceSufficient({
             amount: state.amount.value,
             balance: state.asset.balance,
-            gasTotal: state.gas.gasTotal ?? '0x0',
+            gasTotal: state.gas.gasTotal ?? ZERO_VALUE,
           }):
           state.amount.error = INSUFFICIENT_FUNDS_ERROR;
           break;
@@ -1044,7 +1045,7 @@ const slice = createSlice({
         // than the amount of token the user is attempting to send.
         case state.asset.type === ASSET_TYPES.TOKEN &&
           !isTokenBalanceSufficient({
-            tokenBalance: state.asset.balance ?? '0x0',
+            tokenBalance: state.asset.balance ?? ZERO_VALUE,
             amount: state.amount.value,
             decimals: state.asset.details.decimals,
           }):
@@ -1070,9 +1071,11 @@ const slice = createSlice({
       // + amount then the error will be displayed on the amount field.
       const insufficientFunds = !isBalanceSufficient({
         amount:
-          state.asset.type === ASSET_TYPES.NATIVE ? state.amount.value : '0x0',
+          state.asset.type === ASSET_TYPES.NATIVE
+            ? state.amount.value
+            : ZERO_VALUE,
         balance: state.account.balance,
-        gasTotal: state.gas.gasTotal ?? '0x0',
+        gasTotal: state.gas.gasTotal ?? ZERO_VALUE,
       });
 
       state.gas.error = insufficientFunds ? INSUFFICIENT_FUNDS_ERROR : null;
@@ -1501,7 +1504,7 @@ export function toggleSendMaxMode() {
     const state = getState();
     if (state.send.amount.mode === AMOUNT_MODES.MAX) {
       await dispatch(actions.updateAmountMode(AMOUNT_MODES.INPUT));
-      await dispatch(actions.updateSendAmount('0x0'));
+      await dispatch(actions.updateSendAmount(ZERO_VALUE));
     } else {
       await dispatch(actions.updateAmountMode(AMOUNT_MODES.MAX));
       await dispatch(actions.updateAmountToMax());

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -949,7 +949,8 @@ const slice = createSlice({
 
           if (
             !state.draftTransaction.txParams.maxPriorityFeePerGas ||
-            state.draftTransaction.txParams.maxPriorityFeePerGas === HEX_ZERO_VALUE
+            state.draftTransaction.txParams.maxPriorityFeePerGas ===
+              HEX_ZERO_VALUE
           ) {
             state.draftTransaction.txParams.maxPriorityFeePerGas =
               state.draftTransaction.txParams.maxFeePerGas;

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -19,6 +19,8 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
   TRANSACTION_TYPES,
 } from '../../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+
 import sendReducer, {
   initialState,
   initializeSendState,
@@ -71,7 +73,7 @@ jest.mock('../../store/actions', () => {
   const actual = jest.requireActual('../../store/actions');
   return {
     ...actual,
-    estimateGas: jest.fn(() => Promise.resolve('0x0')),
+    estimateGas: jest.fn(() => Promise.resolve(ZERO_VALUE)),
     getGasFeeEstimatesAndStartPolling: jest.fn(() => Promise.resolve()),
     updateTokenType: jest.fn(() => Promise.resolve({ isERC721: false })),
   };
@@ -82,7 +84,7 @@ jest.mock('./send', () => {
   return {
     __esModule: true,
     ...actual,
-    getERC20Balance: jest.fn(() => '0x0'),
+    getERC20Balance: jest.fn(() => ZERO_VALUE),
   };
 });
 
@@ -200,7 +202,7 @@ describe('Send Slice', () => {
         const gasState = {
           ...initialState,
           gas: {
-            gasLimit: '0x0',
+            gasLimit: ZERO_VALUE,
             gasPrice: '0x3b9aca00', // 1000000000
           },
         };
@@ -439,7 +441,9 @@ describe('Send Slice', () => {
           expect(result.draftTransaction.txParams.to).toStrictEqual(
             detailsForDraftTransactionState.asset.details.address,
           );
-          expect(result.draftTransaction.txParams.value).toStrictEqual('0x0');
+          expect(result.draftTransaction.txParams.value).toStrictEqual(
+            ZERO_VALUE,
+          );
           expect(result.draftTransaction.txParams.gas).toStrictEqual(
             detailsForDraftTransactionState.gas.gasLimit,
           );
@@ -538,7 +542,9 @@ describe('Send Slice', () => {
           expect(result.draftTransaction.txParams.to).toStrictEqual(
             detailsForDraftTransactionState.asset.details.address,
           );
-          expect(result.draftTransaction.txParams.value).toStrictEqual('0x0');
+          expect(result.draftTransaction.txParams.value).toStrictEqual(
+            ZERO_VALUE,
+          );
           expect(result.draftTransaction.txParams.gas).toStrictEqual(
             detailsForDraftTransactionState.gas.gasLimit,
           );
@@ -833,7 +839,7 @@ describe('Send Slice', () => {
         const gasFieldState = {
           ...initialState,
           account: {
-            balance: '0x0',
+            balance: ZERO_VALUE,
           },
           gas: {
             gasTotal: '0x1319718a5000', // 21000000000000
@@ -996,7 +1002,7 @@ describe('Send Slice', () => {
         const olderState = {
           ...initialState,
           account: {
-            balance: '0x0',
+            balance: ZERO_VALUE,
             address: '0xAddress',
           },
         };
@@ -1029,7 +1035,7 @@ describe('Send Slice', () => {
           stage: SEND_STAGES.EDIT,
           account: {
             address: '0xAddress',
-            balance: '0x0',
+            balance: ZERO_VALUE,
           },
         };
 
@@ -1056,7 +1062,7 @@ describe('Send Slice', () => {
           stage: SEND_STAGES.EDIT,
           account: {
             address: '0xAddress',
-            balance: '0x0',
+            balance: ZERO_VALUE,
           },
         };
 
@@ -1109,7 +1115,7 @@ describe('Send Slice', () => {
             accounts: {
               '0xAddress': {
                 address: '0xAddress',
-                balance: '0x0',
+                balance: ZERO_VALUE,
               },
             },
             cachedBalances: {
@@ -1177,10 +1183,10 @@ describe('Send Slice', () => {
         const gasState = {
           ...initialState,
           gas: {
-            gasPrice: '0x0',
-            gasPriceEstimate: '0x0',
+            gasPrice: ZERO_VALUE,
+            gasPriceEstimate: ZERO_VALUE,
             gasLimit: '0x5208',
-            gasTotal: '0x0',
+            gasTotal: ZERO_VALUE,
             minimumGasLimit: '0x5208',
           },
         };
@@ -1215,7 +1221,7 @@ describe('Send Slice', () => {
           },
         });
 
-        const newGasPrice = '0x0';
+        const newGasPrice = ZERO_VALUE;
 
         await store.dispatch(updateGasPrice(newGasPrice));
 
@@ -1225,7 +1231,7 @@ describe('Send Slice', () => {
           {
             type: 'send/updateGasFees',
             payload: {
-              gasPrice: '0x0',
+              gasPrice: ZERO_VALUE,
               transactionType: TRANSACTION_ENVELOPE_TYPES.LEGACY,
             },
           },
@@ -1497,7 +1503,7 @@ describe('Send Slice', () => {
         expect(actionResult[1].type).toStrictEqual('HIDE_LOADING_INDICATION');
         expect(actionResult[2].payload).toStrictEqual({
           ...newSendAsset,
-          balance: '0x0',
+          balance: ZERO_VALUE,
         });
 
         expect(actionResult[3].type).toStrictEqual(
@@ -2155,7 +2161,7 @@ describe('Send Slice', () => {
                   to: '0xTokenAddress',
                   gas: GAS_LIMITS.SIMPLE,
                   gasPrice: '0x3b9aca00', // 1000000000
-                  value: '0x0',
+                  value: ZERO_VALUE,
                 },
               },
             },
@@ -2163,7 +2169,7 @@ describe('Send Slice', () => {
           send: {
             account: {
               address: '0xAddress',
-              balance: '0x0',
+              balance: ZERO_VALUE,
             },
             asset: {
               type: '',
@@ -2216,7 +2222,7 @@ describe('Send Slice', () => {
         expect(actionResult[1].type).toStrictEqual('HIDE_LOADING_INDICATION');
         expect(actionResult[2].type).toStrictEqual('send/updateAsset');
         expect(actionResult[2].payload).toStrictEqual({
-          balance: '0x0',
+          balance: ZERO_VALUE,
           type: ASSET_TYPES.TOKEN,
           details: {
             address: '0xTokenAddress',
@@ -2273,15 +2279,15 @@ describe('Send Slice', () => {
   describe('selectors', () => {
     describe('gas selectors', () => {
       it('has a selector that gets gasLimit', () => {
-        expect(getGasLimit({ send: initialState })).toBe('0x0');
+        expect(getGasLimit({ send: initialState })).toBe(ZERO_VALUE);
       });
 
       it('has a selector that gets gasPrice', () => {
-        expect(getGasPrice({ send: initialState })).toBe('0x0');
+        expect(getGasPrice({ send: initialState })).toBe(ZERO_VALUE);
       });
 
       it('has a selector that gets gasTotal', () => {
-        expect(getGasTotal({ send: initialState })).toBe('0x0');
+        expect(getGasTotal({ send: initialState })).toBe(ZERO_VALUE);
       });
 
       it('has a selector to determine if gas fee is in error', () => {
@@ -2405,7 +2411,7 @@ describe('Send Slice', () => {
             send: {
               ...initialState,
               asset: {
-                balance: '0x0',
+                balance: ZERO_VALUE,
                 details: { address: '0x0' },
                 type: ASSET_TYPES.TOKEN,
               },
@@ -2433,7 +2439,7 @@ describe('Send Slice', () => {
 
     describe('amount selectors', () => {
       it('has a selector to get send amount', () => {
-        expect(getSendAmount({ send: initialState })).toBe('0x0');
+        expect(getSendAmount({ send: initialState })).toBe(ZERO_VALUE);
       });
 
       it('has a selector to get if there is an insufficient funds error', () => {

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -69,22 +69,24 @@ import sendReducer, {
 
 const mockStore = createMockStore([thunk]);
 
+const mockEstimateGas = jest.fn(() => Promise.resolve(ZERO_VALUE));
 jest.mock('../../store/actions', () => {
   const actual = jest.requireActual('../../store/actions');
   return {
     ...actual,
-    estimateGas: jest.fn(() => Promise.resolve(ZERO_VALUE)),
+    estimateGas: mockEstimateGas,
     getGasFeeEstimatesAndStartPolling: jest.fn(() => Promise.resolve()),
     updateTokenType: jest.fn(() => Promise.resolve({ isERC721: false })),
   };
 });
 
+const mockGetERC20Balance = jest.fn(() => ZERO_VALUE);
 jest.mock('./send', () => {
   const actual = jest.requireActual('./send');
   return {
     __esModule: true,
     ...actual,
-    getERC20Balance: jest.fn(() => ZERO_VALUE),
+    getERC20Balance: mockGetERC20Balance,
   };
 });
 

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -19,7 +19,7 @@ import {
   TRANSACTION_ENVELOPE_TYPES,
   TRANSACTION_TYPES,
 } from '../../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 import sendReducer, {
   initialState,
@@ -69,7 +69,7 @@ import sendReducer, {
 
 const mockStore = createMockStore([thunk]);
 
-const mockEstimateGas = jest.fn(() => Promise.resolve(ZERO_VALUE));
+const mockEstimateGas = jest.fn(() => Promise.resolve(HEX_ZERO_VALUE));
 jest.mock('../../store/actions', () => {
   const actual = jest.requireActual('../../store/actions');
   return {
@@ -80,7 +80,7 @@ jest.mock('../../store/actions', () => {
   };
 });
 
-const mockGetERC20Balance = jest.fn(() => ZERO_VALUE);
+const mockGetERC20Balance = jest.fn(() => HEX_ZERO_VALUE);
 jest.mock('./send', () => {
   const actual = jest.requireActual('./send');
   return {
@@ -204,7 +204,7 @@ describe('Send Slice', () => {
         const gasState = {
           ...initialState,
           gas: {
-            gasLimit: ZERO_VALUE,
+            gasLimit: HEX_ZERO_VALUE,
             gasPrice: '0x3b9aca00', // 1000000000
           },
         };
@@ -444,7 +444,7 @@ describe('Send Slice', () => {
             detailsForDraftTransactionState.asset.details.address,
           );
           expect(result.draftTransaction.txParams.value).toStrictEqual(
-            ZERO_VALUE,
+            HEX_ZERO_VALUE,
           );
           expect(result.draftTransaction.txParams.gas).toStrictEqual(
             detailsForDraftTransactionState.gas.gasLimit,
@@ -545,7 +545,7 @@ describe('Send Slice', () => {
             detailsForDraftTransactionState.asset.details.address,
           );
           expect(result.draftTransaction.txParams.value).toStrictEqual(
-            ZERO_VALUE,
+            HEX_ZERO_VALUE,
           );
           expect(result.draftTransaction.txParams.gas).toStrictEqual(
             detailsForDraftTransactionState.gas.gasLimit,
@@ -841,7 +841,7 @@ describe('Send Slice', () => {
         const gasFieldState = {
           ...initialState,
           account: {
-            balance: ZERO_VALUE,
+            balance: HEX_ZERO_VALUE,
           },
           gas: {
             gasTotal: '0x1319718a5000', // 21000000000000
@@ -1004,7 +1004,7 @@ describe('Send Slice', () => {
         const olderState = {
           ...initialState,
           account: {
-            balance: ZERO_VALUE,
+            balance: HEX_ZERO_VALUE,
             address: '0xAddress',
           },
         };
@@ -1037,7 +1037,7 @@ describe('Send Slice', () => {
           stage: SEND_STAGES.EDIT,
           account: {
             address: '0xAddress',
-            balance: ZERO_VALUE,
+            balance: HEX_ZERO_VALUE,
           },
         };
 
@@ -1064,7 +1064,7 @@ describe('Send Slice', () => {
           stage: SEND_STAGES.EDIT,
           account: {
             address: '0xAddress',
-            balance: ZERO_VALUE,
+            balance: HEX_ZERO_VALUE,
           },
         };
 
@@ -1117,7 +1117,7 @@ describe('Send Slice', () => {
             accounts: {
               '0xAddress': {
                 address: '0xAddress',
-                balance: ZERO_VALUE,
+                balance: HEX_ZERO_VALUE,
               },
             },
             cachedBalances: {
@@ -1185,10 +1185,10 @@ describe('Send Slice', () => {
         const gasState = {
           ...initialState,
           gas: {
-            gasPrice: ZERO_VALUE,
-            gasPriceEstimate: ZERO_VALUE,
+            gasPrice: HEX_ZERO_VALUE,
+            gasPriceEstimate: HEX_ZERO_VALUE,
             gasLimit: '0x5208',
-            gasTotal: ZERO_VALUE,
+            gasTotal: HEX_ZERO_VALUE,
             minimumGasLimit: '0x5208',
           },
         };
@@ -1223,7 +1223,7 @@ describe('Send Slice', () => {
           },
         });
 
-        const newGasPrice = ZERO_VALUE;
+        const newGasPrice = HEX_ZERO_VALUE;
 
         await store.dispatch(updateGasPrice(newGasPrice));
 
@@ -1233,7 +1233,7 @@ describe('Send Slice', () => {
           {
             type: 'send/updateGasFees',
             payload: {
-              gasPrice: ZERO_VALUE,
+              gasPrice: HEX_ZERO_VALUE,
               transactionType: TRANSACTION_ENVELOPE_TYPES.LEGACY,
             },
           },
@@ -1505,7 +1505,7 @@ describe('Send Slice', () => {
         expect(actionResult[1].type).toStrictEqual('HIDE_LOADING_INDICATION');
         expect(actionResult[2].payload).toStrictEqual({
           ...newSendAsset,
-          balance: ZERO_VALUE,
+          balance: HEX_ZERO_VALUE,
         });
 
         expect(actionResult[3].type).toStrictEqual(
@@ -2163,7 +2163,7 @@ describe('Send Slice', () => {
                   to: '0xTokenAddress',
                   gas: GAS_LIMITS.SIMPLE,
                   gasPrice: '0x3b9aca00', // 1000000000
-                  value: ZERO_VALUE,
+                  value: HEX_ZERO_VALUE,
                 },
               },
             },
@@ -2171,7 +2171,7 @@ describe('Send Slice', () => {
           send: {
             account: {
               address: '0xAddress',
-              balance: ZERO_VALUE,
+              balance: HEX_ZERO_VALUE,
             },
             asset: {
               type: '',
@@ -2224,7 +2224,7 @@ describe('Send Slice', () => {
         expect(actionResult[1].type).toStrictEqual('HIDE_LOADING_INDICATION');
         expect(actionResult[2].type).toStrictEqual('send/updateAsset');
         expect(actionResult[2].payload).toStrictEqual({
-          balance: ZERO_VALUE,
+          balance: HEX_ZERO_VALUE,
           type: ASSET_TYPES.TOKEN,
           details: {
             address: '0xTokenAddress',
@@ -2281,15 +2281,15 @@ describe('Send Slice', () => {
   describe('selectors', () => {
     describe('gas selectors', () => {
       it('has a selector that gets gasLimit', () => {
-        expect(getGasLimit({ send: initialState })).toBe(ZERO_VALUE);
+        expect(getGasLimit({ send: initialState })).toBe(HEX_ZERO_VALUE);
       });
 
       it('has a selector that gets gasPrice', () => {
-        expect(getGasPrice({ send: initialState })).toBe(ZERO_VALUE);
+        expect(getGasPrice({ send: initialState })).toBe(HEX_ZERO_VALUE);
       });
 
       it('has a selector that gets gasTotal', () => {
-        expect(getGasTotal({ send: initialState })).toBe(ZERO_VALUE);
+        expect(getGasTotal({ send: initialState })).toBe(HEX_ZERO_VALUE);
       });
 
       it('has a selector to determine if gas fee is in error', () => {
@@ -2413,7 +2413,7 @@ describe('Send Slice', () => {
             send: {
               ...initialState,
               asset: {
-                balance: ZERO_VALUE,
+                balance: HEX_ZERO_VALUE,
                 details: { address: '0x0' },
                 type: ASSET_TYPES.TOKEN,
               },
@@ -2441,7 +2441,7 @@ describe('Send Slice', () => {
 
     describe('amount selectors', () => {
       it('has a selector to get send amount', () => {
-        expect(getSendAmount({ send: initialState })).toBe(ZERO_VALUE);
+        expect(getSendAmount({ send: initialState })).toBe(HEX_ZERO_VALUE);
       });
 
       it('has a selector to get if there is an insufficient funds error', () => {

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -66,7 +66,7 @@ import {
   SWAP_FAILED_ERROR,
   SWAPS_FETCH_ORDER_CONFLICT,
 } from '../../../shared/constants/swaps';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import { TRANSACTION_TYPES } from '../../../shared/constants/transaction';
 import { getGasFeeEstimates } from '../metamask/metamask';
 
@@ -747,7 +747,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       usedQuote?.gasEstimateWithRefund ||
       `0x${decimalToHex(usedQuote?.averageGas || 0)}`;
     const totalGasLimitEstimate = new BigNumber(usedGasLimitEstimate, 16)
-      .plus(usedQuote.approvalNeeded?.gas || ZERO_VALUE, 16)
+      .plus(usedQuote.approvalNeeded?.gas || HEX_ZERO_VALUE, 16)
       .toString(16);
     const gasEstimateTotalInUSD = getValueFromWeiHex({
       value: calcGasTotal(
@@ -827,7 +827,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       }
       const approveTxMeta = await dispatch(
         addUnapprovedTransaction(
-          { ...approveTxParams, amount: ZERO_VALUE },
+          { ...approveTxParams, amount: HEX_ZERO_VALUE },
           'metamask',
         ),
       );

--- a/ui/ducks/swaps/swaps.js
+++ b/ui/ducks/swaps/swaps.js
@@ -66,6 +66,7 @@ import {
   SWAP_FAILED_ERROR,
   SWAPS_FETCH_ORDER_CONFLICT,
 } from '../../../shared/constants/swaps';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import { TRANSACTION_TYPES } from '../../../shared/constants/transaction';
 import { getGasFeeEstimates } from '../metamask/metamask';
 
@@ -746,7 +747,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       usedQuote?.gasEstimateWithRefund ||
       `0x${decimalToHex(usedQuote?.averageGas || 0)}`;
     const totalGasLimitEstimate = new BigNumber(usedGasLimitEstimate, 16)
-      .plus(usedQuote.approvalNeeded?.gas || '0x0', 16)
+      .plus(usedQuote.approvalNeeded?.gas || ZERO_VALUE, 16)
       .toString(16);
     const gasEstimateTotalInUSD = getValueFromWeiHex({
       value: calcGasTotal(
@@ -826,7 +827,7 @@ export const signAndSendTransactions = (history, metaMetricsEvent) => {
       }
       const approveTxMeta = await dispatch(
         addUnapprovedTransaction(
-          { ...approveTxParams, amount: '0x0' },
+          { ...approveTxParams, amount: ZERO_VALUE },
           'metamask',
         ),
       );

--- a/ui/helpers/utils/confirm-tx.util.js
+++ b/ui/helpers/utils/confirm-tx.util.js
@@ -10,11 +10,11 @@ import {
   multiplyCurrencies,
   conversionGreaterThan,
 } from '../../../shared/modules/conversion.utils';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 export function increaseLastGasPrice(lastGasPrice) {
   return addHexPrefix(
-    multiplyCurrencies(lastGasPrice || ZERO_VALUE, 1.1, {
+    multiplyCurrencies(lastGasPrice || HEX_ZERO_VALUE, 1.1, {
       multiplicandBase: 16,
       multiplierBase: 10,
       toNumericBase: 'hex',
@@ -31,7 +31,7 @@ export function hexGreaterThan(a, b) {
 
 export function getHexGasTotal({ gasLimit, gasPrice }) {
   return addHexPrefix(
-    multiplyCurrencies(gasLimit || ZERO_VALUE, gasPrice || ZERO_VALUE, {
+    multiplyCurrencies(gasLimit || HEX_ZERO_VALUE, gasPrice || HEX_ZERO_VALUE, {
       toNumericBase: 'hex',
       multiplicandBase: 16,
       multiplierBase: 16,

--- a/ui/helpers/utils/confirm-tx.util.js
+++ b/ui/helpers/utils/confirm-tx.util.js
@@ -10,10 +10,11 @@ import {
   multiplyCurrencies,
   conversionGreaterThan,
 } from '../../../shared/modules/conversion.utils';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 export function increaseLastGasPrice(lastGasPrice) {
   return addHexPrefix(
-    multiplyCurrencies(lastGasPrice || '0x0', 1.1, {
+    multiplyCurrencies(lastGasPrice || ZERO_VALUE, 1.1, {
       multiplicandBase: 16,
       multiplierBase: 10,
       toNumericBase: 'hex',
@@ -30,7 +31,7 @@ export function hexGreaterThan(a, b) {
 
 export function getHexGasTotal({ gasLimit, gasPrice }) {
   return addHexPrefix(
-    multiplyCurrencies(gasLimit || '0x0', gasPrice || '0x0', {
+    multiplyCurrencies(gasLimit || ZERO_VALUE, gasPrice || ZERO_VALUE, {
       toNumericBase: 'hex',
       multiplicandBase: 16,
       multiplierBase: 16,

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -1,4 +1,5 @@
 import { BN } from 'ethereumjs-util';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import * as util from './util';
 
 describe('util', () => {
@@ -27,7 +28,7 @@ describe('util', () => {
     });
 
     it('should render 0 eth correctly', () => {
-      const input = '0x0';
+      const input = ZERO_VALUE;
       const output = util.parseBalance(input);
       expect(output).toStrictEqual(['0', '0']);
     });

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -1,5 +1,5 @@
 import { BN } from 'ethereumjs-util';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import * as util from './util';
 
 describe('util', () => {
@@ -28,7 +28,7 @@ describe('util', () => {
     });
 
     it('should render 0 eth correctly', () => {
-      const input = ZERO_VALUE;
+      const input = HEX_ZERO_VALUE;
       const output = util.parseBalance(input);
       expect(output).toStrictEqual(['0', '0']);
     });

--- a/ui/hooks/useGasFeeErrors.js
+++ b/ui/hooks/useGasFeeErrors.js
@@ -17,6 +17,7 @@ import {
   bnLessThanEqualTo,
 } from '../helpers/utils/util';
 import { GAS_FORM_ERRORS } from '../helpers/constants/gas';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 
 const HIGH_FEE_WARNING_MULTIPLIER = 1.5;
 
@@ -137,7 +138,7 @@ const getMaxFeeWarning = (
 const getBalanceError = (minimumCostInHexWei, transaction, ethBalance) => {
   const minimumTxCostInHexWei = addHexes(
     minimumCostInHexWei,
-    transaction?.txParams?.value || '0x0',
+    transaction?.txParams?.value || ZERO_VALUE,
   );
 
   return conversionGreaterThan(

--- a/ui/hooks/useGasFeeErrors.js
+++ b/ui/hooks/useGasFeeErrors.js
@@ -17,7 +17,7 @@ import {
   bnLessThanEqualTo,
 } from '../helpers/utils/util';
 import { GAS_FORM_ERRORS } from '../helpers/constants/gas';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 
 const HIGH_FEE_WARNING_MULTIPLIER = 1.5;
 
@@ -138,7 +138,7 @@ const getMaxFeeWarning = (
 const getBalanceError = (minimumCostInHexWei, transaction, ethBalance) => {
   const minimumTxCostInHexWei = addHexes(
     minimumCostInHexWei,
-    transaction?.txParams?.value || ZERO_VALUE,
+    transaction?.txParams?.value || HEX_ZERO_VALUE,
   );
 
   return conversionGreaterThan(

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isEqual } from 'lodash';
 import { GAS_ESTIMATE_TYPES, EDIT_GAS_MODES } from '../../shared/constants/gas';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import {
   getMaximumGasTotalInHexWei,
@@ -214,7 +214,7 @@ export function useGasFeeInputs(
     initialGasPrice && initialFeeParamsAreCustom ? initialGasPrice : null,
   );
   const [gasLimit, setGasLimit] = useState(
-    Number(hexToDecimal(transaction?.txParams?.gas ?? ZERO_VALUE)),
+    Number(hexToDecimal(transaction?.txParams?.gas ?? HEX_ZERO_VALUE)),
   );
 
   const userPrefersAdvancedGas = useSelector(getAdvancedInlineGasShown);
@@ -292,7 +292,7 @@ export function useGasFeeInputs(
       gasFeeEstimates.estimatedBaseFee ?? '0',
     );
   } else if (gasEstimateType === GAS_ESTIMATE_TYPES.NONE) {
-    gasSettings.gasPrice = ZERO_VALUE;
+    gasSettings.gasPrice = HEX_ZERO_VALUE;
   } else {
     gasSettings.gasPrice = decGWEIToHexWEI(gasPriceToUse);
   }

--- a/ui/hooks/useGasFeeInputs.js
+++ b/ui/hooks/useGasFeeInputs.js
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isEqual } from 'lodash';
 import { GAS_ESTIMATE_TYPES, EDIT_GAS_MODES } from '../../shared/constants/gas';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import {
   getMaximumGasTotalInHexWei,
@@ -213,7 +214,7 @@ export function useGasFeeInputs(
     initialGasPrice && initialFeeParamsAreCustom ? initialGasPrice : null,
   );
   const [gasLimit, setGasLimit] = useState(
-    Number(hexToDecimal(transaction?.txParams?.gas ?? '0x0')),
+    Number(hexToDecimal(transaction?.txParams?.gas ?? ZERO_VALUE)),
   );
 
   const userPrefersAdvancedGas = useSelector(getAdvancedInlineGasShown);
@@ -291,7 +292,7 @@ export function useGasFeeInputs(
       gasFeeEstimates.estimatedBaseFee ?? '0',
     );
   } else if (gasEstimateType === GAS_ESTIMATE_TYPES.NONE) {
-    gasSettings.gasPrice = '0x0';
+    gasSettings.gasPrice = ZERO_VALUE;
   } else {
     gasSettings.gasPrice = decGWEIToHexWEI(gasPriceToUse);
   }

--- a/ui/hooks/useIncrementedGasFees.js
+++ b/ui/hooks/useIncrementedGasFees.js
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import { isEIP1559Transaction } from '../../shared/modules/transaction.utils';
 import { decGWEIToHexWEI } from '../helpers/utils/conversions.util';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 
 /**
@@ -83,7 +84,7 @@ export function useIncrementedGasFees(transaction) {
       temporaryGasSettings.maxFeePerGas =
         transactionMaxFeePerGas === undefined ||
         transactionMaxFeePerGas.startsWith('-')
-          ? '0x0'
+          ? ZERO_VALUE
           : getHighestIncrementedFee(
               transactionMaxFeePerGas,
               suggestedMaxFeePerGas,
@@ -91,7 +92,7 @@ export function useIncrementedGasFees(transaction) {
       temporaryGasSettings.maxPriorityFeePerGas =
         transactionMaxPriorityFeePerGas === undefined ||
         transactionMaxPriorityFeePerGas.startsWith('-')
-          ? '0x0'
+          ? ZERO_VALUE
           : getHighestIncrementedFee(
               transactionMaxPriorityFeePerGas,
               suggestedMaxPriorityFeePerGas,
@@ -100,7 +101,7 @@ export function useIncrementedGasFees(transaction) {
       const transactionGasPrice = transaction.txParams?.gasPrice;
       temporaryGasSettings.gasPrice =
         transactionGasPrice === undefined || transactionGasPrice.startsWith('-')
-          ? '0x0'
+          ? ZERO_VALUE
           : getHighestIncrementedFee(
               transactionGasPrice,
               suggestedMaxFeePerGas,

--- a/ui/hooks/useIncrementedGasFees.js
+++ b/ui/hooks/useIncrementedGasFees.js
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import { isEIP1559Transaction } from '../../shared/modules/transaction.utils';
 import { decGWEIToHexWEI } from '../helpers/utils/conversions.util';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 
 /**
@@ -84,7 +84,7 @@ export function useIncrementedGasFees(transaction) {
       temporaryGasSettings.maxFeePerGas =
         transactionMaxFeePerGas === undefined ||
         transactionMaxFeePerGas.startsWith('-')
-          ? ZERO_VALUE
+          ? HEX_ZERO_VALUE
           : getHighestIncrementedFee(
               transactionMaxFeePerGas,
               suggestedMaxFeePerGas,
@@ -92,7 +92,7 @@ export function useIncrementedGasFees(transaction) {
       temporaryGasSettings.maxPriorityFeePerGas =
         transactionMaxPriorityFeePerGas === undefined ||
         transactionMaxPriorityFeePerGas.startsWith('-')
-          ? ZERO_VALUE
+          ? HEX_ZERO_VALUE
           : getHighestIncrementedFee(
               transactionMaxPriorityFeePerGas,
               suggestedMaxPriorityFeePerGas,
@@ -101,7 +101,7 @@ export function useIncrementedGasFees(transaction) {
       const transactionGasPrice = transaction.txParams?.gasPrice;
       temporaryGasSettings.gasPrice =
         transactionGasPrice === undefined || transactionGasPrice.startsWith('-')
-          ? ZERO_VALUE
+          ? HEX_ZERO_VALUE
           : getHighestIncrementedFee(
               transactionGasPrice,
               suggestedMaxFeePerGas,

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -27,6 +27,7 @@ import {
   TRANSACTION_TYPES,
   TRANSACTION_STATUSES,
 } from '../../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import { getTransactionTypeTitle } from '../../helpers/utils/transactions.util';
 import { toBuffer } from '../../../shared/modules/buffer-utils';
 
@@ -220,7 +221,7 @@ export default class ConfirmTransactionBase extends Component {
       balance &&
       !isBalanceSufficient({
         amount,
-        gasTotal: hexMaximumTransactionFee || '0x0',
+        gasTotal: hexMaximumTransactionFee || ZERO_VALUE,
         balance,
         conversionRate,
       });

--- a/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
+++ b/ui/pages/confirm-transaction-base/confirm-transaction-base.component.js
@@ -27,7 +27,7 @@ import {
   TRANSACTION_TYPES,
   TRANSACTION_STATUSES,
 } from '../../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import { getTransactionTypeTitle } from '../../helpers/utils/transactions.util';
 import { toBuffer } from '../../../shared/modules/buffer-utils';
 
@@ -221,7 +221,7 @@ export default class ConfirmTransactionBase extends Component {
       balance &&
       !isBalanceSufficient({
         amount,
-        gasTotal: hexMaximumTransactionFee || ZERO_VALUE,
+        gasTotal: hexMaximumTransactionFee || HEX_ZERO_VALUE,
         balance,
         conversionRate,
       });

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -9,7 +9,7 @@ import { ensInitialState } from '../../ducks/ens';
 import { renderWithProvider } from '../../../test/jest';
 import { RINKEBY_CHAIN_ID } from '../../../shared/constants/network';
 import { GAS_ESTIMATE_TYPES } from '../../../shared/constants/gas';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import Send from './send';
 
 const middleware = [thunk];
@@ -78,7 +78,7 @@ const baseStore = {
       [RINKEBY_CHAIN_ID]: {},
     },
     accounts: {
-      '0x0': { balance: ZERO_VALUE, address: '0x0' },
+      '0x0': { balance: HEX_ZERO_VALUE, address: '0x0' },
     },
     identities: { '0x0': { address: '0x0' } },
   },

--- a/ui/pages/send/send.test.js
+++ b/ui/pages/send/send.test.js
@@ -9,6 +9,7 @@ import { ensInitialState } from '../../ducks/ens';
 import { renderWithProvider } from '../../../test/jest';
 import { RINKEBY_CHAIN_ID } from '../../../shared/constants/network';
 import { GAS_ESTIMATE_TYPES } from '../../../shared/constants/gas';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import Send from './send';
 
 const middleware = [thunk];
@@ -77,7 +78,7 @@ const baseStore = {
       [RINKEBY_CHAIN_ID]: {},
     },
     accounts: {
-      '0x0': { balance: '0x0', address: '0x0' },
+      '0x0': { balance: ZERO_VALUE, address: '0x0' },
     },
     identities: { '0x0': { address: '0x0' } },
   },

--- a/ui/pages/send/send.utils.js
+++ b/ui/pages/send/send.utils.js
@@ -11,7 +11,7 @@ import {
 import { calcTokenAmount } from '../../helpers/utils/token-util';
 import { addHexPrefix } from '../../../app/scripts/lib/util';
 
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import { TOKEN_TRANSFER_FUNCTION_SIGNATURE } from './send.constants';
 
 export {
@@ -32,10 +32,10 @@ function calcGasTotal(gasLimit = '0', gasPrice = '0') {
 }
 
 function isBalanceSufficient({
-  amount = ZERO_VALUE,
-  balance = ZERO_VALUE,
+  amount = HEX_ZERO_VALUE,
+  balance = HEX_ZERO_VALUE,
   conversionRate = 1,
-  gasTotal = ZERO_VALUE,
+  gasTotal = HEX_ZERO_VALUE,
   primaryCurrency,
 }) {
   const totalAmount = addCurrencies(amount, gasTotal, {
@@ -126,7 +126,7 @@ function addGasBuffer(
 
 function generateTokenTransferData({
   toAddress = '0x0',
-  amount = ZERO_VALUE,
+  amount = HEX_ZERO_VALUE,
   sendToken,
 }) {
   if (!sendToken) {

--- a/ui/pages/send/send.utils.js
+++ b/ui/pages/send/send.utils.js
@@ -11,6 +11,7 @@ import {
 import { calcTokenAmount } from '../../helpers/utils/token-util';
 import { addHexPrefix } from '../../../app/scripts/lib/util';
 
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import { TOKEN_TRANSFER_FUNCTION_SIGNATURE } from './send.constants';
 
 export {
@@ -31,10 +32,10 @@ function calcGasTotal(gasLimit = '0', gasPrice = '0') {
 }
 
 function isBalanceSufficient({
-  amount = '0x0',
-  balance = '0x0',
+  amount = ZERO_VALUE,
+  balance = ZERO_VALUE,
   conversionRate = 1,
-  gasTotal = '0x0',
+  gasTotal = ZERO_VALUE,
   primaryCurrency,
 }) {
   const totalAmount = addCurrencies(amount, gasTotal, {
@@ -125,7 +126,7 @@ function addGasBuffer(
 
 function generateTokenTransferData({
   toAddress = '0x0',
-  amount = '0x0',
+  amount = ZERO_VALUE,
   sendToken,
 }) {
   if (!sendToken) {

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -38,6 +38,7 @@ import {
   OFFLINE_FOR_MAINTENANCE,
   SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP,
 } from '../../../../shared/constants/swaps';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { isSwapsDefaultTokenSymbol } from '../../../../shared/modules/swaps.utils';
 import PulseLoader from '../../../components/ui/pulse-loader';
 
@@ -86,7 +87,7 @@ export default function AwaitingSwap({
   if (usedQuote && swapsGasPrice) {
     const renderableNetworkFees = getRenderableNetworkFeesForQuote({
       tradeGas: usedQuote.gasEstimateWithRefund || usedQuote.averageGas,
-      approveGas: approveTxParams?.gas || '0x0',
+      approveGas: approveTxParams?.gas || ZERO_VALUE,
       gasPrice: swapsGasPrice,
       currentCurrency,
       conversionRate: usdConversionRate,

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -38,7 +38,7 @@ import {
   OFFLINE_FOR_MAINTENANCE,
   SWAPS_CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP,
 } from '../../../../shared/constants/swaps';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import { isSwapsDefaultTokenSymbol } from '../../../../shared/modules/swaps.utils';
 import PulseLoader from '../../../components/ui/pulse-loader';
 
@@ -87,7 +87,7 @@ export default function AwaitingSwap({
   if (usedQuote && swapsGasPrice) {
     const renderableNetworkFees = getRenderableNetworkFeesForQuote({
       tradeGas: usedQuote.gasEstimateWithRefund || usedQuote.averageGas,
-      approveGas: approveTxParams?.gas || ZERO_VALUE,
+      approveGas: approveTxParams?.gas || HEX_ZERO_VALUE,
       gasPrice: swapsGasPrice,
       currentCurrency,
       conversionRate: usdConversionRate,

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
@@ -30,6 +30,7 @@ import {
 } from '../../../helpers/utils/conversions.util';
 import { formatETHFee } from '../../../helpers/utils/formatters';
 import { calcGasTotal, isBalanceSufficient } from '../../send/send.utils';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import SwapsGasCustomizationModalComponent from './swaps-gas-customization-modal.component';
 
 const mapStateToProps = (state) => {
@@ -90,7 +91,7 @@ const mapStateToProps = (state) => {
   );
 
   const sendAmount = sumHexWEIsToRenderableEth(
-    [value, '0x0'],
+    [value, ZERO_VALUE],
     usedCurrencySymbol,
   );
 
@@ -131,7 +132,7 @@ const mapStateToProps = (state) => {
       newTotalFiat,
       newTotalEth,
       transactionFee: sumHexWEIsToRenderableEth(
-        ['0x0', customGasTotal],
+        [ZERO_VALUE, customGasTotal],
         usedCurrencySymbol,
       ),
       sendAmount,

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.js
@@ -30,7 +30,7 @@ import {
 } from '../../../helpers/utils/conversions.util';
 import { formatETHFee } from '../../../helpers/utils/formatters';
 import { calcGasTotal, isBalanceSufficient } from '../../send/send.utils';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import SwapsGasCustomizationModalComponent from './swaps-gas-customization-modal.component';
 
 const mapStateToProps = (state) => {
@@ -91,7 +91,7 @@ const mapStateToProps = (state) => {
   );
 
   const sendAmount = sumHexWEIsToRenderableEth(
-    [value, ZERO_VALUE],
+    [value, HEX_ZERO_VALUE],
     usedCurrencySymbol,
   );
 
@@ -132,7 +132,7 @@ const mapStateToProps = (state) => {
       newTotalFiat,
       newTotalEth,
       transactionFee: sumHexWEIsToRenderableEth(
-        [ZERO_VALUE, customGasTotal],
+        [HEX_ZERO_VALUE, customGasTotal],
         usedCurrencySymbol,
       ),
       sendAmount,

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.stories.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.stories.js
@@ -13,6 +13,7 @@ import {
 import { ETH } from '../../../helpers/constants/common';
 import { calcGasTotal, isBalanceSufficient } from '../../send/send.utils';
 import { conversionLessThan } from '../../../../shared/modules/conversion.utils';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import GasModalPageContainer from './swaps-gas-customization-modal.component';
 
 // Using Test Data For Redux
@@ -53,7 +54,7 @@ export const GasModalPageContainerComponent = () => {
     fromDenomination: ETH,
   });
 
-  const sendAmount = sumHexWEIsToRenderableEth([hexWei, '0x0']);
+  const sendAmount = sumHexWEIsToRenderableEth([hexWei, ZERO_VALUE]);
   const [gasLimit, setGasLimit] = useState('5208');
   const [gasPrice, setGasPrice] = useState('ee6b2800');
   const [transactionFee, setTransactionFee] = useState('');
@@ -69,7 +70,7 @@ export const GasModalPageContainerComponent = () => {
   useEffect(() => {
     // Transfer Fee
     const customGasTotal = calcGasTotal(gasLimit, gasPrice);
-    setTransactionFee(sumHexWEIsToRenderableEth(['0x0', customGasTotal]));
+    setTransactionFee(sumHexWEIsToRenderableEth([ZERO_VALUE, customGasTotal]));
 
     // New Total ETH
     setTotalETH(sumHexWEIsToRenderableEth([hexWei, customGasTotal, '']));

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.stories.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.stories.js
@@ -13,7 +13,7 @@ import {
 import { ETH } from '../../../helpers/constants/common';
 import { calcGasTotal, isBalanceSufficient } from '../../send/send.utils';
 import { conversionLessThan } from '../../../../shared/modules/conversion.utils';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import GasModalPageContainer from './swaps-gas-customization-modal.component';
 
 // Using Test Data For Redux
@@ -54,7 +54,7 @@ export const GasModalPageContainerComponent = () => {
     fromDenomination: ETH,
   });
 
-  const sendAmount = sumHexWEIsToRenderableEth([hexWei, ZERO_VALUE]);
+  const sendAmount = sumHexWEIsToRenderableEth([hexWei, HEX_ZERO_VALUE]);
   const [gasLimit, setGasLimit] = useState('5208');
   const [gasPrice, setGasPrice] = useState('ee6b2800');
   const [transactionFee, setTransactionFee] = useState('');
@@ -70,7 +70,7 @@ export const GasModalPageContainerComponent = () => {
   useEffect(() => {
     // Transfer Fee
     const customGasTotal = calcGasTotal(gasLimit, gasPrice);
-    setTransactionFee(sumHexWEIsToRenderableEth([ZERO_VALUE, customGasTotal]));
+    setTransactionFee(sumHexWEIsToRenderableEth([HEX_ZERO_VALUE, customGasTotal]));
 
     // New Total ETH
     setTotalETH(sumHexWEIsToRenderableEth([hexWei, customGasTotal, '']));

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.stories.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.stories.js
@@ -70,7 +70,9 @@ export const GasModalPageContainerComponent = () => {
   useEffect(() => {
     // Transfer Fee
     const customGasTotal = calcGasTotal(gasLimit, gasPrice);
-    setTransactionFee(sumHexWEIsToRenderableEth([HEX_ZERO_VALUE, customGasTotal]));
+    setTransactionFee(
+      sumHexWEIsToRenderableEth([HEX_ZERO_VALUE, customGasTotal]),
+    );
 
     // New Total ETH
     setTotalETH(sumHexWEIsToRenderableEth([hexWei, customGasTotal, '']));

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -49,7 +49,7 @@ import fetchWithCache from '../../helpers/utils/fetch-with-cache';
 import { calcGasTotal } from '../send/send.utils';
 import { isValidHexAddress } from '../../../shared/modules/hexstring-utils';
 
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 
 const TOKEN_TRANSFER_LOG_TOPIC_HASH =
   '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
@@ -510,8 +510,8 @@ export function getRenderableNetworkFeesForQuote({
   chainId,
   nativeCurrencySymbol,
 }) {
-  const totalGasLimitForCalculation = new BigNumber(tradeGas || ZERO_VALUE, 16)
-    .plus(approveGas || ZERO_VALUE, 16)
+  const totalGasLimitForCalculation = new BigNumber(tradeGas || HEX_ZERO_VALUE, 16)
+    .plus(approveGas || HEX_ZERO_VALUE, 16)
     .toString(16);
   const gasTotalInWeiHex = calcGasTotal(totalGasLimitForCalculation, gasPrice);
 
@@ -686,7 +686,7 @@ export function getSwapsTokensReceivedFromTxMeta(
       return null;
     }
 
-    let approvalTxGasCost = ZERO_VALUE;
+    let approvalTxGasCost = HEX_ZERO_VALUE;
     if (approvalTxMeta && approvalTxMeta.txReceipt) {
       approvalTxGasCost = calcGasTotal(
         approvalTxMeta.txReceipt.gasUsed,

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -49,6 +49,8 @@ import fetchWithCache from '../../helpers/utils/fetch-with-cache';
 import { calcGasTotal } from '../send/send.utils';
 import { isValidHexAddress } from '../../../shared/modules/hexstring-utils';
 
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+
 const TOKEN_TRANSFER_LOG_TOPIC_HASH =
   '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
 
@@ -508,8 +510,8 @@ export function getRenderableNetworkFeesForQuote({
   chainId,
   nativeCurrencySymbol,
 }) {
-  const totalGasLimitForCalculation = new BigNumber(tradeGas || '0x0', 16)
-    .plus(approveGas || '0x0', 16)
+  const totalGasLimitForCalculation = new BigNumber(tradeGas || ZERO_VALUE, 16)
+    .plus(approveGas || ZERO_VALUE, 16)
     .toString(16);
   const gasTotalInWeiHex = calcGasTotal(totalGasLimitForCalculation, gasPrice);
 
@@ -684,7 +686,7 @@ export function getSwapsTokensReceivedFromTxMeta(
       return null;
     }
 
-    let approvalTxGasCost = '0x0';
+    let approvalTxGasCost = ZERO_VALUE;
     if (approvalTxMeta && approvalTxMeta.txReceipt) {
       approvalTxGasCost = calcGasTotal(
         approvalTxMeta.txReceipt.gasUsed,

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -510,7 +510,10 @@ export function getRenderableNetworkFeesForQuote({
   chainId,
   nativeCurrencySymbol,
 }) {
-  const totalGasLimitForCalculation = new BigNumber(tradeGas || HEX_ZERO_VALUE, 16)
+  const totalGasLimitForCalculation = new BigNumber(
+    tradeGas || HEX_ZERO_VALUE,
+    16,
+  )
     .plus(approveGas || HEX_ZERO_VALUE, 16)
     .toString(16);
   const gasTotalInWeiHex = calcGasTotal(totalGasLimitForCalculation, gasPrice);

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -19,7 +19,7 @@ import {
   BSC,
   RINKEBY,
 } from '../../../shared/constants/swaps';
-import { ZERO_VALUE } from '../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../shared/constants/hex-values';
 import {
   TOKENS,
   EXPECTED_TOKENS_RESULT,
@@ -75,7 +75,7 @@ describe('Swaps Util', () => {
           data:
             '0x095ea7b300000000000000000000000095e6f48254609a6ee006f7d493c8e5fb97094cef0000000000000000000000000000000000000000004a817c7ffffffdabf41c00',
           to: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-          value: ZERO_VALUE,
+          value: HEX_ZERO_VALUE,
           from: '0x2369267687A84ac7B494daE2f1542C40E37f4455',
           gas: '0x12',
           gasPrice: '0x34',

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -19,6 +19,7 @@ import {
   BSC,
   RINKEBY,
 } from '../../../shared/constants/swaps';
+import { ZERO_VALUE } from '../../../shared/constants/hex-values';
 import {
   TOKENS,
   EXPECTED_TOKENS_RESULT,
@@ -74,7 +75,7 @@ describe('Swaps Util', () => {
           data:
             '0x095ea7b300000000000000000000000095e6f48254609a6ee006f7d493c8e5fb97094cef0000000000000000000000000000000000000000004a817c7ffffffdabf41c00',
           to: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-          value: '0x0',
+          value: ZERO_VALUE,
           from: '0x2369267687A84ac7B494daE2f1542C40E37f4455',
           gas: '0x12',
           gasPrice: '0x34',

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -94,7 +94,7 @@ import {
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { QUOTES_EXPIRED_ERROR } from '../../../../shared/constants/swaps';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
-import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import CountdownTimer from '../countdown-timer';
 import SwapsFooter from '../swaps-footer';
 import ViewQuotePriceDifference from './view-quote-price-difference';
@@ -153,7 +153,7 @@ export default function ViewQuote() {
   const selectedQuote = useSelector(getSelectedQuote);
   const topQuote = useSelector(getTopQuote);
   const usedQuote = selectedQuote || topQuote;
-  const tradeValue = usedQuote?.trade?.value ?? ZERO_VALUE;
+  const tradeValue = usedQuote?.trade?.value ?? HEX_ZERO_VALUE;
   const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken);
   const chainId = useSelector(getCurrentChainId);
@@ -226,7 +226,7 @@ export default function ViewQuote() {
   const tokenBalance =
     tokensWithBalances?.length &&
     calcTokenAmount(
-      selectedFromToken.balance || ZERO_VALUE,
+      selectedFromToken.balance || HEX_ZERO_VALUE,
       selectedFromToken.decimals,
     ).toFixed(9);
   const tokenBalanceUnavailable =
@@ -317,9 +317,9 @@ export default function ViewQuote() {
 
   const insufficientTokens =
     (tokensWithBalances?.length || balanceError) &&
-    tokenCost.gt(new BigNumber(selectedFromToken.balance || ZERO_VALUE));
+    tokenCost.gt(new BigNumber(selectedFromToken.balance || HEX_ZERO_VALUE));
 
-  const insufficientEth = ethCost.gt(new BigNumber(ethBalance || ZERO_VALUE));
+  const insufficientEth = ethCost.gt(new BigNumber(ethBalance || HEX_ZERO_VALUE));
 
   const tokenBalanceNeeded = insufficientTokens
     ? toPrecisionWithoutTrailingZeros(
@@ -523,7 +523,7 @@ export default function ViewQuote() {
 
   const nonGasFeeIsPositive = new BigNumber(nonGasFee, 16).gt(0);
   const approveGasTotal = calcGasTotal(
-    approveGas || ZERO_VALUE,
+    approveGas || HEX_ZERO_VALUE,
     networkAndAccountSupports1559 ? baseAndPriorityFeePerGas : gasPrice,
   );
   const extraNetworkFeeTotalInHexWEI = new BigNumber(nonGasFee, 16)

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -94,6 +94,7 @@ import {
 import { useTokenTracker } from '../../../hooks/useTokenTracker';
 import { QUOTES_EXPIRED_ERROR } from '../../../../shared/constants/swaps';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
+import { ZERO_VALUE } from '../../../../shared/constants/hex-values';
 import CountdownTimer from '../countdown-timer';
 import SwapsFooter from '../swaps-footer';
 import ViewQuotePriceDifference from './view-quote-price-difference';
@@ -152,7 +153,7 @@ export default function ViewQuote() {
   const selectedQuote = useSelector(getSelectedQuote);
   const topQuote = useSelector(getTopQuote);
   const usedQuote = selectedQuote || topQuote;
-  const tradeValue = usedQuote?.trade?.value ?? '0x0';
+  const tradeValue = usedQuote?.trade?.value ?? ZERO_VALUE;
   const swapsQuoteRefreshTime = useSelector(getSwapsQuoteRefreshTime);
   const defaultSwapsToken = useSelector(getSwapsDefaultToken);
   const chainId = useSelector(getCurrentChainId);
@@ -225,7 +226,7 @@ export default function ViewQuote() {
   const tokenBalance =
     tokensWithBalances?.length &&
     calcTokenAmount(
-      selectedFromToken.balance || '0x0',
+      selectedFromToken.balance || ZERO_VALUE,
       selectedFromToken.decimals,
     ).toFixed(9);
   const tokenBalanceUnavailable =
@@ -316,9 +317,9 @@ export default function ViewQuote() {
 
   const insufficientTokens =
     (tokensWithBalances?.length || balanceError) &&
-    tokenCost.gt(new BigNumber(selectedFromToken.balance || '0x0'));
+    tokenCost.gt(new BigNumber(selectedFromToken.balance || ZERO_VALUE));
 
-  const insufficientEth = ethCost.gt(new BigNumber(ethBalance || '0x0'));
+  const insufficientEth = ethCost.gt(new BigNumber(ethBalance || ZERO_VALUE));
 
   const tokenBalanceNeeded = insufficientTokens
     ? toPrecisionWithoutTrailingZeros(
@@ -522,7 +523,7 @@ export default function ViewQuote() {
 
   const nonGasFeeIsPositive = new BigNumber(nonGasFee, 16).gt(0);
   const approveGasTotal = calcGasTotal(
-    approveGas || '0x0',
+    approveGas || ZERO_VALUE,
     networkAndAccountSupports1559 ? baseAndPriorityFeePerGas : gasPrice,
   );
   const extraNetworkFeeTotalInHexWEI = new BigNumber(nonGasFee, 16)

--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -319,7 +319,9 @@ export default function ViewQuote() {
     (tokensWithBalances?.length || balanceError) &&
     tokenCost.gt(new BigNumber(selectedFromToken.balance || HEX_ZERO_VALUE));
 
-  const insufficientEth = ethCost.gt(new BigNumber(ethBalance || HEX_ZERO_VALUE));
+  const insufficientEth = ethCost.gt(
+    new BigNumber(ethBalance || HEX_ZERO_VALUE),
+  );
 
   const tokenBalanceNeeded = insufficientTokens
     ? toPrecisionWithoutTrailingZeros(

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -18,7 +18,7 @@ import {
 import { TRANSACTION_ENVELOPE_TYPES } from '../../shared/constants/transaction';
 import { decGWEIToHexWEI } from '../helpers/utils/conversions.util';
 import { GAS_ESTIMATE_TYPES } from '../../shared/constants/gas';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 import {
   getMaximumGasTotalInHexWei,
   getMinimumGasTotalInHexWei,
@@ -243,7 +243,7 @@ export const transactionFeeSelector = function (state, txData) {
   );
 
   const gasEstimationObject = {
-    gasLimit: txData.txParams?.gas ?? ZERO_VALUE,
+    gasLimit: txData.txParams?.gas ?? HEX_ZERO_VALUE,
   };
 
   if (networkAndAccountSupportsEIP1559) {
@@ -276,7 +276,7 @@ export const transactionFeeSelector = function (state, txData) {
   } else {
     switch (gasEstimateType) {
       case GAS_ESTIMATE_TYPES.NONE:
-        gasEstimationObject.gasPrice = txData.txParams?.gasPrice ?? ZERO_VALUE;
+        gasEstimationObject.gasPrice = txData.txParams?.gasPrice ?? HEX_ZERO_VALUE;
         break;
       case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
         gasEstimationObject.gasPrice =
@@ -294,7 +294,7 @@ export const transactionFeeSelector = function (state, txData) {
     }
   }
 
-  const { txParams: { value = ZERO_VALUE } = {} } = txData;
+  const { txParams: { value = HEX_ZERO_VALUE } = {} } = txData;
 
   const fiatTransactionAmount = getValueFromWeiHex({
     value,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -18,6 +18,7 @@ import {
 import { TRANSACTION_ENVELOPE_TYPES } from '../../shared/constants/transaction';
 import { decGWEIToHexWEI } from '../helpers/utils/conversions.util';
 import { GAS_ESTIMATE_TYPES } from '../../shared/constants/gas';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 import {
   getMaximumGasTotalInHexWei,
   getMinimumGasTotalInHexWei,
@@ -242,7 +243,7 @@ export const transactionFeeSelector = function (state, txData) {
   );
 
   const gasEstimationObject = {
-    gasLimit: txData.txParams?.gas ?? '0x0',
+    gasLimit: txData.txParams?.gas ?? ZERO_VALUE,
   };
 
   if (networkAndAccountSupportsEIP1559) {
@@ -275,7 +276,7 @@ export const transactionFeeSelector = function (state, txData) {
   } else {
     switch (gasEstimateType) {
       case GAS_ESTIMATE_TYPES.NONE:
-        gasEstimationObject.gasPrice = txData.txParams?.gasPrice ?? '0x0';
+        gasEstimationObject.gasPrice = txData.txParams?.gasPrice ?? ZERO_VALUE;
         break;
       case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
         gasEstimationObject.gasPrice =
@@ -293,7 +294,7 @@ export const transactionFeeSelector = function (state, txData) {
     }
   }
 
-  const { txParams: { value = '0x0' } = {} } = txData;
+  const { txParams: { value = ZERO_VALUE } = {} } = txData;
 
   const fiatTransactionAmount = getValueFromWeiHex({
     value,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -276,7 +276,8 @@ export const transactionFeeSelector = function (state, txData) {
   } else {
     switch (gasEstimateType) {
       case GAS_ESTIMATE_TYPES.NONE:
-        gasEstimationObject.gasPrice = txData.txParams?.gasPrice ?? HEX_ZERO_VALUE;
+        gasEstimationObject.gasPrice =
+          txData.txParams?.gasPrice ?? HEX_ZERO_VALUE;
         break;
       case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
         gasEstimationObject.gasPrice =

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -13,6 +13,7 @@ import {
   GAS_ESTIMATE_TYPES as GAS_FEE_CONTROLLER_ESTIMATE_TYPES,
   GAS_LIMITS,
 } from '../../shared/constants/gas';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 import {
   getGasEstimateType,
   getGasFeeEstimates,
@@ -43,7 +44,7 @@ export function getAveragePriceEstimateInHexWEI(state) {
 
 export function getFastPriceEstimateInHexWEI(state) {
   const fastPriceEstimate = getFastPriceEstimate(state);
-  return getGasPriceInHexWei(fastPriceEstimate || '0x0');
+  return getGasPriceInHexWei(fastPriceEstimate || ZERO_VALUE);
 }
 
 export function getDefaultActiveButtonIndex(

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -13,7 +13,7 @@ import {
   GAS_ESTIMATE_TYPES as GAS_FEE_CONTROLLER_ESTIMATE_TYPES,
   GAS_LIMITS,
 } from '../../shared/constants/gas';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 import {
   getGasEstimateType,
   getGasFeeEstimates,
@@ -44,7 +44,7 @@ export function getAveragePriceEstimateInHexWEI(state) {
 
 export function getFastPriceEstimateInHexWEI(state) {
   const fastPriceEstimate = getFastPriceEstimate(state);
-  return getGasPriceInHexWei(fastPriceEstimate || ZERO_VALUE);
+  return getGasPriceInHexWei(fastPriceEstimate || HEX_ZERO_VALUE);
 }
 
 export function getDefaultActiveButtonIndex(

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1,6 +1,6 @@
 import mockState from '../../test/data/mock-state.json';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 import * as selectors from './selectors';
 
 describe('Selectors', () => {
@@ -64,7 +64,7 @@ describe('Selectors', () => {
 
   it('returns selected account', () => {
     const account = selectors.getSelectedAccount(mockState);
-    expect(account.balance).toStrictEqual(ZERO_VALUE);
+    expect(account.balance).toStrictEqual(HEX_ZERO_VALUE);
     expect(account.address).toStrictEqual(
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
     );
@@ -158,7 +158,7 @@ describe('Selectors', () => {
       mockState,
     );
     expect(accountsWithSendEther).toHaveLength(2);
-    expect(accountsWithSendEther[0].balance).toStrictEqual(ZERO_VALUE);
+    expect(accountsWithSendEther[0].balance).toStrictEqual(HEX_ZERO_VALUE);
     expect(accountsWithSendEther[0].address).toStrictEqual(
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
     );
@@ -169,7 +169,7 @@ describe('Selectors', () => {
     const currentAccountwithSendEther = selectors.getCurrentAccountWithSendEtherInfo(
       mockState,
     );
-    expect(currentAccountwithSendEther.balance).toStrictEqual(ZERO_VALUE);
+    expect(currentAccountwithSendEther.balance).toStrictEqual(HEX_ZERO_VALUE);
     expect(currentAccountwithSendEther.address).toStrictEqual(
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
     );

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -1,5 +1,6 @@
 import mockState from '../../test/data/mock-state.json';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 import * as selectors from './selectors';
 
 describe('Selectors', () => {
@@ -63,7 +64,7 @@ describe('Selectors', () => {
 
   it('returns selected account', () => {
     const account = selectors.getSelectedAccount(mockState);
-    expect(account.balance).toStrictEqual('0x0');
+    expect(account.balance).toStrictEqual(ZERO_VALUE);
     expect(account.address).toStrictEqual(
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
     );
@@ -157,7 +158,7 @@ describe('Selectors', () => {
       mockState,
     );
     expect(accountsWithSendEther).toHaveLength(2);
-    expect(accountsWithSendEther[0].balance).toStrictEqual('0x0');
+    expect(accountsWithSendEther[0].balance).toStrictEqual(ZERO_VALUE);
     expect(accountsWithSendEther[0].address).toStrictEqual(
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
     );
@@ -168,7 +169,7 @@ describe('Selectors', () => {
     const currentAccountwithSendEther = selectors.getCurrentAccountWithSendEtherInfo(
       mockState,
     );
-    expect(currentAccountwithSendEther.balance).toStrictEqual('0x0');
+    expect(currentAccountwithSendEther.balance).toStrictEqual(ZERO_VALUE);
     expect(currentAccountwithSendEther.address).toStrictEqual(
       '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
     );

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import enLocale from '../../app/_locales/en/messages.json';
 import MetaMaskController from '../../app/scripts/metamask-controller';
 import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
+import { ZERO_VALUE } from '../../shared/constants/hex-values';
 import { GAS_LIMITS } from '../../shared/constants/gas';
 import * as actions from './actions';
 
@@ -15,7 +16,7 @@ const defaultState = {
     provider: { chainId: '0x1' },
     accounts: {
       '0xFirstAddress': {
-        balance: '0x0',
+        balance: ZERO_VALUE,
       },
     },
     cachedBalances: {
@@ -259,7 +260,7 @@ describe('Actions', () => {
           },
           accounts: {
             '0xAnotherAddress': {
-              balance: '0x0',
+              balance: ZERO_VALUE,
             },
           },
           cachedBalances: {
@@ -839,7 +840,7 @@ describe('Actions', () => {
       gas: GAS_LIMITS.SIMPLE,
       gasPrice: '0x3b9aca00',
       to: '0x2',
-      value: '0x0',
+      value: ZERO_VALUE,
     };
 
     const txData = {
@@ -903,7 +904,7 @@ describe('Actions', () => {
             gas: GAS_LIMITS.SIMPLE,
             gasPrice: '0x3b9aca00',
             to: '0x2',
-            value: '0x0',
+            value: ZERO_VALUE,
           },
         },
         { type: 'HIDE_LOADING_INDICATION' },
@@ -1698,7 +1699,7 @@ describe('Actions', () => {
             },
             accounts: {
               '0xFirstAddress': {
-                balance: '0x0',
+                balance: ZERO_VALUE,
               },
             },
             cachedBalances: {

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import enLocale from '../../app/_locales/en/messages.json';
 import MetaMaskController from '../../app/scripts/metamask-controller';
 import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
-import { ZERO_VALUE } from '../../shared/constants/hex-values';
+import { HEX_ZERO_VALUE } from '../../shared/constants/hex-values';
 import { GAS_LIMITS } from '../../shared/constants/gas';
 import * as actions from './actions';
 
@@ -16,7 +16,7 @@ const defaultState = {
     provider: { chainId: '0x1' },
     accounts: {
       '0xFirstAddress': {
-        balance: ZERO_VALUE,
+        balance: HEX_ZERO_VALUE,
       },
     },
     cachedBalances: {
@@ -260,7 +260,7 @@ describe('Actions', () => {
           },
           accounts: {
             '0xAnotherAddress': {
-              balance: ZERO_VALUE,
+              balance: HEX_ZERO_VALUE,
             },
           },
           cachedBalances: {
@@ -840,7 +840,7 @@ describe('Actions', () => {
       gas: GAS_LIMITS.SIMPLE,
       gasPrice: '0x3b9aca00',
       to: '0x2',
-      value: ZERO_VALUE,
+      value: HEX_ZERO_VALUE,
     };
 
     const txData = {
@@ -904,7 +904,7 @@ describe('Actions', () => {
             gas: GAS_LIMITS.SIMPLE,
             gasPrice: '0x3b9aca00',
             to: '0x2',
-            value: ZERO_VALUE,
+            value: HEX_ZERO_VALUE,
           },
         },
         { type: 'HIDE_LOADING_INDICATION' },
@@ -1699,7 +1699,7 @@ describe('Actions', () => {
             },
             accounts: {
               '0xFirstAddress': {
-                balance: ZERO_VALUE,
+                balance: HEX_ZERO_VALUE,
               },
             },
             cachedBalances: {


### PR DESCRIPTION
Instead of hardcoding `0x0` everywhere for zero value, we can use a constant.  A different value should be used for `0x0` chain ID, and we should create one constant for a fake address in another PR.