### PR TITLE
Password field non standard

### DIFF
--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -91,6 +91,9 @@ const getMaterialThemeInputProps = ({
   min,
   max,
   autoComplete,
+  placeholder,
+  name,
+  passwordrules,
 }) => ({
   InputLabelProps: {
     classes: {
@@ -109,6 +112,9 @@ const getMaterialThemeInputProps = ({
       min,
       max,
       autoComplete,
+      placeholder,
+      name,
+      passwordrules,
     },
   },
 });
@@ -125,6 +131,9 @@ const getMaterialWhitePaddedThemeInputProps = ({
   min,
   max,
   autoComplete,
+  placeholder,
+  name,
+  passwordrules,
 }) => ({
   InputProps: {
     startAdornment,
@@ -139,6 +148,9 @@ const getMaterialWhitePaddedThemeInputProps = ({
       min,
       max,
       autoComplete,
+      placeholder,
+      name,
+      passwordrules,
     },
   },
 });
@@ -160,6 +172,9 @@ const getBorderedThemeInputProps = ({
   min,
   max,
   autoComplete,
+  placeholder,
+  name,
+  passwordrules,
 }) => ({
   InputLabelProps: {
     shrink: true,
@@ -183,6 +198,9 @@ const getBorderedThemeInputProps = ({
       min,
       max,
       autoComplete,
+      placeholder,
+      name,
+      passwordrules,
     },
   },
 });
@@ -203,6 +221,9 @@ const TextField = ({
   min,
   max,
   autoComplete,
+  placeholder,
+  name,
+  passwordrules,
   ...textFieldProps
 }) => {
   const inputProps = themeToInputProps[theme]({
@@ -213,6 +234,9 @@ const TextField = ({
     min,
     max,
     autoComplete,
+    placeholder,
+    name,
+    passwordrules,
   });
 
   return (
@@ -241,6 +265,9 @@ TextField.propTypes = {
   min: PropTypes.number,
   max: PropTypes.number,
   autoComplete: PropTypes.string,
+  placeholder: PropTypes.string,
+  name: PropTypes.string,
+  passwordrules: PropTypes.string
 };
 
 export default withStyles(styles)(TextField);

--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -267,7 +267,7 @@ TextField.propTypes = {
   autoComplete: PropTypes.string,
   placeholder: PropTypes.string,
   name: PropTypes.string,
-  passwordrules: PropTypes.string
+  passwordrules: PropTypes.string,
 };
 
 export default withStyles(styles)(TextField);

--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -93,7 +93,9 @@ const getMaterialThemeInputProps = ({
   autoComplete,
   placeholder,
   name,
-  passwordrules,
+  minLength,
+  maxLength,
+  pattern,
 }) => ({
   InputLabelProps: {
     classes: {
@@ -114,7 +116,9 @@ const getMaterialThemeInputProps = ({
       autoComplete,
       placeholder,
       name,
-      passwordrules,
+      minLength,
+      maxLength,
+      pattern,
     },
   },
 });
@@ -133,7 +137,9 @@ const getMaterialWhitePaddedThemeInputProps = ({
   autoComplete,
   placeholder,
   name,
-  passwordrules,
+  minLength,
+  maxLength,
+  pattern,
 }) => ({
   InputProps: {
     startAdornment,
@@ -150,7 +156,9 @@ const getMaterialWhitePaddedThemeInputProps = ({
       autoComplete,
       placeholder,
       name,
-      passwordrules,
+      minLength,
+      maxLength,
+      pattern,
     },
   },
 });
@@ -174,7 +182,9 @@ const getBorderedThemeInputProps = ({
   autoComplete,
   placeholder,
   name,
-  passwordrules,
+  minLength,
+  maxLength,
+  pattern,
 }) => ({
   InputLabelProps: {
     shrink: true,
@@ -200,7 +210,9 @@ const getBorderedThemeInputProps = ({
       autoComplete,
       placeholder,
       name,
-      passwordrules,
+      minLength,
+      maxLength,
+      pattern,
     },
   },
 });
@@ -223,7 +235,9 @@ const TextField = ({
   autoComplete,
   placeholder,
   name,
-  passwordrules,
+  minLength,
+  maxLength,
+  pattern,
   ...textFieldProps
 }) => {
   const inputProps = themeToInputProps[theme]({
@@ -236,7 +250,9 @@ const TextField = ({
     autoComplete,
     placeholder,
     name,
-    passwordrules,
+    minLength,
+    maxLength,
+    pattern,
   });
 
   return (
@@ -267,7 +283,9 @@ TextField.propTypes = {
   autoComplete: PropTypes.string,
   placeholder: PropTypes.string,
   name: PropTypes.string,
-  passwordrules: PropTypes.string,
+  minLength: PropTypes.number,
+  maxLength: PropTypes.number,
+  pattern: PropTypes.string,
 };
 
 export default withStyles(styles)(TextField);

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -285,6 +285,8 @@ export default class ImportWithSeedPhrase extends PureComponent {
         </div>
         <TextField
           id="password"
+          name="password"
+          placeholder="New password"
           label={t('newPassword')}
           type="password"
           className="first-time-flow__input"
@@ -292,11 +294,14 @@ export default class ImportWithSeedPhrase extends PureComponent {
           onChange={(event) => this.handlePasswordChange(event.target.value)}
           error={passwordError}
           autoComplete="new-password"
+          passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
           margin="normal"
           largeLabel
         />
         <TextField
           id="confirm-password"
+          name="create-password"
+          placeholder="Confirm password"
           label={t('confirmPassword')}
           type="password"
           className="first-time-flow__input"
@@ -306,6 +311,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
           }
           error={confirmPasswordError}
           autoComplete="new-password"
+          passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
           margin="normal"
           largeLabel
         />

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -294,7 +294,9 @@ export default class ImportWithSeedPhrase extends PureComponent {
           onChange={(event) => this.handlePasswordChange(event.target.value)}
           error={passwordError}
           autoComplete="new-password"
-          passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+          minLength={8}
+          maxLength={20}
+          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
           margin="normal"
           largeLabel
         />
@@ -311,7 +313,9 @@ export default class ImportWithSeedPhrase extends PureComponent {
           }
           error={confirmPasswordError}
           autoComplete="new-password"
-          passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+          minLength={8}
+          maxLength={20}
+          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
           margin="normal"
           largeLabel
         />

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -296,7 +296,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
           autoComplete="new-password"
           minLength={8}
           maxLength={20}
-          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
           margin="normal"
           largeLabel
         />
@@ -315,7 +315,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
           autoComplete="new-password"
           minLength={8}
           maxLength={20}
-          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
           margin="normal"
           largeLabel
         />

--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -295,8 +295,8 @@ export default class ImportWithSeedPhrase extends PureComponent {
           error={passwordError}
           autoComplete="new-password"
           minLength={8}
-          maxLength={20}
-          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+          maxLength={50}
+          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
           margin="normal"
           largeLabel
         />
@@ -314,8 +314,8 @@ export default class ImportWithSeedPhrase extends PureComponent {
           error={confirmPasswordError}
           autoComplete="new-password"
           minLength={8}
-          maxLength={20}
-          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+          maxLength={50}
+          pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
           margin="normal"
           largeLabel
         />

--- a/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -180,7 +180,7 @@ export default class NewAccount extends PureComponent {
             autoComplete="new-password"
             minLength={8}
             maxLength={20}
-            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
             margin="normal"
             fullWidth
             largeLabel
@@ -200,7 +200,7 @@ export default class NewAccount extends PureComponent {
             autoComplete="confirm-password"
             minLength={8}
             maxLength={20}
-            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
             margin="normal"
             fullWidth
             largeLabel

--- a/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -179,8 +179,8 @@ export default class NewAccount extends PureComponent {
             autoFocus
             autoComplete="new-password"
             minLength={8}
-            maxLength={20}
-            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+            maxLength={50}
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
             margin="normal"
             fullWidth
             largeLabel
@@ -199,8 +199,8 @@ export default class NewAccount extends PureComponent {
             error={confirmPasswordError}
             autoComplete="confirm-password"
             minLength={8}
-            maxLength={20}
-            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+            maxLength={50}
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
             margin="normal"
             fullWidth
             largeLabel

--- a/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -168,6 +168,8 @@ export default class NewAccount extends PureComponent {
         <form className="first-time-flow__form" onSubmit={this.handleCreate}>
           <TextField
             id="create-password"
+            name="create-password"
+            placeholder="New password"
             label={t('newPassword')}
             type="password"
             className="first-time-flow__input"
@@ -176,12 +178,15 @@ export default class NewAccount extends PureComponent {
             error={passwordError}
             autoFocus
             autoComplete="new-password"
+            passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
             margin="normal"
             fullWidth
             largeLabel
           />
           <TextField
             id="confirm-password"
+            name="confirm-password"
+            placeholder="Confirm password"
             label={t('confirmPassword')}
             type="password"
             className="first-time-flow__input"
@@ -191,6 +196,7 @@ export default class NewAccount extends PureComponent {
             }
             error={confirmPasswordError}
             autoComplete="confirm-password"
+            passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
             margin="normal"
             fullWidth
             largeLabel

--- a/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -178,7 +178,9 @@ export default class NewAccount extends PureComponent {
             error={passwordError}
             autoFocus
             autoComplete="new-password"
-            passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+            minLength={8}
+            maxLength={20}
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
             margin="normal"
             fullWidth
             largeLabel
@@ -196,7 +198,9 @@ export default class NewAccount extends PureComponent {
             }
             error={confirmPasswordError}
             autoComplete="confirm-password"
-            passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+            minLength={8}
+            maxLength={20}
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
             margin="normal"
             fullWidth
             largeLabel

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -227,8 +227,8 @@ class RestoreVaultPage extends Component {
               error={passwordError}
               autoComplete="new-password"
               minLength={8}
-              maxLength={20}
-              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+              maxLength={50}
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
               margin="normal"
               largeLabel
             />
@@ -246,8 +246,8 @@ class RestoreVaultPage extends Component {
               error={confirmPasswordError}
               autoComplete="confirm-password"
               minLength={8}
-              maxLength={20}
-              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+              maxLength={50}
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
               margin="normal"
               largeLabel
             />

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -228,7 +228,7 @@ class RestoreVaultPage extends Component {
               autoComplete="new-password"
               minLength={8}
               maxLength={20}
-              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
               margin="normal"
               largeLabel
             />
@@ -247,7 +247,7 @@ class RestoreVaultPage extends Component {
               autoComplete="confirm-password"
               minLength={8}
               maxLength={20}
-              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
               margin="normal"
               largeLabel
             />

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -226,7 +226,9 @@ class RestoreVaultPage extends Component {
               }
               error={passwordError}
               autoComplete="new-password"
-              passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+              minLength={8}
+              maxLength={20}
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
               margin="normal"
               largeLabel
             />
@@ -243,7 +245,9 @@ class RestoreVaultPage extends Component {
               }
               error={confirmPasswordError}
               autoComplete="confirm-password"
-              passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+              minLength={8}
+              maxLength={20}
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
               margin="normal"
               largeLabel
             />

--- a/ui/pages/keychains/restore-vault.js
+++ b/ui/pages/keychains/restore-vault.js
@@ -215,6 +215,8 @@ class RestoreVaultPage extends Component {
             </div>
             <TextField
               id="password"
+              name="password"
+              placeholder="New password"
               label={t('newPassword')}
               type="password"
               className="first-time-flow__input"
@@ -224,11 +226,14 @@ class RestoreVaultPage extends Component {
               }
               error={passwordError}
               autoComplete="new-password"
+              passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
               margin="normal"
               largeLabel
             />
             <TextField
               id="confirm-password"
+              name="confirm-password"
+              placeholder="Confirm password"
               label={t('confirmPassword')}
               type="password"
               className="first-time-flow__input"
@@ -238,6 +243,7 @@ class RestoreVaultPage extends Component {
               }
               error={confirmPasswordError}
               autoComplete="confirm-password"
+              passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
               margin="normal"
               largeLabel
             />

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -74,6 +74,8 @@ class RevealSeedPage extends Component {
             type="password"
             placeholder={t('password')}
             id="password-box"
+            name="password-box"
+            passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
             value={this.state.password}
             onChange={(event) =>
               this.setState({ password: event.target.value })

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -76,8 +76,8 @@ class RevealSeedPage extends Component {
             id="password-box"
             name="password-box"
             minLength={8}
-            maxLength={20}
-            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+            maxLength={50}
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
             value={this.state.password}
             onChange={(event) =>
               this.setState({ password: event.target.value })

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -77,7 +77,7 @@ class RevealSeedPage extends Component {
             name="password-box"
             minLength={8}
             maxLength={20}
-            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
             value={this.state.password}
             onChange={(event) =>
               this.setState({ password: event.target.value })

--- a/ui/pages/keychains/reveal-seed.js
+++ b/ui/pages/keychains/reveal-seed.js
@@ -75,7 +75,9 @@ class RevealSeedPage extends Component {
             placeholder={t('password')}
             id="password-box"
             name="password-box"
-            passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+            minLength={8}
+            maxLength={20}
+            pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
             value={this.state.password}
             onChange={(event) =>
               this.setState({ password: event.target.value })

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -164,7 +164,7 @@ export default class UnlockPage extends Component {
               autoComplete="current-password"
               minLength={8}
               maxLength={20}
-              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
               theme="material"
               fullWidth
             />

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -153,6 +153,8 @@ export default class UnlockPage extends Component {
           <form className="unlock-page__form" onSubmit={this.handleSubmit}>
             <TextField
               id="password"
+              name="password"
+              placeholder="Password"
               label={t('password')}
               type="password"
               value={password}
@@ -160,6 +162,7 @@ export default class UnlockPage extends Component {
               error={error}
               autoFocus
               autoComplete="current-password"
+              passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
               theme="material"
               fullWidth
             />

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -162,7 +162,9 @@ export default class UnlockPage extends Component {
               error={error}
               autoFocus
               autoComplete="current-password"
-              passwordrules="minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
+              minLength={8}
+              maxLength={20}
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]"
               theme="material"
               fullWidth
             />

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -163,8 +163,8 @@ export default class UnlockPage extends Component {
               autoFocus
               autoComplete="current-password"
               minLength={8}
-              maxLength={20}
-              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,20}"
+              maxLength={50}
+              pattern="[a-zA-Z0-9!#$%&'()*+,-.:;<=>?@^_`{|}~]{8,}"
               theme="material"
               fullWidth
             />


### PR DESCRIPTION
Fixes: #7355

**Explanation:**  

I did a little more research on this issue. I followed all the guidelines offered on the site https://support.1password.com/compatible-website-design/, but still the password field is incompatible with password managers.

I installed several password managers (RoboForm, 1Password, Dashlane, LastPass and Bitwarden) and on each I tested whether the password filed would be compatible with any of the password managers, but without success.

In each of these password managers it is impossible to do an auto-fill for the password field. Why it can't be done, my guess is, because password managers are extensions just like MetaMask and therefore can't recognize the password field. It doesn't support communication between extension and extension.

If you have any suggestions or additional information so that this problem can be solved, please let me know.

**Example:**


https://user-images.githubusercontent.com/92527393/141992267-05d525dd-ac20-40d1-86c3-4a8723e6b9c3.mp4


