### PR TITLE
shared/modules/hexstring-utils - replace ethereumjs-util with hexstring-utils

### DIFF
--- a/app/scripts/account-import-strategies/account-import-strategies.test.js
+++ b/app/scripts/account-import-strategies/account-import-strategies.test.js
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { stripHexPrefix } from 'ethereumjs-util';
+import { stripHexPrefix } from '../../../shared/modules/hexstring-utils';
 import accountImporter from '.';
 
 describe('Account Import Strategies', function () {

--- a/app/scripts/account-import-strategies/index.js
+++ b/app/scripts/account-import-strategies/index.js
@@ -5,9 +5,9 @@ import {
   toBuffer,
   isValidPrivate,
   bufferToHex,
+  addHexPrefix,
   stripHexPrefix,
-} from 'ethereumjs-util';
-import { addHexPrefix } from '../lib/util';
+} from '../../../shared/modules/hexstring-utils';
 
 const accountImporter = {
   importAccount(strategy, args) {

--- a/app/scripts/controllers/incoming-transactions.js
+++ b/app/scripts/controllers/incoming-transactions.js
@@ -2,7 +2,7 @@ import { ObservableStore } from '@metamask/obs-store';
 import log from 'loglevel';
 import BN from 'bn.js';
 import createId from '../../../shared/modules/random-id';
-import { bnToHex } from '../lib/util';
+import { bnToHex } from '../../../shared/modules/hexstring-utils';
 import getFetchWithTimeout from '../../../shared/modules/fetch-with-timeout';
 
 import {

--- a/app/scripts/controllers/metametrics.js
+++ b/app/scripts/controllers/metametrics.js
@@ -1,6 +1,6 @@
 import { merge, omit } from 'lodash';
 import { ObservableStore } from '@metamask/obs-store';
-import { bufferToHex, keccak } from 'ethereumjs-util';
+import { bufferToHex, keccak } from '../../../shared/modules/hexstring-utils';
 import { ENVIRONMENT_TYPE_BACKGROUND } from '../../../shared/constants/app';
 import {
   METAMETRICS_ANONYMOUS_ID,

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -1,6 +1,5 @@
 import EventEmitter from 'safe-event-emitter';
 import { ObservableStore } from '@metamask/obs-store';
-import { bufferToHex, keccak, toBuffer, isHexString } from 'ethereumjs-util';
 import EthQuery from 'ethjs-query';
 import { ethErrors } from 'eth-rpc-errors';
 import abi from 'human-standard-token-abi';
@@ -11,13 +10,7 @@ import NonceTracker from 'nonce-tracker';
 import log from 'loglevel';
 import BigNumber from 'bignumber.js';
 import cleanErrorStack from '../../lib/cleanErrorStack';
-import {
-  hexToBn,
-  bnToHex,
-  BnMultiplyByFraction,
-  addHexPrefix,
-  getChainType,
-} from '../../lib/util';
+import { BnMultiplyByFraction, getChainType } from '../../lib/util';
 import { TRANSACTION_NO_CONTRACT_ERROR_KEY } from '../../../../ui/helpers/constants/error-keys';
 import { getSwapsTokensReceivedFromTxMeta } from '../../../../ui/pages/swaps/swaps.util';
 import { hexWEIToDecGWEI } from '../../../../ui/helpers/utils/conversions.util';
@@ -41,6 +34,15 @@ import {
   NETWORK_TYPE_RPC,
   CHAIN_ID_TO_GAS_LIMIT_BUFFER_MAP,
 } from '../../../../shared/constants/network';
+import {
+  hexToBn,
+  bnToHex,
+  bufferToHex,
+  toBuffer,
+  addHexPrefix,
+  keccak,
+  isHexString,
+} from '../../../../shared/modules/hexstring-utils';
 import { isEIP1559Transaction } from '../../../../shared/modules/transaction.utils';
 import { readAddressAsContract } from '../../../../shared/modules/contract-utils';
 import TransactionStateManager from './tx-state-manager';

--- a/app/scripts/controllers/transactions/index.test.js
+++ b/app/scripts/controllers/transactions/index.test.js
@@ -1,9 +1,9 @@
 import { strict as assert } from 'assert';
 import EventEmitter from 'events';
-import { toBuffer } from 'ethereumjs-util';
 import { TransactionFactory } from '@ethereumjs/tx';
 import { ObservableStore } from '@metamask/obs-store';
 import sinon from 'sinon';
+import { toBuffer } from '../../../../shared/modules/buffer-utils';
 
 import {
   createTestProviderTools,

--- a/app/scripts/controllers/transactions/lib/util.js
+++ b/app/scripts/controllers/transactions/lib/util.js
@@ -1,11 +1,13 @@
 import { ethErrors } from 'eth-rpc-errors';
-import { addHexPrefix } from '../../../lib/util';
 import {
   TRANSACTION_ENVELOPE_TYPES,
   TRANSACTION_STATUSES,
 } from '../../../../../shared/constants/transaction';
 import { isEIP1559Transaction } from '../../../../../shared/modules/transaction.utils';
-import { isValidHexAddress } from '../../../../../shared/modules/hexstring-utils';
+import {
+  isValidHexAddress,
+  addHexPrefix,
+} from '../../../../../shared/modules/hexstring-utils';
 
 const normalizers = {
   from: addHexPrefix,

--- a/app/scripts/controllers/transactions/tx-gas-utils.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.js
@@ -1,8 +1,12 @@
 import EthQuery from 'ethjs-query';
 import log from 'loglevel';
-import { addHexPrefix } from 'ethereumjs-util';
 import { cloneDeep } from 'lodash';
-import { hexToBn, BnMultiplyByFraction, bnToHex } from '../../lib/util';
+import {
+  addHexPrefix,
+  hexToBn,
+  bnToHex,
+} from '../../../../shared/modules/hexstring-utils';
+import { BnMultiplyByFraction } from '../../lib/util';
 
 /**
  * Result of gas analysis, including either a gas estimate for a successful analysis, or

--- a/app/scripts/controllers/transactions/tx-gas-utils.test.js
+++ b/app/scripts/controllers/transactions/tx-gas-utils.test.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { TransactionFactory } from '@ethereumjs/tx';
 import Common from '@ethereumjs/common';
-import { hexToBn, bnToHex } from '../../lib/util';
+import { hexToBn, bnToHex } from '../../../../shared/modules/hexstring-utils';
 import TxUtils from './tx-gas-utils';
 
 describe('txUtils', function () {

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -27,7 +27,7 @@ import {
   SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN,
   SINGLE_CALL_BALANCES_ADDRESS_KOVAN,
 } from '../constants/contracts';
-import { bnToHex } from './util';
+import { bnToHex } from '../../../shared/modules/hexstring-utils';
 
 /**
  * This module is responsible for tracking any number of accounts and caching their current balances & transaction

--- a/app/scripts/lib/decrypt-message-manager.js
+++ b/app/scripts/lib/decrypt-message-manager.js
@@ -1,12 +1,15 @@
 import EventEmitter from 'events';
 import { ObservableStore } from '@metamask/obs-store';
-import { bufferToHex, stripHexPrefix } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import log from 'loglevel';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
-import { addHexPrefix } from './util';
+import {
+  addHexPrefix,
+  bufferToHex,
+  stripHexPrefix,
+} from '../../../shared/modules/hexstring-utils';
 
 const hexRe = /^[0-9A-Fa-f]+$/gu;
 

--- a/app/scripts/lib/message-manager.js
+++ b/app/scripts/lib/message-manager.js
@@ -1,10 +1,10 @@
 import EventEmitter from 'events';
 import { ObservableStore } from '@metamask/obs-store';
-import { bufferToHex } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
+import { bufferToHex } from '../../../shared/modules/hexstring-utils';
 
 /**
  * Represents, and contains data about, an 'eth_sign' type signature request. These are created when a signature for

--- a/app/scripts/lib/personal-message-manager.js
+++ b/app/scripts/lib/personal-message-manager.js
@@ -1,12 +1,15 @@
 import EventEmitter from 'events';
 import { ObservableStore } from '@metamask/obs-store';
-import { bufferToHex, stripHexPrefix } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import log from 'loglevel';
 import { MESSAGE_TYPE } from '../../../shared/constants/app';
 import { METAMASK_CONTROLLER_EVENTS } from '../metamask-controller';
 import createId from '../../../shared/modules/random-id';
-import { addHexPrefix } from './util';
+import {
+  addHexPrefix,
+  bufferToHex,
+  stripHexPrefix,
+} from '../../../shared/modules/hexstring-utils';
 
 const hexRe = /^[0-9A-Fa-f]+$/gu;
 

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -1,5 +1,4 @@
 import extension from 'extensionizer';
-import { stripHexPrefix } from 'ethereumjs-util';
 import BN from 'bn.js';
 import { memoize } from 'lodash';
 import {
@@ -73,17 +72,6 @@ const getPlatform = () => {
 };
 
 /**
- * Converts a hex string to a BN object
- *
- * @param {string} inputHex - A number represented as a hex string
- * @returns {Object} A BN object
- *
- */
-function hexToBn(inputHex) {
-  return new BN(stripHexPrefix(inputHex), 16);
-}
-
-/**
  * Used to multiply a BN by a fraction
  *
  * @param {BN} targetBN - The number to multiply by a fraction
@@ -116,39 +104,6 @@ function checkForError() {
   return new Error(lastError.message);
 }
 
-/**
- * Prefixes a hex string with '0x' or '-0x' and returns it. Idempotent.
- *
- * @param {string} str - The string to prefix.
- * @returns {string} The prefixed string.
- */
-const addHexPrefix = (str) => {
-  if (typeof str !== 'string' || str.match(/^-?0x/u)) {
-    return str;
-  }
-
-  if (str.match(/^-?0X/u)) {
-    return str.replace('0X', '0x');
-  }
-
-  if (str.startsWith('-')) {
-    return str.replace('-', '-0x');
-  }
-
-  return `0x${str}`;
-};
-
-/**
- * Converts a BN object to a hex string with a '0x' prefix
- *
- * @param {BN} inputBn - The BN to convert to a hex string
- * @returns {string} - A '0x' prefixed hex string
- *
- */
-function bnToHex(inputBn) {
-  return addHexPrefix(inputBn.toString(16));
-}
-
 function getChainType(chainId) {
   if (chainId === MAINNET_CHAIN_ID) {
     return 'mainnet';
@@ -161,10 +116,7 @@ function getChainType(chainId) {
 export {
   getPlatform,
   getEnvironmentType,
-  hexToBn,
   BnMultiplyByFraction,
   checkForError,
-  addHexPrefix,
-  bnToHex,
   getChainType,
 };

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -37,7 +37,10 @@ import {
 import { MAINNET_CHAIN_ID } from '../../shared/constants/network';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
 import { UI_NOTIFICATIONS } from '../../shared/notifications';
-import { toChecksumHexAddress, stripHexPrefix } from '../../shared/modules/hexstring-utils';
+import {
+  toChecksumHexAddress,
+  stripHexPrefix,
+} from '../../shared/modules/hexstring-utils';
 import { MILLISECOND } from '../../shared/constants/time';
 import { POLLING_TOKEN_ENVIRONMENT_TYPES } from '../../shared/constants/app';
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -10,7 +10,6 @@ import createSubscriptionManager from 'eth-json-rpc-filters/subscriptionManager'
 import providerAsMiddleware from 'eth-json-rpc-middleware/providerAsMiddleware';
 import KeyringController from 'eth-keyring-controller';
 import { Mutex } from 'await-semaphore';
-import stripHexPrefix from 'strip-hex-prefix';
 import log from 'loglevel';
 import TrezorKeyring from 'eth-trezor-keyring';
 import LedgerBridgeKeyring from '@metamask/eth-ledger-bridge-keyring';
@@ -38,7 +37,7 @@ import {
 import { MAINNET_CHAIN_ID } from '../../shared/constants/network';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
 import { UI_NOTIFICATIONS } from '../../shared/notifications';
-import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
+import { toChecksumHexAddress, stripHexPrefix } from '../../shared/modules/hexstring-utils';
 import { MILLISECOND } from '../../shared/constants/time';
 import { POLLING_TOKEN_ENVIRONMENT_TYPES } from '../../shared/constants/app';
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -10,7 +10,7 @@ import createSubscriptionManager from 'eth-json-rpc-filters/subscriptionManager'
 import providerAsMiddleware from 'eth-json-rpc-middleware/providerAsMiddleware';
 import KeyringController from 'eth-keyring-controller';
 import { Mutex } from 'await-semaphore';
-import { stripHexPrefix } from 'ethereumjs-util';
+import stripHexPrefix from 'strip-hex-prefix';
 import log from 'loglevel';
 import TrezorKeyring from 'eth-trezor-keyring';
 import LedgerBridgeKeyring from '@metamask/eth-ledger-bridge-keyring';

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -2,7 +2,6 @@ import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { cloneDeep } from 'lodash';
 import nock from 'nock';
-import { pubToAddress, bufferToHex } from 'ethereumjs-util';
 import { obj as createThoughStream } from 'through2';
 import EthQuery from 'eth-query';
 import proxyquire from 'proxyquire';
@@ -10,7 +9,11 @@ import { TRANSACTION_STATUSES } from '../../shared/constants/transaction';
 import createTxMeta from '../../test/lib/createTxMeta';
 import { NETWORK_TYPE_RPC } from '../../shared/constants/network';
 import { KEYRING_TYPES } from '../../shared/constants/hardware-wallets';
-import { addHexPrefix } from './lib/util';
+import {
+  addHexPrefix,
+  pubToAddress,
+  bufferToHex,
+} from '../../shared/modules/hexstring-utils';
 
 const Ganache = require('../../test/e2e/ganache');
 

--- a/app/scripts/migrations/025.js
+++ b/app/scripts/migrations/025.js
@@ -5,7 +5,7 @@ normalizes txParams on unconfirmed txs
 
 */
 import { cloneDeep } from 'lodash';
-import { addHexPrefix } from '../lib/util';
+import { addHexPrefix } from '../../../shared/modules/hexstring-utils';
 import { TRANSACTION_STATUSES } from '../../../shared/constants/transaction';
 
 const version = 25;

--- a/shared/constants/gas.js
+++ b/shared/constants/gas.js
@@ -1,5 +1,5 @@
-import { addHexPrefix } from 'ethereumjs-util';
 import { MIN_GAS_LIMIT_HEX } from '../../ui/pages/send/send.constants';
+import { addHexPrefix } from '../modules/hexstring-utils';
 
 const ONE_HUNDRED_THOUSAND = 100000;
 

--- a/shared/modules/conversion.utils.js
+++ b/shared/modules/conversion.utils.js
@@ -22,8 +22,8 @@
  */
 
 import BigNumber from 'bignumber.js';
-
-import { stripHexPrefix, BN } from 'ethereumjs-util';
+import { BN } from 'bn.js';
+import { stripHexPrefix } from './hexstring-utils';
 
 // Big Number Constants
 const BIG_NUMBER_WEI_MULTIPLIER = new BigNumber('1000000000000000000');

--- a/shared/modules/gas.utils.js
+++ b/shared/modules/gas.utils.js
@@ -1,4 +1,4 @@
-import { addHexPrefix } from 'ethereumjs-util';
+import { addHexPrefix } from './hexstring-utils';
 import {
   addCurrencies,
   conversionGreaterThan,

--- a/shared/modules/gas.utils.test.js
+++ b/shared/modules/gas.utils.test.js
@@ -1,4 +1,4 @@
-const { addHexPrefix } = require('ethereumjs-util');
+const { addHexPrefix } = require('./hexstring-utils');
 const { conversionUtil } = require('./conversion.utils');
 const {
   getMaximumGasTotalInHexWei,

--- a/shared/modules/hexstring-utils.js
+++ b/shared/modules/hexstring-utils.js
@@ -1,3 +1,4 @@
+import BN from 'bn.js';
 import {
   isHexString,
   isValidAddress,
@@ -5,7 +6,27 @@ import {
   addHexPrefix,
   toChecksumAddress,
   zeroAddress,
+  isValidPrivate,
+  bufferToHex,
+  stripHexPrefix,
+  bnToHex,
+  pubToAddress,
+  keccak,
 } from 'ethereumjs-util';
+import { toBuffer } from './buffer-utils';
+
+export {
+  toBuffer,
+  isValidPrivate,
+  bufferToHex,
+  addHexPrefix,
+  stripHexPrefix,
+  bnToHex,
+  isHexString,
+  toChecksumAddress,
+  pubToAddress,
+  keccak,
+};
 
 export const BURN_ADDRESS = zeroAddress();
 
@@ -71,4 +92,15 @@ export function toChecksumHexAddress(address) {
     return hexPrefixed;
   }
   return toChecksumAddress(addHexPrefix(address));
+}
+
+/**
+ * Converts a hex string to a BN object
+ *
+ * @param {string} inputHex - A number represented as a hex string
+ * @returns {Object} A BN object
+ *
+ */
+export function hexToBn(inputHex) {
+  return new BN(stripHexPrefix(inputHex), 16);
 }

--- a/shared/modules/hexstring-utils.js
+++ b/shared/modules/hexstring-utils.js
@@ -12,6 +12,7 @@ import {
   bnToHex,
   pubToAddress,
   keccak,
+  isHexPrefixed,
 } from 'ethereumjs-util';
 import { toBuffer } from './buffer-utils';
 
@@ -26,6 +27,7 @@ export {
   toChecksumAddress,
   pubToAddress,
   keccak,
+  isHexPrefixed,
 };
 
 export const BURN_ADDRESS = zeroAddress();

--- a/shared/modules/hexstring-utils.test.js
+++ b/shared/modules/hexstring-utils.test.js
@@ -1,5 +1,4 @@
-import { toChecksumAddress } from 'ethereumjs-util';
-import { isValidHexAddress } from './hexstring-utils';
+import { isValidHexAddress, toChecksumAddress } from './hexstring-utils';
 
 describe('hexstring utils', function () {
   describe('isValidHexAddress', function () {

--- a/shared/modules/transaction.utils.js
+++ b/shared/modules/transaction.utils.js
@@ -1,4 +1,4 @@
-import { isHexString } from 'ethereumjs-util';
+import { isHexString } from './hexstring-utils';
 
 export function transactionMatchesNetwork(transaction, chainId, networkId) {
   if (typeof transaction.chainId !== 'undefined') {

--- a/ui/components/app/account-list-item/account-list-item-component.test.js
+++ b/ui/components/app/account-list-item/account-list-item-component.test.js
@@ -2,12 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import Identicon from '../../ui/identicon';
-import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
 import AccountListItem from './account-list-item';
 
-jest.mock('../../../../shared/modules/hexstring-utils', () => ({
-  toChecksumHexAddress: jest.fn(() => 'mockCheckSumAddress'),
-}));
+const mockAddress = '0x829bd824b016326a401d083b33d0922933330000';
+const mockChecksumAddress = '0x829BD824B016326a401D083b33d0922933330000';
 
 describe('AccountListItem Component', () => {
   let wrapper, propsMethodSpies;
@@ -22,7 +20,7 @@ describe('AccountListItem Component', () => {
       wrapper = shallow(
         <AccountListItem
           account={{
-            address: 'mockAddress',
+            address: mockAddress,
             name: 'mockName',
             balance: 'mockBalance',
           }}
@@ -57,7 +55,7 @@ describe('AccountListItem Component', () => {
       onClick();
       expect(propsMethodSpies.handleClick.callCount).toStrictEqual(1);
       expect(propsMethodSpies.handleClick.getCall(0).args).toStrictEqual([
-        { address: 'mockAddress', name: 'mockName', balance: 'mockBalance' },
+        { address: mockAddress, name: 'mockName', balance: 'mockBalance' },
       ]);
     });
 
@@ -125,8 +123,7 @@ describe('AccountListItem Component', () => {
       );
       expect(
         wrapper.find('.account-list-item__account-address').text(),
-      ).toStrictEqual('mockCheckSumAddress');
-      expect(toChecksumHexAddress).toHaveBeenCalledWith('mockAddress');
+      ).toStrictEqual(mockChecksumAddress);
     });
 
     it('should not render the account address as a checksumAddress if displayAddress is false', () => {

--- a/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
+++ b/ui/components/app/gas-customization/gas-modal-page-container/gas-modal-page-container.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { addHexPrefix } from '../../../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../../../shared/modules/hexstring-utils';
 import {
   hideModal,
   createRetryTransaction,

--- a/ui/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
+++ b/ui/components/app/modals/export-private-key-modal/export-private-key-modal.component.js
@@ -1,13 +1,14 @@
 import log from 'loglevel';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-import { stripHexPrefix } from 'ethereumjs-util';
 import copyToClipboard from 'copy-to-clipboard';
 import ReadOnlyInput from '../../../ui/readonly-input';
 import Button from '../../../ui/button';
 import AccountModalContainer from '../account-modal-container';
-import { toChecksumHexAddress } from '../../../../../shared/modules/hexstring-utils';
+import {
+  stripHexPrefix,
+  toChecksumHexAddress,
+} from '../../../../../shared/modules/hexstring-utils';
 
 export default class ExportPrivateKeyModal extends Component {
   static contextTypes = {

--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { stripHexPrefix } from 'ethereumjs-util';
 import classnames from 'classnames';
 import { ObjectInspector } from 'react-inspector';
 import LedgerInstructionField from '../ledger-instruction-field';
-
 import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   MESSAGE_TYPE,
@@ -13,6 +11,7 @@ import { getEnvironmentType } from '../../../../app/scripts/lib/util';
 import Identicon from '../../ui/identicon';
 import AccountListItem from '../account-list-item';
 import { conversionUtil } from '../../../../shared/modules/conversion.utils';
+import { stripHexPrefix } from '../../../../shared/modules/hexstring-utils';
 import Button from '../../ui/button';
 import SiteIcon from '../../ui/site-icon';
 

--- a/ui/components/ui/qr-code/qr-code.js
+++ b/ui/components/ui/qr-code/qr-code.js
@@ -2,9 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import qrCode from 'qrcode-generator';
 import { connect } from 'react-redux';
-import { isHexPrefixed } from 'ethereumjs-util';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
-import { toChecksumHexAddress } from '../../../../shared/modules/hexstring-utils';
+import {
+  toChecksumHexAddress,
+  isHexPrefixed,
+} from '../../../../shared/modules/hexstring-utils';
 import Tooltip from '../tooltip';
 import CopyIcon from '../icon/copy-icon.component';
 import { useI18nContext } from '../../../hooks/useI18nContext';

--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import UnitInput from '../unit-input';
 import CurrencyDisplay from '../currency-display';
 import { getWeiHexFromDecimalValue } from '../../../helpers/utils/conversions.util';
+import { addHexPrefix } from '../../../../shared/modules/hexstring-utils';
 import {
   conversionUtil,
   multiplyCurrencies,
 } from '../../../../shared/modules/conversion.utils';
 import { ETH } from '../../../helpers/constants/common';
-import { addHexPrefix } from '../../../../app/scripts/lib/util';
 
 /**
  * Component that allows user to enter token values as a number, and props receive a converted

--- a/ui/ducks/ens.js
+++ b/ui/ducks/ens.js
@@ -3,8 +3,6 @@ import ENS from 'ethjs-ens';
 import log from 'loglevel';
 import networkMap from 'ethereum-ens-network-map';
 import { isConfusing } from 'unicode-confusables';
-import { isHexString } from 'ethereumjs-util';
-
 import { getCurrentChainId } from '../selectors';
 import {
   CHAIN_ID_TO_NETWORK_ID_MAP,
@@ -25,6 +23,7 @@ import {
   BURN_ADDRESS,
   isBurnAddress,
   isValidHexAddress,
+  isHexString,
 } from '../../shared/modules/hexstring-utils';
 
 // Local Constants

--- a/ui/ducks/metamask/metamask.js
+++ b/ui/ducks/metamask/metamask.js
@@ -1,7 +1,11 @@
-import { addHexPrefix, isHexString, stripHexPrefix } from 'ethereumjs-util';
 import * as actionConstants from '../../store/actionConstants';
 import { ALERT_TYPES } from '../../../shared/constants/alerts';
 import { NETWORK_TYPE_RPC } from '../../../shared/constants/network';
+import {
+  addHexPrefix,
+  isHexString,
+  stripHexPrefix,
+} from '../../../shared/modules/hexstring-utils';
 import {
   accountsWithSendEtherInfoSelector,
   checkNetworkAndAccountSupports1559,

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1,7 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import abi from 'human-standard-token-abi';
 import BigNumber from 'bignumber.js';
-import { addHexPrefix } from 'ethereumjs-util';
 import { debounce } from 'lodash';
 import {
   conversionGreaterThan,
@@ -83,6 +82,7 @@ import {
 
 import { resetEnsResolution } from '../ens';
 import {
+  addHexPrefix,
   isBurnAddress,
   isValidHexAddress,
 } from '../../../shared/modules/hexstring-utils';

--- a/ui/helpers/utils/confirm-tx.util.js
+++ b/ui/helpers/utils/confirm-tx.util.js
@@ -1,7 +1,7 @@
 import currencyFormatter from 'currency-formatter';
 import currencies from 'currency-formatter/currencies';
 import BigNumber from 'bignumber.js';
-import { addHexPrefix } from '../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../shared/modules/hexstring-utils';
 
 import { unconfirmedTransactionsCountSelector } from '../../selectors';
 import {

--- a/ui/helpers/utils/conversions.util.js
+++ b/ui/helpers/utils/conversions.util.js
@@ -1,5 +1,5 @@
 import { ETH, GWEI, WEI } from '../constants/common';
-import { addHexPrefix } from '../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../shared/modules/hexstring-utils';
 import {
   conversionUtil,
   addCurrencies,

--- a/ui/helpers/utils/transactions.util.js
+++ b/ui/helpers/utils/transactions.util.js
@@ -2,8 +2,7 @@ import { MethodRegistry } from 'eth-method-registry';
 import abi from 'human-standard-token-abi';
 import { ethers } from 'ethers';
 import log from 'loglevel';
-
-import { addHexPrefix } from '../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../shared/modules/hexstring-utils';
 import {
   TRANSACTION_TYPES,
   TRANSACTION_GROUP_STATUSES,

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -1,9 +1,8 @@
 import punycode from 'punycode/punycode';
 import abi from 'human-standard-token-abi';
 import BigNumber from 'bignumber.js';
-import * as ethUtil from 'ethereumjs-util';
+import { BN } from 'bn.js';
 import { DateTime } from 'luxon';
-import { addHexPrefix } from '../../../app/scripts/lib/util';
 import {
   GOERLI_CHAIN_ID,
   KOVAN_CHAIN_ID,
@@ -12,7 +11,11 @@ import {
   RINKEBY_CHAIN_ID,
   ROPSTEN_CHAIN_ID,
 } from '../../../shared/constants/network';
-import { toChecksumHexAddress } from '../../../shared/modules/hexstring-utils';
+import {
+  toChecksumHexAddress,
+  stripHexPrefix,
+  addHexPrefix,
+} from '../../../shared/modules/hexstring-utils';
 import {
   TRUNCATED_ADDRESS_START_CHARS,
   TRUNCATED_NAME_CHAR_LIMIT,
@@ -87,7 +90,7 @@ export function addressSummary(
   }
   let checked = toChecksumHexAddress(address);
   if (!includeHex) {
-    checked = ethUtil.stripHexPrefix(checked);
+    checked = stripHexPrefix(checked);
   }
   return checked
     ? `${checked.slice(0, firstSegLength)}...${checked.slice(
@@ -119,10 +122,10 @@ export function isOriginContractAddress(to, sendTokenAddress) {
 // Takes wei Hex, returns wei BN, even if input is null
 export function numericBalance(balance) {
   if (!balance) {
-    return new ethUtil.BN(0, 16);
+    return new BN(0, 16);
   }
-  const stripped = ethUtil.stripHexPrefix(balance);
-  return new ethUtil.BN(stripped, 16);
+  const stripped = stripHexPrefix(balance);
+  return new BN(stripped, 16);
 }
 
 // Takes  hex, returns [beforeDecimal, afterDecimal]

--- a/ui/helpers/utils/util.test.js
+++ b/ui/helpers/utils/util.test.js
@@ -1,4 +1,4 @@
-import { BN } from 'ethereumjs-util';
+import { BN } from 'bn.js';
 import * as util from './util';
 
 describe('util', () => {

--- a/ui/hooks/gasFeeInput/useMaxPriorityFeePerGasInput.js
+++ b/ui/hooks/gasFeeInput/useMaxPriorityFeePerGasInput.js
@@ -1,8 +1,6 @@
 import { useSelector } from 'react-redux';
 import { useState } from 'react';
-
-import { addHexPrefix } from 'ethereumjs-util';
-
+import { addHexPrefix } from '../../../shared/modules/hexstring-utils';
 import { SECONDARY } from '../../helpers/constants/common';
 import { hexWEIToDecGWEI } from '../../helpers/utils/conversions.util';
 import {

--- a/ui/hooks/useIncrementedGasFees.js
+++ b/ui/hooks/useIncrementedGasFees.js
@@ -1,8 +1,8 @@
 import BigNumber from 'bignumber.js';
-import { addHexPrefix } from 'ethereumjs-util';
 import { useMemo } from 'react';
 import { multiplyCurrencies } from '../../shared/modules/conversion.utils';
 import { isEIP1559Transaction } from '../../shared/modules/transaction.utils';
+import { addHexPrefix } from '../../shared/modules/hexstring-utils';
 import { decGWEIToHexWEI } from '../helpers/utils/conversions.util';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
 

--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -13,8 +13,10 @@ import {
 import TextField from '../../components/ui/text-field';
 import PageContainer from '../../components/ui/page-container';
 import { Tabs, Tab } from '../../components/ui/tabs';
-import { addHexPrefix } from '../../../app/scripts/lib/util';
-import { isValidHexAddress } from '../../../shared/modules/hexstring-utils';
+import {
+  addHexPrefix,
+  isValidHexAddress,
+} from '../../../shared/modules/hexstring-utils';
 import ActionableMessage from '../../components/ui/actionable-message/actionable-message';
 import Typography from '../../components/ui/typography';
 import { TYPOGRAPHY, FONT_WEIGHT } from '../../helpers/constants/design-system';

--- a/ui/pages/send/send-footer/send-footer.container.js
+++ b/ui/pages/send/send-footer/send-footer.container.js
@@ -15,7 +15,7 @@ import {
   getDraftTransactionID,
 } from '../../../ducks/send';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
-import { addHexPrefix } from '../../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../../shared/modules/hexstring-utils';
 import { getSendToAccounts } from '../../../ducks/metamask/metamask';
 import { CUSTOM_GAS_ESTIMATE } from '../../../../shared/constants/gas';
 import SendFooter from './send-footer.component';

--- a/ui/pages/send/send.constants.js
+++ b/ui/pages/send/send.constants.js
@@ -2,7 +2,7 @@ import {
   conversionUtil,
   multiplyCurrencies,
 } from '../../../shared/modules/conversion.utils';
-import { addHexPrefix } from '../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../shared/modules/hexstring-utils';
 
 const MIN_GAS_PRICE_DEC = '0';
 const MIN_GAS_PRICE_HEX = parseInt(MIN_GAS_PRICE_DEC, 10).toString(16);

--- a/ui/pages/send/send.utils.js
+++ b/ui/pages/send/send.utils.js
@@ -7,10 +7,8 @@ import {
   conversionGreaterThan,
   conversionLessThan,
 } from '../../../shared/modules/conversion.utils';
-
+import { addHexPrefix } from '../../../shared/modules/hexstring-utils';
 import { calcTokenAmount } from '../../helpers/utils/token-util';
-import { addHexPrefix } from '../../../app/scripts/lib/util';
-
 import { TOKEN_TRANSFER_FUNCTION_SIGNATURE } from './send.constants';
 
 export {

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -1,4 +1,4 @@
-import { addHexPrefix } from '../../app/scripts/lib/util';
+import { addHexPrefix } from '../../shared/modules/hexstring-utils';
 import {
   conversionUtil,
   conversionGreaterThan,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1,5 +1,8 @@
 import { createSelector } from 'reselect';
-import { addHexPrefix } from '../../app/scripts/lib/util';
+import {
+  addHexPrefix,
+  toChecksumHexAddress,
+} from '../../shared/modules/hexstring-utils';
 import {
   MAINNET_CHAIN_ID,
   TEST_CHAINS,
@@ -32,7 +35,6 @@ import {
 
 import { TEMPLATED_CONFIRMATION_MESSAGE_TYPES } from '../pages/confirmation/templates';
 
-import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
 import { DAY } from '../../shared/constants/time';
 import {
   getNativeCurrency,

--- a/ui/store/actions.js
+++ b/ui/store/actions.js
@@ -17,7 +17,7 @@ import {
 } from '../../shared/constants/app';
 import { hasUnconfirmedTransactions } from '../helpers/utils/confirm-tx.util';
 import txHelper from '../helpers/utils/tx-helper';
-import { getEnvironmentType, addHexPrefix } from '../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../app/scripts/lib/util';
 import {
   getMetaMaskAccounts,
   getPermittedAccountsForCurrentTab,
@@ -27,7 +27,10 @@ import {
 import { computeEstimatedGasLimit, resetSendState } from '../ducks/send';
 import { switchedToUnconnectedAccount } from '../ducks/alerts/unconnected-account';
 import { getUnconnectedAccountAlertEnabledness } from '../ducks/metamask/metamask';
-import { toChecksumHexAddress } from '../../shared/modules/hexstring-utils';
+import {
+  toChecksumHexAddress,
+  addHexPrefix,
+} from '../../shared/modules/hexstring-utils';
 import {
   LEDGER_TRANSPORT_TYPES,
   LEDGER_USB_VENDOR_ID,


### PR DESCRIPTION
progress towards [reduce cryptography dependencies bundled in ui](https://github.com/MetaMask/metamask-extension/pull/11698)

replaces all our `ethereumjs-util` imports with our own hexstring util built on top. this is intended to make it easier to remove `ethereumjs-util` in the frontend