### PR TITLE
Onboarding v2 e2e test

### DIFF
--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -77,7 +77,10 @@ describe('Metamask Import UI', function () {
           );
 
           await driver.fill('#password', 'correct horse battery staple');
-          await driver.fill('#confirm-password', 'correct horse battery staple');
+          await driver.fill(
+            '#confirm-password',
+            'correct horse battery staple',
+          );
 
           await driver.clickElement('.first-time-flow__terms');
 
@@ -90,7 +93,7 @@ describe('Metamask Import UI', function () {
             tag: 'button',
           });
         }
-        
+
         // Show account information
         await driver.clickElement(
           '[data-testid="account-options-menu-button"]',

--- a/test/e2e/tests/from-import-ui.spec.js
+++ b/test/e2e/tests/from-import-ui.spec.js
@@ -27,39 +27,70 @@ describe('Metamask Import UI', function () {
       async ({ driver }) => {
         await driver.navigate();
 
-        // clicks the continue button on the welcome screen
-        await driver.findElement('.welcome-page__header');
-        await driver.clickElement({
-          text: enLocaleMessages.getStarted.message,
-          tag: 'button',
-        });
+        if (process.env.ONBOARDING_V2 === '1') {
+          // welcome
+          await driver.clickElement('[data-testid="onboarding-import-wallet"]');
 
-        // clicks the "Import Wallet" option
-        await driver.clickElement({ text: 'Import wallet', tag: 'button' });
+          // metrics
+          await driver.clickElement('[data-testid="metametrics-no-thanks"]');
 
-        // clicks the "No thanks" option on the metametrics opt-in screen
-        await driver.clickElement('.btn-secondary');
+          // import with recovery phrase
+          await driver.fill('[data-testid="import-srp-text"]', testSeedPhrase);
+          await driver.clickElement('[data-testid="import-srp-confirm"]');
 
-        // Import Secret Recovery Phrase
-        await driver.fill(
-          'input[placeholder="Paste Secret Recovery Phrase from clipboard"]',
-          testSeedPhrase,
-        );
+          // create password
+          await driver.fill(
+            '[data-testid="create-password-new"]',
+            'correct horse battery staple',
+          );
+          await driver.fill(
+            '[data-testid="create-password-confirm"]',
+            'correct horse battery staple',
+          );
+          await driver.clickElement('[data-testid="create-password-terms"]');
+          await driver.clickElement('[data-testid="create-password-import"]');
 
-        await driver.fill('#password', 'correct horse battery staple');
-        await driver.fill('#confirm-password', 'correct horse battery staple');
+          // complete
+          await driver.clickElement('[data-testid="onboarding-complete-done"]');
 
-        await driver.clickElement('.first-time-flow__terms');
+          // pin extension
+          await driver.clickElement('[data-testid="pin-extension-next"]');
+          await driver.clickElement('[data-testid="pin-extension-done"]');
+        } else {
+          // clicks the continue button on the welcome screen
+          await driver.findElement('.welcome-page__header');
+          await driver.clickElement({
+            text: enLocaleMessages.getStarted.message,
+            tag: 'button',
+          });
 
-        await driver.clickElement({ text: 'Import', tag: 'button' });
+          // clicks the "Import Wallet" option
+          await driver.clickElement({ text: 'Import wallet', tag: 'button' });
 
-        // clicks through the success screen
-        await driver.findElement({ text: 'Congratulations', tag: 'div' });
-        await driver.clickElement({
-          text: enLocaleMessages.endOfFlowMessage10.message,
-          tag: 'button',
-        });
+          // clicks the "No thanks" option on the metametrics opt-in screen
+          await driver.clickElement('.btn-secondary');
 
+          // Import Secret Recovery Phrase
+          await driver.fill(
+            'input[placeholder="Paste Secret Recovery Phrase from clipboard"]',
+            testSeedPhrase,
+          );
+
+          await driver.fill('#password', 'correct horse battery staple');
+          await driver.fill('#confirm-password', 'correct horse battery staple');
+
+          await driver.clickElement('.first-time-flow__terms');
+
+          await driver.clickElement({ text: 'Import', tag: 'button' });
+
+          // clicks through the success screen
+          await driver.findElement({ text: 'Congratulations', tag: 'div' });
+          await driver.clickElement({
+            text: enLocaleMessages.endOfFlowMessage10.message,
+            tag: 'button',
+          });
+        }
+        
         // Show account information
         await driver.clickElement(
           '[data-testid="account-options-menu-button"]',

--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -16,77 +16,125 @@ describe('Metamask Responsive UI', function () {
       async ({ driver }) => {
         await driver.navigate();
 
-        // clicks the continue button on the welcome screen
-        await driver.findElement('.welcome-page__header');
-        await driver.clickElement({
-          text: enLocaleMessages.getStarted.message,
-          tag: 'button',
-        });
-        await driver.delay(tinyDelayMs);
+        if (process.env.ONBOARDING_V2 === '1') {
+          // welcome
+          await driver.clickElement('[data-testid="onboarding-create-wallet"]');
 
-        // clicks the "Create New Wallet" option
-        await driver.clickElement({ text: 'Create a Wallet', tag: 'button' });
+          // metrics
+          await driver.clickElement('[data-testid="metametrics-no-thanks"]');
 
-        // clicks the "I Agree" option on the metametrics opt-in screen
-        await driver.clickElement('.btn-primary');
-
-        // accepts a secure password
-        await driver.fill(
-          '.first-time-flow__form #create-password',
-          'correct horse battery staple',
-        );
-        await driver.fill(
-          '.first-time-flow__form #confirm-password',
-          'correct horse battery staple',
-        );
-        await driver.clickElement('.first-time-flow__checkbox');
-        await driver.clickElement('.first-time-flow__form button');
-
-        // renders the Secret Recovery Phrase intro screen
-        await driver.clickElement('.seed-phrase-intro__left button');
-
-        // reveals the Secret Recovery Phrase
-        await driver.clickElement(
-          '.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button',
-        );
-        const revealedSeedPhrase = await driver.findElement(
-          '.reveal-seed-phrase__secret-words',
-        );
-        const seedPhrase = await revealedSeedPhrase.getText();
-        assert.equal(seedPhrase.split(' ').length, 12);
-
-        await driver.clickElement({
-          text: enLocaleMessages.next.message,
-          tag: 'button',
-        });
-
-        async function clickWordAndWait(word) {
-          await driver.clickElement(
-            `[data-testid="seed-phrase-sorted"] [data-testid="draggable-seed-${word}"]`,
+          // create password
+          await driver.fill(
+            '[data-testid="create-password-new"]',
+            'correct horse battery staple',
           );
+          await driver.fill(
+            '[data-testid="create-password-confirm"]',
+            'correct horse battery staple',
+          );
+          await driver.clickElement('[data-testid="create-password-terms"]');
+          await driver.clickElement('[data-testid="create-password-wallet"]');
+
+          // secure wallet
+          await driver.clickElement('[data-testid="secure-wallet-recommended"]');
+
+          // review
+          await driver.clickElement('[data-testid="recovery-phrase-reveal"]');
+          const chipTwo = await (
+            await driver.findElement('[data-testid="recovery-phrase-chip-2"]')
+          ).getText();
+          const chipThree = await (
+            await driver.findElement('[data-testid="recovery-phrase-chip-3"]')
+          ).getText();
+          const chipSeven = await (
+            await driver.findElement('[data-testid="recovery-phrase-chip-7"]')
+          ).getText();
+          await driver.clickElement('[data-testid="recovery-phrase-next"]');
+
+          // confirm
+          await driver.fill('[data-testid="recovery-phrase-input-2"]', chipTwo);
+          await driver.fill('[data-testid="recovery-phrase-input-3"]', chipThree);
+          await driver.fill('[data-testid="recovery-phrase-input-7"]', chipSeven);
+          await driver.clickElement('[data-testid="recovery-phrase-confirm"]');
+
+          // complete
+          await driver.clickElement('[data-testid="onboarding-complete-done"]');
+
+          // pin extension
+          await driver.clickElement('[data-testid="pin-extension-next"]');
+          await driver.clickElement('[data-testid="pin-extension-done"]');
+        } else {
+          // clicks the continue button on the welcome screen
+          await driver.findElement('.welcome-page__header');
+          await driver.clickElement({
+            text: enLocaleMessages.getStarted.message,
+            tag: 'button',
+          });
           await driver.delay(tinyDelayMs);
+
+          // clicks the "Create New Wallet" option
+          await driver.clickElement({ text: 'Create a Wallet', tag: 'button' });
+
+          // clicks the "I Agree" option on the metametrics opt-in screen
+          await driver.clickElement('.btn-primary');
+
+          // accepts a secure password
+          await driver.fill(
+            '.first-time-flow__form #create-password',
+            'correct horse battery staple',
+          );
+          await driver.fill(
+            '.first-time-flow__form #confirm-password',
+            'correct horse battery staple',
+          );
+          await driver.clickElement('.first-time-flow__checkbox');
+          await driver.clickElement('.first-time-flow__form button');
+
+          // renders the Secret Recovery Phrase intro screen
+          await driver.clickElement('.seed-phrase-intro__left button');
+
+          // reveals the Secret Recovery Phrase
+          await driver.clickElement(
+            '.reveal-seed-phrase__secret-blocker .reveal-seed-phrase__reveal-button',
+          );
+          const revealedSeedPhrase = await driver.findElement(
+            '.reveal-seed-phrase__secret-words',
+          );
+          const seedPhrase = await revealedSeedPhrase.getText();
+          assert.equal(seedPhrase.split(' ').length, 12);
+
+          await driver.clickElement({
+            text: enLocaleMessages.next.message,
+            tag: 'button',
+          });
+
+          async function clickWordAndWait(word) {
+            await driver.clickElement(
+              `[data-testid="seed-phrase-sorted"] [data-testid="draggable-seed-${word}"]`,
+            );
+            await driver.delay(tinyDelayMs);
+          }
+
+          // can retype the Secret Recovery Phrase
+          const words = seedPhrase.split(' ');
+          for (const word of words) {
+            await clickWordAndWait(word);
+          }
+          await driver.clickElement({ text: 'Confirm', tag: 'button' });
+
+          // clicks through the success screen
+          await driver.findElement({ text: 'Congratulations', tag: 'div' });
+          await driver.clickElement({
+            text: enLocaleMessages.endOfFlowMessage10.message,
+            tag: 'button',
+          });
         }
 
-        // can retype the Secret Recovery Phrase
-        const words = seedPhrase.split(' ');
-        for (const word of words) {
-          await clickWordAndWait(word);
-        }
-        await driver.clickElement({ text: 'Confirm', tag: 'button' });
-
-        // clicks through the success screen
-        await driver.findElement({ text: 'Congratulations', tag: 'div' });
-        await driver.clickElement({
-          text: enLocaleMessages.endOfFlowMessage10.message,
-          tag: 'button',
-        });
-
-        // Show account information
-        // balance renders
-        await driver.waitForSelector({
-          css: '[data-testid="eth-overview__primary-currency"]',
-          text: '0 ETH',
-        });
+        // assert balance
+        const balance = await driver.findElement(
+          '[data-testid="wallet-balance"]',
+        );
+        assert.ok(/^0\sETH$/u.test(await balance.getText()));
       },
     );
   });

--- a/test/e2e/tests/metamask-responsive-ui.spec.js
+++ b/test/e2e/tests/metamask-responsive-ui.spec.js
@@ -16,6 +16,13 @@ describe('Metamask Responsive UI', function () {
       async ({ driver }) => {
         await driver.navigate();
 
+        async function clickWordAndWait(word) {
+          await driver.clickElement(
+            `[data-testid="seed-phrase-sorted"] [data-testid="draggable-seed-${word}"]`,
+          );
+          await driver.delay(tinyDelayMs);
+        }
+
         if (process.env.ONBOARDING_V2 === '1') {
           // welcome
           await driver.clickElement('[data-testid="onboarding-create-wallet"]');
@@ -36,7 +43,9 @@ describe('Metamask Responsive UI', function () {
           await driver.clickElement('[data-testid="create-password-wallet"]');
 
           // secure wallet
-          await driver.clickElement('[data-testid="secure-wallet-recommended"]');
+          await driver.clickElement(
+            '[data-testid="secure-wallet-recommended"]',
+          );
 
           // review
           await driver.clickElement('[data-testid="recovery-phrase-reveal"]');
@@ -53,8 +62,14 @@ describe('Metamask Responsive UI', function () {
 
           // confirm
           await driver.fill('[data-testid="recovery-phrase-input-2"]', chipTwo);
-          await driver.fill('[data-testid="recovery-phrase-input-3"]', chipThree);
-          await driver.fill('[data-testid="recovery-phrase-input-7"]', chipSeven);
+          await driver.fill(
+            '[data-testid="recovery-phrase-input-3"]',
+            chipThree,
+          );
+          await driver.fill(
+            '[data-testid="recovery-phrase-input-7"]',
+            chipSeven,
+          );
           await driver.clickElement('[data-testid="recovery-phrase-confirm"]');
 
           // complete
@@ -107,13 +122,6 @@ describe('Metamask Responsive UI', function () {
             text: enLocaleMessages.next.message,
             tag: 'button',
           });
-
-          async function clickWordAndWait(word) {
-            await driver.clickElement(
-              `[data-testid="seed-phrase-sorted"] [data-testid="draggable-seed-${word}"]`,
-            );
-            await driver.delay(tinyDelayMs);
-          }
 
           // can retype the Secret Recovery Phrase
           const words = seedPhrase.split(' ');

--- a/ui/components/ui/chip/chip-with-input.js
+++ b/ui/components/ui/chip/chip-with-input.js
@@ -5,6 +5,7 @@ import { COLORS } from '../../../helpers/constants/design-system';
 import Chip from '.';
 
 export function ChipWithInput({
+  dataTestId,
   className,
   borderColor = COLORS.UI1,
   inputValue,
@@ -17,6 +18,7 @@ export function ChipWithInput({
     >
       {setInputValue && (
         <input
+          data-testid={dataTestId}
           type="text"
           className="chip__input"
           onChange={(e) => {
@@ -30,6 +32,7 @@ export function ChipWithInput({
 }
 
 ChipWithInput.propTypes = {
+  dataTestId: PropTypes.string,
   borderColor: PropTypes.oneOf(Object.values(COLORS)),
   className: PropTypes.string,
   inputValue: PropTypes.string,

--- a/ui/components/ui/chip/chip.js
+++ b/ui/components/ui/chip/chip.js
@@ -6,6 +6,7 @@ import Typography from '../typography';
 import { COLORS, TYPOGRAPHY } from '../../../helpers/constants/design-system';
 
 export default function Chip({
+  dataTestId,
   className,
   children,
   borderColor = COLORS.UI1,
@@ -25,6 +26,7 @@ export default function Chip({
 
   return (
     <div
+      data-testid={dataTestId}
       onClick={onClick}
       onKeyPress={onKeyPress}
       className={classnames(className, 'chip', {
@@ -53,6 +55,7 @@ export default function Chip({
 }
 
 Chip.propTypes = {
+  dataTestId: PropTypes.string,
   borderColor: PropTypes.oneOf(Object.values(COLORS)),
   label: PropTypes.string,
   children: PropTypes.node,

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -16,6 +16,7 @@ import NumericInput from '../numeric-input/numeric-input.component';
 import InfoTooltip from '../info-tooltip/info-tooltip';
 
 export default function FormField({
+  dataTestId,
   titleText,
   titleUnit,
   tooltipText,
@@ -94,6 +95,7 @@ export default function FormField({
             type={password ? 'password' : 'text'}
             autoFocus={autoFocus}
             disabled={disabled}
+            data-testid={dataTestId}
           />
         )}
         {error && (
@@ -111,6 +113,7 @@ export default function FormField({
 }
 
 FormField.propTypes = {
+  dataTestId: PropTypes.string,
   titleText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   titleUnit: PropTypes.string,
   tooltipText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/ui/pages/onboarding-flow/create-password/create-password.js
+++ b/ui/pages/onboarding-flow/create-password/create-password.js
@@ -131,6 +131,7 @@ export default function CreatePassword({
       >
         <form className="create-password__form" onSubmit={handleCreate}>
           <FormField
+            dataTestId="create-password-new"
             autoFocus
             error={passwordError}
             onChange={handlePasswordChange}
@@ -151,6 +152,7 @@ export default function CreatePassword({
             }
           />
           <FormField
+            dataTestId="create-password-confirm"
             onChange={handleConfirmPasswordChange}
             password={!showPassword}
             error={confirmPasswordError}
@@ -170,6 +172,7 @@ export default function CreatePassword({
             marginBottom={4}
           >
             <CheckBox
+              dataTestId="create-password-terms"
               onClick={() => setTermsChecked(!termsChecked)}
               checked={termsChecked}
             />
@@ -190,6 +193,11 @@ export default function CreatePassword({
             </Typography>
           </Box>
           <Button
+            data-testid={
+              secretRecoveryPhrase
+                ? 'create-password-import'
+                : 'create-password-wallet'
+            }
             type="primary"
             className="create-password__form--submit-button"
             disabled={!isValid || !termsChecked}

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.js
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.js
@@ -96,7 +96,13 @@ export default function CreationSuccessful() {
         >
           {t('setAdvancedPrivacySettings')}
         </Button>
-        <Button type="primary" large rounded onClick={onComplete}>
+        <Button
+          data-testid="onboarding-complete-done"
+          type="primary"
+          large
+          rounded
+          onClick={onComplete}
+        >
           {t('done')}
         </Button>
       </Box>

--- a/ui/pages/onboarding-flow/import-srp/import-srp.js
+++ b/ui/pages/onboarding-flow/import-srp/import-srp.js
@@ -78,6 +78,7 @@ export default function ImportSRP({ submitSecretRecoveryPhrase }) {
               />
             </button>
             <textarea
+              data-testid="import-srp-text"
               className={classnames('srp-text-area__textarea', {
                 'srp-text-area__textarea--blur': !revealSRP,
                 'srp-text-area__textarea--error': error,
@@ -96,6 +97,7 @@ export default function ImportSRP({ submitSecretRecoveryPhrase }) {
           </div>
           <Button
             type="primary"
+            data-testid="import-srp-confirm"
             large
             onClick={() => {
               submitSecretRecoveryPhrase(secretRecoveryPhrase);

--- a/ui/pages/onboarding-flow/metametrics/metametrics.js
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.js
@@ -140,10 +140,18 @@ export default function OnboardingMetametrics() {
         ])}
       </Typography>
       <div className="onboarding-metametrics__buttons">
-        <Button type="secondary" onClick={onCancel}>
+        <Button
+          data-testid="metametrics-no-thanks"
+          type="secondary"
+          onClick={onCancel}
+        >
           {t('noThanks')}
         </Button>
-        <Button type="primary" onClick={onConfirm}>
+        <Button
+          data-testid="metametrics-i-agree"
+          type="primary"
+          onClick={onConfirm}
+        >
           {t('affirmAgree')}
         </Button>
       </div>

--- a/ui/pages/onboarding-flow/pin-extension/pin-extension.js
+++ b/ui/pages/onboarding-flow/pin-extension/pin-extension.js
@@ -58,6 +58,9 @@ export default function OnboardingPinExtension() {
       </Carousel>
       <div className="onboarding-pin-extension__buttons">
         <Button
+          data-testid={
+            selectedIndex === 0 ? 'pin-extension-next' : 'pin-extension-done'
+          }
           type="primary"
           onClick={() => {
             if (selectedIndex === 0) {

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
@@ -83,6 +83,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
       />
       <div className="recovery-phrase__footer">
         <Button
+          data-testid="recovery-phrase-confirm"
           type="primary"
           className="recovery-phrase__footer--button"
           onClick={() => {

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.js
@@ -36,6 +36,7 @@ export default function RecoveryPhraseChips({
       className="recovery-phrase__secret"
     >
       <div
+        data-testid="recovery-phrase-chips"
         className={classnames('recovery-phrase__chips', {
           'recovery-phrase__chips--hidden': hideSeedPhrase,
         })}
@@ -52,6 +53,7 @@ export default function RecoveryPhraseChips({
                   {`${index + 1}.`}
                 </div>
                 <ChipWithInput
+                  dataTestId={`recovery-phrase-input-${index}`}
                   borderColor={COLORS.PRIMARY1}
                   className="recovery-phrase__chip--with-input"
                   inputValue={inputValue[index]}
@@ -67,7 +69,11 @@ export default function RecoveryPhraseChips({
               <div className="recovery-phrase__chip-item__number">
                 {`${index + 1}.`}
               </div>
-              <Chip className="recovery-phrase__chip" borderColor={COLORS.UI3}>
+              <Chip
+                dataTestId={`recovery-phrase-chip-${index}`}
+                className="recovery-phrase__chip"
+                borderColor={COLORS.UI3}
+              >
                 {word}
               </Chip>
             </div>

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.js
@@ -96,6 +96,7 @@ export default function RecoveryPhrase({ secretRecoveryPhrase }) {
               {copied ? t('copiedExclamation') : t('copyToClipboard')}
             </Button>
             <Button
+              data-testid="recovery-phrase-next"
               type="primary"
               className="recovery-phrase__footer--button"
               onClick={() => {
@@ -107,6 +108,7 @@ export default function RecoveryPhrase({ secretRecoveryPhrase }) {
           </div>
         ) : (
           <Button
+            data-testid="recovery-phrase-reveal"
             type="primary"
             className="recovery-phrase__footer--button"
             onClick={() => {

--- a/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/secure-your-wallet.js
@@ -103,6 +103,7 @@ export default function SecureYourWallet() {
         className="secure-your-wallet__actions"
       >
         <Button
+          data-testid="secure-wallet-later"
           type="secondary"
           rounded
           large
@@ -110,7 +111,13 @@ export default function SecureYourWallet() {
         >
           {t('seedPhraseIntroNotRecommendedButtonCopy')}
         </Button>
-        <Button type="primary" rounded large onClick={handleClickRecommended}>
+        <Button
+          data-testid="secure-wallet-recommended"
+          type="primary"
+          rounded
+          large
+          onClick={handleClickRecommended}
+        >
           {t('seedPhraseIntroRecommendedButtonCopy')}
         </Button>
       </Box>

--- a/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
+++ b/ui/pages/onboarding-flow/secure-your-wallet/skip-srp-backup-popover.js
@@ -33,6 +33,7 @@ export default function SkipSRPBackup({ handleClose }) {
             {t('goBack')}
           </Button>
           <Button
+            data-testid="skip-srp-backup"
             disabled={!checked}
             type="primary"
             rounded

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -96,12 +96,20 @@ export default function OnboardingWelcome() {
       </Carousel>
       <ul className="onboarding-welcome__buttons">
         <li>
-          <Button type="primary" onClick={onCreateClick}>
+          <Button
+            data-testid="onboarding-create-wallet"
+            type="primary"
+            onClick={onCreateClick}
+          >
             {t('onboardingCreateWallet')}
           </Button>
         </li>
         <li>
-          <Button type="secondary" onClick={onImportClick}>
+          <Button
+            data-testid="onboarding-import-wallet"
+            type="secondary"
+            onClick={onImportClick}
+          >
             {t('onboardingImportWallet')}
           </Button>
         </li>


### PR DESCRIPTION
Explanation:  Onboarding e2e tests
Add data-testid's to elements in the onboarding flow
Updated the following tests to support Onboarding V2
- included:
  -  from-import-ui.spec.js 
  -  metamask-responsive-ui.spec.js 
- excluded;
  - incremental-security.spec.js
  - metamask-ui.spec.js 

Manual testing steps:  
  - build the extension and run included tests above with environment variable ONBOARDING_V2=1 
<img width="1081" alt="onboarding v2" src="https://user-images.githubusercontent.com/53189696/141136160-2285968a-6fed-4275-b3e9-91b729535de1.png">

  - build the extension and run included tests above without environment variable ONBOARDING_V2
<img width="1077" alt="onboarding" src="https://user-images.githubusercontent.com/53189696/141136209-57675f4f-306a-4b1c-8490-6d91cccf3133.png">
  