### PR TITLE
addresses an issue found in 10.6.0 QA

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -187,7 +187,7 @@
     "message": "Approved"
   },
   "approvedAmountWithColon": {
-    "message": "Approved Amount:"
+    "message": "Approved amount:"
   },
   "asset": {
     "message": "Asset"
@@ -1082,7 +1082,7 @@
     "message": "Goerli Test Network"
   },
   "grantedToWithColon": {
-    "message": "Granted To:"
+    "message": "Granted to:"
   },
   "happyToSeeYou": {
     "message": "We’re happy to see you."
@@ -1855,7 +1855,7 @@
     "message": "You have approved this permission"
   },
   "permissionRequest": {
-    "message": "Permission Request"
+    "message": "Permission request"
   },
   "permissionUncheckedIconDescription": {
     "message": "You have not approved this permission"
@@ -2875,7 +2875,7 @@
     "message": "Transaction encountered an error."
   },
   "transactionFee": {
-    "message": "Transaction Fee"
+    "message": "Transaction fee"
   },
   "transactionHistoryBaseFee": {
     "message": "Base Fee (GWEI)"

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -72,13 +72,13 @@ describe('ConfirmApproveContent Component', () => {
     expect(props.showCustomizeNonceModal).toHaveBeenCalledTimes(1);
 
     const showHideTxDetails = getByText('View full transaction details');
-    expect(queryByText('Permission Request')).not.toBeInTheDocument();
-    expect(queryByText('Approved Amount:')).not.toBeInTheDocument();
-    expect(queryByText('Granted To:')).not.toBeInTheDocument();
+    expect(queryByText('Permission request')).not.toBeInTheDocument();
+    expect(queryByText('Approved amount:')).not.toBeInTheDocument();
+    expect(queryByText('Granted to:')).not.toBeInTheDocument();
     fireEvent.click(showHideTxDetails);
-    expect(getByText('Permission Request')).toBeInTheDocument();
-    expect(getByText('Approved Amount:')).toBeInTheDocument();
-    expect(getByText('Granted To:')).toBeInTheDocument();
+    expect(getByText('Permission request')).toBeInTheDocument();
+    expect(getByText('Approved amount:')).toBeInTheDocument();
+    expect(getByText('Granted to:')).toBeInTheDocument();
     expect(getByText('0x9bc5...fef4')).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
+++ b/ui/pages/confirm-approve/confirm-approve-content/confirm-approve-content.component.test.js
@@ -58,7 +58,7 @@ describe('ConfirmApproveContent Component', () => {
 
     const editButtons = getAllByText('Edit');
 
-    expect(queryByText('Transaction Fee')).toBeInTheDocument();
+    expect(queryByText('Transaction fee')).toBeInTheDocument();
     expect(
       queryByText('A fee is associated with this request.'),
     ).toBeInTheDocument();

--- a/ui/pages/confirm-approve/confirm-approve.js
+++ b/ui/pages/confirm-approve/confirm-approve.js
@@ -144,9 +144,7 @@ export default function ConfirmApprove() {
   }, [checkIfContract]);
 
   const { origin } = transaction;
-  const formattedOrigin = origin
-    ? origin[0].toUpperCase() + origin.slice(1)
-    : '';
+  const formattedOrigin = origin || '';
 
   const { icon: siteImage = '' } = domainMetadata[origin] || {};
 

--- a/ui/pages/swaps/swaps-gas-customization-modal/__snapshots__/swaps-gas-customization-modal.component.test.js.snap
+++ b/ui/pages/swaps/swaps-gas-customization-modal/__snapshots__/swaps-gas-customization-modal.component.test.js.snap
@@ -107,7 +107,7 @@ exports[`GasCustomizationModalComponent renders the component with initial props
   <span
     class="gas-modal-content__info-row__transaction-info__label"
   >
-    Transaction Fee
+    Transaction fee
   </span>
   <span
     class="gas-modal-content__info-row__transaction-info__value"

--- a/ui/pages/swaps/swaps-gas-customization-modal/__snapshots__/swaps-gas-customization-modal.container.test.js.snap
+++ b/ui/pages/swaps/swaps-gas-customization-modal/__snapshots__/swaps-gas-customization-modal.container.test.js.snap
@@ -69,7 +69,7 @@ exports[`GasCustomizationModalContainer renders the component with initial props
   <span
     class="gas-modal-content__info-row__transaction-info__label"
   >
-    Transaction Fee
+    Transaction fee
   </span>
   <span
     class="gas-modal-content__info-row__transaction-info__value"

--- a/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.test.js
+++ b/ui/pages/swaps/swaps-gas-customization-modal/swaps-gas-customization-modal.container.test.js
@@ -19,7 +19,7 @@ describe('GasCustomizationModalContainer', () => {
     expect(getByText('Advanced')).toBeInTheDocument();
     expect(getByText('Estimated Processing Times')).toBeInTheDocument();
     expect(getByText('Send Amount')).toBeInTheDocument();
-    expect(getByText('Transaction Fee')).toBeInTheDocument();
+    expect(getByText('Transaction fee')).toBeInTheDocument();
     expect(
       getByTestId('gas-modal-content__info-row__send-info'),
     ).toMatchSnapshot();


### PR DESCRIPTION
Fixes: An issue found in 10.6.0 QA

Explanation:  

Token approval full url under permission tab, [ScreenCap](https://drive.google.com/open?id=1X6v_vkwzZDQQU6iGfjb34GqhnrQjmbl0).
 Design implementation has the capitalized domain name, [Figma](https://www.figma.com/file/eEFSq73S1NLEReogz1WTUG/ERC20-token-approval?node-id=219%3A536).


  - 
  - 
  - 