### PR TITLE
Ensure ledger transport preference is set on import

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1317,6 +1317,13 @@ export default class MetamaskController extends EventEmitter {
         accounts = await keyringController.getAccounts();
       }
 
+      // This must be set as soon as possible to communicate to the
+      // keyring's iframe and have the setting initialized properly
+      // Optimistically called to not block Metamask login due to
+      // Ledger Keyring GitHub downtime
+      const transportPreference = this.preferencesController.getLedgerTransportPreference();
+      this.setLedgerTransportPreference(transportPreference);
+
       // set new identities
       this.preferencesController.setAddresses(accounts);
       this.selectFirstIdentity();


### PR DESCRIPTION
Fixes an issue I found while addressing another problem with the ledger webhid implementation.

This ensures that if a user onboards by importing an existing seed phrase, and then connects their ledger, that `webhid` is correctly set as the transport type in the ledger bridge.