### PR TITLE
ci - fix yarn-audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ workflows:
               only:
                 - /^Version-v(\d+)[.](\d+)[.](\d+)/
       - prep-deps
-      - test-deps-audit
+      - test-deps-audit:
+          requires:
+            - prep-deps
       - test-deps-depcheck:
           requires:
             - prep-deps

--- a/.circleci/scripts/yarn-audit.sh
+++ b/.circleci/scripts/yarn-audit.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
 set -u
+set -x
 set -o pipefail
 
 # use `improved-yarn-audit` since that allows for exclude


### PR DESCRIPTION
this seems to have been broken since https://github.com/MetaMask/metamask-extension/pull/12310

though, we employ `shellcheck` to catch this sort of things, not sure why this is not enforced