### PR TITLE
Rename the function of the Ledger preference renaming

### DIFF
--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -43,7 +43,7 @@ export default class AdvancedTab extends PureComponent {
     setIpfsGateway: PropTypes.func.isRequired,
     ipfsGateway: PropTypes.string.isRequired,
     ledgerTransportType: PropTypes.oneOf(Object.values(LEDGER_TRANSPORT_TYPES)),
-    setLedgerLivePreference: PropTypes.func.isRequired,
+    setLedgerTransportPreference: PropTypes.func.isRequired,
     setDismissSeedBackUpReminder: PropTypes.func.isRequired,
     dismissSeedBackUpReminder: PropTypes.bool.isRequired,
     userHasALedgerAccount: PropTypes.bool.isRequired,
@@ -432,7 +432,7 @@ export default class AdvancedTab extends PureComponent {
     const { t } = this.context;
     const {
       ledgerTransportType,
-      setLedgerLivePreference,
+      setLedgerTransportPreference,
       userHasALedgerAccount,
     } = this.props;
 
@@ -497,7 +497,7 @@ export default class AdvancedTab extends PureComponent {
                 ) {
                   this.setState({ showLedgerTransportWarning: true });
                 }
-                setLedgerLivePreference(transportType);
+                setLedgerTransportPreference(transportType);
                 if (
                   transportType === LEDGER_TRANSPORT_TYPES.WEBHID &&
                   userHasALedgerAccount

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -24,7 +24,7 @@ describe('AdvancedTab Component', () => {
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
         ledgerTransportType={LEDGER_TRANSPORT_TYPES.U2F}
-        setLedgerLivePreference={() => undefined}
+        setLedgerTransportPreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         dismissSeedBackUpReminder={false}
       />,
@@ -52,7 +52,7 @@ describe('AdvancedTab Component', () => {
         threeBoxDisabled
         threeBoxSyncingAllowed={false}
         ledgerTransportType={LEDGER_TRANSPORT_TYPES.U2F}
-        setLedgerLivePreference={() => undefined}
+        setLedgerTransportPreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         dismissSeedBackUpReminder={false}
         setShowTestNetworks={toggleTestnet}

--- a/ui/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.container.js
@@ -12,7 +12,7 @@ import {
   turnThreeBoxSyncingOnAndInitialize,
   setUseNonceField,
   setIpfsGateway,
-  setLedgerLivePreference,
+  setLedgerTransportPreference,
   setDismissSeedBackUpReminder,
 } from '../../../store/actions';
 import { getPreferences } from '../../../selectors';
@@ -87,8 +87,8 @@ export const mapDispatchToProps = (dispatch) => {
     setIpfsGateway: (value) => {
       return dispatch(setIpfsGateway(value));
     },
-    setLedgerLivePreference: (value) => {
-      return dispatch(setLedgerLivePreference(value));
+    setLedgerTransportPreference: (value) => {
+      return dispatch(setLedgerTransportPreference(value));
     },
     setDismissSeedBackUpReminder: (value) => {
       return dispatch(setDismissSeedBackUpReminder(value));

--- a/ui/pages/settings/advanced-tab/advanced-tab.stories.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.stories.js
@@ -16,7 +16,7 @@ export const AdvancedTabComponent = () => {
         setShowTestNetworks={() => undefined}
         setThreeBoxSyncingPermission={() => undefined}
         setIpfsGateway={() => undefined}
-        setLedgerLivePreference={() => undefined}
+        setLedgerTransportPreference={() => undefined}
         setDismissSeedBackUpReminder={() => undefined}
         setUseNonceField={() => undefined}
         setHexDataFeatureFlag={() => undefined}

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2766,7 +2766,7 @@ export function getCurrentWindowTab() {
   };
 }
 
-export function setLedgerLivePreference(value) {
+export function setLedgerTransportPreference(value) {
   return async (dispatch) => {
     dispatch(showLoadingIndication());
     await promisifiedBackground.setLedgerTransportPreference(value);


### PR DESCRIPTION
Since the Ledger transport isn't LedgerLive-centric, we should update our method names.