### PR TITLE
Removing the token detection announcement when the token detection is ON

### DIFF
--- a/ui/pages/import-token/import-token.component.js
+++ b/ui/pages/import-token/import-token.component.js
@@ -44,6 +44,7 @@ class ImportToken extends Component {
     chainId: PropTypes.string,
     rpcPrefs: PropTypes.object,
     tokenList: PropTypes.object,
+    useTokenDetection: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -391,26 +392,28 @@ class ImportToken extends Component {
   }
 
   renderSearchToken() {
-    const { tokenList, history } = this.props;
+    const { tokenList, history, useTokenDetection } = this.props;
     const { tokenSelectorError, selectedTokens, searchResults } = this.state;
     return (
       <div className="import-token__search-token">
-        <ActionableMessage
-          message={this.context.t('tokenDetectionAnnouncement', [
-            <Button
-              type="link"
-              key="token-detection-announcement"
-              className="import-token__link"
-              onClick={() => history.push(EXPERIMENTAL_ROUTE)}
-            >
-              {this.context.t('enableFromSettings')}
-            </Button>,
-          ])}
-          withRightButton
-          useIcon
-          iconFillColor="#037DD6"
-          className="import-token__token-detection-announcement"
-        />
+        {!useTokenDetection && (
+          <ActionableMessage
+            message={this.context.t('tokenDetectionAnnouncement', [
+              <Button
+                type="link"
+                key="token-detection-announcement"
+                className="import-token__link"
+                onClick={() => history.push(EXPERIMENTAL_ROUTE)}
+              >
+                {this.context.t('enableFromSettings')}
+              </Button>,
+            ])}
+            withRightButton
+            useIcon
+            iconFillColor="#037DD6"
+            className="import-token__token-detection-announcement"
+          />
+        )}
         <TokenSearch
           onSearch={({ results = [] }) =>
             this.setState({ searchResults: results })

--- a/ui/pages/import-token/import-token.container.js
+++ b/ui/pages/import-token/import-token.container.js
@@ -34,6 +34,7 @@ const mapStateToProps = (state) => {
     chainId,
     rpcPrefs: getRpcPrefsForCurrentProvider(state),
     tokenList,
+    useTokenDetection,
   };
 };
 

--- a/ui/pages/import-token/index.scss
+++ b/ui/pages/import-token/index.scss
@@ -21,7 +21,7 @@
   }
 
   &__search-token {
-    padding: 0 16px 16px 16px;
+    padding: 16px 16px 16px 16px;
   }
 
   &__token-list {
@@ -57,5 +57,6 @@
 
   &__token-detection-announcement {
     margin-bottom: 16px;
+    margin-top: 0;
   }
 }


### PR DESCRIPTION
Currently, the token detection announcement is visible even when the token detection is ON, this PR will change that to make the announcement disappear when once the token detection is turned ON, and re-appear when the user turns OFF the token detection.