### PR TITLE
Warn the user of insufficient funds when approving a token

### DIFF
--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -236,7 +236,7 @@ describe('Metamask Import UI', function () {
         const currentActiveAccountName = await driver.findElement(
           '.selected-account__name',
         );
-        assert.equal(await currentActiveAccountName.getText(), 'Account 1');
+        assert.equal(await currentActiveAccountName.getText(), 'Account 5');
         await driver.delay(regularDelayMs);
         await driver.clickElement('.account-menu__icon');
 

--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -236,7 +236,7 @@ describe('Metamask Import UI', function () {
         const currentActiveAccountName = await driver.findElement(
           '.selected-account__name',
         );
-        assert.equal(await currentActiveAccountName.getText(), 'Account 5');
+        assert.equal(await currentActiveAccountName.getText(), 'Account 1');
         await driver.delay(regularDelayMs);
         await driver.clickElement('.account-menu__icon');
 

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -125,6 +125,9 @@ export default class ConfirmPageContainer extends Component {
     const showAddToAddressDialog =
       !contact.name && toAddress && !isOwnedAccount && !hideSenderToRecipient;
 
+    const shouldDisplayWarning =
+      contentComponent && disabled && (errorKey || errorMessage);
+
     return (
       <div className="page-container">
         <ConfirmPageContainerNavigation
@@ -193,7 +196,7 @@ export default class ConfirmPageContainer extends Component {
             ethGasPriceWarning={ethGasPriceWarning}
           />
         )}
-        {contentComponent && disabled && (errorKey || errorMessage) && (
+        {shouldDisplayWarning && (
           <div className="confirm-approve-content__warning">
             <ErrorMessage errorKey={errorKey} />
           </div>

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -4,7 +4,7 @@ import SenderToRecipient from '../../ui/sender-to-recipient';
 import { PageContainerFooter } from '../../ui/page-container';
 import EditGasPopover from '../edit-gas-popover';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
-import ErrorMessage from '../../../components/ui/error-message';
+import ErrorMessage from '../../ui/error-message';
 import Dialog from '../../ui/dialog';
 import {
   ConfirmPageContainerHeader,
@@ -193,10 +193,10 @@ export default class ConfirmPageContainer extends Component {
             ethGasPriceWarning={ethGasPriceWarning}
           />
         )}
-        {contentComponent && (disabled && (errorKey || errorMessage)) && (
-            <div className="confirm-approve-content__warning">
-              <ErrorMessage errorKey={errorKey} />
-            </div>
+        {contentComponent && disabled && (errorKey || errorMessage) && (
+          <div className="confirm-approve-content__warning">
+            <ErrorMessage errorKey={errorKey} />
+          </div>
         )}
         {contentComponent && (
           <PageContainerFooter

--- a/ui/components/app/confirm-page-container/confirm-page-container.component.js
+++ b/ui/components/app/confirm-page-container/confirm-page-container.component.js
@@ -4,6 +4,7 @@ import SenderToRecipient from '../../ui/sender-to-recipient';
 import { PageContainerFooter } from '../../ui/page-container';
 import EditGasPopover from '../edit-gas-popover';
 import { EDIT_GAS_MODES } from '../../../../shared/constants/gas';
+import ErrorMessage from '../../../components/ui/error-message';
 import Dialog from '../../ui/dialog';
 import {
   ConfirmPageContainerHeader,
@@ -191,6 +192,11 @@ export default class ConfirmPageContainer extends Component {
             origin={origin}
             ethGasPriceWarning={ethGasPriceWarning}
           />
+        )}
+        {contentComponent && (disabled && (errorKey || errorMessage)) && (
+            <div className="confirm-approve-content__warning">
+              <ErrorMessage errorKey={errorKey} />
+            </div>
         )}
         {contentComponent && (
           <PageContainerFooter

--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -5,6 +5,10 @@
   width: 100%;
   font-style: normal;
 
+  &__warning {
+    padding: 0 24px 16px 24px;
+  }
+
   &__icon-display-content {
     display: flex;
     height: 51px;


### PR DESCRIPTION
**Fixes:** #9442

**Explanation:**  If a user tries to approve a token, and has low gas, they will simply be unable to proceed. Warning message (insufficient funds) is appearing when user try to approve a token. 

**Screenshots:**
![Screenshot from 2021-10-27 15-06-32](https://user-images.githubusercontent.com/92527393/139085777-cc10df7d-9d4d-41bf-9d4e-e77162a8c35a.png)
![Screenshot from 2021-10-27 15-07-03](https://user-images.githubusercontent.com/92527393/139085808-be2d41e9-5413-4648-b40c-8cc42ef44a2e.png)
