### PR TITLE
EIP-1559 V2 : Adding advancedGasFee property to Preference Controller

### DIFF
--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -37,6 +37,7 @@ export default class PreferencesController {
       // set to true means the dynamic list from the API is being used
       // set to false will be using the static list from contract-metadata
       useTokenDetection: false,
+      useAdvancedGasFee: false,
 
       // WARNING: Do not use feature flags for security-sensitive things.
       // Feature flag toggling is available in the global namespace
@@ -127,6 +128,16 @@ export default class PreferencesController {
    */
   setUseTokenDetection(val) {
     this.store.updateState({ useTokenDetection: val });
+  }
+
+  /**
+   * Setter for the `useAdvancedGasFee` property
+   *
+   * @param {boolean} val - Whether or not the user prefers to use the static token list or dynamic token list from the API
+   *
+   */
+  setUseAdvancedGasFee(val) {
+    this.store.updateState({ useAdvancedGasFee: val });
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -37,7 +37,10 @@ export default class PreferencesController {
       // set to true means the dynamic list from the API is being used
       // set to false will be using the static list from contract-metadata
       useTokenDetection: false,
-      useAdvancedGasFee: false,
+      advancedGasFee: {
+        maxBaseFee: '',
+        priorityFee: '',
+      },
 
       // WARNING: Do not use feature flags for security-sensitive things.
       // Feature flag toggling is available in the global namespace
@@ -131,14 +134,13 @@ export default class PreferencesController {
   }
 
   /**
-   * Setter for the `useAdvancedGasFee` property
+   * Setter for the `advancedGasFee` property
    *
-   * @param {boolean} val - Whether or not the user prefers to use the advanced gas settings,
-   *  and the custom Max base fee and priority fee by default
+   * @param {object} val - holds the maxBaseFee and PriorityFee that the user set as default advanced settings.
    *
    */
-  setUseAdvancedGasFee(val) {
-    this.store.updateState({ useAdvancedGasFee: val });
+  setAdvancedGasFee(val) {
+    this.store.updateState({ advancedGasFee: val });
   }
 
   /**

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -38,8 +38,8 @@ export default class PreferencesController {
       // set to false will be using the static list from contract-metadata
       useTokenDetection: false,
       advancedGasFee: {
-        maxBaseFee: '',
-        priorityFee: '',
+        maxBaseFee: undefined,
+        priorityFee: undefined,
       },
 
       // WARNING: Do not use feature flags for security-sensitive things.

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -133,7 +133,8 @@ export default class PreferencesController {
   /**
    * Setter for the `useAdvancedGasFee` property
    *
-   * @param {boolean} val - Whether or not the user prefers to use the static token list or dynamic token list from the API
+   * @param {boolean} val - Whether or not the user prefers to use the advanced gas settings,
+   *  and the custom Max base fee and priority fee by default
    *
    */
   setUseAdvancedGasFee(val) {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -37,10 +37,7 @@ export default class PreferencesController {
       // set to true means the dynamic list from the API is being used
       // set to false will be using the static list from contract-metadata
       useTokenDetection: false,
-      advancedGasFee: {
-        maxBaseFee: undefined,
-        priorityFee: undefined,
-      },
+      advancedGasFee: null,
 
       // WARNING: Do not use feature flags for security-sensitive things.
       // Feature flag toggling is available in the global namespace

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -266,4 +266,23 @@ describe('preferences controller', function () {
       );
     });
   });
+
+  describe('setUseAdvancedGasFee', function () {
+    it('should default to false', function () {
+      const state = preferencesController.store.getState();
+      assert.equal(state.useAdvancedGasFee, false);
+    });
+
+    it('should set the useAdvancedGasFee property in state', function () {
+      assert.equal(
+        preferencesController.store.getState().useAdvancedGasFee,
+        false,
+      );
+      preferencesController.setUseAdvancedGasFee(true);
+      assert.equal(
+        preferencesController.store.getState().useAdvancedGasFee,
+        true,
+      );
+    });
+  });
 });

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -267,21 +267,33 @@ describe('preferences controller', function () {
     });
   });
 
