### PR TITLE
Ensure exchange rate is stringified before passing to bignumber in token confirm component

### DIFF
--- a/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
+++ b/ui/pages/confirm-token-transaction-base/confirm-token-transaction-base.component.js
@@ -35,7 +35,9 @@ export default function ConfirmTokenTransactionBase({
     }
 
     const decimalEthValue = new BigNumber(tokenAmount)
-      .times(new BigNumber(contractExchangeRate))
+      .times(
+        new BigNumber(contractExchangeRate ? String(contractExchangeRate) : 0),
+      )
       .toFixed();
 
     return getWeiHexFromDecimalValue({


### PR DESCRIPTION
With this change, we introduced the possibility of exchange rate numbers having more than 15 significant digits: https://github.com/MetaMask/controllers/pull/585

Our current version of `BigNumber` does not handle that well, but does if the number is stringified.

Currently in prod, users will hit an error screen when this happens. Here is the associated error record in sentry https://sentry.io/organizations/metamask/issues/2745103173/?project=273505&query=is%3Aunresolved+firstRelease%3Alatest&statsPeriod=14d