### PR TITLE
Remove localhost from default network list

### DIFF
--- a/test/e2e/tests/custom-rpc-history.spec.js
+++ b/test/e2e/tests/custom-rpc-history.spec.js
@@ -84,7 +84,7 @@ describe('Stores custom RPC history', function () {
         await rpcUrlInput.clear();
         await rpcUrlInput.sendKeys(duplicateRpcUrl);
         await driver.findElement({
-          text: 'This URL is currently used by the localhost network.',
+          text: 'This URL is currently used by the Localhost 8545 network.',
           tag: 'h6',
         });
       },
@@ -123,7 +123,8 @@ describe('Stores custom RPC history', function () {
         await chainIdInput.clear();
         await chainIdInput.sendKeys(duplicateChainId);
         await driver.findElement({
-          text: 'This Chain ID is currently used by the localhost network.',
+          text:
+            'This Chain ID is currently used by the Localhost 8545 network.',
           tag: 'h6',
         });
       },

--- a/ui/pages/settings/networks-tab/networks-tab.constants.js
+++ b/ui/pages/settings/networks-tab/networks-tab.constants.js
@@ -5,9 +5,6 @@ import {
   KOVAN,
   KOVAN_CHAIN_ID,
   KOVAN_RPC_URL,
-  LOCALHOST,
-  LOCALHOST_CHAIN_ID,
-  LOCALHOST_RPC_URL,
   MAINNET,
   MAINNET_CHAIN_ID,
   MAINNET_RPC_URL,
@@ -64,15 +61,6 @@ const defaultNetworksData = [
     chainId: KOVAN_CHAIN_ID,
     ticker: 'ETH',
     blockExplorerUrl: 'https://kovan.etherscan.io',
-  },
-  {
-    labelKey: LOCALHOST,
-    iconColor: '#29B6AF',
-    providerType: LOCALHOST,
-    rpcUrl: LOCALHOST_RPC_URL,
-    chainId: LOCALHOST_CHAIN_ID,
-    ticker: 'ETH',
-    blockExplorerUrl: '',
   },
 ];
 


### PR DESCRIPTION
Addresses issue found in QA of v10.6.2 (which was also present in v10.6.0)

Ensures that localhost only appears once in the network list in the settings tab

Before:
https://drive.google.com/file/d/1lKH3Fg6fn5nimjQAhz4vuMMXltwqfaFE/view?usp=sharing

After:
![Screenshot from 2021-11-22 17-10-22](https://user-images.githubusercontent.com/7499938/142932214-2e391bec-51d9-4177-8bfe-d92c3f4aaea4.png)
