### PR TITLE
Add fixed json-schema to resolutions file to resolve security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "netmask": "^2.0.1",
     "pubnub/superagent-proxy": "^3.0.0",
     "pull-ws": "^3.3.2",
-    "ws": "^7.4.6"
+    "ws": "^7.4.6",
+    "json-schema": "^0.4.0"
   },
   "dependencies": {
     "3box": "^1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18907,10 +18907,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Currently builds are failing due to this security warning https://github.com/advisories/GHSA-896r-f27r-55mw

The changes between the version of json-schema in our dependency tree (0.2.3) and the version in which the fix to the security advisory was made (0.4.0) are:
https://github.com/kriszyp/json-schema/commit/ae602f03eab4ad24922f72d6d2df68e07270182a
https://github.com/kriszyp/json-schema/commit/22f146111f541d9737e832823699ad3528ca7741
https://github.com/kriszyp/json-schema/commit/b62f1da1ff5442f23443d6be6a92d00e65cba93a

Non of these should be breaking changes. What's more, it seems that the library that uses this dependency `jsprim` only uses it in the `validateJsonObjectJS` function, which is not used by it's parent in our dependency tree (`http-signer`, which only seems to use the `rfc1123` method from jsprim https://github.com/joyent/node-http-signature/blob/master/lib/signer.js)

So forcing a resolution 0.4.0 seems safe. 

Also of relevance, in the `json-schema` repo, there is this description:

> This is a historical repository for the early development of the JSON Schema specification and implementation. This package is considered "finished": it holds the earlier draft specification and a simple, efficient, lightweight implementation of the original core elements of JSON Schema. This repository does not house the latest specifications nor does it implement the latest versions of JSON Schema. This package seeks to maintain the stability (in behavior and size) of this original implementation for the sake of the numerous packages that rely on it.