### PR TITLE
Reload the ledger bride iframe after switching to webhid in settings

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -845,6 +845,7 @@ export default class MetamaskController extends EventEmitter {
         this.setLedgerTransportPreference,
         this,
       ),
+      reloadLedgerIframe: nodeify(this.reloadLedgerIframe, this),
 
       // mobile
       fetchInfoToSync: nodeify(this.fetchInfoToSync, this),
@@ -1547,6 +1548,11 @@ export default class MetamaskController extends EventEmitter {
     keyring.network = this.networkController.getProviderConfig().type;
 
     return keyring;
+  }
+
+  async reloadLedgerIframe() {
+    const keyring = await this.getKeyringForDevice('ledger');
+    keyring.reloadIframe();
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@material-ui/core": "^4.11.0",
     "@metamask/contract-metadata": "^1.28.0",
     "@metamask/controllers": "^17.0.0",
-    "@metamask/eth-ledger-bridge-keyring": "^0.9.0",
+    "@metamask/eth-ledger-bridge-keyring": "git://github.com/MetaMask/eth-ledger-bridge-keyring.git#ab177bec8d9f50104fbaaf2377429b5786c0a080",
     "@metamask/eth-token-tracker": "^3.0.1",
     "@metamask/etherscan-link": "^2.1.0",
     "@metamask/jazzicon": "^2.0.0",

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -7,6 +7,7 @@ import TextField from '../../../components/ui/text-field';
 import Button from '../../../components/ui/button';
 import { MOBILE_SYNC_ROUTE } from '../../../helpers/constants/routes';
 import Dropdown from '../../../components/ui/dropdown';
+import { reloadLedgerIframe } from '../../../store/actions';
 
 import {
   LEDGER_TRANSPORT_TYPES,
@@ -466,6 +467,7 @@ export default class AdvancedTab extends PureComponent {
                   await window.navigator.hid.requestDevice({
                     filters: [{ vendorId: LEDGER_USB_VENDOR_ID }],
                   });
+                  reloadLedgerIframe();
                 }
               }}
             />

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -459,7 +459,7 @@ export default class AdvancedTab extends PureComponent {
               options={transportTypeOptions}
               selectedOption={ledgerTransportType}
               onChange={async (transportType) => {
-                setLedgerLivePreference(transportType);
+                await setLedgerLivePreference(transportType);
                 if (
                   transportType === LEDGER_TRANSPORT_TYPES.WEBHID &&
                   userHasALedgerAccount

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2897,3 +2897,7 @@ export async function setWeb3ShimUsageAlertDismissed(origin) {
 export async function detectNewTokens() {
   return promisifiedBackground.detectNewTokens();
 }
+
+export async function reloadLedgerIframe() {
+  return promisifiedBackground.reloadLedgerIframe();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,10 +2821,9 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-6.0.0.tgz#ec53e8ab278073e882411ed89705bc7d06b78c81"
   integrity sha512-LyakGYGwM8UQOGhwWa+5erAI1hXuiTgf/y7USzOomX6H9KiuY09IAUYnPh7ToPG2sedD2F48UF1bUm8yvCoZOw==
 
-"@metamask/eth-ledger-bridge-keyring@^0.9.0":
+"@metamask/eth-ledger-bridge-keyring@git://github.com/MetaMask/eth-ledger-bridge-keyring.git#ab177bec8d9f50104fbaaf2377429b5786c0a080":
   version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-ledger-bridge-keyring/-/eth-ledger-bridge-keyring-0.9.0.tgz#42e98e7dfeaaa08e7c9ceff261facddd7320df80"
-  integrity sha512-EuNKvodbdJxQPzr+zAE5TE1iKUzuIRWKeVaYoYwpi18RjjtSQMKmZcb3VXY8hmQu+Fj4Ld/ujj22qSYjYAjtPg==
+  resolved "git://github.com/MetaMask/eth-ledger-bridge-keyring.git#ab177bec8d9f50104fbaaf2377429b5786c0a080"
   dependencies:
     "@ethereumjs/tx" "^3.2.0"
     eth-sig-util "^2.0.0"


### PR DESCRIPTION
This depends on https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/124

This PR attempts to address an issue found in v10.4.0 QA:

> 1.1. Loaded Ledger account with Ledger Live, changed transport protocol to WebHID, and attempted to send tx (tx never displayed to ledger device).

1. Succesfully connect the Ledger device to MetaMask via Ledger Live
2. Then switch to WebHID, while Ledger Live is still connected
3. The code in the ledger bridge correctly calls .close() on the WebSocketTransport and we can see in Ledger Live that the device is disconnected
4. However, when we then attempt to sign a transaction the call to await TransportWebHID.create() results in an error with a message "Failed to open the device" and a "name" "Not allowed error", and the connection via WebHID fails, and so no transaction occurs on the device

The same occurs if, between steps 1 and 2, we disconnect Ledger Live from within the Ledger Live app

But the same does not occur if, between steps 1 and 2, we disconnect Ledger Live from within the app and close and reopen the browser. In this case, the connection via WebHID succeeds and the user can sign the transaction on the device

Seems to happen on Mac but not linux.

A member of the Ledger team stated:

> As far as I know, the current LLD usb connection is singleton, ie uses the @ledgerhq/hw-transport-node-hid-singleton package, which takes ownership of the device once it connects to it and therefor attempts to connect via third party apps will fail. The app will be able to see the device, but not connect to it.
This seems to align with the behaviour you are seeing

This attempts to resolve this by reloading the iframe after switching to webhid.