### PR TITLE
Fix currency preference and hex data state when in send screen edit mode

### DIFF
--- a/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.js
+++ b/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.js
@@ -6,21 +6,25 @@ export default class UserPreferencedCurrencyInput extends PureComponent {
   static propTypes = {
     useNativeCurrencyAsPrimaryCurrency: PropTypes.bool,
     passDataToSendAmount: PropTypes.func,
-    location: PropTypes.object
+    location: PropTypes.object,
   };
 
   state = {
-    dataFromCurrency: {}
-  }
+    dataFromCurrency: {},
+  };
 
   getDataFromCurrency = (value) => {
-    this.setState({ dataFromCurrency: value })
-  }
+    this.setState({ dataFromCurrency: value });
+  };
 
   render() {
-    const { useNativeCurrencyAsPrimaryCurrency, location, ...restProps } = this.props;
-    
-    this.props.passDataToSendAmount(this.state)
+    const {
+      useNativeCurrencyAsPrimaryCurrency,
+      location,
+      ...restProps
+    } = this.props;
+
+    this.props.passDataToSendAmount(this.state);
 
     return (
       <CurrencyInput

--- a/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.js
+++ b/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.js
@@ -30,7 +30,7 @@ export default class UserPreferencedCurrencyInput extends PureComponent {
       <CurrencyInput
         {...restProps}
         useFiat={!useNativeCurrencyAsPrimaryCurrency}
-        passDataToUserPeference={this.getDataFromCurrency}
+        passDataToUserPreference={this.getDataFromCurrency}
         location={location}
       />
     );

--- a/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.js
+++ b/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.js
@@ -5,15 +5,29 @@ import CurrencyInput from '../../ui/currency-input';
 export default class UserPreferencedCurrencyInput extends PureComponent {
   static propTypes = {
     useNativeCurrencyAsPrimaryCurrency: PropTypes.bool,
+    passDataToSendAmount: PropTypes.func,
+    location: PropTypes.object
   };
 
+  state = {
+    dataFromCurrency: {}
+  }
+
+  getDataFromCurrency = (value) => {
+    this.setState({ dataFromCurrency: value })
+  }
+
   render() {
-    const { useNativeCurrencyAsPrimaryCurrency, ...restProps } = this.props;
+    const { useNativeCurrencyAsPrimaryCurrency, location, ...restProps } = this.props;
+    
+    this.props.passDataToSendAmount(this.state)
 
     return (
       <CurrencyInput
         {...restProps}
         useFiat={!useNativeCurrencyAsPrimaryCurrency}
+        passDataToUserPeference={this.getDataFromCurrency}
+        location={location}
       />
     );
   }

--- a/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.test.js
+++ b/ui/components/app/user-preferenced-currency-input/user-preferenced-currency-input.component.test.js
@@ -6,15 +6,22 @@ import UserPreferencedCurrencyInput from './user-preferenced-currency-input.comp
 describe('UserPreferencedCurrencyInput Component', () => {
   describe('rendering', () => {
     it('should render properly', () => {
-      const wrapper = shallow(<UserPreferencedCurrencyInput />);
+      const passDataToSend = jest.fn();
+      const wrapper = shallow(
+        <UserPreferencedCurrencyInput passDataToSendAmount={passDataToSend} />,
+      );
 
       expect(wrapper).toHaveLength(1);
       expect(wrapper.find(CurrencyInput)).toHaveLength(1);
     });
 
     it('should render useFiat for CurrencyInput based on preferences.useNativeCurrencyAsPrimaryCurrency', () => {
+      const passDataToSend = jest.fn();
       const wrapper = shallow(
-        <UserPreferencedCurrencyInput useNativeCurrencyAsPrimaryCurrency />,
+        <UserPreferencedCurrencyInput
+          useNativeCurrencyAsPrimaryCurrency
+          passDataToSendAmount={passDataToSend}
+        />,
       );
 
       expect(wrapper).toHaveLength(1);

--- a/ui/components/ui/currency-input/currency-input.component.js
+++ b/ui/components/ui/currency-input/currency-input.component.js
@@ -29,19 +29,30 @@ export default class CurrencyInput extends PureComponent {
     fiatSuffix: PropTypes.string,
     nativeSuffix: PropTypes.string,
     passDataToUserPeference: PropTypes.func,
-    location: PropTypes.object
+    location: PropTypes.object,
   };
 
   constructor(props) {
     super(props);
 
-    const hexValue = (this.props.location && this.props.location.currencyObject) ? this.props.location.currencyObject.hexValue : this.props.value
-    const decimalValue = (this.props.location && this.props.location.currencyObject) ? this.props.location.currencyObject.decimalValue : (hexValue ? this.getDecimalValue(props) : 0)
+    const hexValue =
+      this.props.location && this.props.location.currencyObject
+        ? this.props.location.currencyObject.hexValue
+        : this.props.value;
+    const decimalValue =
+      this.props.location && this.props.location.currencyObject
+        ? this.props.location.currencyObject.decimalValue
+        : hexValue
+        ? this.getDecimalValue(props)
+        : 0;
 
     this.state = {
       decimalValue,
       hexValue,
-      isSwapped: (this.props.location && this.props.location.currencyObject) ? this.props.location.currencyObject.isSwapped : false,
+      isSwapped:
+        this.props.location && this.props.location.currencyObject
+          ? this.props.location.currencyObject.isSwapped
+          : false,
     };
   }
 
@@ -124,7 +135,7 @@ export default class CurrencyInput extends PureComponent {
     const { currentCurrency, nativeCurrency, hideFiat } = this.props;
     const { hexValue } = this.state;
     let currency, numberOfDecimals;
-    
+
     if (hideFiat) {
       return (
         <div className="currency-input__conversion-component">

--- a/ui/components/ui/currency-input/currency-input.component.js
+++ b/ui/components/ui/currency-input/currency-input.component.js
@@ -35,16 +35,17 @@ export default class CurrencyInput extends PureComponent {
   constructor(props) {
     super(props);
 
-    const hexValue =
-      this.props.location && this.props.location.currencyObject
-        ? this.props.location.currencyObject.hexValue
-        : this.props.value;
-    const decimalValue =
-      this.props.location && this.props.location.currencyObject
-        ? this.props.location.currencyObject.decimalValue
-        : hexValue
-        ? this.getDecimalValue(props)
-        : 0;
+    let hexValue = this.props.value;
+    let decimalValue;
+
+    if (this.props.location && this.props.location.currencyObject) {
+      hexValue = this.props.location.currencyObject.hexValue;
+      decimalValue = this.props.location.currencyObject.decimalValue;
+    } else if (hexValue) {
+      decimalValue = this.getDecimalValue(props);
+    } else {
+      decimalValue = 0;
+    }
 
     this.state = {
       decimalValue,

--- a/ui/components/ui/currency-input/currency-input.component.js
+++ b/ui/components/ui/currency-input/currency-input.component.js
@@ -28,7 +28,7 @@ export default class CurrencyInput extends PureComponent {
     value: PropTypes.string,
     fiatSuffix: PropTypes.string,
     nativeSuffix: PropTypes.string,
-    passDataToUserPeference: PropTypes.func,
+    passDataToUserPreference: PropTypes.func,
     location: PropTypes.object,
   };
 
@@ -169,7 +169,7 @@ export default class CurrencyInput extends PureComponent {
     const { fiatSuffix, nativeSuffix, ...restProps } = this.props;
     const { decimalValue } = this.state;
 
-    this.props.passDataToUserPeference(this.state);
+    this.props.passDataToUserPreference(this.state);
 
     return (
       <UnitInput

--- a/ui/components/ui/currency-input/currency-input.component.js
+++ b/ui/components/ui/currency-input/currency-input.component.js
@@ -28,18 +28,20 @@ export default class CurrencyInput extends PureComponent {
     value: PropTypes.string,
     fiatSuffix: PropTypes.string,
     nativeSuffix: PropTypes.string,
+    passDataToUserPeference: PropTypes.func,
+    location: PropTypes.object
   };
 
   constructor(props) {
     super(props);
 
-    const { value: hexValue } = props;
-    const decimalValue = hexValue ? this.getDecimalValue(props) : 0;
+    const hexValue = (this.props.location && this.props.location.currencyObject) ? this.props.location.currencyObject.hexValue : this.props.value
+    const decimalValue = (this.props.location && this.props.location.currencyObject) ? this.props.location.currencyObject.decimalValue : (hexValue ? this.getDecimalValue(props) : 0)
 
     this.state = {
       decimalValue,
       hexValue,
-      isSwapped: false,
+      isSwapped: (this.props.location && this.props.location.currencyObject) ? this.props.location.currencyObject.isSwapped : false,
     };
   }
 
@@ -122,7 +124,7 @@ export default class CurrencyInput extends PureComponent {
     const { currentCurrency, nativeCurrency, hideFiat } = this.props;
     const { hexValue } = this.state;
     let currency, numberOfDecimals;
-
+    
     if (hideFiat) {
       return (
         <div className="currency-input__conversion-component">
@@ -154,6 +156,8 @@ export default class CurrencyInput extends PureComponent {
   render() {
     const { fiatSuffix, nativeSuffix, ...restProps } = this.props;
     const { decimalValue } = this.state;
+
+    this.props.passDataToUserPeference(this.state);
 
     return (
       <UnitInput

--- a/ui/components/ui/currency-input/currency-input.component.test.js
+++ b/ui/components/ui/currency-input/currency-input.component.test.js
@@ -11,13 +11,17 @@ import CurrencyInput from './currency-input.component';
 describe('CurrencyInput Component', () => {
   describe('rendering', () => {
     it('should render properly without a suffix', () => {
-      const wrapper = shallow(<CurrencyInput />);
+      const passDataToUser = jest.fn();
+      const wrapper = shallow(
+        <CurrencyInput passDataToUserPreference={passDataToUser} />,
+      );
 
       expect(wrapper).toHaveLength(1);
       expect(wrapper.find(UnitInput)).toHaveLength(1);
     });
 
     it('should render properly with a suffix', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -33,6 +37,7 @@ describe('CurrencyInput Component', () => {
             nativeSuffix="ETH"
             fiatSuffix="USD"
             nativeCurrency="ETH"
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
       );
@@ -44,6 +49,7 @@ describe('CurrencyInput Component', () => {
     });
 
     it('should render properly with an ETH value', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -62,6 +68,7 @@ describe('CurrencyInput Component', () => {
             nativeCurrency="ETH"
             currentCurrency="usd"
             conversionRate={231.06}
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
       );
@@ -84,6 +91,7 @@ describe('CurrencyInput Component', () => {
     });
 
     it('should render properly with a fiat value', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -103,6 +111,7 @@ describe('CurrencyInput Component', () => {
             nativeCurrency="ETH"
             currentCurrency="usd"
             conversionRate={231.06}
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
       );
@@ -125,6 +134,7 @@ describe('CurrencyInput Component', () => {
     });
 
     it('should render properly with a native value when hideFiat is true', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -146,6 +156,7 @@ describe('CurrencyInput Component', () => {
             nativeCurrency="ETH"
             currentCurrency="usd"
             conversionRate={231.06}
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
         {
@@ -184,6 +195,7 @@ describe('CurrencyInput Component', () => {
     });
 
     it('should call onChange on input changes with the hex value for ETH', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -200,6 +212,7 @@ describe('CurrencyInput Component', () => {
             nativeCurrency="ETH"
             currentCurrency="usd"
             conversionRate={231.06}
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
       );
@@ -233,6 +246,7 @@ describe('CurrencyInput Component', () => {
     });
 
     it('should call onChange on input changes with the hex value for fiat', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -250,6 +264,7 @@ describe('CurrencyInput Component', () => {
             currentCurrency="usd"
             conversionRate={231.06}
             useFiat
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
       );
@@ -283,6 +298,7 @@ describe('CurrencyInput Component', () => {
     });
 
     it('should change the state and pass in a new decimalValue when props.value changes', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -300,6 +316,7 @@ describe('CurrencyInput Component', () => {
             currentCurrency="usd"
             conversionRate={231.06}
             useFiat
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
       );
@@ -324,6 +341,7 @@ describe('CurrencyInput Component', () => {
     });
 
     it('should swap selected currency when swap icon is clicked', () => {
+      const passDataToUser = jest.fn();
       const mockStore = {
         metamask: {
           nativeCurrency: 'ETH',
@@ -341,6 +359,7 @@ describe('CurrencyInput Component', () => {
             nativeCurrency="ETH"
             currentCurrency="usd"
             conversionRate={231.06}
+            passDataToUserPreference={passDataToUser}
           />
         </Provider>,
       );

--- a/ui/pages/confirm-send-ether/confirm-send-ether.component.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.component.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ConfirmTransactionBase from '../confirm-transaction-base';
 import { SEND_ROUTE } from '../../helpers/constants/routes';
-
 export default class ConfirmSendEther extends Component {
   static contextTypes = {
     t: PropTypes.func,
@@ -14,10 +13,20 @@ export default class ConfirmSendEther extends Component {
     txParams: PropTypes.object,
   };
 
+  state = {
+    currencyPreferenceObject: {}
+  }
+
   handleEdit({ txData }) {
     const { editTransaction, history } = this.props;
     editTransaction(txData).then(() => {
-      history.push(SEND_ROUTE);
+      history.push({
+        pathname: SEND_ROUTE,
+        state: {
+          hexData: txData.txParams.data,
+          currencyObject: this.state.currencyPreferenceObject
+        },
+      })
     });
   }
 
@@ -28,6 +37,10 @@ export default class ConfirmSendEther extends Component {
 
   render() {
     const hideData = this.shouldHideData();
+
+    if (this.props.location.state && this.props.location.state.currencyData) {
+      this.state.currencyPreferenceObject = this.props.location.state.currencyData.currencyPreferenceData.dataFromSendAmountRow.dataFromCurrency.dataFromCurrency
+    }
 
     return (
       <ConfirmTransactionBase

--- a/ui/pages/confirm-send-ether/confirm-send-ether.component.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.component.js
@@ -12,10 +12,15 @@ export default class ConfirmSendEther extends Component {
     editTransaction: PropTypes.func,
     history: PropTypes.object,
     txParams: PropTypes.object,
+    location: PropTypes.object,
   };
 
   state = {
-    currencyPreferenceObject: {},
+    currencyPreferenceObject:
+      this.props.location.state && this.props.location.state.currencyData
+        ? this.props.location.state.currencyData.currencyPreferenceData
+            .dataFromSendAmountRow.dataFromCurrency.dataFromCurrency
+        : {},
   };
 
   handleEdit({ txData }) {
@@ -38,10 +43,6 @@ export default class ConfirmSendEther extends Component {
 
   render() {
     const hideData = this.shouldHideData();
-
-    if (this.props.location.state && this.props.location.state.currencyData) {
-      this.state.currencyPreferenceObject = this.props.location.state.currencyData.currencyPreferenceData.dataFromSendAmountRow.dataFromCurrency.dataFromCurrency;
-    }
 
     return (
       <ConfirmTransactionBase

--- a/ui/pages/confirm-send-ether/confirm-send-ether.component.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.component.js
@@ -15,12 +15,25 @@ export default class ConfirmSendEther extends Component {
     location: PropTypes.object,
   };
 
+  getCurrencyPreferenceObject = () => {
+    if (
+      this.props.location.state &&
+      this.props.location.state.currencyData &&
+      this.props.location.state.currencyData.currencyPreferenceData
+    ) {
+      return this.props.location.state.currencyData.currencyPreferenceData
+        .dataFromSendAmountRow.dataFromCurrency.dataFromCurrency;
+    } else if (
+      this.props.location.state &&
+      this.props.location.state.currencyData
+    ) {
+      return this.props.location.state.currencyData.currencyObject;
+    }
+    return {};
+  };
+
   state = {
-    currencyPreferenceObject:
-      this.props.location.state && this.props.location.state.currencyData
-        ? this.props.location.state.currencyData.currencyPreferenceData
-            .dataFromSendAmountRow.dataFromCurrency.dataFromCurrency
-        : {},
+    currencyPreferenceObject: this.getCurrencyPreferenceObject,
   };
 
   handleEdit({ txData }) {

--- a/ui/pages/confirm-send-ether/confirm-send-ether.component.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ConfirmTransactionBase from '../confirm-transaction-base';
 import { SEND_ROUTE } from '../../helpers/constants/routes';
+
 export default class ConfirmSendEther extends Component {
   static contextTypes = {
     t: PropTypes.func,
@@ -14,8 +15,8 @@ export default class ConfirmSendEther extends Component {
   };
 
   state = {
-    currencyPreferenceObject: {}
-  }
+    currencyPreferenceObject: {},
+  };
 
   handleEdit({ txData }) {
     const { editTransaction, history } = this.props;
@@ -24,9 +25,9 @@ export default class ConfirmSendEther extends Component {
         pathname: SEND_ROUTE,
         state: {
           hexData: txData.txParams.data,
-          currencyObject: this.state.currencyPreferenceObject
+          currencyObject: this.state.currencyPreferenceObject,
         },
-      })
+      });
     });
   }
 
@@ -39,7 +40,7 @@ export default class ConfirmSendEther extends Component {
     const hideData = this.shouldHideData();
 
     if (this.props.location.state && this.props.location.state.currencyData) {
-      this.state.currencyPreferenceObject = this.props.location.state.currencyData.currencyPreferenceData.dataFromSendAmountRow.dataFromCurrency.dataFromCurrency
+      this.state.currencyPreferenceObject = this.props.location.state.currencyData.currencyPreferenceData.dataFromSendAmountRow.dataFromCurrency.dataFromCurrency;
     }
 
     return (

--- a/ui/pages/confirm-send-ether/confirm-send-ether.component.js
+++ b/ui/pages/confirm-send-ether/confirm-send-ether.component.js
@@ -33,7 +33,7 @@ export default class ConfirmSendEther extends Component {
   };
 
   state = {
-    currencyPreferenceObject: this.getCurrencyPreferenceObject,
+    currencyPreferenceObject: this.getCurrencyPreferenceObject(),
   };
 
   handleEdit({ txData }) {

--- a/ui/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
+++ b/ui/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
@@ -34,7 +34,9 @@ export default class ConfirmTransactionSwitch extends Component {
 
     if (type === TRANSACTION_TYPES.SIMPLE_SEND) {
       const pathname = `${CONFIRM_TRANSACTION_ROUTE}/${id}${CONFIRM_SEND_ETHER_PATH}`;
-      return <Redirect to={{ pathname, state: { currencyData: location.state } }} />;
+      return (
+        <Redirect to={{ pathname, state: { currencyData: location.state } }} />
+      );
     }
 
     if (data) {

--- a/ui/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
+++ b/ui/pages/confirm-transaction-switch/confirm-transaction-switch.component.js
@@ -20,10 +20,11 @@ import { TRANSACTION_TYPES } from '../../../shared/constants/transaction';
 export default class ConfirmTransactionSwitch extends Component {
   static propTypes = {
     txData: PropTypes.object,
+    location: PropTypes.object,
   };
 
   redirectToTransaction() {
-    const { txData } = this.props;
+    const { txData, location } = this.props;
     const { id, txParams: { data } = {}, type } = txData;
 
     if (type === TRANSACTION_TYPES.DEPLOY_CONTRACT) {
@@ -33,7 +34,7 @@ export default class ConfirmTransactionSwitch extends Component {
 
     if (type === TRANSACTION_TYPES.SIMPLE_SEND) {
       const pathname = `${CONFIRM_TRANSACTION_ROUTE}/${id}${CONFIRM_SEND_ETHER_PATH}`;
-      return <Redirect to={{ pathname }} />;
+      return <Redirect to={{ pathname, state: { currencyData: location.state } }} />;
     }
 
     if (data) {

--- a/ui/pages/send/send-content/send-amount-row/send-amount-row.component.js
+++ b/ui/pages/send/send-content/send-amount-row/send-amount-row.component.js
@@ -13,7 +13,7 @@ export default class SendAmountRow extends Component {
     asset: PropTypes.object,
     updateSendAmount: PropTypes.func,
     passDataToSendContent: PropTypes.func,
-    location: PropTypes.object
+    location: PropTypes.object,
   };
 
   static contextTypes = {
@@ -21,16 +21,16 @@ export default class SendAmountRow extends Component {
   };
 
   state = {
-    dataFromCurrency: {}
-  }
+    dataFromCurrency: {},
+  };
 
   handleChange = (newAmount) => {
     this.props.updateSendAmount(newAmount);
   };
 
   getDataFromCurrency = (value) => {
-    this.setState({ dataFromCurrency: value})
-  }
+    this.setState({ dataFromCurrency: value });
+  };
 
   renderInput() {
     const { amount, inError, asset, location } = this.props;
@@ -56,7 +56,7 @@ export default class SendAmountRow extends Component {
   render() {
     const { inError } = this.props;
 
-    this.props.passDataToSendContent(this.state)
+    this.props.passDataToSendContent(this.state);
 
     return (
       <SendRowWrapper

--- a/ui/pages/send/send-content/send-amount-row/send-amount-row.component.js
+++ b/ui/pages/send/send-content/send-amount-row/send-amount-row.component.js
@@ -12,18 +12,28 @@ export default class SendAmountRow extends Component {
     inError: PropTypes.bool,
     asset: PropTypes.object,
     updateSendAmount: PropTypes.func,
+    passDataToSendContent: PropTypes.func,
+    location: PropTypes.object
   };
 
   static contextTypes = {
     t: PropTypes.func,
   };
 
+  state = {
+    dataFromCurrency: {}
+  }
+
   handleChange = (newAmount) => {
     this.props.updateSendAmount(newAmount);
   };
 
+  getDataFromCurrency = (value) => {
+    this.setState({ dataFromCurrency: value})
+  }
+
   renderInput() {
-    const { amount, inError, asset } = this.props;
+    const { amount, inError, asset, location } = this.props;
 
     return asset.type === ASSET_TYPES.TOKEN ? (
       <UserPreferencedTokenInput
@@ -37,12 +47,16 @@ export default class SendAmountRow extends Component {
         error={inError}
         onChange={this.handleChange}
         value={amount}
+        passDataToSendAmount={this.getDataFromCurrency}
+        location={location}
       />
     );
   }
 
   render() {
     const { inError } = this.props;
+
+    this.props.passDataToSendContent(this.state)
 
     return (
       <SendRowWrapper

--- a/ui/pages/send/send-content/send-amount-row/send-amount-row.component.test.js
+++ b/ui/pages/send/send-content/send-amount-row/send-amount-row.component.test.js
@@ -77,6 +77,7 @@ describe('SendAmountRow Component', () => {
 
 function shallowRenderSendAmountRow() {
   const updateSendAmount = sinon.spy();
+  const passDataToSend = jest.fn();
   const wrapper = shallow(
     <SendAmountRow
       amount="mockAmount"
@@ -87,6 +88,7 @@ function shallowRenderSendAmountRow() {
         details: { address: 'mockTokenAddress' },
       }}
       updateSendAmount={updateSendAmount}
+      passDataToSendContent={passDataToSend}
     />,
     { context: { t: (str) => `${str}_t` } },
   );

--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -33,17 +33,16 @@ export default class SendContent extends Component {
     networkOrAccountNotSupports1559: PropTypes.bool,
     getIsBalanceInsufficient: PropTypes.bool,
     location: PropTypes.object,
-    passDataToSendPage: PropTypes.func
+    passDataToSendPage: PropTypes.func,
   };
 
   state = {
-    dataFromSendAmountRow: {}
-  }
+    dataFromSendAmountRow: {},
+  };
 
   getDataFromSendAmountRow = (value) => {
-    this.setState({ dataFromSendAmountRow: value })
-  }
-
+    this.setState({ dataFromSendAmountRow: value });
+  };
 
   render() {
     const {
@@ -58,8 +57,8 @@ export default class SendContent extends Component {
       location
     } = this.props;
 
-    this.props.passDataToSendPage(this.state)
-    
+    this.props.passDataToSendPage(this.state);
+
     let gasError;
     if (gasIsExcessive) gasError = GAS_PRICE_EXCESSIVE_ERROR_KEY;
     else if (noGasPrice) gasError = GAS_PRICE_FETCH_FAILURE_ERROR_KEY;
@@ -80,7 +79,10 @@ export default class SendContent extends Component {
           {warning ? this.renderWarning() : null}
           {this.maybeRenderAddContact()}
           <SendAssetRow />
-          <SendAmountRow passDataToSendContent={this.getDataFromSendAmountRow} location={location}/>
+          <SendAmountRow
+            passDataToSendContent={this.getDataFromSendAmountRow}
+            location={location}
+          />
           {networkOrAccountNotSupports1559 && <SendGasRow />}
           {this.props.showHexData && <SendHexDataRow location={location} />}
         </div>

--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -54,7 +54,7 @@ export default class SendContent extends Component {
       isAssetSendable,
       networkOrAccountNotSupports1559,
       getIsBalanceInsufficient,
-      location
+      location,
     } = this.props;
 
     this.props.passDataToSendPage(this.state);

--- a/ui/pages/send/send-content/send-content.component.js
+++ b/ui/pages/send/send-content/send-content.component.js
@@ -32,7 +32,18 @@ export default class SendContent extends Component {
     noGasPrice: PropTypes.bool,
     networkOrAccountNotSupports1559: PropTypes.bool,
     getIsBalanceInsufficient: PropTypes.bool,
+    location: PropTypes.object,
+    passDataToSendPage: PropTypes.func
   };
+
+  state = {
+    dataFromSendAmountRow: {}
+  }
+
+  getDataFromSendAmountRow = (value) => {
+    this.setState({ dataFromSendAmountRow: value })
+  }
+
 
   render() {
     const {
@@ -44,8 +55,11 @@ export default class SendContent extends Component {
       isAssetSendable,
       networkOrAccountNotSupports1559,
       getIsBalanceInsufficient,
+      location
     } = this.props;
 
+    this.props.passDataToSendPage(this.state)
+    
     let gasError;
     if (gasIsExcessive) gasError = GAS_PRICE_EXCESSIVE_ERROR_KEY;
     else if (noGasPrice) gasError = GAS_PRICE_FETCH_FAILURE_ERROR_KEY;
@@ -66,9 +80,9 @@ export default class SendContent extends Component {
           {warning ? this.renderWarning() : null}
           {this.maybeRenderAddContact()}
           <SendAssetRow />
-          <SendAmountRow />
-          {networkOrAccountNotSupports1559 ? <SendGasRow /> : null}
-          {this.props.showHexData ? <SendHexDataRow /> : null}
+          <SendAmountRow passDataToSendContent={this.getDataFromSendAmountRow} location={location}/>
+          {networkOrAccountNotSupports1559 && <SendGasRow />}
+          {this.props.showHexData && <SendHexDataRow location={location} />}
         </div>
       </PageContainerContent>
     );

--- a/ui/pages/send/send-content/send-content.component.test.js
+++ b/ui/pages/send/send-content/send-content.component.test.js
@@ -17,10 +17,15 @@ describe('SendContent Component', () => {
     networkAndAccountSupports1559: true,
   };
 
+  const passDataToSend = jest.fn();
+
   beforeEach(() => {
-    wrapper = shallow(<SendContent {...defaultProps} />, {
-      context: { t: (str) => `${str}_t` },
-    });
+    wrapper = shallow(
+      <SendContent passDataToSendPage={passDataToSend} {...defaultProps} />,
+      {
+        context: { t: (str) => `${str}_t` },
+      },
+    );
   });
 
   describe('render', () => {

--- a/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
+++ b/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
@@ -44,7 +44,7 @@ export default class SendHexDataRow extends Component {
           onInput={this.onInput}
           placeholder={t('optional')}
           className="send-v2__hex-data__input"
-          value={
+          defaultValue={
             location && location.hexData && this.state.hexData === ''
               ? location.hexData
               : this.state.hexData

--- a/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
+++ b/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
@@ -6,12 +6,12 @@ export default class SendHexDataRow extends Component {
   static propTypes = {
     inError: PropTypes.bool,
     updateSendHexData: PropTypes.func.isRequired,
-    location: PropTypes.object
+    location: PropTypes.object,
   };
 
   state = {
-    hexData: '' 
-  }
+    hexData: '',
+  };
 
   static contextTypes = {
     t: PropTypes.func,
@@ -21,7 +21,7 @@ export default class SendHexDataRow extends Component {
     const { updateSendHexData } = this.props;
     const data = event.target.value.replace(/\n/gu, '') || null;
     updateSendHexData(data);
-    this.setState({ hexData: data })
+    this.setState({ hexData: data });
   };
 
   render() {
@@ -44,7 +44,11 @@ export default class SendHexDataRow extends Component {
           onInput={this.onInput}
           placeholder={t('optional')}
           className="send-v2__hex-data__input"
-          value={(location && location.hexData && this.state.hexData === '') ? location.hexData : this.state.hexData}
+          value={
+            location && location.hexData && this.state.hexData === ''
+              ? location.hexData
+              : this.state.hexData
+          }
         />
       </SendRowWrapper>
     );

--- a/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
+++ b/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
@@ -6,7 +6,12 @@ export default class SendHexDataRow extends Component {
   static propTypes = {
     inError: PropTypes.bool,
     updateSendHexData: PropTypes.func.isRequired,
+    location: PropTypes.object
   };
+
+  state = {
+    hexData: '' 
+  }
 
   static contextTypes = {
     t: PropTypes.func,
@@ -16,11 +21,18 @@ export default class SendHexDataRow extends Component {
     const { updateSendHexData } = this.props;
     const data = event.target.value.replace(/\n/gu, '') || null;
     updateSendHexData(data);
+    this.setState({ hexData: data })
   };
 
   render() {
-    const { inError } = this.props;
+    const { inError, location } = this.props;
     const { t } = this.context;
+
+    if (location && location.hexData && this.state.hexData === '') {
+      const { updateSendHexData } = this.props;
+      const data = location.hexData.replace(/\n/gu, '') || null;
+      updateSendHexData(data);
+    }
 
     return (
       <SendRowWrapper
@@ -32,6 +44,7 @@ export default class SendHexDataRow extends Component {
           onInput={this.onInput}
           placeholder={t('optional')}
           className="send-v2__hex-data__input"
+          value={(location && location.hexData && this.state.hexData === '') ? location.hexData : this.state.hexData}
         />
       </SendRowWrapper>
     );

--- a/ui/pages/send/send-footer/send-footer.component.js
+++ b/ui/pages/send/send-footer/send-footer.component.js
@@ -58,7 +58,7 @@ export default class SendFooter extends Component {
       toAccounts,
       history,
       gasEstimateType,
-      dataFromSendPage
+      dataFromSendPage,
     } = this.props;
     const { metricsEvent } = this.context;
 
@@ -82,7 +82,7 @@ export default class SendFooter extends Component {
         state: {
           currencyPreferenceData: dataFromSendPage,
         },
-      })
+      });
     });
   }
 

--- a/ui/pages/send/send-footer/send-footer.component.js
+++ b/ui/pages/send/send-footer/send-footer.component.js
@@ -23,6 +23,7 @@ export default class SendFooter extends Component {
     mostRecentOverviewPage: PropTypes.string.isRequired,
     cancelTx: PropTypes.func,
     draftTransactionID: PropTypes.string,
+    dataFromSendPage: PropTypes.object,
   };
 
   static contextTypes = {
@@ -57,6 +58,7 @@ export default class SendFooter extends Component {
       toAccounts,
       history,
       gasEstimateType,
+      dataFromSendPage
     } = this.props;
     const { metricsEvent } = this.context;
 
@@ -75,7 +77,12 @@ export default class SendFooter extends Component {
           gasChanged: gasEstimateType,
         },
       });
-      history.push(CONFIRM_TRANSACTION_ROUTE);
+      history.push({
+        pathname: CONFIRM_TRANSACTION_ROUTE,
+        state: {
+          currencyPreferenceData: dataFromSendPage,
+        },
+      })
     });
   }
 

--- a/ui/pages/send/send-footer/send-footer.component.test.js
+++ b/ui/pages/send/send-footer/send-footer.component.test.js
@@ -123,11 +123,13 @@ describe('SendFooter Component', () => {
     });
 
     it('should call history.push', async () => {
+      const currencyPreferenceData = undefined;
       await wrapper.instance().onSubmit(MOCK_EVENT);
       expect(historySpies.push.callCount).toStrictEqual(1);
-      expect(historySpies.push.getCall(0).args[0]).toStrictEqual(
-        CONFIRM_TRANSACTION_ROUTE,
-      );
+      expect(historySpies.push.getCall(0).args[0]).toStrictEqual({
+        pathname: CONFIRM_TRANSACTION_ROUTE,
+        state: { currencyPreferenceData },
+      });
     });
   });
 

--- a/ui/pages/send/send-header/send-header.component.js
+++ b/ui/pages/send/send-header/send-header.component.js
@@ -28,7 +28,7 @@ export default function SendHeader({ data }) {
 
   const onClose = () => {
     dispatch(resetSendState());
-    if (mostRecentOverviewPage === '/') {
+    if (data !== undefined) {
       history.push({
         pathname: CONFIRM_TRANSACTION_ROUTE,
         state: { currencyObject: data.currencyObject },

--- a/ui/pages/send/send-header/send-header.component.js
+++ b/ui/pages/send/send-header/send-header.component.js
@@ -28,7 +28,7 @@ export default function SendHeader({ data }) {
 
   const onClose = () => {
     dispatch(resetSendState());
-    if (data !== undefined) {
+    if (data) {
       history.push({
         pathname: CONFIRM_TRANSACTION_ROUTE,
         state: { currencyObject: data.currencyObject },

--- a/ui/pages/send/send-header/send-header.component.js
+++ b/ui/pages/send/send-header/send-header.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 import PageContainerHeader from '../../../components/ui/page-container/page-container-header';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -11,8 +12,13 @@ import {
   resetSendState,
   SEND_STAGES,
 } from '../../../ducks/send';
+import { CONFIRM_TRANSACTION_ROUTE } from '../../../helpers/constants/routes';
 
-export default function SendHeader() {
+SendHeader.propTypes = {
+  data: PropTypes.object,
+};
+
+export default function SendHeader({ data }) {
   const history = useHistory();
   const mostRecentOverviewPage = useSelector(getMostRecentOverviewPage);
   const dispatch = useDispatch();
@@ -22,7 +28,14 @@ export default function SendHeader() {
 
   const onClose = () => {
     dispatch(resetSendState());
-    history.push(mostRecentOverviewPage);
+    if (mostRecentOverviewPage === '/') {
+      history.push({
+        pathname: CONFIRM_TRANSACTION_ROUTE,
+        state: { currencyObject: data.currencyObject },
+      });
+    } else {
+      history.push(mostRecentOverviewPage);
+    }
   };
 
   let title = asset.type === ASSET_TYPES.NATIVE ? t('send') : t('sendTokens');

--- a/ui/pages/send/send.js
+++ b/ui/pages/send/send.js
@@ -45,7 +45,7 @@ export default function SendTransactionScreen() {
       name: 'Used QR scanner',
     },
   });
-  const [dataFromSendAmountRow, setStateDataFromSendAmountRow] = useState()
+  const [dataFromSendAmountRow, setStateDataFromSendAmountRow] = useState();
 
   const dispatch = useDispatch();
 
@@ -88,7 +88,11 @@ export default function SendTransactionScreen() {
           location={location.state}
           passDataToSendPage={(value) => setStateDataFromSendAmountRow(value)}
         />
-        <SendFooter key="send-footer" history={history} dataFromSendPage={dataFromSendAmountRow} />
+        <SendFooter
+          key="send-footer"
+          history={history}
+          dataFromSendPage={dataFromSendAmountRow}
+        />
       </>
     );
   } else {

--- a/ui/pages/send/send.js
+++ b/ui/pages/send/send.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import {
@@ -45,6 +45,7 @@ export default function SendTransactionScreen() {
       name: 'Used QR scanner',
     },
   });
+  const [dataFromSendAmountRow, setStateDataFromSendAmountRow] = useState()
 
   const dispatch = useDispatch();
 
@@ -78,21 +79,21 @@ export default function SendTransactionScreen() {
   }, [dispatch, cleanup]);
 
   let content;
-
   if ([SEND_STAGES.EDIT, SEND_STAGES.DRAFT].includes(stage)) {
     content = (
       <>
         <SendContent
           showHexData={showHexData}
           gasIsExcessive={gasIsExcessive}
+          location={location.state}
+          passDataToSendPage={(value) => setStateDataFromSendAmountRow(value)}
         />
-        <SendFooter key="send-footer" history={history} />
+        <SendFooter key="send-footer" history={history} dataFromSendPage={dataFromSendAmountRow} />
       </>
     );
   } else {
     content = <AddRecipient />;
   }
-
   return (
     <div className="page-container">
       <SendHeader history={history} />

--- a/ui/pages/send/send.js
+++ b/ui/pages/send/send.js
@@ -100,7 +100,7 @@ export default function SendTransactionScreen() {
   }
   return (
     <div className="page-container">
-      <SendHeader history={history} />
+      <SendHeader history={history} data={location.state} />
       <EnsInput
         userInput={userInput}
         className="send__to-row"


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/12347

When a user changes currency preference (from ETH which is default to USD), enter some amount, then enter hex data, go further and then go back, those changes will be saved (which was not the case before this fix). 


https://user-images.githubusercontent.com/92310504/139071402-2b2b3692-9131-4550-a7df-55d4f603a0c4.mp4

