### PR TITLE
update anonymous id

### DIFF
--- a/shared/constants/metametrics.js
+++ b/shared/constants/metametrics.js
@@ -110,9 +110,9 @@
  *  the page view
  */
 
-// An empty string "" is a, currently undocumented, way of telling mixpanel
+// An empty string is a, currently undocumented, way of telling mixpanel
 // that these events are meant to be anonymous and not identified to any user
-export const METAMETRICS_ANONYMOUS_ID = '""';
+export const METAMETRICS_ANONYMOUS_ID = '';
 
 /**
  * This object is used to identify events that are triggered by the background


### PR DESCRIPTION
The documentation around mixpanels fix for sharding ids of the same value to the same shard was confusing. It was documented as
```""```

but instead should be documented as 
""

notice the lack of code backticks implies an empty string, versus a literal "" value