### PR TITLE
Show correct base asset in Signature Request view

### DIFF
--- a/ui/components/app/signature-request-original/signature-request-original.component.js
+++ b/ui/components/app/signature-request-original/signature-request-original.component.js
@@ -39,6 +39,7 @@ export default class SignatureRequestOriginal extends Component {
     domainMetadata: PropTypes.object,
     hardwareWalletRequiresConnection: PropTypes.bool,
     isLedgerWallet: PropTypes.bool,
+    nativeCurrency: PropTypes.string.isRequired,
   };
 
   state = {
@@ -108,12 +109,12 @@ export default class SignatureRequestOriginal extends Component {
   };
 
   renderBalance = () => {
-    const { conversionRate } = this.props;
+    const { conversionRate, nativeCurrency } = this.props;
     const {
       fromAccount: { balance },
     } = this.state;
 
-    const balanceInEther = conversionUtil(balance, {
+    const balanceInBaseAsset = conversionUtil(balance, {
       fromNumericBase: 'hex',
       toNumericBase: 'dec',
       fromDenomination: 'WEI',
@@ -127,7 +128,7 @@ export default class SignatureRequestOriginal extends Component {
           {`${this.context.t('balance')}:`}
         </div>
         <div className="request-signature__balance-value">
-          {`${balanceInEther} ETH`}
+          {`${balanceInBaseAsset} ${nativeCurrency}`}
         </div>
       </div>
     );

--- a/ui/components/app/signature-request-original/signature-request-original.container.js
+++ b/ui/components/app/signature-request-original/signature-request-original.container.js
@@ -13,7 +13,10 @@ import {
 import { getAccountByAddress } from '../../../helpers/utils/util';
 import { clearConfirmTransaction } from '../../../ducks/confirm-transaction/confirm-transaction.duck';
 import { getMostRecentOverviewPage } from '../../../ducks/history/history';
-import { isAddressLedger } from '../../../ducks/metamask/metamask';
+import {
+  isAddressLedger,
+  getNativeCurrency,
+} from '../../../ducks/metamask/metamask';
 import SignatureRequestOriginal from './signature-request-original.component';
 
 function mapStateToProps(state, ownProps) {
@@ -34,6 +37,7 @@ function mapStateToProps(state, ownProps) {
     mostRecentOverviewPage: getMostRecentOverviewPage(state),
     hardwareWalletRequiresConnection,
     isLedgerWallet,
+    nativeCurrency: getNativeCurrency(state),
     // not passed to component
     allAccounts: accountsWithSendEtherInfoSelector(state),
     domainMetadata: getDomainMetadata(state),


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/12689

ETH (Rinkeby)
<img width="361" alt="Screen Shot 2021-11-13 at 12 44 54 PM" src="https://user-images.githubusercontent.com/8732757/141657378-7f362efc-ef46-48db-8530-fbed36f99318.png">

BSC
<img width="360" alt="Screen Shot 2021-11-13 at 12 45 42 PM" src="https://user-images.githubusercontent.com/8732757/141657388-f00493ee-a793-4f8b-957e-d8075e2aa746.png">

Polygon
<img width="360" alt="Screen Shot 2021-11-13 at 12 47 29 PM" src="https://user-images.githubusercontent.com/8732757/141657393-1c2c22b5-9e19-42f9-8b15-5f8ee7deac7d.png">

