### PR TITLE
Replace history during onboarding

### DIFF
--- a/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -142,7 +142,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
 
       setSeedPhraseBackedUp(true).then(async () => {
         initializeThreeBox();
-        history.push(INITIALIZE_END_OF_FLOW_ROUTE);
+        history.replace(INITIALIZE_END_OF_FLOW_ROUTE);
       });
     } catch (error) {
       this.setState({ seedPhraseError: error.message });

--- a/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase-component.test.js
+++ b/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase-component.test.js
@@ -25,11 +25,11 @@ describe('ConfirmSeedPhrase Component', () => {
 
   it('should add/remove selected on click', () => {
     const metricsEventSpy = sinon.spy();
-    const pushSpy = sinon.spy();
+    const replaceSpy = sinon.spy();
     const root = shallowRender(
       {
         seedPhrase: '鼠 牛 虎 兔 龍 蛇 馬 羊 猴 雞 狗 豬',
-        history: { push: pushSpy },
+        history: { replace: replaceSpy },
       },
       {
         metricsEvent: metricsEventSpy,
@@ -58,11 +58,11 @@ describe('ConfirmSeedPhrase Component', () => {
 
   it('should render correctly on hover', () => {
     const metricsEventSpy = sinon.spy();
-    const pushSpy = sinon.spy();
+    const replaceSpy = sinon.spy();
     const root = shallowRender(
       {
         seedPhrase: '鼠 牛 虎 兔 龍 蛇 馬 羊 猴 雞 狗 豬',
-        history: { push: pushSpy },
+        history: { replace: replaceSpy },
       },
       {
         metricsEvent: metricsEventSpy,
@@ -93,11 +93,11 @@ describe('ConfirmSeedPhrase Component', () => {
 
   it('should insert seed in place on drop', () => {
     const metricsEventSpy = sinon.spy();
-    const pushSpy = sinon.spy();
+    const replaceSpy = sinon.spy();
     const root = shallowRender(
       {
         seedPhrase: '鼠 牛 虎 兔 龍 蛇 馬 羊 猴 雞 狗 豬',
-        history: { push: pushSpy },
+        history: { replace: replaceSpy },
       },
       {
         metricsEvent: metricsEventSpy,
@@ -138,12 +138,12 @@ describe('ConfirmSeedPhrase Component', () => {
       '豬',
     ];
     const metricsEventSpy = sinon.spy();
-    const pushSpy = sinon.spy();
+    const replaceSpy = sinon.spy();
     const initialize3BoxSpy = sinon.spy();
     const root = shallowRender(
       {
         seedPhrase: '鼠 牛 虎 兔 龍 蛇 馬 羊 猴 雞 狗 豬',
-        history: { push: pushSpy },
+        history: { replace: replaceSpy },
         setSeedPhraseBackedUp: () => Promise.resolve(),
         initializeThreeBox: initialize3BoxSpy,
       },
@@ -174,6 +174,6 @@ describe('ConfirmSeedPhrase Component', () => {
       },
     });
     expect(initialize3BoxSpy.calledOnce).toStrictEqual(true);
-    expect(pushSpy.args[0][0]).toStrictEqual('/initialize/end-of-flow');
+    expect(replaceSpy.args[0][0]).toStrictEqual('/initialize/end-of-flow');
   });
 });

--- a/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/seed-phrase/confirm-seed-phrase/confirm-seed-phrase.component.js
@@ -87,7 +87,7 @@ export default class ConfirmSeedPhrase extends PureComponent {
 
       setSeedPhraseBackedUp(true).then(async () => {
         initializeThreeBox();
-        history.push(INITIALIZE_END_OF_FLOW_ROUTE);
+        history.replace(INITIALIZE_END_OF_FLOW_ROUTE);
       });
     } catch (error) {
       console.error(error.message);

--- a/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
+++ b/ui/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
@@ -54,7 +54,7 @@ export default class RevealSeedPhrase extends PureComponent {
       return;
     }
 
-    history.push(INITIALIZE_CONFIRM_SEED_PHRASE_ROUTE);
+    history.replace(INITIALIZE_CONFIRM_SEED_PHRASE_ROUTE);
   };
 
   handleSkip = async () => {
@@ -78,7 +78,7 @@ export default class RevealSeedPhrase extends PureComponent {
     if (onboardingInitiator) {
       await returnToOnboardingInitiator(onboardingInitiator);
     }
-    history.push(DEFAULT_ROUTE);
+    history.replace(DEFAULT_ROUTE);
   };
 
   renderSecretWordsContainer() {

--- a/ui/pages/onboarding-flow/import-srp/import-srp.js
+++ b/ui/pages/onboarding-flow/import-srp/import-srp.js
@@ -101,7 +101,7 @@ export default function ImportSRP({ submitSecretRecoveryPhrase }) {
             large
             onClick={() => {
               submitSecretRecoveryPhrase(secretRecoveryPhrase);
-              history.push(ONBOARDING_CREATE_PASSWORD_ROUTE);
+              history.replace(ONBOARDING_CREATE_PASSWORD_ROUTE);
             }}
             disabled={error || secretRecoveryPhrase.length === 0}
           >


### PR DESCRIPTION
Manual testing steps:  

* "Create wallet" flow should still work (using onboarding v1)
* "Import wallet" flow should still work (using onboarding v1)
* "Create wallet" flow should still work (using onboarding v2)
* "Import wallet" flow should still work (using onboarding v2)