### PR TITLE
Confirm transaction screen - wrap lengthier values

### DIFF
--- a/test/e2e/tests/send-edit.spec.js
+++ b/test/e2e/tests/send-edit.spec.js
@@ -62,7 +62,7 @@ describe('Editing Confirm Transaction', function () {
 
         // has correct updated value on the confirm screen the transaction
         const editedTransactionAmounts = await driver.findElements(
-          '.transaction-detail-item__row .transaction-detail-item__detail-text .currency-display-component__text',
+          '.transaction-detail-item__row .transaction-detail-item__detail-values .currency-display-component__text:last-of-type',
         );
         const editedTransactionAmount = editedTransactionAmounts[0];
         assert.equal(await editedTransactionAmount.getText(), '0.0008');

--- a/ui/components/app/transaction-detail-item/index.scss
+++ b/ui/components/app/transaction-detail-item/index.scss
@@ -5,12 +5,15 @@
 
   &__row {
     display: flex;
+    justify-content: space-between;
     grid-gap: 5px;
   }
 
-  &__title {
-    flex-grow: 1;
-    word-break: break-word;
+  &__detail-values {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: end;
+    width: 65%;
   }
 
   .info-tooltip {
@@ -20,19 +23,6 @@
     path {
       fill: $ui-3;
     }
-  }
-
-  &__total {
-    font-weight: bold;
-    color: $ui-black;
-  }
-
-  &__subtitle {
-    flex-grow: 1;
-  }
-
-  &__subtext {
-    text-align: end;
   }
 
   .currency-display-component {

--- a/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
+++ b/ui/components/app/transaction-detail-item/transaction-detail-item.component.js
@@ -23,46 +23,35 @@ export default function TransactionDetailItem({
           color={detailTitleColor}
           fontWeight={FONT_WEIGHT.BOLD}
           variant={TYPOGRAPHY.H6}
-          className="transaction-detail-item__title"
         >
           {detailTitle}
         </Typography>
-        {detailText && (
+        <div className="transaction-detail-item__detail-values">
+          {detailText && (
+            <Typography variant={TYPOGRAPHY.H6} color={COLORS.UI4}>
+              {detailText}
+            </Typography>
+          )}
           <Typography
+            color={COLORS.BLACK}
+            fontWeight={FONT_WEIGHT.BOLD}
             variant={TYPOGRAPHY.H6}
-            className="transaction-detail-item__detail-text"
-            color={COLORS.UI4}
+            margin={[1, 1]}
           >
-            {detailText}
+            {detailTotal}
           </Typography>
-        )}
-        <Typography
-          color={COLORS.BLACK}
-          fontWeight={FONT_WEIGHT.BOLD}
-          variant={TYPOGRAPHY.H6}
-          className="transaction-detail-item__total"
-        >
-          {detailTotal}
-        </Typography>
+        </div>
       </div>
       <div className="transaction-detail-item__row">
         {React.isValidElement(subTitle) ? (
-          <div className="transaction-detail-item__subtitle">{subTitle}</div>
+          <div>{subTitle}</div>
         ) : (
-          <Typography
-            variant={TYPOGRAPHY.H7}
-            className="transaction-detail-item__subtitle"
-            color={COLORS.UI4}
-          >
+          <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4}>
             {subTitle}
           </Typography>
         )}
 
-        <Typography
-          variant={TYPOGRAPHY.H7}
-          color={COLORS.UI4}
-          className="transaction-detail-item__subtext"
-        >
+        <Typography variant={TYPOGRAPHY.H7} color={COLORS.UI4} align="end">
           {subText}
         </Typography>
       </div>


### PR DESCRIPTION
Fixes: #12598

Wrap lengthier values on confirm transaction screen:

<img width="481" alt="Screenshot 2021-11-18 at 12 46 46 AM" src="https://user-images.githubusercontent.com/2182307/142267678-5ba7449a-fe6c-405f-a63c-3b9016a5fb4a.png">


<img width="468" alt="Screenshot 2021-11-18 at 12 45 59 AM" src="https://user-images.githubusercontent.com/2182307/142267688-7fe0c281-438a-48d6-b39e-4deeab29d7e1.png">

