### PR TITLE
display hex data on send screen fixed

### DIFF
--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -419,6 +419,7 @@ export const initializeSendState = createAsyncThunk(
       send: { asset, stage, recipient, amount, draftTransaction },
       metamask,
     } = state;
+
     // First determine the correct from address. For new sends this is always
     // the currently selected account and switching accounts switches the from
     // address. If editing an existing transaction (by clicking 'edit' on the
@@ -707,6 +708,7 @@ const slice = createSlice({
       state.recipient.nickname = action.payload.nickname;
       state.draftTransaction.id = action.payload.id;
       state.draftTransaction.txParams.from = action.payload.from;
+      state.draftTransaction.userInputHexData = action.payload.data;
       slice.caseReducers.updateDraftTransaction(state);
     },
     /**
@@ -1601,6 +1603,7 @@ export function editTransaction(
     const { txParams } = transaction;
     if (assetType === ASSET_TYPES.NATIVE) {
       const {
+        data,
         from,
         gas: gasLimit,
         gasPrice,
@@ -1610,6 +1613,7 @@ export function editTransaction(
       const nickname = getAddressBookEntry(state, address)?.name ?? '';
       await dispatch(
         actions.editTransaction({
+          data,
           id: transactionId,
           gasLimit,
           gasPrice,
@@ -1624,7 +1628,13 @@ export function editTransaction(
         `send/editTransaction dispatched with assetType 'TOKEN' but missing assetData or assetDetails parameter`,
       );
     } else {
-      const { from, to: tokenAddress, gas: gasLimit, gasPrice } = txParams;
+      const {
+        data,
+        from,
+        to: tokenAddress,
+        gas: gasLimit,
+        gasPrice,
+      } = txParams;
       const tokenAmountInDec = getTokenValueParam(tokenData);
       const address = getTokenAddressParam(tokenData);
       const nickname = getAddressBookEntry(state, address)?.name ?? '';
@@ -1645,6 +1655,7 @@ export function editTransaction(
 
       await dispatch(
         actions.editTransaction({
+          data,
           id: transactionId,
           gasLimit,
           gasPrice,

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -2077,6 +2077,7 @@ describe('Send Slice', () => {
               1: {
                 id: 1,
                 txParams: {
+                  data: '',
                   from: '0xAddress',
                   to: '0xRecipientAddress',
                   gas: GAS_LIMITS.SIMPLE,
@@ -2107,6 +2108,7 @@ describe('Send Slice', () => {
         expect(actionResult[0].payload).toStrictEqual({
           address: '0xRecipientAddress',
           amount: '0xde0b6b3a7640000',
+          data: '',
           from: '0xAddress',
           gasLimit: GAS_LIMITS.SIMPLE,
           gasPrice: '0x3b9aca00',
@@ -2154,6 +2156,7 @@ describe('Send Slice', () => {
               1: {
                 id: 1,
                 txParams: {
+                  data: '',
                   from: '0xAddress',
                   to: '0xTokenAddress',
                   gas: GAS_LIMITS.SIMPLE,
@@ -2241,6 +2244,7 @@ describe('Send Slice', () => {
         expect(actionResult[6].payload).toStrictEqual({
           address: '0xrecipientaddress', // getting address from tokenData does .toLowerCase
           amount: '0x3a98',
+          data: '',
           from: '0xAddress',
           gasLimit: GAS_LIMITS.SIMPLE,
           gasPrice: '0x3b9aca00',

--- a/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
+++ b/ui/pages/send/send-content/send-hex-data-row/send-hex-data-row.component.js
@@ -5,6 +5,7 @@ import SendRowWrapper from '../send-row-wrapper';
 export default class SendHexDataRow extends Component {
   static propTypes = {
     inError: PropTypes.bool,
+    data: PropTypes.string,
     updateSendHexData: PropTypes.func.isRequired,
   };
 
@@ -19,7 +20,7 @@ export default class SendHexDataRow extends Component {
   };
 
   render() {
-    const { inError } = this.props;
+    const { inError, data } = this.props;
     const { t } = this.context;
 
     return (
@@ -32,6 +33,7 @@ export default class SendHexDataRow extends Component {
           onInput={this.onInput}
           placeholder={t('optional')}
           className="send-v2__hex-data__input"
+          defaultValue={data || ''}
         />
       </SendRowWrapper>
     );


### PR DESCRIPTION
fixes: #12602 
Fixes: 
- Update `Edit Transaction` reducer action  values

Explanation:  
- Like mentioned in the issue ,  reducer was  not properly setting the transaction `data` value

Manual testing steps:  
  - Turn on the "Show Hex Data" toggle in advanced settings
  - Go to the send flow
  - Enter some hex data
  - Click "Next"
  - On the Confirm screen click "Edit"
  
Issue: https://github.com/MetaMask/metamask-extension/issues/12602 