### PR TITLE
Ensure proper transport type is set before attempting to connect ledger wallet

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -849,6 +849,10 @@ export default class MetamaskController extends EventEmitter {
         this.attemptLedgerTransportCreation,
         this,
       ),
+      establishLedgerTransportPreference: nodeify(
+        this.establishLedgerTransportPreference,
+        this,
+      ),
 
       // mobile
       fetchInfoToSync: nodeify(this.fetchInfoToSync, this),
@@ -1252,6 +1256,7 @@ export default class MetamaskController extends EventEmitter {
         this.preferencesController.setAddresses(addresses);
         this.selectFirstIdentity();
       }
+
       return vault;
     } finally {
       releaseLock();
@@ -1563,6 +1568,11 @@ export default class MetamaskController extends EventEmitter {
   async attemptLedgerTransportCreation() {
     const keyring = await this.getKeyringForDevice('ledger');
     return await keyring.attemptMakeApp();
+  }
+
+  async establishLedgerTransportPreference() {
+    const transportPreference = this.preferencesController.getLedgerTransportPreference();
+    return await this.setLedgerTransportPreference(transportPreference);
   }
 
   /**

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -409,6 +409,10 @@ export function connectHardware(deviceName, page, hdPath, t) {
     let accounts;
     try {
       const { ledgerTransportType } = getState().metamask;
+
+      if (deviceName === 'ledger') {
+        await promisifiedBackground.establishLedgerTransportPreference();
+      }
       if (
         deviceName === 'ledger' &&
         ledgerTransportType === LEDGER_TRANSPORT_TYPES.WEBHID

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -548,6 +548,8 @@ describe('Actions', () => {
         (_, __, ___, cb) => cb(),
       );
 
+      background.establishLedgerTransportPreference.callsFake((cb) => cb());
+
       actions._setBackgroundConnection(background);
 
       await store.dispatch(
@@ -562,6 +564,8 @@ describe('Actions', () => {
       background.connectHardware.callsFake((_, __, ___, cb) =>
         cb(new Error('error')),
       );
+
+      background.establishLedgerTransportPreference.callsFake((cb) => cb());
 
       actions._setBackgroundConnection(background);
 


### PR DESCRIPTION
Found during QA of v10.5.0

This ensures that the transport type preference save in state is set in the ledger bridge before attempting to connecting the ledger device