### PR TITLE
Adding metrics event for Advanced Options (EditGasDisplay)

### DIFF
--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -34,6 +34,8 @@ import ActionableMessage from '../../ui/actionable-message/actionable-message';
 import { I18nContext } from '../../../contexts/i18n';
 import GasTiming from '../gas-timing';
 
+import { useMetricEvent } from '../../../hooks/useMetricEvent';
+
 export default function EditGasDisplay({
   mode = EDIT_GAS_MODES.MODIFY_IN_PLACE,
   showEducationButton = false,
@@ -118,6 +120,14 @@ export default function EditGasDisplay({
   } else if (estimatesUnavailableWarning) {
     errorKey = 'gasEstimatesUnavailableWarning';
   }
+
+  const clickedAdvancedOptionsMetricsEvent = useMetricEvent({
+    eventOpts: {
+      category: 'Transactions',
+      action: 'Edit Screen',
+      name: 'Clicked "Advanced Options"',
+    },
+  });
 
   return (
     <div className="edit-gas-display">
@@ -250,7 +260,10 @@ export default function EditGasDisplay({
           !showAdvancedInlineGasIfPossible && (
             <button
               className="edit-gas-display__advanced-button"
-              onClick={() => setShowAdvancedForm(!showAdvancedForm)}
+              onClick={() => {
+                setShowAdvancedForm(!showAdvancedForm);
+                clickedAdvancedOptionsMetricsEvent();
+              }}
             >
               {t('advancedOptions')}{' '}
               {showAdvancedForm ? (


### PR DESCRIPTION
This was removed here: https://github.com/MetaMask/metamask-extension/commit/e2fbc7ce8ea42bd8befdea894ddc8ed0fbdf27be#diff-5d3d46a0f02372d6e748881b8076b5474ef0c5d03a7d436d2a8553544b9d7cebL39 but this is something we still want to keep track of