### PR TITLE
Add RPC method handler hook selection

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js
@@ -12,6 +12,14 @@ import { CHAIN_ID_TO_NETWORK_ID_MAP } from '../../../../../shared/constants/netw
 const addEthereumChain = {
   methodNames: [MESSAGE_TYPE.ADD_ETHEREUM_CHAIN],
   implementation: addEthereumChainHandler,
+  hookNames: {
+    addCustomRpc: true,
+    getCurrentChainId: true,
+    findCustomRpcBy: true,
+    updateRpcTarget: true,
+    requestUserApproval: true,
+    sendMetrics: true,
+  },
 };
 export default addEthereumChain;
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/get-provider-state.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/get-provider-state.js
@@ -9,6 +9,9 @@ import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 const getProviderState = {
   methodNames: [MESSAGE_TYPE.GET_PROVIDER_STATE],
   implementation: getProviderStateHandler,
+  hookNames: {
+    getProviderState: true,
+  },
 };
 export default getProviderState;
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/log-web3-shim-usage.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/log-web3-shim-usage.js
@@ -10,6 +10,11 @@ import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 const logWeb3ShimUsage = {
   methodNames: [MESSAGE_TYPE.LOG_WEB3_SHIM_USAGE],
   implementation: logWeb3ShimUsageHandler,
+  hookNames: {
+    sendMetrics: true,
+    getWeb3ShimUsageState: true,
+    setWeb3ShimUsageRecorded: true,
+  },
 };
 export default logWeb3ShimUsage;
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/switch-ethereum-chain.js
@@ -15,6 +15,13 @@ import {
 const switchEthereumChain = {
   methodNames: [MESSAGE_TYPE.SWITCH_ETHEREUM_CHAIN],
   implementation: switchEthereumChainHandler,
+  hookNames: {
+    getCurrentChainId: true,
+    findCustomRpcBy: true,
+    setProviderType: true,
+    updateRpcTarget: true,
+    requestUserApproval: true,
+  },
 };
 export default switchEthereumChain;
 

--- a/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/watch-asset.js
@@ -3,6 +3,9 @@ import { MESSAGE_TYPE } from '../../../../../shared/constants/app';
 const watchAsset = {
   methodNames: [MESSAGE_TYPE.WATCH_ASSET, MESSAGE_TYPE.WATCH_ASSET_LEGACY],
   implementation: watchAssetHandler,
+  hookNames: {
+    handleWatchAssetRequest: true,
+  },
 };
 export default watchAsset;
 


### PR DESCRIPTION
Adds a property, `hookNames`, to each RPC method handler export in `app/scripts/lib/rpc-method-middleware` and a function, `selectHooks`, to select from them.

`createMethodMiddleware` receives a giant `opts` object that includes a bunch of different methods from `MetaMaskController` and its subcontrollers. Each method implementation only requires a subset of these methods to do its work. Because they need some kind of name, we call these methods "hooks". With this change, whenever an RPC method is called, `selectHooks` will be called to ensure that each method only receives the hooks that it needs in order to do its job.

This implementation is based on [work in `snaps-skunkworks`](https://github.com/MetaMask/snaps-skunkworks/blob/a3e1248/packages/rpc-methods/src/utils.ts#L17-L34) that will be merged in the near future.