### PR TITLE
Add migration to set showTestNetworks to true if there is evidence of testnet use

### DIFF
--- a/app/scripts/migrations/067.js
+++ b/app/scripts/migrations/067.js
@@ -24,45 +24,43 @@ export default {
 };
 
 function transformState(state) {
-  let newState = state;
-
   const PreferencesController = state?.PreferencesController || {};
   const preferences = PreferencesController.preferences || {};
 
-  if (!preferences.showTestNetworks) {
-    const transactions = state?.TransactionController?.transactions || {};
-    const provider = state.NetworkController?.provider || {};
-    const cachedBalances = state.CachedBalancesController?.cachedBalances || {};
-
-    const userIsCurrentlyOnATestNet = TEST_CHAINS.includes(provider?.chainId);
-    const userHasMadeATestNetTransaction = Object.values(
-      transactions,
-    ).some(({ chainId }) => TEST_CHAINS.includes(chainId));
-    const userHasACachedBalanceOnATestnet = TEST_CHAINS.some((chainId) => {
-      const cachedBalancesForChain = Object.values(
-        cachedBalances[chainId] || {},
-      );
-      const userHasABalanceGreaterThanZeroOnThisChain = cachedBalancesForChain.some(
-        hexNumberIsGreaterThanZero,
-      );
-      return userHasABalanceGreaterThanZeroOnThisChain;
-    });
-    const userHasUsedATestnet =
-      userIsCurrentlyOnATestNet ||
-      userHasMadeATestNetTransaction ||
-      userHasACachedBalanceOnATestnet;
-
-    newState = {
-      ...state,
-      PreferencesController: {
-        ...PreferencesController,
-        preferences: {
-          ...preferences,
-          showTestNetworks: userHasUsedATestnet,
-        },
-      },
-    };
+  if (preferences.showTestNetworks) {
+    return state;
   }
+
+  const transactions = state?.TransactionController?.transactions || {};
+  const provider = state.NetworkController?.provider || {};
+  const cachedBalances = state.CachedBalancesController?.cachedBalances || {};
+
+  const userIsCurrentlyOnATestNet = TEST_CHAINS.includes(provider?.chainId);
+  const userHasMadeATestNetTransaction = Object.values(
+    transactions,
+  ).some(({ chainId }) => TEST_CHAINS.includes(chainId));
+  const userHasACachedBalanceOnATestnet = TEST_CHAINS.some((chainId) => {
+    const cachedBalancesForChain = Object.values(cachedBalances[chainId] || {});
+    const userHasABalanceGreaterThanZeroOnThisChain = cachedBalancesForChain.some(
+      hexNumberIsGreaterThanZero,
+    );
+    return userHasABalanceGreaterThanZeroOnThisChain;
+  });
+  const userHasUsedATestnet =
+    userIsCurrentlyOnATestNet ||
+    userHasMadeATestNetTransaction ||
+    userHasACachedBalanceOnATestnet;
+
+  const newState = {
+    ...state,
+    PreferencesController: {
+      ...PreferencesController,
+      preferences: {
+        ...preferences,
+        showTestNetworks: userHasUsedATestnet,
+      },
+    },
+  };
 
   return newState;
 }

--- a/app/scripts/migrations/067.js
+++ b/app/scripts/migrations/067.js
@@ -25,7 +25,7 @@ export default {
 
 function transformState(state) {
   let newState = state;
-  console.log('state', state);
+
   const PreferencesController = state?.PreferencesController || {};
   const preferences = PreferencesController.preferences || {};
 

--- a/app/scripts/migrations/067.js
+++ b/app/scripts/migrations/067.js
@@ -1,0 +1,68 @@
+import { cloneDeep } from 'lodash';
+import BigNumber from 'bignumber.js';
+import { TEST_CHAINS } from '../../../shared/constants/network';
+
+const hexNumberIsGreaterThanZero = (hexNumber) =>
+  new BigNumber(hexNumber || '0x0', 16).gt(0);
+
+const version = 67;
+
+/**
+ * Sets the showTestNetworks property to true if it was false or undefined, and there is evidence
+ * that the user has used a test net
+ */
+export default {
+  version,
+  async migrate(originalVersionedData) {
+    const versionedData = cloneDeep(originalVersionedData);
+    versionedData.meta.version = version;
+    const state = versionedData.data;
+    const newState = transformState(state);
+    versionedData.data = newState;
+    return versionedData;
+  },
+};
+
+function transformState(state) {
+  let newState = state;
+  console.log('state', state);
+  const PreferencesController = state?.PreferencesController || {};
+  const preferences = PreferencesController.preferences || {};
+
+  if (!preferences.showTestNetworks) {
+    const transactions = state?.TransactionController?.transactions || {};
+    const provider = state.NetworkController?.provider || {};
+    const cachedBalances = state.CachedBalancesController?.cachedBalances || {};
+
+    const userIsCurrentlyOnATestNet = TEST_CHAINS.includes(provider?.chainId);
+    const userHasMadeATestNetTransaction = Object.values(
+      transactions,
+    ).some(({ chainId }) => TEST_CHAINS.includes(chainId));
+    const userHasACachedBalanceOnATestnet = TEST_CHAINS.some((chainId) => {
+      const cachedBalancesForChain = Object.values(
+        cachedBalances[chainId] || {},
+      );
+      const userHasABalanceGreaterThanZeroOnThisChain = cachedBalancesForChain.some(
+        hexNumberIsGreaterThanZero,
+      );
+      return userHasABalanceGreaterThanZeroOnThisChain;
+    });
+    const userHasUsedATestnet =
+      userIsCurrentlyOnATestNet ||
+      userHasMadeATestNetTransaction ||
+      userHasACachedBalanceOnATestnet;
+
+    newState = {
+      ...state,
+      PreferencesController: {
+        ...PreferencesController,
+        preferences: {
+          ...preferences,
+          showTestNetworks: userHasUsedATestnet,
+        },
+      },
+    };
+  }
+
+  return newState;
+}

--- a/app/scripts/migrations/067.test.js
+++ b/app/scripts/migrations/067.test.js
@@ -1,0 +1,217 @@
+import { TEST_CHAINS } from '../../../shared/constants/network';
+import migration67 from './067';
+
+describe('migration #67', () => {
+  it('should update the version metadata', async () => {
+    const oldStorage = {
+      meta: {
+        version: 66,
+      },
+      data: {},
+    };
+
+    const newStorage = await migration67.migrate(oldStorage);
+    expect(newStorage.meta).toStrictEqual({
+      version: 67,
+    });
+  });
+
+  it('should set showTestNetworks to true if the user is currently on a test network', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          preferences: {
+            showTestNetworks: false,
+          },
+        },
+        NetworkController: {
+          provider: {
+            chainId: TEST_CHAINS[0],
+          },
+        },
+      },
+    };
+
+    const newStorage = await migration67.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.preferences.showTestNetworks,
+    ).toBe(true);
+  });
+
+  it('should set showTestNetworks to true if there is a transaction on a test network in state', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          preferences: {
+            showTestNetworks: false,
+          },
+        },
+        NetworkController: {
+          provider: {
+            chainId: 'not a test net',
+          },
+        },
+        TransactionController: {
+          transactions: {
+            abc123: {
+              chainId: TEST_CHAINS[0],
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migration67.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.preferences.showTestNetworks,
+    ).toBe(true);
+  });
+
+  it('should set showTestNetworks to true if the user has a cached balance on a test network', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          preferences: {
+            showTestNetworks: false,
+          },
+        },
+        NetworkController: {
+          provider: {
+            chainId: 'not a test net',
+          },
+        },
+        TransactionController: {
+          transactions: {
+            abc123: {
+              chainId: 'not a test net',
+            },
+          },
+        },
+        CachedBalancesController: {
+          cachedBalances: {
+            '0x1': {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x0',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x0',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x0',
+            },
+            [TEST_CHAINS[0]]: {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x0',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x1',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x0',
+            },
+            [TEST_CHAINS[1]]: {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x0',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x0',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x0',
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migration67.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.preferences.showTestNetworks,
+    ).toBe(true);
+  });
+
+  it('should leave showTestNetworks false if there is no evidence of test network usage', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          preferences: {
+            showTestNetworks: false,
+          },
+        },
+        NetworkController: {
+          provider: {
+            chainId: 'not a test net',
+          },
+        },
+        TransactionController: {
+          transactions: {
+            abc123: {
+              chainId: 'not a test net',
+            },
+          },
+        },
+        CachedBalancesController: {
+          cachedBalances: {
+            '0x1': {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x10',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x20',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x30',
+            },
+            [TEST_CHAINS[0]]: {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x0',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x0',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x0',
+            },
+            [TEST_CHAINS[1]]: {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x0',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x0',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x0',
+            },
+          },
+        },
+      },
+    };
+    const newStorage = await migration67.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.preferences.showTestNetworks,
+    ).toBe(false);
+  });
+
+  it('should leave showTestNetworks true if it was true but there is no evidence of test network usage', async () => {
+    const oldStorage = {
+      meta: {},
+      data: {
+        PreferencesController: {
+          preferences: {
+            showTestNetworks: true,
+          },
+        },
+        NetworkController: {
+          provider: {
+            chainId: 'not a test net',
+          },
+        },
+        TransactionController: {
+          transactions: {
+            abc123: {
+              chainId: 'not a test net',
+            },
+          },
+        },
+        CachedBalancesController: {
+          cachedBalances: {
+            '0x1': {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x10',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x20',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x30',
+            },
+            [TEST_CHAINS[0]]: {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x0',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x0',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x0',
+            },
+            [TEST_CHAINS[1]]: {
+              '0x027d4ae98b79d0c52918bab4c3170bea701fb8ab': '0x0',
+              '0x2f318c334780961fb129d2a6c30d0763d9a5c970': '0x0',
+              '0x7a46ce51fbbb29c34aea1fe9833c27b5d2781925': '0x0',
+            },
+          },
+        },
+      },
+    };
+
+    const newStorage = await migration67.migrate(oldStorage);
+    expect(
+      newStorage.data.PreferencesController.preferences.showTestNetworks,
+    ).toBe(true);
+  });
+});

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -70,6 +70,7 @@ import m063 from './063';
 import m064 from './064';
 import m065 from './065';
 import m066 from './066';
+import m067 from './067';
 
 const migrations = [
   m002,
@@ -137,6 +138,7 @@ const migrations = [
   m064,
   m065,
   m066,
+  m067,
 ];
 
 export default migrations;


### PR DESCRIPTION
Addresses this feedback from 10.6.0 QA:

> When on one of the test networks before the update, the network will not show up on the network list after updating. This is just more of an observation/documenting of an odd behavior. There is the banner that notifies and navigates to the test network setting change to bring back the networks. Also, it doesn't impede on switching networks. Maybe it would be beneficial to conditionally set the setting if the user is currently on a test network for the update.

This migrates the users data so that `showTestNetworks` is set to true if we have evidence they have used a test network

What counts as "evidence":
- if the user is currently on a test network
- if the user has sent a transaction on
- if the user has a "cached balance" on a test network, which means that the user has an account with a greater than 0 balance on a test network, and they have selected that account-network combination within MetaMask in the past