### PR TITLE
Update LavaMoat policy

### DIFF
--- a/lavamoat/browserify/policy.json
+++ b/lavamoat/browserify/policy.json
@@ -1556,11 +1556,15 @@
     },
     "eth-json-rpc-middleware": {
       "globals": {
+        "URL": true,
+        "btoa": true,
         "console.error": true,
         "fetch": true,
         "setTimeout": true
       },
       "packages": {
+        "@metamask/safe-event-emitter": true,
+        "browser-resolve": true,
         "btoa": true,
         "clone": true,
         "eth-rpc-errors": true,


### PR DESCRIPTION
The LavaMoat policy has been updated in accordance with the recent update to `eth-json-rpc-middleware` in #10738. These changes were generated with `yarn lavamoat:auto`.