-  describe('setUseAdvancedGasFee', function () {
-    it('should default to false', function () {
+  describe('setAdvancedGasFee', function () {
+    it('should default to empty values for maxFee and priorityFee', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.useAdvancedGasFee, false);
+      assert.equal(state.advancedGasFee.maxBaseFee, '');
+      assert.equal(state.advancedGasFee.priorityFee, '');
     });
 
-    it('should set the useAdvancedGasFee property in state', function () {
+    it('should set the setAdvancedGasFee property in state', function () {
       assert.equal(
-        preferencesController.store.getState().useAdvancedGasFee,
-        false,
+        preferencesController.store.getState().advancedGasFee.maxBaseFee,
+        '',
       );
-      preferencesController.setUseAdvancedGasFee(true);
       assert.equal(
-        preferencesController.store.getState().useAdvancedGasFee,
-        true,
+        preferencesController.store.getState().advancedGasFee.priorityFee,
+        '',
+      );
+      preferencesController.setAdvancedGasFee({
+        maxBaseFee: '1.5',
+        priorityFee: '2',
+      });
+      assert.equal(
+        preferencesController.store.getState().advancedGasFee.maxBaseFee,
+        '1.5',
+      );
+      assert.equal(
+        preferencesController.store.getState().advancedGasFee.priorityFee,
+        '2',
       );
     });
   });

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -268,21 +268,14 @@ describe('preferences controller', function () {
   });
 
   describe('setAdvancedGasFee', function () {
-    it('should default to empty values for maxFee and priorityFee', function () {
+    it('should default to null', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.advancedGasFee.maxBaseFee, undefined);
-      assert.equal(state.advancedGasFee.priorityFee, undefined);
+      assert.equal(state.advancedGasFee, null);
     });
 
     it('should set the setAdvancedGasFee property in state', function () {
-      assert.equal(
-        preferencesController.store.getState().advancedGasFee.maxBaseFee,
-        undefined,
-      );
-      assert.equal(
-        preferencesController.store.getState().advancedGasFee.priorityFee,
-        undefined,
-      );
+      const state = preferencesController.store.getState();
+      assert.equal(state.advancedGasFee, null);
       preferencesController.setAdvancedGasFee({
         maxBaseFee: '1.5',
         priorityFee: '2',

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -277,11 +277,11 @@ describe('preferences controller', function () {
     it('should set the setAdvancedGasFee property in state', function () {
       assert.equal(
         preferencesController.store.getState().advancedGasFee.maxBaseFee,
-        '',
+        undefined,
       );
       assert.equal(
         preferencesController.store.getState().advancedGasFee.priorityFee,
-        '',
+        undefined,
       );
       preferencesController.setAdvancedGasFee({
         maxBaseFee: '1.5',

--- a/app/scripts/controllers/preferences.test.js
+++ b/app/scripts/controllers/preferences.test.js
@@ -270,8 +270,8 @@ describe('preferences controller', function () {
   describe('setAdvancedGasFee', function () {
     it('should default to empty values for maxFee and priorityFee', function () {
       const state = preferencesController.store.getState();
-      assert.equal(state.advancedGasFee.maxBaseFee, '');
-      assert.equal(state.advancedGasFee.priorityFee, '');
+      assert.equal(state.advancedGasFee.maxBaseFee, undefined);
+      assert.equal(state.advancedGasFee.priorityFee, undefined);
     });
 
     it('should set the setAdvancedGasFee property in state', function () {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -924,8 +924,8 @@ export default class MetamaskController extends EventEmitter {
         this.preferencesController.setDismissSeedBackUpReminder,
         this.preferencesController,
       ),
-      setUseAdvancedGasFee: nodeify(
-        preferencesController.setUseAdvancedGasFee,
+      setAdvancedGasFee: nodeify(
+        preferencesController.setAdvancedGasFee,
         preferencesController,
       ),
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -924,6 +924,10 @@ export default class MetamaskController extends EventEmitter {
         this.preferencesController.setDismissSeedBackUpReminder,
         this.preferencesController,
       ),
+      setUseAdvancedGasFee: nodeify(
+        preferencesController.setUseAdvancedGasFee,
+        preferencesController,
+      ),
 
       // AddressController
       setAddressBook: nodeify(

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -160,6 +160,7 @@
       "toNickname": ""
     },
     "useTokenDetection": true,
+    "useAdvancedGasFee": false,
     "tokenList": {
       "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": {
         "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",

--- a/test/data/mock-state.json
+++ b/test/data/mock-state.json
@@ -160,7 +160,10 @@
       "toNickname": ""
     },
     "useTokenDetection": true,
-    "useAdvancedGasFee": false,
+    "advancedGasFee": {
+      "maxBaseFee": "1.5",
+      "priorityFee": "2"
+    },
     "tokenList": {
       "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": {
         "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -734,7 +734,6 @@ export function getAdvancedGasFeeValues(state) {
  */
 export function getIsAdvancedGasFeeDefault(state) {
   const { advancedGasFee } = state.metamask;
-  console.log(advancedGasFee);
   return (
     Boolean(advancedGasFee.maxBaseFee) && Boolean(advancedGasFee.priorityFee)
   );

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -718,3 +718,11 @@ export function getNetworkSupportsSettingGasPrice(state) {
 export function getIsMultiLayerFeeNetwork(state) {
   return getIsOptimism(state);
 }
+/**
+ *  To get the useAdvancedGasFee flag to determine if teh advanced/custom gas fee has to be used as default values.
+ *  @param {*} state
+ *  @returns Boolean
+ */
+export function getUseAdvancedGasFee(state) {
+  return Boolean(state.metamask.useAdvancedGasFee);
+}

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -735,6 +735,6 @@ export function getAdvancedGasFeeValues(state) {
 export function getIsAdvancedGasFeeDefault(state) {
   const { advancedGasFee } = state.metamask;
   return (
-    Boolean(advancedGasFee.maxBaseFee) && Boolean(advancedGasFee.priorityFee)
+    Boolean(advancedGasFee?.maxBaseFee) && Boolean(advancedGasFee?.priorityFee)
   );
 }

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -719,10 +719,23 @@ export function getIsMultiLayerFeeNetwork(state) {
   return getIsOptimism(state);
 }
 /**
- *  To get the useAdvancedGasFee flag to determine if teh advanced/custom gas fee has to be used as default values.
+ *  To retrieve the maxBaseFee and priotitFee teh user has set as default
  *  @param {*} state
  *  @returns Boolean
  */
-export function getUseAdvancedGasFee(state) {
-  return Boolean(state.metamask.useAdvancedGasFee);
+export function getAdvancedGasFeeValues(state) {
+  return state.metamask.advancedGasFee;
+}
+
+/**
+ *  To check if the user has set advanced gas fee settings as default with a non empty  maxBaseFee and priotityFee.
+ *  @param {*} state
+ *  @returns Boolean
+ */
+export function getIsAdvancedGasFeeDefault(state) {
+  const { advancedGasFee } = state.metamask;
+  console.log(advancedGasFee);
+  return (
+    Boolean(advancedGasFee.maxBaseFee) && Boolean(advancedGasFee.priorityFee)
+  );
 }

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -245,4 +245,8 @@ describe('Selectors', () => {
       },
     });
   });
+  it('#getUseAdvancedGasFee', () => {
+    const useAdvancedGasFee = selectors.getUseAdvancedGasFee(mockState);
+    expect(useAdvancedGasFee).toStrictEqual(false);
+  });
 });

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -245,8 +245,17 @@ describe('Selectors', () => {
       },
     });
   });
-  it('#getUseAdvancedGasFee', () => {
-    const useAdvancedGasFee = selectors.getUseAdvancedGasFee(mockState);
-    expect(useAdvancedGasFee).toStrictEqual(false);
+  it('#getAdvancedGasFeeValues', () => {
+    const advancedGasFee = selectors.getAdvancedGasFeeValues(mockState);
+    expect(advancedGasFee).toStrictEqual({
+      maxBaseFee: '1.5',
+      priorityFee: '2',
+    });
+  });
+  it('#getIsAdvancedGasFeeDefault', () => {
+    const isAdvancedGasFeeDefault = selectors.getIsAdvancedGasFeeDefault(
+      mockState,
+    );
+    expect(isAdvancedGasFeeDefault).toStrictEqual(true);
   });
 });

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2090,11 +2090,11 @@ export function setUseTokenDetection(val) {
   };
 }
 
-export function setUseAdvancedGasFee(val) {
+export function setAdvancedGasFee(val) {
   return (dispatch) => {
     dispatch(showLoadingIndication());
-    log.debug(`background.setUseAdvancedGasFee`);
-    background.setUseAdvancedGasFee(val, (err) => {
+    log.debug(`background.setAdvancedGasFee`);
+    background.setAdvancedGasFee(val, (err) => {
       dispatch(hideLoadingIndication());
       if (err) {
         dispatch(displayWarning(err.message));

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -2090,6 +2090,19 @@ export function setUseTokenDetection(val) {
   };
 }
 
+export function setUseAdvancedGasFee(val) {
+  return (dispatch) => {
+    dispatch(showLoadingIndication());
+    log.debug(`background.setUseAdvancedGasFee`);
+    background.setUseAdvancedGasFee(val, (err) => {
+      dispatch(hideLoadingIndication());
+      if (err) {
+        dispatch(displayWarning(err.message));
+      }
+    });
+  };
+}
+
 export function setIpfsGateway(val) {
   return (dispatch) => {
     dispatch(showLoadingIndication());


### PR DESCRIPTION
Fixes: #12447 

EIP-1559 V2 allows the user to save custom settings as defaults, these will include the option to use custom Max Base Fee and Priority Fee values and advanced settings as default.