### PR TITLE
Don't show ledger live option in advanced settings if using firefox

### DIFF
--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -413,21 +413,16 @@ export default class AdvancedTab extends PureComponent {
       U2F: t('u2f'),
     };
 
-    const isFirefox = getPlatform() === PLATFORM_FIREFOX;
-
     const transportTypeOptions = [
+      {
+        name: LEDGER_TRANSPORT_NAMES.LIVE,
+        value: LEDGER_TRANSPORT_TYPES.LIVE,
+      },
       {
         name: LEDGER_TRANSPORT_NAMES.U2F,
         value: LEDGER_TRANSPORT_TYPES.U2F,
       },
     ];
-
-    if (!isFirefox) {
-      transportTypeOptions.push({
-        name: LEDGER_TRANSPORT_NAMES.LIVE,
-        value: LEDGER_TRANSPORT_TYPES.LIVE,
-      });
-    }
 
     if (window.navigator.hid) {
       transportTypeOptions.push({
@@ -597,6 +592,8 @@ export default class AdvancedTab extends PureComponent {
   render() {
     const { warning } = this.props;
 
+    const notUsingFirefox = getPlatform() !== PLATFORM_FIREFOX;
+
     return (
       <div className="settings-page__body">
         {warning ? <div className="settings-tab__error">{warning}</div> : null}
@@ -610,7 +607,7 @@ export default class AdvancedTab extends PureComponent {
         {this.renderAutoLockTimeLimit()}
         {this.renderThreeBoxControl()}
         {this.renderIpfsGatewayControl()}
-        {this.renderLedgerLiveControl()}
+        {notUsingFirefox ? this.renderLedgerLiveControl() : null}
         {this.renderDismissSeedBackupReminderControl()}
       </div>
     );

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -8,6 +8,10 @@ import Button from '../../../components/ui/button';
 import { MOBILE_SYNC_ROUTE } from '../../../helpers/constants/routes';
 import Dropdown from '../../../components/ui/dropdown';
 
+import { getPlatform } from '../../../../app/scripts/lib/util';
+
+import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+
 import {
   LEDGER_TRANSPORT_TYPES,
   LEDGER_USB_VENDOR_ID,
@@ -409,16 +413,21 @@ export default class AdvancedTab extends PureComponent {
       U2F: t('u2f'),
     };
 
+    const isFirefox = getPlatform() === PLATFORM_FIREFOX;
+
     const transportTypeOptions = [
-      {
-        name: LEDGER_TRANSPORT_NAMES.LIVE,
-        value: LEDGER_TRANSPORT_TYPES.LIVE,
-      },
       {
         name: LEDGER_TRANSPORT_NAMES.U2F,
         value: LEDGER_TRANSPORT_TYPES.U2F,
       },
     ];
+
+    if (!isFirefox) {
+      transportTypeOptions.push({
+        name: LEDGER_TRANSPORT_NAMES.LIVE,
+        value: LEDGER_TRANSPORT_TYPES.LIVE,
+      });
+    }
 
     if (window.navigator.hid) {
       transportTypeOptions.push({


### PR DESCRIPTION
Addresses an issue found during QA of v10.4.0

Ledger Live doesn't work with firefox, so this option should not be selected in the advanced tab of settings when on firefox. This is how it works on prod.