### PR TITLE
Throw, and not just display, ledgerDeviceOpenFailureMessage error

### DIFF
--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -441,6 +441,7 @@ export function connectHardware(deviceName, page, hdPath, t) {
         error.message.match('Failed to open the device')
       ) {
         dispatch(displayWarning(t('ledgerDeviceOpenFailureMessage')));
+        throw new Error(t('ledgerDeviceOpenFailureMessage'));
       } else {
         dispatch(displayWarning(error.message));
         throw error;


### PR DESCRIPTION
This should have been part of 12604.

Instead of the call to `connectHardware` resolving and attempting to get accounts in `connect-hardware/index.js`, an error should be thrown and handled by the catch logic in that file.