### PR TITLE
Fixing MetaFox logo display on Approval Screen in full width

### DIFF
--- a/ui/pages/confirm-approve/confirm-approve-content/index.scss
+++ b/ui/pages/confirm-approve/confirm-approve-content/index.scss
@@ -27,6 +27,18 @@
     position: absolute;
   }
 
+  &__metafoxlogo {
+    .app-header {
+      &__metafox-logo--horizontal {
+        display: none;
+      }
+
+      &__metafox-logo--icon {
+        display: block;
+      }
+    }
+  }
+
   &__siteinfo {
     left: 39px;
   }


### PR DESCRIPTION
Before: 
<img width="488" alt="Screen Shot 2021-11-10 at 6 36 12 PM" src="https://user-images.githubusercontent.com/8732757/141223046-8fffa39c-2662-4799-85fb-ca9697b92d3f.png">

After
<img width="1472" alt="Screen Shot 2021-11-10 at 6 45 24 PM" src="https://user-images.githubusercontent.com/8732757/141223099-ff2fb751-f5ff-4857-9453-3d526f75bf3b.png">
:
