### PR TITLE
Update the 3D beta logo

### DIFF
--- a/app/build-types/beta/beta-mascot.json
+++ b/app/build-types/beta/beta-mascot.json
@@ -1,28 +1,78 @@
 {
   "chunks": [
     {
-      "color": [0, 0, 0],
       "faces": [
-        [11, 12, 13],
-        [36, 15, 37],
-        [37, 38, 36],
-        [31, 39, 22],
-        [22, 21, 31],
-        [31, 15, 36],
-        [36, 39, 31],
-        [64, 65, 66],
-        [75, 69, 26],
-        [26, 80, 75],
-        [75, 80, 38],
-        [38, 37, 75],
-        [38, 80, 39],
-        [39, 36, 38],
-        [39, 80, 26],
-        [26, 22, 39]
-      ]
+        [0, 1, 2],
+        [2, 3, 0],
+        [4, 5, 2],
+        [6, 3, 2],
+        [2, 5, 6],
+        [7, 8, 9],
+        [10, 3, 6],
+        [10, 50, 7],
+        [7, 3, 10],
+        [7, 9, 3],
+        [49, 0, 9],
+        [3, 9, 0],
+        [2, 1, 4]
+      ],
+      "name": "left ear",
+      "gradient": "left-ear-gradient"
     },
     {
-      "color": [236, 229, 220],
+      "faces": [
+        [53, 54, 55],
+        [55, 56, 53],
+        [57, 56, 55],
+        [58, 59, 55],
+        [55, 54, 58],
+        [60, 61, 62],
+        [63, 58, 54],
+        [63, 60, 89],
+        [60, 63, 54],
+        [60, 54, 61],
+        [88, 61, 53],
+        [54, 53, 61],
+        [55, 59, 57]
+      ],
+      "name": "right ear",
+      "gradient": "right-ear-gradient"
+    },
+    {
+      "color": [22, 22, 22],
+      "faces": [[11, 12, 13]],
+      "name": "left eye"
+    },
+    {
+      "color": [22, 22, 22],
+      "faces": [[64, 65, 66]],
+      "name": "right eye"
+    },
+    {
+      "faces": [
+        [14, 15, 11],
+        [11, 16, 14]
+      ],
+      "name": "left inner eye",
+      "gradient": "left-inner-eye-gradient"
+    },
+    {
+      "faces": [[17, 12, 18]],
+      "name": "left outer eye",
+      "gradient": "left-outer-eye-gradient"
+    },
+    {
+      "faces": [[41, 64, 37]],
+      "name": "right lower inner eye",
+      "gradient": "right-inner-eye-gradient"
+    },
+    {
+      "faces": [[67, 68, 66]],
+      "name": "right outer eye",
+      "gradient": "right-outer-eye-gradient"
+    },
+    {
+      "color": [192, 173, 158],
       "faces": [
         [19, 20, 21],
         [21, 22, 19],
@@ -34,9 +84,6 @@
         [23, 28, 29],
         [23, 29, 30],
         [25, 23, 30],
-        [21, 20, 24],
-        [24, 31, 21],
-        [24, 25, 30],
         [29, 51, 52],
         [52, 30, 29],
         [27, 26, 69],
@@ -47,126 +94,180 @@
         [51, 74, 72],
         [52, 51, 72],
         [73, 52, 72],
-        [69, 71, 70],
-        [71, 69, 75],
-        [52, 73, 71],
         [19, 27, 74],
         [74, 28, 19],
         [51, 29, 28],
         [28, 74, 51],
         [74, 27, 72],
         [28, 23, 19]
-      ]
+      ],
+      "name": "lower chin"
     },
     {
-      "color": [119, 228, 171],
+      "color": [215, 193, 179],
       "faces": [
-        [5, 4, 35],
-        [57, 59, 79]
-      ]
+        [21, 20, 24],
+        [24, 31, 21]
+      ],
+      "name": "left lower snout"
     },
     {
-      "color": [80, 157, 116],
+      "color": [215, 193, 179],
       "faces": [
-        [4, 5, 2],
-        [2, 5, 6],
-        [57, 56, 55],
-        [58, 59, 55],
-        [2, 1, 4],
-        [55, 59, 57]
-      ]
+        [69, 71, 70],
+        [71, 69, 75]
+      ],
+      "name": "right lower snout"
     },
     {
-      "color": [67, 127, 95],
-      "faces": [
-        [0, 1, 2],
-        [2, 3, 0],
-        [6, 3, 2],
-        [7, 8, 9],
-        [10, 3, 6],
-        [10, 50, 7],
-        [7, 3, 10],
-        [7, 9, 3],
-        [49, 0, 9],
-        [3, 9, 0],
-        [53, 54, 55],
-        [55, 56, 53],
-        [55, 54, 58],
-        [60, 61, 62],
-        [63, 58, 54],
-        [63, 60, 89],
-        [60, 63, 54],
-        [60, 54, 61],
-        [88, 61, 53],
-        [54, 53, 61]
-      ]
+      "faces": [[31, 24, 18]],
+      "name": "left upper snout",
+      "gradient": "left-upper-snout-gradient"
     },
     {
-      "color": [119, 228, 207],
       "faces": [
-        [59, 5, 35],
-        [35, 79, 59]
-      ]
+        [6, 5, 16],
+        [16, 17, 6]
+      ],
+      "name": "left forehead",
+      "gradient": "left-forehead-gradient"
     },
     {
-      "color": [163, 230, 235],
       "faces": [
-        [14, 15, 11],
-        [11, 16, 14],
+        [24, 32, 33],
+        [33, 34, 24]
+      ],
+      "name": "left lower cheek",
+      "gradient": "left-lower-cheek-gradient"
+    },
+    {
+      "faces": [[5, 4, 35]],
+      "name": "left top ear",
+      "gradient": "left-top-ear-gradient"
+    },
+    {
+      "faces": [[75, 68, 71]],
+      "name": "right upper snout",
+      "gradient": "right-upper-snout-gradient"
+    },
+    {
+      "faces": [
+        [58, 67, 40],
+        [40, 59, 58]
+      ],
+      "name": "right forhead",
+      "gradient": "right-forehead-gradient"
+    },
+    {
+      "faces": [
+        [71, 76, 77],
+        [77, 78, 71]
+      ],
+      "name": "right lower cheek",
+      "gradient": "right-lower-cheek-gradient"
+    },
+    {
+      "faces": [[24, 34, 18]],
+      "name": "left middle cheek",
+      "gradient": "left-middle-cheek-gradient"
+    },
+    {
+      "color": [35, 151, 119],
+      "faces": [
         [16, 13, 12],
+        [12, 17, 16],
+        [13, 16, 11]
+      ],
+      "name": "left above eye"
+    },
+    {
+      "faces": [[71, 68, 76]],
+      "name": "right middle cheek",
+      "gradient": "right-middle-cheek-gradient"
+    },
+    {
+      "color": [35, 151, 119],
+      "faces": [
+        [40, 67, 66],
+        [66, 65, 40],
+        [65, 64, 40]
+      ],
+      "name": "right above eye"
+    },
+    {
+      "color": [22, 22, 22],
+      "faces": [
+        [36, 15, 37],
+        [37, 38, 36],
+        [31, 39, 22],
+        [22, 21, 31],
+        [31, 15, 36],
+        [36, 39, 31],
+        [75, 69, 26],
+        [26, 80, 75],
+        [75, 80, 38],
+        [38, 37, 75],
+        [38, 80, 39],
+        [39, 36, 38],
+        [39, 80, 26],
+        [26, 22, 39]
+      ],
+      "name": "nose"
+    },
+    {
+      "faces": [
         [17, 33, 10],
         [17, 18, 34],
         [34, 33, 17],
-        [11, 15, 31],
-        [18, 12, 11],
-        [41, 64, 37],
-        [64, 41, 40],
-        [66, 65, 40],
-        [67, 63, 77],
-        [67, 77, 76],
-        [76, 68, 67],
-        [75, 37, 64],
-        [68, 64, 66]
-      ]
+        [10, 6, 17]
+      ],
+      "name": "left upper cheek",
+      "gradient": "left-upper-cheek-gradient"
     },
     {
-      "color": [204, 237, 236],
       "faces": [
-        [10, 6, 17],
+        [11, 15, 31],
         [31, 18, 11],
+        [18, 12, 11]
+      ],
+      "name": "left below eye",
+      "gradient": "left-below-eye-gradient"
+    },
+    {
+      "faces": [
         [14, 16, 40],
         [40, 41, 14],
-        [63, 67, 58],
-        [64, 68, 75],
+        [59, 5, 35],
+        [35, 79, 59],
         [14, 41, 37],
         [37, 15, 14],
         [5, 59, 40],
         [40, 16, 5]
-      ]
+      ],
+      "name": "forehead",
+      "gradient": "forehead-gradient"
     },
     {
-      "color": [207, 248, 247],
       "faces": [
-        [6, 5, 16],
-        [16, 17, 6],
-        [12, 17, 16],
-        [58, 67, 40],
-        [40, 59, 58],
-        [40, 67, 66]
-      ]
+        [67, 63, 77],
+        [67, 77, 76],
+        [76, 68, 67],
+        [63, 67, 58]
+      ],
+      "name": "right upper cheek",
+      "gradient": "right-upper-cheek-gradient"
     },
     {
-      "color": [127, 185, 228],
       "faces": [
-        [33, 34, 24],
-        [71, 76, 77]
-      ]
+        [64, 68, 75],
+        [75, 37, 64],
+        [68, 64, 66]
+      ],
+      "name": "right below eye",
+      "gradient": "right-below-eye-gradient"
     },
     {
-      "color": [119, 200, 228],
       "faces": [
-        [31, 24, 18],
-        [24, 34, 18],
         [35, 4, 42],
         [4, 1, 42],
         [42, 43, 44],
@@ -174,6 +275,7 @@
         [45, 43, 42],
         [42, 10, 45],
         [30, 32, 24],
+        [24, 25, 30],
         [30, 33, 32],
         [33, 30, 10],
         [44, 43, 46],
@@ -189,8 +291,6 @@
         [1, 0, 42],
         [42, 9, 8],
         [42, 49, 9],
-        [75, 68, 71],
-        [71, 68, 76],
         [79, 81, 57],
         [57, 81, 56],
         [82, 79, 35],
@@ -201,6 +301,7 @@
         [81, 83, 84],
         [44, 46, 85],
         [85, 82, 44],
+        [52, 73, 71],
         [71, 78, 52],
         [52, 78, 77],
         [77, 63, 52],
@@ -223,25 +324,417 @@
         [85, 46, 47],
         [48, 30, 52],
         [52, 87, 48]
-      ]
+      ],
+      "name": "back",
+      "gradient": "back-gradient"
     },
     {
-      "color": [95, 167, 211],
-      "faces": [
-        [24, 32, 33],
-        [77, 78, 71]
-      ]
+      "faces": [[57, 59, 79]],
+      "name": "right top ear",
+      "gradient": "right-top-ear-gradient"
     },
     {
-      "color": [119, 222, 228],
-      "faces": [
-        [17, 12, 18],
-        [13, 16, 11],
-        [67, 68, 66],
-        [65, 64, 40]
-      ]
+      "faces": [[64, 41, 40]],
+      "name": "right inner upper eye",
+      "gradient": "right-inner-eye-gradient"
     }
   ],
