### PR TITLE
Fix browser specific manifest generation

### DIFF
--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -108,6 +108,7 @@ function createManifestTasks({
     if (Array.isArray(objValue)) {
       return [...new Set([...objValue, ...srcValue])];
     }
+    return undefined;
   }
 }
 

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -108,7 +108,6 @@ function createManifestTasks({
     if (Array.isArray(objValue)) {
       return [...new Set([...objValue, ...srcValue])];
     }
-    return null;
   }
 }
 

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -35,7 +35,7 @@ function createManifestTasks({
           platformModifications,
           browserVersionMap[platform],
           getBuildModifications(buildType),
-          customArrayMerge
+          customArrayMerge,
         );
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });
@@ -106,8 +106,9 @@ function createManifestTasks({
   // helper for merging obj value
   function customArrayMerge(objValue, srcValue) {
     if (Array.isArray(objValue)) {
-      return [...new Set([...objValue ,...srcValue])]
+      return [...new Set([...objValue, ...srcValue])];
     }
+    return null;
   }
 }
 

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -1,6 +1,6 @@
 const { promises: fs } = require('fs');
 const path = require('path');
-const { merge, cloneDeep } = require('lodash');
+const { mergeWith, cloneDeep } = require('lodash');
 
 const baseManifest = require('../../app/manifest/_base.json');
 const betaManifestModifications = require('../../app/manifest/_beta_modifications.json');
@@ -30,11 +30,12 @@ function createManifestTasks({
             `${platform}.json`,
           ),
         );
-        const result = merge(
+        const result = mergeWith(
           cloneDeep(baseManifest),
           platformModifications,
           browserVersionMap[platform],
           getBuildModifications(buildType),
+          customArrayMerge
         );
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });
@@ -100,6 +101,13 @@ function createManifestTasks({
         }),
       );
     };
+  }
+
+  // helper for merging obj value
+  function customArrayMerge(objValue, srcValue) {
+    if (Array.isArray(objValue)) {
+      return [...new Set([...objValue ,...srcValue])]
+    }
   }
 }
 


### PR DESCRIPTION
Fixes: #12532

Explanation:  
I tracked a bug inside Metamasks code that creates browser-specific manifests. The idea here is to have `_base.json` manifest that holds manifest properties that are needed on all browsers and then also have browser-specific manifests such as `chrome.json`. Then, when manifest for specific browser distribution is created, these two manifests are merged into one. The problem occurs when you have array property such as `permissions` in both `_base.json` and `chrome.json` (browser-specific manifest). Below you can find examples of how this merge worked before, and how it works now.

**OLD BEHAVIOUR**
```json
  /* _base.json */
  "permissions": [
    "storage",
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications"
  ]
  
  /* chrome.json */
  "permissions": [
    "chrome-extension://*/*"
  ]
  
  /* results in merged permissions as shown below */
  /* problem is that new permissions from browser specific manifest ovveride base permission /*
  "permissions": [
    "chrome-extension://*/*",  /* notice that storage permission is missing */
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications"
  ]
  
```

**NEW BEHAVIOUR**

```json
  /* _base.json */
  "permissions": [
    "storage",
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications"
  ]
  
  /* chrome.json */
  "permissions": [
    "chrome-extension://*/*"
  ]
  
  /* results in merged permissions as shown below */
  "permissions": [ 
    "storage"
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications",
    "chrome-extension://*/*"
  ]
  
```

I have read the CLA Document and I hereby sign the CLA