### PR TITLE
Proper calculation of the gas limit

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1167,6 +1167,9 @@
   "gasLimitInfoTooltipContent": {
     "message": "Gas limit is the maximum amount of units of gas you are willing to spend."
   },
+  "gasLimitIsLessThenCalculatedGasLimit": {
+    "message": "Gas limit must be equal or greater than $1"
+  },
   "gasLimitTooLow": {
     "message": "Gas limit must be at least 21000"
   },
@@ -1179,9 +1182,6 @@
   },
   "gasOption": {
     "message": "Gas option"
-  },
-  "gasLimitIsLessThenCalculatedGasLimit": {
-    "message": "Gas limit must be equal or greater than $1"
   },
   "gasPrice": {
     "message": "Gas Price (GWEI)"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1180,6 +1180,9 @@
   "gasOption": {
     "message": "Gas option"
   },
+  "gasLimitIsLessThenCalculatedGasLimit": {
+    "message": "Gas limit must be equal or greater than $1"
+  },
   "gasPrice": {
     "message": "Gas Price (GWEI)"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1167,8 +1167,8 @@
   "gasLimitInfoTooltipContent": {
     "message": "Gas limit is the maximum amount of units of gas you are willing to spend."
   },
-  "gasLimitIsLessThenCalculatedGasLimit": {
-    "message": "Gas limit must be equal or greater than $1"
+  "gasLimitRecommended": {
+    "message": "Recommended gas limit is $1. If the gas limit is less than estimated transaction can fail."
   },
   "gasLimitTooLow": {
     "message": "Gas limit must be at least 21000"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1168,7 +1168,7 @@
     "message": "Gas limit is the maximum amount of units of gas you are willing to spend."
   },
   "gasLimitRecommended": {
-    "message": "Recommended gas limit is $1. If the gas limit is less than estimated transaction can fail."
+    "message": "Recommended gas limit is $1. If the gas limit is less that, it may fail."
   },
   "gasLimitTooLow": {
     "message": "Gas limit must be at least 21000"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1168,7 +1168,7 @@
     "message": "Gas limit is the maximum amount of units of gas you are willing to spend."
   },
   "gasLimitRecommended": {
-    "message": "Recommended gas limit is $1. If the gas limit is less that, it may fail."
+    "message": "Recommended gas limit is $1. If the gas limit is less than that, it may fail."
   },
   "gasLimitTooLow": {
     "message": "Gas limit must be at least 21000"

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -519,6 +519,7 @@ export default class TransactionController extends EventEmitter {
 
     if (defaultGasLimit && !txMeta.txParams.gas) {
       txMeta.txParams.gas = defaultGasLimit;
+      txMeta.originalGasEstimate = defaultGasLimit;
     }
     return txMeta;
   }

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -116,6 +116,7 @@ export default class TransactionStateManager extends EventEmitter {
       time: new Date().getTime(),
       status: TRANSACTION_STATUSES.UNAPPROVED,
       metamaskNetworkId: netId,
+      originalGasEstimate: opts.txParams.gas,
       chainId,
       loadingDefaults: true,
       dappSuggestedGasFees,

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -117,6 +117,7 @@ export default class TransactionStateManager extends EventEmitter {
       status: TRANSACTION_STATUSES.UNAPPROVED,
       metamaskNetworkId: netId,
       originalGasEstimate: opts.txParams?.gas,
+      userEditedGasLimit: false,
       chainId,
       loadingDefaults: true,
       dappSuggestedGasFees,

--- a/app/scripts/controllers/transactions/tx-state-manager.js
+++ b/app/scripts/controllers/transactions/tx-state-manager.js
@@ -116,7 +116,7 @@ export default class TransactionStateManager extends EventEmitter {
       time: new Date().getTime(),
       status: TRANSACTION_STATUSES.UNAPPROVED,
       metamaskNetworkId: netId,
-      originalGasEstimate: opts.txParams.gas,
+      originalGasEstimate: opts.txParams?.gas,
       chainId,
       loadingDefaults: true,
       dappSuggestedGasFees,

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -219,6 +219,8 @@ export const TRANSACTION_GROUP_CATEGORIES = {
  *  TransactionMeta object.
  * @property {string} origin - A string representing the interface that
  *  suggested the transaction.
+ * @property {string} originalGasEstimate - A string representing the original
+ * gas estimation on the transaction metadata.
  * @property {Object} nonceDetails - A metadata object containing information
  *  used to derive the suggested nonce, useful for debugging nonce issues.
  * @property {string} rawTx - A hex string of the final signed transaction,

--- a/shared/constants/transaction.js
+++ b/shared/constants/transaction.js
@@ -221,6 +221,8 @@ export const TRANSACTION_GROUP_CATEGORIES = {
  *  suggested the transaction.
  * @property {string} originalGasEstimate - A string representing the original
  * gas estimation on the transaction metadata.
+ * @property {boolean} userEditedGasLimit - A boolean representing when the
+ * user manually edited the gas limit.
  * @property {Object} nonceDetails - A metadata object containing information
  *  used to derive the suggested nonce, useful for debugging nonce issues.
  * @property {string} rawTx - A hex string of the final signed transaction,

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -111,9 +111,7 @@ export default function EditGasDisplay({
   let showTopWarning, warningMessage;
   if (gasLimit < properGasLimit) {
     showTopWarning = true;
-    warningMessage = t('gasLimitIsLessThenCalculatedGasLimit', [
-      properGasLimit,
-    ]);
+    warningMessage = t('gasLimitRecommended', [properGasLimit]);
   }
 
   const showTopError =

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -111,7 +111,9 @@ export default function EditGasDisplay({
   let showTopWarning, warningMessage;
   if (gasLimit < properGasLimit) {
     showTopWarning = true;
-    warningMessage = t('gasLimitIsLessThenCalculatedGasLimit', [properGasLimit]);
+    warningMessage = t('gasLimitIsLessThenCalculatedGasLimit', [
+      properGasLimit,
+    ]);
   }
 
   const showTopError =

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -108,9 +108,8 @@ export default function EditGasDisplay({
       dappSuggestedAndTxParamGasFeesAreTheSame,
   );
 
-  let showTopWarning, warningMessage;
+  let warningMessage;
   if (gasLimit < properGasLimit) {
-    showTopWarning = true;
     warningMessage = t('gasLimitRecommended', [properGasLimit]);
   }
 
@@ -153,7 +152,7 @@ export default function EditGasDisplay({
             <ErrorMessage errorKey={errorKey} />
           </div>
         )}
-        {showTopWarning && (
+        {warningMessage && (
           <div className="edit-gas-display__warning">
             <ActionableMessage
               className="actionable-message--warning"

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -2,6 +2,7 @@ import React, { useContext, useLayoutEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import BigNumber from 'bignumber.js';
 import {
   GAS_RECOMMENDATIONS,
   EDIT_GAS_MODES,
@@ -109,7 +110,7 @@ export default function EditGasDisplay({
   );
 
   let warningMessage;
-  if (gasLimit < properGasLimit) {
+  if (new BigNumber(gasLimit).lessThan(new BigNumber(properGasLimit))) {
     warningMessage = t('gasLimitRecommended', [properGasLimit]);
   }
 

--- a/ui/components/app/edit-gas-display/edit-gas-display.component.js
+++ b/ui/components/app/edit-gas-display/edit-gas-display.component.js
@@ -57,6 +57,7 @@ export default function EditGasDisplay({
   setGasPrice,
   gasLimit,
   setGasLimit,
+  properGasLimit,
   estimateToUse,
   setEstimateToUse,
   estimatedMinimumFiat,
@@ -107,6 +108,12 @@ export default function EditGasDisplay({
       dappSuggestedAndTxParamGasFeesAreTheSame,
   );
 
+  let showTopWarning, warningMessage;
+  if (gasLimit < properGasLimit) {
+    showTopWarning = true;
+    warningMessage = t('gasLimitIsLessThenCalculatedGasLimit', [properGasLimit]);
+  }
+
   const showTopError =
     (balanceError || estimatesUnavailableWarning) &&
     (!isGasEstimatesLoading || txParamsHaveBeenCustomized);
@@ -144,6 +151,16 @@ export default function EditGasDisplay({
         {showTopError && (
           <div className="edit-gas-display__warning">
             <ErrorMessage errorKey={errorKey} />
+          </div>
+        )}
+        {showTopWarning && (
+          <div className="edit-gas-display__warning">
+            <ActionableMessage
+              className="actionable-message--warning"
+              message={warningMessage}
+              iconFillColor="#f8c000"
+              useIcon
+            />
           </div>
         )}
         {requireDappAcknowledgement && !isGasEstimatesLoading && (
@@ -330,6 +347,7 @@ EditGasDisplay.propTypes = {
   setGasPrice: PropTypes.func,
   gasLimit: PropTypes.number,
   setGasLimit: PropTypes.func,
+  properGasLimit: PropTypes.number,
   estimateToUse: PropTypes.string,
   setEstimateToUse: PropTypes.func,
   estimatedMinimumFiat: PropTypes.string,

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -165,7 +165,7 @@ export default function EditGasPopover({
 
     const updatedTxMeta = {
       ...updatedTransaction,
-      userEditedGasLimit: userEditedGasLimit, 
+      userEditedGasLimit,
       userFeeLevel: estimateToUse || CUSTOM_GAS_ESTIMATE,
       txParams: {
         ...cleanTransactionParams,
@@ -212,6 +212,7 @@ export default function EditGasPopover({
     closePopover,
     gasLimit,
     gasPrice,
+    userEditedGasLimit,
     maxFeePerGas,
     maxPriorityFeePerGas,
     supportsEIP1559,

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -99,6 +99,7 @@ export default function EditGasPopover({
     gasLimit,
     setGasLimit,
     properGasLimit,
+    userEditedGasLimit,
     estimateToUse,
     setEstimateToUse,
     estimatedMinimumFiat,
@@ -164,6 +165,7 @@ export default function EditGasPopover({
 
     const updatedTxMeta = {
       ...updatedTransaction,
+      userEditedGasLimit: userEditedGasLimit, 
       userFeeLevel: estimateToUse || CUSTOM_GAS_ESTIMATE,
       txParams: {
         ...cleanTransactionParams,

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -98,6 +98,7 @@ export default function EditGasPopover({
     setGasPrice,
     gasLimit,
     setGasLimit,
+    properGasLimit,
     estimateToUse,
     setEstimateToUse,
     estimatedMinimumFiat,
@@ -283,6 +284,7 @@ export default function EditGasPopover({
               setGasPrice={setGasPrice}
               gasLimit={gasLimit}
               setGasLimit={setGasLimit}
+              properGasLimit={properGasLimit}
               estimateToUse={estimateToUse}
               setEstimateToUse={setEstimateToUse}
               estimatedMinimumFiat={estimatedMinimumFiat}

--- a/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
+++ b/ui/components/app/edit-gas-popover/edit-gas-popover.component.js
@@ -99,7 +99,6 @@ export default function EditGasPopover({
     gasLimit,
     setGasLimit,
     properGasLimit,
-    userEditedGasLimit,
     estimateToUse,
     setEstimateToUse,
     estimatedMinimumFiat,
@@ -165,7 +164,7 @@ export default function EditGasPopover({
 
     const updatedTxMeta = {
       ...updatedTransaction,
-      userEditedGasLimit,
+      userEditedGasLimit: gasLimit !== Number(transaction.originalGasEstimate),
       userFeeLevel: estimateToUse || CUSTOM_GAS_ESTIMATE,
       txParams: {
         ...cleanTransactionParams,
@@ -212,7 +211,7 @@ export default function EditGasPopover({
     closePopover,
     gasLimit,
     gasPrice,
-    userEditedGasLimit,
+    transaction.originalGasEstimate,
     maxFeePerGas,
     maxPriorityFeePerGas,
     supportsEIP1559,

--- a/ui/components/ui/actionable-message/index.scss
+++ b/ui/components/ui/actionable-message/index.scss
@@ -14,7 +14,7 @@
   }
 
   &--with-icon.actionable-message--warning {
-    justify-content: center;
+    justify-content: normal;
   }
 
   &--with-icon.actionable-message--with-right-button {

--- a/ui/components/ui/actionable-message/index.scss
+++ b/ui/components/ui/actionable-message/index.scss
@@ -14,7 +14,7 @@
   }
 
   &--with-icon.actionable-message--warning {
-    justify-content: normal;
+    justify-content: center;
   }
 
   &--with-icon.actionable-message--with-right-button {

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -352,9 +352,11 @@ export const computeEstimatedGasLimit = createAsyncThunk(
   async (_, thunkApi) => {
     const state = thunkApi.getState();
     const { send, metamask } = state;
+    const unapprovedTxs = getUnapprovedTxs(state);
+    const transaction = unapprovedTxs[send.draftTransaction.id];
     const isNonStandardEthChain = getIsNonStandardEthChain(state);
     const chainId = getCurrentChainId(state);
-    if (send.stage) {
+    if (send.stage !== SEND_STAGES.EDIT || !transaction.dappSuggestedGasFees?.gas || !transaction.userEditedGasLimit) {
       const gasLimit = await estimateGasLimitForSend({
         gasPrice: send.gas.gasPrice,
         blockGasLimit: metamask.currentBlockGasLimit,
@@ -1540,15 +1542,15 @@ export function signTransaction() {
       // merge in the modified txParams. Once the transaction has been modified
       // we can send that to the background to update the transaction in state.
       const unapprovedTxs = getUnapprovedTxs(state);
+      const unapprovedTx = unapprovedTxs[id];
       // We only update the tx params that can be changed via the edit flow UX
       const eip1559OnlyTxParamsToUpdate = {
         data: txParams.data,
         from: txParams.from,
         to: txParams.to,
         value: txParams.value,
-        gas: txParams.gas,
+        gas: unapprovedTx.userEditedGasLimit ? unapprovedTx.txParams.gas : txParams.gas,
       };
-      const unapprovedTx = unapprovedTxs[id];
       unapprovedTx.originalGasEstimate = eip1559OnlyTxParamsToUpdate.gas;
       const editingTx = {
         ...unapprovedTx,

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -354,7 +354,7 @@ export const computeEstimatedGasLimit = createAsyncThunk(
     const { send, metamask } = state;
     const isNonStandardEthChain = getIsNonStandardEthChain(state);
     const chainId = getCurrentChainId(state);
-    if (send.stage !== SEND_STAGES.EDIT) {
+    if (send.stage) {
       const gasLimit = await estimateGasLimitForSend({
         gasPrice: send.gas.gasPrice,
         blockGasLimit: metamask.currentBlockGasLimit,

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -1549,6 +1549,7 @@ export function signTransaction() {
         gas: txParams.gas,
       };
       const unapprovedTx = unapprovedTxs[id];
+      unapprovedTx.originalGasEstimate = eip1559OnlyTxParamsToUpdate.gas;
       const editingTx = {
         ...unapprovedTx,
         txParams: Object.assign(

--- a/ui/ducks/send/send.js
+++ b/ui/ducks/send/send.js
@@ -356,7 +356,11 @@ export const computeEstimatedGasLimit = createAsyncThunk(
     const transaction = unapprovedTxs[send.draftTransaction.id];
     const isNonStandardEthChain = getIsNonStandardEthChain(state);
     const chainId = getCurrentChainId(state);
-    if (send.stage !== SEND_STAGES.EDIT || !transaction.dappSuggestedGasFees?.gas || !transaction.userEditedGasLimit) {
+    if (
+      send.stage !== SEND_STAGES.EDIT ||
+      !transaction.dappSuggestedGasFees?.gas ||
+      !transaction.userEditedGasLimit
+    ) {
       const gasLimit = await estimateGasLimitForSend({
         gasPrice: send.gas.gasPrice,
         blockGasLimit: metamask.currentBlockGasLimit,
@@ -1549,7 +1553,9 @@ export function signTransaction() {
         from: txParams.from,
         to: txParams.to,
         value: txParams.value,
-        gas: unapprovedTx.userEditedGasLimit ? unapprovedTx.txParams.gas : txParams.gas,
+        gas: unapprovedTx.userEditedGasLimit
+          ? unapprovedTx.txParams.gas
+          : txParams.gas,
       };
       unapprovedTx.originalGasEstimate = eip1559OnlyTxParamsToUpdate.gas;
       const editingTx = {

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1293,9 +1293,6 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[3].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1345,9 +1342,6 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[3].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1388,15 +1382,12 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(4);
+        expect(actionResult).toHaveLength(3);
         expect(actionResult[0].type).toStrictEqual('send/updateSendAmount');
         expect(actionResult[1].type).toStrictEqual(
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[3].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1450,7 +1441,7 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(4);
+        expect(actionResult).toHaveLength(3);
 
         expect(actionResult[0].type).toStrictEqual('send/updateAsset');
         expect(actionResult[0].payload).toStrictEqual({
@@ -1462,9 +1453,6 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[3].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1492,7 +1480,7 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(6);
+        expect(actionResult).toHaveLength(5);
         expect(actionResult[0].type).toStrictEqual('SHOW_LOADING_INDICATION');
         expect(actionResult[1].type).toStrictEqual('HIDE_LOADING_INDICATION');
         expect(actionResult[2].payload).toStrictEqual({
@@ -1504,9 +1492,6 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[4].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[5].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1659,15 +1644,12 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(4);
+        expect(actionResult).toHaveLength(3);
         expect(actionResult[0].type).toStrictEqual('send/updateRecipient');
         expect(actionResult[1].type).toStrictEqual(
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[3].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1727,7 +1709,7 @@ describe('Send Slice', () => {
         );
 
         const actionResult = store.getActions();
-        expect(actionResult).toHaveLength(4);
+        expect(actionResult).toHaveLength(3);
         expect(actionResult[0].type).toStrictEqual('send/updateRecipient');
         expect(actionResult[0].payload.address).toStrictEqual(
           TEST_RECIPIENT_ADDRESS,
@@ -1777,15 +1759,12 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(4);
+        expect(actionResult).toHaveLength(3);
         expect(actionResult[0].type).toStrictEqual('send/updateRecipient');
         expect(actionResult[1].type).toStrictEqual(
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[3].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1851,7 +1830,7 @@ describe('Send Slice', () => {
         await store.dispatch(resetRecipientInput());
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(7);
+        expect(actionResult).toHaveLength(6);
         expect(actionResult[0].type).toStrictEqual(
           'send/updateRecipientUserInput',
         );
@@ -1861,13 +1840,10 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[3].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[4].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
-        expect(actionResult[5].type).toStrictEqual('ENS/resetEnsResolution');
-        expect(actionResult[6].type).toStrictEqual(
+        expect(actionResult[4].type).toStrictEqual('ENS/resetEnsResolution');
+        expect(actionResult[5].type).toStrictEqual(
           'send/validateRecipientUserInput',
         );
       });
@@ -1934,16 +1910,13 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(5);
+        expect(actionResult).toHaveLength(4);
         expect(actionResult[0].type).toStrictEqual('send/updateAmountMode');
         expect(actionResult[1].type).toStrictEqual('send/updateAmountToMax');
         expect(actionResult[2].type).toStrictEqual(
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[3].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[4].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -1981,16 +1954,13 @@ describe('Send Slice', () => {
 
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(5);
+        expect(actionResult).toHaveLength(4);
         expect(actionResult[0].type).toStrictEqual('send/updateAmountMode');
         expect(actionResult[1].type).toStrictEqual('send/updateSendAmount');
         expect(actionResult[2].type).toStrictEqual(
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[3].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[4].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
       });
@@ -2217,7 +2187,7 @@ describe('Send Slice', () => {
         );
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(7);
+        expect(actionResult).toHaveLength(6);
         expect(actionResult[0].type).toStrictEqual('SHOW_LOADING_INDICATION');
         expect(actionResult[1].type).toStrictEqual('HIDE_LOADING_INDICATION');
         expect(actionResult[2].type).toStrictEqual('send/updateAsset');
@@ -2235,13 +2205,10 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[4].type).toStrictEqual(
-          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
-        );
-        expect(actionResult[5].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
-        expect(actionResult[6].type).toStrictEqual('send/editTransaction');
-        expect(actionResult[6].payload).toStrictEqual({
+        expect(actionResult[5].type).toStrictEqual('send/editTransaction');
+        expect(actionResult[5].payload).toStrictEqual({
           address: '0xrecipientaddress', // getting address from tokenData does .toLowerCase
           amount: '0x3a98',
           data: '',
@@ -2252,7 +2219,7 @@ describe('Send Slice', () => {
           nickname: '',
         });
 
-        const action = actionResult[6];
+        const action = actionResult[5];
 
         const result = sendReducer(initialState, action);
 

--- a/ui/ducks/send/send.test.js
+++ b/ui/ducks/send/send.test.js
@@ -1293,7 +1293,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
 
@@ -1342,7 +1342,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
 
@@ -1388,7 +1388,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
     });
@@ -1453,7 +1453,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
 
@@ -1492,7 +1492,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[4].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
     });
@@ -1650,7 +1650,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
 
@@ -1765,7 +1765,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[2].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
     });
@@ -1840,7 +1840,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[3].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
         expect(actionResult[4].type).toStrictEqual('ENS/resetEnsResolution');
         expect(actionResult[5].type).toStrictEqual(
@@ -1917,7 +1917,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[3].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
 
@@ -1961,7 +1961,7 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[3].type).toStrictEqual(
-          'send/computeEstimatedGasLimit/fulfilled',
+          'send/computeEstimatedGasLimit/rejected',
         );
       });
     });
@@ -2187,7 +2187,7 @@ describe('Send Slice', () => {
         );
         const actionResult = store.getActions();
 
-        expect(actionResult).toHaveLength(6);
+        expect(actionResult).toHaveLength(7);
         expect(actionResult[0].type).toStrictEqual('SHOW_LOADING_INDICATION');
         expect(actionResult[1].type).toStrictEqual('HIDE_LOADING_INDICATION');
         expect(actionResult[2].type).toStrictEqual('send/updateAsset');
@@ -2205,10 +2205,13 @@ describe('Send Slice', () => {
           'send/computeEstimatedGasLimit/pending',
         );
         expect(actionResult[4].type).toStrictEqual(
+          'metamask/gas/SET_CUSTOM_GAS_LIMIT',
+        );
+        expect(actionResult[5].type).toStrictEqual(
           'send/computeEstimatedGasLimit/fulfilled',
         );
-        expect(actionResult[5].type).toStrictEqual('send/editTransaction');
-        expect(actionResult[5].payload).toStrictEqual({
+        expect(actionResult[6].type).toStrictEqual('send/editTransaction');
+        expect(actionResult[6].payload).toStrictEqual({
           address: '0xrecipientaddress', // getting address from tokenData does .toLowerCase
           amount: '0x3a98',
           data: '',
@@ -2219,7 +2222,7 @@ describe('Send Slice', () => {
           nickname: '',
         });
 
-        const action = actionResult[5];
+        const action = actionResult[6];
 
         const result = sendReducer(initialState, action);
 

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -137,7 +137,7 @@ export function useGasFeeInputs(
     hexToDecimal(transaction?.originalGasEstimate ?? '0x0'),
   );
 
-  const [userEditedGasLimit, setUserEditedGasLimit] = useState(() => 
+  const [userEditedGasLimit, setUserEditedGasLimit] = useState(() =>
     Boolean(transaction?.userEditedGasLimit),
   );
 

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -133,9 +133,7 @@ export function useGasFeeInputs(
     Number(hexToDecimal(transaction?.txParams?.gas ?? '0x0')),
   );
 
-  const properGasLimit = Number(
-    hexToDecimal(transaction?.originalGasEstimate ?? '0x0'),
-  );
+  const properGasLimit = Number(hexToDecimal(transaction?.originalGasEstimate));
 
   const [userEditedGasLimit, setUserEditedGasLimit] = useState(() =>
     Boolean(transaction?.userEditedGasLimit),

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -133,6 +133,10 @@ export function useGasFeeInputs(
     Number(hexToDecimal(transaction?.txParams?.gas ?? '0x0')),
   );
 
+  const properGasLimit = Number(
+    hexToDecimal(transaction?.originalGasEstimate ?? '0x0'),
+  );
+
   /**
    * In EIP-1559 V2 designs change to gas estimate is always updated to transaction
    * Thus callback setEstimateToUse can be deprecate in favour of this useEffect

--- a/ui/hooks/gasFeeInput/useGasFeeInputs.js
+++ b/ui/hooks/gasFeeInput/useGasFeeInputs.js
@@ -137,6 +137,10 @@ export function useGasFeeInputs(
     hexToDecimal(transaction?.originalGasEstimate ?? '0x0'),
   );
 
+  const [userEditedGasLimit, setUserEditedGasLimit] = useState(() => 
+    Boolean(transaction?.userEditedGasLimit),
+  );
+
   /**
    * In EIP-1559 V2 designs change to gas estimate is always updated to transaction
    * Thus callback setEstimateToUse can be deprecate in favour of this useEffect
@@ -288,6 +292,7 @@ export function useGasFeeInputs(
     // Restore existing values
     setGasPrice(gasPrice);
     setGasLimit(gasLimit);
+    setUserEditedGasLimit(true);
     setMaxFeePerGas(maxFeePerGas);
     setMaxPriorityFeePerGas(maxPriorityFeePerGas);
     setGasPriceHasBeenManuallySet(true);
@@ -299,6 +304,7 @@ export function useGasFeeInputs(
     gasPrice,
     setGasLimit,
     gasLimit,
+    setUserEditedGasLimit,
     setMaxFeePerGas,
     maxFeePerGas,
     setMaxPriorityFeePerGas,
@@ -318,6 +324,8 @@ export function useGasFeeInputs(
     setGasPrice,
     gasLimit,
     setGasLimit,
+    properGasLimit,
+    userEditedGasLimit,
     editGasMode,
     estimateToUse,
     setEstimateToUse,


### PR DESCRIPTION
fixes: #12072

**Explanation:**  Proper calculation of the gas limit filed on the amount change and added warning message when the amount is less then calculated gas limit on manually enter the gas limit. When user manually enter the gas limit, and when that value is less then proper gas limit value, it shows warning message on the top of "Edit priority" popover, when the value is equal or greater then proper gas limit value, it not show warning message on the top of "Edit priority" popover. 

**Steps to reproduce (REQUIRED):**

1. Using MM extension, start a new send to a smart contract recipient address
2. Enter an amount to send and hit "Next"
3. Click the "< Edit" button at the top left
4. Modify the send amount and hit "Next"
5. Click "Edit" in "Estimated gas fee" field
6. Enter manually value in "Gas Limit" field to see warning message

**Screencast where the user has already explicitly set the gas limit:**
This is the second case related to Dan's comment: https://github.com/MetaMask/metamask-extension/pull/12784#discussion_r761031633. 

https://user-images.githubusercontent.com/92527393/145834940-7e6daf08-77d6-4333-9ecc-6886861fb6f2.mp4

**Screencast where gas limit was explicitly proposed by a dapp:**
This is the first case related to Dan's comment: https://github.com/MetaMask/metamask-extension/pull/12784#discussion_r761031633. 


https://user-images.githubusercontent.com/92527393/145835391-8611aadd-583a-4937-b4d0-0955369e9adb.mp4



**Warning message example in screencast:**

![Screenshot from 2021-12-15 15-14-26](https://user-images.githubusercontent.com/92527393/146202862-ddb05ca0-8f88-4a58-8437-1e2c485c163b.png)



