### PR TITLE
metametrics - ensure segment submission failures do not bubble up

### DIFF
--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -288,6 +288,8 @@ export default class MetaMetricsController {
    * @param {MetaMetricsEventOptions} [options] - options for handling/routing the event
    */
   trackEvent(payload, options) {
+    // validation is not caught and handled
+    this.validatePayload(payload);
     try {
       this.submitEvent(payload, options).catch((err) => {
         console.error(err);
@@ -307,20 +309,7 @@ export default class MetaMetricsController {
    * @returns {Promise<void>}
    */
   async submitEvent(payload, options) {
-    // event and category are required fields for all payloads
-    if (!payload.event || !payload.category) {
-      throw new Error(
-        `Must specify event and category. Event was: ${
-          payload.event
-        }. Category was: ${payload.category}. Payload keys were: ${Object.keys(
-          payload,
-        )}. ${
-          typeof payload.properties === 'object'
-            ? `Payload property keys were: ${Object.keys(payload.properties)}`
-            : ''
-        }`,
-      );
-    }
+    this.validatePayload(payload);
 
     if (!this.state.participateInMetaMetrics && !options?.isOptIn) {
       return;
@@ -359,5 +348,26 @@ export default class MetaMetricsController {
     events.push(this._track(this._buildEventPayload(payload), options));
 
     await Promise.all(events);
+  }
+
+  /**
+   * validates a metametrics event
+   * @param {MetaMetricsEventPayload} payload - details of the event
+   */
+  validatePayload(payload) {
+    // event and category are required fields for all payloads
+    if (!payload.event || !payload.category) {
+      throw new Error(
+        `Must specify event and category. Event was: ${
+          payload.event
+        }. Category was: ${payload.category}. Payload keys were: ${Object.keys(
+          payload,
+        )}. ${
+          typeof payload.properties === 'object'
+            ? `Payload property keys were: ${Object.keys(payload.properties)}`
+            : ''
+        }`,
+      );
+    }
   }
 }

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -307,13 +307,9 @@ export default class MetaMetricsController {
   trackEvent(payload, options) {
     // validation is not caught and handled
     this.validatePayload(payload);
-    try {
-      this.submitEvent(payload, options).catch((err) =>
-        this._captureException(err),
-      );
-    } catch (err) {
-      console.error(err);
-    }
+    this.submitEvent(payload, options).catch((err) =>
+      this._captureException(err),
+    );
   }
 
   /**

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -283,7 +283,22 @@ export default class MetaMetricsController {
   }
 
   /**
-   * track a metametrics event, performing necessary payload manipulation and
+   * submits a metametrics event, not waiting for it to complete or allowing its error to bubble up
+   * @param {MetaMetricsEventPayload} payload - details of the event
+   * @param {MetaMetricsEventOptions} [options] - options for handling/routing the event
+   */
+  trackEvent(payload, options) {
+    try {
+      this.submitEvent(payload, options).catch((err) => {
+        console.error(err);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  /**
+   * submits (or queues for submission) a metametrics event, performing necessary payload manipulation and
    * routing the event to the appropriate segment source. Will split events
    * with sensitiveProperties into two events, tracking the sensitiveProperties
    * with the anonymousId only.
@@ -291,20 +306,7 @@ export default class MetaMetricsController {
    * @param {MetaMetricsEventOptions} [options] - options for handling/routing the event
    * @returns {Promise<void>}
    */
-  async trackEvent(payload, options) {
-    try {
-      await this._trackEvent(payload, options);
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  /**
-   * @param {MetaMetricsEventPayload} payload - details of the event
-   * @param {MetaMetricsEventOptions} [options] - options for handling/routing the event
-   * @returns {Promise<void>}
-   */
-  async _trackEvent(payload, options) {
+  async submitEvent(payload, options) {
     // event and category are required fields for all payloads
     if (!payload.event || !payload.category) {
       throw new Error(

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -268,28 +268,35 @@ export default class MetaMetricsController {
    *  view
    */
   trackPage({ name, params, environmentType, page, referrer }, options) {
-    if (this.state.participateInMetaMetrics === false) {
-      return;
-    }
+    try {
+      if (this.state.participateInMetaMetrics === false) {
+        return;
+      }
 
-    if (this.state.participateInMetaMetrics === null && !options?.isOptInPath) {
-      return;
+      if (
+        this.state.participateInMetaMetrics === null &&
+        !options?.isOptInPath
+      ) {
+        return;
+      }
+      const { metaMetricsId } = this.state;
+      const idTrait = metaMetricsId ? 'userId' : 'anonymousId';
+      const idValue = metaMetricsId ?? METAMETRICS_ANONYMOUS_ID;
+      this.segment.page({
+        [idTrait]: idValue,
+        name,
+        properties: {
+          params,
+          locale: this.locale,
+          network: this.network,
+          chain_id: this.chainId,
+          environment_type: environmentType,
+        },
+        context: this._buildContext(referrer, page),
+      });
+    } catch (err) {
+      this._captureException(err);
     }
-    const { metaMetricsId } = this.state;
-    const idTrait = metaMetricsId ? 'userId' : 'anonymousId';
-    const idValue = metaMetricsId ?? METAMETRICS_ANONYMOUS_ID;
-    this.segment.page({
-      [idTrait]: idValue,
-      name,
-      properties: {
-        params,
-        locale: this.locale,
-        network: this.network,
-        chain_id: this.chainId,
-        environment_type: environmentType,
-      },
-      context: this._buildContext(referrer, page),
-    });
   }
 
   /**

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -294,7 +294,9 @@ export default class MetaMetricsController {
       this.submitEvent(payload, options).catch((err) => {
         // throw error on clean stack so its captured by sentry
         // but does not cause any side effects
-        setTimeout(() => { throw err });
+        setTimeout(() => {
+          throw err;
+        });
       });
     } catch (err) {
       console.error(err);

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -292,6 +292,19 @@ export default class MetaMetricsController {
    * @returns {Promise<void>}
    */
   async trackEvent(payload, options) {
+    try {
+      await this._trackEvent(payload, options);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  /**
+   * @param {MetaMetricsEventPayload} payload - details of the event
+   * @param {MetaMetricsEventOptions} [options] - options for handling/routing the event
+   * @returns {Promise<void>}
+   */
+  async _trackEvent(payload, options) {
     // event and category are required fields for all payloads
     if (!payload.event || !payload.category) {
       throw new Error(

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -292,7 +292,9 @@ export default class MetaMetricsController {
     this.validatePayload(payload);
     try {
       this.submitEvent(payload, options).catch((err) => {
-        console.error(err);
+        // throw error on clean stack so its captured by sentry
+        // but does not cause any side effects
+        setTimeout(() => { throw err });
       });
     } catch (err) {
       console.error(err);

--- a/app/scripts/controllers/metametrics.test.js
+++ b/app/scripts/controllers/metametrics.test.js
@@ -196,14 +196,14 @@ describe('MetaMetricsController', function () {
     });
   });
 
-  describe('trackEvent', function () {
+  describe('submitEvent', function () {
     it('should not track an event if user is not participating in metametrics', function () {
       const mock = sinon.mock(segment);
       const metaMetricsController = getMetaMetricsController({
         participateInMetaMetrics: false,
       });
       mock.expects('track').never();
-      metaMetricsController.trackEvent({
+      metaMetricsController.submitEvent({
         event: 'Fake Event',
         category: 'Unit Test',
         properties: {
@@ -230,7 +230,7 @@ describe('MetaMetricsController', function () {
             ...DEFAULT_EVENT_PROPERTIES,
           },
         });
-      metaMetricsController.trackEvent(
+      metaMetricsController.submitEvent(
         {
           event: 'Fake Event',
           category: 'Unit Test',
@@ -260,7 +260,7 @@ describe('MetaMetricsController', function () {
             ...DEFAULT_EVENT_PROPERTIES,
           },
         });
-      metaMetricsController.trackEvent(
+      metaMetricsController.submitEvent(
         {
           event: 'Fake Event',
           category: 'Unit Test',
@@ -289,7 +289,7 @@ describe('MetaMetricsController', function () {
             ...DEFAULT_EVENT_PROPERTIES,
           },
         });
-      metaMetricsController.trackEvent(
+      metaMetricsController.submitEvent(
         {
           event: 'Fake Event',
           category: 'Unit Test',
@@ -317,7 +317,7 @@ describe('MetaMetricsController', function () {
             ...DEFAULT_EVENT_PROPERTIES,
           },
         });
-      metaMetricsController.trackEvent({
+      metaMetricsController.submitEvent({
         event: 'Fake Event',
         category: 'Unit Test',
         properties: {
@@ -331,7 +331,7 @@ describe('MetaMetricsController', function () {
       const metaMetricsController = getMetaMetricsController();
       const flushStub = sinon.stub(segment, 'flush');
       const flushCalled = waitUntilCalled(flushStub, segment);
-      metaMetricsController.trackEvent(
+      metaMetricsController.submitEvent(
         {
           event: 'Fake Event',
           category: 'Unit Test',
@@ -344,13 +344,13 @@ describe('MetaMetricsController', function () {
     it('should throw if event or category not provided', function () {
       const metaMetricsController = getMetaMetricsController();
       assert.rejects(
-        () => metaMetricsController.trackEvent({ event: 'test' }),
+        () => metaMetricsController.submitEvent({ event: 'test' }),
         /Must specify event and category\./u,
         'must specify category',
       );
 
       assert.rejects(
-        () => metaMetricsController.trackEvent({ category: 'test' }),
+        () => metaMetricsController.submitEvent({ category: 'test' }),
         /Must specify event and category\./u,
         'must specify event',
       );
@@ -360,7 +360,7 @@ describe('MetaMetricsController', function () {
       const metaMetricsController = getMetaMetricsController();
       assert.rejects(
         () =>
-          metaMetricsController.trackEvent(
+          metaMetricsController.submitEvent(
             {
               event: 'Fake Event',
               category: 'Unit Test',
@@ -375,7 +375,7 @@ describe('MetaMetricsController', function () {
     it('should track sensitiveProperties in a separate, anonymous event', function () {
       const metaMetricsController = getMetaMetricsController();
       const spy = sinon.spy(segment, 'track');
-      metaMetricsController.trackEvent({
+      metaMetricsController.submitEvent({
         event: 'Fake Event',
         category: 'Unit Test',
         sensitiveProperties: { foo: 'bar' },

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -16,6 +16,7 @@ import TrezorKeyring from 'eth-trezor-keyring';
 import LedgerBridgeKeyring from '@metamask/eth-ledger-bridge-keyring';
 import EthQuery from 'eth-query';
 import nanoid from 'nanoid';
+import { captureException } from '@sentry/browser';
 import {
   AddressBookController,
   ApprovalController,
@@ -189,6 +190,7 @@ export default class MetamaskController extends EventEmitter {
       version: this.platform.getVersion(),
       environment: process.env.METAMASK_ENVIRONMENT,
       initState: initState.MetaMetricsController,
+      captureException,
     });
 
     const gasFeeMessenger = this.controllerMessenger.getRestricted({


### PR DESCRIPTION
Prevents segment submission errors from bubbling up and affecting flows that contain metric events

Does this by separating the metametrics trackEvent call into

`trackEvent`:
  - queue for submission
  - **dont wait** for completion
  - **log, dont throw** errors

`submitEvent`:
  - queue for submission
  - wait for completion
  - error on failure