### PR TITLE
Fix signature-request for new Storybook format

### DIFF
--- a/ui/components/app/signature-request/README.mdx
+++ b/ui/components/app/signature-request/README.mdx
@@ -1,0 +1,15 @@
+import { Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import SignatureRequest from '.';
+
+# Signature Request
+
+Buttons communicate actions that users can take.
+
+<Canvas>
+  <Story id="ui-components-app-signature-request-signature-request-stories-js--default-story" />
+</Canvas>
+
+## Component API
+
+<ArgsTable of={SignatureRequest} />

--- a/ui/components/app/signature-request/README.mdx
+++ b/ui/components/app/signature-request/README.mdx
@@ -4,7 +4,7 @@ import SignatureRequest from '.';
 
 # Signature Request
 
-Buttons communicate actions that users can take.
+dApp requesting a signature from the user.
 
 <Canvas>
   <Story id="ui-components-app-signature-request-signature-request-stories-js--default-story" />

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -25,10 +25,6 @@ export default class SignatureRequest extends PureComponent {
      */
     isLedgerWallet: PropTypes.bool,
     /**
-     * Handler for clearing confirmed transaction
-     */
-    clearConfirmTransaction: PropTypes.func.isRequired,
-    /**
      * Handler for cancel button
      */
     cancel: PropTypes.func.isRequired,

--- a/ui/components/app/signature-request/signature-request.component.js
+++ b/ui/components/app/signature-request/signature-request.component.js
@@ -8,15 +8,37 @@ import Message from './signature-request-message';
 
 export default class SignatureRequest extends PureComponent {
   static propTypes = {
+    /**
+     * The display content of transaction data
+     */
     txData: PropTypes.object.isRequired,
+    /**
+     * The display content of sender account
+     */
     fromAccount: PropTypes.shape({
       address: PropTypes.string.isRequired,
       balance: PropTypes.string,
       name: PropTypes.string,
     }).isRequired,
+    /**
+     * Check if the wallet is ledget wallet or not
+     */
     isLedgerWallet: PropTypes.bool,
+    /**
+     * Handler for clearing confirmed transaction
+     */
+    clearConfirmTransaction: PropTypes.func.isRequired,
+    /**
+     * Handler for cancel button
+     */
     cancel: PropTypes.func.isRequired,
+    /**
+     * Handler for sign button
+     */
     sign: PropTypes.func.isRequired,
+    /**
+     * Whether the hardware wallet requires a connection disables the sign button if true.
+     */
     hardwareWalletRequiresConnection: PropTypes.bool.isRequired,
   };
 

--- a/ui/components/app/signature-request/signature-request.stories.js
+++ b/ui/components/app/signature-request/signature-request.stories.js
@@ -1,40 +1,60 @@
 import React from 'react';
 import testData from '../../../../.storybook/test-data';
+import README from './README.mdx';
 import SignatureRequest from './signature-request.component';
 
 const primaryIdentity = Object.values(testData.metamask.identities)[0];
 
-const containerStyle = {
-  width: '357px',
-};
-
 export default {
   title: 'Components/App/SignatureRequest',
   id: __filename,
+  component: SignatureRequest,
+  parameters: {
+    docs: {
+      page: README,
+    },
+  },
+  argTypes: {
+    txData: { control: 'object' },
+    fromAccount: {
+      table: {
+        address: { control: 'text' },
+        balance: { control: 'text' },
+        name: { control: 'text' },
+      },
+    },
+    isLedgerWallet: { control: 'boolean' },
+    clearConfirmTransaction: { action: 'Clean Confirm' },
+    cancel: { action: 'Cancel' },
+    sign: { action: 'Sign' },
+    hardwareWalletRequiresConnection: {
+      action: 'hardwareWalletRequiresConnection',
+    },
+  },
 };
 
-export const DefaultStory = () => {
-  return (
-    <div style={containerStyle}>
-      <SignatureRequest
-        txData={{
-          msgParams: {
-            data: JSON.stringify({
-              domain: {
-                name: 'happydapp.website',
-              },
-              message: {
-                string: 'haay wuurl',
-                number: 42,
-              },
-            }),
-            origin: 'https://happydapp.website/governance?futarchy=true',
-          },
-        }}
-        fromAccount={primaryIdentity}
-      />
-    </div>
-  );
+export const DefaultStory = (args) => {
+  return <SignatureRequest {...args} />;
+};
+
+DefaultStory.storyName = 'Default';
+
+DefaultStory.args = {
+  txData: {
+    msgParams: {
+      data: JSON.stringify({
+        domain: {
+          name: 'happydapp.website',
+        },
+        message: {
+          string: 'haay wuurl',
+          number: 42,
+        },
+      }),
+      origin: 'https://happydapp.website/governance?futarchy=true',
+    },
+  },
+  fromAccount: primaryIdentity,
 };
 
 DefaultStory.storyName = 'Default';


### PR DESCRIPTION
Updating `SignatureRequest` story:
- Add js doc comments to proptypes to allow ArgsTable to show up
- Add README.MDX
- Add controls for interaction of component

**Manual testing steps**
- Go to latest CI build of storybook
- Search "SignatureRequest"
- Use Controls to interact with component
- Check docs page to see Props table

**Images**

Before

<img width="1440" alt="Screen Shot 2021-12-01 at 12 09 48 PM" src="https://user-images.githubusercontent.com/8112138/144306863-55ee81ea-05a4-4bf4-9674-14eb6f678b59.png">


After

<img width="1439" alt="Screen Shot 2021-12-01 at 12 10 09 PM" src="https://user-images.githubusercontent.com/8112138/144306895-3d953f41-e6ef-462c-af5c-3b9d50c829d1.png">

![screencapture-localhost-6006-2021-12-01-12_10_45](https://user-images.githubusercontent.com/8112138/144306905-a9786119-bc6f-4937-a463-2b339cbfd78f.png)


