### PR TITLE
Exclude files from builds by build type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-const reactVersion = require('./package.json').dependencies.react;
+const { version: reactVersion } = require('react/package.json');
 
 module.exports = {
   root: true,
@@ -215,11 +215,11 @@ module.exports = {
 
   settings: {
     react: {
-      // If this is set to 'detect', eslint will import react in order to find
+      // If this is set to 'detect', ESLint will import React in order to find
       // its version. Because we run ESLint in the build system under LavaMoat,
       // this means that detecting the React version requires a LavaMoat policy
       // for all of React, in the build system. That's a no-go, so we grab it
-      // from package.json.
+      // from React's package.json.
       version: reactVersion,
     },
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+const reactVersion = require('./package.json').dependencies.react;
+
 module.exports = {
   root: true,
   parser: '@babel/eslint-parser',
@@ -213,7 +215,12 @@ module.exports = {
 
   settings: {
     react: {
-      version: 'detect',
+      // If this is set to 'detect', eslint will import react in order to find
+      // its version. Because we run ESLint in the build system under LavaMoat,
+      // this means that detecting the React version requires a LavaMoat policy
+      // for all of React, in the build system. That's a no-go, so we grab it
+      // from package.json.
+      version: reactVersion,
     },
   },
 };

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -33,7 +33,7 @@ require('@babel/core');
 
 defineAndRunBuildTasks();
 
-async function defineAndRunBuildTasks() {
+function defineAndRunBuildTasks() {
   const {
     buildType,
     entryTask,

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -202,13 +202,13 @@ function parseArgv() {
  * build, or `null` if no files are to be ignored.
  */
 function getIgnoredFiles(buildType) {
-  return buildType === BuildType.flask
+  return buildType !== BuildType.main
     ? null
     : globby(
         [
-          '../../app/**/flask/**',
-          '../../shared/**/flask/**',
-          '../../ui/**/flask/**',
+          `../../app/**/${buildType}/**`,
+          `../../shared/**/${buildType}/**`,
+          `../../ui/**/${buildType}/**`,
         ].map((glob) => path.resolve(__dirname, glob)),
       );
 }

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -203,9 +203,9 @@ function parseArgv() {
  */
 function getIgnoredFiles(currentBuildType) {
   const excludedFiles = Object.values(BuildType)
-    // Remove all build types that are neither "main" nor the current build
-    // type. "main" is the default build, and has no files that are excluded
-    // from other builds.
+    // This filter removes "main" and the current build type. The files of any
+    // build types that remain in the array will be excluded. "main" is the
+    // default build type, and has no files that are excluded from other builds.
     .filter(
       (buildType) =>
         buildType !== BuildType.main && buildType !== currentBuildType,

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -20,7 +20,8 @@ const createStaticAssetTasks = require('./static');
 const createEtcTasks = require('./etc');
 const { BuildType, getBrowserVersionMap } = require('./utils');
 
-// packages required dynamically via browserify configuration in dependencies
+// Packages required dynamically via browserify configuration in dependencies
+// Required for LavaMoat policy generation
 require('loose-envify');
 require('@babel/plugin-proposal-object-rest-spread');
 require('@babel/plugin-transform-runtime');
@@ -30,6 +31,20 @@ require('@babel/plugin-proposal-nullish-coalescing-operator');
 require('@babel/preset-env');
 require('@babel/preset-react');
 require('@babel/core');
+// ESLint-related
+require('@babel/eslint-parser');
+require('@babel/eslint-plugin');
+require('@metamask/eslint-config');
+require('@metamask/eslint-config-nodejs');
+require('eslint');
+require('eslint-config-prettier');
+// eslint-disable-next-line import/no-extraneous-dependencies, node/no-extraneous-require
+require('eslint-import-resolver-node');
+require('eslint-plugin-import');
+require('eslint-plugin-node');
+require('eslint-plugin-prettier');
+require('eslint-plugin-react');
+require('eslint-plugin-react-hooks');
 
 defineAndRunBuildTasks();
 

--- a/development/build/index.js
+++ b/development/build/index.js
@@ -38,7 +38,6 @@ require('@metamask/eslint-config');
 require('@metamask/eslint-config-nodejs');
 require('eslint');
 require('eslint-config-prettier');
-// eslint-disable-next-line import/no-extraneous-dependencies, node/no-extraneous-require
 require('eslint-import-resolver-node');
 require('eslint-plugin-import');
 require('eslint-plugin-node');

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -323,7 +323,7 @@ function createFactoredBuild({
 }) {
   return async function () {
     // create bundler setup and apply defaults
-    const buildConfiguration = createBuildConfiguration();
+    const buildConfiguration = createBuildConfiguration(buildType);
     buildConfiguration.label = 'primary';
     const { bundlerOpts, events } = buildConfiguration;
 
@@ -487,7 +487,7 @@ function createNormalBundle({
 }) {
   return async function () {
     // create bundler setup and apply defaults
-    const buildConfiguration = createBuildConfiguration();
+    const buildConfiguration = createBuildConfiguration(buildType);
     buildConfiguration.label = label;
     const { bundlerOpts, events } = buildConfiguration;
 
@@ -532,7 +532,7 @@ function createNormalBundle({
   };
 }
 
-function createBuildConfiguration() {
+function createBuildConfiguration(buildType) {
   const label = '(unnamed bundle)';
   const events = new EventEmitter();
   const bundlerOpts = {
@@ -544,7 +544,7 @@ function createBuildConfiguration() {
     manualExternal: [],
     manualIgnore: [],
   };
-  return { label, bundlerOpts, events };
+  return { buildType, bundlerOpts, events, label };
 }
 
 function setupBundlerDefaults(
@@ -659,11 +659,15 @@ function setupSourcemaps(buildConfiguration, { devMode }) {
 }
 
 async function bundleIt(buildConfiguration) {
-  const { label, bundlerOpts, events } = buildConfiguration;
+  const { buildType, label, bundlerOpts, events } = buildConfiguration;
   const bundler = browserify(bundlerOpts);
   // manually apply non-standard options
   bundler.external(bundlerOpts.manualExternal);
   bundler.ignore(bundlerOpts.manualIgnore);
+  if (buildType !== BuildType.flask) {
+    bundler.exclude('**/*.flask.js');
+  }
+
   // output build logs to terminal
   bundler.on('log', log);
   // forward update event (used by watchify)

--- a/development/build/transforms/utils.js
+++ b/development/build/transforms/utils.js
@@ -4,6 +4,7 @@ const eslintrc = require('../../../.eslintrc.js');
 // We don't want linting to fail for purely stylistic reasons.
 eslintrc.rules['prettier/prettier'] = 'off';
 
+// Remove all test-related overrides. We will never lint test files here.
 eslintrc.overrides = eslintrc.overrides.filter((override) => {
   return !(
     (override.extends &&

--- a/development/build/transforms/utils.js
+++ b/development/build/transforms/utils.js
@@ -1,6 +1,21 @@
 const { ESLint } = require('eslint');
 const eslintrc = require('../../../.eslintrc.js');
 
+// We don't want linting to fail for purely stylistic reasons.
+eslintrc.rules['prettier/prettier'] = 'off';
+
+eslintrc.overrides = eslintrc.overrides.filter((override) => {
+  return !(
+    (override.extends &&
+      override.extends.find(
+        (configName) =>
+          configName.includes('jest') || configName.includes('mocha'),
+      )) ||
+    (override.plugins &&
+      override.plugins.find((pluginName) => pluginName.includes('jest')))
+  );
+});
+
 /**
  * The singleton ESLint instance.
  *

--- a/lavamoat/node/policy-override.json
+++ b/lavamoat/node/policy-override.json
@@ -27,6 +27,11 @@
         "eslint-plugin-react-hooks": true
       }
     },
+    "eslint-module-utils": {
+      "packages": {
+        "eslint-import-resolver-node": true
+      }
+    },
     "node-sass": {
       "native": true
     },

--- a/lavamoat/node/policy-override.json
+++ b/lavamoat/node/policy-override.json
@@ -1,13 +1,5 @@
 {
   "resources": {
-    "node-sass": {
-      "native": true
-    },
-    "module-deps": {
-      "packages": {
-        "loose-envify": true
-      }
-    },
     "@babel/core": {
       "packages": {
         "<root>": true,
@@ -18,6 +10,29 @@
         "@babel/plugin-proposal-object-rest-spread": true,
         "@babel/plugin-proposal-optional-chaining": true,
         "@babel/plugin-proposal-nullish-coalescing-operator": true
+      }
+    },
+    "@eslint/eslintrc": {
+      "packages": {
+        "@babel/eslint-parser": true,
+        "@babel/eslint-plugin": true,
+        "@metamask/eslint-config": true,
+        "@metamask/eslint-config-nodejs": true,
+        "eslint": true,
+        "eslint-config-prettier": true,
+        "eslint-plugin-import": true,
+        "eslint-plugin-node": true,
+        "eslint-plugin-prettier": true,
+        "eslint-plugin-react": true,
+        "eslint-plugin-react-hooks": true
+      }
+    },
+    "node-sass": {
+      "native": true
+    },
+    "module-deps": {
+      "packages": {
+        "loose-envify": true
       }
     },
     "sass": {

--- a/lavamoat/node/policy.json
+++ b/lavamoat/node/policy.json
@@ -41,6 +41,20 @@
         "source-map": true
       }
     },
+    "@babel/eslint-parser": {
+      "packages": {
+        "@babel/core": true,
+        "eslint-scope": true,
+        "eslint-visitor-keys": true,
+        "semver": true
+      }
+    },
+    "@babel/eslint-plugin": {
+      "packages": {
+        "eslint": true,
+        "eslint-rule-composer": true
+      }
+    },
     "@babel/generator": {
       "globals": {
         "console.error": true
@@ -815,7 +829,6 @@
         "espree": true,
         "globals": true,
         "ignore": true,
-        "import-fresh": true,
         "js-yaml": true,
         "minimatch": true,
         "strip-json-comments": true
@@ -1038,6 +1051,15 @@
         "make-iterator": true
       }
     },
+    "array-includes": {
+      "packages": {
+        "call-bind": true,
+        "define-properties": true,
+        "es-abstract": true,
+        "get-intrinsic": true,
+        "is-string": true
+      }
+    },
     "array-initial": {
       "packages": {
         "array-slice": true,
@@ -1052,6 +1074,19 @@
     "array-union": {
       "packages": {
         "array-uniq": true
+      }
+    },
+    "array.prototype.flat": {
+      "packages": {
+        "define-properties": true,
+        "es-abstract": true
+      }
+    },
+    "array.prototype.flatmap": {
+      "packages": {
+        "call-bind": true,
+        "define-properties": true,
+        "es-abstract": true
       }
     },
     "async-done": {
@@ -1340,6 +1375,12 @@
         "process.cwd": true
       }
     },
+    "call-bind": {
+      "packages": {
+        "function-bind": true,
+        "get-intrinsic": true
+      }
+    },
     "chalk": {
       "globals": {
         "process.env.TERM": true,
@@ -1489,6 +1530,11 @@
         "inherits": true,
         "readable-stream": true,
         "typedarray": true
+      }
+    },
+    "contains-path": {
+      "builtin": {
+        "path.normalize": true
       }
     },
     "convert-source-map": {
@@ -1679,7 +1725,8 @@
         "assert": true
       },
       "packages": {
-        "esutils": true
+        "esutils": true,
+        "isarray": true
       }
     },
     "dom-serializer": {
@@ -1753,9 +1800,22 @@
         "WeakRef": true
       },
       "packages": {
+        "call-bind": true,
+        "es-to-primitive": true,
         "function-bind": true,
+        "get-intrinsic": true,
         "has": true,
-        "has-symbols": true
+        "has-symbols": true,
+        "is-callable": true,
+        "is-regex": true,
+        "object-inspect": true
+      }
+    },
+    "es-to-primitive": {
+      "packages": {
+        "is-callable": true,
+        "is-date-object": true,
+        "is-symbol": true
       }
     },
     "es5-ext": {
@@ -1864,6 +1924,141 @@
         "minimatch": true,
         "natural-compare": true,
         "regexpp": true
+      }
+    },
+    "eslint-config-prettier": {
+      "globals": {
+        "process.env.ESLINT_CONFIG_PRETTIER_NO_DEPRECATED": true
+      }
+    },
+    "eslint-import-resolver-node": {
+      "builtin": {
+        "path.dirname": true,
+        "path.resolve": true
+      },
+      "packages": {
+        "debug": true,
+        "resolve": true
+      }
+    },
+    "eslint-module-utils": {
+      "builtin": {
+        "crypto.createHash": true,
+        "fs.existsSync": true,
+        "fs.readdirSync": true,
+        "module": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.join": true,
+        "path.parse": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "__dirname": true,
+        "console.warn": true,
+        "process.cwd": true,
+        "process.hrtime": true
+      },
+      "packages": {
+        "debug": true,
+        "pkg-dir": true
+      }
+    },
+    "eslint-plugin-es": {
+      "packages": {
+        "eslint-utils": true,
+        "regexpp": true
+      }
+    },
+    "eslint-plugin-import": {
+      "builtin": {
+        "fs": true,
+        "path": true,
+        "vm": true
+      },
+      "globals": {
+        "process.cwd": true,
+        "process.env": true
+      },
+      "packages": {
+        "array-includes": true,
+        "array.prototype.flat": true,
+        "contains-path": true,
+        "debug": true,
+        "doctrine": true,
+        "eslint": true,
+        "eslint-module-utils": true,
+        "has": true,
+        "minimatch": true,
+        "object.values": true,
+        "read-pkg-up": true,
+        "resolve": true,
+        "tsconfig-paths": true,
+        "typescript": true
+      }
+    },
+    "eslint-plugin-node": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "fs.readdirSync": true,
+        "fs.statSync": true,
+        "path.basename": true,
+        "path.dirname": true,
+        "path.extname": true,
+        "path.isAbsolute": true,
+        "path.join": true,
+        "path.relative": true,
+        "path.resolve": true,
+        "path.sep": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "eslint-plugin-es": true,
+        "eslint-utils": true,
+        "ignore": true,
+        "minimatch": true,
+        "resolve": true,
+        "semver": true
+      }
+    },
+    "eslint-plugin-prettier": {
+      "packages": {
+        "prettier": true,
+        "prettier-linter-helpers": true
+      }
+    },
+    "eslint-plugin-react": {
+      "builtin": {
+        "fs.statSync": true,
+        "path.dirname": true,
+        "path.extname": true
+      },
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "process.argv.join": true,
+        "process.cwd": true
+      },
+      "packages": {
+        "array-includes": true,
+        "array.prototype.flatmap": true,
+        "doctrine": true,
+        "has": true,
+        "jsx-ast-utils": true,
+        "minimatch": true,
+        "object.entries": true,
+        "object.fromentries": true,
+        "object.values": true,
+        "prop-types": true,
+        "resolve": true,
+        "string.prototype.matchall": true
+      }
+    },
+    "eslint-plugin-react-hooks": {
+      "globals": {
+        "process.env.NODE_ENV": true
       }
     },
     "eslint-scope": {
@@ -2064,6 +2259,17 @@
         "to-regex-range": true
       }
     },
+    "find-up": {
+      "builtin": {
+        "path.dirname": true,
+        "path.join": true,
+        "path.parse": true,
+        "path.resolve": true
+      },
+      "packages": {
+        "locate-path": true
+      }
+    },
     "first-chunk-stream": {
       "builtin": {
         "util.inherits": true
@@ -2232,6 +2438,18 @@
     "get-assigned-identifiers": {
       "builtin": {
         "assert.equal": true
+      }
+    },
+    "get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "function-bind": true,
+        "has": true,
+        "has-symbols": true
       }
     },
     "get-stream": {
@@ -2613,6 +2831,12 @@
         "kind-of": true
       }
     },
+    "hosted-git-info": {
+      "builtin": {
+        "url.URL": true,
+        "url.parse": true
+      }
+    },
     "htmlparser2": {
       "builtin": {
         "buffer.Buffer": true,
@@ -2698,6 +2922,13 @@
         "xtend": true
       }
     },
+    "internal-slot": {
+      "packages": {
+        "get-intrinsic": true,
+        "has": true,
+        "side-channel": true
+      }
+    },
     "is-absolute": {
       "packages": {
         "is-relative": true,
@@ -2721,6 +2952,11 @@
       },
       "packages": {
         "binary-extensions": true
+      }
+    },
+    "is-callable": {
+      "globals": {
+        "document": true
       }
     },
     "is-core-module": {
@@ -2802,9 +3038,20 @@
         "isobject": true
       }
     },
+    "is-regex": {
+      "packages": {
+        "call-bind": true,
+        "has-symbols": true
+      }
+    },
     "is-relative": {
       "packages": {
         "is-unc-path": true
+      }
+    },
+    "is-symbol": {
+      "packages": {
+        "has-symbols": true
       }
     },
     "is-unc-path": {
@@ -2870,6 +3117,14 @@
     "jsonparse": {
       "globals": {
         "Buffer": true
+      }
+    },
+    "jsx-ast-utils": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "object.assign": true
       }
     },
     "just-debounce": {
@@ -2986,6 +3241,29 @@
       "packages": {
         "prelude-ls": true,
         "type-check": true
+      }
+    },
+    "load-json-file": {
+      "builtin": {
+        "path.relative": true
+      },
+      "packages": {
+        "graceful-fs": true,
+        "parse-json": true,
+        "pify": true,
+        "strip-bom": true
+      }
+    },
+    "locate-path": {
+      "builtin": {
+        "path.resolve": true
+      },
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "p-locate": true,
+        "path-exists": true
       }
     },
     "lodash": {
@@ -3285,6 +3563,18 @@
         "osenv": true
       }
     },
+    "normalize-package-data": {
+      "builtin": {
+        "url.parse": true,
+        "util.format": true
+      },
+      "packages": {
+        "hosted-git-info": true,
+        "resolve": true,
+        "semver": true,
+        "validate-npm-package-license": true
+      }
+    },
     "normalize-path": {
       "packages": {
         "remove-trailing-separator": true
@@ -3338,6 +3628,7 @@
     },
     "object.assign": {
       "packages": {
+        "call-bind": true,
         "define-properties": true,
         "es-abstract": true,
         "has-symbols": true,
@@ -3350,6 +3641,21 @@
         "array-slice": true,
         "for-own": true,
         "isobject": true
+      }
+    },
+    "object.entries": {
+      "packages": {
+        "call-bind": true,
+        "define-properties": true,
+        "es-abstract": true,
+        "has": true
+      }
+    },
+    "object.fromentries": {
+      "packages": {
+        "call-bind": true,
+        "define-properties": true,
+        "es-abstract": true
       }
     },
     "object.omit": {
@@ -3367,6 +3673,14 @@
       "packages": {
         "for-own": true,
         "make-iterator": true
+      }
+    },
+    "object.values": {
+      "packages": {
+        "call-bind": true,
+        "define-properties": true,
+        "es-abstract": true,
+        "has": true
       }
     },
     "once": {
@@ -3430,6 +3744,16 @@
         "os-tmpdir": true
       }
     },
+    "p-limit": {
+      "packages": {
+        "p-try": true
+      }
+    },
+    "p-locate": {
+      "packages": {
+        "p-limit": true
+      }
+    },
     "parent-module": {
       "packages": {
         "callsites": true
@@ -3479,6 +3803,12 @@
         "process.platform": true
       }
     },
+    "path-exists": {
+      "builtin": {
+        "fs.access": true,
+        "fs.accessSync": true
+      }
+    },
     "path-is-absolute": {
       "globals": {
         "process.platform": true
@@ -3519,6 +3849,9 @@
       "builtin": {
         "fs": true,
         "util.promisify": true
+      },
+      "packages": {
+        "pify": true
       }
     },
     "pause-stream": {
@@ -3546,6 +3879,14 @@
     "pinkie-promise": {
       "packages": {
         "pinkie": true
+      }
+    },
+    "pkg-dir": {
+      "builtin": {
+        "path.dirname": true
+      },
+      "packages": {
+        "find-up": true
       }
     },
     "plugin-error": {
@@ -3634,9 +3975,60 @@
         "postcss": true
       }
     },
+    "prettier": {
+      "builtin": {
+        "assert": true,
+        "events": true,
+        "fs": true,
+        "module": true,
+        "os": true,
+        "path": true,
+        "stream": true,
+        "tty": true,
+        "util": true
+      },
+      "globals": {
+        "Buffer": true,
+        "Intl": true,
+        "PerformanceObserver": true,
+        "WorkerGlobalScope": true,
+        "XMLHttpRequest": true,
+        "YAML_SILENCE_DEPRECATION_WARNINGS": true,
+        "YAML_SILENCE_WARNINGS": true,
+        "__dirname": true,
+        "__filename": true,
+        "atob": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console": true,
+        "define": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "performance": true,
+        "process": true,
+        "setImmediate": true,
+        "setTimeout": true
+      }
+    },
+    "prettier-linter-helpers": {
+      "packages": {
+        "fast-diff": true
+      }
+    },
     "process-nextick-args": {
       "globals": {
         "process": true
+      }
+    },
+    "prop-types": {
+      "globals": {
+        "console": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "object-assign": true,
+        "react-is": true
       }
     },
     "pump": {
@@ -3709,9 +4101,31 @@
         "strip-json-comments": true
       }
     },
+    "react-is": {
+      "globals": {
+        "console": true,
+        "process.env.NODE_ENV": true
+      }
+    },
     "read-only-stream": {
       "packages": {
         "readable-stream": true
+      }
+    },
+    "read-pkg": {
+      "builtin": {
+        "path.join": true
+      },
+      "packages": {
+        "load-json-file": true,
+        "normalize-package-data": true,
+        "path-type": true
+      }
+    },
+    "read-pkg-up": {
+      "packages": {
+        "find-up": true,
+        "read-pkg": true
       }
     },
     "readable-stream": {
@@ -3786,6 +4200,12 @@
       "packages": {
         "extend-shallow": true,
         "safe-regex": true
+      }
+    },
+    "regexp.prototype.flags": {
+      "packages": {
+        "call-bind": true,
+        "define-properties": true
       }
     },
     "regexpu-core": {
@@ -4052,6 +4472,13 @@
         "shebang-regex": true
       }
     },
+    "side-channel": {
+      "packages": {
+        "call-bind": true,
+        "get-intrinsic": true,
+        "object-inspect": true
+      }
+    },
     "signal-exit": {
       "builtin": {
         "assert.equal": true,
@@ -4130,6 +4557,22 @@
         "urix": true
       }
     },
+    "source-map-support": {
+      "builtin": {
+        "fs": true,
+        "path.dirname": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "XMLHttpRequest": true,
+        "console.error": true,
+        "process": true
+      },
+      "packages": {
+        "buffer-from": true,
+        "source-map": true
+      }
+    },
     "source-map-url": {
       "globals": {
         "define": true
@@ -4138,6 +4581,22 @@
     "sourcemap-codec": {
       "globals": {
         "define": true
+      }
+    },
+    "spdx-correct": {
+      "packages": {
+        "spdx-license-ids": true
+      }
+    },
+    "spdx-expression-parse": {
+      "builtin": {
+        "fs.readFileSync": true,
+        "path.normalize": true
+      },
+      "globals": {
+        "console.log": true,
+        "process.argv.slice": true,
+        "process.exit": true
       }
     },
     "specificity": {
@@ -4235,6 +4694,16 @@
         "emoji-regex": true,
         "is-fullwidth-code-point": true,
         "strip-ansi": true
+      }
+    },
+    "string.prototype.matchall": {
+      "packages": {
+        "call-bind": true,
+        "define-properties": true,
+        "es-abstract": true,
+        "has-symbols": true,
+        "internal-slot": true,
+        "regexp.prototype.flags": true
       }
     },
     "string_decoder": {
@@ -4490,6 +4959,21 @@
         "through2": true
       }
     },
+    "tsconfig-paths": {
+      "builtin": {
+        "fs.existsSync": true,
+        "fs.lstatSync": true,
+        "fs.readFileSync": true,
+        "fs.statSync": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true
+      },
+      "packages": {
+        "json5": true,
+        "strip-bom": true
+      }
+    },
     "type-check": {
       "packages": {
         "prelude-ls": true
@@ -4501,6 +4985,51 @@
       },
       "packages": {
         "is-typedarray": true
+      }
+    },
+    "typescript": {
+      "builtin": {
+        "buffer.Buffer": true,
+        "crypto": true,
+        "fs.closeSync": true,
+        "fs.mkdirSync": true,
+        "fs.openSync": true,
+        "fs.readFileSync": true,
+        "fs.readdirSync": true,
+        "fs.realpathSync": true,
+        "fs.statSync": true,
+        "fs.unlinkSync": true,
+        "fs.unwatchFile": true,
+        "fs.utimesSync": true,
+        "fs.watch": true,
+        "fs.watchFile": true,
+        "fs.writeFileSync": true,
+        "fs.writeSync": true,
+        "inspector": true,
+        "os.EOL": true,
+        "os.platform": true,
+        "path.dirname": true,
+        "path.join": true,
+        "path.resolve": true
+      },
+      "globals": {
+        "Intl": true,
+        "TypeScript": "write",
+        "__dirname": true,
+        "__filename": true,
+        "__magic__": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "gc": true,
+        "globalThis": "write",
+        "onProfilerEvent": true,
+        "performance": true,
+        "process": true,
+        "setTimeout": true,
+        "toolsVersion": "write"
+      },
+      "packages": {
+        "source-map-support": true
       }
     },
     "undeclared-identifiers": {
@@ -4618,6 +5147,12 @@
     "util-deprecate": {
       "builtin": {
         "util.deprecate": true
+      }
+    },
+    "validate-npm-package-license": {
+      "packages": {
+        "spdx-correct": true,
+        "spdx-expression-parse": true
       }
     },
     "vfile": {

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
     "enzyme-adapter-react-16": "^1.15.1",
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.1.0",
+    "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.4",
     "eslint-plugin-mocha": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "pump": "^3.0.0",
     "punycode": "^2.1.1",
     "qrcode-generator": "1.4.1",
-    "react": "^16.12.0",
+    "react": "16.14.0",
     "react-dnd": "^3.0.2",
     "react-dnd-html5-backend": "^7.4.4",
     "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "pump": "^3.0.0",
     "punycode": "^2.1.1",
     "qrcode-generator": "1.4.1",
-    "react": "16.14.0",
+    "react": "^16.12.0",
     "react-dnd": "^3.0.2",
     "react-dnd-html5-backend": "^7.4.4",
     "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -277,6 +277,7 @@
     "ganache-cli": "^6.12.1",
     "ganache-core": "^2.13.1",
     "geckodriver": "^1.21.0",
+    "globby": "^11.0.4",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-dart-sass": "^1.0.2",

--- a/patches/@eslint+eslintrc+0.4.0.patch
+++ b/patches/@eslint+eslintrc+0.4.0.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/@eslint/eslintrc/lib/config-array-factory.js b/node_modules/@eslint/eslintrc/lib/config-array-factory.js
+index c7ff6a0..6a88c6d 100644
+--- a/node_modules/@eslint/eslintrc/lib/config-array-factory.js
++++ b/node_modules/@eslint/eslintrc/lib/config-array-factory.js
+@@ -41,7 +41,6 @@
+ 
+ const fs = require("fs");
+ const path = require("path");
+-const importFresh = require("import-fresh");
+ const stripComments = require("strip-json-comments");
+ const ConfigValidator = require("./shared/config-validator");
+ const naming = require("./shared/naming");
+@@ -222,7 +221,7 @@ function loadLegacyConfigFile(filePath) {
+ function loadJSConfigFile(filePath) {
+     debug(`Loading JS config file: ${filePath}`);
+     try {
+-        return importFresh(filePath);
++        return require(filePath);
+     } catch (e) {
+         debug(`Error reading JavaScript file: ${filePath}`);
+         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;

--- a/patches/eslint+7.23.0.patch
+++ b/patches/eslint+7.23.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/eslint/lib/linter/linter.js b/node_modules/eslint/lib/linter/linter.js
+index adb5c21..4a4be92 100644
+--- a/node_modules/eslint/lib/linter/linter.js
++++ b/node_modules/eslint/lib/linter/linter.js
+@@ -560,7 +560,7 @@ function resolveParserOptions(parserName, providedOptions, enabledEnvironments)
+  */
+ function resolveGlobals(providedGlobals, enabledEnvironments) {
+     return Object.assign(
+-        {},
++        Object.create(null),
+         ...enabledEnvironments.filter(env => env.globals).map(env => env.globals),
+         providedGlobals
+     );

--- a/patches/object.values+1.1.1.patch
+++ b/patches/object.values+1.1.1.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/object.values/index.js b/node_modules/object.values/index.js
+index b8ba091..2dc8083 100644
+--- a/node_modules/object.values/index.js
++++ b/node_modules/object.values/index.js
+@@ -1,17 +1,3 @@
+ 'use strict';
+ 
+-var define = require('define-properties');
+-
+-var implementation = require('./implementation');
+-var getPolyfill = require('./polyfill');
+-var shim = require('./shim');
+-
+-var polyfill = getPolyfill();
+-
+-define(polyfill, {
+-	getPolyfill: getPolyfill,
+-	implementation: implementation,
+-	shim: shim
+-});
+-
+-module.exports = polyfill;
++module.exports = Object.values;

--- a/ui/helpers/utils/build-types.js
+++ b/ui/helpers/utils/build-types.js
@@ -1,7 +1,6 @@
 ///: BEGIN:ONLY_INCLUDE_IN(beta)
 import betaJson from '../../../app/build-types/beta/beta-mascot.json';
 ///: END:ONLY_INCLUDE_IN
-
 ///: BEGIN:ONLY_INCLUDE_IN(flask)
 import flaskJson from '../../../app/build-types/flask/flask-mascot.json';
 ///: END:ONLY_INCLUDE_IN
@@ -11,13 +10,11 @@ const assetList = {
     // Will use default provided by the @metamask/logo library
     foxMeshJson: undefined,
   },
-
   ///: BEGIN:ONLY_INCLUDE_IN(beta)
   beta: {
     foxMeshJson: betaJson,
   },
   ///: END:ONLY_INCLUDE_IN
-
   ///: BEGIN:ONLY_INCLUDE_IN(flask)
   flask: {
     foxMeshJson: flaskJson,

--- a/ui/helpers/utils/build-types.js
+++ b/ui/helpers/utils/build-types.js
@@ -34,8 +34,8 @@ export function getBuildSpecificAsset(assetName) {
     !assetList[buildType] ||
     !Object.keys(assetList[buildType]).includes(assetName)
   ) {
-    console.warn(
-      `Cannot find asset for build ${buildType}: ${assetName}, returning main build asset`,
+    console.error(
+      `Cannot find asset "${assetName}" for build "${buildType}", returning main build asset.`,
     );
     return assetList.main[assetName];
   }

--- a/ui/helpers/utils/build-types.js
+++ b/ui/helpers/utils/build-types.js
@@ -1,17 +1,28 @@
+///: BEGIN:ONLY_INCLUDE_IN(beta)
 import betaJson from '../../../app/build-types/beta/beta-mascot.json';
+///: END:ONLY_INCLUDE_IN
+
+///: BEGIN:ONLY_INCLUDE_IN(flask)
 import flaskJson from '../../../app/build-types/flask/flask-mascot.json';
+///: END:ONLY_INCLUDE_IN
 
 const assetList = {
   main: {
     // Will use default provided by the @metamask/logo library
     foxMeshJson: undefined,
   },
+
+  ///: BEGIN:ONLY_INCLUDE_IN(beta)
   beta: {
     foxMeshJson: betaJson,
   },
+  ///: END:ONLY_INCLUDE_IN
+
+  ///: BEGIN:ONLY_INCLUDE_IN(flask)
   flask: {
     foxMeshJson: flaskJson,
   },
+  ///: END:ONLY_INCLUDE_IN
 };
 
 export function isBeta() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14718,7 +14718,7 @@ globby@11.0.1, globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.2, globby@^11.0.3:
+globby@^11.0.2, globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -24517,7 +24517,7 @@ react-transition-group@^4.4.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@16.14.0:
+react@^16.12.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -24517,7 +24517,7 @@ react-transition-group@^4.4.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^16.12.0:
+react@16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
This PR enables the exclusion of JavaScript and JSON source by `buildType`, and enables the running of `eslint` under LavaMoat. 80-90% of the changes in this PR are `.patch` files and LavaMoat policy additions.

The file exclusion is designed to work in conjunction with our code fencing. If you forget to fence an import statement of an excluded file, the application will now error on boot. **This PR commits us to a particular naming convention for files intended only for certain builds.** Continue reading for details.

### Code Fencing and ESLint

When a file is modified by the code fencing transform, we run ESLint on it to ensure that we fail early for syntax-related issues. This PR adds the first code fences that will be actually be removed in production builds. As a consequence, this was also the first time we attempted to run ESLint under LavaMoat. Making that work required a lot of manual labor because of ESLint's use of dynamic imports, but the manual changes necessary were ultimately quite minor.

### File Exclusion

For all builds, any file in `app/`, `shared/` or `ui/` in a sub-directory matching `**/${otherBuildType}/**` (where `otherBuildType` is any build type except `main`) will be added to the list of excluded files, regardless of its file extension. For example, if we want to add one or more pages to the UI settings in Flask, we'd create the folder `ui/pages/settings/flask`, add any necessary files or sub-folders there, and fence the import statements for anything in that folder. If we wanted the same thing for Beta, we would name the directory `ui/pages/settings/beta`.

As it happens, we already organize some of our source files in this way, namely the logo JSON for Beta and Flask builds. See `ui/helpers/utils/build-types.js` to see how this works in practice.

Because the list of ignored filed is only passed to `browserify.exclude()`, any files not bundled by `browserify` will be ignored. For our purposes, this is mostly relevant for `.scss`. Since we don't have anything like code fencing for SCSS, we'll have to consider how to handle our styles separately.

### Testing

Run the following commands to build the extension locally and observe that everything works. Make sure to reload every time the build script is restarted:
- `yarn start` (builds `main` by default)
- `yarn start --build-type beta`
- `yarn start --build-type flask`

### Future Concerns: SCSS

Regarding SCSS, `gulp.src` accepts globs, can accept an array of strings, and will ignore anything prefixed with `!`. Our best bet may be to create a separate SCSS entry point for Flask files and exclude it depending on the build type. 