### PR TITLE
Add fixture server substitutions

### DIFF
--- a/test/e2e/fixture-server.js
+++ b/test/e2e/fixture-server.js
@@ -1,12 +1,57 @@
 const { promises: fs } = require('fs');
 const path = require('path');
 const Koa = require('koa');
+const { isObject, mapValues } = require('lodash');
 
 const CURRENT_STATE_KEY = '__CURRENT__';
 const DEFAULT_STATE_KEY = '__DEFAULT__';
 
 const FIXTURE_SERVER_HOST = 'localhost';
 const FIXTURE_SERVER_PORT = 12345;
+
+const fixtureSubstitutionPrefix = '__FIXTURE_SUBSTITUTION__';
+const fixtureSubstitutionCommands = {
+  currentDateInMilliseconds: 'currentDateInMilliseconds',
+};
+
+/**
+ * Perform substitutions on a single piece of state.
+ *
+ * @param {unknown} partialState - The piece of state to perform substitutions on.
+ * @returns {unknown} The partial state with substititions performed.
+ */
+function performSubstitution(partialState) {
+  if (Array.isArray(partialState)) {
+    return partialState.map(performSubstitution);
+  } else if (isObject(partialState)) {
+    return mapValues(partialState, performSubstitution);
+  } else if (
+    typeof partialState === 'string' &&
+    partialState.startsWith(fixtureSubstitutionPrefix)
+  ) {
+    const substitutionCommand = partialState.substring(
+      fixtureSubstitutionPrefix.length,
+    );
+    if (
+      substitutionCommand ===
+      fixtureSubstitutionCommands.currentDateInMilliseconds
+    ) {
+      return new Date().getTime();
+    }
+    throw new Error(`Unknown substitution command: ${substitutionCommand}`);
+  }
+  return partialState;
+}
+
+/**
+ * Substitute values in the state fixture.
+ *
+ * @param {object} rawState - The state fixture.
+ * @returns {object} The state fixture with substitutions performed.
+ */
+function performStateSubstitutions(rawState) {
+  return mapValues(rawState, performSubstitution);
+}
 
 class FixtureServer {
   constructor() {
@@ -57,7 +102,8 @@ class FixtureServer {
       state = this._initialStateCache.get(statePath);
     } else {
       const data = await fs.readFile(statePath);
-      state = JSON.parse(data.toString('utf-8'));
+      const rawState = JSON.parse(data.toString('utf-8'));
+      state = performStateSubstitutions(rawState);
       this._initialStateCache.set(statePath, state);
     }
 

--- a/test/e2e/fixtures/custom-token/state.json
+++ b/test/e2e/fixtures/custom-token/state.json
@@ -12,7 +12,7 @@
       "connectedStatusPopoverHasBeenShown": true,
       "defaultHomeActiveTabName": null,
       "recoveryPhraseReminderHasBeenShown": true,
-      "recoveryPhraseReminderLastShown": 1627317428214
+      "recoveryPhraseReminderLastShown": "__FIXTURE_SUBSTITUTION__currentDateInMilliseconds"
     },
     "CachedBalancesController": {
       "cachedBalances": {


### PR DESCRIPTION
The fixture server now supports state substitutions. This allows us to embed dynamic values in our fixtures.

The `custom-token` fixture has been updated to include such a fixture. The date that the seed phrase reminder was last shown has been updated to always be the current date, to prevent the reminder from showing up during e2e tests. This fixes the e2e test failure for the test "add-hide-token.spec.js" that we've been seeing on CI lately.

Manual testing steps:  
  - Try running the e2e test that had failed before this PR: `yarn build:test && yarn test:e2e:single --browser chrome --leave-running ./test/e2e/tests/add-hide-token.spec.js` and see that it passes now.