### PR TITLE
Fix builds from forks

### DIFF
--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -93,7 +93,8 @@ function getInfuraProjectId({ environment, testing }) {
   } else if (environment === ENVIRONMENT.PRODUCTION) {
     return getConfigValue('INFURA_PROD_PROJECT_ID');
   }
-  return getConfigValue('INFURA_PROJECT_ID');
+  // Skip validation because this is unset on PRs from forks
+  return metamaskrc.INFURA_PROJECT_ID;
 }
 
 module.exports = createScriptTasks;


### PR DESCRIPTION
Recently validation was added for our build configuration as part of the PR #12438. This had the unintended consequence of making all builds from forks fail because they don't get secrets injected. Specifically it was the missing `INFURA_PROJECT_ID` that made the builds fail.

The Infura project ID is no longer required for building. In practice it's still required for doing anything with a build but running e2e tests, but that's all we need to do in CI anyway.