### PR TITLE
Fix manifest i18n substitutions for Beta and Flask

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -173,6 +173,14 @@
     "message": "MetaMask",
     "description": "The name of the application"
   },
+  "appNameBeta": {
+    "message": "MetaMask Beta",
+    "description": "The name of the application (Beta)"
+  },
+  "appNameFlask": {
+    "message": "MetaMask Flask",
+    "description": "The name of the application (Flask)"
+  },
   "approvalAndAggregatorTxFeeCost": {
     "message": "Approval and aggregator network fee"
   },

--- a/app/build-types/beta/manifest/_base.json
+++ b/app/build-types/beta/manifest/_base.json
@@ -21,6 +21,6 @@
     "128": "images/icon-128.png",
     "512": "images/icon-512.png"
   },
-  "name": "__MSG_appName__ Beta",
-  "short_name": "__MSG_appName__ Beta"
+  "name": "__MSG_appNameBeta__",
+  "short_name": "__MSG_appNameBeta__"
 }

--- a/app/build-types/flask/manifest/_base.json
+++ b/app/build-types/flask/manifest/_base.json
@@ -21,6 +21,6 @@
     "128": "images/icon-128.png",
     "512": "images/icon-512.png"
   },
-  "name": "__MSG_appName__ Flask",
-  "short_name": "__MSG_appName__ Flask"
+  "name": "__MSG_appNameFlask__",
+  "short_name": "__MSG_appNameFlask__"
 }

--- a/development/verify-locale-strings.js
+++ b/development/verify-locale-strings.js
@@ -216,7 +216,12 @@ async function verifyEnglishLocale() {
   }
 
   // never consider these messages as unused
-  const messageExceptions = ['appName', 'appDescription'];
+  const messageExceptions = [
+    'appName',
+    'appNameBeta',
+    'appNameFlask',
+    'appDescription',
+  ];
 
   const englishMessages = Object.keys(englishLocale);
   const unusedMessages = englishMessages.filter(


### PR DESCRIPTION
We noticed that the Chrome web store wasn't substituting our locale messages in the manifest for Beta and Flask builds. I believe this is because their i18n API expects the entire string value to be of the format `__MSG_messageKey__`. This PR updates the Beta and Flask manifest substitutions to match, by means of new locale messages.