### PR TITLE
Convert token input to BigNumber to handle decimals better.

### DIFF
--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -80,8 +80,10 @@ export default class TokenInput extends PureComponent {
 
     let newDecimalValue = decimalValue;
 
-    if (newDecimalValue.split('.').length > 1) {
-      const decimalsPlaces = newDecimalValue.split('.')[1].length;
+    const newDecimalValueBreakdown = newDecimalValue.split('.');
+
+    if (newDecimalValueBreakdown.length > 1) {
+      const decimalsPlaces = newDecimalValueBreakdown[1].length;
 
       if (decimals && applyDecimals && decimalsPlaces > decimals) {
         newDecimalValue = parseFloat(decimalValue).toFixed(decimals);

--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -80,8 +80,12 @@ export default class TokenInput extends PureComponent {
 
     let newDecimalValue = decimalValue;
 
-    if (decimals && applyDecimals) {
-      newDecimalValue = parseFloat(decimalValue).toFixed(decimals);
+    if (newDecimalValue.split('.').length > 1) {
+      const decimalsPlaces = newDecimalValue.split('.')[1].length;
+
+      if (decimals && applyDecimals && decimalsPlaces > decimals) {
+        newDecimalValue = parseFloat(decimalValue).toFixed(decimals);
+      }
     }
 
     const multiplier = Math.pow(10, Number(decimals || 0));

--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -80,8 +80,8 @@ export default class TokenInput extends PureComponent {
 
     let newDecimalValue = decimalValue;
 
-    if (decimalValue.split('.').length > 1) {
-      const decimalsPlaces = decimalValue.split('.')[1].length;
+    if (newDecimalValue.split('.').length > 1) {
+      const decimalsPlaces = newDecimalValue.split('.')[1].length;
 
       if (decimals && applyDecimals && decimalsPlaces > decimals) {
         newDecimalValue = parseFloat(decimalValue).toFixed(decimals);

--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import BigNumber from 'bignumber.js';
 import UnitInput from '../unit-input';
 import CurrencyDisplay from '../currency-display';
 import { getWeiHexFromDecimalValue } from '../../../helpers/utils/conversions.util';
@@ -7,6 +8,7 @@ import {
   conversionUtil,
   multiplyCurrencies,
 } from '../../../../shared/modules/conversion.utils';
+
 import { ETH } from '../../../helpers/constants/common';
 import { addHexPrefix } from '../../../../app/scripts/lib/util';
 
@@ -80,14 +82,8 @@ export default class TokenInput extends PureComponent {
 
     let newDecimalValue = decimalValue;
 
-    const newDecimalValueBreakdown = newDecimalValue.split('.');
-
-    if (newDecimalValueBreakdown.length > 1) {
-      const decimalsPlaces = newDecimalValueBreakdown[1].length;
-
-      if (decimals && applyDecimals && decimalsPlaces > decimals) {
-        newDecimalValue = parseFloat(decimalValue).toFixed(decimals);
-      }
+    if (decimals && applyDecimals) {
+      newDecimalValue = new BigNumber(decimalValue, 10).toFixed(decimals);
     }
 
     const multiplier = Math.pow(10, Number(decimals || 0));

--- a/ui/components/ui/token-input/token-input.component.js
+++ b/ui/components/ui/token-input/token-input.component.js
@@ -80,8 +80,8 @@ export default class TokenInput extends PureComponent {
 
     let newDecimalValue = decimalValue;
 
-    if (newDecimalValue.split('.').length > 1) {
-      const decimalsPlaces = newDecimalValue.split('.')[1].length;
+    if (decimalValue.split('.').length > 1) {
+      const decimalsPlaces = decimalValue.split('.')[1].length;
 
       if (decimals && applyDecimals && decimalsPlaces > decimals) {
         newDecimalValue = parseFloat(decimalValue).toFixed(decimals);

--- a/ui/components/ui/token-input/token-input.component.test.js
+++ b/ui/components/ui/token-input/token-input.component.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { shallow, mount } from 'enzyme';
-import sinon from 'sinon';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import UnitInput from '../unit-input';

--- a/ui/components/ui/token-input/token-input.component.test.js
+++ b/ui/components/ui/token-input/token-input.component.test.js
@@ -207,12 +207,12 @@ describe('TokenInput Component', () => {
   });
 
   describe('handling actions', () => {
-    const handleChangeSpy = sinon.spy();
-    const handleBlurSpy = sinon.spy();
+    const handleChangeSpy = jest.fn();
+    const handleBlurSpy = jest.fn();
 
     afterEach(() => {
-      handleChangeSpy.resetHistory();
-      handleBlurSpy.resetHistory();
+      handleChangeSpy.mockClear();
+      handleBlurSpy.mockClear();
     });
 
     it('should call onChange on input changes with the hex value for ETH', () => {
@@ -238,8 +238,8 @@ describe('TokenInput Component', () => {
       );
 
       expect(wrapper).toHaveLength(1);
-      expect(handleChangeSpy.callCount).toStrictEqual(0);
-      expect(handleBlurSpy.callCount).toStrictEqual(0);
+      expect(handleChangeSpy.mock.calls).toHaveLength(0);
+      expect(handleBlurSpy.mock.calls).toHaveLength(0);
 
       const tokenInputInstance = wrapper.find(TokenInput).at(0).instance();
       expect(tokenInputInstance.state.decimalValue).toStrictEqual(0);
@@ -250,13 +250,13 @@ describe('TokenInput Component', () => {
       const input = wrapper.find('input');
       expect(input.props().value).toStrictEqual(0);
 
-      input.simulate('change', { target: { value: 1 } });
-      expect(handleChangeSpy.callCount).toStrictEqual(1);
-      expect(handleChangeSpy.calledWith('2710')).toStrictEqual(true);
+      input.simulate('change', { target: { value: '1' } });
+      expect(handleChangeSpy.mock.calls).toHaveLength(1);
+      expect(handleChangeSpy.mock.calls[0][0]).toStrictEqual('2710');
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(
         '2ETH',
       );
-      expect(tokenInputInstance.state.decimalValue).toStrictEqual(1);
+      expect(tokenInputInstance.state.decimalValue).toStrictEqual('1');
       expect(tokenInputInstance.state.hexValue).toStrictEqual('2710');
     });
 
@@ -285,8 +285,8 @@ describe('TokenInput Component', () => {
       );
 
       expect(wrapper).toHaveLength(1);
-      expect(handleChangeSpy.callCount).toStrictEqual(0);
-      expect(handleBlurSpy.callCount).toStrictEqual(0);
+      expect(handleChangeSpy.mock.calls).toHaveLength(0);
+      expect(handleBlurSpy.mock.calls).toHaveLength(0);
 
       const tokenInputInstance = wrapper.find(TokenInput).at(0).instance();
       expect(tokenInputInstance.state.decimalValue).toStrictEqual(0);
@@ -297,13 +297,13 @@ describe('TokenInput Component', () => {
       const input = wrapper.find('input');
       expect(input.props().value).toStrictEqual(0);
 
-      input.simulate('change', { target: { value: 1 } });
-      expect(handleChangeSpy.callCount).toStrictEqual(1);
-      expect(handleChangeSpy.calledWith('2710')).toStrictEqual(true);
+      input.simulate('change', { target: { value: '1' } });
+      expect(handleChangeSpy.mock.calls).toHaveLength(1);
+      expect(handleChangeSpy.mock.calls[0][0]).toStrictEqual('2710');
       expect(wrapper.find('.currency-display-component').text()).toStrictEqual(
         '$462.12USD',
       );
-      expect(tokenInputInstance.state.decimalValue).toStrictEqual(1);
+      expect(tokenInputInstance.state.decimalValue).toStrictEqual('1');
       expect(tokenInputInstance.state.hexValue).toStrictEqual('2710');
     });
 


### PR DESCRIPTION
Fixes #12762

<strike>Adds a decimal length check for inputs and drops excess fractional part.</strike>

Convert token input to BigNumber to handle decimals.
Another edgecase not accounted for is when a token's decimal precision is 0 and attempting sending decimals will result in omitting the fractional part.


Manual testing steps:  
  - Note a token's decimal precision and initiate a transaction with that token, the amount having more fractional parts than the token precision.
  - For instance if a token's precision is `4` and setting the transaction amount to `0.12345` will omit the `5`.