### PR TITLE
Turn off all old notifications

### DIFF
--- a/test/e2e/metamask-ui.spec.js
+++ b/test/e2e/metamask-ui.spec.js
@@ -176,24 +176,6 @@ describe('MetaMask', function () {
     });
   });
 
-  describe("Close the what's new popup", function () {
-    it("should show the what's new popover", async function () {
-      const popoverTitle = await driver.findElement(
-        '.popover-header__title h2',
-      );
-
-      assert.equal(await popoverTitle.getText(), "What's new");
-    });
-
-    it("should close the what's new popup", async function () {
-      const popover = await driver.findElement('.popover-container');
-
-      await driver.clickElement('[data-testid="popover-close"]');
-
-      await popover.waitForElementState('hidden');
-    });
-  });
-
   describe('Import Secret Recovery Phrase', function () {
     it('logs out of the vault', async function () {
       await driver.clickElement('.account-menu__icon');

--- a/test/e2e/tests/add-hide-token.spec.js
+++ b/test/e2e/tests/add-hide-token.spec.js
@@ -27,7 +27,6 @@ describe('Hide token', function () {
           css: '.asset-list-item__token-button',
           text: '0 TST',
         });
-        await driver.clickElement('.popover-header__button');
 
         let assets = await driver.findElements('.asset-list-item');
         assert.equal(assets.length, 2);
@@ -39,7 +38,6 @@ describe('Hide token', function () {
         await driver.clickElement('[data-testid="asset-options__button"]');
 
         await driver.clickElement('[data-testid="asset-options__hide"]');
-
         // wait for confirm hide modal to be visible
         const confirmHideModal = await driver.findVisibleElement('span .modal');
 

--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -60,11 +60,6 @@ describe('Metamask Import UI', function () {
           tag: 'button',
         });
 
-        // close the what's new popup
-        const popover = await driver.findElement('.popover-container');
-        await driver.clickElement('[data-testid="popover-close"]');
-        await popover.waitForElementState('hidden');
-
         // Show account information
         await driver.clickElement(
           '[data-testid="account-options-menu-button"]',

--- a/test/e2e/tests/incremental-security.spec.js
+++ b/test/e2e/tests/incremental-security.spec.js
@@ -65,13 +65,6 @@ describe('Incremental Security', function () {
           tag: 'button',
         });
 
-        // closes the what's new popup
-        const popover = await driver.findElement('.popover-container');
-
-        await driver.clickElement('[data-testid="popover-close"]');
-
-        await popover.waitForElementState('hidden');
-
         await driver.clickElement(
           '[data-testid="account-options-menu-button"]',
         );

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -576,13 +576,13 @@ function getAllowedNotificationIds(state) {
   const currentKeyringIsLedger = currentKeyring?.type === KEYRING_TYPES.LEDGER;
 
   return {
-    1: true,
-    2: true,
-    3: true,
-    4: getCurrentChainId(state) === BSC_CHAIN_ID,
-    5: true,
-    6: currentKeyringIsLedger,
-    7: currentKeyringIsLedger,
+    1: false,
+    2: false,
+    3: false,
+    4: false,
+    5: false,
+    6: false,
+    7: false,
   };
 }
 

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -2,7 +2,6 @@ import { createSelector } from 'reselect';
 import { addHexPrefix } from '../../app/scripts/lib/util';
 import {
   MAINNET_CHAIN_ID,
-  BSC_CHAIN_ID,
   TEST_CHAINS,
   NETWORK_TYPE_RPC,
   NATIVE_CURRENCY_TOKEN_IMAGE_MAP,
@@ -571,10 +570,7 @@ export function getShowWhatsNewPopup(state) {
  * @param {Object} state
  * @returns {Object}
  */
-function getAllowedNotificationIds(state) {
-  const currentKeyring = getCurrentKeyring(state);
-  const currentKeyringIsLedger = currentKeyring?.type === KEYRING_TYPES.LEDGER;
-
+function getAllowedNotificationIds() {
   return {
     1: false,
     2: false,


### PR DESCRIPTION
This PR turns off all existing notifications.

I considered removing those notifications from `shared/notifications/index.js`, but I actually think it would be good to have a record of notifications we have shown in the past.