+  "gradients": {
+    "forehead-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#23FE4A"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#BAD8EF"
+        }
+      ],
+      "x1": "50%",
+      "y1": "20.232164948453608%",
+      "x2": "50%",
+      "y2": "74.87123711340206%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-upper-cheek-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#20B475"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#70BDCE"
+        }
+      ],
+      "x1": "77.19501199040768%",
+      "y1": "44.68123711340206%",
+      "x2": "77.19501199040768%",
+      "y2": "68.2861855670103%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-upper-cheek-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#20B475"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#70BDCE"
+        }
+      ],
+      "x1": "22.820719424460435%",
+      "y1": "44.68123711340206%",
+      "x2": "22.820719424460435%",
+      "y2": "68.2861855670103%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-below-eye-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#85BBE1"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#7CCACA"
+        }
+      ],
+      "x1": "54.34676258992806%",
+      "y1": "68.26917525773197%",
+      "x2": "65.3001438848921%",
+      "y2": "68.26917525773197%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-below-eye-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#7CCACA"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#85BBE1"
+        }
+      ],
+      "x1": "34.731223021582736%",
+      "y1": "68.26917525773197%",
+      "x2": "45.65323741007194%",
+      "y2": "68.26917525773197%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-ear-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#074F1E"
+        },
+        {
+          "offset": 0.4286,
+          "stop-color": "#05541C"
+        },
+        {
+          "offset": 0.62,
+          "stop-color": "#006A13"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#007514"
+        }
+      ],
+      "x1": "61.443549160671466%",
+      "y1": "44.51773195876289%",
+      "x2": "93.802206235012%",
+      "y2": "24.439072164948456%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-ear-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#074F1E"
+        },
+        {
+          "offset": 0.4286,
+          "stop-color": "#05541C"
+        },
+        {
+          "offset": 0.62,
+          "stop-color": "#006A13"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#007514"
+        }
+      ],
+      "x1": "32.7432134292566%",
+      "y1": "44.33329896907217%",
+      "x2": "4.853390887290168%",
+      "y2": "19.18181443298969%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-outer-eye-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#43C3A2"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#4FAFC0"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#4FAFC0"
+        }
+      ],
+      "x1": "27.575539568345324%",
+      "y1": "60.519278350515464%",
+      "x2": "34.982350119904076%",
+      "y2": "60.519278350515464%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-outer-eye-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#4FAFC0"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#43C3A2"
+        }
+      ],
+      "x1": "65.01764988009592%",
+      "y1": "60.519278350515464%",
+      "x2": "72.42446043165468%",
+      "y2": "60.519278350515464%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-lower-cheek-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#59ADCB"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#436CC8"
+        }
+      ],
+      "x1": "77.93247002398083%",
+      "y1": "68.15113402061857%",
+      "x2": "77.93247002398083%",
+      "y2": "86.82577319587631%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-lower-cheek-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#59ADCB"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#436CC8"
+        }
+      ],
+      "x1": "22.083165467625896%",
+      "y1": "68.15113402061857%",
+      "x2": "22.083165467625896%",
+      "y2": "86.82577319587631%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-top-ear-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#0ED54A"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#0ED54A"
+        }
+      ],
+      "x1": "13.954513189448441%",
+      "y1": "22.055670103092787%",
+      "x2": "44.146762589928066%",
+      "y2": "22.055670103092787%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-top-ear-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#0ED54A"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#11EB36"
+        }
+      ],
+      "x1": "55.85333333333334%",
+      "y1": "22.055670103092787%",
+      "x2": "86.04556354916068%",
+      "y2": "22.055670103092787%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-forehead-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#15DC5D"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#48CA9F"
+        }
+      ],
+      "x1": "36.3947242206235%",
+      "y1": "34.11144329896908%",
+      "x2": "36.3947242206235%",
+      "y2": "53.59649484536083%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-forehead-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#15DC5D"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#48CA9F"
+        }
+      ],
+      "x1": "63.6052757793765%",
+      "y1": "34.11144329896908%",
+      "x2": "63.6052757793765%",
+      "y2": "53.59649484536083%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-upper-snout-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#54A8CF"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#5393E3"
+        }
+      ],
+      "x1": "38.829736211031175%",
+      "y1": "68.28865979381443%",
+      "x2": "38.829736211031175%",
+      "y2": "81.55670103092784%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-upper-snout-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#54A8CF"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#5393E3"
+        }
+      ],
+      "x1": "61.17026378896883%",
+      "y1": "68.28865979381443%",
+      "x2": "61.17026378896883%",
+      "y2": "81.55670103092784%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-middle-cheek-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#32819D"
+        },
+        {
+          "offset": 0.3363,
+          "stop-color": "#447DCD"
+        }
+      ],
+      "x1": "69.9137649880096%",
+      "y1": "51.063505154639174%",
+      "x2": "69.9137649880096%",
+      "y2": "85.81041237113402%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-middle-cheek-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#32819D"
+        },
+        {
+          "offset": 0.3363,
+          "stop-color": "#447DCD"
+        }
+      ],
+      "x1": "30.086330935251798%",
+      "y1": "68.15092783505153%",
+      "x2": "30.086330935251798%",
+      "y2": "81.55752577319588%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "right-inner-eye-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#53A9CB"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#44C0A6"
+        }
+      ],
+      "x1": "55.38244604316547%",
+      "y1": "74.87123711340206%",
+      "x2": "55.38244604316547%",
+      "y2": "53.59659793814433%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "left-inner-eye-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#53A9CB"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#44C0A6"
+        }
+      ],
+      "x1": "43.58177458033573%",
+      "y1": "64.2339175257732%",
+      "x2": "45.65323741007194%",
+      "y2": "64.2339175257732%",
+      "gradientUnits": "userSpaceOnUse"
+    },
+    "back-gradient": {
+      "type": "linear",
+      "stops": [
+        {
+          "stop-color": "#27FC4E"
+        },
+        {
+          "offset": 1,
+          "stop-color": "#446FC9"
+        }
+      ],
+      "x1": "50%",
+      "y1": "0%",
+      "x2": "50%",
+      "y2": "100%",
+      "gradientUnits": "userSpaceOnUse"
+    }
+  },
   "positions": [
     [111.024597, 52.604599, 46.225899],
     [114.025002, 87.673302, 58.9818],


### PR DESCRIPTION
The 3D beta logo has been updated to match this demo: https://metamask.github.io/logo/beta/index.html

Manual testing steps:  
  - Create a beta build (e.g. by running `yarn build dev --build-type beta`).
  - Take a look at the 3d logo either on the welcome page or the lock screen