### PR TITLE
Use v2 API for fiat onboarding URL creation, fix wrapping / unwrapping

### DIFF
--- a/app/scripts/lib/buy-eth-url.js
+++ b/app/scripts/lib/buy-eth-url.js
@@ -1,12 +1,13 @@
 import log from 'loglevel';
 
-import { METASWAP_CHAINID_API_HOST_MAP } from '../../../shared/constants/swaps';
+import { SWAPS_API_V2_BASE_URL } from '../../../shared/constants/swaps';
 import {
   GOERLI_CHAIN_ID,
   KOVAN_CHAIN_ID,
   MAINNET_CHAIN_ID,
   RINKEBY_CHAIN_ID,
   ROPSTEN_CHAIN_ID,
+  MAINNET_NETWORK_ID,
 } from '../../../shared/constants/network';
 import { SECOND } from '../../../shared/constants/time';
 import getFetchWithTimeout from '../../../shared/modules/fetch-with-timeout';
@@ -20,7 +21,7 @@ const fetchWithTimeout = getFetchWithTimeout(SECOND * 30);
  * @returns String
  */
 const createWyrePurchaseUrl = async (address) => {
-  const fiatOnRampUrlApi = `${METASWAP_CHAINID_API_HOST_MAP[MAINNET_CHAIN_ID]}/fiatOnRampUrl?serviceName=wyre&destinationAddress=${address}`;
+  const fiatOnRampUrlApi = `${SWAPS_API_V2_BASE_URL}/networks/${MAINNET_NETWORK_ID}/fiatOnRampUrl?serviceName=wyre&destinationAddress=${address}`;
   const wyrePurchaseUrlFallback = `https://pay.sendwyre.com/purchase?dest=ethereum:${address}&destCurrency=ETH&accountId=AC-7AG3W4XH4N2&paymentMethod=debit-card`;
   try {
     const response = await fetchWithTimeout(fiatOnRampUrlApi, {

--- a/app/scripts/lib/buy-eth-url.test.js
+++ b/app/scripts/lib/buy-eth-url.test.js
@@ -28,8 +28,10 @@ const KOVAN = {
 
 describe('buy-eth-url', function () {
   it('returns Wyre url with an ETH address for Ethereum mainnet', async function () {
-    nock('https://api.metaswap.codefi.network')
-      .get(`/fiatOnRampUrl?serviceName=wyre&destinationAddress=${ETH_ADDRESS}`)
+    nock('https://api2.metaswap.codefi.network')
+      .get(
+        `/networks/1/fiatOnRampUrl?serviceName=wyre&destinationAddress=${ETH_ADDRESS}`,
+      )
       .reply(200, {
         url: `https://pay.sendwyre.com/purchase?accountId=${WYRE_ACCOUNT_ID}&utm_campaign=${WYRE_ACCOUNT_ID}&destCurrency=ETH&utm_medium=widget&paymentMethod=debit-card&reservation=MLZVUF8FMXZUMARJC23B&dest=ethereum%3A${ETH_ADDRESS}&utm_source=checkout`,
       });

--- a/app/scripts/lib/buy-eth-url.test.js
+++ b/app/scripts/lib/buy-eth-url.test.js
@@ -7,6 +7,7 @@ import {
   ROPSTEN_CHAIN_ID,
 } from '../../../shared/constants/network';
 import { TRANSAK_API_KEY } from '../constants/on-ramp';
+import { SWAPS_API_V2_BASE_URL } from '../../../shared/constants/swaps';
 import getBuyEthUrl from './buy-eth-url';
 
 const WYRE_ACCOUNT_ID = 'AC-7AG3W4XH4N2';
@@ -28,7 +29,7 @@ const KOVAN = {
 
 describe('buy-eth-url', function () {
   it('returns Wyre url with an ETH address for Ethereum mainnet', async function () {
-    nock('https://api2.metaswap.codefi.network')
+    nock(SWAPS_API_V2_BASE_URL)
       .get(
         `/networks/1/fiatOnRampUrl?serviceName=wyre&destinationAddress=${ETH_ADDRESS}`,
       )

--- a/ui/pages/swaps/swaps.util.js
+++ b/ui/pages/swaps/swaps.util.js
@@ -275,11 +275,18 @@ export const shouldEnableDirectWrapping = (
   sourceToken,
   destinationToken,
 ) => {
+  if (!sourceToken || !destinationToken) {
+    return false;
+  }
   const wrappedToken = SWAPS_WRAPPED_TOKENS_ADDRESSES[chainId];
   const nativeToken = SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId]?.address;
+  const sourceTokenLowerCase = sourceToken.toLowerCase();
+  const destinationTokenLowerCase = destinationToken.toLowerCase();
   return (
-    (sourceToken === wrappedToken && destinationToken === nativeToken) ||
-    (sourceToken === nativeToken && destinationToken === wrappedToken)
+    (sourceTokenLowerCase === wrappedToken &&
+      destinationTokenLowerCase === nativeToken) ||
+    (sourceTokenLowerCase === nativeToken &&
+      destinationTokenLowerCase === wrappedToken)
   );
 };
 

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -424,11 +424,35 @@ describe('Swaps Util', () => {
       ).toBe(true);
     });
 
+    it('returns true if swapping from ETH with uppercase chars to WETH', () => {
+      const ethContractAddressWithUpperCaseChars =
+        '0X0000000000000000000000000000000000000000';
+      expect(
+        shouldEnableDirectWrapping(
+          MAINNET_CHAIN_ID,
+          ethContractAddressWithUpperCaseChars,
+          WETH_CONTRACT_ADDRESS,
+        ),
+      ).toBe(true);
+    });
+
     it('returns true if swapping from WETH to ETH', () => {
       expect(
         shouldEnableDirectWrapping(
           MAINNET_CHAIN_ID,
           WETH_CONTRACT_ADDRESS,
+          SWAPS_CHAINID_DEFAULT_TOKEN_MAP[MAINNET_CHAIN_ID]?.address,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true if swapping from WETH with uppercase chars to ETH', () => {
+      const wethContractAddressWithUpperCaseChars =
+        '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+      expect(
+        shouldEnableDirectWrapping(
+          MAINNET_CHAIN_ID,
+          wethContractAddressWithUpperCaseChars,
           SWAPS_CHAINID_DEFAULT_TOKEN_MAP[MAINNET_CHAIN_ID]?.address,
         ),
       ).toBe(true);

--- a/ui/pages/swaps/swaps.util.test.js
+++ b/ui/pages/swaps/swaps.util.test.js
@@ -425,12 +425,12 @@ describe('Swaps Util', () => {
     });
 
     it('returns true if swapping from ETH with uppercase chars to WETH', () => {
-      const ethContractAddressWithUpperCaseChars =
+      const ethAddressWithUpperCaseChars =
         '0X0000000000000000000000000000000000000000';
       expect(
         shouldEnableDirectWrapping(
           MAINNET_CHAIN_ID,
-          ethContractAddressWithUpperCaseChars,
+          ethAddressWithUpperCaseChars,
           WETH_CONTRACT_ADDRESS,
         ),
       ).toBe(true);


### PR DESCRIPTION
## Description
This PR contains 2 things:
- Use a Swaps v2 APIs to get a fiat onboarding URL, so we can deprecate old APIs
- Fix an issue with wrapping / unwrapping if an address contained uppercase chars

## Manual testing steps
#### v2 API
- Click on "Buy" on the homepage when Ethereum Mainnet network is selected
- Click on "Continue to Wyre"
- New tab with Wyre fiat onboarding is opened and your Ethereum address is prepopulated
- Network tab in MM shows a call to this v2 URL: `https://api2.metaswap.codefi.network/networks/1/fiatOnRampUrl`

#### Wrapping / unwrapping
Homepage:
- On the homepage click on on the "Swap" button 
- Try swaps for ETH -> WETH and WETH -> ETH
- They should both show just one quote from backend (`/trades` API call with the `enableDirectWrapping: true` query param)

Activity tab:
- On the homepage in the Activity tab click on WETH and then on "Swap"
- Try to swap WETH -> ETH
- It should show just one quote from backend (`/trades` API call with the `enableDirectWrapping: true` query param) 