### PR TITLE
Adding scroll bar to handle overflow of long network lists

### DIFF
--- a/ui/components/app/dropdowns/network-dropdown.js
+++ b/ui/components/app/dropdowns/network-dropdown.js
@@ -338,20 +338,23 @@ class NetworkDropdown extends Component {
             </div>
           ) : null}
         </div>
-        {this.renderNetworkEntry('mainnet')}
 
-        {this.renderCustomRpcList(rpcListDetail, this.props.provider)}
+        <div className="network-dropdown-list">
+          {this.renderNetworkEntry('mainnet')}
 
-        <div
-          className={classnames('network-dropdown-testnets', {
-            'network-dropdown-testnets--no-visibility': !shouldShowTestNetworks,
-          })}
-        >
-          {this.renderNetworkEntry('ropsten')}
-          {this.renderNetworkEntry('kovan')}
-          {this.renderNetworkEntry('rinkeby')}
-          {this.renderNetworkEntry('goerli')}
-          {this.renderNetworkEntry('localhost')}
+          {this.renderCustomRpcList(rpcListDetail, this.props.provider)}
+
+          <div
+            className={classnames('network-dropdown-testnets', {
+              'network-dropdown-testnets--no-visibility': !shouldShowTestNetworks,
+            })}
+          >
+            {this.renderNetworkEntry('ropsten')}
+            {this.renderNetworkEntry('kovan')}
+            {this.renderNetworkEntry('rinkeby')}
+            {this.renderNetworkEntry('goerli')}
+            {this.renderNetworkEntry('localhost')}
+          </div>
         </div>
 
         {this.renderAddCustomButton()}

--- a/ui/css/itcss/components/network.scss
+++ b/ui/css/itcss/components/network.scss
@@ -130,7 +130,7 @@
 
 .network-dropdown-list {
   max-height: 330px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .network-dropdown-divider {

--- a/ui/css/itcss/components/network.scss
+++ b/ui/css/itcss/components/network.scss
@@ -128,6 +128,11 @@
   width: 100%;
 }
 
+.network-dropdown-list {
+  max-height: 330px;
+  overflow-y: scroll;
+}
+
 .network-dropdown-divider {
   width: 100%;
   height: 1px;

--- a/ui/css/itcss/components/network.scss
+++ b/ui/css/itcss/components/network.scss
@@ -131,6 +131,7 @@
 .network-dropdown-list {
   max-height: 330px;
   overflow-y: auto;
+  margin-bottom: 8px;
 }
 
 .network-dropdown-divider {


### PR DESCRIPTION
Addresses an issue from 10.6.0 QA

Adds scrolling to the list of networks in the network dropdown, in case the list is too long.


https://user-images.githubusercontent.com/7499938/141774182-13b265be-0f2f-4d41-9da5-72e23796fa9e.mp4

