### PR TITLE
Multi network refactor approach A

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -27,6 +27,7 @@ import getFetchWithTimeout from '../../../../shared/modules/fetch-with-timeout';
 import createMetamaskMiddleware from './createMetamaskMiddleware';
 import createInfuraClient from './createInfuraClient';
 import createJsonRpcClient from './createJsonRpcClient';
+import Network from './network2';
 
 const env = process.env.METAMASK_ENV;
 const fetchWithTimeout = getFetchWithTimeout(30000);
@@ -88,6 +89,13 @@ export default class NetworkController extends EventEmitter {
     this._blockTrackerProxy = null;
 
     this.on(NETWORK_EVENTS.NETWORK_DID_CHANGE, this.lookupNetwork);
+
+    /*
+     * type NetworkOps = { "type": string, "rpcUrl": string, "chainId": string };
+     * type Network = { "provider": Provider, "blockTracker": BlockTracker };
+     * type networks = Map<NetworkOps, Network>;
+     */
+    this.networks = new Map();
   }
 
   /**
@@ -108,7 +116,16 @@ export default class NetworkController extends EventEmitter {
   initializeProvider(providerParams) {
     this._baseProviderParams = providerParams;
     const { type, rpcUrl, chainId } = this.getProviderConfig();
-    this._configureProvider({ type, rpcUrl, chainId });
+    const networkOps = { type, rpcUrl, chainId };
+
+    const networkKey = this._networkKeyForOpts(networkOpts);
+    let network = this.networks.get(networkKey);
+    if (!network) {
+      const network = new Network({...networkOps, infuraProjectId: this.infuraProjectId});
+      this.networks.set(networkKey, network);
+    }
+
+    this._configureProvider(networkOps, network);
     this.lookupNetwork();
   }
 
@@ -297,34 +314,34 @@ export default class NetworkController extends EventEmitter {
     this.emit(NETWORK_EVENTS.NETWORK_DID_CHANGE, opts.type);
   }
 
-  _configureProvider({ type, rpcUrl, chainId }) {
-    // infura type-based endpoints
-    const isInfura = INFURA_PROVIDER_TYPES.includes(type);
-    if (isInfura) {
-      this._configureInfuraProvider(type, this._infuraProjectId);
-      // url-based rpc endpoints
-    } else if (type === NETWORK_TYPE_RPC) {
-      this._configureStandardProvider(rpcUrl, chainId);
-    } else {
-      throw new Error(
-        `NetworkController - _configureProvider - unknown type "${type}"`,
-      );
+  _configureProvider(networkOpts, network) {
+    const { type, rpcUrl, chainId } = networkOpts;
+
+    if (!network) {
+      network = new Network(networkOpts);
     }
+
+    return this._configureNetwork(network);
   }
 
-  _configureInfuraProvider(type, projectId) {
-    log.info('NetworkController - configureInfuraProvider', type);
-    const networkClient = createInfuraClient({
-      network: type,
-      projectId,
-    });
-    this._setNetworkClient(networkClient);
-  }
-
-  _configureStandardProvider(rpcUrl, chainId) {
-    log.info('NetworkController - configureStandardProvider', rpcUrl);
-    const networkClient = createJsonRpcClient({ rpcUrl, chainId });
-    this._setNetworkClient(networkClient);
+  _configureLegacyProxiesFromNetwork (network) {
+    const { provider, blockTracker } = network;
+    // update or intialize proxies
+    if (this._providerProxy) {
+      this._providerProxy.setTarget(provider);
+    } else {
+      this._providerProxy = createSwappableProxy(provider);
+    }
+    if (this._blockTrackerProxy) {
+      this._blockTrackerProxy.setTarget(blockTracker);
+    } else {
+      this._blockTrackerProxy = createEventEmitterProxy(blockTracker, {
+        eventFilter: 'skipInternal',
+      });
+    }
+    // set new provider and blockTracker
+    this._provider = provider;
+    this._blockTracker = blockTracker;
   }
 
   _setNetworkClient({ networkMiddleware, blockTracker }) {
@@ -356,4 +373,9 @@ export default class NetworkController extends EventEmitter {
     this._provider = provider;
     this._blockTracker = blockTracker;
   }
+
+  _networkKeyForOpts({ type, rpcUrl, chainId }) {
+    return JSON.stringify([ type, rpcUrl, chainId ]);
+  }
+
 }

--- a/app/scripts/controllers/network/network2.js
+++ b/app/scripts/controllers/network/network2.js
@@ -1,0 +1,203 @@
+import EventEmitter from 'events';
+import { strict as assert } from 'assert';
+import { JsonRpcEngine } from 'json-rpc-engine';
+import providerFromEngine from 'eth-json-rpc-middleware/providerFromEngine';
+import log from 'loglevel';
+import EthQuery from 'eth-query';
+import {
+  RINKEBY,
+  MAINNET,
+  INFURA_PROVIDER_TYPES,
+  NETWORK_TYPE_RPC,
+  NETWORK_TYPE_TO_ID_MAP,
+  MAINNET_CHAIN_ID,
+  RINKEBY_CHAIN_ID,
+  INFURA_BLOCKED_KEY,
+} from '../../../../shared/constants/network';
+import {
+  isPrefixedFormattedHexString,
+  isSafeChainId,
+} from '../../../../shared/modules/network.utils';
+import getFetchWithTimeout from '../../../../shared/modules/fetch-with-timeout';
+import createMetamaskMiddleware from './createMetamaskMiddleware';
+import createInfuraClient from './createInfuraClient';
+import createJsonRpcClient from './createJsonRpcClient';
+
+export const NETWORK_EVENTS = {
+  // Fired after the actively selected network is changed
+  NETWORK_DID_CHANGE: 'networkDidChange',
+  // Fired when the actively selected network *will* change
+  NETWORK_WILL_CHANGE: 'networkWillChange',
+  // Fired when Infura returns an error indicating no support
+  INFURA_IS_BLOCKED: 'infuraIsBlocked',
+  // Fired when not using an Infura network or when Infura returns no error, indicating support
+  INFURA_IS_UNBLOCKED: 'infuraIsUnblocked',
+};
+
+export default class Network extends EventEmitter {
+
+  // Designed to easily subsitute into the `initializeProvider` method,
+  // and then gradually replace all of the singular-network methods
+  // with instances of this.
+  constructor ({
+    type,
+    rpcUrl,
+    chainId,
+    infuraProjectId,
+    ticker,
+    nickname,
+    rpcPrefs,
+  }) {
+
+    this.type = type;
+    this.rpcUrl = rpcUrl;
+    this.chainId = chainId;
+    this.infuraProjectId = infuraProjectId;
+    this.ticker = ticker;
+    this.nickname = nickname;
+    this.rpcPrefs = rpcPrefs;
+    this.state = 'loading';
+
+    // infura type-based endpoints
+    const isInfura = INFURA_PROVIDER_TYPES.includes(type);
+    if (isInfura) {
+      this._configureInfuraProvider(type, this.infuraProjectId);
+      // url-based rpc endpoints
+    } else if (type === NETWORK_TYPE_RPC) {
+      this._configureStandardProvider(rpcUrl, chainId);
+    } else {
+      throw new Error(
+        `NetworkController - _configureProvider - unknown type "${type}"`,
+      );
+    }
+  }
+
+  _configureInfuraProvider(type, projectId) {
+    log.info('NetworkController - configureInfuraProvider', type);
+    const networkClient = createInfuraClient({
+      network: type,
+      projectId,
+    });
+    this._setNetworkClient(networkClient);
+  }
+
+  _configureStandardProvider(rpcUrl, chainId) {
+    log.info('NetworkController - configureStandardProvider', rpcUrl);
+    const networkClient = createJsonRpcClient({ rpcUrl, chainId });
+    this._setNetworkClient(networkClient);
+  }
+
+  _setNetworkClient({ networkMiddleware, blockTracker }) {
+    const metamaskMiddleware = createMetamaskMiddleware(
+      this._baseProviderParams,
+    );
+    const engine = new JsonRpcEngine();
+    engine.push(metamaskMiddleware);
+    engine.push(networkMiddleware);
+    const provider = providerFromEngine(engine);
+
+    this.provider = provider;
+    this.blockTracker = blockTracker;
+  }
+
+  validateNetwork() {
+    // Prevent firing when provider is not defined.
+    if (!this.provider) {
+      log.warn(
+        'NetworkController - lookupNetwork aborted due to missing provider',
+      );
+      return;
+    }
+
+    const chainId = this.chainId;
+    if (!chainId) {
+      log.warn(
+        'NetworkController - lookupNetwork aborted due to missing chainId',
+      );
+      this.state = 'loading';
+      return;
+    }
+
+    // Ping the RPC endpoint so we can confirm that it works
+    const ethQuery = new EthQuery(this.provider);
+    const initialNetwork = this.chainId;
+    const { type } = this.getProviderConfig();
+    const isInfura = INFURA_PROVIDER_TYPES.includes(type);
+
+    if (isInfura) {
+      this._checkInfuraAvailability(type);
+    } else {
+      this.emit(NETWORK_EVENTS.INFURA_IS_UNBLOCKED);
+    }
+
+    ethQuery.sendAsync({ method: 'net_version' }, (err, networkVersion) => {
+      if (initialNetwork === networkVersion) {
+        if (err) {
+          this.state = 'loading';
+          return;
+        }
+
+        this.state = networkVersion;
+      }
+    });
+  }
+
+  async _checkInfuraAvailability(network) {
+    const rpcUrl = `https://${network}.infura.io/v3/${this.infuraProjectId}`;
+
+    let networkChanged = false;
+    this.once(NETWORK_EVENTS.NETWORK_DID_CHANGE, () => {
+      networkChanged = true;
+    });
+
+    try {
+      const response = await fetchWithTimeout(rpcUrl, {
+        method: 'POST',
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'eth_blockNumber',
+          params: [],
+          id: 1,
+        }),
+      });
+
+      if (networkChanged) {
+        return;
+      }
+
+      if (response.ok) {
+        this.emit(NETWORK_EVENTS.INFURA_IS_UNBLOCKED);
+      } else {
+        const responseMessage = await response.json();
+        if (networkChanged) {
+          return;
+        }
+        if (responseMessage.error === INFURA_BLOCKED_KEY) {
+          this.emit(NETWORK_EVENTS.INFURA_IS_BLOCKED);
+        }
+      }
+    } catch (err) {
+      log.warn(`MetaMask - Infura availability check failed`, err);
+    }
+  }
+
+  setRpcTarget(rpcUrl, chainId, ticker = 'ETH', nickname = '', rpcPrefs) {
+    assert.ok(
+      isPrefixedFormattedHexString(chainId),
+      `Invalid chain ID "${chainId}": invalid hex string.`,
+    );
+    assert.ok(
+      isSafeChainId(parseInt(chainId, 16)),
+      `Invalid chain ID "${chainId}": numerical value greater than max safe value.`,
+    );
+    this.setProviderConfig({
+      type: NETWORK_TYPE_RPC,
+      rpcUrl,
+      chainId,
+      ticker,
+      nickname,
+      rpcPrefs,
+    });
+  }
+
+}


### PR DESCRIPTION
DO NOT MERGE!

A total proof of concept for beginning the multi-simultaneous network refactor, in two parts.

Network.js currently does this this clever work of swapping out properties on a pair of proxies, so it emulates having many networks while only maintaining one in memory. This refactor instead caches many evm-type networks, but strives to maintain a non-breaking interface based on the legacy proxy-swapping behavior, so that multi-network methods can be exposed as needed, without requiring a major refactor.

## 1. Refactor network initialization into reusable network objects

Mostly just moved code from the `network.js` controller to a new `network2.js`, which represents a single network, and modified network.js to reuse those network objects as cached instead of re-initializing them.


## 2. Add chain conditional provider to network controller

Allows a network controller consumer to include a chain_id and have the request routed to an appropriate provider if available, defaulting to the selected network.

## Notes

### BEWARE/TODO:
I am not persisting any state in this, this is not using the current controller architecture, as it's refactoring an old controller, and so for the proof of concept I didn't even use the old style storage. If we choose to go this path, it might be a good time to also upgrade this controller to the new patterns.

### Outstanding ambiguity problem

  There is of course a problem where the user may have many providers with a common chainId. We could approach this in a few ways:
  - Naively to start, just route to one.
  - Parameterize by networkKey, requiring much more specificity (not very dapp friendly to require knowing what provider source is being used)
  - Expose an additional method to allow users to specify the preferred network for a given chainId.
  - Allow users to select the preferred network when connecting to a dapp, and then just remember that networkKey, and route to that provider for that chainId.
  