### PR TITLE
Use TRANSACTION_ENVELOPE_TYPES for legacy transaction type testing

### DIFF
--- a/app/scripts/controllers/network/pending-middleware.test.js
+++ b/app/scripts/controllers/network/pending-middleware.test.js
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import { GAS_LIMITS } from '../../../../shared/constants/gas';
+import { TRANSACTION_ENVELOPE_TYPES } from '../../../../shared/constants/transaction';
 import { txMetaStub } from '../../../../test/stub/tx-meta-stub';
 import {
   createPendingNonceMiddleware,
@@ -63,7 +64,7 @@ describe('PendingNonceMiddleware', function () {
         '0x2cc5a25744486f7383edebbf32003e5a66e18135799593d6b5cdd2bb43674f09',
       input: '0x',
       nonce: '0x4',
-      type: '0x0',
+      type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
       to: '0xf231d46dd78806e1dd93442cf33c7671f8538748',
       transactionIndex: null,
       value: '0x0',

--- a/app/scripts/controllers/network/util.test.js
+++ b/app/scripts/controllers/network/util.test.js
@@ -2,7 +2,9 @@ import { strict as assert } from 'assert';
 import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
+  TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
+
 import { formatTxMetaForRpcResult } from './util';
 
 describe('network utils', function () {
@@ -92,7 +94,7 @@ describe('network utils', function () {
         s: '0x18bfc4eeb7ebcfacc3bd59ea100a6834ea3265e65945dbec69aa2a06564fafff',
         to: '0x1678a085c290ebd122dc42cba69373b5953b831d',
         transactionIndex: null,
-        type: '0x0',
+        type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
         v: '0x29',
         value: '0x0',
       };

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -12,7 +12,9 @@ import {
 import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
+  TRANSACTION_ENVELOPE_TYPES,
 } from '../../../../shared/constants/transaction';
+
 import { SECOND } from '../../../../shared/constants/time';
 import { GAS_ESTIMATE_TYPES } from '../../../../shared/constants/gas';
 import { METAMASK_CONTROLLER_EVENTS } from '../../metamask-controller';
@@ -544,7 +546,7 @@ describe('Transaction Controller', function () {
           txParams: {
             to: VALID_ADDRESS,
             from: VALID_ADDRESS_TWO,
-            type: '0x0',
+            type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
           },
           history: [{}],
         },
@@ -554,7 +556,7 @@ describe('Transaction Controller', function () {
         txParams: {
           from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
           to: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
-          type: '0x0',
+          type: TRANSACTION_ENVELOPE_TYPES.LEGACY,
         },
         history: [{}],
       };


### PR DESCRIPTION
Let's use the constants we have!